### PR TITLE
feat: auto-tune per-model Metal memory limits and return actionable admission errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,7 @@ jobs:
             tests/test_response_format_json_schema_strict.py \
             tests/test_mllm_cache.py \
             tests/test_memory_cache.py \
+            tests/test_metal_memory_budget.py \
             tests/test_optimizations.py \
             tests/test_batching.py \
             tests/test_continuous_batching.py \

--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -40,7 +40,7 @@ vllm_mlx/disk_stream_patch.py 2
 vllm_mlx/doctor/env_health.py 2
 vllm_mlx/embedding.py 7
 vllm_mlx/engine/base.py 1
-vllm_mlx/engine/batched.py 44
+vllm_mlx/engine/batched.py 43
 vllm_mlx/engine_core.py 4
 vllm_mlx/first_run.py 1
 vllm_mlx/gdn_in_proj_fusion.py 1

--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -40,7 +40,7 @@ vllm_mlx/disk_stream_patch.py 2
 vllm_mlx/doctor/env_health.py 2
 vllm_mlx/embedding.py 7
 vllm_mlx/engine/base.py 1
-vllm_mlx/engine/batched.py 43
+vllm_mlx/engine/batched.py 44
 vllm_mlx/engine_core.py 4
 vllm_mlx/first_run.py 1
 vllm_mlx/gdn_in_proj_fusion.py 1

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -46,7 +46,7 @@ flag visible in `rapid-mlx serve --help`, grouped by category — lives in the
 | `--prefill-batch-size` | Max prompts prefilled together in one cold wave; lower for better first-token latency under concurrent cold load | 8 |
 | `--completion-batch-size` | Completion batch size | 32 |
 | `--prefill-step-size` | Chunk size for prompt prefill processing | 2048 |
-| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit (0.0-1.0) | 0.90 |
+| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit (0.0-1.0); advanced override of the automatic per-model budget | auto |
 | `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`); int8/int4 shrink the KV cache 2x/4x at a long-context decode cost. See the [CLI reference](../reference/cli.md#kv-cache-dtype-and-quantization) for the full quantization family (`--kv-cache-quantization*`, `--kv-cache-turboquant*`). | bf16 |
 | `--enable-prefix-cache` / `--disable-prefix-cache` | Toggle prefix caching for repeated prompts | enabled |
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (token trie) or `hash` (legacy) | radix |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -90,7 +90,7 @@ are the argparse defaults from `vllm_mlx/cli.py`.
 | `--completion-batch-size` | Completion batch size | 32 |
 | `--prefill-step-size` | Chunk size for prompt prefill processing; larger values use more memory but can improve prefill throughput | 2048 |
 | `--stream-interval` | Tokens to batch before streaming (1 = smooth, higher = throughput) | 1 |
-| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit and emergency cache-clear threshold (0.0-1.0); increase to 0.95 for very large (200GB+) models | 0.90 |
+| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit and admission cap (0.0-1.0). Advanced override — by default the budget is sized automatically to the loaded model (measured weights + headroom, 0.90–0.97 of the device working-set budget) | auto |
 
 #### Prefix, KV, and response caching
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -69,7 +69,7 @@ needed by the application; leave it unset for URL/base64-only deployments.
 | `--prefill-batch-size` | Max prompts prefilled together in one cold wave; lower for better first-token latency under concurrent cold load | `8` |
 | `--completion-batch-size` | Completion batch size | `32` |
 | `--prefill-step-size` | Chunk size for prompt prefill processing | `2048` |
-| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit (0.0-1.0) | `0.90` |
+| `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit (0.0-1.0); advanced override of the automatic per-model budget | `auto` |
 
 ### Cache Options
 

--- a/tests/test_metal_memory_budget.py
+++ b/tests/test_metal_memory_budget.py
@@ -1,0 +1,217 @@
+"""Per-model Metal memory budgeting tests (#2858).
+
+Covers the three pieces the issue's acceptance criteria name:
+
+* ``plan_metal_limit`` — auto per-model budget selection, including the two
+  required fixtures: a model that fits at the default (0.90 floor) budget
+  and one that requires a higher per-model budget, plus the explicit
+  operator override.
+* ``Scheduler.preflight_metal_admission`` — a model whose resident
+  footprint can never admit a request fails startup with the actionable
+  required-vs-available message instead of reporting healthy and 503ing
+  every request.
+* The rewritten D-METAL-CAP admission 503 — required vs available plus a
+  concrete remediation, while keeping the tokens existing regression tests
+  grep for.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+from vllm_mlx.memory_budget import (  # noqa: E402
+    AUTO_UTILIZATION_CEILING,
+    AUTO_UTILIZATION_FLOOR,
+    MetalPreflightError,
+    format_preflight_error,
+    plan_metal_limit,
+)
+from vllm_mlx.request import Request, SamplingParams  # noqa: E402
+from vllm_mlx.scheduler import (  # noqa: E402
+    BackpressureError,
+    Scheduler,
+    SchedulerConfig,
+)
+
+GB = 10**9
+
+
+def _make_scheduler(*, gpu_memory_utilization: float = 0.9) -> Scheduler:
+    config = SchedulerConfig(
+        max_num_seqs=8,
+        max_concurrent_requests=64,
+        enable_prefix_cache=False,
+        use_memory_aware_cache=False,
+        use_paged_cache=False,
+        gpu_memory_utilization=gpu_memory_utilization,
+    )
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda s: list(range(len(s)))
+    return Scheduler(model=MagicMock(), tokenizer=tokenizer, config=config)
+
+
+class TestPlanMetalLimit:
+    def test_small_model_fits_at_default_floor(self):
+        """#2858 acceptance fixture 1: a model with plenty of headroom
+        resolves to exactly the historical 0.90 default — auto mode is
+        byte-identical to the old behavior for every model that already
+        fit comfortably."""
+        plan = plan_metal_limit(
+            weights_bytes=2 * GB,
+            device_budget_bytes=20 * GB,
+        )
+        assert plan.mode == "auto"
+        assert plan.resolved_utilization == AUTO_UTILIZATION_FLOOR
+        assert plan.limit_bytes == int(20 * GB * AUTO_UTILIZATION_FLOOR)
+
+    def test_large_model_gets_higher_per_model_budget(self):
+        """#2858 acceptance fixture 2: the issue's 20B-MoE-on-16GB shape —
+        weights close to the device budget push the resolved utilization
+        ABOVE the 0.90 floor without the operator touching anything."""
+        weights = 11 * GB
+        device = 12_800_000_000  # ~the working-set budget of a 16 GB Mac
+        plan = plan_metal_limit(weights_bytes=weights, device_budget_bytes=device)
+        assert plan.mode == "auto"
+        assert plan.resolved_utilization > AUTO_UTILIZATION_FLOOR
+        assert plan.resolved_utilization <= AUTO_UTILIZATION_CEILING
+        # The resolved limit must actually cover the weights.
+        assert plan.limit_bytes > weights
+
+    def test_oversized_model_clamps_at_ceiling(self):
+        """Auto mode never plans past the ceiling — a model that cannot
+        fit resolves to the ceiling and the scheduler preflight (not the
+        planner) is what refuses startup."""
+        plan = plan_metal_limit(
+            weights_bytes=15 * GB,
+            device_budget_bytes=12 * GB,
+        )
+        assert plan.resolved_utilization == AUTO_UTILIZATION_CEILING
+
+    def test_explicit_override_is_honored_verbatim(self):
+        """The advanced manual override must bypass auto sizing entirely,
+        including values BELOW what auto would pick."""
+        plan = plan_metal_limit(
+            weights_bytes=11 * GB,
+            device_budget_bytes=12 * GB,
+            requested_utilization=0.5,
+        )
+        assert plan.mode == "manual"
+        assert plan.resolved_utilization == 0.5
+        assert plan.limit_bytes == 6 * GB
+
+    def test_missing_measurement_falls_back_to_floor(self):
+        plan = plan_metal_limit(weights_bytes=0, device_budget_bytes=20 * GB)
+        assert plan.resolved_utilization == AUTO_UTILIZATION_FLOOR
+
+    def test_invalid_device_budget_raises(self):
+        with pytest.raises(ValueError):
+            plan_metal_limit(weights_bytes=GB, device_budget_bytes=0)
+
+
+class TestPreflightErrorMessage:
+    def test_message_reports_required_available_and_remediation(self):
+        """#2858 acceptance: a rejection must report required vs available
+        memory and at least one concrete remediation."""
+        message = format_preflight_error(
+            required_bytes=11_200_000_000,
+            active_bytes=10_700_000_000,
+            min_kv_bytes=500_000_000,
+            cap_bytes=9_100_000_000,
+            utilization=0.75,
+            device_budget_bytes=12_100_000_000,
+        )
+        assert "11.2 GB" in message  # required
+        assert "9.1 GB" in message  # current limit
+        assert "--gpu-memory-utilization" in message  # remediation 1
+        assert "smaller model" in message  # remediation 2
+        assert "close memory-heavy apps" in message.lower()  # remediation 3
+
+
+class TestSchedulerPreflight:
+    def test_noop_when_cap_disabled(self):
+        sched = _make_scheduler(gpu_memory_utilization=0.0)
+        with patch.object(sched, "_current_metal_active_bytes", return_value=10**15):
+            sched.preflight_metal_admission()  # must not raise
+
+    def test_noop_when_active_unreadable(self):
+        """Non-Metal CI hosts and unit-test stubs read 0 active bytes —
+        the preflight must stay silent there exactly like the gate."""
+        sched = _make_scheduler()
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=10 * GB),
+            patch.object(sched, "_current_metal_active_bytes", return_value=0),
+        ):
+            sched.preflight_metal_admission()
+
+    def test_passes_when_model_fits(self):
+        sched = _make_scheduler()
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=12 * GB),
+            patch.object(sched, "_current_metal_active_bytes", return_value=8 * GB),
+        ):
+            sched.preflight_metal_admission()
+
+    def test_fails_startup_when_weights_exceed_cap(self):
+        """The healthy-but-every-request-503s configuration must be caught
+        at startup with the actionable message (#2858 acceptance)."""
+        sched = _make_scheduler()
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=9_100_000_000),
+            patch.object(
+                sched, "_current_metal_active_bytes", return_value=11_200_000_000
+            ),
+            pytest.raises(MetalPreflightError) as exc_info,
+        ):
+            sched.preflight_metal_admission()
+        message = str(exc_info.value)
+        assert "9.1 GB" in message
+        assert "--gpu-memory-utilization" in message
+
+    def test_fails_when_minimum_kv_cannot_fit(self):
+        """Weights just under the cap but no room for even a nominal
+        request's KV — still a deterministic 503 config, still refused."""
+        sched = _make_scheduler()
+        per_tok = 100_000  # bytes per token, via the operator override path
+        sched.config.metal_cap_kv_bytes_per_token = per_tok
+        cap = 10 * GB
+        min_kv = per_tok * Scheduler.PREFLIGHT_NOMINAL_TOKENS
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=cap),
+            patch.object(
+                sched,
+                "_current_metal_active_bytes",
+                return_value=cap - min_kv // 2,
+            ),
+            pytest.raises(MetalPreflightError),
+        ):
+            sched.preflight_metal_admission()
+
+
+class TestActionableAdmission503:
+    def test_backpressure_message_carries_remediation(self):
+        """The runtime D-METAL-CAP 503 must state required vs available and
+        a remediation, while keeping the historical grep tokens."""
+        sched = _make_scheduler(gpu_memory_utilization=0.5)
+        req = Request(
+            request_id="req-503",
+            prompt="x" * 16,
+            prompt_token_ids=list(range(16)),
+            sampling_params=SamplingParams(max_tokens=1),
+        )
+        req.num_prompt_tokens = 16
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=100 * GB),
+            patch.object(sched, "_current_metal_active_bytes", return_value=100 * GB),
+            pytest.raises(BackpressureError) as exc_info,
+        ):
+            sched._enforce_metal_cap_at_admission(req)
+        message = str(exc_info.value)
+        assert "D-METAL-CAP" in message
+        assert "reserved KV" in message
+        assert "current limit is" in message
+        assert "--gpu-memory-utilization" in message

--- a/tests/test_metal_memory_budget.py
+++ b/tests/test_metal_memory_budget.py
@@ -307,6 +307,30 @@ class TestProcessUtilizationRatchet:
             note_resolved_utilization(0.97)
             assert sched._resolve_metal_cap_bytes() == 0
 
+    def test_ratchet_and_apply_is_atomic_and_serialized(self):
+        """Codex round 4 BLOCKING #1: the setter callback must run under
+        the floor lock with the post-ratchet effective value, so a stale
+        lower limit can never be installed after a newer higher one."""
+        import vllm_mlx.memory_budget as mb
+        from vllm_mlx.memory_budget import ratchet_utilization_and_apply
+
+        applied: list[float] = []
+
+        def _apply(effective: float) -> None:
+            # The lock is held across the callback — a concurrent ratchet
+            # cannot interleave between the floor read and this apply.
+            assert mb._process_floor_lock.locked()
+            applied.append(effective)
+
+        eff, gen1 = ratchet_utilization_and_apply(0.95, _apply)
+        assert eff == 0.95
+        # A later, LOWER resolution applies the ratcheted floor, not its
+        # own value — the last setter call carries the highest floor.
+        eff, gen2 = ratchet_utilization_and_apply(0.5, _apply)
+        assert eff == 0.95
+        assert gen2 == gen1  # no upward ratchet, no invalidation
+        assert applied == [0.95, 0.95]
+
 
 class TestActionableAdmission503:
     def test_backpressure_message_carries_remediation(self):

--- a/tests/test_metal_memory_budget.py
+++ b/tests/test_metal_memory_budget.py
@@ -259,6 +259,33 @@ class TestSchedulerPreflight:
         ):
             sched.preflight_metal_admission()
 
+    def test_counts_sliding_window_kv_and_survives_clear_cache_failure(self):
+        """Sliding-window KV is part of the smallest-request estimate, and
+        a failing ``mx.clear_cache`` must not mask the real verdict."""
+        import vllm_mlx.scheduler as sched_mod
+
+        sched = _make_scheduler()
+        per_tok = 100_000
+        cap = 10 * GB
+        with (
+            patch.object(sched, "_resolve_kv_bytes_per_token", return_value=per_tok),
+            patch.object(sched, "_resolve_kv_fixed_baseline_bytes", return_value=0),
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=cap),
+            patch.object(
+                sched, "_current_metal_active_bytes", return_value=cap - per_tok
+            ),
+            patch.object(
+                sched_mod.mx,
+                "clear_cache",
+                side_effect=RuntimeError("no metal"),
+                create=True,
+            ),
+            pytest.raises(MetalPreflightError),
+        ):
+            sched._kv_sliding_slot_bytes = 50_000
+            sched._kv_sliding_window = 8
+            sched.preflight_metal_admission()
+
 
 class TestProcessUtilizationRatchet:
     """Codex round 2 BLOCKING #2: a resident scheduler's cap must follow
@@ -305,6 +332,18 @@ class TestProcessUtilizationRatchet:
         sched = _make_scheduler(gpu_memory_utilization=0.0)
         with self._fake_device():
             note_resolved_utilization(0.97)
+            assert sched._resolve_metal_cap_bytes() == 0
+
+    def test_cap_disables_when_device_info_unreadable(self):
+        import vllm_mlx.scheduler as sched_mod
+
+        sched = _make_scheduler(gpu_memory_utilization=0.5)
+        metal = MagicMock()
+        metal.is_available.return_value = True
+        device_info = MagicMock(side_effect=RuntimeError("no device info"))
+        with patch.multiple(
+            sched_mod.mx, metal=metal, device_info=device_info, create=True
+        ):
             assert sched._resolve_metal_cap_bytes() == 0
 
     def test_ratchet_and_apply_is_atomic_and_serialized(self):
@@ -377,3 +416,144 @@ class TestActionableAdmission503:
         message = str(exc_info.value)
         assert "D-METAL-CAP" in message
         assert "--gpu-memory-utilization" not in message
+
+
+class TestBatchedEngineBudgetInstall:
+    """The BatchedEngine-side wiring: resolve on the worker, install the
+    result, and run the admission preflight (#2858)."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_floor(self):
+        import vllm_mlx.memory_budget as mb
+
+        with mb._process_floor_lock:
+            saved = (mb._process_utilization_floor, mb._process_floor_generation)
+            mb._process_utilization_floor = 0.0
+            mb._process_floor_generation += 1
+        yield
+        with mb._process_floor_lock:
+            mb._process_utilization_floor = saved[0]
+            mb._process_floor_generation += 1
+
+    def _bare_engine(self, requested=None):
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._gpu_memory_utilization = requested
+        engine._model_load_executor = None
+        engine._engine = None
+        return engine
+
+    def _patched_mx(self, *, available=True, budget=100 * GB, active=50 * GB):
+        device_info = {"max_recommended_working_set_size": budget}
+        return patch.multiple(
+            "mlx.core",
+            device_info=MagicMock(return_value=device_info),
+            clear_cache=MagicMock(),
+            get_active_memory=MagicMock(return_value=active),
+            set_memory_limit=MagicMock(),
+            set_cache_limit=MagicMock(),
+        ), patch("mlx.core.metal.is_available", return_value=available)
+
+    def test_resolve_auto_success_installs_ratcheted_limit(self):
+        import mlx.core as mx
+
+        engine = self._bare_engine(requested=None)
+        core_patch, metal_patch = self._patched_mx(active=50 * GB)
+        with core_patch, metal_patch:
+            resolved = engine._resolve_and_set_metal_limits()
+            # 50GB weights + headroom on a 100GB budget needs < the floor,
+            # so auto resolves to the historical 0.90.
+            assert resolved == AUTO_UTILIZATION_FLOOR
+            mx.set_memory_limit.assert_called_once_with(int(100 * GB * 0.90))
+            mx.clear_cache.assert_called_once()
+            assert mx.set_cache_limit.called
+
+    def test_resolve_falls_back_when_metal_unavailable(self):
+        engine = self._bare_engine(requested=0.42)
+        core_patch, metal_patch = self._patched_mx(available=False)
+        with core_patch, metal_patch:
+            assert engine._resolve_and_set_metal_limits() == 0.42
+        engine = self._bare_engine(requested=None)
+        core_patch, metal_patch = self._patched_mx(available=False)
+        with core_patch, metal_patch:
+            assert engine._resolve_and_set_metal_limits() == AUTO_UTILIZATION_FLOOR
+
+    def test_resolve_falls_back_without_device_budget(self):
+        engine = self._bare_engine(requested=None)
+        core_patch, metal_patch = self._patched_mx(budget=0)
+        with core_patch, metal_patch:
+            assert engine._resolve_and_set_metal_limits() == AUTO_UTILIZATION_FLOOR
+
+    def test_resolve_treats_measurement_failure_as_no_measurement(self):
+        import mlx.core as mx
+
+        engine = self._bare_engine(requested=None)
+        core_patch, metal_patch = self._patched_mx()
+        with core_patch, metal_patch:
+            mx.get_active_memory.side_effect = RuntimeError("boom")
+            assert engine._resolve_and_set_metal_limits() == AUTO_UTILIZATION_FLOOR
+            mx.set_memory_limit.assert_called_once_with(int(100 * GB * 0.90))
+
+    def test_resolve_survives_setter_failure(self):
+        """Codex round 1 BLOCKING #2: a setter failure must not poison the
+        resolved utilization the admission cap enforces."""
+        import mlx.core as mx
+
+        engine = self._bare_engine(requested=0.95)
+        core_patch, metal_patch = self._patched_mx()
+        with core_patch, metal_patch:
+            mx.set_memory_limit.side_effect = RuntimeError("metal says no")
+            assert engine._resolve_and_set_metal_limits() == 0.95
+
+    def test_install_stores_resolved_value(self):
+        import concurrent.futures
+
+        engine = self._bare_engine(requested=None)
+        engine._model_load_executor = concurrent.futures.ThreadPoolExecutor(1)
+        try:
+            with patch.object(
+                type(engine), "_resolve_and_set_metal_limits", return_value=0.93
+            ):
+                engine._install_resolved_metal_budget()
+            assert engine._gpu_memory_utilization == 0.93
+        finally:
+            engine._model_load_executor.shutdown(wait=True)
+
+    def test_install_failure_falls_back_to_floor_only_when_unset(self):
+        import concurrent.futures
+
+        for requested, expected in ((None, AUTO_UTILIZATION_FLOOR), (0.5, 0.5)):
+            engine = self._bare_engine(requested=requested)
+            engine._model_load_executor = concurrent.futures.ThreadPoolExecutor(1)
+            try:
+                with patch.object(
+                    type(engine),
+                    "_resolve_and_set_metal_limits",
+                    side_effect=RuntimeError("worker died"),
+                ):
+                    engine._install_resolved_metal_budget()
+                assert engine._gpu_memory_utilization == expected
+            finally:
+                engine._model_load_executor.shutdown(wait=True)
+
+    def test_preflight_runs_on_worker_and_propagates(self):
+        import concurrent.futures
+        from types import SimpleNamespace
+
+        engine = self._bare_engine()
+        engine._model_load_executor = concurrent.futures.ThreadPoolExecutor(1)
+        preflight = MagicMock()
+        engine._engine = SimpleNamespace(
+            engine=SimpleNamespace(
+                scheduler=SimpleNamespace(preflight_metal_admission=preflight)
+            )
+        )
+        try:
+            engine._run_metal_admission_preflight()
+            preflight.assert_called_once()
+            preflight.side_effect = MetalPreflightError("impossible budget")
+            with pytest.raises(MetalPreflightError):
+                engine._run_metal_admission_preflight()
+        finally:
+            engine._model_load_executor.shutdown(wait=True)

--- a/tests/test_metal_memory_budget.py
+++ b/tests/test_metal_memory_budget.py
@@ -131,6 +131,22 @@ class TestPreflightErrorMessage:
         assert "smaller model" in message  # remediation 2
         assert "close memory-heavy apps" in message.lower()  # remediation 3
 
+    def test_no_impossible_advice_at_the_ceiling(self):
+        """Codex round 1 NIT: at or above the auto ceiling, 'increase
+        --gpu-memory-utilization' is impossible advice — the message must
+        say the Mac lacks the memory instead."""
+        message = format_preflight_error(
+            required_bytes=15_000_000_000,
+            active_bytes=14_500_000_000,
+            min_kv_bytes=500_000_000,
+            cap_bytes=11_700_000_000,
+            utilization=0.97,
+            device_budget_bytes=12_100_000_000,
+        )
+        assert "Increase --gpu-memory-utilization" not in message
+        assert "does not have enough unified memory" in message
+        assert "smaller model" in message
+
 
 class TestSchedulerPreflight:
     def test_noop_when_cap_disabled(self):
@@ -172,9 +188,11 @@ class TestSchedulerPreflight:
         assert "9.1 GB" in message
         assert "--gpu-memory-utilization" in message
 
-    def test_fails_when_minimum_kv_cannot_fit(self):
-        """Weights just under the cap but no room for even a nominal
-        request's KV — still a deterministic 503 config, still refused."""
+    def test_passes_when_weights_just_under_cap(self):
+        """Codex round 1 BLOCKING #1: the gate is ``active >= cap`` ALONE.
+        A memory-tight config whose weights sit just under the cap can
+        still serve short requests, so preflight must NOT refuse it even
+        though a nominal request's projected KV would overflow."""
         sched = _make_scheduler()
         per_tok = 100_000  # bytes per token, via the operator override path
         sched.config.metal_cap_kv_bytes_per_token = per_tok
@@ -187,7 +205,23 @@ class TestSchedulerPreflight:
                 "_current_metal_active_bytes",
                 return_value=cap - min_kv // 2,
             ),
-            pytest.raises(MetalPreflightError),
+        ):
+            sched.preflight_metal_admission()
+
+    def test_recovers_when_cache_clear_frees_enough(self):
+        """Codex round 1 BLOCKING #4: reclaimable allocator cache must not
+        fail a load. When the post-clear re-measure drops below the cap,
+        preflight passes."""
+        sched = _make_scheduler()
+        cap = 10 * GB
+        readings = iter([cap + GB, cap - 2 * GB])  # over, then under
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=cap),
+            patch.object(
+                sched,
+                "_current_metal_active_bytes",
+                side_effect=lambda: next(readings),
+            ),
         ):
             sched.preflight_metal_admission()
 

--- a/tests/test_metal_memory_budget.py
+++ b/tests/test_metal_memory_budget.py
@@ -188,11 +188,31 @@ class TestSchedulerPreflight:
         assert "9.1 GB" in message
         assert "--gpu-memory-utilization" in message
 
+    def test_fails_when_smallest_request_cannot_fit(self):
+        """Codex round 2 BLOCKING #1: positive but insufficient headroom
+        for even a one-token exchange is still a deterministic-503 config
+        and must be refused."""
+        sched = _make_scheduler()
+        per_tok = 100_000
+        sched.config.metal_cap_kv_bytes_per_token = per_tok
+        cap = 10 * GB
+        # Room for one token of KV, but the smallest request needs two.
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=cap),
+            patch.object(
+                sched,
+                "_current_metal_active_bytes",
+                return_value=cap - per_tok,
+            ),
+            pytest.raises(MetalPreflightError),
+        ):
+            sched.preflight_metal_admission()
+
     def test_passes_when_weights_just_under_cap(self):
-        """Codex round 1 BLOCKING #1: the gate is ``active >= cap`` ALONE.
-        A memory-tight config whose weights sit just under the cap can
-        still serve short requests, so preflight must NOT refuse it even
-        though a nominal request's projected KV would overflow."""
+        """Codex round 1 BLOCKING #1: a memory-tight config whose weights
+        leave room for the smallest valid request can still serve short
+        requests, so preflight must NOT refuse it even though a nominal
+        1024-token request's projected KV would overflow."""
         sched = _make_scheduler()
         per_tok = 100_000  # bytes per token, via the operator override path
         sched.config.metal_cap_kv_bytes_per_token = per_tok
@@ -226,6 +246,54 @@ class TestSchedulerPreflight:
             sched.preflight_metal_admission()
 
 
+class TestProcessUtilizationRatchet:
+    """Codex round 2 BLOCKING #2: a resident scheduler's cap must follow
+    the process-wide utilization ratchet upward."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_floor(self):
+        import vllm_mlx.memory_budget as mb
+
+        with mb._process_floor_lock:
+            saved = (mb._process_utilization_floor, mb._process_floor_generation)
+            mb._process_utilization_floor = 0.0
+            mb._process_floor_generation += 1
+        yield
+        with mb._process_floor_lock:
+            mb._process_utilization_floor = saved[0]
+            mb._process_floor_generation += 1
+
+    def _fake_device(self):
+        import vllm_mlx.scheduler as sched_mod
+
+        metal = MagicMock()
+        metal.is_available.return_value = True
+        device_info = MagicMock(return_value={"memory_size": 100 * GB})
+        return patch.multiple(
+            sched_mod.mx, metal=metal, device_info=device_info, create=True
+        )
+
+    def test_cap_follows_ratchet_upward(self):
+        from vllm_mlx.memory_budget import note_resolved_utilization
+
+        sched = _make_scheduler(gpu_memory_utilization=0.5)
+        with self._fake_device():
+            assert sched._resolve_metal_cap_bytes() == 50 * GB
+            note_resolved_utilization(0.9)
+            assert sched._resolve_metal_cap_bytes() == 90 * GB
+            # A LOWER later resolution must not lower the enforced cap.
+            note_resolved_utilization(0.6)
+            assert sched._resolve_metal_cap_bytes() == 90 * GB
+
+    def test_disabled_cap_stays_disabled(self):
+        from vllm_mlx.memory_budget import note_resolved_utilization
+
+        sched = _make_scheduler(gpu_memory_utilization=0.0)
+        with self._fake_device():
+            note_resolved_utilization(0.97)
+            assert sched._resolve_metal_cap_bytes() == 0
+
+
 class TestActionableAdmission503:
     def test_backpressure_message_carries_remediation(self):
         """The runtime D-METAL-CAP 503 must state required vs available and
@@ -249,3 +317,25 @@ class TestActionableAdmission503:
         assert "reserved KV" in message
         assert "current limit is" in message
         assert "--gpu-memory-utilization" in message
+
+    def test_no_utilization_advice_when_cap_maxed(self):
+        """Codex round 2 NIT: at an enforced utilization with no headroom
+        left, the 503 must not suggest raising --gpu-memory-utilization."""
+        sched = _make_scheduler(gpu_memory_utilization=1.0)
+        sched._metal_cap_effective_utilization = 1.0
+        req = Request(
+            request_id="req-503-max",
+            prompt="x" * 16,
+            prompt_token_ids=list(range(16)),
+            sampling_params=SamplingParams(max_tokens=1),
+        )
+        req.num_prompt_tokens = 16
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=100 * GB),
+            patch.object(sched, "_current_metal_active_bytes", return_value=100 * GB),
+            pytest.raises(BackpressureError) as exc_info,
+        ):
+            sched._enforce_metal_cap_at_admission(req)
+        message = str(exc_info.value)
+        assert "D-METAL-CAP" in message
+        assert "--gpu-memory-utilization" not in message

--- a/tests/test_metal_memory_budget.py
+++ b/tests/test_metal_memory_budget.py
@@ -131,16 +131,30 @@ class TestPreflightErrorMessage:
         assert "smaller model" in message  # remediation 2
         assert "close memory-heavy apps" in message.lower()  # remediation 3
 
-    def test_no_impossible_advice_at_the_ceiling(self):
-        """Codex round 1 NIT: at or above the auto ceiling, 'increase
-        --gpu-memory-utilization' is impossible advice — the message must
-        say the Mac lacks the memory instead."""
+    def test_advice_survives_at_auto_ceiling(self):
+        """Codex round 3 NIT: at the 0.97 auto ceiling an explicit
+        override can still legally raise the knob toward 1.0, so the
+        advice must stay."""
         message = format_preflight_error(
             required_bytes=15_000_000_000,
             active_bytes=14_500_000_000,
             min_kv_bytes=500_000_000,
             cap_bytes=11_700_000_000,
             utilization=0.97,
+            device_budget_bytes=12_100_000_000,
+        )
+        assert "Increase --gpu-memory-utilization" in message
+
+    def test_no_impossible_advice_at_full_utilization(self):
+        """Codex rounds 1+3 NITs: only at a true 1.0 is 'increase
+        --gpu-memory-utilization' impossible advice — the message must
+        say the Mac lacks the memory instead."""
+        message = format_preflight_error(
+            required_bytes=15_000_000_000,
+            active_bytes=14_500_000_000,
+            min_kv_bytes=500_000_000,
+            cap_bytes=12_100_000_000,
+            utilization=1.0,
             device_budget_bytes=12_100_000_000,
         )
         assert "Increase --gpu-memory-utilization" not in message

--- a/tests/test_metal_memory_budget.py
+++ b/tests/test_metal_memory_budget.py
@@ -495,6 +495,21 @@ class TestBatchedEngineBudgetInstall:
             assert engine._resolve_and_set_metal_limits() == AUTO_UTILIZATION_FLOOR
             mx.set_memory_limit.assert_called_once_with(int(100 * GB * 0.90))
 
+    def test_resolve_measures_weights_even_when_clear_cache_fails(self):
+        """Codex round 6 #1: a failing ``clear_cache`` must not suppress a
+        still-usable weight measurement — a big model must keep its
+        auto-raised budget."""
+        import mlx.core as mx
+
+        engine = self._bare_engine(requested=None)
+        core_patch, metal_patch = self._patched_mx(active=95 * GB)
+        with core_patch, metal_patch:
+            mx.clear_cache.side_effect = RuntimeError("no cache to clear")
+            resolved = engine._resolve_and_set_metal_limits()
+            # 95GB weights + headroom on 100GB pins auto at the ceiling,
+            # not the no-measurement floor.
+            assert resolved == AUTO_UTILIZATION_CEILING
+
     def test_resolve_survives_setter_failure(self):
         """Codex round 1 BLOCKING #2: a setter failure must not poison the
         resolved utilization the admission cap enforces."""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3344,8 +3344,10 @@ def serve_command(args):
             )
             sys.exit(2)
 
-    # Validate gpu-memory-utilization range
-    if not (0.0 < args.gpu_memory_utilization <= 1.0):
+    # Validate gpu-memory-utilization range (None = auto budgeting, #2858)
+    if args.gpu_memory_utilization is not None and not (
+        0.0 < args.gpu_memory_utilization <= 1.0
+    ):
         print(
             "Error: --gpu-memory-utilization must be between 0.0 (exclusive) and 1.0 (inclusive)"
         )
@@ -3837,10 +3839,9 @@ def serve_command(args):
             _dflash_ignored.append("--kv-cache-turboquant")
         if getattr(args, "pflash", None) not in (None, "auto"):
             _dflash_ignored.append("--pflash")
-        # gpu-memory-utilization defaults to 0.90 (not None) in the serve
-        # parser, so an ``is not None`` check would fire on every invocation.
-        # Compare to the real default — only warn when the user explicitly
-        # tuned it. Tolerate a tiny float-equality slack for safety.
+        # gpu-memory-utilization defaults to None (auto, #2858) in the
+        # serve parser; only warn when the user explicitly tuned it away
+        # from the historical 0.90. Tolerate float-equality slack.
         _gpu_mem = getattr(args, "gpu_memory_utilization", _GPU_MEM_DEFAULT)
         if _gpu_mem is not None and abs(_gpu_mem - _GPU_MEM_DEFAULT) > 1e-6:
             _dflash_ignored.append("--gpu-memory-utilization")
@@ -4274,8 +4275,12 @@ def serve_command(args):
         # site — without this line, ``--gpu-memory-utilization 0.45``
         # would still set the soft Metal hint but the admission-time
         # check would stay disabled (SchedulerConfig default 0.0),
-        # silently recreating the D-METAL-CAP regression.
-        gpu_memory_utilization=args.gpu_memory_utilization,
+        # silently recreating the D-METAL-CAP regression. ``None``
+        # (auto, #2858) maps to 0.0 here: BatchedEngine resolves the
+        # per-model budget after load and engine_core's D-METAL-CAP
+        # propagation fills the scheduler config with the RESOLVED
+        # utilization, so both enforcement points share one cap.
+        gpu_memory_utilization=args.gpu_memory_utilization or 0.0,
     )
 
     print("Mode: Continuous batching (for multiple concurrent users)")
@@ -10685,10 +10690,12 @@ Examples:
     serve_parser.add_argument(
         "--gpu-memory-utilization",
         type=float,
-        default=0.90,
-        help="Fraction of device memory for Metal allocation limit and emergency "
-        "cache clear threshold (0.0-1.0, default: 0.90). Increase to 0.95 for "
-        "large models (200GB+) that need more memory headroom.",
+        default=None,
+        help="Fraction of device memory for the Metal allocation limit and "
+        "admission cap (0.0-1.0). Default: auto — the budget is sized to the "
+        "loaded model (measured weights + headroom, between 0.90 and 0.97 of "
+        "the device working-set budget). Pass an explicit value only as an "
+        "advanced override.",
     )
     serve_parser.add_argument(
         "--resident-memory-limit-gb",

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -822,7 +822,7 @@ class BatchedEngine(BaseEngine):
         scheduler_config: Any | None = None,
         stream_interval: int = 1,
         force_mllm: bool = False,
-        gpu_memory_utilization: float = 0.90,
+        gpu_memory_utilization: float | None = None,
         *,
         force_text: bool = False,
         force_hybrid: bool = False,
@@ -846,7 +846,11 @@ class BatchedEngine(BaseEngine):
             stream_interval: Tokens to batch before streaming (1=every token)
             force_mllm: Force loading as MLLM even if not auto-detected
             gpu_memory_utilization: Fraction of device memory for Metal allocation
-                limit and emergency threshold (0.0-1.0, default 0.90)
+                limit and emergency threshold (0.0-1.0). ``None`` (default)
+                selects a per-model budget automatically (#2858): the limit is
+                sized to the measured weight footprint plus runtime headroom,
+                clamped to ``[0.90, 0.97]`` of the device working-set budget.
+                An explicit value is honored verbatim (advanced override).
             force_text: Keyword-only. Force loading as text-only LLM even when
                 auto-detection would route as MLLM (#393 escape hatch).
                 Mutually exclusive with ``force_mllm`` — caller is responsible
@@ -1802,37 +1806,68 @@ class BatchedEngine(BaseEngine):
                 checkpoint_source=checkpoint_source,
             )
 
-        # Set Metal memory limits on the SAME mlx-step worker that loaded
-        # the model. Calling these from the asyncio loop thread would touch
-        # MLX from a thread that doesn't own the worker stream and create
-        # a stray Stream(gpu, 1) reference (#170).
-        def _set_metal_limits() -> None:
+        # Resolve the per-model Metal budget and set the limits on the SAME
+        # mlx-step worker that loaded the model. Calling these from the
+        # asyncio loop thread would touch MLX from a thread that doesn't own
+        # the worker stream and create a stray Stream(gpu, 1) reference
+        # (#170). Runs AFTER the weights are materialized on purpose:
+        # ``mx.get_active_memory()`` here is the model's real Metal footprint
+        # (all resident models, in multi-model mode), so auto mode (#2858)
+        # sizes the limit from a measurement instead of a disk heuristic —
+        # and can only ratchet the process-wide limit upward as more models
+        # load, never below what is already resident.
+        def _resolve_and_set_metal_limits() -> float:
             import mlx.core as mx
 
+            from ..memory_budget import AUTO_UTILIZATION_FLOOR, plan_metal_limit
+
+            requested = self._gpu_memory_utilization
+            fallback = requested if requested is not None else AUTO_UTILIZATION_FLOOR
             if not mx.metal.is_available():
-                return
+                return fallback
             device_info = mx.device_info()
             max_recommended = device_info.get(
                 "max_recommended_working_set_size",
                 device_info.get("memory_size", 0),
             )
-            if max_recommended > 0:
-                soft_limit = int(max_recommended * self._gpu_memory_utilization)
-                mx.set_memory_limit(soft_limit)
-                cache_limit = _compute_metal_cache_limit(soft_limit)
-                mx.set_cache_limit(cache_limit)
-                pct = self._gpu_memory_utilization * 100
-                logger.info(
-                    f"Metal memory limits set: "
-                    f"allocation_limit={soft_limit / 1e9:.1f}GB "
-                    f"({pct:.0f}% of {max_recommended / 1e9:.1f}GB), "
-                    f"cache_limit={cache_limit / 1e9:.1f}GB"
-                )
+            if max_recommended <= 0:
+                return fallback
+            try:
+                weights_bytes = int(mx.get_active_memory())
+            except Exception:
+                weights_bytes = 0
+            plan = plan_metal_limit(
+                weights_bytes=weights_bytes,
+                device_budget_bytes=int(max_recommended),
+                requested_utilization=requested,
+            )
+            mx.set_memory_limit(plan.limit_bytes)
+            cache_limit = _compute_metal_cache_limit(plan.limit_bytes)
+            mx.set_cache_limit(cache_limit)
+            logger.info(
+                f"Metal memory limits set ({plan.mode}): "
+                f"allocation_limit={plan.limit_bytes / 1e9:.1f}GB "
+                f"({plan.resolved_utilization * 100:.0f}% of "
+                f"{max_recommended / 1e9:.1f}GB, "
+                f"weights={weights_bytes / 1e9:.1f}GB), "
+                f"cache_limit={cache_limit / 1e9:.1f}GB"
+            )
+            return plan.resolved_utilization
 
+        # The resolved utilization (== the value actually fed to
+        # ``mx.set_memory_limit``) replaces the requested one so EngineConfig
+        # and, via engine_core's D-METAL-CAP propagation, the scheduler's
+        # admission cap all enforce the SAME budget.
         try:
-            self._model_load_executor.submit(_set_metal_limits).result()
+            self._gpu_memory_utilization = self._model_load_executor.submit(
+                _resolve_and_set_metal_limits
+            ).result()
         except Exception as e:
             logger.warning(f"Failed to set Metal memory limits: {e}")
+            if self._gpu_memory_utilization is None:
+                from ..memory_budget import AUTO_UTILIZATION_FLOOR
+
+                self._gpu_memory_utilization = AUTO_UTILIZATION_FLOOR
 
         # Create engine config
         scheduler_config = self._scheduler_config or SchedulerConfig()
@@ -1856,6 +1891,15 @@ class BatchedEngine(BaseEngine):
             tokenizer=self._tokenizer,
             config=engine_config,
         )
+
+        # #2858 acceptance: a model must not report healthy while every
+        # request deterministically 503s under the resolved cap. The
+        # scheduler exists as of AsyncEngineCore construction, so run its
+        # admission preflight BEFORE the engine loop starts — an impossible
+        # budget fails the load with one actionable message instead of
+        # letting the server come up 503-wedged. MetalPreflightError must
+        # propagate; it is the load failure.
+        self._engine.engine.scheduler.preflight_metal_admission()
 
         await self._engine.engine.start(executor=self._model_load_executor)
         self._engine_started = True

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1830,12 +1830,11 @@ class BatchedEngine(BaseEngine):
         # Create async engine and hand it the EXISTING model-load executor
         # so all subsequent MLX work (forward passes, cache materialization,
         # eval) runs on the same worker thread that owns the model weights.
-        engine_core = AsyncEngineCore(
+        self._engine = AsyncEngineCore(
             model=self._model,
             tokenizer=self._tokenizer,
             config=engine_config,
         )
-        self._engine = engine_core
 
         # #2858 acceptance: a model must not report healthy while every
         # request deterministically 503s under the resolved cap. The
@@ -1844,7 +1843,7 @@ class BatchedEngine(BaseEngine):
         # MetalPreflightError must propagate; it is the load failure.
         self._run_metal_admission_preflight()  # pragma: no cover
 
-        await engine_core.engine.start(executor=self._model_load_executor)
+        await self._engine.engine.start(executor=self._model_load_executor)
         self._engine_started = True
 
     def _resolve_and_set_metal_limits(self) -> float:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1825,7 +1825,11 @@ class BatchedEngine(BaseEngine):
         def _resolve_and_set_metal_limits() -> float:
             import mlx.core as mx
 
-            from ..memory_budget import AUTO_UTILIZATION_FLOOR, plan_metal_limit
+            from ..memory_budget import (
+                AUTO_UTILIZATION_FLOOR,
+                note_resolved_utilization,
+                plan_metal_limit,
+            )
 
             requested = self._gpu_memory_utilization
             fallback = requested if requested is not None else AUTO_UTILIZATION_FLOOR
@@ -1847,6 +1851,14 @@ class BatchedEngine(BaseEngine):
                 device_budget_bytes=int(max_recommended),
                 requested_utilization=requested,
             )
+            # Publish the resolved utilization into the process-wide
+            # ratchet BEFORE applying limits (codex round 2 BLOCKING #2):
+            # every already-resident engine's scheduler re-resolves its
+            # admission cap against this floor, so raising the process
+            # limit for a new model can never strand an existing model
+            # behind a stale lower cap while process-wide ``active`` has
+            # grown past it.
+            note_resolved_utilization(plan.resolved_utilization)
             # Setter failures are contained HERE so the resolved
             # utilization always propagates (codex round 1 BLOCKING #2):
             # if ``mx.set_memory_limit`` succeeds but ``set_cache_limit``

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1836,9 +1836,12 @@ class BatchedEngine(BaseEngine):
             if not mx.metal.is_available():
                 return fallback
             device_info = mx.device_info()
-            max_recommended = device_info.get(
-                "max_recommended_working_set_size",
-                device_info.get("memory_size", 0),
+            max_recommended = int(
+                device_info.get(
+                    "max_recommended_working_set_size",
+                    device_info.get("memory_size", 0),
+                )
+                or 0
             )
             if max_recommended <= 0:
                 return fallback
@@ -1955,8 +1958,11 @@ class BatchedEngine(BaseEngine):
         # MLX allocator calls must stay on the thread that owns the model's
         # stream (#170). MetalPreflightError must propagate; it is the
         # load failure.
-        self._model_load_executor.submit(
-            self._engine.engine.scheduler.preflight_metal_admission
+        preflight_executor = self._model_load_executor
+        preflight_engine = self._engine
+        assert preflight_executor is not None and preflight_engine is not None
+        preflight_executor.submit(
+            preflight_engine.engine.scheduler.preflight_metal_admission
         ).result()
 
         await self._engine.engine.start(executor=self._model_load_executor)

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1827,9 +1827,8 @@ class BatchedEngine(BaseEngine):
 
             from ..memory_budget import (
                 AUTO_UTILIZATION_FLOOR,
-                note_resolved_utilization,
                 plan_metal_limit,
-                process_utilization_floor,
+                ratchet_utilization_and_apply,
             )
 
             requested = self._gpu_memory_utilization
@@ -1844,6 +1843,14 @@ class BatchedEngine(BaseEngine):
             if max_recommended <= 0:
                 return fallback
             try:
+                # Drop reclaimable allocator cache first (codex round 4
+                # NIT): after a dynamic load/unload cycle
+                # ``get_active_memory`` routinely includes cached pages
+                # that are not resident weights — budgeting them would
+                # ratchet the process limit toward the ceiling on memory
+                # that is actually free. Active allocations from resident
+                # models are unaffected by ``clear_cache``.
+                mx.clear_cache()
                 weights_bytes = int(mx.get_active_memory())
             except Exception:
                 weights_bytes = 0
@@ -1852,48 +1859,52 @@ class BatchedEngine(BaseEngine):
                 device_budget_bytes=int(max_recommended),
                 requested_utilization=requested,
             )
+
             # Publish the resolved utilization into the process-wide
-            # ratchet BEFORE applying limits (codex round 2 BLOCKING #2):
-            # every already-resident engine's scheduler re-resolves its
-            # admission cap against this floor, so raising the process
-            # limit for a new model can never strand an existing model
-            # behind a stale lower cap while process-wide ``active`` has
-            # grown past it.
-            note_resolved_utilization(plan.resolved_utilization)
-            # The allocation limit itself follows the process-wide ratchet
-            # too (codex round 3 BLOCKING #1): applying THIS model's plan
-            # verbatim would LOWER the process limit when a later, smaller
-            # model resolves below an earlier model's budget, while every
-            # resident scheduler keeps enforcing the higher floor — the
-            # single-cap invariant requires both enforcement points to use
-            # the same, monotonically non-decreasing utilization.
-            effective_utilization, _generation = process_utilization_floor()
-            effective_limit = int(max_recommended * effective_utilization)
-            # Setter failures are contained HERE so the resolved
-            # utilization always propagates (codex round 1 BLOCKING #2):
-            # if ``mx.set_memory_limit`` succeeds but ``set_cache_limit``
-            # throws, falling back to the floor would leave the scheduler
-            # admission cap desynchronized from the allocation limit
-            # Metal is actually holding.
-            try:
-                mx.set_memory_limit(effective_limit)
-                cache_limit = _compute_metal_cache_limit(effective_limit)
-                mx.set_cache_limit(cache_limit)
-                logger.info(
-                    f"Metal memory limits set ({plan.mode}): "
-                    f"allocation_limit={effective_limit / 1e9:.1f}GB "
-                    f"({effective_utilization * 100:.0f}% of "
-                    f"{max_recommended / 1e9:.1f}GB, "
-                    f"weights={weights_bytes / 1e9:.1f}GB), "
-                    f"cache_limit={cache_limit / 1e9:.1f}GB"
-                )
-            except Exception as limit_exc:
-                logger.warning(
-                    f"Failed to apply Metal memory limits "
-                    f"(resolved {plan.mode} utilization "
-                    f"{effective_utilization:.2f} still governs the "
-                    f"admission cap): {limit_exc}"
-                )
+            # ratchet AND install the Metal limits under the same lock
+            # (codex rounds 2–4). One combined critical section gives the
+            # three invariants at once:
+            # - every already-resident engine's scheduler re-resolves its
+            #   admission cap against the raised floor, so a new model can
+            #   never strand an existing one behind a stale lower cap
+            #   (round 2 BLOCKING #2);
+            # - the allocation limit follows the ratchet, so a later,
+            #   smaller model can never LOWER the process limit below what
+            #   the schedulers enforce (round 3 BLOCKING #1);
+            # - concurrent loads apply their limits serialized in floor
+            #   order, so the LAST setter call always carries the highest
+            #   published utilization (round 4 BLOCKING #1).
+            def _apply_limits(effective_utilization: float) -> None:
+                effective_limit = int(max_recommended * effective_utilization)
+                # Setter failures are contained HERE so the resolved
+                # utilization always propagates (codex round 1 BLOCKING
+                # #2): if ``mx.set_memory_limit`` succeeds but
+                # ``set_cache_limit`` throws, falling back to the floor
+                # would leave the scheduler admission cap desynchronized
+                # from the allocation limit Metal is actually holding.
+                try:
+                    mx.set_memory_limit(effective_limit)
+                    cache_limit = _compute_metal_cache_limit(effective_limit)
+                    mx.set_cache_limit(cache_limit)
+                    logger.info(
+                        f"Metal memory limits set ({plan.mode}): "
+                        f"allocation_limit={effective_limit / 1e9:.1f}GB "
+                        f"({effective_utilization * 100:.0f}% of "
+                        f"{max_recommended / 1e9:.1f}GB, "
+                        f"weights={weights_bytes / 1e9:.1f}GB), "
+                        f"cache_limit={cache_limit / 1e9:.1f}GB"
+                    )
+                except Exception as limit_exc:
+                    logger.warning(
+                        f"Failed to apply Metal memory limits "
+                        f"(resolved {plan.mode} utilization "
+                        f"{effective_utilization:.2f} still governs the "
+                        f"admission cap): {limit_exc}"
+                    )
+
+            effective_utilization, _generation = ratchet_utilization_and_apply(
+                plan.resolved_utilization, _apply_limits
+            )
             return effective_utilization
 
         # The resolved utilization (== the value actually fed to

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1886,15 +1886,19 @@ class BatchedEngine(BaseEngine):
         )
         if max_recommended <= 0:
             return fallback
+        # Drop reclaimable allocator cache first (codex round 4 NIT):
+        # after a dynamic load/unload cycle ``get_active_memory``
+        # routinely includes cached pages that are not resident weights —
+        # budgeting them would ratchet the process limit toward the
+        # ceiling on memory that is actually free. Active allocations
+        # from resident models are unaffected by ``clear_cache``. A
+        # failing clear must not suppress the still-usable measurement
+        # (codex round 6 #1), so the two guard separately.
         try:
-            # Drop reclaimable allocator cache first (codex round 4
-            # NIT): after a dynamic load/unload cycle
-            # ``get_active_memory`` routinely includes cached pages
-            # that are not resident weights — budgeting them would
-            # ratchet the process limit toward the ceiling on memory
-            # that is actually free. Active allocations from resident
-            # models are unaffected by ``clear_cache``.
             mx.clear_cache()
+        except Exception:
+            pass
+        try:
             weights_bytes = int(mx.get_active_memory())
         except Exception:
             weights_bytes = 0

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1829,6 +1829,7 @@ class BatchedEngine(BaseEngine):
                 AUTO_UTILIZATION_FLOOR,
                 note_resolved_utilization,
                 plan_metal_limit,
+                process_utilization_floor,
             )
 
             requested = self._gpu_memory_utilization
@@ -1859,6 +1860,15 @@ class BatchedEngine(BaseEngine):
             # behind a stale lower cap while process-wide ``active`` has
             # grown past it.
             note_resolved_utilization(plan.resolved_utilization)
+            # The allocation limit itself follows the process-wide ratchet
+            # too (codex round 3 BLOCKING #1): applying THIS model's plan
+            # verbatim would LOWER the process limit when a later, smaller
+            # model resolves below an earlier model's budget, while every
+            # resident scheduler keeps enforcing the higher floor — the
+            # single-cap invariant requires both enforcement points to use
+            # the same, monotonically non-decreasing utilization.
+            effective_utilization, _generation = process_utilization_floor()
+            effective_limit = int(max_recommended * effective_utilization)
             # Setter failures are contained HERE so the resolved
             # utilization always propagates (codex round 1 BLOCKING #2):
             # if ``mx.set_memory_limit`` succeeds but ``set_cache_limit``
@@ -1866,13 +1876,13 @@ class BatchedEngine(BaseEngine):
             # admission cap desynchronized from the allocation limit
             # Metal is actually holding.
             try:
-                mx.set_memory_limit(plan.limit_bytes)
-                cache_limit = _compute_metal_cache_limit(plan.limit_bytes)
+                mx.set_memory_limit(effective_limit)
+                cache_limit = _compute_metal_cache_limit(effective_limit)
                 mx.set_cache_limit(cache_limit)
                 logger.info(
                     f"Metal memory limits set ({plan.mode}): "
-                    f"allocation_limit={plan.limit_bytes / 1e9:.1f}GB "
-                    f"({plan.resolved_utilization * 100:.0f}% of "
+                    f"allocation_limit={effective_limit / 1e9:.1f}GB "
+                    f"({effective_utilization * 100:.0f}% of "
                     f"{max_recommended / 1e9:.1f}GB, "
                     f"weights={weights_bytes / 1e9:.1f}GB), "
                     f"cache_limit={cache_limit / 1e9:.1f}GB"
@@ -1881,10 +1891,10 @@ class BatchedEngine(BaseEngine):
                 logger.warning(
                     f"Failed to apply Metal memory limits "
                     f"(resolved {plan.mode} utilization "
-                    f"{plan.resolved_utilization:.2f} still governs the "
+                    f"{effective_utilization:.2f} still governs the "
                     f"admission cap): {limit_exc}"
                 )
-            return plan.resolved_utilization
+            return effective_utilization
 
         # The resolved utilization (== the value actually fed to
         # ``mx.set_memory_limit``) replaces the requested one so EngineConfig

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1815,7 +1815,13 @@ class BatchedEngine(BaseEngine):
         # (all resident models, in multi-model mode), so auto mode (#2858)
         # sizes the limit from a measurement instead of a disk heuristic —
         # and can only ratchet the process-wide limit upward as more models
-        # load, never below what is already resident.
+        # load, never below what is already resident. Loading under the
+        # PREVIOUS model's (lower) limit is safe: ``mx.set_memory_limit``
+        # is a documented guideline the allocator silently grows past
+        # while system RAM is available (the D-METAL-CAP root cause — see
+        # ``Scheduler._resolve_metal_cap_bytes``), so weight
+        # materialization cannot hard-fail on the soft limit; real
+        # enforcement is admission-time only.
         def _resolve_and_set_metal_limits() -> float:
             import mlx.core as mx
 
@@ -1841,17 +1847,31 @@ class BatchedEngine(BaseEngine):
                 device_budget_bytes=int(max_recommended),
                 requested_utilization=requested,
             )
-            mx.set_memory_limit(plan.limit_bytes)
-            cache_limit = _compute_metal_cache_limit(plan.limit_bytes)
-            mx.set_cache_limit(cache_limit)
-            logger.info(
-                f"Metal memory limits set ({plan.mode}): "
-                f"allocation_limit={plan.limit_bytes / 1e9:.1f}GB "
-                f"({plan.resolved_utilization * 100:.0f}% of "
-                f"{max_recommended / 1e9:.1f}GB, "
-                f"weights={weights_bytes / 1e9:.1f}GB), "
-                f"cache_limit={cache_limit / 1e9:.1f}GB"
-            )
+            # Setter failures are contained HERE so the resolved
+            # utilization always propagates (codex round 1 BLOCKING #2):
+            # if ``mx.set_memory_limit`` succeeds but ``set_cache_limit``
+            # throws, falling back to the floor would leave the scheduler
+            # admission cap desynchronized from the allocation limit
+            # Metal is actually holding.
+            try:
+                mx.set_memory_limit(plan.limit_bytes)
+                cache_limit = _compute_metal_cache_limit(plan.limit_bytes)
+                mx.set_cache_limit(cache_limit)
+                logger.info(
+                    f"Metal memory limits set ({plan.mode}): "
+                    f"allocation_limit={plan.limit_bytes / 1e9:.1f}GB "
+                    f"({plan.resolved_utilization * 100:.0f}% of "
+                    f"{max_recommended / 1e9:.1f}GB, "
+                    f"weights={weights_bytes / 1e9:.1f}GB), "
+                    f"cache_limit={cache_limit / 1e9:.1f}GB"
+                )
+            except Exception as limit_exc:
+                logger.warning(
+                    f"Failed to apply Metal memory limits "
+                    f"(resolved {plan.mode} utilization "
+                    f"{plan.resolved_utilization:.2f} still governs the "
+                    f"admission cap): {limit_exc}"
+                )
             return plan.resolved_utilization
 
         # The resolved utilization (== the value actually fed to
@@ -1897,9 +1917,14 @@ class BatchedEngine(BaseEngine):
         # scheduler exists as of AsyncEngineCore construction, so run its
         # admission preflight BEFORE the engine loop starts — an impossible
         # budget fails the load with one actionable message instead of
-        # letting the server come up 503-wedged. MetalPreflightError must
-        # propagate; it is the load failure.
-        self._engine.engine.scheduler.preflight_metal_admission()
+        # letting the server come up 503-wedged. Runs on the model-load
+        # worker because the preflight may call ``mx.clear_cache()`` and
+        # MLX allocator calls must stay on the thread that owns the model's
+        # stream (#170). MetalPreflightError must propagate; it is the
+        # load failure.
+        self._model_load_executor.submit(
+            self._engine.engine.scheduler.preflight_metal_admission
+        ).result()
 
         await self._engine.engine.start(executor=self._model_load_executor)
         self._engine_started = True

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1806,124 +1806,12 @@ class BatchedEngine(BaseEngine):
                 checkpoint_source=checkpoint_source,
             )
 
-        # Resolve the per-model Metal budget and set the limits on the SAME
-        # mlx-step worker that loaded the model. Calling these from the
-        # asyncio loop thread would touch MLX from a thread that doesn't own
-        # the worker stream and create a stray Stream(gpu, 1) reference
-        # (#170). Runs AFTER the weights are materialized on purpose:
-        # ``mx.get_active_memory()`` here is the model's real Metal footprint
-        # (all resident models, in multi-model mode), so auto mode (#2858)
-        # sizes the limit from a measurement instead of a disk heuristic —
-        # and can only ratchet the process-wide limit upward as more models
-        # load, never below what is already resident. Loading under the
-        # PREVIOUS model's (lower) limit is safe: ``mx.set_memory_limit``
-        # is a documented guideline the allocator silently grows past
-        # while system RAM is available (the D-METAL-CAP root cause — see
-        # ``Scheduler._resolve_metal_cap_bytes``), so weight
-        # materialization cannot hard-fail on the soft limit; real
-        # enforcement is admission-time only.
-        def _resolve_and_set_metal_limits() -> float:
-            import mlx.core as mx
-
-            from ..memory_budget import (
-                AUTO_UTILIZATION_FLOOR,
-                plan_metal_limit,
-                ratchet_utilization_and_apply,
-            )
-
-            requested = self._gpu_memory_utilization
-            fallback = requested if requested is not None else AUTO_UTILIZATION_FLOOR
-            if not mx.metal.is_available():
-                return fallback
-            device_info = mx.device_info()
-            max_recommended = int(
-                device_info.get(
-                    "max_recommended_working_set_size",
-                    device_info.get("memory_size", 0),
-                )
-                or 0
-            )
-            if max_recommended <= 0:
-                return fallback
-            try:
-                # Drop reclaimable allocator cache first (codex round 4
-                # NIT): after a dynamic load/unload cycle
-                # ``get_active_memory`` routinely includes cached pages
-                # that are not resident weights — budgeting them would
-                # ratchet the process limit toward the ceiling on memory
-                # that is actually free. Active allocations from resident
-                # models are unaffected by ``clear_cache``.
-                mx.clear_cache()
-                weights_bytes = int(mx.get_active_memory())
-            except Exception:
-                weights_bytes = 0
-            plan = plan_metal_limit(
-                weights_bytes=weights_bytes,
-                device_budget_bytes=int(max_recommended),
-                requested_utilization=requested,
-            )
-
-            # Publish the resolved utilization into the process-wide
-            # ratchet AND install the Metal limits under the same lock
-            # (codex rounds 2–4). One combined critical section gives the
-            # three invariants at once:
-            # - every already-resident engine's scheduler re-resolves its
-            #   admission cap against the raised floor, so a new model can
-            #   never strand an existing one behind a stale lower cap
-            #   (round 2 BLOCKING #2);
-            # - the allocation limit follows the ratchet, so a later,
-            #   smaller model can never LOWER the process limit below what
-            #   the schedulers enforce (round 3 BLOCKING #1);
-            # - concurrent loads apply their limits serialized in floor
-            #   order, so the LAST setter call always carries the highest
-            #   published utilization (round 4 BLOCKING #1).
-            def _apply_limits(effective_utilization: float) -> None:
-                effective_limit = int(max_recommended * effective_utilization)
-                # Setter failures are contained HERE so the resolved
-                # utilization always propagates (codex round 1 BLOCKING
-                # #2): if ``mx.set_memory_limit`` succeeds but
-                # ``set_cache_limit`` throws, falling back to the floor
-                # would leave the scheduler admission cap desynchronized
-                # from the allocation limit Metal is actually holding.
-                try:
-                    mx.set_memory_limit(effective_limit)
-                    cache_limit = _compute_metal_cache_limit(effective_limit)
-                    mx.set_cache_limit(cache_limit)
-                    logger.info(
-                        f"Metal memory limits set ({plan.mode}): "
-                        f"allocation_limit={effective_limit / 1e9:.1f}GB "
-                        f"({effective_utilization * 100:.0f}% of "
-                        f"{max_recommended / 1e9:.1f}GB, "
-                        f"weights={weights_bytes / 1e9:.1f}GB), "
-                        f"cache_limit={cache_limit / 1e9:.1f}GB"
-                    )
-                except Exception as limit_exc:
-                    logger.warning(
-                        f"Failed to apply Metal memory limits "
-                        f"(resolved {plan.mode} utilization "
-                        f"{effective_utilization:.2f} still governs the "
-                        f"admission cap): {limit_exc}"
-                    )
-
-            effective_utilization, _generation = ratchet_utilization_and_apply(
-                plan.resolved_utilization, _apply_limits
-            )
-            return effective_utilization
-
-        # The resolved utilization (== the value actually fed to
-        # ``mx.set_memory_limit``) replaces the requested one so EngineConfig
-        # and, via engine_core's D-METAL-CAP propagation, the scheduler's
-        # admission cap all enforce the SAME budget.
-        try:
-            self._gpu_memory_utilization = self._model_load_executor.submit(
-                _resolve_and_set_metal_limits
-            ).result()
-        except Exception as e:
-            logger.warning(f"Failed to set Metal memory limits: {e}")
-            if self._gpu_memory_utilization is None:
-                from ..memory_budget import AUTO_UTILIZATION_FLOOR
-
-                self._gpu_memory_utilization = AUTO_UTILIZATION_FLOOR
+        # Resolve the per-model Metal budget on the model-owning worker
+        # after the weights are materialized (#2858, #170). The logic lives
+        # in dedicated methods so it is unit-testable without loading a
+        # model; this call site is exercised by the serve smoke and the
+        # stress e2e lane, not by unit tests.
+        self._install_resolved_metal_budget()  # pragma: no cover
 
         # Create engine config
         scheduler_config = self._scheduler_config or SchedulerConfig()
@@ -1942,31 +1830,164 @@ class BatchedEngine(BaseEngine):
         # Create async engine and hand it the EXISTING model-load executor
         # so all subsequent MLX work (forward passes, cache materialization,
         # eval) runs on the same worker thread that owns the model weights.
-        self._engine = AsyncEngineCore(
+        engine_core = AsyncEngineCore(
             model=self._model,
             tokenizer=self._tokenizer,
             config=engine_config,
         )
+        self._engine = engine_core
 
         # #2858 acceptance: a model must not report healthy while every
         # request deterministically 503s under the resolved cap. The
         # scheduler exists as of AsyncEngineCore construction, so run its
-        # admission preflight BEFORE the engine loop starts — an impossible
-        # budget fails the load with one actionable message instead of
-        # letting the server come up 503-wedged. Runs on the model-load
-        # worker because the preflight may call ``mx.clear_cache()`` and
-        # MLX allocator calls must stay on the thread that owns the model's
-        # stream (#170). MetalPreflightError must propagate; it is the
-        # load failure.
+        # admission preflight BEFORE the engine loop starts.
+        # MetalPreflightError must propagate; it is the load failure.
+        self._run_metal_admission_preflight()  # pragma: no cover
+
+        await engine_core.engine.start(executor=self._model_load_executor)
+        self._engine_started = True
+
+    def _resolve_and_set_metal_limits(self) -> float:
+        """Resolve this model's Metal budget and install the limits.
+
+        Must run on the model-owning mlx-step worker: calling MLX from the
+        asyncio loop thread would create a stray Stream(gpu, 1) reference
+        (#170). Runs AFTER the weights are materialized on purpose:
+        ``mx.get_active_memory()`` here is the model's real Metal footprint
+        (all resident models, in multi-model mode), so auto mode (#2858)
+        sizes the limit from a measurement instead of a disk heuristic —
+        and can only ratchet the process-wide limit upward as more models
+        load, never below what is already resident. Loading under the
+        PREVIOUS model's (lower) limit is safe: ``mx.set_memory_limit``
+        is a documented guideline the allocator silently grows past
+        while system RAM is available (the D-METAL-CAP root cause — see
+        ``Scheduler._resolve_metal_cap_bytes``), so weight
+        materialization cannot hard-fail on the soft limit; real
+        enforcement is admission-time only.
+        """
+        import mlx.core as mx
+
+        from ..memory_budget import (
+            AUTO_UTILIZATION_FLOOR,
+            plan_metal_limit,
+            ratchet_utilization_and_apply,
+        )
+
+        requested = self._gpu_memory_utilization
+        fallback = requested if requested is not None else AUTO_UTILIZATION_FLOOR
+        if not mx.metal.is_available():
+            return fallback
+        device_info = mx.device_info()
+        max_recommended = int(
+            device_info.get(
+                "max_recommended_working_set_size",
+                device_info.get("memory_size", 0),
+            )
+            or 0
+        )
+        if max_recommended <= 0:
+            return fallback
+        try:
+            # Drop reclaimable allocator cache first (codex round 4
+            # NIT): after a dynamic load/unload cycle
+            # ``get_active_memory`` routinely includes cached pages
+            # that are not resident weights — budgeting them would
+            # ratchet the process limit toward the ceiling on memory
+            # that is actually free. Active allocations from resident
+            # models are unaffected by ``clear_cache``.
+            mx.clear_cache()
+            weights_bytes = int(mx.get_active_memory())
+        except Exception:
+            weights_bytes = 0
+        plan = plan_metal_limit(
+            weights_bytes=weights_bytes,
+            device_budget_bytes=int(max_recommended),
+            requested_utilization=requested,
+        )
+
+        # Publish the resolved utilization into the process-wide
+        # ratchet AND install the Metal limits under the same lock
+        # (codex rounds 2–4). One combined critical section gives the
+        # three invariants at once:
+        # - every already-resident engine's scheduler re-resolves its
+        #   admission cap against the raised floor, so a new model can
+        #   never strand an existing one behind a stale lower cap
+        #   (round 2 BLOCKING #2);
+        # - the allocation limit follows the ratchet, so a later,
+        #   smaller model can never LOWER the process limit below what
+        #   the schedulers enforce (round 3 BLOCKING #1);
+        # - concurrent loads apply their limits serialized in floor
+        #   order, so the LAST setter call always carries the highest
+        #   published utilization (round 4 BLOCKING #1).
+        def _apply_limits(effective_utilization: float) -> None:
+            effective_limit = int(max_recommended * effective_utilization)
+            # Setter failures are contained HERE so the resolved
+            # utilization always propagates (codex round 1 BLOCKING
+            # #2): if ``mx.set_memory_limit`` succeeds but
+            # ``set_cache_limit`` throws, falling back to the floor
+            # would leave the scheduler admission cap desynchronized
+            # from the allocation limit Metal is actually holding.
+            try:
+                mx.set_memory_limit(effective_limit)
+                cache_limit = _compute_metal_cache_limit(effective_limit)
+                mx.set_cache_limit(cache_limit)
+                logger.info(
+                    f"Metal memory limits set ({plan.mode}): "
+                    f"allocation_limit={effective_limit / 1e9:.1f}GB "
+                    f"({effective_utilization * 100:.0f}% of "
+                    f"{max_recommended / 1e9:.1f}GB, "
+                    f"weights={weights_bytes / 1e9:.1f}GB), "
+                    f"cache_limit={cache_limit / 1e9:.1f}GB"
+                )
+            except Exception as limit_exc:
+                logger.warning(
+                    f"Failed to apply Metal memory limits "
+                    f"(resolved {plan.mode} utilization "
+                    f"{effective_utilization:.2f} still governs the "
+                    f"admission cap): {limit_exc}"
+                )
+
+        effective_utilization, _generation = ratchet_utilization_and_apply(
+            plan.resolved_utilization, _apply_limits
+        )
+        return effective_utilization
+
+    def _install_resolved_metal_budget(self) -> None:
+        """Run the budget resolution on the worker and store the result.
+
+        The resolved utilization (== the value actually fed to
+        ``mx.set_memory_limit``) replaces the requested one so EngineConfig
+        and, via engine_core's D-METAL-CAP propagation, the scheduler's
+        admission cap all enforce the SAME budget.
+        """
+        budget_executor = self._model_load_executor
+        assert budget_executor is not None
+        try:
+            self._gpu_memory_utilization = budget_executor.submit(
+                self._resolve_and_set_metal_limits
+            ).result()
+        except Exception as e:
+            logger.warning(f"Failed to set Metal memory limits: {e}")
+            if self._gpu_memory_utilization is None:
+                from ..memory_budget import AUTO_UTILIZATION_FLOOR
+
+                self._gpu_memory_utilization = AUTO_UTILIZATION_FLOOR
+
+    def _run_metal_admission_preflight(self) -> None:
+        """Fail the load if the resolved cap can never admit a request.
+
+        An impossible budget fails the load with one actionable message
+        instead of letting the server come up 503-wedged. Runs on the
+        model-load worker because the preflight may call
+        ``mx.clear_cache()`` and MLX allocator calls must stay on the
+        thread that owns the model's stream (#170).
+        """
         preflight_executor = self._model_load_executor
         preflight_engine = self._engine
         assert preflight_executor is not None and preflight_engine is not None
         preflight_executor.submit(
             preflight_engine.engine.scheduler.preflight_metal_admission
         ).result()
-
-        await self._engine.engine.start(executor=self._model_load_executor)
-        self._engine_started = True
 
     async def execute_on_model_worker(self, func, *args, **kwargs):
         """Execute auxiliary MLX work on this model's owning worker.

--- a/vllm_mlx/memory_budget.py
+++ b/vllm_mlx/memory_budget.py
@@ -1,0 +1,142 @@
+"""Per-model Metal memory budgeting (#2858).
+
+The engine historically exposed one global knob — ``--gpu-memory-utilization``,
+default ``0.90`` — that had to be tuned per model by hand: a 12B checkpoint
+runs fine at ``0.75`` while a 20B MoE with an ~11.2 GB Metal footprint needs
+``0.95`` on the same 16 GB Mac.  Worse, when the cap was too low the model
+still loaded and reported healthy while the D-METAL-CAP admission gate
+deterministically rejected every request with HTTP 503.
+
+This module closes that loop with two pieces, both pure and unit-testable:
+
+* :func:`plan_metal_limit` — resolve the effective utilization for one loaded
+  model.  When the operator passed an explicit ``--gpu-memory-utilization``
+  the value is honored verbatim (advanced override).  In auto mode (the new
+  default) the limit is sized to the model actually loaded: the MEASURED
+  weight footprint (``mx.get_active_memory()`` right after load — no disk
+  heuristics) plus a runtime headroom, clamped to
+  ``[AUTO_UTILIZATION_FLOOR, AUTO_UTILIZATION_CEILING]`` of the device's
+  recommended working-set budget.  The floor keeps small models byte-identical
+  to the historical ``0.90`` default; the ceiling leaves the OS a margin the
+  same way vLLM's ``gpu_memory_utilization`` never goes to 1.0.
+
+* :func:`format_preflight_error` — the actionable admission-impossible
+  message required by #2858: required vs available memory plus concrete
+  remediations.  Raised (wrapped in :class:`MetalPreflightError`) by
+  ``Scheduler.preflight_metal_admission`` when even a modest request could
+  never be admitted under the resolved cap, so startup fails BEFORE the
+  server reports the model ready instead of serving deterministic 503s.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Auto-mode bounds. The floor matches the historical global default so any
+# model that fit comfortably before resolves to a byte-identical limit; the
+# ceiling reserves ~3% of the device budget for allocator slack so auto mode
+# never plans right up to the working-set edge.
+AUTO_UTILIZATION_FLOOR = 0.90
+AUTO_UTILIZATION_CEILING = 0.97
+
+# Runtime headroom charged on top of the measured weight footprint in auto
+# mode: KV cache for in-flight requests, activation workspace, Metal heap
+# fragmentation. Fractional so big models reserve proportionally more, with an
+# absolute floor so tiny models still get a workable slice.
+_AUTO_HEADROOM_FRACTION = 0.08
+_AUTO_HEADROOM_MIN_BYTES = 512 * 1024**2
+
+
+class MetalPreflightError(RuntimeError):
+    """The resolved Metal cap can never admit a request for this model.
+
+    Raised during engine startup — before the server reports the model
+    ready — so the operator sees one actionable message instead of a
+    healthy-looking model whose every request returns HTTP 503.
+    """
+
+
+@dataclass(frozen=True)
+class MetalBudgetPlan:
+    """The resolved Metal allocation budget for one loaded model."""
+
+    weights_bytes: int
+    device_budget_bytes: int
+    requested_utilization: float | None
+    resolved_utilization: float
+    limit_bytes: int
+    mode: str  # "manual" (operator override) or "auto"
+
+
+def plan_metal_limit(
+    *,
+    weights_bytes: int,
+    device_budget_bytes: int,
+    requested_utilization: float | None = None,
+) -> MetalBudgetPlan:
+    """Resolve the Metal allocation limit for one loaded model.
+
+    Args:
+        weights_bytes: Measured Metal footprint of the loaded weights
+            (``mx.get_active_memory()`` right after load). ``<= 0`` means
+            "no measurement available" and auto mode falls back to the
+            historical floor.
+        device_budget_bytes: The device's recommended working-set size
+            (``max_recommended_working_set_size``). Must be positive.
+        requested_utilization: The operator's explicit
+            ``--gpu-memory-utilization``, or ``None`` for auto.
+
+    Returns:
+        A :class:`MetalBudgetPlan`. ``resolved_utilization`` is the value the
+        engine must feed to BOTH ``mx.set_memory_limit`` and the scheduler's
+        D-METAL-CAP admission gate — the two enforcement points must always
+        agree on the same cap.
+    """
+    if device_budget_bytes <= 0:
+        raise ValueError("device_budget_bytes must be positive")
+
+    if requested_utilization is not None:
+        resolved = float(requested_utilization)
+        mode = "manual"
+    elif weights_bytes <= 0:
+        resolved = AUTO_UTILIZATION_FLOOR
+        mode = "auto"
+    else:
+        headroom = max(
+            int(weights_bytes * _AUTO_HEADROOM_FRACTION), _AUTO_HEADROOM_MIN_BYTES
+        )
+        needed = (weights_bytes + headroom) / device_budget_bytes
+        resolved = min(max(needed, AUTO_UTILIZATION_FLOOR), AUTO_UTILIZATION_CEILING)
+        mode = "auto"
+
+    return MetalBudgetPlan(
+        weights_bytes=max(0, int(weights_bytes)),
+        device_budget_bytes=int(device_budget_bytes),
+        requested_utilization=requested_utilization,
+        resolved_utilization=resolved,
+        limit_bytes=int(device_budget_bytes * resolved),
+        mode=mode,
+    )
+
+
+def format_preflight_error(
+    *,
+    required_bytes: int,
+    active_bytes: int,
+    min_kv_bytes: int,
+    cap_bytes: int,
+    utilization: float,
+    device_budget_bytes: int,
+) -> str:
+    """Build the actionable admission-impossible startup message (#2858)."""
+    return (
+        f"This model needs approximately {required_bytes / 1e9:.1f} GB of "
+        f"Metal memory for the current configuration (weights and runtime "
+        f"{active_bytes / 1e9:.1f} GB + minimum KV cache "
+        f"{min_kv_bytes / 1e9:.1f} GB), but the current limit is "
+        f"{cap_bytes / 1e9:.1f} GB "
+        f"(gpu_memory_utilization={utilization:.2f} of the "
+        f"{device_budget_bytes / 1e9:.1f} GB Metal working-set budget). "
+        f"Increase --gpu-memory-utilization, reduce context length or "
+        f"concurrency, close memory-heavy apps, or choose a smaller model."
+    )

--- a/vllm_mlx/memory_budget.py
+++ b/vllm_mlx/memory_budget.py
@@ -135,7 +135,7 @@ def format_preflight_error(
         f"{active_bytes / 1e9:.1f} GB + minimum KV cache "
         f"{min_kv_bytes / 1e9:.1f} GB), but the current limit is "
         f"{cap_bytes / 1e9:.1f} GB "
-        f"(gpu_memory_utilization={utilization:.2f} of the "
+        f"(gpu_memory_utilization={utilization:g} of the "
         f"{device_budget_bytes / 1e9:.1f} GB Metal working-set budget). "
         f"Increase --gpu-memory-utilization, reduce context length or "
         f"concurrency, close memory-heavy apps, or choose a smaller model."

--- a/vllm_mlx/memory_budget.py
+++ b/vllm_mlx/memory_budget.py
@@ -30,6 +30,7 @@ This module closes that loop with two pieces, both pure and unit-testable:
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 
 # Auto-mode bounds. The floor matches the historical global default so any
@@ -45,6 +46,37 @@ AUTO_UTILIZATION_CEILING = 0.97
 # absolute floor so tiny models still get a workable slice.
 _AUTO_HEADROOM_FRACTION = 0.08
 _AUTO_HEADROOM_MIN_BYTES = 512 * 1024**2
+
+
+# ── Process-wide utilization ratchet (codex round 2 BLOCKING #2) ──
+# In multi-model mode each BatchedEngine resolves its own budget, but the
+# Metal allocator and ``mx.get_active_memory()`` are process-wide: when a
+# second model auto-raises the limit, the FIRST model's scheduler must not
+# keep enforcing its earlier, lower cap against an ``active`` figure that
+# now includes the new model — that would reject every request to the
+# already-resident model. Every resolution notes the utilization here;
+# schedulers read the floor (with a generation counter so their cached cap
+# invalidates on each upward ratchet) and enforce
+# ``max(own configured utilization, process floor)``. The floor only ever
+# rises, mirroring the allocation limit itself.
+_process_floor_lock = threading.Lock()
+_process_utilization_floor: float = 0.0
+_process_floor_generation: int = 0
+
+
+def note_resolved_utilization(utilization: float) -> None:
+    """Record a resolved per-engine utilization into the process floor."""
+    global _process_utilization_floor, _process_floor_generation
+    with _process_floor_lock:
+        if utilization > _process_utilization_floor:
+            _process_utilization_floor = utilization
+            _process_floor_generation += 1
+
+
+def process_utilization_floor() -> tuple[float, int]:
+    """Return ``(floor, generation)`` for cache-invalidating readers."""
+    with _process_floor_lock:
+        return _process_utilization_floor, _process_floor_generation
 
 
 class MetalPreflightError(RuntimeError):

--- a/vllm_mlx/memory_budget.py
+++ b/vllm_mlx/memory_budget.py
@@ -128,7 +128,27 @@ def format_preflight_error(
     utilization: float,
     device_budget_bytes: int,
 ) -> str:
-    """Build the actionable admission-impossible startup message (#2858)."""
+    """Build the actionable admission-impossible startup message (#2858).
+
+    The remediation list is tailored to what can still help (codex round 1
+    NIT): "increase --gpu-memory-utilization" is only suggested while the
+    configured value sits below the auto ceiling — at or above it the knob
+    is exhausted and the honest advice is that this Mac does not have the
+    memory for this configuration.
+    """
+    if utilization < AUTO_UTILIZATION_CEILING:
+        remediation = (
+            "Increase --gpu-memory-utilization, reduce context length or "
+            "concurrency, close memory-heavy apps, or choose a smaller model."
+        )
+    else:
+        remediation = (
+            "This Mac does not have enough unified memory for this "
+            "configuration at the maximum Metal budget — reduce context "
+            "length or concurrency, close memory-heavy apps, retry after "
+            "in-flight requests on other models finish, or choose a "
+            "smaller model."
+        )
     return (
         f"This model needs approximately {required_bytes / 1e9:.1f} GB of "
         f"Metal memory for the current configuration (weights and runtime "
@@ -137,6 +157,5 @@ def format_preflight_error(
         f"{cap_bytes / 1e9:.1f} GB "
         f"(gpu_memory_utilization={utilization:g} of the "
         f"{device_budget_bytes / 1e9:.1f} GB Metal working-set budget). "
-        f"Increase --gpu-memory-utilization, reduce context length or "
-        f"concurrency, close memory-heavy apps, or choose a smaller model."
+        f"{remediation}"
     )

--- a/vllm_mlx/memory_budget.py
+++ b/vllm_mlx/memory_budget.py
@@ -40,6 +40,12 @@ from dataclasses import dataclass
 AUTO_UTILIZATION_FLOOR = 0.90
 AUTO_UTILIZATION_CEILING = 0.97
 
+# The knob's absolute maximum: an explicit --gpu-memory-utilization may go
+# all the way to 1.0, past the auto ceiling. Advice to raise the knob is
+# only impossible (and therefore suppressed) at or beyond this value; a
+# tiny slack absorbs float representation of "1.0".
+MAX_UTILIZATION = 1.0 - 1e-9
+
 # Runtime headroom charged on top of the measured weight footprint in auto
 # mode: KV cache for in-flight requests, activation workspace, Metal heap
 # fragmentation. Fractional so big models reserve proportionally more, with an
@@ -162,13 +168,14 @@ def format_preflight_error(
 ) -> str:
     """Build the actionable admission-impossible startup message (#2858).
 
-    The remediation list is tailored to what can still help (codex round 1
-    NIT): "increase --gpu-memory-utilization" is only suggested while the
-    configured value sits below the auto ceiling — at or above it the knob
-    is exhausted and the honest advice is that this Mac does not have the
-    memory for this configuration.
+    The remediation list is tailored to what can still help (codex rounds
+    1 and 3): "increase --gpu-memory-utilization" is suggested while the
+    enforced utilization sits below 1.0 — an explicit override can legally
+    go all the way there, even past the auto ceiling. Only at a full 1.0
+    is the knob truly exhausted, and the honest advice becomes that this
+    Mac does not have the memory for this configuration.
     """
-    if utilization < AUTO_UTILIZATION_CEILING:
+    if utilization < MAX_UTILIZATION:
         remediation = (
             "Increase --gpu-memory-utilization, reduce context length or "
             "concurrency, close memory-heavy apps, or choose a smaller model."
@@ -176,10 +183,10 @@ def format_preflight_error(
     else:
         remediation = (
             "This Mac does not have enough unified memory for this "
-            "configuration at the maximum Metal budget — reduce context "
-            "length or concurrency, close memory-heavy apps, retry after "
-            "in-flight requests on other models finish, or choose a "
-            "smaller model."
+            "configuration even at the maximum Metal budget — reduce "
+            "context length or concurrency, close memory-heavy apps, "
+            "retry after in-flight requests on other models finish, or "
+            "choose a smaller model."
         )
     return (
         f"This model needs approximately {required_bytes / 1e9:.1f} GB of "

--- a/vllm_mlx/memory_budget.py
+++ b/vllm_mlx/memory_budget.py
@@ -31,6 +31,7 @@ This module closes that loop with two pieces, both pure and unit-testable:
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 
 # Auto-mode bounds. The floor matches the historical global default so any
@@ -83,6 +84,38 @@ def process_utilization_floor() -> tuple[float, int]:
     """Return ``(floor, generation)`` for cache-invalidating readers."""
     with _process_floor_lock:
         return _process_utilization_floor, _process_floor_generation
+
+
+def ratchet_utilization_and_apply(
+    utilization: float,
+    apply: Callable[[float], None] | None = None,
+) -> tuple[float, int]:
+    """Ratchet the floor and apply the effective value atomically.
+
+    Concurrent model loads each publish a resolved utilization and then
+    install the corresponding Metal allocation limit. Doing those as two
+    separate lock acquisitions leaves a window (codex round 4 BLOCKING #1)
+    where a loader holding an older, lower floor applies its limit LAST —
+    schedulers would then enforce the newer higher cap while Metal holds
+    the stale lower allocation limit. Holding the lock across both the
+    ratchet and the ``apply`` callback serializes the setter calls in
+    floor order, so the last limit installed always reflects the highest
+    published utilization.
+
+    ``apply`` receives the effective (post-ratchet) utilization —
+    ``max(utilization, floor)`` — and must contain its own failures if a
+    setter error should not propagate (the callers do; see codex round 1
+    BLOCKING #2). Returns ``(effective_utilization, generation)``.
+    """
+    global _process_utilization_floor, _process_floor_generation
+    with _process_floor_lock:
+        if utilization > _process_utilization_floor:
+            _process_utilization_floor = utilization
+            _process_floor_generation += 1
+        effective = max(utilization, _process_utilization_floor)
+        if apply is not None:
+            apply(effective)
+        return effective, _process_floor_generation
 
 
 class MetalPreflightError(RuntimeError):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3439,6 +3439,9 @@ class Scheduler:
         # device pay zero cost. ``0`` means "no cap" (see
         # ``gpu_memory_utilization`` doc on SchedulerConfig).
         self._metal_cap_bytes: int = 0
+        # The device working-set budget the cap was derived from — kept so
+        # the #2858 preflight error can report "X% of Y GB" faithfully.
+        self._metal_cap_base_bytes: int = 0
         self._metal_cap_bytes_resolved: bool = False
         # D-METAL-CAP: cached per-token KV-cache size for the
         # projection-based admission gate. Auto-derived from the
@@ -4565,6 +4568,7 @@ class Scheduler:
         if self._metal_cap_bytes_resolved:
             return self._metal_cap_bytes
         cap = 0
+        cap_base = 0
         util = float(getattr(self.config, "gpu_memory_utilization", 0.0) or 0.0)
         if util > 0.0:
             try:
@@ -4576,9 +4580,12 @@ class Scheduler:
                     )
                     if base and base > 0:
                         cap = int(base * util)
+                        cap_base = int(base)
             except Exception:
                 cap = 0
+                cap_base = 0
         self._metal_cap_bytes = cap
+        self._metal_cap_base_bytes = cap_base
         self._metal_cap_bytes_resolved = True
         return cap
 
@@ -5301,6 +5308,70 @@ class Scheduler:
         # historical ``per_tok × tokens``.
         return fixed_baseline + per_tok * tokens + sliding_bytes
 
+    # #2858 preflight: the smallest workload the server must be able to
+    # admit for the model to honestly count as "ready" — a short
+    # classification-style request. Big enough that a pass means real
+    # traffic can run; small enough that a config which genuinely serves
+    # short requests today is never refused.
+    PREFLIGHT_NOMINAL_TOKENS = 1024
+
+    def preflight_metal_admission(self) -> None:
+        """Fail startup when the Metal cap can never admit even a modest request.
+
+        #2858 acceptance criterion: a model must not be reported healthy
+        while every request deterministically returns HTTP 503 because the
+        configured cap is below the model's resident footprint. This runs
+        once at engine startup — after the weights are materialized and the
+        Metal limits are set, before the engine loop starts — and mirrors
+        the admission gate's own arithmetic
+        (``_enforce_metal_cap_at_admission``):
+        current Metal active plus the projected KV of one
+        ``PREFLIGHT_NOMINAL_TOKENS``-token request, against the same
+        resolved cap. If that sum already violates the gate, no real
+        request can ever admit, so raise :class:`MetalPreflightError`
+        with the actionable required-vs-available message instead of
+        letting the server come up 503-wedged.
+
+        No-op when the cap is disabled (``gpu_memory_utilization=0``), the
+        Metal probe failed, or active memory reads 0 (non-Metal CI hosts
+        and unit-test stubs) — identical guard conditions to the admission
+        gate itself.
+        """
+        cap = self._resolve_metal_cap_bytes()
+        if cap <= 0:
+            return
+        active = self._current_metal_active_bytes()
+        if active <= 0:
+            return
+        per_tok = self._resolve_kv_bytes_per_token()
+        fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
+        tokens = self.PREFLIGHT_NOMINAL_TOKENS
+        sliding_bytes = 0
+        if self._kv_sliding_slot_bytes > 0 and self._kv_sliding_window > 0:
+            sliding_bytes = self._kv_sliding_slot_bytes * rotating_cache_slots(
+                self._kv_sliding_window, tokens
+            )
+        min_kv = fixed_baseline + per_tok * tokens + sliding_bytes
+        required = active + min_kv
+        # Same comparison shape as the admission gate: a request is
+        # rejected when active >= cap OR the projected sum reaches cap.
+        if active < cap and required < cap:
+            return
+
+        from .memory_budget import MetalPreflightError, format_preflight_error
+
+        util = float(getattr(self.config, "gpu_memory_utilization", 0.0) or 0.0)
+        message = format_preflight_error(
+            required_bytes=required,
+            active_bytes=active,
+            min_kv_bytes=min_kv,
+            cap_bytes=cap,
+            utilization=util,
+            device_budget_bytes=self._metal_cap_base_bytes or cap,
+        )
+        logger.error("[D-METAL-CAP preflight] %s", message)
+        raise MetalPreflightError(message)
+
     def _sum_in_flight_kv_bytes(self) -> int:
         """Sum projected KV reservations of WAITING-only requests.
 
@@ -5466,12 +5537,20 @@ class Scheduler:
                 getattr(self.config, "gpu_memory_utilization", 0.0),
                 rid_str,
             )
+        # #2858: actionable rejection — report required vs available and
+        # concrete remediations, not just the internal cap arithmetic.
+        # Keeps the "D-METAL-CAP" and "reserved KV" tokens the existing
+        # regression tests and operator runbooks grep for.
         raise BackpressureError(
-            f"Metal active {active / 1e9:.1f}GB + reserved KV "
-            f"{reserved_kv / 1e9:.1f}GB + projected KV "
-            f"{projected_kv / 1e9:.1f}GB would exceed "
-            f"gpu_memory_utilization cap {cap / 1e9:.1f}GB "
-            f"(D-METAL-CAP); retry after pressure drops"
+            f"This request needs approximately "
+            f"{(reserved_kv + projected_kv) / 1e9:.1f} GB of Metal memory "
+            f"on top of {active / 1e9:.1f} GB already in use "
+            f"(reserved KV {reserved_kv / 1e9:.1f} GB + projected KV "
+            f"{projected_kv / 1e9:.1f} GB), but the current limit is "
+            f"{cap / 1e9:.1f} GB (D-METAL-CAP). Retry after in-flight "
+            f"requests drain, reduce context length or max_tokens, lower "
+            f"concurrency, or restart with a higher "
+            f"--gpu-memory-utilization."
         )
 
     def _resolve_pressure_evict_fraction(self) -> float:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3443,6 +3443,13 @@ class Scheduler:
         # the #2858 preflight error can report "X% of Y GB" faithfully.
         self._metal_cap_base_bytes: int = 0
         self._metal_cap_bytes_resolved: bool = False
+        # Generation of the process-wide utilization ratchet this cap was
+        # resolved against; a mismatch re-resolves (see
+        # ``memory_budget.process_utilization_floor``).
+        self._metal_cap_floor_generation: int = -1
+        # The utilization the cap actually enforces after the ratchet —
+        # what error messages must report, which can exceed the config's.
+        self._metal_cap_effective_utilization: float = 0.0
         # D-METAL-CAP: cached per-token KV-cache size for the
         # projection-based admission gate. Auto-derived from the
         # model config on first use (operator override via
@@ -4565,12 +4572,27 @@ class Scheduler:
         Metal device probe failed). Callers MUST treat ``0`` as "do not
         check" rather than "no headroom".
         """
-        if self._metal_cap_bytes_resolved:
+        from .memory_budget import process_utilization_floor
+
+        floor, generation = process_utilization_floor()
+        if (
+            self._metal_cap_bytes_resolved
+            and generation == self._metal_cap_floor_generation
+        ):
             return self._metal_cap_bytes
+        self._metal_cap_floor_generation = generation
         cap = 0
         cap_base = 0
         util = float(getattr(self.config, "gpu_memory_utilization", 0.0) or 0.0)
         if util > 0.0:
+            # Codex round 2 BLOCKING #2: in multi-model mode the Metal
+            # allocator (and ``mx.get_active_memory()``) is process-wide,
+            # so once ANY resident engine ratchets the process limit up,
+            # this scheduler must enforce at least that utilization too —
+            # otherwise its stale lower cap rejects every request the
+            # moment another model becomes resident. Never enables a
+            # disabled cap (util == 0 stays disabled), never lowers.
+            util = max(util, floor)
             try:
                 if mx.metal.is_available():
                     info = mx.device_info()
@@ -4586,6 +4608,7 @@ class Scheduler:
                 cap_base = 0
         self._metal_cap_bytes = cap
         self._metal_cap_base_bytes = cap_base
+        self._metal_cap_effective_utilization = util
         self._metal_cap_bytes_resolved = True
         return cap
 
@@ -5324,15 +5347,22 @@ class Scheduler:
         once at engine startup — after the weights are materialized and the
         Metal limits are set, before the engine loop starts.
 
-        Deliberately STRICTER-to-fail than the admission gate: it raises
-        only when ``active >= cap`` — the condition under which
-        ``_enforce_metal_cap_at_admission`` rejects EVERY request
-        regardless of size (codex round 1 BLOCKING #1: gating on a nominal
-        request's projected KV as well would refuse memory-tight
-        configurations that can still serve short requests today). The
-        nominal ``PREFLIGHT_NOMINAL_TOKENS`` KV term is still computed,
-        but only to make the error message's "needs approximately" figure
-        honest about serving at least short requests.
+        The failure condition is EXACTLY "no valid request can ever
+        admit": ``active + smallest-request KV >= cap``, where the
+        smallest valid request is one prompt token plus one generated
+        token (its fixed baseline, two tokens of per-token growth, and
+        the minimum sliding-window slot allocation). Codex round 1
+        BLOCKING #1 established that gating on a NOMINAL 1024-token
+        request over-refuses memory-tight configs that genuinely serve
+        short requests; codex round 2 BLOCKING #1 established that
+        ``active >= cap`` alone under-refuses configs with positive but
+        insufficient room for even the smallest KV allocation. The
+        minimum-request bound is the fixed point of both: any config it
+        refuses rejects EVERY request in ``_enforce_metal_cap_at_admission``
+        (which projects at least this much KV for any request), and any
+        config it admits can serve at least a one-token exchange. The
+        nominal ``PREFLIGHT_NOMINAL_TOKENS`` figure is still computed,
+        but only for the error message's "needs approximately" number.
 
         Before concluding impossibility the allocator cache is cleared and
         active re-measured (codex round 1 BLOCKING #4): ``active`` at load
@@ -5355,7 +5385,22 @@ class Scheduler:
         active = self._current_metal_active_bytes()
         if active <= 0:
             return
-        if active >= cap:
+
+        def _request_kv_bytes(tokens: int) -> int:
+            per_tok = self._resolve_kv_bytes_per_token()
+            fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
+            sliding_bytes = 0
+            if self._kv_sliding_slot_bytes > 0 and self._kv_sliding_window > 0:
+                sliding_bytes = self._kv_sliding_slot_bytes * rotating_cache_slots(
+                    self._kv_sliding_window, tokens
+                )
+            return fixed_baseline + per_tok * tokens + sliding_bytes
+
+        # Smallest valid request: one prompt token + one generated token.
+        # ``_estimate_request_kv_bytes`` projects at least this much for
+        # ANY request, so admission is impossible iff this cannot fit.
+        smallest_kv = _request_kv_bytes(2)
+        if active + smallest_kv >= cap:
             # Give reclaimable allocator-cache pages back before declaring
             # the configuration impossible — post-load ``active`` routinely
             # carries cache the allocator would drop under pressure anyway.
@@ -5364,22 +5409,14 @@ class Scheduler:
             except Exception:
                 pass
             active = self._current_metal_active_bytes()
-        if active < cap:
+        if active + smallest_kv < cap:
             return
-        per_tok = self._resolve_kv_bytes_per_token()
-        fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
-        tokens = self.PREFLIGHT_NOMINAL_TOKENS
-        sliding_bytes = 0
-        if self._kv_sliding_slot_bytes > 0 and self._kv_sliding_window > 0:
-            sliding_bytes = self._kv_sliding_slot_bytes * rotating_cache_slots(
-                self._kv_sliding_window, tokens
-            )
-        min_kv = fixed_baseline + per_tok * tokens + sliding_bytes
+        min_kv = _request_kv_bytes(self.PREFLIGHT_NOMINAL_TOKENS)
         required = active + min_kv
 
         from .memory_budget import MetalPreflightError, format_preflight_error
 
-        util = float(getattr(self.config, "gpu_memory_utilization", 0.0) or 0.0)
+        util = self._metal_cap_effective_utilization
         message = format_preflight_error(
             required_bytes=required,
             active_bytes=active,
@@ -5559,17 +5596,26 @@ class Scheduler:
         # #2858: actionable rejection — report required vs available and
         # concrete remediations, not just the internal cap arithmetic.
         # Keeps the "D-METAL-CAP" and "reserved KV" tokens the existing
-        # regression tests and operator runbooks grep for.
+        # regression tests and operator runbooks grep for. The
+        # --gpu-memory-utilization suggestion is dropped once the enforced
+        # utilization has no room left (codex round 2 NIT).
+        raise_advice = (
+            " Retry after in-flight requests drain, reduce context "
+            "length or max_tokens, or lower concurrency."
+        )
+        if self._metal_cap_effective_utilization < 0.97:
+            raise_advice = (
+                " Retry after in-flight requests drain, reduce context "
+                "length or max_tokens, lower concurrency, or restart "
+                "with a higher --gpu-memory-utilization."
+            )
         raise BackpressureError(
             f"This request needs approximately "
             f"{(reserved_kv + projected_kv) / 1e9:.1f} GB of Metal memory "
             f"on top of {active / 1e9:.1f} GB already in use "
             f"(reserved KV {reserved_kv / 1e9:.1f} GB + projected KV "
             f"{projected_kv / 1e9:.1f} GB), but the current limit is "
-            f"{cap / 1e9:.1f} GB (D-METAL-CAP). Retry after in-flight "
-            f"requests drain, reduce context length or max_tokens, lower "
-            f"concurrency, or restart with a higher "
-            f"--gpu-memory-utilization."
+            f"{cap / 1e9:.1f} GB (D-METAL-CAP)." + raise_advice
         )
 
     def _resolve_pressure_evict_fraction(self) -> float:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5597,13 +5597,17 @@ class Scheduler:
         # concrete remediations, not just the internal cap arithmetic.
         # Keeps the "D-METAL-CAP" and "reserved KV" tokens the existing
         # regression tests and operator runbooks grep for. The
-        # --gpu-memory-utilization suggestion is dropped once the enforced
-        # utilization has no room left (codex round 2 NIT).
+        # --gpu-memory-utilization suggestion is dropped only once the
+        # enforced utilization is truly maximal — an explicit override can
+        # legally be raised to 1.0, past the auto ceiling (codex rounds 2
+        # and 3 NITs).
+        from .memory_budget import MAX_UTILIZATION
+
         raise_advice = (
             " Retry after in-flight requests drain, reduce context "
             "length or max_tokens, or lower concurrency."
         )
-        if self._metal_cap_effective_utilization < 0.97:
+        if self._metal_cap_effective_utilization < MAX_UTILIZATION:
             raise_advice = (
                 " Retry after in-flight requests drain, reduce context "
                 "length or max_tokens, lower concurrency, or restart "

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5308,29 +5308,41 @@ class Scheduler:
         # historical ``per_tok × tokens``.
         return fixed_baseline + per_tok * tokens + sliding_bytes
 
-    # #2858 preflight: the smallest workload the server must be able to
-    # admit for the model to honestly count as "ready" — a short
-    # classification-style request. Big enough that a pass means real
-    # traffic can run; small enough that a config which genuinely serves
-    # short requests today is never refused.
+    # #2858 preflight: nominal short-request size used ONLY to make the
+    # failure message's "needs approximately" figure honest (weights plus
+    # room for one classification-style request). It does NOT gate the
+    # pass/fail decision — that is ``active >= cap`` alone, so a config
+    # that genuinely serves short requests today is never refused.
     PREFLIGHT_NOMINAL_TOKENS = 1024
 
     def preflight_metal_admission(self) -> None:
-        """Fail startup when the Metal cap can never admit even a modest request.
+        """Fail startup when the Metal cap can never admit ANY request.
 
         #2858 acceptance criterion: a model must not be reported healthy
         while every request deterministically returns HTTP 503 because the
         configured cap is below the model's resident footprint. This runs
         once at engine startup — after the weights are materialized and the
-        Metal limits are set, before the engine loop starts — and mirrors
-        the admission gate's own arithmetic
-        (``_enforce_metal_cap_at_admission``):
-        current Metal active plus the projected KV of one
-        ``PREFLIGHT_NOMINAL_TOKENS``-token request, against the same
-        resolved cap. If that sum already violates the gate, no real
-        request can ever admit, so raise :class:`MetalPreflightError`
-        with the actionable required-vs-available message instead of
-        letting the server come up 503-wedged.
+        Metal limits are set, before the engine loop starts.
+
+        Deliberately STRICTER-to-fail than the admission gate: it raises
+        only when ``active >= cap`` — the condition under which
+        ``_enforce_metal_cap_at_admission`` rejects EVERY request
+        regardless of size (codex round 1 BLOCKING #1: gating on a nominal
+        request's projected KV as well would refuse memory-tight
+        configurations that can still serve short requests today). The
+        nominal ``PREFLIGHT_NOMINAL_TOKENS`` KV term is still computed,
+        but only to make the error message's "needs approximately" figure
+        honest about serving at least short requests.
+
+        Before concluding impossibility the allocator cache is cleared and
+        active re-measured (codex round 1 BLOCKING #4): ``active`` at load
+        time includes reclaimable allocator-cache pages and transient KV
+        from other resident models' in-flight traffic. The cache clear
+        removes the reclaimable share; genuinely resident weights that
+        still exceed the cap after that are a deterministic wedge. A
+        dynamic ``/v1/models/load`` that fails here while other models are
+        busy is retryable by the caller once traffic drains — the error
+        message says so when the budget knob is exhausted.
 
         No-op when the cap is disabled (``gpu_memory_utilization=0``), the
         Metal probe failed, or active memory reads 0 (non-Metal CI hosts
@@ -5343,6 +5355,17 @@ class Scheduler:
         active = self._current_metal_active_bytes()
         if active <= 0:
             return
+        if active >= cap:
+            # Give reclaimable allocator-cache pages back before declaring
+            # the configuration impossible — post-load ``active`` routinely
+            # carries cache the allocator would drop under pressure anyway.
+            try:
+                mx.clear_cache()
+            except Exception:
+                pass
+            active = self._current_metal_active_bytes()
+        if active < cap:
+            return
         per_tok = self._resolve_kv_bytes_per_token()
         fixed_baseline = self._resolve_kv_fixed_baseline_bytes()
         tokens = self.PREFLIGHT_NOMINAL_TOKENS
@@ -5353,10 +5376,6 @@ class Scheduler:
             )
         min_kv = fixed_baseline + per_tok * tokens + sliding_bytes
         required = active + min_kv
-        # Same comparison shape as the admission gate: a request is
-        # rejected when active >= cap OR the projected sum reaches cap.
-        if active < cap and required < cap:
-            return
 
         from .memory_budget import MetalPreflightError, format_preflight_error
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -202,7 +202,9 @@ _model_registry = ModelRegistry()
 _residency_manager: ResidentModelManager | None = None
 _resident_memory_limit_bytes: int = 0
 _resident_idle_ttl_seconds: float = 0.0
-_resident_gpu_memory_utilization: float = 0.90
+# ``None`` = per-model auto budgeting (#2858); a float is the operator's
+# explicit --gpu-memory-utilization, applied to every resident model.
+_resident_gpu_memory_utilization: float | None = None
 
 # Global engine instance (single-model legacy path, also primary model in multi-model)
 _engine: BaseEngine | None = None
@@ -1946,7 +1948,7 @@ def load_model(
     stream_interval: int = 1,
     max_tokens: int | None = None,
     force_mllm: bool = False,
-    gpu_memory_utilization: float = 0.90,
+    gpu_memory_utilization: float | None = None,
     prefill_step_size: int | None = None,
     *,
     served_model_name: str | None = None,
@@ -1976,7 +1978,9 @@ def load_model(
             programmatic callers that pass ``max_tokens`` are treated as
             explicit while callers that omit it keep the implicit default.
         force_mllm: Force loading as MLLM even if not auto-detected
-        gpu_memory_utilization: Fraction of device memory (0.0-1.0, default 0.90)
+        gpu_memory_utilization: Fraction of device memory (0.0-1.0).
+            ``None`` (default) auto-sizes the Metal budget to the loaded
+            model (#2858); an explicit float is honored verbatim.
         prefill_step_size: DEPRECATED — pass via
             ``scheduler_config.prefill_step_size`` instead. Pre-0.6.52 this
             parameter was accepted but silently ignored (the value never
@@ -2705,7 +2709,7 @@ def configure_model_residency(
     *,
     memory_limit_gb: float = 0,
     idle_ttl_seconds: float = 0,
-    gpu_memory_utilization: float = 0.90,
+    gpu_memory_utilization: float | None = None,
 ) -> ResidentModelManager:
     """Configure the process-wide resident-model manager before startup."""
 
@@ -2716,7 +2720,9 @@ def configure_model_residency(
 
     _resident_memory_limit_bytes = max(0, int(float(memory_limit_gb) * 1024**3))
     _resident_idle_ttl_seconds = max(0.0, float(idle_ttl_seconds))
-    _resident_gpu_memory_utilization = float(gpu_memory_utilization)
+    _resident_gpu_memory_utilization = (
+        float(gpu_memory_utilization) if gpu_memory_utilization is not None else None
+    )
     _residency_manager = ResidentModelManager(
         _model_registry,
         _load_dynamic_resident_model,


### PR DESCRIPTION
Closes #2858.

## Problem

`--gpu-memory-utilization` (default 0.90) was a global knob that required model-specific knowledge: a 12B checkpoint served at 0.75 while a 20B MoE with an ~11.2 GB Metal footprint needed 0.95 on the same 16 GB Mac. Worse, with too low a cap the model loaded and reported healthy while the D-METAL-CAP admission gate deterministically rejected every request with HTTP 503 and an internal-jargon message.

## Approach

No new estimation machinery — the engine already had the three pieces (measured post-load footprint, the architecture-aware KV estimator behind `_resolve_kv_bytes_per_token`, and the D-METAL-CAP admission gate). This PR wires them into a closed loop, following vLLM's profile-then-budget shape:

1. **`vllm_mlx/memory_budget.py` (new, pure)** — `plan_metal_limit()` resolves the effective utilization. Auto mode (the new default, flag unset) sizes the limit to the **measured** weight footprint (`mx.get_active_memory()` right after load; in multi-model mode this covers every resident model, so the process-wide limit only ratchets upward) plus runtime headroom (max(8%, 512 MB)), clamped to [0.90, 0.97] of `max_recommended_working_set_size`. An explicit `--gpu-memory-utilization` is honored verbatim (advanced override). Small models resolve to exactly the historical 0.90 — byte-identical back-compat.
2. **One cap, two enforcement points** — BatchedEngine feeds the resolved utilization to `mx.set_memory_limit` and, via engine_core's existing D-METAL-CAP propagation, to `SchedulerConfig.gpu_memory_utilization`, so the soft hint and the admission gate always agree.
3. **Startup preflight** — `Scheduler.preflight_metal_admission()` runs before the engine loop starts, mirroring the admission gate's own arithmetic (current active + projected KV of one nominal 1024-token request vs. the resolved cap, reusing `_resolve_kv_bytes_per_token` / fixed-baseline / sliding terms). If no request could ever admit, the load fails with:

   > This model needs approximately 11.2 GB of Metal memory for the current configuration (weights and runtime 10.7 GB + minimum KV cache 0.5 GB), but the current limit is 9.1 GB (gpu_memory_utilization=0.75 of the 12.1 GB Metal working-set budget). Increase --gpu-memory-utilization, reduce context length or concurrency, close memory-heavy apps, or choose a smaller model.

   The server never comes up 503-wedged (acceptance criterion 4).
4. **Actionable runtime 503** — the D-METAL-CAP `BackpressureError` message is rewritten to the same required-vs-available + remediation shape. The `D-METAL-CAP` / `reserved KV` / `projected KV` tokens are kept, so existing regression tests, operator runbooks, and the Mac app's `FailureDiagnosis` memory-signal matchers (`metal-cap`, `projected kv`) keep working unchanged.

The resident multi-model path inherits all of this: `/v1/models/load` goes through the same `BatchedEngine.start()`, so a dynamic load that can't fit returns the actionable message to the API caller, and `configure_model_residency` carries `None` (per-model auto) through.

## Acceptance criteria mapping

- Per-model preflight before ready → `preflight_metal_admission()` in `BatchedEngine.start()`, before the engine loop.
- Defaults work without manual tuning → auto mode; floor keeps small models identical to today, large models get 0.90–0.97 as needed.
- Rejection reports required vs available + a concrete remediation → both the startup preflight error and the runtime 503.
- No healthy-while-deterministically-503 → preflight fails the load; uvicorn lifespan aborts before traffic.
- Manual override surfaced as advanced → flag kept, help text and docs now call it an advanced override of auto.
- Tests cover fits-at-default and needs-higher-budget models → `tests/test_metal_memory_budget.py` (`test_small_model_fits_at_default_floor`, `test_large_model_gets_higher_per_model_budget`), plus preflight pass/fail, override, ceiling clamp, and 503-message tests (13 tests).

## Test plan

- [x] `tests/test_metal_memory_budget.py` — 13 new tests, all pass.
- [x] Coupled suites green: `test_metal_cap_enforcement` (56), `test_cli_metal_cap_kv_flag`, `test_projected_memory_max_context`, `test_kv_estimation`, `test_prefix_cache_pressure_eviction`, `test_prefix_cache_eviction`, `test_mtp_spec_decode`, `test_mtp_cli_wiring`, `test_memory_capacity_check`, `test_hybrid_prefix_cache_growth` (312 + 53 + 107 passed; 3 `test_no_mllm_flag` vision failures reproduce identically on clean origin/main — local mlx-vlm env, not this diff).
- [x] Live smoke on M3 Ultra: auto mode logs `Metal memory limits set (auto): allocation_limit=215.2GB (90% of 239.1GB, weights=0.7GB)` and serves a completion; `--gpu-memory-utilization 0.5` logs `(manual): ... (50% ...)`.
- [x] ruff check/format clean; mypy budget deltas on touched files reproduce identically on clean origin/main (local mypy version skew; CI type-check is authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)