### PR TITLE
fix(ci): recheck stale transcript jump element

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -920,8 +920,19 @@ settle_transcript_at_bottom() {
     if jq -e '.data.ui_elements[]?
               | select(.identifier == "Transcript.JumpToBottom")' \
         "$destination" >/dev/null; then
-        press "$destination" Transcript.JumpToBottom "$press_result" \
-            || die "transcript was not at its tail and Jump to latest was not pressable"
+        if ! press "$destination" Transcript.JumpToBottom "$press_result"; then
+            # The transcript can finish its own scroll between the AX dump and
+            # AXPress, replacing the overlay element that the dump described.
+            # Re-read before calling that a broken control. Disappearance is
+            # not success by itself: the stability loop below must still prove
+            # the correlated transcript is physically at its tail twice.
+            see_main "$destination"
+            if jq -e '.data.ui_elements[]?
+                      | select(.identifier == "Transcript.JumpToBottom")' \
+                "$destination" >/dev/null; then
+                die "transcript was not at its tail and Jump to latest was not pressable"
+            fi
+        fi
     fi
     local previous_tail_key="" stable_samples=0
     for _ in {1..60}; do

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -395,6 +395,116 @@ def test_transcript_settler_accepts_stable_visible_tail_after_scrollbar_hides(tm
     assert completed.stdout.strip() == "3"
 
 
+def test_transcript_settler_rechecks_after_a_stale_jump_press(tmp_path):
+    """A vanished stale AX element still needs the physical tail proof."""
+    source = HARNESS.read_text()
+    helper_body = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[
+        0
+    ]
+    helper = f"settle_transcript_at_bottom() {{{helper_body}\n}}"
+
+    fixture_dir = tmp_path / "fixtures"
+    fixture_dir.mkdir()
+    initial_elements = [
+        {
+            "role": "AXScrollBar",
+            "value": 0.25,
+            "bounds": {"x": 704, "width": 17, "height": 320},
+        },
+        {
+            "identifier": "ChatView.SendOrStopButton",
+            "bounds": {"x": 658, "width": 28, "height": 28},
+        },
+        {"identifier": "Transcript.JumpToBottom"},
+    ]
+    settled_elements = [
+        {
+            "role": "AXScrollBar",
+            "value": 1.0,
+            "bounds": {"x": 704, "width": 17, "height": 320},
+        },
+        {
+            "identifier": "ChatView.SendOrStopButton",
+            "bounds": {"x": 658, "width": 28, "height": 28},
+        },
+    ]
+    for index, elements in enumerate(
+        (initial_elements, settled_elements, settled_elements, settled_elements)
+    ):
+        (fixture_dir / f"fixture-{index}.json").write_text(
+            json.dumps({"data": {"ui_elements": elements}})
+        )
+
+    script = textwrap.dedent(
+        f"""
+        set -u
+        fixture_dir={str(fixture_dir)!r}
+        calls=0
+        see_main() {{
+            local destination="$1" index="$calls"
+            (( index > 3 )) && index=3
+            cp "$fixture_dir/fixture-$index.json" "$destination"
+            calls=$((calls + 1))
+        }}
+        press() {{ return 1; }}
+        die() {{ printf '%s\n' "$*" >&2; exit 97; }}
+        sleep() {{ :; }}
+        {helper}
+        settle_transcript_at_bottom "$fixture_dir/current.json" "$fixture_dir/press.json"
+        printf '%s\n' "$calls"
+        """
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "4"
+
+
+def test_transcript_settler_rejects_failed_press_when_jump_remains(tmp_path):
+    """A live but unpressable affordance must continue to fail closed."""
+    source = HARNESS.read_text()
+    helper_body = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[
+        0
+    ]
+    helper = f"settle_transcript_at_bottom() {{{helper_body}\n}}"
+
+    elements = [
+        {
+            "role": "AXScrollBar",
+            "value": 0.25,
+            "bounds": {"x": 704, "width": 17, "height": 320},
+        },
+        {
+            "identifier": "ChatView.SendOrStopButton",
+            "bounds": {"x": 658, "width": 28, "height": 28},
+        },
+        {"identifier": "Transcript.JumpToBottom"},
+    ]
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({"data": {"ui_elements": elements}}))
+
+    script = textwrap.dedent(
+        f"""
+        set -u
+        fixture={str(fixture)!r}
+        see_main() {{ cp "$fixture" "$1"; }}
+        press() {{ return 1; }}
+        die() {{ printf '%s\n' "$*" >&2; exit 97; }}
+        sleep() {{ :; }}
+        {helper}
+        settle_transcript_at_bottom "$fixture.current.json" "$fixture.press.json"
+        """
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 97
+    assert "was not pressable" in completed.stderr
+
+
 def test_transcript_settler_rejects_a_stable_intermediate_position(tmp_path):
     """Progress plus a hidden button is not proof that the tail was reached."""
     source = HARNESS.read_text()


### PR DESCRIPTION
## Summary

- re-read the live accessibility tree when Jump to latest disappears between observation and AXPress
- retain the existing two-sample physical transcript-tail proof before accepting the vanished control
- add executable positive and fail-closed regression contracts for the stale-element transition

## Intention and scope

A merge-queue Desktop candidate exposed a transient false failure after the transcript automatically reached its tail between an AX snapshot and the attempted Jump-to-latest press. This PR is limited to the GUI golden-flow harness and its focused Python contract tests.

Non-goals: no product Chat UI or scrolling behavior changes, no baseline updates, no model-readiness changes, no release changes, and no broad retry-policy changes.

## Verification

- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- `python -m pytest -q tests/test_gui_preflight_contract.py --no-header` — 28 passed
- `ruff check tests/test_gui_preflight_contract.py`
- `ruff format --check tests/test_gui_preflight_contract.py`
- `git diff --check`

## Risk

Low and test-only. A still-visible but unpressable control continues to fail. A disappeared control is accepted only after the pre-existing correlated scrollbar/tail-marker proof is stable for two observations.
