### PR TITLE
fix(ci): allow dequeued PR label recovery

### DIFF
--- a/.github/workflows/authorize-merge-ready.yml
+++ b/.github/workflows/authorize-merge-ready.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     steps:
       - name: Bind ready authorization to the current head

--- a/tests/test_mergify_batch_queue.py
+++ b/tests/test_mergify_batch_queue.py
@@ -156,7 +156,7 @@ def test_ready_authorization_is_bound_to_the_exact_head_commit():
     assert "merge-ready-mac" in job["if"]
     assert job["permissions"] == {
         "issues": "write",
-        "pull-requests": "read",
+        "pull-requests": "write",
         "statuses": "write",
     }
 


### PR DESCRIPTION
## Summary

- grant the exact PR write permission required by the dequeue-recovery label calls
- keep the workflow's existing issue/status permissions and recovery logic unchanged
- update the focused workflow contract to lock the effective permission set

## Intention and scope

A live dequeue recovery reached `github.rest.issues.addLabels` for an in-repository pull request and GitHub returned 403 `Resource not accessible by integration`; the response advertised `pull_requests=write` as an accepted permission while this job granted only `pull-requests: read`.

This PR only fixes that permission mismatch. Non-goals: no Mergify policy or queue-condition change, no changes to exact-head authorization, event freshness, recovery markers, CI rerun policy, product code, or release behavior.

## Verification

- `python -m pytest -q tests/test_mergify_batch_queue.py --no-header` — 22 passed
- `ruff check tests/test_mergify_batch_queue.py`
- `ruff format --check tests/test_mergify_batch_queue.py`
- `git diff --check`

## Risk

Low and narrowly privileged. The token can write pull-request metadata only inside this guarded in-repository `pull_request_target` job; the existing same-repo check, exact-head status, fresh-event requirement, and one-shot recovery conditions remain unchanged.
