### PR TITLE
fix(ci): use supported recovery for dequeued PRs

### DIFF
--- a/.github/workflows/authorize-merge-ready.yml
+++ b/.github/workflows/authorize-merge-ready.yml
@@ -14,18 +14,16 @@ jobs:
        github.event.label.name == 'merge-ready-mac')
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      pull-requests: read
       statuses: write
     steps:
       - name: Bind ready authorization to the current head
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
-            // A historical Actions rerun must not replay an old labeled event
-            // to clear a dequeue that happened later.  A maintainer can always
-            // create a fresh authorization event by removing/re-applying the
-            // ready label.
+            // A historical Actions rerun must not replay an old labeled event.
+            // A maintainer can always create a fresh authorization event by
+            // removing and re-applying the ready label.
             if (Number(process.env.GITHUB_RUN_ATTEMPT) !== 1) {
               core.setFailed(
                 "A merge-ready authorization event cannot be replayed; remove and re-apply the ready label.",
@@ -35,9 +33,8 @@ jobs:
 
             const readyLabels = new Set(["merge-ready", "merge-ready-mac"]);
             // Close the stale-success window before any fallible live-state
-            // lookup. Mergify cannot admit this event head again unless every
-            // validation and recovery step below completes and publishes the
-            // final success status.
+            // lookup. Mergify cannot admit this event head unless validation
+            // completes and publishes the final success status.
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -60,145 +57,14 @@ jobs:
             );
             const sameHead =
               livePull.head.sha === context.payload.pull_request.head.sha;
-            const baseAuthorized =
+            const authorized =
               sameHead &&
               present.length === 1 &&
               present[0] === context.payload.label.name;
-            const wasDequeued = currentLabels.has("dequeued");
-            const recoveryRequired =
-              wasDequeued || currentLabels.has("merge-requeue-required");
-            const latestLabeledAt = (events, name) =>
-              events
-                .filter(
-                  (event) =>
-                    event.event === "labeled" && event.label?.name === name,
-                )
-                .map((event) => Date.parse(event.created_at))
-                .filter(Number.isFinite)
-                .reduce((latest, value) => Math.max(latest, value), -Infinity);
-            let recoveryEventFresh = true;
-            if (baseAuthorized && recoveryRequired) {
-              const events = await github.paginate(
-                github.rest.issues.listEvents,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  per_page: 100,
-                },
-              );
-              const readyLabeledAt = latestLabeledAt(
-                events,
-                context.payload.label.name,
-              );
-              const dequeuedLabeledAt = latestLabeledAt(events, "dequeued");
-              // GitHub documents created_at for issue events. Require a strict
-              // ordering; same-second or missing events fail closed and can be
-              // resolved by re-applying the ready label once more.
-              recoveryEventFresh = readyLabeledAt > dequeuedLabeledAt;
-            }
-            const authorized = baseAuthorized && recoveryEventFresh;
             const state = authorized ? "success" : "failure";
             const description = authorized
               ? `Authorized ${present[0]} on this exact head`
-              : recoveryRequired && !recoveryEventFresh
-                ? "Re-apply merge-ready after the latest dequeue"
-                : "Apply exactly one merge-ready label";
-
-            // Mergify records a terminal dequeue for this exact head after a
-            // batch outcome. Only a fresh, valid ready-label event may start
-            // one diagnosed retry. A persistent recovery marker makes partial
-            // provider action failure recoverable, while the consumed trigger
-            // prevents either marker from retrying the head by itself.
-            if (authorized && recoveryRequired) {
-              // Clear any token left by a partial recovery while the pending
-              // status still blocks Mergify. A successful recovery mints a new
-              // token only after the exact-head success status is visible, so
-              // that label event can activate the queue rule immediately.
-              if (currentLabels.has("merge-requeue-trigger")) {
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    name: "merge-requeue-trigger",
-                  });
-                } catch (error) {
-                  if (error.status !== 404) {
-                    throw error;
-                  }
-                }
-              }
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: ["merge-requeue-required"],
-              });
-              if (wasDequeued) {
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    name: "dequeued",
-                  });
-                  core.notice(
-                    `Cleared stale dequeued state before re-authorizing ${present[0]}.`,
-                  );
-                } catch (error) {
-                  // A concurrent Mergify reconciliation may remove the label
-                  // first. Missing is desired; every other error must fail
-                  // closed instead of claiming the head was re-authorized.
-                  if (error.status !== 404) {
-                    throw error;
-                  }
-                }
-                // Close the check/remove race: a new dequeue can arrive after
-                // the first event snapshot but before marker removal. Re-read
-                // the authoritative event sequence before publishing success.
-                const postRemovalEvents = await github.paginate(
-                  github.rest.issues.listEvents,
-                  {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    per_page: 100,
-                  },
-                );
-                const postReadyAt = latestLabeledAt(
-                  postRemovalEvents,
-                  context.payload.label.name,
-                );
-                const postDequeueAt = latestLabeledAt(
-                  postRemovalEvents,
-                  "dequeued",
-                );
-                if (!(postReadyAt > postDequeueAt)) {
-                  // Restore the circuit breaker removed above. The pending
-                  // status already blocks admission while this call runs.
-                  await github.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    labels: ["dequeued"],
-                  });
-                  const staleDescription =
-                    "Re-apply merge-ready after the latest dequeue";
-                  await github.rest.repos.createCommitStatus({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    sha: context.payload.pull_request.head.sha,
-                    state: "failure",
-                    context: "merge-ready-head",
-                    description: staleDescription,
-                    target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}`,
-                  });
-                  core.setFailed(staleDescription);
-                  return;
-                }
-              }
-            }
+              : "Apply exactly one merge-ready label";
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -213,17 +79,4 @@ jobs:
             if (!authorized) {
               core.setFailed(description);
               return;
-            }
-
-            if (recoveryRequired) {
-              // This must be the final provider-visible mutation. Mergify does
-              // not reliably re-evaluate pull-request rules for a legacy
-              // commit-status update, so mint the one-shot trigger only after
-              // every other recovery condition is already true.
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: ["merge-requeue-trigger"],
-              });
             }

--- a/.github/workflows/authorize-merge-ready.yml
+++ b/.github/workflows/authorize-merge-ready.yml
@@ -111,16 +111,29 @@ jobs:
             // provider action failure recoverable, while the consumed trigger
             // prevents either marker from retrying the head by itself.
             if (authorized && recoveryRequired) {
-              // Mint the one-shot token while the pending status blocks
-              // Mergify (and, on first recovery, the dequeue marker does too).
-              // Every interruption point is fail-closed and recoverable by a
-              // fresh label event: addLabels is idempotent, and a surviving
-              // token remains blocked until the final success status.
+              // Clear any token left by a partial recovery while the pending
+              // status still blocks Mergify. A successful recovery mints a new
+              // token only after the exact-head success status is visible, so
+              // that label event can activate the queue rule immediately.
+              if (currentLabels.has("merge-requeue-trigger")) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: "merge-requeue-trigger",
+                  });
+                } catch (error) {
+                  if (error.status !== 404) {
+                    throw error;
+                  }
+                }
+              }
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                labels: ["merge-requeue-required", "merge-requeue-trigger"],
+                labels: ["merge-requeue-required"],
               });
               if (wasDequeued) {
                 try {
@@ -200,4 +213,17 @@ jobs:
             if (!authorized) {
               core.setFailed(description);
               return;
+            }
+
+            if (recoveryRequired) {
+              // This must be the final provider-visible mutation. Mergify does
+              // not reliably re-evaluate pull-request rules for a legacy
+              // commit-status update, so mint the one-shot trigger only after
+              // every other recovery condition is already true.
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ["merge-requeue-trigger"],
+              });
             }

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,51 +10,11 @@ merge_protections_settings:
         - label = merge-ready
         - label = merge-ready-mac
 
-# ``auto_merge_conditions`` admits a ready head initially, but Mergify keeps a
-# head in a terminal dequeued state after a batch outcome. The explicit queue
-# actions are the diagnosed re-entry edge: re-applying the same
-# ready label records ``merge-requeue-required``, clears the bot-owned
-# ``dequeued`` marker, and issues the one-shot ``merge-requeue-trigger`` label
-# in authorize-merge-ready.yml. These rules consume the trigger while queueing
-# the still-authorized exact head. The persistent, head-bound recovery marker
-# lets a fresh authorization mint another trigger after any partial provider
-# action failure. Neither marker alone can retry the head.
-pull_request_rules:
-  - name: enqueue an explicitly authorized no-Mac head
-    conditions:
-      - base = main
-      - -draft
-      - -from-fork
-      - label = merge-ready
-      - -label = merge-ready-mac
-      - label = merge-requeue-required
-      - label = merge-requeue-trigger
-      - -label = dequeued
-      - check-success = merge-ready-head
-    actions:
-      queue:
-        name: no-mac-batch
-      label:
-        remove:
-          - merge-requeue-trigger
-
-  - name: enqueue an explicitly authorized Mac head
-    conditions:
-      - base = main
-      - -draft
-      - -from-fork
-      - label = merge-ready-mac
-      - -label = merge-ready
-      - label = merge-requeue-required
-      - label = merge-requeue-trigger
-      - -label = dequeued
-      - check-success = merge-ready-head
-    actions:
-      queue:
-        name: mac-batch
-      label:
-        remove:
-          - merge-requeue-trigger
+# ``auto_merge_conditions`` admits a ready head initially. After a failed
+# batch, Mergify keeps the head in a terminal dequeued state; its supported
+# ``@mergifyio queue <queue-name>`` command resets that state and then enforces
+# the same exact-head queue conditions below. Ordinary pull-request rules do
+# not reset terminal queue state and must not be used as a requeue substitute.
 
 queue_rules:
   - name: no-mac-batch

--- a/docs/engineering/operations/path-aware-merge-queue.md
+++ b/docs/engineering/operations/path-aware-merge-queue.md
@@ -142,24 +142,15 @@ The queue contract lives in `.mergify.yml`:
 
 - label-gated `auto_merge_conditions`, so a ready label automatically enqueues
   the pull request without a second command or checkbox;
-- explicit, named queue actions provide the re-entry edge for a head left in a
-  terminal `dequeued` state after a diagnosed batch outcome. The marker
-  deliberately blocks automatic retry. To authorize one explicit retry of the
-  unchanged head, remove and re-apply its one ready label: the exact-head
-  authorization workflow verifies from the paginated issue-event history that
-  the latest ready-label event occurred strictly after the latest dequeue event,
-  then records a head-bound `merge-requeue-required` marker,
-  clears the stale provider marker, and issues a bot-owned, one-shot
-  `merge-requeue-trigger`. The matching action consumes the trigger while
-  queueing the head again. The persistent recovery marker allows another fresh
-  authorization to mint a replacement if the provider only partially executes
-  its actions. After clearing `dequeued`, the workflow reads the event history
-  again; if a newer dequeue raced the removal, it restores the circuit breaker
-  and fails authorization instead of publishing success. Removing `dequeued` alone
-  cannot reuse an earlier authorization. Do not manually manage either internal label, post a
-  queue command, push an empty commit, or remove `dequeued` by itself. The
-  provider does not expose a machine-readable dequeue-cause condition here, so
-  this fresh maintainer action is the diagnosis and retry boundary;
+- provider-supported recovery for a head left in terminal `dequeued` state.
+  Diagnose the candidate failure and fix the original pull request when the
+  failure is real. Once its exact-head checks are green and exactly one ready
+  label remains, issue `@mergifyio queue no-mac-batch` or
+  `@mergifyio queue mac-batch` in a PR comment. The command resets terminal
+  provider state but does not bypass `queue_conditions`; the authorized head
+  still runs the full combined candidate validation. Re-applying a ready label,
+  removing `dequeued`, pushing an empty commit, or adding a custom trigger label
+  does not reset terminal queue state and must not be used as a substitute;
 - an exact-head authorization status in both queue conditions, preventing a
   newly pushed head from racing asynchronous label revocation;
 - serial mode with one batch in flight, so speculative checks cannot multiply
@@ -224,10 +215,7 @@ Production activation is an owner operation and must happen in this order:
 2. Install the GitHub App for this repository only. Do not grant it access to
    unrelated repositories. Confirm its configuration check validates the
    default-branch policy.
-3. Create the `merge-ready`, `merge-ready-mac`,
-   `merge-requeue-required`, and `merge-requeue-trigger` labels. The last two
-   labels are internal, bot-owned recovery state and must not be applied
-   manually. Applying exactly one
+3. Create the `merge-ready` and `merge-ready-mac` labels. Applying exactly one
    is the explicit authorization to enter the matching queue; removing it
    dequeues the pull request. Applying both fails closed and enters neither.
    Fork pull requests are deliberately ineligible because composing fork code
@@ -236,9 +224,9 @@ Production activation is an owner operation and must happen in this order:
    maintainer branch before authorizing it for the batch queue.
 
 Maintainers who can manage labels are part of the queue's trusted control
-plane: they can already authorize a head by removing and re-applying its ready
-label. Repository label changes remain auditable, but the internal trigger is
-not a security boundary against a malicious maintainer.
+plane: they can authorize a head by applying its ready label. Requeue commands
+remain auditable and are restricted by the provider to users with sufficient
+repository permission.
 4. In the existing `main` protection, retain required contexts `tests`,
    `desktop-tests`, and `version-bump-guard`, required conversation resolution,
    administrator enforcement, and linear history. Disable only **Require
@@ -258,12 +246,12 @@ not a security boundary against a malicious maintainer.
 
 A head update never mutates PR-scoped labels asynchronously. Authorization is a
 commit status, so the prior `merge-ready-head=success` remains attached only to
-the old SHA and cannot admit the new head. Visible ready and recovery labels may
-remain, but the queue stays blocked until a maintainer completes review and
-removes and re-applies the one ready label, creating a fresh authorization event
-for the new exact SHA. Avoiding asynchronous label deletion removes the race in
-which a delayed synchronize job could erase authorization deliberately applied
-to the newer head.
+the old SHA and cannot admit the new head. A visible ready label may remain, but
+the queue stays blocked until a maintainer completes review and removes and
+re-applies that one ready label, creating a fresh authorization event for the
+new exact SHA. Avoiding asynchronous label deletion removes the race in which a
+delayed synchronize job could erase authorization deliberately applied to the
+newer head.
 
 Do not enable batching while strict up-to-date protection remains on, and do
 not weaken or remove any required context to make a batch move. A missing,

--- a/tests/test_mergify_batch_queue.py
+++ b/tests/test_mergify_batch_queue.py
@@ -15,8 +15,6 @@ REQUIRED_CHECKS = {
     "check-success = @github-actions/version-bump-guard",
 }
 HEAD_AUTHORIZATION = "check-success = merge-ready-head"
-REQUEUE_TRIGGER = "label = merge-requeue-trigger"
-REQUEUE_REQUIRED = "label = merge-requeue-required"
 LANE_CHECKS = {
     "no-mac-batch": "check-success = @github-actions/merge-lane-no-mac",
     "mac-batch": "check-success = @github-actions/merge-lane-mac",
@@ -64,45 +62,13 @@ def test_queue_revalidates_every_required_check_on_the_combined_batch():
         assert rule["queue_branch_prefix"] == "mergify/merge-queue/"
 
 
-def test_ready_labels_autoqueue_without_enabling_blind_retries():
+def test_ready_labels_autoqueue_without_unsupported_recovery_rules():
     config = _config()
     queues = _rules_by_name("queue_rules")
     auto_merge = config["merge_protections_settings"]["auto_merge_conditions"]
-    enqueue_rules = _rules_by_name("pull_request_rules")
 
     assert auto_merge == [{"or": ["label = merge-ready", "label = merge-ready-mac"]}]
-    assert set(enqueue_rules) == {
-        "enqueue an explicitly authorized no-Mac head",
-        "enqueue an explicitly authorized Mac head",
-    }
-
-    expected_enqueue = {
-        "enqueue an explicitly authorized no-Mac head": (
-            {"label = merge-ready", "-label = merge-ready-mac"},
-            "no-mac-batch",
-        ),
-        "enqueue an explicitly authorized Mac head": (
-            {"label = merge-ready-mac", "-label = merge-ready"},
-            "mac-batch",
-        ),
-    }
-    for name, (labels, queue_name) in expected_enqueue.items():
-        rule = enqueue_rules[name]
-        conditions = set(rule["conditions"])
-        assert labels <= conditions
-        assert {
-            "base = main",
-            "-draft",
-            "-from-fork",
-            REQUEUE_REQUIRED,
-            REQUEUE_TRIGGER,
-            "-label = dequeued",
-            HEAD_AUTHORIZATION,
-        } <= conditions
-        assert rule["actions"] == {
-            "queue": {"name": queue_name},
-            "label": {"remove": ["merge-requeue-trigger"]},
-        }
+    assert "pull_request_rules" not in config
 
     expected_labels = {
         "no-mac-batch": {"label = merge-ready", "-label = merge-ready-mac"},
@@ -155,8 +121,7 @@ def test_ready_authorization_is_bound_to_the_exact_head_commit():
     assert "merge-ready" in job["if"]
     assert "merge-ready-mac" in job["if"]
     assert job["permissions"] == {
-        "issues": "write",
-        "pull-requests": "write",
+        "pull-requests": "read",
         "statuses": "write",
     }
 
@@ -170,15 +135,9 @@ def test_ready_authorization_is_bound_to_the_exact_head_commit():
     assert "GITHUB_RUN_ATTEMPT" in script
     assert "github.rest.pulls.get" in script
     assert "livePull.head.sha === context.payload.pull_request.head.sha" in script
-    assert 'currentLabels.has("dequeued")' in script
-    assert 'name: "dequeued"' in script
-    assert 'labels: ["merge-requeue-required"]' in script
-    assert 'labels: ["merge-requeue-trigger"]' in script
-    assert "github.paginate" in script
-    assert "github.rest.issues.listEvents" in script
-    assert "readyLabeledAt > dequeuedLabeledAt" in script
-    assert "authorized &&" in script
-    assert "error.status !== 404" in script
+    assert "github.paginate" not in script
+    assert "github.rest.issues" not in script
+    assert "merge-requeue" not in script
     assert "checkout" not in script.lower()
 
 
@@ -190,12 +149,6 @@ def _run_authorization_script(
     live_head: str = "head-sha",
     fail_status_call: int | None = None,
     fail_get: bool = False,
-    fail_add_call: int | None = None,
-    remove_error_status: int | None = None,
-    ready_event_at: str = "2026-09-01T04:01:00Z",
-    dequeue_event_at: str = "2026-09-01T04:00:00Z",
-    late_dequeue_event_at: str | None = None,
-    fail_events: bool = False,
 ) -> dict[str, object]:
     """Execute the exact github-script body against deterministic API mocks."""
 
@@ -212,20 +165,12 @@ def _run_authorization_script(
             "liveHead": live_head,
             "failStatusCall": fail_status_call,
             "failGet": fail_get,
-            "failAddCall": fail_add_call,
-            "removeErrorStatus": remove_error_status,
-            "readyEventAt": ready_event_at,
-            "dequeueEventAt": dequeue_event_at,
-            "lateDequeueEventAt": late_dequeue_event_at,
-            "failEvents": fail_events,
         }
     )
     harness = f"""
 const scenario = {scenario};
 const calls = [];
 let statusCalls = 0;
-let addCalls = 0;
-let eventCalls = 0;
 process.env.GITHUB_RUN_ATTEMPT = String(scenario.runAttempt);
 const context = {{
   repo: {{ owner: "owner", repo: "repo" }},
@@ -237,48 +182,23 @@ const context = {{
   }},
 }};
 const github = {{
-  paginate: async () => {{
-    calls.push(["events"]);
-    eventCalls += 1;
-    if (scenario.failEvents) throw Object.assign(new Error("events failure"), {{ status: 500 }});
-    const dequeueAt = eventCalls > 1 && scenario.lateDequeueEventAt
-      ? scenario.lateDequeueEventAt
-      : scenario.dequeueEventAt;
-    return [
-      {{ event: "labeled", label: {{ name: scenario.eventLabel }}, created_at: scenario.readyEventAt }},
-      {{ event: "labeled", label: {{ name: "dequeued" }}, created_at: dequeueAt }},
-    ];
-  }},
   rest: {{
-  pulls: {{ get: async () => {{
-    calls.push(["get"]);
-    if (scenario.failGet) throw Object.assign(new Error("get failure"), {{ status: 500 }});
-    return {{ data: {{
-      head: {{ sha: scenario.liveHead }},
-      labels: scenario.labels.map((name) => ({{ name }})),
-    }} }};
-  }} }},
-  repos: {{ createCommitStatus: async (args) => {{
-    statusCalls += 1;
-    calls.push(["status", args.state]);
-    if (scenario.failStatusCall === statusCalls) throw Object.assign(new Error("status failure"), {{ status: 500 }});
-  }} }},
-  issues: {{
-    removeLabel: async (args) => {{
-      calls.push(["remove", args.name]);
-      if (scenario.removeErrorStatus) throw Object.assign(new Error("remove failure"), {{ status: scenario.removeErrorStatus }});
-    }},
-    addLabels: async (args) => {{
-      addCalls += 1;
-      calls.push(["add", args.labels]);
-      if (scenario.failAddCall === addCalls) throw Object.assign(new Error("add failure"), {{ status: 500 }});
-    }},
+    pulls: {{ get: async () => {{
+      calls.push(["get"]);
+      if (scenario.failGet) throw new Error("get failure");
+      return {{ data: {{
+        head: {{ sha: scenario.liveHead }},
+        labels: scenario.labels.map((name) => ({{ name }})),
+      }} }};
+    }} }},
+    repos: {{ createCommitStatus: async (args) => {{
+      statusCalls += 1;
+      calls.push(["status", args.state]);
+      if (scenario.failStatusCall === statusCalls) throw new Error("status failure");
+    }} }},
   }},
-}} }};
-const core = {{
-  setFailed: (message) => calls.push(["failed", message]),
-  notice: (message) => calls.push(["notice", message]),
 }};
+const core = {{ setFailed: (message) => calls.push(["failed", message]) }};
 (async () => {{
   try {{
     await (async () => {{
@@ -299,30 +219,7 @@ const core = {{
     return {"calls": json.loads(completed.stdout)}
 
 
-def test_dequeued_head_is_blocked_before_marker_removal_then_reauthorized():
-    result = _run_authorization_script(labels=["merge-ready-mac", "dequeued"])
-    operations = [call[0] for call in result["calls"]]
-
-    assert operations == [
-        "status",
-        "get",
-        "events",
-        "add",
-        "remove",
-        "notice",
-        "events",
-        "status",
-        "add",
-    ]
-    assert [call[1] for call in result["calls"] if call[0] == "status"] == [
-        "pending",
-        "success",
-    ]
-    assert result["calls"][3] == ["add", ["merge-requeue-required"]]
-    assert result["calls"][-1] == ["add", ["merge-requeue-trigger"]]
-
-
-def test_initial_authorization_does_not_issue_a_requeue_trigger():
+def test_initial_authorization_publishes_success_for_the_exact_head():
     result = _run_authorization_script(labels=["merge-ready-mac"])
 
     assert result["calls"] == [
@@ -332,222 +229,52 @@ def test_initial_authorization_does_not_issue_a_requeue_trigger():
     ]
 
 
-def test_consumed_trigger_can_be_reissued_from_persistent_recovery_marker():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "merge-requeue-required"]
-    )
-
-    assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["add", ["merge-requeue-required"]],
-        ["status", "success"],
-        ["add", ["merge-requeue-trigger"]],
-    ]
-
-
-def test_status_failure_cannot_remove_the_dequeue_circuit_breaker():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], fail_status_call=1
-    )
-
-    assert result["calls"] == [
+def test_status_or_live_pull_failure_remains_fail_closed():
+    assert _run_authorization_script(labels=["merge-ready-mac"], fail_status_call=1)[
+        "calls"
+    ] == [
         ["status", "pending"],
         ["threw", "status failure"],
     ]
-
-
-def test_delayed_ready_event_cannot_authorize_a_later_dequeue():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"],
-        ready_event_at="2026-09-01T04:00:00Z",
-        dequeue_event_at="2026-09-01T04:01:00Z",
-    )
-
-    assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["status", "failure"],
-        ["failed", "Re-apply merge-ready after the latest dequeue"],
-    ]
-
-
-def test_recovery_event_lookup_failure_remains_pending():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], fail_events=True
-    )
-
-    assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["threw", "events failure"],
-    ]
-
-
-def test_live_pull_failure_remains_blocked_by_pending_status():
-    result = _run_authorization_script(labels=["merge-ready-mac"], fail_get=True)
-
-    assert result["calls"] == [
+    assert _run_authorization_script(labels=["merge-ready-mac"], fail_get=True)[
+        "calls"
+    ] == [
         ["status", "pending"],
         ["get"],
         ["threw", "get failure"],
     ]
 
 
-def test_persistent_marker_failure_keeps_dequeue_circuit_breaker():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], fail_add_call=1
-    )
+def test_historical_authorization_rerun_cannot_replay_the_label_event():
+    result = _run_authorization_script(labels=["merge-ready-mac"], run_attempt=2)
 
     assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["add", ["merge-requeue-required"]],
-        ["threw", "add failure"],
-    ]
-
-
-def test_dequeue_removal_failure_keeps_recovery_blocked_and_retryable():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], remove_error_status=500
-    )
-
-    assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["add", ["merge-requeue-required"]],
-        ["remove", "dequeued"],
-        ["threw", "remove failure"],
-    ]
-
-
-def test_concurrent_marker_removal_proceeds_to_final_authorization():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], remove_error_status=404
-    )
-
-    assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["add", ["merge-requeue-required"]],
-        ["remove", "dequeued"],
-        ["events"],
-        ["status", "success"],
-        ["add", ["merge-requeue-trigger"]],
-    ]
-
-
-def test_new_dequeue_between_check_and_removal_restores_circuit_breaker():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"],
-        late_dequeue_event_at="2026-09-01T04:02:00Z",
-    )
-
-    assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["add", ["merge-requeue-required"]],
-        ["remove", "dequeued"],
         [
-            "notice",
-            "Cleared stale dequeued state before re-authorizing merge-ready-mac.",
-        ],
-        ["events"],
-        ["add", ["dequeued"]],
-        ["status", "failure"],
-        ["failed", "Re-apply merge-ready after the latest dequeue"],
-    ]
-
-
-def test_activation_docs_provision_the_internal_requeue_label():
-    docs = (ROOT / "docs/engineering/operations/path-aware-merge-queue.md").read_text()
-
-    assert "Create the `merge-ready`, `merge-ready-mac`," in docs
-    assert "`merge-requeue-required`, and `merge-requeue-trigger` labels" in docs
-    assert "internal, bot-owned" in docs
-
-
-def test_final_status_failure_leaves_trigger_blocked_and_retryable():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], fail_status_call=2
-    )
-
-    assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["add", ["merge-requeue-required"]],
-        ["remove", "dequeued"],
-        [
-            "notice",
-            "Cleared stale dequeued state before re-authorizing merge-ready-mac.",
-        ],
-        ["events"],
-        ["status", "success"],
-        ["threw", "status failure"],
-    ]
-
-
-def test_activation_trigger_is_minted_only_after_exact_head_success():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], fail_add_call=2
-    )
-
-    assert result["calls"][-3:] == [
-        ["status", "success"],
-        ["add", ["merge-requeue-trigger"]],
-        ["threw", "add failure"],
-    ]
-
-
-def test_stale_trigger_is_removed_before_fresh_activation_event():
-    result = _run_authorization_script(
-        labels=[
-            "merge-ready-mac",
-            "merge-requeue-required",
-            "merge-requeue-trigger",
+            "failed",
+            "A merge-ready authorization event cannot be replayed; remove and re-apply the ready label.",
         ]
-    )
-
-    assert result["calls"] == [
-        ["status", "pending"],
-        ["get"],
-        ["events"],
-        ["remove", "merge-requeue-trigger"],
-        ["add", ["merge-requeue-required"]],
-        ["status", "success"],
-        ["add", ["merge-requeue-trigger"]],
     ]
 
 
-def test_historical_authorization_rerun_cannot_clear_a_newer_dequeue():
-    result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], run_attempt=2
-    )
-
-    assert result["calls"][0][0] == "failed"
-    assert all(
-        call[0] not in {"get", "status", "remove", "add"} for call in result["calls"]
-    )
-
-
-def test_stale_head_or_double_ready_labels_cannot_clear_dequeue():
+def test_stale_head_or_double_ready_labels_fail_authorization():
     for labels, live_head in (
-        (["merge-ready-mac", "dequeued"], "new-head"),
-        (["merge-ready", "merge-ready-mac", "dequeued"], "head-sha"),
+        (["merge-ready-mac"], "new-head"),
+        (["merge-ready", "merge-ready-mac"], "head-sha"),
     ):
         result = _run_authorization_script(labels=labels, live_head=live_head)
-        assert [call[0] for call in result["calls"]] == [
-            "status",
-            "get",
-            "status",
-            "failed",
+        assert result["calls"] == [
+            ["status", "pending"],
+            ["get"],
+            ["status", "failure"],
+            ["failed", "Apply exactly one merge-ready label"],
         ]
-        assert result["calls"][2] == ["status", "failure"]
+
+
+def test_operations_guide_uses_provider_supported_terminal_requeue():
+    docs = (ROOT / "docs/engineering/operations/path-aware-merge-queue.md").read_text()
+
+    assert "@mergifyio queue no-mac-batch" in docs
+    assert "@mergifyio queue mac-batch" in docs
+    assert "does not bypass `queue_conditions`" in docs
+    assert "merge-requeue-trigger" not in docs
+    assert "merge-requeue-required" not in docs

--- a/tests/test_mergify_batch_queue.py
+++ b/tests/test_mergify_batch_queue.py
@@ -172,7 +172,8 @@ def test_ready_authorization_is_bound_to_the_exact_head_commit():
     assert "livePull.head.sha === context.payload.pull_request.head.sha" in script
     assert 'currentLabels.has("dequeued")' in script
     assert 'name: "dequeued"' in script
-    assert 'labels: ["merge-requeue-required", "merge-requeue-trigger"]' in script
+    assert 'labels: ["merge-requeue-required"]' in script
+    assert 'labels: ["merge-requeue-trigger"]' in script
     assert "github.paginate" in script
     assert "github.rest.issues.listEvents" in script
     assert "readyLabeledAt > dequeuedLabeledAt" in script
@@ -189,7 +190,7 @@ def _run_authorization_script(
     live_head: str = "head-sha",
     fail_status_call: int | None = None,
     fail_get: bool = False,
-    fail_add: bool = False,
+    fail_add_call: int | None = None,
     remove_error_status: int | None = None,
     ready_event_at: str = "2026-09-01T04:01:00Z",
     dequeue_event_at: str = "2026-09-01T04:00:00Z",
@@ -211,7 +212,7 @@ def _run_authorization_script(
             "liveHead": live_head,
             "failStatusCall": fail_status_call,
             "failGet": fail_get,
-            "failAdd": fail_add,
+            "failAddCall": fail_add_call,
             "removeErrorStatus": remove_error_status,
             "readyEventAt": ready_event_at,
             "dequeueEventAt": dequeue_event_at,
@@ -223,6 +224,7 @@ def _run_authorization_script(
 const scenario = {scenario};
 const calls = [];
 let statusCalls = 0;
+let addCalls = 0;
 let eventCalls = 0;
 process.env.GITHUB_RUN_ATTEMPT = String(scenario.runAttempt);
 const context = {{
@@ -262,13 +264,14 @@ const github = {{
     if (scenario.failStatusCall === statusCalls) throw Object.assign(new Error("status failure"), {{ status: 500 }});
   }} }},
   issues: {{
-    removeLabel: async () => {{
-      calls.push(["remove"]);
+    removeLabel: async (args) => {{
+      calls.push(["remove", args.name]);
       if (scenario.removeErrorStatus) throw Object.assign(new Error("remove failure"), {{ status: scenario.removeErrorStatus }});
     }},
     addLabels: async (args) => {{
+      addCalls += 1;
       calls.push(["add", args.labels]);
-      if (scenario.failAdd) throw Object.assign(new Error("add failure"), {{ status: 500 }});
+      if (scenario.failAddCall === addCalls) throw Object.assign(new Error("add failure"), {{ status: 500 }});
     }},
   }},
 }} }};
@@ -309,15 +312,14 @@ def test_dequeued_head_is_blocked_before_marker_removal_then_reauthorized():
         "notice",
         "events",
         "status",
+        "add",
     ]
     assert [call[1] for call in result["calls"] if call[0] == "status"] == [
         "pending",
         "success",
     ]
-    assert result["calls"][3] == [
-        "add",
-        ["merge-requeue-required", "merge-requeue-trigger"],
-    ]
+    assert result["calls"][3] == ["add", ["merge-requeue-required"]]
+    assert result["calls"][-1] == ["add", ["merge-requeue-trigger"]]
 
 
 def test_initial_authorization_does_not_issue_a_requeue_trigger():
@@ -339,8 +341,9 @@ def test_consumed_trigger_can_be_reissued_from_persistent_recovery_marker():
         ["status", "pending"],
         ["get"],
         ["events"],
-        ["add", ["merge-requeue-required", "merge-requeue-trigger"]],
+        ["add", ["merge-requeue-required"]],
         ["status", "success"],
+        ["add", ["merge-requeue-trigger"]],
     ]
 
 
@@ -394,21 +397,21 @@ def test_live_pull_failure_remains_blocked_by_pending_status():
     ]
 
 
-def test_trigger_failure_keeps_both_queue_circuit_breakers():
+def test_persistent_marker_failure_keeps_dequeue_circuit_breaker():
     result = _run_authorization_script(
-        labels=["merge-ready-mac", "dequeued"], fail_add=True
+        labels=["merge-ready-mac", "dequeued"], fail_add_call=1
     )
 
     assert result["calls"] == [
         ["status", "pending"],
         ["get"],
         ["events"],
-        ["add", ["merge-requeue-required", "merge-requeue-trigger"]],
+        ["add", ["merge-requeue-required"]],
         ["threw", "add failure"],
     ]
 
 
-def test_marker_failure_leaves_trigger_blocked_and_retryable():
+def test_dequeue_removal_failure_keeps_recovery_blocked_and_retryable():
     result = _run_authorization_script(
         labels=["merge-ready-mac", "dequeued"], remove_error_status=500
     )
@@ -417,8 +420,8 @@ def test_marker_failure_leaves_trigger_blocked_and_retryable():
         ["status", "pending"],
         ["get"],
         ["events"],
-        ["add", ["merge-requeue-required", "merge-requeue-trigger"]],
-        ["remove"],
+        ["add", ["merge-requeue-required"]],
+        ["remove", "dequeued"],
         ["threw", "remove failure"],
     ]
 
@@ -432,10 +435,11 @@ def test_concurrent_marker_removal_proceeds_to_final_authorization():
         ["status", "pending"],
         ["get"],
         ["events"],
-        ["add", ["merge-requeue-required", "merge-requeue-trigger"]],
-        ["remove"],
+        ["add", ["merge-requeue-required"]],
+        ["remove", "dequeued"],
         ["events"],
         ["status", "success"],
+        ["add", ["merge-requeue-trigger"]],
     ]
 
 
@@ -449,8 +453,8 @@ def test_new_dequeue_between_check_and_removal_restores_circuit_breaker():
         ["status", "pending"],
         ["get"],
         ["events"],
-        ["add", ["merge-requeue-required", "merge-requeue-trigger"]],
-        ["remove"],
+        ["add", ["merge-requeue-required"]],
+        ["remove", "dequeued"],
         [
             "notice",
             "Cleared stale dequeued state before re-authorizing merge-ready-mac.",
@@ -479,8 +483,8 @@ def test_final_status_failure_leaves_trigger_blocked_and_retryable():
         ["status", "pending"],
         ["get"],
         ["events"],
-        ["add", ["merge-requeue-required", "merge-requeue-trigger"]],
-        ["remove"],
+        ["add", ["merge-requeue-required"]],
+        ["remove", "dequeued"],
         [
             "notice",
             "Cleared stale dequeued state before re-authorizing merge-ready-mac.",
@@ -488,6 +492,38 @@ def test_final_status_failure_leaves_trigger_blocked_and_retryable():
         ["events"],
         ["status", "success"],
         ["threw", "status failure"],
+    ]
+
+
+def test_activation_trigger_is_minted_only_after_exact_head_success():
+    result = _run_authorization_script(
+        labels=["merge-ready-mac", "dequeued"], fail_add_call=2
+    )
+
+    assert result["calls"][-3:] == [
+        ["status", "success"],
+        ["add", ["merge-requeue-trigger"]],
+        ["threw", "add failure"],
+    ]
+
+
+def test_stale_trigger_is_removed_before_fresh_activation_event():
+    result = _run_authorization_script(
+        labels=[
+            "merge-ready-mac",
+            "merge-requeue-required",
+            "merge-requeue-trigger",
+        ]
+    )
+
+    assert result["calls"] == [
+        ["status", "pending"],
+        ["get"],
+        ["events"],
+        ["remove", "merge-requeue-trigger"],
+        ["add", ["merge-requeue-required"]],
+        ["status", "success"],
+        ["add", ["merge-requeue-trigger"]],
     ]
 
 


### PR DESCRIPTION
## Summary
- remove the unsupported custom label/rule path for recovering terminally dequeued pull requests
- keep initial queue entry bound to an exact-head authorization status with read-only pull-request access
- document the provider-supported explicit queue command for a diagnosed retry while preserving all queue conditions

## Why
Live validation showed that label mutations and ordinary pull-request rules do not reset terminal merge-queue state. The supported queue command does reset that state and then evaluates the existing exact-head, lane, and required-check conditions, so recovery stays explicit and fail-closed without custom bot-owned markers.

## Scope
Merge-queue recovery configuration, exact-head authorization permissions, operational guidance, and focused executable contracts. No batch policy, required-check changes, CI matrices, product code, automatic retry, manual merge, rebase, or auto-merge.

## Verification
- `uv run --python 3.11 pytest -q tests/test_mergify_batch_queue.py` (12 passed)
- `uv run ruff check tests/test_mergify_batch_queue.py`
- `uv run ruff format --check tests/test_mergify_batch_queue.py`
- `git diff --check`

## Live evidence
On a dequeued exact head, removing/re-applying the ready label and an ordinary rule trigger returned to terminal dequeue. Posting the supported queue command changed the same head to queued without bypassing its queue conditions.