### PR TITLE
fix(mac): overlap dictation model page-in with the utterance itself

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationController.swift
@@ -179,6 +179,10 @@ final class DictationController {
     /// running cannot let its stale continuation start the microphone later.
     private var beginRecordingTask: Task<Void, Never>?
     private var beginRecordingRequestID: UUID?
+    /// The record-start page-in probe (see ``startRecordStartWarmup()``),
+    /// retained so ``disable()`` and a model change can cancel it.
+    private var recordStartWarmupTask: Task<Void, Never>?
+    private var recordStartWarmupRequestID: UUID?
     /// The in-flight prewarm, retained so ``disable()`` and a hotkey press
     /// can cancel it and so concurrent triggers join it (single-flight)
     /// instead of stacking probes in the engine's serial STT lane.
@@ -531,6 +535,9 @@ final class DictationController {
         beginRecordingTask?.cancel()
         beginRecordingTask = nil
         beginRecordingRequestID = nil
+        recordStartWarmupTask?.cancel()
+        recordStartWarmupTask = nil
+        recordStartWarmupRequestID = nil
         prewarmTask?.cancel()
         prewarmTask = nil
         prewarmRequestID = nil
@@ -552,6 +559,9 @@ final class DictationController {
         beginRecordingTask?.cancel()
         beginRecordingTask = nil
         beginRecordingRequestID = nil
+        recordStartWarmupTask?.cancel()
+        recordStartWarmupTask = nil
+        recordStartWarmupRequestID = nil
         if phase == .starting || phase == .recording {
             if let testingRecorderCancel {
                 testingRecorderCancel()
@@ -762,11 +772,15 @@ final class DictationController {
         guard server.isVoiceLaneReady(for: modelAlias) else {
             return false
         }
+        return await sendSilentWarmupProbe(alias: modelAlias)
+    }
+
+    private func sendSilentWarmupProbe(alias: String) async -> Bool {
         if let testingWarmup { return await testingWarmup() }
         do {
             _ = try await client.transcribe(
                 audioData: Self.silentProbeWAV,
-                model: modelAlias,
+                model: alias,
                 context: nil,
                 port: server.activePort,
                 bearer: server.activeBearer
@@ -779,8 +793,37 @@ final class DictationController {
             // Not user-facing — the cost of a failed probe is only that the
             // first real dictation pays the weight load again — but leave a
             // trace so a recurring failure is diagnosable.
-            NSLog("Dictation prewarm probe failed for %@: %@", modelAlias, String(describing: error))
+            NSLog("Dictation prewarm probe failed for %@: %@", alias, String(describing: error))
             return false
+        }
+    }
+
+    /// Fired alongside a successful `startCapture()`. After hours of idle,
+    /// macOS pages the resident STT weights out to disk even though the
+    /// process never unloaded them, and that page-in used to be paid at the
+    /// head of the first real transcription. Probing while the user is still
+    /// speaking overlaps the swap-in with the utterance itself. The engine
+    /// serialises transcriptions, so on a warm engine the probe costs one
+    /// ~0.2 s silence decode; on a cold one it is exactly the work the
+    /// utterance would otherwise pay after the recording stopped.
+    private func startRecordStartWarmup() {
+        // One probe per recording; an enable-time prewarm already in flight
+        // is doing this same page-in.
+        guard recordStartWarmupTask == nil, prewarmTask == nil else { return }
+        let alias = modelAlias
+        let requestID = UUID()
+        recordStartWarmupRequestID = requestID
+        recordStartWarmupTask = Task { [weak self] in
+            if self?.server.isVoiceLaneReady(for: alias) == true {
+                _ = await self?.sendSilentWarmupProbe(alias: alias)
+            }
+            // Only the flight that still owns the slot may clear it — a
+            // cancelled probe finishing late must not free the slot a newer
+            // recording claimed.
+            if let self, self.recordStartWarmupRequestID == requestID {
+                self.recordStartWarmupTask = nil
+                self.recordStartWarmupRequestID = nil
+            }
         }
     }
 
@@ -916,6 +959,7 @@ final class DictationController {
         phase = .starting
         hud.show(.starting)
         startTicking()
+        startRecordStartWarmup()
     }
 
     /// Fresh cache truth used at the recording boundary. Internal so the
@@ -1124,6 +1168,7 @@ final class DictationController {
     /// CoreAudio work behind for the next MainActor test.
     internal var testingHasActiveTicker: Bool { tickTimer?.isValid == true }
     internal var testingHasRecorder: Bool { recorderStorage != nil }
+    internal var testingHasRecordStartWarmup: Bool { recordStartWarmupTask != nil }
 
     // MARK: - Text
 

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -15,6 +15,11 @@ struct DictationTests {
         var cached = true
     }
 
+    @MainActor
+    private final class CancellationFlag {
+        var observed = false
+    }
+
     // MARK: - Transcript tidying
 
     /// The trailing period is stripped because a dictated fragment usually
@@ -917,6 +922,7 @@ struct DictationTests {
     @Test("disable cancels an in-flight record-start probe")
     func disableCancelsRecordStartWarmup() async {
         var continuation: CheckedContinuation<Bool, Never>?
+        let probeCancellation = CancellationFlag()
         var recorderStartCount = 0
         let entry = cachedAudioEntry(alias: "whisper-small")
         let controller = DictationController(
@@ -934,7 +940,11 @@ struct DictationTests {
             ),
             testingPrewarm: { true },
             testingWarmup: {
-                await withCheckedContinuation { continuation = $0 }
+                await withTaskCancellationHandler {
+                    await withCheckedContinuation { continuation = $0 }
+                } onCancel: {
+                    Task { @MainActor in probeCancellation.observed = true }
+                }
             },
             testingHotkeyStart: { true },
             testingRecorderStart: { recorderStartCount += 1 },
@@ -945,9 +955,14 @@ struct DictationTests {
         controller.toggleFromUI()
         while continuation == nil { await Task.yield() }
         #expect(controller.testingHasRecordStartWarmup)
+        #expect(!probeCancellation.observed)
 
         controller.disable()
         #expect(!controller.testingHasRecordStartWarmup)
+        // Cancellation must actually reach the suspended probe — clearing
+        // the task slot alone would leave the request running against the
+        // engine after the feature turned off.
+        while !probeCancellation.observed { await Task.yield() }
 
         // A late probe completion must not resurrect any warmup state.
         continuation?.resume(returning: true)

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -867,6 +867,7 @@ struct DictationTests {
     @Test("record start fires the page-in probe while capture is running")
     func recordStartFiresConcurrentWarmupProbe() async {
         var warmupCount = 0
+        var warmupContinuation: CheckedContinuation<Bool, Never>?
         var recorderStartCount = 0
         let entry = cachedAudioEntry(alias: "whisper-small")
         let controller = DictationController(
@@ -885,7 +886,7 @@ struct DictationTests {
             testingPrewarm: { true },
             testingWarmup: {
                 warmupCount += 1
-                return true
+                return await withCheckedContinuation { warmupContinuation = $0 }
             },
             testingHotkeyStart: { true },
             testingRecorderStart: { recorderStartCount += 1 },
@@ -896,11 +897,18 @@ struct DictationTests {
         #expect(warmupCount == 0, "the test prewarm seam owns enable-time preparation")
 
         controller.toggleFromUI()
-        while recorderStartCount == 0 { await Task.yield() }
-        while warmupCount == 0 { await Task.yield() }
+        while warmupContinuation == nil { await Task.yield() }
 
-        #expect(warmupCount == 1)
+        // The probe is suspended mid-flight, yet capture already started and
+        // the phase advanced — the page-in genuinely overlaps the recording
+        // instead of gating it.
+        #expect(recorderStartCount == 1)
         #expect(controller.phase == .starting, "the probe must not block or advance the capture phase")
+        #expect(controller.testingHasRecordStartWarmup)
+
+        warmupContinuation?.resume(returning: true)
+        while controller.testingHasRecordStartWarmup { await Task.yield() }
+        #expect(warmupCount == 1)
 
         controller.disable()
     }

--- a/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DictationTests.swift
@@ -864,6 +864,91 @@ struct DictationTests {
     }
 
     @MainActor
+    @Test("record start fires the page-in probe while capture is running")
+    func recordStartFiresConcurrentWarmupProbe() async {
+        var warmupCount = 0
+        var recorderStartCount = 0
+        let entry = cachedAudioEntry(alias: "whisper-small")
+        let controller = DictationController(
+            server: ServerManager(
+                testingState: .ready(alias: "whisper-small"),
+                binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
+            ),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingPrewarm: { true },
+            testingWarmup: {
+                warmupCount += 1
+                return true
+            },
+            testingHotkeyStart: { true },
+            testingRecorderStart: { recorderStartCount += 1 },
+            audioCatalogLoader: { _ in [entry] }
+        )
+
+        await controller.enable()
+        #expect(warmupCount == 0, "the test prewarm seam owns enable-time preparation")
+
+        controller.toggleFromUI()
+        while recorderStartCount == 0 { await Task.yield() }
+        while warmupCount == 0 { await Task.yield() }
+
+        #expect(warmupCount == 1)
+        #expect(controller.phase == .starting, "the probe must not block or advance the capture phase")
+
+        controller.disable()
+    }
+
+    @MainActor
+    @Test("disable cancels an in-flight record-start probe")
+    func disableCancelsRecordStartWarmup() async {
+        var continuation: CheckedContinuation<Bool, Never>?
+        var recorderStartCount = 0
+        let entry = cachedAudioEntry(alias: "whisper-small")
+        let controller = DictationController(
+            server: ServerManager(
+                testingState: .ready(alias: "whisper-small"),
+                binaryPath: Self.tempDirectory().appendingPathComponent("rapid-mlx")
+            ),
+            testingEnabled: true,
+            testingModelAlias: "whisper-small",
+            testingReadiness: .init(
+                microphone: true,
+                accessibility: true,
+                modelSelected: true,
+                modelOnDisk: true
+            ),
+            testingPrewarm: { true },
+            testingWarmup: {
+                await withCheckedContinuation { continuation = $0 }
+            },
+            testingHotkeyStart: { true },
+            testingRecorderStart: { recorderStartCount += 1 },
+            audioCatalogLoader: { _ in [entry] }
+        )
+
+        await controller.enable()
+        controller.toggleFromUI()
+        while continuation == nil { await Task.yield() }
+        #expect(controller.testingHasRecordStartWarmup)
+
+        controller.disable()
+        #expect(!controller.testingHasRecordStartWarmup)
+
+        // A late probe completion must not resurrect any warmup state.
+        continuation?.resume(returning: true)
+        for _ in 0..<10 { await Task.yield() }
+        #expect(!controller.testingHasRecordStartWarmup)
+        #expect(controller.phase == .off)
+    }
+
+    @MainActor
     @Test("disabling during model warmup cannot register a stale hotkey")
     func disableDuringWarmupDoesNotArmHotkey() async {
         var continuation: CheckedContinuation<Bool, Never>?


### PR DESCRIPTION
## Why

After hours of idle, the first dictation is dramatically slower than every one after it. Diagnosis (2026-08-31, verified on the M2 Pro mini): macOS pages the resident STT weights out to disk while the app idles — the process never unloads them, so keeping the model "loaded" does not help, and the page-in cost lands at the head of the first real transcription, after the user has already stopped speaking.

Prior art check: superwhisper only offers a "Voice Model Active Duration" unload-timer knob and OpenSuperWhisper pins ~1GB permanently — neither addresses paging. Neither hides the reload inside the recording window.

## Fix

Fire the existing silent warmup probe (0.2s of silence, already used at enable time) concurrently with capture start. The page-in now overlaps with the seconds the user spends speaking instead of delaying the transcription of the finished utterance. The engine serialises transcriptions, so:

- warm engine: the probe costs one tiny silence decode that finishes long before the recording stops;
- cold engine: the probe performs exactly the page-in the utterance would otherwise pay afterwards.

The probe is single-flight per recording (UUID-guarded slot, same idiom as the sibling prewarm/transcribe tasks), skipped while an enable-time prewarm is already loading the same weights, and cancelled by `disable()` and model changes.

## Testing

- `swift build` clean; `swift test --filter DictationTests` 45/45 pass (2 new tests: probe fires concurrently without blocking the capture phase; `disable()` cancels an in-flight probe and a late completion cannot resurrect state).
- Full `swift test`: 3272 tests; 5 unrelated timing-sensitive tests (SSE coalescer, golden-chat timeouts, capability-probe bound) flaked under full-suite parallel load and pass in isolation — no dictation involvement.
- The long-idle cold path itself takes hours to reproduce by nature; verified by construction (the probe request is byte-identical to the enable-time warmup that already forces weight residency). Overnight dogfood on Studio recommended post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
