### PR TITLE
fix(tests): pin prefix-eviction stub to the utilization-ratchet generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,7 @@ jobs:
             tests/test_mllm_cache.py \
             tests/test_memory_cache.py \
             tests/test_metal_memory_budget.py \
+            tests/test_prefix_cache_eviction.py \
             tests/test_optimizations.py \
             tests/test_batching.py \
             tests/test_continuous_batching.py \

--- a/tests/test_prefix_cache_eviction.py
+++ b/tests/test_prefix_cache_eviction.py
@@ -260,6 +260,13 @@ def _make_scheduler_with_stub_cache(stub_cache):
     sched.num_prefix_cache_pressure_evictions = 0
     sched._metal_cap_bytes = 0
     sched._metal_cap_bytes_resolved = True
+    # The resolved-cap short-circuit also checks the process-wide
+    # utilization-ratchet generation (#2858); pin the stub to the current
+    # generation so the pre-resolved cap of 0 keeps meaning "disabled"
+    # instead of tripping a re-resolve against the missing attribute.
+    from vllm_mlx.memory_budget import process_utilization_floor
+
+    _, sched._metal_cap_floor_generation = process_utilization_floor()
     return sched
 
 


### PR DESCRIPTION
## Why

#2880 made `_resolve_metal_cap_bytes` re-resolve whenever the process-wide utilization-ratchet generation moves. The prefix-cache-eviction tests build their Scheduler via `__new__` and pre-resolve the cap to 0, but never set the generation attribute the new short-circuit reads — so all four pressure-eviction tests fail with `AttributeError: 'Scheduler' object has no attribute '_metal_cap_floor_generation'` on any full Apple-silicon pytest run of current main.

CI stayed green because the file is `requires_mlx` (skipped on the Linux full-suite lane) **and** absent from the Apple-silicon whitelist — a lane gap, exactly the class the 0.13.2 lane-parity action item covers.

## Fix

- Pin the stub to the current ratchet generation (`process_utilization_floor()`), preserving the helper's documented contract of "set the attributes `evict_prefix_cache_under_pressure` reads" and keeping the pre-resolved cap of 0 meaning *disabled*.
- Add `tests/test_prefix_cache_eviction.py` to the Apple-silicon CI whitelist so the file runs somewhere again.

## Testing

`python3.12 -m pytest tests/test_prefix_cache_eviction.py` — 15/15 pass (4 failed before on main). The 9 other full-suite failures seen alongside were a stale local `mlx-vlm` (0.6.3 vs pinned 0.6.17), reproduced and cleared by upgrading — 121/121 pass across the affected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)