### PR TITLE
test(mac): retry only unaccepted attachment drags

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -2483,7 +2483,10 @@ final class AutosizingTextView: NSTextView {
     }
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        if Self.containsFileURLs(sender.draggingPasteboard) { return .copy }
+        if Self.containsFileURLs(sender.draggingPasteboard) {
+            recordUITestFileDrop("entered")
+            return .copy
+        }
         return super.draggingEntered(sender)
     }
 
@@ -2498,8 +2501,21 @@ final class AutosizingTextView: NSTextView {
     }
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
-        if consumeFileDrop(from: sender.draggingPasteboard) { return true }
+        if consumeFileDrop(from: sender.draggingPasteboard) {
+            recordUITestFileDrop("performed")
+            return true
+        }
         return super.performDragOperation(sender)
+    }
+
+    /// Test-only destination signal for distinguishing an XCUI gesture that
+    /// never reached the compose field from a product drop that was observed
+    /// but failed to render. Production launches do not set this path.
+    private func recordUITestFileDrop(_ phase: String) {
+        guard let path = ProcessInfo.processInfo.environment["RAPID_XCUI_DROP_EVENT_FILE"] else {
+            return
+        }
+        try? phase.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
     /// Returns true when a file drop was consumed, regardless of whether the

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -2512,7 +2512,14 @@ final class AutosizingTextView: NSTextView {
         guard let path = ProcessInfo.processInfo.environment["RAPID_XCUI_DROP_EVENT_FILE"] else {
             return
         }
-        try? phase.write(toFile: path, atomically: true, encoding: .utf8)
+        do {
+            try phase.write(toFile: path, atomically: true, encoding: .utf8)
+        } catch {
+            // This environment variable exists only in the native UI-test
+            // process. Losing its completion signal must fail closed: treating
+            // a consumed drop as a transport miss could attach the file twice.
+            fatalError("could not record completed UI-test file drop: \(error)")
+        }
     }
 
     /// Returns true when a file drop was consumed, regardless of whether the

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -2483,10 +2483,7 @@ final class AutosizingTextView: NSTextView {
     }
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        if Self.containsFileURLs(sender.draggingPasteboard) {
-            recordUITestFileDrop("entered")
-            return .copy
-        }
+        if Self.containsFileURLs(sender.draggingPasteboard) { return .copy }
         return super.draggingEntered(sender)
     }
 

--- a/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
@@ -7,10 +7,13 @@ import AppKit
 // macOS file-URL drag without depending on Finder's ambient window geometry.
 final class FileDragView: NSView, NSDraggingSource {
     let fileURL: URL
+    private let dropsFirstGesture: Bool
     private var startedDragging = false
+    private var gestureCount = 0
 
-    init(fileURL: URL) {
+    init(fileURL: URL, dropsFirstGesture: Bool) {
         self.fileURL = fileURL
+        self.dropsFirstGesture = dropsFirstGesture
         super.init(frame: .zero)
         setAccessibilityElement(true)
         setAccessibilityRole(.button)
@@ -39,6 +42,8 @@ final class FileDragView: NSView, NSDraggingSource {
     override func mouseDragged(with event: NSEvent) {
         guard !startedDragging else { return }
         startedDragging = true
+        gestureCount += 1
+        if dropsFirstGesture && gestureCount == 1 { return }
         let item = NSDraggingItem(pasteboardWriter: fileURL as NSURL)
         item.setDraggingFrame(bounds, contents: NSWorkspace.shared.icon(forFile: fileURL.path))
         beginDraggingSession(with: [item], event: event, source: self)
@@ -68,7 +73,10 @@ if let path = ProcessInfo.processInfo.environment["RAPID_XCUI_DRAG_FILE"] {
         defer: false
     )
     panel.title = "Drag attachment"
-    panel.contentView = FileDragView(fileURL: URL(fileURLWithPath: path))
+    panel.contentView = FileDragView(
+        fileURL: URL(fileURLWithPath: path),
+        dropsFirstGesture: ProcessInfo.processInfo.environment["RAPID_XCUI_DROP_FIRST_GESTURE"] == "1"
+    )
     panel.level = .floating
     panel.makeKeyAndOrderFront(nil)
     app.activate(ignoringOtherApps: true)

--- a/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
@@ -6,19 +6,8 @@ import AppKit
 // small, deterministic file-drag surface so the production app receives a real
 // macOS file-URL drag without depending on Finder's ambient window geometry.
 final class FileDragView: NSView, NSDraggingSource {
-    private enum DragOutcome: String {
-        case pending
-        case copy
-        case none
-    }
-
     let fileURL: URL
     private var startedDragging = false
-    private var dragOutcome = DragOutcome.pending {
-        didSet {
-            NSAccessibility.post(element: self, notification: .valueChanged)
-        }
-    }
 
     init(fileURL: URL) {
         self.fileURL = fileURL
@@ -31,8 +20,6 @@ final class FileDragView: NSView, NSDraggingSource {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { nil }
-
-    override func accessibilityValue() -> Any? { dragOutcome.rawValue }
 
     override func draw(_ dirtyRect: NSRect) {
         NSColor.windowBackgroundColor.setFill()
@@ -47,7 +34,6 @@ final class FileDragView: NSView, NSDraggingSource {
 
     override func mouseDown(with event: NSEvent) {
         startedDragging = false
-        dragOutcome = .pending
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -63,13 +49,6 @@ final class FileDragView: NSView, NSDraggingSource {
         sourceOperationMaskFor context: NSDraggingContext
     ) -> NSDragOperation { .copy }
 
-    func draggingSession(
-        _ session: NSDraggingSession,
-        endedAt screenPoint: NSPoint,
-        operation: NSDragOperation
-    ) {
-        dragOutcome = operation.contains(.copy) ? .copy : .none
-    }
 }
 
 let app = NSApplication.shared

--- a/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
@@ -10,6 +10,7 @@ final class FileDragView: NSView, NSDraggingSource {
     private let dropsFirstGesture: Bool
     private var startedDragging = false
     private var gestureCount = 0
+    private var dropsCurrentGesture = false
 
     init(fileURL: URL, dropsFirstGesture: Bool) {
         self.fileURL = fileURL
@@ -37,13 +38,14 @@ final class FileDragView: NSView, NSDraggingSource {
 
     override func mouseDown(with event: NSEvent) {
         startedDragging = false
+        gestureCount += 1
+        dropsCurrentGesture = dropsFirstGesture && gestureCount == 1
     }
 
     override func mouseDragged(with event: NSEvent) {
         guard !startedDragging else { return }
         startedDragging = true
-        gestureCount += 1
-        if dropsFirstGesture && gestureCount == 1 { return }
+        if dropsCurrentGesture { return }
         let item = NSDraggingItem(pasteboardWriter: fileURL as NSURL)
         item.setDraggingFrame(bounds, contents: NSWorkspace.shared.icon(forFile: fileURL.path))
         beginDraggingSession(with: [item], event: event, source: self)

--- a/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Host/main.swift
@@ -6,8 +6,19 @@ import AppKit
 // small, deterministic file-drag surface so the production app receives a real
 // macOS file-URL drag without depending on Finder's ambient window geometry.
 final class FileDragView: NSView, NSDraggingSource {
+    private enum DragOutcome: String {
+        case pending
+        case copy
+        case none
+    }
+
     let fileURL: URL
     private var startedDragging = false
+    private var dragOutcome = DragOutcome.pending {
+        didSet {
+            NSAccessibility.post(element: self, notification: .valueChanged)
+        }
+    }
 
     init(fileURL: URL) {
         self.fileURL = fileURL
@@ -20,6 +31,8 @@ final class FileDragView: NSView, NSDraggingSource {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { nil }
+
+    override func accessibilityValue() -> Any? { dragOutcome.rawValue }
 
     override func draw(_ dirtyRect: NSRect) {
         NSColor.windowBackgroundColor.setFill()
@@ -34,6 +47,7 @@ final class FileDragView: NSView, NSDraggingSource {
 
     override func mouseDown(with event: NSEvent) {
         startedDragging = false
+        dragOutcome = .pending
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -48,6 +62,14 @@ final class FileDragView: NSView, NSDraggingSource {
         _ session: NSDraggingSession,
         sourceOperationMaskFor context: NSDraggingContext
     ) -> NSDragOperation { .copy }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        dragOutcome = operation.contains(.copy) ? .copy : .none
+    }
 }
 
 let app = NSApplication.shared

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -135,7 +135,12 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         // to settle (exists + hittable) and re-issues the drop if it is lost, so
         // the control is guaranteed before we send (#2481).
         let imageChip = harness.element("ChatView.Attachment.Remove.\(image.lastPathComponent)")
-        harness.dragFile(image, expectedChip: imageChip)
+        let recoveredAttempts = harness.dragFile(
+            image,
+            expectedChip: imageChip,
+            simulateMissedFirstGesture: true
+        )
+        XCTAssertEqual(recoveredAttempts, 2)
         harness.send("Dragged photo", expectedRequestCount: 1)
 
         let documentChip = harness.element("ChatView.Attachment.Remove.\(document.lastPathComponent)")

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -19,7 +19,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
                 completedDrop: false,
                 attempt: 1,
                 maximumAttempts: 2,
-                remainingTime: 1
+                remainingTime: FileDropRetryPolicy.minimumRetryBudget
             )
         )
         XCTAssertFalse(
@@ -27,7 +27,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
                 completedDrop: false,
                 attempt: 2,
                 maximumAttempts: 2,
-                remainingTime: 1
+                remainingTime: FileDropRetryPolicy.minimumRetryBudget
             )
         )
         XCTAssertFalse(
@@ -35,7 +35,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
                 completedDrop: true,
                 attempt: 1,
                 maximumAttempts: 2,
-                remainingTime: 1
+                remainingTime: FileDropRetryPolicy.minimumRetryBudget
             )
         )
         XCTAssertFalse(
@@ -43,9 +43,22 @@ final class ChatAttachmentJourneyTests: XCTestCase {
                 completedDrop: false,
                 attempt: 1,
                 maximumAttempts: 2,
-                remainingTime: 0
+                remainingTime: FileDropRetryPolicy.minimumRetryBudget - 0.001
             )
         )
+    }
+
+    func testDropEventFileClearIsIdempotent() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-drop-marker-\(UUID().uuidString)")
+        let marker = directory.appendingPathComponent("completed.txt")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try "performed".write(to: marker, atomically: true, encoding: .utf8)
+
+        try DropEventFile.clear(at: marker)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+        try DropEventFile.clear(at: marker)
     }
 
     func testPickerAttachmentsStayWithTheirConversationAndWirePayload() throws {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -144,7 +144,12 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         harness.send("Dragged photo", expectedRequestCount: 1)
 
         let documentChip = harness.element("ChatView.Attachment.Remove.\(document.lastPathComponent)")
-        harness.dragFile(document, expectedChip: documentChip)
+        let delayedChipAttempts = harness.dragFile(
+            document,
+            expectedChip: documentChip,
+            simulateChipVisibilityDelay: 3
+        )
+        XCTAssertEqual(delayedChipAttempts, 1)
         harness.send("Dragged document", expectedRequestCount: 2)
 
         let pdfChip = harness.element("ChatView.Attachment.Remove.\(pdf.lastPathComponent)")

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -13,6 +13,41 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         executionTimeAllowance = 120
     }
 
+    func testFileDropRetryPolicyIsBoundedAndCompletionAware() {
+        XCTAssertTrue(
+            FileDropRetryPolicy.shouldRetry(
+                completedDrop: false,
+                attempt: 1,
+                maximumAttempts: 2,
+                remainingTime: 1
+            )
+        )
+        XCTAssertFalse(
+            FileDropRetryPolicy.shouldRetry(
+                completedDrop: false,
+                attempt: 2,
+                maximumAttempts: 2,
+                remainingTime: 1
+            )
+        )
+        XCTAssertFalse(
+            FileDropRetryPolicy.shouldRetry(
+                completedDrop: true,
+                attempt: 1,
+                maximumAttempts: 2,
+                remainingTime: 1
+            )
+        )
+        XCTAssertFalse(
+            FileDropRetryPolicy.shouldRetry(
+                completedDrop: false,
+                attempt: 1,
+                maximumAttempts: 2,
+                remainingTime: 0
+            )
+        )
+    }
+
     func testPickerAttachmentsStayWithTheirConversationAndWirePayload() throws {
         continueAfterFailure = false
         let harness = try RapidUITestHarness(

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -61,6 +61,22 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         try DropEventFile.clear(at: marker)
     }
 
+    func testDropEventFileCompletionFailsClosed() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-drop-completion-\(UUID().uuidString)")
+        let marker = directory.appendingPathComponent("completed.txt")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        XCTAssertNil(try DropEventFile.completedPhase(at: marker))
+        try "performed".write(to: marker, atomically: true, encoding: .utf8)
+        XCTAssertEqual(try DropEventFile.completedPhase(at: marker), "performed")
+        try "entered".write(to: marker, atomically: true, encoding: .utf8)
+        XCTAssertThrowsError(try DropEventFile.completedPhase(at: marker)) { error in
+            XCTAssertEqual(error as? DropEventFile.EventError, .invalidPhase("entered"))
+        }
+    }
+
     func testPickerAttachmentsStayWithTheirConversationAndWirePayload() throws {
         continueAfterFailure = false
         let harness = try RapidUITestHarness(

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -302,7 +302,8 @@ final class RapidUITestHarness {
         _ url: URL,
         expectedChip chip: XCUIElement? = nil,
         dropSettleTimeout: TimeInterval = 10,
-        simulateMissedFirstGesture: Bool = false
+        simulateMissedFirstGesture: Bool = false,
+        simulateChipVisibilityDelay: TimeInterval = 0
     ) -> Int {
         let dragSource = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")
         dragSource.launchEnvironment = [
@@ -331,6 +332,10 @@ final class RapidUITestHarness {
             return 1
         }
         let settleDeadline = Date().addingTimeInterval(dropSettleTimeout)
+        let chipObservationStart = Date().addingTimeInterval(simulateChipVisibilityDelay)
+        let chipIsSettled = {
+            Date() >= chipObservationStart && chip.exists && chip.isHittable
+        }
         let maximumAttempts = 2
         for attempt in 1...maximumAttempts {
             try? FileManager.default.removeItem(at: dropEventFile)
@@ -341,10 +346,10 @@ final class RapidUITestHarness {
             // signal, then spend the rest of the original budget on an
             // observed drop's chip.
             _ = waitUntil(timeout: min(2, max(0, settleDeadline.timeIntervalSinceNow))) {
-                (chip.exists && chip.isHittable)
+                chipIsSettled()
                     || FileManager.default.fileExists(atPath: self.dropEventFile.path)
             }
-            if chip.exists && chip.isHittable { return attempt }
+            if chipIsSettled() { return attempt }
 
             let observedPhase = try? String(contentsOf: dropEventFile, encoding: .utf8)
             if FileDropRetryPolicy.shouldRetry(
@@ -357,7 +362,7 @@ final class RapidUITestHarness {
             }
 
             let remaining = max(0, settleDeadline.timeIntervalSinceNow)
-            if waitUntil(timeout: remaining, condition: { chip.exists && chip.isHittable }) {
+            if waitUntil(timeout: remaining, condition: chipIsSettled) {
                 return attempt
             }
             XCTFail(

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -277,10 +277,11 @@ final class RapidUITestHarness {
     /// the call site via ``element(_:)`` (which keeps the query literal in the
     /// test source for the xcui workflow contract). A landed drop is treated as
     /// one whose chip settles (exists and is hittable). The product's compose
-    /// destination emits a test-only marker when it observes the gesture. A
-    /// gesture with no destination marker may be retried once within the
-    /// original settle budget. An observed gesture is never retried: if its chip
-    /// does not appear, the test still exposes the product/AX regression. The
+    /// destination emits a test-only marker after `performDragOperation`
+    /// consumes the drop. A gesture with no completion marker may be retried
+    /// once within the original settle budget. A consumed drop is never
+    /// retried: if its chip does not appear, the test still exposes the
+    /// product/AX regression. The
     /// chip is never dereferenced before it exists, so a not-yet-matched
     /// ``firstMatch`` cannot throw (#2481).
     /// Callers without an expected chip (the unsupported-file negative case)
@@ -319,7 +320,7 @@ final class RapidUITestHarness {
             try? FileManager.default.removeItem(at: dropEventFile)
             source.click(forDuration: 1, thenDragTo: dropTarget)
 
-            // The destination marker and the product render arrive
+            // The drop-completion marker and the product render arrive
             // independently. First wait briefly for either authoritative
             // signal, then spend the rest of the original budget on an
             // observed drop's chip.
@@ -342,7 +343,7 @@ final class RapidUITestHarness {
             }
             XCTFail(
                 "dropped attachment chip did not settle within \(dropSettleTimeout)s "
-                    + "(destination phase: \(observedPhase ?? "not observed"), attempts: \(attempt))"
+                    + "(drop phase: \(observedPhase ?? "not performed"), attempts: \(attempt))"
             )
             return
         }

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -66,6 +66,7 @@ final class RapidUITestHarness {
     private let conversationStore: URL
     private let sidecarAlias: String
     private let sidecarPIDFile: URL
+    private let dropEventFile: URL
     private var portReservation: Int32?
     private var originalPasteboardItems: [[NSPasteboard.PasteboardType: Data]]?
     private var ownedPasteboardChangeCount: Int?
@@ -125,6 +126,7 @@ final class RapidUITestHarness {
         let appURL = rapidMacRoot.appendingPathComponent("build/Rapid-MLX Desktop.app")
         eventLog = testHome.appendingPathComponent("fake-events.jsonl")
         sidecarPIDFile = testHome.appendingPathComponent("fake-sidecar.pid")
+        dropEventFile = testHome.appendingPathComponent("xcui-drop-event.txt")
         sidecarAlias = fakeSettings["FAKE_VISION_CHAT"] == "1"
             ? "qwen3-vl-2b-4bit"
             : "fake-alias"
@@ -146,6 +148,7 @@ final class RapidUITestHarness {
             "CFFIXED_USER_HOME": testHome.path,
             "RAPID_BIN": fakeSidecar,
             "FAKE_EVENT_LOG": eventLog.path,
+            "RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path,
             "RAPID_DESKTOP_PORT": String(reservedPort.port),
             "RAPID_DESKTOP_NO_PORT_SWEEP": "1",
         ].merging(fakeSettings) { _, fixture in fixture }
@@ -273,11 +276,10 @@ final class RapidUITestHarness {
     /// ``expectedChip`` is the remove control the drop must produce, fetched at
     /// the call site via ``element(_:)`` (which keeps the query literal in the
     /// test source for the xcui workflow contract). A landed drop is treated as
-    /// one whose chip settles (exists and is hittable). The helper host reports
-    /// the AppKit drag-session outcome through its accessibility value. A
-    /// gesture that AppKit explicitly reports as ``none`` never reached the
-    /// product, so the harness may retry that transport failure once within the
-    /// original settle budget. A reported ``copy`` is never retried: if its chip
+    /// one whose chip settles (exists and is hittable). The product's compose
+    /// destination emits a test-only marker when it observes the gesture. A
+    /// gesture with no destination marker may be retried once within the
+    /// original settle budget. An observed gesture is never retried: if its chip
     /// does not appear, the test still exposes the product/AX regression. The
     /// chip is never dereferenced before it exists, so a not-yet-matched
     /// ``firstMatch`` cannot throw (#2481).
@@ -314,19 +316,21 @@ final class RapidUITestHarness {
         let settleDeadline = Date().addingTimeInterval(dropSettleTimeout)
         let maximumAttempts = 2
         for attempt in 1...maximumAttempts {
+            try? FileManager.default.removeItem(at: dropEventFile)
             source.click(forDuration: 1, thenDragTo: dropTarget)
 
-            // The drag callback and the product render arrive independently.
-            // First wait briefly for either authoritative signal, then spend
-            // the rest of the original budget on a copied drop's chip.
+            // The destination marker and the product render arrive
+            // independently. First wait briefly for either authoritative
+            // signal, then spend the rest of the original budget on an
+            // observed drop's chip.
             _ = waitUntil(timeout: min(2, max(0, settleDeadline.timeIntervalSinceNow))) {
                 (chip.exists && chip.isHittable)
-                    || (source.value as? String ?? "pending") != "pending"
+                    || FileManager.default.fileExists(atPath: self.dropEventFile.path)
             }
             if chip.exists && chip.isHittable { return }
 
-            let dragOperation = source.value as? String ?? "unavailable"
-            if dragOperation == "none", attempt < maximumAttempts,
+            let observedPhase = try? String(contentsOf: dropEventFile, encoding: .utf8)
+            if observedPhase == nil, attempt < maximumAttempts,
                settleDeadline.timeIntervalSinceNow > 0
             {
                 continue
@@ -338,7 +342,7 @@ final class RapidUITestHarness {
             }
             XCTFail(
                 "dropped attachment chip did not settle within \(dropSettleTimeout)s "
-                    + "(drag operation: \(dragOperation), attempts: \(attempt))"
+                    + "(destination phase: \(observedPhase ?? "not observed"), attempts: \(attempt))"
             )
             return
         }

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -57,13 +57,34 @@ struct MemoryConfirmationRetryPolicy {
 }
 
 enum FileDropRetryPolicy {
+    static let minimumRetryBudget: TimeInterval = 3
+
     static func shouldRetry(
         completedDrop: Bool,
         attempt: Int,
         maximumAttempts: Int,
         remainingTime: TimeInterval
     ) -> Bool {
-        !completedDrop && attempt < maximumAttempts && remainingTime > 0
+        !completedDrop
+            && attempt < maximumAttempts
+            && remainingTime >= minimumRetryBudget
+    }
+}
+
+enum DropEventFile {
+    enum ClearError: Error {
+        case remainedAfterRemoval
+    }
+
+    static func clear(at url: URL, fileManager: FileManager = .default) throws {
+        do {
+            try fileManager.removeItem(at: url)
+        } catch let error as CocoaError where error.code == .fileNoSuchFile {
+            // An absent marker is the required pre-drag state.
+        }
+        guard !fileManager.fileExists(atPath: url.path) else {
+            throw ClearError.remainedAfterRemoval
+        }
     }
 }
 
@@ -338,7 +359,12 @@ final class RapidUITestHarness {
         }
         let maximumAttempts = 2
         for attempt in 1...maximumAttempts {
-            try? FileManager.default.removeItem(at: dropEventFile)
+            do {
+                try DropEventFile.clear(at: dropEventFile)
+            } catch {
+                XCTFail("could not clear UI-test drop marker before gesture: \(error)")
+                return attempt
+            }
             source.click(forDuration: 1, thenDragTo: dropTarget)
 
             // The drop-completion marker and the product render arrive

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -72,8 +72,9 @@ enum FileDropRetryPolicy {
 }
 
 enum DropEventFile {
-    enum ClearError: Error {
+    enum EventError: Error, Equatable {
         case remainedAfterRemoval
+        case invalidPhase(String)
     }
 
     static func clear(at url: URL, fileManager: FileManager = .default) throws {
@@ -83,8 +84,18 @@ enum DropEventFile {
             // An absent marker is the required pre-drag state.
         }
         guard !fileManager.fileExists(atPath: url.path) else {
-            throw ClearError.remainedAfterRemoval
+            throw EventError.remainedAfterRemoval
         }
+    }
+
+    static func completedPhase(
+        at url: URL,
+        fileManager: FileManager = .default
+    ) throws -> String? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        let phase = try String(contentsOf: url, encoding: .utf8)
+        guard phase == "performed" else { throw EventError.invalidPhase(phase) }
+        return phase
     }
 }
 
@@ -377,7 +388,13 @@ final class RapidUITestHarness {
             }
             if chipIsSettled() { return attempt }
 
-            let observedPhase = try? String(contentsOf: dropEventFile, encoding: .utf8)
+            let observedPhase: String?
+            do {
+                observedPhase = try DropEventFile.completedPhase(at: dropEventFile)
+            } catch {
+                XCTFail("could not read valid UI-test drop marker after gesture: \(error)")
+                return attempt
+            }
             if FileDropRetryPolicy.shouldRetry(
                 completedDrop: observedPhase != nil,
                 attempt: attempt,

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -56,6 +56,17 @@ struct MemoryConfirmationRetryPolicy {
     }
 }
 
+enum FileDropRetryPolicy {
+    static func shouldRetry(
+        completedDrop: Bool,
+        attempt: Int,
+        maximumAttempts: Int,
+        remainingTime: TimeInterval
+    ) -> Bool {
+        !completedDrop && attempt < maximumAttempts && remainingTime > 0
+    }
+}
+
 @MainActor
 final class RapidUITestHarness {
     let app: XCUIApplication
@@ -331,9 +342,12 @@ final class RapidUITestHarness {
             if chip.exists && chip.isHittable { return }
 
             let observedPhase = try? String(contentsOf: dropEventFile, encoding: .utf8)
-            if observedPhase == nil, attempt < maximumAttempts,
-               settleDeadline.timeIntervalSinceNow > 0
-            {
+            if FileDropRetryPolicy.shouldRetry(
+                completedDrop: observedPhase != nil,
+                attempt: attempt,
+                maximumAttempts: maximumAttempts,
+                remainingTime: settleDeadline.timeIntervalSinceNow
+            ) {
                 continue
             }
 

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -273,13 +273,14 @@ final class RapidUITestHarness {
     /// ``expectedChip`` is the remove control the drop must produce, fetched at
     /// the call site via ``element(_:)`` (which keeps the query literal in the
     /// test source for the xcui workflow contract). A landed drop is treated as
-    /// one whose chip settles (exists and is hittable); the helper waits
-    /// ``dropSettleTimeout`` for that and asserts if it never appears. The chip
-    /// element is polled directly (``exists``/``isHittable``) — never
-    /// dereferenced before it exists, so a not-yet-matched ``firstMatch``
-    /// cannot throw. There is deliberately NO silent re-issue of the synthetic
-    /// drag: a first drop that does not land despite the hittable gate is a
-    /// real product defect the test should surface, not retry over (#2481).
+    /// one whose chip settles (exists and is hittable). The helper host reports
+    /// the AppKit drag-session outcome through its accessibility value. A
+    /// gesture that AppKit explicitly reports as ``none`` never reached the
+    /// product, so the harness may retry that transport failure once within the
+    /// original settle budget. A reported ``copy`` is never retried: if its chip
+    /// does not appear, the test still exposes the product/AX regression. The
+    /// chip is never dereferenced before it exists, so a not-yet-matched
+    /// ``firstMatch`` cannot throw (#2481).
     /// Callers without an expected chip (the unsupported-file negative case)
     /// keep the original single-drop behaviour.
     func dragFile(
@@ -310,9 +311,37 @@ final class RapidUITestHarness {
             source.click(forDuration: 1, thenDragTo: dropTarget)
             return
         }
-        source.click(forDuration: 1, thenDragTo: dropTarget)
-        XCTAssertTrue(waitUntil(timeout: dropSettleTimeout) { chip.exists && chip.isHittable },
-                      "dropped attachment chip did not settle within \(dropSettleTimeout)s")
+        let settleDeadline = Date().addingTimeInterval(dropSettleTimeout)
+        let maximumAttempts = 2
+        for attempt in 1...maximumAttempts {
+            source.click(forDuration: 1, thenDragTo: dropTarget)
+
+            // The drag callback and the product render arrive independently.
+            // First wait briefly for either authoritative signal, then spend
+            // the rest of the original budget on a copied drop's chip.
+            _ = waitUntil(timeout: min(2, max(0, settleDeadline.timeIntervalSinceNow))) {
+                (chip.exists && chip.isHittable)
+                    || (source.value as? String ?? "pending") != "pending"
+            }
+            if chip.exists && chip.isHittable { return }
+
+            let dragOperation = source.value as? String ?? "unavailable"
+            if dragOperation == "none", attempt < maximumAttempts,
+               settleDeadline.timeIntervalSinceNow > 0
+            {
+                continue
+            }
+
+            let remaining = max(0, settleDeadline.timeIntervalSinceNow)
+            if waitUntil(timeout: remaining, condition: { chip.exists && chip.isHittable }) {
+                return
+            }
+            XCTFail(
+                "dropped attachment chip did not settle within \(dropSettleTimeout)s "
+                    + "(drag operation: \(dragOperation), attempts: \(attempt))"
+            )
+            return
+        }
     }
 
     func pasteImage(_ url: URL) throws {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -297,13 +297,18 @@ final class RapidUITestHarness {
     /// ``firstMatch`` cannot throw (#2481).
     /// Callers without an expected chip (the unsupported-file negative case)
     /// keep the original single-drop behaviour.
+    @discardableResult
     func dragFile(
         _ url: URL,
         expectedChip chip: XCUIElement? = nil,
-        dropSettleTimeout: TimeInterval = 10
-    ) {
+        dropSettleTimeout: TimeInterval = 10,
+        simulateMissedFirstGesture: Bool = false
+    ) -> Int {
         let dragSource = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")
-        dragSource.launchEnvironment = ["RAPID_XCUI_DRAG_FILE": url.path]
+        dragSource.launchEnvironment = [
+            "RAPID_XCUI_DRAG_FILE": url.path,
+            "RAPID_XCUI_DROP_FIRST_GESTURE": simulateMissedFirstGesture ? "1" : "0",
+        ]
         dragSource.launch()
         defer { dragSource.terminate() }
         let source = dragSource.descendants(matching: .any)
@@ -323,7 +328,7 @@ final class RapidUITestHarness {
 
         guard let chip = chip else {
             source.click(forDuration: 1, thenDragTo: dropTarget)
-            return
+            return 1
         }
         let settleDeadline = Date().addingTimeInterval(dropSettleTimeout)
         let maximumAttempts = 2
@@ -339,7 +344,7 @@ final class RapidUITestHarness {
                 (chip.exists && chip.isHittable)
                     || FileManager.default.fileExists(atPath: self.dropEventFile.path)
             }
-            if chip.exists && chip.isHittable { return }
+            if chip.exists && chip.isHittable { return attempt }
 
             let observedPhase = try? String(contentsOf: dropEventFile, encoding: .utf8)
             if FileDropRetryPolicy.shouldRetry(
@@ -353,14 +358,15 @@ final class RapidUITestHarness {
 
             let remaining = max(0, settleDeadline.timeIntervalSinceNow)
             if waitUntil(timeout: remaining, condition: { chip.exists && chip.isHittable }) {
-                return
+                return attempt
             }
             XCTFail(
                 "dropped attachment chip did not settle within \(dropSettleTimeout)s "
                     + "(drop phase: \(observedPhase ?? "not performed"), attempts: \(attempt))"
             )
-            return
+            return attempt
         }
+        return maximumAttempts
     }
 
     func pasteImage(_ url: URL) throws {

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -128,6 +128,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert 'recordUITestFileDrop("performed")' in chat_view
     assert '"RAPID_XCUI_DROP_FIRST_GESTURE": simulateMissedFirstGesture ? "1" : "0"' in harness
     assert "XCTAssertEqual(recoveredAttempts, 2)" in chat_source
+    assert "XCTAssertEqual(delayedChipAttempts, 1)" in chat_source
     assert 'let dropTarget = element("rapid.chat.compose")' in harness
     assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness
     assert "func testDragPasteAndRemovalPreserveWireIdentity()" in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -126,6 +126,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert '"RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path' in harness
     assert 'recordUITestFileDrop("entered")' not in chat_view
     assert 'recordUITestFileDrop("performed")' in chat_view
+    assert '"RAPID_XCUI_DROP_FIRST_GESTURE": simulateMissedFirstGesture ? "1" : "0"' in harness
+    assert "XCTAssertEqual(recoveredAttempts, 2)" in chat_source
     assert 'let dropTarget = element("rapid.chat.compose")' in harness
     assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness
     assert "func testDragPasteAndRemovalPreserveWireIdentity()" in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -123,7 +123,9 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "FileDropRetryPolicy.shouldRetry(" in harness
     assert "func testFileDropRetryPolicyIsBoundedAndCompletionAware()" in chat_source
     assert "func testDropEventFileClearIsIdempotent()" in chat_source
+    assert "func testDropEventFileCompletionFailsClosed()" in chat_source
     assert "try DropEventFile.clear(at: dropEventFile)" in harness
+    assert "try DropEventFile.completedPhase(at: dropEventFile)" in harness
     assert "Date().addingTimeInterval(dropSettleTimeout)" in harness
     assert '"RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path' in harness
     assert 'recordUITestFileDrop("entered")' not in chat_view

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -122,6 +122,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "let maximumAttempts = 2" in harness
     assert "FileDropRetryPolicy.shouldRetry(" in harness
     assert "func testFileDropRetryPolicyIsBoundedAndCompletionAware()" in chat_source
+    assert "func testDropEventFileClearIsIdempotent()" in chat_source
+    assert "try DropEventFile.clear(at: dropEventFile)" in harness
     assert "Date().addingTimeInterval(dropSettleTimeout)" in harness
     assert '"RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path' in harness
     assert 'recordUITestFileDrop("entered")' not in chat_view

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -80,6 +80,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     chat_source = (
         MAC / "Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift"
     ).read_text()
+    drag_host = (MAC / "Tests/RapidUITests/Host/main.swift").read_text()
 
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
@@ -118,6 +119,11 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
         'XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")' in harness
     )
     assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
+    assert "let maximumAttempts = 2" in harness
+    assert 'dragOperation == "none"' in harness
+    assert "Date().addingTimeInterval(dropSettleTimeout)" in harness
+    assert "endedAt screenPoint: NSPoint" in drag_host
+    assert "operation.contains(.copy) ? .copy : .none" in drag_host
     assert 'let dropTarget = element("rapid.chat.compose")' in harness
     assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness
     assert "func testDragPasteAndRemovalPreserveWireIdentity()" in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -123,7 +123,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "if observedPhase == nil, attempt < maximumAttempts" in harness
     assert "Date().addingTimeInterval(dropSettleTimeout)" in harness
     assert '"RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path' in harness
-    assert 'recordUITestFileDrop("entered")' in chat_view
+    assert 'recordUITestFileDrop("entered")' not in chat_view
     assert 'recordUITestFileDrop("performed")' in chat_view
     assert 'let dropTarget = element("rapid.chat.compose")' in harness
     assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -126,6 +126,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert '"RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path' in harness
     assert 'recordUITestFileDrop("entered")' not in chat_view
     assert 'recordUITestFileDrop("performed")' in chat_view
+    assert "try? phase.write" not in chat_view
+    assert 'fatalError("could not record completed UI-test file drop' in chat_view
     assert (
         '"RAPID_XCUI_DROP_FIRST_GESTURE": simulateMissedFirstGesture ? "1" : "0"'
         in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -120,7 +120,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     )
     assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
     assert "let maximumAttempts = 2" in harness
-    assert "if observedPhase == nil, attempt < maximumAttempts" in harness
+    assert "FileDropRetryPolicy.shouldRetry(" in harness
+    assert "func testFileDropRetryPolicyIsBoundedAndCompletionAware()" in chat_source
     assert "Date().addingTimeInterval(dropSettleTimeout)" in harness
     assert '"RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path' in harness
     assert 'recordUITestFileDrop("entered")' not in chat_view

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -80,7 +80,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     chat_source = (
         MAC / "Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift"
     ).read_text()
-    drag_host = (MAC / "Tests/RapidUITests/Host/main.swift").read_text()
+    chat_view = (MAC / "Sources/Rapid/UI/ChatView.swift").read_text()
 
     assert "build/Rapid-MLX Desktop.app" in runner
     assert "lsregister" in runner
@@ -120,10 +120,11 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     )
     assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
     assert "let maximumAttempts = 2" in harness
-    assert 'dragOperation == "none"' in harness
+    assert "if observedPhase == nil, attempt < maximumAttempts" in harness
     assert "Date().addingTimeInterval(dropSettleTimeout)" in harness
-    assert "endedAt screenPoint: NSPoint" in drag_host
-    assert "operation.contains(.copy) ? .copy : .none" in drag_host
+    assert '"RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path' in harness
+    assert 'recordUITestFileDrop("entered")' in chat_view
+    assert 'recordUITestFileDrop("performed")' in chat_view
     assert 'let dropTarget = element("rapid.chat.compose")' in harness
     assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness
     assert "func testDragPasteAndRemovalPreserveWireIdentity()" in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -126,7 +126,10 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert '"RAPID_XCUI_DROP_EVENT_FILE": dropEventFile.path' in harness
     assert 'recordUITestFileDrop("entered")' not in chat_view
     assert 'recordUITestFileDrop("performed")' in chat_view
-    assert '"RAPID_XCUI_DROP_FIRST_GESTURE": simulateMissedFirstGesture ? "1" : "0"' in harness
+    assert (
+        '"RAPID_XCUI_DROP_FIRST_GESTURE": simulateMissedFirstGesture ? "1" : "0"'
+        in harness
+    )
     assert "XCTAssertEqual(recoveredAttempts, 2)" in chat_source
     assert "XCTAssertEqual(delayedChipAttempts, 1)" in chat_source
     assert 'let dropTarget = element("rapid.chat.compose")' in harness


### PR DESCRIPTION
## Why

The Mac merge candidate for #2810 failed when the native chat-attachment XCUITest synthesized a file drag but no attachment chip appeared. The three named shell GUI journeys passed; the failure was isolated to `testDragPasteAndRemovalPreserveWireIdentity`. The existing harness documentation claimed a bounded retry, while the implementation unconditionally failed the first synthetic gesture.

## What

- Let the app’s compose destination emit an environment-gated test marker only after `performDragOperation` consumes a file drop; ordinary launches never set the marker path.
- Retry exactly once, within the existing 10-second total budget, only when no completed drop reached the destination.
- Never retry a consumed drop; a missing chip then remains a real product/AX failure.
- Give the test-only drag host an explicit seam that drops its first gesture, and exercise it in the existing native attachment journey to prove exactly two attempts recover.
- Add executable policy tests for retry bounds and completion awareness.

## Scope

Allowed: the environment-gated destination marker in `AutosizingTextView`, `RapidUITestHarness.dragFile`, the test-only drag host, the existing attachment journey, and focused CI contracts. Non-goals: attachment product semantics, #2810 Video behavior, general timeout increases, or unrelated GUI flows.

## Design precedent

Native UI test suites make synthesized gestures reliable by pairing the gesture with an authoritative application-side completion signal, then asserting the resulting UI state. This adapts that pattern at the destination: absence of a completed-drop marker identifies an incomplete driver gesture, while a consumed drop is never retried. A deterministic test-only fault proves the recovery path rather than relying on the flake to recur.

## Testing

- `python3.12 -m pytest -q tests/test_rapid_mac_xcui_target.py` — 5 passed
- `swift test --no-parallel --filter 'ChatFileAttachment'` — 19 passed
- focused `FileDropRetryPolicy` Xcode test — passed (4 boundary assertions)
- `RAPID_XCUI_ONLY_TESTING=RapidUITests/ChatAttachmentJourneyTests/testDragPasteAndRemovalPreserveWireIdentity ./scripts/run-xcui-tests.sh` — passed in 97.273s with forced first-gesture loss and `XCTAssertEqual(recoveredAttempts, 2)`
- UI host/test target compile and `git diff --check` — passed
- Exact-head full CI pending

Fixes #2481
