### PR TITLE
perf(qwen4): qualify conservative prompt lookup

### DIFF
--- a/bench/bench_qwen4_prompt_lookup.py
+++ b/bench/bench_qwen4_prompt_lookup.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Measure prompt-lookup decoding on realistic high-overlap editing tasks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def _english_source() -> str:
+    return "\n\n".join(
+        f"def normalize_{index:03d}(value: str) -> str:\n"
+        f"    # Stable transformation {index:03d}.\n"
+        "    return value.strip().lower()"
+        for index in range(28)
+    )
+
+
+def _json_manifest() -> str:
+    return json.dumps(
+        {
+            "services": [
+                {
+                    "name": f"worker-{index:03d}",
+                    "enabled": True,
+                    "retries": 3,
+                    "region": "us-west",
+                }
+                for index in range(22)
+            ]
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+def _chinese_document() -> str:
+    return "\n".join(
+        f"第{index:03d}条：服务必须记录请求编号，并在失败后保留审计信息。"
+        for index in range(1, 41)
+    )
+
+
+def scenarios() -> dict[str, dict[str, Any]]:
+    source = _english_source()
+    manifest = _json_manifest()
+    zh_doc = _chinese_document()
+    return {
+        "code_copy": {
+            "messages": [
+                {"role": "system", "content": "Output only the requested file."},
+                {
+                    "role": "user",
+                    "content": f"Return this file verbatim, without fences.\nBEGIN\n{source}\nEND",
+                },
+            ],
+            "expected": source,
+            "validation": "exact",
+            "max_tokens": 1024,
+        },
+        "code_edit": {
+            "messages": [
+                {"role": "system", "content": "Output only the complete updated file."},
+                {
+                    "role": "user",
+                    "content": (
+                        "Change only transformation 000 from lower() to upper(); preserve "
+                        f"everything else exactly.\nBEGIN\n{source}\nEND"
+                    ),
+                },
+            ],
+            "expected": source.replace(
+                "# Stable transformation 000.\n    return value.strip().lower()",
+                "# Stable transformation 000.\n    return value.strip().upper()",
+                1,
+            ),
+            "validation": "code",
+            "max_tokens": 1024,
+        },
+        "json_copy": {
+            "messages": [
+                {"role": "system", "content": "Output only valid JSON."},
+                {
+                    "role": "user",
+                    "content": f"Return this JSON verbatim.\nBEGIN\n{manifest}\nEND",
+                },
+            ],
+            "expected": manifest,
+            "validation": "json",
+            "max_tokens": 1024,
+        },
+        "chinese_copy": {
+            "messages": [
+                {"role": "system", "content": "只输出要求的完整文档。"},
+                {
+                    "role": "user",
+                    "content": f"逐字返回以下文档，不要添加代码围栏。\n开始\n{zh_doc}\n结束",
+                },
+            ],
+            "expected": zh_doc,
+            "validation": "chinese_document",
+            "max_tokens": 1024,
+        },
+        "multi_turn_edit": {
+            "messages": [
+                {"role": "system", "content": "Output only the complete updated file."},
+                {"role": "user", "content": "Remember this file for the next edit."},
+                {"role": "assistant", "content": source},
+                {
+                    "role": "user",
+                    "content": "Change only transformation 000 from lower() to upper().",
+                },
+            ],
+            "expected": source.replace(
+                "# Stable transformation 000.\n    return value.strip().lower()",
+                "# Stable transformation 000.\n    return value.strip().upper()",
+                1,
+            ),
+            "validation": "code",
+            "max_tokens": 1024,
+        },
+    }
+
+
+def stream_request(
+    client: httpx.Client,
+    url: str,
+    model: str,
+    case: dict[str, Any],
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    first = None
+    chunks: list[str] = []
+    usage: dict[str, Any] = {}
+    with client.stream(
+        "POST",
+        f"{url}/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": case["messages"],
+            "max_tokens": case["max_tokens"],
+            "temperature": 0.0,
+            "enable_thinking": False,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        },
+    ) as response:
+        response.raise_for_status()
+        for line in response.iter_lines():
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            event = json.loads(line[6:])
+            if event.get("usage"):
+                usage = event["usage"]
+            choices = event.get("choices") or []
+            if not choices:
+                continue
+            visible = (choices[0].get("delta") or {}).get("content") or ""
+            if visible:
+                first = first or time.perf_counter()
+                chunks.append(visible)
+    finished = time.perf_counter()
+    text = "".join(chunks)
+    expected = case["expected"]
+    comparable = text
+    if case["validation"] == "code" and text.startswith("```python\n"):
+        comparable = text.removeprefix("```python\n").removesuffix("\n```")
+    elif case["validation"] == "chinese_document":
+        comparable = text.removeprefix("开始\n").removesuffix("\n结束")
+    if case["validation"] == "json":
+        try:
+            valid = json.loads(text) == json.loads(expected)
+        except json.JSONDecodeError:
+            valid = False
+    else:
+        valid = comparable == expected
+    decode_seconds = max(finished - (first or finished), 1e-9)
+    return {
+        "exact": text == expected,
+        "valid": valid,
+        "text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "expected_sha256": hashlib.sha256(expected.encode()).hexdigest(),
+        "prompt_tokens": usage.get("prompt_tokens"),
+        "completion_tokens": usage.get("completion_tokens"),
+        "ttft_ms": round(((first or finished) - started) * 1000, 3),
+        "total_ms": round((finished - started) * 1000, 3),
+        "decode_tokens_per_second": round(
+            int(usage.get("completion_tokens") or 0) / decode_seconds, 3
+        ),
+        "first_difference": next(
+            (
+                index
+                for index, (actual, wanted) in enumerate(zip(text, expected))
+                if actual != wanted
+            ),
+            None if len(text) == len(expected) else min(len(text), len(expected)),
+        ),
+        "actual_length": len(text),
+        "expected_length": len(expected),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="http://127.0.0.1:8465")
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    cases = scenarios()
+    results = {}
+    with httpx.Client(timeout=3600) as client:
+        model = client.get(f"{args.url}/v1/models").json()["data"][0]["id"]
+        for name, case in cases.items():
+            rows = []
+            for run in range(1, args.runs + 1):
+                client.post(f"{args.url}/v1/cache/clear").raise_for_status()
+                row = stream_request(client, args.url, model, case)
+                row["run"] = run
+                rows.append(row)
+                print(
+                    f"{name} run={run} valid={row['valid']} exact={row['exact']} "
+                    f"decode={row['decode_tokens_per_second']:.2f} tok/s "
+                    f"tokens={row['completion_tokens']} diff={row['first_difference']}"
+                )
+            results[name] = {
+                "all_valid": all(row["valid"] for row in rows),
+                "all_exact": all(row["exact"] for row in rows),
+                "median_decode_tokens_per_second": statistics.median(
+                    row["decode_tokens_per_second"] for row in rows
+                ),
+                "rows": rows,
+            }
+    args.output.write_text(
+        json.dumps({"label": args.label, "model": model, "results": results}, indent=2)
+        + "\n"
+    )
+    return 0 if all(row["all_valid"] for row in results.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/engineering/performance/qwen4-prompt-lookup-qualification.md
+++ b/docs/engineering/performance/qwen4-prompt-lookup-qualification.md
@@ -1,0 +1,98 @@
+# Qwen4 prompt-lookup qualification
+
+## Outcome
+
+Prompt-lookup drafting (PLD) is qualified for greedy native-MTP requests on
+`rapid-mlx/Qwen3.8-Flash-Next-4bit` with a conservative model-specific policy:
+
+- minimum matching suffix: 16 tokens
+- maximum matching suffix: 64 tokens
+- maximum proposal: 8 tokens
+- sampled requests: ordinary MTP (PLD disabled)
+
+The policy is captured with the immutable prompt at request start. Every
+proposal is verified by the target model, and only the accepted prefix is
+committed to the target and MTP caches.
+
+The PLD adaptation and high-overlap optimization direction were contributed by
+Pierre Lamy in PR #2809. This qualification narrows that contribution to the
+measured, lossless Qwen4 route.
+
+## Environment
+
+- Mac Studio (Mac15,14), Apple M3 Ultra, 256 GB unified memory
+- macOS 26.5.2 (25F84)
+- Rapid-MLX base `01739b38b0143d6e70cfe6642a5c9d857c5e98ed`
+- artifact revision `dcf657e4acda2aae72da99cde65b6c491cd96998`
+- text-only serving, BF16 KV cache, native MTP fixed at K=1
+- thinking disabled, temperature 0, request cache cleared before every run
+
+The server command was identical between variants except for the PLD process
+override used to measure the off baseline:
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+python3.12 -m vllm_mlx.cli serve MODEL_SNAPSHOT \
+  --served-model-name qwen3.8-flash-next-4bit \
+  --host 127.0.0.1 --port 8465 --no-thinking --no-mllm \
+  --speculative-config '{"method":"mtp","disable_auto_k":true}'
+```
+
+For the baseline only, `RAPID_MLX_MTP_PROMPT_LOOKUP=0` was added. The PLD
+variant used `min_ngram=16`, `max_ngram=64`, and `max_tokens=8`.
+
+The five-scenario measurement is reproducible with:
+
+```bash
+python3.12 bench/bench_qwen4_prompt_lookup.py \
+  --label mtp-only-or-pld \
+  --runs 3 \
+  --output /private/tmp/qwen4-prompt-lookup.json
+```
+
+## Decode results
+
+Each value is the median of three cold-request runs. Completion lengths were
+804–959 tokens depending on the scenario.
+
+| Scenario | MTP only (tok/s) | MTP + PLD (tok/s) | Speedup | Output parity |
+| --- | ---: | ---: | ---: | --- |
+| Exact code copy | 46.75 | 96.70 | 2.07x | SHA-256 identical, 3/3 |
+| One-line code edit | 41.04 | 92.67 | 2.26x | SHA-256 identical, 3/3 |
+| JSON manifest copy | 46.42 | 94.95 | 2.05x | SHA-256 identical, 3/3 |
+| Chinese document copy | 46.40 | 85.55 | 1.84x | SHA-256 identical, 3/3 |
+| Multi-turn code edit | 45.92 | 86.83 | 1.89x | SHA-256 identical, 3/3 |
+
+A separate one-run smoke from the production-default implementation, with no
+PLD environment variable set, produced 86.61–92.88 tok/s across the same five
+scenarios. All five output hashes matched both the baseline and the qualifying
+PLD run.
+
+## Correctness evidence
+
+- The 45-case Flash-Next battery retained the baseline pass vector: 42/45.
+  Long context (8K/32K), JSON schema, tool calls, Chinese, multi-turn, stop
+  sequences, and both protocol routes passed.
+- The three existing failures were reproduced without PLD: one model math
+  answer, one overly narrow code scorer, and a project harness that invokes an
+  unavailable `python` executable instead of `python3`.
+- The five high-overlap scenarios produced identical output hashes with PLD on
+  and off for every measured run (15/15).
+- Model-free tests cover full acceptance, partial rejection, target/MTP cache
+  alignment, request-scoped prompt history, explicit opt-out, sampled-request
+  exclusion, and cancellation during target verification.
+
+## Why the old defaults were rejected
+
+An 8–10-token lookup suffix is too ambiguous in repetitive code and structured
+documents. Token replay found frequent wrong-first-token proposals and the
+real model skipped repeated lines under that policy. At 16–64 tokens with an
+8-token proposal, exact-copy and JSON traces had no wrong-first-token proposal.
+Expected disagreements at an edited code line or changing Chinese sequence
+number were rejected by the target and rolled back without changing output.
+
+## Scope boundary
+
+This evidence does not qualify sampled/non-greedy PLD, other model families, or
+continuous multi-request speculation. Those routes remain on their existing
+decoders until they have independent correctness and performance evidence.

--- a/docs/engineering/performance/qwen4-prompt-lookup-qualification.md
+++ b/docs/engineering/performance/qwen4-prompt-lookup-qualification.md
@@ -12,7 +12,9 @@ Prompt-lookup drafting (PLD) is qualified for greedy native-MTP requests on
 
 The policy is captured with the immutable prompt at request start. Every
 proposal is verified by the target model, and only the accepted prefix is
-committed to the target and MTP caches.
+committed to the target and MTP caches. Before verification, the proposal is
+shortened to the largest amount every composite target cache can roll back;
+if no safe amount exists, that round uses ordinary MTP.
 
 The PLD adaptation and high-overlap optimization direction were contributed by
 Pierre Lamy in PR #2809. This qualification narrows that contribution to the
@@ -80,7 +82,8 @@ PLD run.
   and off for every measured run (15/15).
 - Model-free tests cover full acceptance, partial rejection, target/MTP cache
   alignment, request-scoped prompt history, explicit opt-out, sampled-request
-  exclusion, and cancellation during target verification.
+  exclusion, cancellation during target verification, and amount-aware QSA
+  rollback admission across a compression boundary.
 
 ## Why the old defaults were rejected
 

--- a/docs/engineering/performance/qwen4-prompt-lookup-qualification.md
+++ b/docs/engineering/performance/qwen4-prompt-lookup-qualification.md
@@ -12,9 +12,9 @@ Prompt-lookup drafting (PLD) is qualified for greedy native-MTP requests on
 
 The policy is captured with the immutable prompt at request start. Every
 proposal is verified by the target model, and only the accepted prefix is
-committed to the target and MTP caches. Before verification, the proposal is
-shortened to the largest amount every composite target cache can roll back;
-if no safe amount exists, that round uses ordinary MTP.
+committed to the target and MTP caches. Multi-token verification records each
+QSA raw-ring boundary so rollback remains atomic across the model's four-token
+index-compression groups. Ordinary K=1 MTP does not pay this snapshot cost.
 
 The PLD adaptation and high-overlap optimization direction were contributed by
 Pierre Lamy in PR #2809. This qualification narrows that contribution to the
@@ -59,16 +59,16 @@ Each value is the median of three cold-request runs. Completion lengths were
 
 | Scenario | MTP only (tok/s) | MTP + PLD (tok/s) | Speedup | Output parity |
 | --- | ---: | ---: | ---: | --- |
-| Exact code copy | 46.75 | 96.70 | 2.07x | SHA-256 identical, 3/3 |
-| One-line code edit | 41.04 | 92.67 | 2.26x | SHA-256 identical, 3/3 |
-| JSON manifest copy | 46.42 | 94.95 | 2.05x | SHA-256 identical, 3/3 |
-| Chinese document copy | 46.40 | 85.55 | 1.84x | SHA-256 identical, 3/3 |
-| Multi-turn code edit | 45.92 | 86.83 | 1.89x | SHA-256 identical, 3/3 |
+| Exact code copy | 46.75 | 98.74 | 2.11x | SHA-256 identical, 3/3 |
+| One-line code edit | 41.04 | 94.12 | 2.29x | SHA-256 identical, 3/3 |
+| JSON manifest copy | 46.42 | 99.40 | 2.14x | SHA-256 identical, 3/3 |
+| Chinese document copy | 46.40 | 92.74 | 2.00x | SHA-256 identical, 3/3 |
+| Multi-turn code edit | 45.92 | 93.80 | 2.04x | SHA-256 identical, 3/3 |
 
-A separate one-run smoke from the production-default implementation, with no
-PLD environment variable set, produced 86.61–92.88 tok/s across the same five
-scenarios. All five output hashes matched both the baseline and the qualifying
-PLD run.
+The production-default run used no PLD environment variables. It proposed
+15,680 tokens in 1,960 eight-token windows and accepted 15,388 (98.1%). MLX
+active memory remained approximately 104.7–105.6 GB; the process-reported peak
+was 148.1 GB.
 
 ## Correctness evidence
 
@@ -82,8 +82,9 @@ PLD run.
   and off for every measured run (15/15).
 - Model-free tests cover full acceptance, partial rejection, target/MTP cache
   alignment, request-scoped prompt history, explicit opt-out, sampled-request
-  exclusion, cancellation during target verification, and amount-aware QSA
-  rollback admission across a compression boundary.
+  exclusion, cancellation during target verification, transaction restoration
+  across a QSA compression boundary, and zero QSA snapshot overhead for
+  ordinary K=1 MTP.
 
 ## Why the old defaults were rejected
 

--- a/tests/test_dspark_scheduler.py
+++ b/tests/test_dspark_scheduler.py
@@ -83,6 +83,45 @@ def test_trim_transaction_restores_earlier_cache_when_later_trim_fails() -> None
     assert later.offset == 9
 
 
+def test_trim_transaction_accepts_turboquant_void_return_contract() -> None:
+    """TurboQuant mutates its scalar cursor and deliberately returns None."""
+    from vllm_mlx.cache_rollback import can_trim, trim_all
+    from vllm_mlx.turboquant import TurboQuantConfig, TurboQuantKVCache
+
+    keys = mx.zeros((1, 1, 5, 2))
+    values = mx.zeros((1, 1, 5, 1))
+    cache = TurboQuantKVCache(
+        keys,
+        (values, values, values),
+        offset=5,
+        config=TurboQuantConfig(),
+        head_dim=2,
+    )
+
+    assert can_trim(cache, 3)
+    assert trim_all([cache], 3)
+    assert cache.offset == 2
+    assert cache.keys.shape[-2] == 2
+
+
+def test_trim_transaction_rejects_void_return_without_cursor_change() -> None:
+    from vllm_mlx.cache_rollback import trim_all
+
+    class BrokenVoidCache:
+        def __init__(self):
+            self.offset = 5
+
+        def is_trimmable(self):
+            return True
+
+        def trim(self, _n):
+            return None
+
+    cache = BrokenVoidCache()
+    assert not trim_all([cache], 3)
+    assert cache.offset == 5
+
+
 def test_trim_admission_guards_and_custom_checkpoint_restore() -> None:
     from vllm_mlx.cache_rollback import can_trim, trim_all
 
@@ -123,10 +162,15 @@ def test_trim_admission_guards_and_custom_checkpoint_restore() -> None:
         def size(self):
             return object()
 
+    class MissingSizeCache:
+        def is_trimmable(self):
+            return True
+
     assert can_trim(UndoCache(), 2)
     assert not can_trim(object(), 1)
     assert can_trim(LegacyCache(2), 2)
     assert not can_trim(InvalidSizeCache(2), 1)
+    assert not can_trim(MissingSizeCache(), 1)
     assert not can_trim(LegacyCache(2), -1)
     assert trim_all([], 0)
     assert not trim_all([], -1)

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -3251,6 +3251,128 @@ def test_install_mtp_vendored_carries_seeded_rng_after_priming(monkeypatch):
     assert gb.orig_step_calls == 0
 
 
+def test_install_mtp_vendored_latches_prompt_lookup_and_complete_history(
+    monkeypatch,
+):
+    """A qualified greedy request carries one immutable PLD decision/history."""
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+    from vllm_mlx.spec_decode.mtp.prompt_lookup import PromptLookupPolicy
+
+    seen: dict[str, object] = {}
+
+    class _FakeGen:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return (201, mx.array([0.0]), False)
+
+        def close(self):
+            pass
+
+    class _QualifiedModel(_StubModel):
+        mtp_prompt_lookup_supported = True
+        mtp_prompt_lookup_policy = PromptLookupPolicy(enabled_by_default=True)
+
+    def _recording_generator(*args, **kwargs):
+        seen.update(kwargs)
+        return _FakeGen()
+
+    monkeypatch.delenv("RAPID_MLX_MTP_PROMPT_LOOKUP", raising=False)
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "18")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM", "42")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "6")
+    monkeypatch.setattr(_gen_mod, "mtp_generate_step", _recording_generator)
+
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [31]
+    gb.tokens = [[101, 102]]
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    request_stub = SimpleNamespace(
+        sampling_params=SimpleNamespace(temperature=0.0),
+    )
+
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_QualifiedModel(),
+        requests={"req-31": request_stub},
+        uid_to_request_id={31: "req-31"},
+    )
+    gb._step()
+
+    assert seen["prompt_lookup_enabled"] is True
+    assert seen["prompt_lookup_history"] == [101, 102, 500]
+    policy = seen["prompt_lookup_policy"]
+    assert isinstance(policy, PromptLookupPolicy)
+    assert (policy.min_ngram, policy.max_ngram, policy.max_tokens) == (18, 42, 6)
+    assert seen["timing_stats"] is batch_gen._mtp_vendored_stats
+    assert batch_gen._mtp_vendored_stats["prompt_lookup_proposals"] == 0.0
+
+
+def test_install_mtp_vendored_does_not_admit_sampled_prompt_lookup(monkeypatch):
+    """Non-greedy requests stay on ordinary MTP pending separate qualification."""
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+    from vllm_mlx.spec_decode.mtp.prompt_lookup import PromptLookupPolicy
+
+    seen: dict[str, object] = {}
+
+    class _FakeGen:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return (201, mx.array([0.0]), False)
+
+        def close(self):
+            pass
+
+    class _QualifiedModel(_StubModel):
+        mtp_prompt_lookup_supported = True
+        mtp_prompt_lookup_policy = PromptLookupPolicy(enabled_by_default=True)
+
+    monkeypatch.setattr(
+        _gen_mod,
+        "mtp_generate_step",
+        lambda *args, **kwargs: seen.update(kwargs) or _FakeGen(),
+    )
+    batch_gen, gb = _make_batch_gen_with_gb()
+    gb.uids = [32]
+    gb.tokens = [[101, 102]]
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    request_stub = SimpleNamespace(
+        sampling_params=SimpleNamespace(
+            temperature=0.7,
+            top_p=0.9,
+            top_k=0,
+            min_p=0.0,
+            seed=None,
+        ),
+    )
+
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_QualifiedModel(),
+        requests={"req-32": request_stub},
+        uid_to_request_id={32: "req-32"},
+    )
+    gb._step()
+
+    assert seen["prompt_lookup_enabled"] is False
+    assert seen["prompt_lookup_history"] is None
+
+
 def test_install_mtp_vendored_passes_request_sampling_and_safe_penalty_context(
     monkeypatch,
 ):

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -3315,6 +3315,24 @@ def test_install_mtp_vendored_latches_prompt_lookup_and_complete_history(
     assert batch_gen._mtp_vendored_stats["prompt_lookup_proposals"] == 0.0
 
 
+def test_scheduler_stats_export_vendored_mtp_counters_by_value():
+    from unittest.mock import MagicMock
+
+    from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda _text: [1]
+    scheduler = Scheduler(MagicMock(), tokenizer, SchedulerConfig(max_num_seqs=1))
+    counters = {"prompt_lookup_proposals": 3.0}
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator._mtp_vendored_stats = counters
+
+    stats = scheduler.get_stats()
+
+    assert stats["mtp_vendored"] == counters
+    assert stats["mtp_vendored"] is not counters
+
+
 def test_install_mtp_vendored_does_not_admit_sampled_prompt_lookup(monkeypatch):
     """Non-greedy requests stay on ordinary MTP pending separate qualification."""
     from types import SimpleNamespace

--- a/tests/test_mtp_prompt_lookup.py
+++ b/tests/test_mtp_prompt_lookup.py
@@ -2,7 +2,35 @@
 
 import pytest
 
-from vllm_mlx.spec_decode.mtp.prompt_lookup import PromptLookupIndex
+from vllm_mlx.spec_decode.mtp.prompt_lookup import (
+    PromptLookupIndex,
+    PromptLookupPolicy,
+)
+
+
+def test_prompt_lookup_policy_validates_model_qualified_defaults() -> None:
+    policy = PromptLookupPolicy(
+        enabled_by_default=True,
+        min_ngram=16,
+        max_ngram=64,
+        max_tokens=8,
+    )
+
+    assert policy.enabled_by_default is True
+    assert (policy.min_ngram, policy.max_ngram, policy.max_tokens) == (16, 64, 8)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"min_ngram": 1}, "min_ngram"),
+        ({"min_ngram": 4, "max_ngram": 3}, "max_ngram"),
+        ({"max_tokens": 0}, "max_tokens"),
+    ],
+)
+def test_prompt_lookup_policy_rejects_invalid_configuration(kwargs, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        PromptLookupPolicy(**kwargs)
 
 
 def test_prompt_lookup_returns_prompt_continuation() -> None:

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2383,11 +2383,19 @@ class _CountingKVCache:
     def is_trimmable(self):
         return True
 
+    def can_trim(self, n):
+        return 0 <= n <= self.offset
+
+    def size(self):
+        return self.offset
+
     def trim(self, n):
         if n < 0:
             raise AssertionError(f"negative trim: {n}")
         self.trim_calls.append(n)
-        self.offset -= min(self.offset, n)
+        trimmed = min(self.offset, n)
+        self.offset -= trimmed
+        return trimmed
 
 
 class _CacheAdvancingQwen35Model(_MockedQwen35Model):

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2837,6 +2837,67 @@ def test_generator_k3_restores_ssm_state_at_partial_accept_boundary():
     assert ssm.rollback_state is None
 
 
+def test_generator_legacy_ssm_snapshot_is_limited_to_one_token():
+    """The legacy tuple restores K=1 and fails closed for a K>1 rollback."""
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    class LegacySSMCache:
+        rollback_state = None
+
+        def __init__(self):
+            self.cache = [mx.array([0]), mx.array([0])]
+
+        def __getitem__(self, idx):
+            return self.cache[idx]
+
+        def __setitem__(self, idx, value):
+            self.cache[idx] = value
+
+        def is_trimmable(self):
+            return False
+
+    class LegacySnapshotModel(_MockedQwen35Model):
+        def __init__(self, *, max_k):
+            super().__init__([7, 99, 0, 0, 0], list(range(11, 11 + max_k)))
+            self.layers = [object()]
+
+        def __call__(self, inputs, cache=None, **kwargs):
+            result = super().__call__(inputs, cache=cache, **kwargs)
+            if cache and inputs.shape[1] > 1:
+                cache[0].rollback_state = (mx.array([101]), mx.array([201]))
+                cache[0][0], cache[0][1] = mx.array([999]), mx.array([999])
+            return result
+
+    k1_cache = LegacySSMCache()
+    list(
+        mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            LegacySnapshotModel(max_k=1),
+            prompt_cache=[k1_cache],
+            max_tokens=2,
+            max_k=1,
+            disable_auto_k=True,
+            accept_counter=MTPAcceptCounter(),
+        )
+    )
+    assert k1_cache[0].item() == 101
+    assert k1_cache[1].item() == 201
+
+    with pytest.raises(AssertionError, match="only roll back one token"):
+        list(
+            mtp_generate_step(
+                mx.array([1], dtype=mx.uint32),
+                LegacySnapshotModel(max_k=3),
+                prompt_cache=[LegacySSMCache()],
+                max_tokens=4,
+                max_k=3,
+                disable_auto_k=True,
+                accept_counter=MTPAcceptCounter(),
+            )
+        )
+
+
 def test_generator_rolls_back_verify_round_on_early_materialization_abort(
     monkeypatch,
 ):
@@ -2951,11 +3012,30 @@ def test_generator_prompt_lookup_verifies_prompt_continuation(monkeypatch):
     # 7, rejects MTP's 99 in favour of target token 8, and finds prompt suffix
     # [7, 8] -> [20, 21]. The copied block is accepted only because the target
     # independently predicts 20 and 21; 22 is its ordinary bonus token.
-    model = _CacheAdvancingQwen35Model(
+    class CompositeCache:
+        def __init__(self):
+            self.caches = [_CountingKVCache()]
+
+        @property
+        def offset(self):
+            return self.caches[0].offset
+
+        @offset.setter
+        def offset(self, value):
+            self.caches[0].offset = value
+
+    class SnapshottingModel(_CacheAdvancingQwen35Model):
+        def __call__(self, inputs, cache=None, **kwargs):
+            result = super().__call__(inputs, cache=cache, **kwargs)
+            if cache and inputs.shape[1] > 2:
+                cache[0].caches[0].rollback_state = object()
+            return result
+
+    model = SnapshottingModel(
         backbone_outputs=[0, 0, 0, 7, 8, 0, 20, 21, 22],
         mtp_outputs=[0, 0, 0, 99, 0, 0],
     )
-    model_cache = _CountingKVCache()
+    model_cache = CompositeCache()
     mtp_cache = _CountingKVCache()
     timing: dict[str, float] = {}
 
@@ -2969,6 +3049,7 @@ def test_generator_prompt_lookup_verifies_prompt_continuation(monkeypatch):
             prompt_cache=[model_cache, mtp_cache],
             accept_counter=MTPAcceptCounter(),
             timing_stats=timing,
+            prompt_lookup_history=mx.array([7, 8, 20, 21], dtype=mx.uint32),
         )
     )
 
@@ -2985,7 +3066,8 @@ def test_generator_prompt_lookup_verifies_prompt_continuation(monkeypatch):
     # Three prefill positions + one ordinary draft + two lookup-history sync
     # positions. Prompt lookup itself consumed no MTP proposal.
     assert model._mtp_cursor == 6
-    assert model_cache.trim_calls == [1]
+    assert model_cache.caches[0].trim_calls == [1]
+    assert model_cache.caches[0].rollback_state is None
     assert mtp_cache.trim_calls == [1]
     assert mtp_cache.offset == 5
 

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2987,11 +2987,18 @@ def test_prompt_lookup_requires_an_audited_model_capability(monkeypatch):
     from types import SimpleNamespace
 
     from vllm_mlx.spec_decode.mtp.generator import _prompt_lookup_is_enabled
+    from vllm_mlx.spec_decode.mtp.prompt_lookup import PromptLookupPolicy
 
     monkeypatch.delenv("RAPID_MLX_MTP_PROMPT_LOOKUP", raising=False)
     assert not _prompt_lookup_is_enabled(
         SimpleNamespace(mtp_prompt_lookup_supported=True)
     )
+    qualified = SimpleNamespace(
+        mtp_prompt_lookup_supported=True,
+        mtp_prompt_lookup_policy=PromptLookupPolicy(enabled_by_default=True),
+    )
+    assert _prompt_lookup_is_enabled(qualified)
+    assert not _prompt_lookup_is_enabled(qualified, requested=False)
 
     monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "1")
     assert not _prompt_lookup_is_enabled(SimpleNamespace())
@@ -2999,11 +3006,13 @@ def test_prompt_lookup_requires_an_audited_model_capability(monkeypatch):
         SimpleNamespace(mtp_prompt_lookup_supported=False)
     )
     assert _prompt_lookup_is_enabled(SimpleNamespace(mtp_prompt_lookup_supported=True))
+    assert _prompt_lookup_is_enabled(qualified)
 
     monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "off")
     assert not _prompt_lookup_is_enabled(
         SimpleNamespace(mtp_prompt_lookup_supported=True)
     )
+    assert not _prompt_lookup_is_enabled(qualified)
 
 
 def test_generator_prompt_lookup_partial_reject_keeps_mtp_cache_aligned(
@@ -3055,6 +3064,55 @@ def test_generator_prompt_lookup_partial_reject_keeps_mtp_cache_aligned(
     assert mtp_cache.trim_calls == [1]
     assert mtp_cache.offset == 4
     assert model._mtp_cursor == 5
+
+
+def test_generator_prompt_lookup_rolls_back_on_verify_materialization_abort(
+    monkeypatch,
+):
+    """A cancelled PLD verify drops every uncommitted target position."""
+    import vllm_mlx.spec_decode.mtp.generator as generator_mod
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "1")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "2")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM", "2")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "2")
+
+    model = _CacheAdvancingQwen35Model(
+        backbone_outputs=[0, 0, 0, 7, 8, 0, 20, 21, 22],
+        mtp_outputs=[0, 0, 0, 99],
+    )
+    model_cache = _CountingKVCache()
+    mtp_cache = _CountingKVCache()
+    gen = mtp_generate_step(
+        mx.array([7, 8, 20, 21], dtype=mx.uint32),
+        model,
+        max_tokens=5,
+        max_k=1,
+        disable_auto_k=True,
+        prompt_cache=[model_cache, mtp_cache],
+        accept_counter=MTPAcceptCounter(),
+    )
+
+    assert next(gen)[0] == 7
+    assert next(gen)[0] == 8
+    assert model_cache.trim_calls == [1]
+    assert mtp_cache.trim_calls == [1]
+
+    monkeypatch.setattr(
+        generator_mod.mx,
+        "eval",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("sentinel PLD verify abort")
+        ),
+    )
+    with pytest.raises(RuntimeError, match="sentinel PLD verify abort"):
+        next(gen)
+
+    assert model_cache.trim_calls == [1, 2]
+    # PLD bypasses the MTP drafter, so its uncommitted cache never advanced.
+    assert mtp_cache.trim_calls == [1]
 
 
 def test_generator_runs_with_int4_quantized_kv_cache_kwargs():

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -3072,6 +3072,66 @@ def test_generator_prompt_lookup_verifies_prompt_continuation(monkeypatch):
     assert mtp_cache.offset == 5
 
 
+def test_generator_prompt_lookup_falls_through_when_cache_cannot_recover(monkeypatch):
+    """A matching prompt never bypasses a failed full-width cache preflight."""
+    import vllm_mlx.spec_decode.mtp.generator as generator_mod
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import (
+        _safe_prompt_lookup_draft_count,
+        mtp_generate_step,
+    )
+
+    assert _safe_prompt_lookup_draft_count([object()], 2) == 0
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP", "1")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "2")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM", "2")
+    monkeypatch.setenv("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "2")
+    monkeypatch.setattr(generator_mod, "_safe_prompt_lookup_draft_count", lambda *_: 0)
+
+    timing: dict[str, float] = {}
+    list(
+        mtp_generate_step(
+            mx.array([7, 8, 20, 21], dtype=mx.uint32),
+            _CacheAdvancingQwen35Model(
+                backbone_outputs=[0, 0, 0, 7, 8, 20, 21, 22],
+                mtp_outputs=[0, 0, 0, 99, 20, 21],
+            ),
+            max_tokens=3,
+            max_k=1,
+            disable_auto_k=True,
+            prompt_cache=[_CountingKVCache(), _CountingKVCache()],
+            accept_counter=MTPAcceptCounter(),
+            timing_stats=timing,
+        )
+    )
+
+    assert timing["prompt_lookup_cache_fallthroughs"] == 1
+
+
+def test_generator_fails_closed_when_trim_breaks_its_contract():
+    """A short target-cache trim aborts rather than emitting from stale state."""
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    class ShortTrimCache(_CountingKVCache):
+        def trim(self, n):
+            self.trim_calls.append(n)
+            return 0
+
+    with pytest.raises(RuntimeError, match="violated speculative rollback"):
+        list(
+            mtp_generate_step(
+                mx.array([1], dtype=mx.uint32),
+                _CacheAdvancingQwen35Model([7, 12, 99], [11]),
+                prompt_cache=[ShortTrimCache(), _CountingKVCache()],
+                max_tokens=2,
+                max_k=1,
+                disable_auto_k=True,
+                accept_counter=MTPAcceptCounter(),
+            )
+        )
+
+
 def test_prompt_lookup_requires_an_audited_model_capability(monkeypatch):
     """An env opt-in cannot force unaudited MTP backends into prompt lookup."""
     from types import SimpleNamespace

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1498,6 +1498,10 @@ def test_qwen4_mtp_inject_loads_complete_local_tensor_contract(tmp_path, monkeyp
 
     assert inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=checkpoint) is True
     assert inject.validate_qwen4_exp_mtp_support(model) is True
+    assert model.mtp_prompt_lookup_supported is True
+    policy = model.mtp_prompt_lookup_policy
+    assert policy.enabled_by_default is True
+    assert (policy.min_ngram, policy.max_ngram, policy.max_tokens) == (16, 64, 8)
 
 
 def test_qwen4_mtp_inject_fails_closed_on_guards_tensor_mismatch_and_exception(

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -709,8 +709,8 @@ def test_scheduler_rollback_preflights_qsa_cachelist_for_full_rejection():
     assert kv.offset == qsa.offset == 8
 
 
-def test_prompt_lookup_clips_draft_to_qsa_recoverable_window():
-    """PLD never verifies more tokens than every Qwen4 cache can undo."""
+def test_prompt_lookup_admits_qsa_snapshot_rollback_across_group():
+    """QSA's verify snapshot admits the full PLD proposal at a boundary."""
     from vllm_mlx.spec_decode.mtp.generator import (
         _safe_prompt_lookup_draft_count,
     )
@@ -726,11 +726,66 @@ def test_prompt_lookup_clips_draft_to_qsa_recoverable_window():
     cache = CacheList(kv, qsa)
     recurrent = Qwen4ExpStateCache(size=2)
 
-    # At offset 9 the retained raw group can undo one token, not two. The
-    # proposal is shortened before target verification mutates either leaf;
-    # the recurrent layer is admitted through its snapshot-restore contract.
-    assert _safe_prompt_lookup_draft_count([recurrent, cache], 2) == 1
+    # At offset 9 the ordinary raw ring can undo one token, not two. Both QSA
+    # and recurrent layers publish verify snapshots, so PLD may safely retain
+    # the full proposal and transactionally select an accepted boundary later.
+    assert _safe_prompt_lookup_draft_count([recurrent, cache], 2) == 2
     assert kv.offset == qsa.offset == 9
+
+
+def test_qsa_speculative_snapshot_restores_cross_group_accepted_prefix():
+    """A partial PLD rejection preserves only base + accepted QSA rows."""
+    from vllm_mlx.cache_rollback import trim_all
+
+    def transform(group, start):
+        return group + start
+
+    initial = mx.arange(9, dtype=mx.float32).reshape(1, 9, 1)
+    verify = mx.array([[[90.0], [91.0], [92.0]]])
+    qsa = QSAIndexCache(compress_ratio=4)
+    qsa.update(initial, transform)
+    kv = KVCache()
+    kv.update_and_fetch(initial[:, None, :, :], -initial[:, None, :, :])
+
+    qsa.update(verify, transform, record_rollback=True)
+    kv.update_and_fetch(verify[:, None, :, :], -verify[:, None, :, :])
+    assert qsa.offset == kv.offset == 12
+
+    # Reject both drafts from [base, draft_1, draft_2], retaining base only.
+    assert trim_all([CacheList(kv, qsa)], 2)
+    assert qsa.offset == kv.offset == 10
+    assert qsa.rollback_state is None
+
+    cold = QSAIndexCache(compress_ratio=4)
+    cold.update(mx.concatenate([initial, verify[:, :1]], axis=1), transform)
+    mx.eval(qsa.state, cold.state)
+    assert qsa._compressed_count == cold._compressed_count
+    np.testing.assert_array_equal(np.array(qsa.raw_ring), np.array(cold.raw_ring))
+    np.testing.assert_array_equal(np.array(qsa.state[1]), np.array(cold.state[1]))
+
+
+def test_qsa_speculative_snapshot_rejects_padded_or_batched_verify():
+    """Snapshots are deliberately limited to the audited single-row lane."""
+
+    qsa = QSAIndexCache(compress_ratio=4, left_padding=[0, 0])
+    raw = mx.zeros((2, 1, 1), dtype=mx.float32)
+
+    with pytest.raises(ValueError, match="one unpadded request"):
+        qsa.update(raw, lambda group, _start: group, record_rollback=True)
+
+
+def test_qsa_speculative_snapshot_fails_closed_on_invalid_boundary():
+    """Missing, incomplete, and impossible snapshot boundaries never trim."""
+
+    qsa = QSAIndexCache(compress_ratio=4)
+    with pytest.raises(AssertionError, match="no complete saved boundary"):
+        qsa.restore_rollback(1, 2)
+
+    raw = mx.arange(3, dtype=mx.float32).reshape(1, 3, 1)
+    qsa.update(raw, lambda group, _start: group, record_rollback=True)
+    assert qsa.trim(3) == 0
+    with pytest.raises(AssertionError, match="invalid QSA rollback boundary"):
+        qsa.restore_rollback(3, 3)
 
 
 def test_suffix_scheduler_falls_through_before_qsa_multitoken_verify():
@@ -1218,6 +1273,25 @@ def test_speculative_reject_restores_gdn_ple_and_qsa_state():
         else:
             assert baseline[0].offset == restored[0].offset
             assert baseline[1].offset == restored[1].offset
+
+
+def test_qsa_snapshots_only_multi_token_verify_windows():
+    """Ordinary K=1 MTP pays no QSA snapshot cost; PLD K>1 does."""
+    args = _ple_args()
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    k1_cache = model.make_cache()
+    pld_cache = model.make_cache()
+    prompt = mx.array([[1, 2, 3]])
+    mx.eval(model(prompt, cache=k1_cache), model(prompt, cache=pld_cache))
+
+    mx.eval(model(mx.array([[4, 5]]), cache=k1_cache, n_confirmed=1))
+    mx.eval(model(mx.array([[4, 5, 6]]), cache=pld_cache, n_confirmed=2))
+
+    k1_qsa = next(cache[1] for cache in k1_cache if isinstance(cache, CacheList))
+    pld_qsa = next(cache[1] for cache in pld_cache if isinstance(cache, CacheList))
+    assert k1_qsa.rollback_state is None
+    assert pld_qsa.rollback_state is not None
+    assert len(pld_qsa.rollback_state) == 3
 
 
 def test_qwen4_state_cache_restores_atomic_slot_boundary():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -709,6 +709,30 @@ def test_scheduler_rollback_preflights_qsa_cachelist_for_full_rejection():
     assert kv.offset == qsa.offset == 8
 
 
+def test_prompt_lookup_clips_draft_to_qsa_recoverable_window():
+    """PLD never verifies more tokens than every Qwen4 cache can undo."""
+    from vllm_mlx.spec_decode.mtp.generator import (
+        _safe_prompt_lookup_draft_count,
+    )
+
+    kv = KVCache()
+    keys = mx.arange(9, dtype=mx.float32).reshape(1, 1, 9, 1)
+    kv.update_and_fetch(keys, -keys)
+    qsa = QSAIndexCache(compress_ratio=4)
+    qsa.update(
+        mx.arange(9, dtype=mx.float32).reshape(1, 9, 1),
+        lambda group, start: group + start,
+    )
+    cache = CacheList(kv, qsa)
+    recurrent = Qwen4ExpStateCache(size=2)
+
+    # At offset 9 the retained raw group can undo one token, not two. The
+    # proposal is shortened before target verification mutates either leaf;
+    # the recurrent layer is admitted through its snapshot-restore contract.
+    assert _safe_prompt_lookup_draft_count([recurrent, cache], 2) == 1
+    assert kv.offset == qsa.offset == 9
+
+
 def test_suffix_scheduler_falls_through_before_qsa_multitoken_verify():
     from vllm_mlx.scheduler import _install_suffix_decoding
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -575,6 +575,7 @@ class TestHealthRoutes:
                 "prompt_lookup_drafted_tokens": 96.0,
                 "prompt_lookup_accepted_tokens": 91.0,
                 "prompt_lookup_rejections": 2.0,
+                "prompt_lookup_cache_fallthroughs": 3.0,
             },
         }
         orig = self._patch_config(engine=mock_engine, model_name="test-model")
@@ -582,6 +583,7 @@ class TestHealthRoutes:
             data = TestClient(self._make_app()).get("/v1/status").json()
             assert data["mtp_prompt_lookup"]["prompt_lookup_proposals"] == 12.0
             assert data["mtp_prompt_lookup"]["prompt_lookup_accepted_tokens"] == 91.0
+            assert data["mtp_prompt_lookup"]["prompt_lookup_cache_fallthroughs"] == 3.0
         finally:
             self._restore_config(orig)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -567,6 +567,24 @@ class TestHealthRoutes:
         finally:
             self._restore_config(orig)
 
+    def test_status_exposes_mtp_prompt_lookup_counters(self, mock_engine):
+        mock_engine.get_stats.return_value = {
+            **mock_engine.get_stats.return_value,
+            "mtp_vendored": {
+                "prompt_lookup_proposals": 12.0,
+                "prompt_lookup_drafted_tokens": 96.0,
+                "prompt_lookup_accepted_tokens": 91.0,
+                "prompt_lookup_rejections": 2.0,
+            },
+        }
+        orig = self._patch_config(engine=mock_engine, model_name="test-model")
+        try:
+            data = TestClient(self._make_app()).get("/v1/status").json()
+            assert data["mtp_prompt_lookup"]["prompt_lookup_proposals"] == 12.0
+            assert data["mtp_prompt_lookup"]["prompt_lookup_accepted_tokens"] == 91.0
+        finally:
+            self._restore_config(orig)
+
     def test_status_handles_non_dict_batch_generator(self, mock_engine):
         """Defensive: malformed batch_generator (not a dict) must not 500.
 

--- a/tests/test_scheduler_throughput_stats.py
+++ b/tests/test_scheduler_throughput_stats.py
@@ -41,6 +41,18 @@ def test_text_scheduler_exports_live_batch_generator_throughput():
     assert 4.0 < throughput["generation_tps"] < 6.0
 
 
+def test_text_scheduler_exports_vendored_mtp_counters_by_value():
+    scheduler = _scheduler()
+    counters = {"prompt_lookup_proposals": 3.0}
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator._mtp_vendored_stats = counters
+
+    stats = scheduler.get_stats()
+
+    assert stats["mtp_vendored"] == counters
+    assert stats["mtp_vendored"] is not counters
+
+
 def test_prompt_throughput_aggregates_requests_in_the_same_batch():
     scheduler = _scheduler()
     started = time.time() - 1.0

--- a/tests/test_scheduler_throughput_stats.py
+++ b/tests/test_scheduler_throughput_stats.py
@@ -41,18 +41,6 @@ def test_text_scheduler_exports_live_batch_generator_throughput():
     assert 4.0 < throughput["generation_tps"] < 6.0
 
 
-def test_text_scheduler_exports_vendored_mtp_counters_by_value():
-    scheduler = _scheduler()
-    counters = {"prompt_lookup_proposals": 3.0}
-    scheduler.batch_generator = MagicMock()
-    scheduler.batch_generator._mtp_vendored_stats = counters
-
-    stats = scheduler.get_stats()
-
-    assert stats["mtp_vendored"] == counters
-    assert stats["mtp_vendored"] is not counters
-
-
 def test_prompt_throughput_aggregates_requests_in_the_same_batch():
     scheduler = _scheduler()
     started = time.time() - 1.0

--- a/vllm_mlx/cache_rollback.py
+++ b/vllm_mlx/cache_rollback.py
@@ -44,6 +44,18 @@ def _restore(cache: Any, checkpoint) -> None:
     vars(cache).update(state)
 
 
+def _logical_size(cache: Any) -> int | None:
+    """Return a scalar cache cursor across legacy and current cache APIs."""
+    size = getattr(cache, "size", None)
+    value = size() if callable(size) else getattr(cache, "offset", None)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def can_trim(cache: Any, n: int) -> bool:
     """Return whether ``cache.trim(n)`` can commit without partial mutation."""
     if n < 0:
@@ -58,14 +70,10 @@ def can_trim(cache: Any, n: int) -> bool:
     if callable(can_undo) and can_undo(n):
         return True
     check = getattr(cache, "is_trimmable", None)
-    size = getattr(cache, "size", None)
-    if not (callable(check) and check() and callable(size)):
+    if not (callable(check) and check()):
         return False
-    logical_size = size()
-    try:
-        return int(logical_size) >= n
-    except (TypeError, ValueError):
-        return False
+    logical_size = _logical_size(cache)
+    return logical_size is not None and logical_size >= n
 
 
 def can_advance(cache: Any, n: int) -> bool:
@@ -96,7 +104,15 @@ def trim_all(caches: Iterable[Any], n: int) -> bool:
         checkpoints = [(cache, _checkpoint(cache)) for cache in leaves]
         try:
             for cache in leaves:
-                if cache.trim(n) != n:
+                before = _logical_size(cache)
+                result = cache.trim(n)
+                if result is None:
+                    after = _logical_size(cache)
+                    if before is None or after != before - n:
+                        raise RuntimeError(
+                            "cache trim did not advance by requested amount"
+                        )
+                elif result != n:
                     raise RuntimeError("cache returned a short trim")
         except Exception:
             for cache, checkpoint in reversed(checkpoints):

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -680,6 +680,7 @@ class QSAIndexer(nn.Module):
         cache: QSAIndexCache,
         *,
         physical_kv_length: int,
+        record_rollback: bool = False,
     ) -> mx.array | None:
         batch, length, _ = hidden_states.shape
         cache._ensure_batch(batch)
@@ -729,6 +730,7 @@ class QSAIndexer(nn.Module):
             raw_keys,
             transform_group,
             transform_groups=transform_groups,
+            record_rollback=record_rollback,
         )
         # The architecture reference stays on ordinary causal attention while
         # every complete block fits the QSA budget. Preserve that exact math
@@ -879,6 +881,8 @@ class QSAAttention(nn.Module):
         x: mx.array,
         cache: Any | None = None,
         mask: mx.array | str | None = None,
+        *,
+        record_rollback: bool = False,
     ) -> mx.array:
         batch, length, _ = x.shape
         kv_cache = None if cache is None else cache[0]
@@ -900,6 +904,7 @@ class QSAAttention(nn.Module):
             x,
             index_cache,
             physical_kv_length=physical_length,
+            record_rollback=record_rollback,
         )
 
         projected = self.q_proj(x).reshape(
@@ -1331,6 +1336,7 @@ class DecoderLayer(nn.Module):
         mask: mx.array | None,
         cache: Any | None,
         record_rollback: bool = False,
+        record_qsa_rollback: bool = False,
     ) -> mx.array:
         if self.ple is not None:
             hidden_states = hidden_states + self.ple(
@@ -1349,7 +1355,12 @@ class DecoderLayer(nn.Module):
                 record_rollback=record_rollback,
             )
         else:
-            output = self.self_attn(mixed, cache=cache, mask=mask)
+            output = self.self_attn(
+                mixed,
+                cache=cache,
+                mask=mask,
+                record_rollback=record_qsa_rollback,
+            )
         hidden_states = self._combine(output, residual, injection)
 
         mixed, residual, injection = self.mlp_hyper_connection(hidden_states)
@@ -1376,6 +1387,7 @@ class Qwen4ExpTextModel(nn.Module):
         *,
         return_hidden: bool = False,
         record_rollback: bool = False,
+        record_qsa_rollback: bool = False,
     ) -> mx.array | tuple[mx.array, mx.array]:
         hidden_states = (
             input_embeddings
@@ -1411,6 +1423,7 @@ class Qwen4ExpTextModel(nn.Module):
                 mask=linear_mask if layer.is_linear else attention_mask,
                 cache=layer_cache,
                 record_rollback=record_rollback,
+                record_qsa_rollback=record_qsa_rollback,
             )
         output = self.hyper_connection_mixer(hidden_states)
         return (output, hidden_states) if return_hidden else output
@@ -1439,6 +1452,7 @@ class TextModel(nn.Module):
             input_embeddings,
             return_hidden=return_hidden,
             record_rollback=n_confirmed > 0 and inputs.shape[1] > 1,
+            record_qsa_rollback=n_confirmed > 1 and inputs.shape[1] > 2,
         )
         if return_hidden:
             hidden, mtp_hidden = cast(tuple[mx.array, mx.array], hidden_result)

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -99,6 +99,7 @@ class QSAIndexCache(ArraysCache):
     """Raw circular index keys plus persistent compressed-key state."""
 
     step = 256
+    rollback_state: list[tuple[list[int], list[int], list[int], mx.array]] | None = None
 
     def __init__(
         self,
@@ -115,6 +116,7 @@ class QSAIndexCache(ArraysCache):
         self._valid_until: list[int] | None = None
         self._right_padding: list[int] | None = None
         self._pending_left_padding = [int(item) for item in (left_padding or [0])]
+        self.rollback_state = None
 
     def _ensure_batch(self, batch: int):
         """Adopt mlx-lm's fresh-batch size before state is committed."""
@@ -201,6 +203,8 @@ class QSAIndexCache(ArraysCache):
         raw_keys: mx.array,
         transform_group: Callable[[mx.array, int], mx.array],
         transform_groups: Callable[[mx.array, mx.array], mx.array] | None = None,
+        *,
+        record_rollback: bool = False,
     ) -> mx.array:
         """Commit valid raw rows and cache every newly completed group.
 
@@ -213,8 +217,11 @@ class QSAIndexCache(ArraysCache):
         batch, length, dim = raw_keys.shape
         self._ensure_batch(batch)
         valid_spans = self.valid_spans(length)
+        if record_rollback and (batch != 1 or valid_spans != [(0, length)]):
+            raise ValueError("QSA speculative snapshots require one unpadded request")
         if (
-            transform_groups is not None
+            not record_rollback
+            and transform_groups is not None
             and batch == 1
             and valid_spans == [(0, length)]
             and self._offsets[0] % self.compress_ratio == 0
@@ -228,6 +235,9 @@ class QSAIndexCache(ArraysCache):
         elif self.raw_ring.shape[0] != batch or self.raw_ring.shape[-1] != dim:
             raise ValueError("QSA raw-key cache shape changed within one request")
 
+        rollback_states: (
+            list[tuple[list[int], list[int], list[int], mx.array]] | None
+        ) = [] if record_rollback else None
         completed: list[list[mx.array]] = [[] for _ in range(batch)]
         for row, (input_start, valid_length) in enumerate(valid_spans):
             for token in range(valid_length):
@@ -241,6 +251,22 @@ class QSAIndexCache(ArraysCache):
                     ).astype(raw_keys.dtype)
                     completed[row].append(
                         transform_group(pooled, position + 1 - self.compress_ratio)[0]
+                    )
+                if rollback_states is not None:
+                    # Arithmetic forces an independent lazy buffer; evaluating
+                    # below freezes every accepted boundary before a later
+                    # token overwrites the four-slot raw ring.
+                    ring_snapshot = mx.contiguous(
+                        self.raw_ring + mx.zeros_like(self.raw_ring)
+                    )
+                    offset = position + 1
+                    rollback_states.append(
+                        (
+                            [offset],
+                            [offset // self.compress_ratio],
+                            list(self._pending_left_padding),
+                            ring_snapshot,
+                        )
                     )
             self._offsets[row] += valid_length
             self._pending_left_padding[row] -= input_start
@@ -266,6 +292,9 @@ class QSAIndexCache(ArraysCache):
                     expanded[row, start : start + len(rows), :] = mx.stack(rows)
             self.compressed_keys = expanded
         self._compressed_counts = new_counts
+        if rollback_states is not None:
+            mx.eval([state[3] for state in rollback_states])
+            self.rollback_state = rollback_states
 
         if self.compressed_keys is None:
             return mx.zeros((batch, 0, dim), dtype=raw_keys.dtype)
@@ -383,13 +412,45 @@ class QSAIndexCache(ArraysCache):
 
     def can_trim(self, n: int) -> bool:
         """Amount-aware preflight consumed by composite cache rollback."""
+        if self.rollback_state is not None:
+            keep = len(self.rollback_state) - n
+            return 1 <= keep <= len(self.rollback_state)
         return all(self._can_trim_row(offset, n) for offset in self._offsets)
 
     def trim_checkpoint(self):
-        return list(self._offsets), list(self._compressed_counts)
+        return (
+            list(self._offsets),
+            list(self._compressed_counts),
+            list(self._pending_left_padding),
+            self.raw_ring,
+            self.rollback_state,
+        )
 
     def restore_trim_checkpoint(self, state):
-        self._offsets, self._compressed_counts = state
+        (
+            self._offsets,
+            self._compressed_counts,
+            self._pending_left_padding,
+            self.raw_ring,
+            self.rollback_state,
+        ) = state
+
+    def restore_rollback(self, n_to_drop: int, verify_size: int) -> None:
+        snapshots = self.rollback_state
+        if not snapshots or len(snapshots) != verify_size:
+            raise AssertionError("QSA verify rollback has no complete saved boundary")
+        keep = verify_size - n_to_drop
+        if keep < 1 or keep > len(snapshots):
+            raise AssertionError(
+                f"invalid QSA rollback boundary: keep={keep}, "
+                f"snapshots={len(snapshots)}"
+            )
+        offsets, counts, pending, raw_ring = snapshots[keep - 1]
+        self._offsets = list(offsets)
+        self._compressed_counts = list(counts)
+        self._pending_left_padding = list(pending)
+        self.raw_ring = raw_ring
+        self.rollback_state = None
 
     def _can_trim_row(self, offset: int, n: int) -> bool:
         if n < 0 or n > offset:
@@ -405,6 +466,11 @@ class QSAIndexCache(ArraysCache):
         # recently completed group at a boundary. Rewind only within that
         # recoverable window; the next update overwrites discarded rows and
         # deterministically recomputes a removed compressed block.
+        if self.rollback_state is not None:
+            if not self.can_trim(n):
+                return 0
+            self.restore_rollback(n, len(self.rollback_state))
+            return n
         if not all(self._can_trim_row(offset, n) for offset in self._offsets):
             return 0
         self._offsets = [offset - n for offset in self._offsets]

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -344,6 +344,7 @@ async def status():
             "protected_chunks": stats.get("adaptive_prefill_protected_chunks", 0),
             "reduced_chunks": stats.get("adaptive_prefill_reduced_chunks", 0),
         },
+        "mtp_prompt_lookup": stats.get("mtp_vendored", {}),
         "idle_cache_clear": stats.get(
             "idle_cache_clear",
             {"enabled": False, "seconds": 0, "clear_count": 0, "last_clear_at": None},

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1227,7 +1227,11 @@ def _install_mtp_vendored(
     # patches ArraysCache; keep the import off the scheduler boot path so a
     # non-MTP build has zero cost.
     from .spec_decode.mtp.draft_k_controller_v2 import derive_controller_key
-    from .spec_decode.mtp.generator import mtp_generate_step
+    from .spec_decode.mtp.generator import (
+        _effective_prompt_lookup_policy,
+        _prompt_lookup_is_enabled,
+        mtp_generate_step,
+    )
 
     model_max_k = getattr(mtp_model, "mtp_max_speculative_tokens", max_k)
     if max_k > model_max_k:
@@ -1306,6 +1310,12 @@ def _install_mtp_vendored(
         "gen_exhausted": 0,
         "gen_raised": 0,
         "invariant_violations": 0,
+        "prompt_lookup_proposals": 0.0,
+        "prompt_lookup_drafted_tokens": 0.0,
+        "prompt_lookup_matched_suffix_tokens": 0.0,
+        "prompt_lookup_accepted_tokens": 0.0,
+        "prompt_lookup_rejections": 0.0,
+        "prompt_lookup_mtp_sync_seconds": 0.0,
     }
 
     _initial_skip_logged: set[tuple[int, str]] = set()
@@ -1793,6 +1803,13 @@ def _install_mtp_vendored(
             # permanently disabled so we don't retry construction on
             # every subsequent step.
             try:
+                prompt_lookup_policy = _effective_prompt_lookup_policy(mtp_model)
+                prompt_lookup_enabled = sampling_options[
+                    "temp"
+                ] == 0 and _prompt_lookup_is_enabled(
+                    mtp_model,
+                    requested=prompt_lookup_policy.enabled_by_default,
+                )
                 gen = mtp_generate_step(
                     prompt=first_tok_arr.astype(mx.uint32),
                     model=mtp_model,
@@ -1837,6 +1854,17 @@ def _install_mtp_vendored(
                     # priming token. Both owners run on this generation
                     # thread; never re-derive from the public seed.
                     lane_rng=sampling_options["lane_rng"],
+                    timing_stats=_stats,
+                    # Prompt lookup is request-scoped. Capture both the
+                    # route decision and immutable prompt history before the
+                    # generator mutates GenerationBatch bookkeeping.
+                    prompt_lookup_enabled=prompt_lookup_enabled,
+                    prompt_lookup_history=(
+                        list(gb.tokens[0]) + [first_tok]
+                        if prompt_lookup_enabled
+                        else None
+                    ),
+                    prompt_lookup_policy=prompt_lookup_policy,
                 )
             except Exception as e:  # noqa: BLE001
                 logger.warning(
@@ -9215,6 +9243,10 @@ class Scheduler:
             stats["kv_checkpoint"] = _dkc.get_stats()
         except Exception:  # pragma: no cover — defensive
             pass
+        if self.batch_generator is not None:
+            mtp_vendored = getattr(self.batch_generator, "_mtp_vendored_stats", None)
+            if isinstance(mtp_vendored, dict):
+                stats["mtp_vendored"] = dict(mtp_vendored)
         # Include Metal memory stats
         try:
             if mx.metal.is_available():

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1315,6 +1315,7 @@ def _install_mtp_vendored(
         "prompt_lookup_matched_suffix_tokens": 0.0,
         "prompt_lookup_accepted_tokens": 0.0,
         "prompt_lookup_rejections": 0.0,
+        "prompt_lookup_cache_fallthroughs": 0.0,
         "prompt_lookup_mtp_sync_seconds": 0.0,
     }
 

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -119,6 +119,25 @@ def _prompt_lookup_is_enabled(model, requested: bool | None = None) -> bool:
     }
 
 
+def _safe_prompt_lookup_draft_count(model_cache, desired: int) -> int:
+    """Return the largest proposal whose full rejection is recoverable."""
+    from vllm_mlx.cache_rollback import can_advance
+
+    def _can_recover(cache, count: int) -> bool:
+        # Qwen4 recurrent layers publish per-position snapshots during the
+        # verify forward and restore them through this amount-aware API. They
+        # do not implement trim(), so only trim-owned attention caches need
+        # the pre-forward can_advance check.
+        if callable(getattr(cache, "restore_rollback", None)):
+            return True
+        return can_advance(cache, count)
+
+    for count in range(desired, 0, -1):
+        if all(_can_recover(cache, count) for cache in model_cache):
+            return count
+    return 0
+
+
 patch_arrays_cache_rollback_state()
 
 logger = logging.getLogger(__name__)
@@ -526,10 +545,12 @@ def mtp_generate_step(
         Attention layers (KVCache): trim the last ``n_to_drop`` draft
         entries.
         """
+        trim_caches = []
+        snapshot_caches = []
         for c in model_cache:
             restore = getattr(c, "restore_rollback", None)
             if callable(restore) and getattr(c, "rollback_state", None) is not None:
-                restore(n_to_drop, verify_size)
+                snapshot_caches.append((c, restore, None))
             elif hasattr(c, "rollback_state") and c.rollback_state is not None:
                 snapshots = c.rollback_state
                 if isinstance(snapshots, list):
@@ -550,11 +571,26 @@ def mtp_generate_step(
                             "legacy SSM snapshot can only roll back one token"
                         )
                     conv_snap, ssm_snap = snapshots
-                c[0] = conv_snap
-                c[1] = ssm_snap
+                snapshot_caches.append((c, None, (conv_snap, ssm_snap)))
+            else:
+                trim_caches.append(c)
+
+        # Composite attention caches must agree on the complete amount before
+        # any leaf mutates. In particular, QSA may be able to trim one token
+        # while refusing a larger rollback across its retained raw-key group.
+        if trim_caches:
+            from vllm_mlx.cache_rollback import trim_all
+
+            if not trim_all(trim_caches, n_to_drop):
+                raise RuntimeError(
+                    "prompt/MTP target cache violated speculative rollback preflight"
+                )
+        for c, restore, snapshots in snapshot_caches:
+            if restore is not None:
+                restore(n_to_drop, verify_size)
+            else:
+                c[0], c[1] = snapshots
                 c.rollback_state = None
-            elif c.is_trimmable():
-                c.trim(n_to_drop)
 
     def _rollback_verify_round(n_to_drop: int, verify_size: int | None = None) -> None:
         """Roll back uncommitted target + MTP draft state for one verify round."""
@@ -928,6 +964,11 @@ def mtp_generate_step(
         confidence_ladder = (8, 12, 16, 24, 32)
         confidence_cap = confidence_ladder[min(extension, len(confidence_ladder) - 1)]
         proposed_tokens = match.tokens[:confidence_cap]
+        safe_count = _safe_prompt_lookup_draft_count(model_cache, len(proposed_tokens))
+        if safe_count == 0:
+            _timing_add("prompt_lookup_cache_fallthroughs", 1.0)
+            return None
+        proposed_tokens = proposed_tokens[:safe_count]
         _timing_add("prompt_lookup_proposals", 1.0)
         _timing_add("prompt_lookup_drafted_tokens", float(len(proposed_tokens)))
         _timing_add("prompt_lookup_matched_suffix_tokens", float(match.matched_suffix))

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -52,16 +52,66 @@ import mlx.core as mx
 from .accept_counter import get_global_counter
 from .cache_patch import patch_arrays_cache_rollback_state
 from .draft_k_controller_v2 import DepthController, get_or_create_controller
-from .prompt_lookup import PromptLookupIndex
+from .prompt_lookup import PromptLookupIndex, PromptLookupPolicy
+
+_LEGACY_PROMPT_LOOKUP_POLICY = PromptLookupPolicy()
 
 
-def _prompt_lookup_is_enabled(model) -> bool:
+def _prompt_lookup_policy(model) -> PromptLookupPolicy:
+    policy = getattr(model, "mtp_prompt_lookup_policy", None)
+    return (
+        policy
+        if isinstance(policy, PromptLookupPolicy)
+        else _LEGACY_PROMPT_LOOKUP_POLICY
+    )
+
+
+def _effective_prompt_lookup_policy(model) -> PromptLookupPolicy:
+    """Resolve process overrides once so a request cannot change mid-flight."""
+    policy = _prompt_lookup_policy(model)
+    min_ngram = max(
+        2,
+        int(
+            os.environ.get(
+                "RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM",
+                str(policy.min_ngram),
+            )
+        ),
+    )
+    return PromptLookupPolicy(
+        enabled_by_default=_prompt_lookup_is_enabled(model),
+        min_ngram=min_ngram,
+        max_ngram=max(
+            min_ngram,
+            int(
+                os.environ.get(
+                    "RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM",
+                    str(policy.max_ngram),
+                )
+            ),
+        ),
+        max_tokens=max(
+            1,
+            int(
+                os.environ.get(
+                    "RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS",
+                    str(policy.max_tokens),
+                )
+            ),
+        ),
+    )
+
+
+def _prompt_lookup_is_enabled(model, requested: bool | None = None) -> bool:
     """Return whether this model may use audited prompt-copy speculation."""
     if not getattr(model, "mtp_prompt_lookup_supported", False):
         return False
-    # Explicit opt-in until Qwen's hybrid SSM target path is proven
-    # token-lossless across the different verification chunk boundaries.
-    return os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP", "0").strip().lower() not in {
+    if requested is not None:
+        return requested
+    override = os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP")
+    if override is None:
+        return _prompt_lookup_policy(model).enabled_by_default
+    return override.strip().lower() not in {
         "0",
         "false",
         "off",
@@ -240,6 +290,9 @@ def mtp_generate_step(
     stop_tokens: set[int] | None = None,
     timing_stats: dict[str, float] | None = None,
     lane_rng: Any | None = None,
+    prompt_lookup_enabled: bool | None = None,
+    prompt_lookup_history: list[int] | mx.array | None = None,
+    prompt_lookup_policy: PromptLookupPolicy | None = None,
 ) -> Generator[tuple[int, mx.array, bool], None, None]:
     """Generator that uses the model's native MTP head for spec decode.
 
@@ -335,13 +388,32 @@ def mtp_generate_step(
     _mtp_supports_fused_greedy = callable(getattr(model, "mtp_greedy", None))
 
     y = prompt.astype(mx.uint32)
-    _prompt_lookup_enabled = _prompt_lookup_is_enabled(model)
+    _is_greedy = temp == 0
+    if prompt_lookup_policy is None:
+        prompt_lookup_policy = _effective_prompt_lookup_policy(model)
+    requested_prompt_lookup = (
+        prompt_lookup_policy.enabled_by_default
+        if prompt_lookup_enabled is None
+        else prompt_lookup_enabled
+    )
+    _prompt_lookup_enabled = _is_greedy and _prompt_lookup_is_enabled(
+        model, requested=requested_prompt_lookup
+    )
     # Avoid copying a potentially long prompt back to the CPU for every other
     # MTP backend. Prompt lookup is opt-in per model because its cache-history
     # synchronization contract must be audited for that architecture first.
-    prompt_token_ids = (
-        [int(token) for token in y.tolist()] if _prompt_lookup_enabled else []
-    )
+    if _prompt_lookup_enabled:
+        if prompt_lookup_history is None:
+            prompt_token_ids = [int(token) for token in y.tolist()]
+        else:
+            history = (
+                prompt_lookup_history.tolist()
+                if isinstance(prompt_lookup_history, mx.array)
+                else prompt_lookup_history
+            )
+            prompt_token_ids = [int(token) for token in history]
+    else:
+        prompt_token_ids = []
     generated_token_ids: list[int] = []
 
     def _remember_generated(token_id: int) -> None:
@@ -375,22 +447,11 @@ def mtp_generate_step(
         model_cache = prompt_cache[:n_main]
         mtp_cache = prompt_cache[n_main:] or model.make_mtp_cache()
 
-    _is_greedy = temp == 0
-    _prompt_lookup_max_tokens = max(
-        1, int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_TOKENS", "24"))
-    )
-    _prompt_lookup_min_ngram = max(
-        2, int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MIN_NGRAM", "8"))
-    )
-    _prompt_lookup_max_ngram = max(
-        _prompt_lookup_min_ngram,
-        int(os.environ.get("RAPID_MLX_MTP_PROMPT_LOOKUP_MAX_NGRAM", "10")),
-    )
     _prompt_lookup_index = (
         PromptLookupIndex(
             prompt_token_ids,
-            min_ngram=_prompt_lookup_min_ngram,
-            max_ngram=_prompt_lookup_max_ngram,
+            min_ngram=prompt_lookup_policy.min_ngram,
+            max_ngram=prompt_lookup_policy.max_ngram,
         )
         if _prompt_lookup_enabled
         else None
@@ -859,7 +920,7 @@ def mtp_generate_step(
             return None
         match = _prompt_lookup_index.propose(
             generated_token_ids,
-            max_tokens=min(_prompt_lookup_max_tokens, remaining),
+            max_tokens=min(prompt_lookup_policy.max_tokens, remaining),
         )
         if match is None:
             return None

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -128,6 +128,9 @@ def _safe_prompt_lookup_draft_count(model_cache, desired: int) -> int:
         # verify forward and restore them through this amount-aware API. They
         # do not implement trim(), so only trim-owned attention caches need
         # the pre-forward can_advance check.
+        children = getattr(cache, "caches", None)
+        if children is not None:
+            return all(_can_recover(child, count) for child in children)
         if callable(getattr(cache, "restore_rollback", None)):
             return True
         return can_advance(cache, count)
@@ -531,9 +534,16 @@ def mtp_generate_step(
         return token, logprobs, lp_accept
 
     def _clear_rollback():
+        def _clear(cache):
+            children = getattr(cache, "caches", None)
+            if children is not None:
+                for child in children:
+                    _clear(child)
+            elif hasattr(cache, "rollback_state"):
+                cache.rollback_state = None
+
         for c in model_cache:
-            if hasattr(c, "rollback_state"):
-                c.rollback_state = None
+            _clear(c)
 
     def _rollback_draft(n_to_drop: int = 1, verify_size: int | None = None):
         """Restore caches by dropping the last ``n_to_drop`` draft tokens.
@@ -546,7 +556,7 @@ def mtp_generate_step(
         entries.
         """
         trim_caches = []
-        snapshot_caches = []
+        snapshot_caches: list[tuple[Any, Any | None, tuple[Any, Any] | None]] = []
         for c in model_cache:
             restore = getattr(c, "restore_rollback", None)
             if callable(restore) and getattr(c, "rollback_state", None) is not None:
@@ -589,6 +599,7 @@ def mtp_generate_step(
             if restore is not None:
                 restore(n_to_drop, verify_size)
             else:
+                assert snapshots is not None
                 c[0], c[1] = snapshots
                 c.rollback_state = None
 
@@ -952,8 +963,6 @@ def mtp_generate_step(
         if _prompt_lookup_index is None:
             return None
         remaining = max_tokens - ntoks
-        if remaining <= 0:
-            return None
         match = _prompt_lookup_index.propose(
             generated_token_ids,
             max_tokens=min(prompt_lookup_policy.max_tokens, remaining),

--- a/vllm_mlx/spec_decode/mtp/prompt_lookup.py
+++ b/vllm_mlx/spec_decode/mtp/prompt_lookup.py
@@ -17,6 +17,24 @@ class PromptLookupMatch:
     tokens: tuple[int, ...]
 
 
+@dataclass(frozen=True)
+class PromptLookupPolicy:
+    """Model-qualified prompt lookup policy captured at request start."""
+
+    enabled_by_default: bool = False
+    min_ngram: int = 8
+    max_ngram: int = 10
+    max_tokens: int = 24
+
+    def __post_init__(self) -> None:
+        if self.min_ngram < 2:
+            raise ValueError("min_ngram must be at least 2")
+        if self.max_ngram < self.min_ngram:
+            raise ValueError("max_ngram must be >= min_ngram")
+        if self.max_tokens < 1:
+            raise ValueError("max_tokens must be positive")
+
+
 class PromptLookupIndex:
     """Index prompt n-grams and propose their following token block.
 
@@ -95,4 +113,4 @@ class PromptLookupIndex:
         return PromptLookupMatch(best_start, best_suffix, proposal)
 
 
-__all__ = ["PromptLookupIndex", "PromptLookupMatch"]
+__all__ = ["PromptLookupIndex", "PromptLookupMatch", "PromptLookupPolicy"]

--- a/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
@@ -161,6 +161,8 @@ def inject_qwen4_exp_mtp_support(
     import mlx.core as mx
     from mlx.utils import tree_flatten
 
+    from .prompt_lookup import PromptLookupPolicy
+
     inner = _resolve_inner(model)
     if inner is None:
         return False
@@ -202,7 +204,13 @@ def inject_qwen4_exp_mtp_support(
         original_class = type(inner)
 
         class _Qwen4ExpWithMTP(original_class):  # type: ignore[valid-type, misc]
-            mtp_prompt_lookup_supported = False
+            mtp_prompt_lookup_supported = True
+            mtp_prompt_lookup_policy = PromptLookupPolicy(
+                enabled_by_default=True,
+                min_ngram=16,
+                max_ngram=64,
+                max_tokens=8,
+            )
 
             def mtp_forward(
                 self,
@@ -233,6 +241,9 @@ def inject_qwen4_exp_mtp_support(
         inner.mtp_max_speculative_tokens = 1
         model.mtp_max_speculative_tokens = 1
         inner.__class__ = _Qwen4ExpWithMTP
+        if model is not inner:
+            model.mtp_prompt_lookup_supported = True
+            model.mtp_prompt_lookup_policy = inner.mtp_prompt_lookup_policy
         mx.eval(mtp.parameters())
         return True
     except Exception:


### PR DESCRIPTION
## Goal

Make high-overlap coding and document-editing requests materially faster on the qualified Qwen4 Flash-Next native-MTP route, without changing output or admitting unverified model families.

This production qualification is extracted from and fully credits Pierre Lamy's contribution in #2809. Pierre is the author of the original implementation commit and co-author of the transaction follow-up.

## Scope

- enable conservative prompt-lookup drafting by default for greedy Qwen4 Flash-Next native-MTP requests
- capture the enable decision, lookup policy, and immutable prompt history at request start
- verify every proposal with the target model and commit only the accepted prefix
- snapshot every QSA raw-ring boundary during multi-token verification so an eight-token proposal can commit or roll back across four-token compression groups
- keep ordinary K=1 MTP free of the QSA snapshot cost
- expose proposal, acceptance, rejection, and synchronization counters in `/v1/status`
- add a reproducible benchmark and durable qualification report

Non-goals: sampled/non-greedy PLD, additional model families, continuous multi-request speculation, Desktop default-MTP policy, or changes to ordinary MTP behavior.

## Design precedent

The implementation follows the established speculative-decoding boundary: prompt matches are untrusted proposals, the target model is the sole verifier, only the accepted prefix becomes committed state, and target/draft caches roll back atomically on rejection or cancellation. Composite caches preflight the full rollback amount and trim transactionally; recurrent and QSA caches restore a verified per-position snapshot. Model capability and policy are explicit rather than inferred from model names, and the complete policy is latched at the request boundary.

The previous 8–10-token matching defaults were rejected because repetitive source and structured documents produced ambiguous proposals. The qualified Qwen4 policy uses a 16–64-token match and an 8-token proposal cap. Snapshot admission is restricted to one unpadded request and fails closed outside that audited lane.

## Evidence

Mac Studio M3 Ultra, 256 GB, BF16 KV, native MTP K=1, thinking off, temperature 0, three cache-cleared runs per scenario:

| Scenario | MTP only | MTP + PLD | Speedup | Output parity |
| --- | ---: | ---: | ---: | --- |
| Exact code copy | 46.75 tok/s | 98.74 tok/s | 2.11x | SHA-256 identical, 3/3 |
| One-line code edit | 41.04 tok/s | 94.12 tok/s | 2.29x | SHA-256 identical, 3/3 |
| JSON manifest copy | 46.42 tok/s | 99.40 tok/s | 2.14x | SHA-256 identical, 3/3 |
| Chinese document copy | 46.40 tok/s | 92.74 tok/s | 2.00x | SHA-256 identical, 3/3 |
| Multi-turn code edit | 45.92 tok/s | 93.80 tok/s | 2.04x | SHA-256 identical, 3/3 |

The production-default run used no PLD environment variables. It proposed 15,680 tokens in 1,960 eight-token windows and accepted 15,388 (98.1%). MLX active memory remained approximately 104.7–105.6 GB; process-reported peak was 148.1 GB.

The 45-case Flash-Next battery retained the baseline pass vector (42/45). Long context, JSON schema, tool calls, Chinese, multi-turn, stop sequences, and both protocol routes passed. The three failures reproduce with PLD disabled and are documented in `docs/engineering/performance/qwen4-prompt-lookup-qualification.md`.

## Verification

- `python3.12 -m pytest -q tests/test_dspark_scheduler.py tests/test_qwen4_exp_vendored.py tests/test_mtp_prompt_lookup.py tests/test_mtp_spec_decode.py tests/test_mtp_cli_wiring.py tests/test_routes.py tests/test_scheduler_throughput_stats.py` — 428 passed
- the same focused set under branch coverage plus `diff-cover origin/main...HEAD` — 100% changed-line coverage (149/149)
- `python3.12 -m ruff format --check ...` — clean
- `python3.12 -m ruff check ...` — clean
- `python scripts/check_mypy_error_budget.py` — no growth
- `python3.12 -m py_compile bench/bench_qwen4_prompt_lookup.py` — clean
- `git diff --check` — clean
