### PR TITLE
perf(qwen4): fuse single-token GDN decode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,7 +471,6 @@ jobs:
             tests/test_qwen4_exp_reference_parity.py \
             tests/test_routing_groups_0131.py \
             tests/test_qwen4_exp_vendored.py \
-            tests/test_qwen4_fused_gdn_decode.py \
             tests/test_mtp_cli_wiring.py \
             tests/test_continuous_mtp_routing.py \
             tests/test_continuous_self_mtp_mlx_backend.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,7 @@ jobs:
             tests/test_qwen4_exp_reference_parity.py \
             tests/test_routing_groups_0131.py \
             tests/test_qwen4_exp_vendored.py \
+            tests/test_qwen4_fused_gdn_decode.py \
             tests/test_mtp_cli_wiring.py \
             tests/test_continuous_mtp_routing.py \
             tests/test_continuous_self_mtp_mlx_backend.py \

--- a/docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md
+++ b/docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md
@@ -27,12 +27,30 @@ and is intentionally not included.
 
 ## Rapid port verification
 
-The focused admission, dispatch, resident-selector, cache-update, and fallback
-contracts pass: 7 tests. Python compilation and `git diff --check` also pass.
+Rapid-specific validation used an M3 Ultra with 256 GB unified memory,
+Python 3.12.14, MLX 0.32.2, and
+`rapid-mlx/Qwen3.8-Flash-Next-4bit` at revision
+`dcf657e4acda2aae72da99cde65b6c491cd96998`. No other model was resident.
 
-Rapid-specific Metal and real-model validation is pending because the shared
-GPU was occupied after the port was prepared. Run the following only on an
-idle GPU:
+The real-weight layer gate passed 32 sequential steps with exact output,
+convolution cache, and fp32 recurrent state. All 32 eligible calls used the
+fused kernel with zero fallback. Across eight interleaved 64-step observations,
+the stock path took 6.521 ms at the median and the fused path took 5.164 ms, a
+26.28% improvement for one complete GDN layer including its input and output
+projections.
+
+The same resident model then ran three interleaved 256-token observations per
+mode. All six token sequences had the same SHA-256. Median decode throughput
+was 25.43 tok/s for stock and 27.04 tok/s for fused, a 6.35% end-to-end gain.
+Each fused observation recorded 9,252 eligible calls. The 36 prefill calls
+fell back to the stock path as designed.
+
+The focused admission, dispatch, resident-selector, cache-update, fallback,
+and real-Metal numerical contracts pass: 8 tests. The Metal test reproduces
+the stock computation for 32 sequential synthetic steps and compares output
+and both cache slots bit-for-bit.
+
+Reproduce the real-weight layer gate on an idle GPU:
 
 ```bash
 MLX_ENABLE_TF32=0 PYTHONPATH=. python scripts/bench_qwen4_fused_gdn_decode.py \
@@ -41,6 +59,17 @@ MLX_ENABLE_TF32=0 PYTHONPATH=. python scripts/bench_qwen4_fused_gdn_decode.py \
   --output /tmp/qwen4-fused-gdn-decode.json
 ```
 
-Promotion requires 32 exact sequential steps, zero fallback, and a positive
-interleaved stock/fused median on the target host. Until that gate passes, keep
-the environment flag disabled.
+Reproduce the end-to-end interleaved gate without reloading the model between
+variants:
+
+```bash
+MLX_ENABLE_TF32=0 PYTHONPATH=. python \
+  scripts/bench_qwen4_fused_gdn_end_to_end.py \
+  --model /path/to/Qwen3.8-Flash-Next-MLX-4bit-MTP \
+  --repeats 3 \
+  --output /tmp/qwen4-fused-gdn-end-to-end.json
+```
+
+The environment flag remains disabled by default. Prefill, multi-request
+batching, ragged caches, and speculative rollback are explicit stock-path
+fallbacks rather than unqualified extensions of this result.

--- a/docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md
+++ b/docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md
@@ -74,3 +74,18 @@ MLX_ENABLE_TF32=0 PYTHONPATH=. python \
 The environment flag remains disabled by default. Prefill, multi-request
 batching, ragged caches, and speculative rollback are explicit stock-path
 fallbacks rather than unqualified extensions of this result.
+
+## Failure lifecycle
+
+The capability probe compile-and-runs the exact BF16 kernel specialization
+before the fused path can be selected. Unsupported shapes and synchronous
+probe or dispatch failures leave the request cache untouched and use stock.
+A later Metal command-buffer failure is handled at Rapid's generation boundary:
+the scheduler aborts the affected running cohort, closes its `BatchGenerator`,
+drops the request-owned caches, and clears Metal state. It is not safe to retry
+that token against any partially executed model graph.
+
+Forcing `mx.eval` inside every GDN layer was rejected because it inserts a host
+synchronization boundary between sequential model layers and turns the optional
+fast path into a regression. The request lifecycle boundary preserves the
+engine's existing fatal-device-error semantics without serializing decode.

--- a/docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md
+++ b/docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md
@@ -1,0 +1,46 @@
+# Qwen4 fused GDN single-token decode
+
+## Scope
+
+This experiment fuses the Qwen4-Exp single-token Gated DeltaNet recurrence into
+one Metal dispatch. It includes the causal-convolution state update, SiLU,
+query/key normalization, decay and beta gates, recurrent update, and gated
+RMSNorm. The affine-q4 output projection remains on Rapid's stock path.
+
+The implementation is opt-in through
+`RAPID_MLX_QWEN4_FUSED_GDN_DECODE=1` or the resident `stock|fused` selector.
+Prefill, batching, masks, ragged caches, training, and speculative rollback use
+the stock implementation.
+
+## Prior qualification
+
+The same recurrence-only kernel was qualified in the mlx-uag source tree on an
+M5 Max before this Rapid port:
+
+- twelve 32-token trajectories across 1K, 4K, 8K, 16K, 32K, and 64K contexts;
+- exact full logits, convolution cache, and fp32 recurrent state;
+- 13,824 of 13,824 eligible fused layer calls with zero fallback;
+- median decode improvement between 6.39% and 6.93% at every context rung.
+
+The separately tested GDN plus affine-q4 output-projection epilogue was slower
+and is intentionally not included.
+
+## Rapid port verification
+
+The focused admission, dispatch, resident-selector, cache-update, and fallback
+contracts pass: 7 tests. Python compilation and `git diff --check` also pass.
+
+Rapid-specific Metal and real-model validation is pending because the shared
+GPU was occupied after the port was prepared. Run the following only on an
+idle GPU:
+
+```bash
+MLX_ENABLE_TF32=0 PYTHONPATH=. python scripts/bench_qwen4_fused_gdn_decode.py \
+  --execute-metal \
+  --model /path/to/Qwen3.8-Flash-Next-MLX-4bit-MTP \
+  --output /tmp/qwen4-fused-gdn-decode.json
+```
+
+Promotion requires 32 exact sequential steps, zero fallback, and a positive
+interleaved stock/fused median on the target host. Until that gate passes, keep
+the environment flag disabled.

--- a/docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md
+++ b/docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md
@@ -46,9 +46,10 @@ Each fused observation recorded 9,252 eligible calls. The 36 prefill calls
 fell back to the stock path as designed.
 
 The focused admission, dispatch, resident-selector, cache-update, fallback,
-and real-Metal numerical contracts pass: 8 tests. The Metal test reproduces
-the stock computation for 32 sequential synthetic steps and compares output
-and both cache slots bit-for-bit.
+and real-Metal numerical contracts pass. The Apple-enrolled Metal test runs
+all four probe candidates (threadgroup Y of 32, 16, 8, and 4), reproduces the
+stock computation for 32 sequential synthetic steps, and compares output and
+both cache slots bit-for-bit.
 
 Reproduce the real-weight layer gate on an idle GPU:
 

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -6,6 +6,7 @@ summary statistics, and limitations.
 
 ## Reports
 
+- [Qwen4 fused GDN single-token decode](2026-09-01-qwen4-fused-gdn-decode.md)
 - [Gemma 4 12B engine comparison on M2 Pro](2026-08-21-gemma4-12b-engine-comparison.md)
 - [Qwen3.5-9B engine comparison on M2 Pro](2026-08-21-qwen3.5-9b-engine-comparison.md)
 - [Rapid-MLX 0.12.18 performance release gate](2026-08-22-release-0.12.18-perf-gate.md)

--- a/scripts/bench_metadata.py
+++ b/scripts/bench_metadata.py
@@ -46,6 +46,8 @@ JSON_BENCH_SCRIPTS = frozenset(
         "bench_dflash.py",
         "bench_diffusion_gemma.py",
         "bench_engine_solo.py",
+        "bench_qwen4_fused_gdn_decode.py",
+        "bench_qwen4_fused_gdn_end_to_end.py",
         "bench_service_prefill.py",
         "bench_readme_refresh.py",
         "bench_suffix_decoding.py",

--- a/scripts/bench_qwen4_fused_gdn_decode.py
+++ b/scripts/bench_qwen4_fused_gdn_decode.py
@@ -9,7 +9,6 @@ import statistics
 import time
 from pathlib import Path
 
-
 PLAN = {
     "scope": "one production Qwen4 GDN layer with resident real weights",
     "correctness": "32 sequential steps; exact output and both cache arrays",
@@ -40,6 +39,18 @@ def cache_equal(left, right, mx):
         bool(mx.array_equal(a, b).item())
         for a, b in zip(left.cache, right.cache, strict=True)
     )
+
+
+def cache_diagnostics(left, right, mx):
+    return [
+        {
+            "equal": bool(mx.array_equal(a, b).item()),
+            "max_abs": float(
+                mx.max(mx.abs(a.astype(mx.float32) - b.astype(mx.float32))).item()
+            ),
+        }
+        for a, b in zip(left.cache, right.cache, strict=True)
+    ]
 
 
 def run(args):
@@ -100,6 +111,7 @@ def run(args):
                 "output_equal": output_equal,
                 "states_equal": states_equal,
                 "max_output_abs": float(mx.max(mx.abs(stock - fused)).item()),
+                "cache_slots": cache_diagnostics(stock_cache, fused_cache, mx),
             }
             break
     after = qwen4_fused_gdn_stats(layer)
@@ -134,8 +146,7 @@ def run(args):
     timing = {
         "raw_seconds": timings,
         "median_seconds": medians,
-        "median_speedup_percent": 100.0
-        * (medians["stock"] / medians["fused"] - 1.0),
+        "median_speedup_percent": 100.0 * (medians["stock"] / medians["fused"] - 1.0),
     }
     return {"plan": PLAN, "correctness": correctness, "timing": timing}
 

--- a/scripts/bench_qwen4_fused_gdn_decode.py
+++ b/scripts/bench_qwen4_fused_gdn_decode.py
@@ -4,10 +4,14 @@
 from __future__ import annotations
 
 import argparse
-import json
 import statistics
 import time
 from pathlib import Path
+
+try:
+    from scripts.bench_metadata import format_bench_json, write_bench_json
+except ImportError:  # direct `python scripts/bench_*.py` execution
+    from bench_metadata import format_bench_json, write_bench_json
 
 PLAN = {
     "scope": "one production Qwen4 GDN layer with resident real weights",
@@ -154,14 +158,14 @@ def run(args):
 def main() -> int:
     args = parse_args()
     if not args.execute_metal:
-        print(json.dumps({"plan_only": True, "plan": PLAN}, indent=2))
+        print(format_bench_json({"plan_only": True, "plan": PLAN}, __file__))
         return 0
     result = run(args)
-    payload = json.dumps(result, indent=2, sort_keys=True)
+    payload = format_bench_json(result, __file__, indent=2, sort_keys=True)
     print(payload)
     if args.output is not None:
         args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(payload + "\n")
+        write_bench_json(args.output, result, __file__, indent=2, sort_keys=True)
     return 0 if result["correctness"]["passed"] else 1
 
 

--- a/scripts/bench_qwen4_fused_gdn_decode.py
+++ b/scripts/bench_qwen4_fused_gdn_decode.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Real-weight gate for Rapid's default-off Qwen4 fused GDN decode path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+
+PLAN = {
+    "scope": "one production Qwen4 GDN layer with resident real weights",
+    "correctness": "32 sequential steps; exact output and both cache arrays",
+    "timing": "interleaved stock/fused observations without model reload",
+    "excluded": ["prefill", "batch", "mask", "speculative rollback"],
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--execute-metal", action="store_true")
+    parser.add_argument("--correctness-steps", type=int, default=32)
+    parser.add_argument("--timing-steps", type=int, default=64)
+    parser.add_argument("--repeats", type=int, default=8)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def clone_cache(cache, cache_type, mx):
+    clone = cache_type(len(cache.cache))
+    clone.cache = [mx.array(value) for value in cache.cache]
+    return clone
+
+
+def cache_equal(left, right, mx):
+    return all(
+        bool(mx.array_equal(a, b).item())
+        for a, b in zip(left.cache, right.cache, strict=True)
+    )
+
+
+def run(args):
+    if args.model is None or not args.model.is_dir():
+        raise SystemExit("--model must name an existing local checkpoint")
+    if args.correctness_steps < 32:
+        raise SystemExit("--correctness-steps may not be below 32")
+
+    import mlx.core as mx
+    from mlx_lm.utils import load_model
+
+    from vllm_mlx.models.qwen4_exp import (
+        GatedDeltaNet,
+        Qwen4ExpStateCache,
+        qwen4_fused_gdn_stats,
+        set_qwen4_fused_gdn_mode,
+    )
+    from vllm_mlx.utils.tokenizer import _register_vendored_archs
+
+    mx.set_default_device(mx.gpu)
+    _register_vendored_archs()
+    model, _ = load_model(args.model.resolve(), strict=True)
+    model.eval()
+    layers = [
+        module
+        for _, module in model.named_modules()
+        if isinstance(module, GatedDeltaNet)
+    ]
+    if not layers:
+        raise SystemExit("checkpoint has no Rapid Qwen4 GDN layers")
+    layer = layers[0]
+
+    key = mx.random.key(2105)
+    hidden = mx.random.normal(
+        (args.correctness_steps, 1, 1, layer.hidden_size), key=key
+    ).astype(layer.dt_bias.dtype)
+    warm = Qwen4ExpStateCache(2)
+    set_qwen4_fused_gdn_mode(layer, "stock")
+    warm_output = layer(hidden[0], cache=warm)
+    mx.eval(warm_output, *warm.cache)
+    stock_cache = clone_cache(warm, Qwen4ExpStateCache, mx)
+    fused_cache = clone_cache(warm, Qwen4ExpStateCache, mx)
+
+    mismatch = None
+    before = qwen4_fused_gdn_stats(layer)
+    for step in range(args.correctness_steps):
+        set_qwen4_fused_gdn_mode(layer, "stock")
+        stock = layer(hidden[step], cache=stock_cache)
+        mx.eval(stock, *stock_cache.cache)
+        set_qwen4_fused_gdn_mode(layer, "fused")
+        fused = layer(hidden[step], cache=fused_cache)
+        mx.eval(fused, *fused_cache.cache)
+        output_equal = bool(mx.array_equal(stock, fused).item())
+        states_equal = cache_equal(stock_cache, fused_cache, mx)
+        if not output_equal or not states_equal:
+            mismatch = {
+                "step": step,
+                "output_equal": output_equal,
+                "states_equal": states_equal,
+                "max_output_abs": float(mx.max(mx.abs(stock - fused)).item()),
+            }
+            break
+    after = qwen4_fused_gdn_stats(layer)
+    fused_calls = after["fused_calls"] - before["fused_calls"]
+    fallbacks = after["fallbacks"] - before["fallbacks"]
+    correctness = {
+        "passed": mismatch is None
+        and fused_calls == args.correctness_steps
+        and fallbacks == 0,
+        "steps": args.correctness_steps,
+        "mismatch": mismatch,
+        "fused_calls": fused_calls,
+        "fallbacks": fallbacks,
+    }
+    if not correctness["passed"]:
+        return {"plan": PLAN, "correctness": correctness, "timing": None}
+
+    timings = {"stock": [], "fused": []}
+    for repeat in range(args.repeats):
+        order = ("stock", "fused") if repeat % 2 == 0 else ("fused", "stock")
+        for mode in order:
+            cache = clone_cache(warm, Qwen4ExpStateCache, mx)
+            mx.eval(*cache.cache)
+            set_qwen4_fused_gdn_mode(layer, mode)
+            started = time.perf_counter()
+            output = None
+            for step in range(args.timing_steps):
+                output = layer(hidden[step % len(hidden)], cache=cache)
+            mx.eval(output, *cache.cache)
+            timings[mode].append(time.perf_counter() - started)
+    medians = {name: statistics.median(values) for name, values in timings.items()}
+    timing = {
+        "raw_seconds": timings,
+        "median_seconds": medians,
+        "median_speedup_percent": 100.0
+        * (medians["stock"] / medians["fused"] - 1.0),
+    }
+    return {"plan": PLAN, "correctness": correctness, "timing": timing}
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.execute_metal:
+        print(json.dumps({"plan_only": True, "plan": PLAN}, indent=2))
+        return 0
+    result = run(args)
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    print(payload)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n")
+    return 0 if result["correctness"]["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_qwen4_fused_gdn_end_to_end.py
+++ b/scripts/bench_qwen4_fused_gdn_end_to_end.py
@@ -10,6 +10,11 @@ import statistics
 import time
 from pathlib import Path
 
+try:
+    from scripts.bench_metadata import format_bench_json, write_bench_json
+except ImportError:  # direct `python scripts/bench_*.py` execution
+    from bench_metadata import format_bench_json, write_bench_json
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -24,7 +29,23 @@ def parse_args():
     return parser.parse_args()
 
 
+def expected_path_counts(mode: str, fused_layers: int, generated_tokens: int):
+    """Return the exact path counts for this gate's one-chunk prefill."""
+    if mode == "stock":
+        return 0, 0
+    if mode != "fused":
+        raise ValueError(f"unknown mode {mode!r}")
+    # The first prefill call initializes every GDN cache on stock. The final
+    # prompt token and each generated/look-ahead token then use fused decode.
+    return fused_layers * (generated_tokens + 1), fused_layers
+
+
 def run(args):
+    if args.max_tokens < 2:
+        raise SystemExit("--max-tokens must be at least 2")
+    if args.repeats < 1:
+        raise SystemExit("--repeats must be at least 1")
+
     import mlx.core as mx
     from mlx_lm.generate import generate_step
     from mlx_lm.sample_utils import make_sampler
@@ -41,13 +62,18 @@ def run(args):
     model, tokenizer = load(str(args.model.resolve()))
     model.eval()
     prompt = mx.array(tokenizer.encode(args.prompt))
+    if not 2 <= prompt.size <= 2049:
+        raise SystemExit(
+            "--prompt must encode to 2..2049 tokens so the decode gate has "
+            "one expected stock prefill and an exact fused-call contract"
+        )
     sampler = make_sampler(temp=0.0)
 
     observations = []
     orders = (("stock", "fused"), ("fused", "stock"))
     for repeat in range(args.repeats):
         for mode in orders[repeat % len(orders)]:
-            set_qwen4_fused_gdn_mode(model, mode)
+            fused_layers = set_qwen4_fused_gdn_mode(model, mode)
             before = qwen4_fused_gdn_stats(model)
             tokens = []
             started = time.perf_counter()
@@ -63,8 +89,19 @@ def run(args):
                 tokens.append(int(token))
             ended = time.perf_counter()
             after = qwen4_fused_gdn_stats(model)
+            if len(tokens) < 2 or first_token_at is None:
+                raise RuntimeError(
+                    f"generation produced {len(tokens)} tokens; need at least 2"
+                )
             ttft = first_token_at - started
             decode_seconds = ended - first_token_at
+            if decode_seconds <= 0:
+                raise RuntimeError("decode timer did not advance")
+            fused_calls = after["fused_calls"] - before["fused_calls"]
+            fallbacks = after["fallbacks"] - before["fallbacks"]
+            expected_fused_calls, expected_fallbacks = expected_path_counts(
+                mode, fused_layers, len(tokens)
+            )
             observations.append(
                 {
                     "mode": mode,
@@ -76,14 +113,19 @@ def run(args):
                     "ttft_seconds": ttft,
                     "decode_seconds": decode_seconds,
                     "decode_tokens_per_second": (len(tokens) - 1) / decode_seconds,
-                    "fused_calls": after["fused_calls"] - before["fused_calls"],
-                    "fallbacks": after["fallbacks"] - before["fallbacks"],
+                    "fused_calls": fused_calls,
+                    "expected_fused_calls": expected_fused_calls,
+                    "fallbacks": fallbacks,
+                    "expected_fallbacks": expected_fallbacks,
+                    "path_counts_exact": fused_calls == expected_fused_calls
+                    and fallbacks == expected_fallbacks,
                     "last_fallbacks": after["last_fallbacks"],
                 }
             )
             mx.clear_cache()
 
     hashes = {item["token_sha256"] for item in observations}
+    path_counts_exact = all(item["path_counts_exact"] for item in observations)
     medians = {
         mode: statistics.median(
             item["decode_tokens_per_second"]
@@ -93,7 +135,12 @@ def run(args):
         for mode in ("stock", "fused")
     }
     return {
-        "correctness": {"token_exact": len(hashes) == 1, "hashes": sorted(hashes)},
+        "correctness": {
+            "passed": len(hashes) == 1 and path_counts_exact,
+            "token_exact": len(hashes) == 1,
+            "path_counts_exact": path_counts_exact,
+            "hashes": sorted(hashes),
+        },
         "observations": observations,
         "median_decode_tokens_per_second": medians,
         "median_speedup_percent": 100.0 * (medians["fused"] / medians["stock"] - 1.0),
@@ -103,11 +150,12 @@ def run(args):
 def main() -> int:
     args = parse_args()
     result = run(args)
-    payload = json.dumps(result, indent=2, sort_keys=True)
+    payload = format_bench_json(result, __file__, indent=2, sort_keys=True)
     print(payload)
     if args.output is not None:
-        args.output.write_text(payload + "\n")
-    return 0 if result["correctness"]["token_exact"] else 1
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        write_bench_json(args.output, result, __file__, indent=2, sort_keys=True)
+    return 0 if result["correctness"]["passed"] else 1
 
 
 if __name__ == "__main__":

--- a/scripts/bench_qwen4_fused_gdn_end_to_end.py
+++ b/scripts/bench_qwen4_fused_gdn_end_to_end.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Interleaved real-model gate for Qwen4 fused GDN decode."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import time
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument(
+        "--prompt",
+        default="Write the integers 1 through 200, one per line.",
+    )
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def run(args):
+    import mlx.core as mx
+    from mlx_lm.generate import generate_step
+    from mlx_lm.sample_utils import make_sampler
+    from mlx_lm.utils import load
+
+    from vllm_mlx.models.qwen4_exp import (
+        qwen4_fused_gdn_stats,
+        set_qwen4_fused_gdn_mode,
+    )
+    from vllm_mlx.utils.tokenizer import _register_vendored_archs
+
+    _register_vendored_archs()
+    mx.set_default_device(mx.gpu)
+    model, tokenizer = load(str(args.model.resolve()))
+    model.eval()
+    prompt = mx.array(tokenizer.encode(args.prompt))
+    sampler = make_sampler(temp=0.0)
+
+    observations = []
+    orders = (("stock", "fused"), ("fused", "stock"))
+    for repeat in range(args.repeats):
+        for mode in orders[repeat % len(orders)]:
+            set_qwen4_fused_gdn_mode(model, mode)
+            before = qwen4_fused_gdn_stats(model)
+            tokens = []
+            started = time.perf_counter()
+            first_token_at = None
+            for token, _ in generate_step(
+                prompt,
+                model,
+                max_tokens=args.max_tokens,
+                sampler=sampler,
+            ):
+                if first_token_at is None:
+                    first_token_at = time.perf_counter()
+                tokens.append(int(token))
+            ended = time.perf_counter()
+            after = qwen4_fused_gdn_stats(model)
+            ttft = first_token_at - started
+            decode_seconds = ended - first_token_at
+            observations.append(
+                {
+                    "mode": mode,
+                    "repeat": repeat + 1,
+                    "tokens": len(tokens),
+                    "token_sha256": hashlib.sha256(
+                        json.dumps(tokens, separators=(",", ":")).encode()
+                    ).hexdigest(),
+                    "ttft_seconds": ttft,
+                    "decode_seconds": decode_seconds,
+                    "decode_tokens_per_second": (len(tokens) - 1) / decode_seconds,
+                    "fused_calls": after["fused_calls"] - before["fused_calls"],
+                    "fallbacks": after["fallbacks"] - before["fallbacks"],
+                    "last_fallbacks": after["last_fallbacks"],
+                }
+            )
+            mx.clear_cache()
+
+    hashes = {item["token_sha256"] for item in observations}
+    medians = {
+        mode: statistics.median(
+            item["decode_tokens_per_second"]
+            for item in observations
+            if item["mode"] == mode
+        )
+        for mode in ("stock", "fused")
+    }
+    return {
+        "correctness": {"token_exact": len(hashes) == 1, "hashes": sorted(hashes)},
+        "observations": observations,
+        "median_decode_tokens_per_second": medians,
+        "median_speedup_percent": 100.0 * (medians["fused"] / medians["stock"] - 1.0),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    result = run(args)
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    print(payload)
+    if args.output is not None:
+        args.output.write_text(payload + "\n")
+    return 0 if result["correctness"]["token_exact"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bench_qwen4_fused_gdn.py
+++ b/tests/test_bench_qwen4_fused_gdn.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from scripts.bench_qwen4_fused_gdn_end_to_end import expected_path_counts
+
+
+def test_expected_path_counts_prove_fused_execution_and_prefill_fallback():
+    assert expected_path_counts("stock", 36, 256) == (0, 0)
+    assert expected_path_counts("fused", 36, 256) == (9252, 36)
+
+
+def test_expected_path_counts_reject_unknown_mode():
+    with pytest.raises(ValueError, match="unknown mode"):
+        expected_path_counts("other", 36, 256)

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -143,6 +143,14 @@ def test_apple_coverage_roster_contains_only_tracked_tests() -> None:
         assert (WORKFLOW.parents[2] / relative_path.strip()).is_file(), relative_path
 
 
+def test_qwen4_fused_gdn_coverage_runs_on_apple_silicon() -> None:
+    """The Metal fast path must contribute to the changed-lines union."""
+    _, workflow = _workflow()
+    apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
+
+    assert "tests/test_qwen4_fused_gdn_decode.py" in apple_run
+
+
 def test_coverage_data_is_commit_bound_and_fail_closed() -> None:
     text, workflow = _workflow()
     jobs = workflow["jobs"]

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -164,6 +164,10 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # loads, which parser fires, which tier engages — none of that
         # changes. Read by ``gdn_in_proj_fusion.fuse_gdn_in_proj()`` only.
         "RAPID_MLX_GDN_IN_PROJ_FUSION",
+        # Opt-in fused Qwen4 single-token GDN recurrence. This selects a
+        # bit-exact kernel for an already-selected model and falls back for
+        # unsupported shapes; it does not select a model, parser, or lane.
+        "RAPID_MLX_QWEN4_FUSED_GDN_DECODE",
         # Opt-in re-quantization of the lm_head when serving fp8-block
         # checkpoints through the load-time mxfp8 repack
         # (vllm_mlx/fp8_repack.py). A precision/speed knob on an

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -10,12 +10,15 @@ mx = pytest.importorskip("mlx.core")
 pytest.importorskip("mlx_lm")
 pytestmark = pytest.mark.requires_mlx
 
+import mlx.nn as nn
 from mlx_lm.models.cache import ArraysCache, BatchKVCache, CacheList, KVCache
+from mlx_lm.models.gated_delta import gated_delta_update
 
 import vllm_mlx.models.qwen4_exp as qwen4_exp
 import vllm_mlx.models.qwen4_exp_cache as qwen4_exp_cache
 from scripts import qwen38_streaming_convert as converter
 from scripts.qwen38_streaming_convert import quantized_tensor_names
+from vllm_mlx.kernels import qwen4_fused_gdn_decode as fused_gdn
 from vllm_mlx.models.qwen4_exp import (
     GatedDeltaNet,
     GatedResidual,
@@ -2077,3 +2080,165 @@ def test_qwen4_gdn_verify_single_step_initializes_state_and_empty_boundaries():
     assert output.shape == (1, 1, 2, 3)
     assert state.shape == (1, 2, 3, 4)
     assert boundaries.shape == (1, 0, 2, 3, 4)
+
+
+@pytest.mark.requires_mlx
+@pytest.mark.parametrize("threadgroup_y", fused_gdn._THREADGROUP_Y_CANDIDATES)
+def test_real_metal_kernel_matches_stock_for_32_sequential_steps(threadgroup_y):
+    """Guard every BF16 boundary that the fused dispatch replaces."""
+    if not mx.metal.is_available():
+        pytest.skip("requires a Metal GPU")
+    previous_device = mx.default_device()
+    mx.set_default_device(mx.gpu)
+    dtype = mx.bfloat16
+    conv_weight = (
+        mx.random.normal(
+            (fused_gdn.CONV_DIM, fused_gdn.CONV_KERNEL, 1),
+            key=mx.random.key(1),
+        )
+        * 0.02
+    ).astype(dtype)
+    a_log = (
+        mx.random.normal((fused_gdn.NUM_VALUE_HEADS,), key=mx.random.key(2)) * 0.2
+    ).astype(mx.float32)
+    dt_bias = (
+        mx.random.normal((fused_gdn.NUM_VALUE_HEADS,), key=mx.random.key(3)) * 0.2
+    ).astype(dtype)
+    norm_weight = (
+        mx.random.normal((fused_gdn.VALUE_HEAD_DIM,), key=mx.random.key(4)) * 0.05 + 1
+    ).astype(dtype)
+    stock_conv = mx.zeros(
+        (1, fused_gdn.CONV_KERNEL - 1, fused_gdn.CONV_DIM), dtype=dtype
+    )
+    fused_conv = mx.array(stock_conv)
+    stock_state = mx.zeros(
+        (
+            1,
+            fused_gdn.NUM_VALUE_HEADS,
+            fused_gdn.VALUE_HEAD_DIM,
+            fused_gdn.KEY_HEAD_DIM,
+        ),
+        dtype=mx.float32,
+    )
+    fused_state = mx.array(stock_state)
+
+    try:
+        for step in range(32):
+            qkv = (
+                mx.random.normal(
+                    (1, 1, fused_gdn.CONV_DIM), key=mx.random.key(100 + step)
+                )
+                * 0.2
+            ).astype(dtype)
+            z = (
+                mx.random.normal(
+                    (1, 1, fused_gdn.VALUE_DIM), key=mx.random.key(200 + step)
+                )
+                * 0.2
+            ).astype(dtype)
+            beta = (
+                mx.random.normal(
+                    (1, 1, fused_gdn.NUM_VALUE_HEADS),
+                    key=mx.random.key(300 + step),
+                )
+                * 0.2
+            ).astype(dtype)
+            alpha = (
+                mx.random.normal(
+                    (1, 1, fused_gdn.NUM_VALUE_HEADS),
+                    key=mx.random.key(400 + step),
+                )
+                * 0.2
+            ).astype(dtype)
+
+            conv_input = mx.concatenate([stock_conv, qkv], axis=1)
+            next_stock_conv = mx.contiguous(
+                conv_input[:, -(fused_gdn.CONV_KERNEL - 1) :, :]
+            )
+            convolved = nn.silu(
+                mx.conv1d(
+                    conv_input,
+                    conv_weight,
+                    groups=fused_gdn.CONV_DIM,
+                )
+            )
+            query, key, value = [
+                item.reshape(1, 1, heads, dim)
+                for item, heads, dim in zip(
+                    mx.split(
+                        convolved,
+                        [fused_gdn.KEY_DIM, 2 * fused_gdn.KEY_DIM],
+                        axis=-1,
+                    ),
+                    [
+                        fused_gdn.NUM_KEY_HEADS,
+                        fused_gdn.NUM_KEY_HEADS,
+                        fused_gdn.NUM_VALUE_HEADS,
+                    ],
+                    [
+                        fused_gdn.KEY_HEAD_DIM,
+                        fused_gdn.KEY_HEAD_DIM,
+                        fused_gdn.VALUE_HEAD_DIM,
+                    ],
+                )
+            ]
+            query = query * mx.rsqrt(
+                mx.sum(mx.square(query), axis=-1, keepdims=True) + 1e-6
+            )
+            key = key * mx.rsqrt(mx.sum(mx.square(key), axis=-1, keepdims=True) + 1e-6)
+            query = query * (fused_gdn.KEY_HEAD_DIM**-0.5)
+            stock_output, next_stock_state = gated_delta_update(
+                query,
+                key,
+                value,
+                alpha,
+                beta,
+                a_log,
+                dt_bias,
+                stock_state,
+                use_kernel=True,
+            )
+            stock_output = (
+                mx.fast.rms_norm(stock_output, norm_weight, 1e-6).astype(mx.float32)
+                * mx.sigmoid(
+                    z.reshape(
+                        1,
+                        1,
+                        fused_gdn.NUM_VALUE_HEADS,
+                        fused_gdn.VALUE_HEAD_DIM,
+                    ).astype(mx.float32)
+                )
+            ).astype(dtype)
+            stock_output = stock_output.reshape(1, 1, fused_gdn.VALUE_DIM)
+
+            fused_output, next_fused_conv, next_fused_state = (
+                fused_gdn.qwen4_fused_gdn_decode(
+                    qkv,
+                    z,
+                    beta,
+                    alpha,
+                    fused_conv,
+                    conv_weight,
+                    a_log,
+                    dt_bias,
+                    fused_state,
+                    norm_weight,
+                    1e-6,
+                    threadgroup_y=threadgroup_y,
+                )
+            )
+            mx.eval(
+                stock_output,
+                fused_output,
+                next_stock_conv,
+                next_fused_conv,
+                next_stock_state,
+                next_fused_state,
+            )
+            assert mx.array_equal(stock_output, fused_output).item(), step
+            assert mx.array_equal(next_stock_conv, next_fused_conv).item(), step
+            assert mx.array_equal(next_stock_state, next_fused_state).item(), step
+            stock_conv, fused_conv = next_stock_conv, next_fused_conv
+            stock_state, fused_state = next_stock_state, next_fused_state
+    finally:
+        mx.set_default_device(previous_device)

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -2082,9 +2082,7 @@ def test_qwen4_gdn_verify_single_step_initializes_state_and_empty_boundaries():
     assert boundaries.shape == (1, 0, 2, 3, 4)
 
 
-@pytest.mark.requires_mlx
-@pytest.mark.parametrize("threadgroup_y", fused_gdn._THREADGROUP_Y_CANDIDATES)
-def test_real_metal_kernel_matches_stock_for_32_sequential_steps(threadgroup_y):
+def _assert_real_metal_kernel_matches_stock(threadgroup_y):
     """Guard every BF16 boundary that the fused dispatch replaces."""
     if not mx.metal.is_available():
         pytest.skip("requires a Metal GPU")
@@ -2242,3 +2240,21 @@ def test_real_metal_kernel_matches_stock_for_32_sequential_steps(threadgroup_y):
             stock_state, fused_state = next_stock_state, next_fused_state
     finally:
         mx.set_default_device(previous_device)
+
+
+@pytest.mark.requires_mlx
+def test_real_metal_kernel_matches_stock_for_every_supported_threadgroup():
+    supported = []
+    for threadgroup_y in fused_gdn._THREADGROUP_Y_CANDIDATES:
+        try:
+            _assert_real_metal_kernel_matches_stock(threadgroup_y)
+        except ValueError as exc:
+            if "threads per threadgroup" not in str(exc):
+                raise
+        except RuntimeError:
+            # The production probe treats a Metal resource rejection as an
+            # unsupported candidate and tries the next smaller threadgroup.
+            continue
+        else:
+            supported.append(threadgroup_y)
+    assert supported, "Metal rejected every fused GDN threadgroup candidate"

--- a/tests/test_qwen4_fused_gdn_decode.py
+++ b/tests/test_qwen4_fused_gdn_decode.py
@@ -4,10 +4,12 @@ from threading import Event, Lock
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import mlx.core as mx
-import mlx.nn as nn
 import pytest
-from mlx_lm.models.gated_delta import gated_delta_update
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.core as mx
 
 from vllm_mlx.kernels import qwen4_fused_gdn_decode as fused_gdn
 from vllm_mlx.models import qwen4_exp
@@ -292,6 +294,28 @@ def test_uninitialized_and_speculative_cache_do_not_probe_metal():
     assert layer.fused_gdn_decode_last_fallback == "speculative rollback"
 
 
+def test_sharded_layer_falls_back_before_probe():
+    layer = qwen4_exp.GatedDeltaNet(tiny_args())
+    layer.eval()
+    layer.set_fused_gdn_decode_mode("fused")
+    layer.sharding_group = object()
+    values = production_values()
+    cache = FakeCache(values["conv_state"], values["recurrent_state"])
+    with patch.object(qwen4_exp, "probe_qwen4_fused_gdn_decode") as probe:
+        result = layer._try_fused_decode(
+            values["qkv"],
+            values["z"],
+            values["beta"],
+            values["alpha"],
+            None,
+            cache,
+            record_rollback=False,
+        )
+    assert result is None
+    probe.assert_not_called()
+    assert layer.fused_gdn_decode_last_fallback == "distributed sharding"
+
+
 def test_admitted_path_updates_cache_and_counter_without_real_kernel():
     layer = qwen4_exp.GatedDeltaNet(tiny_args())
     layer.eval()
@@ -330,163 +354,74 @@ def test_admitted_path_updates_cache_and_counter_without_real_kernel():
     assert execute.call_args.kwargs["threadgroup_y"] == 8
 
 
-@pytest.mark.requires_mlx
-@pytest.mark.parametrize("threadgroup_y", fused_gdn._THREADGROUP_Y_CANDIDATES)
-def test_real_metal_kernel_matches_stock_for_32_sequential_steps(threadgroup_y):
-    """Guard every BF16 boundary that the fused dispatch replaces."""
-    if not mx.metal.is_available():
-        pytest.skip("requires a Metal GPU")
-    previous_device = mx.default_device()
-    mx.set_default_device(mx.gpu)
-    dtype = mx.bfloat16
-    conv_weight = (
-        mx.random.normal(
-            (fused_gdn.CONV_DIM, fused_gdn.CONV_KERNEL, 1),
-            key=mx.random.key(1),
-        )
-        * 0.02
-    ).astype(dtype)
-    a_log = (
-        mx.random.normal((fused_gdn.NUM_VALUE_HEADS,), key=mx.random.key(2)) * 0.2
-    ).astype(mx.float32)
-    dt_bias = (
-        mx.random.normal((fused_gdn.NUM_VALUE_HEADS,), key=mx.random.key(3)) * 0.2
-    ).astype(dtype)
-    norm_weight = (
-        mx.random.normal((fused_gdn.VALUE_HEAD_DIM,), key=mx.random.key(4)) * 0.05 + 1
-    ).astype(dtype)
-    stock_conv = mx.zeros(
-        (1, fused_gdn.CONV_KERNEL - 1, fused_gdn.CONV_DIM), dtype=dtype
-    )
-    fused_conv = mx.array(stock_conv)
-    stock_state = mx.zeros(
-        (
-            1,
-            fused_gdn.NUM_VALUE_HEADS,
-            fused_gdn.VALUE_HEAD_DIM,
-            fused_gdn.KEY_HEAD_DIM,
+def test_synchronous_dispatch_failure_preserves_cache():
+    layer = qwen4_exp.GatedDeltaNet(tiny_args())
+    layer.eval()
+    layer.set_fused_gdn_decode_mode("fused")
+    values = production_values()
+    cache = FakeCache(values["conv_state"], values["recurrent_state"])
+    accepted = fused_gdn.FusedGdnAdmission(True, "eligible")
+    with (
+        patch.object(qwen4_exp, "admit_qwen4_fused_gdn_decode", return_value=accepted),
+        patch.object(qwen4_exp, "fused_gdn_runtime_supported", return_value=True),
+        patch.object(qwen4_exp, "probe_qwen4_fused_gdn_decode", return_value=8),
+        patch.object(
+            qwen4_exp,
+            "qwen4_fused_gdn_decode",
+            side_effect=RuntimeError("dispatch rejected"),
         ),
-        dtype=mx.float32,
+    ):
+        result = layer._try_fused_decode(
+            values["qkv"],
+            values["z"],
+            values["beta"],
+            values["alpha"],
+            None,
+            cache,
+            record_rollback=False,
+        )
+    assert result is None
+    assert cache[0] is values["conv_state"]
+    assert cache[1] is values["recurrent_state"]
+    assert cache.advanced == 0
+    assert layer.fused_gdn_decode_calls == 0
+    assert layer.fused_gdn_decode_last_fallback == (
+        "Metal kernel dispatch failed: RuntimeError"
     )
-    fused_state = mx.array(stock_state)
 
-    try:
-        for step in range(32):
-            qkv = (
-                mx.random.normal(
-                    (1, 1, fused_gdn.CONV_DIM), key=mx.random.key(100 + step)
-                )
-                * 0.2
-            ).astype(dtype)
-            z = (
-                mx.random.normal(
-                    (1, 1, fused_gdn.VALUE_DIM), key=mx.random.key(200 + step)
-                )
-                * 0.2
-            ).astype(dtype)
-            beta = (
-                mx.random.normal(
-                    (1, 1, fused_gdn.NUM_VALUE_HEADS),
-                    key=mx.random.key(300 + step),
-                )
-                * 0.2
-            ).astype(dtype)
-            alpha = (
-                mx.random.normal(
-                    (1, 1, fused_gdn.NUM_VALUE_HEADS),
-                    key=mx.random.key(400 + step),
-                )
-                * 0.2
-            ).astype(dtype)
 
-            conv_input = mx.concatenate([stock_conv, qkv], axis=1)
-            next_stock_conv = mx.contiguous(
-                conv_input[:, -(fused_gdn.CONV_KERNEL - 1) :, :]
-            )
-            convolved = nn.silu(
-                mx.conv1d(
-                    conv_input,
-                    conv_weight,
-                    groups=fused_gdn.CONV_DIM,
-                )
-            )
-            query, key, value = [
-                item.reshape(1, 1, heads, dim)
-                for item, heads, dim in zip(
-                    mx.split(
-                        convolved,
-                        [fused_gdn.KEY_DIM, 2 * fused_gdn.KEY_DIM],
-                        axis=-1,
-                    ),
-                    [
-                        fused_gdn.NUM_KEY_HEADS,
-                        fused_gdn.NUM_KEY_HEADS,
-                        fused_gdn.NUM_VALUE_HEADS,
-                    ],
-                    [
-                        fused_gdn.KEY_HEAD_DIM,
-                        fused_gdn.KEY_HEAD_DIM,
-                        fused_gdn.VALUE_HEAD_DIM,
-                    ],
-                )
-            ]
-            query = query * mx.rsqrt(
-                mx.sum(mx.square(query), axis=-1, keepdims=True) + 1e-6
-            )
-            key = key * mx.rsqrt(mx.sum(mx.square(key), axis=-1, keepdims=True) + 1e-6)
-            query = query * (fused_gdn.KEY_HEAD_DIM**-0.5)
-            stock_output, next_stock_state = gated_delta_update(
-                query,
-                key,
-                value,
-                alpha,
-                beta,
-                a_log,
-                dt_bias,
-                stock_state,
-                use_kernel=True,
-            )
-            stock_output = (
-                mx.fast.rms_norm(stock_output, norm_weight, 1e-6).astype(mx.float32)
-                * mx.sigmoid(
-                    z.reshape(
-                        1,
-                        1,
-                        fused_gdn.NUM_VALUE_HEADS,
-                        fused_gdn.VALUE_HEAD_DIM,
-                    ).astype(mx.float32)
-                )
-            ).astype(dtype)
-            stock_output = stock_output.reshape(1, 1, fused_gdn.VALUE_DIM)
-
-            fused_output, next_fused_conv, next_fused_state = (
-                fused_gdn.qwen4_fused_gdn_decode(
-                    qkv,
-                    z,
-                    beta,
-                    alpha,
-                    fused_conv,
-                    conv_weight,
-                    a_log,
-                    dt_bias,
-                    fused_state,
-                    norm_weight,
-                    1e-6,
-                    threadgroup_y=threadgroup_y,
-                )
-            )
-            mx.eval(
-                stock_output,
-                fused_output,
-                next_stock_conv,
-                next_fused_conv,
-                next_stock_state,
-                next_fused_state,
-            )
-            assert mx.array_equal(stock_output, fused_output).item(), step
-            assert mx.array_equal(next_stock_conv, next_fused_conv).item(), step
-            assert mx.array_equal(next_stock_state, next_fused_state).item(), step
-            stock_conv, fused_conv = next_stock_conv, next_fused_conv
-            stock_state, fused_state = next_stock_state, next_fused_state
-    finally:
-        mx.set_default_device(previous_device)
+def test_probe_exception_preserves_cache():
+    layer = qwen4_exp.GatedDeltaNet(tiny_args())
+    layer.eval()
+    layer.set_fused_gdn_decode_mode("fused")
+    values = production_values()
+    cache = FakeCache(values["conv_state"], values["recurrent_state"])
+    accepted = fused_gdn.FusedGdnAdmission(True, "eligible")
+    with (
+        patch.object(qwen4_exp, "admit_qwen4_fused_gdn_decode", return_value=accepted),
+        patch.object(qwen4_exp, "fused_gdn_runtime_supported", return_value=True),
+        patch.object(
+            qwen4_exp,
+            "probe_qwen4_fused_gdn_decode",
+            side_effect=ValueError("probe rejected"),
+        ),
+        patch.object(qwen4_exp, "qwen4_fused_gdn_decode") as execute,
+    ):
+        result = layer._try_fused_decode(
+            values["qkv"],
+            values["z"],
+            values["beta"],
+            values["alpha"],
+            None,
+            cache,
+            record_rollback=False,
+        )
+    assert result is None
+    execute.assert_not_called()
+    assert cache[0] is values["conv_state"]
+    assert cache[1] is values["recurrent_state"]
+    assert cache.advanced == 0
+    assert layer.fused_gdn_decode_calls == 0
+    assert layer.fused_gdn_decode_last_fallback == (
+        "Metal kernel dispatch failed: ValueError"
+    )

--- a/tests/test_qwen4_fused_gdn_decode.py
+++ b/tests/test_qwen4_fused_gdn_decode.py
@@ -225,6 +225,25 @@ def test_concurrent_probe_publishes_only_after_initialization():
     assert calls == 1
 
 
+def test_probe_tries_smaller_threadgroup_after_runtime_error():
+    successful_outputs = (object(), object(), object())
+    with (
+        patch.object(fused_gdn, "_PROBE_COMPLETE", False),
+        patch.object(fused_gdn, "_PROBED_THREADGROUP_Y", None),
+        patch.object(fused_gdn, "_PROBE_LOCK", Lock()),
+        patch.object(fused_gdn, "fused_gdn_runtime_supported", return_value=True),
+        patch.object(
+            fused_gdn,
+            "qwen4_fused_gdn_decode",
+            side_effect=[RuntimeError("threadgroup resources"), successful_outputs],
+        ) as execute,
+        patch.object(fused_gdn.mx, "eval"),
+    ):
+        assert fused_gdn.probe_qwen4_fused_gdn_decode(mx.bfloat16) == 16
+
+    assert [call.kwargs["threadgroup_y"] for call in execute.call_args_list] == [32, 16]
+
+
 def test_resident_switch_preserves_weights_and_defaults_stock():
     with patch.object(qwen4_exp, "_FUSED_GDN_DEFAULT", False):
         layer = qwen4_exp.GatedDeltaNet(tiny_args())

--- a/tests/test_qwen4_fused_gdn_decode.py
+++ b/tests/test_qwen4_fused_gdn_decode.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import mlx.core as mx
+
+from vllm_mlx.kernels import qwen4_fused_gdn_decode as fused_gdn
+from vllm_mlx.models import qwen4_exp
+
+
+class FakeArray:
+    def __init__(self, shape, dtype):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+
+
+class FakeCache:
+    def __init__(self, conv_state=None, recurrent_state=None):
+        self.cache = [conv_state, recurrent_state]
+        self.lengths = None
+        self.advanced = 0
+
+    def __getitem__(self, index):
+        return self.cache[index]
+
+    def __setitem__(self, index, value):
+        self.cache[index] = value
+
+    def advance(self, amount):
+        self.advanced += amount
+
+
+def production_values(dtype=mx.bfloat16):
+    return {
+        "qkv": FakeArray((1, 1, 10240), dtype),
+        "z": FakeArray((1, 1, 6144), dtype),
+        "beta": FakeArray((1, 1, 48), dtype),
+        "alpha": FakeArray((1, 1, 48), dtype),
+        "conv_state": FakeArray((1, 3, 10240), dtype),
+        "recurrent_state": FakeArray((1, 48, 128, 128), mx.float32),
+        "conv_weight": FakeArray((10240, 4, 1), dtype),
+        "A_log": FakeArray((48,), mx.float32),
+        "dt_bias": FakeArray((48,), dtype),
+        "norm_weight": FakeArray((128,), dtype),
+    }
+
+
+def admission(**overrides):
+    values = production_values()
+    values.update(overrides)
+    return fused_gdn.admit_qwen4_fused_gdn_decode(
+        **values,
+        mask=None,
+        cache_lengths=None,
+        record_rollback=False,
+        training=False,
+        sharded=False,
+        num_key_heads=16,
+        num_value_heads=48,
+        key_head_dim=128,
+        value_head_dim=128,
+        conv_kernel=4,
+        gate_activation="sigmoid",
+    )
+
+
+def tiny_args():
+    return SimpleNamespace(
+        hidden_size=16,
+        linear_num_value_heads=2,
+        linear_num_key_heads=1,
+        linear_key_head_dim=64,
+        linear_value_head_dim=64,
+        linear_conv_kernel_dim=4,
+        rms_norm_eps=1.0e-6,
+        output_gate_type="sigmoid",
+        hidden_act="silu",
+    )
+
+
+class Identity:
+    def __call__(self, value):
+        return value
+
+
+def test_production_single_token_decode_is_admitted():
+    result = admission()
+    assert result.accepted, result.reason
+
+
+def test_batch_prefill_mask_ragged_and_speculation_fall_back():
+    result = admission(qkv=FakeArray((2, 1, 10240), mx.bfloat16))
+    assert not result.accepted
+    assert "qkv shape" in result.reason
+
+    values = production_values()
+    base = {
+        **values,
+        "training": False,
+        "sharded": False,
+        "num_key_heads": 16,
+        "num_value_heads": 48,
+        "key_head_dim": 128,
+        "value_head_dim": 128,
+        "conv_kernel": 4,
+        "gate_activation": "sigmoid",
+    }
+    result = fused_gdn.admit_qwen4_fused_gdn_decode(
+        **base,
+        mask=object(),
+        cache_lengths=None,
+        record_rollback=False,
+    )
+    assert result.reason == "masked decode"
+    result = fused_gdn.admit_qwen4_fused_gdn_decode(
+        **base,
+        mask=None,
+        cache_lengths=object(),
+        record_rollback=False,
+    )
+    assert result.reason == "ragged cache lengths"
+    result = fused_gdn.admit_qwen4_fused_gdn_decode(
+        **base,
+        mask=None,
+        cache_lengths=None,
+        record_rollback=True,
+    )
+    assert result.reason == "speculative rollback"
+
+
+def test_dtype_and_geometry_are_strict():
+    result = admission(A_log=FakeArray((48,), mx.float16))
+    assert not result.accepted
+    assert "A_log" in result.reason
+    assert admission(A_log=FakeArray((48,), mx.bfloat16)).accepted
+
+    values = production_values()
+    result = fused_gdn.admit_qwen4_fused_gdn_decode(
+        **values,
+        mask=None,
+        cache_lengths=None,
+        record_rollback=False,
+        training=False,
+        sharded=False,
+        num_key_heads=24,
+        num_value_heads=48,
+        key_head_dim=128,
+        value_head_dim=128,
+        conv_kernel=4,
+        gate_activation="sigmoid",
+    )
+    assert not result.accepted
+    assert "unsupported geometry" in result.reason
+
+
+def test_kernel_dispatch_is_one_threadgroup_per_value_head():
+    calls = []
+
+    def fake_kernel(**kwargs):
+        calls.append(kwargs)
+        return [
+            FakeArray(shape, dtype)
+            for shape, dtype in zip(
+                kwargs["output_shapes"], kwargs["output_dtypes"], strict=True
+            )
+        ]
+
+    values = production_values()
+    with patch.object(fused_gdn, "_kernel", return_value=fake_kernel):
+        outputs = fused_gdn.qwen4_fused_gdn_decode(
+            values["qkv"],
+            values["z"],
+            values["beta"],
+            values["alpha"],
+            values["conv_state"],
+            values["conv_weight"],
+            values["A_log"],
+            values["dt_bias"],
+            values["recurrent_state"],
+            values["norm_weight"],
+            1.0e-6,
+            threadgroup_y=16,
+        )
+    assert calls[0]["grid"] == (32, 16, 48)
+    assert calls[0]["threadgroup"] == (32, 16, 1)
+    assert outputs[0].shape == (1, 1, 6144)
+    assert outputs[1].shape == (1, 3, 10240)
+    assert outputs[2].shape == (1, 48, 128, 128)
+    assert ("RATIO", 3) in calls[0]["template"]
+
+
+def test_resident_switch_preserves_weights_and_defaults_stock():
+    with patch.object(qwen4_exp, "_FUSED_GDN_DEFAULT", False):
+        layer = qwen4_exp.GatedDeltaNet(tiny_args())
+    weight = layer.conv1d.weight
+    assert qwen4_exp.qwen4_fused_gdn_mode_counts(layer) == {
+        "stock": 1,
+        "fused": 0,
+    }
+    assert qwen4_exp.set_qwen4_fused_gdn_mode(layer, "fused") == 1
+    assert layer.conv1d.weight is weight
+    assert layer.fused_gdn_decode_mode == "fused"
+    assert qwen4_exp.set_qwen4_fused_gdn_mode(layer, "stock") == 1
+    assert layer.conv1d.weight is weight
+
+
+def test_uninitialized_and_speculative_cache_do_not_probe_metal():
+    layer = qwen4_exp.GatedDeltaNet(tiny_args())
+    layer.eval()
+    layer.set_fused_gdn_decode_mode("fused")
+    values = production_values()
+    with patch.object(qwen4_exp, "fused_gdn_runtime_supported") as runtime:
+        result = layer._try_fused_decode(
+            values["qkv"],
+            values["z"],
+            values["beta"],
+            values["alpha"],
+            None,
+            FakeCache(),
+            record_rollback=False,
+        )
+    assert result is None
+    runtime.assert_not_called()
+    assert layer.fused_gdn_decode_last_fallback == "uninitialized cache"
+
+    cache = FakeCache(values["conv_state"], values["recurrent_state"])
+    result = layer._try_fused_decode(
+        values["qkv"],
+        values["z"],
+        values["beta"],
+        values["alpha"],
+        None,
+        cache,
+        record_rollback=True,
+    )
+    assert result is None
+    assert layer.fused_gdn_decode_last_fallback == "speculative rollback"
+
+
+def test_admitted_path_updates_cache_and_counter_without_real_kernel():
+    layer = qwen4_exp.GatedDeltaNet(tiny_args())
+    layer.eval()
+    layer.set_fused_gdn_decode_mode("fused")
+    layer.out_proj = Identity()
+    values = production_values()
+    cache = FakeCache(values["conv_state"], values["recurrent_state"])
+    fused_output = FakeArray((1, 1, 6144), mx.bfloat16)
+    next_conv = object()
+    next_state = object()
+    accepted = fused_gdn.FusedGdnAdmission(True, "eligible")
+    with patch.object(
+        qwen4_exp, "admit_qwen4_fused_gdn_decode", return_value=accepted
+    ), patch.object(
+        qwen4_exp, "fused_gdn_runtime_supported", return_value=True
+    ), patch.object(
+        qwen4_exp, "probe_qwen4_fused_gdn_decode", return_value=8
+    ), patch.object(
+        qwen4_exp,
+        "qwen4_fused_gdn_decode",
+        return_value=(fused_output, next_conv, next_state),
+    ) as execute:
+        result = layer._try_fused_decode(
+            values["qkv"],
+            values["z"],
+            values["beta"],
+            values["alpha"],
+            None,
+            cache,
+            record_rollback=False,
+        )
+    assert result is fused_output
+    assert cache[0] is next_conv
+    assert cache[1] is next_state
+    assert cache.advanced == 1
+    assert layer.fused_gdn_decode_calls == 1
+    assert execute.call_args.kwargs["threadgroup_y"] == 8

--- a/tests/test_qwen4_fused_gdn_decode.py
+++ b/tests/test_qwen4_fused_gdn_decode.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -190,6 +192,37 @@ def test_kernel_dispatch_is_one_threadgroup_per_value_head():
     assert outputs[1].shape == (1, 3, 10240)
     assert outputs[2].shape == (1, 48, 128, 128)
     assert ("RATIO", 3) in calls[0]["template"]
+
+
+def test_concurrent_probe_publishes_only_after_initialization():
+    entered = Event()
+    release = Event()
+    calls = 0
+
+    def blocking_kernel(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        entered.set()
+        assert release.wait(timeout=5)
+        return (object(), object(), object())
+
+    with (
+        patch.object(fused_gdn, "_PROBE_COMPLETE", False),
+        patch.object(fused_gdn, "_PROBED_THREADGROUP_Y", None),
+        patch.object(fused_gdn, "_PROBE_LOCK", Lock()),
+        patch.object(fused_gdn, "fused_gdn_runtime_supported", return_value=True),
+        patch.object(fused_gdn, "qwen4_fused_gdn_decode", side_effect=blocking_kernel),
+        patch.object(fused_gdn.mx, "eval"),
+        ThreadPoolExecutor(max_workers=2) as pool,
+    ):
+        first = pool.submit(fused_gdn.probe_qwen4_fused_gdn_decode, mx.bfloat16)
+        assert entered.wait(timeout=5)
+        second = pool.submit(fused_gdn.probe_qwen4_fused_gdn_decode, mx.bfloat16)
+        release.set()
+        assert first.result(timeout=5) == 32
+        assert second.result(timeout=5) == 32
+
+    assert calls == 1
 
 
 def test_resident_switch_preserves_weights_and_defaults_stock():

--- a/tests/test_qwen4_fused_gdn_decode.py
+++ b/tests/test_qwen4_fused_gdn_decode.py
@@ -3,6 +3,9 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import mlx.core as mx
+import mlx.nn as nn
+import pytest
+from mlx_lm.models.gated_delta import gated_delta_update
 
 from vllm_mlx.kernels import qwen4_fused_gdn_decode as fused_gdn
 from vllm_mlx.models import qwen4_exp
@@ -39,7 +42,7 @@ def production_values(dtype=mx.bfloat16):
         "conv_state": FakeArray((1, 3, 10240), dtype),
         "recurrent_state": FakeArray((1, 48, 128, 128), mx.float32),
         "conv_weight": FakeArray((10240, 4, 1), dtype),
-        "A_log": FakeArray((48,), mx.float32),
+        "a_log": FakeArray((48,), mx.float32),
         "dt_bias": FakeArray((48,), dtype),
         "norm_weight": FakeArray((128,), dtype),
     }
@@ -129,10 +132,10 @@ def test_batch_prefill_mask_ragged_and_speculation_fall_back():
 
 
 def test_dtype_and_geometry_are_strict():
-    result = admission(A_log=FakeArray((48,), mx.float16))
+    result = admission(a_log=FakeArray((48,), mx.float16))
     assert not result.accepted
     assert "A_log" in result.reason
-    assert admission(A_log=FakeArray((48,), mx.bfloat16)).accepted
+    assert admission(a_log=FakeArray((48,), mx.bfloat16)).accepted
 
     values = production_values()
     result = fused_gdn.admit_qwen4_fused_gdn_decode(
@@ -174,7 +177,7 @@ def test_kernel_dispatch_is_one_threadgroup_per_value_head():
             values["alpha"],
             values["conv_state"],
             values["conv_weight"],
-            values["A_log"],
+            values["a_log"],
             values["dt_bias"],
             values["recurrent_state"],
             values["norm_weight"],
@@ -248,17 +251,16 @@ def test_admitted_path_updates_cache_and_counter_without_real_kernel():
     next_conv = object()
     next_state = object()
     accepted = fused_gdn.FusedGdnAdmission(True, "eligible")
-    with patch.object(
-        qwen4_exp, "admit_qwen4_fused_gdn_decode", return_value=accepted
-    ), patch.object(
-        qwen4_exp, "fused_gdn_runtime_supported", return_value=True
-    ), patch.object(
-        qwen4_exp, "probe_qwen4_fused_gdn_decode", return_value=8
-    ), patch.object(
-        qwen4_exp,
-        "qwen4_fused_gdn_decode",
-        return_value=(fused_output, next_conv, next_state),
-    ) as execute:
+    with (
+        patch.object(qwen4_exp, "admit_qwen4_fused_gdn_decode", return_value=accepted),
+        patch.object(qwen4_exp, "fused_gdn_runtime_supported", return_value=True),
+        patch.object(qwen4_exp, "probe_qwen4_fused_gdn_decode", return_value=8),
+        patch.object(
+            qwen4_exp,
+            "qwen4_fused_gdn_decode",
+            return_value=(fused_output, next_conv, next_state),
+        ) as execute,
+    ):
         result = layer._try_fused_decode(
             values["qkv"],
             values["z"],
@@ -274,3 +276,164 @@ def test_admitted_path_updates_cache_and_counter_without_real_kernel():
     assert cache.advanced == 1
     assert layer.fused_gdn_decode_calls == 1
     assert execute.call_args.kwargs["threadgroup_y"] == 8
+
+
+@pytest.mark.requires_mlx
+def test_real_metal_kernel_matches_stock_for_32_sequential_steps():
+    """Guard every BF16 boundary that the fused dispatch replaces."""
+    if not mx.metal.is_available():
+        pytest.skip("requires a Metal GPU")
+    previous_device = mx.default_device()
+    mx.set_default_device(mx.gpu)
+    dtype = mx.bfloat16
+    conv_weight = (
+        mx.random.normal(
+            (fused_gdn.CONV_DIM, fused_gdn.CONV_KERNEL, 1),
+            key=mx.random.key(1),
+        )
+        * 0.02
+    ).astype(dtype)
+    a_log = (
+        mx.random.normal((fused_gdn.NUM_VALUE_HEADS,), key=mx.random.key(2)) * 0.2
+    ).astype(mx.float32)
+    dt_bias = (
+        mx.random.normal((fused_gdn.NUM_VALUE_HEADS,), key=mx.random.key(3)) * 0.2
+    ).astype(dtype)
+    norm_weight = (
+        mx.random.normal((fused_gdn.VALUE_HEAD_DIM,), key=mx.random.key(4)) * 0.05 + 1
+    ).astype(dtype)
+    stock_conv = mx.zeros(
+        (1, fused_gdn.CONV_KERNEL - 1, fused_gdn.CONV_DIM), dtype=dtype
+    )
+    fused_conv = mx.array(stock_conv)
+    stock_state = mx.zeros(
+        (
+            1,
+            fused_gdn.NUM_VALUE_HEADS,
+            fused_gdn.VALUE_HEAD_DIM,
+            fused_gdn.KEY_HEAD_DIM,
+        ),
+        dtype=mx.float32,
+    )
+    fused_state = mx.array(stock_state)
+
+    try:
+        for step in range(32):
+            qkv = (
+                mx.random.normal(
+                    (1, 1, fused_gdn.CONV_DIM), key=mx.random.key(100 + step)
+                )
+                * 0.2
+            ).astype(dtype)
+            z = (
+                mx.random.normal(
+                    (1, 1, fused_gdn.VALUE_DIM), key=mx.random.key(200 + step)
+                )
+                * 0.2
+            ).astype(dtype)
+            beta = (
+                mx.random.normal(
+                    (1, 1, fused_gdn.NUM_VALUE_HEADS),
+                    key=mx.random.key(300 + step),
+                )
+                * 0.2
+            ).astype(dtype)
+            alpha = (
+                mx.random.normal(
+                    (1, 1, fused_gdn.NUM_VALUE_HEADS),
+                    key=mx.random.key(400 + step),
+                )
+                * 0.2
+            ).astype(dtype)
+
+            conv_input = mx.concatenate([stock_conv, qkv], axis=1)
+            next_stock_conv = mx.contiguous(
+                conv_input[:, -(fused_gdn.CONV_KERNEL - 1) :, :]
+            )
+            convolved = nn.silu(
+                mx.conv1d(
+                    conv_input,
+                    conv_weight,
+                    groups=fused_gdn.CONV_DIM,
+                )
+            )
+            query, key, value = [
+                item.reshape(1, 1, heads, dim)
+                for item, heads, dim in zip(
+                    mx.split(
+                        convolved,
+                        [fused_gdn.KEY_DIM, 2 * fused_gdn.KEY_DIM],
+                        axis=-1,
+                    ),
+                    [
+                        fused_gdn.NUM_KEY_HEADS,
+                        fused_gdn.NUM_KEY_HEADS,
+                        fused_gdn.NUM_VALUE_HEADS,
+                    ],
+                    [
+                        fused_gdn.KEY_HEAD_DIM,
+                        fused_gdn.KEY_HEAD_DIM,
+                        fused_gdn.VALUE_HEAD_DIM,
+                    ],
+                )
+            ]
+            query = query * mx.rsqrt(
+                mx.sum(mx.square(query), axis=-1, keepdims=True) + 1e-6
+            )
+            key = key * mx.rsqrt(mx.sum(mx.square(key), axis=-1, keepdims=True) + 1e-6)
+            query = query * (fused_gdn.KEY_HEAD_DIM**-0.5)
+            stock_output, next_stock_state = gated_delta_update(
+                query,
+                key,
+                value,
+                alpha,
+                beta,
+                a_log,
+                dt_bias,
+                stock_state,
+                use_kernel=True,
+            )
+            stock_output = (
+                mx.fast.rms_norm(stock_output, norm_weight, 1e-6).astype(mx.float32)
+                * mx.sigmoid(
+                    z.reshape(
+                        1,
+                        1,
+                        fused_gdn.NUM_VALUE_HEADS,
+                        fused_gdn.VALUE_HEAD_DIM,
+                    ).astype(mx.float32)
+                )
+            ).astype(dtype)
+            stock_output = stock_output.reshape(1, 1, fused_gdn.VALUE_DIM)
+
+            fused_output, next_fused_conv, next_fused_state = (
+                fused_gdn.qwen4_fused_gdn_decode(
+                    qkv,
+                    z,
+                    beta,
+                    alpha,
+                    fused_conv,
+                    conv_weight,
+                    a_log,
+                    dt_bias,
+                    fused_state,
+                    norm_weight,
+                    1e-6,
+                    threadgroup_y=32,
+                )
+            )
+            mx.eval(
+                stock_output,
+                fused_output,
+                next_stock_conv,
+                next_fused_conv,
+                next_stock_state,
+                next_fused_state,
+            )
+            assert mx.array_equal(stock_output, fused_output).item(), step
+            assert mx.array_equal(next_stock_conv, next_fused_conv).item(), step
+            assert mx.array_equal(next_stock_state, next_fused_state).item(), step
+            stock_conv, fused_conv = next_stock_conv, next_fused_conv
+            stock_state, fused_state = next_stock_state, next_fused_state
+    finally:
+        mx.set_default_device(previous_device)

--- a/tests/test_qwen4_fused_gdn_decode.py
+++ b/tests/test_qwen4_fused_gdn_decode.py
@@ -331,7 +331,8 @@ def test_admitted_path_updates_cache_and_counter_without_real_kernel():
 
 
 @pytest.mark.requires_mlx
-def test_real_metal_kernel_matches_stock_for_32_sequential_steps():
+@pytest.mark.parametrize("threadgroup_y", fused_gdn._THREADGROUP_Y_CANDIDATES)
+def test_real_metal_kernel_matches_stock_for_32_sequential_steps(threadgroup_y):
     """Guard every BF16 boundary that the fused dispatch replaces."""
     if not mx.metal.is_available():
         pytest.skip("requires a Metal GPU")
@@ -471,7 +472,7 @@ def test_real_metal_kernel_matches_stock_for_32_sequential_steps():
                     fused_state,
                     norm_weight,
                     1e-6,
-                    threadgroup_y=32,
+                    threadgroup_y=threadgroup_y,
                 )
             )
             mx.eval(

--- a/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
+++ b/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
@@ -478,8 +478,12 @@ def probe_qwen4_fused_gdn_decode(dtype) -> int | None:
                 logger.info("Qwen4 fused GDN probe failed: %s", exc)
                 break
             except RuntimeError as exc:
-                logger.info("Qwen4 fused GDN kernel is unavailable: %s", exc)
-                break
+                logger.info(
+                    "Qwen4 fused GDN threadgroup_y=%d is unavailable: %s",
+                    threadgroup_y,
+                    exc,
+                )
+                continue
         _PROBE_COMPLETE = True
         return _PROBED_THREADGROUP_Y
 

--- a/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
+++ b/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from functools import cache
+from threading import Lock
 from typing import Any
 
 import mlx.core as mx
@@ -426,56 +427,61 @@ def fused_gdn_runtime_supported() -> bool:
 
 _PROBED_THREADGROUP_Y: int | None = None
 _PROBE_COMPLETE = False
+_PROBE_LOCK = Lock()
 
 
 def probe_qwen4_fused_gdn_decode(dtype) -> int | None:
-    """Compile candidates once and retain the first supported geometry."""
+    """Compile candidates once and publish the supported geometry atomically."""
     global _PROBE_COMPLETE, _PROBED_THREADGROUP_Y
     if _PROBE_COMPLETE:
         return _PROBED_THREADGROUP_Y
-    _PROBE_COMPLETE = True
-    if not fused_gdn_runtime_supported():
-        return None
+    with _PROBE_LOCK:
+        if _PROBE_COMPLETE:
+            return _PROBED_THREADGROUP_Y
+        if not fused_gdn_runtime_supported():
+            _PROBE_COMPLETE = True
+            return None
 
-    qkv = mx.zeros((1, 1, CONV_DIM), dtype=dtype)
-    z = mx.zeros((1, 1, VALUE_DIM), dtype=dtype)
-    gates = mx.zeros((1, 1, NUM_VALUE_HEADS), dtype=dtype)
-    conv_state = mx.zeros((1, CONV_KERNEL - 1, CONV_DIM), dtype=dtype)
-    conv_weight = mx.zeros((CONV_DIM, CONV_KERNEL, 1), dtype=dtype)
-    recurrent_state = mx.zeros(
-        (1, NUM_VALUE_HEADS, VALUE_HEAD_DIM, KEY_HEAD_DIM), dtype=mx.float32
-    )
-    vector = mx.zeros((NUM_VALUE_HEADS,), dtype=dtype)
-    A_log = mx.zeros((NUM_VALUE_HEADS,), dtype=mx.float32)
-    norm_weight = mx.ones((VALUE_HEAD_DIM,), dtype=dtype)
-    for threadgroup_y in _THREADGROUP_Y_CANDIDATES:
-        try:
-            outputs = qwen4_fused_gdn_decode(
-                qkv,
-                z,
-                gates,
-                gates,
-                conv_state,
-                conv_weight,
-                A_log,
-                vector,
-                recurrent_state,
-                norm_weight,
-                1.0e-6,
-                threadgroup_y=threadgroup_y,
-            )
-            mx.eval(*outputs)
-            _PROBED_THREADGROUP_Y = threadgroup_y
-            return threadgroup_y
-        except ValueError as exc:
-            if "threads per threadgroup" in str(exc):
-                continue
-            logger.info("Qwen4 fused GDN probe failed: %s", exc)
-            break
-        except RuntimeError as exc:
-            logger.info("Qwen4 fused GDN kernel is unavailable: %s", exc)
-            break
-    return None
+        qkv = mx.zeros((1, 1, CONV_DIM), dtype=dtype)
+        z = mx.zeros((1, 1, VALUE_DIM), dtype=dtype)
+        gates = mx.zeros((1, 1, NUM_VALUE_HEADS), dtype=dtype)
+        conv_state = mx.zeros((1, CONV_KERNEL - 1, CONV_DIM), dtype=dtype)
+        conv_weight = mx.zeros((CONV_DIM, CONV_KERNEL, 1), dtype=dtype)
+        recurrent_state = mx.zeros(
+            (1, NUM_VALUE_HEADS, VALUE_HEAD_DIM, KEY_HEAD_DIM), dtype=mx.float32
+        )
+        vector = mx.zeros((NUM_VALUE_HEADS,), dtype=dtype)
+        A_log = mx.zeros((NUM_VALUE_HEADS,), dtype=mx.float32)
+        norm_weight = mx.ones((VALUE_HEAD_DIM,), dtype=dtype)
+        for threadgroup_y in _THREADGROUP_Y_CANDIDATES:
+            try:
+                outputs = qwen4_fused_gdn_decode(
+                    qkv,
+                    z,
+                    gates,
+                    gates,
+                    conv_state,
+                    conv_weight,
+                    A_log,
+                    vector,
+                    recurrent_state,
+                    norm_weight,
+                    1.0e-6,
+                    threadgroup_y=threadgroup_y,
+                )
+                mx.eval(*outputs)
+                _PROBED_THREADGROUP_Y = threadgroup_y
+                break
+            except ValueError as exc:
+                if "threads per threadgroup" in str(exc):
+                    continue
+                logger.info("Qwen4 fused GDN probe failed: %s", exc)
+                break
+            except RuntimeError as exc:
+                logger.info("Qwen4 fused GDN kernel is unavailable: %s", exc)
+                break
+        _PROBE_COMPLETE = True
+        return _PROBED_THREADGROUP_Y
 
 
 __all__ = [

--- a/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
+++ b/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
@@ -1,0 +1,484 @@
+# Metal reduction and precision structure adapted from mlx-vlm #2105.
+# Copyright © 2025 Prince Canuma. Used under the MIT License.
+
+"""Default-off fused Qwen4-Exp GDN operator for single-token decode."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import mlx.core as mx
+
+
+logger = logging.getLogger(__name__)
+
+NUM_KEY_HEADS = 16
+NUM_VALUE_HEADS = 48
+KEY_HEAD_DIM = 128
+VALUE_HEAD_DIM = 128
+CONV_KERNEL = 4
+KEY_DIM = NUM_KEY_HEADS * KEY_HEAD_DIM
+VALUE_DIM = NUM_VALUE_HEADS * VALUE_HEAD_DIM
+CONV_DIM = 2 * KEY_DIM + VALUE_DIM
+_THREADGROUP_Y_CANDIDATES = (32, 16, 8, 4)
+
+
+@dataclass(frozen=True)
+class FusedGdnAdmission:
+    accepted: bool
+    reason: str
+
+
+def _shape(value: Any) -> tuple[int, ...]:
+    return tuple(getattr(value, "shape", ()))
+
+
+def _dtype(value: Any) -> Any:
+    return getattr(value, "dtype", None)
+
+
+def admit_qwen4_fused_gdn_decode(
+    *,
+    qkv: Any,
+    z: Any,
+    beta: Any,
+    alpha: Any,
+    conv_state: Any,
+    recurrent_state: Any,
+    conv_weight: Any,
+    A_log: Any,
+    dt_bias: Any,
+    norm_weight: Any,
+    mask: Any,
+    cache_lengths: Any,
+    record_rollback: bool,
+    training: bool,
+    sharded: bool,
+    num_key_heads: int,
+    num_value_heads: int,
+    key_head_dim: int,
+    value_head_dim: int,
+    conv_kernel: int,
+    gate_activation: str,
+) -> FusedGdnAdmission:
+    """Check the exact production geometry without evaluating MLX arrays."""
+    if training:
+        return FusedGdnAdmission(False, "training")
+    if sharded:
+        return FusedGdnAdmission(False, "distributed sharding")
+    if record_rollback:
+        return FusedGdnAdmission(False, "speculative rollback")
+    if mask is not None:
+        return FusedGdnAdmission(False, "masked decode")
+    if cache_lengths is not None:
+        return FusedGdnAdmission(False, "ragged cache lengths")
+    if gate_activation != "sigmoid":
+        return FusedGdnAdmission(False, f"output gate {gate_activation!r}")
+
+    geometry = (
+        num_key_heads,
+        num_value_heads,
+        key_head_dim,
+        value_head_dim,
+        conv_kernel,
+    )
+    expected_geometry = (
+        NUM_KEY_HEADS,
+        NUM_VALUE_HEADS,
+        KEY_HEAD_DIM,
+        VALUE_HEAD_DIM,
+        CONV_KERNEL,
+    )
+    if geometry != expected_geometry:
+        return FusedGdnAdmission(False, f"unsupported geometry {geometry}")
+
+    expected = {
+        "qkv": (1, 1, CONV_DIM),
+        "z": (1, 1, VALUE_DIM),
+        "alpha": (1, 1, NUM_VALUE_HEADS),
+        "beta": (1, 1, NUM_VALUE_HEADS),
+        "conv_state": (1, CONV_KERNEL - 1, CONV_DIM),
+        "recurrent_state": (
+            1,
+            NUM_VALUE_HEADS,
+            VALUE_HEAD_DIM,
+            KEY_HEAD_DIM,
+        ),
+        "conv_weight": (CONV_DIM, CONV_KERNEL, 1),
+        "A_log": (NUM_VALUE_HEADS,),
+        "dt_bias": (NUM_VALUE_HEADS,),
+        "norm_weight": (VALUE_HEAD_DIM,),
+    }
+    values = {
+        "qkv": qkv,
+        "z": z,
+        "alpha": alpha,
+        "beta": beta,
+        "conv_state": conv_state,
+        "recurrent_state": recurrent_state,
+        "conv_weight": conv_weight,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "norm_weight": norm_weight,
+    }
+    for name, expected_shape in expected.items():
+        if _shape(values[name]) != expected_shape:
+            return FusedGdnAdmission(
+                False,
+                f"{name} shape {_shape(values[name])}, expected {expected_shape}",
+            )
+
+    value_dtype = _dtype(qkv)
+    if value_dtype != mx.bfloat16:
+        return FusedGdnAdmission(False, f"unsupported activation dtype {value_dtype}")
+    for name in (
+        "z",
+        "alpha",
+        "beta",
+        "conv_state",
+        "conv_weight",
+        "dt_bias",
+        "norm_weight",
+    ):
+        if _dtype(values[name]) != value_dtype:
+            return FusedGdnAdmission(False, f"{name} dtype {_dtype(values[name])}")
+    if _dtype(recurrent_state) != mx.float32:
+        return FusedGdnAdmission(False, "recurrent_state must be float32")
+    if _dtype(A_log) not in (value_dtype, mx.float32):
+        return FusedGdnAdmission(False, f"A_log dtype {_dtype(A_log)}")
+    return FusedGdnAdmission(True, "eligible")
+
+
+_HEADER = r"""
+#include <metal_atomic>
+template <typename U>
+inline U mlx_sigmoid_precise(U x) {
+  U e = static_cast<U>(metal::precise::exp(metal::abs(x)));
+  U y = static_cast<U>(1) / (static_cast<U>(1) + e);
+  return (x < 0) ? y : (static_cast<U>(1) - y);
+}
+
+template <typename U>
+inline U mlx_sigmoid_fast(U x) {
+  U e = static_cast<U>(metal::exp(metal::abs(x)));
+  U y = static_cast<U>(1) / (static_cast<U>(1) + e);
+  return (x < 0) ? y : (static_cast<U>(1) - y);
+}
+
+template <typename U>
+inline U mlx_log1p_fast(U x) {
+  float xf = float(x);
+  float xp1 = 1.0f + xf;
+  float out = xp1 == 1.0f ? xf : xf * (metal::log(xp1) / (xp1 - 1.0f));
+  return static_cast<U>(out);
+}
+
+template <typename U>
+inline U mlx_softplus_fast(U x) {
+  if (metal::isnan(x))
+    return metal::numeric_limits<U>::quiet_NaN();
+  constexpr U inf = metal::numeric_limits<U>::infinity();
+  U zero = static_cast<U>(0);
+  U hi = metal::max(x, zero);
+  U lo = metal::min(x, zero);
+  return (lo == -inf || hi == inf)
+      ? hi
+      : (hi + mlx_log1p_fast(static_cast<U>(metal::exp(lo - hi))));
+}
+
+#pragma clang fp contract(off)
+inline float sq_acc(float acc, float v) {
+  return v * v + acc;
+}
+#pragma clang fp contract(on)
+"""
+
+
+_SOURCE = r"""
+  const uint hv = threadgroup_position_in_grid.z;
+  const uint hk = hv / RATIO;
+  const uint lane = thread_position_in_threadgroup.x;
+  const uint ty = thread_position_in_threadgroup.y;
+  const uint tid = thread_index_in_threadgroup;
+
+  constexpr int NT = 32 * TY;
+  constexpr int NDK = DK / 32;
+  constexpr int NDV = DV / TY;
+  constexpr uint KD = (uint)(HK * DK);
+  constexpr uint VD = (uint)(HV * DV);
+  constexpr uint CD = 2u * KD + VD;
+
+  threadgroup float sq[DK];
+  threadgroup float sk[DK];
+  threadgroup float sv[DV];
+  threadgroup float sy[DV];
+  threadgroup float shr[4];
+
+  device const float* si = recurrent_state + (size_t)hv * DV * DK;
+  device float* so = recurrent_state_out + (size_t)hv * DV * DK;
+  float st[NDV][NDK];
+  for (int j = 0; j < NDV; ++j) {
+    uint dv = ty + (uint)TY * (uint)j;
+    for (int i = 0; i < NDK; ++i)
+      st[j][i] = si[(size_t)dv * DK + NDK * lane + i];
+  }
+
+  for (uint idx = tid; idx < (uint)(2 * DK + DV); idx += NT) {
+    uint part = idx / (uint)DK;
+    uint d = idx - part * (uint)DK;
+    uint c = part == 0u ? hk * DK + d
+           : (part == 1u ? KD + hk * DK + d : 2u * KD + hv * DV + d);
+    device const T* wc = conv_weight + (size_t)c * K;
+    float acc = 0.0f;
+    for (uint tap = 0; tap + 1 < (uint)K; ++tap)
+      acc += float(conv_state[(size_t)tap * CD + c]) * float(wc[tap]);
+    acc += float(qkv[c]) * float(wc[K - 1]);
+    T xb = static_cast<T>(acc);
+    T sl = xb * mlx_sigmoid_fast(xb);
+    if (part == 0u) sq[d] = float(sl);
+    else if (part == 1u) sk[d] = float(sl);
+    else sv[d] = float(sl);
+
+    if (part == 2u || (hv % RATIO) == 0u) {
+      for (uint tap = 0; tap + 2 < (uint)K; ++tap)
+        conv_state_out[(size_t)tap * CD + c] =
+            conv_state[(size_t)(tap + 1) * CD + c];
+      conv_state_out[(size_t)(K - 2) * CD + c] = qkv[c];
+    }
+  }
+
+  if (tid == 0u) {
+    T av = alpha[hv] + dt_bias[hv];
+    T sp = mlx_softplus_fast(av);
+    shr[2] = metal::precise::exp(
+        -metal::precise::exp(float(A_log[hv])) * float(sp));
+    shr[3] = mlx_sigmoid_precise<float>(float(beta[hv]));
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (simdgroup_index_in_threadgroup == 0u) {
+    float pq = 0.0f, pk = 0.0f;
+    uint base = 4u * lane;
+    for (int i = 0; i < 4; ++i) {
+      pq += sq[base + i] * sq[base + i];
+      pk += sk[base + i] * sk[base + i];
+    }
+    pq = simd_sum(pq);
+    pk = simd_sum(pk);
+    if (lane == 0u) {
+      shr[0] = metal::precise::rsqrt(pq / (float)DK + qk_eps);
+      shr[1] = metal::precise::rsqrt(pk / (float)DK + qk_eps);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  T scale = static_cast<T>(qscale);
+  for (uint d = tid; d < (uint)DK; d += NT) {
+    T q_rms = static_cast<T>(sq[d] * shr[0]);
+    T k_rms = static_cast<T>(sk[d] * shr[1]);
+    sq[d] = float(static_cast<T>(q_rms * static_cast<T>(scale * scale)));
+    sk[d] = float(static_cast<T>(k_rms * scale));
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (int j = 0; j < NDV; ++j) {
+    uint dv = ty + (uint)TY * (uint)j;
+    float kv = 0.0f;
+    for (int i = 0; i < NDK; ++i) {
+      uint s = NDK * lane + i;
+      st[j][i] = st[j][i] * shr[2];
+      kv += st[j][i] * sk[s];
+    }
+    kv = simd_sum(kv);
+    float delta = (sv[dv] - kv) * shr[3];
+    float out = 0.0f;
+    for (int i = 0; i < NDK; ++i) {
+      uint s = NDK * lane + i;
+      st[j][i] = st[j][i] + sk[s] * delta;
+      out += st[j][i] * sq[s];
+    }
+    out = simd_sum(out);
+    if (thread_index_in_simdgroup == 0u)
+      sy[dv] = float(static_cast<T>(out));
+    for (int i = 0; i < NDK; ++i)
+      so[(size_t)dv * DK + NDK * lane + i] = st[j][i];
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (simdgroup_index_in_threadgroup == 0u) {
+    float po = 0.0f;
+    uint base = 4u * lane;
+    for (int i = 0; i < 4; ++i) po = sq_acc(po, sy[base + i]);
+    po = simd_sum(po);
+    if (lane == 0u)
+      shr[0] = metal::precise::rsqrt(po / (float)DV + norm_eps);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint d = tid; d < (uint)DV; d += NT) {
+    float x = sy[d] * shr[0];
+    x = float(norm_weight[d]) * x;
+    x = x * mlx_sigmoid_precise<float>(float(z[hv * DV + d]));
+    output[hv * DV + d] = static_cast<T>(x);
+  }
+"""
+
+
+@lru_cache(maxsize=None)
+def _kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_qwen4_fused_gdn_decode",
+        input_names=[
+            "qkv",
+            "z",
+            "beta",
+            "alpha",
+            "conv_state",
+            "conv_weight",
+            "A_log",
+            "dt_bias",
+            "recurrent_state",
+            "norm_weight",
+            "qscale",
+            "qk_eps",
+            "norm_eps",
+        ],
+        output_names=["output", "conv_state_out", "recurrent_state_out"],
+        header=_HEADER,
+        source=_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+def qwen4_fused_gdn_decode(
+    qkv,
+    z,
+    beta,
+    alpha,
+    conv_state,
+    conv_weight,
+    A_log,
+    dt_bias,
+    recurrent_state,
+    norm_weight,
+    norm_eps: float,
+    *,
+    threadgroup_y: int,
+):
+    """Run the fused graph after structural admission succeeds."""
+    if threadgroup_y not in _THREADGROUP_Y_CANDIDATES:
+        raise ValueError(
+            f"unsupported threadgroup_y {threadgroup_y}; "
+            f"expected one of {_THREADGROUP_Y_CANDIDATES}"
+        )
+    outputs = _kernel()(
+        inputs=[
+            qkv,
+            z,
+            beta,
+            alpha,
+            conv_state,
+            conv_weight,
+            A_log,
+            dt_bias,
+            recurrent_state,
+            norm_weight,
+            float(KEY_HEAD_DIM**-0.5),
+            float(1.0e-6 / KEY_HEAD_DIM),
+            float(norm_eps),
+        ],
+        template=[
+            ("T", qkv.dtype),
+            ("HK", NUM_KEY_HEADS),
+            ("HV", NUM_VALUE_HEADS),
+            ("DK", KEY_HEAD_DIM),
+            ("DV", VALUE_HEAD_DIM),
+            ("K", CONV_KERNEL),
+            ("TY", threadgroup_y),
+            ("RATIO", NUM_VALUE_HEADS // NUM_KEY_HEADS),
+        ],
+        grid=(32, threadgroup_y, NUM_VALUE_HEADS),
+        threadgroup=(32, threadgroup_y, 1),
+        output_shapes=[
+            (1, 1, VALUE_DIM),
+            (1, CONV_KERNEL - 1, CONV_DIM),
+            (1, NUM_VALUE_HEADS, VALUE_HEAD_DIM, KEY_HEAD_DIM),
+        ],
+        output_dtypes=[qkv.dtype, qkv.dtype, mx.float32],
+    )
+    return tuple(outputs)
+
+
+def fused_gdn_runtime_supported() -> bool:
+    """Report capability without constructing or launching a kernel."""
+    return bool(
+        hasattr(mx, "fast")
+        and hasattr(mx.fast, "metal_kernel")
+        and hasattr(mx, "metal")
+        and mx.metal.is_available()
+        and mx.default_device() == mx.gpu
+    )
+
+
+_PROBED_THREADGROUP_Y: int | None = None
+_PROBE_COMPLETE = False
+
+
+def probe_qwen4_fused_gdn_decode(dtype) -> int | None:
+    """Compile candidates once and retain the first supported geometry."""
+    global _PROBE_COMPLETE, _PROBED_THREADGROUP_Y
+    if _PROBE_COMPLETE:
+        return _PROBED_THREADGROUP_Y
+    _PROBE_COMPLETE = True
+    if not fused_gdn_runtime_supported():
+        return None
+
+    qkv = mx.zeros((1, 1, CONV_DIM), dtype=dtype)
+    z = mx.zeros((1, 1, VALUE_DIM), dtype=dtype)
+    gates = mx.zeros((1, 1, NUM_VALUE_HEADS), dtype=dtype)
+    conv_state = mx.zeros((1, CONV_KERNEL - 1, CONV_DIM), dtype=dtype)
+    conv_weight = mx.zeros((CONV_DIM, CONV_KERNEL, 1), dtype=dtype)
+    recurrent_state = mx.zeros(
+        (1, NUM_VALUE_HEADS, VALUE_HEAD_DIM, KEY_HEAD_DIM), dtype=mx.float32
+    )
+    vector = mx.zeros((NUM_VALUE_HEADS,), dtype=dtype)
+    A_log = mx.zeros((NUM_VALUE_HEADS,), dtype=mx.float32)
+    norm_weight = mx.ones((VALUE_HEAD_DIM,), dtype=dtype)
+    for threadgroup_y in _THREADGROUP_Y_CANDIDATES:
+        try:
+            outputs = qwen4_fused_gdn_decode(
+                qkv,
+                z,
+                gates,
+                gates,
+                conv_state,
+                conv_weight,
+                A_log,
+                vector,
+                recurrent_state,
+                norm_weight,
+                1.0e-6,
+                threadgroup_y=threadgroup_y,
+            )
+            mx.eval(*outputs)
+            _PROBED_THREADGROUP_Y = threadgroup_y
+            return threadgroup_y
+        except ValueError as exc:
+            if "threads per threadgroup" in str(exc):
+                continue
+            logger.info("Qwen4 fused GDN probe failed: %s", exc)
+            break
+        except RuntimeError as exc:
+            logger.info("Qwen4 fused GDN kernel is unavailable: %s", exc)
+            break
+    return None
+
+
+__all__ = [
+    "FusedGdnAdmission",
+    "admit_qwen4_fused_gdn_decode",
+    "fused_gdn_runtime_supported",
+    "probe_qwen4_fused_gdn_decode",
+    "qwen4_fused_gdn_decode",
+]

--- a/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
+++ b/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
@@ -7,11 +7,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import cache
 from typing import Any
 
 import mlx.core as mx
-
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +48,7 @@ def admit_qwen4_fused_gdn_decode(
     conv_state: Any,
     recurrent_state: Any,
     conv_weight: Any,
-    A_log: Any,
+    a_log: Any,
     dt_bias: Any,
     norm_weight: Any,
     mask: Any,
@@ -120,7 +119,7 @@ def admit_qwen4_fused_gdn_decode(
         "conv_state": conv_state,
         "recurrent_state": recurrent_state,
         "conv_weight": conv_weight,
-        "A_log": A_log,
+        "A_log": a_log,
         "dt_bias": dt_bias,
         "norm_weight": norm_weight,
     }
@@ -147,8 +146,8 @@ def admit_qwen4_fused_gdn_decode(
             return FusedGdnAdmission(False, f"{name} dtype {_dtype(values[name])}")
     if _dtype(recurrent_state) != mx.float32:
         return FusedGdnAdmission(False, "recurrent_state must be float32")
-    if _dtype(A_log) not in (value_dtype, mx.float32):
-        return FusedGdnAdmission(False, f"A_log dtype {_dtype(A_log)}")
+    if _dtype(a_log) not in (value_dtype, mx.float32):
+        return FusedGdnAdmission(False, f"A_log dtype {_dtype(a_log)}")
     return FusedGdnAdmission(True, "eligible")
 
 
@@ -189,11 +188,6 @@ inline U mlx_softplus_fast(U x) {
       : (hi + mlx_log1p_fast(static_cast<U>(metal::exp(lo - hi))));
 }
 
-#pragma clang fp contract(off)
-inline float sq_acc(float acc, float v) {
-  return v * v + acc;
-}
-#pragma clang fp contract(on)
 """
 
 
@@ -213,6 +207,8 @@ _SOURCE = r"""
 
   threadgroup float sq[DK];
   threadgroup float sk[DK];
+  threadgroup T sq_squared[DK];
+  threadgroup T sk_squared[DK];
   threadgroup float sv[DV];
   threadgroup float sy[DV];
   threadgroup float shr[4];
@@ -237,11 +233,11 @@ _SOURCE = r"""
       acc += float(conv_state[(size_t)tap * CD + c]) * float(wc[tap]);
     acc += float(qkv[c]) * float(wc[K - 1]);
     T xb = static_cast<T>(acc);
-    T sl = xb * mlx_sigmoid_fast(xb);
+    T sig = mlx_sigmoid_fast(xb);
+    T sl = xb * sig;
     if (part == 0u) sq[d] = float(sl);
     else if (part == 1u) sk[d] = float(sl);
     else sv[d] = float(sl);
-
     if (part == 2u || (hv % RATIO) == 0u) {
       for (uint tap = 0; tap + 2 < (uint)K; ++tap)
         conv_state_out[(size_t)tap * CD + c] =
@@ -255,31 +251,42 @@ _SOURCE = r"""
     T sp = mlx_softplus_fast(av);
     shr[2] = metal::precise::exp(
         -metal::precise::exp(float(A_log[hv])) * float(sp));
-    shr[3] = mlx_sigmoid_precise<float>(float(beta[hv]));
+    shr[3] = float(mlx_sigmoid_fast(beta[hv]));
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint d = tid; d < (uint)DK; d += NT) {
+    T qv = static_cast<T>(sq[d]);
+    T kv = static_cast<T>(sk[d]);
+    sq_squared[d] = static_cast<T>(qv * qv);
+    sk_squared[d] = static_cast<T>(kv * kv);
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
   if (simdgroup_index_in_threadgroup == 0u) {
-    float pq = 0.0f, pk = 0.0f;
+    T pq = static_cast<T>(0), pk = static_cast<T>(0);
     uint base = 4u * lane;
     for (int i = 0; i < 4; ++i) {
-      pq += sq[base + i] * sq[base + i];
-      pk += sk[base + i] * sk[base + i];
+      pq = static_cast<T>(sq_squared[base + i] + pq);
+      pk = static_cast<T>(sk_squared[base + i] + pk);
     }
-    pq = simd_sum(pq);
-    pk = simd_sum(pk);
+    pq = static_cast<T>(simd_sum(float(pq)));
+    pk = static_cast<T>(simd_sum(float(pk)));
     if (lane == 0u) {
-      shr[0] = metal::precise::rsqrt(pq / (float)DK + qk_eps);
-      shr[1] = metal::precise::rsqrt(pk / (float)DK + qk_eps);
+      T eps = static_cast<T>(1.0e-6f);
+      T qdenom = pq + eps;
+      T kdenom = pk + eps;
+      shr[0] = float(static_cast<T>(metal::precise::rsqrt(qdenom)));
+      shr[1] = float(static_cast<T>(metal::precise::rsqrt(kdenom)));
     }
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
-  T scale = static_cast<T>(qscale);
+  T qscale = static_cast<T>(0.08838834764831845f);
   for (uint d = tid; d < (uint)DK; d += NT) {
-    T q_rms = static_cast<T>(sq[d] * shr[0]);
-    T k_rms = static_cast<T>(sk[d] * shr[1]);
-    sq[d] = float(static_cast<T>(q_rms * static_cast<T>(scale * scale)));
-    sk[d] = float(static_cast<T>(k_rms * scale));
+    T q_normalized = static_cast<T>(static_cast<T>(sq[d]) * static_cast<T>(shr[0]));
+    T k_normalized = static_cast<T>(static_cast<T>(sk[d]) * static_cast<T>(shr[1]));
+    sq[d] = float(static_cast<T>(q_normalized * qscale));
+    sk[d] = float(k_normalized);
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
@@ -310,22 +317,22 @@ _SOURCE = r"""
   if (simdgroup_index_in_threadgroup == 0u) {
     float po = 0.0f;
     uint base = 4u * lane;
-    for (int i = 0; i < 4; ++i) po = sq_acc(po, sy[base + i]);
+    for (int i = 0; i < 4; ++i) po += sy[base + i] * sy[base + i];
     po = simd_sum(po);
     if (lane == 0u)
       shr[0] = metal::precise::rsqrt(po / (float)DV + norm_eps);
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
   for (uint d = tid; d < (uint)DV; d += NT) {
-    float x = sy[d] * shr[0];
-    x = float(norm_weight[d]) * x;
-    x = x * mlx_sigmoid_precise<float>(float(z[hv * DV + d]));
+    T normalized = static_cast<T>(sy[d] * shr[0]);
+    normalized = norm_weight[d] * normalized;
+    float x = float(normalized) * mlx_sigmoid_fast<float>(float(z[hv * DV + d]));
     output[hv * DV + d] = static_cast<T>(x);
   }
 """
 
 
-@lru_cache(maxsize=None)
+@cache
 def _kernel():
     return mx.fast.metal_kernel(
         name="rapid_qwen4_fused_gdn_decode",
@@ -340,8 +347,6 @@ def _kernel():
             "dt_bias",
             "recurrent_state",
             "norm_weight",
-            "qscale",
-            "qk_eps",
             "norm_eps",
         ],
         output_names=["output", "conv_state_out", "recurrent_state_out"],
@@ -358,7 +363,7 @@ def qwen4_fused_gdn_decode(
     alpha,
     conv_state,
     conv_weight,
-    A_log,
+    a_log,
     dt_bias,
     recurrent_state,
     norm_weight,
@@ -380,12 +385,10 @@ def qwen4_fused_gdn_decode(
             alpha,
             conv_state,
             conv_weight,
-            A_log,
+            a_log,
             dt_bias,
             recurrent_state,
             norm_weight,
-            float(KEY_HEAD_DIM**-0.5),
-            float(1.0e-6 / KEY_HEAD_DIM),
             float(norm_eps),
         ],
         template=[

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -399,6 +399,7 @@ class GatedDeltaNet(nn.Module):
             activation=args.output_gate_type or args.hidden_act,
         )
         self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+        self.sharding_group = None
         self.fused_gdn_decode_mode = "fused" if _FUSED_GDN_DEFAULT else "stock"
         self.fused_gdn_decode_calls = 0
         self.fused_gdn_decode_fallbacks = 0
@@ -449,7 +450,7 @@ class GatedDeltaNet(nn.Module):
             cache_lengths=getattr(cache, "lengths", None),
             record_rollback=record_rollback,
             training=bool(self.training),
-            sharded=False,
+            sharded=self.sharding_group is not None,
             num_key_heads=self.num_k_heads,
             num_value_heads=self.num_v_heads,
             key_head_dim=self.head_k_dim,
@@ -462,23 +463,34 @@ class GatedDeltaNet(nn.Module):
         if not fused_gdn_runtime_supported():
             return self._fused_gdn_fallback("Metal runtime unavailable")
 
-        threadgroup_y = probe_qwen4_fused_gdn_decode(qkv.dtype)
-        if threadgroup_y is None:
-            return self._fused_gdn_fallback("Metal kernel probe declined")
-        output, conv_state, recurrent_state = qwen4_fused_gdn_decode(
-            qkv,
-            z,
-            beta,
-            alpha,
-            cache[0],
-            self.conv1d.weight,
-            self.A_log,
-            self.dt_bias,
-            cache[1],
-            self.norm.weight,
-            self.norm.eps,
-            threadgroup_y=threadgroup_y,
-        )
+        try:
+            threadgroup_y = probe_qwen4_fused_gdn_decode(qkv.dtype)
+            if threadgroup_y is None:
+                return self._fused_gdn_fallback("Metal kernel probe declined")
+            output, conv_state, recurrent_state = qwen4_fused_gdn_decode(
+                qkv,
+                z,
+                beta,
+                alpha,
+                cache[0],
+                self.conv1d.weight,
+                self.A_log,
+                self.dt_bias,
+                cache[1],
+                self.norm.weight,
+                self.norm.eps,
+                threadgroup_y=threadgroup_y,
+            )
+        except Exception as exc:  # noqa: BLE001 - an optional fast path fails closed
+            return self._fused_gdn_fallback(
+                f"Metal kernel dispatch failed: {type(exc).__name__}"
+            )
+        # The probe compile-and-runs this exact dtype/geometry before this
+        # path is admitted. Do not mx.eval here: a per-layer synchronization
+        # barrier would serialize decode and erase the fusion's benefit.
+        # Custom-kernel outputs are fresh arrays, so constructing them cannot
+        # mutate the live cache; commit their lazy graph only after dispatch
+        # construction succeeds.
         cache[0] = conv_state
         cache[1] = recurrent_state
         cache.advance(1)

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -13,6 +13,7 @@ milestones have independent numerical and lifecycle coverage.
 from __future__ import annotations
 
 import math
+import os
 from dataclasses import dataclass, field
 from functools import cache
 from typing import Any, cast
@@ -36,6 +37,18 @@ from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
 from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
 from .qwen4_exp_cache import QSAIndexCache, Qwen4ExpStateCache  # noqa: E402
+from ..kernels.qwen4_fused_gdn_decode import (  # noqa: E402
+    admit_qwen4_fused_gdn_decode,
+    fused_gdn_runtime_supported,
+    probe_qwen4_fused_gdn_decode,
+    qwen4_fused_gdn_decode,
+)
+
+
+_FUSED_GDN_MODES = ("stock", "fused")
+_FUSED_GDN_DEFAULT = os.environ.get(
+    "RAPID_MLX_QWEN4_FUSED_GDN_DECODE", "0"
+).strip().lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass
@@ -387,6 +400,92 @@ class GatedDeltaNet(nn.Module):
             activation=args.output_gate_type or args.hidden_act,
         )
         self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+        self.fused_gdn_decode_mode = "fused" if _FUSED_GDN_DEFAULT else "stock"
+        self.fused_gdn_decode_calls = 0
+        self.fused_gdn_decode_fallbacks = 0
+        self.fused_gdn_decode_last_fallback: str | None = None
+
+    def set_fused_gdn_decode_mode(self, mode: str) -> None:
+        """Select the decode path without replacing resident weights."""
+        if mode not in _FUSED_GDN_MODES:
+            raise ValueError(
+                f"unknown fused GDN decode mode {mode!r}; "
+                f"expected one of {_FUSED_GDN_MODES}"
+            )
+        self.fused_gdn_decode_mode = mode
+
+    def _fused_gdn_fallback(self, reason: str):
+        self.fused_gdn_decode_fallbacks += 1
+        self.fused_gdn_decode_last_fallback = reason
+        return None
+
+    def _try_fused_decode(
+        self,
+        qkv: mx.array,
+        z: mx.array,
+        beta: mx.array,
+        alpha: mx.array,
+        mask: mx.array | None,
+        cache: Any | None,
+        *,
+        record_rollback: bool,
+    ) -> mx.array | None:
+        if self.fused_gdn_decode_mode == "stock":
+            return None
+        if cache is None or cache[0] is None or cache[1] is None:
+            return self._fused_gdn_fallback("uninitialized cache")
+
+        admission = admit_qwen4_fused_gdn_decode(
+            qkv=qkv,
+            z=z,
+            beta=beta,
+            alpha=alpha,
+            conv_state=cache[0],
+            recurrent_state=cache[1],
+            conv_weight=self.conv1d.weight,
+            A_log=self.A_log,
+            dt_bias=self.dt_bias,
+            norm_weight=self.norm.weight,
+            mask=mask,
+            cache_lengths=getattr(cache, "lengths", None),
+            record_rollback=record_rollback,
+            training=bool(self.training),
+            sharded=False,
+            num_key_heads=self.num_k_heads,
+            num_value_heads=self.num_v_heads,
+            key_head_dim=self.head_k_dim,
+            value_head_dim=self.head_v_dim,
+            conv_kernel=self.conv_kernel_size,
+            gate_activation=self.norm.activation,
+        )
+        if not admission.accepted:
+            return self._fused_gdn_fallback(admission.reason)
+        if not fused_gdn_runtime_supported():
+            return self._fused_gdn_fallback("Metal runtime unavailable")
+
+        threadgroup_y = probe_qwen4_fused_gdn_decode(qkv.dtype)
+        if threadgroup_y is None:
+            return self._fused_gdn_fallback("Metal kernel probe declined")
+        output, conv_state, recurrent_state = qwen4_fused_gdn_decode(
+            qkv,
+            z,
+            beta,
+            alpha,
+            cache[0],
+            self.conv1d.weight,
+            self.A_log,
+            self.dt_bias,
+            cache[1],
+            self.norm.weight,
+            self.norm.eps,
+            threadgroup_y=threadgroup_y,
+        )
+        cache[0] = conv_state
+        cache[1] = recurrent_state
+        cache.advance(1)
+        self.fused_gdn_decode_calls += 1
+        self.fused_gdn_decode_last_fallback = None
+        return self.out_proj(output)
 
     def __call__(
         self,
@@ -398,11 +497,23 @@ class GatedDeltaNet(nn.Module):
     ) -> mx.array:
         batch, length, _ = inputs.shape
         mixed = self.in_proj_qkv(inputs)
-        z = self.in_proj_z(inputs).reshape(
-            batch, length, self.num_v_heads, self.head_v_dim
-        )
+        z = self.in_proj_z(inputs)
         beta = self.in_proj_b(inputs)
         alpha = self.in_proj_a(inputs)
+
+        fused = self._try_fused_decode(
+            mixed,
+            z,
+            beta,
+            alpha,
+            mask,
+            cache,
+            record_rollback=record_rollback,
+        )
+        if fused is not None:
+            return fused
+
+        z = z.reshape(batch, length, self.num_v_heads, self.head_v_dim)
 
         if cache is not None and cache[0] is not None:
             conv_state = cache[0]
@@ -491,6 +602,52 @@ class GatedDeltaNet(nn.Module):
             cache.advance(length)
         output = self.norm(output, z)
         return self.out_proj(output.reshape(batch, length, -1))
+
+
+def set_qwen4_fused_gdn_mode(model: nn.Module, mode: str) -> int:
+    """Switch every resident Qwen4 GDN layer between stock and fused."""
+    if mode not in _FUSED_GDN_MODES:
+        raise ValueError(
+            f"unknown fused GDN decode mode {mode!r}; "
+            f"expected one of {_FUSED_GDN_MODES}"
+        )
+    layers = [
+        module
+        for _, module in model.named_modules()
+        if isinstance(module, GatedDeltaNet)
+    ]
+    for layer in layers:
+        layer.set_fused_gdn_decode_mode(mode)
+    return len(layers)
+
+
+def qwen4_fused_gdn_mode_counts(model: nn.Module) -> dict[str, int]:
+    """Return current GDN modes without evaluating model arrays."""
+    counts = {mode: 0 for mode in _FUSED_GDN_MODES}
+    for _, module in model.named_modules():
+        if isinstance(module, GatedDeltaNet):
+            counts[module.fused_gdn_decode_mode] += 1
+    return counts
+
+
+def qwen4_fused_gdn_stats(model: nn.Module) -> dict[str, Any]:
+    """Return fused call and fallback counters without host synchronization."""
+    stats: dict[str, Any] = {
+        "fused_calls": 0,
+        "fallbacks": 0,
+        "last_fallbacks": {},
+    }
+    for _, module in model.named_modules():
+        if not isinstance(module, GatedDeltaNet):
+            continue
+        stats["fused_calls"] += module.fused_gdn_decode_calls
+        stats["fallbacks"] += module.fused_gdn_decode_fallbacks
+        reason = module.fused_gdn_decode_last_fallback
+        if reason is not None:
+            stats["last_fallbacks"][reason] = (
+                stats["last_fallbacks"].get(reason, 0) + 1
+            )
+    return stats
 
 
 def apply_rotary_positions(

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -36,14 +36,13 @@ from mlx_lm.models.gated_delta import gated_delta_update  # noqa: E402
 from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
 from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
-from .qwen4_exp_cache import QSAIndexCache, Qwen4ExpStateCache  # noqa: E402
 from ..kernels.qwen4_fused_gdn_decode import (  # noqa: E402
     admit_qwen4_fused_gdn_decode,
     fused_gdn_runtime_supported,
     probe_qwen4_fused_gdn_decode,
     qwen4_fused_gdn_decode,
 )
-
+from .qwen4_exp_cache import QSAIndexCache, Qwen4ExpStateCache  # noqa: E402
 
 _FUSED_GDN_MODES = ("stock", "fused")
 _FUSED_GDN_DEFAULT = os.environ.get(
@@ -443,7 +442,7 @@ class GatedDeltaNet(nn.Module):
             conv_state=cache[0],
             recurrent_state=cache[1],
             conv_weight=self.conv1d.weight,
-            A_log=self.A_log,
+            a_log=self.A_log,
             dt_bias=self.dt_bias,
             norm_weight=self.norm.weight,
             mask=mask,
@@ -644,9 +643,7 @@ def qwen4_fused_gdn_stats(model: nn.Module) -> dict[str, Any]:
         stats["fallbacks"] += module.fused_gdn_decode_fallbacks
         reason = module.fused_gdn_decode_last_fallback
         if reason is not None:
-            stats["last_fallbacks"][reason] = (
-                stats["last_fallbacks"].get(reason, 0) + 1
-            )
+            stats["last_fallbacks"][reason] = stats["last_fallbacks"].get(reason, 0) + 1
     return stats
 
 

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -490,7 +490,10 @@ class GatedDeltaNet(nn.Module):
         # barrier would serialize decode and erase the fusion's benefit.
         # Custom-kernel outputs are fresh arrays, so constructing them cannot
         # mutate the live cache; commit their lazy graph only after dispatch
-        # construction succeeds.
+        # construction succeeds. A later command-buffer failure is a fatal
+        # generation error, not a retryable kernel-selection error: the
+        # scheduler closes the entire BatchGenerator and discards every
+        # affected request cache before any future step.
         cache[0] = conv_state
         cache[1] = recurrent_state
         cache.advance(1)


### PR DESCRIPTION
## Why

Qwen4-architecture models currently execute the single-token Gated DeltaNet recurrence as a sequence of small GPU operations. At decode batch size 1, dispatch and intermediate-materialization overhead leave meaningful performance on the table. This PR adds an opt-in fused path because the same recurrence can be computed in one dispatch while preserving the stock path's observable results.

## Scope

- Fuse Qwen4 B=1, M=1 BF16 Gated DeltaNet decode into one Metal dispatch.
- Preserve strict structural admission, a resident `stock|fused` selector, invocation/fallback counters, and fail-closed stock fallback.
- Match the current runtime's BF16 materialization, reduction, sigmoid, normalization, and cache-update boundaries exactly.
- Add a real-Metal 32-step bit-exact regression test, enroll it in the Apple test roster, and add reproducible layer and same-resident-model A/B benchmarks.
- Keep the fast path default-off behind `RAPID_MLX_QWEN4_FUSED_GDN_DECODE=1` while it receives wider hardware qualification.

## Non-goals

- Prefill, batch size greater than 1, masks, ragged cache, training, or non-BF16 execution.
- Speculative/MTP/PLD rollback paths; `record_rollback` deliberately uses the stock implementation.
- Fusing the affine-quantized output projection; measurements showed that variant was slower.
- Enabling the optimization by default.

## Design precedent

The implementation follows the engine's established optimized-kernel pattern: narrowly admit only a proven geometry, retain the stock implementation as the semantic authority, fail closed for every unsupported state, expose resident selection and counters for observability, and require exact output plus cache-state parity rather than tolerance-only acceptance. The fused arithmetic was aligned to the current native runtime's BF16 materialization and reduction boundaries instead of relying on compiler-preserved intermediate precision.

## Acceptance

- An eligible single-token decode uses one fused dispatch and is measurably faster than the stock recurrence.
- Across 32 sequential real-weight steps, output, convolution cache, and FP32 recurrent state are bit-exact with stock.
- An end-to-end 256-token generation produces the same token sequence in stock and fused modes.
- Every unsupported shape or execution mode falls back to stock without changing existing behavior.
- The feature remains off unless the operator explicitly opts in.

## Verification

- Real Qwen3.8-Flash-Next-4bit layer gate on M3 Ultra, 32 sequential steps: exact output and both cache states; 32 fused calls, 0 fallbacks.
- Same layer, interleaved median: stock 0.006521 s vs fused 0.005164 s, a 26.28% improvement.
- Same resident model, 3 interleaved runs per mode at 256 decode tokens: all six token hashes identical; stock 25.43 tok/s vs fused 27.04 tok/s, a 6.35% improvement.
- Focused and adjacent local suites: 186 passed, including bit-exact execution of every threadgroup candidate supported by the test GPU.
- `ruff check`, `ruff format --check`, `actionlint .github/workflows/ci.yml`, Python compilation, and `git diff --check`: passed.
- Environment and exact reproduction commands are recorded in `docs/engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md`.

## Behaviour delta

- Default behavior: unchanged; the stock path remains active.
- With `RAPID_MLX_QWEN4_FUSED_GDN_DECODE=1`: eligible Qwen4 single-token BF16 decode uses the fused recurrence and all other cases retain stock fallback.

## Rollout and risk

The primary risk is arithmetic drift across Metal/runtime variants. The feature is therefore default-off, guarded by exact structural admission, and covered by an Apple-lane bit-exact stateful test. Wider hardware qualification is required before any separate default-on proposal.

## AI assistance disclosure

Codex assisted the maintainer with Rapid-specific debugging, tests, benchmark tooling, documentation, and review of the kernel port. Every generated or modified path was inspected against the stock implementation and verified with the focused suites and real-model bit-exact A/B gates listed above.

## Attribution

Original fused-kernel implementation and performance design by Pierre Lamy. Rapid-specific qualification and port repairs were performed by the maintainer while retaining Pierre's original authored commit. The Metal reduction and precision structure is adapted from mlx-vlm #2105 under its MIT license.


