### PR TITLE
Expose per-model request performance metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,7 @@ jobs:
         run: |
           pytest \
             tests/test_cancellation_protocol.py \
+            tests/test_model_performance_metrics.py \
             tests/test_mllm.py \
             tests/test_server.py \
             tests/test_paged_cache.py \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,18 @@ _HF_CACHE_ENV_VARS = ("HF_HOME", "HF_HUB_CACHE", "TRANSFORMERS_CACHE")
 _NETWORK_OPT_IN_MARKER = "requires_network"
 
 
+@pytest.fixture(autouse=True)
+def _isolate_model_performance_registry():
+    """Keep process-owned per-model ledgers isolated between unit tests."""
+    from vllm_mlx.runtime.model_performance import (
+        _reset_model_performance_registry_for_tests,
+    )
+
+    _reset_model_performance_registry_for_tests()
+    yield
+    _reset_model_performance_registry_for_tests()
+
+
 class HermeticNetworkAccessError(RuntimeError):
     """A hermetic (non-``requires_network``) test tried to reach the network.
 

--- a/tests/headless_mlx/test_engine_lifecycle.py
+++ b/tests/headless_mlx/test_engine_lifecycle.py
@@ -957,6 +957,8 @@ def test_mllm_lifecycle_abort_records_reason_until_terminal_delivery():
 
 
 def test_mllm_abort_remains_queued_until_terminal_delivery():
+    from vllm_mlx.runtime.model_performance import ModelPerformanceLedger
+
     scheduler = MLLMScheduler.__new__(MLLMScheduler)
     scheduler.waiting = []
     scheduler.running = {}
@@ -967,6 +969,7 @@ def test_mllm_abort_remains_queued_until_terminal_delivery():
     scheduler.total_completion_tokens = 0
     scheduler.num_requests_cancelled = 0
     scheduler.num_requests_cancelled_via_disconnect = 0
+    scheduler.performance = ModelPerformanceLedger(None)
     scheduler.batch_generator = None
     scheduler.vision_cache = None
 
@@ -974,6 +977,8 @@ def test_mllm_abort_remains_queued_until_terminal_delivery():
 
 
 def test_mllm_terminal_delivery_is_counted_by_engine_lifecycle():
+    from vllm_mlx.runtime.model_performance import ModelPerformanceLedger
+
     engine, _ = _engine()
     scheduler = MLLMScheduler.__new__(MLLMScheduler)
     scheduler.waiting = []
@@ -985,6 +990,7 @@ def test_mllm_terminal_delivery_is_counted_by_engine_lifecycle():
     scheduler.total_completion_tokens = 0
     scheduler.num_requests_cancelled = 0
     scheduler.num_requests_cancelled_via_disconnect = 0
+    scheduler.performance = ModelPerformanceLedger(None)
     scheduler.batch_generator = None
     scheduler.vision_cache = None
     engine._is_mllm = True

--- a/tests/test_mllm_batch_generator.py
+++ b/tests/test_mllm_batch_generator.py
@@ -2077,6 +2077,7 @@ def test_bare_generator_without_prefix_cache_keeps_legacy_cold_path():
 
 def _make_cache_scheduler(*, batch_generator):
     from vllm_mlx.mllm_scheduler import MLLMScheduler
+    from vllm_mlx.runtime.model_performance import ModelPerformanceLedger
 
     scheduler = MLLMScheduler.__new__(MLLMScheduler)
     scheduler._step_executor = None
@@ -2090,6 +2091,7 @@ def _make_cache_scheduler(*, batch_generator):
     scheduler.total_completion_tokens = 4
     scheduler.num_requests_cancelled = 0
     scheduler.num_requests_cancelled_via_disconnect = 0
+    scheduler.performance = ModelPerformanceLedger(None)
     scheduler.batch_generator = batch_generator
     scheduler.vision_cache = None
     return scheduler

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1884,7 +1884,13 @@ class TestPrefillErrorCleanup:
 
         # Manually insert a request as if it was scheduled
         req_id = "bad-req"
-        scheduler.requests[req_id] = MagicMock()
+        from vllm_mlx.mllm_scheduler import MLLMRequest
+
+        scheduler.requests[req_id] = MLLMRequest(
+            request_id=req_id,
+            prompt="oversized prompt",
+            num_prompt_tokens=7,
+        )
         scheduler.running[req_id] = scheduler.requests[req_id]
         scheduler.output_queues[req_id] = asyncio.Queue()
 
@@ -1914,6 +1920,9 @@ class TestPrefillErrorCleanup:
         queued = scheduler.output_queues[req_id].get_nowait()
         assert queued.finished is True
         assert queued.finish_reason == "length"
+        performance = scheduler.performance.snapshot()
+        assert performance.requests_failed == 1
+        assert performance.prompt_tokens == 7
 
     def test_subsequent_request_not_poisoned(self):
         """A good request after a failed one should not be affected."""

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1867,6 +1867,7 @@ class TestPrefillErrorCleanup:
 
         from vllm_mlx.mllm_batch_generator import MLLMBatchRequest
         from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+        from vllm_mlx.request import RequestStatus
 
         mock_model = MagicMock()
         mock_processor = MagicMock()
@@ -1891,6 +1892,7 @@ class TestPrefillErrorCleanup:
             prompt="oversized prompt",
             num_prompt_tokens=7,
         )
+        scheduler.requests[req_id].status = RequestStatus.RUNNING
         scheduler.running[req_id] = scheduler.requests[req_id]
         scheduler.output_queues[req_id] = asyncio.Queue()
 

--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -200,6 +200,7 @@ def test_mllm_failed_request_records_partial_work():
         num_prompt_tokens=17,
         num_output_tokens=2,
     )
+    request.status = RequestStatus.RUNNING
 
     scheduler._record_terminal_performance(request, "failed")
 
@@ -209,6 +210,21 @@ def test_mllm_failed_request_records_partial_work():
     assert performance.completion_tokens == 2
     assert performance.ttft_seconds_count == 1
     assert performance.decode_observations == 1
+
+
+def test_mllm_waiting_failure_records_no_unprocessed_prompt_tokens():
+    scheduler = _bare_scheduler()
+    request = MLLMRequest(
+        request_id="waiting-failure",
+        prompt="hello",
+        num_prompt_tokens=17,
+    )
+
+    scheduler._record_terminal_performance(request, "failed")
+
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_failed == 1
+    assert performance.prompt_tokens == 0
 
 
 def test_mllm_does_not_commit_success_when_later_response_fails():

--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -212,6 +212,14 @@ def test_mllm_failed_request_records_partial_work():
     assert performance.decode_observations == 1
 
 
+def test_mllm_best_effort_failure_does_not_assume_request_fields(caplog):
+    scheduler = _bare_scheduler()
+
+    scheduler._record_terminal_performance(object(), "failed")
+
+    assert scheduler.performance.snapshot().requests_failed == 0
+
+
 def test_mllm_waiting_failure_records_no_unprocessed_prompt_tokens():
     scheduler = _bare_scheduler()
     request = MLLMRequest(

--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from vllm_mlx.engine.batched import BatchedEngine
 from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler
 from vllm_mlx.request import RequestStatus
+from vllm_mlx.runtime.model_performance import ModelPerformanceLedger
 
 
 class _FakeDetokenizer:
@@ -50,6 +51,7 @@ def _bare_scheduler() -> MLLMScheduler:
     scheduler.total_prompt_tokens = 0
     scheduler.total_completion_tokens = 0
     scheduler.num_requests_processed = 0
+    scheduler.performance = ModelPerformanceLedger("gemma-test")
     return scheduler
 
 
@@ -69,6 +71,10 @@ def test_batched_engine_promotes_mllm_stats_to_common_top_level():
                     "misses": 1,
                     "evictions": 0,
                     "tokens_saved": 30,
+                },
+                "model_performance": {
+                    "model_name": "gemma-test",
+                    "requests_succeeded": 3,
                 },
             }
 
@@ -91,6 +97,7 @@ def test_batched_engine_promotes_mllm_stats_to_common_top_level():
     assert stats["total_prompt_tokens"] == 40
     assert stats["total_completion_tokens"] == 7
     assert stats["prefix_cache"]["tokens_saved"] == 30
+    assert stats["model_performance"]["model_name"] == "gemma-test"
     assert stats["steps_executed"] == 12
     assert stats["uptime_seconds"] >= 2.0
 
@@ -149,6 +156,12 @@ def test_mllm_completed_request_adds_prompt_and_completion_tokens():
     assert scheduler.total_prompt_tokens == 19
     assert scheduler.total_completion_tokens == 1
     assert scheduler.num_requests_processed == 1
+    performance = scheduler.performance.snapshot()
+    assert performance.model_name == "gemma-test"
+    assert performance.requests_succeeded == 1
+    assert performance.prompt_tokens == 19
+    assert performance.completion_tokens == 1
+    assert performance.ttft_seconds_count == 1
 
 
 def test_mllm_cancelled_request_adds_prompt_tokens_without_completion_tokens():
@@ -172,3 +185,27 @@ def test_mllm_cancelled_request_adds_prompt_tokens_without_completion_tokens():
     assert scheduler.total_prompt_tokens == 23
     assert scheduler.total_completion_tokens == 0
     assert request.status is RequestStatus.FINISHED_CANCELLED
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_cancelled == 1
+    assert performance.prompt_tokens == 23
+
+
+def test_mllm_failed_request_records_partial_work():
+    scheduler = _bare_scheduler()
+    request = MLLMRequest(
+        request_id="req-failed",
+        prompt="hello",
+        arrival_time=time.time() - 0.2,
+        first_token_time=time.time() - 0.1,
+        num_prompt_tokens=17,
+        num_output_tokens=2,
+    )
+
+    scheduler._record_terminal_performance(request, "failed")
+
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_failed == 1
+    assert performance.prompt_tokens == 17
+    assert performance.completion_tokens == 2
+    assert performance.ttft_seconds_count == 1
+    assert performance.decode_observations == 1

--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -209,3 +209,35 @@ def test_mllm_failed_request_records_partial_work():
     assert performance.completion_tokens == 2
     assert performance.ttft_seconds_count == 1
     assert performance.decode_observations == 1
+
+
+def test_mllm_does_not_commit_success_when_later_response_fails():
+    scheduler = _bare_scheduler()
+    first = MLLMRequest(request_id="first", prompt="hello")
+    second = MLLMRequest(request_id="second", prompt="hello")
+    scheduler.running = {"first": first, "second": second}
+    scheduler.uid_to_request_id = {1: "first", 2: "second"}
+    scheduler._detokenizer_pool["second"] = SimpleNamespace(
+        add_token=lambda _token: (_ for _ in ()).throw(RuntimeError("decode failed"))
+    )
+    first_response = SimpleNamespace(
+        uid=1,
+        token=11,
+        prompt_tokens=3,
+        finish_reason="stop",
+        token_is_stop_token=False,
+        logprobs=None,
+    )
+    second_response = SimpleNamespace(
+        uid=2,
+        token=12,
+        prompt_tokens=4,
+        finish_reason=None,
+        token_is_stop_token=False,
+        logprobs=None,
+    )
+
+    with pytest.raises(RuntimeError, match="decode failed"):
+        scheduler._process_batch_responses([first_response, second_response])
+
+    assert scheduler.performance.snapshot().requests_succeeded == 0

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -100,7 +100,35 @@ def test_ledger_records_outcomes_once_and_ignores_bad_values():
         decode_tokens_per_second=1,
     )
     assert not ledger.record_failure("success")
+    assert not ledger.record_cancelled(
+        "cancelled",
+        prompt_tokens=99,
+        completion_tokens=99,
+        ttft_seconds=99,
+        decode_tokens_per_second=99,
+    )
+    assert ledger.model_name == "model-a"
     assert ledger.snapshot().prompt_tokens == 12
+
+
+def test_ledger_ignores_unusable_timing_observations():
+    ledger = ModelPerformanceLedger("model-b")
+    ledger.record_success(
+        "invalid-timings",
+        prompt_tokens=1,
+        completion_tokens=2,
+        ttft_seconds=float("nan"),
+        decode_tokens_per_second=-5,
+    )
+
+    snapshot = ledger.snapshot()
+    assert snapshot.requests_succeeded == 1
+    assert snapshot.prompt_tokens == 1
+    assert snapshot.completion_tokens == 2
+    assert snapshot.ttft_seconds_count == 0
+    assert snapshot.decode_observations == 0
+    assert snapshot.ttft_seconds_max is None
+    assert snapshot.decode_tokens_per_second_max is None
 
 
 def test_ledger_histograms_are_cumulative_and_memory_bounded():

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -13,6 +13,7 @@ import pytest
 from vllm_mlx.output_collector import RequestOutputCollector
 from vllm_mlx.runtime.model_performance import (
     MODEL_LEDGER_REGISTRY_LIMIT,
+    RETIRED_MODEL_SNAPSHOT_LIMIT,
     SEEN_REQUEST_ID_LIMIT,
     ModelPerformanceLedger,
 )
@@ -794,6 +795,7 @@ def test_metrics_preserves_unseen_events_across_scheduler_reloads():
 def test_process_model_registry_is_lru_bounded():
     from vllm_mlx.runtime.model_performance import (
         _MODEL_LEDGER_REGISTRY,
+        _RETIRED_MODEL_SNAPSHOTS,
         get_model_performance_ledger,
         get_model_performance_snapshots,
     )
@@ -821,16 +823,29 @@ def test_process_model_registry_is_lru_bounded():
         for snapshot in retained
     )
 
-    revived = get_model_performance_ledger("model-0")
-    assert revived.snapshot().requests_succeeded == 1
-    revived.record_success(
-        "after-retirement",
-        prompt_tokens=5,
-        completion_tokens=4,
-        ttft_seconds=0.4,
-        decode_tokens_per_second=20,
+    from types import SimpleNamespace
+
+    post_eviction = SimpleNamespace(
+        request_id="after-retirement",
+        status=SimpleNamespace(name="RUNNING"),
+        num_prompt_tokens=5,
+        num_output_tokens=4,
     )
-    continuity = revived.snapshot()
+    assert first.record_request_performance(post_eviction, "succeeded") is True
+    revived = get_model_performance_ledger("model-0")
+    assert revived is first
+    continuity = first.snapshot()
     assert continuity.requests_succeeded == 2
     assert continuity.prompt_tokens == 8
     assert len(_MODEL_LEDGER_REGISTRY) == MODEL_LEDGER_REGISTRY_LIMIT
+
+    for index in range(
+        MODEL_LEDGER_REGISTRY_LIMIT + 1,
+        MODEL_LEDGER_REGISTRY_LIMIT + RETIRED_MODEL_SNAPSHOT_LIMIT + 3,
+    ):
+        get_model_performance_ledger(f"model-{index}")
+    assert len(_MODEL_LEDGER_REGISTRY) == MODEL_LEDGER_REGISTRY_LIMIT
+    assert len(_RETIRED_MODEL_SNAPSHOTS) == RETIRED_MODEL_SNAPSHOT_LIMIT
+    assert len(get_model_performance_snapshots()) <= (
+        MODEL_LEDGER_REGISTRY_LIMIT + RETIRED_MODEL_SNAPSHOT_LIMIT
+    )

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -348,6 +348,8 @@ def test_waiting_cancellation_records_no_unprocessed_prompt_tokens():
 
 
 def test_mllm_waiting_cancellation_records_zero_prompt_tokens():
+    pytest.importorskip("mlx")
+
     from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
 
     processor = MagicMock()
@@ -369,6 +371,8 @@ def test_mllm_waiting_cancellation_records_zero_prompt_tokens():
 
 
 def test_mllm_reset_accounts_waiting_and_running_requests():
+    pytest.importorskip("mlx")
+
     from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
     from vllm_mlx.request import RequestStatus
 

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -669,3 +669,26 @@ def test_metrics_preserves_model_counters_across_fresh_ledgers():
 
     reset_config()
     _reset_accumulator_for_tests()
+
+
+def test_model_accumulator_rejects_delayed_retired_ledger_snapshot():
+    from vllm_mlx.routes.metrics import _ModelPerformanceAccumulator
+
+    accumulator = _ModelPerformanceAccumulator()
+    old_snapshot = {"requests:succeeded": 1.0, "ttft:count": 1.0}
+    new_snapshot = {"requests:succeeded": 2.0, "ttft:count": 2.0}
+
+    assert accumulator.advance("model", 10, old_snapshot) == old_snapshot
+    current = accumulator.advance("model", 11, new_snapshot)
+    assert current == {"requests:succeeded": 3.0, "ttft:count": 3.0}
+
+    # Simulate an old scrape that captured generation 10 before the reload but
+    # reached the accumulator after generation 11 had already advanced it.
+    delayed = accumulator.advance("model", 10, old_snapshot)
+    assert delayed == current
+
+    # A stale snapshot from the active generation must not decrease any series.
+    stale_current = accumulator.advance(
+        "model", 11, {"requests:succeeded": 1.0, "ttft:count": 1.0}
+    )
+    assert stale_current == current

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -193,6 +193,22 @@ def test_request_owned_idempotency_survives_low_level_cache_eviction():
     assert ledger.snapshot().requests_failed == SEEN_REQUEST_ID_LIMIT + 2
 
 
+def test_request_accounting_uses_compressed_model_prompt_tokens():
+    from types import SimpleNamespace
+
+    ledger = ModelPerformanceLedger("compressed-model")
+    request = SimpleNamespace(
+        request_id="compressed",
+        status=SimpleNamespace(name="RUNNING"),
+        num_prompt_tokens=100_000,
+        model_prompt_tokens=4_096,
+        num_output_tokens=2,
+    )
+
+    assert ledger.record_request_performance(request, "succeeded") is True
+    assert ledger.snapshot().prompt_tokens == 4_096
+
+
 def test_distinct_request_lifetimes_may_reuse_the_same_id():
     from types import SimpleNamespace
 
@@ -349,6 +365,38 @@ def test_mllm_waiting_cancellation_records_zero_prompt_tokens():
     performance = scheduler.performance.snapshot()
     assert performance.requests_cancelled == 1
     assert performance.prompt_tokens == 0
+
+
+def test_mllm_reset_accounts_waiting_and_running_requests():
+    from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+    from vllm_mlx.request import RequestStatus
+
+    processor = MagicMock()
+    processor.tokenizer = MagicMock()
+    scheduler = MLLMScheduler(
+        MagicMock(),
+        processor,
+        MLLMSchedulerConfig(),
+        model_name="mllm-reset-test",
+    )
+    waiting_id = scheduler.add_request("queued prompt")
+    running_id = scheduler.add_request("active prompt")
+    waiting = scheduler.requests[waiting_id]
+    running = scheduler.requests[running_id]
+    waiting.num_prompt_tokens = 7
+    running.num_prompt_tokens = 5
+    scheduler.waiting.remove(running)
+    running.status = RequestStatus.RUNNING
+    scheduler.running[running_id] = running
+
+    scheduler.reset()
+
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_cancelled == 2
+    assert performance.prompt_tokens == 5
+    assert scheduler.requests == {}
+    assert not scheduler.waiting
+    assert scheduler.running == {}
 
 
 def test_scheduler_records_reconciled_orphan_cancellation():

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -179,6 +179,35 @@ def test_ledger_dedupe_cache_is_bounded():
     assert ledger.record_failure("overflow") is False
 
 
+def test_distinct_request_lifetimes_may_reuse_the_same_id():
+    from types import SimpleNamespace
+
+    ledger = ModelPerformanceLedger("model-b")
+    first = SimpleNamespace(
+        request_id="reused",
+        arrival_time=1.0,
+        first_token_time=None,
+        num_prompt_tokens=2,
+        num_output_tokens=0,
+    )
+    second = SimpleNamespace(
+        request_id="reused",
+        arrival_time=2.0,
+        first_token_time=None,
+        num_prompt_tokens=3,
+        num_output_tokens=0,
+    )
+
+    ledger.record_finished_performance(first)
+    ledger.record_finished_performance(first)
+    ledger.record_cancelled_performance(second)
+
+    snapshot = ledger.snapshot()
+    assert snapshot.requests_succeeded == 1
+    assert snapshot.requests_cancelled == 1
+    assert snapshot.prompt_tokens == 5
+
+
 def test_ledger_histograms_are_cumulative_and_memory_bounded():
     ledger = ModelPerformanceLedger("model-a")
     for ttft, decode in ((0.05, 4.0), (0.3, 25.0), (1.2, 150.0)):
@@ -251,6 +280,22 @@ def test_scheduler_records_explicit_cancellation_once():
 
     scheduler.performance.record_cancelled_performance(scheduler.requests["cancelled"])
     assert scheduler.performance.snapshot().requests_cancelled == 1
+
+
+def test_scheduler_records_generation_recovery_failures():
+    pytest.importorskip("mlx")
+
+    scheduler = _scheduler()
+    _running_request(scheduler, "generation-failure")
+    scheduler.batch_generator.next.side_effect = RuntimeError("Metal OOM")
+
+    output = scheduler.step()
+
+    assert output.finished_request_ids == {"generation-failure"}
+    assert output.outputs[0].error is not None
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_failed == 1
+    assert performance.total_requests == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -131,6 +131,40 @@ def test_ledger_ignores_unusable_timing_observations():
     assert snapshot.decode_tokens_per_second_max is None
 
 
+def test_ledger_best_effort_helpers_ignore_unusable_timings_and_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from types import SimpleNamespace
+
+    request = SimpleNamespace(
+        arrival_time=time.time() - 0.2,
+        first_token_time=time.time() + 5.0,
+        num_output_tokens=2,
+        num_prompt_tokens=3,
+        request_id="future-first-token",
+    )
+    ledger = ModelPerformanceLedger("model-b")
+
+    assert ledger.decode_rate_for_request(request) is None
+
+    monkeypatch.setattr(
+        ledger,
+        "record_success",
+        MagicMock(side_effect=RuntimeError("accounting failure")),
+    )
+    monkeypatch.setattr(
+        ledger,
+        "record_cancelled",
+        MagicMock(side_effect=RuntimeError("accounting failure")),
+    )
+
+    ledger.record_finished_performance(request)
+    ledger.record_cancelled_performance(request)
+
+    snapshot = ledger.snapshot()
+    assert snapshot.total_requests == 0
+
+
 def test_ledger_histograms_are_cumulative_and_memory_bounded():
     ledger = ModelPerformanceLedger("model-a")
     for ttft, decode in ((0.05, 4.0), (0.3, 25.0), (1.2, 150.0)):

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -266,6 +266,24 @@ def test_scheduler_records_terminal_success_once():
     assert scheduler.performance.snapshot().requests_succeeded == 1
 
 
+def test_scheduler_does_not_commit_success_when_later_response_fails():
+    scheduler = _scheduler()
+    _running_request(scheduler, "first")
+    second = _running_request(scheduler, "second")
+    scheduler.uid_to_request_id[1] = "first"
+    scheduler.uid_to_request_id[2] = "second"
+    first_response = _terminal_response()
+    second_response = _terminal_response()
+    second_response.uid = 2
+    second.append_output_token = MagicMock(side_effect=RuntimeError("later failure"))
+
+    with pytest.raises(RuntimeError, match="later failure"):
+        scheduler._process_batch_responses([first_response, second_response])
+
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_succeeded == 0
+
+
 def test_scheduler_records_explicit_cancellation_once():
     pytest.importorskip("mlx")
 

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -510,8 +510,9 @@ def test_metrics_renders_model_performance_series():
 
     from vllm_mlx.config import reset_config
     from vllm_mlx.routes.metrics import _reset_accumulator_for_tests, router
+    from vllm_mlx.runtime.model_performance import get_model_performance_ledger
 
-    ledger = ModelPerformanceLedger("gemma-4-12b")
+    ledger = get_model_performance_ledger("gemma-4-12b")
     ledger.record_success(
         "1",
         prompt_tokens=7,
@@ -599,12 +600,8 @@ def test_metrics_preserves_unseen_events_across_scheduler_reloads():
 
     from vllm_mlx.config import reset_config
     from vllm_mlx.routes.metrics import _reset_accumulator_for_tests, router
-    from vllm_mlx.runtime.model_performance import (
-        _reset_model_performance_registry_for_tests,
-        get_model_performance_ledger,
-    )
+    from vllm_mlx.runtime.model_performance import get_model_performance_ledger
 
-    _reset_model_performance_registry_for_tests()
     first = get_model_performance_ledger("reloadable-model")
     first.record_success(
         "first",
@@ -687,6 +684,27 @@ def test_metrics_preserves_unseen_events_across_scheduler_reloads():
         in second_body
     )
 
+    # Unloading the active engine must not make the retained model series stale.
+    cfg.engine = None
+    unloaded_body = client.get("/metrics").text
+    assert (
+        'rapid_mlx_model_requests_total{model="reloadable-model",outcome="succeeded"} 3'
+        in unloaded_body
+    )
+
+    switched = get_model_performance_ledger("second-model")
+    switched.record_failure("failure-after-switch")
+    switched_body = client.get("/metrics").text
+    assert (
+        'rapid_mlx_model_requests_total{model="reloadable-model",outcome="succeeded"} 3'
+        in switched_body
+    )
+    assert (
+        'rapid_mlx_model_requests_total{model="second-model",outcome="failed"} 1'
+        in switched_body
+    )
+    assert switched_body.count("# HELP rapid_mlx_model_requests_total ") == 1
+    assert switched_body.count("# TYPE rapid_mlx_model_requests_total ") == 1
+
     reset_config()
     _reset_accumulator_for_tests()
-    _reset_model_performance_registry_for_tests()

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -210,6 +210,23 @@ def test_request_accounting_uses_compressed_model_prompt_tokens():
     assert ledger.snapshot().prompt_tokens == 4_096
 
 
+def test_request_accounting_rejects_unknown_outcome_without_marking_request():
+    from types import SimpleNamespace
+
+    ledger = ModelPerformanceLedger("invalid-outcome-model")
+    request = SimpleNamespace(
+        request_id="invalid-outcome",
+        num_prompt_tokens=3,
+        num_output_tokens=2,
+    )
+
+    with pytest.raises(ValueError, match="unsupported terminal outcome: unknown"):
+        ledger.record_request_performance(request, "unknown")
+
+    assert request._performance_recorded is False
+    assert ledger.snapshot().total_requests == 0
+
+
 def test_distinct_request_lifetimes_may_reuse_the_same_id():
     from types import SimpleNamespace
 
@@ -675,6 +692,13 @@ def test_metrics_renders_model_performance_series():
 
     reset_config()
     _reset_accumulator_for_tests()
+
+
+def test_model_performance_renderer_ignores_missing_or_malformed_payload():
+    from vllm_mlx.routes.metrics import _render_model_performance
+
+    assert _render_model_performance({}) == []
+    assert _render_model_performance({"model_performance": "malformed"}) == []
 
 
 def test_metrics_preserves_unseen_events_across_scheduler_reloads():

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -559,8 +559,7 @@ def test_metrics_renders_model_performance_series():
         in body
     )
     assert (
-        'rapid_mlx_model_requests_total{model="gemma-4-12b",outcome="failed"} 1'
-        in body
+        'rapid_mlx_model_requests_total{model="gemma-4-12b",outcome="failed"} 1' in body
     )
     assert 'outcome="total"' not in body
     outcome_samples = [
@@ -573,8 +572,7 @@ def test_metrics_renders_model_performance_series():
     assert 'rapid_mlx_model_completion_tokens_total{model="gemma-4-12b"} 9' in body
     assert 'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="0.1"} 1' in body
     assert (
-        'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="+Inf"} 3'
-        in body
+        'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="+Inf"} 3' in body
     )
     assert (
         'rapid_mlx_model_decode_tokens_per_second_bucket{model="gemma-4-12b",le="50"} 1'
@@ -584,8 +582,7 @@ def test_metrics_renders_model_performance_series():
     assert 'rapid_mlx_model_ttft_seconds_count{model="gemma-4-12b"} 3' in body
     assert 'rapid_mlx_model_ttft_seconds_sum{model="gemma-4-12b"} 1.37' in body
     assert (
-        'rapid_mlx_model_decode_tokens_per_second_last{model="gemma-4-12b"} 20'
-        in body
+        'rapid_mlx_model_decode_tokens_per_second_last{model="gemma-4-12b"} 20' in body
     )
 
     reset_config()
@@ -614,9 +611,7 @@ def test_metrics_preserves_unseen_events_across_scheduler_reloads():
     cfg = reset_config()
     _reset_accumulator_for_tests()
     cfg.engine = SimpleNamespace(
-        get_stats=lambda: {
-            "model_performance": current["ledger"].snapshot().__dict__
-        }
+        get_stats=lambda: {"model_performance": current["ledger"].snapshot().__dict__}
     )
     app = FastAPI()
     app.include_router(router)
@@ -666,10 +661,11 @@ def test_metrics_preserves_unseen_events_across_scheduler_reloads():
         in second_body
     )
     assert (
-        'rapid_mlx_model_ttft_seconds_count{model="reloadable-model"} 3'
-        in second_body
+        'rapid_mlx_model_ttft_seconds_count{model="reloadable-model"} 3' in second_body
     )
-    assert 'rapid_mlx_model_ttft_seconds_sum{model="reloadable-model"} 1.1' in second_body
+    assert (
+        'rapid_mlx_model_ttft_seconds_sum{model="reloadable-model"} 1.1' in second_body
+    )
     assert (
         'rapid_mlx_model_decode_tokens_per_second_count{model="reloadable-model"} 3'
         in second_body
@@ -678,7 +674,9 @@ def test_metrics_preserves_unseen_events_across_scheduler_reloads():
         'rapid_mlx_model_decode_tokens_per_second_sum{model="reloadable-model"} 45.0'
         in second_body
     )
-    assert 'rapid_mlx_model_ttft_seconds_max{model="reloadable-model"} 0.8' in second_body
+    assert (
+        'rapid_mlx_model_ttft_seconds_max{model="reloadable-model"} 0.8' in second_body
+    )
     assert (
         'rapid_mlx_model_decode_tokens_per_second_max{model="reloadable-model"} 30.0'
         in second_body

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -5,22 +5,24 @@ from __future__ import annotations
 
 import asyncio
 import time
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
-pytest.importorskip("mlx")
-pytestmark = pytest.mark.requires_mlx
-
-
-from vllm_mlx.engine_core import EngineConfig, EngineCore
 from vllm_mlx.output_collector import RequestOutputCollector
-from vllm_mlx.request import Request, RequestStatus, SamplingParams
 from vllm_mlx.runtime.model_performance import ModelPerformanceLedger
-from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+if TYPE_CHECKING:
+    from vllm_mlx.request import Request
+    from vllm_mlx.scheduler import Scheduler
 
 
 def _scheduler() -> Scheduler:
+    pytest.importorskip("mlx")
+
+    from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
     tokenizer = MagicMock()
     tokenizer.encode = lambda text: list(range(len(text.split())))
     tokenizer.decode = lambda tokens, **_kwargs: " ".join(map(str, tokens))
@@ -35,6 +37,8 @@ def _scheduler() -> Scheduler:
 
 
 def _running_request(scheduler: Scheduler, request_id: str) -> Request:
+    from vllm_mlx.request import Request, RequestStatus, SamplingParams
+
     request = Request(
         request_id,
         "ignored prompt",
@@ -133,6 +137,8 @@ def test_ledger_histograms_are_cumulative_and_memory_bounded():
 
 
 def test_scheduler_records_terminal_success_once():
+    pytest.importorskip("mlx")
+
     scheduler = _scheduler()
     request = _running_request(scheduler, "success")
     response = _terminal_response()
@@ -156,6 +162,8 @@ def test_scheduler_records_terminal_success_once():
 
 
 def test_scheduler_records_explicit_cancellation_once():
+    pytest.importorskip("mlx")
+
     scheduler = _scheduler()
     _running_request(scheduler, "cancelled")
 
@@ -171,6 +179,10 @@ def test_scheduler_records_explicit_cancellation_once():
 
 @pytest.mark.asyncio
 async def test_engine_loop_records_pending_failures():
+    pytest.importorskip("mlx")
+
+    from vllm_mlx.engine_core import EngineConfig, EngineCore
+
     engine = EngineCore(
         MagicMock(), MagicMock(), EngineConfig(model_name="model-under-test")
     )

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -185,7 +185,7 @@ def test_scheduler_records_terminal_success_once():
     assert performance.decode_observations == 1
 
     # Re-delivery of the same terminal response must not double-count.
-    scheduler._record_finished_performance(request)
+    scheduler.performance.record_finished_performance(request)
     assert scheduler.performance.snapshot().requests_succeeded == 1
 
 
@@ -201,7 +201,7 @@ def test_scheduler_records_explicit_cancellation_once():
     assert performance.prompt_tokens == 5
     assert performance.completion_tokens == 2
 
-    scheduler._record_cancelled_performance(scheduler.requests["cancelled"])
+    scheduler.performance.record_cancelled_performance(scheduler.requests["cancelled"])
     assert scheduler.performance.snapshot().requests_cancelled == 1
 
 

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -591,7 +591,7 @@ def test_metrics_renders_model_performance_series():
     _reset_accumulator_for_tests()
 
 
-def test_metrics_preserves_model_counters_across_fresh_ledgers():
+def test_metrics_preserves_unseen_events_across_scheduler_reloads():
     from types import SimpleNamespace
 
     from fastapi import FastAPI
@@ -599,8 +599,13 @@ def test_metrics_preserves_model_counters_across_fresh_ledgers():
 
     from vllm_mlx.config import reset_config
     from vllm_mlx.routes.metrics import _reset_accumulator_for_tests, router
+    from vllm_mlx.runtime.model_performance import (
+        _reset_model_performance_registry_for_tests,
+        get_model_performance_ledger,
+    )
 
-    first = ModelPerformanceLedger("reloadable-model")
+    _reset_model_performance_registry_for_tests()
+    first = get_model_performance_ledger("reloadable-model")
     first.record_success(
         "first",
         prompt_tokens=7,
@@ -626,7 +631,17 @@ def test_metrics_preserves_model_counters_across_fresh_ledgers():
         in first_body
     )
 
-    replacement = ModelPerformanceLedger("reloadable-model")
+    # This request finishes after the last scrape but before the scheduler is
+    # replaced. Process-owned ledger state must retain it without a final scrape.
+    first.record_success(
+        "between-scrapes",
+        prompt_tokens=6,
+        completion_tokens=1,
+        ttft_seconds=0.8,
+        decode_tokens_per_second=30,
+    )
+    replacement = get_model_performance_ledger("reloadable-model")
+    assert replacement is first
     replacement.record_success(
         "second",
         prompt_tokens=3,
@@ -638,62 +653,40 @@ def test_metrics_preserves_model_counters_across_fresh_ledgers():
     second_body = client.get("/metrics").text
 
     assert (
-        'rapid_mlx_model_requests_total{model="reloadable-model",outcome="succeeded"} 2'
+        'rapid_mlx_model_requests_total{model="reloadable-model",outcome="succeeded"} 3'
         in second_body
     )
     assert (
-        'rapid_mlx_model_prompt_tokens_total{model="reloadable-model"} 10'
+        'rapid_mlx_model_prompt_tokens_total{model="reloadable-model"} 16'
         in second_body
     )
     assert (
-        'rapid_mlx_model_completion_tokens_total{model="reloadable-model"} 6'
+        'rapid_mlx_model_completion_tokens_total{model="reloadable-model"} 7'
         in second_body
     )
     assert (
-        'rapid_mlx_model_ttft_seconds_bucket{model="reloadable-model",le="+Inf"} 2'
+        'rapid_mlx_model_ttft_seconds_bucket{model="reloadable-model",le="+Inf"} 3'
         in second_body
     )
     assert (
-        'rapid_mlx_model_ttft_seconds_count{model="reloadable-model"} 2'
+        'rapid_mlx_model_ttft_seconds_count{model="reloadable-model"} 3'
         in second_body
     )
-    assert 'rapid_mlx_model_ttft_seconds_sum{model="reloadable-model"} 0.3' in second_body
+    assert 'rapid_mlx_model_ttft_seconds_sum{model="reloadable-model"} 1.1' in second_body
     assert (
-        'rapid_mlx_model_decode_tokens_per_second_count{model="reloadable-model"} 2'
+        'rapid_mlx_model_decode_tokens_per_second_count{model="reloadable-model"} 3'
         in second_body
     )
     assert (
-        'rapid_mlx_model_decode_tokens_per_second_sum{model="reloadable-model"} 15.0'
+        'rapid_mlx_model_decode_tokens_per_second_sum{model="reloadable-model"} 45.0'
         in second_body
     )
-    assert 'rapid_mlx_model_ttft_seconds_max{model="reloadable-model"} 0.2' in second_body
+    assert 'rapid_mlx_model_ttft_seconds_max{model="reloadable-model"} 0.8' in second_body
     assert (
-        'rapid_mlx_model_decode_tokens_per_second_max{model="reloadable-model"} 10.0'
+        'rapid_mlx_model_decode_tokens_per_second_max{model="reloadable-model"} 30.0'
         in second_body
     )
 
     reset_config()
     _reset_accumulator_for_tests()
-
-
-def test_model_accumulator_rejects_delayed_retired_ledger_snapshot():
-    from vllm_mlx.routes.metrics import _ModelPerformanceAccumulator
-
-    accumulator = _ModelPerformanceAccumulator()
-    old_snapshot = {"requests:succeeded": 1.0, "ttft:count": 1.0}
-    new_snapshot = {"requests:succeeded": 2.0, "ttft:count": 2.0}
-
-    assert accumulator.advance("model", 10, old_snapshot)[0] == old_snapshot
-    current = accumulator.advance("model", 11, new_snapshot)[0]
-    assert current == {"requests:succeeded": 3.0, "ttft:count": 3.0}
-
-    # Simulate an old scrape that captured generation 10 before the reload but
-    # reached the accumulator after generation 11 had already advanced it.
-    delayed = accumulator.advance("model", 10, old_snapshot)[0]
-    assert delayed == current
-
-    # A stale snapshot from the active generation must not decrease any series.
-    stale_current = accumulator.advance(
-        "model", 11, {"requests:succeeded": 1.0, "ttft:count": 1.0}
-    )[0]
-    assert stale_current == current
+    _reset_model_performance_registry_for_tests()

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -312,6 +312,10 @@ def test_scheduler_records_generation_recovery_failures():
     performance = scheduler.performance.snapshot()
     assert performance.requests_failed == 1
     assert performance.total_requests == 1
+    assert performance.prompt_tokens == 5
+    assert performance.completion_tokens == 2
+    assert performance.ttft_seconds_count == 1
+    assert performance.decode_observations == 1
 
 
 @pytest.mark.asyncio
@@ -326,7 +330,13 @@ async def test_engine_loop_records_pending_failures():
 
     from types import SimpleNamespace
 
-    failed_request = SimpleNamespace(request_id="failure", arrival_time=time.time())
+    failed_request = SimpleNamespace(
+        request_id="failure",
+        arrival_time=time.time() - 0.25,
+        first_token_time=time.time() - 0.2,
+        num_prompt_tokens=5,
+        num_output_tokens=2,
+    )
 
     class _BoomScheduler:
         performance = ModelPerformanceLedger("model-under-test")
@@ -366,6 +376,8 @@ async def test_engine_loop_records_pending_failures():
 
     performance = engine.scheduler.performance.snapshot()
     assert performance.requests_failed == 1
+    assert performance.prompt_tokens == 5
+    assert performance.completion_tokens == 2
     final = engine._output_collectors["failure"].get_nowait()
     assert final is not None and final.finished and final.error
 

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -558,7 +558,8 @@ def test_metrics_renders_model_performance_series():
         in body
     )
     assert (
-        'rapid_mlx_model_requests_total{model="gemma-4-12b",outcome="failed"} 1' in body
+        'rapid_mlx_model_requests_total{model="gemma-4-12b",outcome="failed"} 1'
+        in body
     )
     assert 'outcome="total"' not in body
     outcome_samples = [
@@ -571,20 +572,99 @@ def test_metrics_renders_model_performance_series():
     assert 'rapid_mlx_model_completion_tokens_total{model="gemma-4-12b"} 9' in body
     assert 'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="0.1"} 1' in body
     assert (
-        'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="+Inf"} 3' in body
+        'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="+Inf"} 3'
+        in body
     )
     assert (
         'rapid_mlx_model_decode_tokens_per_second_bucket{model="gemma-4-12b",le="50"} 1'
         in body
     )
     assert 'rapid_mlx_model_ttft_seconds_max{model="gemma-4-12b"} 0.9' in body
-    assert (
-        'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="+Inf"} 3' in body
-    )
     assert 'rapid_mlx_model_ttft_seconds_count{model="gemma-4-12b"} 3' in body
     assert 'rapid_mlx_model_ttft_seconds_sum{model="gemma-4-12b"} 1.37' in body
     assert (
-        'rapid_mlx_model_decode_tokens_per_second_last{model="gemma-4-12b"} 20' in body
+        'rapid_mlx_model_decode_tokens_per_second_last{model="gemma-4-12b"} 20'
+        in body
+    )
+
+    reset_config()
+    _reset_accumulator_for_tests()
+
+
+def test_metrics_preserves_model_counters_across_fresh_ledgers():
+    from types import SimpleNamespace
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.metrics import _reset_accumulator_for_tests, router
+
+    first = ModelPerformanceLedger("reloadable-model")
+    first.record_success(
+        "first",
+        prompt_tokens=7,
+        completion_tokens=2,
+        ttft_seconds=0.2,
+        decode_tokens_per_second=10,
+    )
+    current = {"ledger": first}
+    cfg = reset_config()
+    _reset_accumulator_for_tests()
+    cfg.engine = SimpleNamespace(
+        get_stats=lambda: {
+            "model_performance": current["ledger"].snapshot().__dict__
+        }
+    )
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    first_body = client.get("/metrics").text
+    assert (
+        'rapid_mlx_model_requests_total{model="reloadable-model",outcome="succeeded"} 1'
+        in first_body
+    )
+
+    replacement = ModelPerformanceLedger("reloadable-model")
+    replacement.record_success(
+        "second",
+        prompt_tokens=3,
+        completion_tokens=4,
+        ttft_seconds=0.4,
+        decode_tokens_per_second=20,
+    )
+    current["ledger"] = replacement
+    second_body = client.get("/metrics").text
+
+    assert (
+        'rapid_mlx_model_requests_total{model="reloadable-model",outcome="succeeded"} 2'
+        in second_body
+    )
+    assert (
+        'rapid_mlx_model_prompt_tokens_total{model="reloadable-model"} 10'
+        in second_body
+    )
+    assert (
+        'rapid_mlx_model_completion_tokens_total{model="reloadable-model"} 6'
+        in second_body
+    )
+    assert (
+        'rapid_mlx_model_ttft_seconds_bucket{model="reloadable-model",le="+Inf"} 2'
+        in second_body
+    )
+    assert (
+        'rapid_mlx_model_ttft_seconds_count{model="reloadable-model"} 2'
+        in second_body
+    )
+    assert 'rapid_mlx_model_ttft_seconds_sum{model="reloadable-model"} 0.6' in second_body
+    assert (
+        'rapid_mlx_model_decode_tokens_per_second_count{model="reloadable-model"} 2'
+        in second_body
+    )
+    assert (
+        'rapid_mlx_model_decode_tokens_per_second_sum{model="reloadable-model"} 30.0'
+        in second_body
     )
 
     reset_config()

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -631,8 +631,8 @@ def test_metrics_preserves_model_counters_across_fresh_ledgers():
         "second",
         prompt_tokens=3,
         completion_tokens=4,
-        ttft_seconds=0.4,
-        decode_tokens_per_second=20,
+        ttft_seconds=0.1,
+        decode_tokens_per_second=5,
     )
     current["ledger"] = replacement
     second_body = client.get("/metrics").text
@@ -657,13 +657,18 @@ def test_metrics_preserves_model_counters_across_fresh_ledgers():
         'rapid_mlx_model_ttft_seconds_count{model="reloadable-model"} 2'
         in second_body
     )
-    assert 'rapid_mlx_model_ttft_seconds_sum{model="reloadable-model"} 0.6' in second_body
+    assert 'rapid_mlx_model_ttft_seconds_sum{model="reloadable-model"} 0.3' in second_body
     assert (
         'rapid_mlx_model_decode_tokens_per_second_count{model="reloadable-model"} 2'
         in second_body
     )
     assert (
-        'rapid_mlx_model_decode_tokens_per_second_sum{model="reloadable-model"} 30.0'
+        'rapid_mlx_model_decode_tokens_per_second_sum{model="reloadable-model"} 15.0'
+        in second_body
+    )
+    assert 'rapid_mlx_model_ttft_seconds_max{model="reloadable-model"} 0.2' in second_body
+    assert (
+        'rapid_mlx_model_decode_tokens_per_second_max{model="reloadable-model"} 10.0'
         in second_body
     )
 
@@ -678,17 +683,17 @@ def test_model_accumulator_rejects_delayed_retired_ledger_snapshot():
     old_snapshot = {"requests:succeeded": 1.0, "ttft:count": 1.0}
     new_snapshot = {"requests:succeeded": 2.0, "ttft:count": 2.0}
 
-    assert accumulator.advance("model", 10, old_snapshot) == old_snapshot
-    current = accumulator.advance("model", 11, new_snapshot)
+    assert accumulator.advance("model", 10, old_snapshot)[0] == old_snapshot
+    current = accumulator.advance("model", 11, new_snapshot)[0]
     assert current == {"requests:succeeded": 3.0, "ttft:count": 3.0}
 
     # Simulate an old scrape that captured generation 10 before the reload but
     # reached the accumulator after generation 11 had already advanced it.
-    delayed = accumulator.advance("model", 10, old_snapshot)
+    delayed = accumulator.advance("model", 10, old_snapshot)[0]
     assert delayed == current
 
     # A stale snapshot from the active generation must not decrease any series.
     stale_current = accumulator.advance(
         "model", 11, {"requests:succeeded": 1.0, "ttft:count": 1.0}
-    )
+    )[0]
     assert stale_current == current

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -300,6 +300,22 @@ def test_scheduler_records_explicit_cancellation_once():
     assert scheduler.performance.snapshot().requests_cancelled == 1
 
 
+def test_waiting_cancellation_records_no_unprocessed_prompt_tokens():
+    from vllm_mlx.request import Request, SamplingParams
+
+    scheduler = _scheduler()
+    request = Request("waiting", "queued prompt", SamplingParams(max_tokens=8))
+    request.num_prompt_tokens = 5
+    scheduler.requests[request.request_id] = request
+    scheduler.waiting.append(request)
+
+    assert scheduler._do_abort_request(request.request_id) is True
+
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_cancelled == 1
+    assert performance.prompt_tokens == 0
+
+
 def test_scheduler_records_reconciled_orphan_cancellation():
     pytest.importorskip("mlx")
 

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -331,6 +331,14 @@ def test_metrics_renders_model_performance_series():
     )
     body = TestClient(app).get("/metrics").text
 
+    for metric_name in (
+        "rapid_mlx_model_requests_total",
+        "rapid_mlx_model_ttft_seconds_bucket",
+        "rapid_mlx_model_decode_tokens_per_second_bucket",
+    ):
+        assert body.count(f"# TYPE {metric_name} ") == 1
+        assert body.count(f"# HELP {metric_name} ") == 1
+
     assert (
         'rapid_mlx_model_requests_total{model="gemma-4-12b",outcome="succeeded"} 3'
         in body

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for per-model engine performance metrics."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+
+from vllm_mlx.engine_core import EngineConfig, EngineCore
+from vllm_mlx.output_collector import RequestOutputCollector
+from vllm_mlx.request import Request, RequestStatus, SamplingParams
+from vllm_mlx.runtime.model_performance import ModelPerformanceLedger
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+
+def _scheduler() -> Scheduler:
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda text: list(range(len(text.split())))
+    tokenizer.decode = lambda tokens, **_kwargs: " ".join(map(str, tokens))
+    scheduler = Scheduler(
+        MagicMock(),
+        tokenizer,
+        SchedulerConfig(max_num_seqs=1, model_name="model-under-test"),
+    )
+    scheduler.batch_generator = MagicMock()
+    scheduler.batch_generator.remove.return_value = {}
+    return scheduler
+
+
+def _running_request(scheduler: Scheduler, request_id: str) -> Request:
+    request = Request(
+        request_id,
+        "ignored prompt",
+        SamplingParams(max_tokens=16),
+    )
+    request.status = RequestStatus.RUNNING
+    request.num_prompt_tokens = 5
+    request.arrival_time = time.time() - 0.25
+    request.first_token_time = time.time() - 0.2
+    for token in (11, 12):
+        request.append_output_token(token)
+    scheduler.running[request_id] = request
+    scheduler.uid_to_request_id[1] = request_id
+    scheduler.requests[request_id] = request
+    scheduler.request_id_to_uid[request_id] = 1
+    return request
+
+
+def _terminal_response() -> MagicMock:
+    response = MagicMock(
+        uid=1,
+        token=13,
+        finish_reason="stop",
+        logprobs=None,
+    )
+    del response.prompt_cache
+    return response
+
+
+def test_ledger_records_outcomes_once_and_ignores_bad_values():
+    ledger = ModelPerformanceLedger("model-a")
+    assert ledger.record_success(
+        "success",
+        prompt_tokens=8,
+        completion_tokens=12,
+        ttft_seconds=0.07,
+        decode_tokens_per_second=42.0,
+    )
+    assert ledger.record_cancelled(
+        "cancelled",
+        prompt_tokens=4,
+        completion_tokens=2,
+        ttft_seconds=0.2,
+        decode_tokens_per_second=18.0,
+    )
+    assert ledger.record_failure("failure")
+
+    snapshot = ledger.snapshot()
+    assert snapshot.total_requests == 3
+    assert snapshot.requests_succeeded == 1
+    assert snapshot.requests_cancelled == 1
+    assert snapshot.requests_failed == 1
+
+    assert not ledger.record_success(
+        "success",
+        prompt_tokens=99,
+        completion_tokens=99,
+        ttft_seconds=1,
+        decode_tokens_per_second=1,
+    )
+    assert not ledger.record_failure("success")
+    assert ledger.snapshot().prompt_tokens == 12
+
+
+def test_ledger_histograms_are_cumulative_and_memory_bounded():
+    ledger = ModelPerformanceLedger("model-a")
+    for ttft, decode in ((0.05, 4.0), (0.3, 25.0), (1.2, 150.0)):
+        ledger.record_success(
+            str(ttft),
+            prompt_tokens=1,
+            completion_tokens=4,
+            ttft_seconds=ttft,
+            decode_tokens_per_second=decode,
+        )
+
+    snapshot = ledger.snapshot()
+    assert snapshot.ttft_bucket_counts == {
+        "0.05": 1,
+        "0.1": 1,
+        "0.25": 1,
+        "0.5": 2,
+        "1": 2,
+        "2": 3,
+        "5": 3,
+        "10": 3,
+        "30": 3,
+        "+Inf": 3,
+    }
+    assert snapshot.decode_bucket_counts["1"] == 0
+    assert snapshot.decode_bucket_counts["5"] == 1
+    assert snapshot.decode_bucket_counts["20"] == 1
+    assert snapshot.decode_bucket_counts["50"] == 2
+    assert snapshot.decode_bucket_counts["+Inf"] == 3
+    assert snapshot.ttft_seconds_count == 3
+    assert snapshot.decode_observations == 3
+
+
+def test_scheduler_records_terminal_success_once():
+    scheduler = _scheduler()
+    request = _running_request(scheduler, "success")
+    response = _terminal_response()
+
+    outputs, finished = scheduler._process_batch_responses([response])
+    assert finished == {"success"}
+    assert outputs[0].finished is True
+
+    performance = scheduler.performance.snapshot()
+    assert performance.model_name == "model-under-test"
+    assert performance.requests_succeeded == 1
+    assert performance.prompt_tokens == 5
+    assert performance.completion_tokens == 3
+    assert performance.ttft_seconds_count == 1
+    assert performance.ttft_seconds_sum >= 0.04
+    assert performance.decode_observations == 1
+
+    # Re-delivery of the same terminal response must not double-count.
+    scheduler._record_finished_performance(request)
+    assert scheduler.performance.snapshot().requests_succeeded == 1
+
+
+def test_scheduler_records_explicit_cancellation_once():
+    scheduler = _scheduler()
+    _running_request(scheduler, "cancelled")
+
+    assert scheduler._do_abort_request("cancelled") is True
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_cancelled == 1
+    assert performance.prompt_tokens == 5
+    assert performance.completion_tokens == 2
+
+    scheduler._record_cancelled_performance(scheduler.requests["cancelled"])
+    assert scheduler.performance.snapshot().requests_cancelled == 1
+
+
+@pytest.mark.asyncio
+async def test_engine_loop_records_pending_failures():
+    engine = EngineCore(
+        MagicMock(), MagicMock(), EngineConfig(model_name="model-under-test")
+    )
+
+    class _BoomScheduler:
+        performance = ModelPerformanceLedger("model-under-test")
+
+        def has_requests(self):
+            return True
+
+        def step(self):
+            raise RuntimeError("Metal command buffer failure")
+
+        def add_request(self, *_args, **_kwargs):
+            pass
+
+        def abort_request(self, *_args, **_kwargs):
+            return True
+
+        def remove_finished_request(self, *_args, **_kwargs):
+            pass
+
+    engine.scheduler = _BoomScheduler()
+    engine._output_collectors["failure"] = RequestOutputCollector(aggregate=True)
+    engine._finished_events["failure"] = asyncio.Event()
+    engine._running = True
+    loop_task = asyncio.create_task(engine._engine_loop())
+    try:
+        await asyncio.wait_for(engine._finished_events["failure"].wait(), timeout=1)
+    finally:
+        engine._running = False
+        loop_task.cancel()
+        try:
+            await loop_task
+        except asyncio.CancelledError:
+            pass
+
+    performance = engine.scheduler.performance.snapshot()
+    assert performance.requests_failed == 1
+    final = engine._output_collectors["failure"].get_nowait()
+    assert final is not None and final.finished and final.error
+
+
+def test_metrics_renders_model_performance_series():
+    from types import SimpleNamespace
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.metrics import _reset_accumulator_for_tests, router
+
+    ledger = ModelPerformanceLedger("gemma-4-12b")
+    ledger.record_success(
+        "1",
+        prompt_tokens=7,
+        completion_tokens=4,
+        ttft_seconds=0.07,
+        decode_tokens_per_second=120,
+    )
+    ledger.record_success(
+        "2",
+        prompt_tokens=5,
+        completion_tokens=3,
+        ttft_seconds=0.4,
+        decode_tokens_per_second=80,
+    )
+    ledger.record_success(
+        "3",
+        prompt_tokens=3,
+        completion_tokens=2,
+        ttft_seconds=0.9,
+        decode_tokens_per_second=20,
+    )
+    ledger.record_failure("4")
+
+    cfg = reset_config()
+    cfg.model_name = "gemma-4-12b"
+    _reset_accumulator_for_tests()
+    app = FastAPI()
+    app.include_router(router)
+    cfg.engine = SimpleNamespace(
+        get_stats=lambda: {"model_performance": ledger.snapshot().__dict__}
+    )
+    body = TestClient(app).get("/metrics").text
+
+    assert (
+        'rapid_mlx_model_requests_total{model="gemma-4-12b",outcome="succeeded"} 3'
+        in body
+    )
+    assert (
+        'rapid_mlx_model_requests_total{model="gemma-4-12b",outcome="failed"} 1' in body
+    )
+    assert 'rapid_mlx_model_prompt_tokens_total{model="gemma-4-12b"} 15' in body
+    assert 'rapid_mlx_model_completion_tokens_total{model="gemma-4-12b"} 9' in body
+    assert 'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="0.1"} 1' in body
+    assert (
+        'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="+Inf"} 3' in body
+    )
+    assert (
+        'rapid_mlx_model_decode_tokens_per_second_bucket{model="gemma-4-12b",le="50"} 1'
+        in body
+    )
+    assert 'rapid_mlx_model_ttft_seconds_max{model="gemma-4-12b"} 0.9' in body
+    assert (
+        'rapid_mlx_model_decode_tokens_per_second_last{model="gemma-4-12b"} 20' in body
+    )
+
+    reset_config()
+    _reset_accumulator_for_tests()

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -12,6 +12,7 @@ import pytest
 
 from vllm_mlx.output_collector import RequestOutputCollector
 from vllm_mlx.runtime.model_performance import (
+    MODEL_LEDGER_REGISTRY_LIMIT,
     SEEN_REQUEST_ID_LIMIT,
     ModelPerformanceLedger,
 )
@@ -152,12 +153,7 @@ def test_ledger_best_effort_helpers_ignore_unusable_timings_and_errors(
 
     monkeypatch.setattr(
         ledger,
-        "record_success",
-        MagicMock(side_effect=RuntimeError("accounting failure")),
-    )
-    monkeypatch.setattr(
-        ledger,
-        "record_cancelled",
+        "record_request_performance",
         MagicMock(side_effect=RuntimeError("accounting failure")),
     )
 
@@ -177,6 +173,24 @@ def test_ledger_dedupe_cache_is_bounded():
     assert len(ledger._seen_request_ids) == SEEN_REQUEST_ID_LIMIT
     assert ledger.record_failure("0") is True
     assert ledger.record_failure("overflow") is False
+
+
+def test_request_owned_idempotency_survives_low_level_cache_eviction():
+    from types import SimpleNamespace
+
+    ledger = ModelPerformanceLedger("model-b")
+    request = SimpleNamespace(
+        request_id="request-owned",
+        status=SimpleNamespace(name="RUNNING"),
+        num_prompt_tokens=3,
+        num_output_tokens=2,
+    )
+    assert ledger.record_request_performance(request, "failed") is True
+    for request_id in range(SEEN_REQUEST_ID_LIMIT + 1):
+        ledger.record_failure(f"synthetic-{request_id}")
+
+    assert ledger.record_request_performance(request, "failed") is False
+    assert ledger.snapshot().requests_failed == SEEN_REQUEST_ID_LIMIT + 2
 
 
 def test_distinct_request_lifetimes_may_reuse_the_same_id():
@@ -310,6 +324,27 @@ def test_waiting_cancellation_records_no_unprocessed_prompt_tokens():
     scheduler.waiting.append(request)
 
     assert scheduler._do_abort_request(request.request_id) is True
+
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_cancelled == 1
+    assert performance.prompt_tokens == 0
+
+
+def test_mllm_waiting_cancellation_records_zero_prompt_tokens():
+    from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+    processor = MagicMock()
+    processor.tokenizer = MagicMock()
+    scheduler = MLLMScheduler(
+        MagicMock(),
+        processor,
+        MLLMSchedulerConfig(),
+        model_name="mllm-cancel-test",
+    )
+    request_id = scheduler.add_request("queued prompt")
+    scheduler.requests[request_id].num_prompt_tokens = 5
+
+    scheduler._do_abort_request(request_id)
 
     performance = scheduler.performance.snapshot()
     assert performance.requests_cancelled == 1
@@ -706,3 +741,21 @@ def test_metrics_preserves_unseen_events_across_scheduler_reloads():
 
     reset_config()
     _reset_accumulator_for_tests()
+
+
+def test_process_model_registry_is_lru_bounded():
+    from vllm_mlx.runtime.model_performance import (
+        get_model_performance_ledger,
+        get_model_performance_snapshots,
+    )
+
+    for index in range(MODEL_LEDGER_REGISTRY_LIMIT + 1):
+        get_model_performance_ledger(f"model-{index}")
+
+    retained = get_model_performance_snapshots()
+    assert len(retained) == MODEL_LEDGER_REGISTRY_LIMIT
+    assert all(snapshot.model_name != "model-0" for snapshot in retained)
+    assert any(
+        snapshot.model_name == f"model-{MODEL_LEDGER_REGISTRY_LIMIT}"
+        for snapshot in retained
+    )

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -324,6 +324,10 @@ async def test_engine_loop_records_pending_failures():
         MagicMock(), MagicMock(), EngineConfig(model_name="model-under-test")
     )
 
+    from types import SimpleNamespace
+
+    failed_request = SimpleNamespace(request_id="failure", arrival_time=time.time())
+
     class _BoomScheduler:
         performance = ModelPerformanceLedger("model-under-test")
 
@@ -341,6 +345,9 @@ async def test_engine_loop_records_pending_failures():
 
         def remove_finished_request(self, *_args, **_kwargs):
             pass
+
+        def get_request(self, request_id):
+            return failed_request if request_id == failed_request.request_id else None
 
     engine.scheduler = _BoomScheduler()
     engine._output_collectors["failure"] = RequestOutputCollector(aggregate=True)
@@ -361,6 +368,57 @@ async def test_engine_loop_records_pending_failures():
     assert performance.requests_failed == 1
     final = engine._output_collectors["failure"].get_nowait()
     assert final is not None and final.finished and final.error
+
+
+@pytest.mark.asyncio
+async def test_engine_loop_does_not_count_failure_before_scheduler_admission():
+    pytest.importorskip("mlx")
+
+    from vllm_mlx.engine_core import EngineConfig, EngineCore
+
+    engine = EngineCore(
+        MagicMock(), MagicMock(), EngineConfig(model_name="model-under-test")
+    )
+
+    class _AdmissionRaceScheduler:
+        performance = ModelPerformanceLedger("model-under-test")
+
+        def has_requests(self):
+            return True
+
+        def step(self):
+            raise RuntimeError("Metal command buffer failure")
+
+        def get_request(self, _request_id):
+            return None
+
+        def add_request(self, *_args, **_kwargs):
+            pass
+
+        def abort_request(self, *_args, **_kwargs):
+            return True
+
+        def remove_finished_request(self, *_args, **_kwargs):
+            pass
+
+    engine.scheduler = _AdmissionRaceScheduler()
+    engine._output_collectors["not-admitted"] = RequestOutputCollector(aggregate=True)
+    engine._finished_events["not-admitted"] = asyncio.Event()
+    engine._running = True
+    loop_task = asyncio.create_task(engine._engine_loop())
+    try:
+        await asyncio.wait_for(
+            engine._finished_events["not-admitted"].wait(), timeout=1
+        )
+    finally:
+        engine._running = False
+        loop_task.cancel()
+        try:
+            await loop_task
+        except asyncio.CancelledError:
+            pass
+
+    assert engine.scheduler.performance.snapshot().total_requests == 0
 
 
 def test_metrics_renders_model_performance_series():

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -282,6 +282,22 @@ def test_scheduler_records_explicit_cancellation_once():
     assert scheduler.performance.snapshot().requests_cancelled == 1
 
 
+def test_scheduler_records_reconciled_orphan_cancellation():
+    pytest.importorskip("mlx")
+
+    scheduler = _scheduler()
+    request = _running_request(scheduler, "disconnect-orphan")
+    scheduler.remove_finished_request(request.request_id)
+
+    scheduler.step()
+
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_cancelled == 1
+    assert performance.prompt_tokens == 5
+    assert performance.completion_tokens == 2
+    assert request.request_id not in scheduler.running
+
+
 def test_scheduler_records_generation_recovery_failures():
     pytest.importorskip("mlx")
 

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -491,6 +491,13 @@ def test_metrics_renders_model_performance_series():
     assert (
         'rapid_mlx_model_requests_total{model="gemma-4-12b",outcome="failed"} 1' in body
     )
+    assert 'outcome="total"' not in body
+    outcome_samples = [
+        float(line.rsplit(" ", 1)[1])
+        for line in body.splitlines()
+        if line.startswith("rapid_mlx_model_requests_total{")
+    ]
+    assert sum(outcome_samples) == 4
     assert 'rapid_mlx_model_prompt_tokens_total{model="gemma-4-12b"} 15' in body
     assert 'rapid_mlx_model_completion_tokens_total{model="gemma-4-12b"} 9' in body
     assert 'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="0.1"} 1' in body

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -793,17 +793,44 @@ def test_metrics_preserves_unseen_events_across_scheduler_reloads():
 
 def test_process_model_registry_is_lru_bounded():
     from vllm_mlx.runtime.model_performance import (
+        _MODEL_LEDGER_REGISTRY,
         get_model_performance_ledger,
         get_model_performance_snapshots,
     )
 
-    for index in range(MODEL_LEDGER_REGISTRY_LIMIT + 1):
+    first = get_model_performance_ledger("model-0")
+    first.record_success(
+        "before-retirement",
+        prompt_tokens=3,
+        completion_tokens=2,
+        ttft_seconds=0.2,
+        decode_tokens_per_second=10,
+    )
+    for index in range(1, MODEL_LEDGER_REGISTRY_LIMIT + 1):
         get_model_performance_ledger(f"model-{index}")
 
     retained = get_model_performance_snapshots()
-    assert len(retained) == MODEL_LEDGER_REGISTRY_LIMIT
-    assert all(snapshot.model_name != "model-0" for snapshot in retained)
+    assert len(_MODEL_LEDGER_REGISTRY) == MODEL_LEDGER_REGISTRY_LIMIT
+    assert len(retained) == MODEL_LEDGER_REGISTRY_LIMIT + 1
+    retired = next(
+        snapshot for snapshot in retained if snapshot.model_name == "model-0"
+    )
+    assert retired.requests_succeeded == 1
     assert any(
         snapshot.model_name == f"model-{MODEL_LEDGER_REGISTRY_LIMIT}"
         for snapshot in retained
     )
+
+    revived = get_model_performance_ledger("model-0")
+    assert revived.snapshot().requests_succeeded == 1
+    revived.record_success(
+        "after-retirement",
+        prompt_tokens=5,
+        completion_tokens=4,
+        ttft_seconds=0.4,
+        decode_tokens_per_second=20,
+    )
+    continuity = revived.snapshot()
+    assert continuity.requests_succeeded == 2
+    assert continuity.prompt_tokens == 8
+    assert len(_MODEL_LEDGER_REGISTRY) == MODEL_LEDGER_REGISTRY_LIMIT

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -352,6 +352,41 @@ def test_scheduler_records_generation_recovery_failures():
     assert performance.decode_observations == 1
 
 
+def test_mllm_global_failure_does_not_charge_queued_prompt_tokens():
+    pytest.importorskip("mlx")
+
+    from vllm_mlx.mllm_scheduler import (
+        MLLMRequest,
+        MLLMScheduler,
+        MLLMSchedulerConfig,
+    )
+    from vllm_mlx.request import RequestStatus
+
+    processor = MagicMock()
+    processor.tokenizer = MagicMock()
+    scheduler = MLLMScheduler(
+        MagicMock(),
+        processor,
+        MLLMSchedulerConfig(),
+        model_name="model-under-test",
+    )
+    running = MLLMRequest(request_id="running", prompt="started")
+    running.status = RequestStatus.RUNNING
+    running.num_prompt_tokens = 5
+    waiting = MLLMRequest(request_id="waiting", prompt="not started")
+    waiting.num_prompt_tokens = 7
+    scheduler.requests = {running.request_id: running, waiting.request_id: waiting}
+    scheduler.running = {running.request_id: running}
+    scheduler.waiting.append(waiting)
+
+    output = scheduler._fail_all_inflight(RuntimeError("Metal OOM"))
+
+    assert output.finished_request_ids == {"running", "waiting"}
+    performance = scheduler.performance.snapshot()
+    assert performance.requests_failed == 2
+    assert performance.prompt_tokens == 5
+
+
 @pytest.mark.asyncio
 async def test_engine_loop_records_pending_failures():
     pytest.importorskip("mlx")

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -333,8 +333,8 @@ def test_metrics_renders_model_performance_series():
 
     for metric_name in (
         "rapid_mlx_model_requests_total",
-        "rapid_mlx_model_ttft_seconds_bucket",
-        "rapid_mlx_model_decode_tokens_per_second_bucket",
+        "rapid_mlx_model_ttft_seconds",
+        "rapid_mlx_model_decode_tokens_per_second",
     ):
         assert body.count(f"# TYPE {metric_name} ") == 1
         assert body.count(f"# HELP {metric_name} ") == 1
@@ -357,6 +357,11 @@ def test_metrics_renders_model_performance_series():
         in body
     )
     assert 'rapid_mlx_model_ttft_seconds_max{model="gemma-4-12b"} 0.9' in body
+    assert (
+        'rapid_mlx_model_ttft_seconds_bucket{model="gemma-4-12b",le="+Inf"} 3' in body
+    )
+    assert 'rapid_mlx_model_ttft_seconds_count{model="gemma-4-12b"} 3' in body
+    assert 'rapid_mlx_model_ttft_seconds_sum{model="gemma-4-12b"} 1.37' in body
     assert (
         'rapid_mlx_model_decode_tokens_per_second_last{model="gemma-4-12b"} 20' in body
     )

--- a/tests/test_model_performance_metrics.py
+++ b/tests/test_model_performance_metrics.py
@@ -11,7 +11,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from vllm_mlx.output_collector import RequestOutputCollector
-from vllm_mlx.runtime.model_performance import ModelPerformanceLedger
+from vllm_mlx.runtime.model_performance import (
+    SEEN_REQUEST_ID_LIMIT,
+    ModelPerformanceLedger,
+)
 
 if TYPE_CHECKING:
     from vllm_mlx.request import Request
@@ -163,6 +166,17 @@ def test_ledger_best_effort_helpers_ignore_unusable_timings_and_errors(
 
     snapshot = ledger.snapshot()
     assert snapshot.total_requests == 0
+
+
+def test_ledger_dedupe_cache_is_bounded():
+    ledger = ModelPerformanceLedger("model-b")
+    for request_id in range(SEEN_REQUEST_ID_LIMIT):
+        assert ledger.record_failure(str(request_id))
+
+    assert ledger.record_failure("overflow") is True
+    assert len(ledger._seen_request_ids) == SEEN_REQUEST_ID_LIMIT
+    assert ledger.record_failure("0") is True
+    assert ledger.record_failure("overflow") is False
 
 
 def test_ledger_histograms_are_cumulative_and_memory_bounded():

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1639,6 +1639,7 @@ class BatchedEngine(BaseEngine):
             processor=self._processor,
             config=mllm_config,
             step_executor=self._model_load_executor,
+            model_name=self._model_name,
         )
         await self._mllm_scheduler.start()
 
@@ -3815,6 +3816,7 @@ class BatchedEngine(BaseEngine):
                 "vision_embedding_cache",
                 "vision_cache",
                 "prefix_cache",
+                "model_performance",
             ):
                 if key in mllm_stats:
                     stats[key] = mllm_stats[key]

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1033,7 +1033,13 @@ class EngineCore:
                     if is_metal
                     else f"Engine loop error: {type(e).__name__}: {e}"
                 )
+                performance = getattr(self.scheduler, "performance", None)
                 for rid in list(self._finished_events.keys()):
+                    if performance is not None:
+                        try:
+                            performance.record_failure(rid)
+                        except Exception:
+                            logger.debug("Failed to record engine failure for %s", rid)
                     collector = self._output_collectors.get(rid)
                     if collector is not None:
                         try:

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1043,8 +1043,6 @@ class EngineCore:
                             )
                             if request is not None:
                                 performance.record_failed_performance(request)
-                            else:
-                                performance.record_failure(rid)
                         except Exception:  # pragma: no cover — defensive
                             logger.debug("Failed to record engine failure for %s", rid)
                     collector = self._output_collectors.get(rid)

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1038,7 +1038,7 @@ class EngineCore:
                     if performance is not None:
                         try:
                             performance.record_failure(rid)
-                        except Exception:
+                        except Exception:  # pragma: no cover — defensive
                             logger.debug("Failed to record engine failure for %s", rid)
                     collector = self._output_collectors.get(rid)
                     if collector is not None:

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1037,7 +1037,14 @@ class EngineCore:
                 for rid in list(self._finished_events.keys()):
                     if performance is not None:
                         try:
-                            performance.record_failure(rid)
+                            get_request = getattr(self.scheduler, "get_request", None)
+                            request = (
+                                get_request(rid) if get_request is not None else None
+                            )
+                            if request is not None:
+                                performance.record_failed_performance(request)
+                            else:
+                                performance.record_failure(rid)
                         except Exception:  # pragma: no cover — defensive
                             logger.debug("Failed to record engine failure for %s", rid)
                     collector = self._output_collectors.get(rid)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -416,7 +416,10 @@ class MLLMScheduler:
                 decode_tokens_per_second=decode_rate,
             )
         except Exception:
-            logger.debug("Failed to record MLLM performance for %s", request.request_id)
+            logger.debug(
+                "Failed to record MLLM performance for %s",
+                getattr(request, "request_id", "<unknown>"),
+            )
 
     def _match_user_stop(
         self, text: str, new_text_start_len: int, stop_params: list[str]

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -54,7 +54,7 @@ from .request import (  # noqa: E402
     RequestStatus,
     SamplingParams,
 )
-from .runtime.model_performance import ModelPerformanceLedger  # noqa: E402
+from .runtime.model_performance import get_model_performance_ledger  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -388,7 +388,7 @@ class MLLMScheduler:
         # rationale. Observability only — abort semantics unchanged.
         self.num_requests_cancelled = 0
         self.num_requests_cancelled_via_disconnect = 0
-        self.performance = ModelPerformanceLedger(model_name)
+        self.performance = get_model_performance_ledger(model_name)
 
     def _request_timings(
         self, request: MLLMRequest

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -144,6 +144,7 @@ class MLLMRequest:
     video_max_frames: int | None = None
     arrival_time: float = field(default_factory=time.time)
     first_token_time: float | None = None
+    _performance_recorded: bool = field(default=False, init=False, repr=False)
 
     # Batch generator UID (assigned when scheduled)
     batch_uid: int | None = None
@@ -408,33 +409,12 @@ class MLLMScheduler:
         """Record one MLLM request lifetime without changing its lifecycle."""
         try:
             ttft, decode_rate = self._request_timings(request)
-            if outcome == "succeeded":
-                self.performance.record_success(
-                    request.request_id,
-                    prompt_tokens=self.performance.prompt_tokens_for_request(request),
-                    completion_tokens=request.num_output_tokens,
-                    ttft_seconds=ttft,
-                    decode_tokens_per_second=decode_rate,
-                    request_lifetime=request.arrival_time,
-                )
-            elif outcome == "cancelled":
-                self.performance.record_cancelled(
-                    request.request_id,
-                    prompt_tokens=self.performance.prompt_tokens_for_request(request),
-                    completion_tokens=request.num_output_tokens,
-                    ttft_seconds=ttft,
-                    decode_tokens_per_second=decode_rate,
-                    request_lifetime=request.arrival_time,
-                )
-            else:
-                self.performance.record_failure(
-                    request.request_id,
-                    prompt_tokens=self.performance.prompt_tokens_for_request(request),
-                    completion_tokens=request.num_output_tokens,
-                    ttft_seconds=ttft,
-                    decode_tokens_per_second=decode_rate,
-                    request_lifetime=request.arrival_time,
-                )
+            self.performance.record_request_performance(
+                request,
+                outcome,
+                ttft_seconds=ttft,
+                decode_tokens_per_second=decode_rate,
+            )
         except Exception:
             logger.debug("Failed to record MLLM performance for %s", request.request_id)
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1000,6 +1000,7 @@ class MLLMScheduler:
         """
         outputs = []
         finished_ids = set()
+        terminal_performance_requests: list[MLLMRequest] = []
 
         tokenizer = (
             self.processor.tokenizer
@@ -1264,7 +1265,7 @@ class MLLMScheduler:
                 self.total_prompt_tokens += request.num_prompt_tokens
                 self.total_completion_tokens += request.num_output_tokens
                 self.num_requests_processed += 1
-                self._record_terminal_performance(request, "succeeded")
+                terminal_performance_requests.append(request)
 
                 logger.debug(
                     f"Request {request_id} finished: {finish_reason}, "
@@ -1302,6 +1303,11 @@ class MLLMScheduler:
                 )
             )
 
+        # Commit outcomes only after the entire response batch has processed.
+        # A later response can still fail decoding/finalization, in which case
+        # the process loop converts every pending request to a failure.
+        for request in terminal_performance_requests:
+            self._record_terminal_performance(request, "succeeded")
         return outputs, finished_ids
 
     def _cleanup_finished(self, finished_ids: set[str]) -> None:
@@ -1358,6 +1364,7 @@ class MLLMScheduler:
                 err_msg = str(e)
                 logger.error(f"Batch generation failed: {err_msg}")
                 error_ids = set(self.running.keys())
+                failed_requests = [self.running[rid] for rid in error_ids]
 
                 # Remove from batch generator BEFORE scheduler cleanup so
                 # stale requests don't poison subsequent batches.
@@ -1407,6 +1414,8 @@ class MLLMScheduler:
                         )
                     )
                 output.finished_request_ids = error_ids
+                for request in failed_requests:
+                    self._record_terminal_performance(request, "failed")
                 self._cleanup_finished(error_ids)
                 return output
 

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -411,7 +411,7 @@ class MLLMScheduler:
             if outcome == "succeeded":
                 self.performance.record_success(
                     request.request_id,
-                    prompt_tokens=request.num_prompt_tokens,
+                    prompt_tokens=self.performance.prompt_tokens_for_request(request),
                     completion_tokens=request.num_output_tokens,
                     ttft_seconds=ttft,
                     decode_tokens_per_second=decode_rate,
@@ -420,7 +420,7 @@ class MLLMScheduler:
             elif outcome == "cancelled":
                 self.performance.record_cancelled(
                     request.request_id,
-                    prompt_tokens=request.num_prompt_tokens,
+                    prompt_tokens=self.performance.prompt_tokens_for_request(request),
                     completion_tokens=request.num_output_tokens,
                     ttft_seconds=ttft,
                     decode_tokens_per_second=decode_rate,
@@ -429,7 +429,7 @@ class MLLMScheduler:
             else:
                 self.performance.record_failure(
                     request.request_id,
-                    prompt_tokens=request.num_prompt_tokens,
+                    prompt_tokens=self.performance.prompt_tokens_for_request(request),
                     completion_tokens=request.num_output_tokens,
                     ttft_seconds=ttft,
                     decode_tokens_per_second=decode_rate,

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -2213,6 +2213,16 @@ class MLLMScheduler:
 
     def reset(self) -> None:
         """Reset the scheduler state."""
+        # ``abort_request`` may only enqueue work when the step loop owns the
+        # scheduler. Account every visible lifetime before any queue/map is
+        # cleared; request-owned idempotency prevents a synchronous abort from
+        # double-counting the same object.
+        reset_requests = dict(self.requests)
+        reset_requests.update(self.running)
+        reset_requests.update({request.request_id: request for request in self.waiting})
+        for request in reset_requests.values():
+            self._record_terminal_performance(request, "cancelled")
+
         # Abort all requests
         for request_id in list(self.requests.keys()):
             self.abort_request(request_id)

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -54,6 +54,7 @@ from .request import (  # noqa: E402
     RequestStatus,
     SamplingParams,
 )
+from .runtime.model_performance import ModelPerformanceLedger  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,7 @@ class MLLMRequest:
     video_fps: float | None = None
     video_max_frames: int | None = None
     arrival_time: float = field(default_factory=time.time)
+    first_token_time: float | None = None
 
     # Batch generator UID (assigned when scheduled)
     batch_uid: int | None = None
@@ -246,6 +248,7 @@ class MLLMScheduler:
         processor: Any,
         config: MLLMSchedulerConfig | None = None,
         step_executor: Any | None = None,
+        model_name: str | None = None,
     ):
         """
         Initialize MLLM scheduler.
@@ -385,6 +388,55 @@ class MLLMScheduler:
         # rationale. Observability only — abort semantics unchanged.
         self.num_requests_cancelled = 0
         self.num_requests_cancelled_via_disconnect = 0
+        self.performance = ModelPerformanceLedger(model_name)
+
+    def _request_timings(
+        self, request: MLLMRequest
+    ) -> tuple[float | None, float | None]:
+        """Return TTFT and inverse-TPOT decode speed for a terminal request."""
+        if request.first_token_time is None or request.num_output_tokens == 0:
+            return None, None
+        ttft = max(0.0, request.first_token_time - request.arrival_time)
+        decode_rate = None
+        if request.num_output_tokens >= 2:
+            elapsed = time.time() - request.first_token_time
+            if elapsed > 0:
+                decode_rate = (request.num_output_tokens - 1) / elapsed
+        return ttft, decode_rate
+
+    def _record_terminal_performance(self, request: MLLMRequest, outcome: str) -> None:
+        """Record one MLLM request lifetime without changing its lifecycle."""
+        try:
+            ttft, decode_rate = self._request_timings(request)
+            if outcome == "succeeded":
+                self.performance.record_success(
+                    request.request_id,
+                    prompt_tokens=request.num_prompt_tokens,
+                    completion_tokens=request.num_output_tokens,
+                    ttft_seconds=ttft,
+                    decode_tokens_per_second=decode_rate,
+                    request_lifetime=request.arrival_time,
+                )
+            elif outcome == "cancelled":
+                self.performance.record_cancelled(
+                    request.request_id,
+                    prompt_tokens=request.num_prompt_tokens,
+                    completion_tokens=request.num_output_tokens,
+                    ttft_seconds=ttft,
+                    decode_tokens_per_second=decode_rate,
+                    request_lifetime=request.arrival_time,
+                )
+            else:
+                self.performance.record_failure(
+                    request.request_id,
+                    prompt_tokens=request.num_prompt_tokens,
+                    completion_tokens=request.num_output_tokens,
+                    ttft_seconds=ttft,
+                    decode_tokens_per_second=decode_rate,
+                    request_lifetime=request.arrival_time,
+                )
+        except Exception:
+            logger.debug("Failed to record MLLM performance for %s", request.request_id)
 
     def _match_user_stop(
         self, text: str, new_text_start_len: int, stop_params: list[str]
@@ -836,6 +888,7 @@ class MLLMScheduler:
             self.total_prompt_tokens += request.num_prompt_tokens
             if request.num_output_tokens > 0:
                 self.total_completion_tokens += request.num_output_tokens
+            self._record_terminal_performance(request, "cancelled")
 
         # Mark as aborted
         if request is not None:
@@ -998,6 +1051,8 @@ class MLLMScheduler:
             if not token_is_control_stop_token:
                 request.output_tokens.append(response.token)
             request.num_output_tokens = len(request.output_tokens)
+            if request.num_output_tokens and request.first_token_time is None:
+                request.first_token_time = time.time()
 
             finish_reason = response.finish_reason
 
@@ -1209,6 +1264,7 @@ class MLLMScheduler:
                 self.total_prompt_tokens += request.num_prompt_tokens
                 self.total_completion_tokens += request.num_output_tokens
                 self.num_requests_processed += 1
+                self._record_terminal_performance(request, "succeeded")
 
                 logger.debug(
                     f"Request {request_id} finished: {finish_reason}, "
@@ -1501,9 +1557,10 @@ class MLLMScheduler:
         )
 
         for request_id in request_ids:
-            request = self.requests.get(request_id)
+            request = self.requests.get(request_id) or self.running.get(request_id)
             if request is not None:
                 request.status = RequestStatus.FINISHED_ABORTED
+                self._record_terminal_performance(request, "failed")
         if self.batch_generator is not None:
             try:
                 self.batch_generator.close()
@@ -2103,6 +2160,7 @@ class MLLMScheduler:
             "num_requests_cancelled_via_disconnect": (
                 self.num_requests_cancelled_via_disconnect
             ),
+            "model_performance": self.performance.snapshot().__dict__,
         }
 
         if self.batch_generator is not None:

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1568,8 +1568,12 @@ class MLLMScheduler:
         for request_id in request_ids:
             request = self.requests.get(request_id) or self.running.get(request_id)
             if request is not None:
-                request.status = RequestStatus.FINISHED_ABORTED
+                # Account while the pre-terminal status still distinguishes
+                # queued requests (zero model work) from requests that reached
+                # prefill.  Marking every request aborted first would charge a
+                # waiting request's entire tokenized prompt to the model.
                 self._record_terminal_performance(request, "failed")
+                request.status = RequestStatus.FINISHED_ABORTED
         if self.batch_generator is not None:
             try:
                 self.batch_generator.close()

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -161,6 +161,9 @@ class Request:
     num_computed_tokens: int = 0
     output_token_ids: list[int] = field(default_factory=list)
     output_text: str = ""
+    # Terminal metrics idempotency belongs to this request lifetime, not a
+    # bounded global ID cache that can forget delayed duplicate delivery.
+    _performance_recorded: bool = field(default=False, init=False, repr=False)
 
     # For BatchGenerator integration
     batch_uid: int | None = None  # UID assigned by BatchGenerator

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -114,14 +114,43 @@ class _StickyCounterAccumulator:
             return baseline + raw
 
 
+class _ModelPerformanceAccumulator:
+    """Keep one model's counter/histogram series monotonic across reloads."""
+
+    def __init__(self) -> None:
+        # series key -> (ledger identity, last raw value, retired baseline)
+        self._state: dict[str, tuple[str, float, float]] = {}
+        self._lock = threading.Lock()
+
+    def advance(self, key: str, ledger_id: str, raw: float) -> float:
+        raw = max(0.0, float(raw))
+        with self._lock:
+            previous = self._state.get(key)
+            if previous is None:
+                baseline = 0.0
+            else:
+                previous_ledger_id, last_raw, baseline = previous
+                if ledger_id != previous_ledger_id:
+                    # A replacement scheduler starts a fresh ledger even when
+                    # the model label is unchanged. Retire the old raw total.
+                    baseline += last_raw
+                elif raw < last_raw:
+                    # Defensive support for an in-place ledger reset.
+                    baseline += last_raw
+            self._state[key] = (ledger_id, raw, baseline)
+            return baseline + raw
+
+
 # Module-level accumulator — one process, one cumulative cache series.
 _cache_counter_accumulator = _StickyCounterAccumulator()
+_model_performance_accumulator = _ModelPerformanceAccumulator()
 
 
 def _reset_accumulator_for_tests() -> None:
     """Test-only hook: clear the sticky-counter state between tests."""
-    global _cache_counter_accumulator
+    global _cache_counter_accumulator, _model_performance_accumulator
     _cache_counter_accumulator = _StickyCounterAccumulator()
+    _model_performance_accumulator = _ModelPerformanceAccumulator()
 
 
 def _escape_label_value(value: str) -> str:
@@ -214,8 +243,14 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
         return []
 
     model_name = str(performance.get("model_name") or "")
+    ledger_id = str(performance.get("ledger_id") or f"legacy:{model_name}")
     labels = {"model": model_name}
     lines: list[str] = []
+
+    def cumulative(key: str, raw: Any) -> float:
+        return _model_performance_accumulator.advance(
+            f"{model_name}\0{key}", ledger_id, _coerce_number(raw, 0.0)
+        )
 
     lines.extend(
         _fmt_metric_family(
@@ -226,7 +261,10 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 *[
                     (
                         int(
-                            _coerce_number(performance.get(f"requests_{outcome}"), 0.0)
+                            cumulative(
+                                f"requests:{outcome}",
+                                performance.get(f"requests_{outcome}"),
+                            )
                         ),
                         {**labels, "outcome": outcome},
                     )
@@ -242,7 +280,12 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 f"rapid_mlx_model_{token_kind}_tokens_total",
                 "counter",
                 f"Cumulative {token_kind} tokens processed by the model.",
-                int(_coerce_number(performance.get(f"{token_kind}_tokens"), 0.0)),
+                int(
+                    cumulative(
+                        f"tokens:{token_kind}",
+                        performance.get(f"{token_kind}_tokens"),
+                    )
+                ),
                 labels=labels,
             )
         )
@@ -255,7 +298,10 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "histogram",
                 "Time to first token, in seconds, by model.",
                 [
-                    (int(_coerce_number(count, 0.0)), {**labels, "le": str(bucket)})
+                    (
+                        int(cumulative(f"ttft:bucket:{bucket}", count)),
+                        {**labels, "le": str(bucket)},
+                    )
                     for bucket, count in ttft_buckets.items()
                 ],
                 sample_name="rapid_mlx_model_ttft_seconds_bucket",
@@ -266,7 +312,11 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "rapid_mlx_model_ttft_seconds_count",
                 [
                     (
-                        int(_coerce_number(performance.get("ttft_seconds_count"), 0.0)),
+                        int(
+                            cumulative(
+                                "ttft:count", performance.get("ttft_seconds_count")
+                            )
+                        ),
                         labels,
                     )
                 ],
@@ -278,7 +328,9 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         round(
-                            _coerce_number(performance.get("ttft_seconds_sum"), 0.0),
+                            cumulative(
+                                "ttft:sum", performance.get("ttft_seconds_sum")
+                            ),
                             6,
                         ),
                         labels,
@@ -295,7 +347,10 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "histogram",
                 "Post-first-token decode speed in tokens per second by model.",
                 [
-                    (int(_coerce_number(count, 0.0)), {**labels, "le": str(bucket)})
+                    (
+                        int(cumulative(f"decode:bucket:{bucket}", count)),
+                        {**labels, "le": str(bucket)},
+                    )
                     for bucket, count in decode_buckets.items()
                 ],
                 sample_name="rapid_mlx_model_decode_tokens_per_second_bucket",
@@ -307,7 +362,9 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         int(
-                            _coerce_number(performance.get("decode_observations"), 0.0)
+                            cumulative(
+                                "decode:count", performance.get("decode_observations")
+                            )
                         ),
                         labels,
                     )
@@ -320,8 +377,9 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         round(
-                            _coerce_number(
-                                performance.get("decode_tokens_per_second_sum"), 0.0
+                            cumulative(
+                                "decode:sum",
+                                performance.get("decode_tokens_per_second_sum"),
                             ),
                             6,
                         ),

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -373,17 +373,17 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
 def _render_retained_model_performance() -> list[str]:
     """Render every process-owned model ledger as shared metric families."""
     lines: list[str] = []
-    for index, snapshot in enumerate(get_model_performance_snapshots()):
+    declarations: set[tuple[str, str]] = set()
+    for snapshot in get_model_performance_snapshots():
         rendered = _render_model_performance({"model_performance": snapshot.__dict__})
-        if index:
-            # HELP/TYPE declarations belong to the family, not each label set.
-            rendered = [
-                line
-                for line in rendered
-                if not line.startswith("# HELP rapid_mlx_model_")
-                and not line.startswith("# TYPE rapid_mlx_model_")
-            ]
-        lines.extend(rendered)
+        for line in rendered:
+            if line.startswith(("# HELP ", "# TYPE ")):
+                kind, metric_name = line.split(maxsplit=3)[1:3]
+                declaration = (kind, metric_name)
+                if declaration in declarations:
+                    continue
+                declarations.add(declaration)
+            lines.append(line)
     return lines
 
 

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -217,20 +217,12 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
     labels = {"model": model_name}
     lines: list[str] = []
 
-    reported_total = performance.get("total_requests")
-    if reported_total is None:
-        reported_total = sum(
-            _coerce_number(performance.get(f"requests_{outcome}"), 0.0)
-            for outcome in ("succeeded", "cancelled", "failed")
-        )
-    requests_total = _coerce_number(reported_total, 0.0)
     lines.extend(
         _fmt_metric_family(
             "rapid_mlx_model_requests_total",
             "counter",
             "Text-engine requests by terminal outcome and model.",
             [
-                (requests_total, {**labels, "outcome": "total"}),
                 *[
                     (
                         int(

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -51,6 +51,7 @@ from fastapi.responses import PlainTextResponse
 
 from .. import __version__
 from ..config import get_config
+from ..runtime.model_performance import get_model_performance_snapshots
 
 router = APIRouter()
 
@@ -366,6 +367,25 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 )
             )
 
+    return lines
+
+
+def _render_retained_model_performance() -> list[str]:
+    """Render every process-owned model ledger as shared metric families."""
+    lines: list[str] = []
+    for index, snapshot in enumerate(get_model_performance_snapshots()):
+        rendered = _render_model_performance(
+            {"model_performance": snapshot.__dict__}
+        )
+        if index:
+            # HELP/TYPE declarations belong to the family, not each label set.
+            rendered = [
+                line
+                for line in rendered
+                if not line.startswith("# HELP rapid_mlx_model_")
+                and not line.startswith("# TYPE rapid_mlx_model_")
+            ]
+        lines.extend(rendered)
     return lines
 
 
@@ -1339,6 +1359,11 @@ def _render_prometheus(cfg: Any) -> str:
     # dashboards see the active mode + skip rate even between restarts.
     lines.extend(_render_turboquant_metrics(cfg))
 
+    # Per-model ledgers are process-owned rather than engine-owned. Render all
+    # retained models before engine early returns so unload windows and model
+    # switches do not make historical labelled series disappear.
+    lines.extend(_render_retained_model_performance())
+
     if cfg.engine is None:
         # No engine yet — return build info + response_format counters
         # only. Prometheus must NOT see a 500 here or the whole target
@@ -1354,7 +1379,6 @@ def _render_prometheus(cfg: Any) -> str:
         return "\n".join(lines) + "\n"
 
     # ---- Scheduler counters & gauges -----------------------------------
-    lines.extend(_render_model_performance(stats))
     lines.extend(
         _fmt_metric(
             "rapid_mlx_requests_processed_total",

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -114,83 +114,14 @@ class _StickyCounterAccumulator:
             return baseline + raw
 
 
-class _ModelPerformanceAccumulator:
-    """Atomically keep one model snapshot monotonic across scheduler reloads."""
-
-    def __init__(self) -> None:
-        # model -> (active generation, retired baseline, active raw snapshot)
-        self._state: dict[
-            str,
-            tuple[
-                int, dict[str, float], dict[str, float], dict[str, float]
-            ],
-        ] = {}
-        self._lock = threading.Lock()
-
-    def advance(
-        self,
-        model_name: str,
-        ledger_id: int,
-        raw: dict[str, float],
-        maxima: dict[str, float] | None = None,
-    ) -> tuple[dict[str, float], dict[str, float]]:
-        normalized = {key: max(0.0, float(value)) for key, value in raw.items()}
-        normalized_maxima = {
-            key: max(0.0, float(value)) for key, value in (maxima or {}).items()
-        }
-        with self._lock:
-            previous = self._state.get(model_name)
-            if previous is None:
-                active_id = ledger_id
-                baseline: dict[str, float] = {}
-                active_raw = normalized
-                process_maxima = normalized_maxima
-            else:
-                active_id, baseline, active_raw, process_maxima = previous
-                baseline = dict(baseline)
-                process_maxima = dict(process_maxima)
-                if ledger_id > active_id:
-                    # Retire every series from the old scheduler as one atomic
-                    # snapshot so a scrape cannot mix ledger generations.
-                    for key, value in active_raw.items():
-                        baseline[key] = baseline.get(key, 0.0) + value
-                    active_id = ledger_id
-                    active_raw = normalized
-                elif ledger_id == active_id:
-                    # Two scrapes can capture the same live ledger at different
-                    # instants and arrive out of order. Counters never decrease,
-                    # so retain the newest value for every component.
-                    active_raw = {
-                        key: max(active_raw.get(key, 0.0), value)
-                        for key, value in normalized.items()
-                    }
-                # A lower generation is a delayed scrape from a retired
-                # scheduler. Return the current view without mutating state.
-                for key, value in normalized_maxima.items():
-                    process_maxima[key] = max(process_maxima.get(key, 0.0), value)
-            self._state[model_name] = (
-                active_id,
-                baseline,
-                active_raw,
-                process_maxima,
-            )
-            cumulative = {
-                key: baseline.get(key, 0.0) + value
-                for key, value in active_raw.items()
-            }
-            return cumulative, dict(process_maxima)
-
-
 # Module-level accumulator — one process, one cumulative cache series.
 _cache_counter_accumulator = _StickyCounterAccumulator()
-_model_performance_accumulator = _ModelPerformanceAccumulator()
 
 
 def _reset_accumulator_for_tests() -> None:
     """Test-only hook: clear the sticky-counter state between tests."""
-    global _cache_counter_accumulator, _model_performance_accumulator
+    global _cache_counter_accumulator
     _cache_counter_accumulator = _StickyCounterAccumulator()
-    _model_performance_accumulator = _ModelPerformanceAccumulator()
 
 
 def _escape_label_value(value: str) -> str:
@@ -283,55 +214,8 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
         return []
 
     model_name = str(performance.get("model_name") or "")
-    ledger_id = int(_coerce_number(performance.get("ledger_id"), 0.0))
     labels = {"model": model_name}
     lines: list[str] = []
-    ttft_buckets = performance.get("ttft_bucket_counts")
-    decode_buckets = performance.get("decode_bucket_counts")
-    raw_counters = {
-        **{
-            f"requests:{outcome}": _coerce_number(
-                performance.get(f"requests_{outcome}"), 0.0
-            )
-            for outcome in ("succeeded", "cancelled", "failed")
-        },
-        **{
-            f"tokens:{kind}": _coerce_number(
-                performance.get(f"{kind}_tokens"), 0.0
-            )
-            for kind in ("prompt", "completion")
-        },
-        "ttft:count": _coerce_number(performance.get("ttft_seconds_count"), 0.0),
-        "ttft:sum": _coerce_number(performance.get("ttft_seconds_sum"), 0.0),
-        "decode:count": _coerce_number(
-            performance.get("decode_observations"), 0.0
-        ),
-        "decode:sum": _coerce_number(
-            performance.get("decode_tokens_per_second_sum"), 0.0
-        ),
-    }
-    if isinstance(ttft_buckets, dict):
-        raw_counters.update(
-            {
-                f"ttft:bucket:{bucket}": _coerce_number(count, 0.0)
-                for bucket, count in ttft_buckets.items()
-            }
-        )
-    if isinstance(decode_buckets, dict):
-        raw_counters.update(
-            {
-                f"decode:bucket:{bucket}": _coerce_number(count, 0.0)
-                for bucket, count in decode_buckets.items()
-            }
-        )
-    raw_maxima = {
-        key: _coerce_number(performance[key])
-        for key in ("ttft_seconds_max", "decode_tokens_per_second_max")
-        if performance.get(key) is not None
-    }
-    cumulative, process_maxima = _model_performance_accumulator.advance(
-        model_name, ledger_id, raw_counters, raw_maxima
-    )
 
     lines.extend(
         _fmt_metric_family(
@@ -342,7 +226,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 *[
                     (
                         int(
-                            cumulative[f"requests:{outcome}"]
+                            _coerce_number(performance.get(f"requests_{outcome}"), 0.0)
                         ),
                         {**labels, "outcome": outcome},
                     )
@@ -358,13 +242,12 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 f"rapid_mlx_model_{token_kind}_tokens_total",
                 "counter",
                 f"Cumulative {token_kind} tokens processed by the model.",
-                int(
-                    cumulative[f"tokens:{token_kind}"]
-                ),
+                int(_coerce_number(performance.get(f"{token_kind}_tokens"), 0.0)),
                 labels=labels,
             )
         )
 
+    ttft_buckets = performance.get("ttft_bucket_counts")
     if isinstance(ttft_buckets, dict):
         lines.extend(
             _fmt_metric_family(
@@ -373,7 +256,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "Time to first token, in seconds, by model.",
                 [
                     (
-                        int(cumulative[f"ttft:bucket:{bucket}"]),
+                        int(_coerce_number(count, 0.0)),
                         {**labels, "le": str(bucket)},
                     )
                     for bucket, count in ttft_buckets.items()
@@ -386,9 +269,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "rapid_mlx_model_ttft_seconds_count",
                 [
                     (
-                        int(
-                            cumulative["ttft:count"]
-                        ),
+                        int(_coerce_number(performance.get("ttft_seconds_count"), 0.0)),
                         labels,
                     )
                 ],
@@ -400,7 +281,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         round(
-                            cumulative["ttft:sum"],
+                            _coerce_number(performance.get("ttft_seconds_sum"), 0.0),
                             6,
                         ),
                         labels,
@@ -409,6 +290,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
             )
         )
 
+    decode_buckets = performance.get("decode_bucket_counts")
     if isinstance(decode_buckets, dict):
         lines.extend(
             _fmt_metric_family(
@@ -417,7 +299,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "Post-first-token decode speed in tokens per second by model.",
                 [
                     (
-                        int(cumulative[f"decode:bucket:{bucket}"]),
+                        int(_coerce_number(count, 0.0)),
                         {**labels, "le": str(bucket)},
                     )
                     for bucket, count in decode_buckets.items()
@@ -431,7 +313,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         int(
-                            cumulative["decode:count"]
+                            _coerce_number(performance.get("decode_observations"), 0.0)
                         ),
                         labels,
                     )
@@ -444,7 +326,9 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         round(
-                            cumulative["decode:sum"],
+                            _coerce_number(
+                                performance.get("decode_tokens_per_second_sum"), 0.0
+                            ),
                             6,
                         ),
                         labels,
@@ -470,11 +354,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
             "Most recent terminal request's post-first-token decode speed.",
         ),
     ):
-        value = (
-            process_maxima.get(value_key)
-            if value_key in ("ttft_seconds_max", "decode_tokens_per_second_max")
-            else performance.get(value_key)
-        )
+        value = performance.get(value_key)
         if value is not None:
             lines.extend(
                 _fmt_metric(

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -115,30 +115,50 @@ class _StickyCounterAccumulator:
 
 
 class _ModelPerformanceAccumulator:
-    """Keep one model's counter/histogram series monotonic across reloads."""
+    """Atomically keep one model snapshot monotonic across scheduler reloads."""
 
     def __init__(self) -> None:
-        # series key -> (ledger identity, last raw value, retired baseline)
-        self._state: dict[str, tuple[str, float, float]] = {}
+        # model -> (active generation, retired baseline, active raw snapshot)
+        self._state: dict[
+            str, tuple[int, dict[str, float], dict[str, float]]
+        ] = {}
         self._lock = threading.Lock()
 
-    def advance(self, key: str, ledger_id: str, raw: float) -> float:
-        raw = max(0.0, float(raw))
+    def advance(
+        self, model_name: str, ledger_id: int, raw: dict[str, float]
+    ) -> dict[str, float]:
+        normalized = {key: max(0.0, float(value)) for key, value in raw.items()}
         with self._lock:
-            previous = self._state.get(key)
+            previous = self._state.get(model_name)
             if previous is None:
-                baseline = 0.0
+                active_id = ledger_id
+                baseline: dict[str, float] = {}
+                active_raw = normalized
             else:
-                previous_ledger_id, last_raw, baseline = previous
-                if ledger_id != previous_ledger_id:
-                    # A replacement scheduler starts a fresh ledger even when
-                    # the model label is unchanged. Retire the old raw total.
-                    baseline += last_raw
-                elif raw < last_raw:
-                    # Defensive support for an in-place ledger reset.
-                    baseline += last_raw
-            self._state[key] = (ledger_id, raw, baseline)
-            return baseline + raw
+                active_id, baseline, active_raw = previous
+                baseline = dict(baseline)
+                if ledger_id > active_id:
+                    # Retire every series from the old scheduler as one atomic
+                    # snapshot so a scrape cannot mix ledger generations.
+                    for key, value in active_raw.items():
+                        baseline[key] = baseline.get(key, 0.0) + value
+                    active_id = ledger_id
+                    active_raw = normalized
+                elif ledger_id == active_id:
+                    # Two scrapes can capture the same live ledger at different
+                    # instants and arrive out of order. Counters never decrease,
+                    # so retain the newest value for every component.
+                    active_raw = {
+                        key: max(active_raw.get(key, 0.0), value)
+                        for key, value in normalized.items()
+                    }
+                # A lower generation is a delayed scrape from a retired
+                # scheduler. Return the current view without mutating state.
+            self._state[model_name] = (active_id, baseline, active_raw)
+            return {
+                key: baseline.get(key, 0.0) + value
+                for key, value in active_raw.items()
+            }
 
 
 # Module-level accumulator — one process, one cumulative cache series.
@@ -243,14 +263,50 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
         return []
 
     model_name = str(performance.get("model_name") or "")
-    ledger_id = str(performance.get("ledger_id") or f"legacy:{model_name}")
+    ledger_id = int(_coerce_number(performance.get("ledger_id"), 0.0))
     labels = {"model": model_name}
     lines: list[str] = []
-
-    def cumulative(key: str, raw: Any) -> float:
-        return _model_performance_accumulator.advance(
-            f"{model_name}\0{key}", ledger_id, _coerce_number(raw, 0.0)
+    ttft_buckets = performance.get("ttft_bucket_counts")
+    decode_buckets = performance.get("decode_bucket_counts")
+    raw_counters = {
+        **{
+            f"requests:{outcome}": _coerce_number(
+                performance.get(f"requests_{outcome}"), 0.0
+            )
+            for outcome in ("succeeded", "cancelled", "failed")
+        },
+        **{
+            f"tokens:{kind}": _coerce_number(
+                performance.get(f"{kind}_tokens"), 0.0
+            )
+            for kind in ("prompt", "completion")
+        },
+        "ttft:count": _coerce_number(performance.get("ttft_seconds_count"), 0.0),
+        "ttft:sum": _coerce_number(performance.get("ttft_seconds_sum"), 0.0),
+        "decode:count": _coerce_number(
+            performance.get("decode_observations"), 0.0
+        ),
+        "decode:sum": _coerce_number(
+            performance.get("decode_tokens_per_second_sum"), 0.0
+        ),
+    }
+    if isinstance(ttft_buckets, dict):
+        raw_counters.update(
+            {
+                f"ttft:bucket:{bucket}": _coerce_number(count, 0.0)
+                for bucket, count in ttft_buckets.items()
+            }
         )
+    if isinstance(decode_buckets, dict):
+        raw_counters.update(
+            {
+                f"decode:bucket:{bucket}": _coerce_number(count, 0.0)
+                for bucket, count in decode_buckets.items()
+            }
+        )
+    cumulative = _model_performance_accumulator.advance(
+        model_name, ledger_id, raw_counters
+    )
 
     lines.extend(
         _fmt_metric_family(
@@ -261,10 +317,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 *[
                     (
                         int(
-                            cumulative(
-                                f"requests:{outcome}",
-                                performance.get(f"requests_{outcome}"),
-                            )
+                            cumulative[f"requests:{outcome}"]
                         ),
                         {**labels, "outcome": outcome},
                     )
@@ -281,16 +334,12 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "counter",
                 f"Cumulative {token_kind} tokens processed by the model.",
                 int(
-                    cumulative(
-                        f"tokens:{token_kind}",
-                        performance.get(f"{token_kind}_tokens"),
-                    )
+                    cumulative[f"tokens:{token_kind}"]
                 ),
                 labels=labels,
             )
         )
 
-    ttft_buckets = performance.get("ttft_bucket_counts")
     if isinstance(ttft_buckets, dict):
         lines.extend(
             _fmt_metric_family(
@@ -299,7 +348,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "Time to first token, in seconds, by model.",
                 [
                     (
-                        int(cumulative(f"ttft:bucket:{bucket}", count)),
+                        int(cumulative[f"ttft:bucket:{bucket}"]),
                         {**labels, "le": str(bucket)},
                     )
                     for bucket, count in ttft_buckets.items()
@@ -313,9 +362,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         int(
-                            cumulative(
-                                "ttft:count", performance.get("ttft_seconds_count")
-                            )
+                            cumulative["ttft:count"]
                         ),
                         labels,
                     )
@@ -328,9 +375,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         round(
-                            cumulative(
-                                "ttft:sum", performance.get("ttft_seconds_sum")
-                            ),
+                            cumulative["ttft:sum"],
                             6,
                         ),
                         labels,
@@ -339,7 +384,6 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
             )
         )
 
-    decode_buckets = performance.get("decode_bucket_counts")
     if isinstance(decode_buckets, dict):
         lines.extend(
             _fmt_metric_family(
@@ -348,7 +392,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 "Post-first-token decode speed in tokens per second by model.",
                 [
                     (
-                        int(cumulative(f"decode:bucket:{bucket}", count)),
+                        int(cumulative[f"decode:bucket:{bucket}"]),
                         {**labels, "le": str(bucket)},
                     )
                     for bucket, count in decode_buckets.items()
@@ -362,9 +406,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         int(
-                            cumulative(
-                                "decode:count", performance.get("decode_observations")
-                            )
+                            cumulative["decode:count"]
                         ),
                         labels,
                     )
@@ -377,10 +419,7 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 [
                     (
                         round(
-                            cumulative(
-                                "decode:sum",
-                                performance.get("decode_tokens_per_second_sum"),
-                            ),
+                            cumulative["decode:sum"],
                             6,
                         ),
                         labels,

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -120,23 +120,35 @@ class _ModelPerformanceAccumulator:
     def __init__(self) -> None:
         # model -> (active generation, retired baseline, active raw snapshot)
         self._state: dict[
-            str, tuple[int, dict[str, float], dict[str, float]]
+            str,
+            tuple[
+                int, dict[str, float], dict[str, float], dict[str, float]
+            ],
         ] = {}
         self._lock = threading.Lock()
 
     def advance(
-        self, model_name: str, ledger_id: int, raw: dict[str, float]
-    ) -> dict[str, float]:
+        self,
+        model_name: str,
+        ledger_id: int,
+        raw: dict[str, float],
+        maxima: dict[str, float] | None = None,
+    ) -> tuple[dict[str, float], dict[str, float]]:
         normalized = {key: max(0.0, float(value)) for key, value in raw.items()}
+        normalized_maxima = {
+            key: max(0.0, float(value)) for key, value in (maxima or {}).items()
+        }
         with self._lock:
             previous = self._state.get(model_name)
             if previous is None:
                 active_id = ledger_id
                 baseline: dict[str, float] = {}
                 active_raw = normalized
+                process_maxima = normalized_maxima
             else:
-                active_id, baseline, active_raw = previous
+                active_id, baseline, active_raw, process_maxima = previous
                 baseline = dict(baseline)
+                process_maxima = dict(process_maxima)
                 if ledger_id > active_id:
                     # Retire every series from the old scheduler as one atomic
                     # snapshot so a scrape cannot mix ledger generations.
@@ -154,11 +166,19 @@ class _ModelPerformanceAccumulator:
                     }
                 # A lower generation is a delayed scrape from a retired
                 # scheduler. Return the current view without mutating state.
-            self._state[model_name] = (active_id, baseline, active_raw)
-            return {
+                for key, value in normalized_maxima.items():
+                    process_maxima[key] = max(process_maxima.get(key, 0.0), value)
+            self._state[model_name] = (
+                active_id,
+                baseline,
+                active_raw,
+                process_maxima,
+            )
+            cumulative = {
                 key: baseline.get(key, 0.0) + value
                 for key, value in active_raw.items()
             }
+            return cumulative, dict(process_maxima)
 
 
 # Module-level accumulator — one process, one cumulative cache series.
@@ -304,8 +324,13 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
                 for bucket, count in decode_buckets.items()
             }
         )
-    cumulative = _model_performance_accumulator.advance(
-        model_name, ledger_id, raw_counters
+    raw_maxima = {
+        key: _coerce_number(performance[key])
+        for key in ("ttft_seconds_max", "decode_tokens_per_second_max")
+        if performance.get(key) is not None
+    }
+    cumulative, process_maxima = _model_performance_accumulator.advance(
+        model_name, ledger_id, raw_counters, raw_maxima
     )
 
     lines.extend(
@@ -445,7 +470,11 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
             "Most recent terminal request's post-first-token decode speed.",
         ),
     ):
-        value = performance.get(value_key)
+        value = (
+            process_maxima.get(value_key)
+            if value_key in ("ttft_seconds_max", "decode_tokens_per_second_max")
+            else performance.get(value_key)
+        )
         if value is not None:
             lines.extend(
                 _fmt_metric(

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -154,6 +154,26 @@ def _fmt_metric(
     return out
 
 
+def _fmt_metric_family(
+    name: str,
+    metric_type: str,
+    help_text: str,
+    samples: list[tuple[float | int, dict[str, str]]],
+) -> list[str]:
+    """Render one metric family with zero or more samples."""
+    out = [
+        f"# HELP {name} {help_text}",
+        f"# TYPE {name} {metric_type}",
+    ]
+    for value, labels in samples:
+        label_str = ",".join(
+            f'{key}="{_escape_label_value(str(value_))}"'
+            for key, value_ in labels.items()
+        )
+        out.append(f"{name}{{{label_str}}} {value}")
+    return out
+
+
 def _coerce_number(value: Any, default: float = 0.0) -> float:
     """Best-effort numeric coercion — Prometheus samples must be numbers.
 
@@ -189,24 +209,24 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
         )
     requests_total = _coerce_number(reported_total, 0.0)
     lines.extend(
-        _fmt_metric(
+        _fmt_metric_family(
             "rapid_mlx_model_requests_total",
             "counter",
             "Text-engine requests by terminal outcome and model.",
-            requests_total,
-            labels={**labels, "outcome": "total"},
+            [
+                (requests_total, {**labels, "outcome": "total"}),
+                *[
+                    (
+                        int(
+                            _coerce_number(performance.get(f"requests_{outcome}"), 0.0)
+                        ),
+                        {**labels, "outcome": outcome},
+                    )
+                    for outcome in ("succeeded", "cancelled", "failed")
+                ],
+            ],
         )
     )
-    for outcome in ("succeeded", "cancelled", "failed"):
-        lines.extend(
-            _fmt_metric(
-                "rapid_mlx_model_requests_total",
-                "counter",
-                "Text-engine requests by terminal outcome and model.",
-                int(_coerce_number(performance.get(f"requests_{outcome}"), 0.0)),
-                labels={**labels, "outcome": outcome},
-            )
-        )
 
     for token_kind in ("prompt", "completion"):
         lines.extend(
@@ -221,16 +241,17 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
 
     ttft_buckets = performance.get("ttft_bucket_counts")
     if isinstance(ttft_buckets, dict):
-        for bucket, count in ttft_buckets.items():
-            lines.extend(
-                _fmt_metric(
-                    "rapid_mlx_model_ttft_seconds_bucket",
-                    "histogram",
-                    "Time to first token, in seconds, by model.",
-                    int(_coerce_number(count, 0.0)),
-                    labels={**labels, "le": str(bucket)},
-                )
+        lines.extend(
+            _fmt_metric_family(
+                "rapid_mlx_model_ttft_seconds_bucket",
+                "histogram",
+                "Time to first token, in seconds, by model.",
+                [
+                    (int(_coerce_number(count, 0.0)), {**labels, "le": str(bucket)})
+                    for bucket, count in ttft_buckets.items()
+                ],
             )
+        )
         lines.extend(
             _fmt_metric(
                 "rapid_mlx_model_ttft_seconds_count",
@@ -252,16 +273,17 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
 
     decode_buckets = performance.get("decode_bucket_counts")
     if isinstance(decode_buckets, dict):
-        for bucket, count in decode_buckets.items():
-            lines.extend(
-                _fmt_metric(
-                    "rapid_mlx_model_decode_tokens_per_second_bucket",
-                    "histogram",
-                    "Post-first-token decode speed in tokens per second by model.",
-                    int(_coerce_number(count, 0.0)),
-                    labels={**labels, "le": str(bucket)},
-                )
+        lines.extend(
+            _fmt_metric_family(
+                "rapid_mlx_model_decode_tokens_per_second_bucket",
+                "histogram",
+                "Post-first-token decode speed in tokens per second by model.",
+                [
+                    (int(_coerce_number(count, 0.0)), {**labels, "le": str(bucket)})
+                    for bucket, count in decode_buckets.items()
+                ],
             )
+        )
         lines.extend(
             _fmt_metric(
                 "rapid_mlx_model_decode_tokens_per_second_count",

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -374,9 +374,7 @@ def _render_retained_model_performance() -> list[str]:
     """Render every process-owned model ledger as shared metric families."""
     lines: list[str] = []
     for index, snapshot in enumerate(get_model_performance_snapshots()):
-        rendered = _render_model_performance(
-            {"model_performance": snapshot.__dict__}
-        )
+        rendered = _render_model_performance({"model_performance": snapshot.__dict__})
         if index:
             # HELP/TYPE declarations belong to the family, not each label set.
             rendered = [

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -11,9 +11,9 @@ Design choices
   well-specified (https://prometheus.io/docs/instrumenting/exposition_formats/).
   Hand-rolling ~40 LOC avoids pulling in ``prometheus_client`` (and its
   global default registry, which would fight with multi-engine tests).
-- **No new instrumentation sites.** Every metric maps onto a field that
-  ``engine.get_stats()`` already returns — no per-request hot-path cost,
-  no new counters scattered across the engine.
+- **No new runtime dependency.** Request outcome/token/timing series are
+  produced by the scheduler's small in-memory performance ledger and are
+  still exposed through ``engine.get_stats()``.
 - **Unauthenticated**, on ``probe_router`` rather than the auth-gated
   router, to match the standard Prometheus scrape model. Mirrors
   ``/healthz`` exactly.
@@ -169,6 +169,153 @@ def _coerce_number(value: Any, default: float = 0.0) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
+
+
+def _render_model_performance(stats: dict[str, Any]) -> list[str]:
+    """Render model-labelled request outcomes and latency distributions."""
+    performance = stats.get("model_performance")
+    if not isinstance(performance, dict):
+        return []
+
+    model_name = str(performance.get("model_name") or "")
+    labels = {"model": model_name}
+    lines: list[str] = []
+
+    reported_total = performance.get("total_requests")
+    if reported_total is None:
+        reported_total = sum(
+            _coerce_number(performance.get(f"requests_{outcome}"), 0.0)
+            for outcome in ("succeeded", "cancelled", "failed")
+        )
+    requests_total = _coerce_number(reported_total, 0.0)
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_model_requests_total",
+            "counter",
+            "Text-engine requests by terminal outcome and model.",
+            requests_total,
+            labels={**labels, "outcome": "total"},
+        )
+    )
+    for outcome in ("succeeded", "cancelled", "failed"):
+        lines.extend(
+            _fmt_metric(
+                "rapid_mlx_model_requests_total",
+                "counter",
+                "Text-engine requests by terminal outcome and model.",
+                int(_coerce_number(performance.get(f"requests_{outcome}"), 0.0)),
+                labels={**labels, "outcome": outcome},
+            )
+        )
+
+    for token_kind in ("prompt", "completion"):
+        lines.extend(
+            _fmt_metric(
+                f"rapid_mlx_model_{token_kind}_tokens_total",
+                "counter",
+                f"Cumulative {token_kind} tokens processed by the model.",
+                int(_coerce_number(performance.get(f"{token_kind}_tokens"), 0.0)),
+                labels=labels,
+            )
+        )
+
+    ttft_buckets = performance.get("ttft_bucket_counts")
+    if isinstance(ttft_buckets, dict):
+        for bucket, count in ttft_buckets.items():
+            lines.extend(
+                _fmt_metric(
+                    "rapid_mlx_model_ttft_seconds_bucket",
+                    "histogram",
+                    "Time to first token, in seconds, by model.",
+                    int(_coerce_number(count, 0.0)),
+                    labels={**labels, "le": str(bucket)},
+                )
+            )
+        lines.extend(
+            _fmt_metric(
+                "rapid_mlx_model_ttft_seconds_count",
+                "histogram",
+                "Time to first token, in seconds, by model.",
+                int(_coerce_number(performance.get("ttft_seconds_count"), 0.0)),
+                labels=labels,
+            )
+        )
+        lines.extend(
+            _fmt_metric(
+                "rapid_mlx_model_ttft_seconds_sum",
+                "histogram",
+                "Time to first token, in seconds, by model.",
+                round(_coerce_number(performance.get("ttft_seconds_sum"), 0.0), 6),
+                labels=labels,
+            )
+        )
+
+    decode_buckets = performance.get("decode_bucket_counts")
+    if isinstance(decode_buckets, dict):
+        for bucket, count in decode_buckets.items():
+            lines.extend(
+                _fmt_metric(
+                    "rapid_mlx_model_decode_tokens_per_second_bucket",
+                    "histogram",
+                    "Post-first-token decode speed in tokens per second by model.",
+                    int(_coerce_number(count, 0.0)),
+                    labels={**labels, "le": str(bucket)},
+                )
+            )
+        lines.extend(
+            _fmt_metric(
+                "rapid_mlx_model_decode_tokens_per_second_count",
+                "histogram",
+                "Post-first-token decode speed in tokens per second by model.",
+                int(_coerce_number(performance.get("decode_observations"), 0.0)),
+                labels=labels,
+            )
+        )
+        lines.extend(
+            _fmt_metric(
+                "rapid_mlx_model_decode_tokens_per_second_sum",
+                "histogram",
+                "Post-first-token decode speed in tokens per second by model.",
+                round(
+                    _coerce_number(
+                        performance.get("decode_tokens_per_second_sum"), 0.0
+                    ),
+                    6,
+                ),
+                labels=labels,
+            )
+        )
+
+    for metric_name, value_key, help_text in (
+        (
+            "rapid_mlx_model_ttft_seconds_max",
+            "ttft_seconds_max",
+            "Largest observed time to first token, in seconds, since start.",
+        ),
+        (
+            "rapid_mlx_model_decode_tokens_per_second_max",
+            "decode_tokens_per_second_max",
+            "Largest observed post-first-token decode speed since start.",
+        ),
+        (
+            "rapid_mlx_model_decode_tokens_per_second_last",
+            "last_decode_tokens_per_second",
+            "Most recent terminal request's post-first-token decode speed.",
+        ),
+    ):
+        value = performance.get(value_key)
+        if value is not None:
+            lines.extend(
+                _fmt_metric(
+                    metric_name,
+                    "gauge",
+                    help_text,
+                    round(_coerce_number(value), 6),
+                    labels=labels,
+                )
+            )
+
+    return lines
 
 
 def _render_kv_cache_dtype_gauge(cfg: Any) -> list[str]:
@@ -1156,6 +1303,7 @@ def _render_prometheus(cfg: Any) -> str:
         return "\n".join(lines) + "\n"
 
     # ---- Scheduler counters & gauges -----------------------------------
+    lines.extend(_render_model_performance(stats))
     lines.extend(
         _fmt_metric(
             "rapid_mlx_requests_processed_total",

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -159,12 +159,28 @@ def _fmt_metric_family(
     metric_type: str,
     help_text: str,
     samples: list[tuple[float | int, dict[str, str]]],
+    sample_name: str | None = None,
 ) -> list[str]:
     """Render one metric family with zero or more samples."""
     out = [
         f"# HELP {name} {help_text}",
         f"# TYPE {name} {metric_type}",
     ]
+    for value, labels in samples:
+        label_str = ",".join(
+            f'{key}="{_escape_label_value(str(value_))}"'
+            for key, value_ in labels.items()
+        )
+        out.append(f"{sample_name or name}{{{label_str}}} {value}")
+    return out
+
+
+def _fmt_metric_samples(
+    name: str,
+    samples: list[tuple[float | int, dict[str, str]]],
+) -> list[str]:
+    """Render additional samples for an already-declared metric family."""
+    out: list[str] = []
     for value, labels in samples:
         label_str = ",".join(
             f'{key}="{_escape_label_value(str(value_))}"'
@@ -243,31 +259,39 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
     if isinstance(ttft_buckets, dict):
         lines.extend(
             _fmt_metric_family(
-                "rapid_mlx_model_ttft_seconds_bucket",
+                "rapid_mlx_model_ttft_seconds",
                 "histogram",
                 "Time to first token, in seconds, by model.",
                 [
                     (int(_coerce_number(count, 0.0)), {**labels, "le": str(bucket)})
                     for bucket, count in ttft_buckets.items()
                 ],
+                sample_name="rapid_mlx_model_ttft_seconds_bucket",
             )
         )
         lines.extend(
-            _fmt_metric(
+            _fmt_metric_samples(
                 "rapid_mlx_model_ttft_seconds_count",
-                "histogram",
-                "Time to first token, in seconds, by model.",
-                int(_coerce_number(performance.get("ttft_seconds_count"), 0.0)),
-                labels=labels,
+                [
+                    (
+                        int(_coerce_number(performance.get("ttft_seconds_count"), 0.0)),
+                        labels,
+                    )
+                ],
             )
         )
         lines.extend(
-            _fmt_metric(
+            _fmt_metric_samples(
                 "rapid_mlx_model_ttft_seconds_sum",
-                "histogram",
-                "Time to first token, in seconds, by model.",
-                round(_coerce_number(performance.get("ttft_seconds_sum"), 0.0), 6),
-                labels=labels,
+                [
+                    (
+                        round(
+                            _coerce_number(performance.get("ttft_seconds_sum"), 0.0),
+                            6,
+                        ),
+                        labels,
+                    )
+                ],
             )
         )
 
@@ -275,36 +299,43 @@ def _render_model_performance(stats: dict[str, Any]) -> list[str]:
     if isinstance(decode_buckets, dict):
         lines.extend(
             _fmt_metric_family(
-                "rapid_mlx_model_decode_tokens_per_second_bucket",
+                "rapid_mlx_model_decode_tokens_per_second",
                 "histogram",
                 "Post-first-token decode speed in tokens per second by model.",
                 [
                     (int(_coerce_number(count, 0.0)), {**labels, "le": str(bucket)})
                     for bucket, count in decode_buckets.items()
                 ],
+                sample_name="rapid_mlx_model_decode_tokens_per_second_bucket",
             )
         )
         lines.extend(
-            _fmt_metric(
+            _fmt_metric_samples(
                 "rapid_mlx_model_decode_tokens_per_second_count",
-                "histogram",
-                "Post-first-token decode speed in tokens per second by model.",
-                int(_coerce_number(performance.get("decode_observations"), 0.0)),
-                labels=labels,
+                [
+                    (
+                        int(
+                            _coerce_number(performance.get("decode_observations"), 0.0)
+                        ),
+                        labels,
+                    )
+                ],
             )
         )
         lines.extend(
-            _fmt_metric(
+            _fmt_metric_samples(
                 "rapid_mlx_model_decode_tokens_per_second_sum",
-                "histogram",
-                "Post-first-token decode speed in tokens per second by model.",
-                round(
-                    _coerce_number(
-                        performance.get("decode_tokens_per_second_sum"), 0.0
-                    ),
-                    6,
-                ),
-                labels=labels,
+                [
+                    (
+                        round(
+                            _coerce_number(
+                                performance.get("decode_tokens_per_second_sum"), 0.0
+                            ),
+                            6,
+                        ),
+                        labels,
+                    )
+                ],
             )
         )
 

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -8,10 +8,11 @@ decoded after that first token.  This ledger keeps the small amount of additiona
 state needed by :mod:`vllm_mlx.routes.metrics` without changing request
 semantics.
 
-The object is per ``Scheduler`` rather than process-global.  A sidecar serves one
-primary engine at a time; the Prometheus series carry the model label, and the
-later Desktop inspector is responsible for retaining observations across sidecar
-restarts if it wants longer-term history.
+Schedulers obtain their ledger from a process-owned, per-model registry. Model
+reloads therefore retain terminal events even when they occur between Prometheus
+scrapes, while a sidecar process restart starts fresh counters in the standard
+Prometheus fashion. The series carry the model label so operators can separate
+models without coupling metric ownership to a replaceable scheduler instance.
 """
 
 from __future__ import annotations
@@ -62,16 +63,6 @@ DECODE_TOKENS_PER_SECOND_BUCKETS = (
 # enough recent IDs to absorb duplicate terminal/cancellation events.
 SEEN_REQUEST_ID_LIMIT = 65_536
 
-_LEDGER_GENERATION_LOCK = threading.Lock()
-_LEDGER_GENERATION = 0
-
-
-def _next_ledger_generation() -> int:
-    global _LEDGER_GENERATION
-    with _LEDGER_GENERATION_LOCK:
-        _LEDGER_GENERATION += 1
-        return _LEDGER_GENERATION
-
 
 def _empty_bucket_counts(buckets: tuple[float, ...]) -> dict[str, int]:
     """Return zeroed cumulative histogram buckets."""
@@ -107,7 +98,6 @@ class ModelPerformanceSnapshot:
     """An immutable Prometheus-ready view of one model's request outcomes."""
 
     model_name: str
-    ledger_id: int
     requests_succeeded: int
     requests_cancelled: int
     requests_failed: int
@@ -133,11 +123,6 @@ class ModelPerformanceLedger:
 
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name or ""
-        # The exporter uses this process-local identity to distinguish a
-        # freshly loaded scheduler from another ledger for the same model.
-        # Model labels alone cannot reveal a reset when the replacement has
-        # already accumulated as many samples as its predecessor.
-        self._ledger_id = _next_ledger_generation()
         self._lock = threading.Lock()
         self._seen_request_ids: OrderedDict[str | tuple[str, float], None] = (
             OrderedDict()
@@ -313,7 +298,6 @@ class ModelPerformanceLedger:
         with self._lock:
             return ModelPerformanceSnapshot(
                 model_name=self._model_name,
-                ledger_id=self._ledger_id,
                 requests_succeeded=self._requests_succeeded,
                 requests_cancelled=self._requests_cancelled,
                 requests_failed=self._requests_failed,
@@ -383,3 +367,27 @@ class ModelPerformanceLedger:
                 or decode_tokens_per_second > self._decode_tokens_per_second_max
             ):
                 self._decode_tokens_per_second_max = decode_tokens_per_second
+
+
+# Scheduler instances are replaceable; Prometheus counters are not. Keep one
+# process-owned ledger per model so terminal events completed between scrapes
+# survive an unload/reload of that model.
+_MODEL_LEDGER_REGISTRY: dict[str, ModelPerformanceLedger] = {}
+_MODEL_LEDGER_REGISTRY_LOCK = threading.Lock()
+
+
+def get_model_performance_ledger(
+    model_name: str | None = None,
+) -> ModelPerformanceLedger:
+    key = model_name or ""
+    with _MODEL_LEDGER_REGISTRY_LOCK:
+        ledger = _MODEL_LEDGER_REGISTRY.get(key)
+        if ledger is None:
+            ledger = ModelPerformanceLedger(key)
+            _MODEL_LEDGER_REGISTRY[key] = ledger
+        return ledger
+
+
+def _reset_model_performance_registry_for_tests() -> None:
+    with _MODEL_LEDGER_REGISTRY_LOCK:
+        _MODEL_LEDGER_REGISTRY.clear()

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -389,9 +389,9 @@ def get_model_performance_ledger(
 
 
 def get_model_performance_snapshots() -> list[ModelPerformanceSnapshot]:
-    """Return coherent snapshots for every model observed by this process."""
+    """Return deterministic snapshots for every model observed by this process."""
     with _MODEL_LEDGER_REGISTRY_LOCK:
-        ledgers = list(_MODEL_LEDGER_REGISTRY.values())
+        ledgers = [ledger for _, ledger in sorted(_MODEL_LEDGER_REGISTRY.items())]
     return [ledger.snapshot() for ledger in ledgers]
 
 

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -16,9 +16,17 @@ restarts if it wants longer-term history.
 
 from __future__ import annotations
 
+import logging
 import math
 import threading
+import time
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from vllm_mlx.request import Request
 
 # Prometheus histograms need fixed buckets.  These cover the local-model
 # operating range without making every bucket width a UI policy: TTFT spans
@@ -127,6 +135,46 @@ class ModelPerformanceLedger:
         self._decode_tokens_per_second_sum = 0.0
         self._decode_tokens_per_second_max: float | None = None
         self._last_decode_tokens_per_second: float | None = None
+
+    def decode_rate_for_request(self, request: Request) -> float | None:
+        """Return inverse-TPOT decode speed, or None when not measurable."""
+        if request.first_token_time is None or request.num_output_tokens < 2:
+            return None
+        decode_seconds = time.time() - request.first_token_time
+        if decode_seconds <= 0:
+            return None
+        return (request.num_output_tokens - 1) / decode_seconds
+
+    def ttft_for_request(self, request: Request) -> float | None:
+        if request.first_token_time is None or request.num_output_tokens == 0:
+            return None
+        return max(0.0, request.first_token_time - request.arrival_time)
+
+    def record_finished_performance(self, request: Request) -> None:
+        """Best-effort performance accounting for a terminal response."""
+        try:
+            self.record_success(
+                request.request_id,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                ttft_seconds=self.ttft_for_request(request),
+                decode_tokens_per_second=self.decode_rate_for_request(request),
+            )
+        except Exception:
+            logger.debug("Failed to record performance for %s", request.request_id)
+
+    def record_cancelled_performance(self, request: Request) -> None:
+        """Best-effort performance accounting for an aborted request."""
+        try:
+            self.record_cancelled(
+                request.request_id,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                ttft_seconds=self.ttft_for_request(request),
+                decode_tokens_per_second=self.decode_rate_for_request(request),
+            )
+        except Exception:
+            logger.debug("Failed to record cancellation for %s", request.request_id)
 
     @property
     def model_name(self) -> str:

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -75,7 +75,6 @@ def _bucket_count(
         label = "+Inf" if math.isinf(bucket) else _format_bucket(bucket)
         if value <= bucket:
             counts[label] += 1
-    return counts
 
 
 def _format_bucket(value: float) -> str:

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -122,28 +122,44 @@ class ModelPerformanceSnapshot:
 class ModelPerformanceLedger:
     """Thread-safe, process-lifetime performance observations for one model."""
 
-    def __init__(self, model_name: str | None = None):
+    def __init__(
+        self,
+        model_name: str | None = None,
+        baseline: ModelPerformanceSnapshot | None = None,
+    ):
         self._model_name = model_name or ""
         self._lock = threading.Lock()
         self._seen_request_ids: OrderedDict[str | tuple[str, float], None] = (
             OrderedDict()
         )
-        self._requests_succeeded = 0
-        self._requests_cancelled = 0
-        self._requests_failed = 0
-        self._prompt_tokens = 0
-        self._completion_tokens = 0
-        self._ttft_bucket_counts = _empty_bucket_counts(TTFT_SECONDS_BUCKETS)
-        self._ttft_observations = 0
-        self._ttft_seconds_sum = 0.0
-        self._ttft_seconds_max: float | None = None
-        self._decode_bucket_counts = _empty_bucket_counts(
-            DECODE_TOKENS_PER_SECOND_BUCKETS
+        self._requests_succeeded = baseline.requests_succeeded if baseline else 0
+        self._requests_cancelled = baseline.requests_cancelled if baseline else 0
+        self._requests_failed = baseline.requests_failed if baseline else 0
+        self._prompt_tokens = baseline.prompt_tokens if baseline else 0
+        self._completion_tokens = baseline.completion_tokens if baseline else 0
+        self._ttft_bucket_counts = (
+            dict(baseline.ttft_bucket_counts)
+            if baseline
+            else _empty_bucket_counts(TTFT_SECONDS_BUCKETS)
         )
-        self._decode_observations = 0
-        self._decode_tokens_per_second_sum = 0.0
-        self._decode_tokens_per_second_max: float | None = None
-        self._last_decode_tokens_per_second: float | None = None
+        self._ttft_observations = baseline.ttft_seconds_count if baseline else 0
+        self._ttft_seconds_sum = baseline.ttft_seconds_sum if baseline else 0.0
+        self._ttft_seconds_max = baseline.ttft_seconds_max if baseline else None
+        self._decode_bucket_counts = (
+            dict(baseline.decode_bucket_counts)
+            if baseline
+            else _empty_bucket_counts(DECODE_TOKENS_PER_SECOND_BUCKETS)
+        )
+        self._decode_observations = baseline.decode_observations if baseline else 0
+        self._decode_tokens_per_second_sum = (
+            baseline.decode_tokens_per_second_sum if baseline else 0.0
+        )
+        self._decode_tokens_per_second_max = (
+            baseline.decode_tokens_per_second_max if baseline else None
+        )
+        self._last_decode_tokens_per_second = (
+            baseline.last_decode_tokens_per_second if baseline else None
+        )
 
     def decode_rate_for_request(self, request: Request) -> float | None:
         """Return inverse-TPOT decode speed, or None when not measurable."""
@@ -403,6 +419,7 @@ class ModelPerformanceLedger:
 # process-owned ledger per model so terminal events completed between scrapes
 # survive an unload/reload of that model.
 _MODEL_LEDGER_REGISTRY: OrderedDict[str, ModelPerformanceLedger] = OrderedDict()
+_RETIRED_MODEL_SNAPSHOTS: dict[str, ModelPerformanceSnapshot] = {}
 _MODEL_LEDGER_REGISTRY_LOCK = threading.Lock()
 
 
@@ -413,10 +430,13 @@ def get_model_performance_ledger(
     with _MODEL_LEDGER_REGISTRY_LOCK:
         ledger = _MODEL_LEDGER_REGISTRY.get(key)
         if ledger is None:
-            ledger = ModelPerformanceLedger(key)
+            ledger = ModelPerformanceLedger(
+                key, baseline=_RETIRED_MODEL_SNAPSHOTS.pop(key, None)
+            )
             _MODEL_LEDGER_REGISTRY[key] = ledger
             if len(_MODEL_LEDGER_REGISTRY) > MODEL_LEDGER_REGISTRY_LIMIT:
-                _MODEL_LEDGER_REGISTRY.popitem(last=False)
+                retired_key, retired_ledger = _MODEL_LEDGER_REGISTRY.popitem(last=False)
+                _RETIRED_MODEL_SNAPSHOTS[retired_key] = retired_ledger.snapshot()
         else:
             _MODEL_LEDGER_REGISTRY.move_to_end(key)
         return ledger
@@ -425,10 +445,13 @@ def get_model_performance_ledger(
 def get_model_performance_snapshots() -> list[ModelPerformanceSnapshot]:
     """Return deterministic snapshots for every model observed by this process."""
     with _MODEL_LEDGER_REGISTRY_LOCK:
+        retired = dict(_RETIRED_MODEL_SNAPSHOTS)
         ledgers = [ledger for _, ledger in sorted(_MODEL_LEDGER_REGISTRY.items())]
-    return [ledger.snapshot() for ledger in ledgers]
+    active = [ledger.snapshot() for ledger in ledgers]
+    return [*sorted(retired.values(), key=lambda item: item.model_name), *active]
 
 
 def _reset_model_performance_registry_for_tests() -> None:
     with _MODEL_LEDGER_REGISTRY_LOCK:
         _MODEL_LEDGER_REGISTRY.clear()
+        _RETIRED_MODEL_SNAPSHOTS.clear()

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -20,6 +20,7 @@ import logging
 import math
 import threading
 import time
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -56,6 +57,10 @@ DECODE_TOKENS_PER_SECOND_BUCKETS = (
     500.0,
     math.inf,
 )
+
+# Keep duplicate-delivery dedupe bounded for 24/7 servers while retaining
+# enough recent IDs to absorb duplicate terminal/cancellation events.
+SEEN_REQUEST_ID_LIMIT = 65_536
 
 
 def _empty_bucket_counts(buckets: tuple[float, ...]) -> dict[str, int]:
@@ -118,7 +123,7 @@ class ModelPerformanceLedger:
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name or ""
         self._lock = threading.Lock()
-        self._seen_request_ids: set[str] = set()
+        self._seen_request_ids: OrderedDict[str, None] = OrderedDict()
         self._requests_succeeded = 0
         self._requests_cancelled = 0
         self._requests_failed = 0
@@ -192,11 +197,14 @@ class ModelPerformanceLedger:
         """Record a completed request; return False when already accounted."""
         with self._lock:
             if request_id in self._seen_request_ids:
+                self._seen_request_ids.move_to_end(request_id)
                 return False
-            self._seen_request_ids.add(request_id)
+            prompt_tokens = max(0, int(prompt_tokens))
+            completion_tokens = max(0, int(completion_tokens))
+            self._remember_request_id(request_id)
             self._requests_succeeded += 1
-            self._prompt_tokens += max(0, int(prompt_tokens))
-            self._completion_tokens += max(0, int(completion_tokens))
+            self._prompt_tokens += prompt_tokens
+            self._completion_tokens += completion_tokens
             self._observe_timings(
                 ttft_seconds=ttft_seconds,
                 decode_tokens_per_second=decode_tokens_per_second,
@@ -215,11 +223,14 @@ class ModelPerformanceLedger:
         """Record an explicitly cancelled request exactly once."""
         with self._lock:
             if request_id in self._seen_request_ids:
+                self._seen_request_ids.move_to_end(request_id)
                 return False
-            self._seen_request_ids.add(request_id)
+            prompt_tokens = max(0, int(prompt_tokens))
+            completion_tokens = max(0, int(completion_tokens))
+            self._remember_request_id(request_id)
             self._requests_cancelled += 1
-            self._prompt_tokens += max(0, int(prompt_tokens))
-            self._completion_tokens += max(0, int(completion_tokens))
+            self._prompt_tokens += prompt_tokens
+            self._completion_tokens += completion_tokens
             self._observe_timings(
                 ttft_seconds=ttft_seconds,
                 decode_tokens_per_second=decode_tokens_per_second,
@@ -230,8 +241,9 @@ class ModelPerformanceLedger:
         """Record an engine/runtime failure exactly once."""
         with self._lock:
             if request_id in self._seen_request_ids:
+                self._seen_request_ids.move_to_end(request_id)
                 return False
-            self._seen_request_ids.add(request_id)
+            self._remember_request_id(request_id)
             self._requests_failed += 1
             return True
 
@@ -255,6 +267,12 @@ class ModelPerformanceLedger:
                 decode_tokens_per_second_max=self._decode_tokens_per_second_max,
                 last_decode_tokens_per_second=self._last_decode_tokens_per_second,
             )
+
+    def _remember_request_id(self, request_id: str) -> None:
+        """Store a terminal request ID under a bounded memory limit."""
+        self._seen_request_ids[request_id] = None
+        if len(self._seen_request_ids) > SEEN_REQUEST_ID_LIMIT:
+            self._seen_request_ids.popitem(last=False)
 
     def _observe_timings(
         self,

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -21,6 +21,7 @@ import logging
 import math
 import threading
 import time
+import weakref
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -63,6 +64,7 @@ DECODE_TOKENS_PER_SECOND_BUCKETS = (
 # enough recent IDs to absorb duplicate terminal/cancellation events.
 SEEN_REQUEST_ID_LIMIT = 65_536
 MODEL_LEDGER_REGISTRY_LIMIT = 128
+RETIRED_MODEL_SNAPSHOT_LIMIT = 128
 
 
 def _empty_bucket_counts(buckets: tuple[float, ...]) -> dict[str, int]:
@@ -244,7 +246,8 @@ class ModelPerformanceLedger:
                 ttft_seconds=ttft_seconds,
                 decode_tokens_per_second=decode_tokens_per_second,
             )
-            return True
+        _touch_model_performance_ledger(self)
+        return True
 
     def record_success(
         self,
@@ -419,8 +422,38 @@ class ModelPerformanceLedger:
 # process-owned ledger per model so terminal events completed between scrapes
 # survive an unload/reload of that model.
 _MODEL_LEDGER_REGISTRY: OrderedDict[str, ModelPerformanceLedger] = OrderedDict()
-_RETIRED_MODEL_SNAPSHOTS: dict[str, ModelPerformanceSnapshot] = {}
+_RETIRED_MODEL_SNAPSHOTS: OrderedDict[
+    str,
+    tuple[
+        ModelPerformanceSnapshot,
+        weakref.ReferenceType[ModelPerformanceLedger],
+    ],
+] = OrderedDict()
 _MODEL_LEDGER_REGISTRY_LOCK = threading.Lock()
+
+
+def _retire_oldest_model_ledger_locked() -> None:
+    if len(_MODEL_LEDGER_REGISTRY) <= MODEL_LEDGER_REGISTRY_LIMIT:
+        return
+    key, ledger = _MODEL_LEDGER_REGISTRY.popitem(last=False)
+    _RETIRED_MODEL_SNAPSHOTS[key] = (ledger.snapshot(), weakref.ref(ledger))
+    _RETIRED_MODEL_SNAPSHOTS.move_to_end(key)
+    if len(_RETIRED_MODEL_SNAPSHOTS) > RETIRED_MODEL_SNAPSHOT_LIMIT:
+        _RETIRED_MODEL_SNAPSHOTS.popitem(last=False)
+
+
+def _touch_model_performance_ledger(ledger: ModelPerformanceLedger) -> None:
+    """Make a writing ledger visible, including after an LRU retirement."""
+    key = ledger.model_name
+    with _MODEL_LEDGER_REGISTRY_LOCK:
+        current = _MODEL_LEDGER_REGISTRY.get(key)
+        if current is ledger:
+            _MODEL_LEDGER_REGISTRY.move_to_end(key)
+            return
+        _RETIRED_MODEL_SNAPSHOTS.pop(key, None)
+        _MODEL_LEDGER_REGISTRY[key] = ledger
+        _MODEL_LEDGER_REGISTRY.move_to_end(key)
+        _retire_oldest_model_ledger_locked()
 
 
 def get_model_performance_ledger(
@@ -430,13 +463,13 @@ def get_model_performance_ledger(
     with _MODEL_LEDGER_REGISTRY_LOCK:
         ledger = _MODEL_LEDGER_REGISTRY.get(key)
         if ledger is None:
-            ledger = ModelPerformanceLedger(
-                key, baseline=_RETIRED_MODEL_SNAPSHOTS.pop(key, None)
+            retired = _RETIRED_MODEL_SNAPSHOTS.pop(key, None)
+            retained_ledger = retired[1]() if retired is not None else None
+            ledger = retained_ledger or ModelPerformanceLedger(
+                key, baseline=retired[0] if retired is not None else None
             )
             _MODEL_LEDGER_REGISTRY[key] = ledger
-            if len(_MODEL_LEDGER_REGISTRY) > MODEL_LEDGER_REGISTRY_LIMIT:
-                retired_key, retired_ledger = _MODEL_LEDGER_REGISTRY.popitem(last=False)
-                _RETIRED_MODEL_SNAPSHOTS[retired_key] = retired_ledger.snapshot()
+            _retire_oldest_model_ledger_locked()
         else:
             _MODEL_LEDGER_REGISTRY.move_to_end(key)
         return ledger
@@ -445,10 +478,10 @@ def get_model_performance_ledger(
 def get_model_performance_snapshots() -> list[ModelPerformanceSnapshot]:
     """Return deterministic snapshots for every model observed by this process."""
     with _MODEL_LEDGER_REGISTRY_LOCK:
-        retired = dict(_RETIRED_MODEL_SNAPSHOTS)
+        retired = [entry[0] for entry in _RETIRED_MODEL_SNAPSHOTS.values()]
         ledgers = [ledger for _, ledger in sorted(_MODEL_LEDGER_REGISTRY.items())]
     active = [ledger.snapshot() for ledger in ledgers]
-    return [*sorted(retired.values(), key=lambda item: item.model_name), *active]
+    return [*sorted(retired, key=lambda item: item.model_name), *active]
 
 
 def _reset_model_performance_registry_for_tests() -> None:

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -69,8 +69,6 @@ def _bucket_count(
     buckets: tuple[float, ...],
 ) -> None:
     """Add one finite, non-negative value to cumulative histogram buckets."""
-    if not math.isfinite(value) or value < 0:
-        return
     for bucket in buckets:
         label = "+Inf" if math.isinf(bucket) else _format_bucket(bucket)
         if value <= bucket:

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -62,6 +62,7 @@ DECODE_TOKENS_PER_SECOND_BUCKETS = (
 # Keep duplicate-delivery dedupe bounded for 24/7 servers while retaining
 # enough recent IDs to absorb duplicate terminal/cancellation events.
 SEEN_REQUEST_ID_LIMIT = 65_536
+MODEL_LEDGER_REGISTRY_LIMIT = 128
 
 
 def _empty_bucket_counts(buckets: tuple[float, ...]) -> dict[str, int]:
@@ -169,13 +170,11 @@ class ModelPerformanceLedger:
     def record_finished_performance(self, request: Request) -> None:
         """Best-effort performance accounting for a terminal response."""
         try:
-            self.record_success(
-                request.request_id,
-                prompt_tokens=self.prompt_tokens_for_request(request),
-                completion_tokens=request.num_output_tokens,
+            self.record_request_performance(
+                request,
+                "succeeded",
                 ttft_seconds=self.ttft_for_request(request),
                 decode_tokens_per_second=self.decode_rate_for_request(request),
-                request_lifetime=request.arrival_time,
             )
         except Exception:
             logger.debug("Failed to record performance for %s", request.request_id)
@@ -183,13 +182,11 @@ class ModelPerformanceLedger:
     def record_cancelled_performance(self, request: Request) -> None:
         """Best-effort performance accounting for an aborted request."""
         try:
-            self.record_cancelled(
-                request.request_id,
-                prompt_tokens=self.prompt_tokens_for_request(request),
-                completion_tokens=request.num_output_tokens,
+            self.record_request_performance(
+                request,
+                "cancelled",
                 ttft_seconds=self.ttft_for_request(request),
                 decode_tokens_per_second=self.decode_rate_for_request(request),
-                request_lifetime=request.arrival_time,
             )
         except Exception:
             logger.debug("Failed to record cancellation for %s", request.request_id)
@@ -197,6 +194,38 @@ class ModelPerformanceLedger:
     @property
     def model_name(self) -> str:
         return self._model_name
+
+    def record_request_performance(
+        self,
+        request: Any,
+        outcome: str,
+        *,
+        ttft_seconds: float | None = None,
+        decode_tokens_per_second: float | None = None,
+    ) -> bool:
+        """Atomically account one request object exactly once for its lifetime."""
+        with self._lock:
+            if getattr(request, "_performance_recorded", False):
+                return False
+            request._performance_recorded = True
+            prompt_tokens = max(0, self.prompt_tokens_for_request(request))
+            completion_tokens = max(0, int(request.num_output_tokens))
+            if outcome == "succeeded":
+                self._requests_succeeded += 1
+            elif outcome == "cancelled":
+                self._requests_cancelled += 1
+            elif outcome == "failed":
+                self._requests_failed += 1
+            else:
+                request._performance_recorded = False
+                raise ValueError(f"unsupported terminal outcome: {outcome}")
+            self._prompt_tokens += prompt_tokens
+            self._completion_tokens += completion_tokens
+            self._observe_timings(
+                ttft_seconds=ttft_seconds,
+                decode_tokens_per_second=decode_tokens_per_second,
+            )
+            return True
 
     def record_success(
         self,
@@ -284,13 +313,11 @@ class ModelPerformanceLedger:
 
     def record_failed_performance(self, request: Request) -> bool:
         """Record one failed request lifetime, even when its ID is later reused."""
-        return self.record_failure(
-            request.request_id,
-            prompt_tokens=self.prompt_tokens_for_request(request),
-            completion_tokens=request.num_output_tokens,
+        return self.record_request_performance(
+            request,
+            "failed",
             ttft_seconds=self.ttft_for_request(request),
             decode_tokens_per_second=self.decode_rate_for_request(request),
-            request_lifetime=request.arrival_time,
         )
 
     def snapshot(self) -> ModelPerformanceSnapshot:
@@ -372,7 +399,7 @@ class ModelPerformanceLedger:
 # Scheduler instances are replaceable; Prometheus counters are not. Keep one
 # process-owned ledger per model so terminal events completed between scrapes
 # survive an unload/reload of that model.
-_MODEL_LEDGER_REGISTRY: dict[str, ModelPerformanceLedger] = {}
+_MODEL_LEDGER_REGISTRY: OrderedDict[str, ModelPerformanceLedger] = OrderedDict()
 _MODEL_LEDGER_REGISTRY_LOCK = threading.Lock()
 
 
@@ -385,6 +412,10 @@ def get_model_performance_ledger(
         if ledger is None:
             ledger = ModelPerformanceLedger(key)
             _MODEL_LEDGER_REGISTRY[key] = ledger
+            if len(_MODEL_LEDGER_REGISTRY) > MODEL_LEDGER_REGISTRY_LIMIT:
+                _MODEL_LEDGER_REGISTRY.popitem(last=False)
+        else:
+            _MODEL_LEDGER_REGISTRY.move_to_end(key)
         return ledger
 
 

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-model request performance counters for the text scheduler.
+
+The scheduler already records process-lifetime token and cancellation counters,
+but those aggregates are not enough for a per-model inspector: they cannot say
+which requests failed, how long the first token took, or how fast a request
+decoded after that first token.  This ledger keeps the small amount of additional
+state needed by :mod:`vllm_mlx.routes.metrics` without changing request
+semantics.
+
+The object is per ``Scheduler`` rather than process-global.  A sidecar serves one
+primary engine at a time; the Prometheus series carry the model label, and the
+later Desktop inspector is responsible for retaining observations across sidecar
+restarts if it wants longer-term history.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from dataclasses import dataclass
+
+# Prometheus histograms need fixed buckets.  These cover the local-model
+# operating range without making every bucket width a UI policy: TTFT spans
+# warm-cache requests through long cold prefills, and decode speed spans tiny
+# dense models through large MoE deployments.
+TTFT_SECONDS_BUCKETS = (
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.0,
+    5.0,
+    10.0,
+    30.0,
+    math.inf,
+)
+
+DECODE_TOKENS_PER_SECOND_BUCKETS = (
+    1.0,
+    5.0,
+    10.0,
+    20.0,
+    50.0,
+    100.0,
+    200.0,
+    500.0,
+    math.inf,
+)
+
+
+def _empty_bucket_counts(buckets: tuple[float, ...]) -> dict[str, int]:
+    """Return zeroed cumulative histogram buckets."""
+    counts = dict.fromkeys(
+        (
+            "+Inf" if math.isinf(bucket) else _format_bucket(bucket)
+            for bucket in buckets
+        ),
+        0,
+    )
+
+    return counts
+
+
+def _bucket_count(
+    counts: dict[str, int],
+    value: float,
+    buckets: tuple[float, ...],
+) -> None:
+    """Add one finite, non-negative value to cumulative histogram buckets."""
+    if not math.isfinite(value) or value < 0:
+        return
+    for bucket in buckets:
+        label = "+Inf" if math.isinf(bucket) else _format_bucket(bucket)
+        if value <= bucket:
+            counts[label] += 1
+    return counts
+
+
+def _format_bucket(value: float) -> str:
+    return f"{value:g}"
+
+
+@dataclass(frozen=True)
+class ModelPerformanceSnapshot:
+    """An immutable Prometheus-ready view of one model's request outcomes."""
+
+    model_name: str
+    requests_succeeded: int
+    requests_cancelled: int
+    requests_failed: int
+    prompt_tokens: int
+    completion_tokens: int
+    ttft_bucket_counts: dict[str, int]
+    ttft_seconds_count: int
+    ttft_seconds_sum: float
+    ttft_seconds_max: float | None
+    decode_bucket_counts: dict[str, int]
+    decode_observations: int
+    decode_tokens_per_second_sum: float
+    decode_tokens_per_second_max: float | None
+    last_decode_tokens_per_second: float | None
+
+    @property
+    def total_requests(self) -> int:
+        return self.requests_succeeded + self.requests_cancelled + self.requests_failed
+
+
+class ModelPerformanceLedger:
+    """Thread-safe, process-lifetime performance observations for one model."""
+
+    def __init__(self, model_name: str | None = None):
+        self._model_name = model_name or ""
+        self._lock = threading.Lock()
+        self._seen_request_ids: set[str] = set()
+        self._requests_succeeded = 0
+        self._requests_cancelled = 0
+        self._requests_failed = 0
+        self._prompt_tokens = 0
+        self._completion_tokens = 0
+        self._ttft_bucket_counts = _empty_bucket_counts(TTFT_SECONDS_BUCKETS)
+        self._ttft_observations = 0
+        self._ttft_seconds_sum = 0.0
+        self._ttft_seconds_max: float | None = None
+        self._decode_bucket_counts = _empty_bucket_counts(
+            DECODE_TOKENS_PER_SECOND_BUCKETS
+        )
+        self._decode_observations = 0
+        self._decode_tokens_per_second_sum = 0.0
+        self._decode_tokens_per_second_max: float | None = None
+        self._last_decode_tokens_per_second: float | None = None
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    def record_success(
+        self,
+        request_id: str,
+        *,
+        prompt_tokens: int,
+        completion_tokens: int,
+        ttft_seconds: float | None,
+        decode_tokens_per_second: float | None,
+    ) -> bool:
+        """Record a completed request; return False when already accounted."""
+        with self._lock:
+            if request_id in self._seen_request_ids:
+                return False
+            self._seen_request_ids.add(request_id)
+            self._requests_succeeded += 1
+            self._prompt_tokens += max(0, int(prompt_tokens))
+            self._completion_tokens += max(0, int(completion_tokens))
+            self._observe_timings(
+                ttft_seconds=ttft_seconds,
+                decode_tokens_per_second=decode_tokens_per_second,
+            )
+            return True
+
+    def record_cancelled(
+        self,
+        request_id: str,
+        *,
+        prompt_tokens: int,
+        completion_tokens: int,
+        ttft_seconds: float | None,
+        decode_tokens_per_second: float | None,
+    ) -> bool:
+        """Record an explicitly cancelled request exactly once."""
+        with self._lock:
+            if request_id in self._seen_request_ids:
+                return False
+            self._seen_request_ids.add(request_id)
+            self._requests_cancelled += 1
+            self._prompt_tokens += max(0, int(prompt_tokens))
+            self._completion_tokens += max(0, int(completion_tokens))
+            self._observe_timings(
+                ttft_seconds=ttft_seconds,
+                decode_tokens_per_second=decode_tokens_per_second,
+            )
+            return True
+
+    def record_failure(self, request_id: str) -> bool:
+        """Record an engine/runtime failure exactly once."""
+        with self._lock:
+            if request_id in self._seen_request_ids:
+                return False
+            self._seen_request_ids.add(request_id)
+            self._requests_failed += 1
+            return True
+
+    def snapshot(self) -> ModelPerformanceSnapshot:
+        """Return a coherent copy of the counters."""
+        with self._lock:
+            return ModelPerformanceSnapshot(
+                model_name=self._model_name,
+                requests_succeeded=self._requests_succeeded,
+                requests_cancelled=self._requests_cancelled,
+                requests_failed=self._requests_failed,
+                prompt_tokens=self._prompt_tokens,
+                completion_tokens=self._completion_tokens,
+                ttft_bucket_counts=dict(self._ttft_bucket_counts),
+                ttft_seconds_count=self._ttft_observations,
+                ttft_seconds_sum=self._ttft_seconds_sum,
+                ttft_seconds_max=self._ttft_seconds_max,
+                decode_bucket_counts=dict(self._decode_bucket_counts),
+                decode_observations=self._decode_observations,
+                decode_tokens_per_second_sum=self._decode_tokens_per_second_sum,
+                decode_tokens_per_second_max=self._decode_tokens_per_second_max,
+                last_decode_tokens_per_second=self._last_decode_tokens_per_second,
+            )
+
+    def _observe_timings(
+        self,
+        *,
+        ttft_seconds: float | None,
+        decode_tokens_per_second: float | None,
+    ) -> None:
+        if (
+            ttft_seconds is not None
+            and math.isfinite(ttft_seconds)
+            and ttft_seconds >= 0
+        ):
+            _bucket_count(
+                self._ttft_bucket_counts,
+                ttft_seconds,
+                TTFT_SECONDS_BUCKETS,
+            )
+            self._ttft_observations += 1
+            self._ttft_seconds_sum += ttft_seconds
+            if self._ttft_seconds_max is None or ttft_seconds > self._ttft_seconds_max:
+                self._ttft_seconds_max = ttft_seconds
+
+        if (
+            decode_tokens_per_second is not None
+            and math.isfinite(decode_tokens_per_second)
+            and decode_tokens_per_second >= 0
+        ):
+            _bucket_count(
+                self._decode_bucket_counts,
+                decode_tokens_per_second,
+                DECODE_TOKENS_PER_SECOND_BUCKETS,
+            )
+            self._decode_observations += 1
+            self._decode_tokens_per_second_sum += decode_tokens_per_second
+            self._last_decode_tokens_per_second = decode_tokens_per_second
+            if (
+                self._decode_tokens_per_second_max is None
+                or decode_tokens_per_second > self._decode_tokens_per_second_max
+            ):
+                self._decode_tokens_per_second_max = decode_tokens_per_second

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -388,6 +388,13 @@ def get_model_performance_ledger(
         return ledger
 
 
+def get_model_performance_snapshots() -> list[ModelPerformanceSnapshot]:
+    """Return coherent snapshots for every model observed by this process."""
+    with _MODEL_LEDGER_REGISTRY_LOCK:
+        ledgers = list(_MODEL_LEDGER_REGISTRY.values())
+    return [ledger.snapshot() for ledger in ledgers]
+
+
 def _reset_model_performance_registry_for_tests() -> None:
     with _MODEL_LEDGER_REGISTRY_LOCK:
         _MODEL_LEDGER_REGISTRY.clear()

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -246,7 +246,14 @@ class ModelPerformanceLedger:
             return True
 
     def record_failure(
-        self, request_id: str, *, request_lifetime: float | None = None
+        self,
+        request_id: str,
+        *,
+        prompt_tokens: int = 0,
+        completion_tokens: int = 0,
+        ttft_seconds: float | None = None,
+        decode_tokens_per_second: float | None = None,
+        request_lifetime: float | None = None,
     ) -> bool:
         """Record an engine/runtime failure exactly once."""
         with self._lock:
@@ -254,14 +261,26 @@ class ModelPerformanceLedger:
             if request_key in self._seen_request_ids:
                 self._seen_request_ids.move_to_end(request_key)
                 return False
+            prompt_tokens = max(0, int(prompt_tokens))
+            completion_tokens = max(0, int(completion_tokens))
             self._remember_request_id(request_key)
             self._requests_failed += 1
+            self._prompt_tokens += prompt_tokens
+            self._completion_tokens += completion_tokens
+            self._observe_timings(
+                ttft_seconds=ttft_seconds,
+                decode_tokens_per_second=decode_tokens_per_second,
+            )
             return True
 
     def record_failed_performance(self, request: Request) -> bool:
         """Record one failed request lifetime, even when its ID is later reused."""
         return self.record_failure(
             request.request_id,
+            prompt_tokens=request.num_prompt_tokens,
+            completion_tokens=request.num_output_tokens,
+            ttft_seconds=self.ttft_for_request(request),
+            decode_tokens_per_second=self.decode_rate_for_request(request),
             request_lifetime=request.arrival_time,
         )
 

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -22,7 +22,7 @@ import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger(__name__)
 
@@ -157,12 +157,20 @@ class ModelPerformanceLedger:
             return None
         return max(0.0, request.first_token_time - request.arrival_time)
 
+    @staticmethod
+    def prompt_tokens_for_request(request: Any) -> int:
+        """Return prompt work attributable to the model for this lifetime."""
+        status = getattr(request, "status", None)
+        if getattr(status, "name", None) == "WAITING":
+            return 0
+        return int(request.num_prompt_tokens)
+
     def record_finished_performance(self, request: Request) -> None:
         """Best-effort performance accounting for a terminal response."""
         try:
             self.record_success(
                 request.request_id,
-                prompt_tokens=request.num_prompt_tokens,
+                prompt_tokens=self.prompt_tokens_for_request(request),
                 completion_tokens=request.num_output_tokens,
                 ttft_seconds=self.ttft_for_request(request),
                 decode_tokens_per_second=self.decode_rate_for_request(request),
@@ -176,7 +184,7 @@ class ModelPerformanceLedger:
         try:
             self.record_cancelled(
                 request.request_id,
-                prompt_tokens=request.num_prompt_tokens,
+                prompt_tokens=self.prompt_tokens_for_request(request),
                 completion_tokens=request.num_output_tokens,
                 ttft_seconds=self.ttft_for_request(request),
                 decode_tokens_per_second=self.decode_rate_for_request(request),
@@ -277,7 +285,7 @@ class ModelPerformanceLedger:
         """Record one failed request lifetime, even when its ID is later reused."""
         return self.record_failure(
             request.request_id,
-            prompt_tokens=request.num_prompt_tokens,
+            prompt_tokens=self.prompt_tokens_for_request(request),
             completion_tokens=request.num_output_tokens,
             ttft_seconds=self.ttft_for_request(request),
             decode_tokens_per_second=self.decode_rate_for_request(request),

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -20,7 +20,6 @@ import logging
 import math
 import threading
 import time
-import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -63,6 +62,16 @@ DECODE_TOKENS_PER_SECOND_BUCKETS = (
 # enough recent IDs to absorb duplicate terminal/cancellation events.
 SEEN_REQUEST_ID_LIMIT = 65_536
 
+_LEDGER_GENERATION_LOCK = threading.Lock()
+_LEDGER_GENERATION = 0
+
+
+def _next_ledger_generation() -> int:
+    global _LEDGER_GENERATION
+    with _LEDGER_GENERATION_LOCK:
+        _LEDGER_GENERATION += 1
+        return _LEDGER_GENERATION
+
 
 def _empty_bucket_counts(buckets: tuple[float, ...]) -> dict[str, int]:
     """Return zeroed cumulative histogram buckets."""
@@ -98,7 +107,7 @@ class ModelPerformanceSnapshot:
     """An immutable Prometheus-ready view of one model's request outcomes."""
 
     model_name: str
-    ledger_id: str
+    ledger_id: int
     requests_succeeded: int
     requests_cancelled: int
     requests_failed: int
@@ -128,7 +137,7 @@ class ModelPerformanceLedger:
         # freshly loaded scheduler from another ledger for the same model.
         # Model labels alone cannot reveal a reset when the replacement has
         # already accumulated as many samples as its predecessor.
-        self._ledger_id = uuid.uuid4().hex
+        self._ledger_id = _next_ledger_generation()
         self._lock = threading.Lock()
         self._seen_request_ids: OrderedDict[str | tuple[str, float], None] = (
             OrderedDict()

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -20,6 +20,7 @@ import logging
 import math
 import threading
 import time
+import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -97,6 +98,7 @@ class ModelPerformanceSnapshot:
     """An immutable Prometheus-ready view of one model's request outcomes."""
 
     model_name: str
+    ledger_id: str
     requests_succeeded: int
     requests_cancelled: int
     requests_failed: int
@@ -122,6 +124,11 @@ class ModelPerformanceLedger:
 
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name or ""
+        # The exporter uses this process-local identity to distinguish a
+        # freshly loaded scheduler from another ledger for the same model.
+        # Model labels alone cannot reveal a reset when the replacement has
+        # already accumulated as many samples as its predecessor.
+        self._ledger_id = uuid.uuid4().hex
         self._lock = threading.Lock()
         self._seen_request_ids: OrderedDict[str | tuple[str, float], None] = (
             OrderedDict()
@@ -297,6 +304,7 @@ class ModelPerformanceLedger:
         with self._lock:
             return ModelPerformanceSnapshot(
                 model_name=self._model_name,
+                ledger_id=self._ledger_id,
                 requests_succeeded=self._requests_succeeded,
                 requests_cancelled=self._requests_cancelled,
                 requests_failed=self._requests_failed,

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -123,7 +123,9 @@ class ModelPerformanceLedger:
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name or ""
         self._lock = threading.Lock()
-        self._seen_request_ids: OrderedDict[str, None] = OrderedDict()
+        self._seen_request_ids: OrderedDict[str | tuple[str, float], None] = (
+            OrderedDict()
+        )
         self._requests_succeeded = 0
         self._requests_cancelled = 0
         self._requests_failed = 0
@@ -164,6 +166,7 @@ class ModelPerformanceLedger:
                 completion_tokens=request.num_output_tokens,
                 ttft_seconds=self.ttft_for_request(request),
                 decode_tokens_per_second=self.decode_rate_for_request(request),
+                request_lifetime=request.arrival_time,
             )
         except Exception:
             logger.debug("Failed to record performance for %s", request.request_id)
@@ -177,6 +180,7 @@ class ModelPerformanceLedger:
                 completion_tokens=request.num_output_tokens,
                 ttft_seconds=self.ttft_for_request(request),
                 decode_tokens_per_second=self.decode_rate_for_request(request),
+                request_lifetime=request.arrival_time,
             )
         except Exception:
             logger.debug("Failed to record cancellation for %s", request.request_id)
@@ -193,15 +197,17 @@ class ModelPerformanceLedger:
         completion_tokens: int,
         ttft_seconds: float | None,
         decode_tokens_per_second: float | None,
+        request_lifetime: float | None = None,
     ) -> bool:
         """Record a completed request; return False when already accounted."""
         with self._lock:
-            if request_id in self._seen_request_ids:
-                self._seen_request_ids.move_to_end(request_id)
+            request_key = self._request_key(request_id, request_lifetime)
+            if request_key in self._seen_request_ids:
+                self._seen_request_ids.move_to_end(request_key)
                 return False
             prompt_tokens = max(0, int(prompt_tokens))
             completion_tokens = max(0, int(completion_tokens))
-            self._remember_request_id(request_id)
+            self._remember_request_id(request_key)
             self._requests_succeeded += 1
             self._prompt_tokens += prompt_tokens
             self._completion_tokens += completion_tokens
@@ -219,15 +225,17 @@ class ModelPerformanceLedger:
         completion_tokens: int,
         ttft_seconds: float | None,
         decode_tokens_per_second: float | None,
+        request_lifetime: float | None = None,
     ) -> bool:
         """Record an explicitly cancelled request exactly once."""
         with self._lock:
-            if request_id in self._seen_request_ids:
-                self._seen_request_ids.move_to_end(request_id)
+            request_key = self._request_key(request_id, request_lifetime)
+            if request_key in self._seen_request_ids:
+                self._seen_request_ids.move_to_end(request_key)
                 return False
             prompt_tokens = max(0, int(prompt_tokens))
             completion_tokens = max(0, int(completion_tokens))
-            self._remember_request_id(request_id)
+            self._remember_request_id(request_key)
             self._requests_cancelled += 1
             self._prompt_tokens += prompt_tokens
             self._completion_tokens += completion_tokens
@@ -237,15 +245,25 @@ class ModelPerformanceLedger:
             )
             return True
 
-    def record_failure(self, request_id: str) -> bool:
+    def record_failure(
+        self, request_id: str, *, request_lifetime: float | None = None
+    ) -> bool:
         """Record an engine/runtime failure exactly once."""
         with self._lock:
-            if request_id in self._seen_request_ids:
-                self._seen_request_ids.move_to_end(request_id)
+            request_key = self._request_key(request_id, request_lifetime)
+            if request_key in self._seen_request_ids:
+                self._seen_request_ids.move_to_end(request_key)
                 return False
-            self._remember_request_id(request_id)
+            self._remember_request_id(request_key)
             self._requests_failed += 1
             return True
+
+    def record_failed_performance(self, request: Request) -> bool:
+        """Record one failed request lifetime, even when its ID is later reused."""
+        return self.record_failure(
+            request.request_id,
+            request_lifetime=request.arrival_time,
+        )
 
     def snapshot(self) -> ModelPerformanceSnapshot:
         """Return a coherent copy of the counters."""
@@ -268,7 +286,15 @@ class ModelPerformanceLedger:
                 last_decode_tokens_per_second=self._last_decode_tokens_per_second,
             )
 
-    def _remember_request_id(self, request_id: str) -> None:
+    @staticmethod
+    def _request_key(
+        request_id: str, request_lifetime: float | None
+    ) -> str | tuple[str, float]:
+        return (
+            request_id if request_lifetime is None else (request_id, request_lifetime)
+        )
+
+    def _remember_request_id(self, request_id: str | tuple[str, float]) -> None:
         """Store a terminal request ID under a bounded memory limit."""
         self._seen_request_ids[request_id] = None
         if len(self._seen_request_ids) > SEEN_REQUEST_ID_LIMIT:

--- a/vllm_mlx/runtime/model_performance.py
+++ b/vllm_mlx/runtime/model_performance.py
@@ -165,6 +165,9 @@ class ModelPerformanceLedger:
         status = getattr(request, "status", None)
         if getattr(status, "name", None) == "WAITING":
             return 0
+        model_prompt_tokens = int(getattr(request, "model_prompt_tokens", 0) or 0)
+        if model_prompt_tokens > 0:
+            return model_prompt_tokens
         return int(request.num_prompt_tokens)
 
     def record_finished_performance(self, request: Request) -> None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -131,6 +131,7 @@ from .repetition_guard import (
     detect_repeated_token_suffix,
 )
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
+from .runtime.model_performance import ModelPerformanceLedger
 from .utils.decode import IncrementalDecoder
 from .utils.mamba_cache import ensure_mamba_support
 
@@ -3515,6 +3516,9 @@ class Scheduler:
         self.config = config or SchedulerConfig()
         self._tool_logits_processor_factory = tool_logits_processor_factory
         self.model_config = model_config
+        self.performance = ModelPerformanceLedger(
+            model_name=getattr(self.config, "model_name", None)
+        )
         if os.environ.get("RAPID_DUMP_SCHED_CONFIG"):
             import dataclasses as _dc
 
@@ -7315,6 +7319,7 @@ class Scheduler:
             self.total_prompt_tokens += request.num_prompt_tokens
 
         if request is not None:
+            self._record_cancelled_performance(request)
             request.set_finished(RequestStatus.FINISHED_CANCELLED)
             # Release cache references so Metal buffers can be freed
             request.prompt_cache = None
@@ -8245,6 +8250,7 @@ class Scheduler:
 
                 self.total_completion_tokens += request.num_output_tokens
                 self.num_requests_processed += 1
+                self._record_finished_performance(request)
 
                 logger.debug(
                     f"Request {request_id} finished: {response.finish_reason}, "
@@ -8256,6 +8262,46 @@ class Scheduler:
         if prompt_tps_this_batch > 0:
             self._last_prompt_tps = prompt_tps_this_batch
         return outputs, finished_ids
+
+    def _decode_rate_for_request(self, request: Request) -> float | None:
+        """Return inverse-TPOT decode speed, or None when not measurable."""
+        if request.first_token_time is None or request.num_output_tokens < 2:
+            return None
+        decode_seconds = time.time() - request.first_token_time
+        if decode_seconds <= 0:
+            return None
+        return (request.num_output_tokens - 1) / decode_seconds
+
+    def _ttft_for_request(self, request: Request) -> float | None:
+        if request.first_token_time is None or request.num_output_tokens == 0:
+            return None
+        return max(0.0, request.first_token_time - request.arrival_time)
+
+    def _record_finished_performance(self, request: Request) -> None:
+        """Best-effort performance accounting for a terminal response."""
+        try:
+            self.performance.record_success(
+                request.request_id,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                ttft_seconds=self._ttft_for_request(request),
+                decode_tokens_per_second=self._decode_rate_for_request(request),
+            )
+        except Exception:
+            logger.debug("Failed to record performance for %s", request.request_id)
+
+    def _record_cancelled_performance(self, request: Request) -> None:
+        """Best-effort performance accounting for an aborted request."""
+        try:
+            self.performance.record_cancelled(
+                request.request_id,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                ttft_seconds=self._ttft_for_request(request),
+                decode_tokens_per_second=self._decode_rate_for_request(request),
+            )
+        except Exception:
+            logger.debug("Failed to record cancellation for %s", request.request_id)
 
     def _safe_disk_checkpoint(self, request: Request, response: Any) -> None:
         """Wrap ``_maybe_disk_checkpoint`` in a never-raise contract.
@@ -9183,6 +9229,7 @@ class Scheduler:
             "num_requests_cancelled_via_disconnect": (
                 self.num_requests_cancelled_via_disconnect
             ),
+            "model_performance": self.performance.snapshot().__dict__,
             # D-METAL-CAP / D-METAL-PFX observability — pre-fix, both
             # were silent: the cap was violated with no warning and the
             # prefix cache pinned slabs through one 32k prefill that

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -8638,6 +8638,7 @@ class Scheduler:
         for request_id in list(self.running):
             request = self.running.get(request_id)
             if request is not None:
+                self.performance.record_failed_performance(request)
                 request.set_finished(RequestStatus.FINISHED_ABORTED)
             aborted_ids.add(request_id)
             self.finished_req_ids.add(request_id)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -8290,19 +8290,6 @@ class Scheduler:
         except Exception:
             logger.debug("Failed to record performance for %s", request.request_id)
 
-    def _record_cancelled_performance(self, request: Request) -> None:
-        """Best-effort performance accounting for an aborted request."""
-        try:
-            self.performance.record_cancelled(
-                request.request_id,
-                prompt_tokens=request.num_prompt_tokens,
-                completion_tokens=request.num_output_tokens,
-                ttft_seconds=self._ttft_for_request(request),
-                decode_tokens_per_second=self._decode_rate_for_request(request),
-            )
-        except Exception:
-            logger.debug("Failed to record cancellation for %s", request.request_id)
-
     def _safe_disk_checkpoint(self, request: Request, response: Any) -> None:
         """Wrap ``_maybe_disk_checkpoint`` in a never-raise contract.
 
@@ -8464,6 +8451,19 @@ class Scheduler:
             except Exception:  # pragma: no cover — defensive of the defensive
                 pass
             logger.warning("[kv_checkpoint] enforce_disk_cap failed: %r", _evict_err)
+
+    def _record_cancelled_performance(self, request: Request) -> None:
+        """Best-effort performance accounting for an aborted request."""
+        try:
+            self.performance.record_cancelled(
+                request.request_id,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                ttft_seconds=self._ttft_for_request(request),
+                decode_tokens_per_second=self._decode_rate_for_request(request),
+            )
+        except Exception:
+            logger.debug("Failed to record cancellation for %s", request.request_id)
 
     def _cleanup_finished(self, finished_ids: set[str]) -> None:
         """Clean up finished requests and store caches for reuse."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7319,7 +7319,7 @@ class Scheduler:
             self.total_prompt_tokens += request.num_prompt_tokens
 
         if request is not None:
-            self._record_cancelled_performance(request)
+            self.performance.record_cancelled_performance(request)
             request.set_finished(RequestStatus.FINISHED_CANCELLED)
             # Release cache references so Metal buffers can be freed
             request.prompt_cache = None
@@ -8250,7 +8250,7 @@ class Scheduler:
 
                 self.total_completion_tokens += request.num_output_tokens
                 self.num_requests_processed += 1
-                self._record_finished_performance(request)
+                self.performance.record_finished_performance(request)
 
                 logger.debug(
                     f"Request {request_id} finished: {response.finish_reason}, "
@@ -9405,43 +9405,3 @@ class Scheduler:
             )
         logger.info("[cache_persist] no memory-aware cache to load into")
         return 0
-
-    def _record_cancelled_performance(self, request: Request) -> None:
-        """Best-effort performance accounting for an aborted request."""
-        try:
-            self.performance.record_cancelled(
-                request.request_id,
-                prompt_tokens=request.num_prompt_tokens,
-                completion_tokens=request.num_output_tokens,
-                ttft_seconds=self._ttft_for_request(request),
-                decode_tokens_per_second=self._decode_rate_for_request(request),
-            )
-        except Exception:
-            logger.debug("Failed to record cancellation for %s", request.request_id)
-
-    def _decode_rate_for_request(self, request: Request) -> float | None:
-        """Return inverse-TPOT decode speed, or None when not measurable."""
-        if request.first_token_time is None or request.num_output_tokens < 2:
-            return None
-        decode_seconds = time.time() - request.first_token_time
-        if decode_seconds <= 0:
-            return None
-        return (request.num_output_tokens - 1) / decode_seconds
-
-    def _ttft_for_request(self, request: Request) -> float | None:
-        if request.first_token_time is None or request.num_output_tokens == 0:
-            return None
-        return max(0.0, request.first_token_time - request.arrival_time)
-
-    def _record_finished_performance(self, request: Request) -> None:
-        """Best-effort performance accounting for a terminal response."""
-        try:
-            self.performance.record_success(
-                request.request_id,
-                prompt_tokens=request.num_prompt_tokens,
-                completion_tokens=request.num_output_tokens,
-                ttft_seconds=self._ttft_for_request(request),
-                decode_tokens_per_second=self._decode_rate_for_request(request),
-            )
-        except Exception:
-            logger.debug("Failed to record performance for %s", request.request_id)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7917,6 +7917,7 @@ class Scheduler:
         """
         outputs = []
         finished_ids = set()
+        terminal_performance_requests: list[Request] = []
         prompt_tps_this_batch = 0.0
 
         for response in responses:
@@ -8261,7 +8262,7 @@ class Scheduler:
 
                 self.total_completion_tokens += request.num_output_tokens
                 self.num_requests_processed += 1
-                self.performance.record_finished_performance(request)
+                terminal_performance_requests.append(request)
 
                 logger.debug(
                     f"Request {request_id} finished: {response.finish_reason}, "
@@ -8272,6 +8273,12 @@ class Scheduler:
 
         if prompt_tps_this_batch > 0:
             self._last_prompt_tps = prompt_tps_this_batch
+        # Commit observability outcomes only after every response in the step
+        # has processed successfully. If a later response raises, EngineCore
+        # converts all pending clients to failures; recording an earlier
+        # success here would make lifetime deduplication reject that outcome.
+        for request in terminal_performance_requests:
+            self.performance.record_finished_performance(request)
         return outputs, finished_ids
 
     def _safe_disk_checkpoint(self, request: Request, response: Any) -> None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -8263,33 +8263,6 @@ class Scheduler:
             self._last_prompt_tps = prompt_tps_this_batch
         return outputs, finished_ids
 
-    def _decode_rate_for_request(self, request: Request) -> float | None:
-        """Return inverse-TPOT decode speed, or None when not measurable."""
-        if request.first_token_time is None or request.num_output_tokens < 2:
-            return None
-        decode_seconds = time.time() - request.first_token_time
-        if decode_seconds <= 0:
-            return None
-        return (request.num_output_tokens - 1) / decode_seconds
-
-    def _ttft_for_request(self, request: Request) -> float | None:
-        if request.first_token_time is None or request.num_output_tokens == 0:
-            return None
-        return max(0.0, request.first_token_time - request.arrival_time)
-
-    def _record_finished_performance(self, request: Request) -> None:
-        """Best-effort performance accounting for a terminal response."""
-        try:
-            self.performance.record_success(
-                request.request_id,
-                prompt_tokens=request.num_prompt_tokens,
-                completion_tokens=request.num_output_tokens,
-                ttft_seconds=self._ttft_for_request(request),
-                decode_tokens_per_second=self._decode_rate_for_request(request),
-            )
-        except Exception:
-            logger.debug("Failed to record performance for %s", request.request_id)
-
     def _safe_disk_checkpoint(self, request: Request, response: Any) -> None:
         """Wrap ``_maybe_disk_checkpoint`` in a never-raise contract.
 
@@ -8464,6 +8437,33 @@ class Scheduler:
             )
         except Exception:
             logger.debug("Failed to record cancellation for %s", request.request_id)
+
+    def _decode_rate_for_request(self, request: Request) -> float | None:
+        """Return inverse-TPOT decode speed, or None when not measurable."""
+        if request.first_token_time is None or request.num_output_tokens < 2:
+            return None
+        decode_seconds = time.time() - request.first_token_time
+        if decode_seconds <= 0:
+            return None
+        return (request.num_output_tokens - 1) / decode_seconds
+
+    def _ttft_for_request(self, request: Request) -> float | None:
+        if request.first_token_time is None or request.num_output_tokens == 0:
+            return None
+        return max(0.0, request.first_token_time - request.arrival_time)
+
+    def _record_finished_performance(self, request: Request) -> None:
+        """Best-effort performance accounting for a terminal response."""
+        try:
+            self.performance.record_success(
+                request.request_id,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                ttft_seconds=self._ttft_for_request(request),
+                decode_tokens_per_second=self._decode_rate_for_request(request),
+            )
+        except Exception:
+            logger.debug("Failed to record performance for %s", request.request_id)
 
     def _cleanup_finished(self, finished_ids: set[str]) -> None:
         """Clean up finished requests and store caches for reuse."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -8425,46 +8425,6 @@ class Scheduler:
                 pass
             logger.warning("[kv_checkpoint] enforce_disk_cap failed: %r", _evict_err)
 
-    def _record_cancelled_performance(self, request: Request) -> None:
-        """Best-effort performance accounting for an aborted request."""
-        try:
-            self.performance.record_cancelled(
-                request.request_id,
-                prompt_tokens=request.num_prompt_tokens,
-                completion_tokens=request.num_output_tokens,
-                ttft_seconds=self._ttft_for_request(request),
-                decode_tokens_per_second=self._decode_rate_for_request(request),
-            )
-        except Exception:
-            logger.debug("Failed to record cancellation for %s", request.request_id)
-
-    def _decode_rate_for_request(self, request: Request) -> float | None:
-        """Return inverse-TPOT decode speed, or None when not measurable."""
-        if request.first_token_time is None or request.num_output_tokens < 2:
-            return None
-        decode_seconds = time.time() - request.first_token_time
-        if decode_seconds <= 0:
-            return None
-        return (request.num_output_tokens - 1) / decode_seconds
-
-    def _ttft_for_request(self, request: Request) -> float | None:
-        if request.first_token_time is None or request.num_output_tokens == 0:
-            return None
-        return max(0.0, request.first_token_time - request.arrival_time)
-
-    def _record_finished_performance(self, request: Request) -> None:
-        """Best-effort performance accounting for a terminal response."""
-        try:
-            self.performance.record_success(
-                request.request_id,
-                prompt_tokens=request.num_prompt_tokens,
-                completion_tokens=request.num_output_tokens,
-                ttft_seconds=self._ttft_for_request(request),
-                decode_tokens_per_second=self._decode_rate_for_request(request),
-            )
-        except Exception:
-            logger.debug("Failed to record performance for %s", request.request_id)
-
     def _cleanup_finished(self, finished_ids: set[str]) -> None:
         """Clean up finished requests and store caches for reuse."""
         for request_id in finished_ids:
@@ -9445,3 +9405,43 @@ class Scheduler:
             )
         logger.info("[cache_persist] no memory-aware cache to load into")
         return 0
+
+    def _record_cancelled_performance(self, request: Request) -> None:
+        """Best-effort performance accounting for an aborted request."""
+        try:
+            self.performance.record_cancelled(
+                request.request_id,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                ttft_seconds=self._ttft_for_request(request),
+                decode_tokens_per_second=self._decode_rate_for_request(request),
+            )
+        except Exception:
+            logger.debug("Failed to record cancellation for %s", request.request_id)
+
+    def _decode_rate_for_request(self, request: Request) -> float | None:
+        """Return inverse-TPOT decode speed, or None when not measurable."""
+        if request.first_token_time is None or request.num_output_tokens < 2:
+            return None
+        decode_seconds = time.time() - request.first_token_time
+        if decode_seconds <= 0:
+            return None
+        return (request.num_output_tokens - 1) / decode_seconds
+
+    def _ttft_for_request(self, request: Request) -> float | None:
+        if request.first_token_time is None or request.num_output_tokens == 0:
+            return None
+        return max(0.0, request.first_token_time - request.arrival_time)
+
+    def _record_finished_performance(self, request: Request) -> None:
+        """Best-effort performance accounting for a terminal response."""
+        try:
+            self.performance.record_success(
+                request.request_id,
+                prompt_tokens=request.num_prompt_tokens,
+                completion_tokens=request.num_output_tokens,
+                ttft_seconds=self._ttft_for_request(request),
+                decode_tokens_per_second=self._decode_rate_for_request(request),
+            )
+        except Exception:
+            logger.debug("Failed to record performance for %s", request.request_id)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -131,7 +131,7 @@ from .repetition_guard import (
     detect_repeated_token_suffix,
 )
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
-from .runtime.model_performance import ModelPerformanceLedger
+from .runtime.model_performance import get_model_performance_ledger
 from .utils.decode import IncrementalDecoder
 from .utils.mamba_cache import ensure_mamba_support
 
@@ -3516,7 +3516,7 @@ class Scheduler:
         self.config = config or SchedulerConfig()
         self._tool_logits_processor_factory = tool_logits_processor_factory
         self.model_config = model_config
-        self.performance = ModelPerformanceLedger(
+        self.performance = get_model_performance_ledger(
             model_name=getattr(self.config, "model_name", None)
         )
         if os.environ.get("RAPID_DUMP_SCHED_CONFIG"):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -7251,9 +7251,17 @@ class Scheduler:
                 and request_id not in self.requests
             ):
                 return False
-            return self._do_abort_request_impl(request_id)
+            return self._do_abort_request_impl(
+                request_id,
+                orphan_request=expected_orphan,
+            )
 
-    def _do_abort_request_impl(self, request_id: str) -> bool:
+    def _do_abort_request_impl(
+        self,
+        request_id: str,
+        *,
+        orphan_request: Request | None = None,
+    ) -> bool:
         """
         Actually abort a request. Must be called from the executor thread.
 
@@ -7267,7 +7275,10 @@ class Scheduler:
         Returns:
             True if any cleanup was performed, False otherwise
         """
-        request = self.requests.get(request_id)
+        # Engine cleanup deliberately removes the canonical request before the
+        # orphan reconciler reaps its still-running batch slot. Preserve that
+        # exact, identity-validated lifetime for cancellation accounting.
+        request = orphan_request or self.requests.get(request_id)
         was_waiting = False
         was_running = False
         removed_from_batch = False


### PR DESCRIPTION
## Summary
- Add process-lifetime scheduler accounting for terminal request outcomes, prompt/completion tokens, TTFT, and post-first-token decode speed.
- Expose model-labelled Prometheus series through the existing `/metrics` endpoint.
- Record successful, cancelled, and engine-failed requests exactly once without adding request hot-path dependencies.

## Scope
- Server-side metrics and scheduler accounting only.
- No Desktop UI, metrics persistence, or historical dashboards in this PR.
- Preserve all existing global metric names and values.

## Test Plan
- Added ledger, scheduler, engine-loop, and Prometheus rendering regression tests.
- Focused: `pytest -q tests/test_model_performance_metrics.py tests/test_metrics_route.py tests/test_cancelled_requests_metric.py tests/test_metal_error_recovery.py` — 72 passed.
- Repository checks: `make lint`, `make audit`.
- Full unit suite (same selectors as repository unit tier): 20,313 passed, 107 skipped, 229 deselected, 6 xfailed. Two pre-existing Codex/agent setup failures also fail on the unmodified base.

## Compatibility
- New series are additive and use the existing process-local engine stats path.
- Histogram buckets are fixed and stored cumulatively to avoid unbounded sample retention on 24/7 servers.