### PR TITLE
[codex] Add lightweight desktop update discovery card

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -174,6 +174,20 @@ struct ContentView: View {
             && handedOffVersion != releaseVersion
     }
 
+    /// Record the visual ownership transfer only after Sparkle accepts the
+    /// foreground check. Its KVO state can change after SwiftUI renders an
+    /// enabled button but before the action executes.
+    @discardableResult
+    static func handOffUpdate(
+        version: String,
+        start: () -> Bool,
+        onAccepted: (String) -> Void
+    ) -> Bool {
+        guard start() else { return false }
+        onAccepted(version)
+        return true
+    }
+
     private var presentedUpdateRelease: UpdateChecker.Release? {
         guard let release = updater.availableUpdate else { return nil }
         let releaseURL = Self.missingOverlayDownloadURL(for: release)
@@ -236,10 +250,10 @@ struct ContentView: View {
                     sparkleCanCheck: sparkleUpdater.canCheckForUpdates,
                     releaseURL: Self.missingOverlayDownloadURL(for: release),
                     onUpdate: {
-                        // Hide first so the visual ownership transfer is
-                        // atomic even when Sparkle presents synchronously.
-                        updateHandedOffVersion = release.version
-                        sparkleUpdater.checkForUpdates()
+                        Self.handOffUpdate(
+                            version: release.version,
+                            start: sparkleUpdater.checkForUpdates
+                        ) { updateHandedOffVersion = $0 }
                     },
                     onDismiss: {
                         dismissedUpdateVersion = release.version

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -62,6 +62,10 @@ struct ContentView: View {
     /// Defaults key backing the log drawer's visibility. Shared with the View
     /// menu command in ``RapidApp`` so both toggles drive one flag.
     static let showLogsKey = "Rapid.showLogs"
+    /// Version-scoped dismissal for the lightweight update discovery card.
+    /// A dismissed release stays quiet, while the next release is eligible
+    /// without requiring the user to reset a global preference.
+    static let dismissedUpdateVersionKey = "Rapid.dismissedUpdateVersion"
 
     // There is deliberately no detail-pane height floor here. The detail is a
     // scrolling surface with no natural vertical minimum; the only vertical
@@ -103,6 +107,12 @@ struct ContentView: View {
     // restoration data. With a single main window the persistence scope is
     // the same in practice.
     @AppStorage(ContentView.showLogsKey) private var showLogs: Bool = false
+    @AppStorage(ContentView.dismissedUpdateVersionKey) private var dismissedUpdateVersion = ""
+    /// Session-only hand-off guard. Pressing Update transfers UI ownership to
+    /// Sparkle's standard panel; keeping our card visible beside it would look
+    /// like two independent updaters. Unlike dismissal, this is intentionally
+    /// not persisted: if Sparkle is cancelled, a relaunch may offer it again.
+    @State private var updateHandedOffVersion: String?
     @State private var showCommandPalette = false
     /// Per-session "browse all models" dismissal of the Quickstart card.
     @State private var quickstartDismissedThisSession: Bool = false
@@ -145,6 +155,39 @@ struct ContentView: View {
     /// retry without turning session restoration into a polling loop.
     @State private var catalogRestoreRetryAttempted = false
 
+    /// Phase-one presentation policy. Discovery is intentionally quiet while
+    /// onboarding or a window-level command surface owns attention. The
+    /// release remains eligible and appears as soon as that surface closes.
+    /// Dismissal is version-scoped; Sparkle hand-off is session-scoped.
+    static func shouldPresentUpdateCard(
+        releaseVersion: String?,
+        dismissedVersion: String,
+        handedOffVersion: String?,
+        onboardingVisible: Bool,
+        blockingOverlayVisible: Bool,
+        hasAction: Bool
+    ) -> Bool {
+        guard let releaseVersion, hasAction else { return false }
+        return !onboardingVisible
+            && !blockingOverlayVisible
+            && dismissedVersion != releaseVersion
+            && handedOffVersion != releaseVersion
+    }
+
+    private var presentedUpdateRelease: UpdateChecker.Release? {
+        guard let release = updater.availableUpdate else { return nil }
+        let releaseURL = Self.missingOverlayDownloadURL(for: release)
+        guard Self.shouldPresentUpdateCard(
+            releaseVersion: release.version,
+            dismissedVersion: dismissedUpdateVersion,
+            handedOffVersion: updateHandedOffVersion,
+            onboardingVisible: quickstartVisible,
+            blockingOverlayVisible: showConversationSearch || showCommandPalette,
+            hasAction: sparkleUpdater.isEnabled || releaseURL != nil
+        ) else { return nil }
+        return release
+    }
+
     var body: some View {
         // Capture the identity owned by this alert render. A delayed dismiss
         // callback must not cancel a newer warning that has reached the queue
@@ -185,6 +228,30 @@ struct ContentView: View {
                 commandPaletteOverlay
             }
         }
+        .overlay(alignment: .bottomTrailing) {
+            if let release = presentedUpdateRelease {
+                UpdateDiscoveryCard(
+                    release: release,
+                    sparkleEnabled: sparkleUpdater.isEnabled,
+                    sparkleCanCheck: sparkleUpdater.canCheckForUpdates,
+                    releaseURL: Self.missingOverlayDownloadURL(for: release),
+                    onUpdate: {
+                        // Hide first so the visual ownership transfer is
+                        // atomic even when Sparkle presents synchronously.
+                        updateHandedOffVersion = release.version
+                        sparkleUpdater.checkForUpdates()
+                    },
+                    onDismiss: {
+                        dismissedUpdateVersion = release.version
+                    }
+                )
+                .padding(16)
+            }
+        }
+        .animation(
+            reduceMotion ? nil : .easeOut(duration: 0.15),
+            value: presentedUpdateRelease?.version
+        )
         .onChange(of: commandPaletteRequest.requestID) { _, requestID in
             showCommandPaletteFromRequest(requestID)
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/UpdateDiscoveryCard.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/UpdateDiscoveryCard.swift
@@ -13,6 +13,17 @@ struct UpdateDiscoveryCard: View {
     let onUpdate: () -> Void
     let onDismiss: () -> Void
 
+    @discardableResult
+    static func openManualDownload(
+        _ url: URL,
+        using opener: (URL) -> Bool,
+        onOpened: () -> Void
+    ) -> Bool {
+        guard opener(url) else { return false }
+        onOpened()
+        return true
+    }
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
@@ -73,8 +84,11 @@ struct UpdateDiscoveryCard: View {
                 .accessibilityIdentifier("UpdateCard.Update")
             } else if let releaseURL {
                 Button {
-                    NSWorkspace.shared.open(releaseURL)
-                    onDismiss()
+                    Self.openManualDownload(
+                        releaseURL,
+                        using: NSWorkspace.shared.open,
+                        onOpened: onDismiss
+                    )
                 } label: {
                     Label("Download from release page", systemImage: "arrow.up.right.square")
                         .frame(maxWidth: .infinity)

--- a/apps/rapid-mac/Sources/Rapid/UI/UpdateDiscoveryCard.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/UpdateDiscoveryCard.swift
@@ -1,0 +1,100 @@
+import AppKit
+import SwiftUI
+
+/// Lightweight discovery surface for an update already resolved by
+/// ``UpdateChecker``. Phase one deliberately stops at the hand-off boundary:
+/// Sparkle's standard user driver remains the sole owner of download,
+/// verification, installation, and all UI after the primary action is pressed.
+struct UpdateDiscoveryCard: View {
+    let release: UpdateChecker.Release
+    let sparkleEnabled: Bool
+    let sparkleCanCheck: Bool
+    let releaseURL: URL?
+    let onUpdate: () -> Void
+    let onDismiss: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+            HStack(alignment: .top, spacing: RapidTheme.Space.sm) {
+                VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                    Text("Update Available")
+                        .font(RapidFont.bodyEmphasis)
+                        .foregroundStyle(RapidTheme.textPrimary)
+                    Text("Rapid-MLX v\(release.version) is ready.")
+                        .font(RapidFont.body)
+                        .foregroundStyle(RapidTheme.textPrimary)
+                }
+
+                Spacer(minLength: RapidTheme.Space.sm)
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .frame(width: 28, height: 28)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
+                .help("Dismiss this update")
+                .accessibilityLabel("Dismiss update v\(release.version)")
+                .accessibilityIdentifier("UpdateCard.Dismiss")
+                .padding(.top, -8)
+                .padding(.trailing, -8)
+            }
+
+            Text("Download in the background. Restarting to install will stop active generations and local API sessions.")
+                .font(RapidFont.caption)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let releaseURL {
+                Link("View release notes", destination: releaseURL)
+                    .font(RapidFont.caption)
+                    .accessibilityIdentifier("UpdateCard.ReleaseNotes")
+            }
+
+            if sparkleEnabled {
+                Button(action: onUpdate) {
+                    HStack(spacing: RapidTheme.Space.sm) {
+                        if !sparkleCanCheck {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(sparkleCanCheck ? "Update Rapid-MLX" : "Update in progress…")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.rapidPrimary)
+                .disabled(!sparkleCanCheck)
+                .accessibilityIdentifier("UpdateCard.Update")
+            } else if let releaseURL {
+                Button {
+                    NSWorkspace.shared.open(releaseURL)
+                    onDismiss()
+                } label: {
+                    Label("Download from release page", systemImage: "arrow.up.right.square")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.rapidPrimary)
+                .accessibilityIdentifier("UpdateCard.ManualDownload")
+            }
+        }
+        .padding(RapidTheme.Space.lg)
+        .frame(width: 360, alignment: .leading)
+        .background(RapidTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RapidTheme.cardRadius, style: .continuous)
+                .strokeBorder(RapidTheme.hairline, lineWidth: 1)
+        }
+        .shadow(color: Color.black.opacity(0.14), radius: 18, y: 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Rapid-MLX update v\(release.version) available")
+        .accessibilityIdentifier("UpdateCard")
+        .transition(reduceMotion ? .opacity : .move(edge: .trailing).combined(with: .opacity))
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Updater/SparkleUpdateController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/SparkleUpdateController.swift
@@ -83,11 +83,13 @@ final class SparkleUpdateController {
     /// Foreground check used by menu and Settings commands. The standard
     /// Sparkle UI reports current/update/error states and, when an update was
     /// already downloaded in the background, offers the install action.
-    func checkForUpdates() {
-        guard isEnabled else { return }
+    @discardableResult
+    func checkForUpdates() -> Bool {
+        guard isEnabled else { return false }
         if !isStarted { start() }
-        guard canCheckForUpdates else { return }
-        standardController?.checkForUpdates(nil)
+        guard canCheckForUpdates, let standardController else { return false }
+        standardController.checkForUpdates(nil)
+        return true
     }
 
     func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {

--- a/apps/rapid-mac/Sources/Rapid/Updater/SparkleUpdateController.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/SparkleUpdateController.swift
@@ -83,12 +83,36 @@ final class SparkleUpdateController {
     /// Foreground check used by menu and Settings commands. The standard
     /// Sparkle UI reports current/update/error states and, when an update was
     /// already downloaded in the background, offers the install action.
+    ///
+    /// The observable mirror is presentation state and may trail Sparkle's
+    /// KVO value by one main-actor hop. Re-read the updater synchronously at
+    /// dispatch time so a stale enabled button cannot hide the discovery card
+    /// after Sparkle has already become unable to accept the action.
     @discardableResult
     func checkForUpdates() -> Bool {
         guard isEnabled else { return false }
         if !isStarted { start() }
-        guard canCheckForUpdates, let standardController else { return false }
-        standardController.checkForUpdates(nil)
+        guard let updater = standardController?.updater else { return false }
+        return Self.dispatchForegroundCheck(
+            authoritativeCanCheck: { updater.canCheckForUpdates },
+            synchronizeMirror: { canCheckForUpdates = $0 },
+            perform: { updater.checkForUpdates() }
+        )
+    }
+
+    /// Keep the authoritative read and foreground dispatch in one synchronous
+    /// main-actor turn. Sparkle requires both operations on the main thread, so
+    /// its state cannot change through a queued KVO delivery between them.
+    @discardableResult
+    static func dispatchForegroundCheck(
+        authoritativeCanCheck: () -> Bool,
+        synchronizeMirror: (Bool) -> Void,
+        perform: () -> Void
+    ) -> Bool {
+        let canCheck = authoritativeCanCheck()
+        synchronizeMirror(canCheck)
+        guard canCheck else { return false }
+        perform()
         return true
     }
 

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -32,6 +32,13 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
       AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
+      AXGroup id="UpdateCard" desc="Rapid-MLX update <version> available" enabled=true
+        AXStaticText value=text enabled=true
+        AXStaticText value=text enabled=true
+        AXButton id="UpdateCard.Dismiss" desc="Dismiss update <version>" help="Dismiss this update" enabled=true
+        AXStaticText value=text enabled=true
+        AXLink id="UpdateCard.ReleaseNotes" desc="View release notes" enabled=true
+        AXBusyIndicator id="UpdateCard.Update" desc="Update in progress…" value=number enabled=false
       AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -31,7 +31,6 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="Tokens per second: no data yet" enabled=true
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
-      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
       AXGroup id="UpdateCard" desc="Rapid-MLX update <version> available" enabled=true
         AXStaticText value=text enabled=true
         AXStaticText value=text enabled=true
@@ -39,6 +38,7 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXLink id="UpdateCard.ReleaseNotes" desc="View release notes" enabled=true
         AXBusyIndicator id="UpdateCard.Update" desc="Update in progress…" value=number enabled=false
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
       AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/SparkleUpdateControllerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SparkleUpdateControllerTests.swift
@@ -73,5 +73,17 @@ struct SparkleUpdateControllerTests {
         controller.start()
         #expect(controller.isStarted)
         #expect(!controller.canCheckForUpdates)
+        #expect(!controller.checkForUpdates())
+    }
+
+    @MainActor
+    @Test("disabled controller rejects foreground update hand-off")
+    func disabledCheckIsRejected() {
+        let controller = SparkleUpdateController(
+            infoDictionary: [:],
+            checksEnabled: false
+        )
+        #expect(!controller.checkForUpdates())
+        #expect(!controller.isStarted)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SparkleUpdateControllerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SparkleUpdateControllerTests.swift
@@ -86,4 +86,34 @@ struct SparkleUpdateControllerTests {
         #expect(!controller.checkForUpdates())
         #expect(!controller.isStarted)
     }
+
+    @MainActor
+    @Test("foreground check rejects a stale enabled mirror when Sparkle is busy")
+    func authoritativeBusyStateRejectsStaleMirror() {
+        var mirroredCanCheck = true
+        var dispatches = 0
+
+        #expect(!SparkleUpdateController.dispatchForegroundCheck(
+            authoritativeCanCheck: { false },
+            synchronizeMirror: { mirroredCanCheck = $0 },
+            perform: { dispatches += 1 }
+        ))
+        #expect(!mirroredCanCheck)
+        #expect(dispatches == 0)
+    }
+
+    @MainActor
+    @Test("foreground check dispatches after authoritative acceptance")
+    func authoritativeReadyStateDispatches() {
+        var mirroredCanCheck = false
+        var dispatches = 0
+
+        #expect(SparkleUpdateController.dispatchForegroundCheck(
+            authoritativeCanCheck: { true },
+            synchronizeMirror: { mirroredCanCheck = $0 },
+            perform: { dispatches += 1 }
+        ))
+        #expect(mirroredCanCheck)
+        #expect(dispatches == 1)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/UpdateDiscoveryCardTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/UpdateDiscoveryCardTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import Rapid
+
+@MainActor
+@Suite("Update discovery card presentation")
+struct UpdateDiscoveryCardTests {
+    @Test("A new actionable release is presented")
+    func presentsNewRelease() {
+        #expect(ContentView.shouldPresentUpdateCard(
+            releaseVersion: "0.13.4",
+            dismissedVersion: "",
+            handedOffVersion: nil,
+            onboardingVisible: false,
+            blockingOverlayVisible: false,
+            hasAction: true
+        ))
+    }
+
+    @Test("Dismissal applies only to the dismissed version")
+    func dismissalIsVersionScoped() {
+        #expect(!ContentView.shouldPresentUpdateCard(
+            releaseVersion: "0.13.4",
+            dismissedVersion: "0.13.4",
+            handedOffVersion: nil,
+            onboardingVisible: false,
+            blockingOverlayVisible: false,
+            hasAction: true
+        ))
+        #expect(ContentView.shouldPresentUpdateCard(
+            releaseVersion: "0.13.5",
+            dismissedVersion: "0.13.4",
+            handedOffVersion: nil,
+            onboardingVisible: false,
+            blockingOverlayVisible: false,
+            hasAction: true
+        ))
+    }
+
+    @Test("Sparkle hand-off suppresses the duplicate card for this session")
+    func handoffSuppressesDuplicateSurface() {
+        #expect(!ContentView.shouldPresentUpdateCard(
+            releaseVersion: "0.13.4",
+            dismissedVersion: "",
+            handedOffVersion: "0.13.4",
+            onboardingVisible: false,
+            blockingOverlayVisible: false,
+            hasAction: true
+        ))
+    }
+
+    @Test("Onboarding and blocking overlays defer presentation")
+    func defersForHigherPrioritySurfaces() {
+        for state in [(true, false), (false, true)] {
+            #expect(!ContentView.shouldPresentUpdateCard(
+                releaseVersion: "0.13.4",
+                dismissedVersion: "",
+                handedOffVersion: nil,
+                onboardingVisible: state.0,
+                blockingOverlayVisible: state.1,
+                hasAction: true
+            ))
+        }
+    }
+
+    @Test("A card without a safe action stays hidden")
+    func hidesWithoutAction() {
+        #expect(!ContentView.shouldPresentUpdateCard(
+            releaseVersion: "0.13.4",
+            dismissedVersion: "",
+            handedOffVersion: nil,
+            onboardingVisible: false,
+            blockingOverlayVisible: false,
+            hasAction: false
+        ))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/UpdateDiscoveryCardTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/UpdateDiscoveryCardTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Rapid
 
@@ -46,6 +47,43 @@ struct UpdateDiscoveryCardTests {
             blockingOverlayVisible: false,
             hasAction: true
         ))
+    }
+
+    @Test("Sparkle hand-off is recorded only after the check is accepted")
+    func handoffRequiresAcceptance() {
+        var handedOff: String?
+        #expect(!ContentView.handOffUpdate(
+            version: "0.13.4",
+            start: { false },
+            onAccepted: { handedOff = $0 }
+        ))
+        #expect(handedOff == nil)
+
+        #expect(ContentView.handOffUpdate(
+            version: "0.13.4",
+            start: { true },
+            onAccepted: { handedOff = $0 }
+        ))
+        #expect(handedOff == "0.13.4")
+    }
+
+    @Test("Manual download dismisses only after Launch Services accepts the URL")
+    func manualDownloadRequiresSuccessfulOpen() throws {
+        let url = try #require(URL(string: "https://example.com/releases/0.13.4"))
+        var dismissals = 0
+        #expect(!UpdateDiscoveryCard.openManualDownload(
+            url,
+            using: { _ in false },
+            onOpened: { dismissals += 1 }
+        ))
+        #expect(dismissals == 0)
+
+        #expect(UpdateDiscoveryCard.openManualDownload(
+            url,
+            using: { $0 == url },
+            onOpened: { dismissals += 1 }
+        ))
+        #expect(dismissals == 1)
     }
 
     @Test("Onboarding and blocking overlays defer presentation")


### PR DESCRIPTION
## What changed

- add a Rapid-styled update discovery card in the main window
- persist dismissal per release version and suppress duplicate UI after Sparkle hand-off
- defer the card during onboarding, command palette, and conversation search
- preserve a safe manual-download action for unsigned builds
- verify authoritative updater readiness at hand-off time
- add presentation-policy and updater-race regression tests

## Why

Rapid-MLX already discovers releases through UpdateChecker and safely installs them through Sparkle, but update discovery currently requires the footer, Settings, or Sparkle standard UI. This adds a calm, direct discovery surface without changing the updater security boundary.

## Update boundary

This is phase one only. UpdateChecker still discovers the release, and the existing SPUStandardUpdaterController remains the sole owner of download, EdDSA verification, app replacement, and restart UI after hand-off.

## Validation

- swift test --filter UpdateDiscoveryCardTests (5 passed)
- swift test --filter SparkleUpdateControllerTests|SettingsAppUpdateStatusTests|DesktopVersionPillTests|UpdateDiscoveryCardTests (29 passed)
- swift build -c release
- scripts/gui-golden-flows.sh --flow update-state
- scripts/gui-golden-flows.sh --flow update-busy
- git diff --check