### PR TITLE
Qualify Qwen3.8-27B DFlash2 as an explicit experimental route

### DIFF
--- a/docs/engineering/performance/qwen38-27b-dflash2-qualification.md
+++ b/docs/engineering/performance/qwen38-27b-dflash2-qualification.md
@@ -1,0 +1,87 @@
+# Qwen3.8-27B DFlash2 qualification
+
+Date: 2026-09-01
+
+## Decision
+
+Do not select DFlash2 by default for `qwen3.8-27b-4bit`. The released
+DFlash2 runtime works and preserves sensible target-model output, but both the
+full-precision and 4-bit drafters were slower than Rapid-MLX's already-default
+continuous MTP path on the qualification workload. The known DFlash2 pairing
+remains available only through explicit experimental configuration.
+
+## Environment
+
+- Mac Studio, Apple M3 Ultra (28 CPU cores), 256 GB unified memory
+- macOS 26.5.2 (25F84)
+- Rapid-MLX `63dac4f10bf188feacafcd692734e0a148165930`
+- `mlx==0.32.2`, `mlx-lm==0.31.3`, `mlx-vlm==0.6.17`
+- Target: `rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX`, revision
+  `aa985c29ff5b334cbfdcbbc787d47e66e9d9e456`
+- DFlash2 source drafter: `z-lab/Qwen3.8-27B-DFlash2`, revision
+  `50307d4c4cde6860d4eee73e2547cd786fe8e8a4`
+- One large model pair resident at a time; prefix caching disabled
+- Greedy decoding, thinking disabled, 256-token ceiling, three runs per case
+
+## Commands
+
+The 4-bit drafter was produced with the released optional runtime:
+
+```bash
+mlx_vlm.convert \
+  --hf-path z-lab/Qwen3.8-27B-DFlash2 \
+  --revision 50307d4c4cde6860d4eee73e2547cd786fe8e8a4 \
+  --mlx-path /private/tmp/vector-qwen38-dflash2-4bit \
+  --quantize --q-bits 4 --q-group-size 64
+```
+
+The paired benchmark command was:
+
+```bash
+python scripts/bench_dflash.py \
+  --model qwen3.8-27b-4bit \
+  --draft-model /private/tmp/vector-qwen38-dflash2-4bit \
+  --runs 3 --max-tokens 256 --port 8765
+```
+
+The baseline command intentionally uses the alias's default policy, which is
+continuous MTP for this qualified target. DFlash2 runs in Rapid-MLX's dedicated
+single-user serial speculative server. Comparing against plain autoregressive
+decode would overstate the user-visible gain because ordinary users already
+receive MTP.
+
+## Results
+
+Median decode throughput, three runs per case:
+
+| Workload | Default MTP (tok/s) | DFlash2 q4 (tok/s) | DFlash2 / MTP |
+| --- | ---: | ---: | ---: |
+| Fibonacci | 57.6 | 54.2 | 0.94x |
+| Quicksort | 53.7 | 50.4 | 0.94x |
+| Hash table | 56.0 | 52.5 | 0.94x |
+| Sorted list | 57.6 | 50.1 | 0.87x |
+| Chat | 49.8 | 46.7 | 0.94x |
+| **Code median speedup** |  |  | **0.94x** |
+
+The full-precision drafter also failed qualification: code median 0.92x and
+chat 0.83x versus the alias default. Its draft weights occupied about 3.6 GB;
+the local 4-bit conversion occupied about 1.0 GB.
+
+## Correctness spot-check
+
+Five greedy requests were run through both the default MTP route and DFlash2:
+coding, creative writing, factual chat, compact JSON, and a tool call. Coding,
+JSON, and the normalized tool call were byte-for-byte identical. Creative
+writing and factual chat differed in wording while remaining coherent,
+instruction-following, and semantically equivalent. This is consistent with
+the two routes using different target-model loading/generation paths; it is not
+evidence for claiming byte identity across engines.
+
+## Revisit criteria
+
+Re-run qualification only if the DFlash2 runtime, target checkpoint, or
+Rapid-MLX verifier path changes materially. Graduation requires a code-workload
+median of at least 1.30x over the then-current default, no non-code workload
+below 1.00x, correct tool/structured output, and explicit runtime identity in
+`/healthz`. Until those conditions hold, the registry must not advertise the
+pair as verified.

--- a/docs/engineering/performance/qwen38-27b-dflash2-qualification.md
+++ b/docs/engineering/performance/qwen38-27b-dflash2-qualification.md
@@ -41,6 +41,7 @@ The paired benchmark command was:
 python scripts/bench_dflash.py \
   --model qwen3.8-27b-4bit \
   --draft-model /private/tmp/vector-qwen38-dflash2-4bit \
+  --expected-algorithm dflash2 \
   --runs 3 --max-tokens 256 --port 8765
 ```
 

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -385,6 +385,59 @@ class ModeResult:
     raw_runs: dict[str, list[WorkloadRun]]
 
 
+@dataclass(frozen=True)
+class QualificationResult:
+    code_median: float | None
+    non_code_speedups: dict[str, float]
+    median_speedup: float | None
+    ship: bool
+    decision: str
+
+
+def _qualify(
+    speedup: dict[str, float],
+    *,
+    gate: float,
+    non_code_floor: float,
+) -> QualificationResult:
+    """Apply the mixed-workload gate, failing closed on missing evidence."""
+    code_speedups = [v for k, v in speedup.items() if k in _CODE_WORKLOADS]
+    code_median = median(code_speedups) if code_speedups else None
+    non_code_speedups = {k: v for k, v in speedup.items() if k not in _CODE_WORKLOADS}
+    median_speedup = median(speedup.values()) if speedup else None
+    missing = [name for name in WORKLOADS if name not in speedup]
+    non_code_regress = {
+        key: value for key, value in non_code_speedups.items() if value < non_code_floor
+    }
+
+    if missing:
+        ship = False
+        decision = f"DO NOT SHIP (missing valid workloads: {', '.join(missing)})"
+    elif code_median is None:
+        ship = False
+        decision = "DO NOT SHIP (no valid code workloads)"
+    elif code_median < gate:
+        ship = False
+        decision = "DO NOT SHIP"
+    elif non_code_regress:
+        ship = False
+        regressed = ", ".join(
+            f"{key} {value:.2f}x" for key, value in non_code_regress.items()
+        )
+        decision = f"DO NOT SHIP (non-code regression: {regressed})"
+    else:
+        ship = True
+        decision = "SHIP (supports_dflash=true)"
+
+    return QualificationResult(
+        code_median=code_median,
+        non_code_speedups=non_code_speedups,
+        median_speedup=median_speedup,
+        ship=ship,
+        decision=decision,
+    )
+
+
 def bench_one_mode(
     model: str,
     port: int,
@@ -505,36 +558,17 @@ def main(argv: list[str] | None = None) -> int:
             continue
         speedup[name] = round(s / v, 3)
 
-    # Code median = the four code-gen workloads only. Chat is graded
-    # separately as a non-regression floor — prior bench rounds showed
-    # DFlash speedup is heavily code-biased and SHIPping a 1.3x code
-    # model that regresses to 0.8x on chat would be a bad user trade.
-    code_speedups = [v for k, v in speedup.items() if k in _CODE_WORKLOADS]
-    code_median = median(code_speedups) if code_speedups else None
-    non_code_speedups = {k: v for k, v in speedup.items() if k not in _CODE_WORKLOADS}
     non_code_floor = args.non_code_floor
-    non_code_regress = {
-        k: v for k, v in non_code_speedups.items() if v < non_code_floor
-    }
-
-    median_speedup = median(speedup.values()) if speedup else None
-
-    # Boolean ship/no-ship is the load-bearing signal; the human-readable
-    # ``decision`` string is just for the scorecard. Keeping them separate
-    # avoids string-shape coupling in callers / exit codes.
-    if code_median is None:
-        ship = False
-        decision = "DO NOT SHIP (no valid code workloads)"
-    elif code_median < args.gate:
-        ship = False
-        decision = "DO NOT SHIP"
-    elif non_code_regress:
-        ship = False
-        regressed = ", ".join(f"{k} {v:.2f}x" for k, v in non_code_regress.items())
-        decision = f"DO NOT SHIP (non-code regression: {regressed})"
-    else:
-        ship = True
-        decision = "SHIP (supports_dflash=true)"
+    qualification = _qualify(
+        speedup,
+        gate=args.gate,
+        non_code_floor=non_code_floor,
+    )
+    code_median = qualification.code_median
+    non_code_speedups = qualification.non_code_speedups
+    median_speedup = qualification.median_speedup
+    ship = qualification.ship
+    decision = qualification.decision
 
     def _serialize_runs(raw: dict[str, list[WorkloadRun]]) -> dict[str, list[dict]]:
         return {

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -434,6 +434,19 @@ class ModeResult:
 
 
 @dataclass(frozen=True)
+class PairReceipt:
+    target_model: str
+    target_revision: str | None
+    draft_model: str
+    draft_revision: str | None
+    algorithm: str
+
+    @property
+    def immutable(self) -> bool:
+        return bool(self.target_revision and self.draft_revision)
+
+
+@dataclass(frozen=True)
 class QualificationResult:
     code_median: float | None
     non_code_speedups: dict[str, float]
@@ -447,6 +460,7 @@ def _qualify(
     *,
     gate: float,
     non_code_floor: float,
+    immutable_receipt: bool = True,
 ) -> QualificationResult:
     """Apply the mixed-workload gate, failing closed on missing evidence."""
     code_speedups = [v for k, v in speedup.items() if k in _CODE_WORKLOADS]
@@ -458,7 +472,10 @@ def _qualify(
         key: value for key, value in non_code_speedups.items() if value < non_code_floor
     }
 
-    if missing:
+    if not immutable_receipt:
+        ship = False
+        decision = "DO NOT SHIP (missing immutable target/drafter revision receipt)"
+    elif missing:
         ship = False
         decision = f"DO NOT SHIP (missing valid workloads: {', '.join(missing)})"
     elif code_median is None:
@@ -537,28 +554,57 @@ def bench_one_mode(
         handle.stop()
 
 
+def _resolve_pair_receipt(
+    model: str,
+    draft_model: str | None,
+    explicit: str | None,
+) -> PairReceipt:
+    """Resolve and persist the effective immutable benchmark pair."""
+
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile(model)
+    target_model = profile.hf_path if profile is not None else model
+    effective_draft = draft_model
+    if effective_draft is None and profile is not None and profile.supports_dflash:
+        effective_draft = profile.dflash_draft_model
+    if not effective_draft:
+        raise ValueError(
+            "cannot infer the DFlash drafter for this model; pass --draft-model"
+        )
+
+    algorithm = explicit
+    exact_registry_draft = (
+        profile is not None and effective_draft == profile.dflash_draft_model
+    )
+    if algorithm is None and exact_registry_draft:
+        algorithm = profile.dflash_algorithm
+    if algorithm not in {"dflash", "dflash2"}:
+        raise ValueError(
+            "cannot infer the DFlash algorithm for this model/drafter pair; "
+            "pass --expected-algorithm dflash or --expected-algorithm dflash2"
+        )
+    return PairReceipt(
+        target_model=target_model,
+        target_revision=(
+            profile.dflash_target_revision if profile is not None else None
+        ),
+        draft_model=effective_draft,
+        draft_revision=(
+            profile.dflash_draft_revision if exact_registry_draft else None
+        ),
+        algorithm=algorithm,
+    )
+
+
 def _resolve_expected_algorithm(
     model: str,
     draft_model: str | None,
     explicit: str | None,
 ) -> str:
-    """Preserve legacy alias invocations while keeping qualification fail-closed."""
+    """Compatibility wrapper for callers that only need algorithm identity."""
 
-    if explicit is not None:
-        return explicit
-    from vllm_mlx.model_aliases import resolve_profile
-
-    profile = resolve_profile(model)
-    if profile is not None and (
-        draft_model is None or draft_model == profile.dflash_draft_model
-    ):
-        algorithm = profile.dflash_algorithm
-        if algorithm in {"dflash", "dflash2"}:
-            return algorithm
-    raise ValueError(
-        "cannot infer the DFlash algorithm for this model/drafter pair; "
-        "pass --expected-algorithm dflash or --expected-algorithm dflash2"
-    )
+    return _resolve_pair_receipt(model, draft_model, explicit).algorithm
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -610,7 +656,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     try:
-        expected_algorithm = _resolve_expected_algorithm(
+        pair = _resolve_pair_receipt(
             args.model, args.draft_model, args.expected_algorithm
         )
     except ValueError as exc:
@@ -640,7 +686,7 @@ def main(argv: list[str] | None = None) -> int:
         runs=args.runs,
         max_tokens=args.max_tokens,
         draft_model=args.draft_model,
-        expected_algorithm=expected_algorithm,
+        expected_algorithm=pair.algorithm,
     )
 
     speedup: dict[str, float] = {}
@@ -663,6 +709,7 @@ def main(argv: list[str] | None = None) -> int:
         speedup,
         gate=args.gate,
         non_code_floor=non_code_floor,
+        immutable_receipt=pair.immutable,
     )
     code_median = qualification.code_median
     non_code_speedups = qualification.non_code_speedups
@@ -687,7 +734,10 @@ def main(argv: list[str] | None = None) -> int:
 
     summary = {
         "model": args.model,
-        "draft_model": args.draft_model,
+        "target_model": pair.target_model,
+        "target_revision": pair.target_revision,
+        "draft_model": pair.draft_model,
+        "draft_revision": pair.draft_revision,
         "dflash_algorithm": dflash.algorithm,
         "max_tokens": args.max_tokens,
         "runs": args.runs,

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -3,7 +3,7 @@
 """DFlash speculative-decoding speedup bench (Model Onboarding SOP §6).
 
 Measures the per-workload TPS speedup of ``--enable-dflash`` vs the
-baseline (autoregressive) decode on a fixed prompt set. Mirrors the
+alias's default decode policy on a fixed prompt set. Mirrors the
 sequential two-server pattern of ``bench_suffix_decoding_integrated.py``
 and reuses the same reliability gates (decode-time floor, TPS ceiling,
 raw-runs persistence).
@@ -186,7 +186,12 @@ class ServerHandle:
                     pass
 
 
-def start_server(model: str, port: int, dflash: bool) -> ServerHandle:
+def start_server(
+    model: str,
+    port: int,
+    dflash: bool,
+    draft_model: str | None = None,
+) -> ServerHandle:
     """Spin up ``rapid-mlx serve`` and wait for /v1/models to answer.
 
     Sets ``--disable-prefix-cache`` to prevent disk-persisted cache
@@ -208,6 +213,8 @@ def start_server(model: str, port: int, dflash: bool) -> ServerHandle:
     ]
     if dflash:
         cmd.append("--enable-dflash")
+        if draft_model:
+            cmd.extend(["--dflash-drafter-path", draft_model])
 
     logger.info("  starting server: port=%d dflash=%s", port, dflash)
     logf = open(log_path, "w")
@@ -384,8 +391,9 @@ def bench_one_mode(
     dflash: bool,
     runs: int,
     max_tokens: int,
+    draft_model: str | None = None,
 ) -> ModeResult:
-    handle = start_server(model, port, dflash)
+    handle = start_server(model, port, dflash, draft_model=draft_model)
     try:
         # Discard warmup: Metal JIT + cache population + drafter load.
         run_workload(handle, WORKLOADS["fibonacci"], max_tokens=32)
@@ -424,6 +432,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--model", required=True, help="HF repo or alias")
     parser.add_argument("--max-tokens", type=int, default=256)
     parser.add_argument("--runs", type=int, default=3, help="runs per workload")
+    parser.add_argument(
+        "--draft-model",
+        default=None,
+        help=(
+            "Explicit DFlash drafter repo or local path. Omit to use the "
+            "alias-qualified drafter."
+        ),
+    )
     parser.add_argument("--port", type=int, default=8765, help="ephemeral port")
     parser.add_argument(
         "--output",
@@ -455,7 +471,7 @@ def main(argv: list[str] | None = None) -> int:
             "bypassed (PoC mode)"
         )
 
-    logger.info("--- baseline (autoregressive) ---")
+    logger.info("--- baseline (alias default policy) ---")
     base = bench_one_mode(
         args.model,
         args.port,
@@ -471,6 +487,7 @@ def main(argv: list[str] | None = None) -> int:
         dflash=True,
         runs=args.runs,
         max_tokens=args.max_tokens,
+        draft_model=args.draft_model,
     )
 
     speedup: dict[str, float] = {}
@@ -536,6 +553,7 @@ def main(argv: list[str] | None = None) -> int:
 
     summary = {
         "model": args.model,
+        "draft_model": args.draft_model,
         "max_tokens": args.max_tokens,
         "runs": args.runs,
         "gate": args.gate,

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -194,6 +194,7 @@ def start_server(
     dflash: bool,
     draft_model: str | None = None,
     expected_algorithm: str | None = None,
+    speculative_config: str | None = None,
 ) -> ServerHandle:
     """Spin up ``rapid-mlx serve`` and wait for /v1/models to answer.
 
@@ -222,6 +223,8 @@ def start_server(
         cmd.append("--enable-dflash")
         if draft_model:
             cmd.extend(["--dflash-drafter-path", draft_model])
+    elif speculative_config is not None:
+        cmd.extend(["--speculative-config", speculative_config])
 
     logger.info("  starting server: port=%d dflash=%s", port, dflash)
     logf = open(log_path, "w")
@@ -440,6 +443,7 @@ class PairReceipt:
     draft_model: str
     draft_revision: str | None
     algorithm: str
+    baseline_mtp_tokens: int | None = None
 
     @property
     def immutable(self) -> bool:
@@ -511,6 +515,7 @@ def bench_one_mode(
     max_tokens: int,
     draft_model: str | None = None,
     expected_algorithm: str | None = None,
+    speculative_config: str | None = None,
 ) -> ModeResult:
     handle = start_server(
         model,
@@ -518,6 +523,7 @@ def bench_one_mode(
         dflash,
         draft_model=draft_model,
         expected_algorithm=expected_algorithm,
+        speculative_config=speculative_config,
     )
     try:
         # Discard warmup: Metal JIT + cache population + drafter load.
@@ -594,6 +600,12 @@ def _resolve_pair_receipt(
             profile.dflash_draft_revision if exact_registry_draft else None
         ),
         algorithm=algorithm,
+        baseline_mtp_tokens=(
+            profile.mtp_speculative_tokens
+            if profile is not None
+            and profile.mtp_continuous_batching_tier == "verified"
+            else None
+        ),
     )
 
 
@@ -605,6 +617,47 @@ def _resolve_expected_algorithm(
     """Compatibility wrapper for callers that only need algorithm identity."""
 
     return _resolve_pair_receipt(model, draft_model, explicit).algorithm
+
+
+def _materialize_target(pair: PairReceipt) -> str:
+    """Return one immutable target snapshot shared by both benchmark modes."""
+
+    if pair.target_revision is None:
+        return pair.target_model
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(
+        repo_id=pair.target_model,
+        revision=pair.target_revision,
+    )
+
+
+def _materialize_drafter(pair: PairReceipt) -> str:
+    """Return the pinned drafter snapshot, or the explicit local source."""
+
+    if pair.draft_revision is None:
+        return pair.draft_model
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(
+        repo_id=pair.draft_model,
+        revision=pair.draft_revision,
+    )
+
+
+def _baseline_speculative_config(pair: PairReceipt, target_source: str) -> str | None:
+    """Reproduce a verified alias MTP default against the pinned snapshot."""
+
+    if pair.baseline_mtp_tokens is None:
+        return None
+    return json.dumps(
+        {
+            "method": "mtp",
+            "model": target_source,
+            "num_speculative_tokens": pair.baseline_mtp_tokens,
+        },
+        separators=(",", ":"),
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -661,6 +714,9 @@ def main(argv: list[str] | None = None) -> int:
         )
     except ValueError as exc:
         parser.error(str(exc))
+    target_source = _materialize_target(pair)
+    draft_source = _materialize_drafter(pair)
+    baseline_speculative_config = _baseline_speculative_config(pair, target_source)
 
     logger.info("Bench DFlash: %s", args.model)
     if os.environ.get("RAPID_MLX_DFLASH_BYPASS_MOE_GATE") == "1":
@@ -671,21 +727,22 @@ def main(argv: list[str] | None = None) -> int:
 
     logger.info("--- baseline (alias default policy) ---")
     base = bench_one_mode(
-        args.model,
+        target_source,
         args.port,
         dflash=False,
         runs=args.runs,
         max_tokens=args.max_tokens,
+        speculative_config=baseline_speculative_config,
     )
 
     logger.info("--- DFlash ---")
     dflash = bench_one_mode(
-        args.model,
+        target_source,
         args.port,
         dflash=True,
         runs=args.runs,
         max_tokens=args.max_tokens,
-        draft_model=args.draft_model,
+        draft_model=draft_source,
         expected_algorithm=pair.algorithm,
     )
 

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -537,6 +537,30 @@ def bench_one_mode(
         handle.stop()
 
 
+def _resolve_expected_algorithm(
+    model: str,
+    draft_model: str | None,
+    explicit: str | None,
+) -> str:
+    """Preserve legacy alias invocations while keeping qualification fail-closed."""
+
+    if explicit is not None:
+        return explicit
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile(model)
+    if profile is not None and (
+        draft_model is None or draft_model == profile.dflash_draft_model
+    ):
+        algorithm = profile.dflash_algorithm
+        if algorithm in {"dflash", "dflash2"}:
+            return algorithm
+    raise ValueError(
+        "cannot infer the DFlash algorithm for this model/drafter pair; "
+        "pass --expected-algorithm dflash or --expected-algorithm dflash2"
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Bench DFlash speedup for one alias (Model Onboarding SOP §6)."
@@ -555,10 +579,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--expected-algorithm",
         choices=("dflash", "dflash2"),
-        required=True,
+        default=None,
         help=(
             "Require /healthz to report this concrete drafter algorithm. "
-            "Use this for publication/qualification runs."
+            "Known alias pairs infer it for backward compatibility; explicit "
+            "or local drafters must set it."
         ),
     )
     parser.add_argument("--port", type=int, default=8765, help="ephemeral port")
@@ -584,6 +609,12 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+    try:
+        expected_algorithm = _resolve_expected_algorithm(
+            args.model, args.draft_model, args.expected_algorithm
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
 
     logger.info("Bench DFlash: %s", args.model)
     if os.environ.get("RAPID_MLX_DFLASH_BYPASS_MOE_GATE") == "1":
@@ -609,7 +640,7 @@ def main(argv: list[str] | None = None) -> int:
         runs=args.runs,
         max_tokens=args.max_tokens,
         draft_model=args.draft_model,
-        expected_algorithm=args.expected_algorithm,
+        expected_algorithm=expected_algorithm,
     )
 
     speedup: dict[str, float] = {}

--- a/scripts/bench_dflash.py
+++ b/scripts/bench_dflash.py
@@ -20,7 +20,8 @@ Decision rule (SOP §6 / Model Onboarding SOP):
 
 Usage:
     python3.12 scripts/bench_dflash.py \\
-        --model qwen3.5-4b-8bit --runs 3 --max-tokens 256
+        --model qwen3.5-4b-8bit --expected-algorithm dflash \\
+        --runs 3 --max-tokens 256
 
 The script does NOT auto-edit aliases.json. It prints the patch the
 contributor can paste, and persists the raw bench data to
@@ -166,6 +167,7 @@ class ServerHandle:
     proc: subprocess.Popen
     base_url: str
     model: str
+    algorithm: str | None = None
     # File the child's stdout/stderr is piped into. Held for the
     # lifetime of the server so the OS keeps the descriptor open for
     # writes from the child; closed in stop() once the process exits.
@@ -191,6 +193,7 @@ def start_server(
     port: int,
     dflash: bool,
     draft_model: str | None = None,
+    expected_algorithm: str | None = None,
 ) -> ServerHandle:
     """Spin up ``rapid-mlx serve`` and wait for /v1/models to answer.
 
@@ -198,6 +201,10 @@ def start_server(
     entries from a prior session pinning TPS to bogus 1000+ tok/s.
     DFlash speedup measurement requires real decode work on every run.
     """
+    if dflash and expected_algorithm is None:
+        raise ValueError(
+            "DFlash qualification requires expected_algorithm='dflash' or 'dflash2'"
+        )
     log_path = f"/tmp/bench_dflash_{port}.log"
     cmd = [
         sys.executable,
@@ -246,18 +253,58 @@ def start_server(
                 raise RuntimeError("server died during startup")
             try:
                 r = httpx.get(f"{base_url}/models", timeout=2.0)
-                if r.status_code == 200:
-                    logger.info("  server up at %s", base_url)
-                    return ServerHandle(
-                        proc=proc, base_url=base_url, model=model, logf=logf
-                    )
-            except Exception:
-                pass
+            except httpx.HTTPError:
+                r = None
+            if r is not None and r.status_code == 200:
+                algorithm = None
+                if dflash:
+                    try:
+                        health = httpx.get(
+                            f"http://127.0.0.1:{port}/healthz", timeout=2.0
+                        )
+                    except httpx.HTTPError:
+                        time.sleep(2)
+                        continue
+                    if health.status_code != 200:
+                        raise RuntimeError(
+                            "DFlash server became ready without a healthy "
+                            f"runtime receipt (HTTP {health.status_code})"
+                        )
+                    payload = health.json()
+                    algorithm = payload.get("algorithm")
+                    if algorithm not in {"dflash", "dflash2"}:
+                        raise RuntimeError(
+                            "DFlash /healthz did not report a recognized "
+                            f"algorithm: {algorithm!r}"
+                        )
+                    if algorithm != expected_algorithm:
+                        raise RuntimeError(
+                            "DFlash runtime algorithm mismatch: expected "
+                            f"{expected_algorithm!r}, got {algorithm!r}"
+                        )
+                logger.info(
+                    "  server up at %s%s",
+                    base_url,
+                    f" (algorithm={algorithm})" if algorithm else "",
+                )
+                return ServerHandle(
+                    proc=proc,
+                    base_url=base_url,
+                    model=model,
+                    algorithm=algorithm,
+                    logf=logf,
+                )
             time.sleep(2)
 
-        proc.kill()
         raise RuntimeError(f"server did not become ready within deadline (port={port})")
     except BaseException:
+        if proc.poll() is None:
+            try:
+                proc.send_signal(signal.SIGINT)
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
         logf.close()
         raise
 
@@ -383,6 +430,7 @@ def _classify_run(
 class ModeResult:
     median_tps: dict[str, float | None]
     raw_runs: dict[str, list[WorkloadRun]]
+    algorithm: str | None = None
 
 
 @dataclass(frozen=True)
@@ -445,8 +493,15 @@ def bench_one_mode(
     runs: int,
     max_tokens: int,
     draft_model: str | None = None,
+    expected_algorithm: str | None = None,
 ) -> ModeResult:
-    handle = start_server(model, port, dflash, draft_model=draft_model)
+    handle = start_server(
+        model,
+        port,
+        dflash,
+        draft_model=draft_model,
+        expected_algorithm=expected_algorithm,
+    )
     try:
         # Discard warmup: Metal JIT + cache population + drafter load.
         run_workload(handle, WORKLOADS["fibonacci"], max_tokens=32)
@@ -473,7 +528,11 @@ def bench_one_mode(
             valid = [r.tps for r in workload_runs if r.tps is not None]
             median_tps[name] = median(valid) if valid else None
             raw[name] = workload_runs
-        return ModeResult(median_tps=median_tps, raw_runs=raw)
+        return ModeResult(
+            median_tps=median_tps,
+            raw_runs=raw,
+            algorithm=handle.algorithm,
+        )
     finally:
         handle.stop()
 
@@ -491,6 +550,15 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Explicit DFlash drafter repo or local path. Omit to use the "
             "alias-qualified drafter."
+        ),
+    )
+    parser.add_argument(
+        "--expected-algorithm",
+        choices=("dflash", "dflash2"),
+        required=True,
+        help=(
+            "Require /healthz to report this concrete drafter algorithm. "
+            "Use this for publication/qualification runs."
         ),
     )
     parser.add_argument("--port", type=int, default=8765, help="ephemeral port")
@@ -541,6 +609,7 @@ def main(argv: list[str] | None = None) -> int:
         runs=args.runs,
         max_tokens=args.max_tokens,
         draft_model=args.draft_model,
+        expected_algorithm=args.expected_algorithm,
     )
 
     speedup: dict[str, float] = {}
@@ -588,6 +657,7 @@ def main(argv: list[str] | None = None) -> int:
     summary = {
         "model": args.model,
         "draft_model": args.draft_model,
+        "dflash_algorithm": dflash.algorithm,
         "max_tokens": args.max_tokens,
         "runs": args.runs,
         "gate": args.gate,

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -79,6 +79,7 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "suffix_bench_speedup",
         "supports_dflash",
         "dflash_draft_model",
+        "dflash_algorithm",
         "supports_ddtree",
         "ddtree_draft_model",
         "ddtree_speculative_tokens",
@@ -581,6 +582,9 @@ def test_dflash_requires_drafter(alias: str) -> None:
             f"{alias}: dflash_draft_model={profile.dflash_draft_model!r} "
             f"must be 'org/repo' format"
         )
+        assert profile.dflash_algorithm in {"dflash", "dflash2"}, (
+            f"{alias}: verified DFlash pair must pin its runtime algorithm"
+        )
 
 
 @pytest.mark.parametrize("alias", _alias_ids())
@@ -601,13 +605,9 @@ def test_dflash_excludes_moe_architectures(alias: str) -> None:
 
 
 @pytest.mark.parametrize("alias", _alias_ids())
-def test_dflash_excludes_4bit_precision(alias: str) -> None:
-    """DFlash on a 4-bit MLX main model regresses (PoC: 0.63-0.96× on
-    Qwen3.5-4B-MLX-4bit, accept_len 2.35-3.88). 4-bit AR is already at
-    memory-bandwidth floor; drafter overhead dominates. Pattern is
-    detected from the HF path naming convention (``-4bit`` suffix or
-    ``-4bit-`` infix), which is how mlx-community publishes quantized
-    variants."""
+def test_dflash_4bit_precision_requires_dflash2_qualification(alias: str) -> None:
+    """Legacy DFlash remains blocked on 4-bit; a separately qualified
+    DFlash2 pair may opt in with an explicit runtime-identity receipt."""
     profile = list_profiles()[alias]
     if not profile.supports_dflash:
         return
@@ -617,14 +617,14 @@ def test_dflash_excludes_4bit_precision(alias: str) -> None:
     # the two would let an alias green-light here but crash at boot.
     hf_lc = hf.lower()
     is_4bit = "-4bit" in hf_lc or "mxfp4" in hf_lc or "nvfp4" in hf_lc
-    assert not is_4bit, (
-        f"{alias}: supports_dflash=True but hf_path={hf!r} looks like a "
-        f"4-bit quantized variant. DFlash regresses on 4-bit precision "
-        f"(accept rate collapses). Use an 8-bit or higher quantization."
-    )
+    if is_4bit:
+        assert profile.dflash_algorithm == "dflash2", (
+            f"{alias}: only an explicitly qualified DFlash2 pair may enable "
+            f"DFlash on 4-bit target {hf!r}"
+        )
 
 
-def test_dflash_eligible_aliases_have_qwen35_36_drafter() -> None:
+def test_dflash_eligible_aliases_have_qualified_drafter_family() -> None:
     """DFlash drafters today are published by ``z-lab/`` for Qwen3,
     Qwen3.5, Qwen3.6, Gemma-4 and LLaMA-3.1 families. Any eligible
     alias must point at one of these prefixes and bear the ``DFlash``
@@ -636,6 +636,7 @@ def test_dflash_eligible_aliases_have_qwen35_36_drafter() -> None:
         "z-lab/Qwen3-",
         "z-lab/Qwen3.5-",
         "z-lab/Qwen3.6-",
+        "z-lab/Qwen3.8-",
         "z-lab/gemma-4-",
         "z-lab/LLaMA3.1-",
     )
@@ -649,7 +650,7 @@ def test_dflash_eligible_aliases_have_qwen35_36_drafter() -> None:
         # end-of-string so we don't accept ``-notDFlash-utils`` or
         # other strings where ``DFlash`` is just a substring of an
         # unrelated word.
-        has_marker = bool(re.search(r"(?:^|-)DFlash(?:$|-)", d))
+        has_marker = bool(re.search(r"(?:^|-)DFlash(?:2)?(?:$|-)", d))
         assert has_marker and ok, (
             f"{alias}: dflash_draft_model={d!r} doesn't match the "
             f"expected ``z-lab/{{Qwen3,Qwen3.5,Qwen3.6,gemma-4,LLaMA3.1}}-*"
@@ -685,6 +686,20 @@ def test_negative_control_dflash_missing_drafter_is_caught() -> None:
         _coerce(
             "fake-alias",
             {"hf_path": "fake/Model", "supports_dflash": True},
+        )
+
+
+def test_negative_control_dflash_missing_algorithm_is_caught() -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="dflash_algorithm"):
+        _coerce(
+            "fake-alias",
+            {
+                "hf_path": "fake/Model",
+                "supports_dflash": True,
+                "dflash_draft_model": "fake/DFlash",
+            },
         )
 
 

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -79,6 +79,8 @@ ALLOWED_PROFILE_KEYS: frozenset[str] = frozenset(
         "suffix_bench_speedup",
         "supports_dflash",
         "dflash_draft_model",
+        "dflash_target_revision",
+        "dflash_draft_revision",
         "dflash_algorithm",
         "supports_ddtree",
         "ddtree_draft_model",
@@ -585,6 +587,12 @@ def test_dflash_requires_drafter(alias: str) -> None:
         assert profile.dflash_algorithm in {"dflash", "dflash2"}, (
             f"{alias}: verified DFlash pair must pin its runtime algorithm"
         )
+        assert (
+            profile.dflash_target_revision and len(profile.dflash_target_revision) == 40
+        )
+        assert (
+            profile.dflash_draft_revision and len(profile.dflash_draft_revision) == 40
+        )
 
 
 @pytest.mark.parametrize("alias", _alias_ids())
@@ -699,6 +707,34 @@ def test_negative_control_dflash_missing_algorithm_is_caught() -> None:
                 "hf_path": "fake/Model",
                 "supports_dflash": True,
                 "dflash_draft_model": "fake/DFlash",
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "target_revision,draft_revision",
+    [
+        (None, "b" * 40),
+        ("a" * 40, None),
+        ("short", "b" * 40),
+        ("A" * 40, "b" * 40),
+    ],
+)
+def test_dflash_pair_requires_immutable_full_revision_pins(
+    target_revision, draft_revision
+) -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="revision"):
+        _coerce(
+            "fake-alias",
+            {
+                "hf_path": "fake/Model",
+                "supports_dflash": True,
+                "dflash_draft_model": "fake/DFlash",
+                "dflash_algorithm": "dflash",
+                "dflash_target_revision": target_revision,
+                "dflash_draft_revision": draft_revision,
             },
         )
 

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -711,6 +711,40 @@ def test_negative_control_dflash_missing_algorithm_is_caught() -> None:
         )
 
 
+def test_negative_control_dflash_algorithm_without_drafter_is_caught() -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="requires dflash_draft_model"):
+        _coerce(
+            "fake-alias",
+            {"hf_path": "fake/Model", "dflash_algorithm": "dflash2"},
+        )
+
+
+def test_negative_control_unknown_dflash_algorithm_is_caught() -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="not in"):
+        _coerce(
+            "fake-alias",
+            {
+                "hf_path": "fake/Model",
+                "dflash_draft_model": "fake/DFlash",
+                "dflash_algorithm": "unknown",
+            },
+        )
+
+
+def test_negative_control_dflash_revision_without_drafter_is_caught() -> None:
+    from vllm_mlx.model_aliases import _coerce
+
+    with pytest.raises(ValueError, match="revision pins require"):
+        _coerce(
+            "fake-alias",
+            {"hf_path": "fake/Model", "dflash_target_revision": "a" * 40},
+        )
+
+
 @pytest.mark.parametrize(
     "target_revision,draft_revision",
     [

--- a/tests/test_bench_dflash.py
+++ b/tests/test_bench_dflash.py
@@ -41,6 +41,18 @@ def test_complete_mixed_workload_can_qualify() -> None:
     assert result.decision == "SHIP (supports_dflash=true)"
 
 
+def test_complete_workload_without_immutable_pair_receipt_cannot_qualify() -> None:
+    result = _qualify(
+        _passing_speedups(),
+        gate=1.3,
+        non_code_floor=1.0,
+        immutable_receipt=False,
+    )
+
+    assert result.ship is False
+    assert "immutable" in result.decision
+
+
 def test_start_server_requires_health_algorithm_receipt(monkeypatch) -> None:
     proc = MagicMock()
     proc.poll.return_value = None
@@ -87,6 +99,29 @@ def test_expected_algorithm_is_inferred_for_known_alias_pair() -> None:
         )
         == "dflash2"
     )
+
+
+def test_alias_pair_receipt_records_effective_repositories_and_revisions() -> None:
+    receipt = bench_dflash._resolve_pair_receipt(
+        "qwen3.8-27b-4bit", "z-lab/Qwen3.8-27B-DFlash2", None
+    )
+
+    assert receipt.target_model == "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX"
+    assert receipt.target_revision == "aa985c29ff5b334cbfdcbbc787d47e66e9d9e456"
+    assert receipt.draft_model == "z-lab/Qwen3.8-27B-DFlash2"
+    assert receipt.draft_revision == "50307d4c4cde6860d4eee73e2547cd786fe8e8a4"
+    assert receipt.algorithm == "dflash2"
+    assert receipt.immutable is True
+
+
+def test_local_drafter_receipt_keeps_target_pin_but_cannot_qualify() -> None:
+    receipt = bench_dflash._resolve_pair_receipt(
+        "qwen3.8-27b-4bit", "/tmp/local-drafter", "dflash2"
+    )
+
+    assert receipt.target_revision == "aa985c29ff5b334cbfdcbbc787d47e66e9d9e456"
+    assert receipt.draft_revision is None
+    assert receipt.immutable is False
 
 
 def test_expected_algorithm_requires_receipt_for_unknown_override() -> None:

--- a/tests/test_bench_dflash.py
+++ b/tests/test_bench_dflash.py
@@ -80,6 +80,22 @@ def test_start_server_requires_expected_algorithm_before_spawn(monkeypatch) -> N
     popen.assert_not_called()
 
 
+def test_expected_algorithm_is_inferred_for_known_alias_pair() -> None:
+    assert (
+        bench_dflash._resolve_expected_algorithm(
+            "qwen3.8-27b-4bit", "z-lab/Qwen3.8-27B-DFlash2", None
+        )
+        == "dflash2"
+    )
+
+
+def test_expected_algorithm_requires_receipt_for_unknown_override() -> None:
+    with pytest.raises(ValueError, match="cannot infer"):
+        bench_dflash._resolve_expected_algorithm(
+            "qwen3.8-27b-4bit", "/tmp/local-drafter", None
+        )
+
+
 def test_start_server_stops_process_on_algorithm_mismatch(monkeypatch) -> None:
     proc = MagicMock()
     proc.poll.return_value = None

--- a/tests/test_bench_dflash.py
+++ b/tests/test_bench_dflash.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed contracts for the DFlash qualification harness."""
+
+from scripts.bench_dflash import WORKLOADS, _qualify
+
+
+def _passing_speedups() -> dict[str, float]:
+    return {name: 1.4 for name in WORKLOADS}
+
+
+def test_rejected_chat_cannot_qualify_from_code_results_alone() -> None:
+    speedups = _passing_speedups()
+    speedups.pop("chat")
+
+    result = _qualify(speedups, gate=1.3, non_code_floor=1.0)
+
+    assert result.ship is False
+    assert "missing valid workloads: chat" in result.decision
+
+
+def test_partially_rejected_code_cannot_qualify_from_one_code_result() -> None:
+    speedups = {"fibonacci": 1.8, "chat": 1.1}
+
+    result = _qualify(speedups, gate=1.3, non_code_floor=1.0)
+
+    assert result.ship is False
+    assert "quicksort" in result.decision
+    assert "hashtable" in result.decision
+    assert "sortedlist" in result.decision
+
+
+def test_complete_mixed_workload_can_qualify() -> None:
+    result = _qualify(_passing_speedups(), gate=1.3, non_code_floor=1.0)
+
+    assert result.ship is True
+    assert result.decision == "SHIP (supports_dflash=true)"

--- a/tests/test_bench_dflash.py
+++ b/tests/test_bench_dflash.py
@@ -57,7 +57,8 @@ def test_start_server_requires_health_algorithm_receipt(monkeypatch) -> None:
     proc = MagicMock()
     proc.poll.return_value = None
     proc.wait.return_value = 0
-    monkeypatch.setattr(bench_dflash.subprocess, "Popen", lambda *args, **kwargs: proc)
+    popen = MagicMock(return_value=proc)
+    monkeypatch.setattr(bench_dflash.subprocess, "Popen", popen)
 
     def _get(url: str, timeout: float):
         del timeout
@@ -78,6 +79,9 @@ def test_start_server_requires_health_algorithm_receipt(monkeypatch) -> None:
     )
     try:
         assert handle.algorithm == "dflash2"
+        cmd = popen.call_args.args[0]
+        assert cmd[cmd.index("serve") + 1] == "target"
+        assert cmd[cmd.index("--dflash-drafter-path") + 1] == "draft"
     finally:
         handle.stop()
 
@@ -90,6 +94,35 @@ def test_start_server_requires_expected_algorithm_before_spawn(monkeypatch) -> N
         bench_dflash.start_server("target", 8765, True, draft_model="draft")
 
     popen.assert_not_called()
+
+
+def test_baseline_server_command_uses_pinned_target_and_explicit_mtp(
+    monkeypatch,
+) -> None:
+    proc = MagicMock()
+    proc.poll.return_value = None
+    proc.wait.return_value = 0
+    popen = MagicMock(return_value=proc)
+    monkeypatch.setattr(bench_dflash.subprocess, "Popen", popen)
+    monkeypatch.setattr(
+        bench_dflash.httpx,
+        "get",
+        lambda *_args, **_kwargs: MagicMock(status_code=200),
+    )
+    config = '{"method":"mtp","model":"/cache/target","num_speculative_tokens":3}'
+
+    handle = bench_dflash.start_server(
+        "/cache/target",
+        8765,
+        False,
+        speculative_config=config,
+    )
+    try:
+        cmd = popen.call_args.args[0]
+        assert cmd[cmd.index("serve") + 1] == "/cache/target"
+        assert cmd[cmd.index("--speculative-config") + 1] == config
+    finally:
+        handle.stop()
 
 
 def test_expected_algorithm_is_inferred_for_known_alias_pair() -> None:
@@ -122,6 +155,54 @@ def test_local_drafter_receipt_keeps_target_pin_but_cannot_qualify() -> None:
     assert receipt.target_revision == "aa985c29ff5b334cbfdcbbc787d47e66e9d9e456"
     assert receipt.draft_revision is None
     assert receipt.immutable is False
+
+
+def test_main_uses_same_pinned_target_for_baseline_and_dflash(
+    monkeypatch, tmp_path
+) -> None:
+    calls: list[dict] = []
+
+    monkeypatch.setattr(
+        bench_dflash, "_materialize_target", lambda _pair: "/cache/target-snapshot"
+    )
+    monkeypatch.setattr(
+        bench_dflash, "_materialize_drafter", lambda _pair: "/cache/draft-snapshot"
+    )
+
+    def _bench(model, port, dflash, runs, max_tokens, **kwargs):
+        calls.append({"model": model, "dflash": dflash, **kwargs})
+        return bench_dflash.ModeResult(
+            median_tps={name: 10.0 for name in WORKLOADS},
+            raw_runs={name: [] for name in WORKLOADS},
+            algorithm="dflash2" if dflash else None,
+        )
+
+    monkeypatch.setattr(bench_dflash, "bench_one_mode", _bench)
+    monkeypatch.setattr(bench_dflash, "write_bench_json", lambda *_args: None)
+
+    assert (
+        bench_dflash.main(
+            [
+                "--model",
+                "qwen3.8-27b-4bit",
+                "--draft-model",
+                "z-lab/Qwen3.8-27B-DFlash2",
+                "--runs",
+                "1",
+                "--output",
+                str(tmp_path / "result.json"),
+            ]
+        )
+        == 1
+    )
+    assert [call["model"] for call in calls] == [
+        "/cache/target-snapshot",
+        "/cache/target-snapshot",
+    ]
+    baseline_config = calls[0]["speculative_config"]
+    assert '"method":"mtp"' in baseline_config
+    assert '"model":"/cache/target-snapshot"' in baseline_config
+    assert calls[1]["draft_model"] == "/cache/draft-snapshot"
 
 
 def test_expected_algorithm_requires_receipt_for_unknown_override() -> None:

--- a/tests/test_bench_dflash.py
+++ b/tests/test_bench_dflash.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fail-closed contracts for the DFlash qualification harness."""
 
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts import bench_dflash
 from scripts.bench_dflash import WORKLOADS, _qualify
 
 
@@ -34,3 +39,74 @@ def test_complete_mixed_workload_can_qualify() -> None:
 
     assert result.ship is True
     assert result.decision == "SHIP (supports_dflash=true)"
+
+
+def test_start_server_requires_health_algorithm_receipt(monkeypatch) -> None:
+    proc = MagicMock()
+    proc.poll.return_value = None
+    proc.wait.return_value = 0
+    monkeypatch.setattr(bench_dflash.subprocess, "Popen", lambda *args, **kwargs: proc)
+
+    def _get(url: str, timeout: float):
+        del timeout
+        response = MagicMock(status_code=200)
+        response.json.return_value = (
+            {"algorithm": "dflash2"} if url.endswith("/healthz") else {}
+        )
+        return response
+
+    monkeypatch.setattr(bench_dflash.httpx, "get", _get)
+
+    handle = bench_dflash.start_server(
+        "target",
+        8765,
+        True,
+        draft_model="draft",
+        expected_algorithm="dflash2",
+    )
+    try:
+        assert handle.algorithm == "dflash2"
+    finally:
+        handle.stop()
+
+
+def test_start_server_requires_expected_algorithm_before_spawn(monkeypatch) -> None:
+    popen = MagicMock()
+    monkeypatch.setattr(bench_dflash.subprocess, "Popen", popen)
+
+    with pytest.raises(ValueError, match="requires expected_algorithm"):
+        bench_dflash.start_server("target", 8765, True, draft_model="draft")
+
+    popen.assert_not_called()
+
+
+def test_start_server_stops_process_on_algorithm_mismatch(monkeypatch) -> None:
+    proc = MagicMock()
+    proc.poll.return_value = None
+    proc.wait.return_value = 0
+    monkeypatch.setattr(bench_dflash.subprocess, "Popen", lambda *args, **kwargs: proc)
+
+    def _get(url: str, timeout: float):
+        del timeout
+        response = MagicMock(status_code=200)
+        response.json.return_value = (
+            {"algorithm": "dflash"} if url.endswith("/healthz") else {}
+        )
+        return response
+
+    monkeypatch.setattr(bench_dflash.httpx, "get", _get)
+
+    try:
+        bench_dflash.start_server(
+            "target",
+            8765,
+            True,
+            draft_model="draft",
+            expected_algorithm="dflash2",
+        )
+    except RuntimeError as exc:
+        assert "algorithm mismatch" in str(exc)
+    else:
+        raise AssertionError("mismatched runtime algorithm must fail")
+    proc.send_signal.assert_called()
+    proc.wait.assert_called()

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -150,6 +150,32 @@ def test_registry_pair_receipt_requires_exact_verified_tuple(monkeypatch) -> Non
     assert not is_registry_verified_pair("user/target-4bit", "user/dflash2", "dflash")
 
 
+def test_registry_pair_searches_past_duplicate_experimental_alias(monkeypatch) -> None:
+    from vllm_mlx import model_aliases
+
+    experimental = AliasProfile(
+        hf_path="user/shared-target-4bit",
+        supports_dflash=False,
+        dflash_draft_model="user/shared-dflash2",
+        dflash_algorithm="dflash2",
+    )
+    verified = AliasProfile(
+        hf_path="user/shared-target-4bit",
+        supports_dflash=True,
+        dflash_draft_model="user/shared-dflash2",
+        dflash_algorithm="dflash2",
+    )
+    monkeypatch.setattr(
+        model_aliases,
+        "list_profiles",
+        lambda: {"experimental-first": experimental, "verified-second": verified},
+    )
+
+    assert is_registry_verified_pair(
+        "user/shared-target-4bit", "user/shared-dflash2", "dflash2"
+    )
+
+
 def test_check_message_lists_eligible_aliases() -> None:
     """Error messages must point users at a working alias — saves a
     docs round-trip."""

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -15,6 +15,7 @@ from vllm_mlx.speculative.dflash.eligibility import (
     DFlashUnavailable,
     _looks_like_4bit,
     check,
+    is_registry_verified_pair,
     report,
 )
 
@@ -128,6 +129,25 @@ def test_legacy_dflash_4bit_cannot_become_curated_by_registry_flag_alone() -> No
     assert "explicit experimental opt-in" in " ".join(result.reasons)
     with pytest.raises(DFlashUnavailable, match="explicit experimental opt-in"):
         check(profile, alias="legacy-4bit")
+
+
+def test_registry_pair_receipt_requires_exact_verified_tuple(monkeypatch) -> None:
+    from vllm_mlx import model_aliases
+
+    profile = AliasProfile(
+        hf_path="user/target-4bit",
+        supports_dflash=True,
+        dflash_draft_model="user/dflash2",
+        dflash_algorithm="dflash2",
+    )
+    monkeypatch.setattr(model_aliases, "list_profiles", lambda: {"target": profile})
+
+    assert is_registry_verified_pair("user/target-4bit", "user/dflash2", "dflash2")
+    assert not is_registry_verified_pair("user/other-4bit", "user/dflash2", "dflash2")
+    assert not is_registry_verified_pair(
+        "user/target-4bit", "user/other-drafter", "dflash2"
+    )
+    assert not is_registry_verified_pair("user/target-4bit", "user/dflash2", "dflash")
 
 
 def test_check_message_lists_eligible_aliases() -> None:

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -28,6 +28,8 @@ def _good_profile() -> AliasProfile:
         is_moe=False,
         supports_dflash=True,
         dflash_draft_model="z-lab/Qwen3.5-27B-DFlash",
+        dflash_target_revision="a" * 40,
+        dflash_draft_revision="b" * 40,
         dflash_algorithm="dflash",
     )
 
@@ -138,16 +140,27 @@ def test_registry_pair_receipt_requires_exact_verified_tuple(monkeypatch) -> Non
         hf_path="user/target-4bit",
         supports_dflash=True,
         dflash_draft_model="user/dflash2",
+        dflash_target_revision="a" * 40,
+        dflash_draft_revision="b" * 40,
         dflash_algorithm="dflash2",
     )
     monkeypatch.setattr(model_aliases, "list_profiles", lambda: {"target": profile})
 
-    assert is_registry_verified_pair("user/target-4bit", "user/dflash2", "dflash2")
-    assert not is_registry_verified_pair("user/other-4bit", "user/dflash2", "dflash2")
-    assert not is_registry_verified_pair(
-        "user/target-4bit", "user/other-drafter", "dflash2"
+    assert is_registry_verified_pair(
+        "user/target-4bit", "a" * 40, "user/dflash2", "b" * 40, "dflash2"
     )
-    assert not is_registry_verified_pair("user/target-4bit", "user/dflash2", "dflash")
+    assert not is_registry_verified_pair(
+        "user/other-4bit", "a" * 40, "user/dflash2", "b" * 40, "dflash2"
+    )
+    assert not is_registry_verified_pair(
+        "user/target-4bit", "a" * 40, "user/other-drafter", "b" * 40, "dflash2"
+    )
+    assert not is_registry_verified_pair(
+        "user/target-4bit", "a" * 40, "user/dflash2", "b" * 40, "dflash"
+    )
+    assert not is_registry_verified_pair(
+        "user/target-4bit", "c" * 40, "user/dflash2", "b" * 40, "dflash2"
+    )
 
 
 def test_registry_pair_searches_past_duplicate_experimental_alias(monkeypatch) -> None:
@@ -157,12 +170,16 @@ def test_registry_pair_searches_past_duplicate_experimental_alias(monkeypatch) -
         hf_path="user/shared-target-4bit",
         supports_dflash=False,
         dflash_draft_model="user/shared-dflash2",
+        dflash_target_revision="a" * 40,
+        dflash_draft_revision="b" * 40,
         dflash_algorithm="dflash2",
     )
     verified = AliasProfile(
         hf_path="user/shared-target-4bit",
         supports_dflash=True,
         dflash_draft_model="user/shared-dflash2",
+        dflash_target_revision="a" * 40,
+        dflash_draft_revision="b" * 40,
         dflash_algorithm="dflash2",
     )
     monkeypatch.setattr(
@@ -172,7 +189,11 @@ def test_registry_pair_searches_past_duplicate_experimental_alias(monkeypatch) -
     )
 
     assert is_registry_verified_pair(
-        "user/shared-target-4bit", "user/shared-dflash2", "dflash2"
+        "user/shared-target-4bit",
+        "a" * 40,
+        "user/shared-dflash2",
+        "b" * 40,
+        "dflash2",
     )
 
 

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -27,6 +27,7 @@ def _good_profile() -> AliasProfile:
         is_moe=False,
         supports_dflash=True,
         dflash_draft_model="z-lab/Qwen3.5-27B-DFlash",
+        dflash_algorithm="dflash",
     )
 
 
@@ -175,6 +176,27 @@ def test_qwen3_5_27b_8bit_alias_passes_check() -> None:
     profile = resolve_profile("qwen3.5-27b-8bit")
     assert profile is not None, "qwen3.5-27b-8bit alias missing"
     check(profile, alias="qwen3.5-27b-8bit")
+
+
+def test_qwen3_8_27b_dflash2_pair_remains_explicit_after_negative_bench() -> None:
+    """Known pairing metadata must not turn a failed qualification into support."""
+    from vllm_mlx.model_aliases import resolve_profile
+
+    profile = resolve_profile("qwen3.8-27b-4bit")
+    assert profile is not None
+    default_result = report(profile, alias="qwen3.8-27b-4bit")
+    assert default_result.recommendation == "experimental"
+    assert default_result.reasons
+
+    explicit_result = report(
+        profile,
+        alias="qwen3.8-27b-4bit",
+        explicit=True,
+        drafter_model=profile.dflash_draft_model,
+    )
+    assert explicit_result.reasons == ()
+    assert explicit_result.recommendation == "experimental"
+    assert "performance-validated" in " ".join(explicit_result.warnings)
 
 
 def test_default_qwen3_5_27b_alias_fails_check_with_4bit_reason() -> None:

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -197,6 +197,18 @@ def test_registry_pair_searches_past_duplicate_experimental_alias(monkeypatch) -
     )
 
 
+def test_registry_pair_lookup_fails_closed_on_registry_error(monkeypatch) -> None:
+    from vllm_mlx import model_aliases
+
+    def _raise():
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(model_aliases, "list_profiles", _raise)
+    assert not is_registry_verified_pair(
+        "user/target", "a" * 40, "user/drafter", "b" * 40, "dflash"
+    )
+
+
 def test_check_message_lists_eligible_aliases() -> None:
     """Error messages must point users at a working alias — saves a
     docs round-trip."""

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -116,6 +116,20 @@ def test_explicit_4bit_main_model_is_experimental() -> None:
         check(p, alias="qwen3.5-27b-4bit")
 
 
+def test_legacy_dflash_4bit_cannot_become_curated_by_registry_flag_alone() -> None:
+    profile = AliasProfile(
+        hf_path="user/target-4bit",
+        supports_dflash=True,
+        dflash_draft_model="user/legacy-dflash",
+        dflash_algorithm="dflash",
+    )
+    result = report(profile, alias="legacy-4bit")
+    assert result.recommendation == "experimental"
+    assert "explicit experimental opt-in" in " ".join(result.reasons)
+    with pytest.raises(DFlashUnavailable, match="explicit experimental opt-in"):
+        check(profile, alias="legacy-4bit")
+
+
 def test_check_message_lists_eligible_aliases() -> None:
     """Error messages must point users at a working alias — saves a
     docs round-trip."""

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -186,6 +186,23 @@ def test_expected_algorithm_only_applies_to_exact_registry_pair() -> None:
     assert _resolve_dflash_expected_algorithm(profile, "operator/override") is None
 
 
+def test_dflash_revision_pins_only_apply_to_exact_registry_pair() -> None:
+    from types import SimpleNamespace
+
+    from vllm_mlx.cli import _resolve_dflash_revisions
+
+    profile = SimpleNamespace(
+        dflash_draft_model="z-lab/Qwen3.8-27B-DFlash2",
+        dflash_target_revision="a" * 40,
+        dflash_draft_revision="b" * 40,
+    )
+    assert _resolve_dflash_revisions(profile, "z-lab/Qwen3.8-27B-DFlash2") == (
+        "a" * 40,
+        "b" * 40,
+    )
+    assert _resolve_dflash_revisions(profile, "operator/override") == (None, None)
+
+
 def test_programmatic_4bit_requires_explicit_experimental_opt_in(monkeypatch) -> None:
     from vllm_mlx.speculative.dflash.eligibility import DFlashUnavailable
     from vllm_mlx.speculative.dflash.server import run_dflash_server
@@ -447,6 +464,8 @@ def test_healthz_and_models_routes() -> None:
         drafter=MagicMock(),
         kind="dflash",
         drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        target_revision="a" * 40,
+        drafter_revision="b" * 40,
     )
     app = _build_app(
         model=MagicMock(),
@@ -465,6 +484,8 @@ def test_healthz_and_models_routes() -> None:
     assert body["engine"] == "dflash"
     assert body["algorithm"] == "dflash"
     assert body["drafter"] == "z-lab/Qwen3.5-27B-DFlash"
+    assert body["target_revision"] == "a" * 40
+    assert body["drafter_revision"] == "b" * 40
 
     r = client.get("/v1/models")
     assert r.status_code == 200
@@ -2380,6 +2401,46 @@ def test_load_runtime_fails_closed_on_algorithm_mismatch(monkeypatch) -> None:
         runtime_module.load_runtime("known/drafter", expected_algorithm="dflash")
 
 
+def test_load_runtime_resolves_pinned_drafter_revision(monkeypatch) -> None:
+    import sys
+    import types
+    from types import SimpleNamespace
+
+    from vllm_mlx.speculative.dflash import runtime as runtime_module
+
+    calls: dict[str, object] = {}
+    fake_speculative = types.ModuleType("mlx_vlm.speculative")
+    fake_drafters = types.ModuleType("mlx_vlm.speculative.drafters")
+    fake_utils = types.ModuleType("mlx_vlm.utils")
+
+    def _get_model_path(repo, revision):
+        calls["resolve"] = (repo, revision)
+        return "/cache/pinned-drafter"
+
+    def _load_drafter(source, kind):
+        calls["load"] = (source, kind)
+        return SimpleNamespace(config=SimpleNamespace(model_type="dflash2")), kind
+
+    fake_utils.get_model_path = _get_model_path
+    fake_drafters.load_drafter = _load_drafter
+    monkeypatch.setitem(sys.modules, "mlx_vlm.speculative", fake_speculative)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.speculative.drafters", fake_drafters)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.utils", fake_utils)
+    monkeypatch.setattr(runtime_module, "have_runtime", lambda: True)
+
+    loaded = runtime_module.load_runtime(
+        "known/drafter",
+        target_revision="a" * 40,
+        drafter_revision="b" * 40,
+        expected_algorithm="dflash2",
+    )
+
+    assert calls["resolve"] == ("known/drafter", "b" * 40)
+    assert calls["load"] == ("/cache/pinned-drafter", "dflash")
+    assert loaded.target_revision == "a" * 40
+    assert loaded.drafter_revision == "b" * 40
+
+
 # =============================================================================
 # Eligibility error surfaces (CLI startup) — the gate must fail fast
 # with an actionable error before the user wastes 5 min downloading weights.
@@ -2425,13 +2486,16 @@ def test_run_dflash_server_loads_models_on_executor_thread(monkeypatch) -> None:
     from vllm_mlx.speculative.dflash import server as srv
 
     load_thread: dict[str, str | None] = {"load": None, "load_runtime": None}
+    load_receipt: dict[str, object] = {}
 
-    def _fake_load(_repo):
+    def _fake_load(_repo, **kwargs):
         load_thread["load"] = threading.current_thread().name
+        load_receipt["target"] = (_repo, kwargs)
         return MagicMock(), MagicMock()
 
-    def _fake_load_runtime(_repo, **_kwargs):
+    def _fake_load_runtime(_repo, **kwargs):
         load_thread["load_runtime"] = threading.current_thread().name
+        load_receipt["drafter"] = (_repo, kwargs)
         return MagicMock()
 
     # Patch the imports at the point of use inside ``run_dflash_server``.
@@ -2447,7 +2511,10 @@ def test_run_dflash_server_loads_models_on_executor_thread(monkeypatch) -> None:
 
     srv.run_dflash_server(
         main_model_repo="mlx-community/Qwen3.5-27B-8bit",
+        main_model_revision="d49462a9487464de69e2240d2bd65e50bb7d1cbc",
         drafter_repo="z-lab/Qwen3.5-27B-DFlash",
+        drafter_revision="25ee0025ff950496a634e100b75c2db4515e9824",
+        expected_algorithm="dflash",
         host="127.0.0.1",
         port=58998,
         served_model_name="qwen3.5-27b-8bit",
@@ -2460,6 +2527,18 @@ def test_run_dflash_server_loads_models_on_executor_thread(monkeypatch) -> None:
     # ThreadPoolExecutor was constructed at module load).
     assert load_thread["load"] is not None, "load() was not called"
     assert load_thread["load_runtime"] is not None, "load_runtime() was not called"
+    assert load_receipt["target"] == (
+        "mlx-community/Qwen3.5-27B-8bit",
+        {"revision": "d49462a9487464de69e2240d2bd65e50bb7d1cbc"},
+    )
+    assert load_receipt["drafter"] == (
+        "z-lab/Qwen3.5-27B-DFlash",
+        {
+            "target_revision": "d49462a9487464de69e2240d2bd65e50bb7d1cbc",
+            "drafter_revision": "25ee0025ff950496a634e100b75c2db4515e9824",
+            "expected_algorithm": "dflash",
+        },
+    )
     assert load_thread["load"].startswith("dflash-worker"), (
         f"model load must run on dflash-worker thread, ran on "
         f"{load_thread['load']!r} — Stream(gpu, N) would not be visible "

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -200,7 +200,7 @@ def test_dflash_revision_pins_only_apply_to_exact_registry_pair() -> None:
         "a" * 40,
         "b" * 40,
     )
-    assert _resolve_dflash_revisions(profile, "operator/override") == (None, None)
+    assert _resolve_dflash_revisions(profile, "operator/override") == ("a" * 40, None)
 
 
 def test_programmatic_4bit_requires_explicit_experimental_opt_in(monkeypatch) -> None:

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -184,6 +184,8 @@ def test_expected_algorithm_only_applies_to_exact_registry_pair() -> None:
         == "dflash2"
     )
     assert _resolve_dflash_expected_algorithm(profile, "operator/override") is None
+    assert _resolve_dflash_expected_algorithm(None, "operator/override") is None
+    assert _resolve_dflash_expected_algorithm(profile, None) is None
 
 
 def test_dflash_revision_pins_only_apply_to_exact_registry_pair() -> None:
@@ -201,6 +203,8 @@ def test_dflash_revision_pins_only_apply_to_exact_registry_pair() -> None:
         "b" * 40,
     )
     assert _resolve_dflash_revisions(profile, "operator/override") == ("a" * 40, None)
+    assert _resolve_dflash_revisions(None, "operator/override") == (None, None)
+    assert _resolve_dflash_revisions(profile, None) == (None, None)
 
 
 def test_programmatic_4bit_requires_explicit_experimental_opt_in(monkeypatch) -> None:
@@ -240,6 +244,44 @@ def test_programmatic_dflash2_identity_cannot_bypass_registry_qualification(
             cors_origins=[],
             uvicorn_log_level="error",
         )
+
+
+def test_programmatic_experimental_4bit_logs_unverified_pair(
+    monkeypatch, caplog
+) -> None:
+    import sys
+    import types
+
+    from vllm_mlx.speculative.dflash import server as srv
+    from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+
+    runtime = DFlashRuntime(
+        drafter=MagicMock(), kind="dflash", drafter_repo="user/drafter"
+    )
+    monkeypatch.setattr(srv, "have_runtime", lambda: True)
+    monkeypatch.setattr(srv, "load_runtime", lambda _repo, **_kwargs: runtime)
+    fake_mlx_vlm = types.ModuleType("mlx_vlm")
+    fake_mlx_vlm.load = lambda _repo, **_kwargs: (MagicMock(), MagicMock())
+    monkeypatch.setitem(sys.modules, "mlx_vlm", fake_mlx_vlm)
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda *_args, **_kwargs: None)
+    with caplog.at_level("WARNING"):
+        srv.run_dflash_server(
+            main_model_repo="user/target-4bit",
+            drafter_repo="user/drafter",
+            expected_algorithm="dflash",
+            experimental_opt_in=True,
+            host="127.0.0.1",
+            port=58996,
+            served_model_name="target",
+            default_max_tokens=32,
+            cors_origins=[],
+            uvicorn_log_level="error",
+        )
+
+    assert "has not been performance-validated" in caplog.text
 
 
 def test_dflash_preflight_rejects_legacy_mtp_alias(capsys) -> None:
@@ -327,6 +369,23 @@ def test_info_dflash_marks_4bit_alias_experimental(capsys) -> None:
     captured = capsys.readouterr()
     assert "DFlash eligibility" in captured.out
     assert "experimental" in captured.out
+
+
+def test_info_dflash_marks_pinned_4bit_dflash2_pair_qualified(capsys) -> None:
+    from vllm_mlx.cli import _print_dflash_status
+    from vllm_mlx.model_aliases import AliasProfile
+
+    profile = AliasProfile(
+        hf_path="user/target-4bit",
+        supports_dflash=True,
+        dflash_draft_model="user/dflash2",
+        dflash_target_revision="a" * 40,
+        dflash_draft_revision="b" * 40,
+        dflash_algorithm="dflash2",
+    )
+    _print_dflash_status("target", profile)
+
+    assert "4-bit (exact pair qualified)" in capsys.readouterr().out
 
 
 def test_info_qwen38_exposes_exact_dflash2_experiment_without_recommending_it(

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -170,6 +170,22 @@ def test_unverified_dflash_profile_cannot_inherit_residual_drafter() -> None:
     assert _resolve_dflash_drafter_repo(args, profile) is None
 
 
+def test_expected_algorithm_only_applies_to_exact_registry_pair() -> None:
+    from types import SimpleNamespace
+
+    from vllm_mlx.cli import _resolve_dflash_expected_algorithm
+
+    profile = SimpleNamespace(
+        dflash_draft_model="z-lab/Qwen3.8-27B-DFlash2",
+        dflash_algorithm="dflash2",
+    )
+    assert (
+        _resolve_dflash_expected_algorithm(profile, "z-lab/Qwen3.8-27B-DFlash2")
+        == "dflash2"
+    )
+    assert _resolve_dflash_expected_algorithm(profile, "operator/override") is None
+
+
 def test_programmatic_4bit_requires_explicit_experimental_opt_in(monkeypatch) -> None:
     from vllm_mlx.speculative.dflash.eligibility import DFlashUnavailable
     from vllm_mlx.speculative.dflash.server import run_dflash_server
@@ -273,6 +289,19 @@ def test_info_dflash_marks_4bit_alias_experimental(capsys) -> None:
     captured = capsys.readouterr()
     assert "DFlash eligibility" in captured.out
     assert "experimental" in captured.out
+
+
+def test_info_qwen38_exposes_exact_dflash2_experiment_without_recommending_it(
+    capsys,
+) -> None:
+    from vllm_mlx.cli import info_command
+
+    args = type("Args", (), {"model": "qwen3.8-27b-4bit"})()
+    info_command(args)
+    output = capsys.readouterr().out
+    assert "Drafter algorithm : dflash2" in output
+    assert '\'{"method":"dflash","model":"z-lab/Qwen3.8-27B-DFlash2"}\'' in output
+    assert "recommended / verified" not in output
 
 
 def test_info_dflash_start_with_uses_alias_not_hf_path(capsys, monkeypatch) -> None:
@@ -413,6 +442,7 @@ def test_healthz_and_models_routes() -> None:
     body = r.json()
     assert body["status"] == "ok"
     assert body["engine"] == "dflash"
+    assert body["algorithm"] == "dflash"
     assert body["drafter"] == "z-lab/Qwen3.5-27B-DFlash"
 
     r = client.get("/v1/models")
@@ -444,7 +474,7 @@ def test_run_dflash_server_wires_security_configuration(monkeypatch) -> None:
         drafter_repo="z-lab/Qwen3.5-27B-DFlash",
     )
     monkeypatch.setattr(srv, "have_runtime", lambda: True)
-    monkeypatch.setattr(srv, "load_runtime", lambda _repo: runtime)
+    monkeypatch.setattr(srv, "load_runtime", lambda _repo, **_kwargs: runtime)
 
     fake_mlx_vlm = types.ModuleType("mlx_vlm")
     fake_mlx_vlm.load = lambda _repo: (MagicMock(), MagicMock())
@@ -2294,6 +2324,41 @@ def test_dflashruntime_accept_lens_tolerates_wrong_type(caplog) -> None:
     assert rt.accept_lens_snapshot() == []
 
 
+def test_runtime_algorithm_distinguishes_dflash2_from_dispatch_kind() -> None:
+    """Both generations dispatch as kind=dflash; config identity is the receipt."""
+    from types import SimpleNamespace
+
+    from vllm_mlx.speculative.dflash.runtime import _runtime_algorithm
+
+    legacy = SimpleNamespace(config=SimpleNamespace(model_type="qwen3"))
+    dflash2 = SimpleNamespace(config=SimpleNamespace(model_type="dflash2"))
+    assert _runtime_algorithm(legacy) == "dflash"
+    assert _runtime_algorithm(dflash2) == "dflash2"
+
+
+def test_load_runtime_fails_closed_on_algorithm_mismatch(monkeypatch) -> None:
+    import sys
+    import types
+    from types import SimpleNamespace
+
+    from vllm_mlx.speculative.dflash import runtime as runtime_module
+
+    fake_speculative = types.ModuleType("mlx_vlm.speculative")
+    fake_drafters = types.ModuleType("mlx_vlm.speculative.drafters")
+    fake_drafters.load_drafter = lambda _repo, kind: (
+        SimpleNamespace(config=SimpleNamespace(model_type="dflash2")),
+        kind,
+    )
+    monkeypatch.setitem(sys.modules, "mlx_vlm.speculative", fake_speculative)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.speculative.drafters", fake_drafters)
+    monkeypatch.setattr(runtime_module, "have_runtime", lambda: True)
+
+    loaded = runtime_module.load_runtime("known/drafter", expected_algorithm="dflash2")
+    assert loaded.algorithm == "dflash2"
+    with pytest.raises(RuntimeError, match="architecture mismatch"):
+        runtime_module.load_runtime("known/drafter", expected_algorithm="dflash")
+
+
 # =============================================================================
 # Eligibility error surfaces (CLI startup) — the gate must fail fast
 # with an actionable error before the user wastes 5 min downloading weights.
@@ -2344,7 +2409,7 @@ def test_run_dflash_server_loads_models_on_executor_thread(monkeypatch) -> None:
         load_thread["load"] = threading.current_thread().name
         return MagicMock(), MagicMock()
 
-    def _fake_load_runtime(_repo):
+    def _fake_load_runtime(_repo, **_kwargs):
         load_thread["load_runtime"] = threading.current_thread().name
         return MagicMock()
 

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -204,6 +204,27 @@ def test_programmatic_4bit_requires_explicit_experimental_opt_in(monkeypatch) ->
         )
 
 
+def test_programmatic_dflash2_identity_cannot_bypass_registry_qualification(
+    monkeypatch,
+) -> None:
+    from vllm_mlx.speculative.dflash.eligibility import DFlashUnavailable
+    from vllm_mlx.speculative.dflash.server import run_dflash_server
+
+    monkeypatch.setattr("vllm_mlx.speculative.dflash.server.have_runtime", lambda: True)
+    with pytest.raises(DFlashUnavailable, match="experimental_opt_in=True"):
+        run_dflash_server(
+            main_model_repo="user/target-4bit",
+            drafter_repo="user/dflash2",
+            expected_algorithm="dflash2",
+            host="127.0.0.1",
+            port=8000,
+            served_model_name="target",
+            default_max_tokens=32,
+            cors_origins=[],
+            uvicorn_log_level="error",
+        )
+
+
 def test_dflash_preflight_rejects_legacy_mtp_alias(capsys) -> None:
     from vllm_mlx.cli import _preflight_dflash_mutexes_or_exit
 

--- a/tests/test_modality_field.py
+++ b/tests/test_modality_field.py
@@ -152,6 +152,9 @@ class TestNonTextLaneRejectsARGates:
                     "supports_spec_decode": False,
                     "supports_dflash": True,
                     "dflash_draft_model": "z-lab/whatever",
+                    "dflash_target_revision": "a" * 40,
+                    "dflash_draft_revision": "b" * 40,
+                    "dflash_algorithm": "dflash",
                 },
             )
 

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -1446,6 +1446,13 @@ def test_alias_profile_str_fields_are_explicitly_listed():
             "chat_template_id",
             "suffix_decoding_tier",  # one of VALID_SUFFIX_TIERS — non-routing data
             "dflash_draft_model",  # HF path for the spec-decode drafter
+            # Immutable Hub commit SHAs. They constrain artifact identity and
+            # cannot select an engine lane; _coerce requires full 40-char pins.
+            "dflash_target_revision",
+            "dflash_draft_revision",
+            # Closed runtime identity receipt validated against
+            # VALID_DFLASH_ALGORITHMS before the DFlash lane can start.
+            "dflash_algorithm",
             "ddtree_draft_model",  # HF path for the DDTree/DFlash drafter
             "mtp_draft_model",  # HF 'org/repo' path for the MTP drafter (#1987);
             # validated as non-empty org/repo at JSON load in model_aliases.py,

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -48,6 +48,7 @@ def test_verified_entries_do_not_require_experimental_opt_in():
         supports_dflash=True,
         supports_ddtree=True,
         dflash_draft_model="user/dflash-drafter",
+        dflash_algorithm="dflash",
         ddtree_draft_model="user/ddtree-drafter",
         ddtree_speculative_tokens=16,
         ddtree_tree_budget=24,
@@ -85,6 +86,19 @@ def test_quantized_curated_flags_remain_experimental():
             assessment = assess_method(profile, method)
             assert assessment.recommendation == "experimental"
             assert assessment.explicit_opt_in is True
+
+
+def test_quantized_exact_pair_with_runtime_identity_is_verified():
+    profile = AliasProfile(
+        hf_path="user/target-4bit",
+        supports_dflash=True,
+        dflash_draft_model="user/dflash2-drafter",
+        dflash_algorithm="dflash2",
+    )
+    assessment = assess_method(profile, "dflash")
+    assert assessment.recommendation == "verified"
+    assert assessment.explicit_opt_in is False
+    assert assessment.capable is True
 
 
 def test_quantization_recognizes_hyphenated_spellings():

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -48,6 +48,8 @@ def test_verified_entries_do_not_require_experimental_opt_in():
         supports_dflash=True,
         supports_ddtree=True,
         dflash_draft_model="user/dflash-drafter",
+        dflash_target_revision="a" * 40,
+        dflash_draft_revision="b" * 40,
         dflash_algorithm="dflash",
         ddtree_draft_model="user/ddtree-drafter",
         ddtree_speculative_tokens=16,
@@ -94,12 +96,27 @@ def test_quantized_exact_pair_with_runtime_identity_is_verified():
         hf_path="user/target-4bit",
         supports_dflash=True,
         dflash_draft_model="user/dflash2-drafter",
+        dflash_target_revision="a" * 40,
+        dflash_draft_revision="b" * 40,
         dflash_algorithm="dflash2",
     )
     assessment = assess_method(profile, "dflash")
     assert assessment.recommendation == "verified"
     assert assessment.explicit_opt_in is False
     assert assessment.capable is True
+
+
+def test_dflash_without_immutable_revision_receipt_is_experimental():
+    profile = AliasProfile(
+        hf_path="user/target-8bit",
+        supports_dflash=True,
+        dflash_draft_model="user/dflash-drafter",
+        dflash_algorithm="dflash",
+    )
+    assessment = assess_method(profile, "dflash")
+    assert assessment.recommendation == "experimental"
+    assert assessment.explicit_opt_in is True
+    assert assessment.capable is None
 
 
 def test_quantization_recognizes_hyphenated_spellings():

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -80,6 +80,7 @@ def test_quantized_curated_flags_remain_experimental():
             hf_path=hf_path,
             supports_dflash=True,
             dflash_draft_model="user/drafter",
+            dflash_algorithm="dflash",
             mtp_draft_model="user/mtp-head",
         )
         for method in ("dflash", "mtp"):

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -247,6 +247,7 @@
     "supports_spec_decode": false,
     "supports_dflash": true,
     "dflash_draft_model": "z-lab/Qwen3.5-27B-DFlash",
+    "dflash_algorithm": "dflash",
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
   },
@@ -393,7 +394,9 @@
     "supports_spec_decode": false,
     "mtp_draft_model": "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX",
     "mtp_speculative_tokens": 3,
-    "mtp_continuous_batching_tier": "verified"
+    "mtp_continuous_batching_tier": "verified",
+    "dflash_draft_model": "z-lab/Qwen3.8-27B-DFlash2",
+    "dflash_algorithm": "dflash2"
   },
   "qwen3.8-27b-mixed-3.5bpw": {
     "hf_path": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -247,6 +247,8 @@
     "supports_spec_decode": false,
     "supports_dflash": true,
     "dflash_draft_model": "z-lab/Qwen3.5-27B-DFlash",
+    "dflash_target_revision": "d49462a9487464de69e2240d2bd65e50bb7d1cbc",
+    "dflash_draft_revision": "25ee0025ff950496a634e100b75c2db4515e9824",
     "dflash_algorithm": "dflash",
     "pflash_tier": "verified",
     "turboquant_tier": "k8v4_verified"
@@ -396,6 +398,8 @@
     "mtp_speculative_tokens": 3,
     "mtp_continuous_batching_tier": "verified",
     "dflash_draft_model": "z-lab/Qwen3.8-27B-DFlash2",
+    "dflash_target_revision": "aa985c29ff5b334cbfdcbbc787d47e66e9d9e456",
+    "dflash_draft_revision": "50307d4c4cde6860d4eee73e2547cd786fe8e8a4",
     "dflash_algorithm": "dflash2"
   },
   "qwen3.8-27b-mixed-3.5bpw": {

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2584,7 +2584,7 @@ def _resolve_dflash_revisions(
     if profile is None or not drafter_repo:
         return None, None
     if getattr(profile, "dflash_draft_model", None) != drafter_repo:
-        return None, None
+        return getattr(profile, "dflash_target_revision", None), None
     return (
         getattr(profile, "dflash_target_revision", None),
         getattr(profile, "dflash_draft_revision", None),

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2563,6 +2563,19 @@ def _resolve_dflash_drafter_repo(args, profile) -> str | None:
     return None
 
 
+def _resolve_dflash_expected_algorithm(profile, drafter_repo: str | None) -> str | None:
+    """Return a registry receipt only for the exact declared pairing.
+
+    Explicit operator overrides remain experimental and are identified from
+    the loaded config instead of inheriting an unrelated alias expectation.
+    """
+    if profile is None or not drafter_repo:
+        return None
+    if getattr(profile, "dflash_draft_model", None) != drafter_repo:
+        return None
+    return getattr(profile, "dflash_algorithm", None)
+
+
 def _preflight_dflash_mutexes_or_exit(args) -> None:
     """Reject DFlash flag combinations before optional-runtime probes."""
 
@@ -4096,6 +4109,12 @@ def serve_command(args):
             ),
             reasoning_parser_name=args.reasoning_parser,
             experimental_opt_in=getattr(args, "_dflash_experimental", False),
+            verified_pair=not getattr(args, "_dflash_experimental", False),
+            expected_algorithm=(
+                _resolve_dflash_expected_algorithm(
+                    _profile, getattr(args, "_dflash_drafter_repo", None)
+                )
+            ),
         )
         return
 
@@ -9331,11 +9350,10 @@ def info_command(args):
 
 
 def _print_dflash_status(alias: str, profile) -> None:
-    """Render a 3-row DFlash status block for ``rapid-mlx info <alias>``.
+    """Render the DFlash status block for ``rapid-mlx info <alias>``.
 
-    Shows each gate (declared support / not MoE / not 4-bit / drafter
-    present) so a user who tried DFlash and got a vague error can see
-    exactly which gate they're tripping.
+    Shows qualification, target precision, declared pairing, and runtime
+    identity so an explicit experiment cannot be mistaken for a recommendation.
     """
     from vllm_mlx.spec_decode.capability import assess_method
     from vllm_mlx.speculative.dflash.eligibility import (
@@ -9352,6 +9370,14 @@ def _print_dflash_status(alias: str, profile) -> None:
     def _yes(ok: bool, msg_ok: str, msg_no: str) -> str:
         return ("✓ " + msg_ok) if ok else ("✗ " + msg_no)
 
+    quantized_target = _looks_like_4bit(profile.hf_path)
+    if not quantized_target:
+        precision_status = "✓ 8-bit or higher"
+    elif profile.supports_dflash and profile.dflash_algorithm == "dflash2":
+        precision_status = "✓ 4-bit (exact pair qualified)"
+    else:
+        precision_status = "⚠ 4-bit (experimental pair)"
+
     rows = [
         (
             "Declared support",
@@ -9359,12 +9385,12 @@ def _print_dflash_status(alias: str, profile) -> None:
         ),
         ("Not MoE", _yes(not profile.is_moe, "yes (dense)", "no (MoE)")),
         (
-            "Precision ≥8-bit",
-            _yes(
-                not _looks_like_4bit(profile.hf_path),
-                "yes",
-                "no (4-bit/mxfp4/nvfp4)",
-            ),
+            "Target precision",
+            precision_status,
+        ),
+        (
+            "Drafter algorithm",
+            profile.dflash_algorithm or "unknown (load-time detection only)",
         ),
         (
             "Drafter declared",
@@ -9412,10 +9438,11 @@ def _print_dflash_status(alias: str, profile) -> None:
         )
         print()
     elif capable:
+        drafter_hint = profile.dflash_draft_model or "<drafter>"
         print(
             f"  Experimental opt-in: rapid-mlx serve {alias} "
             "--speculative-config "
-            '\'{"method":"dflash","model":"<drafter>"}\''
+            f'\'{{"method":"dflash","model":"{drafter_hint}"}}\''
         )
         print("  Performance and output quality are not Rapid-MLX recommendations.")
         print()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -9392,7 +9392,12 @@ def _print_dflash_status(alias: str, profile) -> None:
     quantized_target = _looks_like_4bit(profile.hf_path)
     if not quantized_target:
         precision_status = "✓ 8-bit or higher"
-    elif profile.supports_dflash and profile.dflash_algorithm == "dflash2":
+    elif (
+        profile.supports_dflash
+        and profile.dflash_algorithm == "dflash2"
+        and profile.dflash_target_revision
+        and profile.dflash_draft_revision
+    ):
         precision_status = "✓ 4-bit (exact pair qualified)"
     else:
         precision_status = "⚠ 4-bit (experimental pair)"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2576,6 +2576,21 @@ def _resolve_dflash_expected_algorithm(profile, drafter_repo: str | None) -> str
     return getattr(profile, "dflash_algorithm", None)
 
 
+def _resolve_dflash_revisions(
+    profile, drafter_repo: str | None
+) -> tuple[str | None, str | None]:
+    """Return immutable target/drafter pins for the exact registry pair."""
+
+    if profile is None or not drafter_repo:
+        return None, None
+    if getattr(profile, "dflash_draft_model", None) != drafter_repo:
+        return None, None
+    return (
+        getattr(profile, "dflash_target_revision", None),
+        getattr(profile, "dflash_draft_revision", None),
+    )
+
+
 def _preflight_dflash_mutexes_or_exit(args) -> None:
     """Reject DFlash flag combinations before optional-runtime probes."""
 
@@ -4086,10 +4101,17 @@ def serve_command(args):
         _check_disk_space(args.model, force=getattr(args, "force_disk_check", False))
         _check_memory_capacity(args.model, alias=_alias_name)
         server._sync_config()
+        _drafter_repo = getattr(args, "_dflash_drafter_repo", None) or (
+            _resolve_dflash_drafter_repo(args, _profile)
+        )
+        _target_revision, _drafter_revision = _resolve_dflash_revisions(
+            _profile, _drafter_repo
+        )
         run_dflash_server(
             main_model_repo=_profile.hf_path if _profile else args.model,
-            drafter_repo=getattr(args, "_dflash_drafter_repo", None)
-            or _resolve_dflash_drafter_repo(args, _profile),
+            main_model_revision=_target_revision,
+            drafter_repo=_drafter_repo,
+            drafter_revision=_drafter_revision,
             host=args.host,
             port=args.port,
             served_model_name=args.served_model_name or _alias_name,
@@ -4110,9 +4132,7 @@ def serve_command(args):
             reasoning_parser_name=args.reasoning_parser,
             experimental_opt_in=getattr(args, "_dflash_experimental", False),
             expected_algorithm=(
-                _resolve_dflash_expected_algorithm(
-                    _profile, getattr(args, "_dflash_drafter_repo", None)
-                )
+                _resolve_dflash_expected_algorithm(_profile, _drafter_repo)
             ),
         )
         return

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4109,7 +4109,6 @@ def serve_command(args):
             ),
             reasoning_parser_name=args.reasoning_parser,
             experimental_opt_in=getattr(args, "_dflash_experimental", False),
-            verified_pair=not getattr(args, "_dflash_experimental", False),
             expected_algorithm=(
                 _resolve_dflash_expected_algorithm(
                     _profile, getattr(args, "_dflash_drafter_repo", None)

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -79,6 +79,11 @@ VALID_PFLASH_TIERS: frozenset[str] = frozenset({"unknown", "verified"})
 # explicit CLI still wins. Mirrors ``pflash_tier`` in shape.
 VALID_TURBOQUANT_TIERS: frozenset[str] = frozenset({"unknown", "k8v4_verified"})
 
+# Drafter architectures whose runtime identity can be asserted at startup.
+# This is intentionally narrower than mlx-vlm's generic ``draft_kind``
+# (DFlash and DFlash2 both dispatch through kind="dflash").
+VALID_DFLASH_ALGORITHMS: frozenset[str] = frozenset({"dflash", "dflash2"})
+
 # Bundled chat-template contracts that may be selected by a model profile.
 # The value is declarative model data, not a request-time heuristic: aliases
 # opt into one exact template and the tokenizer loader resolves it once.
@@ -196,6 +201,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "suffix_bench_speedup",
             "supports_dflash",
             "dflash_draft_model",
+            "dflash_algorithm",
             "supports_ddtree",
             "ddtree_draft_model",
             "ddtree_speculative_tokens",
@@ -368,6 +374,20 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         raise ValueError(
             f"alias {alias!r}: dflash_draft_model must be a string, "
             f"got {type(dflash_draft_model).__name__}"
+        )
+    dflash_algorithm = value.get("dflash_algorithm")
+    if dflash_draft_model and not dflash_algorithm:
+        raise ValueError(
+            f"alias {alias!r}: dflash_draft_model requires dflash_algorithm to be set"
+        )
+    if dflash_algorithm and not dflash_draft_model:
+        raise ValueError(
+            f"alias {alias!r}: dflash_algorithm requires dflash_draft_model to be set"
+        )
+    if dflash_algorithm is not None and dflash_algorithm not in VALID_DFLASH_ALGORITHMS:
+        raise ValueError(
+            f"alias {alias!r}: dflash_algorithm={dflash_algorithm!r} not in "
+            f"{sorted(VALID_DFLASH_ALGORITHMS)}"
         )
     supports_ddtree = _strict_bool("supports_ddtree", False)
     ddtree_draft_model = value.get("ddtree_draft_model")
@@ -649,6 +669,7 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         suffix_bench_speedup=speedup,
         supports_dflash=supports_dflash,
         dflash_draft_model=dflash_draft_model,
+        dflash_algorithm=dflash_algorithm,
         supports_ddtree=supports_ddtree,
         ddtree_draft_model=ddtree_draft_model,
         ddtree_speculative_tokens=ddtree_speculative_tokens,

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -201,6 +201,8 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             "suffix_bench_speedup",
             "supports_dflash",
             "dflash_draft_model",
+            "dflash_target_revision",
+            "dflash_draft_revision",
             "dflash_algorithm",
             "supports_ddtree",
             "ddtree_draft_model",
@@ -389,6 +391,31 @@ def _coerce(alias: str, value: object) -> AliasProfile:
             f"alias {alias!r}: dflash_algorithm={dflash_algorithm!r} not in "
             f"{sorted(VALID_DFLASH_ALGORITHMS)}"
         )
+    dflash_target_revision = value.get("dflash_target_revision")
+    dflash_draft_revision = value.get("dflash_draft_revision")
+    revisions = (dflash_target_revision, dflash_draft_revision)
+    if dflash_draft_model and any(revision is None for revision in revisions):
+        raise ValueError(
+            f"alias {alias!r}: dflash_draft_model requires immutable "
+            "dflash_target_revision and dflash_draft_revision pins"
+        )
+    if not dflash_draft_model and any(revision is not None for revision in revisions):
+        raise ValueError(
+            f"alias {alias!r}: DFlash revision pins require dflash_draft_model"
+        )
+    for key, revision in (
+        ("dflash_target_revision", dflash_target_revision),
+        ("dflash_draft_revision", dflash_draft_revision),
+    ):
+        if revision is not None and (
+            not isinstance(revision, str)
+            or len(revision) != 40
+            or any(char not in "0123456789abcdef" for char in revision)
+        ):
+            raise ValueError(
+                f"alias {alias!r}: {key} must be a full lowercase 40-character "
+                "Hub commit SHA"
+            )
     supports_ddtree = _strict_bool("supports_ddtree", False)
     ddtree_draft_model = value.get("ddtree_draft_model")
     if supports_ddtree and not ddtree_draft_model:
@@ -669,6 +696,8 @@ def _coerce(alias: str, value: object) -> AliasProfile:
         suffix_bench_speedup=speedup,
         supports_dflash=supports_dflash,
         dflash_draft_model=dflash_draft_model,
+        dflash_target_revision=dflash_target_revision,
+        dflash_draft_revision=dflash_draft_revision,
         dflash_algorithm=dflash_algorithm,
         supports_ddtree=supports_ddtree,
         ddtree_draft_model=ddtree_draft_model,

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -198,14 +198,18 @@ class ModelProfile:
     suffix_decoding_tier: str = "unknown"
     suffix_bench_speedup: tuple[tuple[str, float], ...] | None = None
     # DFlash speculative-decoding eligibility (issue #264). Explicit opt-in
-    # per alias rather than auto-derived because the PoC showed
-    # precision-dependent regressions: 4-bit kills acceptance even on dense
-    # models. Aliases keep ``supports_dflash=False`` until benched to win
-    # by ≥1.3× on the canonical Fibonacci/Quicksort/HashTable prompts.
+    # per concrete target/drafter pair rather than auto-derived: quantization
+    # and drafter architecture both materially affect acceptance. Aliases keep
+    # ``supports_dflash=False`` until the exact pair clears the mixed-workload
+    # qualification gate.
     # ``dflash_draft_model`` is the matching drafter HF path (e.g.
     # ``z-lab/Qwen3.5-27B-DFlash``); required if ``supports_dflash=True``.
     supports_dflash: bool = False
     dflash_draft_model: str | None = None
+    # Expected runtime architecture.  Startup compares this receipt with the
+    # loaded drafter's normalized config and fails closed on mismatch, avoiding
+    # a misleading "DFlash enabled" server that loaded a different algorithm.
+    dflash_algorithm: str | None = None
     # Recommended sampling defaults — curated per-family overrides that
     # sit above HF ``generation_config.json`` in the resolve chain (see
     # ``service/helpers.py``). Tuple-of-pairs (not dict) because the

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -206,6 +206,11 @@ class ModelProfile:
     # ``z-lab/Qwen3.5-27B-DFlash``); required if ``supports_dflash=True``.
     supports_dflash: bool = False
     dflash_draft_model: str | None = None
+    # Immutable Hub revisions for both sides of the qualified pair. Repository
+    # names alone are mutable and therefore are not a sufficient qualification
+    # receipt.
+    dflash_target_revision: str | None = None
+    dflash_draft_revision: str | None = None
     # Expected runtime architecture.  Startup compares this receipt with the
     # loaded drafter's normalized config and fails closed on mismatch, avoiding
     # a misleading "DFlash enabled" server that loaded a different algorithm.

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -74,7 +74,7 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
         verified = (
             profile.supports_dflash
             and bool(profile.dflash_draft_model)
-            and not _is_experimental_quantization(profile)
+            and bool(profile.dflash_algorithm)
         )
         return SpecCapability(
             method,

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -75,6 +75,10 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             profile.supports_dflash
             and bool(profile.dflash_draft_model)
             and bool(profile.dflash_algorithm)
+            and (
+                not _is_experimental_quantization(profile)
+                or profile.dflash_algorithm == "dflash2"
+            )
         )
         return SpecCapability(
             method,

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -75,6 +75,8 @@ def assess_method(profile: ModelProfile, method: str) -> SpecCapability:
             profile.supports_dflash
             and bool(profile.dflash_draft_model)
             and bool(profile.dflash_algorithm)
+            and bool(profile.dflash_target_revision)
+            and bool(profile.dflash_draft_revision)
             and (
                 not _is_experimental_quantization(profile)
                 or profile.dflash_algorithm == "dflash2"

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -83,6 +83,7 @@ def report(
     curated_pair = (
         profile.supports_dflash
         and bool(profile.dflash_algorithm)
+        and (not is_4bit or profile.dflash_algorithm == "dflash2")
         and bool(drafter_model or profile.dflash_draft_model)
         and (drafter_model is None or drafter_model == profile.dflash_draft_model)
     )

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -168,9 +168,8 @@ def is_registry_verified_pair(
                 and profile.dflash_algorithm == expected_algorithm
             ):
                 assessment = report(profile, alias=alias)
-                return (
-                    not assessment.reasons and assessment.recommendation == "verified"
-                )
+                if not assessment.reasons and assessment.recommendation == "verified":
+                    return True
     except Exception:  # noqa: BLE001 — qualification lookup must fail closed
         return False
     return False

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -83,6 +83,8 @@ def report(
     curated_pair = (
         profile.supports_dflash
         and bool(profile.dflash_algorithm)
+        and bool(profile.dflash_target_revision)
+        and bool(profile.dflash_draft_revision)
         and (not is_4bit or profile.dflash_algorithm == "dflash2")
         and bool(drafter_model or profile.dflash_draft_model)
         and (drafter_model is None or drafter_model == profile.dflash_draft_model)
@@ -146,7 +148,9 @@ def eligible_aliases() -> list[str]:
 
 def is_registry_verified_pair(
     main_model_repo: str,
+    main_model_revision: str | None,
     drafter_repo: str,
+    drafter_revision: str | None,
     expected_algorithm: str | None,
 ) -> bool:
     """Return whether the exact runtime tuple is registry-qualified.
@@ -156,7 +160,15 @@ def is_registry_verified_pair(
     verified; arbitrary programmatic callers therefore retain the explicit
     experimental opt-in requirement.
     """
-    if not main_model_repo or not drafter_repo or not expected_algorithm:
+    if not all(
+        (
+            main_model_repo,
+            main_model_revision,
+            drafter_repo,
+            drafter_revision,
+            expected_algorithm,
+        )
+    ):
         return False
     try:
         from vllm_mlx.model_aliases import list_profiles
@@ -164,7 +176,9 @@ def is_registry_verified_pair(
         for alias, profile in list_profiles().items():
             if (
                 profile.hf_path == main_model_repo
+                and profile.dflash_target_revision == main_model_revision
                 and profile.dflash_draft_model == drafter_repo
+                and profile.dflash_draft_revision == drafter_revision
                 and profile.dflash_algorithm == expected_algorithm
             ):
                 assessment = report(profile, alias=alias)

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -6,14 +6,12 @@ This is the single chokepoint between user intent
 Failures here surface as actionable error
 messages at server-start, never as silent regressions at request time.
 
-Gates derived from PoC bench data (see issue #264):
+Gates derived from qualification bench data (see issue #264):
   - Alias must declare ``supports_dflash=True`` (explicit opt-in)
   - Alias must NOT be ``is_moe=True`` (MoE acceptance floors at ~1.5)
-  - Main model must be 8-bit or higher; detected from the HF path
-    naming convention (``-4bit``/``mxfp4``/``nvfp4`` suffixes used by
-    mlx-community). A custom-named 4-bit repo would slip through this
-    heuristic — for v1 we accept that risk since every supported alias
-    is curated; load-time quant-config inspection is a phase-2 item.
+  - A curated alias pins both a drafter repository and its expected runtime
+    algorithm. Quantized pairs remain experimental unless that exact registry
+    entry has passed the benchmark gate.
   - Drafter HF path must be reachable (no auth-gated repo without token)
 """
 
@@ -82,7 +80,13 @@ def report(
             "measured on Qwen3.6-35B-A3B"
         )
     is_4bit = _looks_like_4bit(profile.hf_path)
-    if is_4bit:
+    curated_pair = (
+        profile.supports_dflash
+        and bool(profile.dflash_algorithm)
+        and bool(drafter_model or profile.dflash_draft_model)
+        and (drafter_model is None or drafter_model == profile.dflash_draft_model)
+    )
+    if is_4bit and not curated_pair:
         warnings.append(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "
             "this pair has not been performance-validated and may be slower"
@@ -97,12 +101,6 @@ def report(
         # Should be caught at JSON-load time by _coerce, but defend
         # against direct AliasProfile construction in tests/code.
         reasons.append("DFlash requires an explicit drafter model")
-    curated_pair = (
-        not is_4bit
-        and profile.supports_dflash
-        and has_drafter
-        and (drafter_model is None or drafter_model == profile.dflash_draft_model)
-    )
     if explicit and not curated_pair:
         warnings.append(
             "this target/drafter pair is experimental and has not been "

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -144,6 +144,38 @@ def eligible_aliases() -> list[str]:
         return []
 
 
+def is_registry_verified_pair(
+    main_model_repo: str,
+    drafter_repo: str,
+    expected_algorithm: str | None,
+) -> bool:
+    """Return whether the exact runtime tuple is registry-qualified.
+
+    The server uses this instead of trusting a caller-supplied bypass boolean.
+    Every component must match one profile whose normal eligibility report is
+    verified; arbitrary programmatic callers therefore retain the explicit
+    experimental opt-in requirement.
+    """
+    if not main_model_repo or not drafter_repo or not expected_algorithm:
+        return False
+    try:
+        from vllm_mlx.model_aliases import list_profiles
+
+        for alias, profile in list_profiles().items():
+            if (
+                profile.hf_path == main_model_repo
+                and profile.dflash_draft_model == drafter_repo
+                and profile.dflash_algorithm == expected_algorithm
+            ):
+                assessment = report(profile, alias=alias)
+                return (
+                    not assessment.reasons and assessment.recommendation == "verified"
+                )
+    except Exception:  # noqa: BLE001 — qualification lookup must fail closed
+        return False
+    return False
+
+
 def check(
     profile: AliasProfile,
     alias: str | None = None,

--- a/vllm_mlx/speculative/dflash/runtime.py
+++ b/vllm_mlx/speculative/dflash/runtime.py
@@ -38,6 +38,8 @@ class DFlashRuntime:
     drafter: Any
     kind: str
     drafter_repo: str
+    target_revision: str | None = None
+    drafter_revision: str | None = None
     algorithm: str = "dflash"
 
     def reset_accept_lens(self) -> None:
@@ -90,6 +92,8 @@ def load_runtime(
     drafter_repo: str,
     kind: str = "dflash",
     *,
+    target_revision: str | None = None,
+    drafter_revision: str | None = None,
     expected_algorithm: str | None = None,
 ) -> DFlashRuntime:
     """Lazy-import mlx-vlm's drafter loader and return a ``DFlashRuntime``.
@@ -107,8 +111,18 @@ def load_runtime(
     # Import here, not at module top, so the optional dep stays optional.
     from mlx_vlm.speculative.drafters import load_drafter
 
-    logger.info("Loading DFlash drafter: %s (kind=%s)", drafter_repo, kind)
-    drafter, resolved_kind = load_drafter(drafter_repo, kind=kind)
+    load_source = drafter_repo
+    if drafter_revision is not None:
+        from mlx_vlm.utils import get_model_path
+
+        load_source = str(get_model_path(drafter_repo, revision=drafter_revision))
+    logger.info(
+        "Loading DFlash drafter: %s revision=%s (kind=%s)",
+        drafter_repo,
+        drafter_revision or "default",
+        kind,
+    )
+    drafter, resolved_kind = load_drafter(load_source, kind=kind)
     algorithm = _runtime_algorithm(drafter)
     if expected_algorithm is not None and algorithm != expected_algorithm:
         raise RuntimeError(
@@ -122,5 +136,7 @@ def load_runtime(
         drafter=drafter,
         kind=resolved_kind,
         drafter_repo=drafter_repo,
+        target_revision=target_revision,
+        drafter_revision=drafter_revision,
         algorithm=algorithm,
     )

--- a/vllm_mlx/speculative/dflash/runtime.py
+++ b/vllm_mlx/speculative/dflash/runtime.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """DFlash runtime — lazy bridge into mlx-vlm's spec-decode machinery.
 
-mlx-vlm 0.5.0+ implements DFlash: drafter loading
+mlx-vlm implements DFlash drafter loading
 (``load_drafter``), the per-step draft-verify-walk loop
 (``_dflash_rounds``), and hidden-state capture on Qwen3.5/3.6 language
-models. We don't vendor any of that — we *call into* it from
-``BatchedEngine._step``. This module is the import boundary so the
-mlx-vlm dependency stays optional (``pip install rapid-mlx[dflash]``).
+models. Version 0.6.17 adds DFlash2 under the same dispatch kind. We don't
+vendor any of that — the dedicated DFlash server calls into it. This module is
+the import boundary so the dependency stays optional
+(``pip install rapid-mlx[dflash]``).
 
 Public surface:
   - ``DFlashRuntime`` — handle owning the drafter + the call adapter
@@ -37,6 +38,7 @@ class DFlashRuntime:
     drafter: Any
     kind: str
     drafter_repo: str
+    algorithm: str = "dflash"
 
     def reset_accept_lens(self) -> None:
         """Clear the per-round acceptance counters between requests so
@@ -65,7 +67,31 @@ class DFlashRuntime:
         return list(accept_lens)
 
 
-def load_runtime(drafter_repo: str, kind: str = "dflash") -> DFlashRuntime:
+def _runtime_algorithm(drafter: Any) -> str:
+    """Return the concrete DFlash architecture loaded by mlx-vlm.
+
+    ``draft_kind`` cannot distinguish DFlash2 because both generations use
+    kind="dflash".  mlx-vlm normalizes DFlash2's config.model_type to
+    ``dflash2``; the class-name check is a compatibility fallback for config
+    wrappers that do not expose attributes directly.
+    """
+    config = getattr(drafter, "config", None)
+    model_type = (
+        config.get("model_type")
+        if isinstance(config, dict)
+        else getattr(config, "model_type", None)
+    )
+    if model_type == "dflash2" or type(drafter).__name__ == "DFlash2DraftModel":
+        return "dflash2"
+    return "dflash"
+
+
+def load_runtime(
+    drafter_repo: str,
+    kind: str = "dflash",
+    *,
+    expected_algorithm: str | None = None,
+) -> DFlashRuntime:
     """Lazy-import mlx-vlm's drafter loader and return a ``DFlashRuntime``.
 
     The mlx-vlm import is deferred to call time so installing rapid-mlx
@@ -83,4 +109,18 @@ def load_runtime(drafter_repo: str, kind: str = "dflash") -> DFlashRuntime:
 
     logger.info("Loading DFlash drafter: %s (kind=%s)", drafter_repo, kind)
     drafter, resolved_kind = load_drafter(drafter_repo, kind=kind)
-    return DFlashRuntime(drafter=drafter, kind=resolved_kind, drafter_repo=drafter_repo)
+    algorithm = _runtime_algorithm(drafter)
+    if expected_algorithm is not None and algorithm != expected_algorithm:
+        raise RuntimeError(
+            "DFlash drafter architecture mismatch: "
+            f"expected {expected_algorithm!r}, loaded {algorithm!r} from "
+            f"{drafter_repo!r}. Refusing to serve with a misleading or "
+            "unqualified speculative-decoding route."
+        )
+    logger.info("Loaded DFlash runtime algorithm=%s", algorithm)
+    return DFlashRuntime(
+        drafter=drafter,
+        kind=resolved_kind,
+        drafter_repo=drafter_repo,
+        algorithm=algorithm,
+    )

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -770,6 +770,7 @@ def _build_app(
         return {
             "status": "ok",
             "engine": "dflash",
+            "algorithm": runtime.algorithm,
             "mode": "single-user-serial",
             "drafter": runtime.drafter_repo,
         }
@@ -2075,6 +2076,8 @@ def run_dflash_server(
     tool_call_parser: str | None = "hermes",
     reasoning_parser_name: str | None = "qwen3",
     experimental_opt_in: bool = False,
+    verified_pair: bool = False,
+    expected_algorithm: str | None = None,
 ) -> None:
     """Load the model + DFlash drafter via mlx-vlm and start uvicorn.
 
@@ -2107,16 +2110,17 @@ def run_dflash_server(
     from .eligibility import DFlashUnavailable, _looks_like_4bit
 
     if _looks_like_4bit(main_model_repo):
-        if not experimental_opt_in:
+        if not (experimental_opt_in or verified_pair):
             raise DFlashUnavailable(
                 "4-bit DFlash is unverified. Programmatic callers must pass "
                 "experimental_opt_in=True after accepting that it may provide "
                 "no speedup or may be slower than autoregressive decoding."
             )
-        logger.warning(
-            "Experimental DFlash: this 4-bit target/drafter pair has not "
-            "been performance-validated by Rapid-MLX and may be slower"
-        )
+        if not verified_pair:
+            logger.warning(
+                "Experimental DFlash: this 4-bit target/drafter pair has not "
+                "been performance-validated by Rapid-MLX and may be slower"
+            )
     if not drafter_repo:
         raise DFlashUnavailable(
             "DFlash requires a non-empty drafter_repo — pass the DFlash "
@@ -2137,7 +2141,7 @@ def run_dflash_server(
         t0 = time.perf_counter()
         m, p = load(main_model_repo)
         logger.info("DFlash: main model loaded in %.1fs", time.perf_counter() - t0)
-        rt = load_runtime(drafter_repo)
+        rt = load_runtime(drafter_repo, expected_algorithm=expected_algorithm)
         return m, p, rt
 
     logger.info("DFlash: loading main model via mlx-vlm: %s", main_model_repo)

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -773,6 +773,8 @@ def _build_app(
             "algorithm": runtime.algorithm,
             "mode": "single-user-serial",
             "drafter": runtime.drafter_repo,
+            "target_revision": runtime.target_revision,
+            "drafter_revision": runtime.drafter_revision,
         }
 
     @app.get(
@@ -2058,7 +2060,9 @@ async def _non_stream_completion(
 def run_dflash_server(
     *,
     main_model_repo: str,
+    main_model_revision: str | None = None,
     drafter_repo: str,
+    drafter_revision: str | None = None,
     host: str,
     port: int,
     served_model_name: str,
@@ -2114,7 +2118,9 @@ def run_dflash_server(
 
     registry_verified_pair = is_registry_verified_pair(
         main_model_repo,
+        main_model_revision,
         drafter_repo,
+        drafter_revision,
         expected_algorithm,
     )
 
@@ -2148,9 +2154,17 @@ def run_dflash_server(
     # streams stay reachable for the lifetime of the process.
     def _load_all():
         t0 = time.perf_counter()
-        m, p = load(main_model_repo)
+        load_kwargs = (
+            {"revision": main_model_revision} if main_model_revision is not None else {}
+        )
+        m, p = load(main_model_repo, **load_kwargs)
         logger.info("DFlash: main model loaded in %.1fs", time.perf_counter() - t0)
-        rt = load_runtime(drafter_repo, expected_algorithm=expected_algorithm)
+        rt = load_runtime(
+            drafter_repo,
+            target_revision=main_model_revision,
+            drafter_revision=drafter_revision,
+            expected_algorithm=expected_algorithm,
+        )
         return m, p, rt
 
     logger.info("DFlash: loading main model via mlx-vlm: %s", main_model_repo)

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -2076,7 +2076,6 @@ def run_dflash_server(
     tool_call_parser: str | None = "hermes",
     reasoning_parser_name: str | None = "qwen3",
     experimental_opt_in: bool = False,
-    verified_pair: bool = False,
     expected_algorithm: str | None = None,
 ) -> None:
     """Load the model + DFlash drafter via mlx-vlm and start uvicorn.
@@ -2107,16 +2106,26 @@ def run_dflash_server(
             "for optional extras."
         )
 
-    from .eligibility import DFlashUnavailable, _looks_like_4bit
+    from .eligibility import (
+        DFlashUnavailable,
+        _looks_like_4bit,
+        is_registry_verified_pair,
+    )
+
+    registry_verified_pair = is_registry_verified_pair(
+        main_model_repo,
+        drafter_repo,
+        expected_algorithm,
+    )
 
     if _looks_like_4bit(main_model_repo):
-        if not (experimental_opt_in or verified_pair):
+        if not (experimental_opt_in or registry_verified_pair):
             raise DFlashUnavailable(
                 "4-bit DFlash is unverified. Programmatic callers must pass "
                 "experimental_opt_in=True after accepting that it may provide "
                 "no speedup or may be slower than autoregressive decoding."
             )
-        if not verified_pair:
+        if not registry_verified_pair:
             logger.warning(
                 "Experimental DFlash: this 4-bit target/drafter pair has not "
                 "been performance-validated by Rapid-MLX and may be slower"


### PR DESCRIPTION
## Summary

- add concrete DFlash/DFlash2 runtime identity to model profiles, startup validation, logs, and `/healthz`
- pin both target and drafter to immutable Hub revisions so an upstream repository update cannot inherit a stale qualification receipt
- expose the known Qwen3.8-27B DFlash2 pairing through `rapid-mlx info` while keeping it experimental after a negative qualification against the faster default MTP route
- extend the benchmark harness with an explicit draft-model input and record reproducible FP/q4 throughput plus five-scenario correctness evidence

## User impact

Users who intentionally evaluate Qwen3.8-27B with DFlash2 get a copyable command and an auditable runtime receipt instead of relying on a generic `draft_kind=dflash` label. A wrong drafter generation or revision now fails closed. Ordinary users keep the existing continuous-MTP default because DFlash2 measured 0.94x code median and 0.94x chat throughput versus that default.

## Scope

- DFlash registry/profile metadata and immutable artifact qualification
- DFlash runtime identity, startup validation, and health reporting
- DFlash benchmark harness and durable Qwen3.8 evidence
- focused contracts for alias parsing, capability reporting, CLI status, and fail-closed loading

## Non-goals

- no speculative kernel implementation or vendoring
- no default-policy change for Qwen3.8-27B
- no change to MTP scheduling, target model weights, Desktop, CI, or release metadata
- no claim of byte-identical output across the MTP and DFlash serving paths

## Design precedent

The implementation follows the established production speculative-decoding contract: keep the drafter algorithm in the optional runtime, make the target model the verifier, qualify immutable target/drafter artifact pairs rather than mutable repository names or architecture-name families, expose the concrete loaded algorithm and revisions, and fail startup when the registry receipt disagrees with the loaded config. Experimental operator overrides remain possible but cannot inherit a verified receipt or silently become a recommendation.

## Verification

- `3106 passed, 1 skipped` on focused DFlash, alias-schema, modality, and routing contracts
- `540 passed` on adjacent CLI, model-profile, capability, serve-wiring, and audio-registry contracts
- ruff check and format clean; `git diff --check` clean
- real M3 Ultra 256 GB paired benchmark, 3 runs/workload, 256-token ceiling:
  - default MTP: 57.6 / 53.7 / 56.0 / 57.6 tok/s on four code cases; chat 49.8
  - DFlash2 q4: 54.2 / 50.4 / 52.5 / 50.1 tok/s; chat 46.7
  - code median 0.94x; chat 0.94x => remains experimental
- five real greedy scenarios: coding, JSON, and normalized tool call exact; creative/chat semantically equivalent but not byte-identical
- exact released optional runtime: `mlx-vlm==0.6.17`; pinned-load and `/healthz` receipts covered by contract tests

## Test plan

- Focused unit/integration contracts: complete
- Lint, format, and diff hygiene: complete
- Real target plus full-precision and 4-bit DFlash2 benchmark: complete
- Coding/chat/creative/JSON/tool correctness spot-check: complete
- Independent Codex review: rerun requested on exact head
- `pr_validate`: pending exact-head rerun
- Required CI: running on exact head
