### PR TITLE
perf(dflash): stage optimized Qwen3.8 DFlash2 runtime

### DIFF
--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -158,6 +158,19 @@ def test_speculative_config_dflash_normalizes_to_legacy_server_flag() -> None:
     assert _resolve_dflash_drafter_repo(args, profile) == "z-lab/Qwen3.5-27B-DFlash"
 
 
+def test_speculative_config_dflash_normalizes_explicit_runtime() -> None:
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _dflash_cli_args(
+        speculative_config='{"method":"dflash","runtime":"dflash-mlx"}'
+    )
+
+    _normalize_speculative_config_or_exit(args)
+
+    assert args.enable_dflash is True
+    assert args.dflash_runtime == "dflash-mlx"
+
+
 def test_unverified_dflash_profile_cannot_inherit_residual_drafter() -> None:
     from vllm_mlx.cli import _resolve_dflash_drafter_repo
 
@@ -244,6 +257,83 @@ def test_programmatic_dflash2_identity_cannot_bypass_registry_qualification(
             cors_origins=[],
             uvicorn_log_level="error",
         )
+
+
+def test_optimized_runtime_cannot_bypass_registry_qualification(monkeypatch) -> None:
+    from vllm_mlx.speculative.dflash.eligibility import DFlashUnavailable
+    from vllm_mlx.speculative.dflash.server import run_dflash_server
+
+    monkeypatch.setattr("vllm_mlx.speculative.dflash.server.have_runtime", lambda: True)
+    with pytest.raises(DFlashUnavailable, match="exact immutable target/drafter pair"):
+        run_dflash_server(
+            main_model_repo="user/target-4bit",
+            main_model_revision="a" * 40,
+            drafter_repo="user/dflash2",
+            drafter_revision="b" * 40,
+            expected_algorithm="dflash2",
+            runtime_backend="dflash-mlx",
+            experimental_opt_in=True,
+            host="127.0.0.1",
+            port=8000,
+            served_model_name="target",
+            default_max_tokens=32,
+            cors_origins=[],
+            uvicorn_log_level="error",
+        )
+
+
+def test_optimized_runtime_loads_qualified_pair_on_dflash_executor(monkeypatch) -> None:
+    import threading
+
+    from fastapi.testclient import TestClient
+
+    from vllm_mlx.speculative.dflash import eligibility, upstream_runtime
+    from vllm_mlx.speculative.dflash import server as srv
+
+    receipt: dict[str, object] = {}
+    loaded = SimpleNamespace(
+        model=MagicMock(), processor=MagicMock(), drafter=MagicMock()
+    )
+
+    def _load_upstream_runtime(**kwargs):
+        receipt["load"] = kwargs
+        receipt["thread"] = threading.current_thread().name
+        return loaded
+
+    monkeypatch.setattr(eligibility, "is_registry_verified_pair", lambda *_args: True)
+    monkeypatch.setattr(
+        upstream_runtime, "load_upstream_runtime", _load_upstream_runtime
+    )
+
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda app, **_kwargs: receipt.update(app=app))
+    srv.run_dflash_server(
+        main_model_repo="rapid-mlx/target-4bit",
+        main_model_revision="a" * 40,
+        drafter_repo="z-lab/dflash2",
+        drafter_revision="b" * 40,
+        expected_algorithm="dflash2",
+        runtime_backend="dflash-mlx",
+        host="127.0.0.1",
+        port=8000,
+        served_model_name="target",
+        default_max_tokens=32,
+        cors_origins=[],
+        uvicorn_log_level="error",
+    )
+
+    assert receipt["load"] == {
+        "main_model_repo": "rapid-mlx/target-4bit",
+        "main_model_revision": "a" * 40,
+        "drafter_repo": "z-lab/dflash2",
+        "drafter_revision": "b" * 40,
+    }
+    assert str(receipt["thread"]).startswith("dflash-worker")
+    health = TestClient(receipt["app"]).get("/healthz")
+    assert health.status_code == 200
+    assert health.json()["runtime"] == "dflash-mlx"
+    assert health.json()["algorithm"] == "dflash2"
 
 
 def test_programmatic_experimental_4bit_logs_unverified_pair(
@@ -677,6 +767,7 @@ def test_dflash_cli_forwards_security_and_resource_limits() -> None:
             "args.tool_call_parser if args.enable_auto_tool_choice else None"
         ),
         "reasoning_parser_name": "args.reasoning_parser",
+        "runtime_backend": "getattr(args, 'dflash_runtime', 'mlx-vlm')",
     }
     assert {name: ast.unparse(keywords[name]) for name in expected} == expected
 

--- a/tests/test_dflash_upstream_runtime.py
+++ b/tests/test_dflash_upstream_runtime.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-free contracts for the optional optimized DFlash runtime adapter."""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.speculative.dflash import upstream_runtime as upstream
+from vllm_mlx.speculative.dflash.generation import generate, stream_generate
+from vllm_mlx.speculative.dflash.runtime import DFlashRuntime
+
+
+def test_optimized_runtime_requires_published_dflash2_capability(monkeypatch) -> None:
+    monkeypatch.setattr(upstream, "version", lambda _name: "0.1.8")
+    monkeypatch.delitem(sys.modules, "dflash_mlx.draft.dflash2", raising=False)
+
+    with pytest.raises(RuntimeError, match="does not contain.*DFlash2"):
+        upstream.require_dflash_mlx_runtime()
+
+    fake_dflash2 = types.ModuleType("dflash_mlx.draft.dflash2")
+    fake_dflash2.DFlash2DraftModel = object
+    fake_dflash2.normalize_dflash2_config = lambda config: config
+    monkeypatch.setitem(sys.modules, "dflash_mlx.draft.dflash2", fake_dflash2)
+    assert upstream.require_dflash_mlx_runtime() == "0.1.8"
+
+
+def test_optimized_runtime_requires_immutable_remote_revision() -> None:
+    with pytest.raises(RuntimeError, match="immutable revision pin"):
+        upstream._immutable_snapshot("not-a-local-target", None, role="target")
+
+
+def test_generation_dispatch_uses_explicit_optimized_backend() -> None:
+    calls: list[tuple[str, dict]] = []
+
+    class Backend:
+        def stream_generate(self, prompt, **kwargs):
+            calls.append((prompt, kwargs))
+            return iter(("chunk",))
+
+        def generate(self, prompt, **kwargs):
+            calls.append((prompt, kwargs))
+            return "result"
+
+    runtime = DFlashRuntime(
+        drafter=object(),
+        kind="dflash",
+        drafter_repo="draft",
+        algorithm="dflash2",
+        backend="dflash-mlx",
+        backend_state=Backend(),
+    )
+
+    assert list(
+        stream_generate(runtime, object(), object(), "prompt", max_tokens=8)
+    ) == ["chunk"]
+    assert generate(runtime, object(), object(), "prompt", max_tokens=8) == "result"
+    assert calls == [
+        ("prompt", {"max_tokens": 8}),
+        ("prompt", {"max_tokens": 8}),
+    ]
+
+
+def test_greedy_adapter_preserves_counts_and_does_not_decode_eos(monkeypatch) -> None:
+    @dataclass
+    class PrefillCompleteEvent:
+        prompt_token_count: int
+
+    @dataclass
+    class TokenEvent:
+        token_id: int
+        generated_tokens: int
+
+    @dataclass
+    class SummaryEvent:
+        prompt_token_count: int
+        generation_tokens: int
+
+    known_types = (PrefillCompleteEvent, TokenEvent, SummaryEvent)
+    fake_events = types.ModuleType("dflash_mlx.engine.events")
+    fake_events.PrefillCompleteEvent = PrefillCompleteEvent
+    fake_events.TokenEvent = TokenEvent
+    fake_events.SummaryEvent = SummaryEvent
+    fake_events.is_engine_event = lambda event: isinstance(event, known_types)
+
+    receipt: dict[str, object] = {}
+
+    def _stream_dflash_generate(**kwargs):
+        receipt.update(kwargs)
+        yield PrefillCompleteEvent(prompt_token_count=3)
+        yield TokenEvent(token_id=7, generated_tokens=1)
+        yield TokenEvent(token_id=99, generated_tokens=2)
+        yield SummaryEvent(prompt_token_count=3, generation_tokens=2)
+
+    fake_runtime = types.ModuleType("dflash_mlx.runtime")
+    fake_runtime.get_stop_token_ids = lambda _tokenizer: [99]
+    fake_runtime.stream_dflash_generate = _stream_dflash_generate
+    monkeypatch.setitem(sys.modules, "dflash_mlx.engine.events", fake_events)
+    monkeypatch.setitem(sys.modules, "dflash_mlx.runtime", fake_runtime)
+
+    class Detokenizer:
+        last_segment = ""
+
+        def reset(self):
+            self.last_segment = ""
+
+        def add_token(self, token):
+            self.last_segment = f"<{token}>"
+
+        def finalize(self):
+            self.last_segment = ""
+
+    tokenizer = SimpleNamespace(detokenizer=Detokenizer())
+    bundle = SimpleNamespace(
+        target_model=object(),
+        tokenizer=tokenizer,
+        draft_model=object(),
+        draft_backend=object(),
+        target_ops=object(),
+    )
+    runtime = upstream.UpstreamDFlashRuntime(
+        bundle=bundle, runtime_context=object(), version="0.1.10"
+    )
+
+    chunks = list(runtime.stream_generate("prompt", max_tokens=8))
+
+    assert [(chunk.text, chunk.token) for chunk in chunks] == [
+        ("<7>", 7),
+        ("", 99),
+    ]
+    assert chunks[-1].prompt_tokens == 3
+    assert chunks[-1].generation_tokens == 2
+    assert receipt["stop_token_ids"] == [99]
+    assert receipt["quantize_kv_cache"] is False
+    assert runtime.last_summary == SummaryEvent(
+        prompt_token_count=3, generation_tokens=2
+    )
+
+
+def test_greedy_adapter_rejects_unknown_engine_event(monkeypatch) -> None:
+    class PrefillCompleteEvent:
+        pass
+
+    class TokenEvent:
+        pass
+
+    class SummaryEvent:
+        pass
+
+    fake_events = types.ModuleType("dflash_mlx.engine.events")
+    fake_events.PrefillCompleteEvent = PrefillCompleteEvent
+    fake_events.TokenEvent = TokenEvent
+    fake_events.SummaryEvent = SummaryEvent
+    fake_events.is_engine_event = lambda _event: False
+    fake_runtime = types.ModuleType("dflash_mlx.runtime")
+    fake_runtime.get_stop_token_ids = lambda _tokenizer: []
+    fake_runtime.stream_dflash_generate = lambda **_kwargs: iter((object(),))
+    monkeypatch.setitem(sys.modules, "dflash_mlx.engine.events", fake_events)
+    monkeypatch.setitem(sys.modules, "dflash_mlx.runtime", fake_runtime)
+
+    tokenizer = SimpleNamespace(
+        detokenizer=SimpleNamespace(reset=lambda: None, finalize=lambda: None)
+    )
+    bundle = SimpleNamespace(
+        target_model=object(),
+        tokenizer=tokenizer,
+        draft_model=object(),
+        draft_backend=object(),
+        target_ops=object(),
+    )
+    runtime = upstream.UpstreamDFlashRuntime(
+        bundle=bundle, runtime_context=object(), version="0.1.10"
+    )
+
+    with pytest.raises(TypeError, match="Unsupported DFlash engine event"):
+        list(runtime.stream_generate("prompt", max_tokens=8))
+
+
+def test_sampled_request_uses_target_only_generation(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+    expected_chunk = SimpleNamespace(
+        text="sampled", token=4, prompt_tokens=2, generation_tokens=1
+    )
+    fake_mlx_lm = types.ModuleType("mlx_lm")
+    fake_sampling = types.ModuleType("mlx_lm.sample_utils")
+
+    def _make_sampler(**kwargs):
+        calls["sampler_kwargs"] = kwargs
+        return "sampler"
+
+    def _stream_generate(model, tokenizer, prompt, **kwargs):
+        calls["generate"] = (model, tokenizer, prompt, kwargs)
+        yield expected_chunk
+
+    fake_mlx_lm.stream_generate = _stream_generate
+    fake_sampling.make_sampler = _make_sampler
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_mlx_lm)
+    monkeypatch.setitem(sys.modules, "mlx_lm.sample_utils", fake_sampling)
+
+    bundle = SimpleNamespace(
+        target_model=object(),
+        tokenizer=object(),
+        draft_model=object(),
+    )
+    runtime = upstream.UpstreamDFlashRuntime(
+        bundle=bundle, runtime_context=object(), version="0.1.10"
+    )
+
+    assert list(
+        runtime.stream_generate("prompt", max_tokens=8, temperature=0.7, top_p=0.9)
+    ) == [expected_chunk]
+    assert calls["sampler_kwargs"] == {"temp": 0.7, "top_p": 0.9}
+    assert calls["generate"] == (
+        bundle.target_model,
+        bundle.tokenizer,
+        "prompt",
+        {"max_tokens": 8, "sampler": "sampler"},
+    )
+
+
+def test_load_runtime_disables_unqualified_custom_qmm(monkeypatch) -> None:
+    @dataclass(frozen=True)
+    class VerifyConfig:
+        mode: str
+        enable_qmm: bool
+
+    @dataclass(frozen=True)
+    class RuntimeContext:
+        verify: object
+
+    receipt: dict[str, object] = {}
+    bundle = SimpleNamespace(
+        target_model=object(),
+        tokenizer=object(),
+        draft_model=object(),
+    )
+    fake_runtime = types.ModuleType("dflash_mlx.runtime")
+    fake_runtime.VerifyConfig = VerifyConfig
+    fake_bundle = types.ModuleType("dflash_mlx.runtime.bundle")
+    fake_context = types.ModuleType("dflash_mlx.runtime.context")
+
+    def _load_runtime_bundle(**kwargs):
+        receipt["load"] = kwargs
+        return bundle
+
+    def _build_offline_runtime_context(**kwargs):
+        receipt["context"] = kwargs
+        return RuntimeContext(verify=VerifyConfig(mode="adaptive", enable_qmm=True))
+
+    fake_bundle.load_runtime_bundle = _load_runtime_bundle
+    fake_context.build_offline_runtime_context = _build_offline_runtime_context
+    monkeypatch.setitem(sys.modules, "dflash_mlx.runtime", fake_runtime)
+    monkeypatch.setitem(sys.modules, "dflash_mlx.runtime.bundle", fake_bundle)
+    monkeypatch.setitem(sys.modules, "dflash_mlx.runtime.context", fake_context)
+    monkeypatch.setattr(upstream, "require_dflash_mlx_runtime", lambda: "0.1.10")
+    monkeypatch.setattr(
+        upstream,
+        "_immutable_snapshot",
+        lambda repo, _revision, *, role: f"/cache/{role}/{repo.rsplit('/', 1)[-1]}",
+    )
+
+    loaded = upstream.load_upstream_runtime(
+        main_model_repo="rapid-mlx/target",
+        main_model_revision="a" * 40,
+        drafter_repo="z-lab/draft",
+        drafter_revision="b" * 40,
+    )
+
+    assert loaded.bundle is bundle
+    assert loaded.runtime_context.verify == VerifyConfig(
+        mode="adaptive", enable_qmm=False
+    )
+    assert receipt["context"] == {
+        "verify_mode": "adaptive",
+        "copyspec_mode": "off",
+        "quantize_kv_cache": False,
+    }
+    assert receipt["load"] == {
+        "model_ref": "/cache/target/target",
+        "draft_ref": "/cache/drafter/draft",
+        "draft_quant": "w4:gs64",
+        "verify_config": VerifyConfig(mode="adaptive", enable_qmm=False),
+        "quantize_kv_cache": False,
+    }
+
+
+def test_runtime_backend_contract_is_explicit() -> None:
+    runtime = DFlashRuntime(
+        drafter=object(),
+        kind="dflash",
+        drafter_repo="draft",
+        algorithm="dflash2",
+        backend="dflash-mlx",
+        backend_state=SimpleNamespace(),
+    )
+
+    assert runtime.backend == "dflash-mlx"

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -56,6 +56,14 @@ def test_parse_dflash_speculative_config_accepts_drafter_model() -> None:
     assert cfg.tree_budget is None
 
 
+def test_parse_dflash_speculative_config_accepts_explicit_runtime() -> None:
+    cfg = parse_speculative_config('{"method":"dflash","runtime":"dflash-mlx"}')
+
+    assert cfg is not None
+    assert cfg.method == "dflash"
+    assert cfg.runtime == "dflash-mlx"
+
+
 def test_parse_dspark_speculative_config_accepts_native_depth() -> None:
     cfg = parse_speculative_config('{"method":"dspark","num_speculative_tokens":5}')
 
@@ -115,6 +123,8 @@ def test_parse_suffix_speculative_config_accepts_existing_knobs() -> None:
             "unsupported speculative-config",
         ),
         ('{"method":"dflash","tree_budget":24}', "unsupported speculative-config"),
+        ('{"method":"dflash","runtime":"custom"}', "must be 'mlx-vlm'"),
+        ('{"method":"mtp","runtime":"dflash-mlx"}', "unsupported speculative-config"),
         ('{"method":"unknown"}', "unsupported speculative decoding method"),
     ],
 )
@@ -228,6 +238,7 @@ def _spec_config_args(**overrides):
         "enable_dflash": False,
         "spec_decode": "none",
         "dflash_drafter_path": "",
+        "dflash_runtime": "mlx-vlm",
         "mtp_num_draft_tokens": 1,
         "mtp_optimistic": False,
         "mtp_sidecar": None,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2175,6 +2175,7 @@ def _normalize_speculative_config_or_exit(args):
             "enable_dflash": False,
             "spec_decode": "none",
             "dflash_drafter_path": "",
+            "dflash_runtime": "mlx-vlm",
             "enable_mtp": False,
             "mtp_num_draft_tokens": 1,
             "mtp_optimistic": False,
@@ -2461,6 +2462,7 @@ def _normalize_speculative_config_or_exit(args):
         args.enable_ddtree = True
     elif config.method == "dflash":
         args.enable_dflash = True
+        args.dflash_runtime = config.runtime or "mlx-vlm"
         if config.model:
             args.dflash_drafter_path = config.model
     elif config.method == "dspark":
@@ -4134,6 +4136,7 @@ def serve_command(args):
             expected_algorithm=(
                 _resolve_dflash_expected_algorithm(_profile, _drafter_repo)
             ),
+            runtime_backend=getattr(args, "dflash_runtime", "mlx-vlm"),
         )
         return
 

--- a/vllm_mlx/spec_decode/config.py
+++ b/vllm_mlx/spec_decode/config.py
@@ -26,6 +26,10 @@ class SpeculativeConfig:
 
     method: str
     model: str | None = None
+    # DFlash alone has two independently versioned runtime implementations.
+    # Omitted keeps the mature mlx-vlm path; ``dflash-mlx`` is an explicit
+    # opt-in until its package, correctness, and workload gates converge.
+    runtime: str | None = None
     num_speculative_tokens: int | None = None
     tree_budget: int | None = None
     disable_auto_k: bool | None = None
@@ -48,7 +52,7 @@ _COMMON_KEYS = frozenset(
 
 _METHOD_KEYS = {
     "ddtree": frozenset({"model", "num_speculative_tokens", "tree_budget"}),
-    "dflash": frozenset({"model"}),
+    "dflash": frozenset({"model", "runtime"}),
     "dspark": frozenset({"num_speculative_tokens"}),
     "mtp": frozenset(
         {
@@ -158,6 +162,7 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
     config = SpeculativeConfig(
         method=method,
         model=_optional_string(payload.get("model"), "model"),
+        runtime=_optional_string(payload.get("runtime"), "runtime"),
         num_speculative_tokens=_positive_int(
             payload.get("num_speculative_tokens"), "num_speculative_tokens"
         ),
@@ -182,6 +187,16 @@ def parse_speculative_config(value: str | None) -> SpeculativeConfig | None:
         raise SpeculativeConfigError(
             "allow_dynamic_membership requires continuous_batching=true"
         )
+    if config.method == "dflash" and config.runtime not in (
+        None,
+        "mlx-vlm",
+        "dflash-mlx",
+    ):
+        raise SpeculativeConfigError(
+            "runtime for 'dflash' must be 'mlx-vlm' or 'dflash-mlx'"
+        )
+    if config.method != "dflash" and config.runtime is not None:
+        raise SpeculativeConfigError("runtime is only supported for method='dflash'")
     return config
 
 

--- a/vllm_mlx/speculative/dflash/generation.py
+++ b/vllm_mlx/speculative/dflash/generation.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generation dispatch for DFlash runtime backends."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def stream_generate(
+    runtime: Any | None,
+    model: Any,
+    processor: Any,
+    prompt: str,
+    **kwargs: Any,
+):
+    if runtime is not None and runtime.backend == "dflash-mlx":
+        return runtime.backend_state.stream_generate(prompt, **kwargs)
+    from mlx_vlm import stream_generate as mlx_vlm_stream_generate
+
+    return mlx_vlm_stream_generate(model, processor, prompt, **kwargs)
+
+
+def generate(
+    runtime: Any | None,
+    model: Any,
+    processor: Any,
+    prompt: str,
+    **kwargs: Any,
+):
+    if runtime is not None and runtime.backend == "dflash-mlx":
+        return runtime.backend_state.generate(prompt, **kwargs)
+    from mlx_vlm import generate as mlx_vlm_generate
+
+    return mlx_vlm_generate(model, processor, prompt, **kwargs)

--- a/vllm_mlx/speculative/dflash/runtime.py
+++ b/vllm_mlx/speculative/dflash/runtime.py
@@ -41,6 +41,8 @@ class DFlashRuntime:
     target_revision: str | None = None
     drafter_revision: str | None = None
     algorithm: str = "dflash"
+    backend: str = "mlx-vlm"
+    backend_state: Any | None = None
 
     def reset_accept_lens(self) -> None:
         """Clear the per-round acceptance counters between requests so
@@ -139,4 +141,5 @@ def load_runtime(
         target_revision=target_revision,
         drafter_revision=drafter_revision,
         algorithm=algorithm,
+        backend="mlx-vlm",
     )

--- a/vllm_mlx/speculative/dflash/server.py
+++ b/vllm_mlx/speculative/dflash/server.py
@@ -771,6 +771,7 @@ def _build_app(
             "status": "ok",
             "engine": "dflash",
             "algorithm": runtime.algorithm,
+            "runtime": runtime.backend,
             "mode": "single-user-serial",
             "drafter": runtime.drafter_repo,
             "target_revision": runtime.target_revision,
@@ -1075,6 +1076,7 @@ def _build_app(
                         gen_kwargs=gen_kwargs,
                         model=model,
                         processor=processor,
+                        runtime=runtime,
                         timeout=effective_timeout,
                         timeout_label=request_timeout_for_diagnostics,
                         deadline=request_deadline,
@@ -1102,6 +1104,7 @@ def _build_app(
                 gen_kwargs=gen_kwargs,
                 model=model,
                 processor=processor,
+                runtime=runtime,
                 timeout=effective_timeout,
                 timeout_label=request_timeout_for_diagnostics,
                 deadline=request_deadline,
@@ -1242,6 +1245,7 @@ async def _stream_completion(
     gen_kwargs: dict[str, Any],
     model: Any,
     processor: Any,
+    runtime: DFlashRuntime | None = None,
     timeout: float | None = None,
     timeout_label: float | None = None,
     deadline: float | None = None,
@@ -1264,7 +1268,7 @@ async def _stream_completion(
     human-facing timeout messages (codex round-5 #6), so a client sees the
     limit it actually asked for rather than the render-reduced remainder. When
     omitted (direct callers/tests) it mirrors ``timeout``."""
-    from mlx_vlm import stream_generate
+    from .generation import stream_generate
 
     if timeout_label is None:
         timeout_label = timeout
@@ -1537,7 +1541,9 @@ async def _stream_completion(
             # the same as the mid-stream error path below.
             def _make_gen():
                 try:
-                    return stream_generate(model, processor, prompt, **gen_kwargs)
+                    return stream_generate(
+                        runtime, model, processor, prompt, **gen_kwargs
+                    )
                 except Exception as e:  # noqa: BLE001 — surface upstream; outer code converts to error SSE
                     return e
 
@@ -1855,6 +1861,7 @@ async def _non_stream_completion(
     gen_kwargs: dict[str, Any],
     model: Any,
     processor: Any,
+    runtime: DFlashRuntime | None = None,
     timeout: float = 1800.0,
     timeout_label: float | None = None,
     deadline: float | None = None,
@@ -1875,7 +1882,7 @@ async def _non_stream_completion(
     request timeout reported in the 504 message (codex round-5 #6). Omitted →
     mirrors ``timeout``.
     """
-    from mlx_vlm import generate
+    from .generation import generate
 
     if timeout_label is None:
         timeout_label = timeout
@@ -1944,7 +1951,7 @@ async def _non_stream_completion(
         # the stream path's error handling.
         def _generate_safely():
             try:
-                return generate(model, processor, prompt, **gen_kwargs)
+                return generate(runtime, model, processor, prompt, **gen_kwargs)
             except Exception as e:  # noqa: BLE001 — surface as HTTPException below
                 return e
 
@@ -2081,16 +2088,15 @@ def run_dflash_server(
     reasoning_parser_name: str | None = "qwen3",
     experimental_opt_in: bool = False,
     expected_algorithm: str | None = None,
+    runtime_backend: str = "mlx-vlm",
 ) -> None:
-    """Load the model + DFlash drafter via mlx-vlm and start uvicorn.
+    """Load the model + DFlash drafter with the selected runtime and start uvicorn.
 
-    The mlx-vlm load path is mandatory: the DFlash hooks
-    (``capture_layer_ids``, ``_dflash_rounds``) live on the mlx-vlm
-    model classes, not mlx-lm's. Loading via ``mlx_lm.load`` would give
-    us a model without the hooks and DFlash would silently fall back to
-    AR — exactly the kind of "silent regression" the eligibility gate
-    is meant to prevent. We surface a clear error if mlx-vlm is missing
-    or too old.
+    The default mlx-vlm route owns its DFlash hooks and keeps all existing
+    model pairs on that implementation.  The optimized backend is a separate,
+    exact-version runtime and is accepted only for the immutable DFlash2 pair
+    qualified by the registry; selecting it never silently changes legacy
+    requests or unverified model combinations.
 
     Eligibility re-check: even though the CLI's ``serve_command`` gates
     on the alias before calling here, a *programmatic* caller (e.g. a
@@ -2102,7 +2108,12 @@ def run_dflash_server(
     arbitrary ``main_model_repo`` programmatically are responsible for
     not pointing it at a MoE model. Documented in CALLERS.md.
     """
-    if not have_runtime():
+    if runtime_backend not in {"mlx-vlm", "dflash-mlx"}:
+        raise RuntimeError(
+            f"Unsupported DFlash runtime backend {runtime_backend!r}; "
+            "expected 'mlx-vlm' or 'dflash-mlx'."
+        )
+    if runtime_backend == "mlx-vlm" and not have_runtime():
         raise RuntimeError(
             "DFlash server requires mlx-vlm 0.5.0+ — install with "
             "pip install 'rapid-mlx[dflash]'. Homebrew installs the "
@@ -2123,6 +2134,11 @@ def run_dflash_server(
         drafter_revision,
         expected_algorithm,
     )
+    if runtime_backend == "dflash-mlx" and not registry_verified_pair:
+        raise DFlashUnavailable(
+            "The optimized DFlash runtime requires the exact immutable "
+            "target/drafter pair qualified by the Rapid-MLX registry."
+        )
 
     if _looks_like_4bit(main_model_repo):
         if not (experimental_opt_in or registry_verified_pair):
@@ -2143,7 +2159,6 @@ def run_dflash_server(
         )
 
     import uvicorn
-    from mlx_vlm import load
 
     # CRITICAL: load model + drafter on the dedicated DFlash executor
     # thread (not the main thread). mlx-lm 0.31.3+ keeps GPU streams in
@@ -2154,6 +2169,38 @@ def run_dflash_server(
     # streams stay reachable for the lifetime of the process.
     def _load_all():
         t0 = time.perf_counter()
+        if runtime_backend == "dflash-mlx":
+            if expected_algorithm != "dflash2":
+                raise RuntimeError(
+                    "The optimized dflash-mlx backend is qualified only for "
+                    "an immutable registry pair with algorithm='dflash2'."
+                )
+            from .upstream_runtime import load_upstream_runtime
+
+            upstream = load_upstream_runtime(
+                main_model_repo=main_model_repo,
+                main_model_revision=main_model_revision,
+                drafter_repo=drafter_repo,
+                drafter_revision=drafter_revision,
+            )
+            rt = DFlashRuntime(
+                drafter=upstream.drafter,
+                kind="dflash",
+                drafter_repo=drafter_repo,
+                target_revision=main_model_revision,
+                drafter_revision=drafter_revision,
+                algorithm="dflash2",
+                backend="dflash-mlx",
+                backend_state=upstream,
+            )
+            logger.info(
+                "DFlash: optimized runtime loaded in %.1fs",
+                time.perf_counter() - t0,
+            )
+            return upstream.model, upstream.processor, rt
+
+        from mlx_vlm import load
+
         load_kwargs = (
             {"revision": main_model_revision} if main_model_revision is not None else {}
         )
@@ -2167,7 +2214,11 @@ def run_dflash_server(
         )
         return m, p, rt
 
-    logger.info("DFlash: loading main model via mlx-vlm: %s", main_model_repo)
+    logger.info(
+        "DFlash: loading main model via %s: %s",
+        runtime_backend,
+        main_model_repo,
+    )
     model, processor, runtime = _dflash_executor.submit(_load_all).result()
 
     app = _build_app(

--- a/vllm_mlx/speculative/dflash/upstream_runtime.py
+++ b/vllm_mlx/speculative/dflash/upstream_runtime.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adapter for the independently packaged optimized DFlash MLX runtime.
+
+The dependency owns target-specific speculative execution and cache
+transactions.  Rapid continues to own artifact revision policy, request
+admission, authentication, cancellation, deadlines, prompt rendering, and the
+OpenAI wire surface.  Keeping that boundary explicit prevents a second server
+control plane from bypassing Rapid's production contracts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class UpstreamGenerationChunk:
+    """Small common shape consumed by Rapid's existing DFlash server."""
+
+    text: str
+    token: int | None
+    prompt_tokens: int
+    generation_tokens: int
+
+
+@dataclass(frozen=True)
+class UpstreamGenerationResult:
+    text: str
+    prompt_tokens: int
+    generation_tokens: int
+
+
+def require_dflash_mlx_runtime() -> str:
+    """Require a published runtime build that contains the DFlash2 API.
+
+    The public v0.1.10 source tag predates the DFlash2 implementation even
+    though the later, unreleased branch still reports that package version.
+    Capability detection therefore remains mandatory in addition to the exact
+    dependency pin that will be added when upstream assigns a release version.
+    """
+
+    try:
+        installed = version("dflash-mlx")
+    except PackageNotFoundError as exc:
+        raise RuntimeError(
+            "The optimized DFlash runtime requires a published dflash-mlx "
+            "release with Qwen3.8 DFlash2 support."
+        ) from exc
+    try:
+        from dflash_mlx.draft.dflash2 import (
+            DFlash2DraftModel,
+            normalize_dflash2_config,
+        )
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise RuntimeError(
+            f"dflash-mlx=={installed} does not contain the required Qwen3.8 "
+            "DFlash2 runtime. Wait for the upstream DFlash2 release."
+        ) from exc
+    if not callable(normalize_dflash2_config) or DFlash2DraftModel is None:
+        raise RuntimeError(
+            f"dflash-mlx=={installed} exposes an incomplete DFlash2 runtime."
+        )
+    return installed
+
+
+def _immutable_snapshot(repo: str, revision: str | None, *, role: str) -> str:
+    candidate = Path(repo).expanduser()
+    if candidate.exists():
+        return str(candidate)
+    if not revision:
+        raise RuntimeError(
+            f"The optimized DFlash {role} requires an immutable revision pin."
+        )
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(repo_id=repo, revision=revision)
+
+
+@dataclass
+class UpstreamDFlashRuntime:
+    """Loaded optimized target/drafter bundle behind Rapid's server API."""
+
+    bundle: Any
+    runtime_context: Any
+    version: str
+    last_summary: Any | None = None
+
+    @property
+    def model(self) -> Any:
+        return self.bundle.target_model
+
+    @property
+    def processor(self) -> Any:
+        return self.bundle.tokenizer
+
+    @property
+    def drafter(self) -> Any:
+        return self.bundle.draft_model
+
+    def stream_generate(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        **_ignored: Any,
+    ):
+        """Yield the common chunk shape from DFlash or exact target AR.
+
+        The optimized speculative verifier is greedy.  Sampled requests retain
+        their requested semantics by using the already-loaded target model's
+        ordinary MLX-LM path, matching the dependency server's target-only
+        fallback instead of silently forcing greedy output.
+        """
+
+        if float(temperature) > 0.0 or float(top_p) < 1.0:
+            from mlx_lm import stream_generate
+            from mlx_lm.sample_utils import make_sampler
+
+            sampler = make_sampler(temp=float(temperature), top_p=float(top_p))
+            yield from stream_generate(
+                self.model,
+                self.processor,
+                prompt,
+                max_tokens=int(max_tokens),
+                sampler=sampler,
+            )
+            return
+
+        from dflash_mlx.engine.events import (
+            PrefillCompleteEvent,
+            SummaryEvent,
+            TokenEvent,
+            is_engine_event,
+        )
+        from dflash_mlx.runtime import get_stop_token_ids, stream_dflash_generate
+
+        tokenizer = self.processor
+        detokenizer = tokenizer.detokenizer
+        if hasattr(detokenizer, "reset"):
+            detokenizer.reset()
+        prompt_tokens = 0
+        generated_tokens = 0
+        last_token: int | None = None
+        stop_token_ids = {int(token) for token in get_stop_token_ids(tokenizer)}
+        event_iter = stream_dflash_generate(
+            target_model=self.model,
+            target_ops=self.bundle.target_ops,
+            tokenizer=tokenizer,
+            draft_model=self.drafter,
+            draft_backend=self.bundle.draft_backend,
+            prompt=prompt,
+            max_new_tokens=int(max_tokens),
+            use_chat_template=False,
+            block_tokens=16,
+            stop_token_ids=list(stop_token_ids),
+            quantize_kv_cache=False,
+            runtime_context=self.runtime_context,
+        )
+        try:
+            for event in event_iter:
+                if isinstance(event, PrefillCompleteEvent):
+                    prompt_tokens = int(event.prompt_token_count)
+                    continue
+                if isinstance(event, SummaryEvent):
+                    self.last_summary = event
+                    prompt_tokens = int(event.prompt_token_count)
+                    generated_tokens = int(event.generation_tokens)
+                    continue
+                if not isinstance(event, TokenEvent):
+                    if not is_engine_event(event):
+                        raise TypeError(
+                            f"Unsupported DFlash engine event: {type(event).__name__}"
+                        )
+                    continue
+                last_token = int(event.token_id)
+                generated_tokens = int(event.generated_tokens)
+                text = ""
+                if last_token not in stop_token_ids:
+                    detokenizer.add_token(last_token)
+                    text = str(detokenizer.last_segment)
+                yield UpstreamGenerationChunk(
+                    text=text,
+                    token=last_token,
+                    prompt_tokens=prompt_tokens,
+                    generation_tokens=generated_tokens,
+                )
+        finally:
+            close = getattr(event_iter, "close", None)
+            if close is not None:
+                close()
+
+        detokenizer.finalize()
+        tail = str(detokenizer.last_segment)
+        if tail:
+            yield UpstreamGenerationChunk(
+                text=tail,
+                token=last_token,
+                prompt_tokens=prompt_tokens,
+                generation_tokens=generated_tokens,
+            )
+
+    def generate(self, prompt: str, **kwargs: Any) -> UpstreamGenerationResult:
+        chunks = list(self.stream_generate(prompt, **kwargs))
+        if not chunks:
+            return UpstreamGenerationResult(
+                text="", prompt_tokens=0, generation_tokens=0
+            )
+        return UpstreamGenerationResult(
+            text="".join(str(chunk.text) for chunk in chunks),
+            prompt_tokens=int(chunks[-1].prompt_tokens),
+            generation_tokens=int(chunks[-1].generation_tokens),
+        )
+
+
+def load_upstream_runtime(
+    *,
+    main_model_repo: str,
+    main_model_revision: str | None,
+    drafter_repo: str,
+    drafter_revision: str | None,
+) -> UpstreamDFlashRuntime:
+    """Load the exact pinned pair with custom verify QMM disabled."""
+
+    installed = require_dflash_mlx_runtime()
+    target_path = _immutable_snapshot(
+        main_model_repo, main_model_revision, role="target"
+    )
+    draft_path = _immutable_snapshot(drafter_repo, drafter_revision, role="drafter")
+
+    from dflash_mlx.runtime import VerifyConfig
+    from dflash_mlx.runtime.bundle import load_runtime_bundle
+    from dflash_mlx.runtime.context import build_offline_runtime_context
+
+    verify = VerifyConfig(mode="adaptive", enable_qmm=False)
+    context = build_offline_runtime_context(
+        verify_mode="adaptive",
+        copyspec_mode="off",
+        quantize_kv_cache=False,
+    )
+    # ``build_offline_runtime_context`` constructs the package default verify
+    # object, whose custom QMM setting is too permissive for the Studio parity
+    # gate.  Replace it before either model is loaded or a kernel is installed.
+    context = replace(context, verify=verify)
+    bundle = load_runtime_bundle(
+        model_ref=target_path,
+        draft_ref=draft_path,
+        draft_quant="w4:gs64",
+        verify_config=verify,
+        quantize_kv_cache=False,
+    )
+    return UpstreamDFlashRuntime(
+        bundle=bundle,
+        runtime_context=context,
+        version=installed,
+    )


### PR DESCRIPTION
## Summary

- adds an explicit `runtime: "dflash-mlx"` opt-in to the existing DFlash speculative configuration
- adapts the optimized runtime behind Rapid-MLX authentication, admission, cancellation, deadlines, prompt rendering, and OpenAI response handling
- keeps the current `mlx-vlm` route unchanged and default-on for existing DFlash requests
- allows only the immutable, registry-qualified Qwen3.8-27B target/drafter pair

## Status — BLOCKED on upstream release

This PR is intentionally Draft/WIP and must not enter the merge queue. PyPI currently exposes `dflash-mlx==0.1.8`, which lacks Qwen3.8 DFlash2 support. The public v0.1.10 source tag also predates that implementation; the required API currently exists only on the unreleased upstream branch.

Before readiness, the newly assigned release version must be pinned exactly in both `[dflash]` and `[all]`, then proven through a fresh Python 3.12 wheel install. No Git dependency, vendoring, floating pin, or compatibility shim will be used.

## Design precedent

The optimized executor remains a model-runtime plugin behind Rapid-MLX server ownership rather than introducing a second control plane. Artifact identities fail closed, runtime capabilities are checked at load time, sampled requests retain semantics through target-only generation, and an unknown engine event aborts instead of being silently ignored.

## Safety boundaries

- explicit opt-in only; no default change
- exact target, draft, and immutable revisions required
- custom verification QMM disabled because the Studio numerical parity probe missed tolerance
- greedy DFlash2 only; non-greedy sampling falls back to the already loaded target model
- EOS is counted but never decoded into response text

## Current evidence

- 238 passed, 1 skipped across speculative config, DFlash server/integration, eligibility, optional-extra coherence, and adapter contracts
- ruff and diff checks clean
- unreleased upstream main API contract imports successfully
- prior Studio probe with the optimized runtime measured 64.3 tok/s with custom target QMM disabled versus roughly 54 tok/s on the current Rapid path; this is provisional until the released wheel is requalified

## Readiness gates after release

- [ ] add the exact published dependency pin to `[dflash]` and `[all]`
- [ ] fresh Python 3.12 `pip install <wheel>[dflash]` clean-resolver proof
- [ ] 45-case correctness battery plus streaming, tool-call, JSON, Chinese, cancellation, and sampled-request checks
- [ ] same-box median performance rerun with acceptance and memory evidence
- [ ] Codex review converged and `pr_validate` green on the exact head

Credit: the optimized runtime and DFlash2 implementation are upstream community work; this PR only supplies the Rapid-MLX integration and production boundaries.