### PR TITLE
feat(benchmark): add consent-gated atomic uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Also: word-level timestamps on transcription, and local text-to-music at
 | **Chat in the terminal** | `rapid-mlx chat qwen3.5-9b-4bit` | Streaming REPL, `/help` for slash commands, `--think` / `--no-think` to control CoT. |
 | **OpenAI server for your apps** | `rapid-mlx serve qwen3.5-9b-4bit` | Point Aider, LibreChat, Open WebUI, or LangChain at `http://localhost:8000/v1`. |
 | **Agent backends** | `rapid-mlx serve qwen3.6-35b-8bit &`<br>`rapid-mlx agents codex --setup && codex` | 10 agents auto-configure via `agents <name> --setup` once the server is up (12 wire-verified total, 5 Tier-1) — see [Agent support](#agent-support). |
-| **Benchmark your Mac** | `rapid-mlx benchmark run qwen3.5-9b-4bit` | Reproducible model-first benchmark; saves a private local result and uploads nothing. |
+| **Benchmark your Mac** | `rapid-mlx benchmark run qwen3.5-9b-4bit` | Reproducible model-first benchmark; saves privately, with a separate consent-gated `benchmark share RUN_ID`. |
 
 → [One-shot IDE setup](https://rapidmlx.com/docs/cli.html#launch) with `rapid-mlx launch <claude-code|cline|continue-dev>`
 
@@ -443,7 +443,7 @@ Top three things that go wrong:
 - **Questions & builds:** Ask or share in [GitHub Discussions](https://github.com/raullenchai/Rapid-MLX/discussions).
 - **Feedback & ideas:** [Report a bug, request a model, or propose a feature](https://github.com/raullenchai/Rapid-MLX/issues/new/choose).
 - **Security:** Send sensitive reports through a [private advisory](https://github.com/raullenchai/Rapid-MLX/security/advisories/new); see [SECURITY.md](SECURITY.md).
-- **Contributing:** Start with [CONTRIBUTING.md](CONTRIBUTING.md). Explore compatible benchmark models with `rapid-mlx benchmark catalog`; runs are local-only in the internal beta.
+- **Contributing:** Start with [CONTRIBUTING.md](CONTRIBUTING.md). Explore compatible benchmark models with `rapid-mlx benchmark catalog`; runs stay local unless you explicitly share one in the internal beta.
 - **Show support:** [Star this repository](https://github.com/raullenchai/Rapid-MLX) to follow releases and help others discover the project.
 
 **Privacy:** Anonymous telemetry is off by default and requires an explicit

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -140,6 +140,7 @@ struct CommunityBenchmarkUploadPreview: Identifiable {
     let target: String
     let installID: String
     let payloadDigest: String
+    let bodyDigest: String
     let payloadJSON: String
 
     var id: String { runID }
@@ -368,11 +369,13 @@ enum CommunityBenchmarkCommand {
     }
 
     static func benchmarkShareArguments(
-        runID: String, installID: String, payloadDigest: String, target: String
+        runID: String, installID: String, payloadDigest: String,
+        bodyDigest: String, target: String
     ) -> [String] {
         [
             "benchmark", "share", runID, "--yes", "--install-id", installID,
-            "--payload-digest", payloadDigest, "--target", target, "--json",
+            "--payload-digest", payloadDigest, "--body-digest", bodyDigest,
+            "--target", target, "--json",
         ]
     }
 
@@ -383,22 +386,17 @@ enum CommunityBenchmarkCommand {
               let target = root["target"] as? String,
               let installID = root["install_id"] as? String,
               let payloadDigest = root["payload_digest"] as? String,
-              let payload = root["payload"] as? [String: Any]
+              let bodyDigest = root["body_digest"] as? String,
+              let payloadJSON = root["payload_json"] as? String
         else {
             throw Failure(message: "The benchmark preview was incomplete.")
-        }
-        let payloadData = try JSONSerialization.data(
-            withJSONObject: payload,
-            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-        )
-        guard let payloadJSON = String(data: payloadData, encoding: .utf8) else {
-            throw Failure(message: "The benchmark preview could not be displayed.")
         }
         return CommunityBenchmarkUploadPreview(
             runID: runID,
             target: target,
             installID: installID,
             payloadDigest: payloadDigest,
+            bodyDigest: bodyDigest,
             payloadJSON: payloadJSON
         )
     }
@@ -823,6 +821,7 @@ struct CommunityBenchmarkView: View {
                         runID: preview.runID,
                         installID: preview.installID,
                         payloadDigest: preview.payloadDigest,
+                        bodyDigest: preview.bodyDigest,
                         target: preview.target
                     )
                 )

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -620,8 +620,10 @@ struct CommunityBenchmarkView: View {
                 HStack {
                     Spacer()
                     Button("Cancel", role: .cancel) { shareCandidate = nil }
+                        .accessibilityIdentifier("CommunityBenchmark.Share.Cancel")
                     Button("Share") { share(preview) }
                         .buttonStyle(.borderedProminent)
+                        .accessibilityIdentifier("CommunityBenchmark.Share.Confirm")
                 }
             }
             .padding(24)

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -833,8 +833,10 @@ struct CommunityBenchmarkView: View {
                         message: "The benchmark was not uploaded."
                     )
                 }
-                receipts[preview.runID] = response.receipt
-                if !response.receiptSaved {
+                if response.receiptSaved {
+                    receipts[preview.runID] = response.receipt
+                } else {
+                    await refreshResults()
                     errorMessage = "Uploaded, but Rapid couldn’t save the local receipt."
                 }
             } catch is CancellationError {

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -611,7 +611,9 @@ struct CommunityBenchmarkView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 Text(
                     "No name, hostname, serial number, hardware UUID, prompts, "
-                        + "outputs, or file paths are included."
+                        + "outputs, file paths, or IP-address field are included in the JSON. "
+                        + "The service observes the source IP for short-lived rate limiting "
+                        + "but does not put it in the benchmark record."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -135,6 +135,15 @@ private struct CommunityBenchmarkShareResponse: Decodable {
     }
 }
 
+struct CommunityBenchmarkUploadPreview: Identifiable {
+    let runID: String
+    let target: String
+    let installID: String
+    let payloadJSON: String
+
+    var id: String { runID }
+}
+
 private struct CommunityBenchmarkResult: Decodable, Identifiable {
     struct Workload: Decodable { let taskType: String
         enum CodingKeys: String, CodingKey { case taskType = "task_type" }
@@ -221,20 +230,6 @@ private struct CommunityBenchmarkResult: Decodable, Identifiable {
 
     var repoID: String { model.components.first?.source.repoID ?? "Local model" }
 
-    var shareDisclosure: String {
-        let profile = machine.map {
-            let gpu = $0.profile.gpuCores.map { ", \($0) GPU cores" } ?? ""
-            return "\($0.profile.chip), \($0.profile.memoryGib) GB memory, "
-                + "\($0.profile.cpuCores) CPU cores\(gpu), macOS \($0.os.version)"
-        } ?? "machine probe unavailable"
-        let digest = execution.configDigest.replacingOccurrences(of: "sha256:", with: "")
-        return "Model: \(repoID)\nMachine: \(profile)\nRuntime: rapid-mlx "
-            + "\(execution.runtime.rapidMLX), MLX \(execution.runtime.mlx), Python "
-            + "\(execution.runtime.python)\nExecution: \(workload.taskType), config "
-            + "\(digest.prefix(12))…\nMeasurements: \(measurements?.count ?? 0) rows\n\n"
-            + "A random, resettable install ID is added for abuse control. No name, "
-            + "hostname, serial number, prompts, outputs, or file paths are sent."
-    }
 }
 
 final class BenchmarkProcessBox: @unchecked Sendable {
@@ -367,8 +362,40 @@ enum CommunityBenchmarkCommand {
         ["benchmark", "results", "--limit", String(limit), "--json"]
     }
 
-    static func benchmarkShareArguments(runID: String) -> [String] {
-        ["benchmark", "share", runID, "--yes", "--json"]
+    static func benchmarkSharePreviewArguments(runID: String) -> [String] {
+        ["benchmark", "share", runID, "--preview", "--json"]
+    }
+
+    static func benchmarkShareArguments(runID: String, installID: String) -> [String] {
+        [
+            "benchmark", "share", runID, "--yes", "--install-id", installID,
+            "--json",
+        ]
+    }
+
+    static func decodeSharePreview(_ data: Data, runID: String) throws
+        -> CommunityBenchmarkUploadPreview
+    {
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let target = root["target"] as? String,
+              let installID = root["install_id"] as? String,
+              let payload = root["payload"] as? [String: Any]
+        else {
+            throw Failure(message: "The benchmark preview was incomplete.")
+        }
+        let payloadData = try JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+        guard let payloadJSON = String(data: payloadData, encoding: .utf8) else {
+            throw Failure(message: "The benchmark preview could not be displayed.")
+        }
+        return CommunityBenchmarkUploadPreview(
+            runID: runID,
+            target: target,
+            installID: installID,
+            payloadJSON: payloadJSON
+        )
     }
 
     @MainActor
@@ -523,7 +550,7 @@ struct CommunityBenchmarkView: View {
     @State private var errorMessage: String?
     @State private var runTask: Task<Void, Never>?
     @State private var shareTask: Task<Void, Never>?
-    @State private var shareCandidate: CommunityBenchmarkResult?
+    @State private var shareCandidate: CommunityBenchmarkUploadPreview?
     @State private var sharingRunID: String?
     @State private var receipts: [String: CommunityBenchmarkReceipt] = [:]
     @State private var benchmarkMetadata: [String: CommunityBenchmarkCatalogModel] = [:]
@@ -562,18 +589,36 @@ struct CommunityBenchmarkView: View {
             runTask?.cancel()
             shareTask?.cancel()
         }
-        .alert(
-            "Share benchmark result?",
-            isPresented: Binding(
-                get: { shareCandidate != nil },
-                set: { if !$0 { shareCandidate = nil } }
-            ),
-            presenting: shareCandidate
-        ) { result in
-            Button("Cancel", role: .cancel) { shareCandidate = nil }
-            Button("Share") { share(result) }
-        } message: { result in
-            Text(result.shareDisclosure)
+        .sheet(item: $shareCandidate) { preview in
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Share benchmark result?")
+                    .font(.title2.weight(.semibold))
+                Text("Everything in the JSON below will be sent to \(preview.target).")
+                    .foregroundStyle(.secondary)
+                ScrollView {
+                    Text(preview.payloadJSON)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                }
+                .background(RapidTheme.surfaceCanvas)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                Text(
+                    "No name, hostname, serial number, hardware UUID, prompts, "
+                        + "outputs, or file paths are included."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                HStack {
+                    Spacer()
+                    Button("Cancel", role: .cancel) { shareCandidate = nil }
+                    Button("Share") { share(preview) }
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding(24)
+            .frame(minWidth: 680, minHeight: 600)
         }
     }
 
@@ -668,7 +713,7 @@ struct CommunityBenchmarkView: View {
                                     .foregroundStyle(.green)
                             } else {
                                 Button(sharingRunID == result.id ? "Sharing…" : "Share") {
-                                    shareCandidate = result
+                                    prepareShare(result)
                                 }
                                 .buttonStyle(.link)
                                 .font(.caption)
@@ -731,17 +776,43 @@ struct CommunityBenchmarkView: View {
         }
     }
 
-    private func share(_ result: CommunityBenchmarkResult) {
+    private func prepareShare(_ result: CommunityBenchmarkResult) {
         guard let binary else { return }
-        shareCandidate = nil
         sharingRunID = result.id
         errorMessage = nil
         shareTask = Task {
             do {
                 let data = try await CommunityBenchmarkCommand.run(
                     binary: binary,
-                    arguments: CommunityBenchmarkCommand.benchmarkShareArguments(
+                    arguments: CommunityBenchmarkCommand.benchmarkSharePreviewArguments(
                         runID: result.id
+                    )
+                )
+                shareCandidate = try CommunityBenchmarkCommand.decodeSharePreview(
+                    data, runID: result.id
+                )
+            } catch is CancellationError {
+                // Navigation cancelled the preview command.
+            } catch {
+                errorMessage = "Couldn’t prepare benchmark upload: \(error.localizedDescription)"
+            }
+            sharingRunID = nil
+            shareTask = nil
+        }
+    }
+
+    private func share(_ preview: CommunityBenchmarkUploadPreview) {
+        guard let binary else { return }
+        shareCandidate = nil
+        sharingRunID = preview.runID
+        errorMessage = nil
+        shareTask = Task {
+            do {
+                let data = try await CommunityBenchmarkCommand.run(
+                    binary: binary,
+                    arguments: CommunityBenchmarkCommand.benchmarkShareArguments(
+                        runID: preview.runID,
+                        installID: preview.installID
                     )
                 )
                 let response = try JSONDecoder().decode(
@@ -752,7 +823,7 @@ struct CommunityBenchmarkView: View {
                         message: "The benchmark was not uploaded."
                     )
                 }
-                receipts[result.id] = response.receipt
+                receipts[preview.runID] = response.receipt
                 if !response.receiptSaved {
                     errorMessage = "Uploaded, but Rapid couldn’t save the local receipt."
                 }

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -109,6 +109,30 @@ private struct CommunityBenchmarkCatalogEnvelope: Decodable {
 
 private struct CommunityBenchmarkResults: Decodable {
     let runs: [CommunityBenchmarkResult]
+    let receipts: [String: CommunityBenchmarkReceipt]?
+}
+
+private struct CommunityBenchmarkReceipt: Decodable {
+    let submissionID: String
+    let alreadyExists: Bool
+    let acceptedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case submissionID = "submission_id"
+        case alreadyExists = "already_exists"
+        case acceptedAt = "accepted_at"
+    }
+}
+
+private struct CommunityBenchmarkShareResponse: Decodable {
+    let uploaded: Bool
+    let receiptSaved: Bool
+    let receipt: CommunityBenchmarkReceipt
+
+    enum CodingKeys: String, CodingKey {
+        case uploaded, receipt
+        case receiptSaved = "receipt_saved"
+    }
 }
 
 private struct CommunityBenchmarkResult: Decodable, Identifiable {
@@ -133,17 +157,56 @@ private struct CommunityBenchmarkResult: Decodable, Identifiable {
         }
         let components: [Component]
     }
+    struct Machine: Decodable {
+        struct Profile: Decodable {
+            let chip: String
+            let memoryGib: Int
+            let cpuCores: Int
+            let gpuCores: Int?
+
+            enum CodingKeys: String, CodingKey {
+                case chip
+                case memoryGib = "memory_gib"
+                case cpuCores = "cpu_cores"
+                case gpuCores = "gpu_cores"
+            }
+        }
+        struct OS: Decodable { let version: String }
+        let profile: Profile
+        let os: OS
+    }
+    struct Execution: Decodable {
+        struct Runtime: Decodable {
+            let rapidMLX: String
+            let mlx: String
+            let python: String
+
+            enum CodingKeys: String, CodingKey {
+                case rapidMLX = "rapid_mlx"
+                case mlx, python
+            }
+        }
+        let runtime: Runtime
+        let configDigest: String
+
+        enum CodingKeys: String, CodingKey {
+            case runtime
+            case configDigest = "config_digest"
+        }
+    }
     let id: String
     let completedAt: String
     let workload: Workload
     let outcome: Outcome
     let measurements: [Measurement]?
     let model: Model
+    let machine: Machine?
+    let execution: Execution
 
     enum CodingKeys: String, CodingKey {
         case id = "run_id"
         case completedAt = "completed_at"
-        case workload, outcome, measurements, model
+        case workload, outcome, measurements, model, machine, execution
     }
 
     var duration: String? {
@@ -157,6 +220,21 @@ private struct CommunityBenchmarkResult: Decodable, Identifiable {
     }
 
     var repoID: String { model.components.first?.source.repoID ?? "Local model" }
+
+    var shareDisclosure: String {
+        let profile = machine.map {
+            let gpu = $0.profile.gpuCores.map { ", \($0) GPU cores" } ?? ""
+            return "\($0.profile.chip), \($0.profile.memoryGib) GB memory, "
+                + "\($0.profile.cpuCores) CPU cores\(gpu), macOS \($0.os.version)"
+        } ?? "machine probe unavailable"
+        let digest = execution.configDigest.replacingOccurrences(of: "sha256:", with: "")
+        return "Model: \(repoID)\nMachine: \(profile)\nRuntime: rapid-mlx "
+            + "\(execution.runtime.rapidMLX), MLX \(execution.runtime.mlx), Python "
+            + "\(execution.runtime.python)\nExecution: \(workload.taskType), config "
+            + "\(digest.prefix(12))…\nMeasurements: \(measurements?.count ?? 0) rows\n\n"
+            + "A random, resettable install ID is added for abuse control. No name, "
+            + "hostname, serial number, prompts, outputs, or file paths are sent."
+    }
 }
 
 final class BenchmarkProcessBox: @unchecked Sendable {
@@ -287,6 +365,10 @@ enum CommunityBenchmarkCommand {
 
     static func benchmarkResultsArguments(limit: Int = 8) -> [String] {
         ["benchmark", "results", "--limit", String(limit), "--json"]
+    }
+
+    static func benchmarkShareArguments(runID: String) -> [String] {
+        ["benchmark", "share", runID, "--yes", "--json"]
     }
 
     @MainActor
@@ -440,6 +522,10 @@ struct CommunityBenchmarkView: View {
     @State private var isRunning = false
     @State private var errorMessage: String?
     @State private var runTask: Task<Void, Never>?
+    @State private var shareTask: Task<Void, Never>?
+    @State private var shareCandidate: CommunityBenchmarkResult?
+    @State private var sharingRunID: String?
+    @State private var receipts: [String: CommunityBenchmarkReceipt] = [:]
     @State private var benchmarkMetadata: [String: CommunityBenchmarkCatalogModel] = [:]
     @State private var benchmarkCLIAvailable = false
 
@@ -474,6 +560,20 @@ struct CommunityBenchmarkView: View {
             // control disappears. ServerManager keeps the lease until the
             // subprocess tree has actually been reaped.
             runTask?.cancel()
+            shareTask?.cancel()
+        }
+        .alert(
+            "Share benchmark result?",
+            isPresented: Binding(
+                get: { shareCandidate != nil },
+                set: { if !$0 { shareCandidate = nil } }
+            ),
+            presenting: shareCandidate
+        ) { result in
+            Button("Cancel", role: .cancel) { shareCandidate = nil }
+            Button("Share") { share(result) }
+        } message: { result in
+            Text(result.shareDisclosure)
         }
     }
 
@@ -560,9 +660,21 @@ struct CommunityBenchmarkView: View {
                                 .font(.caption).foregroundStyle(.secondary)
                         }
                         Spacer()
-                        VStack(alignment: .trailing, spacing: 3) {
+                        VStack(alignment: .trailing, spacing: 5) {
                             Text(result.duration ?? result.outcome.status.capitalized)
-                            Text("Local").font(.caption).foregroundStyle(.secondary)
+                            if receipts[result.id] != nil {
+                                Label("Shared", systemImage: "checkmark.circle.fill")
+                                    .font(.caption)
+                                    .foregroundStyle(.green)
+                            } else {
+                                Button(sharingRunID == result.id ? "Sharing…" : "Share") {
+                                    shareCandidate = result
+                                }
+                                .buttonStyle(.link)
+                                .font(.caption)
+                                .disabled(sharingRunID != nil || binary == nil)
+                                .accessibilityIdentifier("CommunityBenchmark.Share.\(result.id)")
+                            }
                         }
                     }
                     .padding(.vertical, 8)
@@ -619,6 +731,41 @@ struct CommunityBenchmarkView: View {
         }
     }
 
+    private func share(_ result: CommunityBenchmarkResult) {
+        guard let binary else { return }
+        shareCandidate = nil
+        sharingRunID = result.id
+        errorMessage = nil
+        shareTask = Task {
+            do {
+                let data = try await CommunityBenchmarkCommand.run(
+                    binary: binary,
+                    arguments: CommunityBenchmarkCommand.benchmarkShareArguments(
+                        runID: result.id
+                    )
+                )
+                let response = try JSONDecoder().decode(
+                    CommunityBenchmarkShareResponse.self, from: data
+                )
+                guard response.uploaded else {
+                    throw CommunityBenchmarkCommand.Failure(
+                        message: "The benchmark was not uploaded."
+                    )
+                }
+                receipts[result.id] = response.receipt
+                if !response.receiptSaved {
+                    errorMessage = "Uploaded, but Rapid couldn’t save the local receipt."
+                }
+            } catch is CancellationError {
+                // Navigation cancelled the upload command and its subprocess.
+            } catch {
+                errorMessage = "Couldn’t share benchmark: \(error.localizedDescription)"
+            }
+            sharingRunID = nil
+            shareTask = nil
+        }
+    }
+
     private func refreshResults() async {
         guard benchmarkCLIAvailable, let binary else { return }
         do {
@@ -626,7 +773,9 @@ struct CommunityBenchmarkView: View {
                 binary: binary,
                 arguments: CommunityBenchmarkCommand.benchmarkResultsArguments()
             )
-            results = try JSONDecoder().decode(CommunityBenchmarkResults.self, from: data).runs
+            let envelope = try JSONDecoder().decode(CommunityBenchmarkResults.self, from: data)
+            results = envelope.runs
+            receipts = envelope.receipts ?? [:]
         } catch {
             if results.isEmpty { errorMessage = "Couldn’t read local results: \(error.localizedDescription)" }
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -368,11 +368,11 @@ enum CommunityBenchmarkCommand {
     }
 
     static func benchmarkShareArguments(
-        runID: String, installID: String, payloadDigest: String
+        runID: String, installID: String, payloadDigest: String, target: String
     ) -> [String] {
         [
             "benchmark", "share", runID, "--yes", "--install-id", installID,
-            "--payload-digest", payloadDigest, "--json",
+            "--payload-digest", payloadDigest, "--target", target, "--json",
         ]
     }
 
@@ -820,7 +820,8 @@ struct CommunityBenchmarkView: View {
                     arguments: CommunityBenchmarkCommand.benchmarkShareArguments(
                         runID: preview.runID,
                         installID: preview.installID,
-                        payloadDigest: preview.payloadDigest
+                        payloadDigest: preview.payloadDigest,
+                        target: preview.target
                     )
                 )
                 let response = try JSONDecoder().decode(

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -139,6 +139,7 @@ struct CommunityBenchmarkUploadPreview: Identifiable {
     let runID: String
     let target: String
     let installID: String
+    let payloadDigest: String
     let payloadJSON: String
 
     var id: String { runID }
@@ -366,10 +367,12 @@ enum CommunityBenchmarkCommand {
         ["benchmark", "share", runID, "--preview", "--json"]
     }
 
-    static func benchmarkShareArguments(runID: String, installID: String) -> [String] {
+    static func benchmarkShareArguments(
+        runID: String, installID: String, payloadDigest: String
+    ) -> [String] {
         [
             "benchmark", "share", runID, "--yes", "--install-id", installID,
-            "--json",
+            "--payload-digest", payloadDigest, "--json",
         ]
     }
 
@@ -379,6 +382,7 @@ enum CommunityBenchmarkCommand {
         guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let target = root["target"] as? String,
               let installID = root["install_id"] as? String,
+              let payloadDigest = root["payload_digest"] as? String,
               let payload = root["payload"] as? [String: Any]
         else {
             throw Failure(message: "The benchmark preview was incomplete.")
@@ -394,6 +398,7 @@ enum CommunityBenchmarkCommand {
             runID: runID,
             target: target,
             installID: installID,
+            payloadDigest: payloadDigest,
             payloadJSON: payloadJSON
         )
     }
@@ -812,7 +817,8 @@ struct CommunityBenchmarkView: View {
                     binary: binary,
                     arguments: CommunityBenchmarkCommand.benchmarkShareArguments(
                         runID: preview.runID,
-                        installID: preview.installID
+                        installID: preview.installID,
+                        payloadDigest: preview.payloadDigest
                     )
                 )
                 let response = try JSONDecoder().decode(

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -163,13 +163,38 @@ struct CommunityBenchmarkModelTests {
             ]
         )
         #expect(
-            CommunityBenchmarkCommand.benchmarkShareArguments(
+            CommunityBenchmarkCommand.benchmarkSharePreviewArguments(
                 runID: "00000000-0000-4000-8000-000000000001"
             ) == [
                 "benchmark", "share", "00000000-0000-4000-8000-000000000001",
-                "--yes", "--json",
+                "--preview", "--json",
             ]
         )
+        #expect(
+            CommunityBenchmarkCommand.benchmarkShareArguments(
+                runID: "00000000-0000-4000-8000-000000000001",
+                installID: "012345abcdef"
+            ) == [
+                "benchmark", "share", "00000000-0000-4000-8000-000000000001",
+                "--yes", "--install-id", "012345abcdef", "--json",
+            ]
+        )
+    }
+
+    @Test("Desktop consent preview displays the exact upload payload")
+    func exactSharePreview() throws {
+        let data = Data(
+            #"{"schema_version":1,"target":"https://rapidmlx.com/api/benchmarks/atomic","install_id":"012345abcdef","payload":{"run_id":"00000000-0000-4000-8000-000000000001","install_id":"012345abcdef","measurements":[{"round_index":1,"total_duration_ms":123.5}],"execution":{"task":{"max_tokens":128}}}}"#.utf8
+        )
+        let preview = try CommunityBenchmarkCommand.decodeSharePreview(
+            data, runID: "00000000-0000-4000-8000-000000000001"
+        )
+
+        #expect(preview.installID == "012345abcdef")
+        #expect(preview.payloadJSON.contains("\"measurements\""))
+        #expect(preview.payloadJSON.contains("\"total_duration_ms\" : 123.5"))
+        #expect(preview.payloadJSON.contains("\"max_tokens\" : 128"))
+        #expect(preview.payloadJSON.contains("\"install_id\" : \"012345abcdef\""))
     }
 
     @Test("Benchmark pipe capture bounds stdout heads and stderr tails")

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -173,10 +173,12 @@ struct CommunityBenchmarkModelTests {
         #expect(
             CommunityBenchmarkCommand.benchmarkShareArguments(
                 runID: "00000000-0000-4000-8000-000000000001",
-                installID: "012345abcdef"
+                installID: "012345abcdef",
+                payloadDigest: "sha256:aaaaaaaa"
             ) == [
                 "benchmark", "share", "00000000-0000-4000-8000-000000000001",
-                "--yes", "--install-id", "012345abcdef", "--json",
+                "--yes", "--install-id", "012345abcdef",
+                "--payload-digest", "sha256:aaaaaaaa", "--json",
             ]
         )
     }
@@ -184,13 +186,14 @@ struct CommunityBenchmarkModelTests {
     @Test("Desktop consent preview displays the exact upload payload")
     func exactSharePreview() throws {
         let data = Data(
-            #"{"schema_version":1,"target":"https://rapidmlx.com/api/benchmarks/atomic","install_id":"012345abcdef","payload":{"run_id":"00000000-0000-4000-8000-000000000001","install_id":"012345abcdef","measurements":[{"round_index":1,"total_duration_ms":123.5}],"execution":{"task":{"max_tokens":128}}}}"#.utf8
+            #"{"schema_version":1,"target":"https://rapidmlx.com/api/benchmarks/atomic","install_id":"012345abcdef","payload_digest":"sha256:aaaaaaaa","payload":{"run_id":"00000000-0000-4000-8000-000000000001","install_id":"012345abcdef","measurements":[{"round_index":1,"total_duration_ms":123.5}],"execution":{"task":{"max_tokens":128}}}}"#.utf8
         )
         let preview = try CommunityBenchmarkCommand.decodeSharePreview(
             data, runID: "00000000-0000-4000-8000-000000000001"
         )
 
         #expect(preview.installID == "012345abcdef")
+        #expect(preview.payloadDigest == "sha256:aaaaaaaa")
         #expect(preview.payloadJSON.contains("\"measurements\""))
         #expect(preview.payloadJSON.contains("\"total_duration_ms\" : 123.5"))
         #expect(preview.payloadJSON.contains("\"max_tokens\" : 128"))

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -162,6 +162,14 @@ struct CommunityBenchmarkModelTests {
                 "benchmark", "results", "--limit", "8", "--json",
             ]
         )
+        #expect(
+            CommunityBenchmarkCommand.benchmarkShareArguments(
+                runID: "00000000-0000-4000-8000-000000000001"
+            ) == [
+                "benchmark", "share", "00000000-0000-4000-8000-000000000001",
+                "--yes", "--json",
+            ]
+        )
     }
 
     @Test("Benchmark pipe capture bounds stdout heads and stderr tails")

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -175,11 +175,13 @@ struct CommunityBenchmarkModelTests {
                 runID: "00000000-0000-4000-8000-000000000001",
                 installID: "012345abcdef",
                 payloadDigest: "sha256:aaaaaaaa",
+                bodyDigest: "sha256:bbbbbbbb",
                 target: "https://rapidmlx.com/api/benchmarks/atomic"
             ) == [
                 "benchmark", "share", "00000000-0000-4000-8000-000000000001",
                 "--yes", "--install-id", "012345abcdef",
-                "--payload-digest", "sha256:aaaaaaaa", "--target",
+                "--payload-digest", "sha256:aaaaaaaa",
+                "--body-digest", "sha256:bbbbbbbb", "--target",
                 "https://rapidmlx.com/api/benchmarks/atomic", "--json",
             ]
         )
@@ -188,7 +190,7 @@ struct CommunityBenchmarkModelTests {
     @Test("Desktop consent preview displays the exact upload payload")
     func exactSharePreview() throws {
         let data = Data(
-            #"{"schema_version":1,"target":"https://rapidmlx.com/api/benchmarks/atomic","install_id":"012345abcdef","payload_digest":"sha256:aaaaaaaa","payload":{"run_id":"00000000-0000-4000-8000-000000000001","install_id":"012345abcdef","measurements":[{"round_index":1,"total_duration_ms":123.5}],"execution":{"task":{"max_tokens":128}}}}"#.utf8
+            #"{"schema_version":1,"target":"https://rapidmlx.com/api/benchmarks/atomic","install_id":"012345abcdef","payload_digest":"sha256:aaaaaaaa","body_digest":"sha256:bbbbbbbb","payload_json":"{\"run_id\": \"00000000-0000-4000-8000-000000000001\", \"install_id\": \"012345abcdef\", \"measurements\": [{\"round_index\": 1, \"total_duration_ms\": 123.5}], \"execution\": {\"task\": {\"max_tokens\": 128}}}"}"#.utf8
         )
         let preview = try CommunityBenchmarkCommand.decodeSharePreview(
             data, runID: "00000000-0000-4000-8000-000000000001"
@@ -196,10 +198,11 @@ struct CommunityBenchmarkModelTests {
 
         #expect(preview.installID == "012345abcdef")
         #expect(preview.payloadDigest == "sha256:aaaaaaaa")
-        #expect(preview.payloadJSON.contains("\"measurements\""))
-        #expect(preview.payloadJSON.contains("\"total_duration_ms\" : 123.5"))
-        #expect(preview.payloadJSON.contains("\"max_tokens\" : 128"))
-        #expect(preview.payloadJSON.contains("\"install_id\" : \"012345abcdef\""))
+        #expect(preview.bodyDigest == "sha256:bbbbbbbb")
+        #expect(
+            preview.payloadJSON
+                == #"{"run_id": "00000000-0000-4000-8000-000000000001", "install_id": "012345abcdef", "measurements": [{"round_index": 1, "total_duration_ms": 123.5}], "execution": {"task": {"max_tokens": 128}}}"#
+        )
     }
 
     @Test("Benchmark pipe capture bounds stdout heads and stderr tails")

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -174,11 +174,13 @@ struct CommunityBenchmarkModelTests {
             CommunityBenchmarkCommand.benchmarkShareArguments(
                 runID: "00000000-0000-4000-8000-000000000001",
                 installID: "012345abcdef",
-                payloadDigest: "sha256:aaaaaaaa"
+                payloadDigest: "sha256:aaaaaaaa",
+                target: "https://rapidmlx.com/api/benchmarks/atomic"
             ) == [
                 "benchmark", "share", "00000000-0000-4000-8000-000000000001",
                 "--yes", "--install-id", "012345abcdef",
-                "--payload-digest", "sha256:aaaaaaaa", "--json",
+                "--payload-digest", "sha256:aaaaaaaa", "--target",
+                "https://rapidmlx.com/api/benchmarks/atomic", "--json",
             ]
         )
     }

--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -18,6 +18,7 @@ rapid-mlx benchmark plan MODEL [--json]
 rapid-mlx benchmark run MODEL [--json]
 rapid-mlx benchmark results [--limit N] [--json]
 rapid-mlx benchmark inspect RUN_ID [--json]
+rapid-mlx benchmark share RUN_ID
 ```
 
 `rapid-mlx bench` remains available as the legacy freeform/submission surface
@@ -28,7 +29,9 @@ records rather than parse legacy submission JSON.
 
 - A run is private by default. The client writes a schema-valid JSON record to
   `~/.rapid-mlx/benchmarks/runs/` with directory mode `0700` and file mode
-  `0600`. No network upload or share control is part of this execution path.
+  `0600`. Running a benchmark never uploads it. A separate share action shows
+  the complete wire payload and destination, requires explicit consent, then
+  adds only a random resettable install ID for abuse control.
 - Desktop stops its active inference server before benchmarking so two large
   model processes cannot compete for unified memory. An owner-scoped lifecycle
   reservation remains active until cancellation has terminated and reaped the
@@ -109,7 +112,12 @@ Wan alias, matching the CLI planner rather than advertising LTX/CogVideoX.
 
 ## Follow-up
 
-Sharing is a separate post-result capability. It must show the exact privacy
-allowlist, resolve model identity where possible, revalidate the record, and
-require explicit user action. Server ingestion, public aggregation, campaign
-prompts, rewards, and leaderboard growth mechanics do not belong in this PR.
+The internal-beta share action revalidates a run, POSTs it to the separate
+atomic ingestion endpoint, and saves a schema-valid acceptance receipt under
+`~/.rapid-mlx/benchmarks/receipts/`. Retries are idempotent by run ID and exact
+run digest. Atomic rows remain outside the legacy public aggregation path.
+
+Model-identity resolution, public aggregation, campaign prompts, rewards, and
+leaderboard growth mechanics remain later work. The ingestion boundary accepts
+the current unresolved identities deliberately; it never upgrades them to
+formally comparable evidence.

--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -33,9 +33,10 @@ records rather than parse legacy submission JSON.
   the complete wire payload and destination, including the candidate random
   resettable install ID used for abuse control, and requires explicit consent.
   Previewing writes nothing. The subsequent upload is pinned to that candidate
-  and the preview payload digest. It aborts if another process established a
-  different install ID or the archived run changed while the consent sheet was
-  open; it never silently sends data different from the approved JSON.
+  and the preview payload digest and destination. It aborts if another process
+  established a different install ID, the archived run changed, or endpoint
+  configuration changed while the consent sheet was open; it never silently
+  sends data or sends to a destination different from what was approved.
   The JSON has no IP-address field. The HTTPS service necessarily observes the
   source IP and uses it for short-lived request limiting, but the application
   does not retain it in the benchmark record.

--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -30,8 +30,11 @@ records rather than parse legacy submission JSON.
 - A run is private by default. The client writes a schema-valid JSON record to
   `~/.rapid-mlx/benchmarks/runs/` with directory mode `0700` and file mode
   `0600`. Running a benchmark never uploads it. A separate share action shows
-  the complete wire payload and destination, requires explicit consent, then
-  adds only a random resettable install ID for abuse control.
+  the complete wire payload and destination, including the candidate random
+  resettable install ID used for abuse control, and requires explicit consent.
+  Previewing writes nothing. The subsequent upload is pinned to that candidate
+  and aborts if another process established a different install ID meanwhile;
+  it never silently sends data different from the approved JSON.
 - Desktop stops its active inference server before benchmarking so two large
   model processes cannot compete for unified memory. An owner-scoped lifecycle
   reservation remains active until cancellation has terminated and reaped the
@@ -115,7 +118,9 @@ Wan alias, matching the CLI planner rather than advertising LTX/CogVideoX.
 The internal-beta share action revalidates a run, POSTs it to the separate
 atomic ingestion endpoint, and saves a schema-valid acceptance receipt under
 `~/.rapid-mlx/benchmarks/receipts/`. Retries are idempotent by run ID and exact
-run digest. Atomic rows remain outside the legacy public aggregation path.
+run digest. The client verifies that the returned receipt digest identifies the
+exact uploaded payload before marking a result shared. Atomic rows remain
+outside the legacy public aggregation path.
 
 Model-identity resolution, public aggregation, campaign prompts, rewards, and
 leaderboard growth mechanics remain later work. The ingestion boundary accepts

--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -33,10 +33,12 @@ records rather than parse legacy submission JSON.
   the complete wire payload and destination, including the candidate random
   resettable install ID used for abuse control, and requires explicit consent.
   Previewing writes nothing. The subsequent upload is pinned to that candidate
-  and the preview payload digest and destination. It aborts if another process
-  established a different install ID, the archived run changed, or endpoint
+  and the preview's canonical payload digest, exact serialized HTTP-body
+  digest, and destination. Desktop displays that exact body string without
+  parsing and reformatting it. Upload aborts if another process established a
+  different install ID, the archived run or serialization changed, or endpoint
   configuration changed while the consent sheet was open; it never silently
-  sends data or sends to a destination different from what was approved.
+  sends bytes or sends to a destination different from what was approved.
   The JSON has no IP-address field. The HTTPS service necessarily observes the
   source IP and uses it for short-lived request limiting, but the application
   does not retain it in the benchmark record.

--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -36,6 +36,9 @@ records rather than parse legacy submission JSON.
   and the preview payload digest. It aborts if another process established a
   different install ID or the archived run changed while the consent sheet was
   open; it never silently sends data different from the approved JSON.
+  The JSON has no IP-address field. The HTTPS service necessarily observes the
+  source IP and uses it for short-lived request limiting, but the application
+  does not retain it in the benchmark record.
 - Desktop stops its active inference server before benchmarking so two large
   model processes cannot compete for unified memory. An owner-scoped lifecycle
   reservation remains active until cancellation has terminated and reaped the

--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -33,8 +33,9 @@ records rather than parse legacy submission JSON.
   the complete wire payload and destination, including the candidate random
   resettable install ID used for abuse control, and requires explicit consent.
   Previewing writes nothing. The subsequent upload is pinned to that candidate
-  and aborts if another process established a different install ID meanwhile;
-  it never silently sends data different from the approved JSON.
+  and the preview payload digest. It aborts if another process established a
+  different install ID or the archived run changed while the consent sheet was
+  open; it never silently sends data different from the approved JSON.
 - Desktop stops its active inference server before benchmarking so two large
   model processes cannot compete for unified memory. An owner-scoped lifecycle
   reservation remains active until cancellation has terminated and reaped the

--- a/proto/community-benchmark/README.md
+++ b/proto/community-benchmark/README.md
@@ -8,6 +8,8 @@ Community benchmark is one consumer of the product-neutral atomic contracts:
   layer built on those objects.
 - [`v1/benchmark-run.schema.json`](v1/benchmark-run.schema.json) adds only a
   workload, raw measurements, outcome, collector, and run envelope.
+- [`v1/submission-receipt.schema.json`](v1/submission-receipt.schema.json)
+  records the server acceptance boundary without mutating the archived run.
 
 The run union supports `text_generation`, `vision_language`,
 `image_generation`, and `video_generation`. Image and video are first-class,
@@ -16,8 +18,9 @@ resolution, frames, steps, guidance, prompt/output length, and seed live in the
 workload. Runtime choices such as MTP, KV cache, attention backend, VAE tiling,
 offload, and temporal chunking live in `ExecutionConfig`.
 
-The production `community-benchmarks/schema.json` v1-v3 remains unchanged until
-a later rollout PR adds an adapter and switches producers/ingestion.
+The legacy production `community-benchmarks/schema.json` v1-v3 remains
+unchanged. Atomic runs use a separate internal-beta ingestion endpoint and do
+not enter the legacy public leaderboard.
 
 ## Registered protocols and datasets
 

--- a/proto/community-benchmark/v1/submission-receipt.schema.json
+++ b/proto/community-benchmark/v1/submission-receipt.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/raullenchai/Rapid-MLX/proto/community-benchmark/v1/submission-receipt.schema.json",
+  "title": "Community Benchmark Submission Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "submission_id",
+    "status",
+    "already_exists",
+    "accepted_at",
+    "run_digest",
+    "contributor"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "submission_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "status": { "const": "accepted" },
+    "already_exists": { "type": "boolean" },
+    "accepted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "run_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "contributor": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "tag"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 96
+            },
+            "tag": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{3}$"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_community_benchmark_proto.py
+++ b/tests/test_community_benchmark_proto.py
@@ -29,7 +29,21 @@ SCHEMA_PATHS = (
     CATALOG_V1_ROOT / "recommendation-policy.schema.json",
     CATALOG_ROOT / "catalog-snapshot.schema.json",
     BENCH_ROOT / "benchmark-run.schema.json",
+    BENCH_ROOT / "submission-receipt.schema.json",
 )
+
+
+def test_submission_receipt_contract(schemas, registry) -> None:
+    receipt = {
+        "schema_version": 1,
+        "submission_id": "00000000-0000-4000-8000-000000000001",
+        "status": "accepted",
+        "already_exists": False,
+        "accepted_at": "2026-09-01T20:00:00Z",
+        "run_digest": "sha256:" + "a" * 64,
+        "contributor": {"name": "quiet-amber-orca", "tag": "0af"},
+    }
+    _validator(schemas["submission-receipt.schema.json"], registry).validate(receipt)
 
 
 def _load(path: Path) -> dict:

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -329,6 +329,7 @@ def test_atomic_preview_is_the_exact_later_payload(
         assume_yes=True,
         approved_install_id=preview["install_id"],
         approved_payload_digest=preview["payload_digest"],
+        approved_target=preview["target"],
     )
 
 
@@ -378,6 +379,37 @@ def test_atomic_upload_aborts_if_approved_install_id_loses_race(
             approved_install_id="a" * 12,
         )
     assert sent == []
+
+
+def test_atomic_upload_aborts_if_destination_changes_after_preview(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _text_run()
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    monkeypatch.setenv(
+        "RAPID_MLX_BENCH_BOARD_URL", "https://first.example/api/benchmarks/atomic"
+    )
+    preview = atomic_upload.preview_run(run)
+    monkeypatch.setenv(
+        "RAPID_MLX_BENCH_BOARD_URL", "https://second.example/api/benchmarks/atomic"
+    )
+    sent = []
+    monkeypatch.setattr(
+        atomic_upload,
+        "post_submission",
+        lambda *args, **kwargs: sent.append(args),
+    )
+
+    with pytest.raises(SubmitError, match="destination changed"):
+        atomic_upload.upload_run(
+            run,
+            assume_yes=True,
+            approved_install_id=preview["install_id"],
+            approved_payload_digest=preview["payload_digest"],
+            approved_target=preview["target"],
+        )
+    assert sent == []
+    assert not (tmp_path / "bench-install-id").exists()
 
 
 def test_share_cli_rejects_archive_changed_after_preview(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -9,6 +9,7 @@ import json
 import multiprocessing
 import os
 import signal
+import stat
 import subprocess
 import sys
 import textwrap
@@ -532,6 +533,23 @@ def test_install_id_cleanup_errors_do_not_reverse_a_committed_identity(
 
     assert benchmark_upload.commit_install_id("a" * 12) == "a" * 12
     assert (tmp_path / "bench-install-id").read_text().strip() == "a" * 12
+
+
+def test_install_id_commit_syncs_file_and_parent_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    real_fsync = benchmark_upload.os.fsync
+    synced = []
+
+    def observed_fsync(descriptor):
+        synced.append(stat.S_ISDIR(os.fstat(descriptor).st_mode))
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(benchmark_upload.os, "fsync", observed_fsync)
+
+    assert benchmark_upload.commit_install_id("a" * 12) == "a" * 12
+    assert synced == [False, True]
 
 
 def test_local_archive_receipt_marks_only_an_existing_run_shared(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -409,6 +409,20 @@ def test_local_archive_receipt_marks_only_an_existing_run_shared(
         archive.save_receipt(malformed)
 
 
+@pytest.mark.parametrize("contents", [b'{"schema_version":', b"\xff\xfe"])
+def test_corrupt_optional_receipt_does_not_hide_local_runs(
+    tmp_path: Path, contents: bytes
+) -> None:
+    archive = LocalRunArchive(tmp_path)
+    run = _text_run()
+    archive.save(run)
+    archive.receipts_dir.mkdir(parents=True, exist_ok=True)
+    (archive.receipts_dir / f"{run['run_id']}.json").write_bytes(contents)
+
+    assert archive.receipt(run["run_id"]) is None
+    assert archive.list() == [run]
+
+
 def test_share_cli_saves_server_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -276,7 +276,9 @@ def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(
         sent.update(payload)
         return {
             "ok": True,
-            "receipt": _receipt(run["run_id"], run_digest=rcj_digest(payload)),
+            "receipt": _receipt(
+                run["run_id"], run_digest=atomic_upload.atomic_run_digest(payload)
+            ),
         }
 
     monkeypatch.setattr(atomic_upload, "post_submission", post)
@@ -288,7 +290,9 @@ def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(
 
     receipt = atomic_upload.upload_run(run, assume_yes=True)
 
-    assert receipt == _receipt(run["run_id"], run_digest=rcj_digest(sent))
+    assert receipt == _receipt(
+        run["run_id"], run_digest=atomic_upload.atomic_run_digest(sent)
+    )
     assert len(sent["install_id"]) == 12
     assert "install_id" not in run
     assert sent
@@ -299,6 +303,7 @@ def test_atomic_preview_is_the_exact_later_payload(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     run = _text_run()
+    run["measurements"][0]["total_duration_ms"] = 100.25
     monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
     preview = atomic_upload.preview_run(run)
     assert not (tmp_path / "bench-install-id").exists()
@@ -306,7 +311,11 @@ def test_atomic_preview_is_the_exact_later_payload(
     def post(payload, **kwargs):
         assert payload == preview["payload"]
         assert kwargs["url"] == preview["target"]
-        return {"receipt": _receipt(run["run_id"], run_digest=rcj_digest(payload))}
+        return {
+            "receipt": _receipt(
+                run["run_id"], run_digest=atomic_upload.atomic_run_digest(payload)
+            )
+        }
 
     monkeypatch.setattr(atomic_upload, "post_submission", post)
     atomic_upload.upload_run(
@@ -314,6 +323,17 @@ def test_atomic_preview_is_the_exact_later_payload(
         assume_yes=True,
         approved_install_id=preview["install_id"],
     )
+
+
+def test_atomic_run_digest_uses_ingestion_service_number_format() -> None:
+    render = atomic_upload._ecmascript_number
+    assert render(100.0) == "100"
+    assert render(-0.0) == "0"
+    assert render(0.00123) == "0.00123"
+    assert render(1e-6) == "0.000001"
+    assert render(1e-7) == "1e-7"
+    assert render(1e20) == "100000000000000000000"
+    assert render(1e21) == "1e+21"
 
 
 def test_atomic_upload_rejects_receipt_for_different_payload(
@@ -357,21 +377,13 @@ def test_install_id_commit_is_stable_across_same_process_threads(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
-    real_link = benchmark_upload.os.link
-    barrier = threading.Barrier(2)
+    (tmp_path / "bench-install-id").write_text("malformed\n")
+    candidates = [f"{index:012x}" for index in range(16)]
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        settled = list(pool.map(benchmark_upload.commit_install_id, candidates))
 
-    def synchronized_link(source, destination):
-        barrier.wait(timeout=2)
-        return real_link(source, destination)
-
-    monkeypatch.setattr(benchmark_upload.os, "link", synchronized_link)
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        settled = list(
-            pool.map(benchmark_upload.commit_install_id, ["a" * 12, "b" * 12])
-        )
-
-    assert settled[0] == settled[1]
-    assert settled[0] in {"a" * 12, "b" * 12}
+    assert len(set(settled)) == 1
+    assert settled[0] in candidates
     assert (tmp_path / "bench-install-id").read_text().strip() == settled[0]
     assert list(tmp_path.glob(".bench-install-id.*.tmp")) == []
 

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -552,6 +552,25 @@ def test_install_id_commit_syncs_file_and_parent_directory(
     assert synced == [False, True]
 
 
+def test_install_id_commit_completes_a_partial_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    real_write = benchmark_upload.os.write
+    calls = 0
+
+    def partial_first_write(descriptor, data):
+        nonlocal calls
+        calls += 1
+        return real_write(descriptor, data[:3] if calls == 1 else data)
+
+    monkeypatch.setattr(benchmark_upload.os, "write", partial_first_write)
+
+    assert benchmark_upload.commit_install_id("a" * 12) == "a" * 12
+    assert calls == 2
+    assert (tmp_path / "bench-install-id").read_text() == "a" * 12 + "\n"
+
+
 def test_local_archive_receipt_marks_only_an_existing_run_shared(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -40,6 +40,7 @@ from vllm_mlx.community_bench.benchmark_contracts import (
 from vllm_mlx.community_bench.hardware import Hardware, Software
 from vllm_mlx.community_bench.run_builder import build_run, execution_config, utc_now
 from vllm_mlx.community_bench.runner import BenchResult, BucketResult, RoundResult
+from vllm_mlx.community_bench.upload import SubmitError
 from vllm_mlx.community_bench.workspace import (
     LocalRunArchive,
     benchmark_catalog,
@@ -223,14 +224,16 @@ def test_results_cli_forwards_latest_limit(
     }
 
 
-def _receipt(run_id: str, *, already: bool = False) -> dict:
+def _receipt(
+    run_id: str, *, already: bool = False, run_digest: str | None = None
+) -> dict:
     return {
         "schema_version": 1,
         "submission_id": run_id,
         "status": "accepted",
         "already_exists": already,
         "accepted_at": "2026-09-01T20:00:00Z",
-        "run_digest": "sha256:" + "a" * 64,
+        "run_digest": run_digest or "sha256:" + "a" * 64,
         "contributor": {"name": "rapid-silver-otter", "tag": "abc"},
     }
 
@@ -269,7 +272,10 @@ def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(
     def post(payload, **kwargs):
         assert kwargs["url"] == "https://rapidmlx.com/api/benchmarks/atomic"
         sent.update(payload)
-        return {"ok": True, "receipt": _receipt(run["run_id"])}
+        return {
+            "ok": True,
+            "receipt": _receipt(run["run_id"], run_digest=rcj_digest(payload)),
+        }
 
     monkeypatch.setattr(atomic_upload, "post_submission", post)
     monkeypatch.setattr(
@@ -280,11 +286,69 @@ def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(
 
     receipt = atomic_upload.upload_run(run, assume_yes=True)
 
-    assert receipt == _receipt(run["run_id"])
+    assert receipt == _receipt(run["run_id"], run_digest=rcj_digest(sent))
     assert len(sent["install_id"]) == 12
     assert "install_id" not in run
     assert sent
     BenchmarkRunValidator().validate(sent)
+
+
+def test_atomic_preview_is_the_exact_later_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _text_run()
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    preview = atomic_upload.preview_run(run)
+    assert not (tmp_path / "bench-install-id").exists()
+
+    def post(payload, **kwargs):
+        assert payload == preview["payload"]
+        assert kwargs["url"] == preview["target"]
+        return {"receipt": _receipt(run["run_id"], run_digest=rcj_digest(payload))}
+
+    monkeypatch.setattr(atomic_upload, "post_submission", post)
+    atomic_upload.upload_run(
+        run,
+        assume_yes=True,
+        approved_install_id=preview["install_id"],
+    )
+
+
+def test_atomic_upload_rejects_receipt_for_different_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _text_run()
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        atomic_upload,
+        "post_submission",
+        lambda payload, **kwargs: {"receipt": _receipt(run["run_id"])},
+    )
+
+    with pytest.raises(SubmitError, match="uploaded payload"):
+        atomic_upload.upload_run(run, assume_yes=True)
+
+
+def test_atomic_upload_aborts_if_approved_install_id_loses_race(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _text_run()
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    sent = []
+    monkeypatch.setattr(atomic_upload, "commit_install_id", lambda candidate: "b" * 12)
+    monkeypatch.setattr(
+        atomic_upload,
+        "post_submission",
+        lambda *args, **kwargs: sent.append(args),
+    )
+
+    with pytest.raises(SubmitError, match="install id changed"):
+        atomic_upload.upload_run(
+            run,
+            assume_yes=True,
+            approved_install_id="a" * 12,
+        )
+    assert sent == []
 
 
 def test_local_archive_receipt_marks_only_an_existing_run_shared(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -322,6 +322,7 @@ def test_atomic_preview_is_the_exact_later_payload(
         run,
         assume_yes=True,
         approved_install_id=preview["install_id"],
+        approved_payload_digest=preview["payload_digest"],
     )
 
 
@@ -371,6 +372,47 @@ def test_atomic_upload_aborts_if_approved_install_id_loses_race(
             approved_install_id="a" * 12,
         )
     assert sent == []
+
+
+def test_share_cli_rejects_archive_changed_after_preview(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    archive = LocalRunArchive(tmp_path)
+    run = _text_run()
+    archive.save(run)
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    preview = atomic_upload.preview_run(run)
+
+    changed = json.loads(json.dumps(run))
+    changed["measurements"][0]["total_duration_ms"] += 0.5
+    archive.save(changed)
+    sent = []
+    monkeypatch.setattr(
+        community_cli.LocalRunArchive,
+        "default",
+        classmethod(lambda cls: archive),
+    )
+    monkeypatch.setattr(
+        atomic_upload,
+        "post_submission",
+        lambda *args, **kwargs: sent.append(args),
+    )
+    args = SimpleNamespace(
+        benchmark_action="share",
+        run_id=run["run_id"],
+        yes=True,
+        json=True,
+        preview=False,
+        install_id=preview["install_id"],
+        payload_digest=preview["payload_digest"],
+    )
+
+    assert community_cli.benchmark_command(args) == 1
+    assert "changed after preview" in capsys.readouterr().err
+    assert sent == []
+    assert not (tmp_path / "bench-install-id").exists()
 
 
 def test_install_id_commit_is_stable_across_same_process_threads(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -23,7 +23,12 @@ import pytest
 
 from vllm_mlx.bench import _server
 from vllm_mlx.catalog import rcj_digest
-from vllm_mlx.community_bench import benchmark_contracts, local_runner, run_builder
+from vllm_mlx.community_bench import (
+    atomic_upload,
+    benchmark_contracts,
+    local_runner,
+    run_builder,
+)
 from vllm_mlx.community_bench import cli as community_cli
 from vllm_mlx.community_bench import runner as bench_runner
 from vllm_mlx.community_bench import workspace as workspace_module
@@ -94,6 +99,7 @@ def _mock_local_context(
     ("packaged", "source"),
     [
         ("benchmark-run.schema.json", "benchmark-run.schema.json"),
+        ("submission-receipt.schema.json", "submission-receipt.schema.json"),
         ("rapid-community-speed-v1.json", "protocols/rapid-community-speed-v1.json"),
         ("rapid-community-speed-v2.json", "protocols/rapid-community-speed-v2.json"),
         ("rapid-image-speed-v1.json", "protocols/rapid-image-speed-v1.json"),
@@ -139,7 +145,10 @@ def test_unresolved_alias_is_local_evidence_not_formally_comparable() -> None:
     plan = plan_for_alias("flux2-klein-4b")
     assert plan["model"]["identity_strength"] == "unresolved"
     assert plan["model"]["comparable"] is False
-    assert plan["privacy"] == {"storage": "local", "uploads": False}
+    assert plan["privacy"] == {
+        "storage": "local",
+        "upload": "explicit_consent_only",
+    }
     assert registered_workload("text_generation")["protocol_version"] == 2
 
 
@@ -207,7 +216,126 @@ def test_results_cli_forwards_latest_limit(
     args = SimpleNamespace(benchmark_action="results", limit=8, json=True)
 
     assert community_cli.benchmark_command(args) == 0
-    assert json.loads(capsys.readouterr().out) == {"schema_version": 1, "runs": []}
+    assert json.loads(capsys.readouterr().out) == {
+        "schema_version": 1,
+        "runs": [],
+        "receipts": {},
+    }
+
+
+def _receipt(run_id: str, *, already: bool = False) -> dict:
+    return {
+        "schema_version": 1,
+        "submission_id": run_id,
+        "status": "accepted",
+        "already_exists": already,
+        "accepted_at": "2026-09-01T20:00:00Z",
+        "run_digest": "sha256:" + "a" * 64,
+        "contributor": {"name": "rapid-silver-otter", "tag": "abc"},
+    }
+
+
+def test_atomic_upload_decline_has_no_disk_or_network_side_effect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _text_run()
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    called = []
+    monkeypatch.setattr(
+        atomic_upload,
+        "post_submission",
+        lambda *args, **kwargs: called.append(1),
+    )
+
+    result = atomic_upload.upload_run(
+        run,
+        stdin=io.StringIO("n\n"),
+        stdout=io.StringIO(),
+        url="https://rapidmlx.com/api/benchmarks/atomic",
+    )
+
+    assert result is None
+    assert called == []
+    assert not (tmp_path / "bench-install-id").exists()
+
+
+def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _text_run()
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    sent = {}
+
+    def post(payload, **kwargs):
+        assert kwargs["url"] == "https://rapidmlx.com/api/benchmarks/atomic"
+        sent.update(payload)
+        return {"ok": True, "receipt": _receipt(run["run_id"])}
+
+    monkeypatch.setattr(atomic_upload, "post_submission", post)
+    monkeypatch.setattr(
+        atomic_upload,
+        "board_url",
+        lambda: "https://rapidmlx.com/api/benchmarks",
+    )
+
+    receipt = atomic_upload.upload_run(run, assume_yes=True)
+
+    assert receipt == _receipt(run["run_id"])
+    assert len(sent["install_id"]) == 12
+    assert "install_id" not in run
+    assert sent
+    BenchmarkRunValidator().validate(sent)
+
+
+def test_local_archive_receipt_marks_only_an_existing_run_shared(
+    tmp_path: Path,
+) -> None:
+    archive = LocalRunArchive(tmp_path)
+    run = _text_run()
+    archive.save(run)
+    receipt = _receipt(run["run_id"])
+
+    path = archive.save_receipt(receipt)
+
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert archive.receipt(run["run_id"]) == receipt
+    unknown = dict(receipt, submission_id="00000000-0000-4000-8000-000000000099")
+    with pytest.raises(FileNotFoundError):
+        archive.save_receipt(unknown)
+
+    malformed = dict(receipt, status="maybe")
+    with pytest.raises(ValueError, match="submission_receipt"):
+        archive.save_receipt(malformed)
+
+
+def test_share_cli_saves_server_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    archive = LocalRunArchive(tmp_path)
+    run = _text_run()
+    archive.save(run)
+    receipt = _receipt(run["run_id"])
+    monkeypatch.setattr(
+        community_cli.LocalRunArchive,
+        "default",
+        classmethod(lambda cls: archive),
+    )
+    monkeypatch.setattr(
+        community_cli,
+        "upload_run",
+        lambda local_run, **kwargs: receipt,
+    )
+    args = SimpleNamespace(
+        benchmark_action="share", run_id=run["run_id"], yes=True, json=True
+    )
+
+    assert community_cli.benchmark_command(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["uploaded"] is True
+    assert payload["receipt"] == receipt
+    assert archive.receipt(run["run_id"]) == receipt
 
 
 def test_unknown_run_model_returns_structured_unsaved_cli_error(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -252,6 +252,7 @@ def test_atomic_upload_decline_has_no_disk_or_network_side_effect(
         "post_submission",
         lambda *args, **kwargs: called.append(1),
     )
+    monkeypatch.setattr(atomic_upload, "peek_install_id", lambda: "a" * 12)
     output = io.StringIO()
 
     result = atomic_upload.upload_run(
@@ -266,6 +267,10 @@ def test_atomic_upload_decline_has_no_disk_or_network_side_effect(
     assert not (tmp_path / "bench-install-id").exists()
     assert "observes the source IP" in output.getvalue()
     assert "does not put it in the benchmark record" in output.getvalue()
+    exact_body = benchmark_upload.submission_body(
+        {**run, "install_id": "a" * 12}
+    ).decode()
+    assert exact_body in output.getvalue()
 
 
 def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -288,11 +288,13 @@ def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(
         lambda: "https://rapidmlx.com/api/benchmarks",
     )
 
-    receipt = atomic_upload.upload_run(run, assume_yes=True)
+    acceptance = atomic_upload.upload_run(run, assume_yes=True)
 
-    assert receipt == _receipt(
+    assert acceptance is not None
+    assert acceptance.receipt == _receipt(
         run["run_id"], run_digest=atomic_upload.atomic_run_digest(sent)
     )
+    assert acceptance.install_id == sent["install_id"]
     assert len(sent["install_id"]) == 12
     assert "install_id" not in run
     assert sent
@@ -436,19 +438,26 @@ def test_local_archive_receipt_marks_only_an_existing_run_shared(
     archive = LocalRunArchive(tmp_path)
     run = _text_run()
     archive.save(run)
-    receipt = _receipt(run["run_id"])
+    install_id = "012345abcdef"
+    wire = {**run, "install_id": install_id}
+    receipt = _receipt(run["run_id"], run_digest=atomic_upload.atomic_run_digest(wire))
 
-    path = archive.save_receipt(receipt)
+    path = archive.save_receipt(receipt, install_id=install_id)
 
     assert path.stat().st_mode & 0o777 == 0o600
     assert archive.receipt(run["run_id"]) == receipt
     unknown = dict(receipt, submission_id="00000000-0000-4000-8000-000000000099")
     with pytest.raises(FileNotFoundError):
-        archive.save_receipt(unknown)
+        archive.save_receipt(unknown, install_id=install_id)
 
     malformed = dict(receipt, status="maybe")
     with pytest.raises(ValueError, match="submission_receipt"):
-        archive.save_receipt(malformed)
+        archive.save_receipt(malformed, install_id=install_id)
+
+    changed = json.loads(json.dumps(run))
+    changed["measurements"][0]["total_duration_ms"] += 0.5
+    archive.save(changed)
+    assert archive.receipt(run["run_id"]) is None
 
 
 @pytest.mark.parametrize("contents", [b'{"schema_version":', b"\xff\xfe"])
@@ -473,7 +482,14 @@ def test_share_cli_saves_server_receipt(
     archive = LocalRunArchive(tmp_path)
     run = _text_run()
     archive.save(run)
-    receipt = _receipt(run["run_id"])
+    install_id = "012345abcdef"
+    wire = {**run, "install_id": install_id}
+    receipt = _receipt(run["run_id"], run_digest=atomic_upload.atomic_run_digest(wire))
+    acceptance = atomic_upload.AtomicUploadAcceptance(
+        receipt=receipt,
+        install_id=install_id,
+        payload_digest=receipt["run_digest"],
+    )
     monkeypatch.setattr(
         community_cli.LocalRunArchive,
         "default",
@@ -482,7 +498,7 @@ def test_share_cli_saves_server_receipt(
     monkeypatch.setattr(
         community_cli,
         "upload_run",
-        lambda local_run, **kwargs: receipt,
+        lambda local_run, **kwargs: acceptance,
     )
     args = SimpleNamespace(
         benchmark_action="share", run_id=run["run_id"], yes=True, json=True
@@ -493,6 +509,48 @@ def test_share_cli_saves_server_receipt(
     assert payload["uploaded"] is True
     assert payload["receipt"] == receipt
     assert archive.receipt(run["run_id"]) == receipt
+
+
+def test_share_cli_reports_acceptance_when_receipt_persistence_loses_archive_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    archive = LocalRunArchive(tmp_path)
+    run = _text_run()
+    archive.save(run)
+    install_id = "012345abcdef"
+    receipt = _receipt(
+        run["run_id"],
+        run_digest=atomic_upload.atomic_run_digest({**run, "install_id": install_id}),
+    )
+    acceptance = atomic_upload.AtomicUploadAcceptance(
+        receipt=receipt,
+        install_id=install_id,
+        payload_digest=receipt["run_digest"],
+    )
+
+    def accepted_then_archive_changes(local_run, **kwargs):
+        changed = json.loads(json.dumps(local_run))
+        changed["measurements"][0]["total_duration_ms"] += 0.5
+        archive.save(changed)
+        return acceptance
+
+    monkeypatch.setattr(
+        community_cli.LocalRunArchive,
+        "default",
+        classmethod(lambda cls: archive),
+    )
+    monkeypatch.setattr(community_cli, "upload_run", accepted_then_archive_changes)
+    args = SimpleNamespace(
+        benchmark_action="share", run_id=run["run_id"], yes=True, json=True
+    )
+
+    assert community_cli.benchmark_command(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["uploaded"] is True
+    assert payload["receipt_saved"] is False
+    assert archive.receipt(run["run_id"]) is None
 
 
 def test_unknown_run_model_returns_structured_unsaved_cli_error(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -274,6 +274,27 @@ def test_atomic_upload_decline_has_no_disk_or_network_side_effect(
     assert exact_body in output.getvalue()
 
 
+def test_atomic_upload_rejects_cleartext_explicit_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    sent = []
+    monkeypatch.setattr(
+        atomic_upload,
+        "post_submission",
+        lambda *args, **kwargs: sent.append(args),
+    )
+
+    with pytest.raises(SubmitError, match="must be an https:// URL"):
+        atomic_upload.upload_run(
+            _text_run(),
+            assume_yes=True,
+            url="http://collector.example/submit",
+        )
+    assert sent == []
+    assert not (tmp_path / "bench-install-id").exists()
+
+
 def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -352,6 +373,41 @@ def test_atomic_run_digest_uses_ingestion_service_number_format() -> None:
     assert render(1e-7) == "1e-7"
     assert render(1e20) == "100000000000000000000"
     assert render(1e21) == "1e+21"
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        ({"ok": True}, "without a submission receipt"),
+        ({"receipt": {"schema_version": 1}}, "invalid submission receipt"),
+    ],
+)
+def test_atomic_upload_rejects_missing_or_invalid_receipt(
+    response: dict, message: str
+) -> None:
+    with pytest.raises(SubmitError, match=message):
+        atomic_upload._validated_receipt(
+            response, _text_run()["run_id"], "sha256:" + "a" * 64
+        )
+
+
+def test_atomic_upload_rejects_receipt_for_different_run() -> None:
+    run = _text_run()
+    receipt = _receipt(
+        "00000000-0000-4000-8000-000000000099",
+        run_digest="sha256:" + "a" * 64,
+    )
+    with pytest.raises(SubmitError, match="uploaded run"):
+        atomic_upload._validated_receipt(
+            {"receipt": receipt}, run["run_id"], receipt["run_digest"]
+        )
+
+
+def test_atomic_digest_rejects_non_finite_and_unsupported_values() -> None:
+    with pytest.raises(ValueError, match="non-finite"):
+        atomic_upload.atomic_run_digest({"value": float("nan")})
+    with pytest.raises(TypeError, match="unsupported benchmark payload value"):
+        atomic_upload.atomic_run_digest({"value": object()})
 
 
 def test_atomic_upload_rejects_receipt_for_different_payload(
@@ -571,6 +627,35 @@ def test_install_id_commit_completes_a_partial_write(
     assert (tmp_path / "bench-install-id").read_text() == "a" * 12 + "\n"
 
 
+def test_install_id_commit_handles_zero_progress_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    monkeypatch.setattr(benchmark_upload.os, "write", lambda descriptor, data: 0)
+
+    assert benchmark_upload.commit_install_id("a" * 12) == "a" * 12
+    assert not (tmp_path / "bench-install-id").exists()
+    assert list(tmp_path.glob(".bench-install-id.*.tmp")) == []
+
+
+def test_install_id_directory_close_error_is_best_effort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    real_close = benchmark_upload.os.close
+
+    def close_then_report_directory_error(descriptor):
+        is_directory = stat.S_ISDIR(os.fstat(descriptor).st_mode)
+        real_close(descriptor)
+        if is_directory:
+            raise OSError("directory close reported failure")
+
+    monkeypatch.setattr(benchmark_upload.os, "close", close_then_report_directory_error)
+
+    assert benchmark_upload.commit_install_id("a" * 12) == "a" * 12
+    assert (tmp_path / "bench-install-id").read_text().strip() == "a" * 12
+
+
 def test_local_archive_receipt_marks_only_an_existing_run_shared(
     tmp_path: Path,
 ) -> None:
@@ -611,6 +696,40 @@ def test_corrupt_optional_receipt_does_not_hide_local_runs(
 
     assert archive.receipt(run["run_id"]) is None
     assert archive.list() == [run]
+
+
+def test_optional_receipt_rejects_invalid_envelope_shapes(tmp_path: Path) -> None:
+    archive = LocalRunArchive(tmp_path)
+    run = _text_run()
+    archive.save(run)
+    archive.receipts_dir.mkdir(parents=True, exist_ok=True)
+    path = archive.receipts_dir / f"{run['run_id']}.json"
+
+    for envelope in (
+        {"schema_version": 2},
+        {"schema_version": 1, "install_id": 7, "receipt": {}},
+        {
+            "schema_version": 1,
+            "install_id": "012345abcdef",
+            "receipt": _receipt(run["run_id"]) | {"status": "invalid"},
+        },
+    ):
+        path.write_text(json.dumps(envelope))
+        assert archive.receipt(run["run_id"]) is None
+
+
+def test_save_receipt_defensively_rejects_missing_submission_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = LocalRunArchive(tmp_path)
+    monkeypatch.setattr(
+        workspace_module.SubmissionReceiptValidator,
+        "validate",
+        lambda self, receipt: None,
+    )
+
+    with pytest.raises(ValueError, match="missing a submission id"):
+        archive.save_receipt({}, install_id="012345abcdef")
 
 
 def test_share_cli_saves_server_receipt(
@@ -690,6 +809,94 @@ def test_share_cli_reports_acceptance_when_receipt_persistence_loses_archive_rac
     assert payload["uploaded"] is True
     assert payload["receipt_saved"] is False
     assert archive.receipt(run["run_id"]) is None
+
+
+def test_share_cli_requires_confirmation_for_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _cli_archive(monkeypatch, SimpleNamespace())
+    args = SimpleNamespace(
+        benchmark_action="share",
+        run_id="00000000-0000-4000-8000-000000000001",
+        yes=False,
+        json=True,
+        preview=False,
+    )
+
+    assert community_cli.benchmark_command(args) == 1
+    assert "requires --yes" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("json_output", [False, True])
+def test_share_cli_preview_prints_exact_preview(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    json_output: bool,
+) -> None:
+    run = _text_run()
+
+    class Archive:
+        def get(self, run_id: str):
+            return run
+
+    _cli_archive(monkeypatch, Archive())
+    monkeypatch.setattr(
+        community_cli,
+        "preview_run",
+        lambda local_run: {"target": "https://example.test/atomic"},
+    )
+    args = SimpleNamespace(
+        benchmark_action="share",
+        run_id=run["run_id"],
+        yes=False,
+        json=json_output,
+        preview=True,
+    )
+
+    assert community_cli.benchmark_command(args) == 0
+    assert (
+        json.loads(capsys.readouterr().out)["target"] == "https://example.test/atomic"
+    )
+
+
+def test_share_cli_text_reports_cancel_and_unsaved_existing_acceptance(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    run = _text_run()
+
+    class Archive:
+        def get(self, run_id: str):
+            return run
+
+        def save_receipt(self, receipt, *, install_id):
+            raise OSError("read-only archive")
+
+    _cli_archive(monkeypatch, Archive())
+    args = SimpleNamespace(
+        benchmark_action="share",
+        run_id=run["run_id"],
+        yes=False,
+        json=False,
+        preview=False,
+    )
+    monkeypatch.setattr(community_cli, "upload_run", lambda local_run, **kwargs: None)
+    assert community_cli.benchmark_command(args) == 0
+    assert "Upload cancelled" in capsys.readouterr().out
+
+    receipt = _receipt(run["run_id"], already=True)
+    acceptance = atomic_upload.AtomicUploadAcceptance(
+        receipt=receipt,
+        install_id="012345abcdef",
+        payload_digest=receipt["run_digest"],
+    )
+    monkeypatch.setattr(
+        community_cli, "upload_run", lambda local_run, **kwargs: acceptance
+    )
+    args.yes = True
+    assert community_cli.benchmark_command(args) == 0
+    output = capsys.readouterr().out
+    assert "already uploaded" in output
+    assert "local receipt could not be saved" in output
 
 
 def test_unknown_run_model_returns_structured_unsaved_cli_error(
@@ -2382,7 +2589,9 @@ def test_cli_plan_prints_protocol_and_local_storage(
     out = capsys.readouterr().out
     assert "Model:    example-text" in out
     assert "Protocol: rapid-community-speed v2" in out
-    assert "Storage:  local only (no upload)" in out
+    assert (
+        "Storage:  local; upload requires a separate share command and consent" in out
+    )
 
 
 def test_cli_results_prints_empty_hint_then_rows(
@@ -2393,6 +2602,9 @@ def test_cli_results_prints_empty_hint_then_rows(
     class Archive:
         def list(self, *, limit=None):
             return list(rows)
+
+        def receipt(self, run_id: str):
+            return None
 
     _cli_archive(monkeypatch, Archive())
     args = SimpleNamespace(benchmark_action="results", limit=None, json=False)

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -15,6 +15,7 @@ import textwrap
 import threading
 import time
 import types
+from concurrent.futures import ThreadPoolExecutor
 from importlib import resources
 from pathlib import Path
 from types import SimpleNamespace
@@ -31,6 +32,7 @@ from vllm_mlx.community_bench import (
 )
 from vllm_mlx.community_bench import cli as community_cli
 from vllm_mlx.community_bench import runner as bench_runner
+from vllm_mlx.community_bench import upload as benchmark_upload
 from vllm_mlx.community_bench import workspace as workspace_module
 from vllm_mlx.community_bench.benchmark_contracts import (
     BenchmarkRunValidator,
@@ -349,6 +351,29 @@ def test_atomic_upload_aborts_if_approved_install_id_loses_race(
             approved_install_id="a" * 12,
         )
     assert sent == []
+
+
+def test_install_id_commit_is_stable_across_same_process_threads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    real_link = benchmark_upload.os.link
+    barrier = threading.Barrier(2)
+
+    def synchronized_link(source, destination):
+        barrier.wait(timeout=2)
+        return real_link(source, destination)
+
+    monkeypatch.setattr(benchmark_upload.os, "link", synchronized_link)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        settled = list(
+            pool.map(benchmark_upload.commit_install_id, ["a" * 12, "b" * 12])
+        )
+
+    assert settled[0] == settled[1]
+    assert settled[0] in {"a" * 12, "b" * 12}
+    assert (tmp_path / "bench-install-id").read_text().strip() == settled[0]
+    assert list(tmp_path.glob(".bench-install-id.*.tmp")) == []
 
 
 def test_local_archive_receipt_marks_only_an_existing_run_shared(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -313,6 +313,9 @@ def test_atomic_preview_is_the_exact_later_payload(
     monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
     preview = atomic_upload.preview_run(run)
     assert not (tmp_path / "bench-install-id").exists()
+    assert preview["payload_json"].encode() == benchmark_upload.submission_body(
+        preview["payload"]
+    )
 
     def post(payload, **kwargs):
         assert payload == preview["payload"]
@@ -329,6 +332,7 @@ def test_atomic_preview_is_the_exact_later_payload(
         assume_yes=True,
         approved_install_id=preview["install_id"],
         approved_payload_digest=preview["payload_digest"],
+        approved_body_digest=preview["body_digest"],
         approved_target=preview["target"],
     )
 
@@ -406,6 +410,34 @@ def test_atomic_upload_aborts_if_destination_changes_after_preview(
             assume_yes=True,
             approved_install_id=preview["install_id"],
             approved_payload_digest=preview["payload_digest"],
+            approved_body_digest=preview["body_digest"],
+            approved_target=preview["target"],
+        )
+    assert sent == []
+    assert not (tmp_path / "bench-install-id").exists()
+
+
+def test_atomic_upload_binds_exact_serialized_body_not_only_semantics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run = _text_run()
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    preview = atomic_upload.preview_run(run)
+    reordered = {key: run[key] for key in reversed(run)}
+    sent = []
+    monkeypatch.setattr(
+        atomic_upload,
+        "post_submission",
+        lambda *args, **kwargs: sent.append(args),
+    )
+
+    with pytest.raises(SubmitError, match="serialized benchmark changed"):
+        atomic_upload.upload_run(
+            reordered,
+            assume_yes=True,
+            approved_install_id=preview["install_id"],
+            approved_payload_digest=preview["payload_digest"],
+            approved_body_digest=preview["body_digest"],
             approved_target=preview["target"],
         )
     assert sent == []
@@ -445,6 +477,8 @@ def test_share_cli_rejects_archive_changed_after_preview(
         preview=False,
         install_id=preview["install_id"],
         payload_digest=preview["payload_digest"],
+        body_digest=preview["body_digest"],
+        target=preview["target"],
     )
 
     assert community_cli.benchmark_command(args) == 1

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -150,6 +150,7 @@ def test_unresolved_alias_is_local_evidence_not_formally_comparable() -> None:
     assert plan["model"]["comparable"] is False
     assert plan["privacy"] == {
         "storage": "local",
+        "uploads": False,
         "upload": "explicit_consent_only",
     }
     assert registered_workload("text_generation")["protocol_version"] == 2
@@ -251,17 +252,20 @@ def test_atomic_upload_decline_has_no_disk_or_network_side_effect(
         "post_submission",
         lambda *args, **kwargs: called.append(1),
     )
+    output = io.StringIO()
 
     result = atomic_upload.upload_run(
         run,
         stdin=io.StringIO("n\n"),
-        stdout=io.StringIO(),
+        stdout=output,
         url="https://rapidmlx.com/api/benchmarks/atomic",
     )
 
     assert result is None
     assert called == []
     assert not (tmp_path / "bench-install-id").exists()
+    assert "observes the source IP" in output.getvalue()
+    assert "does not put it in the benchmark record" in output.getvalue()
 
 
 def test_atomic_upload_sends_validated_run_and_requires_matching_receipt(
@@ -430,6 +434,33 @@ def test_install_id_commit_is_stable_across_same_process_threads(
     assert settled[0] in candidates
     assert (tmp_path / "bench-install-id").read_text().strip() == settled[0]
     assert list(tmp_path.glob(".bench-install-id.*.tmp")) == []
+
+
+def test_install_id_cleanup_errors_do_not_reverse_a_committed_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("RAPID_MLX_HOME", str(tmp_path))
+    real_flock = benchmark_upload.fcntl.flock
+    real_close = benchmark_upload.os.close
+    lock_fd = None
+
+    def flaky_flock(descriptor, operation):
+        nonlocal lock_fd
+        if operation == benchmark_upload.fcntl.LOCK_EX:
+            lock_fd = descriptor
+            return real_flock(descriptor, operation)
+        raise OSError("unlock failed")
+
+    def flaky_close(descriptor):
+        real_close(descriptor)
+        if descriptor == lock_fd:
+            raise OSError("close reported failure")
+
+    monkeypatch.setattr(benchmark_upload.fcntl, "flock", flaky_flock)
+    monkeypatch.setattr(benchmark_upload.os, "close", flaky_close)
+
+    assert benchmark_upload.commit_install_id("a" * 12) == "a" * 12
+    assert (tmp_path / "bench-install-id").read_text().strip() == "a" * 12
 
 
 def test_local_archive_receipt_marks_only_an_existing_run_shared(

--- a/vllm_mlx/catalog/schemas/submission-receipt.schema.json
+++ b/vllm_mlx/catalog/schemas/submission-receipt.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/raullenchai/Rapid-MLX/proto/community-benchmark/v1/submission-receipt.schema.json",
+  "title": "Community Benchmark Submission Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "submission_id",
+    "status",
+    "already_exists",
+    "accepted_at",
+    "run_digest",
+    "contributor"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "submission_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "status": { "const": "accepted" },
+    "already_exists": { "type": "boolean" },
+    "accepted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "run_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "contributor": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "tag"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 96
+            },
+            "tag": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{3}$"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -11802,6 +11802,10 @@ Examples:
         "--payload-digest",
         help=argparse.SUPPRESS,
     )
+    community_share.add_argument(
+        "--target",
+        help=argparse.SUPPRESS,
+    )
     community_share.add_argument("--json", action="store_true")
 
     # Models command. ``ls`` is registered as a top-level alias that

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -11803,6 +11803,10 @@ Examples:
         help=argparse.SUPPRESS,
     )
     community_share.add_argument(
+        "--body-digest",
+        help=argparse.SUPPRESS,
+    )
+    community_share.add_argument(
         "--target",
         help=argparse.SUPPRESS,
     )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -11780,6 +11780,16 @@ Examples:
     )
     community_inspect.add_argument("run_id")
     community_inspect.add_argument("--json", action="store_true")
+    community_share = community_subparsers.add_parser(
+        "share", help="Explicitly upload one locally saved benchmark result"
+    )
+    community_share.add_argument("run_id")
+    community_share.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm upload (for callers that already presented a consent dialog)",
+    )
+    community_share.add_argument("--json", action="store_true")
 
     # Models command. ``ls`` is registered as a top-level alias that
     # defaults to ``models --cached`` (the locally-cached view) — two

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -11798,6 +11798,10 @@ Examples:
         "--install-id",
         help=argparse.SUPPRESS,
     )
+    community_share.add_argument(
+        "--payload-digest",
+        help=argparse.SUPPRESS,
+    )
     community_share.add_argument("--json", action="store_true")
 
     # Models command. ``ls`` is registered as a top-level alias that

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -11789,6 +11789,15 @@ Examples:
         action="store_true",
         help="Confirm upload (for callers that already presented a consent dialog)",
     )
+    community_share.add_argument(
+        "--preview",
+        action="store_true",
+        help="Print the exact upload payload without writing or sending it",
+    )
+    community_share.add_argument(
+        "--install-id",
+        help=argparse.SUPPRESS,
+    )
     community_share.add_argument("--json", action="store_true")
 
     # Models command. ``ls`` is registered as a top-level alias that

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
+import math
 import sys
 from typing import Any, TextIO
-
-from vllm_mlx.catalog import rcj_digest
 
 from .benchmark_contracts import BenchmarkRunValidator, SubmissionReceiptValidator
 from .upload import (
@@ -62,6 +62,68 @@ def _validated_receipt(
     return copy.deepcopy(receipt)
 
 
+def _ecmascript_number(value: float) -> str:
+    """Render one finite float like JSON.stringify / ECMAScript Number::toString."""
+
+    if not math.isfinite(value):
+        raise ValueError("benchmark payload contains a non-finite number")
+    if value == 0:
+        return "0"
+    sign = "-" if value < 0 else ""
+    raw = repr(abs(value)).lower()
+    mantissa, _, exponent_text = raw.partition("e")
+    exponent = int(exponent_text or "0")
+    whole, dot, fraction = mantissa.partition(".")
+    combined = whole + (fraction if dot else "")
+    leading_zeroes = len(combined) - len(combined.lstrip("0"))
+    digits = combined.lstrip("0").rstrip("0")
+    decimal_position = len(whole) + exponent - leading_zeroes
+    if -6 < decimal_position <= 21:
+        if decimal_position <= 0:
+            return sign + "0." + "0" * (-decimal_position) + digits
+        if decimal_position >= len(digits):
+            return sign + digits + "0" * (decimal_position - len(digits))
+        return sign + digits[:decimal_position] + "." + digits[decimal_position:]
+    coefficient = digits[0] + ("." + digits[1:] if len(digits) > 1 else "")
+    scientific_exponent = decimal_position - 1
+    exponent_sign = "+" if scientific_exponent >= 0 else ""
+    return f"{sign}{coefficient}e{exponent_sign}{scientific_exponent}"
+
+
+def _atomic_canonical(value: Any) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return _ecmascript_number(value)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, list):
+        return "[" + ",".join(_atomic_canonical(item) for item in value) + "]"
+    if isinstance(value, dict):
+        return (
+            "{"
+            + ",".join(
+                f"{_atomic_canonical(key)}:{_atomic_canonical(value[key])}"
+                for key in sorted(value)
+            )
+            + "}"
+        )
+    raise TypeError(f"unsupported benchmark payload value: {type(value).__name__}")
+
+
+def atomic_run_digest(run: dict[str, Any]) -> str:
+    """Digest a run with the ingestion service's sorted JSON canonical form."""
+
+    canonical = _atomic_canonical(run).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
 def preview_run(
     run: dict[str, Any], *, install_id: str | None = None, url: str | None = None
 ) -> dict[str, Any]:
@@ -108,7 +170,7 @@ def upload_run(
             "the install id changed before upload; review the payload and try again"
         )
     response = post_submission(wire, url=target)
-    return _validated_receipt(response, run["run_id"], rcj_digest(wire))
+    return _validated_receipt(response, run["run_id"], atomic_run_digest(wire))
 
 
-__all__ = ["preview_run", "upload_run"]
+__all__ = ["atomic_run_digest", "preview_run", "upload_run"]

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -19,6 +19,7 @@ from .upload import (
     peek_install_id,
     post_submission,
     submission_body,
+    validate_board_url,
 )
 
 
@@ -140,7 +141,7 @@ def preview_run(
     """Build the exact wire payload without writing or sending anything."""
 
     BenchmarkRunValidator().validate(run)
-    base = (url or board_url()).rstrip("/")
+    base = (validate_board_url(url) if url is not None else board_url()).rstrip("/")
     target = base if url or base.endswith("/atomic") else f"{base}/atomic"
     candidate = install_id or peek_install_id()
     wire = copy.deepcopy(run)

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -18,6 +18,7 @@ from .upload import (
     commit_install_id,
     peek_install_id,
     post_submission,
+    submission_body,
 )
 
 
@@ -147,10 +148,13 @@ def preview_run(
     wire = copy.deepcopy(run)
     wire["install_id"] = candidate
     BenchmarkRunValidator().validate(wire)
+    body = submission_body(wire)
     return {
         "target": target,
         "install_id": candidate,
         "payload_digest": atomic_run_digest(wire),
+        "body_digest": f"sha256:{hashlib.sha256(body).hexdigest()}",
+        "payload_json": body.decode("utf-8"),
         "payload": wire,
     }
 
@@ -164,6 +168,7 @@ def upload_run(
     url: str | None = None,
     approved_install_id: str | None = None,
     approved_payload_digest: str | None = None,
+    approved_body_digest: str | None = None,
     approved_target: str | None = None,
 ) -> AtomicUploadAcceptance | None:
     """Upload one validated run, returning its server receipt.
@@ -177,6 +182,7 @@ def upload_run(
     candidate = preview["install_id"]
     wire = preview["payload"]
     wire_digest = preview["payload_digest"]
+    body_digest = preview["body_digest"]
     if approved_target is not None and approved_target != target:
         raise SubmitError(
             "the upload destination changed after preview; review the payload again"
@@ -184,6 +190,10 @@ def upload_run(
     if approved_payload_digest is not None and approved_payload_digest != wire_digest:
         raise SubmitError(
             "the archived benchmark changed after preview; review the payload again"
+        )
+    if approved_body_digest is not None and approved_body_digest != body_digest:
+        raise SubmitError(
+            "the serialized benchmark changed after preview; review the payload again"
         )
 
     out = stdout or sys.stdout

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import math
 import sys
+from dataclasses import dataclass
 from typing import Any, TextIO
 
 from .benchmark_contracts import BenchmarkRunValidator, SubmissionReceiptValidator
@@ -18,6 +19,13 @@ from .upload import (
     peek_install_id,
     post_submission,
 )
+
+
+@dataclass(frozen=True)
+class AtomicUploadAcceptance:
+    receipt: dict[str, Any]
+    install_id: str
+    payload_digest: str
 
 
 def _ask_consent(
@@ -153,7 +161,7 @@ def upload_run(
     url: str | None = None,
     approved_install_id: str | None = None,
     approved_payload_digest: str | None = None,
-) -> dict[str, Any] | None:
+) -> AtomicUploadAcceptance | None:
     """Upload one validated run, returning its server receipt.
 
     ``None`` means an interactive user declined. ``assume_yes`` exists for a
@@ -181,7 +189,13 @@ def upload_run(
             "the install id changed before upload; review the payload and try again"
         )
     response = post_submission(wire, url=target)
-    return _validated_receipt(response, run["run_id"], wire_digest)
+    receipt = _validated_receipt(response, run["run_id"], wire_digest)
+    return AtomicUploadAcceptance(receipt, candidate, wire_digest)
 
 
-__all__ = ["atomic_run_digest", "preview_run", "upload_run"]
+__all__ = [
+    "AtomicUploadAcceptance",
+    "atomic_run_digest",
+    "preview_run",
+    "upload_run",
+]

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -136,7 +136,12 @@ def preview_run(
     wire = copy.deepcopy(run)
     wire["install_id"] = candidate
     BenchmarkRunValidator().validate(wire)
-    return {"target": target, "install_id": candidate, "payload": wire}
+    return {
+        "target": target,
+        "install_id": candidate,
+        "payload_digest": atomic_run_digest(wire),
+        "payload": wire,
+    }
 
 
 def upload_run(
@@ -147,6 +152,7 @@ def upload_run(
     stdout: TextIO | None = None,
     url: str | None = None,
     approved_install_id: str | None = None,
+    approved_payload_digest: str | None = None,
 ) -> dict[str, Any] | None:
     """Upload one validated run, returning its server receipt.
 
@@ -158,6 +164,11 @@ def upload_run(
     target = preview["target"]
     candidate = preview["install_id"]
     wire = preview["payload"]
+    wire_digest = preview["payload_digest"]
+    if approved_payload_digest is not None and approved_payload_digest != wire_digest:
+        raise SubmitError(
+            "the archived benchmark changed after preview; review the payload again"
+        )
 
     out = stdout or sys.stdout
     inp = stdin or sys.stdin
@@ -170,7 +181,7 @@ def upload_run(
             "the install id changed before upload; review the payload and try again"
         )
     response = post_submission(wire, url=target)
-    return _validated_receipt(response, run["run_id"], atomic_run_digest(wire))
+    return _validated_receipt(response, run["run_id"], wire_digest)
 
 
 __all__ = ["atomic_run_digest", "preview_run", "upload_run"]

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit upload flow for atomic Community Benchmark runs."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from typing import Any, TextIO
+
+from .benchmark_contracts import BenchmarkRunValidator, SubmissionReceiptValidator
+from .upload import (
+    SubmitError,
+    board_url,
+    commit_install_id,
+    peek_install_id,
+    post_submission,
+)
+
+
+def _ask_consent(
+    payload: dict[str, Any], *, target: str, stdin: TextIO, stdout: TextIO
+) -> bool:
+    print("", file=stdout)
+    print(f"About to upload this benchmark to {target}:", file=stdout)
+    print("=" * 72, file=stdout)
+    print(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), file=stdout
+    )
+    print("=" * 72, file=stdout)
+    print(
+        "Everything shown above leaves this Mac. It includes model source, "
+        "Mac configuration, OS/runtime versions, execution settings, timings, "
+        "and a random resettable install id. It does not include your name, "
+        "hostname, serial number, hardware UUID, IP address, prompts, outputs, "
+        "or file paths.",
+        file=stdout,
+    )
+    print("Upload this result? [y/N] ", end="", flush=True, file=stdout)
+    answer = stdin.readline()
+    return answer.strip().lower() in {"y", "yes"}
+
+
+def _validated_receipt(response: dict[str, Any], run_id: str) -> dict[str, Any]:
+    receipt = response.get("receipt")
+    if not isinstance(receipt, dict):
+        raise SubmitError("the board accepted the request without a submission receipt")
+    try:
+        SubmissionReceiptValidator().validate(receipt)
+    except ValueError as exc:
+        raise SubmitError(
+            f"the board returned an invalid submission receipt: {exc}"
+        ) from exc
+    if receipt["submission_id"] != run_id:
+        raise SubmitError("the board receipt does not identify the uploaded run")
+    return copy.deepcopy(receipt)
+
+
+def upload_run(
+    run: dict[str, Any],
+    *,
+    assume_yes: bool = False,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    url: str | None = None,
+) -> dict[str, Any] | None:
+    """Upload one validated run, returning its server receipt.
+
+    ``None`` means an interactive user declined. ``assume_yes`` exists for a
+    caller such as Rapid Desktop that presents its own native confirmation.
+    """
+
+    BenchmarkRunValidator().validate(run)
+    base = (url or board_url()).rstrip("/")
+    target = base if url or base.endswith("/atomic") else f"{base}/atomic"
+    candidate = peek_install_id()
+    wire = copy.deepcopy(run)
+    wire["install_id"] = candidate
+    BenchmarkRunValidator().validate(wire)
+
+    out = stdout or sys.stdout
+    inp = stdin or sys.stdin
+    if not assume_yes and not _ask_consent(wire, target=target, stdin=inp, stdout=out):
+        return None
+
+    settled = commit_install_id(candidate)
+    wire["install_id"] = settled
+    BenchmarkRunValidator().validate(wire)
+    response = post_submission(wire, url=target)
+    return _validated_receipt(response, run["run_id"])
+
+
+__all__ = ["upload_run"]

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -35,9 +35,7 @@ def _ask_consent(
     print("", file=stdout)
     print(f"About to upload this benchmark to {target}:", file=stdout)
     print("=" * 72, file=stdout)
-    print(
-        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), file=stdout
-    )
+    print(submission_body(payload).decode("utf-8"), file=stdout)
     print("=" * 72, file=stdout)
     print(
         "Everything shown above leaves this Mac. It includes model source, "

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -8,6 +8,8 @@ import json
 import sys
 from typing import Any, TextIO
 
+from vllm_mlx.catalog import rcj_digest
+
 from .benchmark_contracts import BenchmarkRunValidator, SubmissionReceiptValidator
 from .upload import (
     SubmitError,
@@ -41,7 +43,9 @@ def _ask_consent(
     return answer.strip().lower() in {"y", "yes"}
 
 
-def _validated_receipt(response: dict[str, Any], run_id: str) -> dict[str, Any]:
+def _validated_receipt(
+    response: dict[str, Any], run_id: str, run_digest: str
+) -> dict[str, Any]:
     receipt = response.get("receipt")
     if not isinstance(receipt, dict):
         raise SubmitError("the board accepted the request without a submission receipt")
@@ -53,7 +57,24 @@ def _validated_receipt(response: dict[str, Any], run_id: str) -> dict[str, Any]:
         ) from exc
     if receipt["submission_id"] != run_id:
         raise SubmitError("the board receipt does not identify the uploaded run")
+    if receipt["run_digest"] != run_digest:
+        raise SubmitError("the board receipt does not identify the uploaded payload")
     return copy.deepcopy(receipt)
+
+
+def preview_run(
+    run: dict[str, Any], *, install_id: str | None = None, url: str | None = None
+) -> dict[str, Any]:
+    """Build the exact wire payload without writing or sending anything."""
+
+    BenchmarkRunValidator().validate(run)
+    base = (url or board_url()).rstrip("/")
+    target = base if url or base.endswith("/atomic") else f"{base}/atomic"
+    candidate = install_id or peek_install_id()
+    wire = copy.deepcopy(run)
+    wire["install_id"] = candidate
+    BenchmarkRunValidator().validate(wire)
+    return {"target": target, "install_id": candidate, "payload": wire}
 
 
 def upload_run(
@@ -63,6 +84,7 @@ def upload_run(
     stdin: TextIO | None = None,
     stdout: TextIO | None = None,
     url: str | None = None,
+    approved_install_id: str | None = None,
 ) -> dict[str, Any] | None:
     """Upload one validated run, returning its server receipt.
 
@@ -70,13 +92,10 @@ def upload_run(
     caller such as Rapid Desktop that presents its own native confirmation.
     """
 
-    BenchmarkRunValidator().validate(run)
-    base = (url or board_url()).rstrip("/")
-    target = base if url or base.endswith("/atomic") else f"{base}/atomic"
-    candidate = peek_install_id()
-    wire = copy.deepcopy(run)
-    wire["install_id"] = candidate
-    BenchmarkRunValidator().validate(wire)
+    preview = preview_run(run, install_id=approved_install_id, url=url)
+    target = preview["target"]
+    candidate = preview["install_id"]
+    wire = preview["payload"]
 
     out = stdout or sys.stdout
     inp = stdin or sys.stdin
@@ -84,10 +103,12 @@ def upload_run(
         return None
 
     settled = commit_install_id(candidate)
-    wire["install_id"] = settled
-    BenchmarkRunValidator().validate(wire)
+    if settled != candidate:
+        raise SubmitError(
+            "the install id changed before upload; review the payload and try again"
+        )
     response = post_submission(wire, url=target)
-    return _validated_receipt(response, run["run_id"])
+    return _validated_receipt(response, run["run_id"], rcj_digest(wire))
 
 
-__all__ = ["upload_run"]
+__all__ = ["preview_run", "upload_run"]

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -164,6 +164,7 @@ def upload_run(
     url: str | None = None,
     approved_install_id: str | None = None,
     approved_payload_digest: str | None = None,
+    approved_target: str | None = None,
 ) -> AtomicUploadAcceptance | None:
     """Upload one validated run, returning its server receipt.
 
@@ -176,6 +177,10 @@ def upload_run(
     candidate = preview["install_id"]
     wire = preview["payload"]
     wire_digest = preview["payload_digest"]
+    if approved_target is not None and approved_target != target:
+        raise SubmitError(
+            "the upload destination changed after preview; review the payload again"
+        )
     if approved_payload_digest is not None and approved_payload_digest != wire_digest:
         raise SubmitError(
             "the archived benchmark changed after preview; review the payload again"

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -43,7 +43,10 @@ def _ask_consent(
         "Mac configuration, OS/runtime versions, execution settings, timings, "
         "and a random resettable install id. It does not include your name, "
         "hostname, serial number, hardware UUID, IP address, prompts, outputs, "
-        "or file paths.",
+        "or file paths. The JSON payload has no IP-address field. Like any "
+        "HTTPS service, the destination observes the source IP; this endpoint "
+        "uses it for short-lived request rate limiting and does not put it in "
+        "the benchmark record.",
         file=stdout,
     )
     print("Upload this result? [y/N] ", end="", flush=True, file=stdout)

--- a/vllm_mlx/community_bench/benchmark_contracts.py
+++ b/vllm_mlx/community_bench/benchmark_contracts.py
@@ -72,6 +72,27 @@ def public_prompt(case_id: str) -> str:
     raise ValueError(f"no registered prompt for case {case_id!r}")
 
 
+class SubmissionReceiptValidator:
+    """Validate the immutable server acceptance boundary."""
+
+    def __init__(self) -> None:
+        schema = _read_json("submission-receipt.schema.json")
+        self._validator = jsonschema.Draft202012Validator(
+            schema,
+            format_checker=jsonschema.FormatChecker(),
+        )
+
+    def validate(self, receipt: dict[str, Any]) -> None:
+        failures = sorted(
+            self._validator.iter_errors(receipt),
+            key=lambda error: tuple(str(part) for part in error.path),
+        )
+        if failures:
+            failure = failures[0]
+            path = "/".join(str(part) for part in failure.absolute_path)
+            raise CatalogValidationError("submission_receipt", path, failure.message)
+
+
 class BenchmarkRunValidator:
     """Validate a run and pin registered claims to their packaged workload."""
 

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -7,7 +7,7 @@ import json
 import sys
 from typing import Any
 
-from .atomic_upload import upload_run
+from .atomic_upload import preview_run, upload_run
 from .local_runner import LocalBenchmarkError, run_local
 from .workspace import LocalRunArchive, benchmark_catalog, plan_for_alias
 
@@ -70,24 +70,33 @@ def benchmark_command(args) -> int:
         elif action == "inspect":
             value = archive.get(args.run_id)
         elif action == "share":
-            if args.json and not args.yes:
+            is_preview = getattr(args, "preview", False)
+            if args.json and not args.yes and not is_preview:
                 raise ValueError("benchmark share --json requires --yes")
             run = archive.get(args.run_id)
-            receipt = upload_run(run, assume_yes=args.yes)
-            if receipt is None:
-                value = {"schema_version": 1, "uploaded": False, "cancelled": True}
+            if is_preview:
+                preview = preview_run(run)
+                value = {"schema_version": 1, **preview}
             else:
-                receipt_saved = True
-                try:
-                    archive.save_receipt(receipt)
-                except OSError:
-                    receipt_saved = False
-                value = {
-                    "schema_version": 1,
-                    "uploaded": True,
-                    "receipt_saved": receipt_saved,
-                    "receipt": receipt,
-                }
+                receipt = upload_run(
+                    run,
+                    assume_yes=args.yes,
+                    approved_install_id=getattr(args, "install_id", None),
+                )
+                if receipt is None:
+                    value = {"schema_version": 1, "uploaded": False, "cancelled": True}
+                else:
+                    receipt_saved = True
+                    try:
+                        archive.save_receipt(receipt)
+                    except OSError:
+                        receipt_saved = False
+                    value = {
+                        "schema_version": 1,
+                        "uploaded": True,
+                        "receipt_saved": receipt_saved,
+                        "receipt": receipt,
+                    }
         else:  # pragma: no cover - argparse owns this invariant
             raise ValueError(f"unknown benchmark action {action!r}")
     except Exception as exc:
@@ -122,7 +131,9 @@ def benchmark_command(args) -> int:
     elif action == "inspect":
         _print_json(value)
     elif action == "share":
-        if value["uploaded"]:
+        if getattr(args, "preview", False):
+            _print_json(value)
+        elif value["uploaded"]:
             receipt = value["receipt"]
             suffix = " (already uploaded)" if receipt["already_exists"] else ""
             print(f"Accepted benchmark {receipt['submission_id']}{suffix}.")

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -83,6 +83,7 @@ def benchmark_command(args) -> int:
                     assume_yes=args.yes,
                     approved_install_id=getattr(args, "install_id", None),
                     approved_payload_digest=getattr(args, "payload_digest", None),
+                    approved_body_digest=getattr(args, "body_digest", None),
                     approved_target=getattr(args, "target", None),
                 )
                 if acceptance is None:

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -83,6 +83,7 @@ def benchmark_command(args) -> int:
                     assume_yes=args.yes,
                     approved_install_id=getattr(args, "install_id", None),
                     approved_payload_digest=getattr(args, "payload_digest", None),
+                    approved_target=getattr(args, "target", None),
                 )
                 if acceptance is None:
                     value = {"schema_version": 1, "uploaded": False, "cancelled": True}

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -82,6 +82,7 @@ def benchmark_command(args) -> int:
                     run,
                     assume_yes=args.yes,
                     approved_install_id=getattr(args, "install_id", None),
+                    approved_payload_digest=getattr(args, "payload_digest", None),
                 )
                 if receipt is None:
                     value = {"schema_version": 1, "uploaded": False, "cancelled": True}

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -78,19 +78,20 @@ def benchmark_command(args) -> int:
                 preview = preview_run(run)
                 value = {"schema_version": 1, **preview}
             else:
-                receipt = upload_run(
+                acceptance = upload_run(
                     run,
                     assume_yes=args.yes,
                     approved_install_id=getattr(args, "install_id", None),
                     approved_payload_digest=getattr(args, "payload_digest", None),
                 )
-                if receipt is None:
+                if acceptance is None:
                     value = {"schema_version": 1, "uploaded": False, "cancelled": True}
                 else:
+                    receipt = acceptance.receipt
                     receipt_saved = True
                     try:
-                        archive.save_receipt(receipt)
-                    except OSError:
+                        archive.save_receipt(receipt, install_id=acceptance.install_id)
+                    except (OSError, UnicodeError, ValueError):
                         receipt_saved = False
                     value = {
                         "schema_version": 1,

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -7,6 +7,7 @@ import json
 import sys
 from typing import Any
 
+from .atomic_upload import upload_run
 from .local_runner import LocalBenchmarkError, run_local
 from .workspace import LocalRunArchive, benchmark_catalog, plan_for_alias
 
@@ -56,12 +57,37 @@ def benchmark_command(args) -> int:
                 inherit_process_group=getattr(args, "inherit_process_group", False),
             )
         elif action == "results":
+            runs = archive.list(limit=getattr(args, "limit", None))
             value = {
                 "schema_version": 1,
-                "runs": archive.list(limit=getattr(args, "limit", None)),
+                "runs": runs,
+                "receipts": {
+                    run["run_id"]: receipt
+                    for run in runs
+                    if (receipt := archive.receipt(run["run_id"])) is not None
+                },
             }
         elif action == "inspect":
             value = archive.get(args.run_id)
+        elif action == "share":
+            if args.json and not args.yes:
+                raise ValueError("benchmark share --json requires --yes")
+            run = archive.get(args.run_id)
+            receipt = upload_run(run, assume_yes=args.yes)
+            if receipt is None:
+                value = {"schema_version": 1, "uploaded": False, "cancelled": True}
+            else:
+                receipt_saved = True
+                try:
+                    archive.save_receipt(receipt)
+                except OSError:
+                    receipt_saved = False
+                value = {
+                    "schema_version": 1,
+                    "uploaded": True,
+                    "receipt_saved": receipt_saved,
+                    "receipt": receipt,
+                }
         else:  # pragma: no cover - argparse owns this invariant
             raise ValueError(f"unknown benchmark action {action!r}")
     except Exception as exc:
@@ -83,7 +109,7 @@ def benchmark_command(args) -> int:
         print(
             f"Protocol: {model['protocol_id']} v{value['workload']['protocol_version']}"
         )
-        print("Storage:  local only (no upload)")
+        print("Storage:  local; upload requires a separate share command and consent")
     elif action == "results":
         runs = value["runs"]
         if not runs:
@@ -95,6 +121,17 @@ def benchmark_command(args) -> int:
             )
     elif action == "inspect":
         _print_json(value)
+    elif action == "share":
+        if value["uploaded"]:
+            receipt = value["receipt"]
+            suffix = " (already uploaded)" if receipt["already_exists"] else ""
+            print(f"Accepted benchmark {receipt['submission_id']}{suffix}.")
+            if not value["receipt_saved"]:
+                print(
+                    "Warning: the upload succeeded but its local receipt could not be saved."
+                )
+        else:
+            print("Upload cancelled. Nothing was sent.")
     else:  # run
         print(f"Saved local result {value['run_id']}")
         print("Nothing was uploaded.")

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -76,27 +76,33 @@ def board_url() -> str:
     override = os.environ.get(BOARD_URL_ENV, "").strip()
     if not override:
         return DEFAULT_BOARD_URL
-    parsed = urllib.parse.urlparse(override)
+    return validate_board_url(override, source=BOARD_URL_ENV)
+
+
+def validate_board_url(value: str, *, source: str = "benchmark upload URL") -> str:
+    """Apply the HTTPS/loopback policy to configured and explicit targets."""
+
+    parsed = urllib.parse.urlparse(value)
     # The resolved target is printed on the consent screen and repeated in
     # error messages, so embedded credentials would land in terminals and CI
     # logs. Refuse rather than redact: a URL needing userinfo to reach the
     # board is not a configuration we want to support silently.
     if parsed.username or parsed.password:
         raise SubmitError(
-            f"{BOARD_URL_ENV} must not embed credentials in the URL — the "
+            f"{source} must not embed credentials in the URL — the "
             f"destination is displayed and logged."
         )
     if parsed.scheme == "https":
-        return override
+        return value
     if parsed.scheme == "http" and (parsed.hostname or "") in {
         "localhost",
         "127.0.0.1",
         "::1",
     }:
-        return override
+        return value
     raise SubmitError(
-        f"{BOARD_URL_ENV} must be an https:// URL (or http:// on loopback for "
-        f"local development); got {override!r}. Refusing to send your "
+        f"{source} must be an https:// URL (or http:// on loopback for "
+        f"local development); got {value!r}. Refusing to send your "
         f"submission in clear text."
     )
 
@@ -331,4 +337,5 @@ __all__ = [
     "new_run_group",
     "post_submission",
     "submission_body",
+    "validate_board_url",
 ]

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -180,8 +180,12 @@ def commit_install_id(candidate: str) -> str:
         if lock_fd is not None:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            finally:
+            except OSError:
+                pass
+            try:
                 os.close(lock_fd)
+            except OSError:
+                pass
 
 
 def _valid_id(value: str) -> bool:

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import json
 import os
 import secrets
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -152,8 +153,10 @@ def commit_install_id(candidate: str) -> str:
     tmp = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-        fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+        )
+        tmp = Path(tmp_name)
         try:
             os.write(fd, (candidate + "\n").encode())
         finally:

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -163,7 +163,13 @@ def commit_install_id(candidate: str) -> str:
         )
         tmp = Path(tmp_name)
         try:
-            os.write(fd, (candidate + "\n").encode())
+            encoded = (candidate + "\n").encode()
+            offset = 0
+            while offset < len(encoded):
+                written = os.write(fd, encoded[offset:])
+                if written <= 0:
+                    raise OSError("install identity write made no progress")
+                offset += written
             os.fsync(fd)
         finally:
             os.close(fd)

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -228,7 +228,7 @@ def post_submission(payload: dict, *, url: str | None = None) -> dict:
     the opposite of what the response is asking for.
     """
     target = url or board_url()
-    body = json.dumps(payload).encode("utf-8")
+    body = submission_body(payload)
     last: Exception | None = None
 
     for attempt in range(1, _MAX_ATTEMPTS + 1):
@@ -298,6 +298,12 @@ def post_submission(payload: dict, *, url: str | None = None) -> dict:
     raise SubmitError(str(last))
 
 
+def submission_body(payload: dict) -> bytes:
+    """Serialize the exact HTTP request body used by preview and upload."""
+
+    return json.dumps(payload).encode("utf-8")
+
+
 __all__ = [
     "DEFAULT_BOARD_URL",
     "BOARD_URL_ENV",
@@ -308,4 +314,5 @@ __all__ = [
     "peek_install_id",
     "new_run_group",
     "post_submission",
+    "submission_body",
 ]

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -37,6 +37,7 @@ anyone correlate a public board entry with a private telemetry stream.
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import secrets
@@ -132,27 +133,30 @@ def commit_install_id(candidate: str) -> str:
     Returns the id that is now on disk — which may be another process's if it
     won the race. Callers must use the return value, not their candidate.
 
-    The write is a fully-written temp file plus ``os.link``, not ``O_EXCL`` on
-    the destination: link is atomic and the file only ever becomes visible
-    already containing an id, so a concurrent reader can never observe an
-    empty file and mistake it for corruption.
+    A per-install advisory lock serializes both first creation and repair of a
+    malformed file across processes and threads. The value is fully written to
+    a unique mode-0600 tempfile before an atomic replace, so readers never see
+    a partial value.
 
     Never raises. An unwritable home costs a stable identity, not a
     submission; the only consequence is that the server counts this run
     against a fresh per-install bucket.
     """
     path = _install_id_path()
-    try:
-        existing = path.read_text().strip()
-        if _valid_id(existing):
-            return existing
-        malformed = True
-    except (OSError, UnicodeError):
-        malformed = path.exists()
-
     tmp = None
+    lock_fd = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = path.with_name(f".{path.name}.lock")
+        lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            existing = path.read_text().strip()
+            if _valid_id(existing):
+                return existing
+        except (OSError, UnicodeError):
+            pass
+
         fd, tmp_name = tempfile.mkstemp(
             prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
         )
@@ -162,20 +166,9 @@ def commit_install_id(candidate: str) -> str:
         finally:
             os.close(fd)
 
-        if malformed:
-            # Garbage on disk: replace it. Two processes both repairing will
-            # disagree on the id for this one run and agree from the next one
-            # onwards. Rarer and less harmful than the alternative, which is
-            # never repairing and re-minting on every single submission.
-            os.replace(tmp, path)
-            tmp = None
-            return candidate
-        try:
-            os.link(tmp, path)
-            return candidate
-        except FileExistsError:
-            winner = path.read_text().strip()
-            return winner if _valid_id(winner) else candidate
+        os.replace(tmp, path)
+        tmp = None
+        return candidate
     except (OSError, UnicodeError):
         return candidate
     finally:
@@ -184,6 +177,11 @@ def commit_install_id(candidate: str) -> str:
                 os.unlink(tmp)
             except OSError:
                 pass
+        if lock_fd is not None:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            finally:
+                os.close(lock_fd)
 
 
 def _valid_id(value: str) -> bool:

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -145,6 +145,7 @@ def commit_install_id(candidate: str) -> str:
     path = _install_id_path()
     tmp = None
     lock_fd = None
+    directory_fd = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         lock_path = path.with_name(f".{path.name}.lock")
@@ -163,11 +164,14 @@ def commit_install_id(candidate: str) -> str:
         tmp = Path(tmp_name)
         try:
             os.write(fd, (candidate + "\n").encode())
+            os.fsync(fd)
         finally:
             os.close(fd)
 
         os.replace(tmp, path)
         tmp = None
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        os.fsync(directory_fd)
         return candidate
     except (OSError, UnicodeError):
         return candidate
@@ -182,6 +186,12 @@ def commit_install_id(candidate: str) -> str:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
             except OSError:
                 pass
+        if directory_fd is not None:
+            try:
+                os.close(directory_fd)
+            except OSError:
+                pass
+        if lock_fd is not None:
             try:
                 os.close(lock_fd)
             except OSError:

--- a/vllm_mlx/community_bench/workspace.py
+++ b/vllm_mlx/community_bench/workspace.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import heapq
 import json
 import os
@@ -184,29 +185,54 @@ class LocalRunArchive:
         BenchmarkRunValidator().validate(run)
         return self._atomic_save(self.runs_dir, run["run_id"], run)
 
-    def save_receipt(self, receipt: dict[str, Any]) -> Path:
+    def save_receipt(self, receipt: dict[str, Any], *, install_id: str) -> Path:
         SubmissionReceiptValidator().validate(receipt)
         run_id = receipt.get("submission_id")
         if not isinstance(run_id, str):
             raise ValueError("receipt is missing a submission id")
         # A receipt may only exist for a locally archived run. This prevents a
         # forged receipt file from making an unrelated row look shared.
-        self.get(run_id)
-        return self._atomic_save(self.receipts_dir, run_id, receipt)
+        run = self.get(run_id)
+        from .atomic_upload import atomic_run_digest
+
+        wire = copy.deepcopy(run)
+        wire["install_id"] = install_id
+        if atomic_run_digest(wire) != receipt["run_digest"]:
+            raise ValueError("receipt does not identify the current archived run")
+        envelope = {
+            "schema_version": 1,
+            "install_id": install_id,
+            "receipt": receipt,
+        }
+        return self._atomic_save(self.receipts_dir, run_id, envelope)
 
     def receipt(self, run_id: str) -> dict[str, Any] | None:
         # Reuse the run-id validation and require that the result still exists.
         self.get(run_id)
         path = self.receipts_dir / f"{run_id}.json"
         try:
-            value = json.loads(path.read_text(encoding="utf-8"))
+            envelope = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, UnicodeError, json.JSONDecodeError):
             return None
-        if not isinstance(value, dict) or value.get("submission_id") != run_id:
+        if not isinstance(envelope, dict) or envelope.get("schema_version") != 1:
+            return None
+        install_id = envelope.get("install_id")
+        value = envelope.get("receipt")
+        if (
+            not isinstance(install_id, str)
+            or not isinstance(value, dict)
+            or value.get("submission_id") != run_id
+        ):
             return None
         try:
             SubmissionReceiptValidator().validate(value)
         except ValueError:
+            return None
+        from .atomic_upload import atomic_run_digest
+
+        wire = copy.deepcopy(self.get(run_id))
+        wire["install_id"] = install_id
+        if atomic_run_digest(wire) != value["run_digest"]:
             return None
         return value
 

--- a/vllm_mlx/community_bench/workspace.py
+++ b/vllm_mlx/community_bench/workspace.py
@@ -200,7 +200,7 @@ class LocalRunArchive:
         path = self.receipts_dir / f"{run_id}.json"
         try:
             value = json.loads(path.read_text(encoding="utf-8"))
-        except FileNotFoundError:
+        except (OSError, UnicodeError, json.JSONDecodeError):
             return None
         if not isinstance(value, dict) or value.get("submission_id") != run_id:
             return None

--- a/vllm_mlx/community_bench/workspace.py
+++ b/vllm_mlx/community_bench/workspace.py
@@ -13,7 +13,11 @@ from typing import Any
 
 from vllm_mlx.catalog import build_legacy_catalog_snapshot
 
-from .benchmark_contracts import BenchmarkRunValidator, registered_workload
+from .benchmark_contracts import (
+    BenchmarkRunValidator,
+    SubmissionReceiptValidator,
+    registered_workload,
+)
 
 _TASK_PROTOCOL = {
     "text_generation": "rapid-community-speed",
@@ -121,7 +125,10 @@ def plan_for_alias(alias_name: str) -> dict[str, Any]:
                 "schema_version": 1,
                 "model": entry,
                 "workload": registered_workload(entry["task_type"]),
-                "privacy": {"storage": "local", "uploads": False},
+                "privacy": {
+                    "storage": "local",
+                    "upload": "explicit_consent_only",
+                },
             }
     raise ValueError(f"unknown or unsupported benchmark model {alias_name!r}")
 
@@ -146,17 +153,21 @@ class LocalRunArchive:
     def runs_dir(self) -> Path:
         return self.root / "runs"
 
-    def save(self, run: dict[str, Any]) -> Path:
-        BenchmarkRunValidator().validate(run)
-        self.runs_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-        os.chmod(self.runs_dir, 0o700)
-        target = self.runs_dir / f"{run['run_id']}.json"
+    @property
+    def receipts_dir(self) -> Path:
+        return self.root / "receipts"
+
+    @staticmethod
+    def _atomic_save(directory: Path, name: str, value: dict[str, Any]) -> Path:
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+        target = directory / f"{name}.json"
         descriptor, temporary_name = tempfile.mkstemp(
-            prefix=f".{run['run_id']}.", suffix=".tmp", dir=self.runs_dir
+            prefix=f".{name}.", suffix=".tmp", dir=directory
         )
         try:
             with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-                json.dump(run, handle, ensure_ascii=False, indent=2, sort_keys=True)
+                json.dump(value, handle, ensure_ascii=False, indent=2, sort_keys=True)
                 handle.write("\n")
                 handle.flush()
                 os.fsync(handle.fileno())
@@ -168,6 +179,36 @@ class LocalRunArchive:
             except FileNotFoundError:
                 pass
         return target
+
+    def save(self, run: dict[str, Any]) -> Path:
+        BenchmarkRunValidator().validate(run)
+        return self._atomic_save(self.runs_dir, run["run_id"], run)
+
+    def save_receipt(self, receipt: dict[str, Any]) -> Path:
+        SubmissionReceiptValidator().validate(receipt)
+        run_id = receipt.get("submission_id")
+        if not isinstance(run_id, str):
+            raise ValueError("receipt is missing a submission id")
+        # A receipt may only exist for a locally archived run. This prevents a
+        # forged receipt file from making an unrelated row look shared.
+        self.get(run_id)
+        return self._atomic_save(self.receipts_dir, run_id, receipt)
+
+    def receipt(self, run_id: str) -> dict[str, Any] | None:
+        # Reuse the run-id validation and require that the result still exists.
+        self.get(run_id)
+        path = self.receipts_dir / f"{run_id}.json"
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return None
+        if not isinstance(value, dict) or value.get("submission_id") != run_id:
+            return None
+        try:
+            SubmissionReceiptValidator().validate(value)
+        except ValueError:
+            return None
+        return value
 
     def get(self, run_id: str) -> dict[str, Any]:
         if not run_id or any(

--- a/vllm_mlx/community_bench/workspace.py
+++ b/vllm_mlx/community_bench/workspace.py
@@ -128,6 +128,7 @@ def plan_for_alias(alias_name: str) -> dict[str, Any]:
                 "workload": registered_workload(entry["task_type"]),
                 "privacy": {
                     "storage": "local",
+                    "uploads": False,
                     "upload": "explicit_consent_only",
                 },
             }


### PR DESCRIPTION
## Why

Community Benchmark runs are local-only today, so the internal beta needs an explicit, inspectable way for a contributor to send one atomic result to the private ingestion endpoint. This keeps running a benchmark private by default while enabling server-side corpus collection only after exact-payload consent.

## Module and scope

Community Benchmark upload only, now restacked directly onto main after #2882 landed. This PR owns:

- `proto/community-benchmark/v1`: immutable submission-receipt contract
- `vllm_mlx/community_bench` + CLI parser: explicit `benchmark share RUN_ID`, side-effect-free exact preview, preflight validation, stable random install ID, idempotent receipt persistence
- `apps/rapid-mac/.../CommunityBenchmarkView`: per-result Share action, scrollable exact-wire consent, and digest-bound persistent Shared state

Out of scope: public aggregation/leaderboard, campaign prompts/rewards, model-identity resolution, unrelated Desktop surfaces, and production deployment.

## Behavior

- Running a benchmark remains local-only.
- Interactive CLI prints the exact request body and defaults to No.
- GUI previews the exact serialized HTTP body, then pins destination, install ID, canonical payload digest, and body digest across confirmation.
- The local archived run is never mutated; server acceptance is stored as a separate schema-valid receipt envelope and displayed as Shared only while its digest matches the archived run.
- Default destination is the separate `/api/benchmarks/atomic` endpoint; explicit targets use the same HTTPS/loopback policy.

## Verification

- `python -m pytest -q tests/test_community_benchmark_workspace.py tests/test_community_benchmark_proto.py` — 231 passed
- `swift test --filter CommunityBenchmarkModelTests` — 14 passed
- `tests/test_rapid_mac_ax_identifiers.py::test_shipping_tree_has_no_unlabelled_native_controls` — passed
- `ruff check` / `ruff format --check` on changed Python files
- `git diff --check`
- independent Codex review round 15: LGTM
- exact-head `pr_validate` (stress intentionally skipped as unrelated to upload/UI): MERGE-SAFE; 20,271 passed, patch coverage 89.2%

## Dependency / rollout

#2882 is landed. The matching private ingestion endpoint is rapidmlx.com#112 and must land before shipping this client. No production deploy is performed by this PR.