### PR TITLE
fix(mtp): preserve requests on admission failure

### DIFF
--- a/tests/test_continuous_mtp_routing.py
+++ b/tests/test_continuous_mtp_routing.py
@@ -504,6 +504,7 @@ def test_live_installer_drives_join_detach_remove_and_compat_response(monkeypatc
         dynamic_membership = True
         lane_uids = (1, 2)
         pending_join_uids = ()
+        last_attached_uids = ()
         has_work = True
         closed = False
         has_pending_responses = False
@@ -712,7 +713,7 @@ def test_live_installer_retains_base_queue_when_initial_prepare_fails(monkeypatc
 
 
 @pytest.mark.requires_mlx
-def test_live_installer_retains_base_queue_when_dynamic_join_fails(monkeypatch):
+def test_live_installer_restores_base_queue_when_deferred_join_fails(monkeypatch):
     from vllm_mlx.scheduler import SchedulerConfig, _install_continuous_mtp_router
     from vllm_mlx.spec_decode.mtp import continuous_runtime
     from vllm_mlx.spec_decode.mtp.continuous_driver import ContinuousMTPDriver
@@ -738,19 +739,38 @@ def test_live_installer_retains_base_queue_when_dynamic_join_fails(monkeypatch):
     class _Driver:
         dynamic_membership = True
         lane_uids = (1, 2)
-        pending_join_uids = ()
         has_work = True
         closed = False
         has_pending_responses = False
 
+        def __init__(self):
+            self.pending = ()
+            self.removed = []
+
+        @property
+        def pending_join_uids(self):
+            return self.pending
+
+        @property
+        def last_attached_uids(self):
+            return ()
+
         def next(self):
+            if self.pending:
+                raise RuntimeError("simulated deferred prepare failure")
             return []
 
         def take_terminal_detaches(self):
             return ()
 
-        def queue_lanes(self, *_args, **_kwargs):
-            raise RuntimeError("simulated join failure")
+        def queue_lanes(self, specs, **_kwargs):
+            self.pending = tuple(spec.uid for spec in specs)
+            return self.pending
+
+        def remove_uids(self, uids):
+            self.removed.append(tuple(uids))
+            self.pending = tuple(uid for uid in self.pending if uid not in uids)
+            return ()
 
     driver = _Driver()
     monkeypatch.setattr(
@@ -787,8 +807,11 @@ def test_live_installer_retains_base_queue_when_dynamic_join_fails(monkeypatch):
     batch_gen._unprocessed_sequences.append(joining)
 
     batch_gen.next()
+    assert list(batch_gen._unprocessed_sequences) == []
+    batch_gen.next()
 
     assert list(batch_gen._unprocessed_sequences) == [joining]
+    assert driver.removed == [(3,)]
 
 
 @pytest.mark.requires_mlx

--- a/tests/test_continuous_mtp_routing.py
+++ b/tests/test_continuous_mtp_routing.py
@@ -660,6 +660,138 @@ def test_live_installer_drives_join_detach_remove_and_compat_response(monkeypatc
 
 
 @pytest.mark.requires_mlx
+def test_live_installer_retains_base_queue_when_initial_prepare_fails(monkeypatch):
+    from vllm_mlx.scheduler import SchedulerConfig, _install_continuous_mtp_router
+    from vllm_mlx.spec_decode.mtp import continuous_runtime
+    from vllm_mlx.spec_decode.mtp.continuous_driver import ContinuousMTPDriver
+    from vllm_mlx.spec_decode.mtp.continuous_engine import (
+        ContinuousSelfMTPCapabilities,
+    )
+
+    runtime = SimpleNamespace(
+        capabilities=ContinuousSelfMTPCapabilities(
+            target_return_hidden=True,
+            mtp_return_hidden=True,
+            confirmed_target_forward=True,
+            ragged_rollback=True,
+            atomic_cache_commit=True,
+            dynamic_membership=True,
+        )
+    )
+    monkeypatch.setattr(
+        continuous_runtime,
+        "assemble_continuous_self_mtp_runtime",
+        lambda *_args, **_kwargs: runtime,
+    )
+
+    def fail_create(_cls, *_args, **_kwargs):
+        raise RuntimeError("simulated prepare failure")
+
+    monkeypatch.setattr(ContinuousMTPDriver, "create", classmethod(fail_create))
+    batch_gen = _SchedulerBatchGenerator(raw_next=([], [SimpleNamespace(uid=99)]))
+    sequences = [_scheduler_sequence(1), _scheduler_sequence(2)]
+    batch_gen._unprocessed_sequences.extend(sequences)
+    config = SchedulerConfig(
+        spec_decode="mtp",
+        mtp_continuous_batching=True,
+        max_num_seqs=4,
+        completion_batch_size=4,
+    )
+    assert _install_continuous_mtp_router(
+        batch_gen,
+        _Model(),
+        config,
+        requests={"req-1": _scheduler_request(), "req-2": _scheduler_request()},
+        uid_to_request_id={1: "req-1", 2: "req-2"},
+        free_bytes_getter=lambda: 16 * 1024**3,
+    )
+
+    assert batch_gen.next()[1][0].uid == 99
+    assert list(batch_gen._unprocessed_sequences) == sequences
+    assert batch_gen._continuous_mtp_driver is None
+
+
+@pytest.mark.requires_mlx
+def test_live_installer_retains_base_queue_when_dynamic_join_fails(monkeypatch):
+    from vllm_mlx.scheduler import SchedulerConfig, _install_continuous_mtp_router
+    from vllm_mlx.spec_decode.mtp import continuous_runtime
+    from vllm_mlx.spec_decode.mtp.continuous_driver import ContinuousMTPDriver
+    from vllm_mlx.spec_decode.mtp.continuous_engine import (
+        ContinuousSelfMTPCapabilities,
+    )
+
+    capabilities = ContinuousSelfMTPCapabilities(
+        target_return_hidden=True,
+        mtp_return_hidden=True,
+        confirmed_target_forward=True,
+        ragged_rollback=True,
+        atomic_cache_commit=True,
+        dynamic_membership=True,
+    )
+    runtime = SimpleNamespace(capabilities=capabilities)
+    monkeypatch.setattr(
+        continuous_runtime,
+        "assemble_continuous_self_mtp_runtime",
+        lambda *_args, **_kwargs: runtime,
+    )
+
+    class _Driver:
+        dynamic_membership = True
+        lane_uids = (1, 2)
+        pending_join_uids = ()
+        has_work = True
+        closed = False
+        has_pending_responses = False
+
+        def next(self):
+            return []
+
+        def take_terminal_detaches(self):
+            return ()
+
+        def queue_lanes(self, *_args, **_kwargs):
+            raise RuntimeError("simulated join failure")
+
+    driver = _Driver()
+    monkeypatch.setattr(
+        ContinuousMTPDriver,
+        "create",
+        classmethod(lambda _cls, *_args, **_kwargs: driver),
+    )
+    batch_gen = _SchedulerBatchGenerator()
+    batch_gen._unprocessed_sequences.extend(
+        [_scheduler_sequence(1), _scheduler_sequence(2)]
+    )
+    requests = {
+        "req-1": _scheduler_request(),
+        "req-2": _scheduler_request(),
+        "req-3": _scheduler_request(),
+    }
+    config = SchedulerConfig(
+        spec_decode="mtp",
+        mtp_continuous_batching=True,
+        mtp_allow_dynamic_membership=True,
+        max_num_seqs=4,
+        completion_batch_size=4,
+    )
+    assert _install_continuous_mtp_router(
+        batch_gen,
+        _Model(),
+        config,
+        requests=requests,
+        uid_to_request_id={1: "req-1", 2: "req-2", 3: "req-3"},
+        free_bytes_getter=lambda: 16 * 1024**3,
+    )
+    batch_gen.next()
+    joining = _scheduler_sequence(3)
+    batch_gen._unprocessed_sequences.append(joining)
+
+    batch_gen.next()
+
+    assert list(batch_gen._unprocessed_sequences) == [joining]
+
+
+@pytest.mark.requires_mlx
 def test_live_installer_handles_empty_pressure_and_optional_base_hooks(monkeypatch):
     from vllm_mlx.scheduler import SchedulerConfig, _install_continuous_mtp_router
     from vllm_mlx.spec_decode.mtp import continuous_runtime

--- a/tests/test_continuous_mtp_routing.py
+++ b/tests/test_continuous_mtp_routing.py
@@ -512,9 +512,13 @@ def test_live_installer_drives_join_detach_remove_and_compat_response(monkeypatc
         def __init__(self):
             self.calls = []
             self.fail_discard = False
+            self.fail_join = False
+            self.fail_next = False
 
         def next(self):
             self.calls.append("next")
+            if self.fail_next:
+                raise RuntimeError("driver step failed")
             return [SimpleNamespace(uid=1, token=31)]
 
         def take_terminal_detaches(self):
@@ -527,6 +531,8 @@ def test_live_installer_drives_join_detach_remove_and_compat_response(monkeypatc
 
         def queue_lanes(self, specs, *, stop_tokens):
             self.calls.append(("join", tuple(spec.uid for spec in specs), stop_tokens))
+            if self.fail_join:
+                raise RuntimeError("join preparation rejected")
             return tuple(spec.uid for spec in specs)
 
         def discard_all(self):
@@ -642,11 +648,24 @@ def test_live_installer_drives_join_detach_remove_and_compat_response(monkeypatc
 
     driver.lane_uids = (1, 2, 4, 5)
     batch_gen.next()
+    driver.lane_uids = (1, 2)
+    driver.last_attached_uids = (4, 5)
+    driver.fail_join = True
+    queued_before_failed_join = list(batch_gen._unprocessed_sequences)
+    batch_gen.next()
+    assert list(batch_gen._unprocessed_sequences) == queued_before_failed_join
+    driver.fail_join = False
+    driver.last_attached_uids = ()
     driver.dynamic_membership = False
     batch_gen.next()
     driver.closed = True
     batch_gen.next()
     assert "resume" in driver.calls
+
+    driver.fail_next = True
+    with pytest.raises(RuntimeError, match="driver step failed"):
+        batch_gen.next()
+    driver.fail_next = False
 
     removed = batch_gen.remove([1], return_prompt_caches=True)
     assert removed[1] == ("target-cache", [10, 11])

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -987,6 +987,10 @@ def _install_continuous_mtp_router(
         )
 
     driver: ContinuousMTPDriver | None = None
+    # Dynamic joins leave the base queue before their cache preparation runs at
+    # the next driver boundary.  Retain the exact source tuples until that
+    # boundary succeeds so a deferred admission failure can restore ownership.
+    staged_join_sequences: dict[int, Any] = {}
 
     def _stage_initial() -> None:
         nonlocal driver
@@ -1036,6 +1040,7 @@ def _install_continuous_mtp_router(
             return
         joining_specs: list[SelfMTPLaneSpec] = []
         joining_stops: dict[int, frozenset[int]] = {}
+        joining_sequences: dict[int, Any] = {}
         for sequence, metadata in _queued_candidates():
             if len(joining_specs) >= room:
                 break
@@ -1063,6 +1068,7 @@ def _install_continuous_mtp_router(
             )
             joining_specs.append(spec)
             joining_stops[spec.uid] = metadata.stop_tokens
+            joining_sequences[spec.uid] = sequence
         if not joining_specs:
             return
         try:
@@ -1076,13 +1082,46 @@ def _install_continuous_mtp_router(
                 exc,
             )
             return
-        _remove_queued({spec.uid for spec in joining_specs})
+        joining_uids = {spec.uid for spec in joining_specs}
+        _remove_queued(joining_uids)
+        staged_join_sequences.update(joining_sequences)
 
     def _continuous_next(self):
         nonlocal driver
         continuous_responses = []
+        deferred_join_failed = False
         if driver is not None and driver.has_work:
-            continuous_responses = driver.next()
+            pending_before = tuple(driver.pending_join_uids)
+            try:
+                continuous_responses = driver.next()
+            except Exception as exc:
+                # ``queue_lanes`` validates synchronously but prepares caches
+                # at the following driver boundary.  If that deferred step
+                # fails before attachment, retract the staged specs and put the
+                # original mlx-lm queue tuples back at the front in FIFO order.
+                still_pending = set(driver.pending_join_uids)
+                failed_join_uids = tuple(
+                    uid for uid in pending_before if uid in still_pending
+                )
+                if not failed_join_uids:
+                    raise
+                driver.remove_uids(failed_join_uids)
+                restored = [
+                    staged_join_sequences.pop(uid)
+                    for uid in failed_join_uids
+                    if uid in staged_join_sequences
+                ]
+                batch_gen._unprocessed_sequences.extendleft(reversed(restored))
+                logger.warning(
+                    "[MTP-continuous] deferred lane preparation failed; restored "
+                    "vendored/plain queue ownership: %s",
+                    exc,
+                )
+                continuous_responses = []
+                deferred_join_failed = True
+            else:
+                for uid in driver.last_attached_uids:
+                    staged_join_sequences.pop(uid, None)
             # Completed lanes deliver their KV/MTP caches by value on the
             # response above; the driver's terminal-detach retention is then
             # redundant.  Drain it every cycle so finished requests' caches are
@@ -1103,7 +1142,7 @@ def _install_continuous_mtp_router(
             driver = None
             batch_gen._continuous_mtp_driver = None
             _stage_initial()
-        else:
+        elif not deferred_join_failed:
             _stage_joins()
 
         raw = original_next()
@@ -1119,6 +1158,7 @@ def _install_continuous_mtp_router(
                 driver.discard_all()
             except Exception as exc:  # noqa: BLE001 - close remains best effort
                 logger.debug("[MTP-continuous] close detach skipped: %s", exc)
+        staged_join_sequences.clear()
         if callable(original_close):
             return original_close()
         return None
@@ -1127,6 +1167,8 @@ def _install_continuous_mtp_router(
         removed_packages = ()
         if driver is not None:
             removed_packages = driver.remove_uids(uids)
+            for uid in uids:
+                staged_join_sequences.pop(uid, None)
         base = {}
         if callable(original_remove):
             base = original_remove(uids, *args, **kwargs)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -999,13 +999,26 @@ def _install_continuous_mtp_router(
             return
         specs = [lane.spec for lane in routed.cohort]
         selected = {spec.uid for spec in specs}
+        try:
+            candidate_driver = ContinuousMTPDriver.create(
+                specs,
+                runtime,
+                stop_tokens={lane.spec.uid: lane.stop_tokens for lane in routed.cohort},
+                response_factory=_response_factory,
+            )
+        except Exception as exc:  # noqa: BLE001 - optional route fails closed
+            # Admission is transactional: until preparation succeeds, the
+            # ordinary queue remains the owner of every selected request.  The
+            # base generator can therefore process them on this same call
+            # instead of losing the cohort after an allocation/prepare failure.
+            logger.warning(
+                "[MTP-continuous] cohort preparation failed; retaining "
+                "vendored/plain queue ownership: %s",
+                exc,
+            )
+            return
         _remove_queued(selected)
-        driver = ContinuousMTPDriver.create(
-            specs,
-            runtime,
-            stop_tokens={lane.spec.uid: lane.stop_tokens for lane in routed.cohort},
-            response_factory=_response_factory,
-        )
+        driver = candidate_driver
         batch_gen._continuous_mtp_driver = driver
         logger.info(
             "[MTP-continuous] admitted continuous cohort "
@@ -1052,8 +1065,18 @@ def _install_continuous_mtp_router(
             joining_stops[spec.uid] = metadata.stop_tokens
         if not joining_specs:
             return
+        try:
+            driver.queue_lanes(joining_specs, stop_tokens=joining_stops)
+        except Exception as exc:  # noqa: BLE001 - optional route fails closed
+            # A staged join owns no continuous cache yet.  Keep the base queue
+            # authoritative when validation or allocation rejects the join.
+            logger.warning(
+                "[MTP-continuous] lane join failed; retaining vendored/plain "
+                "queue ownership: %s",
+                exc,
+            )
+            return
         _remove_queued({spec.uid for spec in joining_specs})
-        driver.queue_lanes(joining_specs, stop_tokens=joining_stops)
 
     def _continuous_next(self):
         nonlocal driver


### PR DESCRIPTION
## Why

Continuous MTP removed an admitted cohort from the ordinary scheduler queue before driver construction or dynamic-join staging succeeded. An allocation, preparation, or validation exception could therefore leave requests owned by neither execution path.

## What

- construct the initial continuous driver before transferring queue ownership
- stage dynamic joins before removing their source queue entries
- fail closed to the vendored/plain path when optional continuous admission fails
- add focused fault-injection coverage for both boundaries

## Design precedent

Production continuous-batching schedulers model waiting, staged, and running requests as explicit ownership states. Failed admission retracts to the waiting state; queue ownership is transferred only after resource preparation succeeds. This patch applies that transactional boundary without changing routing policy or MTP math.

## Scope

Admission transaction ordering only. No speculative-decoding math, routing criteria, defaults, timeouts, or public API changes.

## Verification

- `uv run --python 3.12 --with pytest --with packaging python -m pytest -q tests/test_continuous_mtp_routing.py` (33 passed)
- `ruff check` and `ruff format --check` on changed Python files
- `git diff --check`

Fixes #2932