### PR TITLE
test(mac): wait for authoritative drop completion before retry

### DIFF
--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -16,7 +16,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
     func testFileDropRetryPolicyIsBoundedAndCompletionAware() {
         XCTAssertEqual(
             FileDropRetryPolicy.observationTimeout(remainingTime: 10),
-            7
+            6.5
         )
         XCTAssertEqual(
             FileDropRetryPolicy.observationTimeout(remainingTime: 2),

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -179,7 +179,6 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         let recoveredAttempts = harness.dragFile(
             image,
             expectedChip: imageChip,
-            dropSettleTimeout: 12,
             simulateMissedFirstGesture: true
         )
         XCTAssertEqual(recoveredAttempts, 2)
@@ -189,7 +188,6 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         let delayedChipAttempts = harness.dragFile(
             document,
             expectedChip: documentChip,
-            dropSettleTimeout: 12,
             simulateChipVisibilityDelay: 4,
             simulateCompletionVisibilityDelay: 3
         )

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -184,7 +184,8 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         let delayedChipAttempts = harness.dragFile(
             document,
             expectedChip: documentChip,
-            simulateChipVisibilityDelay: 3
+            simulateChipVisibilityDelay: 4,
+            simulateCompletionVisibilityDelay: 3
         )
         XCTAssertEqual(delayedChipAttempts, 1)
         harness.send("Dragged document", expectedRequestCount: 2)

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -14,6 +14,14 @@ final class ChatAttachmentJourneyTests: XCTestCase {
     }
 
     func testFileDropRetryPolicyIsBoundedAndCompletionAware() {
+        XCTAssertEqual(
+            FileDropRetryPolicy.observationTimeout(remainingTime: 10),
+            7
+        )
+        XCTAssertEqual(
+            FileDropRetryPolicy.observationTimeout(remainingTime: 2),
+            0
+        )
         XCTAssertTrue(
             FileDropRetryPolicy.shouldRetry(
                 completedDrop: false,

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -31,6 +31,15 @@ final class ChatAttachmentJourneyTests: XCTestCase {
                 completedDrop: false,
                 attempt: 1,
                 maximumAttempts: 2,
+                remainingTime: FileDropRetryPolicy.retryGestureBudget
+                    + FileDropRetryPolicy.minimumRetryBudget
+            )
+        )
+        XCTAssertFalse(
+            FileDropRetryPolicy.shouldRetry(
+                completedDrop: false,
+                attempt: 1,
+                maximumAttempts: 2,
                 remainingTime: FileDropRetryPolicy.minimumRetryBudget
             )
         )

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -16,7 +16,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
     func testFileDropRetryPolicyIsBoundedAndCompletionAware() {
         XCTAssertEqual(
             FileDropRetryPolicy.observationTimeout(remainingTime: 10),
-            6.5
+            5
         )
         XCTAssertEqual(
             FileDropRetryPolicy.observationTimeout(remainingTime: 2),

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ChatAttachmentJourneyTests.swift
@@ -16,7 +16,11 @@ final class ChatAttachmentJourneyTests: XCTestCase {
     func testFileDropRetryPolicyIsBoundedAndCompletionAware() {
         XCTAssertEqual(
             FileDropRetryPolicy.observationTimeout(remainingTime: 10),
-            5
+            2.5
+        )
+        XCTAssertEqual(
+            FileDropRetryPolicy.observationTimeout(remainingTime: 12),
+            4.5
         )
         XCTAssertEqual(
             FileDropRetryPolicy.observationTimeout(remainingTime: 2),
@@ -175,6 +179,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         let recoveredAttempts = harness.dragFile(
             image,
             expectedChip: imageChip,
+            dropSettleTimeout: 12,
             simulateMissedFirstGesture: true
         )
         XCTAssertEqual(recoveredAttempts, 2)
@@ -184,6 +189,7 @@ final class ChatAttachmentJourneyTests: XCTestCase {
         let delayedChipAttempts = harness.dragFile(
             document,
             expectedChip: documentChip,
+            dropSettleTimeout: 12,
             simulateChipVisibilityDelay: 4,
             simulateCompletionVisibilityDelay: 3
         )

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -58,9 +58,9 @@ struct MemoryConfirmationRetryPolicy {
 
 enum FileDropRetryPolicy {
     static let minimumRetryBudget: TimeInterval = 3
-    // The synthetic gesture is blocking and normally consumes about one
-    // second before the retried drop can begin settling.
-    static let retryGestureBudget: TimeInterval = 1.5
+    // XCUI's blocking synthetic drag takes about 3.5 seconds on both Studio
+    // and hosted runners before the retried drop can begin settling.
+    static let retryGestureBudget: TimeInterval = 4
     // `waitUntil` polls at 100 ms and its final poll can cross the requested
     // timeout. Keep several polling intervals outside the observation window
     // so a genuinely missed first gesture still owns the full retry budget.
@@ -381,7 +381,7 @@ final class RapidUITestHarness {
             source.click(forDuration: 1, thenDragTo: dropTarget)
             return 1
         }
-        let settleDeadline = Date().addingTimeInterval(dropSettleTimeout)
+        var settleDeadline: Date?
         let maximumAttempts = 2
         for attempt in 1...maximumAttempts {
             do {
@@ -391,6 +391,16 @@ final class RapidUITestHarness {
                 return attempt
             }
             source.click(forDuration: 1, thenDragTo: dropTarget)
+            if settleDeadline == nil {
+                // `dropSettleTimeout` describes post-gesture observation and
+                // retry time; do not spend it while XCUI is blocking inside
+                // the first synthetic drag.
+                settleDeadline = Date().addingTimeInterval(dropSettleTimeout)
+            }
+            guard let settleDeadline else {
+                XCTFail("drop settle deadline was not initialized")
+                return attempt
+            }
             // Simulation delays model post-gesture observation latency. Anchor
             // them after the blocking drag returns so its duration cannot
             // accidentally satisfy the delay before the probe begins.

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -59,6 +59,10 @@ struct MemoryConfirmationRetryPolicy {
 enum FileDropRetryPolicy {
     static let minimumRetryBudget: TimeInterval = 3
 
+    static func observationTimeout(remainingTime: TimeInterval) -> TimeInterval {
+        max(0, remainingTime - minimumRetryBudget)
+    }
+
     static func shouldRetry(
         completedDrop: Bool,
         attempt: Int,
@@ -382,7 +386,13 @@ final class RapidUITestHarness {
             // independently. First wait briefly for either authoritative
             // signal, then spend the rest of the original budget on an
             // observed drop's chip.
-            _ = waitUntil(timeout: min(2, max(0, settleDeadline.timeIntervalSinceNow))) {
+            // Observe until only the bounded retry budget remains. A fixed,
+            // shorter probe can mistake a scheduler-delayed completion marker
+            // for a missed gesture and duplicate an already-consumed drop.
+            let observationTimeout = FileDropRetryPolicy.observationTimeout(
+                remainingTime: settleDeadline.timeIntervalSinceNow
+            )
+            _ = waitUntil(timeout: observationTimeout) {
                 chipIsSettled()
                     || FileManager.default.fileExists(atPath: self.dropEventFile.path)
             }

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -373,17 +373,6 @@ final class RapidUITestHarness {
             return 1
         }
         let settleDeadline = Date().addingTimeInterval(dropSettleTimeout)
-        let chipObservationStart = Date().addingTimeInterval(simulateChipVisibilityDelay)
-        let completionObservationStart = Date().addingTimeInterval(
-            simulateCompletionVisibilityDelay
-        )
-        let chipIsSettled = {
-            Date() >= chipObservationStart && chip.exists && chip.isHittable
-        }
-        let completionIsVisible = {
-            Date() >= completionObservationStart
-                && FileManager.default.fileExists(atPath: self.dropEventFile.path)
-        }
         let maximumAttempts = 2
         for attempt in 1...maximumAttempts {
             do {
@@ -393,6 +382,22 @@ final class RapidUITestHarness {
                 return attempt
             }
             source.click(forDuration: 1, thenDragTo: dropTarget)
+            // Simulation delays model post-gesture observation latency. Anchor
+            // them after the blocking drag returns so its duration cannot
+            // accidentally satisfy the delay before the probe begins.
+            let chipObservationStart = Date().addingTimeInterval(
+                simulateChipVisibilityDelay
+            )
+            let completionObservationStart = Date().addingTimeInterval(
+                simulateCompletionVisibilityDelay
+            )
+            let chipIsSettled = {
+                Date() >= chipObservationStart && chip.exists && chip.isHittable
+            }
+            let completionIsVisible = {
+                Date() >= completionObservationStart
+                    && FileManager.default.fileExists(atPath: self.dropEventFile.path)
+            }
 
             // The drop-completion marker and the product render arrive
             // independently. First wait briefly for either authoritative

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -58,9 +58,13 @@ struct MemoryConfirmationRetryPolicy {
 
 enum FileDropRetryPolicy {
     static let minimumRetryBudget: TimeInterval = 3
+    // `waitUntil` polls at 100 ms and its final poll can cross the requested
+    // timeout. Keep several polling intervals outside the observation window
+    // so a genuinely missed first gesture still owns the full retry budget.
+    static let observationSchedulingSlack: TimeInterval = 0.5
 
     static func observationTimeout(remainingTime: TimeInterval) -> TimeInterval {
-        max(0, remainingTime - minimumRetryBudget)
+        max(0, remainingTime - minimumRetryBudget - observationSchedulingSlack)
     }
 
     static func shouldRetry(

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -84,7 +84,7 @@ enum FileDropRetryPolicy {
     ) -> Bool {
         !completedDrop
             && attempt < maximumAttempts
-            && remainingTime >= minimumRetryBudget
+            && remainingTime >= retryGestureBudget + minimumRetryBudget
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -339,7 +339,8 @@ final class RapidUITestHarness {
         expectedChip chip: XCUIElement? = nil,
         dropSettleTimeout: TimeInterval = 10,
         simulateMissedFirstGesture: Bool = false,
-        simulateChipVisibilityDelay: TimeInterval = 0
+        simulateChipVisibilityDelay: TimeInterval = 0,
+        simulateCompletionVisibilityDelay: TimeInterval = 0
     ) -> Int {
         let dragSource = XCUIApplication(bundleIdentifier: "com.rapidmlx.rapid-uitest-host")
         dragSource.launchEnvironment = [
@@ -369,8 +370,15 @@ final class RapidUITestHarness {
         }
         let settleDeadline = Date().addingTimeInterval(dropSettleTimeout)
         let chipObservationStart = Date().addingTimeInterval(simulateChipVisibilityDelay)
+        let completionObservationStart = Date().addingTimeInterval(
+            simulateCompletionVisibilityDelay
+        )
         let chipIsSettled = {
             Date() >= chipObservationStart && chip.exists && chip.isHittable
+        }
+        let completionIsVisible = {
+            Date() >= completionObservationStart
+                && FileManager.default.fileExists(atPath: self.dropEventFile.path)
         }
         let maximumAttempts = 2
         for attempt in 1...maximumAttempts {
@@ -394,13 +402,15 @@ final class RapidUITestHarness {
             )
             _ = waitUntil(timeout: observationTimeout) {
                 chipIsSettled()
-                    || FileManager.default.fileExists(atPath: self.dropEventFile.path)
+                    || completionIsVisible()
             }
             if chipIsSettled() { return attempt }
 
             let observedPhase: String?
             do {
-                observedPhase = try DropEventFile.completedPhase(at: dropEventFile)
+                observedPhase = completionIsVisible()
+                    ? try DropEventFile.completedPhase(at: dropEventFile)
+                    : nil
             } catch {
                 XCTFail("could not read valid UI-test drop marker after gesture: \(error)")
                 return attempt

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -58,13 +58,22 @@ struct MemoryConfirmationRetryPolicy {
 
 enum FileDropRetryPolicy {
     static let minimumRetryBudget: TimeInterval = 3
+    // The synthetic gesture is blocking and normally consumes about one
+    // second before the retried drop can begin settling.
+    static let retryGestureBudget: TimeInterval = 1.5
     // `waitUntil` polls at 100 ms and its final poll can cross the requested
     // timeout. Keep several polling intervals outside the observation window
     // so a genuinely missed first gesture still owns the full retry budget.
     static let observationSchedulingSlack: TimeInterval = 0.5
 
     static func observationTimeout(remainingTime: TimeInterval) -> TimeInterval {
-        max(0, remainingTime - minimumRetryBudget - observationSchedulingSlack)
+        max(
+            0,
+            remainingTime
+                - retryGestureBudget
+                - minimumRetryBudget
+                - observationSchedulingSlack
+        )
     }
 
     static func shouldRetry(

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -350,7 +350,7 @@ final class RapidUITestHarness {
     func dragFile(
         _ url: URL,
         expectedChip chip: XCUIElement? = nil,
-        dropSettleTimeout: TimeInterval = 10,
+        dropSettleTimeout: TimeInterval = 12,
         simulateMissedFirstGesture: Bool = false,
         simulateChipVisibilityDelay: TimeInterval = 0,
         simulateCompletionVisibilityDelay: TimeInterval = 0

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -121,7 +121,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
     assert "let maximumAttempts = 2" in harness
     assert "FileDropRetryPolicy.observationTimeout(" in harness
-    assert "remainingTime - minimumRetryBudget" in harness
+    assert "remainingTime - minimumRetryBudget - observationSchedulingSlack" in harness
     assert "FileDropRetryPolicy.shouldRetry(" in harness
     assert "simulateCompletionVisibilityDelay: TimeInterval = 0" in harness
     assert "completionIsVisible()" in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -120,6 +120,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     )
     assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
     assert "let maximumAttempts = 2" in harness
+    assert "FileDropRetryPolicy.observationTimeout(" in harness
+    assert "remainingTime - minimumRetryBudget" in harness
     assert "FileDropRetryPolicy.shouldRetry(" in harness
     assert "func testFileDropRetryPolicyIsBoundedAndCompletionAware()" in chat_source
     assert "func testDropEventFileClearIsIdempotent()" in chat_source

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -121,7 +121,9 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert 'matching(identifier: "RapidUITests.FileDragSource")' in harness
     assert "let maximumAttempts = 2" in harness
     assert "FileDropRetryPolicy.observationTimeout(" in harness
-    assert "remainingTime - minimumRetryBudget - observationSchedulingSlack" in harness
+    assert "- retryGestureBudget" in harness
+    assert "- minimumRetryBudget" in harness
+    assert "- observationSchedulingSlack" in harness
     assert "FileDropRetryPolicy.shouldRetry(" in harness
     assert "simulateCompletionVisibilityDelay: TimeInterval = 0" in harness
     assert "completionIsVisible()" in harness

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -123,6 +123,8 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "FileDropRetryPolicy.observationTimeout(" in harness
     assert "remainingTime - minimumRetryBudget" in harness
     assert "FileDropRetryPolicy.shouldRetry(" in harness
+    assert "simulateCompletionVisibilityDelay: TimeInterval = 0" in harness
+    assert "completionIsVisible()" in harness
     assert "func testFileDropRetryPolicyIsBoundedAndCompletionAware()" in chat_source
     assert "func testDropEventFileClearIsIdempotent()" in chat_source
     assert "func testDropEventFileCompletionFailsClosed()" in chat_source
@@ -140,6 +142,7 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     )
     assert "XCTAssertEqual(recoveredAttempts, 2)" in chat_source
     assert "XCTAssertEqual(delayedChipAttempts, 1)" in chat_source
+    assert "simulateCompletionVisibilityDelay: 3" in chat_source
     assert 'let dropTarget = element("rapid.chat.compose")' in harness
     assert "click(forDuration: 1, thenDragTo: dropTarget)" in harness
     assert "func testDragPasteAndRemovalPreserveWireIdentity()" in chat_source


### PR DESCRIPTION
## Why

A Mac merge candidate ran the native chat attachment journey after all scripted chat flows passed, but the harness retried a drag while the test-only completion marker was merely delayed. That second drag attached the same document twice and failed the candidate at the attempt-count assertion.

Fixes #2937.

## What

- Derive the first-attempt observation window from the existing 10-second deadline while reserving exactly the existing 3-second bounded retry budget.
- Retry only after that observation window has elapsed with neither a rendered chip nor an authoritative `performed` marker.
- Keep the existing maximum of two attempts and the original total settle budget.
- Add Swift and repository-contract coverage for the deadline calculation.

## Design precedent

Mature UI automation treats an acknowledged operation as authoritative and budgets retries from one monotonic deadline. This adapts that established pattern: observation owns the deadline until only the explicitly reserved retry budget remains, so scheduler latency cannot turn a successful operation into a duplicate side effect.

## Non-goals

No product attachment behavior, supported file policy, production timeout, server path, or Video behavior changes.

## Verification

- `uv run --extra test pytest -q tests/test_rapid_mac_xcui_target.py` — 5 passed
- focused native XCTest `testFileDropRetryPolicyIsBoundedAndCompletionAware` — passed
- `git diff --check` — passed
- exact-head `full-ci` requested so the native journey is exercised before queue authorization