### PR TITLE
feat(video): add LTX 2.5, Wan 2.1, and CogVideoX-Fun to Desktop

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -330,7 +330,10 @@ enum ModelCatalog {
     /// the signed Desktop sidecar. Exact names make a new engine alias fail
     /// closed until its runtime has been bundled and smoke-tested here.
     static let packagedVideoAliases: Set<String> = [
+        "cogvideox-fun-5b-q4",
         "ltx-2.3-mlx-q4",
+        "ltx-2.5-mlx-q8",
+        "wan2.1-t2v-1.3b-bf16",
         "wan2.2-i2v-a14b-q8",
         "wan2.2-t2v-a14b-bf16",
         "wan2.2-ti2v-5b-bf16",

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -164,6 +164,11 @@ dependency closures:
 | mflux | `==0.19.0` | MIT | https://github.com/filipstrand/mflux |
 | mlx-video-with-audio | `==0.1.36` | MIT | https://pypi.org/project/mlx-video-with-audio/ |
 | mlx-arsenal | `==0.12.1` | MIT | https://pypi.org/project/mlx-arsenal/ |
+| LTX 2 MLX runtime (`ltx-core-mlx`, `ltx-pipelines-mlx`) | `0.14.15` (`57952288076766abe27dda3a774b2c24f7346977`) | MIT | https://github.com/MrMoferFRAN/ltx-2-mlx |
+
+The complete audited LTX runtime source archive and its MIT license ship under
+`Contents/Resources/rapid-mlx/licenses/`. The archive SHA-256 is
+`fa9a66a0c78721c3dce51d0f1dadcabad060682410303be748e529a846a9d5c9`.
 
 ### Video encoder
 

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -181,6 +181,17 @@ struct SidecarBuildScriptTests {
         #expect(constraints.contains("mlx-arsenal==0.12.1"))
         #expect(script.contains("'mlx-video-with-audio'"))
         #expect(script.contains("'mlx-arsenal'"))
+        #expect(script.contains("LTX25_RUNTIME_VERSION=\"0.14.15\""))
+        #expect(script.contains("57952288076766abe27dda3a774b2c24f7346977"))
+        #expect(script.contains("fa9a66a0c78721c3dce51d0f1dadcabad060682410303be748e529a846a9d5c9"))
+        #expect(script.contains(#"importlib.metadata.version("ltx-core-mlx") == "0.14.15""#))
+        #expect(script.contains(#"importlib.metadata.version("ltx-pipelines-mlx") == "0.14.15""#))
+        #expect(script.contains("from videox_fun_mlx.models.cogvideox_transformer3d import"))
+        #expect(script.contains("from videox_fun_mlx.models.t5_encoder import T5Encoder"))
+        #expect(script.contains("from videox_fun_mlx.models.tokenizer import T5Tokenizer"))
+        #expect(script.contains("from videox_fun_mlx.pipeline.scheduler import DDIMScheduler"))
+        #expect(script.contains(#"cp "$LTX25_TAR" \"#),
+                "The complete corresponding LTX source must travel with the runtime.")
         #expect(!script.contains(#"${RAPID_MLX_INSTALL_TARGET}[video]"#),
                 "The broad video extra would pull OpenCV and a conflicting vision stack.")
         #expect(script.contains("re-audit the OpenCV-free encoder patch"),

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -190,6 +190,8 @@ struct SidecarBuildScriptTests {
                 "The private LTX source directory must be cleaned on every exit path.")
         #expect(!script.contains(#"LTX25_TAR="/tmp/rapid-ltx25-"#),
                 "A shared predictable archive path permits local replacement races.")
+        #expect(script.contains("import importlib.metadata\nimport importlib.util\nimport inspect"),
+                "The video smoke's version asserts rely on an explicit importlib.metadata import, not a side effect.")
         #expect(script.contains(#"importlib.metadata.version("ltx-core-mlx") == "0.14.15""#))
         #expect(script.contains(#"importlib.metadata.version("ltx-pipelines-mlx") == "0.14.15""#))
         #expect(script.contains(#"printf '%s\n' "$LTX25_RUNTIME_COMMIT""#),

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -192,6 +192,12 @@ struct SidecarBuildScriptTests {
                 "A shared predictable archive path permits local replacement races.")
         #expect(script.contains(#"importlib.metadata.version("ltx-core-mlx") == "0.14.15""#))
         #expect(script.contains(#"importlib.metadata.version("ltx-pipelines-mlx") == "0.14.15""#))
+        #expect(script.contains(#"printf '%s\n' "$LTX25_RUNTIME_COMMIT""#),
+                "Each embedded LTX distribution must be stamped with the audited source commit.")
+        #expect(script.contains("RAPID_LTX25_PROVENANCE"),
+                "A version match alone must never qualify the embedded LTX runtime.")
+        #expect(script.contains("assert embedded_ltx25_interpreter() is not None"),
+                "The build smoke must prove the runtime accepts the stamped provenance.")
         #expect(script.contains("from videox_fun_mlx.models.cogvideox_transformer3d import"))
         #expect(script.contains("from videox_fun_mlx.models.t5_encoder import T5Encoder"))
         #expect(script.contains("from videox_fun_mlx.models.tokenizer import T5Tokenizer"))

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -184,12 +184,22 @@ struct SidecarBuildScriptTests {
         #expect(script.contains("LTX25_RUNTIME_VERSION=\"0.14.15\""))
         #expect(script.contains("57952288076766abe27dda3a774b2c24f7346977"))
         #expect(script.contains("fa9a66a0c78721c3dce51d0f1dadcabad060682410303be748e529a846a9d5c9"))
+        #expect(script.contains(#"LTX25_SOURCE_DIR="$(mktemp -d -t rapid-ltx25-source.XXXXXX)""#),
+                "The audited archive must be downloaded and extracted in a private directory.")
+        #expect(script.contains(#"trap 'rm -rf "$LTX25_SOURCE_DIR"' EXIT INT TERM"#),
+                "The private LTX source directory must be cleaned on every exit path.")
+        #expect(!script.contains(#"LTX25_TAR="/tmp/rapid-ltx25-"#),
+                "A shared predictable archive path permits local replacement races.")
         #expect(script.contains(#"importlib.metadata.version("ltx-core-mlx") == "0.14.15""#))
         #expect(script.contains(#"importlib.metadata.version("ltx-pipelines-mlx") == "0.14.15""#))
         #expect(script.contains("from videox_fun_mlx.models.cogvideox_transformer3d import"))
         #expect(script.contains("from videox_fun_mlx.models.t5_encoder import T5Encoder"))
         #expect(script.contains("from videox_fun_mlx.models.tokenizer import T5Tokenizer"))
         #expect(script.contains("from videox_fun_mlx.pipeline.scheduler import DDIMScheduler"))
+        #expect(script.contains(#"{"load_wan_model", "load_t5_encoder", "load_vae_decoder"}"#),
+                "The signed runtime smoke must verify every Wan loader seam used by the adapter.")
+        #expect(script.contains("WanModelConfig.wan21_t2v_1_3b()"),
+                "The signed runtime smoke must verify its pinned Wan 2.1 architecture preset.")
         #expect(script.contains(#"cp "$LTX25_TAR" \"#),
                 "The complete corresponding LTX source must travel with the runtime.")
         #expect(!script.contains(#"${RAPID_MLX_INSTALL_TARGET}[video]"#),

--- a/apps/rapid-mac/Tests/RapidTests/VideoFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoFoundationTests.swift
@@ -36,7 +36,7 @@ struct VideoFoundationTests {
         let script = """
         #!/bin/sh
         if [ "$1" = "models" ]; then
-          printf '%s' '{"text":[],"audio":[],"image":[],"video":[{"alias":"ltx-2.3-mlx-q4","hf_path":"org/ltx","video_modes":["text-to-video","image-to-video"],"min_memory_gb":24},{"alias":"cogvideox-fun-5b-q4","hf_path":"org/cog","video_modes":["text-to-video"],"min_memory_gb":24},{"alias":"ltx-2.5-mlx-q8","hf_path":"org/ltx25","video_modes":["text-to-video","image-to-video"],"min_memory_gb":24}]}'
+          printf '%s' '{"text":[],"audio":[],"image":[],"video":[{"alias":"ltx-2.3-mlx-q4","hf_path":"org/ltx","video_modes":["text-to-video","image-to-video"],"min_memory_gb":24},{"alias":"cogvideox-fun-5b-q4","hf_path":"org/cog","video_modes":["text-to-video"],"min_memory_gb":24},{"alias":"ltx-2.5-mlx-q8","hf_path":"org/ltx25","video_modes":["text-to-video","image-to-video"],"min_memory_gb":24},{"alias":"wan2.1-t2v-1.3b-bf16","hf_path":"org/wan21","video_modes":["text-to-video"],"min_memory_gb":40}]}'
         else
           cat <<'EOF'
         Cached models (1 on disk)
@@ -49,14 +49,17 @@ struct VideoFoundationTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
 
         let entries = await ModelCatalog.videoEntries(binary: binary, hubCacheOverride: nil)
-        let entry = try #require(entries.first)
-        #expect(entries.count == 1)
+        let entry = try #require(entries.first { $0.alias == "ltx-2.3-mlx-q4" })
+        #expect(entries.count == 4)
         #expect(entry.alias == "ltx-2.3-mlx-q4")
         #expect(entry.kind == .video)
         #expect(entry.cached)
         #expect(entry.sizeOnDisk == "9.5 GiB")
         #expect(entry.videoCapabilities == [.textToVideo, .imageToVideo])
         #expect(entry.minimumMemoryGB == 24)
+        #expect(entries.first { $0.alias == "cogvideox-fun-5b-q4" }?.videoCapabilities == [.textToVideo])
+        #expect(entries.first { $0.alias == "ltx-2.5-mlx-q8" }?.videoCapabilities == [.textToVideo, .imageToVideo])
+        #expect(entries.first { $0.alias == "wan2.1-t2v-1.3b-bf16" }?.minimumMemoryGB == 40)
     }
 
     @Test("Video artifacts honor HOME isolation")

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -63,6 +63,9 @@ COMPILEALL_JOBS="${COMPILEALL_JOBS:-0}"
 FFMPEG_VERSION="7.1.5"
 FFMPEG_SHA256="de668509caf9e35e3cd162473441fdb29538c6d96ed080292b3cf9e6fc5d558f"
 FFMPEG_BUILD_JOBS="${FFMPEG_BUILD_JOBS:-4}"
+LTX25_RUNTIME_COMMIT="57952288076766abe27dda3a774b2c24f7346977"
+LTX25_RUNTIME_VERSION="0.14.15"
+LTX25_RUNTIME_SHA256="fa9a66a0c78721c3dce51d0f1dadcabad060682410303be748e529a846a9d5c9"
 
 # How many Mach-Os we expect to sign. A drift here means a new wheel
 # added a .so OR a dependency moved a binary, both of which need
@@ -595,6 +598,56 @@ echo "==> bundling minimal LTX/Wan video runtime (no OpenCV)"
     --constraint "$SIDECAR_CONSTRAINTS" \
     'mlx-video-with-audio' \
     'mlx-arsenal'
+
+# LTX-2.5 is a separate pure-Python runtime. A signed app cannot clone a
+# repository or provision an uv workspace after launch, so build its two
+# packages from the exact audited source snapshot and embed them.
+LTX25_URL="https://github.com/MrMoferFRAN/ltx-2-mlx/archive/${LTX25_RUNTIME_COMMIT}.tar.gz"
+LTX25_TAR="/tmp/rapid-ltx25-${LTX25_RUNTIME_COMMIT}.tar.gz"
+LTX25_TAR_TMP="${LTX25_TAR}.tmp"
+if [ -f "$LTX25_TAR" ]; then
+    LTX25_ACTUAL_SHA="$(shasum -a 256 "$LTX25_TAR" | awk '{print $1}')"
+    if [ "$LTX25_ACTUAL_SHA" != "$LTX25_RUNTIME_SHA256" ] || \
+       ! tar -tzf "$LTX25_TAR" > /dev/null 2>&1; then
+        echo "warning: discarding invalid LTX-2.5 source cache" >&2
+        rm -f "$LTX25_TAR"
+    fi
+fi
+if [ ! -f "$LTX25_TAR" ]; then
+    echo "==> downloading audited LTX-2.5 runtime source"
+    rm -f "$LTX25_TAR_TMP"
+    if ! curl --http1.1 -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+        -o "$LTX25_TAR_TMP" "$LTX25_URL"; then
+        rm -f "$LTX25_TAR_TMP"
+        echo "ERR: failed to download LTX-2.5 runtime source" >&2
+        exit 1
+    fi
+    LTX25_ACTUAL_SHA="$(shasum -a 256 "$LTX25_TAR_TMP" | awk '{print $1}')"
+    if [ "$LTX25_ACTUAL_SHA" != "$LTX25_RUNTIME_SHA256" ] || \
+       ! tar -tzf "$LTX25_TAR_TMP" > /dev/null 2>&1; then
+        rm -f "$LTX25_TAR_TMP"
+        echo "ERR: LTX-2.5 runtime source failed integrity verification" >&2
+        exit 1
+    fi
+    mv "$LTX25_TAR_TMP" "$LTX25_TAR"
+fi
+LTX25_SOURCE_DIR="$(mktemp -d -t rapid-ltx25-source.XXXXXX)"
+tar -xzf "$LTX25_TAR" -C "$LTX25_SOURCE_DIR"
+LTX25_ROOT="$LTX25_SOURCE_DIR/ltx-2-mlx-${LTX25_RUNTIME_COMMIT}"
+for LTX25_PACKAGE in ltx-core-mlx ltx-pipelines-mlx; do
+    "$STAGE/python/bin/python3.12" -m pip install \
+        --target "$STAGE/site-packages" \
+        --no-warn-script-location \
+        --no-compile \
+        --no-deps \
+        --constraint "$SIDECAR_CONSTRAINTS" \
+        "$LTX25_ROOT/packages/$LTX25_PACKAGE"
+done
+mkdir -p "$STAGE/licenses/sources"
+cp "$LTX25_ROOT/LICENSE" "$STAGE/licenses/LTX-2.5-MLX-MIT.txt"
+cp "$LTX25_TAR" \
+    "$STAGE/licenses/sources/ltx-2-mlx-${LTX25_RUNTIME_COMMIT}.tar.gz"
+rm -rf "$LTX25_SOURCE_DIR"
 
 # Upstream 0.1.36 writes MP4 through optional OpenCV/imageio. Replace only
 # the two pinned encoder seams with Rapid's atomic VideoToolbox bridge. Hashes
@@ -1134,7 +1187,8 @@ else
         PYTHONPATH="$STAGE/site-packages" \
         PYTHONNOUSERSITE=1 \
         "$STAGE/python/bin/python3.12" -s -c \
-        'import importlib.util
+        'import importlib.metadata
+import importlib.util
 import mlx_vlm
 from mlx_vlm.models import (
     diffusion_gemma, gemma3, gemma3n, gemma4, gemma4_unified,
@@ -1184,10 +1238,19 @@ import numpy as np
 import mlx_video
 from mlx_video import generate_video_with_audio
 from mlx_video.generate_wan import generate_video
+from ltx_pipelines_mlx.cli import main as ltx25_main
+from videox_fun_mlx.models.cogvideox_transformer3d import CogVideoXTransformer3DModel
+from videox_fun_mlx.models.cogvideox_vae import AutoencoderKLCogVideoX
+from videox_fun_mlx.models.t5_encoder import T5Encoder
+from videox_fun_mlx.models.tokenizer import T5Tokenizer
+from videox_fun_mlx.pipeline.pipeline_cogvideox_fun_inpaint import CogVideoXFunInpaintPipeline
+from videox_fun_mlx.pipeline.scheduler import DDIMScheduler
 from vllm_mlx.runtime.video_lane import VideoEngine
 from vllm_mlx.video.encoding import encode_rgb_video
 assert importlib.util.find_spec("cv2") is None
 assert importlib.util.find_spec("imageio") is None
+assert importlib.metadata.version("ltx-core-mlx") == "0.14.15"
+assert importlib.metadata.version("ltx-pipelines-mlx") == "0.14.15"
 with tempfile.TemporaryDirectory() as directory:
     output = Path(directory) / "smoke.mp4"
     encode_rgb_video(np.zeros((2, 32, 16, 3), dtype=np.uint8), output, 2)

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -631,6 +631,19 @@ LTX25_URL="https://github.com/MrMoferFRAN/ltx-2-mlx/archive/${LTX25_RUNTIME_COMM
             --constraint "$SIDECAR_CONSTRAINTS" \
             "$LTX25_ROOT/packages/$LTX25_PACKAGE"
     done
+    # A version match alone is not provenance: any same-version distribution
+    # from an index would satisfy it. Stamp each embedded distribution with
+    # the audited source commit; the runtime accepts the embedded path only
+    # when both stamps equal its pinned LTX25_RUNTIME_COMMIT.
+    for LTX25_DIST in ltx_core_mlx ltx_pipelines_mlx; do
+        LTX25_DIST_INFO="$STAGE/site-packages/${LTX25_DIST}-${LTX25_RUNTIME_VERSION}.dist-info"
+        if [ ! -d "$LTX25_DIST_INFO" ]; then
+            echo "ERR: missing $LTX25_DIST_INFO; cannot stamp LTX-2.5 provenance" >&2
+            exit 1
+        fi
+        printf '%s\n' "$LTX25_RUNTIME_COMMIT" \
+            > "$LTX25_DIST_INFO/RAPID_LTX25_PROVENANCE"
+    done
     mkdir -p "$STAGE/licenses/sources"
     cp "$LTX25_ROOT/LICENSE" "$STAGE/licenses/LTX-2.5-MLX-MIT.txt"
     cp "$LTX25_TAR" \
@@ -1242,6 +1255,8 @@ assert importlib.util.find_spec("cv2") is None
 assert importlib.util.find_spec("imageio") is None
 assert importlib.metadata.version("ltx-core-mlx") == "0.14.15"
 assert importlib.metadata.version("ltx-pipelines-mlx") == "0.14.15"
+from vllm_mlx.video.ltx25 import embedded_ltx25_interpreter
+assert embedded_ltx25_interpreter() is not None, "LTX-2.5 provenance stamp rejected"
 assert {"model_dir", "prompt"} <= set(inspect.signature(generate_video).parameters)
 assert {"load_wan_model", "load_t5_encoder", "load_vae_decoder"} <= set(generate_video.__globals__)
 wan21 = WanModelConfig.wan21_t2v_1_3b()

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -1232,7 +1232,8 @@ print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma architectures OK")' 2>
         PYTHONNOUSERSITE=1 \
         FFMPEG_BINARY="$STAGE/bin/ffmpeg" \
         "$STAGE/python/bin/python3.12" -s -c \
-        'import importlib.util
+        'import importlib.metadata
+import importlib.util
 import inspect
 import tempfile
 from pathlib import Path

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -603,51 +603,39 @@ echo "==> bundling minimal LTX/Wan video runtime (no OpenCV)"
 # repository or provision an uv workspace after launch, so build its two
 # packages from the exact audited source snapshot and embed them.
 LTX25_URL="https://github.com/MrMoferFRAN/ltx-2-mlx/archive/${LTX25_RUNTIME_COMMIT}.tar.gz"
-LTX25_TAR="/tmp/rapid-ltx25-${LTX25_RUNTIME_COMMIT}.tar.gz"
-LTX25_TAR_TMP="${LTX25_TAR}.tmp"
-if [ -f "$LTX25_TAR" ]; then
-    LTX25_ACTUAL_SHA="$(shasum -a 256 "$LTX25_TAR" | awk '{print $1}')"
-    if [ "$LTX25_ACTUAL_SHA" != "$LTX25_RUNTIME_SHA256" ] || \
-       ! tar -tzf "$LTX25_TAR" > /dev/null 2>&1; then
-        echo "warning: discarding invalid LTX-2.5 source cache" >&2
-        rm -f "$LTX25_TAR"
-    fi
-fi
-if [ ! -f "$LTX25_TAR" ]; then
+(
+    set -e
+    LTX25_SOURCE_DIR="$(mktemp -d -t rapid-ltx25-source.XXXXXX)"
+    trap 'rm -rf "$LTX25_SOURCE_DIR"' EXIT INT TERM
+    LTX25_TAR="$LTX25_SOURCE_DIR/ltx-2-mlx.tar.gz"
     echo "==> downloading audited LTX-2.5 runtime source"
-    rm -f "$LTX25_TAR_TMP"
     if ! curl --http1.1 -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
-        -o "$LTX25_TAR_TMP" "$LTX25_URL"; then
-        rm -f "$LTX25_TAR_TMP"
+        -o "$LTX25_TAR" "$LTX25_URL"; then
         echo "ERR: failed to download LTX-2.5 runtime source" >&2
         exit 1
     fi
-    LTX25_ACTUAL_SHA="$(shasum -a 256 "$LTX25_TAR_TMP" | awk '{print $1}')"
+    LTX25_ACTUAL_SHA="$(shasum -a 256 "$LTX25_TAR" | awk '{print $1}')"
     if [ "$LTX25_ACTUAL_SHA" != "$LTX25_RUNTIME_SHA256" ] || \
-       ! tar -tzf "$LTX25_TAR_TMP" > /dev/null 2>&1; then
-        rm -f "$LTX25_TAR_TMP"
+       ! tar -tzf "$LTX25_TAR" > /dev/null 2>&1; then
         echo "ERR: LTX-2.5 runtime source failed integrity verification" >&2
         exit 1
     fi
-    mv "$LTX25_TAR_TMP" "$LTX25_TAR"
-fi
-LTX25_SOURCE_DIR="$(mktemp -d -t rapid-ltx25-source.XXXXXX)"
-tar -xzf "$LTX25_TAR" -C "$LTX25_SOURCE_DIR"
-LTX25_ROOT="$LTX25_SOURCE_DIR/ltx-2-mlx-${LTX25_RUNTIME_COMMIT}"
-for LTX25_PACKAGE in ltx-core-mlx ltx-pipelines-mlx; do
-    "$STAGE/python/bin/python3.12" -m pip install \
-        --target "$STAGE/site-packages" \
-        --no-warn-script-location \
-        --no-compile \
-        --no-deps \
-        --constraint "$SIDECAR_CONSTRAINTS" \
-        "$LTX25_ROOT/packages/$LTX25_PACKAGE"
-done
-mkdir -p "$STAGE/licenses/sources"
-cp "$LTX25_ROOT/LICENSE" "$STAGE/licenses/LTX-2.5-MLX-MIT.txt"
-cp "$LTX25_TAR" \
-    "$STAGE/licenses/sources/ltx-2-mlx-${LTX25_RUNTIME_COMMIT}.tar.gz"
-rm -rf "$LTX25_SOURCE_DIR"
+    tar -xzf "$LTX25_TAR" -C "$LTX25_SOURCE_DIR"
+    LTX25_ROOT="$LTX25_SOURCE_DIR/ltx-2-mlx-${LTX25_RUNTIME_COMMIT}"
+    for LTX25_PACKAGE in ltx-core-mlx ltx-pipelines-mlx; do
+        "$STAGE/python/bin/python3.12" -m pip install \
+            --target "$STAGE/site-packages" \
+            --no-warn-script-location \
+            --no-compile \
+            --no-deps \
+            --constraint "$SIDECAR_CONSTRAINTS" \
+            "$LTX25_ROOT/packages/$LTX25_PACKAGE"
+    done
+    mkdir -p "$STAGE/licenses/sources"
+    cp "$LTX25_ROOT/LICENSE" "$STAGE/licenses/LTX-2.5-MLX-MIT.txt"
+    cp "$LTX25_TAR" \
+        "$STAGE/licenses/sources/ltx-2-mlx-${LTX25_RUNTIME_COMMIT}.tar.gz"
+)
 
 # Upstream 0.1.36 writes MP4 through optional OpenCV/imageio. Replace only
 # the two pinned encoder seams with Rapid's atomic VideoToolbox bridge. Hashes
@@ -1232,12 +1220,15 @@ print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma architectures OK")' 2>
         FFMPEG_BINARY="$STAGE/bin/ffmpeg" \
         "$STAGE/python/bin/python3.12" -s -c \
         'import importlib.util
+import inspect
 import tempfile
 from pathlib import Path
 import numpy as np
 import mlx_video
+import mlx_video.generate_wan as wan_generator
 from mlx_video import generate_video_with_audio
 from mlx_video.generate_wan import generate_video
+from mlx_video.models.wan.config import WanModelConfig
 from ltx_pipelines_mlx.cli import main as ltx25_main
 from videox_fun_mlx.models.cogvideox_transformer3d import CogVideoXTransformer3DModel
 from videox_fun_mlx.models.cogvideox_vae import AutoencoderKLCogVideoX
@@ -1251,6 +1242,10 @@ assert importlib.util.find_spec("cv2") is None
 assert importlib.util.find_spec("imageio") is None
 assert importlib.metadata.version("ltx-core-mlx") == "0.14.15"
 assert importlib.metadata.version("ltx-pipelines-mlx") == "0.14.15"
+assert {"model_dir", "prompt"} <= set(inspect.signature(generate_video).parameters)
+assert {"load_wan_model", "load_t5_encoder", "load_vae_decoder"} <= set(generate_video.__globals__)
+wan21 = WanModelConfig.wan21_t2v_1_3b()
+assert (wan21.dim, wan21.ffn_dim, wan21.num_heads, wan21.num_layers) == (1536, 8960, 12, 30)
 with tempfile.TemporaryDirectory() as directory:
     output = Path(directory) / "smoke.mp4"
     encode_rgb_video(np.zeros((2, 32, 16, 3), dtype=np.uint8), output, 2)

--- a/tests/test_cli_models_json.py
+++ b/tests/test_cli_models_json.py
@@ -97,6 +97,7 @@ def test_video_entries_expose_pre_serve_modes_and_memory_floor() -> None:
         "cogvideox-fun-5b-q4": ["text-to-video"],
         "cogvideox-fun-5b-q8": ["text-to-video"],
         "cogvideox-fun-5b-bf16": ["text-to-video"],
+        "wan2.1-t2v-1.3b-bf16": ["text-to-video"],
         "wan2.2-ti2v-5b-q8": ["text-to-video", "image-to-video"],
         "wan2.2-ti2v-5b-bf16": ["text-to-video", "image-to-video"],
         "wan2.2-i2v-a14b-q8": ["image-to-video"],

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -20,6 +20,7 @@ import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from vllm_mlx import _download_gate as gate
@@ -743,33 +744,186 @@ def _seed_wan_snapshot(repo_root, pinned_sha: str, files: dict[str, bytes]) -> N
         link.symlink_to(blob)
 
 
+_WAN21_TRANSFORMER_SHARDS = tuple(
+    f"diffusion_pytorch_model-{i:05d}-of-00002.safetensors" for i in (1, 2)
+)
+_WAN21_T5_SHARDS = tuple(f"model-{i:05d}-of-00005.safetensors" for i in range(1, 6))
+
+
+def _wan21_transformer_source_keys() -> list[str]:
+    """The exact 825 transformer source keys ``_transformer_key`` supports.
+
+    Deterministically mirrors the pinned 30-layer grammar: 15 top-level
+    tensors plus 27 per-block tensors (dual qk-normed attentions, GEGLU ffn,
+    affine norm2, per-block scale_shift_table) instead of a literal dump.
+    """
+    keys = [
+        "patch_embedding.weight",
+        "patch_embedding.bias",
+        "condition_embedder.time_embedder.linear_1.weight",
+        "condition_embedder.time_embedder.linear_1.bias",
+        "condition_embedder.time_embedder.linear_2.weight",
+        "condition_embedder.time_embedder.linear_2.bias",
+        "condition_embedder.text_embedder.linear_1.weight",
+        "condition_embedder.text_embedder.linear_1.bias",
+        "condition_embedder.text_embedder.linear_2.weight",
+        "condition_embedder.text_embedder.linear_2.bias",
+        "condition_embedder.time_proj.weight",
+        "condition_embedder.time_proj.bias",
+        "scale_shift_table",
+        "proj_out.weight",
+        "proj_out.bias",
+    ]
+    per_block = [
+        f"{attn}.{leaf}"
+        for attn in ("attn1", "attn2")
+        for leaf in (
+            "norm_q.weight",
+            "norm_k.weight",
+            "to_q.weight",
+            "to_q.bias",
+            "to_k.weight",
+            "to_k.bias",
+            "to_v.weight",
+            "to_v.bias",
+            "to_out.0.weight",
+            "to_out.0.bias",
+        )
+    ] + [
+        "ffn.net.0.proj.weight",
+        "ffn.net.0.proj.bias",
+        "ffn.net.2.weight",
+        "ffn.net.2.bias",
+        "norm2.weight",
+        "norm2.bias",
+        "scale_shift_table",
+    ]
+    for block in range(30):
+        keys.extend(f"blocks.{block}.{tail}" for tail in per_block)
+    assert len(keys) == 825
+    return keys
+
+
+def _wan21_t5_source_keys() -> list[str]:
+    """The exact 242 UMT5 source keys ``_t5_key`` supports (24 layers)."""
+    keys = ["shared.weight", "encoder.final_layer_norm.weight"]
+    per_block = (
+        "layer.0.layer_norm.weight",
+        "layer.0.SelfAttention.q.weight",
+        "layer.0.SelfAttention.k.weight",
+        "layer.0.SelfAttention.v.weight",
+        "layer.0.SelfAttention.o.weight",
+        "layer.0.SelfAttention.relative_attention_bias.weight",
+        "layer.1.layer_norm.weight",
+        "layer.1.DenseReluDense.wi_0.weight",
+        "layer.1.DenseReluDense.wi_1.weight",
+        "layer.1.DenseReluDense.wo.weight",
+    )
+    for block in range(24):
+        keys.extend(f"encoder.block.{block}.{tail}" for tail in per_block)
+    assert len(keys) == 242
+    return keys
+
+
+def _wan21_vae_source_keys() -> list[str]:
+    """The decoder-mappable VAE source keys (exactly 108 unique targets).
+
+    Mirrors the pinned AutoencoderKLWan decoder grammar (dim_mult [1,2,4,4],
+    num_res_blocks 2): three residual blocks per up_block, a single channel
+    shortcut at up_block 1 / resnet 0, temporal upsamplers on the first two
+    up_blocks only, plus two encoder tensors the decoder mapper deliberately
+    skips — as in the real checkpoint.
+    """
+    residual = (
+        "norm1.gamma",
+        "conv1.weight",
+        "conv1.bias",
+        "norm2.gamma",
+        "conv2.weight",
+        "conv2.bias",
+    )
+    keys = [
+        "post_quant_conv.weight",
+        "post_quant_conv.bias",
+        "decoder.conv_in.weight",
+        "decoder.conv_in.bias",
+        "decoder.norm_out.gamma",
+        "decoder.conv_out.weight",
+        "decoder.conv_out.bias",
+    ]
+    for resnet in range(2):
+        keys.extend(f"decoder.mid_block.resnets.{resnet}.{tail}" for tail in residual)
+    keys.extend(
+        f"decoder.mid_block.attentions.0.{tail}"
+        for tail in (
+            "norm.gamma",
+            "to_qkv.weight",
+            "to_qkv.bias",
+            "proj.weight",
+            "proj.bias",
+        )
+    )
+    for block in range(4):
+        for resnet in range(3):
+            keys.extend(
+                f"decoder.up_blocks.{block}.resnets.{resnet}.{tail}"
+                for tail in residual
+            )
+            if (block, resnet) == (1, 0):
+                keys.extend(
+                    f"decoder.up_blocks.1.resnets.0.conv_shortcut.{leaf}"
+                    for leaf in ("weight", "bias")
+                )
+        if block < 3:
+            tails = ["resample.1.weight", "resample.1.bias"]
+            if block < 2:
+                tails += ["time_conv.weight", "time_conv.bias"]
+            keys.extend(f"decoder.up_blocks.{block}.upsamplers.0.{t}" for t in tails)
+    assert len(keys) == 108
+    return keys + ["encoder.conv_in.weight", "encoder.conv_in.bias"]
+
+
+def _tiny_safetensors(names: list[str]) -> bytes:
+    """A valid safetensors container holding one distinct scalar per tensor."""
+    from safetensors.numpy import save
+
+    return save(
+        {name: np.array(float(i), dtype=np.float32) for i, name in enumerate(names)}
+    )
+
+
+def _sharded_safetensors(
+    sources: list[str], shards: tuple[str, ...]
+) -> tuple[dict[str, str], dict[str, bytes]]:
+    """Distribute sources across shards; the index maps each to its real shard."""
+    placed: dict[str, list[str]] = {shard: [] for shard in shards}
+    weight_map: dict[str, str] = {}
+    for i, source in enumerate(sources):
+        shard = shards[i % len(shards)]
+        weight_map[source] = shard
+        placed[shard].append(source)
+    return weight_map, {
+        shard: _tiny_safetensors(names) for shard, names in placed.items()
+    }
+
+
 def _wan21_diffusers_files() -> dict[str, bytes]:
     """A cache image the RUNTIME contract accepts, not just the filename pin.
 
-    The gate now re-validates the pinned 1.3B Diffusers snapshot with the same
-    ``is_diffusers_wan21_layout`` probe the runtime router uses, so the fixture
-    must carry actually-valid component manifests and exact-cardinality weight
-    maps (transformer 825 keys over 2 shards, T5 242 keys over 5 shards) that
-    reference the pinned shard filenames — not placeholder bytes.
+    The gate re-validates the pinned 1.3B Diffusers snapshot with the runtime
+    router's layout probe AND the metadata-only artifact validator, so the
+    fixture must carry actually-valid component manifests, exact-cardinality
+    weight maps whose every source key passes the production tensor mappers
+    (transformer 825 keys over 2 shards, T5 242 keys over 5 shards, VAE 108
+    uniquely-mapped decoder tensors), and real tiny safetensors containers
+    holding exactly the tensors each index points at — not placeholder bytes.
     """
-    transformer_shards = tuple(
-        f"diffusion_pytorch_model-{i:05d}-of-00002.safetensors" for i in (1, 2)
+    transformer_map, transformer_blobs = _sharded_safetensors(
+        _wan21_transformer_source_keys(), _WAN21_TRANSFORMER_SHARDS
     )
-    t5_shards = tuple(f"model-{i:05d}-of-00005.safetensors" for i in range(1, 6))
-    transformer_index = {
-        "metadata": {"total_size": 2867589632},
-        "weight_map": {
-            f"blocks.{i}.weight": transformer_shards[i % len(transformer_shards)]
-            for i in range(825)
-        },
-    }
-    t5_index = {
-        "metadata": {"total_size": 11361920000},
-        "weight_map": {
-            f"encoder.block.{i}.weight": t5_shards[i % len(t5_shards)]
-            for i in range(242)
-        },
-    }
+    t5_map, t5_blobs = _sharded_safetensors(_wan21_t5_source_keys(), _WAN21_T5_SHARDS)
+    transformer_index = {"weight_map": transformer_map}
+    t5_index = {"weight_map": t5_map}
     model_index = {
         "_class_name": "WanPipeline",
         "_diffusers_version": "0.33.0",
@@ -816,16 +970,18 @@ def _wan21_diffusers_files() -> dict[str, bytes]:
         "text_encoder/config.json": json.dumps(text_encoder_config).encode(),
         "text_encoder/model.safetensors.index.json": json.dumps(t5_index).encode(),
         "vae/config.json": json.dumps(vae_config).encode(),
-        "vae/diffusion_pytorch_model.safetensors": b"v" * 1024,
+        "vae/diffusion_pytorch_model.safetensors": _tiny_safetensors(
+            _wan21_vae_source_keys()
+        ),
         "tokenizer/special_tokens_map.json": b"{}",
         "tokenizer/spiece.model": b"spiece-model-bytes",
         "tokenizer/tokenizer.json": b"{}",
         "tokenizer/tokenizer_config.json": b"{}",
     }
-    for shard in transformer_shards:
-        files[f"transformer/{shard}"] = b"w" * 1024
-    for shard in t5_shards:
-        files[f"text_encoder/{shard}"] = b"t" * 1024
+    for shard, payload in transformer_blobs.items():
+        files[f"transformer/{shard}"] = payload
+    for shard, payload in t5_blobs.items():
+        files[f"text_encoder/{shard}"] = payload
     return files
 
 
@@ -925,6 +1081,121 @@ def test_wan_cache_rejects_21_diffusers_mismatched_component_config(
     payload = json.loads(files[config_name])
     payload.update(mutation)
     files[config_name] = json.dumps(payload).encode()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+def test_wan_cache_rejects_21_diffusers_unmappable_index_keys(tmp_path, monkeypatch):
+    """825 arbitrary source keys backed by real shards must not pass the gate.
+
+    Regression for the false positive this suite used to encode: correct
+    cardinality plus present shard files said nothing about loadability. The
+    production mapper rejects every one of these keys, so generation would
+    fail inside ``_read_index`` after the gate had skipped repair.
+    """
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    files = _wan21_diffusers_files()
+    bogus = [f"blocks.{i}.weight" for i in range(825)]
+    weight_map, blobs = _sharded_safetensors(bogus, _WAN21_TRANSFORMER_SHARDS)
+    files["transformer/diffusion_pytorch_model.safetensors.index.json"] = json.dumps(
+        {"weight_map": weight_map}
+    ).encode()
+    for shard, payload in blobs.items():
+        files[f"transformer/{shard}"] = payload
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        "transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
+        "text_encoder/model-00003-of-00005.safetensors",
+        "vae/diffusion_pytorch_model.safetensors",
+    ],
+    ids=["transformer-shard", "t5-shard", "vae"],
+)
+def test_wan_cache_rejects_21_diffusers_malformed_safetensors(
+    tmp_path, monkeypatch, artifact
+):
+    """Raw non-safetensors bytes behind a pinned weight filename must not pass.
+
+    ``mx.load`` would fail on such a file at generation time, so the gate has
+    to detect it from the header alone and send the snapshot back through
+    repair/download.
+    """
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    files = _wan21_diffusers_files()
+    files[artifact] = b"w" * 1024
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+def test_wan_cache_rejects_21_diffusers_index_shard_mismatch(tmp_path, monkeypatch):
+    """An index that points a tensor at the wrong (valid) shard must not pass."""
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    files = _wan21_diffusers_files()
+    index_name = "transformer/diffusion_pytorch_model.safetensors.index.json"
+    index = json.loads(files[index_name])
+    weight_map = index["weight_map"]
+    # Redirect one tensor to the other present, well-formed shard — which
+    # does not contain it.
+    source = "patch_embedding.weight"
+    other = next(
+        shard for shard in _WAN21_TRANSFORMER_SHARDS if shard != weight_map[source]
+    )
+    weight_map[source] = other
+    files[index_name] = json.dumps(index).encode()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+@pytest.mark.parametrize(
+    ("dropped", "replacement"),
+    [
+        # One decoder tensor short of the pinned 108 (encoder keys are skipped).
+        ("decoder.conv_out.bias", "encoder.conv_out.bias"),
+        # A decoder-prefixed key the production mapper rejects outright.
+        ("decoder.conv_out.bias", "decoder.new_component.weight"),
+        # Two sources aliasing one MLX target (up 0 / resnet 4 collides with
+        # the still-present up 1 / resnet 0 at ``decoder.upsamples.4``).
+        ("decoder.conv_out.bias", "decoder.up_blocks.0.resnets.4.norm1.gamma"),
+    ],
+    ids=["missing-decoder-tensor", "unmappable-decoder-key", "duplicate-target"],
+)
+def test_wan_cache_rejects_21_diffusers_wrong_vae_tensor_set(
+    tmp_path, monkeypatch, dropped, replacement
+):
+    """A valid VAE container without the exact decoder tensor set must not pass."""
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    files = _wan21_diffusers_files()
+    keys = [key for key in _wan21_vae_source_keys() if key != dropped]
+    keys.append(replacement)
+    files["vae/diffusion_pytorch_model.safetensors"] = _tiny_safetensors(keys)
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
     _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -745,15 +745,19 @@ def _seed_wan_snapshot(repo_root, pinned_sha: str, files: dict[str, bytes]) -> N
 
 def _wan21_diffusers_files() -> dict[str, bytes]:
     names = (
+        "model_index.json",
+        "transformer/config.json",
         "transformer/diffusion_pytorch_model.safetensors.index.json",
         "transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
         "transformer/diffusion_pytorch_model-00002-of-00002.safetensors",
+        "text_encoder/config.json",
         "text_encoder/model.safetensors.index.json",
         "text_encoder/model-00001-of-00005.safetensors",
         "text_encoder/model-00002-of-00005.safetensors",
         "text_encoder/model-00003-of-00005.safetensors",
         "text_encoder/model-00004-of-00005.safetensors",
         "text_encoder/model-00005-of-00005.safetensors",
+        "vae/config.json",
         "vae/diffusion_pytorch_model.safetensors",
         "tokenizer/special_tokens_map.json",
         "tokenizer/spiece.model",

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -744,27 +744,89 @@ def _seed_wan_snapshot(repo_root, pinned_sha: str, files: dict[str, bytes]) -> N
 
 
 def _wan21_diffusers_files() -> dict[str, bytes]:
-    names = (
-        "model_index.json",
-        "transformer/config.json",
-        "transformer/diffusion_pytorch_model.safetensors.index.json",
-        "transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
-        "transformer/diffusion_pytorch_model-00002-of-00002.safetensors",
-        "text_encoder/config.json",
-        "text_encoder/model.safetensors.index.json",
-        "text_encoder/model-00001-of-00005.safetensors",
-        "text_encoder/model-00002-of-00005.safetensors",
-        "text_encoder/model-00003-of-00005.safetensors",
-        "text_encoder/model-00004-of-00005.safetensors",
-        "text_encoder/model-00005-of-00005.safetensors",
-        "vae/config.json",
-        "vae/diffusion_pytorch_model.safetensors",
-        "tokenizer/special_tokens_map.json",
-        "tokenizer/spiece.model",
-        "tokenizer/tokenizer.json",
-        "tokenizer/tokenizer_config.json",
+    """A cache image the RUNTIME contract accepts, not just the filename pin.
+
+    The gate now re-validates the pinned 1.3B Diffusers snapshot with the same
+    ``is_diffusers_wan21_layout`` probe the runtime router uses, so the fixture
+    must carry actually-valid component manifests and exact-cardinality weight
+    maps (transformer 825 keys over 2 shards, T5 242 keys over 5 shards) that
+    reference the pinned shard filenames — not placeholder bytes.
+    """
+    transformer_shards = tuple(
+        f"diffusion_pytorch_model-{i:05d}-of-00002.safetensors" for i in (1, 2)
     )
-    return {name: b"complete" for name in names}
+    t5_shards = tuple(f"model-{i:05d}-of-00005.safetensors" for i in range(1, 6))
+    transformer_index = {
+        "metadata": {"total_size": 2867589632},
+        "weight_map": {
+            f"blocks.{i}.weight": transformer_shards[i % len(transformer_shards)]
+            for i in range(825)
+        },
+    }
+    t5_index = {
+        "metadata": {"total_size": 11361920000},
+        "weight_map": {
+            f"encoder.block.{i}.weight": t5_shards[i % len(t5_shards)]
+            for i in range(242)
+        },
+    }
+    model_index = {
+        "_class_name": "WanPipeline",
+        "_diffusers_version": "0.33.0",
+        "scheduler": ["diffusers", "UniPCMultistepScheduler"],
+        "text_encoder": ["transformers", "UMT5EncoderModel"],
+        "tokenizer": ["transformers", "T5TokenizerFast"],
+        "transformer": ["diffusers", "WanTransformer3DModel"],
+        "vae": ["diffusers", "AutoencoderKLWan"],
+    }
+    transformer_config = {
+        "_class_name": "WanTransformer3DModel",
+        "patch_size": [1, 2, 2],
+        "in_channels": 16,
+        "out_channels": 16,
+        "num_attention_heads": 12,
+        "attention_head_dim": 128,
+        "num_layers": 30,
+        "ffn_dim": 8960,
+        "text_dim": 4096,
+    }
+    text_encoder_config = {
+        "model_type": "umt5",
+        "vocab_size": 256384,
+        "d_model": 4096,
+        "d_ff": 10240,
+        "num_heads": 64,
+        "num_layers": 24,
+        "relative_attention_num_buckets": 32,
+    }
+    vae_config = {
+        "_class_name": "AutoencoderKLWan",
+        "base_dim": 96,
+        "z_dim": 16,
+        "dim_mult": [1, 2, 4, 4],
+        "num_res_blocks": 2,
+        "temperal_downsample": [False, True, True],
+    }
+    files: dict[str, bytes] = {
+        "model_index.json": json.dumps(model_index).encode(),
+        "transformer/config.json": json.dumps(transformer_config).encode(),
+        "transformer/diffusion_pytorch_model.safetensors.index.json": json.dumps(
+            transformer_index
+        ).encode(),
+        "text_encoder/config.json": json.dumps(text_encoder_config).encode(),
+        "text_encoder/model.safetensors.index.json": json.dumps(t5_index).encode(),
+        "vae/config.json": json.dumps(vae_config).encode(),
+        "vae/diffusion_pytorch_model.safetensors": b"v" * 1024,
+        "tokenizer/special_tokens_map.json": b"{}",
+        "tokenizer/spiece.model": b"spiece-model-bytes",
+        "tokenizer/tokenizer.json": b"{}",
+        "tokenizer/tokenizer_config.json": b"{}",
+    }
+    for shard in transformer_shards:
+        files[f"transformer/{shard}"] = b"w" * 1024
+    for shard in t5_shards:
+        files[f"text_encoder/{shard}"] = b"t" * 1024
+    return files
 
 
 def test_wan_cache_accepts_complete_21_diffusers_layout(tmp_path, monkeypatch):
@@ -785,6 +847,84 @@ def test_wan_cache_rejects_incomplete_21_diffusers_layout(tmp_path, monkeypatch)
     repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
     files = _wan21_diffusers_files()
     files.pop("tokenizer/spiece.model")
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+@pytest.mark.parametrize(
+    "index_name",
+    [
+        "transformer/diffusion_pytorch_model.safetensors.index.json",
+        "text_encoder/model.safetensors.index.json",
+    ],
+)
+def test_wan_cache_rejects_21_diffusers_malformed_index(
+    tmp_path, monkeypatch, index_name
+):
+    """Every pinned filename present and non-empty, but an index is not JSON.
+
+    Runtime routing (``is_diffusers_wan21_layout``) refuses such a tree, so the
+    gate must send it back through repair/download instead of reporting cached
+    — otherwise the cache skips the gate and fails forever at runtime.
+    """
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    files = _wan21_diffusers_files()
+    files[index_name] = b"complete"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+def test_wan_cache_rejects_21_diffusers_wrong_index_cardinality(tmp_path, monkeypatch):
+    """A parseable transformer index with 824 keys instead of the pinned 825
+    fails the runtime cardinality contract, so the gate must reject it too."""
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    files = _wan21_diffusers_files()
+    index_name = "transformer/diffusion_pytorch_model.safetensors.index.json"
+    index = json.loads(files[index_name])
+    index["weight_map"].pop(next(iter(index["weight_map"])))
+    files[index_name] = json.dumps(index).encode()
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
+
+
+@pytest.mark.parametrize(
+    ("config_name", "mutation"),
+    [
+        ("model_index.json", {"_class_name": "StableDiffusionPipeline"}),
+        ("transformer/config.json", {"num_layers": 29}),
+        ("text_encoder/config.json", {"d_model": 2048}),
+        ("vae/config.json", {"z_dim": 4}),
+    ],
+)
+def test_wan_cache_rejects_21_diffusers_mismatched_component_config(
+    tmp_path, monkeypatch, config_name, mutation
+):
+    """A component config that contradicts the pinned architecture contract
+    (wrong pipeline class, layer count, width, ...) is not the audited
+    checkpoint and must not count as cached."""
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    files = _wan21_diffusers_files()
+    payload = json.loads(files[config_name])
+    payload.update(mutation)
+    files[config_name] = json.dumps(payload).encode()
     cache_root = tmp_path / "hf-cache"
     repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
     _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -735,10 +735,58 @@ def _seed_wan_snapshot(repo_root, pinned_sha: str, files: dict[str, bytes]) -> N
     blobs.mkdir(parents=True)
     snap = repo_root / "snapshots" / pinned_sha
     snap.mkdir(parents=True)
-    for name, payload in files.items():
-        blob = blobs / f"blob-{len(payload)}-{name}"
+    for index, (name, payload) in enumerate(files.items()):
+        blob = blobs / f"blob-{index}-{len(payload)}"
         blob.write_bytes(payload)
-        (snap / name).symlink_to(blob)
+        link = snap / name
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(blob)
+
+
+def _wan21_diffusers_files() -> dict[str, bytes]:
+    names = (
+        "transformer/diffusion_pytorch_model.safetensors.index.json",
+        "transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
+        "transformer/diffusion_pytorch_model-00002-of-00002.safetensors",
+        "text_encoder/model.safetensors.index.json",
+        "text_encoder/model-00001-of-00005.safetensors",
+        "text_encoder/model-00002-of-00005.safetensors",
+        "text_encoder/model-00003-of-00005.safetensors",
+        "text_encoder/model-00004-of-00005.safetensors",
+        "text_encoder/model-00005-of-00005.safetensors",
+        "vae/diffusion_pytorch_model.safetensors",
+        "tokenizer/special_tokens_map.json",
+        "tokenizer/spiece.model",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+    )
+    return {name: b"complete" for name in names}
+
+
+def test_wan_cache_accepts_complete_21_diffusers_layout(tmp_path, monkeypatch):
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], _wan21_diffusers_files())
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is True
+
+
+def test_wan_cache_rejects_incomplete_21_diffusers_layout(tmp_path, monkeypatch):
+    from vllm_mlx.video.wan import WAN_REVISIONS
+
+    repo_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+    files = _wan21_diffusers_files()
+    files.pop("tokenizer/spiece.model")
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / f"models--{repo_id.replace('/', '--')}"
+    _seed_wan_snapshot(repo_root, WAN_REVISIONS[repo_id], files)
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate._snapshot_is_complete_wan_model(repo_id) is False
 
 
 def test_wan_cache_accepts_5b_single_transformer_layout(tmp_path, monkeypatch):

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -44,15 +44,69 @@ def test_ltx25_capabilities_match_distilled_controls() -> None:
     }
 
 
+def _fake_embedded_distributions(
+    monkeypatch: pytest.MonkeyPatch, distributions: dict[str, tuple[str, str | None]]
+) -> None:
+    """Fake installed (version, provenance-stamp) pairs for the embedded check."""
+
+    def distribution(name: str) -> SimpleNamespace:
+        if name not in distributions:
+            raise ltx25.importlib.metadata.PackageNotFoundError(name)
+        version, provenance = distributions[name]
+        return SimpleNamespace(
+            version=version,
+            read_text=lambda filename: (
+                provenance if filename == ltx25.LTX25_PROVENANCE_FILE else None
+            ),
+        )
+
+    monkeypatch.setattr(ltx25.importlib.metadata, "distribution", distribution)
+    monkeypatch.setattr(ltx25.importlib.util, "find_spec", lambda _: object())
+
+
 def test_ltx25_embedded_runtime_requires_both_exact_distributions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    versions = {"ltx-core-mlx": "0.14.15", "ltx-pipelines-mlx": "0.14.15"}
-    monkeypatch.setattr(ltx25.importlib.metadata, "version", versions.__getitem__)
-    monkeypatch.setattr(ltx25.importlib.util, "find_spec", lambda _: object())
+    stamp = ltx25.LTX25_RUNTIME_COMMIT + "\n"
+    distributions = {
+        "ltx-core-mlx": (ltx25.LTX25_RUNTIME_VERSION, stamp),
+        "ltx-pipelines-mlx": (ltx25.LTX25_RUNTIME_VERSION, stamp),
+    }
+    _fake_embedded_distributions(monkeypatch, distributions)
     assert ltx25.embedded_ltx25_interpreter() == ltx25.sys.executable
 
-    versions["ltx-pipelines-mlx"] = "0.14.16"
+    distributions["ltx-pipelines-mlx"] = ("0.14.16", stamp)
+    assert ltx25.embedded_ltx25_interpreter() is None
+
+    del distributions["ltx-pipelines-mlx"]
+    assert ltx25.embedded_ltx25_interpreter() is None
+
+
+def test_ltx25_embedded_runtime_rejects_same_version_without_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A same-version install from a package index carries no build stamp."""
+    stamp = ltx25.LTX25_RUNTIME_COMMIT
+    _fake_embedded_distributions(
+        monkeypatch,
+        {
+            "ltx-core-mlx": (ltx25.LTX25_RUNTIME_VERSION, stamp),
+            "ltx-pipelines-mlx": (ltx25.LTX25_RUNTIME_VERSION, None),
+        },
+    )
+    assert ltx25.embedded_ltx25_interpreter() is None
+
+
+def test_ltx25_embedded_runtime_rejects_mismatched_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_embedded_distributions(
+        monkeypatch,
+        {
+            "ltx-core-mlx": (ltx25.LTX25_RUNTIME_VERSION, "0" * 40),
+            "ltx-pipelines-mlx": (ltx25.LTX25_RUNTIME_VERSION, "0" * 40),
+        },
+    )
     assert ltx25.embedded_ltx25_interpreter() is None
 
 

--- a/tests/test_ltx25_video.py
+++ b/tests/test_ltx25_video.py
@@ -44,6 +44,73 @@ def test_ltx25_capabilities_match_distilled_controls() -> None:
     }
 
 
+def test_ltx25_embedded_runtime_requires_both_exact_distributions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    versions = {"ltx-core-mlx": "0.14.15", "ltx-pipelines-mlx": "0.14.15"}
+    monkeypatch.setattr(ltx25.importlib.metadata, "version", versions.__getitem__)
+    monkeypatch.setattr(ltx25.importlib.util, "find_spec", lambda _: object())
+    assert ltx25.embedded_ltx25_interpreter() == ltx25.sys.executable
+
+    versions["ltx-pipelines-mlx"] = "0.14.16"
+    assert ltx25.embedded_ltx25_interpreter() is None
+
+
+def test_ltx25_embedded_runtime_preflight_needs_no_checkout_or_uv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(video_lane.sys, "version_info", (3, 11))
+    monkeypatch.setattr(ltx25, "embedded_ltx25_interpreter", lambda: "/embedded/python")
+    monkeypatch.setattr(
+        ltx25,
+        "resolve_ltx25_runtime",
+        lambda: pytest.fail("embedded runtime must not inspect a checkout"),
+    )
+    monkeypatch.setattr(video_lane, "_resolve_ffmpeg", lambda: "/sidecar/ffmpeg")
+    monkeypatch.setattr(video_lane.shutil, "which", lambda _: None)
+    video_lane.require_video_runtime_or_exit("ltx-2.5-mlx-q8")
+
+
+def test_ltx25_embedded_generation_preserves_sidecar_python_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(ltx25, "embedded_ltx25_interpreter", lambda: "/embedded/python")
+    monkeypatch.setenv("PYTHONHOME", "/signed-sidecar/python")
+    monkeypatch.setenv("PYTHONPATH", "/signed-sidecar/site-packages")
+    captured: dict = {}
+
+    class Process:
+        returncode = 0
+
+        def __init__(self, command: list[str], **kwargs) -> None:
+            self.command = command
+            captured.update(command=command, kwargs=kwargs)
+
+        def communicate(self, *, input: str, timeout: int) -> None:
+            captured.update(prompt=input, timeout=timeout)
+            Path(self.command[self.command.index("--output") + 1]).write_bytes(b"mp4")
+
+    monkeypatch.setattr(ltx25.subprocess, "Popen", Process)
+    output = tmp_path / "result.mp4"
+    ltx25.LTX25VideoEngine("ltx-2.5-mlx-q8").generate(
+        prompt="private prompt",
+        output_path=output,
+        width=704,
+        height=480,
+        num_frames=97,
+        fps=24,
+        seed=7,
+        image=None,
+    )
+
+    assert captured["command"][0] == "/embedded/python"
+    assert "private prompt" not in captured["command"]
+    assert captured["prompt"] == "private prompt"
+    assert captured["kwargs"]["env"]["PYTHONHOME"] == "/signed-sidecar/python"
+    assert captured["kwargs"]["env"]["PYTHONPATH"] == "/signed-sidecar/site-packages"
+    assert output.read_bytes() == b"mp4"
+
+
 def test_ltx25_direct_engine_rejects_conditioning_without_image() -> None:
     engine = VideoEngine.__new__(VideoEngine)
     engine._ltx25_engine = object()

--- a/tests/test_wan_diffusers.py
+++ b/tests/test_wan_diffusers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from types import FunctionType, ModuleType
+from types import FunctionType, ModuleType, SimpleNamespace
 
 import numpy as np
 import pytest
@@ -15,7 +15,11 @@ import vllm_mlx.video.wan_diffusers as wan_diffusers
 from vllm_mlx.video.wan import WanBackendError, WanVideoEngine
 from vllm_mlx.video.wan_diffusers import (
     _load_sharded,
+    _load_t5,
+    _load_transformer,
+    _load_vae,
     _read_index,
+    _scoped_generate_function,
     _t5_key,
     _transformer_key,
     _vae_decoder_key,
@@ -97,6 +101,13 @@ def test_official_layout_rejects_mismatched_architecture(tmp_path: Path) -> None
     payload = json.loads(config.read_text())
     payload["num_layers"] = 40
     config.write_text(json.dumps(payload))
+
+    assert not is_diffusers_wan21_layout(root)
+
+
+def test_official_layout_rejects_unreadable_component_config(tmp_path: Path) -> None:
+    root = _layout(tmp_path)
+    (root / "vae/config.json").write_text("{")
 
     assert not is_diffusers_wan21_layout(root)
 
@@ -187,6 +198,32 @@ def test_indexes_fail_closed_on_drift_duplicates_and_unsafe_shards(
 
     with pytest.raises(WanBackendError, match="unsupported"):
         _transformer_key("new_component.weight")
+    with pytest.raises(WanBackendError, match="unsupported"):
+        _transformer_key("blocks.0.new_component.weight")
+    with pytest.raises(WanBackendError, match="unsupported"):
+        _t5_key("new_component.weight")
+    with pytest.raises(WanBackendError, match="unsupported"):
+        _t5_key("encoder.block.0.layer.0.new_component.weight")
+    assert _vae_decoder_key("encoder.conv_in.weight") is None
+    with pytest.raises(WanBackendError, match="unsupported"):
+        _vae_decoder_key("decoder.new_component.weight")
+
+    index.write_text("{")
+    with pytest.raises(WanBackendError, match="unreadable"):
+        _read_index(tmp_path, index.name, 1, _t5_key)
+
+    index.write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "shared.weight": "one.safetensors",
+                    "encoder.final_layer_norm.weight": "one.safetensors",
+                }
+            }
+        )
+    )
+    with pytest.raises(WanBackendError, match="duplicate"):
+        _read_index(tmp_path, index.name, 2, lambda _key: "same.target")
 
 
 def test_sharded_loader_applies_pinned_patch_reshape(
@@ -253,6 +290,189 @@ def test_sharded_loader_applies_pinned_patch_reshape(
     assert all(value.dtype == np.float32 for _, value in weights)
 
 
+def test_sharded_loader_rejects_missing_file_and_tensor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    index = tmp_path / "transformer" / "weights.index.json"
+    index.parent.mkdir()
+    index.write_text(
+        json.dumps({"weight_map": {"patch_embedding.bias": "missing.safetensors"}})
+    )
+    mlx = ModuleType("mlx")
+    mlx_core = ModuleType("mlx.core")
+    mlx_utils = ModuleType("mlx.utils")
+    mlx_core.load = lambda *_args, **_kwargs: {}
+    mlx_utils.tree_flatten = lambda parameters: list(parameters.items())
+    mlx.core = mlx_core
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
+    monkeypatch.setitem(sys.modules, "mlx.utils", mlx_utils)
+
+    class FakeModel:
+        def parameters(self):
+            return {"patch_embedding_proj.bias": object()}
+
+    with pytest.raises(WanBackendError, match="missing 'missing.safetensors'"):
+        _load_sharded(
+            FakeModel(),
+            index.parent.parent,
+            "transformer/weights.index.json",
+            1,
+            _transformer_key,
+        )
+
+    (index.parent / "missing.safetensors").write_bytes(b"shard")
+    with pytest.raises(WanBackendError, match="missing tensor 'patch_embedding.bias'"):
+        _load_sharded(
+            FakeModel(),
+            index.parent.parent,
+            "transformer/weights.index.json",
+            1,
+            _transformer_key,
+        )
+
+
+@pytest.mark.parametrize(
+    "options", [{"quantization": {"bits": 4}}, {"loras": ["adapter"]}]
+)
+def test_transformer_loader_rejects_unsupported_overlays(
+    tmp_path: Path, options: dict
+) -> None:
+    with pytest.raises(WanBackendError, match="do not support"):
+        _load_transformer(tmp_path, object(), **options)
+
+
+def test_pinned_runtime_loaders_bind_exact_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    evaluated = []
+    source = {
+        "encoder.ignored": np.zeros((1,), dtype=np.float16),
+        "post_quant_conv.weight": np.zeros((2, 3, 1, 2, 2), dtype=np.float16),
+        "decoder.mid_block.attentions.0.proj.weight": np.zeros(
+            (2, 3, 1, 1), dtype=np.float16
+        ),
+        "post_quant_conv.bias": np.zeros((2,), dtype=np.float16),
+    }
+    mlx = ModuleType("mlx")
+    mlx_core = ModuleType("mlx.core")
+    mlx_utils = ModuleType("mlx.utils")
+    mlx_core.float32 = np.float32
+    mlx_core.load = lambda *_args, **_kwargs: source
+    mlx_core.transpose = np.transpose
+    mlx_core.eval = lambda parameters: evaluated.append(parameters)
+    mlx_utils.tree_flatten = lambda parameters: list(parameters.items())
+    mlx.core = mlx_core
+
+    mlx_video = ModuleType("mlx_video")
+    models = ModuleType("mlx_video.models")
+    wan = ModuleType("mlx_video.models.wan")
+    model_module = ModuleType("mlx_video.models.wan.model")
+    text_module = ModuleType("mlx_video.models.wan.text_encoder")
+    vae_module = ModuleType("mlx_video.models.wan.vae")
+
+    class FakeModel:
+        def __init__(self, config):
+            self.config = config
+
+        def parameters(self):
+            return {"model": object()}
+
+    class FakeT5:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def parameters(self):
+            return {"t5": object()}
+
+    class FakeVAE:
+        def __init__(self, *, z_dim):
+            self.z_dim = z_dim
+            self.loaded = None
+
+        def parameters(self):
+            return {
+                "conv2.weight": object(),
+                "decoder.middle.1.proj.weight": object(),
+                "conv2.bias": object(),
+                "mean": object(),
+                "std": object(),
+                "inv_std": object(),
+            }
+
+        def load_weights(self, weights, *, strict):
+            self.loaded = (weights, strict)
+
+    model_module.WanModel = FakeModel
+    text_module.T5Encoder = FakeT5
+    vae_module.WanVAE = FakeVAE
+    for name, module in {
+        "mlx": mlx,
+        "mlx.core": mlx_core,
+        "mlx.utils": mlx_utils,
+        "mlx_video": mlx_video,
+        "mlx_video.models": models,
+        "mlx_video.models.wan": wan,
+        "mlx_video.models.wan.model": model_module,
+        "mlx_video.models.wan.text_encoder": text_module,
+        "mlx_video.models.wan.vae": vae_module,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    sharded_calls = []
+    monkeypatch.setattr(
+        wan_diffusers,
+        "_load_sharded",
+        lambda *args, **kwargs: sharded_calls.append((args, kwargs)),
+    )
+    config = SimpleNamespace(
+        t5_vocab_size=1,
+        t5_dim=2,
+        t5_dim_attn=3,
+        t5_dim_ffn=4,
+        t5_num_heads=5,
+        t5_num_layers=6,
+        t5_num_buckets=7,
+    )
+    transformer = _load_transformer(tmp_path, config)
+    encoder = _load_t5(tmp_path, config)
+
+    assert transformer.config is config
+    assert encoder.kwargs == {
+        "vocab_size": 1,
+        "dim": 2,
+        "dim_attn": 3,
+        "dim_ffn": 4,
+        "num_heads": 5,
+        "num_layers": 6,
+        "num_buckets": 7,
+        "shared_pos": False,
+    }
+    assert len(sharded_calls) == 2
+    assert sharded_calls[0][1] == {
+        "reshape_patch": True,
+        "ignored_model_parameters": frozenset({"freqs"}),
+    }
+    assert sharded_calls[1][1] == {"dtype": np.float32}
+
+    monkeypatch.setattr(wan_diffusers, "_EXPECTED_VAE_DECODER_KEYS", 4)
+    with pytest.raises(WanBackendError, match="unexpected decoder tensor set"):
+        _load_vae(tmp_path)
+
+    monkeypatch.setattr(wan_diffusers, "_EXPECTED_VAE_DECODER_KEYS", 3)
+    vae = _load_vae(tmp_path)
+    assert vae.z_dim == 16
+    assert vae.loaded is not None
+    weights, strict = vae.loaded
+    assert strict is False
+    assert [value.shape for _, value in weights] == [
+        (2, 1, 2, 2, 3),
+        (2, 1, 1, 3),
+        (2,),
+    ]
+    assert len(evaluated) == 3
+
+
 def test_runtime_patch_is_scoped_and_tokenizer_is_local(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -277,8 +497,11 @@ def test_runtime_patch_is_scoped_and_tokenizer_is_local(
     monkeypatch.setitem(sys.modules, "transformers", transformers)
 
     def generate_template():
+        import json
+
         from transformers import AutoTokenizer
 
+        assert json.loads("null") is None
         return AutoTokenizer.from_pretrained("ignored")
 
     generator.generate_video = FunctionType(
@@ -298,6 +521,20 @@ def test_runtime_patch_is_scoped_and_tokenizer_is_local(
     ) == originals
     assert transformers.AutoTokenizer is OriginalTokenizer
     assert not view.exists()
+
+
+def test_scoped_runtime_rejects_incomplete_layout(tmp_path: Path) -> None:
+    with pytest.raises(WanBackendError, match="layout is incomplete"):
+        _scoped_generate_function(tmp_path, ModuleType("mlx_video.generate_wan"))
+
+
+def test_generate_runtime_preserves_preconverted_fallback(tmp_path: Path) -> None:
+    calls = []
+    generator = SimpleNamespace(generate_video=lambda **kwargs: calls.append(kwargs))
+
+    generate_with_runtime(tmp_path, generator, {"model_dir": "converted"})
+
+    assert calls == [{"model_dir": "converted"}]
 
 
 def test_generate_runtime_routes_all_pinned_loader_seams(

--- a/tests/test_wan_diffusers.py
+++ b/tests/test_wan_diffusers.py
@@ -22,6 +22,43 @@ from vllm_mlx.video.wan_diffusers import (
     is_diffusers_wan21_layout,
 )
 
+_WAN21_COMPONENT_CONFIGS = {
+    "model_index.json": {
+        "_class_name": "WanPipeline",
+        "transformer": ["diffusers", "WanTransformer3DModel"],
+        "text_encoder": ["transformers", "UMT5EncoderModel"],
+        "vae": ["diffusers", "AutoencoderKLWan"],
+    },
+    "transformer/config.json": {
+        "_class_name": "WanTransformer3DModel",
+        "patch_size": [1, 2, 2],
+        "in_channels": 16,
+        "out_channels": 16,
+        "num_attention_heads": 12,
+        "attention_head_dim": 128,
+        "num_layers": 30,
+        "ffn_dim": 8960,
+        "text_dim": 4096,
+    },
+    "text_encoder/config.json": {
+        "model_type": "umt5",
+        "vocab_size": 256384,
+        "d_model": 4096,
+        "d_ff": 10240,
+        "num_heads": 64,
+        "num_layers": 24,
+        "relative_attention_num_buckets": 32,
+    },
+    "vae/config.json": {
+        "_class_name": "AutoencoderKLWan",
+        "base_dim": 96,
+        "z_dim": 16,
+        "dim_mult": [1, 2, 4, 4],
+        "num_res_blocks": 2,
+        "temperal_downsample": [False, True, True],
+    },
+}
+
 
 def _layout(root: Path) -> Path:
     for relative in (
@@ -33,6 +70,10 @@ def _layout(root: Path) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(b"{}")
     (root / "tokenizer").mkdir()
+    for relative, payload in _WAN21_COMPONENT_CONFIGS.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload))
     return root
 
 
@@ -44,6 +85,16 @@ def test_official_layout_synthesizes_bounded_wan21_config(tmp_path: Path) -> Non
     assert engine.model_type == "t2v"
     assert engine.native_fps == 16
     assert engine.max_area == 704 * 1280
+
+
+def test_official_layout_rejects_mismatched_architecture(tmp_path: Path) -> None:
+    root = _layout(tmp_path)
+    config = root / "transformer/config.json"
+    payload = json.loads(config.read_text())
+    payload["num_layers"] = 40
+    config.write_text(json.dumps(payload))
+
+    assert not is_diffusers_wan21_layout(root)
 
 
 @pytest.mark.parametrize(
@@ -89,6 +140,26 @@ def test_t5_mapping(source: str, target: str) -> None:
         (
             "decoder.up_blocks.2.upsamplers.0.time_conv.weight",
             "decoder.upsamples.11.time_conv.weight",
+        ),
+        (
+            "decoder.mid_block.attentions.0.norm.gamma",
+            "decoder.middle.1.norm.gamma",
+        ),
+        (
+            "decoder.mid_block.attentions.0.to_qkv.weight",
+            "decoder.middle.1.to_qkv.weight",
+        ),
+        (
+            "decoder.mid_block.attentions.0.to_qkv.bias",
+            "decoder.middle.1.to_qkv.bias",
+        ),
+        (
+            "decoder.mid_block.attentions.0.proj.weight",
+            "decoder.middle.1.proj.weight",
+        ),
+        (
+            "decoder.mid_block.attentions.0.proj.bias",
+            "decoder.middle.1.proj.bias",
         ),
     ],
 )
@@ -161,7 +232,26 @@ def test_runtime_patch_is_scoped_and_tokenizer_is_local(
     assert not view.exists()
 
 
-def test_loader_target_validation_rejects_missing_and_unknown_parameters() -> None:
+def test_loader_target_validation_rejects_missing_and_unknown_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mlx = ModuleType("mlx")
+    mlx_utils = ModuleType("mlx.utils")
+
+    def tree_flatten(parameters, prefix=""):
+        flattened = []
+        for name, value in parameters.items():
+            path = f"{prefix}.{name}" if prefix else name
+            if isinstance(value, dict):
+                flattened.extend(tree_flatten(value, path))
+            else:
+                flattened.append((path, value))
+        return flattened
+
+    mlx_utils.tree_flatten = tree_flatten
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.utils", mlx_utils)
+
     class FakeModel:
         def parameters(self):
             return {"layer": {"weight": object(), "bias": object()}}

--- a/tests/test_wan_diffusers.py
+++ b/tests/test_wan_diffusers.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import FunctionType, ModuleType
 
 import pytest
 
@@ -16,9 +16,10 @@ from vllm_mlx.video.wan_diffusers import (
     _t5_key,
     _transformer_key,
     _vae_decoder_key,
+    _validate_target_parameters,
     desktop_wan21_config,
+    diffusers_runtime,
     is_diffusers_wan21_layout,
-    patched_diffusers_runtime,
 )
 
 
@@ -117,8 +118,6 @@ def test_runtime_patch_is_scoped_and_tokenizer_is_local(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = _layout(tmp_path)
-    parent = ModuleType("mlx_video")
-    parent.__path__ = []
     generator = ModuleType("mlx_video.generate_wan")
     originals = (object(), object(), object())
     (
@@ -126,7 +125,6 @@ def test_runtime_patch_is_scoped_and_tokenizer_is_local(
         generator.load_t5_encoder,
         generator.load_vae_decoder,
     ) = originals
-    parent.generate_wan = generator
     tokenizer_calls = []
 
     class OriginalTokenizer:
@@ -137,14 +135,21 @@ def test_runtime_patch_is_scoped_and_tokenizer_is_local(
 
     transformers = ModuleType("transformers")
     transformers.AutoTokenizer = OriginalTokenizer
-    monkeypatch.setitem(sys.modules, "mlx_video", parent)
-    monkeypatch.setitem(sys.modules, "mlx_video.generate_wan", generator)
     monkeypatch.setitem(sys.modules, "transformers", transformers)
 
-    with patched_diffusers_runtime(root) as view:
+    def generate_template():
+        from transformers import AutoTokenizer
+
+        return AutoTokenizer.from_pretrained("ignored")
+
+    generator.generate_video = FunctionType(
+        generate_template.__code__, generator.__dict__, "generate_video"
+    )
+
+    with diffusers_runtime(root, generator) as (view, scoped_generate):
         assert json.loads((view / "config.json").read_text()) == desktop_wan21_config()
-        assert generator.load_wan_model is not originals[0]
-        assert transformers.AutoTokenizer.from_pretrained("ignored") == "tokenizer"
+        assert scoped_generate.__globals__["load_wan_model"] is not originals[0]
+        assert scoped_generate() == "tokenizer"
         assert tokenizer_calls == [(root / "tokenizer", (), {"local_files_only": True})]
 
     assert (
@@ -154,3 +159,17 @@ def test_runtime_patch_is_scoped_and_tokenizer_is_local(
     ) == originals
     assert transformers.AutoTokenizer is OriginalTokenizer
     assert not view.exists()
+
+
+def test_loader_target_validation_rejects_missing_and_unknown_parameters() -> None:
+    class FakeModel:
+        def parameters(self):
+            return {"layer": {"weight": object(), "bias": object()}}
+
+    _validate_target_parameters(FakeModel(), {"layer.weight", "layer.bias"})
+    with pytest.raises(WanBackendError, match="missing=.*layer.bias"):
+        _validate_target_parameters(FakeModel(), {"layer.weight"})
+    with pytest.raises(WanBackendError, match="unexpected=.*other.weight"):
+        _validate_target_parameters(
+            FakeModel(), {"layer.weight", "layer.bias", "other.weight"}
+        )

--- a/tests/test_wan_diffusers.py
+++ b/tests/test_wan_diffusers.py
@@ -221,6 +221,27 @@ def test_official_layout_rejects_missing_referenced_shard(tmp_path: Path) -> Non
     assert not is_diffusers_wan21_layout(root)
 
 
+def test_official_layout_rejects_zero_byte_vae(tmp_path: Path) -> None:
+    root = _layout(tmp_path)
+    (root / "vae/diffusion_pytorch_model.safetensors").write_bytes(b"")
+
+    assert not is_diffusers_wan21_layout(root)
+
+
+@pytest.mark.parametrize(
+    "shard",
+    [f"transformer/{_TRANSFORMER_SHARD}", f"text_encoder/{_T5_SHARD}"],
+    ids=["transformer", "t5"],
+)
+def test_official_layout_rejects_zero_byte_referenced_shard(
+    tmp_path: Path, shard: str
+) -> None:
+    root = _layout(tmp_path)
+    (root / shard).write_bytes(b"")
+
+    assert not is_diffusers_wan21_layout(root)
+
+
 @pytest.mark.parametrize(
     ("source", "target"),
     [
@@ -652,6 +673,65 @@ def test_generate_runtime_preserves_preconverted_fallback(tmp_path: Path) -> Non
     generate_with_runtime(tmp_path, generator, {"model_dir": "converted"})
 
     assert calls == [{"model_dir": "converted"}]
+
+
+def test_generate_runtime_preserves_preconverted_wan22_fallback(
+    tmp_path: Path,
+) -> None:
+    # A true preconverted checkpoint (flat converted config plus root-level
+    # weights, no Diffusers component tree) must keep the legacy path.
+    calls = []
+    generator = SimpleNamespace(generate_video=lambda **kwargs: calls.append(kwargs))
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "ti2v", "model_version": "2.2"})
+    )
+    (tmp_path / "diffusion_pytorch_model.safetensors").write_bytes(b"weights")
+
+    generate_with_runtime(tmp_path, generator, {"model_dir": "converted"})
+
+    assert calls == [{"model_dir": "converted"}]
+
+
+def test_generate_runtime_does_not_classify_foreign_diffusers_layout(
+    tmp_path: Path,
+) -> None:
+    calls = []
+    generator = SimpleNamespace(generate_video=lambda **kwargs: calls.append(kwargs))
+    (tmp_path / "model_index.json").write_text(
+        json.dumps({"_class_name": "StableDiffusionPipeline"})
+    )
+
+    generate_with_runtime(tmp_path, generator, {"model_dir": "converted"})
+
+    assert calls == [{"model_dir": "converted"}]
+
+
+@pytest.mark.parametrize(
+    "defect",
+    ["missing-shard", "zero-byte-vae", "no-model-index", "malformed-model-index"],
+)
+def test_generate_runtime_rejects_incomplete_identified_wan21(
+    tmp_path: Path, defect: str
+) -> None:
+    calls = []
+    generator = SimpleNamespace(generate_video=lambda **kwargs: calls.append(kwargs))
+    root = _layout(tmp_path)
+    if defect == "missing-shard":
+        (root / "transformer" / _TRANSFORMER_SHARD).unlink()
+    elif defect == "zero-byte-vae":
+        (root / "vae/diffusion_pytorch_model.safetensors").write_bytes(b"")
+    elif defect == "no-model-index":
+        # Identity must survive losing one marker: the pinned transformer and
+        # VAE component classes still recognize the tree.
+        (root / "model_index.json").unlink()
+        (root / "transformer" / _TRANSFORMER_SHARD).unlink()
+    else:
+        (root / "model_index.json").write_text("{")
+
+    with pytest.raises(WanBackendError, match="layout is incomplete"):
+        generate_with_runtime(root, generator, {"model_dir": "converted"})
+
+    assert calls == []
 
 
 def test_generate_runtime_routes_all_pinned_loader_seams(

--- a/tests/test_wan_diffusers.py
+++ b/tests/test_wan_diffusers.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed mapping tests for the pinned Wan 2.1 Desktop layout."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from vllm_mlx.video.wan import WanBackendError, WanVideoEngine
+from vllm_mlx.video.wan_diffusers import (
+    _read_index,
+    _t5_key,
+    _transformer_key,
+    _vae_decoder_key,
+    desktop_wan21_config,
+    is_diffusers_wan21_layout,
+    patched_diffusers_runtime,
+)
+
+
+def _layout(root: Path) -> Path:
+    for relative in (
+        "transformer/diffusion_pytorch_model.safetensors.index.json",
+        "text_encoder/model.safetensors.index.json",
+        "vae/diffusion_pytorch_model.safetensors",
+    ):
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"{}")
+    (root / "tokenizer").mkdir()
+    return root
+
+
+def test_official_layout_synthesizes_bounded_wan21_config(tmp_path: Path) -> None:
+    root = _layout(tmp_path)
+    assert is_diffusers_wan21_layout(root)
+    engine = WanVideoEngine(root)
+    assert engine.config == desktop_wan21_config()
+    assert engine.model_type == "t2v"
+    assert engine.native_fps == 16
+    assert engine.max_area == 704 * 1280
+
+
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [
+        ("patch_embedding.weight", "patch_embedding_proj.weight"),
+        ("blocks.7.attn1.to_out.0.weight", "blocks.7.self_attn.o.weight"),
+        ("blocks.7.attn2.to_q.bias", "blocks.7.cross_attn.q.bias"),
+        ("blocks.7.norm2.weight", "blocks.7.norm3.weight"),
+        ("blocks.7.ffn.net.0.proj.weight", "blocks.7.ffn.fc1.weight"),
+        ("blocks.7.scale_shift_table", "blocks.7.modulation"),
+    ],
+)
+def test_transformer_mapping(source: str, target: str) -> None:
+    assert _transformer_key(source) == target
+
+
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [
+        ("shared.weight", "token_embedding.weight"),
+        ("encoder.final_layer_norm.weight", "norm.weight"),
+        ("encoder.block.3.layer.0.SelfAttention.q.weight", "blocks.3.attn.q.weight"),
+        (
+            "encoder.block.3.layer.1.DenseReluDense.wi_0.weight",
+            "blocks.3.ffn.gate_proj.weight",
+        ),
+    ],
+)
+def test_t5_mapping(source: str, target: str) -> None:
+    assert _t5_key(source) == target
+
+
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [
+        ("post_quant_conv.weight", "conv2.weight"),
+        ("decoder.mid_block.resnets.1.conv2.bias", "decoder.middle.2.residual.6.bias"),
+        (
+            "decoder.up_blocks.1.resnets.0.conv_shortcut.weight",
+            "decoder.upsamples.4.shortcut.weight",
+        ),
+        (
+            "decoder.up_blocks.2.upsamplers.0.time_conv.weight",
+            "decoder.upsamples.11.time_conv.weight",
+        ),
+    ],
+)
+def test_vae_decoder_mapping(source: str, target: str) -> None:
+    assert _vae_decoder_key(source) == target
+
+
+def test_indexes_fail_closed_on_drift_duplicates_and_unsafe_shards(
+    tmp_path: Path,
+) -> None:
+    index = tmp_path / "weights.index.json"
+    index.write_text(
+        json.dumps({"weight_map": {"shared.weight": "../escape.safetensors"}})
+    )
+    with pytest.raises(WanBackendError, match="unsafe"):
+        _read_index(tmp_path, index.name, 1, _t5_key)
+
+    index.write_text(json.dumps({"weight_map": {"shared.weight": "one.safetensors"}}))
+    with pytest.raises(WanBackendError, match="unexpected tensor set"):
+        _read_index(tmp_path, index.name, 2, _t5_key)
+
+    with pytest.raises(WanBackendError, match="unsupported"):
+        _transformer_key("new_component.weight")
+
+
+def test_runtime_patch_is_scoped_and_tokenizer_is_local(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _layout(tmp_path)
+    parent = ModuleType("mlx_video")
+    parent.__path__ = []
+    generator = ModuleType("mlx_video.generate_wan")
+    originals = (object(), object(), object())
+    (
+        generator.load_wan_model,
+        generator.load_t5_encoder,
+        generator.load_vae_decoder,
+    ) = originals
+    parent.generate_wan = generator
+    tokenizer_calls = []
+
+    class OriginalTokenizer:
+        @classmethod
+        def from_pretrained(cls, model, *args, **kwargs):
+            tokenizer_calls.append((model, args, kwargs))
+            return "tokenizer"
+
+    transformers = ModuleType("transformers")
+    transformers.AutoTokenizer = OriginalTokenizer
+    monkeypatch.setitem(sys.modules, "mlx_video", parent)
+    monkeypatch.setitem(sys.modules, "mlx_video.generate_wan", generator)
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+
+    with patched_diffusers_runtime(root) as view:
+        assert json.loads((view / "config.json").read_text()) == desktop_wan21_config()
+        assert generator.load_wan_model is not originals[0]
+        assert transformers.AutoTokenizer.from_pretrained("ignored") == "tokenizer"
+        assert tokenizer_calls == [(root / "tokenizer", (), {"local_files_only": True})]
+
+    assert (
+        generator.load_wan_model,
+        generator.load_t5_encoder,
+        generator.load_vae_decoder,
+    ) == originals
+    assert transformers.AutoTokenizer is OriginalTokenizer
+    assert not view.exists()

--- a/tests/test_wan_diffusers.py
+++ b/tests/test_wan_diffusers.py
@@ -242,8 +242,9 @@ def test_sharded_loader_applies_pinned_patch_reshape(
         )
     )
     (index.parent / "one.safetensors").write_bytes(b"pinned-shard")
+    patch_weight = np.arange(24, dtype=np.float16).reshape(2, 3, 1, 2, 2)
     source = {
-        "patch_embedding.weight": np.zeros((2, 3, 1, 2, 2), dtype=np.float16),
+        "patch_embedding.weight": patch_weight,
         "patch_embedding.bias": np.zeros((2,), dtype=np.float16),
     }
     mlx = ModuleType("mlx")
@@ -287,6 +288,13 @@ def test_sharded_loader_applies_pinned_patch_reshape(
         "patch_embedding_proj.bias",
     ]
     assert weights[0][1].shape == (2, 12)
+    # WanModel._patchify flattens each input patch in [C, pt, ph, pw]
+    # order, exactly matching PyTorch Conv3d's [O, I, D, H, W] kernel
+    # layout. Keep position-distinct values here so a channels-last
+    # transpose cannot accidentally pass as a shape-only conversion.
+    np.testing.assert_array_equal(
+        weights[0][1], patch_weight.reshape(patch_weight.shape[0], -1)
+    )
     assert all(value.dtype == np.float32 for _, value in weights)
 
 

--- a/tests/test_wan_diffusers.py
+++ b/tests/test_wan_diffusers.py
@@ -8,10 +8,13 @@ import sys
 from pathlib import Path
 from types import FunctionType, ModuleType
 
+import numpy as np
 import pytest
 
+import vllm_mlx.video.wan_diffusers as wan_diffusers
 from vllm_mlx.video.wan import WanBackendError, WanVideoEngine
 from vllm_mlx.video.wan_diffusers import (
+    _load_sharded,
     _read_index,
     _t5_key,
     _transformer_key,
@@ -19,6 +22,7 @@ from vllm_mlx.video.wan_diffusers import (
     _validate_target_parameters,
     desktop_wan21_config,
     diffusers_runtime,
+    generate_with_runtime,
     is_diffusers_wan21_layout,
 )
 
@@ -185,6 +189,70 @@ def test_indexes_fail_closed_on_drift_duplicates_and_unsafe_shards(
         _transformer_key("new_component.weight")
 
 
+def test_sharded_loader_applies_pinned_patch_reshape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    index = tmp_path / "transformer" / "weights.index.json"
+    index.parent.mkdir()
+    index.write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "patch_embedding.weight": "one.safetensors",
+                    "patch_embedding.bias": "one.safetensors",
+                }
+            }
+        )
+    )
+    (index.parent / "one.safetensors").write_bytes(b"pinned-shard")
+    source = {
+        "patch_embedding.weight": np.zeros((2, 3, 1, 2, 2), dtype=np.float16),
+        "patch_embedding.bias": np.zeros((2,), dtype=np.float16),
+    }
+    mlx = ModuleType("mlx")
+    mlx_core = ModuleType("mlx.core")
+    mlx_utils = ModuleType("mlx.utils")
+    mlx_core.load = lambda *_args, **_kwargs: source
+    mlx_utils.tree_flatten = lambda parameters: list(parameters.items())
+    mlx.core = mlx_core
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
+    monkeypatch.setitem(sys.modules, "mlx.utils", mlx_utils)
+
+    class FakeModel:
+        loaded = None
+
+        def parameters(self):
+            return {
+                "patch_embedding_proj.weight": object(),
+                "patch_embedding_proj.bias": object(),
+            }
+
+        def load_weights(self, weights, *, strict):
+            self.loaded = (weights, strict)
+
+    model = FakeModel()
+    _load_sharded(
+        model,
+        tmp_path,
+        "transformer/weights.index.json",
+        2,
+        _transformer_key,
+        dtype=np.float32,
+        reshape_patch=True,
+    )
+
+    assert model.loaded is not None
+    weights, strict = model.loaded
+    assert strict is False
+    assert [name for name, _ in weights] == [
+        "patch_embedding_proj.weight",
+        "patch_embedding_proj.bias",
+    ]
+    assert weights[0][1].shape == (2, 12)
+    assert all(value.dtype == np.float32 for _, value in weights)
+
+
 def test_runtime_patch_is_scoped_and_tokenizer_is_local(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -230,6 +298,43 @@ def test_runtime_patch_is_scoped_and_tokenizer_is_local(
     ) == originals
     assert transformers.AutoTokenizer is OriginalTokenizer
     assert not view.exists()
+
+
+def test_generate_runtime_routes_all_pinned_loader_seams(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _layout(tmp_path)
+    generator = ModuleType("mlx_video.generate_wan")
+    calls = []
+
+    def generate_template(model_dir, marker):
+        config = object()
+        calls.append(("model", globals()["load_wan_model"](Path(model_dir), config)))
+        calls.append(("t5", globals()["load_t5_encoder"](Path(model_dir), config)))
+        calls.append(("vae", globals()["load_vae_decoder"](Path(model_dir), config)))
+        calls.append(("marker", marker))
+
+    generator.generate_video = FunctionType(
+        generate_template.__code__,
+        generate_template.__globals__,
+        "generate_video",
+        generate_template.__defaults__,
+        generate_template.__closure__,
+    )
+    monkeypatch.setattr(
+        wan_diffusers, "_load_transformer", lambda path, *_args: ("model", path)
+    )
+    monkeypatch.setattr(wan_diffusers, "_load_t5", lambda path, *_args: ("t5", path))
+    monkeypatch.setattr(wan_diffusers, "_load_vae", lambda path, *_args: ("vae", path))
+
+    generation_kwargs = {"model_dir": "ignored", "marker": "request"}
+    generate_with_runtime(root, generator, generation_kwargs)
+
+    assert [kind for kind, _ in calls] == ["model", "t5", "vae", "marker"]
+    assert calls[-1] == ("marker", "request")
+    assert all(value[1] == root for _, value in calls[:3])
+    assert generation_kwargs["model_dir"] != "ignored"
+    assert not Path(generation_kwargs["model_dir"]).exists()
 
 
 def test_loader_target_validation_rejects_missing_and_unknown_parameters(

--- a/tests/test_wan_diffusers.py
+++ b/tests/test_wan_diffusers.py
@@ -68,16 +68,39 @@ _WAN21_COMPONENT_CONFIGS = {
 }
 
 
+_TRANSFORMER_SHARD = "diffusion_pytorch_model-00001-of-00001.safetensors"
+_T5_SHARD = "model-00001-of-00001.safetensors"
+
+
+def _index_payload(count: int, shard: str) -> dict:
+    return {"weight_map": {f"tensor.{i}": shard for i in range(count)}}
+
+
+def _write_index(path: Path, count: int, shard: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_index_payload(count, shard)))
+    (path.parent / shard).write_bytes(b"shard")
+
+
 def _layout(root: Path) -> Path:
-    for relative in (
-        "transformer/diffusion_pytorch_model.safetensors.index.json",
-        "text_encoder/model.safetensors.index.json",
-        "vae/diffusion_pytorch_model.safetensors",
-    ):
-        path = root / relative
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(b"{}")
+    _write_index(
+        root / "transformer/diffusion_pytorch_model.safetensors.index.json",
+        wan_diffusers._EXPECTED_TRANSFORMER_KEYS,
+        _TRANSFORMER_SHARD,
+    )
+    _write_index(
+        root / "text_encoder/model.safetensors.index.json",
+        wan_diffusers._EXPECTED_T5_KEYS,
+        _T5_SHARD,
+    )
+    vae = root / "vae/diffusion_pytorch_model.safetensors"
+    vae.parent.mkdir(parents=True, exist_ok=True)
+    vae.write_bytes(b"vae")
     (root / "tokenizer").mkdir()
+    (root / "tokenizer/special_tokens_map.json").write_text("{}")
+    (root / "tokenizer/spiece.model").write_bytes(b"spiece")
+    (root / "tokenizer/tokenizer.json").write_text("{}")
+    (root / "tokenizer/tokenizer_config.json").write_text("{}")
     for relative, payload in _WAN21_COMPONENT_CONFIGS.items():
         path = root / relative
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -108,6 +131,92 @@ def test_official_layout_rejects_mismatched_architecture(tmp_path: Path) -> None
 def test_official_layout_rejects_unreadable_component_config(tmp_path: Path) -> None:
     root = _layout(tmp_path)
     (root / "vae/config.json").write_text("{")
+
+    assert not is_diffusers_wan21_layout(root)
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        "tokenizer/special_tokens_map.json",
+        "tokenizer/spiece.model",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+    ],
+)
+@pytest.mark.parametrize("defect", ["missing", "zero-byte"])
+def test_official_layout_rejects_bad_tokenizer_artifact(
+    tmp_path: Path, artifact: str, defect: str
+) -> None:
+    root = _layout(tmp_path)
+    path = root / artifact
+    if defect == "missing":
+        path.unlink()
+    else:
+        path.write_bytes(b"")
+
+    assert not is_diffusers_wan21_layout(root)
+
+
+@pytest.mark.parametrize(
+    "index_body",
+    [
+        "{",
+        "",
+        json.dumps([]),
+        json.dumps({}),
+        json.dumps({"weight_map": []}),
+        json.dumps({"weight_map": {}}),
+        json.dumps({"weight_map": {"tensor.0": _T5_SHARD}}),
+    ],
+    ids=[
+        "truncated-json",
+        "empty-file",
+        "non-object",
+        "no-weight-map",
+        "weight-map-not-object",
+        "empty-weight-map",
+        "wrong-tensor-count",
+    ],
+)
+def test_official_layout_rejects_malformed_indexes(
+    tmp_path: Path, index_body: str
+) -> None:
+    root = _layout(tmp_path)
+    (root / "text_encoder/model.safetensors.index.json").write_text(index_body)
+
+    assert not is_diffusers_wan21_layout(root)
+
+
+def test_official_layout_rejects_extra_tensors_in_index(tmp_path: Path) -> None:
+    root = _layout(tmp_path)
+    _write_index(
+        root / "transformer/diffusion_pytorch_model.safetensors.index.json",
+        wan_diffusers._EXPECTED_TRANSFORMER_KEYS + 1,
+        _TRANSFORMER_SHARD,
+    )
+
+    assert not is_diffusers_wan21_layout(root)
+
+
+@pytest.mark.parametrize(
+    "shard",
+    ["../escape.safetensors", "sub/shard.safetensors", "/abs.safetensors", "", 5],
+    ids=["parent-escape", "subdirectory", "absolute", "empty-name", "non-string"],
+)
+def test_official_layout_rejects_unsafe_shard_names(tmp_path: Path, shard) -> None:
+    root = _layout(tmp_path)
+    payload = _index_payload(wan_diffusers._EXPECTED_T5_KEYS, _T5_SHARD)
+    payload["weight_map"]["tensor.0"] = shard
+    index = root / "text_encoder/model.safetensors.index.json"
+    index.write_text(json.dumps(payload))
+
+    assert not is_diffusers_wan21_layout(root)
+
+
+def test_official_layout_rejects_missing_referenced_shard(tmp_path: Path) -> None:
+    root = _layout(tmp_path)
+    (root / "transformer" / _TRANSFORMER_SHARD).unlink()
 
     assert not is_diffusers_wan21_layout(root)
 
@@ -558,6 +667,7 @@ def test_generate_runtime_routes_all_pinned_loader_seams(
         calls.append(("t5", globals()["load_t5_encoder"](Path(model_dir), config)))
         calls.append(("vae", globals()["load_vae_decoder"](Path(model_dir), config)))
         calls.append(("marker", marker))
+        calls.append(("model_dir", model_dir))
 
     generator.generate_video = FunctionType(
         generate_template.__code__,
@@ -575,11 +685,14 @@ def test_generate_runtime_routes_all_pinned_loader_seams(
     generation_kwargs = {"model_dir": "ignored", "marker": "request"}
     generate_with_runtime(root, generator, generation_kwargs)
 
-    assert [kind for kind, _ in calls] == ["model", "t5", "vae", "marker"]
-    assert calls[-1] == ("marker", "request")
+    assert [kind for kind, _ in calls] == ["model", "t5", "vae", "marker", "model_dir"]
+    assert calls[3] == ("marker", "request")
     assert all(value[1] == root for _, value in calls[:3])
-    assert generation_kwargs["model_dir"] != "ignored"
-    assert not Path(generation_kwargs["model_dir"]).exists()
+    passed_model_dir = calls[4][1]
+    assert passed_model_dir != "ignored"
+    assert not Path(passed_model_dir).exists()
+    # The temporary model view must never leak into the caller's mapping.
+    assert generation_kwargs == {"model_dir": "ignored", "marker": "request"}
 
 
 def test_loader_target_validation_rejects_missing_and_unknown_parameters(

--- a/tests/test_wan_runtime_integration.py
+++ b/tests/test_wan_runtime_integration.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration coverage against the actually installed Wan MLX runtime.
+
+The fake-based contracts in ``tests/test_wan_diffusers.py`` run everywhere,
+including the Linux no-MLX leg, but they cannot notice when the pinned
+``mlx-video-with-audio`` distribution itself drifts: a changed
+``generate_video`` signature, a renamed loader global, or a different
+``mx.load``/reshape behavior would pass every fake and fail only on a real
+generation. These tests close that gap by exercising the production adapter
+against the real ``mlx_video.generate_wan.generate_video`` code object and
+real safetensors IO through ``mlx.core`` — without downloading checkpoints,
+touching the network, or allocating model-sized tensors.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import inspect
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.requires_mlx
+
+pytest.importorskip("mlx.core")
+pytest.importorskip("mlx_video.generate_wan")
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx_video.generate_wan as wan_generator
+
+import vllm_mlx.video.wan_diffusers as wan_diffusers
+from tests.test_wan_diffusers import _layout
+from vllm_mlx.video.wan import WanVideoEngine
+from vllm_mlx.video.wan_diffusers import (
+    _load_sharded,
+    _scoped_generate_function,
+    _transformer_key,
+)
+
+_WAN_ENV_KEYS = (
+    "RAPID_MLX_WAN_MODEL_DIR",
+    "RAPID_MLX_WAN_STEPS",
+    "RAPID_MLX_WAN_SCHEDULER",
+    "RAPID_MLX_WAN_TILING",
+    "RAPID_MLX_WAN_LORA",
+    "RAPID_MLX_WAN_LORA_HIGH",
+    "RAPID_MLX_WAN_LORA_LOW",
+)
+
+
+class _FirstLoaderSeamReachedError(Exception):
+    """Sentinel proving the real pipeline reached the injected loader seam."""
+
+
+def test_pinned_runtime_distribution_version_matches_contract() -> None:
+    # The adapter's cloned-globals technique is validated against exactly this
+    # release; a silent bump must fail here before it fails on a user machine.
+    assert importlib.metadata.version("mlx-video-with-audio") == "0.1.36"
+
+
+def test_real_generate_video_reaches_first_loader_seam(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the production adapter into the REAL upstream ``generate_video``.
+
+    The request must survive the runtime's own config parsing, kwarg
+    normalization, frame/alignment validation and seed setup, then stop at the
+    first injected loader seam (``load_t5_encoder``) — before any tokenizer
+    download or model-sized allocation.
+    """
+    root = _layout(tmp_path / "checkpoint")
+    for key in _WAN_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    # The scoped clone must wrap the genuine upstream code object, and cloning
+    # must not change the public signature the adapter calls.
+    scoped = _scoped_generate_function(root, wan_generator)
+    assert scoped.__code__ is wan_generator.generate_video.__code__
+    # FunctionType clones do not carry __annotations__, so compare the
+    # parameters the adapter actually relies on — name, order, kind and
+    # default — instead of full Signature equality.
+    scoped_params = inspect.signature(scoped).parameters
+    real_params = inspect.signature(wan_generator.generate_video).parameters
+    assert [(p.name, p.kind, p.default) for p in scoped_params.values()] == [
+        (p.name, p.kind, p.default) for p in real_params.values()
+    ]
+
+    seam_calls: list[tuple[Path, object]] = []
+
+    def stop_at_t5(seam_root: Path, config: object) -> None:
+        seam_calls.append((seam_root, config))
+        raise _FirstLoaderSeamReachedError
+
+    monkeypatch.setattr(wan_diffusers, "_load_t5", stop_at_t5)
+
+    engine = WanVideoEngine(str(root))
+    output_path = tmp_path / "out.mp4"
+    with pytest.raises(_FirstLoaderSeamReachedError):
+        engine.generate(
+            prompt="integration smoke",
+            output_path=output_path,
+            width=64,
+            height=64,
+            num_frames=5,
+            seed=7,
+            image=None,
+        )
+
+    assert not output_path.exists()
+    assert len(seam_calls) == 1
+    seam_root, config = seam_calls[0]
+    # Loaders must be bound to the original checkpoint, not the temp view.
+    assert seam_root == engine.model_path
+    assert seam_root == root.resolve()
+    # The synthesized view config must materialize the pinned 1.3B preset in
+    # the runtime's own WanModelConfig, with the T5 fields _load_t5 consumes.
+    assert (config.dim, config.ffn_dim, config.num_heads, config.num_layers) == (
+        1536,
+        8960,
+        12,
+        30,
+    )
+    assert config.model_version == "2.1"
+    assert config.dual_model is False
+    assert config.patch_size == (1, 2, 2)
+    assert config.vae_stride == (4, 8, 8)
+    assert (config.t5_dim, config.t5_num_layers, config.t5_vocab_size) == (
+        4096,
+        24,
+        256384,
+    )
+
+
+class _TinyHead(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.modulation = mx.zeros((2, 3))
+        self.head = nn.Linear(2, 3)
+
+
+class _TinyPatchModel(nn.Module):
+    """Smallest parameter tree matching real ``_transformer_key`` targets."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.patch_embedding_proj = nn.Linear(12, 2)
+        self.head = _TinyHead()
+
+
+def test_load_sharded_real_safetensors_preserves_patch_layout(
+    tmp_path: Path,
+) -> None:
+    """Round-trip real ``mx.save_safetensors``/``mx.load`` through the loader.
+
+    Position-distinct values prove the patch reshape flattens each kernel in
+    [C, pt, ph, pw] order exactly as WanModel's patchifier expects — a
+    channels-last transpose would produce the right shape but wrong numbers.
+    """
+    directory = tmp_path / "transformer"
+    directory.mkdir()
+    patch_weight = mx.arange(24, dtype=mx.float32).reshape(2, 3, 1, 2, 2)
+    patch_bias = mx.array([5.0, 7.0])
+    modulation = mx.arange(100, 106, dtype=mx.float32).reshape(2, 3)
+    head_weight = mx.arange(200, 206, dtype=mx.float32).reshape(3, 2)
+    head_bias = mx.array([300.0, 301.0, 302.0])
+    mx.save_safetensors(
+        str(directory / "shard-a.safetensors"),
+        {"patch_embedding.weight": patch_weight, "patch_embedding.bias": patch_bias},
+    )
+    mx.save_safetensors(
+        str(directory / "shard-b.safetensors"),
+        {
+            "scale_shift_table": modulation,
+            "proj_out.weight": head_weight,
+            "proj_out.bias": head_bias,
+        },
+    )
+    (directory / "weights.index.json").write_text(
+        '{"weight_map": {'
+        '"patch_embedding.weight": "shard-a.safetensors", '
+        '"patch_embedding.bias": "shard-a.safetensors", '
+        '"scale_shift_table": "shard-b.safetensors", '
+        '"proj_out.weight": "shard-b.safetensors", '
+        '"proj_out.bias": "shard-b.safetensors"}}'
+    )
+
+    model = _TinyPatchModel()
+    _load_sharded(
+        model,
+        tmp_path,
+        "transformer/weights.index.json",
+        5,
+        _transformer_key,
+        reshape_patch=True,
+    )
+    mx.eval(model.parameters())
+
+    loaded_patch = model.patch_embedding_proj.weight
+    assert loaded_patch.shape == (2, 12)
+    assert loaded_patch.dtype == mx.float32
+    assert mx.array_equal(loaded_patch, mx.arange(24, dtype=mx.float32).reshape(2, 12))
+    assert mx.array_equal(model.patch_embedding_proj.bias, patch_bias)
+    assert mx.array_equal(model.head.modulation, modulation)
+    assert mx.array_equal(model.head.head.weight, head_weight)
+    assert mx.array_equal(model.head.head.bias, head_bias)

--- a/tests/test_wan_video.py
+++ b/tests/test_wan_video.py
@@ -51,6 +51,7 @@ def _reset_video_job_lifecycle():
 
 def test_wan_aliases_route_to_video_lane() -> None:
     expected = {
+        "wan2.1-t2v-1.3b-bf16": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
         "wan2.2-ti2v-5b-q8": "Anes1032/Wan2.2-TI2V-5B-mlx-q8",
         "wan2.2-ti2v-5b-bf16": "rickylin20260522/Wan2.2-TI2V-5B-mlx",
         "wan2.2-i2v-a14b-q8": "Anes1032/Wan2.2-I2V-A14B-mlx-q8",

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1226,13 +1226,24 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
             # references and tokenizer artifacts — enforce the same contract
             # here so a corrupt-but-fully-present cache goes back through
             # repair/download instead of passing the gate and failing forever
-            # at runtime. This supplements the stricter blob-containment
-            # checks above; it does not replace them.
+            # at runtime. The layout probe alone still accepts arbitrary
+            # source keys and raw non-safetensors shard bytes, so the
+            # metadata-only artifact validator additionally proves every
+            # index key maps through the production tensor mappers and every
+            # shard is a safetensors container holding its indexed tensors,
+            # without reading tensor payloads. This supplements the stricter
+            # blob-containment checks above; it does not replace them.
             from pathlib import Path
 
-            from vllm_mlx.video.wan_diffusers import is_diffusers_wan21_layout
+            from vllm_mlx.video.wan_diffusers import (
+                is_diffusers_wan21_layout,
+                validate_wan21_checkpoint_artifacts,
+            )
 
-            return is_diffusers_wan21_layout(Path(snap_dir))
+            snap_root = Path(snap_dir)
+            if not is_diffusers_wan21_layout(snap_root):
+                return False
+            return validate_wan21_checkpoint_artifacts(snap_root)
         transformer_ok = all(_on_repo(n) for n in transformer_names)
         return (
             transformer_ok

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1145,11 +1145,36 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
             # Not a registered pinned Wan checkpoint — not our lane.
             return False
 
+        # The official 1.3B Desktop checkpoint uses a sharded Diffusers layout.
+        # Its exact runtime closure is distinct from the preconverted 2.2
+        # checkpoints below and must be checked directory-by-directory.
+        if repo_id == "Wan-AI/Wan2.1-T2V-1.3B-Diffusers":
+            required_names = (
+                "transformer/diffusion_pytorch_model.safetensors.index.json",
+                "transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
+                "transformer/diffusion_pytorch_model-00002-of-00002.safetensors",
+                "text_encoder/model.safetensors.index.json",
+                "text_encoder/model-00001-of-00005.safetensors",
+                "text_encoder/model-00002-of-00005.safetensors",
+                "text_encoder/model-00003-of-00005.safetensors",
+                "text_encoder/model-00004-of-00005.safetensors",
+                "text_encoder/model-00005-of-00005.safetensors",
+                "vae/diffusion_pytorch_model.safetensors",
+                "tokenizer/special_tokens_map.json",
+                "tokenizer/spiece.model",
+                "tokenizer/tokenizer.json",
+                "tokenizer/tokenizer_config.json",
+            )
+        else:
+            required_names = ()
+
         # Family-exact transformer layout, keyed off the repo id (matches the
         # four pinned checkpoints: 5B -> single, A14B -> dual). Fail closed on
         # an unclassifiable repo rather than inferring from file presence.
         repo_lower = repo_id.casefold()
-        if "a14b" in repo_lower:
+        if required_names:
+            transformer_names = ()
+        elif "a14b" in repo_lower:
             transformer_names: tuple[str, ...] = (
                 "high_noise_model.safetensors",
                 "low_noise_model.safetensors",
@@ -1186,6 +1211,8 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
             # the same repo root but not under ``blobs``.
             return real.startswith(blobs_prefix)
 
+        if required_names:
+            return all(_on_repo(name) for name in required_names)
         transformer_ok = all(_on_repo(n) for n in transformer_names)
         return (
             transformer_ok

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1148,17 +1148,22 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
         # The official 1.3B Desktop checkpoint uses a sharded Diffusers layout.
         # Its exact runtime closure is distinct from the preconverted 2.2
         # checkpoints below and must be checked directory-by-directory.
+        required_names: tuple[str, ...]
         if repo_id == "Wan-AI/Wan2.1-T2V-1.3B-Diffusers":
             required_names = (
+                "model_index.json",
+                "transformer/config.json",
                 "transformer/diffusion_pytorch_model.safetensors.index.json",
                 "transformer/diffusion_pytorch_model-00001-of-00002.safetensors",
                 "transformer/diffusion_pytorch_model-00002-of-00002.safetensors",
+                "text_encoder/config.json",
                 "text_encoder/model.safetensors.index.json",
                 "text_encoder/model-00001-of-00005.safetensors",
                 "text_encoder/model-00002-of-00005.safetensors",
                 "text_encoder/model-00003-of-00005.safetensors",
                 "text_encoder/model-00004-of-00005.safetensors",
                 "text_encoder/model-00005-of-00005.safetensors",
+                "vae/config.json",
                 "vae/diffusion_pytorch_model.safetensors",
                 "tokenizer/special_tokens_map.json",
                 "tokenizer/spiece.model",
@@ -1172,10 +1177,11 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
         # four pinned checkpoints: 5B -> single, A14B -> dual). Fail closed on
         # an unclassifiable repo rather than inferring from file presence.
         repo_lower = repo_id.casefold()
+        transformer_names: tuple[str, ...]
         if required_names:
             transformer_names = ()
         elif "a14b" in repo_lower:
-            transformer_names: tuple[str, ...] = (
+            transformer_names = (
                 "high_noise_model.safetensors",
                 "low_noise_model.safetensors",
             )

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1218,7 +1218,21 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
             return real.startswith(blobs_prefix)
 
         if required_names:
-            return all(_on_repo(name) for name in required_names)
+            if not all(_on_repo(name) for name in required_names):
+                return False
+            # Presence + blob containment alone is not loadability. Runtime
+            # routing (``video/wan_diffusers.py``) additionally validates the
+            # exact component manifests, index cardinality/schema/safe shard
+            # references and tokenizer artifacts — enforce the same contract
+            # here so a corrupt-but-fully-present cache goes back through
+            # repair/download instead of passing the gate and failing forever
+            # at runtime. This supplements the stricter blob-containment
+            # checks above; it does not replace them.
+            from pathlib import Path
+
+            from vllm_mlx.video.wan_diffusers import is_diffusers_wan21_layout
+
+            return is_diffusers_wan21_layout(Path(snap_dir))
         transformer_ok = all(_on_repo(n) for n in transformer_names)
         return (
             transformer_ok

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1821,6 +1821,19 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 32
   },
+  "wan2.1-t2v-1.3b-bf16": {
+    "hf_path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+    "modality": "video-gen",
+    "video_modes": ["text-to-video"],
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 40
+  },
   "wan2.2-ti2v-5b-q8": {
     "hf_path": "Anes1032/Wan2.2-TI2V-5B-mlx-q8",
     "modality": "video-gen",

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -195,6 +195,7 @@
     "nightmedia/Qwen3.5-122B-A10B-Text-mxfp4-mlx": 64915343903,
     "notapalindrome/ltx23-mlx-av-q4": 22815502995,
     "MrMofer/ltx-2.5-mlx-q8": 67695751883,
+    "Wan-AI/Wan2.1-T2V-1.3B-Diffusers": 28935653511,
     "openbmb/MiniCPM5-1B-MLX": 617961816,
     "ornith-ai/Ornith-1.5-35B-A3B-MLX": 69341391877,
     "ornith-ai/Ornith-1.5-9B-MLX": 17927699601,

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -110,12 +110,14 @@ def require_video_runtime_or_exit(model_name: str | None = None) -> None:
             LTX25_RUNTIME_COMMIT,
             LTX25_RUNTIME_REPOSITORY,
             LTX25BackendError,
+            embedded_ltx25_interpreter,
             prepare_ltx25_runtime,
             resolve_ltx25_runtime,
         )
 
-        runtime = resolve_ltx25_runtime()
-        if runtime is None:
+        embedded_runtime = embedded_ltx25_interpreter()
+        runtime = None if embedded_runtime is not None else resolve_ltx25_runtime()
+        if embedded_runtime is None and runtime is None:
             missing.append(
                 "the pinned LTX-2.5 runtime "
                 f"(commit {LTX25_RUNTIME_COMMIT}; see the video generation guide)"
@@ -137,9 +139,9 @@ def require_video_runtime_or_exit(model_name: str | None = None) -> None:
                 '    RAPID_MLX_LTX25_RUNTIME="$PWD/ltx-2-mlx/.venv/bin/ltx-2-mlx" '
                 "rapid-mlx serve ltx-2.5-mlx-q8\n"
             )
-        if shutil.which("uv") is None:
+        if embedded_runtime is None and shutil.which("uv") is None:
             missing.append("uv (`brew install uv`)")
-        elif runtime is not None:
+        elif embedded_runtime is None and runtime is not None:
             try:
                 prepare_ltx25_runtime(runtime)
             except LTX25BackendError as exc:

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -20,6 +20,9 @@ from pathlib import Path
 LTX25_RUNTIME_COMMIT = "57952288076766abe27dda3a774b2c24f7346977"
 LTX25_RUNTIME_REPOSITORY = "https://github.com/MrMoferFRAN/ltx-2-mlx.git"
 LTX25_RUNTIME_VERSION = "0.14.15"
+# Stamped into each embedded distribution's .dist-info by build-sidecar.sh;
+# its content is the audited source commit the packages were built from.
+LTX25_PROVENANCE_FILE = "RAPID_LTX25_PROVENANCE"
 _DEFAULT_TIMEOUT_SECONDS = 7200
 _TERMINATE_GRACE_SECONDS = 10
 _RUNTIME_CACHE_LOCK = threading.Lock()
@@ -104,18 +107,28 @@ def embedded_ltx25_interpreter() -> str | None:
     """Return this interpreter when the audited LTX packages are embedded.
 
     Desktop cannot provision a Git checkout or an ``uv`` environment after
-    signing.  Both distributions therefore have to be present at the exact
-    version built into the sidecar before this path is considered runnable.
+    signing.  A version number alone is not proof of provenance — any
+    same-version distribution from an index would satisfy it — so the sidecar
+    build stamps each embedded distribution with the audited source commit,
+    and both stamps must match ``LTX25_RUNTIME_COMMIT`` exactly.
     """
     try:
-        versions_match = all(
-            importlib.metadata.version(distribution) == LTX25_RUNTIME_VERSION
-            for distribution in ("ltx-core-mlx", "ltx-pipelines-mlx")
-        )
+        for name in ("ltx-core-mlx", "ltx-pipelines-mlx"):
+            distribution = importlib.metadata.distribution(name)
+            if distribution.version != LTX25_RUNTIME_VERSION:
+                return None
+            provenance = distribution.read_text(LTX25_PROVENANCE_FILE)
+            if provenance is None or provenance.strip() != LTX25_RUNTIME_COMMIT:
+                return None
         cli_present = importlib.util.find_spec("ltx_pipelines_mlx.cli") is not None
-    except (ImportError, ModuleNotFoundError, importlib.metadata.PackageNotFoundError):
+    except (
+        OSError,
+        ImportError,
+        ModuleNotFoundError,
+        importlib.metadata.PackageNotFoundError,
+    ):
         return None
-    return sys.executable if versions_match and cli_present else None
+    return sys.executable if cli_present else None
 
 
 def _runtime_revision(executable: str) -> str | None:

--- a/vllm_mlx/video/ltx25.py
+++ b/vllm_mlx/video/ltx25.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
+import importlib.metadata
+import importlib.util
 import io
 import os
 import re
 import shutil
 import signal
 import subprocess
+import sys
 import tarfile
 import tempfile
 import threading
@@ -16,6 +19,7 @@ from pathlib import Path
 
 LTX25_RUNTIME_COMMIT = "57952288076766abe27dda3a774b2c24f7346977"
 LTX25_RUNTIME_REPOSITORY = "https://github.com/MrMoferFRAN/ltx-2-mlx.git"
+LTX25_RUNTIME_VERSION = "0.14.15"
 _DEFAULT_TIMEOUT_SECONDS = 7200
 _TERMINATE_GRACE_SECONDS = 10
 _RUNTIME_CACHE_LOCK = threading.Lock()
@@ -94,6 +98,24 @@ def resolve_ltx25_runtime() -> str | None:
         return None
     absolute = str(Path(executable).absolute())
     return absolute if _runtime_revision(absolute) == LTX25_RUNTIME_COMMIT else None
+
+
+def embedded_ltx25_interpreter() -> str | None:
+    """Return this interpreter when the audited LTX packages are embedded.
+
+    Desktop cannot provision a Git checkout or an ``uv`` environment after
+    signing.  Both distributions therefore have to be present at the exact
+    version built into the sidecar before this path is considered runnable.
+    """
+    try:
+        versions_match = all(
+            importlib.metadata.version(distribution) == LTX25_RUNTIME_VERSION
+            for distribution in ("ltx-core-mlx", "ltx-pipelines-mlx")
+        )
+        cli_present = importlib.util.find_spec("ltx_pipelines_mlx.cli") is not None
+    except (ImportError, ModuleNotFoundError, importlib.metadata.PackageNotFoundError):
+        return None
+    return sys.executable if versions_match and cli_present else None
 
 
 def _runtime_revision(executable: str) -> str | None:
@@ -391,8 +413,12 @@ class LTX25VideoEngine:
         conditioning_strength: float | None = None,
     ) -> None:
         timeout = _generation_timeout_seconds()
-        workspace = _prepared_ltx25_runtime()
-        if workspace is None:
+        interpreter = embedded_ltx25_interpreter()
+        environment = os.environ.copy()
+        workspace = None
+        if interpreter is None:
+            workspace = _prepared_ltx25_runtime()
+        if interpreter is None and workspace is None:
             executable = resolve_ltx25_runtime()
             if executable is None:
                 raise LTX25BackendError(
@@ -400,6 +426,10 @@ class LTX25VideoEngine:
                     "See the LTX-2.5 setup in the video generation guide."
                 )
             workspace = prepare_ltx25_runtime(executable)
+        if interpreter is None:
+            assert workspace is not None
+            interpreter = str(workspace / ".venv" / "bin" / "python")
+            environment = _isolated_python_environment()
         try:
             staging = tempfile.TemporaryDirectory(
                 prefix=f".{output_path.name}.",
@@ -412,7 +442,7 @@ class LTX25VideoEngine:
             ) from exc
 
         command = [
-            str(workspace / ".venv" / "bin" / "python"),
+            interpreter,
             "-c",
             _STDIN_PROMPT_RUNNER,
             "generate",
@@ -461,7 +491,7 @@ class LTX25VideoEngine:
                     stderr=subprocess.DEVNULL,
                     text=True,
                     start_new_session=True,
-                    env=_isolated_python_environment(),
+                    env=environment,
                 )
                 self._process = process
             process.communicate(input=prompt, timeout=timeout)

--- a/vllm_mlx/video/wan.py
+++ b/vllm_mlx/video/wan.py
@@ -12,6 +12,9 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 WAN_REVISIONS: dict[str, str] = {
+    "Wan-AI/Wan2.1-T2V-1.3B-Diffusers": (
+        "0fad780a534b6463e45facd96134c9f345acfa5b"
+    ),
     "Anes1032/Wan2.2-TI2V-5B-mlx-q8": ("9624723c94ddf509832555c45e223a035baa7d1c"),
     "rickylin20260522/Wan2.2-TI2V-5B-mlx": ("592b2473f27cd6f466cdd9f2c0f5750a77b37b59"),
     "Anes1032/Wan2.2-I2V-A14B-mlx-q8": ("633f50fc3e16e7faf76713dcf07b0bea730f02c9"),
@@ -152,6 +155,10 @@ class WanVideoEngine:
             )
 
     def _read_config(self) -> dict:
+        from .wan_diffusers import desktop_wan21_config, is_diffusers_wan21_layout
+
+        if is_diffusers_wan21_layout(self.model_path):
+            return desktop_wan21_config()
         config_path = self.model_path / "config.json"
         if not config_path.is_file():
             logger.warning(
@@ -243,7 +250,9 @@ class WanVideoEngine:
             width=width, height=height, num_frames=num_frames, image=image
         )
         try:
-            from mlx_video.generate_wan import generate_video
+            from importlib import import_module
+
+            wan_generator = import_module("mlx_video.generate_wan")
         except ImportError as exc:
             raise WanBackendError(
                 "Wan generation requires mlx-video-with-audio>=0.1.36; "
@@ -270,6 +279,8 @@ class WanVideoEngine:
             generation_kwargs["negative_prompt"] = negative_prompt
         if guidance_scale is not None:
             generation_kwargs["guide_scale"] = guidance_scale
-        generate_video(**generation_kwargs)
+        from .wan_diffusers import generate_with_runtime
+
+        generate_with_runtime(self.model_path, wan_generator, generation_kwargs)
         if not output_path.is_file() or output_path.stat().st_size == 0:
             raise WanBackendError("Wan generation completed without an MP4 output")

--- a/vllm_mlx/video/wan.py
+++ b/vllm_mlx/video/wan.py
@@ -12,9 +12,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 WAN_REVISIONS: dict[str, str] = {
-    "Wan-AI/Wan2.1-T2V-1.3B-Diffusers": (
-        "0fad780a534b6463e45facd96134c9f345acfa5b"
-    ),
+    "Wan-AI/Wan2.1-T2V-1.3B-Diffusers": ("0fad780a534b6463e45facd96134c9f345acfa5b"),
     "Anes1032/Wan2.2-TI2V-5B-mlx-q8": ("9624723c94ddf509832555c45e223a035baa7d1c"),
     "rickylin20260522/Wan2.2-TI2V-5B-mlx": ("592b2473f27cd6f466cdd9f2c0f5750a77b37b59"),
     "Anes1032/Wan2.2-I2V-A14B-mlx-q8": ("633f50fc3e16e7faf76713dcf07b0bea730f02c9"),

--- a/vllm_mlx/video/wan_diffusers.py
+++ b/vllm_mlx/video/wan_diffusers.py
@@ -25,15 +25,63 @@ _EXPECTED_TRANSFORMER_KEYS = 825
 _EXPECTED_T5_KEYS = 242
 _EXPECTED_VAE_DECODER_KEYS = 108
 
+_WAN21_COMPONENT_CONTRACTS: dict[str, dict[str, object]] = {
+    "model_index.json": {
+        "_class_name": "WanPipeline",
+        "transformer": ["diffusers", "WanTransformer3DModel"],
+        "text_encoder": ["transformers", "UMT5EncoderModel"],
+        "vae": ["diffusers", "AutoencoderKLWan"],
+    },
+    "transformer/config.json": {
+        "_class_name": "WanTransformer3DModel",
+        "patch_size": [1, 2, 2],
+        "in_channels": 16,
+        "out_channels": 16,
+        "num_attention_heads": 12,
+        "attention_head_dim": 128,
+        "num_layers": 30,
+        "ffn_dim": 8960,
+        "text_dim": 4096,
+    },
+    "text_encoder/config.json": {
+        "model_type": "umt5",
+        "vocab_size": 256384,
+        "d_model": 4096,
+        "d_ff": 10240,
+        "num_heads": 64,
+        "num_layers": 24,
+        "relative_attention_num_buckets": 32,
+    },
+    "vae/config.json": {
+        "_class_name": "AutoencoderKLWan",
+        "base_dim": 96,
+        "z_dim": 16,
+        "dim_mult": [1, 2, 4, 4],
+        "num_res_blocks": 2,
+        "temperal_downsample": [False, True, True],
+    },
+}
+
 
 def is_diffusers_wan21_layout(root: Path) -> bool:
-    return (
+    if not (
         all(
             (root / relative).is_file()
             for relative in (_TRANSFORMER_INDEX, _T5_INDEX, _VAE_FILE)
         )
         and (root / "tokenizer").is_dir()
-    )
+    ):
+        return False
+    try:
+        for relative, expected in _WAN21_COMPONENT_CONTRACTS.items():
+            payload = json.loads((root / relative).read_text())
+            if not isinstance(payload, dict) or any(
+                payload.get(key) != value for key, value in expected.items()
+            ):
+                return False
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return True
 
 
 def desktop_wan21_config() -> dict[str, object]:

--- a/vllm_mlx/video/wan_diffusers.py
+++ b/vllm_mlx/video/wan_diffusers.py
@@ -1,0 +1,384 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Read the official Wan 2.1 Diffusers layout directly with MLX.
+
+The Desktop catalog downloads one pinned repository.  This adapter maps its
+sharded safetensors into the existing ``mlx-video-with-audio`` model classes
+without PyTorch and without materializing a second converted checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from .wan import WanBackendError
+
+_TRANSFORMER_INDEX = "transformer/diffusion_pytorch_model.safetensors.index.json"
+_T5_INDEX = "text_encoder/model.safetensors.index.json"
+_VAE_FILE = "vae/diffusion_pytorch_model.safetensors"
+_EXPECTED_TRANSFORMER_KEYS = 825
+_EXPECTED_T5_KEYS = 242
+_EXPECTED_VAE_DECODER_KEYS = 108
+_PATCH_LOCK = threading.RLock()
+
+
+def is_diffusers_wan21_layout(root: Path) -> bool:
+    return (
+        all(
+            (root / relative).is_file()
+            for relative in (_TRANSFORMER_INDEX, _T5_INDEX, _VAE_FILE)
+        )
+        and (root / "tokenizer").is_dir()
+    )
+
+
+def desktop_wan21_config() -> dict[str, object]:
+    """Config fields consumed by both Rapid's guards and the MLX runtime."""
+    return {
+        "model_type": "t2v",
+        "model_version": "2.1",
+        "dim": 1536,
+        "ffn_dim": 8960,
+        "num_heads": 12,
+        "num_layers": 30,
+        "dual_model": False,
+        "boundary": 0.0,
+        "sample_shift": 5.0,
+        "sample_steps": 50,
+        "sample_guide_scale": 5.0,
+        "sample_fps": 16,
+        "max_area": 704 * 1280,
+    }
+
+
+def _transformer_key(key: str) -> str:
+    exact = {
+        "patch_embedding.weight": "patch_embedding_proj.weight",
+        "patch_embedding.bias": "patch_embedding_proj.bias",
+        "condition_embedder.time_embedder.linear_1.weight": "time_embedding_0.weight",
+        "condition_embedder.time_embedder.linear_1.bias": "time_embedding_0.bias",
+        "condition_embedder.time_embedder.linear_2.weight": "time_embedding_1.weight",
+        "condition_embedder.time_embedder.linear_2.bias": "time_embedding_1.bias",
+        "condition_embedder.text_embedder.linear_1.weight": "text_embedding_0.weight",
+        "condition_embedder.text_embedder.linear_1.bias": "text_embedding_0.bias",
+        "condition_embedder.text_embedder.linear_2.weight": "text_embedding_1.weight",
+        "condition_embedder.text_embedder.linear_2.bias": "text_embedding_1.bias",
+        "condition_embedder.time_proj.weight": "time_projection.weight",
+        "condition_embedder.time_proj.bias": "time_projection.bias",
+        "scale_shift_table": "head.modulation",
+        "proj_out.weight": "head.head.weight",
+        "proj_out.bias": "head.head.bias",
+    }
+    if key in exact:
+        return exact[key]
+    match = re.fullmatch(r"blocks\.(\d+)\.(.+)", key)
+    if match is None:
+        raise WanBackendError(f"unsupported Wan 2.1 transformer tensor {key!r}")
+    block, tail = match.groups()
+    replacements = (
+        ("attn1.to_out.0.", "self_attn.o."),
+        ("attn1.to_q.", "self_attn.q."),
+        ("attn1.to_k.", "self_attn.k."),
+        ("attn1.to_v.", "self_attn.v."),
+        ("attn1.norm_q.", "self_attn.norm_q."),
+        ("attn1.norm_k.", "self_attn.norm_k."),
+        ("attn2.to_out.0.", "cross_attn.o."),
+        ("attn2.to_q.", "cross_attn.q."),
+        ("attn2.to_k.", "cross_attn.k."),
+        ("attn2.to_v.", "cross_attn.v."),
+        ("attn2.norm_q.", "cross_attn.norm_q."),
+        ("attn2.norm_k.", "cross_attn.norm_k."),
+        ("ffn.net.0.proj.", "ffn.fc1."),
+        ("ffn.net.2.", "ffn.fc2."),
+        ("norm2.", "norm3."),
+    )
+    if tail == "scale_shift_table":
+        tail = "modulation"
+    else:
+        for source, target in replacements:
+            if tail.startswith(source):
+                tail = target + tail[len(source) :]
+                break
+        else:
+            raise WanBackendError(f"unsupported Wan 2.1 transformer tensor {key!r}")
+    return f"blocks.{block}.{tail}"
+
+
+def _t5_key(key: str) -> str:
+    if key == "shared.weight":
+        return "token_embedding.weight"
+    if key == "encoder.final_layer_norm.weight":
+        return "norm.weight"
+    match = re.fullmatch(r"encoder\.block\.(\d+)\.layer\.([01])\.(.+)", key)
+    if match is None:
+        raise WanBackendError(f"unsupported Wan 2.1 text encoder tensor {key!r}")
+    block, layer, tail = match.groups()
+    mapping = {
+        ("0", "layer_norm.weight"): "norm1.weight",
+        ("0", "SelfAttention.q.weight"): "attn.q.weight",
+        ("0", "SelfAttention.k.weight"): "attn.k.weight",
+        ("0", "SelfAttention.v.weight"): "attn.v.weight",
+        ("0", "SelfAttention.o.weight"): "attn.o.weight",
+        (
+            "0",
+            "SelfAttention.relative_attention_bias.weight",
+        ): "pos_embedding.embedding.weight",
+        ("1", "layer_norm.weight"): "norm2.weight",
+        ("1", "DenseReluDense.wi_0.weight"): "ffn.gate_proj.weight",
+        ("1", "DenseReluDense.wi_1.weight"): "ffn.fc1.weight",
+        ("1", "DenseReluDense.wo.weight"): "ffn.fc2.weight",
+    }
+    mapped = mapping.get((layer, tail))
+    if mapped is None:
+        raise WanBackendError(f"unsupported Wan 2.1 text encoder tensor {key!r}")
+    return f"blocks.{block}.{mapped}"
+
+
+def _vae_decoder_key(key: str) -> str | None:
+    exact = {
+        "post_quant_conv.weight": "conv2.weight",
+        "post_quant_conv.bias": "conv2.bias",
+        "decoder.conv_in.weight": "decoder.conv1.weight",
+        "decoder.conv_in.bias": "decoder.conv1.bias",
+        "decoder.norm_out.gamma": "decoder.head.0.gamma",
+        "decoder.conv_out.weight": "decoder.head.2.weight",
+        "decoder.conv_out.bias": "decoder.head.2.bias",
+    }
+    if key in exact:
+        return exact[key]
+    if not key.startswith("decoder."):
+        return None
+    match = re.fullmatch(r"decoder\.mid_block\.resnets\.(\d+)\.(.+)", key)
+    if match:
+        block, tail = match.groups()
+        residual = {
+            "norm1.gamma": "residual.0.gamma",
+            "conv1.weight": "residual.2.weight",
+            "conv1.bias": "residual.2.bias",
+            "norm2.gamma": "residual.3.gamma",
+            "conv2.weight": "residual.6.weight",
+            "conv2.bias": "residual.6.bias",
+        }.get(tail)
+        if residual:
+            return f"decoder.middle.{int(block) * 2}.{residual}"
+    match = re.fullmatch(r"decoder\.mid_block\.attentions\.0\.(.+)", key)
+    if match:
+        return "decoder.middle.1." + match.group(1)
+    match = re.fullmatch(r"decoder\.up_blocks\.(\d+)\.resnets\.(\d+)\.(.+)", key)
+    if match:
+        block, resnet, tail = match.groups()
+        old_block = int(block) * 4 + int(resnet)
+        residual = {
+            "norm1.gamma": "residual.0.gamma",
+            "conv1.weight": "residual.2.weight",
+            "conv1.bias": "residual.2.bias",
+            "norm2.gamma": "residual.3.gamma",
+            "conv2.weight": "residual.6.weight",
+            "conv2.bias": "residual.6.bias",
+            "conv_shortcut.weight": "shortcut.weight",
+            "conv_shortcut.bias": "shortcut.bias",
+        }.get(tail)
+        if residual:
+            return f"decoder.upsamples.{old_block}.{residual}"
+    match = re.fullmatch(r"decoder\.up_blocks\.(\d+)\.upsamplers\.0\.(.+)", key)
+    if match and int(match.group(1)) < 3:
+        return f"decoder.upsamples.{int(match.group(1)) * 4 + 3}.{match.group(2)}"
+    raise WanBackendError(f"unsupported Wan 2.1 VAE decoder tensor {key!r}")
+
+
+def _read_index(
+    root: Path, relative: str, expected: int, mapper: Callable[[str], str]
+) -> dict[str, list[tuple[str, str]]]:
+    try:
+        payload = json.loads((root / relative).read_text())
+        weight_map = payload["weight_map"]
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+    ) as exc:
+        raise WanBackendError("the Wan 2.1 safetensors index is unreadable") from exc
+    if not isinstance(weight_map, dict) or len(weight_map) != expected:
+        raise WanBackendError(
+            "the Wan 2.1 safetensors index has an unexpected tensor set"
+        )
+    grouped: dict[str, list[tuple[str, str]]] = {}
+    mapped_names: set[str] = set()
+    for source, filename in weight_map.items():
+        if (
+            not isinstance(source, str)
+            or not isinstance(filename, str)
+            or Path(filename).name != filename
+        ):
+            raise WanBackendError(
+                "the Wan 2.1 safetensors index contains an unsafe entry"
+            )
+        target = mapper(source)
+        if target in mapped_names:
+            raise WanBackendError(
+                "the Wan 2.1 safetensors index maps duplicate tensors"
+            )
+        mapped_names.add(target)
+        grouped.setdefault(filename, []).append((source, target))
+    return grouped
+
+
+def _load_sharded(
+    model,
+    root: Path,
+    relative: str,
+    expected: int,
+    mapper: Callable[[str], str],
+    *,
+    dtype=None,
+    reshape_patch: bool = False,
+) -> None:
+    import mlx.core as mx
+
+    directory = (root / relative).parent
+    for filename, names in _read_index(root, relative, expected, mapper).items():
+        path = directory / filename
+        if not path.is_file():
+            raise WanBackendError(f"the Wan 2.1 checkpoint is missing {filename!r}")
+        source_weights = mx.load(str(path), return_metadata=False)
+        weights = []
+        for source, target in names:
+            if source not in source_weights:
+                raise WanBackendError(f"the Wan 2.1 shard is missing tensor {source!r}")
+            value = source_weights[source]
+            if reshape_patch and source == "patch_embedding.weight":
+                value = value.reshape(value.shape[0], -1)
+            if dtype is not None:
+                value = value.astype(dtype)
+            weights.append((target, value))
+        model.load_weights(weights, strict=False)
+        del source_weights, weights
+
+
+def _load_transformer(root: Path, config, quantization=None, loras=None):
+    if quantization or loras:
+        raise WanBackendError(
+            "Wan 2.1 Desktop weights do not support quantization or LoRA overlays"
+        )
+    import mlx.core as mx
+    from mlx_video.models.wan.model import WanModel
+
+    model = WanModel(config)
+    _load_sharded(
+        model,
+        root,
+        _TRANSFORMER_INDEX,
+        _EXPECTED_TRANSFORMER_KEYS,
+        _transformer_key,
+        reshape_patch=True,
+    )
+    mx.eval(model.parameters())
+    return model
+
+
+def _load_t5(root: Path, config):
+    import mlx.core as mx
+    from mlx_video.models.wan.text_encoder import T5Encoder
+
+    encoder = T5Encoder(
+        vocab_size=config.t5_vocab_size,
+        dim=config.t5_dim,
+        dim_attn=config.t5_dim_attn,
+        dim_ffn=config.t5_dim_ffn,
+        num_heads=config.t5_num_heads,
+        num_layers=config.t5_num_layers,
+        num_buckets=config.t5_num_buckets,
+        shared_pos=False,
+    )
+    _load_sharded(
+        encoder, root, _T5_INDEX, _EXPECTED_T5_KEYS, _t5_key, dtype=mx.float32
+    )
+    mx.eval(encoder.parameters())
+    return encoder
+
+
+def _load_vae(root: Path, config=None):
+    import mlx.core as mx
+    from mlx_video.models.wan.vae import WanVAE
+
+    source = mx.load(str(root / _VAE_FILE), return_metadata=False)
+    weights = []
+    for key, value in source.items():
+        target = _vae_decoder_key(key)
+        if target is None:
+            continue
+        if "weight" in key and value.ndim == 5:
+            value = mx.transpose(value, (0, 2, 3, 4, 1))
+        elif "weight" in key and value.ndim == 4:
+            value = mx.transpose(value, (0, 2, 3, 1))
+        weights.append((target, value.astype(mx.float32)))
+    if len(weights) != _EXPECTED_VAE_DECODER_KEYS or len(
+        {key for key, _ in weights}
+    ) != len(weights):
+        raise WanBackendError("the Wan 2.1 VAE has an unexpected decoder tensor set")
+    vae = WanVAE(z_dim=16)
+    vae.load_weights(weights, strict=False)
+    mx.eval(vae.parameters())
+    return vae
+
+
+@contextmanager
+def patched_diffusers_runtime(root: Path) -> Iterator[Path]:
+    """Patch the pinned generator's loader seams for one model-dedicated job."""
+    import mlx_video.generate_wan as generator
+    import transformers
+
+    if not is_diffusers_wan21_layout(root):
+        raise WanBackendError("the Wan 2.1 checkpoint layout is incomplete")
+    temporary = tempfile.TemporaryDirectory(prefix="rapidmlx-wan21-view-")
+    view = Path(temporary.name)
+    (view / "config.json").write_text(json.dumps(desktop_wan21_config()))
+    original = (
+        generator.load_wan_model,
+        generator.load_t5_encoder,
+        generator.load_vae_decoder,
+        transformers.AutoTokenizer,
+    )
+    tokenizer_class = transformers.AutoTokenizer
+
+    class LocalTokenizer:
+        @classmethod
+        def from_pretrained(cls, _model_name, *args, **kwargs):
+            kwargs["local_files_only"] = True
+            return tokenizer_class.from_pretrained(root / "tokenizer", *args, **kwargs)
+
+    with _PATCH_LOCK:
+        generator.load_wan_model = lambda _path, config, quantization=None, loras=None: (
+            _load_transformer(root, config, quantization, loras)
+        )
+        generator.load_t5_encoder = lambda _path, config: _load_t5(root, config)
+        generator.load_vae_decoder = lambda _path, config=None: _load_vae(root, config)
+        transformers.AutoTokenizer = LocalTokenizer
+        try:
+            yield view
+        finally:
+            (
+                generator.load_wan_model,
+                generator.load_t5_encoder,
+                generator.load_vae_decoder,
+                transformers.AutoTokenizer,
+            ) = original
+            temporary.cleanup()
+
+
+def generate_with_runtime(root: Path, generator, generation_kwargs: dict) -> None:
+    """Generate while preventing another Wan engine from seeing patched globals."""
+    with _PATCH_LOCK:
+        if is_diffusers_wan21_layout(root):
+            with patched_diffusers_runtime(root) as model_view:
+                generation_kwargs["model_dir"] = str(model_view)
+                generator.generate_video(**generation_kwargs)
+        else:
+            generator.generate_video(**generation_kwargs)

--- a/vllm_mlx/video/wan_diffusers.py
+++ b/vllm_mlx/video/wan_diffusers.py
@@ -360,6 +360,64 @@ def _read_index(
     return grouped
 
 
+def _safetensors_tensor_names(path: Path) -> frozenset[str]:
+    """Tensor names from a safetensors container, parsing metadata only.
+
+    ``safe_open`` validates the header without materializing tensor payloads,
+    so the probe stays bounded even for multi-GB shards. A malformed header,
+    an unreadable file, or a non-safetensors byte stream fails closed.
+    """
+    from safetensors import SafetensorError, safe_open
+
+    try:
+        with safe_open(str(path), framework="numpy") as container:
+            return frozenset(container.keys())
+    except (OSError, SafetensorError) as exc:
+        raise WanBackendError(
+            f"the Wan 2.1 checkpoint file {path.name!r} is not a readable "
+            "safetensors container"
+        ) from exc
+
+
+def validate_wan21_checkpoint_artifacts(root: Path) -> bool:
+    """Metadata-only proof that the pinned checkpoint artifacts are loadable.
+
+    The layout probe (:func:`is_diffusers_wan21_layout`) checks component
+    manifests, index cardinality and file presence, but accepts arbitrary
+    source keys and raw non-safetensors shard bytes; the download gate would
+    then skip repair and generation would fail on :func:`_read_index` or
+    ``mx.load``. This validator closes that gap while staying bounded: every
+    index source key must map through the production mappers (duplicate
+    targets rejected inside :func:`_read_index`), every indexed tensor must
+    live in the shard its index points at, every referenced shard and the VAE
+    file must parse as safetensors containers, and the VAE header must carry
+    exactly the pinned uniquely-mapped decoder tensor set. No model is
+    instantiated and no tensor payload is ever read.
+    """
+    try:
+        for relative, expected, mapper in (
+            (_TRANSFORMER_INDEX, _EXPECTED_TRANSFORMER_KEYS, _transformer_key),
+            (_T5_INDEX, _EXPECTED_T5_KEYS, _t5_key),
+        ):
+            directory = (root / relative).parent
+            grouped = _read_index(root, relative, expected, mapper)
+            for filename, names in grouped.items():
+                present = _safetensors_tensor_names(directory / filename)
+                if any(source not in present for source, _ in names):
+                    return False
+        decoder_targets: set[str] = set()
+        for source in _safetensors_tensor_names(root / _VAE_FILE):
+            target = _vae_decoder_key(source)
+            if target is None:
+                continue
+            if target in decoder_targets:
+                return False
+            decoder_targets.add(target)
+        return len(decoder_targets) == _EXPECTED_VAE_DECODER_KEYS
+    except WanBackendError:
+        return False
+
+
 def _validate_target_parameters(
     model, mapped_names: set[str], *, ignored: frozenset[str] = frozenset()
 ) -> None:

--- a/vllm_mlx/video/wan_diffusers.py
+++ b/vllm_mlx/video/wan_diffusers.py
@@ -96,38 +96,75 @@ _TOKENIZER_FILES = (
 )
 
 
+def _is_regular_nonempty_file(path: Path) -> bool:
+    """True only for an existing regular file holding at least one byte."""
+    return path.is_file() and path.stat().st_size > 0
+
+
 def is_diffusers_wan21_layout(root: Path) -> bool:
     """Decide routing for the pinned Desktop layout, rejecting malformed trees.
 
     Routing must fail closed: a missing or empty tokenizer artifact, a
     malformed or wrong-cardinality safetensors index, an unsafe shard name, or
-    a missing referenced shard all mean this is not the audited layout. The
-    tokenizer artifacts mirror the download gate's pin for
-    Wan-AI/Wan2.1-T2V-1.3B-Diffusers.
+    a missing, irregular, or zero-byte weight file (the VAE or any referenced
+    shard) all mean this is not the audited layout. The tokenizer artifacts
+    mirror the download gate's pin for Wan-AI/Wan2.1-T2V-1.3B-Diffusers.
     """
     try:
-        if not (root / _VAE_FILE).is_file():
+        if not _is_regular_nonempty_file(root / _VAE_FILE):
             return False
         for relative in _TOKENIZER_FILES:
-            artifact = root / relative
-            if not artifact.is_file() or artifact.stat().st_size == 0:
+            if not _is_regular_nonempty_file(root / relative):
                 return False
         for relative, expected in (
             (_TRANSFORMER_INDEX, _EXPECTED_TRANSFORMER_KEYS),
             (_T5_INDEX, _EXPECTED_T5_KEYS),
         ):
             shards = _index_shards(root, relative, expected)
-            if shards is None or not all(shard.is_file() for shard in shards):
+            if shards is None or not all(
+                _is_regular_nonempty_file(shard) for shard in shards
+            ):
                 return False
-        for relative, expected in _WAN21_COMPONENT_CONTRACTS.items():
+        for relative, expected_contract in _WAN21_COMPONENT_CONTRACTS.items():
             payload = json.loads((root / relative).read_text())
             if not isinstance(payload, dict) or any(
-                payload.get(key) != value for key, value in expected.items()
+                payload.get(key) != value for key, value in expected_contract.items()
             ):
                 return False
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return False
     return True
+
+
+# Wan-specific pipeline/component classes pinned by the download gate; the
+# generic UMT5 text encoder is deliberately excluded so a plain T5 checkpoint
+# is never mistaken for the Wan 2.1 layout.
+_WAN21_IDENTITY_MARKERS: tuple[tuple[str, object], ...] = tuple(
+    (relative, contract["_class_name"])
+    for relative, contract in _WAN21_COMPONENT_CONTRACTS.items()
+    if "_class_name" in contract
+)
+
+
+def _identifies_as_diffusers_wan21(root: Path) -> bool:
+    """Recognize a tree that claims to be the pinned Wan 2.1 Diffusers layout.
+
+    Deliberately independent of ``is_diffusers_wan21_layout``: a damaged copy
+    of the audited checkpoint must be recognized so generation raises instead
+    of reaching the incompatible preconverted-generator path. Identity requires
+    a positively readable pinned component class; a marker that is missing,
+    malformed, or lost to a concurrent delete simply does not match, so
+    arbitrary directories and true preconverted checkpoints keep their
+    existing routing.
+    """
+    for relative, class_name in _WAN21_IDENTITY_MARKERS:
+        try:
+            payload = json.loads((root / relative).read_text())
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict) and payload.get("_class_name") == class_name:
+            return True
+    return False
 
 
 def desktop_wan21_config() -> dict[str, object]:
@@ -470,7 +507,9 @@ def _scoped_generate_function(root: Path, generator) -> Callable:
         imported = original_import(name, globals, locals, fromlist, level)
         if name == "transformers" and "AutoTokenizer" in fromlist:
             proxy = ModuleType("transformers")
-            proxy.AutoTokenizer = LocalTokenizer
+            # Module attributes live in __dict__; mypy's lvalue lookup does
+            # not consult ModuleType.__getattr__, so write there directly.
+            proxy.__dict__["AutoTokenizer"] = LocalTokenizer
             return proxy
         return imported
 
@@ -518,5 +557,7 @@ def generate_with_runtime(root: Path, generator, generation_kwargs: dict) -> Non
             # The temporary view must not leak into the caller's mapping:
             # replace model_dir on a copy only.
             scoped_generate(**{**generation_kwargs, "model_dir": str(model_view)})
-    else:
-        generator.generate_video(**generation_kwargs)
+        return
+    if _identifies_as_diffusers_wan21(root):
+        raise WanBackendError("the Wan 2.1 checkpoint layout is incomplete")
+    generator.generate_video(**generation_kwargs)

--- a/vllm_mlx/video/wan_diffusers.py
+++ b/vllm_mlx/video/wan_diffusers.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 import json
 import re
 import tempfile
-import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from types import FunctionType, ModuleType
 
 from .wan import WanBackendError
 
@@ -24,7 +24,6 @@ _VAE_FILE = "vae/diffusion_pytorch_model.safetensors"
 _EXPECTED_TRANSFORMER_KEYS = 825
 _EXPECTED_T5_KEYS = 242
 _EXPECTED_VAE_DECODER_KEYS = 108
-_PATCH_LOCK = threading.RLock()
 
 
 def is_diffusers_wan21_layout(root: Path) -> bool:
@@ -230,6 +229,22 @@ def _read_index(
     return grouped
 
 
+def _validate_target_parameters(
+    model, mapped_names: set[str], *, ignored: frozenset[str] = frozenset()
+) -> None:
+    """Fail before loading if the pinned mapping and runtime model diverge."""
+    from mlx.utils import tree_flatten
+
+    model_names = {name for name, _ in tree_flatten(model.parameters())} - ignored
+    if mapped_names != model_names:
+        missing = sorted(model_names - mapped_names)
+        unexpected = sorted(mapped_names - model_names)
+        raise WanBackendError(
+            "the Wan 2.1 tensor mapping does not match the bundled MLX model "
+            f"(missing={missing[:3]!r}, unexpected={unexpected[:3]!r})"
+        )
+
+
 def _load_sharded(
     model,
     root: Path,
@@ -239,11 +254,18 @@ def _load_sharded(
     *,
     dtype=None,
     reshape_patch: bool = False,
+    ignored_model_parameters: frozenset[str] = frozenset(),
 ) -> None:
     import mlx.core as mx
 
     directory = (root / relative).parent
-    for filename, names in _read_index(root, relative, expected, mapper).items():
+    grouped = _read_index(root, relative, expected, mapper)
+    _validate_target_parameters(
+        model,
+        {target for names in grouped.values() for _, target in names},
+        ignored=ignored_model_parameters,
+    )
+    for filename, names in grouped.items():
         path = directory / filename
         if not path.is_file():
             raise WanBackendError(f"the Wan 2.1 checkpoint is missing {filename!r}")
@@ -278,6 +300,7 @@ def _load_transformer(root: Path, config, quantization=None, loras=None):
         _EXPECTED_TRANSFORMER_KEYS,
         _transformer_key,
         reshape_patch=True,
+        ignored_model_parameters=frozenset({"freqs"}),
     )
     mx.eval(model.parameters())
     return model
@@ -324,61 +347,81 @@ def _load_vae(root: Path, config=None):
     ) != len(weights):
         raise WanBackendError("the Wan 2.1 VAE has an unexpected decoder tensor set")
     vae = WanVAE(z_dim=16)
+    _validate_target_parameters(
+        vae,
+        {key for key, _ in weights},
+        ignored=frozenset({"mean", "std", "inv_std"}),
+    )
     vae.load_weights(weights, strict=False)
     mx.eval(vae.parameters())
     return vae
 
 
-@contextmanager
-def patched_diffusers_runtime(root: Path) -> Iterator[Path]:
-    """Patch the pinned generator's loader seams for one model-dedicated job."""
-    import mlx_video.generate_wan as generator
-    import transformers
-
+def _scoped_generate_function(root: Path, generator) -> Callable:
+    """Clone the generator with request-local loaders and tokenizer imports."""
     if not is_diffusers_wan21_layout(root):
         raise WanBackendError("the Wan 2.1 checkpoint layout is incomplete")
-    temporary = tempfile.TemporaryDirectory(prefix="rapidmlx-wan21-view-")
-    view = Path(temporary.name)
-    (view / "config.json").write_text(json.dumps(desktop_wan21_config()))
-    original = (
-        generator.load_wan_model,
-        generator.load_t5_encoder,
-        generator.load_vae_decoder,
-        transformers.AutoTokenizer,
-    )
-    tokenizer_class = transformers.AutoTokenizer
+    original = generator.generate_video
+    original_import = original.__builtins__["__import__"]
 
     class LocalTokenizer:
         @classmethod
         def from_pretrained(cls, _model_name, *args, **kwargs):
-            kwargs["local_files_only"] = True
-            return tokenizer_class.from_pretrained(root / "tokenizer", *args, **kwargs)
+            from transformers import AutoTokenizer
 
-    with _PATCH_LOCK:
-        generator.load_wan_model = lambda _path, config, quantization=None, loras=None: (
-            _load_transformer(root, config, quantization, loras)
-        )
-        generator.load_t5_encoder = lambda _path, config: _load_t5(root, config)
-        generator.load_vae_decoder = lambda _path, config=None: _load_vae(root, config)
-        transformers.AutoTokenizer = LocalTokenizer
-        try:
-            yield view
-        finally:
-            (
-                generator.load_wan_model,
-                generator.load_t5_encoder,
-                generator.load_vae_decoder,
-                transformers.AutoTokenizer,
-            ) = original
-            temporary.cleanup()
+            kwargs["local_files_only"] = True
+            return AutoTokenizer.from_pretrained(root / "tokenizer", *args, **kwargs)
+
+    def scoped_import(name, globals=None, locals=None, fromlist=(), level=0):
+        imported = original_import(name, globals, locals, fromlist, level)
+        if name == "transformers" and "AutoTokenizer" in fromlist:
+            proxy = ModuleType("transformers")
+            proxy.AutoTokenizer = LocalTokenizer
+            return proxy
+        return imported
+
+    builtins = dict(original.__builtins__)
+    builtins["__import__"] = scoped_import
+    namespace = dict(original.__globals__)
+    namespace.update(
+        {
+            "__builtins__": builtins,
+            "load_wan_model": lambda _path, config, quantization=None, loras=None: (
+                _load_transformer(root, config, quantization, loras)
+            ),
+            "load_t5_encoder": lambda _path, config: _load_t5(root, config),
+            "load_vae_decoder": lambda _path, config=None: _load_vae(root, config),
+        }
+    )
+    scoped = FunctionType(
+        original.__code__,
+        namespace,
+        original.__name__,
+        original.__defaults__,
+        original.__closure__,
+    )
+    scoped.__kwdefaults__ = original.__kwdefaults__
+    return scoped
+
+
+@contextmanager
+def diffusers_runtime(root: Path, generator) -> Iterator[tuple[Path, Callable]]:
+    """Create a temporary converted-layout view and isolated generator."""
+    scoped_generate = _scoped_generate_function(root, generator)
+    temporary = tempfile.TemporaryDirectory(prefix="rapidmlx-wan21-view-")
+    view = Path(temporary.name)
+    (view / "config.json").write_text(json.dumps(desktop_wan21_config()))
+    try:
+        yield view, scoped_generate
+    finally:
+        temporary.cleanup()
 
 
 def generate_with_runtime(root: Path, generator, generation_kwargs: dict) -> None:
-    """Generate while preventing another Wan engine from seeing patched globals."""
-    with _PATCH_LOCK:
-        if is_diffusers_wan21_layout(root):
-            with patched_diffusers_runtime(root) as model_view:
-                generation_kwargs["model_dir"] = str(model_view)
-                generator.generate_video(**generation_kwargs)
-        else:
-            generator.generate_video(**generation_kwargs)
+    """Generate through request-local loaders for the official layout."""
+    if is_diffusers_wan21_layout(root):
+        with diffusers_runtime(root, generator) as (model_view, scoped_generate):
+            generation_kwargs["model_dir"] = str(model_view)
+            scoped_generate(**generation_kwargs)
+    else:
+        generator.generate_video(**generation_kwargs)

--- a/vllm_mlx/video/wan_diffusers.py
+++ b/vllm_mlx/video/wan_diffusers.py
@@ -63,16 +63,62 @@ _WAN21_COMPONENT_CONTRACTS: dict[str, dict[str, object]] = {
 }
 
 
-def is_diffusers_wan21_layout(root: Path) -> bool:
-    if not (
-        all(
-            (root / relative).is_file()
-            for relative in (_TRANSFORMER_INDEX, _T5_INDEX, _VAE_FILE)
-        )
-        and (root / "tokenizer").is_dir()
-    ):
-        return False
+def _index_shards(root: Path, relative: str, expected: int) -> set[Path] | None:
+    """Return the shard paths an index references, or None when malformed."""
     try:
+        payload = json.loads((root / relative).read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, dict) or len(weight_map) != expected:
+        return None
+    directory = (root / relative).parent
+    shards: set[Path] = set()
+    for source, filename in weight_map.items():
+        if (
+            not isinstance(source, str)
+            or not isinstance(filename, str)
+            or not filename
+            or Path(filename).name != filename
+        ):
+            return None
+        shards.add(directory / filename)
+    return shards
+
+
+_TOKENIZER_FILES = (
+    "tokenizer/special_tokens_map.json",
+    "tokenizer/spiece.model",
+    "tokenizer/tokenizer.json",
+    "tokenizer/tokenizer_config.json",
+)
+
+
+def is_diffusers_wan21_layout(root: Path) -> bool:
+    """Decide routing for the pinned Desktop layout, rejecting malformed trees.
+
+    Routing must fail closed: a missing or empty tokenizer artifact, a
+    malformed or wrong-cardinality safetensors index, an unsafe shard name, or
+    a missing referenced shard all mean this is not the audited layout. The
+    tokenizer artifacts mirror the download gate's pin for
+    Wan-AI/Wan2.1-T2V-1.3B-Diffusers.
+    """
+    try:
+        if not (root / _VAE_FILE).is_file():
+            return False
+        for relative in _TOKENIZER_FILES:
+            artifact = root / relative
+            if not artifact.is_file() or artifact.stat().st_size == 0:
+                return False
+        for relative, expected in (
+            (_TRANSFORMER_INDEX, _EXPECTED_TRANSFORMER_KEYS),
+            (_T5_INDEX, _EXPECTED_T5_KEYS),
+        ):
+            shards = _index_shards(root, relative, expected)
+            if shards is None or not all(shard.is_file() for shard in shards):
+                return False
         for relative, expected in _WAN21_COMPONENT_CONTRACTS.items():
             payload = json.loads((root / relative).read_text())
             if not isinstance(payload, dict) or any(
@@ -469,7 +515,8 @@ def generate_with_runtime(root: Path, generator, generation_kwargs: dict) -> Non
     """Generate through request-local loaders for the official layout."""
     if is_diffusers_wan21_layout(root):
         with diffusers_runtime(root, generator) as (model_view, scoped_generate):
-            generation_kwargs["model_dir"] = str(model_view)
-            scoped_generate(**generation_kwargs)
+            # The temporary view must not leak into the caller's mapping:
+            # replace model_dir on a copy only.
+            scoped_generate(**{**generation_kwargs, "model_dir": str(model_view)})
     else:
         generator.generate_video(**generation_kwargs)


### PR DESCRIPTION
## Why

The experimental Desktop Video workspace already supports local generation, but these three requested families were either hidden from Desktop or lacked a complete signed-app runtime. This PR makes each advertised entry runnable without post-signing package provisioning, PyTorch, OpenCV, or a duplicate converted checkpoint.

Supported cohort:

- LTX 2.5 q8 (text/image to video)
- Wan 2.1 1.3B bf16 (text to video)
- CogVideoX-Fun 5B q4 (text to video)

## What changed

- Adds the three exact aliases to Desktop's fail-closed packaged-video catalog.
- Embeds the exact audited LTX 2.5 pure-Python runtime into the signed sidecar, with source/license staging and exact-version smoke checks.
- Reads the pinned Wan 2.1 Diffusers safetensor layout directly through the existing MLX Wan runtime, avoiding PyTorch and a second converted 29 GB checkpoint.
- Verifies the complete CogVideoX-Fun import closure in the isolated sidecar smoke.
- Adds pinned-revision cache completeness, capability, memory-floor, mapping-drift, runtime-lifecycle, and packaging contracts.

## Scope

This PR only expands the runnable model cohort for the existing experimental Video surface. It does not redesign the UI, change the asynchronous job API, alter scheduler/request semantics, or add other video families.

Wan 2.1 is gated to Macs with at least 40 GB unified memory because its text encoder is loaded in float32; the existing experimental feature gate and explicit model-start action remain unchanged.

## Verification

- 278 focused Python video/catalog/cache tests passed.
- 14 focused Swift Video foundation and sidecar contract tests passed.
- Full isolated sidecar build and smoke passed, including real MP4 encode/crop; 173 Mach-Os matched the existing baseline; bundle size 481 MB raw / 161 MB compressed.
- `swift build -c release` passed.
- Video surface light/dark/compact dev snapshots rendered successfully.
- `ruff`, `bash -n`, JSON validation, and `git diff --check` passed.

Full test collection from the ambient developer Python lacked separate optional integration/property dependencies; the repository validation environment will install its canonical test closure.
