### PR TITLE
docs: qualify headless macOS service deployment

### DIFF
--- a/docs/engineering/operations/2026-09-02-headless-launchdaemon-qualification.md
+++ b/docs/engineering/operations/2026-09-02-headless-launchdaemon-qualification.md
@@ -1,0 +1,188 @@
+# Headless LaunchDaemon qualification — 2026-09-02
+
+## Goal
+
+Qualify the manual, phase-one deployment of `rapid-mlx serve` as a macOS
+LaunchDaemon before publishing an operator guide or designing a
+`rapid-mlx service` command. The target behavior is system boot, no GUI login,
+crash recovery, explicit runtime ownership, and a safe update runbook.
+
+## Initial compatibility host
+
+- Host: `Raullen's Mac mini` (SSH alias `mac-mini`)
+- Hardware: Apple M2 Pro, 32 GiB unified memory
+- OS: macOS 26.5.2
+- Disk free at admission: 65 GiB
+- Auto-login: off or unset
+- FileVault: **on**
+- Idle sleep: disabled
+- Automatic restart after power loss: disabled at admission
+- Existing unrelated workloads were left running throughout qualification.
+
+The host's SSH account could not run `sudo` non-interactively, so it was used
+only for a user-domain compatibility rehearsal. No credentials were requested
+or handled by the test operator.
+
+## Baseline runtime
+
+The existing curl-installer environment was:
+
+- Rapid-MLX 0.12.15 at `~/.rapid-mlx`
+- Python 3.13.2 arm64
+- mlx 0.32.1
+- mlx-lm 0.31.3
+- mlx-vlm 0.6.15
+- transformers 5.15.1
+- empty Hugging Face model cache
+
+The pre-upgrade package set was captured at
+`/tmp/rapid-mlx-before-headless-test.txt` on the test host.
+
+## Upgrade observations
+
+Installing current `main` (commit `65a0fbc6`, package version 0.13.3) over the
+compatible venv preserved both `mlx-vlm 0.6.15` and `transformers 5.15.1`.
+That proves a base in-place upgrade does not remove arbitrary extras; it does
+**not** make those retained versions compatible with the new release.
+
+Reasserting the declared vision extra upgraded mlx-vlm to the required 0.6.17:
+
+```bash
+~/.rapid-mlx/bin/python -m pip install --upgrade '/tmp/rapid-mlx-headless-src[vision]'
+```
+
+This is why the public runbook records and explicitly reinstalls the
+appliance's extras after every update.
+
+Doctor from this exact `main` build correctly identified the incompatible
+mlx-vlm version before the extra was reapplied. It also falsely reported the
+importable core packages (`mlx`, `mlx-lm`, `transformers`, `fastapi`, and
+`uvicorn`) as broken. Direct checks under the same
+`~/.rapid-mlx/bin/python` imported those packages and resolved their metadata.
+The false-negative Doctor result is a release blocker for claiming Doctor as a
+headless post-update gate; it must be resolved or explicitly accounted for
+before this guide is published as fully qualified.
+
+## Non-privileged launchd qualification
+
+Before requesting a privileged install, the same plist shape was loaded into
+the logged-in user's `gui/<uid>` domain. `UserName` is ignored in that domain;
+the purpose was to validate absolute paths, explicit HOME, cache resolution,
+logs, throttling, KeepAlive, model loading, and API probes without touching the
+system domain.
+
+Configuration:
+
+- Model: `bonsai-1.7b-2bit` (approximately 473 MiB)
+- Served model name: `default`
+- Address: `127.0.0.1:18000`
+- Separate stdout/stderr logs under `~/Library/Logs/Rapid-MLX`
+- KeepAlive: unconditional
+- ThrottleInterval: 10 seconds
+
+The first generated test plist accidentally retained the template executable
+as a second argument. The process exited with an argparse error and launchd
+retried at the configured ten-second interval. This confirmed throttling and
+also established that generated arrays must be inspected with `plutil` before
+bootstrap. The corrected array was:
+
+```text
+rapid-mlx serve bonsai-1.7b-2bit --served-model-name default \
+  --host 127.0.0.1 --port 18000 --max-num-seqs 4
+```
+
+After correction, all four smoke stages passed:
+
+1. registered job and expected process owner;
+2. `/livez`;
+3. `/readyz` plus `/v1/models`; and
+4. a real one-token `/v1/chat/completions` request.
+
+KeepAlive was then tested by sending SIGTERM to PID 55169. launchd created PID
+57116, readiness returned, and the full four-stage smoke passed again. No GUI
+or unrelated service was stopped.
+
+## System-domain qualification host
+
+The privileged and reboot gates were run on a separate, otherwise clean test
+machine:
+
+- Hardware: Apple M4 Pro, 48 GiB unified memory
+- OS: macOS 26.5.1
+- FileVault: off
+- Automatic login: off
+- Rapid-MLX before admission: not installed
+- Disk free at admission: approximately 403 GiB
+
+The curl installer was used to establish Rapid-MLX 0.13.3 and its pinned
+Python 3.12 runtime. Because that host timed out while downloading the Python
+artifact directly from GitHub, the exact installer-pinned artifact was
+downloaded on the operator machine, checksum-verified, and copied to the test
+host. This was a network transport workaround, not a runtime substitution.
+
+The root-owned plist was installed with mode 0644, loaded as
+`system/com.rapidmlx.server`, and verified to run as the unprivileged service
+account. The qualification model was `bonsai-1.7b-2bit`, served only on
+`127.0.0.1:18000`.
+
+All smoke stages passed in the system domain:
+
+1. launchd registration, PID, and process owner;
+2. `/livez`;
+3. `/readyz` and `/v1/models`; and
+4. a real one-token chat completion.
+
+KeepAlive was tested by asking launchd to send SIGTERM. The service restarted
+from PID 1905 to PID 1974, became ready, and passed the full smoke test again.
+
+## Update and extras qualification
+
+The clean installation did not include the optional vision extra. After
+installing `rapid-mlx[vision]`, the layered runtime contained `mlx-vlm 0.6.17`
+and `transformers 5.15.1`. A subsequent base-package upgrade preserved both
+versions. The system service was kept booted out during the update, loaded
+again afterwards, and passed the completion smoke test.
+
+Doctor returned a non-zero result even though direct imports of `mlx`,
+`mlx_lm`, `transformers`, `fastapi`, `uvicorn`, `PIL`, and `mlx_vlm` succeeded
+under the exact application interpreter and the server completed requests.
+It incorrectly classified those imports as broken. This is a separate Doctor
+probe defect; until it is fixed, Doctor is useful evidence but cannot be the
+sole post-update gate. The API smoke test remains authoritative for this
+deployment procedure.
+
+## Reboot qualification
+
+The M4 Pro host was restarted with the system service loaded. After SSH became
+available again:
+
+- the kernel boot time had advanced;
+- `/dev/console` was owned by `root`;
+- `uptime` reported zero logged-in users;
+- the LaunchDaemon was running as the service account with PID 336; and
+- all four smoke stages, including a real completion, passed.
+
+This qualifies normal boot recovery without automatic login. The test also
+confirmed that `/tmp` is not durable across reboot, so operator tooling and
+backups must not be stored there for an appliance deployment.
+
+`pmset -a sleep 0 autorestart 1` was configured and inspected, but an actual AC
+power interruption was not performed because the host had no remotely
+controlled power source. The guide therefore treats power-loss recovery as a
+site-specific acceptance test. FileVault must also be considered separately:
+the initial M2 Pro host could not provide unattended cold-boot recovery while
+its data volume required preboot unlock.
+
+## Cleanup
+
+The user-domain rehearsal job was removed with:
+
+```bash
+launchctl bootout gui/$(id -u)/com.rapidmlx.server
+```
+
+After the M4 Pro qualification, the system job was booted out, its test plist
+was removed, port 18000 was confirmed closed, and the admission power settings
+were restored (`sleep 1`, `autorestart 0`). Rapid-MLX and the small cached model
+were retained for follow-up testing. No persistent daemon or power-policy
+change was left on either host.

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -159,13 +159,13 @@ Test KeepAlive without rebooting:
 
 ```bash
 sudo launchctl kill SIGTERM system/com.rapidmlx.server
-sleep 12
 ./scripts/headless_service_smoke.sh
 ```
 
-The smoke test must pass again with a new process. To test the actual
-requirement, disable automatic login, reboot while physical recovery is
-available, leave the Mac at the login window, and run the same smoke remotely.
+The smoke test waits up to 120 seconds for readiness and must pass again with a
+new process. To test the actual requirement, disable automatic login, reboot
+while physical recovery is available, leave the Mac at the login window, and
+run the same smoke remotely.
 
 For desktop Macs that must restart when power returns, review the current
 settings and then enable Apple's power-loss restart option:
@@ -222,6 +222,7 @@ restore the previous application version plus the same extras before loading
 the service again:
 
 ```bash
+sudo launchctl bootout system/com.rapidmlx.server 2>/dev/null || true
 ~/.rapid-mlx/bin/python -m pip install \
   'rapid-mlx==PREVIOUS_VERSION' 'rapid-mlx[vision]==PREVIOUS_VERSION'
 ~/.rapid-mlx/bin/rapid-mlx doctor || true

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -119,22 +119,16 @@ proxy or an SSH tunnel:
 ssh -L 8000:127.0.0.1:8000 serveuser@your-mac
 ```
 
-If clients must connect directly, change `--host` to a specific private
-interface address or `0.0.0.0` and require authentication. Do not put an API
-key in `ProgramArguments`: command-line arguments are visible to other local
-processes. Add `RAPID_MLX_API_KEY` under `EnvironmentVariables` instead, then
-restrict the installed plist because it now contains a secret:
+Do not put an API key in `ProgramArguments` or the plist's
+`EnvironmentVariables`. Arguments are visible to other local processes, and
+launchd can display configured environment values through `launchctl print`
+even when the plist itself is mode 0600.
 
-```bash
-sudo chmod 600 /Library/LaunchDaemons/com.rapidmlx.server.plist
-sudo launchctl bootout system/com.rapidmlx.server
-sudo launchctl bootstrap system \
-  /Library/LaunchDaemons/com.rapidmlx.server.plist
-```
-
-Also configure the macOS firewall or an external firewall, use a trusted-host
-allowlist where appropriate, and avoid exposing the unauthenticated endpoint to
-the public internet.
+For direct LAN or internet access, keep Rapid-MLX on loopback and put a
+separately managed TLS-terminating, authenticating reverse proxy in front of
+it. Restrict the proxy with the host or network firewall and a trusted-host
+allowlist. This template deliberately does not provide a public-listener
+recipe.
 
 ## 4. Verify the running appliance
 
@@ -158,7 +152,16 @@ export RAPID_MLX_API_KEY='your-key'
 Test KeepAlive without rebooting:
 
 ```bash
+old_pid=$(launchctl print system/com.rapidmlx.server | \
+  awk -F'= ' '/^[[:space:]]*pid =/{print $2; exit}')
 sudo launchctl kill SIGTERM system/com.rapidmlx.server
+for _ in {1..30}; do
+  new_pid=$(launchctl print system/com.rapidmlx.server 2>/dev/null | \
+    awk -F'= ' '/^[[:space:]]*pid =/{print $2; exit}')
+  [ -n "$new_pid" ] && [ "$new_pid" != "$old_pid" ] && break
+  sleep 1
+done
+[ -n "${new_pid:-}" ] && [ "$new_pid" != "$old_pid" ] || exit 1
 ./scripts/headless_service_smoke.sh
 ```
 

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -35,7 +35,8 @@ boot behavior of your own machine.
 
 ## 1. Prepare the service account
 
-Log in as the service account while the machine still has a display, then:
+Log in as the service account while the machine still has a display. Run every
+command in this section as that account, without `sudo`:
 
 ```bash
 curl -fsSL https://rapidmlx.com/install.sh | bash
@@ -85,7 +86,9 @@ is required: a process in the system launchd domain does not inherit the GUI
 session's shell environment, and Hugging Face otherwise cannot reliably find
 the service account's cache.
 
-Install the validated file:
+Switch to a separate administrator session for the remaining system setup.
+Keep `serveuser` in every absolute path; do not substitute the administrator's
+home directory. Install the validated file:
 
 ```bash
 sudo install -o root -g wheel -m 644 \
@@ -182,12 +185,16 @@ This setting cannot bypass FileVault's preboot unlock.
 
 ## 5. Update without fighting KeepAlive
 
-Record the working state first. Include every optional extra the service uses;
-`pip freeze` records versions but cannot reconstruct which extras you intended:
+Run this section from the administrator session. Commands that modify the
+application runtime explicitly switch back to `serveuser`; this prevents an
+update from accidentally installing into the administrator's home. Record the
+working state first. Include every optional extra the service uses; `pip freeze`
+records versions but cannot reconstruct which extras you intended:
 
 ```bash
-rapid-mlx --version
-~/.rapid-mlx/bin/python -m pip freeze > "$HOME/rapid-mlx-before-upgrade.txt"
+sudo -u serveuser -H /Users/serveuser/.local/bin/rapid-mlx --version
+sudo -u serveuser -H /bin/bash -c \
+  '/Users/serveuser/.rapid-mlx/bin/python -m pip freeze > "$HOME/rapid-mlx-before-upgrade.txt"'
 sudo cp -p /Library/LaunchDaemons/com.rapidmlx.server.plist \
   /Library/LaunchDaemons/com.rapidmlx.server.plist.pre-upgrade
 ```
@@ -196,12 +203,13 @@ Then use this order:
 
 ```bash
 sudo launchctl bootout system/com.rapidmlx.server
-curl -fsSL https://rapidmlx.com/install.sh | bash
+curl -fsSL https://rapidmlx.com/install.sh | sudo -u serveuser -H /bin/bash
 
 # Re-assert the extras required by this appliance. Examples:
-~/.rapid-mlx/bin/python -m pip install --upgrade 'rapid-mlx[vision]'
+sudo -u serveuser -H /Users/serveuser/.rapid-mlx/bin/python \
+  -m pip install --upgrade 'rapid-mlx[vision]'
 
-~/.rapid-mlx/bin/rapid-mlx doctor || \
+sudo -u serveuser -H /Users/serveuser/.rapid-mlx/bin/rapid-mlx doctor || \
   echo 'Doctor reported issues; keep the daemon stopped and continue validation.'
 plutil -lint /Library/LaunchDaemons/com.rapidmlx.server.plist
 sudo launchctl bootstrap system \
@@ -226,9 +234,9 @@ the service again:
 
 ```bash
 sudo launchctl bootout system/com.rapidmlx.server 2>/dev/null || true
-~/.rapid-mlx/bin/python -m pip install \
+sudo -u serveuser -H /Users/serveuser/.rapid-mlx/bin/python -m pip install \
   'rapid-mlx==PREVIOUS_VERSION' 'rapid-mlx[vision]==PREVIOUS_VERSION'
-~/.rapid-mlx/bin/rapid-mlx doctor || true
+sudo -u serveuser -H /Users/serveuser/.rapid-mlx/bin/rapid-mlx doctor || true
 sudo launchctl bootstrap system \
   /Library/LaunchDaemons/com.rapidmlx.server.plist
 ./scripts/headless_service_smoke.sh

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -235,7 +235,9 @@ the service again:
 ```bash
 sudo launchctl bootout system/com.rapidmlx.server 2>/dev/null || true
 sudo -u serveuser -H /Users/serveuser/.rapid-mlx/bin/python -m pip install \
-  'rapid-mlx==PREVIOUS_VERSION' 'rapid-mlx[vision]==PREVIOUS_VERSION'
+  --force-reinstall -r /Users/serveuser/rapid-mlx-before-upgrade.txt
+sudo cp -p /Library/LaunchDaemons/com.rapidmlx.server.plist.pre-upgrade \
+  /Library/LaunchDaemons/com.rapidmlx.server.plist
 sudo -u serveuser -H /Users/serveuser/.rapid-mlx/bin/rapid-mlx doctor || true
 sudo launchctl bootstrap system \
   /Library/LaunchDaemons/com.rapidmlx.server.plist

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -107,8 +107,8 @@ Inspect the service and logs:
 
 ```bash
 sudo launchctl print system/com.rapidmlx.server
-tail -F "$HOME/Library/Logs/Rapid-MLX/server.stdout.log" \
-        "$HOME/Library/Logs/Rapid-MLX/server.stderr.log"
+tail -F /Users/serveuser/Library/Logs/Rapid-MLX/server.stdout.log \
+        /Users/serveuser/Library/Logs/Rapid-MLX/server.stderr.log
 ```
 
 `launchctl print` is diagnostic output, not a stable machine-readable API.

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -1,0 +1,260 @@
+# Headless macOS service
+
+Run Rapid-MLX as a system `launchd` daemon when a Mac is used as an unattended
+inference appliance. A system daemon starts after macOS boots and does not
+depend on a graphical login. This is the macOS equivalent of an enabled
+`systemd` service.
+
+> **Operational scope:** this guide uses the existing CLI and Apple's
+> `launchd`. Rapid-MLX does not yet install or manage the daemon for you. Test
+> the procedure while you still have physical or out-of-band access to the Mac.
+
+## Before you begin
+
+You need:
+
+- an Apple silicon Mac running macOS 13 or later;
+- a dedicated, non-administrator local account, shown below as `serveuser`;
+- Rapid-MLX installed by that account with the one-line installer;
+- the model downloaded once before the machine becomes headless;
+- administrator access for `/Library/LaunchDaemons` and `launchctl`; and
+- a recovery path if the service or network configuration is wrong.
+
+### FileVault changes the boot guarantee
+
+A LaunchDaemon does run without a GUI login, but only after macOS has booted
+and the data volume is available. On a FileVault-protected Mac, a cold boot
+after power loss can stop at the preboot unlock screen. No user daemon, SSH
+server, or Rapid-MLX process can run before that unlock.
+
+If recovery after a complete power loss must be unattended, decide explicitly
+whether to disable FileVault or provide a physical/out-of-band unlock process.
+Do not disable disk encryption merely to follow this guide. An authenticated
+restart used by some managed updates is not a substitute for testing the cold
+boot behavior of your own machine.
+
+## 1. Prepare the service account
+
+Log in as the service account while the machine still has a display, then:
+
+```bash
+curl -fsSL https://rapidmlx.com/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+rapid-mlx doctor
+rapid-mlx models
+```
+
+Start the intended model once so its weights are present in this account's
+cache, then stop the foreground server:
+
+```bash
+rapid-mlx serve qwen3.5-4b-4bit --host 127.0.0.1 --port 8000
+```
+
+The daemon uses these service-account paths:
+
+| Path | Purpose |
+|---|---|
+| `/Users/serveuser/.local/bin/rapid-mlx` | Stable CLI symlink created by the installer |
+| `/Users/serveuser/.rapid-mlx/` | Rapid-MLX virtual environment and app state |
+| `/Users/serveuser/.rapid-mlx-python/` | Standalone base Python, when the installer supplied one |
+| `/Users/serveuser/.cache/huggingface/hub/` | Default model cache resolved from `HOME` |
+| `/Users/serveuser/Library/Logs/Rapid-MLX/` | Recommended daemon logs |
+
+Create the log directory as the service account:
+
+```bash
+mkdir -p "$HOME/Library/Logs/Rapid-MLX"
+chmod 750 "$HOME/Library/Logs/Rapid-MLX"
+```
+
+## 2. Configure the LaunchDaemon
+
+Copy the repository template and replace every occurrence of `serveuser`. Also
+select the model and launch flags appropriate for the machine:
+
+```bash
+cp examples/launchd/com.rapidmlx.server.plist /tmp/com.rapidmlx.server.plist
+sed -i '' 's/serveuser/YOUR_SERVICE_ACCOUNT/g' /tmp/com.rapidmlx.server.plist
+plutil -lint /tmp/com.rapidmlx.server.plist
+```
+
+`launchd` does not expand `$HOME` or `~` in plist values. Keep executable,
+working-directory, cache, and log paths absolute. The explicit `HOME` variable
+is required: a process in the system launchd domain does not inherit the GUI
+session's shell environment, and Hugging Face otherwise cannot reliably find
+the service account's cache.
+
+Install the validated file:
+
+```bash
+sudo install -o root -g wheel -m 644 \
+  /tmp/com.rapidmlx.server.plist \
+  /Library/LaunchDaemons/com.rapidmlx.server.plist
+sudo launchctl bootstrap system \
+  /Library/LaunchDaemons/com.rapidmlx.server.plist
+```
+
+The template uses unconditional `KeepAlive`. A crash or unexpected clean exit
+is restarted, while `ThrottleInterval` prevents a broken configuration from
+spawning more than once every ten seconds. Always use `bootout` before planned
+maintenance so KeepAlive does not fight the operator.
+
+Inspect the service and logs:
+
+```bash
+sudo launchctl print system/com.rapidmlx.server
+tail -F "$HOME/Library/Logs/Rapid-MLX/server.stdout.log" \
+        "$HOME/Library/Logs/Rapid-MLX/server.stderr.log"
+```
+
+`launchctl print` is diagnostic output, not a stable machine-readable API.
+
+## 3. Network security
+
+The template binds to `127.0.0.1` by default. That is safe for a local reverse
+proxy or an SSH tunnel:
+
+```bash
+ssh -L 8000:127.0.0.1:8000 serveuser@your-mac
+```
+
+If clients must connect directly, change `--host` to a specific private
+interface address or `0.0.0.0` and require authentication. Do not put an API
+key in `ProgramArguments`: command-line arguments are visible to other local
+processes. Add `RAPID_MLX_API_KEY` under `EnvironmentVariables` instead, then
+restrict the installed plist because it now contains a secret:
+
+```bash
+sudo chmod 600 /Library/LaunchDaemons/com.rapidmlx.server.plist
+sudo launchctl bootout system/com.rapidmlx.server
+sudo launchctl bootstrap system \
+  /Library/LaunchDaemons/com.rapidmlx.server.plist
+```
+
+Also configure the macOS firewall or an external firewall, use a trusted-host
+allowlist where appropriate, and avoid exposing the unauthenticated endpoint to
+the public internet.
+
+## 4. Verify the running appliance
+
+Run the repository smoke test on the Mac. It checks the system-domain job,
+process owner, liveness, readiness, model inventory, and one real completion:
+
+```bash
+RAPID_MLX_SERVICE_USER=serveuser \
+RAPID_MLX_SMOKE_MODEL=default \
+./scripts/headless_service_smoke.sh
+```
+
+For an authenticated service, provide the key through the environment. The
+script puts it in a mode-600 temporary curl configuration, not argv or output:
+
+```bash
+RAPID_MLX_API_KEY='your-key' \
+RAPID_MLX_SERVICE_USER=serveuser \
+./scripts/headless_service_smoke.sh
+```
+
+Test KeepAlive without rebooting:
+
+```bash
+sudo launchctl kill SIGTERM system/com.rapidmlx.server
+sleep 12
+./scripts/headless_service_smoke.sh
+```
+
+The smoke test must pass again with a new process. To test the actual
+requirement, disable automatic login, reboot while physical recovery is
+available, leave the Mac at the login window, and run the same smoke remotely.
+
+For desktop Macs that must restart when power returns, review the current
+settings and then enable Apple's power-loss restart option:
+
+```bash
+pmset -g custom
+sudo pmset -a sleep 0 autorestart 1
+```
+
+This setting cannot bypass FileVault's preboot unlock.
+
+## 5. Update without fighting KeepAlive
+
+Record the working state first. Include every optional extra the service uses;
+`pip freeze` records versions but cannot reconstruct which extras you intended:
+
+```bash
+rapid-mlx --version
+~/.rapid-mlx/bin/python -m pip freeze > "$HOME/rapid-mlx-before-upgrade.txt"
+cp /Library/LaunchDaemons/com.rapidmlx.server.plist \
+   "$HOME/com.rapidmlx.server.plist.backup"
+```
+
+Then use this order:
+
+```bash
+sudo launchctl bootout system/com.rapidmlx.server
+curl -fsSL https://rapidmlx.com/install.sh | bash
+
+# Re-assert the extras required by this appliance. Examples:
+~/.rapid-mlx/bin/python -m pip install --upgrade 'rapid-mlx[vision]'
+
+~/.rapid-mlx/bin/rapid-mlx doctor
+plutil -lint /Library/LaunchDaemons/com.rapidmlx.server.plist
+sudo launchctl bootstrap system \
+  /Library/LaunchDaemons/com.rapidmlx.server.plist
+./scripts/headless_service_smoke.sh
+```
+
+Doctor should pass, but do not use it as the only acceptance test: the API
+smoke test proves that the daemon can load the configured model and serve a
+request in its real launchd environment.
+
+The installer upgrades a compatible `~/.rapid-mlx` environment in place, so
+unrelated installed packages normally remain. It deliberately rebuilds the
+venv when its Python is missing, broken, non-native, or too old; a rebuild does
+not preserve optional extras. Re-installing the declared extras and running
+Doctor are therefore required parts of the runbook, not optional cleanup.
+
+If validation fails, keep the daemon booted out, inspect the stderr log, and
+restore the previous application version plus the same extras before loading
+the service again:
+
+```bash
+~/.rapid-mlx/bin/python -m pip install \
+  'rapid-mlx==PREVIOUS_VERSION' 'rapid-mlx[vision]==PREVIOUS_VERSION'
+~/.rapid-mlx/bin/rapid-mlx doctor
+sudo launchctl bootstrap system \
+  /Library/LaunchDaemons/com.rapidmlx.server.plist
+./scripts/headless_service_smoke.sh
+```
+
+## 6. Stop or remove the service
+
+Stop it for maintenance:
+
+```bash
+sudo launchctl bootout system/com.rapidmlx.server
+```
+
+Remove it permanently:
+
+```bash
+sudo launchctl bootout system/com.rapidmlx.server 2>/dev/null || true
+sudo rm /Library/LaunchDaemons/com.rapidmlx.server.plist
+```
+
+Removing the plist does not delete the service account, model cache, virtual
+environment, or logs.
+
+## Known limits
+
+- There is no `rapid-mlx service install` command yet; this is an operator-run
+  deployment.
+- Rapid-MLX does not rotate the two log files. Configure your existing log
+  collector or rotation policy and monitor free disk space.
+- A full application update causes downtime while the daemon is booted out.
+- FileVault-protected cold boots require an unlock before the system can reach
+  the state in which this daemon runs.
+- Enabling `autorestart` is not proof of recovery after an AC outage. Perform a
+  controlled site acceptance test if power-loss recovery is a requirement.

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -142,8 +142,8 @@ Run the repository smoke test on the Mac. It checks the system-domain job,
 process owner, liveness, readiness, model inventory, and one real completion:
 
 ```bash
-RAPID_MLX_SERVICE_USER=serveuser \
-RAPID_MLX_SMOKE_MODEL=default \
+export RAPID_MLX_SERVICE_USER=serveuser
+export RAPID_MLX_SMOKE_MODEL=default
 ./scripts/headless_service_smoke.sh
 ```
 
@@ -151,8 +151,7 @@ For an authenticated service, provide the key through the environment. The
 script puts it in a mode-600 temporary curl configuration, not argv or output:
 
 ```bash
-RAPID_MLX_API_KEY='your-key' \
-RAPID_MLX_SERVICE_USER=serveuser \
+export RAPID_MLX_API_KEY='your-key'
 ./scripts/headless_service_smoke.sh
 ```
 
@@ -186,8 +185,8 @@ Record the working state first. Include every optional extra the service uses;
 ```bash
 rapid-mlx --version
 ~/.rapid-mlx/bin/python -m pip freeze > "$HOME/rapid-mlx-before-upgrade.txt"
-cp /Library/LaunchDaemons/com.rapidmlx.server.plist \
-   "$HOME/com.rapidmlx.server.plist.backup"
+sudo cp -p /Library/LaunchDaemons/com.rapidmlx.server.plist \
+  /Library/LaunchDaemons/com.rapidmlx.server.plist.pre-upgrade
 ```
 
 Then use this order:
@@ -199,16 +198,18 @@ curl -fsSL https://rapidmlx.com/install.sh | bash
 # Re-assert the extras required by this appliance. Examples:
 ~/.rapid-mlx/bin/python -m pip install --upgrade 'rapid-mlx[vision]'
 
-~/.rapid-mlx/bin/rapid-mlx doctor
+~/.rapid-mlx/bin/rapid-mlx doctor || \
+  echo 'Doctor reported issues; keep the daemon stopped and continue validation.'
 plutil -lint /Library/LaunchDaemons/com.rapidmlx.server.plist
 sudo launchctl bootstrap system \
   /Library/LaunchDaemons/com.rapidmlx.server.plist
 ./scripts/headless_service_smoke.sh
 ```
 
-Doctor should pass, but do not use it as the only acceptance test: the API
-smoke test proves that the daemon can load the configured model and serve a
-request in its real launchd environment.
+Investigate every Doctor issue, but do not use Doctor alone to accept or reject
+the update. Some 0.13.3 runtime layouts can produce false import failures. The
+API smoke test is the actionable gate: it proves that the daemon can load the
+configured model and serve a request in its real launchd environment.
 
 The installer upgrades a compatible `~/.rapid-mlx` environment in place, so
 unrelated installed packages normally remain. It deliberately rebuilds the
@@ -223,7 +224,7 @@ the service again:
 ```bash
 ~/.rapid-mlx/bin/python -m pip install \
   'rapid-mlx==PREVIOUS_VERSION' 'rapid-mlx[vision]==PREVIOUS_VERSION'
-~/.rapid-mlx/bin/rapid-mlx doctor
+~/.rapid-mlx/bin/rapid-mlx doctor || true
 sudo launchctl bootstrap system \
   /Library/LaunchDaemons/com.rapidmlx.server.plist
 ./scripts/headless_service_smoke.sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ GPU acceleration to local AI workloads by integrating:
 
 ### User Guides
 - [OpenAI-Compatible Server](guides/server.md)
+- [Headless macOS service](guides/headless-macos-service.md)
 - [Python API](guides/python-api.md)
 - [Multimodal (Images & Video)](guides/multimodal.md)
 - [Audio (STT/TTS)](guides/audio.md)

--- a/examples/launchd/com.rapidmlx.server.plist
+++ b/examples/launchd/com.rapidmlx.server.plist
@@ -49,7 +49,8 @@
     <key>ProcessType</key>
     <string>Background</string>
     <key>Umask</key>
-    <string>027</string>
+    <!-- plist integers are decimal; 23 is octal 027. -->
+    <integer>23</integer>
 
     <key>StandardOutPath</key>
     <string>/Users/serveuser/Library/Logs/Rapid-MLX/server.stdout.log</string>

--- a/examples/launchd/com.rapidmlx.server.plist
+++ b/examples/launchd/com.rapidmlx.server.plist
@@ -46,8 +46,6 @@
     <integer>10</integer>
     <key>ExitTimeOut</key>
     <integer>30</integer>
-    <key>ProcessType</key>
-    <string>Background</string>
     <key>Umask</key>
     <!-- plist integers are decimal; 23 is octal 027. -->
     <integer>23</integer>

--- a/examples/launchd/com.rapidmlx.server.plist
+++ b/examples/launchd/com.rapidmlx.server.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rapidmlx.server</string>
+
+    <!-- Replace serveuser in every path and in UserName. launchd does not
+         expand $HOME or ~ in plist values. -->
+    <key>UserName</key>
+    <string>serveuser</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/serveuser/.local/bin/rapid-mlx</string>
+        <string>serve</string>
+        <string>qwen3.5-4b-4bit</string>
+        <string>--served-model-name</string>
+        <string>default</string>
+        <string>--host</string>
+        <string>127.0.0.1</string>
+        <string>--port</string>
+        <string>8000</string>
+        <string>--max-num-seqs</string>
+        <string>4</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/serveuser</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <!-- HOME is mandatory in the system launchd domain. Without it,
+             Hugging Face cannot resolve the service account's model cache. -->
+        <key>HOME</key>
+        <string>/Users/serveuser</string>
+        <key>PATH</key>
+        <string>/Users/serveuser/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <!-- Unconditional KeepAlive is the launchd equivalent of a continuously
+         enabled appliance service. Use bootout before a planned upgrade. -->
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>ExitTimeOut</key>
+    <integer>30</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>Umask</key>
+    <string>027</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/serveuser/Library/Logs/Rapid-MLX/server.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/serveuser/Library/Logs/Rapid-MLX/server.stderr.log</string>
+</dict>
+</plist>

--- a/scripts/headless_service_smoke.sh
+++ b/scripts/headless_service_smoke.sh
@@ -21,16 +21,14 @@ esac
 case "$MODEL" in
     *[!A-Za-z0-9._/-]*|'') echo "invalid model name: $MODEL" >&2; exit 2 ;;
 esac
-case "$BASE_URL" in
-    http://127.0.0.1:*|http://localhost:*|https://*) ;;
-    *)
-        echo "refusing cleartext smoke test to a non-loopback host: $BASE_URL" >&2
-        echo "use HTTPS, or run this script on the server over SSH" >&2
-        exit 2
-        ;;
-esac
+if [[ ! "$BASE_URL" =~ ^http://(127\.0\.0\.1|localhost):[0-9]{1,5}$ ]] &&
+   [[ ! "$BASE_URL" =~ ^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?$ ]]; then
+    echo "invalid or unsafe base URL: $BASE_URL" >&2
+    echo "use an exact loopback HTTP origin or an HTTPS origin without userinfo or a path" >&2
+    exit 2
+fi
 case "${RAPID_MLX_API_KEY:-}" in
-    *$'\n'*|*$'\r'*|*'"'*|*'\\'*)
+    *$'\n'*|*$'\r'*|*\"*|*\\*)
         echo "RAPID_MLX_API_KEY contains characters unsafe for a curl config" >&2
         exit 2
         ;;
@@ -56,12 +54,16 @@ SERVICE_PRINT="$(launchctl print "$DOMAIN/$LABEL" 2>&1)" || {
     exit 1
 }
 PID="$(printf '%s\n' "$SERVICE_PRINT" | awk -F'= ' '/^[[:space:]]*pid = [0-9]+/ {gsub(/[^0-9]/, "", $2); print $2; exit}')"
-if [ -z "$PID" ] || ! kill -0 "$PID" 2>/dev/null; then
+if [ -z "$PID" ]; then
     echo "service is registered but has no live process" >&2
     exit 1
 fi
+ACTUAL_USER="$(ps -o user= -p "$PID" | awk '{$1=$1; print}')"
+if [ -z "$ACTUAL_USER" ]; then
+    echo "service reports pid $PID, but that process is not visible" >&2
+    exit 1
+fi
 if [ -n "$EXPECTED_USER" ]; then
-    ACTUAL_USER="$(ps -o user= -p "$PID" | awk '{$1=$1; print}')"
     [ "$ACTUAL_USER" = "$EXPECTED_USER" ] || {
         echo "service runs as $ACTUAL_USER, expected $EXPECTED_USER" >&2
         exit 1
@@ -70,22 +72,22 @@ fi
 echo "  running (pid $PID${EXPECTED_USER:+, user $EXPECTED_USER})"
 
 echo "[2/4] liveness"
-curl --config "$CURL_CONFIG" "$BASE_URL/livez" > "$RESPONSE"
+curl -q --config "$CURL_CONFIG" "$BASE_URL/livez" > "$RESPONSE"
 grep -Eq '"status"[[:space:]]*:[[:space:]]*"(ok|alive|healthy)"|^OK$' "$RESPONSE" || {
     echo "unexpected /livez response" >&2; exit 1;
 }
 
 echo "[3/4] readiness and model inventory"
-curl --config "$CURL_CONFIG" "$BASE_URL/readyz" > "$RESPONSE"
+curl -q --config "$CURL_CONFIG" "$BASE_URL/readyz" > "$RESPONSE"
 grep -Eq '"ready"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"(ok|ready|healthy)"|^OK$' "$RESPONSE" || {
     echo "unexpected /readyz response" >&2; exit 1;
 }
-curl --config "$CURL_CONFIG" "$BASE_URL/v1/models" > "$RESPONSE"
+curl -q --config "$CURL_CONFIG" "$BASE_URL/v1/models" > "$RESPONSE"
 grep -q '"data"' "$RESPONSE" || { echo "unexpected /v1/models response" >&2; exit 1; }
 
 echo "[4/4] one-token completion"
 printf '{"model":"%s","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":1,"temperature":0}' "$MODEL" > "$RESPONSE"
-curl --config "$CURL_CONFIG" \
+curl -q --config "$CURL_CONFIG" \
     -H 'Content-Type: application/json' \
     --data-binary "@$RESPONSE" \
     "$BASE_URL/v1/chat/completions" > "$RESPONSE_NEXT"

--- a/scripts/headless_service_smoke.sh
+++ b/scripts/headless_service_smoke.sh
@@ -78,10 +78,19 @@ grep -Eq '"status"[[:space:]]*:[[:space:]]*"(ok|alive|healthy)"|^OK$' "$RESPONSE
 }
 
 echo "[3/4] readiness and model inventory"
-curl -q --config "$CURL_CONFIG" "$BASE_URL/readyz" > "$RESPONSE"
-grep -Eq '"ready"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"(ok|ready|healthy)"|^OK$' "$RESPONSE" || {
-    echo "unexpected /readyz response" >&2; exit 1;
-}
+READY=false
+for _ in {1..60}; do
+    if curl -q --config "$CURL_CONFIG" "$BASE_URL/readyz" > "$RESPONSE" 2>/dev/null &&
+       grep -Eq '"ready"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"(ok|ready|healthy)"|^OK$' "$RESPONSE"; then
+        READY=true
+        break
+    fi
+    sleep 2
+done
+if [ "$READY" != true ]; then
+    echo "service did not become ready within 120 seconds" >&2
+    exit 1
+fi
 curl -q --config "$CURL_CONFIG" "$BASE_URL/v1/models" > "$RESPONSE"
 grep -q '"data"' "$RESPONSE" || { echo "unexpected /v1/models response" >&2; exit 1; }
 

--- a/scripts/headless_service_smoke.sh
+++ b/scripts/headless_service_smoke.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Post-deployment smoke test for the documented launchd service. This script is
+# read-only: it neither loads nor restarts the daemon. A bearer token is read
+# from RAPID_MLX_API_KEY and stored in a mode-600 temporary curl config so it
+# never appears in argv or test output.
+set -euo pipefail
+
+LABEL="${RAPID_MLX_SERVICE_LABEL:-com.rapidmlx.server}"
+DOMAIN="${RAPID_MLX_SERVICE_DOMAIN:-system}"
+BASE_URL="${RAPID_MLX_BASE_URL:-http://127.0.0.1:8000}"
+MODEL="${RAPID_MLX_SMOKE_MODEL:-default}"
+EXPECTED_USER="${RAPID_MLX_SERVICE_USER:-}"
+
+case "$LABEL" in
+    *[!A-Za-z0-9._-]*|'') echo "invalid service label: $LABEL" >&2; exit 2 ;;
+esac
+case "$DOMAIN" in
+    system|user/[0-9]*|gui/[0-9]*) ;;
+    *) echo "invalid launchd domain: $DOMAIN" >&2; exit 2 ;;
+esac
+case "$MODEL" in
+    *[!A-Za-z0-9._/-]*|'') echo "invalid model name: $MODEL" >&2; exit 2 ;;
+esac
+case "$BASE_URL" in
+    http://127.0.0.1:*|http://localhost:*|https://*) ;;
+    *)
+        echo "refusing cleartext smoke test to a non-loopback host: $BASE_URL" >&2
+        echo "use HTTPS, or run this script on the server over SSH" >&2
+        exit 2
+        ;;
+esac
+case "${RAPID_MLX_API_KEY:-}" in
+    *$'\n'*|*$'\r'*|*'"'*|*'\\'*)
+        echo "RAPID_MLX_API_KEY contains characters unsafe for a curl config" >&2
+        exit 2
+        ;;
+esac
+
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 2; }
+
+CURL_CONFIG="$(mktemp "${TMPDIR:-/tmp}/rapidmlx-smoke.XXXXXX")"
+RESPONSE="$(mktemp "${TMPDIR:-/tmp}/rapidmlx-response.XXXXXX")"
+RESPONSE_NEXT="$(mktemp "${TMPDIR:-/tmp}/rapidmlx-response-next.XXXXXX")"
+cleanup() { rm -f "$CURL_CONFIG" "$RESPONSE" "$RESPONSE_NEXT"; }
+trap cleanup EXIT
+chmod 600 "$CURL_CONFIG" "$RESPONSE" "$RESPONSE_NEXT"
+printf '%s\n' 'silent' 'show-error' 'fail-with-body' 'connect-timeout = 5' 'max-time = 120' > "$CURL_CONFIG"
+if [ -n "${RAPID_MLX_API_KEY:-}" ]; then
+    printf 'header = "Authorization: Bearer %s"\n' "$RAPID_MLX_API_KEY" >> "$CURL_CONFIG"
+fi
+
+echo "[1/4] launchd registration"
+SERVICE_PRINT="$(launchctl print "$DOMAIN/$LABEL" 2>&1)" || {
+    echo "service is not registered in the $DOMAIN domain: $LABEL" >&2
+    echo "run: sudo launchctl bootstrap system /Library/LaunchDaemons/$LABEL.plist" >&2
+    exit 1
+}
+PID="$(printf '%s\n' "$SERVICE_PRINT" | awk -F'= ' '/^[[:space:]]*pid = [0-9]+/ {gsub(/[^0-9]/, "", $2); print $2; exit}')"
+if [ -z "$PID" ] || ! kill -0 "$PID" 2>/dev/null; then
+    echo "service is registered but has no live process" >&2
+    exit 1
+fi
+if [ -n "$EXPECTED_USER" ]; then
+    ACTUAL_USER="$(ps -o user= -p "$PID" | awk '{$1=$1; print}')"
+    [ "$ACTUAL_USER" = "$EXPECTED_USER" ] || {
+        echo "service runs as $ACTUAL_USER, expected $EXPECTED_USER" >&2
+        exit 1
+    }
+fi
+echo "  running (pid $PID${EXPECTED_USER:+, user $EXPECTED_USER})"
+
+echo "[2/4] liveness"
+curl --config "$CURL_CONFIG" "$BASE_URL/livez" > "$RESPONSE"
+grep -Eq '"status"[[:space:]]*:[[:space:]]*"(ok|alive|healthy)"|^OK$' "$RESPONSE" || {
+    echo "unexpected /livez response" >&2; exit 1;
+}
+
+echo "[3/4] readiness and model inventory"
+curl --config "$CURL_CONFIG" "$BASE_URL/readyz" > "$RESPONSE"
+grep -Eq '"ready"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"(ok|ready|healthy)"|^OK$' "$RESPONSE" || {
+    echo "unexpected /readyz response" >&2; exit 1;
+}
+curl --config "$CURL_CONFIG" "$BASE_URL/v1/models" > "$RESPONSE"
+grep -q '"data"' "$RESPONSE" || { echo "unexpected /v1/models response" >&2; exit 1; }
+
+echo "[4/4] one-token completion"
+printf '{"model":"%s","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":1,"temperature":0}' "$MODEL" > "$RESPONSE"
+curl --config "$CURL_CONFIG" \
+    -H 'Content-Type: application/json' \
+    --data-binary "@$RESPONSE" \
+    "$BASE_URL/v1/chat/completions" > "$RESPONSE_NEXT"
+mv "$RESPONSE_NEXT" "$RESPONSE"
+grep -q '"choices"' "$RESPONSE" || { echo "completion response has no choices" >&2; exit 1; }
+
+echo "PASS: $LABEL is registered, ready, and serving completions"

--- a/scripts/headless_service_smoke.sh
+++ b/scripts/headless_service_smoke.sh
@@ -72,20 +72,17 @@ fi
 echo "  running (pid $PID${EXPECTED_USER:+, user $EXPECTED_USER})"
 
 echo "[2/4] liveness"
-curl -q --config "$CURL_CONFIG" "$BASE_URL/livez" > "$RESPONSE"
-grep -Eq '"status"[[:space:]]*:[[:space:]]*"(ok|alive|healthy)"|^OK$' "$RESPONSE" || {
-    echo "unexpected /livez response" >&2; exit 1;
-}
-
 echo "[3/4] readiness and model inventory"
 READY=false
 for _ in {1..40}; do
-    if curl -q --config "$CURL_CONFIG" --max-time 1 "$BASE_URL/readyz" > "$RESPONSE" 2>/dev/null &&
+    if curl -q --config "$CURL_CONFIG" --max-time 1 "$BASE_URL/livez" > "$RESPONSE" 2>/dev/null &&
+       grep -Eq '"status"[[:space:]]*:[[:space:]]*"(ok|alive|healthy)"|^OK$' "$RESPONSE" &&
+       curl -q --config "$CURL_CONFIG" --max-time 1 "$BASE_URL/readyz" > "$RESPONSE" 2>/dev/null &&
        grep -Eq '"ready"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"(ok|ready|healthy)"|^OK$' "$RESPONSE"; then
         READY=true
         break
     fi
-    sleep 2
+    sleep 1
 done
 if [ "$READY" != true ]; then
     echo "service did not become ready within 120 seconds" >&2

--- a/scripts/headless_service_smoke.sh
+++ b/scripts/headless_service_smoke.sh
@@ -74,7 +74,8 @@ echo "  running (pid $PID${EXPECTED_USER:+, user $EXPECTED_USER})"
 echo "[2/4] liveness"
 echo "[3/4] readiness and model inventory"
 READY=false
-for _ in {1..40}; do
+READY_DEADLINE=$((SECONDS + 120))
+while ((SECONDS < READY_DEADLINE)); do
     if curl -q --config "$CURL_CONFIG" --max-time 1 "$BASE_URL/livez" > "$RESPONSE" 2>/dev/null &&
        grep -Eq '"status"[[:space:]]*:[[:space:]]*"(ok|alive|healthy)"|^OK$' "$RESPONSE" &&
        curl -q --config "$CURL_CONFIG" --max-time 1 "$BASE_URL/readyz" > "$RESPONSE" 2>/dev/null &&

--- a/scripts/headless_service_smoke.sh
+++ b/scripts/headless_service_smoke.sh
@@ -79,8 +79,8 @@ grep -Eq '"status"[[:space:]]*:[[:space:]]*"(ok|alive|healthy)"|^OK$' "$RESPONSE
 
 echo "[3/4] readiness and model inventory"
 READY=false
-for _ in {1..60}; do
-    if curl -q --config "$CURL_CONFIG" "$BASE_URL/readyz" > "$RESPONSE" 2>/dev/null &&
+for _ in {1..40}; do
+    if curl -q --config "$CURL_CONFIG" --max-time 1 "$BASE_URL/readyz" > "$RESPONSE" 2>/dev/null &&
        grep -Eq '"ready"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"(ok|ready|healthy)"|^OK$' "$RESPONSE"; then
         READY=true
         break

--- a/tests/test_headless_service_assets.py
+++ b/tests/test_headless_service_assets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import plistlib
 import subprocess
 from pathlib import Path
@@ -24,6 +25,7 @@ def test_launchdaemon_template_is_valid_and_safe_by_default() -> None:
     assert config["ProgramArguments"][host_index + 1] == "127.0.0.1"
     assert config["KeepAlive"] is True
     assert config["ThrottleInterval"] >= 10
+    assert config["Umask"] == 0o27
     assert "RAPID_MLX_API_KEY" not in config["EnvironmentVariables"]
     assert config["StandardOutPath"] != config["StandardErrorPath"]
 
@@ -35,10 +37,23 @@ def test_smoke_script_is_syntactically_valid_and_does_not_accept_key_argv() -> N
     assert "RAPID_MLX_SERVICE_DOMAIN" in source
     assert "--api-key" not in source
     assert "unsafe for a curl config" in source
+    assert 'curl -q --config "$CURL_CONFIG"' in source
+    assert "kill -0" not in source
     assert "launchctl print" in source
     assert "/livez" in source
     assert "/readyz" in source
     assert "/v1/chat/completions" in source
+
+
+def test_smoke_script_rejects_loopback_userinfo_url() -> None:
+    env = {
+        **os.environ,
+        "RAPID_MLX_BASE_URL": "http://127.0.0.1:8000@attacker.example",
+        "RAPID_MLX_API_KEY": "secret",
+    }
+    result = subprocess.run([str(SMOKE)], env=env, text=True, capture_output=True)
+    assert result.returncode == 2
+    assert "invalid or unsafe base URL" in result.stderr
 
 
 def test_guide_pins_operational_and_security_boundaries() -> None:

--- a/tests/test_headless_service_assets.py
+++ b/tests/test_headless_service_assets.py
@@ -38,6 +38,7 @@ def test_smoke_script_is_syntactically_valid_and_does_not_accept_key_argv() -> N
     assert "--api-key" not in source
     assert "unsafe for a curl config" in source
     assert 'curl -q --config "$CURL_CONFIG"' in source
+    assert '--max-time 1 "$BASE_URL/readyz"' in source
     assert "kill -0" not in source
     assert "launchctl print" in source
     assert "/livez" in source

--- a/tests/test_headless_service_assets.py
+++ b/tests/test_headless_service_assets.py
@@ -6,7 +6,6 @@ import plistlib
 import subprocess
 from pathlib import Path
 
-
 ROOT = Path(__file__).parents[1]
 PLIST = ROOT / "examples/launchd/com.rapidmlx.server.plist"
 SMOKE = ROOT / "scripts/headless_service_smoke.sh"

--- a/tests/test_headless_service_assets.py
+++ b/tests/test_headless_service_assets.py
@@ -1,0 +1,58 @@
+"""Static contracts for the documented headless launchd deployment."""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+PLIST = ROOT / "examples/launchd/com.rapidmlx.server.plist"
+SMOKE = ROOT / "scripts/headless_service_smoke.sh"
+GUIDE = ROOT / "docs/guides/headless-macos-service.md"
+
+
+def test_launchdaemon_template_is_valid_and_safe_by_default() -> None:
+    with PLIST.open("rb") as handle:
+        config = plistlib.load(handle)
+
+    assert config["Label"] == "com.rapidmlx.server"
+    assert config["UserName"] == "serveuser"
+    assert config["EnvironmentVariables"]["HOME"] == "/Users/serveuser"
+    assert config["ProgramArguments"][0].startswith("/Users/serveuser/")
+    host_index = config["ProgramArguments"].index("--host")
+    assert config["ProgramArguments"][host_index + 1] == "127.0.0.1"
+    assert config["KeepAlive"] is True
+    assert config["ThrottleInterval"] >= 10
+    assert "RAPID_MLX_API_KEY" not in config["EnvironmentVariables"]
+    assert config["StandardOutPath"] != config["StandardErrorPath"]
+
+
+def test_smoke_script_is_syntactically_valid_and_does_not_accept_key_argv() -> None:
+    subprocess.run(["bash", "-n", str(SMOKE)], check=True)
+    source = SMOKE.read_text()
+    assert "RAPID_MLX_API_KEY" in source
+    assert "RAPID_MLX_SERVICE_DOMAIN" in source
+    assert "--api-key" not in source
+    assert "unsafe for a curl config" in source
+    assert "launchctl print" in source
+    assert "/livez" in source
+    assert "/readyz" in source
+    assert "/v1/chat/completions" in source
+
+
+def test_guide_pins_operational_and_security_boundaries() -> None:
+    guide = GUIDE.read_text()
+    for required in (
+        "FileVault",
+        "launchctl bootstrap system",
+        "launchctl bootout system/com.rapidmlx.server",
+        "HOME",
+        "KeepAlive",
+        "RAPID_MLX_API_KEY",
+        "rapid-mlx doctor",
+        "headless_service_smoke.sh",
+        "autorestart 1",
+    ):
+        assert required in guide

--- a/tests/test_headless_service_assets.py
+++ b/tests/test_headless_service_assets.py
@@ -26,6 +26,7 @@ def test_launchdaemon_template_is_valid_and_safe_by_default() -> None:
     assert config["KeepAlive"] is True
     assert config["ThrottleInterval"] >= 10
     assert config["Umask"] == 0o27
+    assert "ProcessType" not in config
     assert "RAPID_MLX_API_KEY" not in config["EnvironmentVariables"]
     assert config["StandardOutPath"] != config["StandardErrorPath"]
 
@@ -39,6 +40,7 @@ def test_smoke_script_is_syntactically_valid_and_does_not_accept_key_argv() -> N
     assert "unsafe for a curl config" in source
     assert 'curl -q --config "$CURL_CONFIG"' in source
     assert '--max-time 1 "$BASE_URL/readyz"' in source
+    assert '--max-time 1 "$BASE_URL/livez"' in source
     assert "kill -0" not in source
     assert "launchctl print" in source
     assert "/livez" in source

--- a/tests/test_headless_service_assets.py
+++ b/tests/test_headless_service_assets.py
@@ -42,6 +42,7 @@ def test_smoke_script_is_syntactically_valid_and_does_not_accept_key_argv() -> N
     assert "launchctl print" in source
     assert "/livez" in source
     assert "/readyz" in source
+    assert "did not become ready within 120 seconds" in source
     assert "/v1/chat/completions" in source
 
 

--- a/tests/test_headless_service_assets.py
+++ b/tests/test_headless_service_assets.py
@@ -41,6 +41,7 @@ def test_smoke_script_is_syntactically_valid_and_does_not_accept_key_argv() -> N
     assert 'curl -q --config "$CURL_CONFIG"' in source
     assert '--max-time 1 "$BASE_URL/readyz"' in source
     assert '--max-time 1 "$BASE_URL/livez"' in source
+    assert "READY_DEADLINE=$((SECONDS + 120))" in source
     assert "kill -0" not in source
     assert "launchctl print" in source
     assert "/livez" in source


### PR DESCRIPTION
## Summary

- add a safe LaunchDaemon template and post-deployment smoke test
- document boot-without-login, KeepAlive, FileVault, network security, upgrades, rollback, and power policy
- record real M2 Pro rehearsal and M4 Pro system-domain/reboot qualification

## Validation

- M4 Pro / macOS 26.5.1: system LaunchDaemon, KeepAlive PID replacement, update with vision extras preserved, and full reboot with `CONSOLE=root` / zero logged-in users
- post-reboot `/livez`, `/readyz`, `/v1/models`, and one-token chat completion passed
- `python3 -m pytest -q tests/test_headless_service_assets.py`
- `bash -n scripts/headless_service_smoke.sh`
- `plutil -lint examples/launchd/com.rapidmlx.server.plist`
- `git diff --check`

## Known boundary

A real AC interruption was not simulated because the host had no remotely controlled power source. `autorestart 1` was configured and inspected; the guide requires a site-specific power-loss acceptance test.

The temporary system job/plist were removed and admission power settings restored after qualification.