### PR TITLE
fix: reject explicit quantized KV pre-ready on unsupported families (#2954)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,7 @@ jobs:
             tests/test_mllm_cache.py \
             tests/test_memory_cache.py \
             tests/test_metal_memory_budget.py \
+            tests/test_kv_cache_gemma4_gate.py \
             tests/test_prefix_cache_eviction.py \
             tests/test_optimizations.py \
             tests/test_batching.py \

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -122,7 +122,7 @@ are the argparse defaults from `vllm_mlx/cli.py`.
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`). int8/int4 shrink the KV cache 2x/4x for memory-constrained hosts, but dequant-on-read costs decode throughput at long context (measured -27% int4 / -36% int8 at 16k). Sliding-window (Gemma 3, GPT-OSS) and MLA (DeepSeek V3+, Kimi K2.5) models auto-downgrade to bf16. | bf16 |
+| `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`). int8/int4 shrink the KV cache 2x/4x for memory-constrained hosts, but dequant-on-read costs decode throughput at long context (measured -27% int4 / -36% int8 at 16k). An explicit int8/int4 on a sliding-window (Gemma 3/4, GPT-OSS) or MLA (DeepSeek V3+, Kimi K2.5) model is rejected before the server reports ready; only auto/profile-selected quantization downgrades to bf16. | bf16 |
 | `--reasoning` | Reasoning profile: pins `--kv-cache-dtype` to int8 regardless of the dtype flag (sub-4-bit KV drops accuracy on AIME-class math) | off |
 | `--kv-cache-quantization` | Deprecated alias of `--kv-cache-dtype int8`; wins when both flags are passed (backwards compatibility) | off |
 | `--kv-cache-quantization-bits` | Bit width for KV cache quantization (4 or 8) | 8 |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -92,7 +92,7 @@ needed by the application; leave it unset for URL/base64-only deployments.
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`). int8/int4 shrink the KV cache 2x/4x for memory-constrained hosts at a decode-throughput cost at long context; sliding-window and MLA models auto-downgrade to bf16. | `bf16` |
+| `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`). int8/int4 shrink the KV cache 2x/4x for memory-constrained hosts at a decode-throughput cost at long context. An explicit int8/int4 request on a sliding-window (Gemma 3/4, GPT-OSS) or MLA (DeepSeek V3+, Kimi K2.5) model is rejected before the server reports ready; only auto/profile-selected quantization downgrades to bf16. | `bf16` |
 | `--reasoning` | Pins `--kv-cache-dtype` to int8 (reasoning-accuracy profile) | `false` |
 | `--kv-cache-quantization` | Deprecated alias of `--kv-cache-dtype int8`; wins when both are passed | `false` |
 | `--kv-cache-quantization-bits` | Bit width for KV cache quantization (4 or 8) | `8` |

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -361,3 +361,43 @@ def test_resident_performance_supported_family_passes(monkeypatch):
     )
     assert performance is not None
     assert performance.kv_cache_dtype == "int8"
+
+
+# ---------------------------------------------------------------------------
+# Legacy --kv-cache-quantization shape shares the same reject-before-ready
+# contract (both bit widths), not just the new --kv-cache-dtype flag.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bits", [4, 8])
+def test_serve_exits_before_load_for_explicit_gemma4_legacy_flag(tmp_path, bits):
+    """The deprecated ``--kv-cache-quantization [--kv-cache-quantization-bits
+    N]`` shape is equally operator-explicit and must reject an unsupported
+    family BEFORE the server reports ready, with the same exit code (2) and
+    actionable message as ``--kv-cache-dtype`` (#78). A config-only local
+    directory keeps the run fast and cache/network-independent so the gate is
+    reachable without downloading Gemma-4 weights."""
+    model_dir = tmp_path / "gemma4-config-only"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps(GEMMA4_UNIFIED_CONFIG))
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vllm_mlx.cli",
+            "serve",
+            str(model_dir),
+            "--kv-cache-quantization",
+            "--kv-cache-quantization-bits",
+            str(bits),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    assert proc.returncode == 2, combined
+    dtype = "int8" if bits == 8 else "int4"
+    assert f"--kv-cache-dtype {dtype}" in combined
+    assert "cannot be honored" in combined
+    assert "bf16" in combined

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -173,6 +173,32 @@ def test_serve_exits_before_load_for_explicit_gemma4_dtype(tmp_path, dtype):
     assert "bf16" in combined
 
 
+@pytest.mark.requires_mlx
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--kv-cache-dtype", "int8"],
+        ["--kv-cache-quantization", "--kv-cache-quantization-bits", "8"],
+    ],
+)
+def test_serve_command_maps_both_explicit_flag_shapes_to_exit_two(
+    tmp_path, flags, capsys
+):
+    """Exercise the in-process CLI exception mapping as well as subprocess E2E."""
+    from vllm_mlx import cli
+
+    model_dir = tmp_path / "gemma4-config-only"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps(GEMMA4_UNIFIED_CONFIG))
+    args = cli.build_parser().parse_args(["serve", str(model_dir), "--no-mllm", *flags])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.serve_command(args)
+
+    assert exc_info.value.code == 2
+    assert "cannot be honored" in capsys.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # MLLM-lane admission (pre-ready)
 # ---------------------------------------------------------------------------
@@ -283,6 +309,20 @@ def test_live_cache_probe_accepts_plain_kvcache():
     assert Scheduler._quantized_live_cache_incompatibility(_FakeModel()) is None
 
 
+@pytest.mark.requires_mlx
+def test_live_cache_probe_treats_empty_cache_list_as_unprobeable():
+    from vllm_mlx.scheduler import Scheduler
+
+    class _EmptyModel:
+        def make_cache(self):
+            return []
+
+    assert (
+        Scheduler._quantized_live_cache_incompatibility(_EmptyModel())
+        == Scheduler._KV_CACHE_UNPROBEABLE
+    )
+
+
 @pytest.mark.requires_mlx  # imports mlx_lm.models.cache + vllm_mlx.scheduler (mlx)
 def test_explicit_request_fails_closed_on_incompatible_cache():
     """Rotating cache + explicit request: engine start raises pre-ready."""
@@ -321,6 +361,47 @@ def test_auto_request_disables_quantization_on_incompatible_cache(caplog):
     with caplog.at_level(logging.WARNING):
         sched._init_kv_quantization(_FakeModel())
     assert sched._kv_quant_live_disabled is True
+
+
+@pytest.mark.requires_mlx
+def test_serve_command_maps_runtime_backstop_to_exit_two(tmp_path, monkeypatch, capsys):
+    """A late structural rejection keeps the same actionable CLI contract."""
+    from vllm_mlx import cli, server
+
+    model_dir = tmp_path / "supported-config"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps(SUPPORTED_CONFIG))
+    args = cli.build_parser().parse_args(
+        ["serve", str(model_dir), "--no-mllm", "--kv-cache-dtype", "int8"]
+    )
+    error = KVCacheQuantizationUnsupportedError(
+        requested="int8",
+        model_name="probe-model",
+        family_reason="the live cache layout could not be probed",
+    )
+    monkeypatch.setattr(
+        cli,
+        "_gather_kv_cache_dtype_inputs",
+        lambda model: (SUPPORTED_CONFIG, None),
+    )
+    monkeypatch.setattr(cli, "_port_preflight_or_die", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_check_alias_min_memory", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        server, "configure_model_residency", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        server, "load_model", lambda *args, **kwargs: (_ for _ in ()).throw(error)
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.serve_command(args)
+
+    assert exc_info.value.code == 2
+    output = capsys.readouterr().out
+    assert "--kv-cache-dtype int8 cannot be honored" in output
+    assert "live cache layout could not be probed" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capability gate for quantized KV on Gemma-4-class families (#78).
+
+Bug #78: ``--kv-cache-dtype int8/int4`` on a Gemma-4 alias slipped the
+sliding-window safelist (the multimodal config nests ``sliding_window``
+under ``text_config``), the server reported ready, and then either the
+text lane 503'd every request (quantized tuples reached ``gemma4_text``
+attention) or the MLLM lane silently ignored the flag.
+
+Pinned contract: nested ``text_config`` is detected structurally; an
+EXPLICIT int8/int4 request that cannot be honored raises the single
+typed ``KVCacheQuantizationUnsupportedError`` before ready on every
+lane (text CLI, MLLM engine start, scheduler backstop, residency);
+auto/profile selection may downgrade to bf16; supported full-attention
+families are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx.kv_cache_dtype import (
+    KVCacheQuantizationUnsupportedError,
+    quantized_kv_unsupported_reason,
+    resolve_kv_cache_dtype,
+)
+
+# Mirrors mlx-community/gemma-4-26b-a4b-it-4bit / gemma-4-e2b-it-8bit:
+# no top-level sliding_window, backbone fields nested under text_config.
+GEMMA4_MLLM_CONFIG = {
+    "model_type": "gemma4",
+    "architectures": ["Gemma4ForConditionalGeneration"],
+    "text_config": {"model_type": "gemma4_text", "sliding_window": 1024},
+    "vision_config": {"model_type": "siglip_vision_model"},
+}
+
+# Mirrors mlx-community/gemma-4-12B-it-4bit (unified audio variant).
+GEMMA4_UNIFIED_CONFIG = {
+    "model_type": "gemma4_unified",
+    "text_config": {"model_type": "gemma4_unified_text", "sliding_window": 1024},
+}
+
+# Full-attention control family (Qwen3.5-style): no sliding window, no MLA.
+SUPPORTED_CONFIG = {
+    "model_type": "qwen3_5",
+    "hidden_size": 4096,
+    "num_hidden_layers": 36,
+}
+
+
+# ---------------------------------------------------------------------------
+# Nested text_config detection (structural, no model-name patterns)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cfg", [GEMMA4_MLLM_CONFIG, GEMMA4_UNIFIED_CONFIG])
+def test_gemma4_nested_config_is_unsupported_for_quantized_kv(cfg):
+    reason = quantized_kv_unsupported_reason(model_name="some-alias", hf_config=cfg)
+    assert reason is not None
+    assert "sliding-window" in reason.lower()
+
+
+@pytest.mark.parametrize("dtype", ["int8", "int4"])
+def test_gemma4_nested_auto_request_downgrades_to_bf16(dtype):
+    """Auto/profile-selected quantization may safely fall back to bf16."""
+    decision = resolve_kv_cache_dtype(
+        dtype,
+        model_name="gemma-4-26b-alias",
+        hf_config=GEMMA4_MLLM_CONFIG,
+    )
+    assert decision.dtype == "bf16"
+    assert decision.downgraded is True
+    assert "sliding-window" in decision.reason.lower()
+
+
+@pytest.mark.parametrize("dtype", ["int8", "int4"])
+def test_gemma4_nested_explicit_request_is_rejected(dtype):
+    """Explicit --kv-cache-dtype int8/int4 must fail, never silently serve."""
+    with pytest.raises(KVCacheQuantizationUnsupportedError) as exc_info:
+        resolve_kv_cache_dtype(
+            dtype,
+            explicit=True,
+            model_name="mlx-community/gemma-4-e2b-it-8bit",
+            hf_config=GEMMA4_MLLM_CONFIG,
+        )
+    message = str(exc_info.value)
+    assert dtype in message
+    assert "gemma-4-e2b" in message
+    # Actionable: tells the operator what to do instead.
+    assert "bf16" in message
+
+
+def test_gemma4_unified_explicit_request_is_rejected():
+    with pytest.raises(KVCacheQuantizationUnsupportedError):
+        resolve_kv_cache_dtype(
+            "int8",
+            explicit=True,
+            model_name="gemma-4-12b-alias",
+            hf_config=GEMMA4_UNIFIED_CONFIG,
+        )
+
+
+@pytest.mark.parametrize("dtype", ["int8", "int4"])
+def test_supported_family_explicit_request_is_unchanged(dtype):
+    """Regression control: full-attention families keep quantized KV."""
+    decision = resolve_kv_cache_dtype(
+        dtype,
+        explicit=True,
+        model_name="qwen3.5-9b-4bit",
+        hf_config=SUPPORTED_CONFIG,
+    )
+    assert decision.dtype == dtype
+    assert decision.downgraded is False
+
+
+def test_explicit_bf16_never_rejects():
+    """bf16 is safe everywhere — the gate only guards sub-bf16 requests."""
+    decision = resolve_kv_cache_dtype(
+        "bf16",
+        explicit=True,
+        model_name="gemma-4-26b-alias",
+        hf_config=GEMMA4_MLLM_CONFIG,
+    )
+    assert decision.dtype == "bf16"
+    assert decision.downgraded is False
+
+
+# ---------------------------------------------------------------------------
+# CLI: pre-load exit before any weights load (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", ["int8", "int4"])
+def test_serve_exits_before_load_for_explicit_gemma4_dtype(tmp_path, dtype):
+    """``serve <local-gemma4-dir> --kv-cache-dtype int8/int4`` must exit
+    non-zero at the resolver gate — before any weight load or ready
+    report. A config-only local directory keeps this fast and
+    cache/network-independent (the gate reads ``<dir>/config.json``);
+    if the gate did NOT fire, the run would instead die later with a
+    weights-loading error that lacks the actionable dtype message.
+    """
+    # The unified (no vision_config) shape keeps the run on the text lane
+    # so no vision-runtime preflight fires before the dtype gate; the
+    # nested-text_config detection is identical for both shapes.
+    model_dir = tmp_path / "gemma4-config-only"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps(GEMMA4_UNIFIED_CONFIG))
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vllm_mlx.cli",
+            "serve",
+            str(model_dir),
+            "--kv-cache-dtype",
+            dtype,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    assert proc.returncode != 0
+    assert f"--kv-cache-dtype {dtype}" in combined
+    assert "cannot be honored" in combined
+    assert "bf16" in combined
+
+
+# ---------------------------------------------------------------------------
+# MLLM-lane admission (pre-ready)
+# ---------------------------------------------------------------------------
+
+
+def _scheduler_config(**overrides):
+    defaults = {
+        "kv_cache_quantization": True,
+        "kv_cache_quantization_bits": 8,
+        "kv_cache_dtype": "int8",
+        "kv_cache_dtype_explicit": True,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_mllm_lane_rejects_explicit_quantized_kv_before_ready():
+    """The MLLM lane has no quantized-KV wiring; explicit requests must
+    fail during engine start (pre-ready) with the shared typed error."""
+    from vllm_mlx.engine.batched import _check_mllm_kv_quantization
+
+    with pytest.raises(KVCacheQuantizationUnsupportedError) as exc_info:
+        _check_mllm_kv_quantization(
+            _scheduler_config(), "mlx-community/gemma-4-e2b-it-8bit"
+        )
+    message = str(exc_info.value)
+    assert "int8" in message
+    assert "MLLM" in message
+    assert "bf16" in message
+
+
+def test_mllm_lane_explicit_int4_rejected_with_dtype_in_message():
+    from vllm_mlx.engine.batched import _check_mllm_kv_quantization
+
+    with pytest.raises(KVCacheQuantizationUnsupportedError, match="int4"):
+        _check_mllm_kv_quantization(
+            _scheduler_config(kv_cache_dtype="int4", kv_cache_quantization_bits=4),
+            "gemma-4-26b-alias",
+        )
+
+
+def test_mllm_lane_auto_quantization_warns_and_serves(caplog):
+    """Auto/profile-selected quantization (e.g. --reasoning pin) keeps the
+    lane serving bf16 but says so instead of staying silent."""
+    from vllm_mlx.engine.batched import _check_mllm_kv_quantization
+
+    with caplog.at_level(logging.WARNING):
+        _check_mllm_kv_quantization(
+            _scheduler_config(kv_cache_dtype_explicit=False), "qwen3-vl-alias"
+        )
+    assert any("bf16" in rec.message for rec in caplog.records)
+
+
+def test_mllm_lane_without_quantization_is_untouched(caplog):
+    from vllm_mlx.engine.batched import _check_mllm_kv_quantization
+
+    with caplog.at_level(logging.WARNING):
+        _check_mllm_kv_quantization(
+            _scheduler_config(kv_cache_quantization=False), "qwen3-vl-alias"
+        )
+    assert not caplog.records
+
+
+# ---------------------------------------------------------------------------
+# Text-lane structural backstop (config-free capability probe)
+# ---------------------------------------------------------------------------
+
+
+def _scheduler_stub(explicit: bool):
+    from vllm_mlx.scheduler import Scheduler
+
+    sched = Scheduler.__new__(Scheduler)
+    sched.config = _scheduler_config(
+        kv_cache_dtype_explicit=explicit,
+        kv_cache_turboquant=None,
+        kv_cache_quantization_group_size=64,
+        model_name="probe-model",
+    )
+    return sched
+
+
+def test_live_cache_probe_flags_rotating_cache():
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from vllm_mlx.scheduler import Scheduler
+
+    class _FakeModel:
+        def make_cache(self):
+            return [KVCache(), RotatingKVCache(max_size=8, keep=0)]
+
+    assert (
+        Scheduler._quantized_live_cache_incompatibility(_FakeModel())
+        == "RotatingKVCache"
+    )
+
+
+def test_live_cache_probe_accepts_plain_kvcache():
+    from mlx_lm.models.cache import KVCache
+
+    from vllm_mlx.scheduler import Scheduler
+
+    class _FakeModel:
+        def make_cache(self):
+            return [KVCache(), KVCache()]
+
+    assert Scheduler._quantized_live_cache_incompatibility(_FakeModel()) is None
+
+
+def test_explicit_request_fails_closed_on_incompatible_cache():
+    """Rotating cache + explicit request: engine start raises pre-ready."""
+    from mlx_lm.models.cache import RotatingKVCache
+
+    class _FakeModel:
+        def make_cache(self):
+            return [RotatingKVCache(max_size=8, keep=0)]
+
+    with pytest.raises(KVCacheQuantizationUnsupportedError, match="RotatingKVCache"):
+        _scheduler_stub(explicit=True)._init_kv_quantization(_FakeModel())
+
+
+def test_explicit_request_fails_closed_on_unprobeable_cache():
+    """A cache layout that cannot be verified must not report ready and
+    gamble on the first request (fail closed for explicit requests)."""
+
+    class _Broken:
+        def make_cache(self):
+            raise ValueError("stub")
+
+    with pytest.raises(KVCacheQuantizationUnsupportedError, match="probed"):
+        _scheduler_stub(explicit=True)._init_kv_quantization(_Broken())
+
+
+def test_auto_request_disables_quantization_on_incompatible_cache(caplog):
+    from mlx_lm.models.cache import RotatingKVCache
+
+    class _FakeModel:
+        def make_cache(self):
+            return [RotatingKVCache(max_size=8, keep=0)]
+
+    sched = _scheduler_stub(explicit=False)
+    with caplog.at_level(logging.WARNING):
+        sched._init_kv_quantization(_FakeModel())
+    assert sched._kv_quant_live_disabled is True
+
+
+# ---------------------------------------------------------------------------
+# Residency (runtime) path shares the same SSOT
+# ---------------------------------------------------------------------------
+
+
+def test_resident_performance_explicit_int8_gemma4_rejected(monkeypatch):
+    import vllm_mlx.cli as cli
+    from vllm_mlx.runtime.resident_models import (
+        ResidentPerformanceConfig,
+        resolve_resident_performance,
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "_gather_kv_cache_dtype_inputs",
+        lambda name: (GEMMA4_MLLM_CONFIG, None),
+    )
+    with pytest.raises(KVCacheQuantizationUnsupportedError):
+        resolve_resident_performance(
+            ResidentPerformanceConfig(kv_cache_dtype="int8"),
+            model_name="gemma-4-26b-alias",
+            model_path=None,
+        )
+
+
+def test_resident_performance_supported_family_passes(monkeypatch):
+    import vllm_mlx.cli as cli
+    from vllm_mlx.runtime.resident_models import (
+        ResidentPerformanceConfig,
+        resolve_resident_performance,
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "_gather_kv_cache_dtype_inputs",
+        lambda name: (SUPPORTED_CONFIG, None),
+    )
+    performance = resolve_resident_performance(
+        ResidentPerformanceConfig(kv_cache_dtype="int8"),
+        model_name="qwen3.5-9b-4bit",
+        model_path=None,
+    )
+    assert performance is not None
+    assert performance.kv_cache_dtype == "int8"

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -136,6 +136,7 @@ def test_explicit_bf16_never_rejects():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.requires_mlx  # boots `serve`, which imports mlx at CLI load
 @pytest.mark.parametrize("dtype", ["int8", "int4"])
 def test_serve_exits_before_load_for_explicit_gemma4_dtype(tmp_path, dtype):
     """``serve <local-gemma4-dir> --kv-cache-dtype int8/int4`` must exit
@@ -253,6 +254,7 @@ def _scheduler_stub(explicit: bool):
     return sched
 
 
+@pytest.mark.requires_mlx  # imports mlx_lm.models.cache + vllm_mlx.scheduler (mlx)
 def test_live_cache_probe_flags_rotating_cache():
     from mlx_lm.models.cache import KVCache, RotatingKVCache
 
@@ -268,6 +270,7 @@ def test_live_cache_probe_flags_rotating_cache():
     )
 
 
+@pytest.mark.requires_mlx  # imports mlx_lm.models.cache + vllm_mlx.scheduler (mlx)
 def test_live_cache_probe_accepts_plain_kvcache():
     from mlx_lm.models.cache import KVCache
 
@@ -280,6 +283,7 @@ def test_live_cache_probe_accepts_plain_kvcache():
     assert Scheduler._quantized_live_cache_incompatibility(_FakeModel()) is None
 
 
+@pytest.mark.requires_mlx  # imports mlx_lm.models.cache + vllm_mlx.scheduler (mlx)
 def test_explicit_request_fails_closed_on_incompatible_cache():
     """Rotating cache + explicit request: engine start raises pre-ready."""
     from mlx_lm.models.cache import RotatingKVCache
@@ -292,6 +296,7 @@ def test_explicit_request_fails_closed_on_incompatible_cache():
         _scheduler_stub(explicit=True)._init_kv_quantization(_FakeModel())
 
 
+@pytest.mark.requires_mlx  # _scheduler_stub imports vllm_mlx.scheduler (mlx)
 def test_explicit_request_fails_closed_on_unprobeable_cache():
     """A cache layout that cannot be verified must not report ready and
     gamble on the first request (fail closed for explicit requests)."""
@@ -304,6 +309,7 @@ def test_explicit_request_fails_closed_on_unprobeable_cache():
         _scheduler_stub(explicit=True)._init_kv_quantization(_Broken())
 
 
+@pytest.mark.requires_mlx  # imports mlx_lm.models.cache + vllm_mlx.scheduler (mlx)
 def test_auto_request_disables_quantization_on_incompatible_cache(caplog):
     from mlx_lm.models.cache import RotatingKVCache
 
@@ -369,6 +375,7 @@ def test_resident_performance_supported_family_passes(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.requires_mlx  # boots `serve`, which imports mlx at CLI load
 @pytest.mark.parametrize("bits", [4, 8])
 def test_serve_exits_before_load_for_explicit_gemma4_legacy_flag(tmp_path, bits):
     """The deprecated ``--kv-cache-quantization [--kv-cache-quantization-bits

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -2961,19 +2961,20 @@ def test_residency_control_plane_validates_and_forwards_performance(monkeypatch)
 
 
 def test_resident_performance_uses_cli_kv_safety_gate(monkeypatch):
+    """#78: a control-plane kv_cache_dtype is operator-explicit, so an
+    unsupported family is now REJECTED with the shared typed error
+    (mapped to 422 by the residency route) instead of being silently
+    downgraded to bf16 as before."""
+    from vllm_mlx.kv_cache_dtype import KVCacheQuantizationUnsupportedError
     from vllm_mlx.runtime.resident_models import resolve_resident_performance
 
     monkeypatch.setattr(
         "vllm_mlx.cli._gather_kv_cache_dtype_inputs",
         lambda _name: ({"sliding_window": 4096}, None),
     )
-    resolved = resolve_resident_performance(
-        ResidentPerformanceConfig(kv_cache_dtype="int4", cache_memory_mb=2048),
-        model_name="example/sliding-model",
-        model_path=None,
-    )
-
-    assert resolved == ResidentPerformanceConfig(
-        kv_cache_dtype="bf16",
-        cache_memory_mb=2048,
-    )
+    with pytest.raises(KVCacheQuantizationUnsupportedError):
+        resolve_resident_performance(
+            ResidentPerformanceConfig(kv_cache_dtype="int4", cache_memory_mb=2048),
+            model_name="example/sliding-model",
+            model_path=None,
+        )

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -2978,3 +2978,40 @@ def test_resident_performance_uses_cli_kv_safety_gate(monkeypatch):
             model_name="example/sliding-model",
             model_path=None,
         )
+
+
+def test_residency_route_maps_kv_unsupported_rejection_to_422(monkeypatch):
+    """#78: the residency route must surface the shared typed rejection as an
+    actionable 422 BEFORE load, not a 500 from the generic handler."""
+    from types import SimpleNamespace
+
+    from vllm_mlx.routes.residency import router
+
+    manager, _, _, _ = manager_fixture(limit_gib=20)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.residency.get_config",
+        lambda: SimpleNamespace(residency_manager=manager),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.cli._gather_kv_cache_dtype_inputs",
+        # Sliding-window layout with an explicit quantized-KV perf request:
+        # resolve_resident_performance raises KVCacheQuantizationUnsupportedError.
+        lambda _name: ({"sliding_window": 4096}, None),
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/models/load",
+            json={
+                "model": "sliding-model",
+                "performance": {
+                    "kv_cache_dtype": "int4",
+                    "cache_memory_mb": 2048,
+                },
+            },
+        )
+    assert response.status_code == 422
+    assert "#78" not in response.json()["detail"]
+    assert "kv" in response.json()["detail"].lower()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4195,9 +4195,15 @@ def serve_command(args):
     # the legacy --kv-cache-quantization flag is passed, honor it
     # verbatim for backwards compatibility; the new dtype flag only
     # takes effect on operators who haven't pinned the legacy bool.
+    # Operator-explicit quantization (either CLI shape), computed BEFORE
+    # the branch below mutates ``args.kv_cache_quantization`` (#78).
+    _kv_quant_explicit = bool(args.kv_cache_quantization) or (
+        args.kv_cache_dtype != "bf16"
+    )
     kv_cache_decision = None
     if not args.kv_cache_turboquant and not args.kv_cache_quantization:
         from .kv_cache_dtype import (
+            KVCacheQuantizationUnsupportedError,
             dtype_to_quantization_bits,
             log_kv_cache_decision,
             resolve_kv_cache_dtype,
@@ -4205,17 +4211,22 @@ def serve_command(args):
 
         hf_cfg, alias_meta = _gather_kv_cache_dtype_inputs(args.model)
         _continuous_mtp = getattr(args, "mtp_continuous_batching", False)
-        kv_cache_decision = resolve_kv_cache_dtype(
-            args.kv_cache_dtype,
-            # BF16 is at least as quality-preserving as the reasoning
-            # profile's int8 cache. Continuous MTP requires the unquantized
-            # transactional cache, so the method-specific capability wins.
-            reasoning=args.reasoning and not _continuous_mtp,
-            model_name=args.model,
-            hf_path=(alias_meta or {}).get("hf_path"),
-            hf_config=hf_cfg,
-            alias_metadata=alias_meta,
-        )
+        try:
+            kv_cache_decision = resolve_kv_cache_dtype(
+                args.kv_cache_dtype,
+                # BF16 is at least as quality-preserving as the reasoning
+                # profile's int8 cache. Continuous MTP requires the unquantized
+                # transactional cache, so the method-specific capability wins.
+                reasoning=args.reasoning and not _continuous_mtp,
+                explicit=_kv_quant_explicit,
+                model_name=args.model,
+                hf_path=(alias_meta or {}).get("hf_path"),
+                hf_config=hf_cfg,
+                alias_metadata=alias_meta,
+            )
+        except KVCacheQuantizationUnsupportedError as e:
+            print(f"\n  Error: {e}\n")
+            sys.exit(2)
         if _continuous_mtp and args.reasoning:
             logging.getLogger(__name__).info(
                 "Continuous MTP cache policy: keeping BF16 KV cache; the "
@@ -4245,6 +4256,8 @@ def serve_command(args):
         from .kv_cache_dtype import (
             REASONING_KV_CACHE_DTYPE,
             KVCacheDtypeDecision,
+            KVCacheQuantizationUnsupportedError,
+            resolve_kv_cache_dtype,
         )
 
         # The two rejections that used to live here (``--reasoning`` +
@@ -4252,6 +4265,21 @@ def serve_command(args):
         # ``kv_cache_flag_conflict`` and already fired above, so anything
         # reaching this point has a legal bits value.
         legacy_dtype = "int4" if args.kv_cache_quantization_bits == 4 else "int8"
+        # The legacy flag is equally operator-explicit, so it goes through
+        # the same resolver gate as --kv-cache-dtype (#78).
+        _legacy_hf_cfg, _legacy_alias_meta = _gather_kv_cache_dtype_inputs(args.model)
+        try:
+            resolve_kv_cache_dtype(
+                legacy_dtype,
+                explicit=True,
+                model_name=args.model,
+                hf_path=(_legacy_alias_meta or {}).get("hf_path"),
+                hf_config=_legacy_hf_cfg,
+                alias_metadata=_legacy_alias_meta,
+            )
+        except KVCacheQuantizationUnsupportedError as e:
+            print(f"\n  Error: {e}\n")
+            sys.exit(2)
         # When --reasoning is set alongside the (compatible) bits=8
         # legacy flag, the operator-facing reason should still
         # advertise the reasoning profile so the startup banner is
@@ -4421,6 +4449,9 @@ def serve_command(args):
         kv_cache_quantization_bits=args.kv_cache_quantization_bits,
         kv_cache_quantization_group_size=args.kv_cache_quantization_group_size,
         kv_cache_min_quantize_tokens=args.kv_cache_min_quantize_tokens,
+        # Lane-level gates (MLLM engine, live-cache probe) hard-fail
+        # explicit requests they cannot honor (#78).
+        kv_cache_dtype_explicit=_kv_quant_explicit,
         # TurboQuant compression (R15 Phase 4: mode-aware). Shared
         # helper (#969) — ``python -m vllm_mlx.server`` calls the same
         # ``turboquant_scheduler_kwargs`` so both entrypoints stay in
@@ -10661,8 +10692,10 @@ Examples:
             "KV cache 2x/4x for memory-constrained hosts, but the live-cache "
             "dequant-on-read costs O(context) per decode step — measured "
             "-27%% (int4) / -36%% (int8) at 16k context (#1853). "
-            "Sliding-window (Gemma 3, GPT-OSS) and MLA (DeepSeek V3+, "
-            "Kimi K2.5) models auto-downgrade to bf16. Use --reasoning "
+            "An explicit int8/int4 on a sliding-window (Gemma 3/4, "
+            "GPT-OSS) or MLA (DeepSeek V3+, Kimi K2.5) model is rejected "
+            "before the server reports ready (#78); only auto/profile-"
+            "selected quantization downgrades to bf16. Use --reasoning "
             "for AIME / hard math."
         ),
     )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4200,6 +4200,12 @@ def serve_command(args):
     _kv_quant_explicit = bool(args.kv_cache_quantization) or (
         args.kv_cache_dtype != "bf16"
     )
+    # The typed rejection must be importable at the point the
+    # scheduler/MLLM-lane backstop raises it during load_model, regardless
+    # of which KV branch ran above (#78). Imported into this function scope
+    # so the ``except`` clause below always resolves the name.
+    from .kv_cache_dtype import KVCacheQuantizationUnsupportedError
+
     kv_cache_decision = None
     if not args.kv_cache_turboquant and not args.kv_cache_quantization:
         from .kv_cache_dtype import (
@@ -4765,6 +4771,15 @@ def serve_command(args):
             enable_disk_stream=getattr(args, "disk_stream", False),
             disk_stream_cache_gb=getattr(args, "disk_stream_cache_gb", 1.0),
         )
+    except KVCacheQuantizationUnsupportedError as e:
+        # The scheduler/MLLM-lane backstop (#78) rejects an explicit
+        # quantized-KV request that the CLI-time resolver could not see (a
+        # freshly-downloaded model whose config wasn't readable yet surfaces
+        # only once weights load). Surface the SAME actionable error and exit
+        # code (2) as the CLI resolver so every serving lane reports the dtype
+        # contract identically instead of a generic model-load failure.
+        print(f"\n  Error: {e}\n")
+        sys.exit(2)
     except Exception as e:
         # Opt-in telemetry (Phase 2.2 error wiring): record that a model
         # failed to load on the ``serve`` path. The payload carries only a
@@ -10694,8 +10709,8 @@ Examples:
             "-27%% (int4) / -36%% (int8) at 16k context (#1853). "
             "An explicit int8/int4 on a sliding-window (Gemma 3/4, "
             "GPT-OSS) or MLA (DeepSeek V3+, Kimi K2.5) model is rejected "
-            "before the server reports ready (#78); only auto/profile-"
-            "selected quantization downgrades to bf16. Use --reasoning "
+            "before the server reports ready; only auto/profile-selected "
+            "quantization downgrades to bf16. Use --reasoning "
             "for AIME / hard math."
         ),
     )

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -647,6 +647,36 @@ def _probe_mllm_cache_type(language_model: Any) -> str | None:
     return first_incompatible_mllm_cache_type(test_cache)
 
 
+def _check_mllm_kv_quantization(scheduler_config: Any, model_name: str) -> None:
+    """MLLM-lane capability gate for quantized KV caches (#78).
+
+    The MLLM continuous-batching lane has no quantized-KV wiring
+    (``MLLMSchedulerConfig`` carries no quantization knobs). An
+    operator-explicit request therefore fails before weights load and
+    before the port reports ready; auto/profile-selected quantization
+    (e.g. the ``--reasoning`` int8 pin) serves bf16 with a warning
+    instead of staying silent.
+    """
+    if not getattr(scheduler_config, "kv_cache_quantization", False):
+        return
+    if getattr(scheduler_config, "kv_cache_dtype_explicit", False):
+        from ..kv_cache_dtype import KVCacheQuantizationUnsupportedError
+
+        raise KVCacheQuantizationUnsupportedError(
+            requested=getattr(scheduler_config, "kv_cache_dtype", "int8"),
+            model_name=model_name,
+            family_reason=(
+                "the multimodal (MLLM) serving lane has no quantized "
+                "KV-cache path, so the request would be silently ignored"
+            ),
+        )
+    logger.warning(
+        "[kv-cache] quantized KV cache (auto-selected) is not available on "
+        "the MLLM serving lane for '%s'; serving a bf16 KV cache.",
+        model_name,
+    )
+
+
 def _resolve_mllm_cache_policy(
     cache_type: str | None,
     max_num_seqs: int,
@@ -1423,6 +1453,9 @@ class BatchedEngine(BaseEngine):
         from ..mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
         from ..models.mllm import MLXMultimodalLM, TextOnlyCheckpointError
         from ..scheduler import SchedulerConfig
+
+        # Capability gate BEFORE loading weights (#78).
+        _check_mllm_kv_quantization(self._scheduler_config, self._model_name)
 
         # MLLM-tuned default for ``prefill_step_size``. Vision tokens balloon
         # the prompt size on VLMs (~2200 tokens for a 1920×1080 Qwen3-VL

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -25,12 +25,20 @@ short-context numbers that motivated the int4 default (#910,
 fused quantized-attention kernel, quantized KV is a memory/quality
 trade-off the operator must opt into, not a free speedup (#1853).
 
-Auto-downgrade safelist (forces ``bf16``):
+Unsupported-family safelist:
 
-* Sliding-window attention (Gemma 3, GPT-OSS) — the rotating buffer
-  can't tolerate arbitrary-boundary quant blocks.
+* Sliding-window attention (Gemma 3/4, GPT-OSS) — the rotating buffer
+  can't tolerate arbitrary-boundary quant blocks; on Gemma 4 the
+  quantized cache reaches the KV-shared text layers as raw tuples and
+  every request fails (#78).
 * Multi-head Latent Attention (DeepSeek V3+, Kimi K2.5) — the K
   projection is already compressed; quantizing on top compounds error.
+
+An operator-EXPLICIT int8/int4 request on a safelisted family raises
+:class:`KVCacheQuantizationUnsupportedError` before the server reports
+ready (#78) — never a silent bf16 fallback. Only auto/profile-selected
+quantization downgrades to ``bf16``. Nested ``text_config`` dicts
+(multimodal wrappers) are scanned structurally.
 
 The ``--reasoning`` profile pins to ``int8`` regardless of the dtype
 flag (AIME-class hard math collapses ~20pt at sub-4-bit on Qwen3
@@ -108,6 +116,50 @@ _SLIDING_WINDOW_MODEL_TYPES: frozenset[str] = frozenset(
 )
 
 
+class KVCacheQuantizationUnsupportedError(ValueError):
+    """An explicit int8/int4 KV-cache request cannot be honored (#78).
+
+    The single typed rejection contract for every serving lane (text
+    CLI, MLLM engine start, residency route): raised — before the
+    server reports ready — instead of silently serving bf16 when the
+    operator explicitly asked for a quantized KV cache that the model
+    or lane has no supported path for. Only auto/profile-selected
+    quantization may downgrade to bf16.
+
+    Attributes:
+        requested: The dtype the operator asked for.
+        model_name: Model alias / path the request targeted.
+        family_reason: Why the request cannot be honored.
+    """
+
+    def __init__(self, *, requested: str, model_name: str, family_reason: str):
+        self.requested = requested
+        self.model_name = model_name
+        self.family_reason = family_reason
+        super().__init__(
+            f"--kv-cache-dtype {requested} cannot be honored for "
+            f"'{model_name}': {family_reason}. Remove the flag (bf16 is "
+            f"the default and safe everywhere), or pick a full-attention "
+            f"model family for quantized KV."
+        )
+
+
+def _candidate_configs(hf_config: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Config dicts to scan: the top level plus a nested ``text_config``.
+
+    Multimodal checkpoints (Gemma 4) nest the language backbone's fields
+    under ``text_config``; the top-level-only read let int8/int4 through
+    on every Gemma-4 alias (#78).
+    """
+    if hf_config is None:
+        return []
+    configs = [hf_config]
+    text_config = hf_config.get("text_config")
+    if isinstance(text_config, dict):
+        configs.append(text_config)
+    return configs
+
+
 @dataclass(frozen=True)
 class KVCacheDtypeDecision:
     """Outcome of :func:`resolve_kv_cache_dtype`.
@@ -143,13 +195,15 @@ def _is_sliding_window(
     if alias_metadata is not None and alias_metadata.get("sliding_window"):
         return True
 
-    if hf_config is not None:
+    for cfg in _candidate_configs(hf_config):
         # Canonical HF field — populated when the architecture rotates a
         # fixed window per layer (Gemma 3, GPT-OSS, Mistral sliding).
-        sw = hf_config.get("sliding_window")
+        # Checked on the top level AND the nested ``text_config`` so a
+        # multimodal wrapper config (Gemma 4) can't hide the field (#78).
+        sw = cfg.get("sliding_window")
         if isinstance(sw, int) and sw > 0:
             return True
-        model_type = hf_config.get("model_type")
+        model_type = cfg.get("model_type")
         if isinstance(model_type, str) and model_type in _SLIDING_WINDOW_MODEL_TYPES:
             return True
 
@@ -188,8 +242,8 @@ def _is_mla(
     needle = f"{model_name or ''} {hf_path or ''}".lower()
     name_hit = any(pat in needle for pat in _MLA_PATTERNS)
 
-    if hf_config is not None:
-        model_type = hf_config.get("model_type")
+    for cfg in _candidate_configs(hf_config):
+        model_type = cfg.get("model_type")
         if isinstance(model_type, str) and model_type in _MLA_MODEL_TYPES:
             return True
 
@@ -197,8 +251,8 @@ def _is_mla(
         # signal (name match). Avoids the false-positive class where a
         # non-DeepSeek/Kimi model ships both rank fields for unrelated
         # reasons.
-        q_rank = hf_config.get("q_lora_rank")
-        kv_rank = hf_config.get("kv_lora_rank")
+        q_rank = cfg.get("q_lora_rank")
+        kv_rank = cfg.get("kv_lora_rank")
         rank_pair = (
             isinstance(q_rank, int)
             and q_rank > 0
@@ -211,10 +265,48 @@ def _is_mla(
     return name_hit
 
 
+def quantized_kv_unsupported_reason(
+    *,
+    model_name: str | None = None,
+    hf_path: str | None = None,
+    hf_config: dict[str, Any] | None = None,
+    alias_metadata: dict[str, Any] | None = None,
+) -> str | None:
+    """Return why this model cannot serve a quantized KV cache, or None.
+
+    Single source of truth for the family-capability policy — the
+    dtype resolver, the legacy ``--kv-cache-quantization`` CLI branch,
+    and the runtime residency gate all consume this one predicate so
+    the serving lanes cannot drift (#78).
+    """
+    if _is_sliding_window(
+        model_name=model_name or "",
+        hf_path=hf_path,
+        hf_config=hf_config,
+        alias_metadata=alias_metadata,
+    ):
+        return (
+            "sliding-window attention (rotating KV buffers are "
+            "incompatible with QuantizedKVCache block boundaries)"
+        )
+    if _is_mla(
+        model_name=model_name or "",
+        hf_path=hf_path,
+        hf_config=hf_config,
+        alias_metadata=alias_metadata,
+    ):
+        return (
+            "MLA architecture (K projection already compressed via "
+            "q_lora_rank/kv_lora_rank; quantizing on top compounds error)"
+        )
+    return None
+
+
 def resolve_kv_cache_dtype(
     requested: str,
     *,
     reasoning: bool = False,
+    explicit: bool = False,
     model_name: str | None = None,
     hf_path: str | None = None,
     hf_config: dict[str, Any] | None = None,
@@ -228,6 +320,12 @@ def resolve_kv_cache_dtype(
         reasoning: When True, pin to :data:`REASONING_KV_CACHE_DTYPE`
             regardless of ``requested`` — for AIME / hard math / code
             workloads where sub-4-bit drops -20pt on thinking variants.
+        explicit: True when the operator explicitly asked for
+            ``requested`` (CLI flag / control-plane request). An
+            explicit int8/int4 on an unsupported family then raises
+            :class:`KVCacheQuantizationUnsupportedError` pre-ready
+            instead of silently falling back to bf16 (#78); auto/
+            default requests keep the downgrade behavior.
         model_name: Alias key or display name. Used for substring
             detection when ``hf_config`` is unavailable.
         hf_path: Resolved HuggingFace repo path. Same as ``model_name``
@@ -283,34 +381,20 @@ def resolve_kv_cache_dtype(
     # Safelist only kicks in for sub-bf16 requests; an operator who
     # explicitly asked for bf16 should never be silently moved.
     if requested != "bf16":
-        if _is_sliding_window(
-            model_name=model_name or "",
+        family_reason = quantized_kv_unsupported_reason(
+            model_name=model_name,
             hf_path=hf_path,
             hf_config=hf_config,
             alias_metadata=alias_metadata,
-        ):
-            reason = (
-                f"sliding-window attention detected (rotating buffer is "
-                f"incompatible with QuantizedKVCache block boundaries); "
-                f"falling back from {requested} to bf16"
-            )
-            return KVCacheDtypeDecision(
-                dtype="bf16",
-                reason=reason,
-                downgraded=True,
-                requested=requested,
-            )
-        if _is_mla(
-            model_name=model_name or "",
-            hf_path=hf_path,
-            hf_config=hf_config,
-            alias_metadata=alias_metadata,
-        ):
-            reason = (
-                f"MLA architecture detected (K projection already "
-                f"compressed via q_lora_rank/kv_lora_rank); falling back "
-                f"from {requested} to bf16 to avoid compounding error"
-            )
+        )
+        if family_reason is not None:
+            if explicit:
+                raise KVCacheQuantizationUnsupportedError(
+                    requested=requested,
+                    model_name=model_name or hf_path or "unknown",
+                    family_reason=family_reason,
+                )
+            reason = f"{family_reason} detected; falling back from {requested} to bf16"
             return KVCacheDtypeDecision(
                 dtype="bf16",
                 reason=reason,

--- a/vllm_mlx/routes/residency.py
+++ b/vllm_mlx/routes/residency.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, Field, StrictBool, model_validator
 
 from ..config import get_config
+from ..kv_cache_dtype import KVCacheQuantizationUnsupportedError
 from ..middleware.auth import verify_api_key
 from ..middleware.exception_handlers import (
     register_request_model,
@@ -186,6 +187,10 @@ async def load_resident_model(request: ModelLoadRequest):
         )
     except HTTPException:
         raise
+    except KVCacheQuantizationUnsupportedError as exc:
+        # Explicit quantized-KV request the model can't serve (#78):
+        # reject before load with the actionable reason.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     except ResidentModelCapacityError as exc:
         projection = exc.replacement_projection
         if projection is None:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -160,8 +160,12 @@ def resolve_resident_performance(
 
     lookup_name = model_path or model_name
     hf_config, alias_metadata = _gather_kv_cache_dtype_inputs(lookup_name)
+    # A control-plane dtype is operator-explicit: an unsupported family
+    # raises KVCacheQuantizationUnsupportedError before any weights load
+    # (mapped to 422 by the residency route, #78).
     decision = resolve_kv_cache_dtype(
         performance.kv_cache_dtype,
+        explicit=True,
         model_name=model_name,
         hf_path=model_path or (alias_metadata or {}).get("hf_path"),
         hf_config=hf_config,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -269,11 +269,6 @@ class SchedulerConfig:
     kv_cache_quantization_bits: int = 8
     kv_cache_quantization_group_size: int = 64
     kv_cache_min_quantize_tokens: int = 256
-    # True when quantization was an operator-explicit request (CLI flag /
-    # control-plane) rather than an auto/profile default (#78). Lane
-    # capability gates hard-fail explicit requests they cannot honor
-    # (before the server reports ready) instead of silently serving bf16.
-    kv_cache_dtype_explicit: bool = False
 
     # TurboQuant KV cache compression (R15 Phase 4).
     #
@@ -535,6 +530,16 @@ class SchedulerConfig:
     # this independent flag permits membership mutation only when the loaded
     # model descriptor and runtime also attest it.
     mtp_allow_dynamic_membership: bool = False
+
+    # True when quantization was an operator-explicit request (CLI flag /
+    # control-plane) rather than an auto/profile default (#78). Lane
+    # capability gates hard-fail explicit requests they cannot honor
+    # (before the server reports ready) instead of silently serving bf16.
+    # APPEND-ONLY: kept at the tail so the historical positional prefix
+    # (``model_name`` / ``vision_min_pixels`` / ``vision_max_pixels``) is
+    # not shifted — see ``test_scheduler_config_preserves_the_historical_
+    # positional_prefix``.
+    kv_cache_dtype_explicit: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.mtp_continuous_batching, bool):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -269,6 +269,11 @@ class SchedulerConfig:
     kv_cache_quantization_bits: int = 8
     kv_cache_quantization_group_size: int = 64
     kv_cache_min_quantize_tokens: int = 256
+    # True when quantization was an operator-explicit request (CLI flag /
+    # control-plane) rather than an auto/profile default (#78). Lane
+    # capability gates hard-fail explicit requests they cannot honor
+    # (before the server reports ready) instead of silently serving bf16.
+    kv_cache_dtype_explicit: bool = False
 
     # TurboQuant KV cache compression (R15 Phase 4).
     #
@@ -4244,6 +4249,35 @@ class Scheduler:
             self._sampler_cache.popitem(last=False)
         return sampler
 
+    #: Sentinel for a model whose cache layout could not be probed at all.
+    _KV_CACHE_UNPROBEABLE = "unprobeable"
+
+    @classmethod
+    def _quantized_live_cache_incompatibility(cls, model) -> str | None:
+        """Structural capability probe for the quantized live cache (#78).
+
+        Asks the model what caches it actually builds — no family names,
+        no config heuristics. Returns ``None`` when every cache is a
+        plain ``KVCache`` (verified quantized read path), the offending
+        type name otherwise (``RotatingKVCache`` for sliding windows,
+        ``ArraysCache``/``MambaCache`` for hybrids), or
+        :data:`_KV_CACHE_UNPROBEABLE` when no cache list could be built.
+        Backstops the config-level safelist for models whose HF config
+        was not readable at CLI time (fresh download).
+        """
+        try:
+            from mlx_lm.models.cache import KVCache, make_prompt_cache
+
+            caches = make_prompt_cache(model)
+        except Exception:
+            return cls._KV_CACHE_UNPROBEABLE
+        if not caches:
+            return cls._KV_CACHE_UNPROBEABLE
+        for c in caches:
+            if type(c) is not KVCache:
+                return type(c).__name__
+        return None
+
     def _init_kv_quantization(self, model) -> None:
         """Resolve the LIVE cache's group size + install gate (#1197).
 
@@ -4271,6 +4305,40 @@ class Scheduler:
             and not getattr(self.config, "kv_cache_turboquant", None)
         ):
             return
+
+        incompatible_cache = self._quantized_live_cache_incompatibility(model)
+        if incompatible_cache is not None:
+            unprobeable = incompatible_cache == self._KV_CACHE_UNPROBEABLE
+            if getattr(self.config, "kv_cache_dtype_explicit", False):
+                # Fail closed (#78): an explicit quantized request must not
+                # report ready and gamble on the first request — neither on
+                # a known-incompatible layout nor on an unverifiable one.
+                from .kv_cache_dtype import KVCacheQuantizationUnsupportedError
+
+                raise KVCacheQuantizationUnsupportedError(
+                    requested=getattr(self.config, "kv_cache_dtype", "int8"),
+                    model_name=getattr(self.config, "model_name", None)
+                    or type(model).__name__,
+                    family_reason=(
+                        "the model's KV-cache layout could not be probed, so "
+                        "a supported quantized read path cannot be verified"
+                        if unprobeable
+                        else f"the model builds a {incompatible_cache} KV "
+                        f"cache (sliding-window/hybrid attention) with no "
+                        f"supported quantized read path"
+                    ),
+                )
+            if not unprobeable:
+                self._kv_quant_live_disabled = True
+                logger.warning(
+                    "[kv-cache] live KV quantization disabled: model builds a "
+                    "%s cache (sliding-window/hybrid attention) with no "
+                    "supported quantized read path; serving a bf16 live cache.",
+                    incompatible_cache,
+                )
+                return
+            # Unprobeable + auto-selected: the head-dim probe below keeps
+            # the pre-#78 disable behavior.
 
         from .quantized_batch_cache import (
             probe_kv_head_dims,


### PR DESCRIPTION
Closes #2954 — release blocker.

## Problem
Starting a Gemma-4 checkpoint with an explicit `--kv-cache-dtype int8`/`int4`
(also the legacy `--kv-cache-quantization` shape) can report ready and then
503 every generation request: the Gemma-4 backbone stores its sliding-window
metadata under `text_config`, so the old eligibility check read only the top
level of the wrapper config, let the quantized cache through, and the text lane
failed at `scaled_dot_product_attention`.

## Change
- Detect sliding-window / MLA from the structurally nested `text_config` (no
  model-name patterns), so Gemma-4 aliases are no longer admitted.
- New typed rejection contract: an operator-EXPLICIT `int8`/`int4` that cannot
  be honored fails **before the server reports ready** on every lane — CLI
  (both flag shapes, exit 2), MLLM engine start, the text-lane structural
  cache probe, and the residency route (422 pre-load) — with an actionable
  message. Auto/profile-selected quantization still downgrades to `bf16` with
  a logged reason. Supported full-attention families keep their existing
  explicit quantized-KV behavior.
- `serve` now surfaces a scheduler/MLLM backstop rejection with the same
  clean message + exit 2 as the CLI resolver (a fresh-download config that
  isn't readable until weights load previously fell into the generic
  model-load error + exit 1).

## Tests
- New `tests/test_kv_cache_gemma4_gate.py`: nested `text_config` for both
  Gemma-4 shapes and both dtypes, auto-downgrade, explicit rejection, the
  supported-family control, CLI/startup exit, MLLM-lane admission, the
  structural live-cache backstop (known-incompatible and unprobeable layouts),
  residency pre-load, plus the legacy `--kv-cache-quantization` flag shape
  (bits 4 and 8).
- Updated the residency test to assert the new 422 pre-load rejection.
- 320 relevant KV/residency/CLI/config-fidelity/docs/MLLM tests pass;
  `ruff check` and `ruff format --check` clean.

## Non-goals
No new quantized-attention kernel, and no changes to dependencies, CI, release
metadata, prefix-cache, or paged-cache behavior.