### PR TITLE
fix(cache): fail closed and transact paged prefix reuse

### DIFF
--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -3130,3 +3130,114 @@ async def test_start_mllm_does_not_degrade_on_unrelated_load_error(monkeypatch):
         "the mllm-step ThreadPoolExecutor must be shut down and cleared even "
         "when the load failure is not a degrade signal, or its worker thread leaks"
     )
+
+
+# ---------------------------------------------------------------------------
+# #2955 — lane-capability admission at the BatchedEngine text/MLLM split.
+# ---------------------------------------------------------------------------
+
+
+class TestPagedCacheLaneAdmission:
+    """``--use-paged-cache`` is a text-Scheduler capability. The MLLM lane
+    must fail closed at the ``BatchedEngine`` split — before any model
+    weights load or a scheduler is constructed — instead of printing Ready
+    and serving with the flag silently ineffective (the #2955 failure
+    mode, one lane over). The text lane keeps its structural layout gate
+    at Scheduler construction."""
+
+    def _paged_scheduler_config(self):
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        return SchedulerConfig(
+            max_num_seqs=4,
+            enable_prefix_cache=True,
+            use_memory_aware_cache=False,
+            use_paged_cache=True,
+            paged_cache_block_size=16,
+            max_cache_blocks=32,
+        )
+
+    def test_mllm_lane_rejects_paged_cache_before_model_load(self, monkeypatch):
+        import asyncio
+
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+
+        engine = BatchedEngine(
+            "unit-test/mllm-model",
+            force_mllm=True,
+            scheduler_config=self._paged_scheduler_config(),
+        )
+        entered = []
+
+        async def _spy_start_mllm():  # pragma: no cover - must never run
+            entered.append("mllm")
+
+        monkeypatch.setattr(engine, "_start_mllm", _spy_start_mllm)
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
+            asyncio.run(engine.start())
+
+        # The admission fired at the lane split: _start_mllm was never
+        # entered, so no loader executor, no MLLMScheduler, nothing loaded.
+        assert entered == []
+        assert engine._mllm_scheduler is None
+        assert engine._model_load_executor is None
+        assert engine._loaded is False
+        # Actionable: names the flag and both ways out, no model families.
+        message = str(excinfo.value)
+        assert "--use-paged-cache" in message
+        assert "Remove --use-paged-cache" in message
+        assert "--no-mllm" in message
+
+    def test_text_lane_still_reaches_structural_gate(self, monkeypatch):
+        """force_text + paged on a rotating-layout model must PASS the lane
+        admission, run the real text startup path, and abort at the
+        Scheduler's structural gate during engine construction."""
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        import vllm_mlx.gdn_in_proj_fusion as gdn_fusion
+        import vllm_mlx.moe_fusion as moe_fusion
+        import vllm_mlx.runtime.cache as runtime_cache
+        import vllm_mlx.utils.tokenizer as tok_mod
+        from vllm_mlx.engine.batched import BatchedEngine
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+
+        model = MagicMock()
+        model.make_cache = lambda: [KVCache(), RotatingKVCache(max_size=512)]
+        tokenizer = MagicMock()
+        tokenizer.encode = lambda s: list(range(len(s)))
+
+        monkeypatch.setattr(
+            tok_mod,
+            "load_model_with_fallback",
+            lambda name, return_source=True, **kw: (model, tokenizer, "unit-test"),
+        )
+        # Neutralize the weight-touching side steps of the real _start_llm
+        # path; they are irrelevant to the gate under test and would trip
+        # over the mock model.
+        monkeypatch.setattr(moe_fusion, "fuse_gate_up", lambda m: None)
+        monkeypatch.setattr(gdn_fusion, "fuse_gdn_in_proj", lambda m: None)
+        monkeypatch.setattr(
+            runtime_cache, "pin_prefix_cache_identity", lambda *a, **kw: None
+        )
+
+        engine = BatchedEngine(
+            "unit-test/text-model",
+            force_text=True,
+            scheduler_config=self._paged_scheduler_config(),
+        )
+        monkeypatch.setattr(engine, "_install_resolved_metal_budget", lambda: None)
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
+            asyncio.run(engine.start())
+
+        assert "RotatingKVCache" in str(excinfo.value)
+        assert engine._loaded is False
+        # The aborted startup leaves the mlx-step worker behind; reap it so
+        # the test does not leak a thread.
+        if engine._model_load_executor is not None:
+            engine._model_load_executor.shutdown(wait=False)

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -1173,6 +1173,72 @@ class TestSchedulerStartupGate:
         assert "--use-paged-cache" in message
         assert "TurboQuant" in message
 
+    @pytest.mark.parametrize(
+        "layout, config_overrides",
+        [
+            # Plain supported layout: the contradiction alone must reject.
+            ("plain", {}),
+            # Unsupported layout: still the same fail-closed rejection —
+            # never a silent no-cache boot.
+            ("rotating", {}),
+            # Explicit transforms on top of the contradiction: rejected.
+            ("plain", {"kv_cache_quantization": True, "kv_cache_quantization_bits": 4}),
+            ("plain", {"kv_cache_turboquant": True}),
+        ],
+    )
+    def test_paged_without_prefix_cache_rejected(self, layout, config_overrides):
+        """use_paged_cache=True with enable_prefix_cache=False is a
+        contradictory config: pre-fix the capability gate was nested under
+        the enablement branch, so the explicit paged request was silently
+        ignored. It must fail closed at construction with the typed
+        actionable error, regardless of layout or transform flags."""
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+        from vllm_mlx.scheduler import Scheduler
+
+        config = self._config()
+        config.enable_prefix_cache = False
+        for key, value in config_overrides.items():
+            setattr(config, key, value)
+
+        model = MagicMock()
+        if layout == "plain":
+            model.make_cache = lambda: [KVCache(), KVCache()]
+        else:
+            model.make_cache = lambda: [KVCache(), RotatingKVCache(max_size=512)]
+        tokenizer = MagicMock()
+        tokenizer.encode = lambda s: list(range(len(s)))
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
+            Scheduler(model=model, tokenizer=tokenizer, config=config)
+        message = str(excinfo.value)
+        assert "--use-paged-cache" in message
+        assert "prefix cache" in message
+
+    def test_prefix_cache_disabled_without_paged_boots(self):
+        """Negative control: disabling the prefix cache WITHOUT an explicit
+        paged request is a valid configuration and boots with no caches."""
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.scheduler import Scheduler
+
+        config = self._config()
+        config.enable_prefix_cache = False
+        config.use_paged_cache = False
+
+        model = MagicMock()
+        tokenizer = MagicMock()
+        tokenizer.encode = lambda s: list(range(len(s)))
+
+        sched = Scheduler(model=model, tokenizer=tokenizer, config=config)
+        assert sched.block_aware_cache is None
+        assert sched.paged_cache_manager is None
+        assert sched.prefix_cache is None
+        assert sched.memory_aware_cache is None
+
 
 class TestStoreMaterializationFailure:
     """A store whose block materialization fails must report failure (None),

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -1775,3 +1775,758 @@ class TestStoredBlockBufferIndependence:
         # If any stored block aliased the caller's tensors, their full
         # backing buffers would stay resident past this point.
         assert before - after >= int(0.9 * state_bytes)
+
+
+# ---------------------------------------------------------------------------
+# Paged-cache lifecycle invariants (#2955): cumulative identity, reallocated
+# and stale metadata, transactional acquisition/materialization/rollback,
+# pin/unpin, and the scheduler's hit / fallback / cancel / pressure paths.
+# ---------------------------------------------------------------------------
+
+
+def _make_paged_scheduler(block_size=4, max_blocks=32):
+    """Real ``Scheduler`` with a paged ``BlockAwarePrefixCache`` behind a
+    plain full-attention cache factory (passes the #2955 structural gate)."""
+    from unittest.mock import MagicMock
+
+    from mlx_lm.models.cache import KVCache
+
+    from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+    config = SchedulerConfig(
+        max_num_seqs=4,
+        enable_prefix_cache=True,
+        use_memory_aware_cache=False,
+        use_paged_cache=True,
+        paged_cache_block_size=block_size,
+        max_cache_blocks=max_blocks,
+    )
+    model = MagicMock()
+    model.make_cache = lambda: [KVCache(), KVCache()]
+    tokenizer = MagicMock()
+    tokenizer.encode = lambda s: list(range(len(s)))
+    return Scheduler(model=model, tokenizer=tokenizer, config=config)
+
+
+def _make_request(request_id, tokens):
+    from vllm_mlx.request import Request, SamplingParams
+
+    return Request(
+        request_id=request_id,
+        prompt=list(tokens),
+        sampling_params=SamplingParams(max_tokens=4),
+        prompt_token_ids=list(tokens),
+    )
+
+
+def _pressure_tick(sched, max_evict=10):
+    """One pressure-eviction call with Metal reported far above the cap."""
+    from unittest.mock import patch
+
+    with (
+        patch.object(sched, "_resolve_metal_cap_bytes", return_value=100 * 10**9),
+        patch.object(sched, "_current_metal_active_bytes", return_value=200 * 10**9),
+    ):
+        return sched.evict_prefix_cache_under_pressure(max_evict=max_evict)
+
+
+class TestPrefixHasherCumulativeIdentity:
+    """``PrefixHasher`` is the one identity that index keys, block
+    registrations and ownership guards all agree on: it hashes the whole
+    token history through a block, never the block's own chunk."""
+
+    def test_seeded_constructor_continues_the_same_chain(self):
+        from vllm_mlx.paged_cache import PrefixHasher
+
+        chained = PrefixHasher()
+        chained.update([1, 2])
+        chained.update([3, 4])
+        assert PrefixHasher([1, 2, 3, 4]).hexdigest() == chained.hexdigest()
+
+        # store_cache seeds the hasher with the tokens a fetched table
+        # already covers and extends it per new block: same chain.
+        seeded = PrefixHasher([1, 2])
+        seeded.update([3, 4])
+        assert seeded.hexdigest() == chained.hexdigest()
+
+        # No seed tokens, however spelled, is the empty chain.
+        assert PrefixHasher([]).hexdigest() == PrefixHasher().hexdigest()
+        assert PrefixHasher(None).hexdigest() == PrefixHasher().hexdigest()
+
+    def test_identity_depends_on_history_not_on_chunk(self):
+        from vllm_mlx.paged_cache import PrefixHasher
+
+        full = PrefixHasher([1, 2, 3, 4]).hexdigest()
+        same_chunk_other_history = PrefixHasher([9, 9, 3, 4]).hexdigest()
+        chunk_alone = PrefixHasher([3, 4]).hexdigest()
+        assert len({full, same_chunk_other_history, chunk_alone}) == 3
+
+
+class TestReallocatedSlotIdentity:
+    """A slot refilled with new KV must never resurrect as a hit for the
+    tokens it used to hold, and the legacy hash map is never authoritative
+    over the identity a block actually claims."""
+
+    def test_reallocation_retires_legacy_only_registration(self):
+        from vllm_mlx.paged_cache import PagedCacheManager
+
+        # One usable slot (block 0 is the reserved null block).
+        manager = PagedCacheManager(block_size=4, max_blocks=2)
+        block = manager.allocate_block()
+        assert block is not None
+        old_hash = manager.compute_block_hash([1, 2, 3, 4])
+        block.token_count = 4
+        block.cache_data = [object()]  # stands in for a resident KV slice
+        block.cache_class_name = "KVCache"
+        # store_cache registers full blocks exactly like this: identity +
+        # legacy map only, no chain ``block_hash``.
+        manager.register_block_hash_value(block, old_hash)
+        assert block.block_hash is None
+        assert manager.find_cached_block_by_hash(old_hash, record_stats=False) is block
+
+        assert manager.free_block(block.block_id) is True
+        # The freed slab keeps its registration while parked...
+        assert manager.hash_to_block.get(old_hash) == block.block_id
+
+        reused = manager.allocate_block()
+        assert reused is block
+        # ...and reuse retires it BEFORE the slot is handed to a new owner.
+        assert old_hash not in manager.hash_to_block
+        assert reused.hash_value is None
+        assert reused.cache_data is None
+        assert reused.cache_class_name is None
+        misses_before = manager.stats.cache_misses
+        assert manager.find_cached_block_by_hash(old_hash) is None
+        assert manager.stats.cache_misses == misses_before + 1
+
+    def test_lookup_prunes_mapping_superseded_by_a_new_identity(self):
+        from vllm_mlx.paged_cache import PagedCacheManager
+
+        manager = PagedCacheManager(block_size=4, max_blocks=4)
+        block = manager.allocate_block()
+        first = manager.compute_block_hash([1, 2, 3, 4])
+        second = manager.compute_block_hash([5, 6, 7, 8])
+        manager.register_block_hash_value(block, first)
+        manager.register_block_hash_value(block, second)
+        assert manager.hash_to_block[first] == block.block_id  # left behind
+
+        # The block no longer claims ``first``: the lookup must not serve
+        # the slot for the old tokens — it prunes the mapping, counts a
+        # miss, and stays a plain miss afterwards.
+        misses_before = manager.stats.cache_misses
+        assert manager.find_cached_block_by_hash(first) is None
+        assert first not in manager.hash_to_block
+        assert manager.stats.cache_misses == misses_before + 1
+        assert manager.find_cached_block_by_hash(first) is None
+        assert manager.stats.cache_misses == misses_before + 2
+        # The identity the block does claim still resolves as a hit.
+        hits_before = manager.stats.cache_hits
+        assert manager.find_cached_block_by_hash(second) is block
+        assert manager.stats.cache_hits == hits_before + 1
+
+    def test_paged_fork_onto_reused_id_releases_old_table(self):
+        from vllm_mlx.paged_cache import PagedCacheManager
+
+        manager = PagedCacheManager(block_size=4, max_blocks=8)
+        source = manager.create_block_table("src")
+        src_block = manager.allocate_block()
+        manager.add_block_to_table(source, src_block, 4)
+        stale = manager.create_block_table("dst")
+        stale_block = manager.allocate_block()
+        manager.add_block_to_table(stale, stale_block, 4)
+        free_before = manager.free_blocks
+
+        forked = manager.fork_block_table(source, "dst")
+
+        assert forked is not stale and forked.request_id == "dst"
+        assert manager.request_tables["dst"] is forked
+        # The overwritten table's only reference was released, not leaked.
+        assert stale_block.block_id not in manager.allocated_blocks
+        assert manager.free_blocks == free_before + 1
+        # The source block is shared by both tables — exactly once.
+        assert manager.allocated_blocks[src_block.block_id].ref_count == 2
+        manager.delete_block_table("dst")
+        assert manager.allocated_blocks[src_block.block_id].ref_count == 1
+
+
+class TestStoreLayoutFailClosed:
+    """Every unblockizable layout is refused before any block, table or
+    index entry is touched; the slice helper refuses what it cannot back."""
+
+    def test_store_refuses_unblockizable_layouts_without_side_effects(self):
+        states = _kv_layer_states(4)
+        cases = {
+            "empty-list": [],
+            "tuple": (),
+            "string": "state",
+            "layer-without-state": [{"class_name": "KVCache"}],
+            "layer-not-a-dict": [["not", "a", "dict"]],
+            "layer-without-class": [{"state": states[0]["state"], "class_name": None}],
+            "rotating-class": [
+                {"state": states[0]["state"], "class_name": "RotatingKVCache"}
+            ],
+            "second-layer-bad": states + [{"class_name": "KVCache"}],
+        }
+        for label, cache_data in cases.items():
+            cache, manager = _make_cache(block_size=4)
+            allocated_before = manager.stats.allocated_blocks
+            assert cache.store_cache("req", list(range(8)), cache_data) is None, label
+            assert manager.stats.allocated_blocks == allocated_before, label
+            assert manager.get_block_table("req") is None, label
+            assert "req" not in cache._request_tables, label
+            assert cache._prefix_index == {}, label
+
+    def test_slice_helper_refuses_layer_without_state(self):
+        cache, _ = _make_cache(block_size=4)
+        assert (
+            cache._extract_block_tensor_slice([{"class_name": "KVCache"}], 0, 4) is None
+        )
+
+    def test_slice_helper_refuses_block_beyond_backed_rows(self):
+        cache, _ = _make_cache(block_size=4)
+        states = _kv_layer_states(6)
+        assert cache._extract_block_tensor_slice(states, 0, 4) is not None
+        # Rows 4..8 are only partially backed (6 rows): the whole block is
+        # refused rather than a short slice being stored.
+        assert cache._extract_block_tensor_slice(states, 4, 8) is None
+
+
+class TestStoreHonesty:
+    """A store claims exactly the tokens it materialized blocks for."""
+
+    def test_state_with_no_rows_stores_nothing(self):
+        import mlx.core as mx
+
+        cache, manager = _make_cache(block_size=4)
+        empty = mx.zeros((1, 2, 0, 4), dtype=mx.float32)
+        states = [{"state": (empty, empty), "class_name": "KVCache"}]
+        allocated_before = manager.stats.allocated_blocks
+
+        assert cache.store_cache("req", list(range(8)), states) is None
+
+        assert manager.stats.allocated_blocks == allocated_before
+        assert manager.get_block_table("req") is None
+        assert "req" not in cache._request_tables
+        assert cache._prefix_index == {}
+
+    def test_short_state_stores_backed_tokens_with_partial_block_identity(self):
+        from vllm_mlx.paged_cache import PrefixHasher
+
+        cache, manager = _make_cache(block_size=4)
+        tokens8 = list(range(8))
+        # Only 6 of the 8 prompt tokens are backed by KV rows.
+        table = cache.store_cache("req", tokens8, _kv_layer_states(6))
+        assert table is not None
+        assert table.num_tokens == 6 and len(table.block_ids) == 2
+        full, partial = (manager.allocated_blocks[b] for b in table.block_ids)
+        assert full.token_count == 4 and partial.token_count == 2
+
+        # Both blocks carry the cumulative identity through their end...
+        assert full.hash_value == PrefixHasher(tokens8[:4]).hexdigest()
+        assert partial.hash_value == PrefixHasher(tokens8[:6]).hexdigest()
+        # ...but only the full block is registered for sharing.
+        assert manager.hash_to_block[full.hash_value] == full.block_id
+        assert partial.hash_value not in manager.hash_to_block
+
+        # The index covers exactly the backed prefix and verifies live.
+        assert set(cache._prefix_index) == {full.hash_value, partial.hash_value}
+        assert cache._prefix_index[partial.hash_value] == (
+            tokens8[:6],
+            list(table.block_ids),
+        )
+        assert cache.index_entry_is_stale(tokens8[:6], list(table.block_ids)) is False
+
+        # A later request reuses the full block only — a partial block is
+        # never shared — and is told to compute the rest.
+        fetched, remaining = cache.fetch_cache("other", tokens8)
+        assert fetched is not None
+        assert list(fetched.block_ids) == [full.block_id]
+        assert remaining == tokens8[4:]
+
+    def test_slice_failure_truncates_store_at_last_whole_block(self):
+        from unittest.mock import patch
+
+        import mlx.core as mx
+
+        cache, manager = _make_cache(block_size=4)
+        tokens8 = list(range(8))
+        real_contiguous = mx.contiguous
+        calls = {"n": 0}
+
+        def flaky_contiguous(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 3:  # first tensor of the SECOND block
+                raise RuntimeError("injected slice failure")
+            return real_contiguous(*args, **kwargs)
+
+        with patch("mlx.core.contiguous", side_effect=flaky_contiguous):
+            table = cache.store_cache("req", tokens8, _kv_layer_states(8))
+
+        assert calls["n"] >= 3
+        assert table is not None
+        assert len(table.block_ids) == 1 and table.num_tokens == 4
+        assert manager.stats.allocated_blocks == 2  # null block + one block
+        # Index and identity cover only the materialized prefix.
+        (entry,) = cache._prefix_index.values()
+        assert entry == (tokens8[:4], list(table.block_ids))
+        fetched, remaining = cache.fetch_cache("other", tokens8)
+        assert fetched is not None
+        assert fetched.num_tokens == 4 and remaining == tokens8[4:]
+
+
+class TestAcquisitionRollback:
+    """Candidate acquisition is transactional: a block that vanishes
+    between lookup and acquisition truncates the candidate at the last
+    contiguous block, a candidate with nothing acquired leaves no table
+    behind, and a reference taken on a vanished block is given back."""
+
+    def test_owner_release_after_lookup_truncates_candidate(self):
+        from unittest.mock import patch
+
+        cache, manager = _make_cache(block_size=4)
+        tokens8 = list(range(8))
+        # "short" owns block A; "long" extends a fetch hit on A with B.
+        short = cache.store_cache("short", tokens8[:4], _kv_layer_states(4))
+        (a,) = short.block_ids
+        held, _ = cache.fetch_cache("long", tokens8)
+        assert held is not None and list(held.block_ids) == [a]
+        long = cache.store_cache("long", tokens8, _kv_layer_states(8))
+        assert list(long.block_ids)[0] == a
+        b = long.block_ids[1]
+        hits_before, saved_before = cache._hits, cache._tokens_saved
+        real_lookup = manager.find_shared_prefix
+
+        def lookup_then_owner_releases(tokens, **kwargs):
+            ids, rest = real_lookup(tokens, **kwargs)
+            assert ids == [a, b]
+            cache.release_cache("long")  # B's only owner goes away
+            return ids, rest
+
+        with patch.object(
+            manager, "find_shared_prefix", side_effect=lookup_then_owner_releases
+        ):
+            table, remaining = cache.fetch_cache("req", tokens8)
+
+        # Truncated at the vanished block: only A's tokens are claimed.
+        assert table is not None and list(table.block_ids) == [a]
+        assert table.num_tokens == 4 and remaining == tokens8[4:]
+        assert b not in manager.allocated_blocks
+        assert manager.allocated_blocks[a].ref_count == 2
+        assert cache._hits == hits_before + 1
+        assert cache._tokens_saved == saved_before + 4
+        assert cache.reconstruct_cache(table)[0].offset == 4
+
+    def test_owner_release_after_lookup_aborts_with_no_table(self):
+        from unittest.mock import patch
+
+        cache, manager = _make_cache(block_size=4)
+        tokens = list(range(8))
+        seed = cache.store_cache("seed", tokens, _kv_layer_states(8))
+        seed_ids = list(seed.block_ids)
+        real_lookup = manager.find_shared_prefix
+
+        def lookup_then_owner_releases(tokens_, **kwargs):
+            ids, rest = real_lookup(tokens_, **kwargs)
+            assert ids == seed_ids
+            cache.release_cache("seed")
+            return ids, rest
+
+        with patch.object(
+            manager, "find_shared_prefix", side_effect=lookup_then_owner_releases
+        ):
+            table, remaining = cache.fetch_cache("req", tokens)
+
+        assert table is None and remaining == tokens
+        assert manager.get_block_table("req") is None
+        assert "req" not in cache._pending_reconstructed
+        assert cache._misses == 1 and cache._hits == 0
+        for bid in seed_ids:
+            assert bid not in manager.allocated_blocks
+        # Every slot is back in the pool: nothing leaked.
+        assert manager.free_blocks == manager.max_blocks - 1
+
+    def test_block_vanishing_after_ref_bump_is_rolled_back(self):
+        cache, manager = _make_cache(block_size=4)
+        tokens = list(range(8))
+        seed = cache.store_cache("seed", tokens, _kv_layer_states(8))
+        a, victim = seed.block_ids
+
+        class _VanishOnce(dict):
+            """Reports the victim gone exactly once — the lookup that
+            follows a successful ref bump, as if another owner had freed
+            it in between (the manager lock is not held across the two)."""
+
+            armed = True
+
+            def get(self, key, default=None):
+                if self.armed and key == victim:
+                    self.armed = False
+                    return None
+                return super().get(key, default)
+
+        manager.allocated_blocks = _VanishOnce(manager.allocated_blocks)
+
+        table, remaining = cache.fetch_cache("req", tokens)
+
+        assert table is not None and list(table.block_ids) == [a]
+        assert remaining == tokens[4:]
+        # The tentative reference on the vanished block was given back.
+        assert manager.allocated_blocks[victim].ref_count == 1
+        assert manager.allocated_blocks[a].ref_count == 2
+        assert cache._hits == 1 and cache._tokens_saved == 4
+
+
+class TestPrefixIndexOwnershipGuard:
+    """Index metadata is served only while every referenced block still
+    owns the recorded cumulative prefix; anything else is a miss for
+    fetch and pin, and prunable metadata for pressure."""
+
+    def test_reallocated_slot_is_rejected_and_flagged_stale(self):
+        # One usable slot, so the second store reuses the first one's.
+        cache, manager = _make_cache(block_size=4, max_blocks=2)
+        old = [1, 2, 3, 4]
+        new = [5, 6, 7, 8]
+        first = cache.store_cache("first", old, _kv_layer_states(4))
+        (slot,) = first.block_ids
+        (old_key,) = cache._prefix_index
+        assert cache._prefix_index[old_key] == (old, [slot])
+
+        # The owner releases, then the slot is refilled for other tokens.
+        cache.release_cache("first")
+        second = cache.store_cache("second", new, _kv_layer_states(4, base=50.0))
+        assert list(second.block_ids) == [slot]
+        assert manager.allocated_blocks[slot].cache_data is not None
+        # The old entry survives as metadata pointing at the reused slot.
+        assert cache._prefix_index[old_key] == (old, [slot])
+
+        # Identity mismatch: the resident KV belongs to ``new``.
+        assert cache.index_entry_is_stale(old, [slot]) is True
+        assert cache._find_best_prefix_match(old) is None
+        table, remaining = cache.fetch_cache("probe", old)
+        assert table is None and remaining == old
+        assert cache._misses == 1 and cache._hits == 0
+        assert manager.allocated_blocks[slot].ref_count == 1
+
+        # The new owner's prefix is intact and still served.
+        assert cache.index_entry_is_stale(new, [slot]) is False
+        table, remaining = cache.fetch_cache("probe-new", new)
+        assert table is not None and remaining == []
+        assert manager.allocated_blocks[slot].ref_count == 2
+
+    def test_entry_claiming_more_tokens_than_its_blocks_verify_is_skipped(self):
+        from vllm_mlx.paged_cache import PrefixHasher
+
+        cache, _ = _make_cache(block_size=4)
+        tokens8 = list(range(8))
+        table = cache.store_cache("seed", tokens8[:4], _kv_layer_states(4))
+        (slot,) = table.block_ids
+        # Metadata that claims 8 tokens but names only the 4-token block.
+        cache._prefix_index[PrefixHasher(tokens8).hexdigest()] = (tokens8, [slot])
+
+        # The over-claiming entry is skipped; the longest VERIFIED prefix
+        # wins instead.
+        assert cache._find_best_prefix_match(tokens8) == (tokens8[:4], [slot])
+
+    def test_entry_whose_blocks_exceed_its_tokens_is_not_served(self):
+        from vllm_mlx.paged_cache import PrefixHasher
+
+        cache, _ = _make_cache(block_size=4)
+        tokens8 = list(range(8))
+        table = cache.store_cache("seed", tokens8, _kv_layer_states(8))
+        a, b = table.block_ids
+        # Metadata for 4 tokens that names two 4-token blocks.
+        key4 = PrefixHasher(tokens8[:4]).hexdigest()
+        cache._prefix_index[key4] = (tokens8[:4], [a, b])
+
+        assert cache._find_best_prefix_match(tokens8[:4]) is None
+        assert cache.index_entry_is_stale(tokens8[:4], [a, b]) is True
+
+    def test_unhashed_blocks_extend_the_chain_without_being_stale(self):
+        from vllm_mlx.paged_cache import PrefixHasher
+
+        cache, manager = _make_cache(block_size=4)
+        tokens8 = list(range(8))
+        table = cache.store_cache("seed", tokens8, _kv_layer_states(8))
+        a, b = table.block_ids
+
+        # A block that claims no identity (legacy/unhashed) is tolerated:
+        # the chain continues through its span so a later hashed block is
+        # still verified against the SAME cumulative identity.
+        manager.allocated_blocks[a].hash_value = None
+        assert cache.index_entry_is_stale(tokens8, [a, b]) is False
+        # ...and a later hashed block that disagrees still flags the entry.
+        manager.allocated_blocks[b].hash_value = PrefixHasher([9] * 8).hexdigest()
+        assert cache.index_entry_is_stale(tokens8, [a, b]) is True
+        # When the entry's tokens run out before an unhashed block, the
+        # rest is unverifiable, not stale.
+        manager.allocated_blocks[b].hash_value = None
+        assert cache.index_entry_is_stale(tokens8[:4], [a, b]) is False
+
+    def test_index_never_records_a_prefix_past_an_unverifiable_block(self):
+        from vllm_mlx.paged_cache import PrefixHasher
+
+        cache, _ = _make_cache(block_size=4)
+        tokens8 = list(range(8))
+        table = cache.store_cache("seed", tokens8[:4], _kv_layer_states(4))
+        (a,) = table.block_ids
+        cache._prefix_index.clear()
+
+        cache._update_prefix_index(tokens8, [a, 999])  # 999: no such block
+
+        assert cache._prefix_index == {
+            PrefixHasher(tokens8[:4]).hexdigest(): (tokens8[:4], [a]),
+        }
+
+
+class TestPrefixIndexFallbackAndPinning:
+    """The block-hash map is a dedup accelerator; the prefix index plus
+    per-block identities are the ownership record. Fetch and pin keep
+    working through the index when the map has no mapping, and pinning
+    sticks to the verified blocks."""
+
+    def test_fetch_falls_back_to_verified_index_entry(self):
+        cache, manager = _make_cache(block_size=4)
+        tokens = list(range(8))
+        seed = cache.store_cache("seed", tokens, _kv_layer_states(8))
+        manager.hash_to_block.clear()
+        assert manager.find_shared_prefix(tokens, record_stats=False) == ([], tokens)
+
+        table, remaining = cache.fetch_cache("req", tokens + [42])
+
+        assert table is not None
+        assert list(table.block_ids) == list(seed.block_ids)
+        assert table.num_tokens == 8 and remaining == [42]
+        for bid in seed.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 2
+        assert cache._hits == 1 and cache._tokens_saved == 8
+        assert cache.reconstruct_cache(table)[0].offset == 8
+
+    def test_pin_and_unpin_through_shared_prefix(self):
+        cache, manager = _make_cache(block_size=4)
+        tokens = list(range(8))
+        seed = cache.store_cache("seed", tokens, _kv_layer_states(8))
+
+        assert cache.pin_prefix(tokens) is True
+        assert sorted(manager.get_pinned_block_ids()) == sorted(seed.block_ids)
+        assert cache.unpin_prefix(tokens) is True
+        assert manager.get_pinned_block_ids() == []
+        # Nothing pinned any more: a repeat unpin reports no work done.
+        assert cache.unpin_prefix(tokens) is False
+
+    def test_pin_and_unpin_through_index_fallback(self):
+        cache, manager = _make_cache(block_size=4)
+        tokens = list(range(8))
+        seed = cache.store_cache("seed", tokens, _kv_layer_states(8))
+        manager.hash_to_block.clear()
+
+        assert cache.pin_prefix(tokens) is True
+        assert sorted(manager.get_pinned_block_ids()) == sorted(seed.block_ids)
+        assert cache.unpin_prefix(tokens) is True
+        assert manager.get_pinned_block_ids() == []
+
+    def test_pin_and_unpin_unknown_prefix_report_false(self):
+        cache, manager = _make_cache(block_size=4)
+        cache.store_cache("seed", list(range(8)), _kv_layer_states(8))
+        unknown = [77, 78, 79, 80]
+
+        assert cache.pin_prefix(unknown) is False
+        assert cache.unpin_prefix(unknown) is False
+        assert manager.get_pinned_block_ids() == []
+
+
+class TestSchedulerPagedRequestLifecycle:
+    """The scheduler's paged-cache lifecycle end to end: an admitted
+    request commits a fetch hit and owns its refs, a cancelled request
+    releases what its hit acquired, and a committed fetch that cannot be
+    rehosted is released and served as a miss — never a phantom hit."""
+
+    def _seed(self, sched, tokens):
+        table = sched.block_aware_cache.store_cache(
+            "seed", tokens, _kv_layer_states(len(tokens))
+        )
+        assert table is not None
+        return table
+
+    def test_admitted_request_commits_hit_and_owns_refs(self):
+        sched = _make_paged_scheduler()
+        cache = sched.block_aware_cache
+        manager = cache.paged_cache
+        tokens = list(range(8))
+        seed = self._seed(sched, tokens)
+
+        request = _make_request("req-hit", tokens + [100, 101])
+        sched.add_request(request)
+
+        assert request.cache_hit_type == "hit"
+        assert request.cached_tokens == 8
+        assert request.shared_prefix_blocks == 2
+        assert request.remaining_tokens == [100, 101]
+        assert request.block_table is not None
+        assert request.block_table.request_id == "req-hit"
+        assert list(request.block_table.block_ids) == list(seed.block_ids)
+        # The caches the fetch transaction built are handed to the request
+        # (stash consumed), rehosted at the cached offset.
+        assert request.prompt_cache is not None
+        assert request.prompt_cache[0].offset == 8
+        assert "req-hit" not in cache._pending_reconstructed
+        for bid in seed.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 2
+        assert cache._hits == 1 and cache._misses == 0
+        assert "req-hit" in sched.requests
+
+    def test_unrelated_prompt_is_a_miss_holding_nothing(self):
+        sched = _make_paged_scheduler()
+        cache = sched.block_aware_cache
+        manager = cache.paged_cache
+        self._seed(sched, list(range(8)))
+
+        request = _make_request("req-miss", [500, 501, 502, 503, 504])
+        sched.add_request(request)
+
+        assert request.cache_hit_type == "miss"
+        assert request.cached_tokens == 0
+        assert request.prompt_cache is None
+        assert request.block_table is None
+        assert request.remaining_tokens == request.prompt_token_ids
+        assert manager.get_block_table("req-miss") is None
+        assert cache._misses == 1 and cache._hits == 0
+
+    def test_cancel_releases_refs_acquired_by_the_hit(self):
+        from vllm_mlx.request import RequestStatus
+
+        sched = _make_paged_scheduler()
+        cache = sched.block_aware_cache
+        manager = cache.paged_cache
+        tokens = list(range(8))
+        seed = self._seed(sched, tokens)
+        request = _make_request("req-cancel", tokens)
+        sched.add_request(request)
+        for bid in seed.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 2
+
+        assert sched.abort_request("req-cancel") is True
+        sched._process_pending_aborts()
+
+        assert request.status == RequestStatus.FINISHED_CANCELLED
+        assert request.prompt_cache is None
+        assert "req-cancel" in sched.finished_req_ids
+        assert manager.get_block_table("req-cancel") is None
+        assert "req-cancel" not in cache._pending_reconstructed
+        for bid in seed.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 1
+            assert manager.allocated_blocks[bid].cache_data is not None
+        # Idempotent: the later finished-cleanup release finds nothing held.
+        cache.release_cache("req-cancel")
+        for bid in seed.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 1
+        # The seed entry still serves hits.
+        table, remaining = cache.fetch_cache("req-after", tokens)
+        assert table is not None and remaining == []
+
+    def test_unrehostable_committed_fetch_is_released_and_served_as_miss(self, caplog):
+        import logging
+        from unittest.mock import patch
+
+        sched = _make_paged_scheduler()
+        cache = sched.block_aware_cache
+        manager = cache.paged_cache
+        tokens = list(range(8))
+        seed = self._seed(sched, tokens)
+        request = _make_request("req-fallback", tokens + [7, 7])
+
+        with (
+            patch.object(cache, "reconstruct_cache", return_value=None),
+            caplog.at_level(logging.WARNING),
+        ):
+            sched.add_request(request)
+
+        assert request.cache_hit_type == "miss"
+        assert request.prompt_cache is None
+        assert request.block_table is None
+        assert request.cached_tokens == 0
+        assert request.remaining_tokens == request.prompt_token_ids
+        # The refs the committed fetch held were released: nothing is
+        # owned by a request that will now prefill from scratch.
+        assert manager.get_block_table("req-fallback") is None
+        assert "req-fallback" not in cache._pending_reconstructed
+        for bid in seed.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 1
+        assert any(
+            "reconstruction failed after committed fetch" in record.getMessage()
+            for record in caplog.records
+        )
+        # Admission still completed.
+        assert "req-fallback" in sched.requests
+
+
+class TestSchedulerPagedPressureCleanup:
+    """Pressure ticks drain stored owners first, then prune only index
+    metadata that no longer owns its prefix — never a live block."""
+
+    def test_owner_eviction_then_stale_metadata_prune_then_quiescence(self):
+        sched = _make_paged_scheduler()
+        cache = sched.block_aware_cache
+        manager = cache.paged_cache
+        tokens = list(range(8))
+        seed = cache.store_cache("seed", tokens, _kv_layer_states(8))
+        seed_ids = list(seed.block_ids)
+        index_keys = set(cache._prefix_index)
+        assert len(index_keys) == 2
+
+        # Tick 1: the stored owner is evicted (blocks cleared + released).
+        assert _pressure_tick(sched, max_evict=1) == 1
+        assert "seed" not in cache._request_tables
+        for bid in seed_ids:
+            assert bid not in manager.allocated_blocks
+        # The index outlived its blocks: dead metadata, still present.
+        assert set(cache._prefix_index) == index_keys
+
+        # Tick 2: with no owner left, the index path prunes entries whose
+        # blocks are gone — one per eviction — without touching any slot.
+        free_before = manager.free_blocks
+        assert _pressure_tick(sched, max_evict=10) == 2
+        assert cache._prefix_index == {}
+        assert manager.free_blocks == free_before
+        assert sched.num_prefix_cache_pressure_evictions == 3
+
+        # Tick 3: nothing left to reclaim.
+        assert _pressure_tick(sched, max_evict=10) == 0
+        # A later request is a clean miss — no phantom hit on freed slots.
+        table, remaining = cache.fetch_cache("later", tokens)
+        assert table is None and remaining == tokens
+
+    def test_index_prune_leaves_active_fetch_blocks_untouched(self):
+        sched = _make_paged_scheduler()
+        cache = sched.block_aware_cache
+        manager = cache.paged_cache
+        tokens = list(range(8))
+        seed = cache.store_cache("seed", tokens, _kv_layer_states(8))
+        seed_ids = list(seed.block_ids)
+        # An active request holds the seed's blocks through a fetch hit.
+        held, _ = cache.fetch_cache("active", tokens)
+        assert held is not None
+        for bid in seed_ids:
+            assert manager.allocated_blocks[bid].ref_count == 2
+
+        # Owner eviction: shared blocks keep their KV (ref > 1) and the
+        # active fetch becomes the sole owner.
+        assert _pressure_tick(sched, max_evict=1) == 1
+        for bid in seed_ids:
+            blk = manager.allocated_blocks[bid]
+            assert blk.ref_count == 1 and blk.cache_data is not None
+
+        # Index-only pass: the entries still verify against the live,
+        # identity-intact blocks, so nothing is pruned or cleared.
+        assert _pressure_tick(sched, max_evict=10) == 0
+        assert len(cache._prefix_index) == 2
+        for bid in seed_ids:
+            blk = manager.allocated_blocks[bid]
+            assert blk.ref_count == 1 and blk.cache_data is not None
+        # The active request can still be rehosted from its table.
+        assert cache.reconstruct_cache(held) is not None
+
+        # Once the active request releases, the entries are dead and the
+        # next tick prunes them.
+        cache.release_cache("active")
+        assert _pressure_tick(sched, max_evict=10) == 2
+        assert cache._prefix_index == {}

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -14,6 +14,38 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _kv_layer_states(num_tokens, layers=1, heads=2, head_dim=4, base=0.0):
+    """Build extracted layer-state dicts backed by real mlx-lm KVCache state.
+
+    ``store_cache`` only accepts the extracted-tensor-state layout (list of
+    dicts with 'state' + 'class_name' where every layer is a plain 4D
+    KVCache); tests that exercise the supported path build inputs here.
+    """
+    import mlx.core as mx
+    from mlx_lm.models.cache import KVCache
+
+    states = []
+    for layer in range(layers):
+        cache = KVCache()
+        n = num_tokens * heads * head_dim
+        keys = (
+            mx.arange(n, dtype=mx.float32).reshape(1, heads, num_tokens, head_dim)
+            + base
+            + layer
+        )
+        values = keys + 0.5
+        cache.update_and_fetch(keys, values)
+        states.append(
+            {
+                "state": cache.state,
+                "meta_state": cache.meta_state,
+                "class_name": "KVCache",
+                "class_ref": KVCache,
+            }
+        )
+    return states
+
+
 class TestCacheBlock:
     """Test CacheBlock dataclass."""
 
@@ -605,17 +637,21 @@ class TestBlockAwarePrefixCache:
 
         # Store cache for first request
         tokens1 = list(range(128))  # 2 blocks worth
-        cache_data1 = ["cache_data_1"]
+        cache_data1 = _kv_layer_states(128)
         block_table = cache.store_cache("req-1", tokens1, cache_data1)
 
         assert block_table is not None
         assert block_table.num_tokens == 128
         assert len(block_table.block_ids) == 2
+        # Every stored block must carry reconstructable tensor data.
+        for bid in block_table.block_ids:
+            assert paged_manager.allocated_blocks[bid].cache_data is not None
 
         # Fetch cache for second request with same prefix
         block_table2, remaining = cache.fetch_cache("req-2", tokens1 + [999, 1000])
 
         # Should hit the prefix
+        assert block_table2 is not None
         assert remaining == [999, 1000]
 
     def test_release_cache(self):
@@ -627,7 +663,7 @@ class TestBlockAwarePrefixCache:
         cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
 
         tokens = list(range(64))
-        cache.store_cache("req-1", tokens, ["data"])
+        cache.store_cache("req-1", tokens, _kv_layer_states(64))
 
         assert len(cache) == 1
 
@@ -644,7 +680,7 @@ class TestBlockAwarePrefixCache:
         cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
 
         tokens = list(range(128))
-        cache.store_cache("req-1", tokens, ["shared_data"])
+        cache.store_cache("req-1", tokens, _kv_layer_states(128))
 
         # Fork to new request
         forked_table = cache.fork_cache("req-1", "req-2")
@@ -656,40 +692,11 @@ class TestBlockAwarePrefixCache:
         stats = cache.get_stats()
         assert stats["shared_blocks"] > 0
 
-    def test_get_cache_for_generation(self):
-        """Test getting cache for generation with COW."""
-        from vllm_mlx.paged_cache import PagedCacheManager
-        from vllm_mlx.prefix_cache import BlockAwarePrefixCache
-
-        paged_manager = PagedCacheManager(block_size=64, max_blocks=100)
-        cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
-
-        tokens = list(range(64))
-        cache.store_cache("req-1", tokens, ["data"])
-
-        # Get cache for generation (no COW needed)
-        cache_data, was_copied = cache.get_cache_for_generation("req-1")
-
-        assert cache_data == ["data"]
-        assert was_copied is False
-
-    def test_get_cache_for_generation_with_cow(self):
-        """Test COW is triggered for shared blocks."""
-        from vllm_mlx.paged_cache import PagedCacheManager
-        from vllm_mlx.prefix_cache import BlockAwarePrefixCache
-
-        paged_manager = PagedCacheManager(block_size=64, max_blocks=100)
-        cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
-
-        tokens = list(range(64))
-        cache.store_cache("req-1", tokens, ["shared_data"])
-        cache.fork_cache("req-1", "req-2")
-
-        # Get cache for forked request - should trigger COW
-        cache_data, was_copied = cache.get_cache_for_generation("req-2")
-
-        assert cache_data is not None
-        assert was_copied is True
+        # Blocks are the source of truth: the forked table reconstructs the
+        # same KV state the source stored.
+        reconstructed = cache.reconstruct_cache(forked_table)
+        assert reconstructed is not None
+        assert reconstructed[0].offset == 128
 
     def test_stats(self):
         """Test statistics."""
@@ -715,8 +722,8 @@ class TestBlockAwarePrefixCache:
         cache = BlockAwarePrefixCache(model=None, paged_cache_manager=paged_manager)
 
         tokens = list(range(128))
-        cache.store_cache("req-1", tokens, ["data"])
-        cache.store_cache("req-2", tokens, ["data2"])
+        cache.store_cache("req-1", tokens, _kv_layer_states(128))
+        cache.store_cache("req-2", tokens, _kv_layer_states(128, base=100.0))
 
         assert len(cache) == 2
 
@@ -727,15 +734,15 @@ class TestBlockAwarePrefixCache:
         # After clear, null block is still allocated (vLLM style)
         assert stats["allocated_blocks"] == 1  # only null block
 
-    def test_slices_3d_kv_along_seq_axis(self):
-        """3D KV state (Qwen3.5-style ``(n_kv_heads, seq, head_dim)``) must
-        be sliced along seq (axis 1), not axis 2 (which is ``head_dim``).
-        Regression for upstream waybarrios#286 — pre-fix, the 4D-hardcoded
-        slice ``keys[:, :, start:end, :]`` crashed on 3D state and dropped
-        the whole entry, masking the issue. ``reconstruct_cache`` still
-        refuses 3D state because mlx_lm's ``KVCache`` accessors hard-code
-        ``shape[2]`` for seq; hosting 3D state there would silently corrupt
-        downstream generation."""
+    def test_rejects_3d_kv_state_everywhere(self):
+        """3D KV state (``(n_kv_heads, seq, head_dim)``) is refused at
+        store AND reconstruct. Historically (upstream waybarrios#286) the
+        store side sliced 3D state along axis 1 while ``reconstruct_cache``
+        refused it — mlx_lm's ``KVCache`` accessors hard-code ``shape[2]``
+        for seq — so 3D blocks were stored but never reusable: dead weight
+        that read as a healthy cache with zero reuse (#2955). Store and
+        reconstruct must agree, so both now fail closed on anything but
+        4D."""
         import mlx.core as mx
         from mlx_lm.models.cache import KVCache
 
@@ -754,12 +761,12 @@ class TestBlockAwarePrefixCache:
             "class_name": "KVCache",
         }
 
-        sliced = cache._extract_block_tensor_slice([layer_state], 0, 4)
-        assert sliced is not None and len(sliced) == 1
-        sliced_keys, sliced_values = sliced[0]
-        assert sliced_keys.tolist() == kv_keys[:, :4, :].tolist()
-        assert sliced_values.tolist() == kv_values[:, :4, :].tolist()
-        assert cache._cache_state_seq_axis((kv_keys, kv_values)) == 1
+        # 3D state is not blockizable: no slice, no store, no blocks.
+        assert cache._extract_block_tensor_slice([layer_state], 0, 4) is None
+        assert cache.store_cache("req-3d", list(range(8)), [layer_state]) is None
+        assert paged_manager.stats.allocated_blocks == 1  # null block only
+        assert cache._cache_state_seq_axis((kv_keys, kv_values)) is None
+
         four_d = mx.zeros((1, 2, 8, 3))
         assert cache._cache_state_seq_axis((four_d, four_d)) == 2
         assert cache._cache_state_seq_axis((four_d,)) is None
@@ -771,11 +778,11 @@ class TestBlockAwarePrefixCache:
         assert cache._cache_state_seq_axis((None, four_d)) is None
         assert cache._cache_state_seq_axis((None, None)) is None
         # Class-name gate: a Mamba/DeltaNet ``ArraysCache`` may happen to
-        # hold two same-shape 3D tensors, but its tensors are NOT seq-
+        # hold two same-shape tensors, but its tensors are NOT seq-
         # indexed. The gate must reject any class outside the allowlist.
         # Regression for codex round-3 finding on PR #392.
         assert (
-            cache._cache_state_seq_axis((kv_keys, kv_values), class_name="ArraysCache")
+            cache._cache_state_seq_axis((four_d, four_d), class_name="ArraysCache")
             is None
         )
         assert (
@@ -783,12 +790,12 @@ class TestBlockAwarePrefixCache:
             is None
         )
         assert cache._cache_state_seq_axis((four_d, four_d), class_name="KVCache") == 2
-        # When class_name is omitted, fall back to the shape-only heuristic.
+        # When class_name is omitted, fall back to the shape-only check.
         assert cache._cache_state_seq_axis((four_d, four_d)) == 2
         # Extract path itself rejects layers whose class_name is not KVCache,
         # even when their tensors look slicable.
         non_kv_layer = {
-            "state": (kv_keys, kv_values),
+            "state": (four_d, four_d),
             "meta_state": "",
             "class_ref": None,
             "class_name": "ArraysCache",
@@ -918,3 +925,608 @@ class TestBlockAwarePrefixCache:
         assert dst is not None
         assert dst.cache_data == src.cache_data
         assert dst.cache_class_name == "KVCache"
+
+
+# =============================================================================
+# #2955 — capability validation, transactional fetch, snapshot-free stores.
+# Folded into this (CI-enrolled) module so the Apple lane runs them.
+#
+# Two invariants of ``--use-paged-cache``:
+#
+# 1. Capability is structural and fails closed pre-ready: the loaded model's
+#    prompt-cache factory must produce a layout the block serializer can
+#    losslessly slice and reconstruct (plain full-attention ``KVCache`` on
+#    every layer). Rotating/sliding, Arrays/hybrid, recurrent, quantized and
+#    unknown layouts abort startup with a typed, actionable error — never a
+#    healthy server with silent zero reuse. No model/architecture names are
+#    consulted.
+#
+# 2. Cache hit acquisition is a transaction: candidate lookup tentatively
+#    holds block refs, reconstruction validates the result, and only then do
+#    hit/tokens-saved counters commit. Any failure aborts — refs and table
+#    state released, exactly one miss counted — and release is idempotent
+#    after both commit and abort.
+# =============================================================================
+
+
+def _make_cache(block_size=64, max_blocks=100):
+    from vllm_mlx.paged_cache import PagedCacheManager
+    from vllm_mlx.prefix_cache import BlockAwarePrefixCache
+
+    manager = PagedCacheManager(block_size=block_size, max_blocks=max_blocks)
+    return BlockAwarePrefixCache(model=None, paged_cache_manager=manager), manager
+
+
+class _FactoryModel:
+    """Model stub whose prompt-cache factory returns the given layers."""
+
+    def __init__(self, factory):
+        self._factory = factory
+
+    def make_cache(self):
+        return self._factory()
+
+
+class TestStructuralCapabilityMatrix:
+    """Layout family matrix for ``validate_paged_cache_capability``."""
+
+    def test_plain_kv_accepted(self):
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.prefix_cache import validate_paged_cache_capability
+
+        validate_paged_cache_capability(_FactoryModel(lambda: [KVCache(), KVCache()]))
+
+    def test_default_factory_plain_kv_accepted(self):
+        """A model without ``make_cache`` gets mlx-lm's default plain-KV
+        factory — accepted."""
+        from vllm_mlx.prefix_cache import validate_paged_cache_capability
+
+        class NoFactory:
+            layers = [object(), object()]
+
+        validate_paged_cache_capability(NoFactory())
+
+    def test_sliding_capable_arch_with_inactive_sliding_accepted(self):
+        """The gate is structural: an architecture that CAN slide but whose
+        factory returns plain KV (sliding disabled in its config) is
+        accepted — no architecture-name allowlist involved."""
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.prefix_cache import validate_paged_cache_capability
+
+        class SlidingCapable(_FactoryModel):
+            sliding_window = None  # inactive
+
+        validate_paged_cache_capability(SlidingCapable(lambda: [KVCache(), KVCache()]))
+
+    @pytest.mark.parametrize(
+        "layer_factory, expected",
+        [
+            # Rotating/sliding-window layout.
+            (
+                lambda cachemod: [
+                    cachemod.KVCache(),
+                    cachemod.RotatingKVCache(max_size=512),
+                ],
+                "RotatingKVCache",
+            ),
+            # Recurrent/Mamba-style hybrid (ArraysCache holds conv/recurrent
+            # state; not seq-indexed).
+            (
+                lambda cachemod: [cachemod.KVCache(), cachemod.ArraysCache(2)],
+                "ArraysCache",
+            ),
+            # Quantized tuple layout.
+            (
+                lambda cachemod: [cachemod.QuantizedKVCache()],
+                "QuantizedKVCache",
+            ),
+        ],
+    )
+    def test_unsupported_families_rejected(self, layer_factory, expected):
+        from mlx_lm.models import cache as cachemod
+
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+        from vllm_mlx.prefix_cache import validate_paged_cache_capability
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
+            validate_paged_cache_capability(
+                _FactoryModel(lambda: layer_factory(cachemod))
+            )
+        assert expected in excinfo.value.incompatible_layers
+        # Actionable: names the flag and the way out.
+        assert "--use-paged-cache" in str(excinfo.value)
+        assert "Remove --use-paged-cache" in str(excinfo.value)
+
+    def test_unknown_layout_rejected(self):
+        """Fail closed on classes the serializer has never seen — including
+        a same-named class that is not mlx-lm's ``KVCache``."""
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+        from vllm_mlx.prefix_cache import validate_paged_cache_capability
+
+        class KVCache:  # same name, unknown type — must NOT pass
+            pass
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
+            validate_paged_cache_capability(_FactoryModel(lambda: [KVCache()]))
+        assert "KVCache" in excinfo.value.incompatible_layers
+
+    def test_unverifiable_probe_rejected(self):
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+        from vllm_mlx.prefix_cache import validate_paged_cache_capability
+
+        def boom():
+            raise RuntimeError("no cache for you")
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError):
+            validate_paged_cache_capability(_FactoryModel(boom))
+        # Non-list factory output is just as unverifiable.
+        with pytest.raises(PagedCacheUnsupportedLayoutError):
+            validate_paged_cache_capability(_FactoryModel(lambda: object()))
+
+    def test_quantized_kv_config_rejected(self):
+        """Active KV quantization stores weight/scale/bias tuples the
+        serializer cannot slice — rejected even on a plain-KV factory."""
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+        from vllm_mlx.prefix_cache import validate_paged_cache_capability
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError):
+            validate_paged_cache_capability(
+                _FactoryModel(lambda: [KVCache()]), kv_cache_quantized=True
+            )
+
+
+class TestSchedulerStartupGate:
+    """Explicit --use-paged-cache on an unsupported layout must fail at
+    scheduler construction — before readiness or any request service."""
+
+    def _config(self):
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        return SchedulerConfig(
+            max_num_seqs=4,
+            enable_prefix_cache=True,
+            use_memory_aware_cache=False,
+            use_paged_cache=True,
+            paged_cache_block_size=16,
+            max_cache_blocks=32,
+        )
+
+    def test_rotating_layout_fails_before_ready(self):
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+        from vllm_mlx.scheduler import Scheduler
+
+        model = MagicMock()
+        model.make_cache = lambda: [KVCache(), RotatingKVCache(max_size=512)]
+        tokenizer = MagicMock()
+        tokenizer.encode = lambda s: list(range(len(s)))
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
+            Scheduler(model=model, tokenizer=tokenizer, config=self._config())
+        assert "RotatingKVCache" in str(excinfo.value)
+        assert "--use-paged-cache" in str(excinfo.value)
+
+    def test_plain_layout_boots_with_paged_cache(self):
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.scheduler import Scheduler
+
+        model = MagicMock()
+        model.make_cache = lambda: [KVCache(), KVCache()]
+        tokenizer = MagicMock()
+        tokenizer.encode = lambda s: list(range(len(s)))
+
+        sched = Scheduler(model=model, tokenizer=tokenizer, config=self._config())
+        assert sched.block_aware_cache is not None
+
+
+class TestTransactionalFetch:
+    """Fetch commits counters only after successful reconstruction; every
+    failure aborts cleanly."""
+
+    def _seed(self, cache, tokens):
+        table = cache.store_cache("seed", tokens, _kv_layer_states(len(tokens)))
+        assert table is not None and len(table.block_ids) == 2
+        return table
+
+    def _assert_aborted(self, cache, manager, seed_table, request_id):
+        assert cache._hits == 0
+        assert cache._tokens_saved == 0
+        assert cache._misses == 1
+        # Tentative refs released: back to the store entry's single ref.
+        for bid in seed_table.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 1
+        # No table or stash retained for the failed request.
+        assert manager.get_block_table(request_id) is None
+        assert request_id not in cache._request_tables
+        assert request_id not in cache._pending_reconstructed
+
+    def test_commit_on_success(self):
+        cache, manager = _make_cache()
+        tokens = list(range(128))
+        seed = self._seed(cache, tokens)
+
+        table, remaining = cache.fetch_cache("req-a", tokens + [7, 8])
+        assert table is not None
+        assert remaining == [7, 8]
+        assert cache._hits == 1
+        assert cache._misses == 0
+        assert cache._tokens_saved == 128
+        for bid in seed.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 2
+
+        reconstructed = cache.reconstruct_cache(table)
+        assert reconstructed is not None and len(reconstructed) == 1
+        assert reconstructed[0].offset == 128
+
+    def test_missing_tensor_data_aborts(self):
+        cache, manager = _make_cache()
+        seed = self._seed(cache, list(range(128)))
+        manager.allocated_blocks[seed.block_ids[1]].cache_data = None
+
+        table, remaining = cache.fetch_cache("req-b", list(range(128)))
+        assert table is None and remaining == list(range(128))
+        self._assert_aborted(cache, manager, seed, "req-b")
+
+    def test_wrong_cache_class_aborts(self):
+        cache, manager = _make_cache()
+        seed = self._seed(cache, list(range(128)))
+        manager.allocated_blocks[seed.block_ids[0]].cache_class_name = "RotatingKVCache"
+
+        table, _ = cache.fetch_cache("req-c", list(range(128)))
+        assert table is None
+        self._assert_aborted(cache, manager, seed, "req-c")
+
+    def test_wrong_shape_aborts(self):
+        import mlx.core as mx
+
+        cache, manager = _make_cache()
+        seed = self._seed(cache, list(range(128)))
+        bad = mx.zeros((2, 64, 4))  # 3D — not hostable by mlx-lm KVCache
+        manager.allocated_blocks[seed.block_ids[0]].cache_data = [(bad, bad)]
+
+        table, _ = cache.fetch_cache("req-d", list(range(128)))
+        assert table is None
+        self._assert_aborted(cache, manager, seed, "req-d")
+
+    def test_reconstruction_exception_aborts(self):
+        import mlx.core as mx
+
+        cache, manager = _make_cache()
+        seed = self._seed(cache, list(range(128)))
+        # Head-count mismatch between blocks: mx.concatenate raises.
+        bad = mx.zeros((1, 3, 64, 4))
+        manager.allocated_blocks[seed.block_ids[1]].cache_data = [(bad, bad)]
+
+        table, _ = cache.fetch_cache("req-e", list(range(128)))
+        assert table is None
+        self._assert_aborted(cache, manager, seed, "req-e")
+
+    def test_release_idempotent_after_commit(self):
+        cache, manager = _make_cache()
+        seed = self._seed(cache, list(range(128)))
+        table, _ = cache.fetch_cache("req-f", list(range(128)))
+        assert table is not None
+        for _ in range(3):
+            cache.release_cache("req-f")
+            for bid in seed.block_ids:
+                assert manager.allocated_blocks[bid].ref_count == 1
+        assert manager.get_block_table("req-f") is None
+
+    def test_release_idempotent_after_abort(self):
+        cache, manager = _make_cache()
+        seed = self._seed(cache, list(range(128)))
+        manager.allocated_blocks[seed.block_ids[1]].cache_data = None
+        table, _ = cache.fetch_cache("req-g", list(range(128)))
+        assert table is None
+        for _ in range(3):
+            cache.release_cache("req-g")
+            for bid in seed.block_ids:
+                assert manager.allocated_blocks[bid].ref_count == 1
+
+    def test_repeated_prefix_reuse_returns_identical_kv(self):
+        """Supported full-attention store/fetch/reconstruct over a repeated
+        prefix keeps working and returns the exact stored KV state."""
+        import mlx.core as mx
+
+        cache, _ = _make_cache()
+        tokens = list(range(128))
+        states = _kv_layer_states(128)
+        cache.store_cache("seed", tokens, states)
+
+        for i, request_id in enumerate(("req-h", "req-i")):
+            table, remaining = cache.fetch_cache(request_id, tokens + [500 + i])
+            assert table is not None
+            assert remaining == [500 + i]
+            reconstructed = cache.reconstruct_cache(table)
+            assert reconstructed is not None
+            assert reconstructed[0].offset == 128
+            orig_keys, orig_values = states[0]["state"]
+            assert mx.array_equal(reconstructed[0].keys, orig_keys).item()
+            assert mx.array_equal(reconstructed[0].values, orig_values).item()
+            cache.release_cache(request_id)
+
+        assert cache._hits == 2
+        assert cache._tokens_saved == 256
+
+
+class TestStoreRetention:
+    """Blocks are the source of truth; stores never retain snapshots."""
+
+    def test_unsupported_store_retains_nothing(self):
+        """A rotating-layout store must allocate zero blocks and retain
+        zero snapshots — the exact baseline failure of #2955 (2 stored
+        blocks, 0 with tensor data, full snapshot retained)."""
+        import mlx.core as mx
+        from mlx_lm.models.cache import RotatingKVCache
+
+        cache, manager = _make_cache(block_size=64, max_blocks=16)
+        rot = RotatingKVCache(max_size=256)
+        rot.update_and_fetch(mx.zeros((1, 2, 128, 8)), mx.zeros((1, 2, 128, 8)))
+        cache_data = [
+            {
+                "state": rot.state,
+                "meta_state": rot.meta_state,
+                "class_name": "RotatingKVCache",
+                "class_ref": RotatingKVCache,
+            }
+        ]
+
+        assert cache.store_cache("req-rot", list(range(128)), cache_data) is None
+        assert manager.stats.allocated_blocks == 1  # null block only
+        assert len(cache._request_tables) == 0
+        assert len(cache._prefix_index) == 0
+        assert manager.get_block_table("req-rot") is None
+
+    def test_supported_store_does_not_retain_original_by_identity(self):
+        """The stored entry and blocks must not hold the caller's cache
+        objects: no snapshot on the entry, and block tensors are
+        materialized copies, not the caller's arrays."""
+        cache, manager = _make_cache()
+        tokens = list(range(128))
+        states = _kv_layer_states(128)
+        table = cache.store_cache("req-1", tokens, states)
+        assert table is not None
+
+        entry = cache._request_tables["req-1"]
+        assert not hasattr(entry, "cache_data")
+
+        original_tensors = {id(t) for layer in states for t in layer["state"]}
+        original_tensors.add(id(states))
+        for bid in table.block_ids:
+            block = manager.allocated_blocks[bid]
+            assert block.cache_data is not None
+            for keys, values in block.cache_data:
+                assert id(keys) not in original_tensors
+                assert id(values) not in original_tensors
+
+
+class TestContextualBlockIdentity:
+    """Block identity must cover the whole preceding history (#2955).
+
+    KV for block N depends on blocks 0..N-1, so equal token chunks with
+    divergent histories must never share storage — while truly identical
+    prefixes must still deduplicate.
+    """
+
+    def test_divergent_histories_do_not_share_equal_chunks(self):
+        import mlx.core as mx
+
+        cache, _ = _make_cache(block_size=4, max_blocks=16)
+        a_tokens = [1, 1, 1, 1, 7, 7, 7, 7]
+        b_tokens = [2, 2, 2, 2, 7, 7, 7, 7]
+        a_states = _kv_layer_states(8, base=10.0)
+        b_states = _kv_layer_states(8, base=20.0)
+        table_a = cache.store_cache("req-a", a_tokens, a_states)
+        table_b = cache.store_cache("req-b", b_tokens, b_states)
+        assert table_a is not None and len(table_a.block_ids) == 2
+        assert table_b is not None and len(table_b.block_ids) == 2
+        # The equal trailing chunk must NOT dedup across divergent
+        # histories: its KV was computed under different context.
+        assert set(table_a.block_ids).isdisjoint(table_b.block_ids)
+
+        # Each fetch must reconstruct its OWN stored KV, bit for bit.
+        for request_id, tokens, states in (
+            ("read-a", a_tokens, a_states),
+            ("read-b", b_tokens, b_states),
+        ):
+            table, remaining = cache.fetch_cache(request_id, tokens)
+            assert table is not None and remaining == []
+            reconstructed = cache.reconstruct_cache(table)
+            keys, values = states[0]["state"]
+            assert mx.array_equal(reconstructed[0].keys, keys).item()
+            assert mx.array_equal(reconstructed[0].values, values).item()
+            cache.release_cache(request_id)
+
+    def test_identical_prefixes_still_dedup(self):
+        cache, manager = _make_cache(block_size=4, max_blocks=16)
+        tokens = [1, 1, 1, 1, 7, 7, 7, 7]
+        table_1 = cache.store_cache("req-1", tokens, _kv_layer_states(8, base=1.0))
+        table_2 = cache.store_cache("req-2", tokens, _kv_layer_states(8, base=1.0))
+        assert table_1.block_ids == table_2.block_ids
+        for bid in table_1.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 2
+
+    def test_suffix_chunk_never_matches_as_prefix(self):
+        """A stored SECOND block's chunk offered at position 0 must miss:
+        under chunk-local hashing it would fetch mid-sequence KV as if it
+        were a sequence head."""
+        cache, _ = _make_cache(block_size=4, max_blocks=16)
+        cache.store_cache("req-a", [1, 1, 1, 1, 7, 7, 7, 7], _kv_layer_states(8))
+
+        table, remaining = cache.fetch_cache("read-c", [7, 7, 7, 7, 9, 9])
+        assert table is None
+        assert remaining == [7, 7, 7, 7, 9, 9]
+
+
+class TestEngineStartupBoundary:
+    """The typed capability error must surface through the real engine
+    startup boundary: ``EngineCore`` constructs the ``Scheduler`` during
+    ``__init__`` — before readiness or any request service — and must not
+    swallow or downgrade the exception."""
+
+    def test_engine_core_surfaces_unsupported_layout(self):
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        from vllm_mlx.engine_core import EngineConfig, EngineCore
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+        from vllm_mlx.scheduler import SchedulerConfig
+
+        model = MagicMock()
+        model.make_cache = lambda: [KVCache(), RotatingKVCache(max_size=512)]
+        tokenizer = MagicMock()
+        tokenizer.encode = lambda s: list(range(len(s)))
+
+        scheduler_config = SchedulerConfig(
+            max_num_seqs=4,
+            enable_prefix_cache=True,
+            use_memory_aware_cache=False,
+            use_paged_cache=True,
+            paged_cache_block_size=16,
+            max_cache_blocks=32,
+        )
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
+            EngineCore(
+                model=model,
+                tokenizer=tokenizer,
+                config=EngineConfig(scheduler_config=scheduler_config),
+            )
+        assert "RotatingKVCache" in str(excinfo.value)
+        assert "--use-paged-cache" in str(excinfo.value)
+
+
+class TestReusedRequestIdInvariants:
+    """Reusing a request id must release prior state instead of leaking
+    block references."""
+
+    def test_fetch_with_reused_id_releases_prior_state(self):
+        cache, manager = _make_cache(block_size=4, max_blocks=16)
+        tokens = list(range(8))
+        table = cache.store_cache("req-1", tokens, _kv_layer_states(8))
+        old_ids = list(table.block_ids)
+        free_before = manager.free_blocks
+
+        result_table, remaining = cache.fetch_cache("req-1", tokens)
+
+        # The stored entry held the only reference: releasing it frees the
+        # blocks, so the fetch under the reused id is a clean miss with no
+        # leaked table and the slots back in the pool.
+        assert result_table is None and remaining == tokens
+        assert manager.get_block_table("req-1") is None
+        assert "req-1" not in cache._request_tables
+        for bid in old_ids:
+            assert bid not in manager.allocated_blocks
+        assert manager.free_blocks == free_before + len(old_ids)
+
+    def test_create_block_table_releases_overwritten_table(self):
+        from vllm_mlx.paged_cache import PagedCacheManager
+
+        manager = PagedCacheManager(block_size=4, max_blocks=8)
+        table = manager.create_block_table("req-1")
+        block = manager.allocate_block()
+        manager.add_block_to_table(table, block, 4)
+        assert manager.allocated_blocks[block.block_id].ref_count == 1
+
+        manager.create_block_table("req-1")  # reused id
+
+        # The old table's reference was released, not leaked.
+        assert block.block_id not in manager.allocated_blocks
+        assert manager.get_block_table("req-1").block_ids == []
+
+    def test_fork_onto_existing_id_does_not_leak(self):
+        cache, manager = _make_cache(block_size=4, max_blocks=16)
+        table_a = cache.store_cache("req-a", [1, 1, 1, 1], _kv_layer_states(4))
+        table_b = cache.store_cache("req-b", [2, 2, 2, 2], _kv_layer_states(4))
+        old_b_ids = list(table_b.block_ids)
+
+        forked = cache.fork_cache("req-a", "req-b")
+
+        assert forked is not None
+        # req-b's old blocks were released (their only ref was its entry).
+        for bid in old_b_ids:
+            assert bid not in manager.allocated_blocks
+        # req-a's blocks are now shared by its entry and the fork.
+        for bid in table_a.block_ids:
+            assert manager.allocated_blocks[bid].ref_count == 2
+
+    def test_self_fork_is_noop_and_does_not_leak(self):
+        """fork_cache(id, id) must not bump refs and then overwrite the
+        only owning entry — release afterwards must free everything."""
+        cache, manager = _make_cache(block_size=4, max_blocks=16)
+        table = cache.store_cache("same", [1, 2, 3, 4], _kv_layer_states(4))
+        assert table is not None
+        bid = table.block_ids[0]
+
+        forked = cache.fork_cache("same", "same")
+
+        # No-op: the existing table IS the fork; no reference was added.
+        assert forked is table
+        assert manager.allocated_blocks[bid].ref_count == 1
+
+        cache.release_cache("same")
+        assert bid not in manager.allocated_blocks
+        assert manager.get_block_table("same") is None
+
+    def test_paged_self_fork_block_table_is_noop(self):
+        """fork_block_table onto the id the table is registered under must
+        be a no-op at the paged layer too."""
+        from vllm_mlx.paged_cache import PagedCacheManager
+
+        manager = PagedCacheManager(block_size=4, max_blocks=8)
+        table = manager.create_block_table("same")
+        block = manager.allocate_block()
+        manager.add_block_to_table(table, block, 4)
+
+        forked = manager.fork_block_table(table, "same")
+
+        assert forked is table
+        assert manager.request_tables["same"] is table
+        assert manager.allocated_blocks[block.block_id].ref_count == 1
+
+        manager.delete_block_table("same")
+        assert block.block_id not in manager.allocated_blocks
+
+
+class TestStoredBlockBufferIndependence:
+    """Stored blocks must own their KV memory: dropping the caller's
+    extracted state must actually free its buffers. Guards against MLX
+    slice aliasing — a seq-axis slice with a single KV head is already
+    row-contiguous, so a no-copy materialization shortcut would silently
+    retain the caller's entire KV buffer for every block."""
+
+    def test_store_releases_caller_buffers_single_kv_head(self):
+        import gc
+
+        import mlx.core as mx
+
+        cache, _ = _make_cache(block_size=64, max_blocks=80)
+        num_tokens = 4096
+        states = _kv_layer_states(num_tokens, heads=1, head_dim=64)
+        keys, values = states[0]["state"]
+        state_bytes = keys.nbytes + values.nbytes
+
+        table = cache.store_cache("req-mem", list(range(num_tokens)), states)
+        assert table is not None
+        assert len(table.block_ids) == num_tokens // 64
+
+        del keys, values
+        gc.collect()
+        before = mx.get_active_memory()
+        del states
+        gc.collect()
+        after = mx.get_active_memory()
+
+        # If any stored block aliased the caller's tensors, their full
+        # backing buffers would stay resident past this point.
+        assert before - after >= int(0.9 * state_bytes)

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -1065,18 +1065,22 @@ class TestStructuralCapabilityMatrix:
         with pytest.raises(PagedCacheUnsupportedLayoutError):
             validate_paged_cache_capability(_FactoryModel(lambda: object()))
 
-    def test_quantized_kv_config_rejected(self):
-        """Active KV quantization stores weight/scale/bias tuples the
-        serializer cannot slice — rejected even on a plain-KV factory."""
+    def test_kv_transform_request_rejected(self):
+        """An explicit KV-cache transform request (quantization or
+        TurboQuant) is rejected even on a plain-KV factory: the paged store
+        implements neither, so it must not silently serve plain blocks."""
         from mlx_lm.models.cache import KVCache
 
         from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
         from vllm_mlx.prefix_cache import validate_paged_cache_capability
 
-        with pytest.raises(PagedCacheUnsupportedLayoutError):
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
             validate_paged_cache_capability(
-                _FactoryModel(lambda: [KVCache()]), kv_cache_quantized=True
+                _FactoryModel(lambda: [KVCache()]),
+                kv_cache_transform_requested=True,
             )
+        assert "--use-paged-cache" in str(excinfo.value)
+        assert "TurboQuant" in str(excinfo.value)
 
 
 class TestSchedulerStartupGate:
@@ -1127,6 +1131,181 @@ class TestSchedulerStartupGate:
 
         sched = Scheduler(model=model, tokenizer=tokenizer, config=self._config())
         assert sched.block_aware_cache is not None
+
+    @pytest.mark.parametrize(
+        "config_overrides",
+        [
+            # Ordinary live KV quantization toggles — rejected even though
+            # the runtime head-dim probe might later fall back and disable
+            # the transform: an explicit flag pair that cannot be honored
+            # must fail closed, not silently serve plain BF16 blocks.
+            {"kv_cache_quantization": True, "kv_cache_quantization_bits": 4},
+            {"kv_cache_quantization": True, "kv_cache_quantization_bits": 8},
+            # TurboQuant request — equally unimplemented by the paged store.
+            {"kv_cache_turboquant": True},
+        ],
+    )
+    def test_explicit_kv_transform_plus_paged_fails_before_ready(
+        self, config_overrides
+    ):
+        """Real Scheduler configuration: --use-paged-cache combined with an
+        explicit KV quantization/TurboQuant request fails at construction
+        even on a plain full-attention KV layout."""
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.errors import PagedCacheUnsupportedLayoutError
+        from vllm_mlx.scheduler import Scheduler
+
+        config = self._config()
+        for key, value in config_overrides.items():
+            setattr(config, key, value)
+
+        model = MagicMock()
+        model.make_cache = lambda: [KVCache(), KVCache()]
+        tokenizer = MagicMock()
+        tokenizer.encode = lambda s: list(range(len(s)))
+
+        with pytest.raises(PagedCacheUnsupportedLayoutError) as excinfo:
+            Scheduler(model=model, tokenizer=tokenizer, config=config)
+        message = str(excinfo.value)
+        assert "--use-paged-cache" in message
+        assert "TurboQuant" in message
+
+
+class TestStoreMaterializationFailure:
+    """A store whose block materialization fails must report failure (None),
+    never the fetch-held table as success — and the scheduler's cleanup
+    branch must then release the fetch-held refs/table/stash."""
+
+    def test_extension_store_failure_returns_none_and_release_restores(self):
+        from unittest.mock import patch
+
+        cache, manager = _make_cache(block_size=4)
+        tokens4 = list(range(4))
+        tokens8 = list(range(8))
+
+        seed_table = cache.store_cache("seed", tokens4, _kv_layer_states(4))
+        assert seed_table is not None and len(seed_table.block_ids) == 1
+        bid = seed_table.block_ids[0]
+
+        # Successful fetch: one shared ref held by req-x's table.
+        table, remaining = cache.fetch_cache("req-x", tokens8)
+        assert table is not None
+        assert remaining == tokens8[4:]
+        assert manager.allocated_blocks[bid].ref_count == 2
+
+        allocated_before = manager.stats.allocated_blocks
+        with patch("mlx.core.eval", side_effect=RuntimeError("injected")):
+            stored = cache.store_cache("req-x", tokens8, _kv_layer_states(8))
+
+        # Failure is reported as failure — not the fetch-held table.
+        assert stored is None
+        # Materialization fails before any table/block mutation: nothing
+        # new allocated, no entry claims ownership of the fetched blocks.
+        assert manager.stats.allocated_blocks == allocated_before
+        assert "req-x" not in cache._request_tables
+
+        # The scheduler acts on None by releasing; mirror that here and
+        # prove it restores every counter and leaves no ownerless state.
+        cache.release_cache("req-x")
+        assert manager.get_block_table("req-x") is None
+        assert "req-x" not in cache._pending_reconstructed
+        assert manager.allocated_blocks[bid].ref_count == 1
+        assert manager.allocated_blocks[bid].cache_data is not None
+
+        # The seed entry is unharmed and still serves hits.
+        table2, remaining2 = cache.fetch_cache("req-y", tokens4)
+        assert table2 is not None and remaining2 == []
+
+    def test_scheduler_cleanup_releases_after_store_failure(self):
+        """Production path: ``_cleanup_finished`` sees ``stored_table is
+        None`` from the failed store and releases the fetch-held
+        table/refs/stash — counters stay coherent, no ownerless table."""
+        from unittest.mock import MagicMock, patch
+
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+        config = SchedulerConfig(
+            max_num_seqs=4,
+            enable_prefix_cache=True,
+            use_memory_aware_cache=False,
+            use_paged_cache=True,
+            paged_cache_block_size=4,
+            max_cache_blocks=32,
+        )
+        model = MagicMock()
+        model.make_cache = lambda: [KVCache(), KVCache()]
+        tokenizer = MagicMock()
+        tokenizer.encode = lambda s: list(range(len(s)))
+        sched = Scheduler(model=model, tokenizer=tokenizer, config=config)
+        cache = sched.block_aware_cache
+        assert cache is not None
+        manager = cache.paged_cache
+
+        tokens4 = list(range(4))
+        tokens8 = list(range(8))
+        assert cache.store_cache("seed", tokens4, _kv_layer_states(4)) is not None
+        bid = cache._request_tables["seed"].block_table.block_ids[0]
+        allocated_after_seed = manager.stats.allocated_blocks
+
+        table, _ = cache.fetch_cache("req-x", tokens8)
+        assert table is not None
+        assert manager.allocated_blocks[bid].ref_count == 2
+
+        request = MagicMock()
+        request.prompt_token_ids = tokens8
+        request.output_token_ids = []
+        request.pflash_metadata = None
+        request._extracted_cache = _kv_layer_states(8)
+        sched.running["req-x"] = request
+
+        # Spy on the store's return value; fail ONLY its materialization
+        # eval (first mx.eval inside _cleanup_finished), then pass through
+        # so the later incremental per-layer eval loop runs for real.
+        store_returns = []
+        real_store = cache.store_cache
+
+        def spying_store(*args, **kwargs):
+            result = real_store(*args, **kwargs)
+            store_returns.append(result)
+            return result
+
+        real_eval = mx.eval
+        eval_calls = {"n": 0}
+
+        def flaky_eval(*args, **kwargs):
+            eval_calls["n"] += 1
+            if eval_calls["n"] == 1:
+                raise RuntimeError("injected materialization failure")
+            return real_eval(*args, **kwargs)
+
+        with (
+            patch.object(cache, "store_cache", side_effect=spying_store),
+            patch("mlx.core.eval", side_effect=flaky_eval),
+        ):
+            sched._cleanup_finished({"req-x"})
+
+        assert eval_calls["n"] >= 1  # the injection actually fired
+        assert store_returns == [None]  # store reported failure
+
+        # Production cleanup released everything the fetch held: no
+        # ownerless table, no stash, no entry — and the shared ref is back
+        # to the seed entry's single ref with its KV intact.
+        assert manager.get_block_table("req-x") is None
+        assert "req-x" not in cache._request_tables
+        assert "req-x" not in cache._pending_reconstructed
+        assert manager.allocated_blocks[bid].ref_count == 1
+        assert manager.allocated_blocks[bid].cache_data is not None
+        assert "seed" in cache._request_tables
+        # Counters coherent: no allocation survived beyond the seed store.
+        assert manager.stats.allocated_blocks == allocated_after_seed
+        assert "req-x" not in sched.running
+        assert "req-x" in sched.finished_req_ids
 
 
 class TestTransactionalFetch:

--- a/tests/test_paged_cache_benefits.py
+++ b/tests/test_paged_cache_benefits.py
@@ -57,6 +57,28 @@ def print_table(
     print(f"+{separator}+")
 
 
+def _kv(num_tokens, base=0.0):
+    """Real extracted KVCache layer states — ``store_cache`` refuses
+    anything the block serializer cannot losslessly reconstruct (#2955)."""
+    import mlx.core as mx
+    from mlx_lm.models.cache import KVCache
+
+    cache = KVCache()
+    keys = (
+        mx.arange(num_tokens * 2 * 4, dtype=mx.float32).reshape(1, 2, num_tokens, 4)
+        + base
+    )
+    cache.update_and_fetch(keys, keys + 0.5)
+    return [
+        {
+            "state": cache.state,
+            "meta_state": cache.meta_state,
+            "class_name": "KVCache",
+            "class_ref": KVCache,
+        }
+    ]
+
+
 def test_benefit_1_shared_system_prompts():
     """
     Benefit 1: Multiple users sharing the same system prompt.
@@ -92,7 +114,7 @@ def test_benefit_1_shared_system_prompts():
 
     # Simulate storing cache for first request (establishes the prefix)
     first_request_tokens = system_prompt_tokens + user_queries[0]
-    cache.store_cache("req-0", first_request_tokens, ["kv_cache_data"])
+    cache.store_cache("req-0", first_request_tokens, _kv(len(first_request_tokens)))
 
     initial_blocks = paged_manager.stats.allocated_blocks
     print(f"After 1st request: {initial_blocks} blocks allocated")
@@ -111,7 +133,7 @@ def test_benefit_1_shared_system_prompts():
         total_shared_tokens += shared_tokens
 
         # Store the new request
-        cache.store_cache(f"req-{i}", full_tokens, [f"kv_cache_data_{i}"])
+        cache.store_cache(f"req-{i}", full_tokens, _kv(len(full_tokens), base=float(i)))
 
         results.append(
             [
@@ -201,15 +223,15 @@ def test_benefit_2_memory_efficiency():
     for i in range(20):
         # Each request: 128 shared + 128 unique = 256 total
         tokens = common_prefix_1 + list(range(5000 + i * 200, 5128 + i * 200))
-        cache.store_cache(f"group1-req-{i}", tokens, [f"cache_{i}"])
+        cache.store_cache(f"group1-req-{i}", tokens, _kv(len(tokens), base=float(i)))
 
     for i in range(15):
         tokens = common_prefix_2 + list(range(10000 + i * 200, 10128 + i * 200))
-        cache.store_cache(f"group2-req-{i}", tokens, [f"cache_{i}"])
+        cache.store_cache(f"group2-req-{i}", tokens, _kv(len(tokens), base=100.0 + i))
 
     for i in range(15):
         tokens = common_prefix_3 + list(range(15000 + i * 200, 15128 + i * 200))
-        cache.store_cache(f"group3-req-{i}", tokens, [f"cache_{i}"])
+        cache.store_cache(f"group3-req-{i}", tokens, _kv(len(tokens), base=200.0 + i))
 
     paged_total = paged_manager.stats.allocated_blocks
     shared_blocks = paged_manager.stats.shared_blocks
@@ -291,7 +313,7 @@ def test_benefit_3_prefix_sharing():
 
     # First conversation: Python discussion
     python_intro = root_tokens + list(range(100, 140))  # "Tell me about Python"
-    cache.store_cache("conv-python", python_intro, ["python_cache"])
+    cache.store_cache("conv-python", python_intro, _kv(len(python_intro)))
 
     # Follow-ups share the python_intro prefix
     python_followups = [
@@ -309,7 +331,9 @@ def test_benefit_3_prefix_sharing():
         print(
             f"    Follow-up {i + 1}: {len(tokens)} tokens, {shared} shared ({shared * 100 // len(tokens)}%)"
         )
-        cache.store_cache(f"python-followup-{i}", tokens, [f"followup_{i}"])
+        cache.store_cache(
+            f"python-followup-{i}", tokens, _kv(len(tokens), base=10.0 + i)
+        )
 
     # Second conversation: Rust discussion
     rust_intro = root_tokens + list(range(500, 540))  # "Tell me about Rust"
@@ -321,7 +345,7 @@ def test_benefit_3_prefix_sharing():
     print("\nRust conversation:")
     print(f"  Shares root with Python: {root_shared} tokens (system prompt)")
 
-    cache.store_cache("conv-rust", rust_intro, ["rust_cache"])
+    cache.store_cache("conv-rust", rust_intro, _kv(len(rust_intro), base=50.0))
 
     rust_followups = [
         rust_intro + list(range(600, 650)),  # "Ownership model?"
@@ -334,7 +358,7 @@ def test_benefit_3_prefix_sharing():
         print(
             f"    Follow-up {i + 1}: {len(tokens)} tokens, {shared} shared ({shared * 100 // len(tokens)}%)"
         )
-        cache.store_cache(f"rust-followup-{i}", tokens, [f"rust_followup_{i}"])
+        cache.store_cache(f"rust-followup-{i}", tokens, _kv(len(tokens), base=60.0 + i))
 
     # Summary
     stats = cache.get_stats()
@@ -393,7 +417,7 @@ def test_copy_on_write_demo():
 
     # Original conversation
     original_tokens = list(range(128))  # 2 blocks
-    cache.store_cache("original", original_tokens, ["original_kv_cache"])
+    cache.store_cache("original", original_tokens, _kv(len(original_tokens)))
 
     initial_blocks = paged_manager.stats.allocated_blocks
     print(f"Original conversation: 128 tokens, {initial_blocks} blocks")
@@ -408,8 +432,9 @@ def test_copy_on_write_demo():
     print(f"  Blocks allocated: {blocks_after_fork} (same as before)")
     print(f"  Shared blocks: {shared_after_fork} (both point to same data)")
 
-    # Get cache for generation - triggers COW if shared
-    cache_data, was_copied = cache.get_cache_for_generation("forked")
+    # Prepare the forked table for generation - triggers COW if shared
+    forked_entry = cache._request_tables["forked"]
+    _, was_copied = paged_manager.get_blocks_for_generation(forked_entry.block_table)
 
     blocks_after_cow = paged_manager.stats.allocated_blocks
     cow_copies = paged_manager.stats.cow_copies

--- a/tests/test_prefix_cache_pressure_eviction.py
+++ b/tests/test_prefix_cache_pressure_eviction.py
@@ -666,6 +666,11 @@ class TestBlockAwareCacheEviction:
         tokenizer = MagicMock()
         tokenizer.encode = lambda s: list(range(len(s)))
         model = MagicMock()
+        # use_paged_cache triggers the structural capability probe at
+        # Scheduler init (#2955); a plain full-attention factory passes it.
+        from mlx_lm.models.cache import KVCache
+
+        model.make_cache = lambda: [KVCache(), KVCache()]
         return Scheduler(model=model, tokenizer=tokenizer, config=config)
 
     def test_pressure_evicts_block_aware_entries(self):
@@ -802,12 +807,10 @@ class TestBlockAwareCacheEviction:
         bac._prefix_index["h1"] = ([1, 2, 3, 4], [b.block_id for b in blocks[:2]])
         bac._request_tables["req-1"] = BlockCacheEntry(
             block_table=MagicMock(block_ids=[b.block_id for b in blocks[:2]]),
-            cache_data=[MagicMock()],  # full KV tensor
             last_access=1.0,
         )
         bac._request_tables["req-2"] = BlockCacheEntry(
             block_table=MagicMock(block_ids=[b.block_id for b in blocks[2:]]),
-            cache_data=[MagicMock()],
             last_access=2.0,
         )
 
@@ -857,7 +860,6 @@ class TestBlockAwareCacheEviction:
         blocks[0].is_pinned = True  # system-prompt block, referenced by req-1
         bac._request_tables["req-1"] = BlockCacheEntry(
             block_table=MagicMock(block_ids=[b.block_id for b in blocks]),
-            cache_data=[MagicMock()],
             last_access=1.0,
         )
 
@@ -891,7 +893,6 @@ class TestBlockAwareCacheEviction:
         private.ref_count = 1
         bac._request_tables["req-1"] = BlockCacheEntry(
             block_table=MagicMock(block_ids=[shared.block_id, private.block_id]),
-            cache_data=[MagicMock()],
             last_access=1.0,
         )
 
@@ -945,8 +946,11 @@ class TestBlockAwareCacheEviction:
 
         blk = paged.allocate_block()
         blk.cache_data = [MagicMock()]
-        # store_cache registers a full block as hash_value = hash(its tokens);
-        # index is keyed by the prefix hash the fetch path recomputes.
+        # store_cache records every block's span and its cumulative identity
+        # hash (the hash of the whole prefix through the block — for the
+        # first block that equals hash(its own tokens)); the index is keyed
+        # by the same cumulative hash the fetch path recomputes.
+        blk.token_count = bs
         blk.hash_value = paged.compute_block_hash(tokens)
         bac._prefix_index[paged.compute_block_hash(tokens)] = (tokens, [blk.block_id])
 

--- a/tests/test_prefix_cache_pressure_eviction.py
+++ b/tests/test_prefix_cache_pressure_eviction.py
@@ -783,6 +783,64 @@ class TestBlockAwareCacheEviction:
             assert b.block_id in paged.allocated_blocks
         assert sched.num_prefix_cache_pressure_evictions == 2
 
+    def test_released_missing_block_metadata_pruned_without_touching_live_blocks(
+        self,
+    ):
+        """Codex round 2 #1: after owner release a referenced block is
+        ABSENT from ``allocated_blocks``, making the index entry forever
+        unreachable (``increment_ref`` fails on absent slots) — pressure
+        must prune that dead metadata. It must do so without clearing or
+        freeing anything physical: live blocks referenced by other entries
+        keep their KV/refs, and the released slot's resident slab is left
+        for the free-queue sweep."""
+        sched = self._make_paged_scheduler()
+        bac = sched.block_aware_cache
+        paged = bac.paged_cache
+        bs = paged.block_size  # 4 in this fixture
+        live_tokens = list(range(bs))
+
+        # Live entry first, so the slot released below cannot be handed
+        # back as this allocation.
+        live = paged.allocate_block()
+        live.cache_data = [MagicMock()]
+        live.token_count = bs
+        live.hash_value = paged.compute_block_hash(live_tokens)
+        live_key = paged.compute_block_hash(live_tokens)
+
+        # Released block: its owner freed it, so the slot left
+        # allocated_blocks for the free queue (KV still resident).
+        gone = paged.allocate_block()
+        gone.cache_data = [MagicMock()]
+        gid = gone.block_id
+        paged.free_block(gid)
+        assert gid not in paged.allocated_blocks
+
+        bac._prefix_index["h_gone"] = ([11, 12, 13, 14], [gid])
+        bac._prefix_index[live_key] = (live_tokens, [live.block_id])
+
+        free_before = paged.free_block_queue.num_free_blocks
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=100 * 10**9),
+            patch.object(
+                sched, "_current_metal_active_bytes", return_value=200 * 10**9
+            ),
+        ):
+            n = sched.evict_prefix_cache_under_pressure(max_evict=10)
+
+        # Exactly the dead metadata was pruned; the live entry survives.
+        assert n == 1
+        assert "h_gone" not in bac._prefix_index
+        assert live_key in bac._prefix_index
+        assert live.cache_data is not None
+        assert live.ref_count == 1
+        assert live.block_id in paged.allocated_blocks
+        assert bac._find_best_prefix_match(live_tokens) is not None
+        # Nothing physical was touched: the released slot was not freed
+        # again and its resident slab is intact (reclaiming it is the
+        # free-queue sweep's job, not the metadata prune's).
+        assert paged.free_block_queue.num_free_blocks == free_before
+        assert gone.cache_data is not None
+
     def test_no_eviction_when_index_empty(self):
         """Empty prefix index -> no-op (no crash, no counter tick)."""
         sched = self._make_paged_scheduler()

--- a/tests/test_prefix_cache_pressure_eviction.py
+++ b/tests/test_prefix_cache_pressure_eviction.py
@@ -40,6 +40,34 @@ from vllm_mlx.prefix_cache import BlockCacheEntry
 from vllm_mlx.scheduler import Scheduler, SchedulerConfig
 
 
+def _kv_layer_states(num_tokens, layers=1, heads=2, head_dim=4, base=0.0):
+    """Extracted layer-state dicts backed by real mlx-lm KVCache state —
+    the only layout ``store_cache`` accepts (see tests/test_paged_cache.py)."""
+    import mlx.core as mx
+    from mlx_lm.models.cache import KVCache
+
+    states = []
+    for layer in range(layers):
+        cache = KVCache()
+        n = num_tokens * heads * head_dim
+        keys = (
+            mx.arange(n, dtype=mx.float32).reshape(1, heads, num_tokens, head_dim)
+            + base
+            + layer
+        )
+        values = keys + 0.5
+        cache.update_and_fetch(keys, values)
+        states.append(
+            {
+                "state": cache.state,
+                "meta_state": cache.meta_state,
+                "class_name": "KVCache",
+                "class_ref": KVCache,
+            }
+        )
+    return states
+
+
 def _make_scheduler_with_legacy_cache(
     gpu_memory_utilization: float = 0.5,
 ) -> Scheduler:
@@ -648,8 +676,16 @@ class TestBlockAwareCacheEviction:
     (``release_pressure_blocks`` / ``evict_lru_blocks``) starves. Under
     Metal pressure the admission gate then rejects ALL new requests while
     ``active`` stays pinned above cap — a permanent 503 wedge. These tests
-    pin the fix: pressure evicts the LRU prefix-index entry and drops its
-    resident block tensors so active memory falls back under cap.
+    pin the fix: pressure evicts the LRU STORED entry (request-table
+    owner), clearing its private blocks' tensors and releasing its refs.
+
+    Ownership model (#2955 codex round 1): the prefix index holds
+    METADATA only — never a physical block reference. Every live
+    reference belongs to a stored request-table entry or an active
+    fetch-held table, so the index pressure path may prune stale
+    metadata but must never clear or free an allocated block; resident
+    KV on unreferenced (ref_count == 0) free-queue slabs is reclaimed
+    exclusively by ``release_paged_cache_blocks_under_pressure``.
     """
 
     def _make_paged_scheduler(self, gpu_memory_utilization: float = 0.5):
@@ -673,17 +709,18 @@ class TestBlockAwareCacheEviction:
         model.make_cache = lambda: [KVCache(), KVCache()]
         return Scheduler(model=model, tokenizer=tokenizer, config=config)
 
-    def test_pressure_evicts_block_aware_entries(self):
-        """Pressure must evict LRU prefix-index entries and drop the
-        resident KV tensors of their blocks (the pre-fix wedge)."""
+    def test_index_pressure_never_touches_allocated_blocks(self):
+        """The index owns metadata, not a physical reference: with no
+        stored request-table entries to drain, sustained pressure must not
+        clear or free ANY allocated block via the index path — a
+        ref_count of 1 here can be an active fetch's sole reference."""
         sched = self._make_paged_scheduler()
         bac = sched.block_aware_cache
         assert bac is not None
         paged = bac.paged_cache
 
-        # Manually populate the prefix index + resident block tensors the
-        # way store_cache does: hash entry -> (tokens, block_ids) with
-        # blocks that carry cache_data (resident Metal memory).
+        # Index entries pointing at allocated blocks (ref_count == 1)
+        # whose reference is held elsewhere (e.g. a fetch-held table).
         blocks = []
         for i in range(4):
             blk = paged.allocate_block()
@@ -700,17 +737,21 @@ class TestBlockAwareCacheEviction:
             ),
         ):
             n = sched.evict_prefix_cache_under_pressure(max_evict=10)
-        # Pressure stays high, so BOTH entries are evicted (max_evict=10
-        # is not the binding constraint; the empty index is). Each entry's
-        # resident block tensors must be dropped.
-        assert n == 2
-        assert "h1" not in bac._prefix_index
-        assert "h2" not in bac._prefix_index
-        assert all(b.cache_data is None for b in blocks)
-        assert sched.num_prefix_cache_pressure_evictions == 2
+        # Entries still own their recorded prefixes (nothing stale), so no
+        # metadata is pruned and — critically — no block is cleared/freed.
+        assert n == 0
+        assert "h1" in bac._prefix_index
+        assert "h2" in bac._prefix_index
+        for b in blocks:
+            assert b.cache_data is not None
+            assert b.ref_count == 1
+            assert b.block_id in paged.allocated_blocks
+        assert sched.num_prefix_cache_pressure_evictions == 0
 
-    def test_pressure_drains_until_index_empty(self):
-        """Persistent pressure drains entries until the index is empty."""
+    def test_pressure_prunes_stale_index_metadata_until_empty(self):
+        """Persistent pressure prunes STALE index entries (slots freed and
+        reallocated for different tokens) until none remain — without
+        touching the reallocated blocks' live KV."""
         sched = self._make_paged_scheduler()
         bac = sched.block_aware_cache
         paged = bac.paged_cache
@@ -718,6 +759,10 @@ class TestBlockAwareCacheEviction:
         for i in range(4):
             blk = paged.allocate_block()
             blk.cache_data = [MagicMock()]
+            # Reallocated slot: it now owns a DIFFERENT token history, so
+            # its cumulative identity mismatches the index entry's tokens.
+            blk.token_count = paged.block_size
+            blk.hash_value = paged.compute_block_hash([900 + i] * paged.block_size)
             blocks.append(blk)
         bac._prefix_index["h1"] = ([1, 2, 3, 4], [b.block_id for b in blocks[:2]])
         bac._prefix_index["h2"] = ([5, 6, 7, 8], [b.block_id for b in blocks[2:]])
@@ -729,9 +774,13 @@ class TestBlockAwareCacheEviction:
             ),
         ):
             n = sched.evict_prefix_cache_under_pressure(max_evict=10)
-        assert n == 2  # both entries evicted
+        assert n == 2  # both stale entries pruned
         assert len(bac._prefix_index) == 0
-        assert all(b.cache_data is None for b in blocks)
+        # The blocks belong to their new owners: KV and refs untouched.
+        for b in blocks:
+            assert b.cache_data is not None
+            assert b.ref_count == 1
+            assert b.block_id in paged.allocated_blocks
         assert sched.num_prefix_cache_pressure_evictions == 2
 
     def test_no_eviction_when_index_empty(self):
@@ -747,20 +796,30 @@ class TestBlockAwareCacheEviction:
         assert n == 0
         assert sched.num_prefix_cache_pressure_evictions == 0
 
-    def test_pinned_blocks_not_evicted(self):
-        """Pinned blocks (system prompt) must survive pressure eviction."""
+    def test_pinned_prefix_survives_and_stays_reachable(self):
+        """A pinned prefix (system prompt) must survive index-path pressure
+        AND remain reachable: its entry keeps verifying ownership, so it is
+        never pruned, while a stale sibling entry is."""
         sched = self._make_paged_scheduler()
         bac = sched.block_aware_cache
         paged = bac.paged_cache
-        blocks = []
-        for i in range(4):
-            blk = paged.allocate_block()
-            blk.cache_data = [MagicMock()]
-            blocks.append(blk)
-        # Pin the first block of entry h1 — its tensor must survive.
-        blocks[0].is_pinned = True
-        bac._prefix_index["h1"] = ([1, 2, 3, 4], [b.block_id for b in blocks[:2]])
-        bac._prefix_index["h2"] = ([5, 6, 7, 8], [b.block_id for b in blocks[2:]])
+        bs = paged.block_size  # 4 in this fixture
+        pinned_tokens = list(range(bs))
+
+        pinned = paged.allocate_block()
+        pinned.cache_data = [MagicMock()]
+        pinned.cache_class_name = "cache"
+        pinned.is_pinned = True
+        pinned.token_count = bs
+        pinned.hash_value = paged.compute_block_hash(pinned_tokens)
+        pinned_key = paged.compute_block_hash(pinned_tokens)
+        bac._prefix_index[pinned_key] = (pinned_tokens, [pinned.block_id])
+
+        stale = paged.allocate_block()
+        stale.cache_data = [MagicMock()]
+        stale.token_count = bs
+        stale.hash_value = paged.compute_block_hash([999] * bs)  # reallocated
+        bac._prefix_index["h_stale"] = ([5, 6, 7, 8], [stale.block_id])
 
         with (
             patch.object(sched, "_resolve_metal_cap_bytes", return_value=100 * 10**9),
@@ -769,15 +828,14 @@ class TestBlockAwareCacheEviction:
             ),
         ):
             n = sched.evict_prefix_cache_under_pressure(max_evict=10)
-        # Both entries are evicted under sustained pressure, but the
-        # pinned block (h1's first block) keeps its tensor — only
-        # non-pinned resident tensors are released.
-        assert n == 2
-        assert blocks[0].cache_data is not None  # pinned survives
-        assert blocks[1].cache_data is None
-        assert blocks[2].cache_data is None
-        assert blocks[3].cache_data is None
-        assert sched.num_prefix_cache_pressure_evictions == 2
+        # Only the stale metadata is pruned; the pinned prefix keeps its
+        # entry, its tensor, and its reachability.
+        assert n == 1
+        assert "h_stale" not in bac._prefix_index
+        assert pinned_key in bac._prefix_index
+        assert pinned.cache_data is not None
+        assert stale.cache_data is not None  # reallocated block untouched
+        assert bac._find_best_prefix_match(pinned_tokens) is not None
 
     def test_pressure_releases_full_kv_request_table_entries(self):
         """Pressure must drop the FULL-KV tensor held by ``_request_tables``
@@ -907,32 +965,90 @@ class TestBlockAwareCacheEviction:
         assert shared.cache_data is not None  # live KV preserved
         assert private.cache_data is None  # unshared block reclaimed
 
-    def test_index_eviction_returns_blocks_to_free_queue(self):
-        """Index-path eviction must not just clear tensors — it must also
-        return the block slots to the free queue (decrement ref_count),
-        or the pool leaks and eventually exhausts max_cache_blocks."""
+    def test_owner_eviction_preserves_active_fetch_then_free_queue_reclaims(self):
+        """Full ownership lifecycle under pressure (real KV, no mocks):
+
+        stored owner + active fetch share blocks → pressure evicts the
+        stored owner (shared blocks survive on the fetch's reference) →
+        another pressure tick leaves the active fetch's block data/table
+        intact (index path prunes nothing live) → releasing the active
+        fetch sends the blocks to the free queue with KV resident → the
+        normal free-queue pressure path reclaims the slabs."""
         sched = self._make_paged_scheduler()
         bac = sched.block_aware_cache
         paged = bac.paged_cache
-        blk = paged.allocate_block()  # ref_count == 1
-        blk.cache_data = [MagicMock()]
-        bid = blk.block_id
-        assert bid in paged.allocated_blocks
-        free_before = paged.free_block_queue.num_free_blocks
-        bac._prefix_index["h1"] = ([1, 2, 3, 4], [bid])
+        tokens = list(range(8))  # two full blocks (block_size=4)
 
+        # Stored owner: a finished request whose entry owns the blocks.
+        assert bac.store_cache("owner", tokens, _kv_layer_states(8)) is not None
+        owner_bids = list(bac._request_tables["owner"].block_table.block_ids)
+        assert len(owner_bids) == 2
+        blocks = [paged.allocated_blocks[b] for b in owner_bids]
+        assert all(b.ref_count == 1 for b in blocks)
+
+        # Active fetch shares the same blocks: fetch-held table + one
+        # tentative-committed reference per block, but NO request-table
+        # entry (only store_cache creates those).
+        table, remaining = bac.fetch_cache("active", tokens)
+        assert table is not None and remaining == []
+        assert list(table.block_ids) == owner_bids
+        assert all(b.ref_count == 2 for b in blocks)
+
+        # Tick 1: the stored owner (the only rt entry) is evicted. Its
+        # blocks are shared (ref_count > 1) so their KV must survive; the
+        # entry's references are released to the active fetch alone.
         with (
             patch.object(sched, "_resolve_metal_cap_bytes", return_value=100 * 10**9),
             patch.object(
                 sched, "_current_metal_active_bytes", return_value=200 * 10**9
             ),
         ):
-            sched.evict_prefix_cache_under_pressure(max_evict=1)
+            n = sched.evict_prefix_cache_under_pressure(max_evict=1)
+        assert n == 1
+        assert "owner" not in bac._request_tables
+        for b in blocks:
+            assert b.ref_count == 1  # held by the ACTIVE fetch table only
+            assert b.cache_data is not None
+            assert b.block_id in paged.allocated_blocks
 
-        # Tensor cleared AND the slot returned to the pool.
-        assert blk.cache_data is None
-        assert bid not in paged.allocated_blocks
-        assert paged.free_block_queue.num_free_blocks == free_before + 1
+        # Tick 2: only index metadata remains. The entries still verify
+        # their recorded ownership, so the index path prunes nothing and —
+        # critically — never clears/frees the active fetch's blocks.
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=100 * 10**9),
+            patch.object(
+                sched, "_current_metal_active_bytes", return_value=200 * 10**9
+            ),
+        ):
+            n = sched.evict_prefix_cache_under_pressure(max_evict=10)
+        assert n == 0
+        assert paged.get_block_table("active") is not None
+        assert len(bac._prefix_index) > 0  # prefix metadata stays
+        for b in blocks:
+            assert b.ref_count == 1
+            assert b.cache_data is not None
+            assert b.block_id in paged.allocated_blocks
+
+        # Release the active fetch: blocks drop to ref 0 and re-enter the
+        # free queue with their KV still resident (reusable slabs).
+        free_before = paged.free_block_queue.num_free_blocks
+        bac.release_cache("active")
+        assert paged.free_block_queue.num_free_blocks == free_before + len(blocks)
+        assert all(b.cache_data is not None for b in blocks)
+
+        # The normal free-queue pressure path is what reclaims the slabs.
+        with (
+            patch.object(sched, "_resolve_metal_cap_bytes", return_value=100 * 10**9),
+            patch.object(
+                sched, "_current_metal_active_bytes", return_value=200 * 10**9
+            ),
+        ):
+            released = sched.release_paged_cache_blocks_under_pressure()
+        assert released == len(blocks)
+        assert all(b.cache_data is None for b in blocks)
+        # No resurrection: a later fetch of the same tokens is a clean miss.
+        miss_table, miss_remaining = bac.fetch_cache("later", tokens)
+        assert miss_table is None and miss_remaining == tokens
 
     def test_fetch_guard_rejects_reallocated_block(self):
         """A prefix-index hit whose block was freed and REALLOCATED for

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4571,8 +4571,12 @@ def serve_command(args):
         )
     print(f"Stream interval: {args.stream_interval} tokens")
     if args.use_paged_cache:
+        # Echo the REQUEST, not an active cache: lane and layout capability
+        # are validated at engine startup and fail closed (#2955), so this
+        # line must not read as a running paged cache.
         print(
-            f"Paged cache: block_size={args.paged_cache_block_size}, max_blocks={args.max_cache_blocks}"
+            f"Paged cache requested: block_size={args.paged_cache_block_size}, "
+            f"max_blocks={args.max_cache_blocks} (validated at engine startup)"
         )
     elif enable_prefix_cache and not args.no_memory_aware_cache:
         cache_info = (
@@ -5583,7 +5587,8 @@ def bench_command(args):
 
         if args.use_paged_cache:
             print(
-                f"Paged cache: block_size={args.paged_cache_block_size}, max_blocks={args.max_cache_blocks}"
+                f"Paged cache requested: block_size={args.paged_cache_block_size}, "
+                f"max_blocks={args.max_cache_blocks} (validated at engine startup)"
             )
 
         # Generate prompts
@@ -11005,7 +11010,12 @@ Examples:
     serve_parser.add_argument(
         "--use-paged-cache",
         action="store_true",
-        help="Use paged KV cache for memory efficiency (experimental)",
+        help=(
+            "Use paged KV cache for memory efficiency (experimental). "
+            "Requires a model whose prompt cache is plain full-attention "
+            "KV on every layer; startup fails with an actionable error "
+            "for rotating/hybrid/recurrent/quantized cache layouts."
+        ),
     )
     serve_parser.add_argument(
         "--paged-cache-block-size",
@@ -11618,7 +11628,12 @@ Examples:
     bench_parser.add_argument(
         "--use-paged-cache",
         action="store_true",
-        help="Use paged KV cache for memory efficiency (experimental)",
+        help=(
+            "Use paged KV cache for memory efficiency (experimental). "
+            "Requires a model whose prompt cache is plain full-attention "
+            "KV on every layer; startup fails with an actionable error "
+            "for rotating/hybrid/recurrent/quantized cache layouts."
+        ),
     )
     bench_parser.add_argument(
         "--paged-cache-block-size",

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1406,6 +1406,12 @@ class BatchedEngine(BaseEngine):
         if self._loaded:
             return
 
+        # Lane-capability admission at the text/MLLM split — BEFORE any
+        # weights are loaded or a scheduler is constructed, so an
+        # unsupported explicit configuration can never come up "Ready"
+        # while silently inactive (#2955).
+        self._validate_lane_capabilities()
+
         if self._is_mllm:
             await self._start_mllm()
         else:
@@ -1414,6 +1420,30 @@ class BatchedEngine(BaseEngine):
         self._loaded = True
         self._start_time = time.monotonic()
         logger.info(f"BatchedEngine loaded: {self._model_name} (mllm={self._is_mllm})")
+
+    def _validate_lane_capabilities(self) -> None:
+        """Fail closed on capabilities the selected serving lane cannot honor.
+
+        The paged prefix cache is a text-Scheduler capability: the MLLM
+        lane runs ``MLLMScheduler``, which never constructs it, so an
+        explicit ``use_paged_cache`` there would previously load weights,
+        print Ready, and serve with the flag silently ineffective — the
+        exact #2955 failure mode, one lane over. The text lane's own
+        structural layout gate still runs later, at Scheduler construction
+        inside ``_start_llm``.
+        """
+        from ..errors import PagedCacheUnsupportedLayoutError
+
+        if self._is_mllm and getattr(self._scheduler_config, "use_paged_cache", False):
+            raise PagedCacheUnsupportedLayoutError(
+                "--use-paged-cache is not supported on the multimodal "
+                "serving lane: the paged prefix cache is a text-lane "
+                "capability and would be silently inactive here. Remove "
+                "--use-paged-cache to use the multimodal lane's default "
+                "prefix cache, or force the text-only lane (--no-mllm) if "
+                "this model should be served as text and its cache layout "
+                "passes the text lane's structural check."
+            )
 
     async def _start_mllm(self) -> None:
         """Start the MLLM engine with MLLMScheduler (continuous batching)."""

--- a/vllm_mlx/errors.py
+++ b/vllm_mlx/errors.py
@@ -13,3 +13,23 @@ class BackpressureError(Exception):
     distinct from ``ValueError`` so narrow batch-error handlers do not swallow
     admission failures.
     """
+
+
+class PagedCacheUnsupportedLayoutError(Exception):
+    """Raised at startup when ``--use-paged-cache`` cannot serve the model.
+
+    The paged prefix cache only supports cache layouts its block serializer
+    can losslessly slice and reconstruct (plain full-attention KV layers).
+    The check is structural — it inspects the loaded model's prompt-cache
+    factory output, so it can only run after weights/model construction —
+    and it fails closed: an explicit ``--use-paged-cache`` must abort before
+    the server starts serving requests rather than degrade into a
+    healthy-looking mode that provides zero reuse.
+
+    ``incompatible_layers`` carries the offending cache class names (empty
+    when the layout could not be determined at all).
+    """
+
+    def __init__(self, message: str, *, incompatible_layers: tuple[str, ...] = ()):
+        super().__init__(message)
+        self.incompatible_layers = incompatible_layers

--- a/vllm_mlx/paged_cache.py
+++ b/vllm_mlx/paged_cache.py
@@ -76,6 +76,29 @@ def compute_block_hash(
     return BlockHash(hasher.digest())
 
 
+class PrefixHasher:
+    """Incremental cumulative-prefix hasher for block identity.
+
+    After feeding tokens ``t0..tn`` via ``update``, ``hexdigest()`` equals
+    ``PagedCacheManager.compute_block_hash([t0, ..., tn])``. The prefix-cache
+    paths use this so a block's identity covers ALL tokens that precede it,
+    not just its own chunk: KV state for a block depends on the entire
+    prefix, so two sequences that share a later chunk but diverge earlier
+    must never deduplicate onto (or fetch) the same block.
+    """
+
+    def __init__(self, tokens: list[int] | None = None):
+        self._hasher = hashlib.sha256()
+        if tokens:
+            self.update(tokens)
+
+    def update(self, tokens: list[int]) -> None:
+        self._hasher.update(b"".join(t.to_bytes(4, "big") for t in tokens))
+
+    def hexdigest(self) -> str:
+        return self._hasher.hexdigest()[:16]
+
+
 # =============================================================================
 # KVCacheBlock - Following vLLM's design
 # =============================================================================
@@ -698,6 +721,18 @@ class PagedCacheManager:
             return False
 
         if block.block_hash is None:
+            # Legacy-only registration (``register_block_hash`` sets
+            # ``hash_value`` but leaves the chain ``block_hash`` as None)
+            # must be cleaned on reallocation too: a surviving
+            # ``hash_to_block`` entry would resurrect this slot as a false
+            # hit for the OLD tokens after it is refilled with new KV.
+            if block.hash_value is not None:
+                if self.hash_to_block.get(block.hash_value) == block.block_id:
+                    del self.hash_to_block[block.hash_value]
+                block.hash_value = None
+                block.cache_data = None
+                block.cache_class_name = None
+                return True
             return False
 
         evicted = self.cached_block_hash_to_block.pop(block.block_hash, block.block_id)
@@ -933,28 +968,65 @@ class PagedCacheManager:
         token_bytes = b"".join(t.to_bytes(4, "big") for t in tokens)
         return hashlib.sha256(token_bytes).hexdigest()[:16]
 
-    def find_cached_block(self, tokens: list[int]) -> CacheBlock | None:
+    def find_cached_block(
+        self, tokens: list[int], *, record_stats: bool = True
+    ) -> CacheBlock | None:
         """
-        Find a cached block matching the given tokens (legacy method).
+        Find a cached block whose identity hash matches ``tokens``.
+
+        ``tokens`` must be the FULL token prefix ending at the block — the
+        block's own chunk preceded by every earlier token of the sequence.
+        Block KV state depends on its entire history, so the identity/dedup
+        key must cover the whole prefix; matching a chunk alone would let
+        sequences with divergent histories share KV silently.
+
+        ``record_stats=False`` makes this a pure lookup: transactional
+        callers (fetch/store in ``BlockAwarePrefixCache``) probe candidates
+        here and commit hit/miss counters only once the outcome is known,
+        so a candidate that later fails reconstruction is never exposed as
+        a successful cache hit.
+        """
+        return self.find_cached_block_by_hash(
+            self.compute_block_hash(tokens), record_stats=record_stats
+        )
+
+    def find_cached_block_by_hash(
+        self, hash_value: str, *, record_stats: bool = True
+    ) -> CacheBlock | None:
+        """Find a cached block by a precomputed identity hash.
+
+        Verifies the block still OWNS that identity: a block freed and
+        reallocated for other tokens re-registers under a different hash,
+        so a mapping whose target no longer carries ``hash_value`` is stale
+        — it is pruned and reported as a miss, never served as a false hit.
         """
         with self._lock:
-            hash_value = self.compute_block_hash(tokens)
-
-            if hash_value in self.hash_to_block:
-                block_id = self.hash_to_block[hash_value]
-                if block_id in self.allocated_blocks:
-                    block = self.allocated_blocks[block_id]
+            block_id = self.hash_to_block.get(hash_value)
+            if block_id is not None and block_id in self.allocated_blocks:
+                block = self.allocated_blocks[block_id]
+                if block.hash_value == hash_value:
                     block.touch()
-                    self.stats.cache_hits += 1
+                    if record_stats:
+                        self.stats.cache_hits += 1
                     return block
+                # Stale mapping left behind by a reallocated block — prune.
+                del self.hash_to_block[hash_value]
 
-            self.stats.cache_misses += 1
+            if record_stats:
+                self.stats.cache_misses += 1
             return None
 
     def register_block_hash(self, block: CacheBlock, tokens: list[int]) -> None:
-        """Register a block's hash for deduplication (legacy method)."""
+        """Register a block's identity hash for deduplication.
+
+        ``tokens`` must be the full token prefix ending at this block (see
+        ``find_cached_block``).
+        """
+        self.register_block_hash_value(block, self.compute_block_hash(tokens))
+
+    def register_block_hash_value(self, block: CacheBlock, hash_value: str) -> None:
+        """Register a block under a precomputed identity hash."""
         with self._lock:
-            hash_value = self.compute_block_hash(tokens)
             block.hash_value = hash_value
             self.hash_to_block[hash_value] = block.block_id
 
@@ -963,8 +1035,15 @@ class PagedCacheManager:
     # =========================================================================
 
     def create_block_table(self, request_id: str) -> BlockTable:
-        """Create a new block table for a request."""
+        """Create a new block table for a request.
+
+        Any existing table under ``request_id`` (a reused id) is released
+        first — silently overwriting it would leak the block references the
+        old table holds.
+        """
         with self._lock:
+            if request_id in self.request_tables:
+                self.delete_block_table(request_id)
             table = BlockTable(request_id=request_id)
             self.request_tables[request_id] = table
             return table
@@ -1009,25 +1088,43 @@ class PagedCacheManager:
     def find_shared_prefix(
         self,
         tokens: list[int],
+        *,
+        record_stats: bool = True,
     ) -> tuple[list[int], list[int]]:
         """
         Find shared prefix blocks for a token sequence.
+
+        Blocks match by cumulative identity: block ``i`` is shared only when
+        a cached block is registered under the hash of ``tokens`` through
+        the END of block ``i`` — its chunk plus every preceding token. A
+        block whose chunk matches but whose history diverges is a miss: its
+        KV was computed under different context and must never be reused.
+
+        ``record_stats=False`` keeps the lookup counter-neutral for
+        transactional callers (see ``find_cached_block``).
         """
         with self._lock:
             shared_blocks = []
-            remaining_tokens = tokens.copy()
+            consumed = 0
+            hasher = PrefixHasher()
 
-            while len(remaining_tokens) >= self.block_size:
-                chunk = remaining_tokens[: self.block_size]
-                cached_block = self.find_cached_block(chunk)
+            while len(tokens) - consumed >= self.block_size:
+                hasher.update(tokens[consumed : consumed + self.block_size])
+                cached_block = self.find_cached_block_by_hash(
+                    hasher.hexdigest(), record_stats=record_stats
+                )
 
-                if cached_block:
+                # Shared blocks must span exactly one block_size chunk —
+                # the cumulative walk advances in block_size steps, so a
+                # block claiming a different span would desynchronize the
+                # token accounting of every later block.
+                if cached_block and cached_block.token_count == self.block_size:
                     shared_blocks.append(cached_block.block_id)
-                    remaining_tokens = remaining_tokens[self.block_size :]
+                    consumed += self.block_size
                 else:
                     break
 
-            return shared_blocks, remaining_tokens
+            return shared_blocks, tokens[consumed:]
 
     def fork_block_table(
         self,
@@ -1036,8 +1133,22 @@ class PagedCacheManager:
     ) -> BlockTable:
         """
         Fork a block table for a new request (COW).
+
+        Forking a table onto the id it is already registered under
+        (self-fork) is a no-op returning the table itself: copying would
+        bump every block's refcount and then overwrite the only owning
+        registration, leaking one reference per block forever.
         """
         with self._lock:
+            existing = self.request_tables.get(new_request_id)
+            if existing is source_table:
+                # Self-fork: the id already owns exactly this table.
+                return source_table
+            if existing is not None:
+                # A reused target id must not silently leak its old
+                # table's block references.
+                self.delete_block_table(new_request_id)
+
             new_table = source_table.copy(new_request_id)
 
             for block_id in new_table.block_ids:

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -463,7 +463,7 @@ def find_paged_incompatible_layers(caches: list[Any]) -> list[str]:
 
 
 def validate_paged_cache_capability(
-    model: Any, *, kv_cache_quantized: bool = False
+    model: Any, *, kv_cache_transform_requested: bool = False
 ) -> None:
     """Fail closed when the paged prefix cache cannot serve ``model``.
 
@@ -474,17 +474,27 @@ def validate_paged_cache_capability(
     or architecture names — so an architecture whose sliding mode is inactive
     and whose factory returns plain KV layers is accepted.
 
+    ``kv_cache_transform_requested`` covers every EXPLICIT KV-cache
+    transform request (ordinary live quantization or TurboQuant): the paged
+    block store implements neither, so the combination is rejected even
+    when the transform itself would later fall back or disable at runtime —
+    honoring the flag pair by silently serving untransformed plain blocks
+    would be exactly the #2955 failure mode.
+
     This necessarily runs after the model is loaded (the cache factory does
     not exist earlier); callers must invoke it before serving any request so
     an explicit ``--use-paged-cache`` aborts pre-ready instead of silently
     providing zero reuse.
     """
     action = "Remove --use-paged-cache to use the default prefix cache for this model."
-    if kv_cache_quantized:
+    if kv_cache_transform_requested:
         raise PagedCacheUnsupportedLayoutError(
-            "--use-paged-cache is incompatible with KV cache quantization: "
-            "quantized KV state is stored as weight/scale/bias tuples the "
-            f"paged block serializer cannot slice. {action}"
+            "--use-paged-cache is incompatible with KV cache "
+            "quantization/TurboQuant: the paged block store keeps plain "
+            "untransformed KV tensors and implements neither transform, so "
+            "an explicit request for both cannot be honored (this fails "
+            "closed even when the transform would fall back at runtime). "
+            f"Remove the KV quantization/TurboQuant flags, or: {action}"
         )
     try:
         from mlx_lm.models.cache import make_prompt_cache
@@ -794,10 +804,14 @@ class BlockAwarePrefixCache:
             if block_slices and HAS_MLX:
                 mx.eval([t for layers in block_slices for kv in layers for t in kv])
         except Exception as exc:
+            # Report failure, never the fetch-held table as a "successful"
+            # store: a non-None return tells the scheduler an entry owns the
+            # blocks, so it would skip the release path and the fetch-held
+            # refs/pending state would leak with no owning entry.
             logger.warning(
                 f"Failed to materialize block tensors for {request_id}: {exc}"
             )
-            return existing_table
+            return None
 
         # All tensor data is ready; now mutate table/block state.
         block_table = existing_table or self.paged_cache.create_block_table(request_id)

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -1401,25 +1401,29 @@ class BlockAwarePrefixCache:
         cached_tokens: list[int],
         block_ids: list[int],
     ) -> bool:
-        """Return True when a live block no longer owns the cumulative
-        token prefix this index entry records.
+        """Return True when this index entry can no longer serve the
+        cumulative token prefix it records — safe to prune as metadata.
 
-        Used by pressure eviction to prune index entries whose slots were
-        freed and reallocated for different tokens — clearing such a slot
-        would destroy another request's live KV. Absent blocks are NOT
-        stale (the caller's eligibility checks handle them, and later
-        identities cannot be verified past a missing span). Blocks that
-        claim no identity (``hash_value`` None — legacy/unhashed fixtures)
-        are tolerated. A block that claims an identity WITHOUT a
-        consistent span is unverifiable — fail closed: prune the entry,
-        touch no block.
+        Used by pressure eviction to prune index entries without touching
+        any physical block. Two prunable conditions:
+
+        * A referenced block is ABSENT from ``allocated_blocks`` (its
+          owner released it): the entry can never be acquired again
+          (``increment_ref`` fails on absent slots), so keeping it would
+          leak dead metadata forever after owner release.
+        * A block was reallocated for different tokens (identity
+          mismatch), or claims an identity WITHOUT a consistent span —
+          unverifiable, fail closed: prune the entry, touch no block.
+
+        Blocks that claim no identity (``hash_value`` None —
+        legacy/unhashed fixtures) are tolerated as live.
         """
         hasher = PrefixHasher()
         end = 0
         for block_id in block_ids:
             block = self.paged_cache.allocated_blocks.get(block_id)
             if block is None:
-                return False
+                return True
             if block.hash_value is None:
                 # Nothing to verify; extend the chain on a best-effort span
                 # so later hashed blocks can still be checked. When the

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -908,8 +908,7 @@ class BlockAwarePrefixCache:
         if not HAS_MLX or not isinstance(cache_data, list) or not cache_data:
             return None
 
-        usable_tokens: int | None = None
-        class_name: str | None = None
+        layouts: list[tuple[str, int]] = []
         for layer_state in cache_data:
             if not isinstance(layer_state, dict) or "state" not in layer_state:
                 return None
@@ -925,13 +924,13 @@ class BlockAwarePrefixCache:
                 return None
             keys, values = state
             seq_len = min(keys.shape[seq_axis], values.shape[seq_axis])
-            usable_tokens = (
-                seq_len if usable_tokens is None else min(usable_tokens, seq_len)
-            )
-            class_name = name
+            layouts.append((name, seq_len))
 
-        if class_name is None or usable_tokens is None:
-            return None
+        # ``cache_data`` is a non-empty list (checked above) and every
+        # iteration either refused the layout or recorded one, so at least
+        # one layout is present here.
+        class_name = layouts[-1][0]
+        usable_tokens = min(seq_len for _, seq_len in layouts)
         return class_name, usable_tokens
 
     # Cache classes whose ``state`` is ``(keys, values)`` and whose seq

--- a/vllm_mlx/prefix_cache.py
+++ b/vllm_mlx/prefix_cache.py
@@ -24,7 +24,8 @@ try:
 except ImportError:
     HAS_MLX = False
 
-from .paged_cache import BlockTable, PagedCacheManager
+from .errors import PagedCacheUnsupportedLayoutError
+from .paged_cache import BlockTable, PagedCacheManager, PrefixHasher
 
 logger = logging.getLogger(__name__)
 
@@ -446,12 +447,81 @@ class PrefixCacheManager:
 # =============================================================================
 
 
+def find_paged_incompatible_layers(caches: list[Any]) -> list[str]:
+    """Return cache class names the paged block serializer cannot host.
+
+    Structural check: a layer is block-compatible only when it is exactly
+    mlx-lm's plain full-attention ``KVCache`` — the one layout the serializer
+    can losslessly slice into blocks and reconstruct. Rotating/sliding,
+    Arrays/hybrid, recurrent, quantized, subclassed, and unknown cache
+    classes all fail closed. Returns a sorted, de-duplicated list of the
+    offending class names (empty = fully compatible).
+    """
+    from mlx_lm.models.cache import KVCache
+
+    return sorted({type(c).__name__ for c in caches if type(c) is not KVCache})
+
+
+def validate_paged_cache_capability(
+    model: Any, *, kv_cache_quantized: bool = False
+) -> None:
+    """Fail closed when the paged prefix cache cannot serve ``model``.
+
+    Probes the model's actual prompt-cache factory
+    (``mlx_lm.models.cache.make_prompt_cache``) and raises
+    :class:`PagedCacheUnsupportedLayoutError` unless every layer is a plain
+    full-attention ``KVCache``. The decision is purely structural — no model
+    or architecture names — so an architecture whose sliding mode is inactive
+    and whose factory returns plain KV layers is accepted.
+
+    This necessarily runs after the model is loaded (the cache factory does
+    not exist earlier); callers must invoke it before serving any request so
+    an explicit ``--use-paged-cache`` aborts pre-ready instead of silently
+    providing zero reuse.
+    """
+    action = "Remove --use-paged-cache to use the default prefix cache for this model."
+    if kv_cache_quantized:
+        raise PagedCacheUnsupportedLayoutError(
+            "--use-paged-cache is incompatible with KV cache quantization: "
+            "quantized KV state is stored as weight/scale/bias tuples the "
+            f"paged block serializer cannot slice. {action}"
+        )
+    try:
+        from mlx_lm.models.cache import make_prompt_cache
+
+        probe = make_prompt_cache(model)
+    except Exception as exc:
+        raise PagedCacheUnsupportedLayoutError(
+            "--use-paged-cache could not verify this model's prompt-cache "
+            f"layout (cache factory probe failed: {exc!r}); refusing to "
+            f"enable an unverifiable paged cache. {action}"
+        ) from exc
+    if not isinstance(probe, list) or not probe:
+        raise PagedCacheUnsupportedLayoutError(
+            "--use-paged-cache could not verify this model's prompt-cache "
+            f"layout (cache factory returned {type(probe).__name__}); "
+            f"refusing to enable an unverifiable paged cache. {action}",
+        )
+    incompatible = find_paged_incompatible_layers(probe)
+    if incompatible:
+        raise PagedCacheUnsupportedLayoutError(
+            "--use-paged-cache only supports models whose prompt cache is "
+            "plain full-attention KVCache on every layer; this model's cache "
+            f"layout contains: {', '.join(incompatible)}. {action}",
+            incompatible_layers=tuple(incompatible),
+        )
+
+
 @dataclass
 class BlockCacheEntry:
-    """Entry mapping a token sequence to cache blocks."""
+    """LRU bookkeeping for a stored request's block table.
+
+    Blocks (``PagedCacheManager.allocated_blocks[*].cache_data``) are the
+    source of truth for KV state; this entry deliberately does NOT retain
+    the request's original full cache snapshot.
+    """
 
     block_table: BlockTable
-    cache_data: list[Any]  # Actual KV cache data per block
     last_access: float
 
 
@@ -506,6 +576,12 @@ class BlockAwarePrefixCache:
         # Request to block table mapping
         self._request_tables: dict[str, BlockCacheEntry] = {}
 
+        # Reconstructed caches produced inside a committed fetch
+        # transaction, keyed by request_id. ``reconstruct_cache`` pops from
+        # here so the scheduler's fetch -> reconstruct call pair does not
+        # rebuild the tensors a second time.
+        self._pending_reconstructed: dict[str, list[Any]] = {}
+
         # Statistics
         self._hits = 0
         self._misses = 0
@@ -517,7 +593,19 @@ class BlockAwarePrefixCache:
         tokens: list[int],
     ) -> tuple[BlockTable | None, list[int]]:
         """
-        Find cached prefix blocks for the given tokens.
+        Find cached prefix blocks for the given tokens — transactionally.
+
+        The whole acquisition is one transaction: candidate lookup
+        tentatively holds block references, reconstruction validates that
+        every candidate block can actually be rebuilt into usable KV state,
+        and only then do the hit/tokens-saved counters commit. Any missing
+        block, wrong cache class/shape, or reconstruction failure aborts:
+        all tentative references and table state are released, exactly one
+        miss is counted, and no hit or saved tokens are reported.
+
+        On commit the reconstructed caches are stashed so the follow-up
+        ``reconstruct_cache(block_table)`` call returns them without
+        rebuilding.
 
         Args:
             request_id: Unique request identifier
@@ -525,67 +613,106 @@ class BlockAwarePrefixCache:
 
         Returns:
             Tuple of (block_table, remaining_tokens)
-            - block_table: BlockTable if prefix found, None otherwise
+            - block_table: BlockTable if prefix found AND reconstructable,
+              None otherwise
             - remaining_tokens: Tokens that need processing
         """
         if not tokens:
             return None, tokens
 
-        # Try to find shared prefix blocks
-        shared_block_ids, remaining = self.paged_cache.find_shared_prefix(tokens)
+        # A reused request id starts a new lifecycle: release any prior
+        # state held under it (stored entry, stale table, pending stash)
+        # BEFORE acquiring, so the old table's block references cannot leak
+        # when this transaction registers its own table under the same id.
+        if (
+            request_id in self._request_tables
+            or request_id in self._pending_reconstructed
+            or self.paged_cache.get_block_table(request_id) is not None
+        ):
+            self.release_cache(request_id)
 
+        candidate = self._acquire_candidate_blocks(request_id, tokens)
+        if candidate is None:
+            self._misses += 1
+            self.paged_cache.stats.cache_misses += 1
+            logger.debug(f"Cache miss for {request_id}")
+            return None, tokens
+
+        block_table, remaining = candidate
+        reconstructed = self._reconstruct_from_table(block_table)
+        if reconstructed is None:
+            # Abort: release the tentative refs and table state, count a
+            # miss. ``delete_block_table`` decrements exactly the reference
+            # this transaction added per block, restoring prior refcounts.
+            self.paged_cache.delete_block_table(request_id)
+            self._misses += 1
+            self.paged_cache.stats.cache_misses += 1
+            logger.debug(
+                f"Cache candidate for {request_id} failed reconstruction; "
+                "aborted fetch transaction (counted as miss)"
+            )
+            return None, tokens
+
+        # Commit: counters reflect a hit only now that usable KV state
+        # exists for the caller.
+        self._hits += 1
+        self._tokens_saved += block_table.num_tokens
+        self.paged_cache.stats.cache_hits += len(block_table.block_ids)
+        self._pending_reconstructed[request_id] = reconstructed
+
+        logger.debug(
+            f"Cache hit for {request_id}: {len(block_table.block_ids)} "
+            f"blocks, {block_table.num_tokens} tokens"
+        )
+        return block_table, remaining
+
+    def _acquire_candidate_blocks(
+        self,
+        request_id: str,
+        tokens: list[int],
+    ) -> tuple[BlockTable, list[int]] | None:
+        """Tentatively acquire candidate prefix blocks for ``tokens``.
+
+        Holds one reference per candidate block and registers a block table
+        for ``request_id``. Counts nothing — the caller commits or aborts.
+        Returns None (with no state held) when there is no candidate.
+        """
+        shared_block_ids, _ = self.paged_cache.find_shared_prefix(
+            tokens, record_stats=False
+        )
+
+        matched_block_ids: list[int] = []
         if shared_block_ids:
-            # Create block table for this request with shared blocks
-            block_table = self.paged_cache.create_block_table(request_id)
+            matched_block_ids = shared_block_ids
+        else:
+            best_match = self._find_best_prefix_match(tokens)
+            if best_match:
+                _, matched_block_ids = best_match
 
-            for block_id in shared_block_ids:
-                # Increment ref count for sharing
-                self.paged_cache.increment_ref(block_id)
-                block = self.paged_cache.allocated_blocks.get(block_id)
-                if block:
-                    block_table.block_ids.append(block_id)
-                    block_table.num_tokens += block.token_count
+        if not matched_block_ids:
+            return None
 
-            num_prefix_tokens = len(tokens) - len(remaining)
-            self._hits += 1
-            self._tokens_saved += num_prefix_tokens
+        block_table = self.paged_cache.create_block_table(request_id)
+        for block_id in matched_block_ids:
+            # A block that vanished mid-lookup truncates the candidate at
+            # the last contiguous block — a gap would silently misalign the
+            # reconstructed prefix against the token sequence.
+            if not self.paged_cache.increment_ref(block_id):
+                break
+            block = self.paged_cache.allocated_blocks.get(block_id)
+            if block is None:
+                self.paged_cache.decrement_ref(block_id)
+                break
+            block_table.block_ids.append(block_id)
+            block_table.num_tokens += block.token_count
 
-            logger.debug(
-                f"Cache hit for {request_id}: "
-                f"{len(shared_block_ids)} blocks, {num_prefix_tokens} tokens"
-            )
+        if not block_table.block_ids:
+            self.paged_cache.delete_block_table(request_id)
+            return None
 
-            return block_table, remaining
-
-        # Try prefix index for longer matches
-        best_match = self._find_best_prefix_match(tokens)
-        if best_match:
-            matched_tokens, matched_block_ids = best_match
-
-            # Fork the matched blocks
-            block_table = self.paged_cache.create_block_table(request_id)
-            for block_id in matched_block_ids:
-                self.paged_cache.increment_ref(block_id)
-                block = self.paged_cache.allocated_blocks.get(block_id)
-                if block:
-                    block_table.block_ids.append(block_id)
-                    block_table.num_tokens += block.token_count
-
-            remaining = tokens[len(matched_tokens) :]
-            self._hits += 1
-            self._tokens_saved += len(matched_tokens)
-
-            logger.debug(
-                f"Prefix index hit for {request_id}: "
-                f"{len(matched_tokens)} tokens matched"
-            )
-
-            return block_table, remaining
-
-        # No cache hit
-        self._misses += 1
-        logger.debug(f"Cache miss for {request_id}")
-        return None, tokens
+        # Derive remaining from the tokens actually covered by acquired
+        # blocks so a truncated candidate never over-claims coverage.
+        return block_table, tokens[block_table.num_tokens :]
 
     def store_cache(
         self,
@@ -596,59 +723,108 @@ class BlockAwarePrefixCache:
         """
         Store computed cache for future reuse.
 
-        This method stores actual tensor data (not references) when cache_data
-        contains extracted states from mlx-lm's KVCache.state property.
+        Blocks are the source of truth: tensor slices are extracted per
+        block and materialized as independent arrays, and the original
+        ``cache_data`` object is never retained (neither by identity nor via
+        MLX slice views into its backing buffers).
+
+        The layout is validated up front. Unsupported layouts — anything
+        other than extracted per-layer state dicts whose every layer is a
+        plain 4D full-attention ``KVCache`` state — are refused without
+        allocating or retaining anything, so an incompatible request leaves
+        zero blocks and zero snapshots behind. Every stored block carries
+        reconstructable tensor data; a block that cannot be fully backed is
+        never added.
 
         Args:
             request_id: Unique request identifier
             tokens: Token sequence that was processed
-            cache_data: The computed KV cache to store. Can be:
-                - List of KVCache objects (legacy, stores references)
-                - List of dicts with 'state': (keys, values) tensors (new, stores slices)
+            cache_data: List of extracted layer-state dicts with
+                'state': (keys, values) tensors and 'class_name'.
 
         Returns:
-            BlockTable for the stored cache, or None on failure
+            BlockTable for the stored cache, or None when the layout is
+            unsupported (nothing stored).
         """
         if not tokens:
             return None
 
-        # Check if cache_data contains extracted tensor states
-        is_tensor_data = (
-            cache_data
-            and isinstance(cache_data, list)
-            and len(cache_data) > 0
-            and isinstance(cache_data[0], dict)
-            and "state" in cache_data[0]
-        )
+        layout = self._validate_blockizable_layout(cache_data)
+        if layout is None:
+            logger.debug(
+                f"Refusing paged store for {request_id}: cache layout is not "
+                "blockizable (only plain 4D KVCache state is supported)"
+            )
+            return None
+        class_name, usable_tokens = layout
 
-        # Get or create block table
-        block_table = self.paged_cache.get_block_table(request_id)
-        if not block_table:
-            block_table = self.paged_cache.create_block_table(request_id)
+        # Only tokens fully backed by tensor data are storable — a block
+        # whose token span exceeds the available KV rows would reconstruct
+        # into a cache shorter than the prefix it claims.
+        storable_tokens = tokens[: min(len(tokens), usable_tokens)]
 
-        # Determine tokens we need to cache (not already in block_table)
-        existing_tokens = block_table.num_tokens
-        new_tokens = tokens[existing_tokens:]
+        existing_tokens = 0
+        existing_table = self.paged_cache.get_block_table(request_id)
+        if existing_table:
+            existing_tokens = existing_table.num_tokens
+        new_tokens = storable_tokens[existing_tokens:]
 
-        if not new_tokens:
-            # All tokens already cached
-            return block_table
+        if not new_tokens and existing_table is None:
+            return None
 
-        # Allocate blocks for new tokens
+        # Extract (lazily) and then materialize every block slice BEFORE
+        # touching any block/table state, so a failure leaves nothing to
+        # roll back. ``mx.eval`` forces the contiguous copies so the stored
+        # blocks own their buffers and drop every reference to the caller's
+        # full KV tensors.
+        block_slices: list[list[tuple[Any, Any]]] = []
         num_new_blocks = (len(new_tokens) + self.block_size - 1) // self.block_size
-
         for i in range(num_new_blocks):
+            global_start = existing_tokens + i * self.block_size
+            global_end = min(
+                global_start + self.block_size, existing_tokens + len(new_tokens)
+            )
+            block_kv_data = self._extract_block_tensor_slice(
+                cache_data, global_start, global_end
+            )
+            if not block_kv_data:
+                break
+            block_slices.append(block_kv_data)
+        try:
+            if block_slices and HAS_MLX:
+                mx.eval([t for layers in block_slices for kv in layers for t in kv])
+        except Exception as exc:
+            logger.warning(
+                f"Failed to materialize block tensors for {request_id}: {exc}"
+            )
+            return existing_table
+
+        # All tensor data is ready; now mutate table/block state.
+        block_table = existing_table or self.paged_cache.create_block_table(request_id)
+
+        # Cumulative identity: each block is keyed by the hash of the ENTIRE
+        # token prefix through its end, seeded with the tokens already
+        # covered by a fetched table. KV for a block depends on all
+        # preceding blocks, so two sequences that share a chunk but diverge
+        # earlier must get distinct identities — chunk-local hashing would
+        # dedup them onto one block and silently serve wrong KV.
+        identity = PrefixHasher(tokens[:existing_tokens])
+
+        for i, block_kv_data in enumerate(block_slices):
             start_idx = i * self.block_size
             end_idx = min(start_idx + self.block_size, len(new_tokens))
             block_tokens = new_tokens[start_idx:end_idx]
+            identity.update(block_tokens)
+            block_identity = identity.hexdigest()
 
-            # Token range in the original sequence (accounting for existing tokens)
-            global_start = existing_tokens + start_idx
-            global_end = existing_tokens + end_idx
-
-            # Check if this block already exists (deduplication)
+            # Check if this block already exists (deduplication). A hash
+            # match pins both the full preceding prefix and the block's end
+            # position; registered blocks are always full-size, so a match
+            # is exactly the same token span under the same history.
             if len(block_tokens) == self.block_size:
-                existing_block = self.paged_cache.find_cached_block(block_tokens)
+                existing_block = self.paged_cache.find_cached_block_by_hash(
+                    block_identity, record_stats=False
+                )
                 if existing_block:
                     # Reuse existing block
                     self.paged_cache.increment_ref(existing_block.block_id)
@@ -671,58 +847,78 @@ class BlockAwarePrefixCache:
             block.token_count = len(block_tokens)
             block_table.block_ids.append(block.block_id)
             block_table.num_tokens += len(block_tokens)
+            block.cache_data = block_kv_data
+            block.cache_class_name = class_name
 
-            # Extract and store actual tensor slices for this block
-            if is_tensor_data and HAS_MLX:
-                block_kv_data = self._extract_block_tensor_slice(
-                    cache_data, global_start, global_end
-                )
-                if block_kv_data:
-                    block.cache_data = block_kv_data
-                    # ``_extract_block_tensor_slice`` only returns non-None
-                    # when every layer's ``class_name`` is in
-                    # ``_SEQ_AXIS_KV_CLASSES``, so reading the first layer's
-                    # name is safe and guaranteed non-None.
-                    block.cache_class_name = cache_data[0]["class_name"]
-                    logger.debug(
-                        f"Stored tensor slice for block {block.block_id}: "
-                        f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
-                    )
-
-            # Record the block's content hash so the fetch-side ownership
-            # guard can detect a freed-then-reallocated block for EVERY
-            # block, including the trailing partial one. Only FULL blocks
-            # are additionally registered in ``hash_to_block`` for dedup —
-            # partial blocks must never be shared, but they still need a
-            # hash_value the guard can re-derive and compare.
-            block.hash_value = self.paged_cache.compute_block_hash(block_tokens)
+            # Record the block's cumulative identity hash so the fetch-side
+            # ownership guard can detect a freed-then-reallocated block for
+            # EVERY block, including the trailing partial one. Only FULL
+            # blocks are additionally registered in ``hash_to_block`` for
+            # dedup — partial blocks must never be shared, but they still
+            # need a hash_value the guard can re-derive and compare.
             if len(block_tokens) == self.block_size:
-                self.paged_cache.register_block_hash(block, block_tokens)
+                self.paged_cache.register_block_hash_value(block, block_identity)
+            else:
+                block.hash_value = block_identity
 
-        # Update prefix index
-        self._update_prefix_index(tokens, block_table.block_ids)
-
-        # Store entry for request (for legacy compatibility)
-        self._request_tables[request_id] = BlockCacheEntry(
-            block_table=block_table,
-            cache_data=cache_data,
-            last_access=time.time(),
+        # Index only the prefix actually backed by the table's blocks.
+        self._update_prefix_index(
+            tokens[: block_table.num_tokens], block_table.block_ids
         )
 
-        blocks_with_data = sum(
-            1
-            for bid in block_table.block_ids
-            if self.paged_cache.allocated_blocks.get(bid)
-            and self.paged_cache.allocated_blocks[bid].cache_data is not None
+        self._request_tables[request_id] = BlockCacheEntry(
+            block_table=block_table,
+            last_access=time.time(),
         )
 
         logger.debug(
             f"Stored cache for {request_id}: "
-            f"{len(block_table.block_ids)} blocks ({blocks_with_data} with tensor data), "
+            f"{len(block_table.block_ids)} blocks, "
             f"{block_table.num_tokens} tokens"
         )
 
         return block_table
+
+    def _validate_blockizable_layout(
+        self, cache_data: list[Any]
+    ) -> tuple[str, int] | None:
+        """Validate that ``cache_data`` can be losslessly blockized.
+
+        Accepts only a non-empty list of extracted layer-state dicts whose
+        every layer has an allowlisted ``class_name`` and a 4D
+        ``(batch, n_kv_heads, seq, head_dim)`` KV state — the one layout
+        ``reconstruct_cache`` can rebuild. Returns ``(class_name,
+        usable_tokens)`` where ``usable_tokens`` is the minimum sequence
+        length across layers, or None when the layout is unsupported.
+        """
+        if not HAS_MLX or not isinstance(cache_data, list) or not cache_data:
+            return None
+
+        usable_tokens: int | None = None
+        class_name: str | None = None
+        for layer_state in cache_data:
+            if not isinstance(layer_state, dict) or "state" not in layer_state:
+                return None
+            name = layer_state.get("class_name")
+            # Explicit gate: ``_cache_state_seq_axis`` skips the class check
+            # when ``class_name`` is None, but a layer without a recorded
+            # class must fail closed here.
+            if name not in self._SEQ_AXIS_KV_CLASSES:
+                return None
+            state = layer_state["state"]
+            seq_axis = self._cache_state_seq_axis(state, class_name=name)
+            if seq_axis is None:
+                return None
+            keys, values = state
+            seq_len = min(keys.shape[seq_axis], values.shape[seq_axis])
+            usable_tokens = (
+                seq_len if usable_tokens is None else min(usable_tokens, seq_len)
+            )
+            class_name = name
+
+        if class_name is None or usable_tokens is None:
+            return None
+        return class_name, usable_tokens
 
     # Cache classes whose ``state`` is ``(keys, values)`` and whose seq
     # axis is well-defined by ndim alone. Other classes (Mamba/DeltaNet
@@ -736,16 +932,19 @@ class BlockAwarePrefixCache:
     ) -> int | None:
         """Return the sequence axis for cache states that support block concat.
 
-        Supports two KV-cache layouts emitted by mlx-lm:
-        - 4D ``(batch, n_kv_heads, seq, head_dim)`` → seq_axis = 2
-        - 3D ``(n_kv_heads, seq, head_dim)`` (Qwen3.5-style) → seq_axis = 1
+        Only the 4D ``(batch, n_kv_heads, seq, head_dim)`` layout is
+        supported (seq_axis = 2): mlx-lm's ``KVCache`` accessors hard-code
+        ``shape[2]`` for seq, so any state the serializer stores but
+        ``reconstruct_cache`` cannot host (e.g. 3D layouts) would be dead
+        weight that silently yields zero reuse. Store and reconstruct must
+        agree, so both fail closed on anything but 4D.
 
         ``class_name``, when supplied, must be in ``_SEQ_AXIS_KV_CLASSES`` —
         a Mamba/DeltaNet ``ArraysCache`` may incidentally hold two same-
-        shape 3D tensors but is NOT seq-indexed, and slicing it along axis
-        1 would silently corrupt the cache. When ``class_name`` is omitted
-        the legacy shape-only heuristic is used (kept for the standalone
-        unit test that does not flow through the full extract path).
+        shape tensors but is NOT seq-indexed, and slicing it along a
+        guessed axis would silently corrupt the cache. When ``class_name``
+        is omitted the shape-only check is used (reconstruct-side rehost
+        check on already-gated block data).
 
         Returns ``None`` for unsupported shapes or class names.
         """
@@ -764,16 +963,8 @@ class BlockAwarePrefixCache:
         if class_name is not None and class_name not in self._SEQ_AXIS_KV_CLASSES:
             return None
 
-        ndims = {len(tensor.shape) for tensor in state}
-        if len(ndims) != 1:
-            return None
-
-        ndim = next(iter(ndims))
-        if ndim == 4:
+        if all(len(tensor.shape) == 4 for tensor in state):
             return 2
-        # Qwen3.5-style KV caches use (n_kv_heads, seq, head_dim).
-        if ndim == 3:
-            return 1
         return None
 
     def _extract_block_tensor_slice(
@@ -791,7 +982,14 @@ class BlockAwarePrefixCache:
             end_idx: End token index in the sequence
 
         Returns:
-            List of (keys_slice, values_slice) for each layer, or None on failure
+            List of (keys_slice, values_slice) for each layer, or None on
+            failure. Slices are wrapped in ``mx.contiguous`` and later
+            force-evaluated by ``store_cache`` so the stored copies do not
+            retain the caller's full KV buffers. Verified by active-memory
+            accounting in ``TestStoredBlockBufferIndependence`` — including
+            the single-KV-head case, where a seq-axis slice is already
+            row-contiguous and a no-copy shortcut would silently alias the
+            whole buffer.
         """
         if not HAS_MLX or not cache_data:
             return None
@@ -800,7 +998,7 @@ class BlockAwarePrefixCache:
             block_slices = []
             for layer_state in cache_data:
                 if "state" not in layer_state:
-                    continue
+                    return None
 
                 keys, values = layer_state["state"]
 
@@ -817,7 +1015,7 @@ class BlockAwarePrefixCache:
                     (keys, values), class_name=class_name
                 )
                 if seq_axis is None:
-                    # Tensor shape didn't match any known KV layout even
+                    # Tensor shape didn't match the supported KV layout even
                     # though the class name was right (e.g. corrupted
                     # state). Bail out entirely.
                     return None
@@ -829,24 +1027,20 @@ class BlockAwarePrefixCache:
                 seq_len = min(keys.shape[seq_axis], values.shape[seq_axis])
 
                 if end_idx > seq_len:
-                    # Requested range extends beyond available data
+                    # A partially-backed block would reconstruct into fewer
+                    # KV rows than the tokens it claims — refuse the whole
+                    # block rather than store a short slice.
                     logger.debug(
-                        f"Block slice [{start_idx}:{end_idx}] exceeds seq_len {seq_len}"
+                        f"Block slice [{start_idx}:{end_idx}] exceeds seq_len "
+                        f"{seq_len}; refusing partial block"
                     )
-                    actual_end = min(end_idx, seq_len)
-                    if start_idx >= actual_end:
-                        continue
-                else:
-                    actual_end = end_idx
+                    return None
 
-                # Build a slice tuple that addresses only the seq axis; all
-                # other axes pass through. Avoids hardcoding rank (3D vs 4D).
-                key_slices: list[slice] = [slice(None)] * len(keys.shape)
-                val_slices: list[slice] = [slice(None)] * len(values.shape)
-                key_slices[seq_axis] = slice(start_idx, actual_end)
-                val_slices[seq_axis] = slice(start_idx, actual_end)
                 block_slices.append(
-                    (keys[tuple(key_slices)], values[tuple(val_slices)])
+                    (
+                        mx.contiguous(keys[:, :, start_idx:end_idx, :]),
+                        mx.contiguous(values[:, :, start_idx:end_idx, :]),
+                    )
                 )
 
             return block_slices if block_slices else None
@@ -855,48 +1049,22 @@ class BlockAwarePrefixCache:
             logger.warning(f"Failed to extract block tensor slice: {e}")
             return None
 
-    def get_cache_for_generation(
-        self,
-        request_id: str,
-    ) -> tuple[list[Any] | None, bool]:
-        """
-        Get cache data for generation, applying COW if needed.
-
-        Args:
-            request_id: Request identifier
-
-        Returns:
-            Tuple of (cache_data, was_copied)
-        """
-        entry = self._request_tables.get(request_id)
-        if not entry:
-            return None, False
-
-        # Get blocks with COW
-        blocks, was_copied = self.paged_cache.get_blocks_for_generation(
-            entry.block_table
-        )
-
-        if was_copied:
-            # Deep copy cache data for modified blocks
-            cache_data = copy.deepcopy(entry.cache_data)
-        else:
-            cache_data = entry.cache_data
-
-        entry.last_access = time.time()
-        return cache_data, was_copied
-
     def release_cache(self, request_id: str) -> None:
         """
-        Release cache blocks for a completed request.
+        Release cache/block state held for a request — idempotent.
+
+        Covers every acquisition path: a committed fetch transaction (block
+        table + pending reconstructed caches), an aborted one (nothing
+        left), and a stored entry. Safe to call repeatedly and after either
+        commit or abort.
 
         Args:
             request_id: Request identifier
         """
-        entry = self._request_tables.pop(request_id, None)
-        if entry:
-            self.paged_cache.delete_block_table(request_id)
-            logger.debug(f"Released cache for {request_id}")
+        self._pending_reconstructed.pop(request_id, None)
+        self._request_tables.pop(request_id, None)
+        self.paged_cache.delete_block_table(request_id)
+        logger.debug(f"Released cache for {request_id}")
 
     def fork_cache(
         self,
@@ -906,16 +1074,38 @@ class BlockAwarePrefixCache:
         """
         Fork cache from one request to another (COW).
 
+        Only the block table is forked (with reference counts bumped) —
+        blocks carry the KV state, so there is no snapshot to share.
+        Forking a request onto its own id is a no-op returning the
+        existing table (no reference counts change).
+
         Args:
             source_request_id: Source request ID
             new_request_id: New request ID
 
         Returns:
-            Forked BlockTable, or None if source not found
+            Forked BlockTable (the existing table for a self-fork), or
+            None if source not found
         """
         source_entry = self._request_tables.get(source_request_id)
         if not source_entry:
             return None
+
+        # Self-fork is a no-op returning the existing table: the entry
+        # already owns it, and a real fork would bump every block ref and
+        # then overwrite the only owning entry — leaking one reference per
+        # block forever.
+        if new_request_id == source_request_id:
+            source_entry.last_access = time.time()
+            return source_entry.block_table
+
+        # A reused target id must release its prior entry/refs first, or
+        # the overwrite below would leak them.
+        if (
+            new_request_id in self._request_tables
+            or self.paged_cache.get_block_table(new_request_id) is not None
+        ):
+            self.release_cache(new_request_id)
 
         # Fork block table (increments ref counts)
         forked_table = self.paged_cache.fork_block_table(
@@ -923,10 +1113,8 @@ class BlockAwarePrefixCache:
             new_request_id,
         )
 
-        # Create new entry with reference to same cache data
         self._request_tables[new_request_id] = BlockCacheEntry(
             block_table=forked_table,
-            cache_data=source_entry.cache_data,  # Shared reference
             last_access=time.time(),
         )
 
@@ -941,8 +1129,10 @@ class BlockAwarePrefixCache:
         """
         Reconstruct KVCache objects from stored block tensor data.
 
-        This method concatenates tensor slices from all blocks and
-        creates new KVCache objects that can be used for inference.
+        When ``block_table`` came from a committed ``fetch_cache``
+        transaction, this returns the caches already built and validated by
+        that transaction (popping the stash). Otherwise it concatenates the
+        block tensor slices and builds new KVCache objects.
 
         Args:
             block_table: BlockTable containing block IDs to reconstruct from
@@ -951,6 +1141,17 @@ class BlockAwarePrefixCache:
             List of reconstructed KVCache objects (one per layer),
             or None if reconstruction fails
         """
+        if block_table is not None and block_table.request_id:
+            pending = self._pending_reconstructed.pop(block_table.request_id, None)
+            if pending is not None:
+                return pending
+        return self._reconstruct_from_table(block_table)
+
+    def _reconstruct_from_table(
+        self,
+        block_table: BlockTable,
+    ) -> list[Any] | None:
+        """Concatenate block tensor slices into fresh KVCache objects."""
         if not block_table or not block_table.block_ids:
             return None
 
@@ -1091,17 +1292,17 @@ class BlockAwarePrefixCache:
         best_match = None
         best_len = 0
 
-        # Try progressively longer prefixes
+        # Try progressively longer block-aligned prefixes; the index is
+        # keyed by cumulative-identity hashes, computed incrementally here.
+        probe = PrefixHasher()
         for num_blocks in range(1, len(tokens) // self.block_size + 1):
             prefix_len = num_blocks * self.block_size
-            if prefix_len > len(tokens):
-                break
-
-            prefix_tokens = tokens[:prefix_len]
-            prefix_hash = self.paged_cache.compute_block_hash(prefix_tokens)
+            probe.update(tokens[prefix_len - self.block_size : prefix_len])
+            prefix_hash = probe.hexdigest()
 
             if prefix_hash in self._prefix_index:
                 cached_tokens, block_ids = self._prefix_index[prefix_hash]
+                prefix_tokens = tokens[:prefix_len]
                 if cached_tokens == prefix_tokens and len(cached_tokens) > best_len:
                     # Hermes patch: stale-block guard. The prefix index
                     # is never pruned when a block is released to the
@@ -1114,31 +1315,37 @@ class BlockAwarePrefixCache:
                     # Require every referenced block to still be live
                     # with resident tensor data AND still own the tokens
                     # this prefix expects before trusting the hit.
+                    #
+                    # Ownership check. cache_data != None is necessary
+                    # but NOT sufficient: a block freed under pressure
+                    # and then REALLOCATED for different tokens carries
+                    # fresh cache_data yet the wrong KV. store_cache
+                    # records EVERY block's cumulative identity hash —
+                    # the hash of the whole prefix through that block,
+                    # full and trailing partial alike — and reallocation
+                    # replaces it. Recompute the expected identities over
+                    # the ACTUAL stored block spans and require an exact
+                    # match, so a reallocated block is rejected even
+                    # though its cache_data is non-None.
                     live = True
-                    bs = self.block_size
-                    for j, bid in enumerate(block_ids):
+                    guard = PrefixHasher()
+                    end = 0
+                    for bid in block_ids:
                         blk = self.paged_cache.allocated_blocks.get(bid)
                         if blk is None or blk.cache_data is None:
                             live = False
                             break
-                        # Ownership check. cache_data != None is necessary
-                        # but NOT sufficient: a block freed under pressure
-                        # and then REALLOCATED for different tokens carries
-                        # fresh cache_data yet the wrong KV, so it would
-                        # pass the liveness test above and corrupt decode.
-                        # store_cache records EVERY block's
-                        # ``hash_value = compute_block_hash(its tokens)`` —
-                        # full and trailing partial alike — and a
-                        # reallocation resets/replaces that hash. Re-derive
-                        # the expected hash for this block's token slice and
-                        # require it to still match, so a reallocated block
-                        # (full or partial) is rejected even though its
-                        # cache_data is non-None.
-                        block_tokens = cached_tokens[j * bs : (j + 1) * bs]
-                        expected = self.paged_cache.compute_block_hash(block_tokens)
-                        if blk.hash_value != expected:
+                        span = blk.token_count
+                        if span <= 0 or end + span > len(cached_tokens):
                             live = False
                             break
+                        guard.update(cached_tokens[end : end + span])
+                        end += span
+                        if blk.hash_value != guard.hexdigest():
+                            live = False
+                            break
+                    if live and end != len(cached_tokens):
+                        live = False
                     if not live:
                         continue
                     best_match = (cached_tokens, block_ids)
@@ -1151,13 +1358,73 @@ class BlockAwarePrefixCache:
         tokens: list[int],
         block_ids: list[int],
     ) -> None:
-        """Update prefix index with new token sequence."""
-        # Index block-aligned prefixes
-        for i in range(1, len(block_ids) + 1):
-            prefix_len = min(i * self.block_size, len(tokens))
-            prefix_tokens = tokens[:prefix_len]
-            prefix_hash = self.paged_cache.compute_block_hash(prefix_tokens)
-            self._prefix_index[prefix_hash] = (prefix_tokens, block_ids[:i])
+        """Update prefix index with new token sequence.
+
+        Index keys are cumulative-identity hashes over the ACTUAL stored
+        block spans (``token_count``), matching the identities recorded on
+        the blocks themselves — so index probes, block registrations, and
+        ownership guards all agree on what a prefix hash means.
+        """
+        hasher = PrefixHasher()
+        end = 0
+        for i, block_id in enumerate(block_ids):
+            block = self.paged_cache.allocated_blocks.get(block_id)
+            if (
+                block is None
+                or block.token_count <= 0
+                or end + block.token_count > len(tokens)
+            ):
+                break
+            hasher.update(tokens[end : end + block.token_count])
+            end += block.token_count
+            self._prefix_index[hasher.hexdigest()] = (
+                tokens[:end],
+                block_ids[: i + 1],
+            )
+
+    def index_entry_is_stale(
+        self,
+        cached_tokens: list[int],
+        block_ids: list[int],
+    ) -> bool:
+        """Return True when a live block no longer owns the cumulative
+        token prefix this index entry records.
+
+        Used by pressure eviction to prune index entries whose slots were
+        freed and reallocated for different tokens — clearing such a slot
+        would destroy another request's live KV. Absent blocks are NOT
+        stale (the caller's eligibility checks handle them, and later
+        identities cannot be verified past a missing span). Blocks that
+        claim no identity (``hash_value`` None — legacy/unhashed fixtures)
+        are tolerated. A block that claims an identity WITHOUT a
+        consistent span is unverifiable — fail closed: prune the entry,
+        touch no block.
+        """
+        hasher = PrefixHasher()
+        end = 0
+        for block_id in block_ids:
+            block = self.paged_cache.allocated_blocks.get(block_id)
+            if block is None:
+                return False
+            if block.hash_value is None:
+                # Nothing to verify; extend the chain on a best-effort span
+                # so later hashed blocks can still be checked. When the
+                # entry's tokens run out the rest is unverifiable, not
+                # stale.
+                span = block.token_count if block.token_count > 0 else self.block_size
+                span = min(span, len(cached_tokens) - end)
+                if span <= 0:
+                    return False
+                hasher.update(cached_tokens[end : end + span])
+                end += span
+                continue
+            if block.token_count <= 0 or end + block.token_count > len(cached_tokens):
+                return True
+            hasher.update(cached_tokens[end : end + block.token_count])
+            end += block.token_count
+            if block.hash_value != hasher.hexdigest():
+                return True
+        return False
 
     def get_stats(self) -> dict[str, Any]:
         """Get cache statistics."""
@@ -1186,6 +1453,7 @@ class BlockAwarePrefixCache:
         """Clear all cached data."""
         self._request_tables.clear()
         self._prefix_index.clear()
+        self._pending_reconstructed.clear()
         self.paged_cache.clear(reset_stats=reset_stats)
         if reset_stats:
             self.reset_stats()
@@ -1201,7 +1469,9 @@ class BlockAwarePrefixCache:
             True if blocks were found and pinned
         """
         # Find blocks covering this prefix
-        shared_block_ids, _ = self.paged_cache.find_shared_prefix(tokens)
+        shared_block_ids, _ = self.paged_cache.find_shared_prefix(
+            tokens, record_stats=False
+        )
         if shared_block_ids:
             pinned = self.paged_cache.pin_blocks(shared_block_ids)
             if pinned > 0:
@@ -1234,7 +1504,9 @@ class BlockAwarePrefixCache:
         Returns:
             True if blocks were found and unpinned
         """
-        shared_block_ids, _ = self.paged_cache.find_shared_prefix(tokens)
+        shared_block_ids, _ = self.paged_cache.find_shared_prefix(
+            tokens, record_stats=False
+        )
         if shared_block_ids:
             unpinned = self.paged_cache.unpin_blocks(shared_block_ids)
             return unpinned > 0

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -125,7 +125,11 @@ from .gdn_prefill import install as install_gdn_prefill_kernel
 from .memory_cache import MemoryAwarePrefixCache, MemoryCacheConfig  # noqa: E402
 from .paged_cache import PagedCacheManager
 from .pflash import PFlashConfig, compress_request_tokens
-from .prefix_cache import BlockAwarePrefixCache, PrefixCacheManager
+from .prefix_cache import (
+    BlockAwarePrefixCache,
+    PrefixCacheManager,
+    validate_paged_cache_capability,
+)
 from .repetition_guard import (
     AgentRepetitionLogitsProcessor,
     detect_repeated_token_suffix,
@@ -3770,6 +3774,21 @@ class Scheduler:
 
         if self.config.enable_prefix_cache:
             if self.config.use_paged_cache:
+                # Fail closed BEFORE serving: the paged block serializer only
+                # supports plain full-attention KVCache layouts. An explicit
+                # --use-paged-cache on a rotating/hybrid/recurrent/quantized
+                # layout must abort startup with an actionable typed error
+                # instead of coming up healthy with zero reuse (#2955). This
+                # is a structural probe of the loaded model's prompt-cache
+                # factory — no model/architecture names involved.
+                validate_paged_cache_capability(
+                    model,
+                    kv_cache_quantized=bool(
+                        self.config.kv_cache_quantization
+                        and not getattr(self.config, "kv_cache_turboquant", None)
+                        and not self._kv_quant_live_disabled
+                    ),
+                )
                 # Use paged cache for memory efficiency
                 self.paged_cache_manager = PagedCacheManager(
                     block_size=self.config.paged_cache_block_size,
@@ -6434,17 +6453,13 @@ class Scheduler:
             # fetch-side live check (blk.cache_data is None => miss).
             index = getattr(self.block_aware_cache, "_prefix_index", None)
             paged = self.block_aware_cache.paged_cache
-            # 1) Release the FULL-KV tensor pinned by the oldest
-            # request-table entry FIRST — this is the actual Metal
-            # allocation owner. The block slices are only views into
-            # the same underlying buffer; the entry's ``cache_data`` is
-            # what pins it. Without this, pressure eviction clears
-            # slices forever while active memory never drops (the
-            # observed D-METAL-CAP wedge: evictions_total grows, active
-            # stays pinned above cap). Pop the entry so its block
-            # ref-counts drop and the blocks can re-enter the free
-            # queue. Doing this before the index pop also guarantees
-            # full-KV entries drain even when the LRU index is empty.
+            # 1) Evict the LRU request-table entry FIRST. Since #2955 the
+            # entry retains no full-KV snapshot — blocks own independent
+            # contiguous tensor copies — so eviction means: drop the
+            # private blocks' resident tensors, then release the entry's
+            # block references so the slots re-enter the free queue.
+            # Doing this before the index pop guarantees stored entries
+            # drain even when the LRU index is empty.
             rt = getattr(self.block_aware_cache, "_request_tables", None)
             if rt:
                 # True LRU: evict the least-recently-used entry
@@ -6454,18 +6469,10 @@ class Scheduler:
                     (rid, rentry)
                     for rid in list(rt.keys())
                     if (rentry := rt.get(rid)) is not None
-                    and rentry.cache_data is not None
                 ]
                 if evictable:
                     rid, rentry = min(evictable, key=lambda kv: kv[1].last_access)
                     block_ids = rentry.block_table.block_ids
-                    # Drop this request's OWN full-KV buffer. Its per-block
-                    # tensors are independent MLX slice arrays, so this does
-                    # not invalidate a pinned or shared block's tensor — the
-                    # buffer's memory stays live through whichever slices
-                    # still reference it. Reclaiming the entry's own buffer
-                    # is worthwhile even when every block is pinned/shared.
-                    rentry.cache_data = None
                     for bid in block_ids:
                         blk = paged.allocated_blocks.get(bid)
                         if blk is None or blk.cache_data is None:
@@ -6513,7 +6520,7 @@ class Scheduler:
                                 exc_info=True,
                             )
                     logger.debug(
-                        "[D-METAL-PFX-evict] dropped full-KV entry %s "
+                        "[D-METAL-PFX-evict] dropped stored entry %s "
                         "(request_tables=%d)",
                         rid,
                         len(rt),
@@ -6535,26 +6542,14 @@ class Scheduler:
                     # of those slots was subsequently reallocated, ref_count
                     # alone cannot distinguish the new owner's live KV from
                     # the old prefix. Prune the stale index entry without
-                    # touching any block unless every slot still owns the
-                    # token slice recorded by this prefix.
-                    stale = False
-                    bs = self.block_aware_cache.block_size
-                    for j, bid in enumerate(block_ids):
-                        blk = paged.allocated_blocks.get(bid)
-                        block_tokens = cached_tokens[j * bs : (j + 1) * bs]
-                        expected_hash = paged.compute_block_hash(block_tokens)
-                        # Missing blocks are handled by the eligibility
-                        # check below. A ``None`` hash is retained for
-                        # compatibility with legacy/unhashed fixtures; all
-                        # newly stored production blocks record ownership.
-                        if (
-                            blk is not None
-                            and blk.hash_value is not None
-                            and blk.hash_value != expected_hash
-                        ):
-                            stale = True
-                            break
-                    if stale:
+                    # touching any block unless every verifiable slot still
+                    # owns the CUMULATIVE token prefix recorded by this
+                    # entry — block identities cover the whole preceding
+                    # history, not per-chunk content, so the check must
+                    # recompute the same chained hashes store_cache records.
+                    if self.block_aware_cache.index_entry_is_stale(
+                        cached_tokens, block_ids
+                    ):
                         index.pop(oldest_hash)
                         return True
                     # Skip an entry only when NONE of its blocks are
@@ -6579,8 +6574,8 @@ class Scheduler:
                             continue
                         # Release the block's resident KV tensor regardless
                         # of hash registration variant. store_cache
-                        # registers blocks via register_block_hash (legacy
-                        # hash_value only, block_hash stays None), so the
+                        # registers blocks in the legacy identity map
+                        # (hash_value only, block_hash stays None), so the
                         # chain-hash gated _maybe_evict_cached_block would
                         # short-circuit and leak the tensor. Mirror its
                         # cleanup directly: drop any hash mapping, clear
@@ -6788,16 +6783,18 @@ class Scheduler:
             request.cache_hit_type = "miss"
             request.remaining_tokens = request.prompt_token_ids
         elif self.block_aware_cache is not None:
-            # Use paged cache
+            # Use paged cache. ``fetch_cache`` is transactional: it returns a
+            # block table only after reconstruction succeeded, so a returned
+            # hit always carries usable KV state.
             block_table, remaining = self.block_aware_cache.fetch_cache(
                 request.request_id,
                 request.prompt_token_ids,
             )
             if block_table and block_table.num_tokens > 0:
-                request.cache_hit_type = "hit"
-                # Reconstruct actual KVCache objects from stored tensor data
+                # Returns the caches the committed transaction already built.
                 reconstructed = self.block_aware_cache.reconstruct_cache(block_table)
                 if reconstructed:
+                    request.cache_hit_type = "hit"
                     request.prompt_cache = reconstructed
                     request.block_table = block_table
                     request.cached_tokens = block_table.num_tokens
@@ -6809,11 +6806,16 @@ class Scheduler:
                         f"{len(remaining)} tokens remaining, cache reconstructed"
                     )
                 else:
-                    # Reconstruction failed, treat as cache miss
+                    # Defensive: a committed fetch guarantees a
+                    # reconstructable table, so this should be unreachable.
+                    # Release the held refs and fall back to a full prefill.
+                    self.block_aware_cache.release_cache(request.request_id)
                     request.cache_hit_type = "miss"
                     request.remaining_tokens = request.prompt_token_ids
-                    logger.debug(
-                        f"Request {request.request_id}: paged cache reconstruction failed"
+                    logger.warning(
+                        f"Request {request.request_id}: paged cache "
+                        "reconstruction failed after committed fetch; "
+                        "released refs and treating as miss"
                     )
             else:
                 request.cache_hit_type = "miss"
@@ -7429,6 +7431,11 @@ class Scheduler:
             # Release cache references so Metal buffers can be freed
             request.prompt_cache = None
             request._extracted_cache = None
+        if self.block_aware_cache is not None:
+            # A cancelled request stores nothing, so nothing owns the block
+            # refs its fetch hit acquired — release them here. Idempotent
+            # (safe if _cleanup_finished releases again later).
+            self.block_aware_cache.release_cache(request_id)
         self.finished_req_ids.add(request_id)
         self._cleanup_detokenizer(request_id)
 
@@ -8557,6 +8564,7 @@ class Scheduler:
                 if self.block_aware_cache is not None:
                     # Store in paged cache
                     # Key includes both prompt and output tokens for multi-turn chat caching
+                    stored_table = None
                     if (
                         hasattr(request, "_extracted_cache")
                         and request._extracted_cache is not None
@@ -8565,7 +8573,7 @@ class Scheduler:
                             full_token_sequence = list(request.prompt_token_ids) + list(
                                 request.output_token_ids
                             )
-                            self.block_aware_cache.store_cache(
+                            stored_table = self.block_aware_cache.store_cache(
                                 request_id,
                                 full_token_sequence,
                                 request._extracted_cache,
@@ -8578,9 +8586,15 @@ class Scheduler:
                             logger.debug(
                                 f"Failed to store paged cache for {request_id}: {e}"
                             )
-                    # NOTE: Do NOT call release_cache here - blocks should persist
-                    # for future requests to share. The LRU eviction will clean up
-                    # unused blocks when under memory pressure.
+                    if stored_table is None:
+                        # Nothing stored (no extracted cache, unsupported
+                        # layout, or store failure): no entry owns this
+                        # request's blocks, so release any refs a fetch hit
+                        # acquired. Idempotent no-op when nothing is held.
+                        self.block_aware_cache.release_cache(request_id)
+                    # NOTE (stored case): do NOT call release_cache — the
+                    # stored entry owns the blocks so future requests can
+                    # share them; pressure-driven LRU eviction cleans up.
 
                 elif self.memory_aware_cache is not None:
                     # Keep mid-prefill entry as prefix cache for future

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3781,12 +3781,18 @@ class Scheduler:
                 # instead of coming up healthy with zero reuse (#2955). This
                 # is a structural probe of the loaded model's prompt-cache
                 # factory — no model/architecture names involved.
+                # Any EXPLICIT KV-cache transform request (ordinary live
+                # quantization or TurboQuant) is rejected outright — the
+                # paged store implements neither, so the pair fails closed
+                # even when the transform's own probes would fall back and
+                # disable it at runtime. Honoring the flags with silently
+                # untransformed plain blocks is the same silent-option
+                # failure this gate exists to prevent.
                 validate_paged_cache_capability(
                     model,
-                    kv_cache_quantized=bool(
+                    kv_cache_transform_requested=bool(
                         self.config.kv_cache_quantization
-                        and not getattr(self.config, "kv_cache_turboquant", None)
-                        and not self._kv_quant_live_disabled
+                        or getattr(self.config, "kv_cache_turboquant", None)
                     ),
                 )
                 # Use paged cache for memory efficiency
@@ -6447,10 +6453,12 @@ class Scheduler:
             # admission gate then rejects ALL new requests while active
             # stays pinned above cap — a permanent 503 wedge (the
             # D-METAL-CAP symptom) with no in-process recovery. Fix:
-            # evict the LRU prefix-index entry and drop its resident
-            # block tensors so active memory falls back under cap and
-            # admission resumes. Stale index entries are guarded by the
-            # fetch-side live check (blk.cache_data is None => miss).
+            # evict the LRU stored entry — clear its private blocks'
+            # resident tensors and release the entry — so active memory
+            # falls back under cap and admission resumes. Index entries
+            # that outlive their blocks are guarded by the fetch-side
+            # live checks (increment_ref fails on absent slots;
+            # blk.cache_data is None => miss).
             index = getattr(self.block_aware_cache, "_prefix_index", None)
             paged = self.block_aware_cache.paged_cache
             # 1) Evict the LRU request-table entry FIRST. Since #2955 the
@@ -6526,84 +6534,37 @@ class Scheduler:
                         len(rt),
                     )
                     return True
-            # 2) Then evict the LRU prefix-index entry and drop its
-            # resident block tensors, so stale index entries stop
-            # pinning block slices. Stale entries are guarded by the
-            # fetch-side live check (blk.cache_data is None => miss).
+            # 2) Index-only cleanup. The prefix index owns METADATA, never
+            # a physical block reference: every live reference belongs to a
+            # stored request-table entry (drained above via release_cache)
+            # or an active fetch-held table. So this path must not clear or
+            # free ANY allocated block — a ref_count of 1 here can be an
+            # active fetch's sole reference, and clearing/freeing it would
+            # corrupt live KV or hand the slot back to the free queue while
+            # a table still points at it. We only prune entries whose
+            # recorded cumulative ownership no longer verifies (slot
+            # reallocated / identity mismatch); every other entry stays so
+            # its prefix remains reachable (pinned prefixes keep their
+            # identities and therefore always verify). Resident KV on
+            # unreferenced (ref_count == 0) free-queue slabs is reclaimed
+            # exclusively by release_paged_cache_blocks_under_pressure.
             if index:
-                # dict preserves insertion order: first key = LRU. Walk in
-                # LRU order and skip any entry whose blocks are ALL pinned
-                # or absent: popping such an entry would make the prefix
-                # unreachable while freeing nothing, and returning False on
-                # it would halt the caller's eviction loop prematurely.
+                # dict preserves insertion order: first key = LRU.
                 for oldest_hash in list(index.keys()):
                     cached_tokens, block_ids = index[oldest_hash]
                     # An index entry can outlive its physical blocks. If one
                     # of those slots was subsequently reallocated, ref_count
                     # alone cannot distinguish the new owner's live KV from
-                    # the old prefix. Prune the stale index entry without
-                    # touching any block unless every verifiable slot still
-                    # owns the CUMULATIVE token prefix recorded by this
-                    # entry — block identities cover the whole preceding
-                    # history, not per-chunk content, so the check must
-                    # recompute the same chained hashes store_cache records.
+                    # the old prefix — block identities cover the whole
+                    # preceding history, not per-chunk content, so the check
+                    # recomputes the same chained hashes store_cache records
+                    # and prunes only metadata that no longer owns its
+                    # recorded prefix.
                     if self.block_aware_cache.index_entry_is_stale(
                         cached_tokens, block_ids
                     ):
                         index.pop(oldest_hash)
                         return True
-                    # Skip an entry only when NONE of its blocks are
-                    # clearable — absent, pinned, or still shared with a
-                    # live request (ref_count > 1). Popping such an entry
-                    # would make the prefix unreachable while freeing
-                    # nothing and would halt the caller's eviction loop.
-                    if all(
-                        (blk := paged.allocated_blocks.get(bid)) is None
-                        or blk.is_pinned
-                        or blk.ref_count > 1
-                        for bid in block_ids
-                    ):
-                        continue
-                    index.pop(oldest_hash)
-                    evicted = 0
-                    for bid in block_ids:
-                        blk = paged.allocated_blocks.get(bid)
-                        # Never clear a pinned or still-shared block: its KV
-                        # is live for another request.
-                        if blk is None or blk.is_pinned or blk.ref_count > 1:
-                            continue
-                        # Release the block's resident KV tensor regardless
-                        # of hash registration variant. store_cache
-                        # registers blocks in the legacy identity map
-                        # (hash_value only, block_hash stays None), so the
-                        # chain-hash gated _maybe_evict_cached_block would
-                        # short-circuit and leak the tensor. Mirror its
-                        # cleanup directly: drop any hash mapping, clear
-                        # the tensor.
-                        if (
-                            blk.hash_value is not None
-                            and paged.hash_to_block.get(blk.hash_value) == blk.block_id
-                        ):
-                            del paged.hash_to_block[blk.hash_value]
-                        if blk.block_hash is not None:
-                            paged.cached_block_hash_to_block.pop(
-                                blk.block_hash, blk.block_id
-                            )
-                        if blk.cache_data is not None:
-                            blk.reset_hash()
-                            blk.cache_data = None  # Free tensor memory
-                            blk.cache_class_name = None
-                            paged.stats.evictions += 1
-                            evicted += 1
-                        # Return the block slot to the free queue. Unlike the
-                        # request-table path (which frees via release_cache ->
-                        # delete_block_table), the index path holds its own
-                        # ref, so clearing the tensor alone would leak the
-                        # block from the pool and eventually exhaust
-                        # max_cache_blocks. free_block decrements ref and
-                        # enqueues the (now-empty) block when it reaches 0.
-                        paged.free_block(bid)
-                    return evicted > 0
                 return False
             return False
         return False

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -48,7 +48,7 @@ from ._sampler_fast_path import (  # noqa: E402
     make_fused_top_p_temp_sampler,
 )
 from ._seeded_sampler import make_seeded_sampler  # noqa: E402
-from .errors import BackpressureError  # noqa: E402
+from .errors import BackpressureError, PagedCacheUnsupportedLayoutError  # noqa: E402
 from .kv_estimation import (  # noqa: E402
     _cfg_get,
     _valid_layer_types,
@@ -3771,6 +3771,21 @@ class Scheduler:
         self.memory_aware_cache: MemoryAwarePrefixCache | None = None
         self.paged_cache_manager: PagedCacheManager | None = None
         self.block_aware_cache: BlockAwarePrefixCache | None = None
+
+        # Fail closed on the contradictory pair BEFORE the enablement
+        # branch: an explicit --use-paged-cache with the prefix cache
+        # disabled would otherwise be silently ignored (the paged store IS
+        # a prefix-cache backend, so nothing would be constructed) — the
+        # same silent-option failure the capability gate below exists to
+        # prevent (#2955).
+        if self.config.use_paged_cache and not self.config.enable_prefix_cache:
+            raise PagedCacheUnsupportedLayoutError(
+                "--use-paged-cache requires the prefix cache: the paged "
+                "block store is a prefix-cache backend, and prefix caching "
+                "is disabled in this configuration, so the explicit paged "
+                "request cannot take effect. Remove --use-paged-cache, or "
+                "drop --disable-prefix-cache so the prefix cache is enabled."
+            )
 
         if self.config.enable_prefix_cache:
             if self.config.use_paged_cache:


### PR DESCRIPTION
## Summary

- Reject explicit paged-cache requests before readiness when the selected lane or loaded KV layout cannot support lossless block reconstruction.
- Make prefix fetch transactional: acquire candidate refs, reconstruct, then commit hit metrics; any failure rolls back refs/table state and records one miss.
- Use cumulative prefix identities for block deduplication so identical later token chunks from divergent histories can never share context-dependent KV.
- Store independently materialized block tensors without retaining a duplicate full-request KV snapshot.

## User impact

Rotating, hybrid, recurrent, quantized, unknown, and multimodal-lane cache layouts now fail with an actionable startup error instead of reporting healthy while paged reuse is ineffective. Supported plain full-attention models retain real paged prefix reuse with correct metrics and cleanup.

## Design precedent

The implementation follows established serving-engine patterns: validate a backend capability at lane admission, derive layout compatibility from the loaded cache factory rather than model names, key KV blocks by the full preceding context, and treat cache acquisition as a commit-or-abort transaction. Blocks become the sole retained KV owner after storage; request metadata no longer pins a second complete snapshot.

## Verification

- `python3.12 -m pytest -q tests/test_paged_cache.py tests/test_paged_cache_benefits.py tests/test_prefix_cache_pressure_eviction.py tests/test_memory_cache.py tests/test_prefix_cache.py tests/test_no_mllm_flag.py::TestPagedCacheLaneAdmission` — 189 passed.
- Ruff check and format check on all changed Python files; `py_compile`; `git diff --check` — passed.
- Offline real-model positive proof, 680 MB plain-attention checkpoint: two identical 2,025-token chat requests returned identical greedy output; the second reported 1,984 cached tokens and completed in 0.137 s versus 0.506 s cold.
- Offline real-model negative proof, rotating-cache multimodal checkpoint: the same explicit option exits with code 3 and `PagedCacheUnsupportedLayoutError` before Ready; no request can reach a silently ineffective server.
- Failure-injection coverage includes missing tensors, wrong cache class/shape, reconstruction exception, reused/self-forked request IDs, divergent-history block collisions, idempotent release, and caller-buffer independence.

## Scope and compatibility

The option remains experimental and default-off. Default prefix caching is unchanged. This does not add paged representations for rotating or recurrent state, and does not change CI, dependencies, versions, or Desktop behavior.

Fixes #2955
