### PR TITLE
fix(mtp): isolate singleton verifier admission

### DIFF
--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -1987,6 +1987,106 @@ def test_install_mtp_vendored_b_gt_1_soft_fallthrough_when_no_state():
     assert gb.orig_step_calls == 1
 
 
+def test_install_mtp_vendored_defers_new_admission_until_singleton_departs(
+    monkeypatch,
+):
+    """A live singleton verifier owns the generation batch exclusively.
+
+    mlx-lm generates first and admits queued prompts later in the same cycle.
+    The first speculative emission must therefore close that cycle's admission
+    boundary; otherwise a concurrently queued tool/plain request extends the
+    persistent batch and both requests fail closed on the following step.
+    """
+    from collections import deque
+    from types import SimpleNamespace
+
+    import mlx.core as mx
+
+    from vllm_mlx.scheduler import _install_mtp_vendored
+    from vllm_mlx.spec_decode.mtp import generator as _gen_mod
+
+    class _FakeGen:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return (1001, mx.array([0.0]), False)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(_gen_mod, "mtp_generate_step", lambda *a, **kw: _FakeGen())
+
+    gb = _StubBatchGen()
+    gb.uids = [7]
+    gb._next_tokens = mx.array([500], dtype=mx.uint32)
+    gb._next_logprobs = [mx.array([0.0])]
+    queued = deque([8])
+
+    class _BatchGenerator:
+        completion_batch_size = 4
+        _generation_batch = gb
+
+        def next(self):
+            # Mirrors mlx-lm's generate-first / admit-afterward boundary.
+            self._generation_batch._step()
+            if len(self._generation_batch.uids) >= self.completion_batch_size:
+                return [], []
+            if queued:
+                self._generation_batch.uids.append(queued.popleft())
+            return [], []
+
+        def _find_uids(self, uids):
+            return {
+                uid: (2, index)
+                for index, uid in enumerate(self._generation_batch.uids)
+                if uid in set(uids)
+            }
+
+        def remove(self, uids, return_prompt_caches=False):
+            removed = set(uids)
+            self._generation_batch.uids = [
+                uid for uid in self._generation_batch.uids if uid not in removed
+            ]
+            return {} if return_prompt_caches else None
+
+    batch_gen = _BatchGenerator()
+    requests = {
+        "req-7": SimpleNamespace(sampling_params=SimpleNamespace(temperature=0.0)),
+        # Request 8 represents a tool/custom-processor request which must stay
+        # queued while request 7 owns the vendored singleton transaction.
+        "req-8": SimpleNamespace(sampling_params=SimpleNamespace(temperature=0.0)),
+    }
+    assert _install_mtp_vendored(
+        batch_gen,
+        model=_StubModel(),
+        requests=requests,
+        uid_to_request_id={7: "req-7", 8: "req-8"},
+    )
+
+    batch_gen.next()
+
+    assert gb.uids == [7]
+    assert list(queued) == [8]
+    assert batch_gen.completion_batch_size == 1
+    assert batch_gen._mtp_vendored_admission_owner == 7
+
+    # An out-of-band row replacement cannot steal the active transaction.
+    gb.uids = [8]
+    with pytest.raises(RuntimeError, match="conflicting singleton admission owners"):
+        gb._step()
+    assert set(gb._mtp_vendored_state) == {7}
+    gb.uids = [7]
+
+    batch_gen.remove([7])
+    assert batch_gen.completion_batch_size == 4
+    assert batch_gen._mtp_vendored_admission_owner is None
+
+    batch_gen.next()
+    assert gb.uids == [8]
+    assert list(queued) == []
+
+
 @pytest.mark.parametrize("departure", ["finish", "remove"])
 def test_install_mtp_vendored_reaps_request_state_on_departure(
     monkeypatch,
@@ -2015,6 +2115,7 @@ def test_install_mtp_vendored_reaps_request_state_on_departure(
     monkeypatch.setattr(_gen_mod, "mtp_generate_step", lambda *a, **kw: _FakeGen())
 
     batch_gen, gb = _make_batch_gen_with_gb()
+    batch_gen.completion_batch_size = 4
     present = {7}
     batch_gen._find_uids = lambda uids: {
         uid: (2, index) for index, uid in enumerate(sorted(present)) if uid in set(uids)
@@ -2040,6 +2141,8 @@ def test_install_mtp_vendored_reaps_request_state_on_departure(
     gb._next_logprobs = [mx.array([0.0])]
     gb._step()
     assert set(gb._mtp_vendored_state) == {7}
+    assert batch_gen.completion_batch_size == 1
+    assert batch_gen._mtp_vendored_admission_owner == 7
 
     if departure == "finish":
         gb.next_responses = [SimpleNamespace(uid=7, finish_reason="stop")]
@@ -2050,6 +2153,8 @@ def test_install_mtp_vendored_reaps_request_state_on_departure(
     assert closed == [7]
     assert gb._mtp_vendored_state == {}
     assert gb._mtp_vendored_disabled_uids == {}
+    assert batch_gen.completion_batch_size == 4
+    assert batch_gen._mtp_vendored_admission_owner is None
 
 
 def test_install_mtp_vendored_reaps_plain_fallthrough_log_key_on_finish(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1380,6 +1380,38 @@ def _install_mtp_vendored(
     # the uid must keep failing closed until removal or verified uid reuse.
     _terminal_uids: dict[int, str | None] = {}
 
+    # mlx-lm's BatchGenerator generates first and admits new prompt work in
+    # the same ``next()`` call.  Once this vendored verifier has emitted for a
+    # singleton, its request-local cache/token transaction owns the persistent
+    # GenerationBatch exclusively; extending that batch before the owner
+    # departs makes a plain handoff impossible without duplicating output.
+    #
+    # Use BatchGenerator's existing completion-capacity admission boundary as
+    # the lock instead of maintaining a second queue.  ``_mtp_step`` lowers
+    # the capacity while it is still on the generate-first half of the cycle,
+    # so mlx-lm's immediately-following capacity check leaves new prompts in
+    # its authoritative FIFO.  Normal finish/cancellation restores the exact
+    # configured capacity before the next admission cycle.
+    _nominal_completion_batch_size = getattr(batch_gen, "completion_batch_size", None)
+    _admission_owner_uid: int | None = None
+
+    def _lock_singleton_admission(uid: int) -> None:
+        nonlocal _admission_owner_uid
+        if _nominal_completion_batch_size is None:
+            return
+        _admission_owner_uid = uid
+        batch_gen.completion_batch_size = 1
+        batch_gen._mtp_vendored_admission_owner = uid
+
+    def _release_singleton_admission(uid: int) -> None:
+        nonlocal _admission_owner_uid
+        if _admission_owner_uid != uid:
+            return
+        if _nominal_completion_batch_size is not None:
+            batch_gen.completion_batch_size = _nominal_completion_batch_size
+        _admission_owner_uid = None
+        batch_gen._mtp_vendored_admission_owner = None
+
     _stats = {
         "vendored_steps": 0,
         "fallthrough_steps": 0,
@@ -1451,6 +1483,7 @@ def _install_mtp_vendored(
         boundary: no generator, marker, or log-once key may retain the request.
         """
         _cleanup_uid(uid)
+        _release_singleton_admission(uid)
         _disabled_uids.pop(uid, None)
         _terminal_uids.pop(uid, None)
         # Materialize the keys before mutating the source set. Passing a
@@ -1702,6 +1735,19 @@ def _install_mtp_vendored(
 
         uid = gb.uids[0]
 
+        # A row cannot replace the speculative owner without passing through
+        # the normal finish/remove boundary that releases both its caches and
+        # admission lock.  Detect an out-of-band filter/replacement before
+        # constructing a generator or mutating token bookkeeping.
+        if _admission_owner_uid not in (None, uid):
+            _stats["invariant_violations"] += 1
+            raise RuntimeError(
+                "[MTP-vendored] conflicting singleton admission owners: "
+                f"active={_admission_owner_uid}, observed={uid}. "
+                "Request removal is required before the generation slot can "
+                "be reassigned."
+            )
+
         if uid in _terminal_uids:
             terminal_req_id = _terminal_uids[uid]
             current_req_id = (
@@ -1825,6 +1871,7 @@ def _install_mtp_vendored(
                 # FIRST-call construction so the new request gets a
                 # fresh MTP path.
                 _cleanup_uid(uid)
+                _release_singleton_admission(uid)
                 state = None
 
         if state is None:
@@ -1994,6 +2041,7 @@ def _install_mtp_vendored(
                 "request_id": _first_call_req_id,
                 "sampling_fingerprint": sampling_options["fingerprint"],
             }
+            _lock_singleton_admission(uid)
             _stats["vendored_steps"] += 1
             # Codex round-I BLOCKING #2 / round-J BLOCKING #2+#3:
             # keep ``gb._next_tokens`` / ``gb._next_logprobs`` in a
@@ -2185,6 +2233,7 @@ def _install_mtp_vendored(
     gb._mtp_vendored_state = _state
     gb._mtp_vendored_disabled_uids = _disabled_uids
     gb._mtp_vendored_terminal_uids = _terminal_uids
+    batch_gen._mtp_vendored_admission_owner = None
 
     logger.info(
         "[MTP-vendored] installed on GenerationBatch._step "


### PR DESCRIPTION
## Why

Automatic MTP could commit output for a singleton request and then allow a concurrently arriving plain/tool request to extend the same persistent generation batch. The existing integrity guard correctly refused the unsafe handoff, but both users received HTTP 503.

Fixes #2963

## What changed

- Give an active vendored singleton MTP transaction explicit ownership of the generation-batch admission boundary.
- Reuse the batch generator’s existing completion-capacity gate so later requests remain in its authoritative FIFO.
- Restore the exact configured capacity on normal completion, cancellation, or verified uid reuse.
- Keep the corruption guard intact as defense in depth.
- Add a deterministic generate-first/admit-afterward regression and lifecycle coverage for finish/remove release.

## Scope

Allowed: scheduler admission ownership and focused regression coverage.

Non-goals: model qualification, tool parsing, sampling, MTP math, timeout policy, or weakening fail-closed behavior.

## Design precedent

Production continuous-batching schedulers treat speculative work as a scheduler-owned transaction: new work remains in the waiting queue until the active execution lane reaches a safe membership boundary. This adapts that established ownership model to the existing batch generator rather than creating a parallel queue or attempting an unsafe mid-stream decode conversion.

## Verification

- `python3.12 -m pytest -q tests/test_*mtp*.py --disable-warnings --maxfail=1` — 710 passed, 2 skipped
- focused admission/lifecycle cases — 5 passed
- `python3.12 -m ruff check vllm_mlx/scheduler.py tests/test_mtp_cli_wiring.py`
- `python3.12 -m ruff format --check vllm_mlx/scheduler.py tests/test_mtp_cli_wiring.py`
- `git diff --check`

Release acceptance additionally requires exact-head CI and real Qwen3.8-27B mixed-agent dogfood.