### PR TITLE
chore: bump version to 0.13.4

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,12 +17,47 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.13.4] — 2026-09-02
+
+Rapid-MLX 0.13.4 makes qualified local models faster under concurrent work,
+adds an experimental end-to-end video workspace, and turns Community
+Benchmark into a private-by-default local workspace with explicit sharing.
+
+### Added
+
+- **Local video generation in Desktop.** An opt-in Video workspace supports
+  LTX 2.5, Wan 2.1, and CogVideoX-Fun with queued jobs, progress, cancellation,
+  restart-safe results, and early memory validation.
+- **Private-by-default Community Benchmark.** CLI and Desktop users can run,
+  inspect, and archive reproducible measurements locally; sharing requires an
+  explicit preview and consent, with duplicate submission protection.
+- **Atomic model discovery and recommendations.** CLI, Server, and Desktop now
+  consume one validated model registry and recommendation policy.
+- Opt-in persistent conversation memory, isolated Mermaid previews, per-model
+  request metrics, and clearer in-app update discovery.
+
 ### Changed
 
 - **Qualified MTP models are fast by default.** Qwen3.5 4B/9B, Qwen3.6 27B,
   and Qwen3.8 27B automatically use their validated continuous speculative
   scheduler in CLI, Server, and Desktop. Desktop shows the active setting and
   keeps a persistent off switch for users who prefer ordinary decoding.
+- Across mixed four-request cohorts, the qualified paths improved aggregate
+  throughput by 14.1%–30.8%. Qwen3.8 27B decode measured 1.43× the 0.13.3
+  ordinary path at 128 tokens of context and 2.34× at 32K.
+- Per-model Metal limits now adapt to available unified memory and failed
+  launches provide actionable fit guidance.
+
+### Fixed
+
+- Singleton MTP retains exclusive scheduler ownership until its request
+  departs, so concurrently arriving plain or tool requests wait instead of
+  aborting both streams with a 503.
+- Quantized-KV and paged-cache requests fail closed on unsupported layouts;
+  paged prefix reuse now rolls back ownership cleanly after reconstruction
+  failures.
+- Model-download, GUI attachment, update, video-job, and MTP lifecycle failures
+  have more bounded cleanup and clearer recovery behavior.
 
 ## [0.13.3] — 2026-08-31
 
@@ -3662,7 +3697,8 @@ Older versions: see the
 [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases)
 for auto-generated notes against earlier tags.
 
-[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.3...HEAD
+[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.4...HEAD
+[0.13.4]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.3...rapid-mac-v0.13.4
 [0.13.3]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2...rapid-mac-v0.13.3
 [0.13.2]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2-rc1...rapid-mac-v0.13.2
 [0.13.2-rc1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.1...rapid-mac-v0.13.2-rc1

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.3</string>
+	<string>0.13.4</string>
 	<key>CFBundleVersion</key>
-	<string>169</string>
+	<string>170</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.13.4.md
+++ b/docs/release-notes/v0.13.4.md
@@ -1,0 +1,101 @@
+# Rapid-MLX 0.13.4
+
+Rapid-MLX 0.13.4 makes qualified local models faster under concurrent work,
+adds an experimental end-to-end video workspace, and turns Community
+Benchmark into a private-by-default local workspace with explicit sharing.
+It also improves memory fitting, model discovery, Markdown rendering, and
+headless operation.
+
+## Highlights
+
+### Faster qualified Qwen models by default
+
+The four exact qualified Qwen3.5/Qwen3.6/Qwen3.8 artifacts now select their
+validated MTP preset and continuous scheduler automatically when no
+speculative-decoding option is supplied. Across mixed four-request cohorts,
+aggregate throughput improved by **14.1%–30.8%**, with no ordinary-pass case
+becoming a continuous-mode failure. CLI and Server users can restore ordinary
+decoding with `--no-spec-decode`; Desktop exposes the same persistent off
+switch.
+
+| Qualified artifact | Aggregate throughput change |
+| --- | ---: |
+| Qwen3.5 4B 4-bit | +30.8% |
+| Qwen3.5 9B 4-bit | +23.9% |
+| Qwen3.6 27B 4-bit | +14.1% |
+| Qwen3.8 27B 4-bit | +25.9% |
+
+For Qwen3.8 27B, the qualified single-request MTP path also scales with
+context: measured decode throughput was **1.43×** the 0.13.3 ordinary path at
+128 tokens of context and **2.34×** at 32K. The new continuous scheduler keeps
+request/cache ownership transactional across admission, cancellation, and
+dynamic joins.
+
+### Local video generation in Desktop
+
+Enable Video Generation under Experimental Features to use a dedicated local
+workspace with queued jobs, progress, cancellation, restart-safe completed
+results, and early memory/workload validation. The signed app includes the
+audited runtime and encoder needed for **LTX 2.5 q8** (text/image to video),
+**Wan 2.1 1.3B bf16** (text to video), and **CogVideoX-Fun 5B q4** (text to
+video), without post-install package provisioning. Wan 2.1 is limited to Macs
+with at least 40 GB unified memory.
+
+### Community Benchmark, private by default
+
+`rapid-mlx benchmark` and the new Desktop Community Benchmark page can plan,
+run, validate, inspect, and archive text, image, and video measurements on the
+local Mac. Results remain local unless the user explicitly chooses to share.
+The consent flow previews the exact destination and payload digest, and a
+durable receipt prevents accidental duplicate submissions.
+
+### Better model and memory decisions
+
+CLI, Server, and Desktop now consume one atomic model registry and
+recommendation policy. Per-model Metal limits are tuned from the machine's
+available unified memory, and rejected launches return actionable fit guidance
+instead of failing deep in model loading. New per-model metrics expose request,
+token, latency, and throughput totals without mixing aliases.
+
+### Desktop quality-of-life improvements
+
+- Opt-in persistent memory can retain useful long-term context across
+  conversations and remains editable or removable in Settings.
+- Mermaid code blocks render as isolated, network-blocked previews.
+- Dictation overlaps speech-model page-in with the utterance to reduce the
+  perceived first-use delay.
+- An update card explains whether the installed app is current, behind, or
+  ahead of the public release without forcing an update.
+
+### Experimental performance routes
+
+Qwen3.8 Flash-Next gains an opt-in fused single-token GDN kernel. On the
+qualified M3 Ultra run it improved one complete GDN layer by **26.28%** and
+end-to-end decode from **25.43 to 27.04 tok/s (+6.35%)**, with bit-identical
+tokens and recurrent state in the qualification workload. It remains disabled
+by default while broader hardware evidence is collected. Qwen3.8 27B also adds
+an explicit experimental DFlash2 route and a conservative prompt-lookup route;
+unsupported requests continue to fail closed or use the ordinary path.
+
+## Reliability and operations
+
+- Explicit quantized-KV and paged-cache requests now reject unsupported cache
+  layouts before Ready instead of starting healthy and failing later.
+- Paged prefix reuse commits hit metrics only after successful reconstruction
+  and rolls back block ownership on failure.
+- Singleton MTP keeps exclusive scheduler ownership until its request departs,
+  so concurrently arriving plain or tool requests wait instead of aborting
+  both streams with a 503.
+- A documented LaunchDaemon deployment supports qualified headless macOS
+  servers while keeping the same user-owned cache and service boundaries.
+- Model-download, GUI attachment, update, video-job, and MTP lifecycle failures
+  have more bounded cleanup and clearer recovery behavior.
+
+## Upgrade
+
+```bash
+pip install -U rapid-mlx
+```
+
+Homebrew follows the PyPI release through its normal autobump process. Desktop
+users receive the signed and notarized update through the production appcast.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.13.3"
+version = "0.13.4"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Ship the reviewed and release-qualified 0.13.4 train from exact main source `f05d8d5025f630de43293d2c2bacc09364790c48`. This release makes qualified Qwen MTP paths faster under concurrent work, adds the opt-in Desktop Video and private-by-default Community Benchmark workspaces, and includes the final singleton-MTP admission fix verified with real Qwen3.8 mixed traffic.

## Scope

- bump the Python package and Desktop short version to 0.13.4
- advance the Desktop build number from 169 to 170
- archive curated 0.13.4 release notes
- roll the Desktop changelog and comparison links

## Non-goals

- no product or engine behavior changes
- no dependency changes
- no manual tags or publication outside the protected auto-release path

## Acceptance

- version sync and release-note contracts pass
- exact-head required checks are green and the PR is 0-behind
- release pre-flight is green on this exact head
- merge uses the exact canonical subject `chore: bump version to 0.13.4`

## Verification

- `make release-smoke` — clean-room release imports passed on the exact source tree
- version/release contract suite — 181 passed
- `scripts/check_release_notes.py` — synchronized
- final server gauntlet — Qwen3.5/Qwen3.8 coherence, 8/8 stress, SDK/tool concurrency, and the release-blocker reproduction passed
- final Desktop walk — Community Benchmark, Video opt-in/workspace, model catalog, Memory, and update surfaces reachable; pre-hotfix exact-tree six-shard GUI gate passed

Source review found no remaining P0/P1 release blockers. #2963 is closed by `f05d8d5025f630de43293d2c2bacc09364790c48`.

Release-Preflight: https://github.com/raullenchai/Rapid-MLX/actions/runs/33708891264