### PR TITLE
ci: dogfood Manzanita managed runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,4 +3,5 @@
 # distinguish it from a typo in a GitHub-hosted runner name.
 self-hosted-runner:
   labels:
+    - manzanita-standard
     - rapid-mlx-release

--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -228,10 +228,9 @@ jobs:
   build:
     needs: changes
     if: needs.changes.outputs.desktop == 'true'
-    # macos-15 → default Xcode 16 → Swift 6.0, matching Package.swift's
-    # swift-tools-version and the release workflow's runner. macos-latest still
-    # resolves to macos-14 (Swift 5.x) on GitHub-hosted runners.
-    runs-on: macos-15
+    # Manzanita's pinned image provides macOS Sequoia, Xcode 16.4, and Swift
+    # 6.1.2, matching Package.swift's Swift 6 toolchain requirement.
+    runs-on: manzanita-standard
     # A hung test would otherwise sit on the 6-hour default. The whole
     # job is ~2 min warm; 20 leaves room for a cold package resolve and
     # still fails fast. Learned the hard way: a headless-incompatible
@@ -361,8 +360,8 @@ jobs:
   # macos.sh in actions/runner-images inserts kTCCServiceAccessibility with
   # auth_value 2 (allowed) for /bin/bash and for the agent that parents the
   # runner, and configure-autologin.sh gives the VM a real logged-in Aqua
-  # session so an .app can actually open a window. Both are image properties,
-  # not promises — which is what the preflight step below is for.
+  # session so an .app can actually open a window. Manzanita's golden image
+  # preserves those properties, and the preflight below verifies them.
   gui-golden-flows:
     needs:
       - changes
@@ -370,9 +369,8 @@ jobs:
     if: >-
       needs.changes.outputs.desktop == 'true' &&
       needs.changes.outputs.full_gate == 'true'
-    # macos-15 for the same reason as the build job: Package.swift is
-    # swift-tools-version 6.0, and macos-14 still defaults to Swift 5.x.
-    runs-on: macos-15
+    # Use the same pinned Swift 6 image as the build job.
+    runs-on: manzanita-standard
     strategy:
       # A failure in one product journey must not cancel independent evidence
       # from the other selected groups. The stable desktop-tests facade still


### PR DESCRIPTION
## Summary

- move the Rapid Mac Swift build/test job to `manzanita-standard`
- move the GUI golden-flow matrix to the same managed Apple Silicon runner
- register the provider custom label with the repository actionlint configuration
- keep the existing toolchain and GUI/TCC preflight checks intact

## Why

This dogfoods Manzanita Managed Runners with Rapid-MLX’s real macOS workloads. The pinned runner image provides macOS Sequoia, Xcode 16.4, and Swift 6.1.2. The provider’s verified job contract uses the scalar `manzanita-standard` label; the actionlint registration distinguishes that supported custom label from a typo.

## Validation

- `actionlint .github/workflows/rapid-mac-ci.yml`
- `git diff --check origin/main...HEAD`
- existing jobs retain their timeouts, dependencies, and preflight checks
- exact-head acceptance requires the Swift build/test job and the full GUI matrix to execute on live Manzanita runners; skipped or queued jobs are not accepted

The PR changes CI runner selection, so `full-ci` must be present when the new exact head triggers.

## Scope

This does not move Linux, generic Apple Silicon, model, release, signing, or publishing jobs. It also does not claim the managed runner is the local `mini-gui` host.