### PR TITLE
feat: quantize compatible layers in hybrid KV caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,9 @@ jobs:
             tests/test_memory_cache.py \
             tests/test_metal_memory_budget.py \
             tests/test_kv_cache_gemma4_gate.py \
+            tests/test_gemma4_unified_routing.py \
+            tests/test_gemma4_kv_share.py \
+            tests/test_quantized_batch_cache.py \
             tests/test_prefix_cache_eviction.py \
             tests/test_optimizations.py \
             tests/test_batching.py \

--- a/config/mypy-error-baseline.txt
+++ b/config/mypy-error-baseline.txt
@@ -62,7 +62,7 @@ vllm_mlx/models/bailing_hybrid.py 1
 vllm_mlx/models/cohere2_moe.py 5
 vllm_mlx/models/deepseek_v4.py 13
 vllm_mlx/models/deepseek_v4_cache.py 24
-vllm_mlx/models/gemma4_text.py 4
+vllm_mlx/models/gemma4_text.py 3
 vllm_mlx/models/gemma4_vendored/language.py 6
 vllm_mlx/models/gpt_oss_puzzle.py 3
 vllm_mlx/models/hy_v3.py 1

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -466,6 +466,56 @@ def test_vendored_fallback_borrow_active():
     _assert_e2b_active_sharing(TextConfig, LanguageModel)
 
 
+@pytest.mark.parametrize("bits", [4, 8])
+def test_quantized_shared_kv_keeps_producer_attention_metadata(bits):
+    """A shared full-attention borrower must reuse the producer's quantized
+    K/V through quantized SDPA without appending to its cache a second time.
+
+    The tiny topology includes a full-attention producer and borrower, and the
+    two calls cross the sliding-window boundary. This is the exact metadata
+    hand-off that previously sent raw quantized triples to ordinary SDPA.
+    """
+    import mlx.core as mx
+    from mlx_lm.models.cache import KVCache
+
+    tc = TextConfig.from_dict(
+        {
+            "num_hidden_layers": 10,
+            "num_kv_shared_layers": 5,
+            "sliding_window": 4,
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 32,
+            "global_head_dim": 32,
+            "vocab_size": 64,
+            "vocab_size_per_layer_input": 64,
+            "hidden_size_per_layer_input": 0,
+            "use_double_wide_mlp": False,
+        }
+    )
+    lm = LanguageModel(tc)
+    caches = lm.make_cache()
+
+    first = lm(mx.array([[1, 2, 3, 4, 5, 6]]), cache=caches).logits
+    caches = [
+        cache.to_quantized(group_size=32, bits=bits)
+        if type(cache) is KVCache
+        else cache
+        for cache in caches
+    ]
+    second = lm(mx.array([[7]]), cache=caches).logits
+    mx.eval(first, second)
+
+    assert first.shape == (1, 6, 64)
+    assert second.shape == (1, 1, 64)
+    assert bool(mx.all(mx.isfinite(second)).item())
+    quantized_full = [cache for cache in caches if hasattr(cache, "bits")]
+    assert quantized_full
+    assert all(cache.bits == bits for cache in quantized_full)
+
+
 # --------------------------------------------------------------------------
 # 3. Guard fires on the real load path
 # --------------------------------------------------------------------------

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -47,6 +47,7 @@ pytest.importorskip("mlx")
 pytestmark = pytest.mark.requires_mlx
 
 
+import inspect
 import json
 import logging
 
@@ -62,6 +63,14 @@ GEMMA4_SIZES = [
     ("26B-A4B", 30, 0),
     ("31B", 60, 0),
 ]
+
+
+def test_shared_cache_extension_preserves_positional_call_order():
+    from vllm_mlx.models.gemma4_vendored import language
+
+    for callable_type in (language.Attention, language.DecoderLayer):
+        parameters = list(inspect.signature(callable_type.__call__).parameters)
+        assert parameters.index("offset") < parameters.index("shared_cache")
 
 
 def _build_text_config(num_hidden_layers: int, num_kv_shared_layers: int) -> TextConfig:

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -467,7 +467,7 @@ def test_vendored_fallback_borrow_active():
 
 
 @pytest.mark.parametrize("bits", [4, 8])
-def test_quantized_shared_kv_keeps_producer_attention_metadata(bits):
+def test_quantized_shared_kv_keeps_producer_attention_metadata(bits, monkeypatch):
     """A shared full-attention borrower must reuse the producer's quantized
     K/V through quantized SDPA without appending to its cache a second time.
 
@@ -480,8 +480,8 @@ def test_quantized_shared_kv_keeps_producer_attention_metadata(bits):
 
     tc = TextConfig.from_dict(
         {
-            "num_hidden_layers": 10,
-            "num_kv_shared_layers": 5,
+            "num_hidden_layers": 15,
+            "num_kv_shared_layers": 10,
             "sliding_window": 4,
             "hidden_size": 64,
             "intermediate_size": 128,
@@ -496,7 +496,34 @@ def test_quantized_shared_kv_keeps_producer_attention_metadata(bits):
         }
     )
     lm = LanguageModel(tc)
-    caches = lm.make_cache()
+    # Exercise a restored one-cache-per-layer layout and a valid same-type
+    # borrower chain. Production checkpoints currently point borrowers
+    # directly at producers, but restored/future layouts may route through a
+    # borrower; its intermediate must still carry the original producer cache.
+    from mlx_lm.models.cache import RotatingKVCache
+
+    caches = [
+        KVCache()
+        if layer.layer_type == "full_attention"
+        else RotatingKVCache(max_size=tc.sliding_window, keep=0)
+        for layer in lm.model.layers
+    ]
+    root_producer_idx = lm.model.previous_kvs[9]
+    assert lm.model.layers[9].layer_type == lm.model.layers[14].layer_type
+    lm.model.previous_kvs[14] = 9
+
+    from vllm_mlx.models.gemma4_vendored import language as language_module
+
+    original_attention = language_module.scaled_dot_product_attention
+    attention_caches = []
+
+    def _recording_attention(*args, **kwargs):
+        attention_caches.append(kwargs.get("cache"))
+        return original_attention(*args, **kwargs)
+
+    monkeypatch.setattr(
+        language_module, "scaled_dot_product_attention", _recording_attention
+    )
 
     first_out = lm(
         mx.array([[1, 2, 3, 4, 5, 6]]),
@@ -510,6 +537,7 @@ def test_quantized_shared_kv_keeps_producer_attention_metadata(bits):
         else cache
         for cache in caches
     ]
+    attention_caches.clear()
     second = lm(mx.array([[7]]), cache=caches).logits
     mx.eval(first, second)
 
@@ -520,6 +548,10 @@ def test_quantized_shared_kv_keeps_producer_attention_metadata(bits):
     quantized_full = [cache for cache in caches if hasattr(cache, "bits")]
     assert quantized_full
     assert all(cache.bits == bits for cache in quantized_full)
+    assert attention_caches[9] is caches[root_producer_idx]
+    assert attention_caches[14] is caches[root_producer_idx], (
+        "a borrower chain must preserve its root producer's cache object"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_gemma4_kv_share.py
+++ b/tests/test_gemma4_kv_share.py
@@ -498,7 +498,12 @@ def test_quantized_shared_kv_keeps_producer_attention_metadata(bits):
     lm = LanguageModel(tc)
     caches = lm.make_cache()
 
-    first = lm(mx.array([[1, 2, 3, 4, 5, 6]]), cache=caches).logits
+    first_out = lm(
+        mx.array([[1, 2, 3, 4, 5, 6]]),
+        cache=caches,
+        return_shared_kv=True,
+    )
+    first = first_out.logits
     caches = [
         cache.to_quantized(group_size=32, bits=bits)
         if type(cache) is KVCache
@@ -511,6 +516,7 @@ def test_quantized_shared_kv_keeps_producer_attention_metadata(bits):
     assert first.shape == (1, 6, 64)
     assert second.shape == (1, 1, 64)
     assert bool(mx.all(mx.isfinite(second)).item())
+    assert first_out.shared_kv_states
     quantized_full = [cache for cache in caches if hasattr(cache, "bits")]
     assert quantized_full
     assert all(cache.bits == bits for cache in quantized_full)

--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -145,6 +145,17 @@ def test_unified_shared_kv_resolver_forces_metadata_preserving_classes():
     ) == (TextConfig, LanguageModel)
 
 
+@pytest.mark.parametrize("bad_value", [True, "1", 1.5, [1], None])
+def test_shared_kv_resolvers_reject_malformed_counts(bad_value):
+    config = {"num_kv_shared_layers": bad_value}
+
+    nonunified = gemma4_text._resolve_gemma4_text_classes(config)
+    unified = gemma4_text._resolve_gemma4_unified_text_classes(config)
+
+    assert nonunified[0].__module__.startswith("mlx_vlm.models.gemma4")
+    assert unified[0].__module__.startswith("mlx_vlm.models.gemma4_unified")
+
+
 def test_is_gemma4_model_is_family_wide_alias(tmp_path):
     """``is_gemma4_model`` is the back-compat family-wide predicate: it
     tracks ``is_gemma4_family_model`` for every model_type (True for

--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -90,6 +90,36 @@ def test_gemma4_nonunified_detected_only_by_base_detector(tmp_path):
     assert gemma4_text.gemma4_family_kind(d) == "nonunified"
 
 
+@pytest.mark.parametrize(
+    "model_type,expected_kind",
+    [("gemma4", "nonunified"), ("gemma4_unified", "unified")],
+)
+def test_load_plan_detects_cross_layer_shared_kv(tmp_path, model_type, expected_kind):
+    d = _write_config(tmp_path, model_type)
+    (d / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": model_type,
+                "text_config": {"num_kv_shared_layers": 20},
+            }
+        )
+    )
+    assert gemma4_text.gemma4_load_plan(d) == (expected_kind, True)
+
+
+def test_load_plan_keeps_dense_gemma_on_native_path(tmp_path):
+    d = _write_config(tmp_path, "gemma4")
+    (d / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "gemma4",
+                "text_config": {"num_kv_shared_layers": 0},
+            }
+        )
+    )
+    assert gemma4_text.gemma4_load_plan(d) == ("nonunified", False)
+
+
 def test_is_gemma4_model_is_family_wide_alias(tmp_path):
     """``is_gemma4_model`` is the back-compat family-wide predicate: it
     tracks ``is_gemma4_family_model`` for every model_type (True for
@@ -349,6 +379,50 @@ def test_dispatch_routes_to_matching_loader(
     assert called.get("loader") == expected_loader, (
         f"{model_type} should route to {expected_loader}, got {called.get('loader')}"
     )
+
+
+@pytest.mark.parametrize(
+    "model_type,expected_loader",
+    [
+        ("gemma4", "load_gemma4_text"),
+        ("gemma4_unified", "load_gemma4_unified_text"),
+    ],
+)
+def test_dispatch_shared_kv_uses_metadata_preserving_loader(
+    tmp_path, monkeypatch, model_type, expected_loader
+):
+    """Shared-KV checkpoints must not enter the native loader first."""
+    from vllm_mlx.utils import tokenizer as tok
+
+    d = _write_config(tmp_path, model_type)
+    (d / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": model_type,
+                "text_config": {"num_kv_shared_layers": 20},
+            }
+        )
+    )
+
+    def _native_must_not_run(*_args, **_kwargs):
+        raise AssertionError("shared-KV Gemma must bypass native mlx_lm.load")
+
+    monkeypatch.setattr("mlx_lm.load", _native_must_not_run)
+    monkeypatch.setattr(tok, "_needs_tokenizer_fallback", lambda *_: False)
+    monkeypatch.setattr(tok, "_is_vendored_arch_model", lambda *_: False)
+    monkeypatch.setattr(tok, "_register_vendored_archs", lambda *_: None)
+
+    called = []
+
+    def _stub(model_name, tokenizer_config=None):
+        called.append((model_name, tokenizer_config))
+        return "MODEL", "TOKENIZER"
+
+    monkeypatch.setattr(gemma4_text, expected_loader, _stub)
+    result = tok._load_model_with_fallback_impl(str(d), {})
+
+    assert result == ("MODEL", "TOKENIZER")
+    assert called == [(str(d), {})]
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_gemma4_unified_routing.py
+++ b/tests/test_gemma4_unified_routing.py
@@ -120,6 +120,31 @@ def test_load_plan_keeps_dense_gemma_on_native_path(tmp_path):
     assert gemma4_text.gemma4_load_plan(d) == ("nonunified", False)
 
 
+@pytest.mark.parametrize("payload", ["[]", "null", '"gemma4"', "42"])
+def test_load_plan_rejects_non_object_config(tmp_path, payload):
+    """Valid JSON primitives are not valid Hugging Face model configs."""
+    d = tmp_path / "non-object-config"
+    d.mkdir()
+    (d / "config.json").write_text(payload)
+
+    assert gemma4_text.gemma4_load_plan(d) == (None, False)
+    assert gemma4_text.gemma4_family_kind(d) is None
+
+
+def test_load_plan_rejects_unknown_object_config(tmp_path):
+    d = _write_config(tmp_path, "not_gemma4")
+    assert gemma4_text.gemma4_load_plan(d) == (None, False)
+
+
+def test_unified_shared_kv_resolver_forces_metadata_preserving_classes():
+    from vllm_mlx.models.gemma4_vendored.config import TextConfig
+    from vllm_mlx.models.gemma4_vendored.language import LanguageModel
+
+    assert gemma4_text._resolve_gemma4_unified_text_classes(
+        {"num_kv_shared_layers": 1}
+    ) == (TextConfig, LanguageModel)
+
+
 def test_is_gemma4_model_is_family_wide_alias(tmp_path):
     """``is_gemma4_model`` is the back-compat family-wide predicate: it
     tracks ``is_gemma4_family_model`` for every model_type (True for

--- a/tests/test_kv_cache_dtype.py
+++ b/tests/test_kv_cache_dtype.py
@@ -365,11 +365,10 @@ def test_bf16_reason_is_neutral_and_not_a_downgrade():
     assert decision.downgraded is False
 
 
-def test_int4_override_reason_cites_decode_cost():
+def test_int4_override_reason_reports_fused_packed_path():
     decision = resolve_kv_cache_dtype("int4", model_name="qwen3-4b-4bit")
-    # Opting into quantized KV must leave a breadcrumb in the log that
-    # the operator accepted the O(context) dequant-on-read decode cost.
-    assert "#1853" in decision.reason
+    assert "packed live KV" in decision.reason
+    assert "fused quantized attention" in decision.reason
     assert decision.downgraded is False
 
 

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -392,7 +392,7 @@ def test_live_cache_probe_rejects_cross_layer_shared_hybrid():
 
 @pytest.mark.requires_mlx
 def test_live_cache_probe_accepts_capability_marked_shared_hybrid():
-    from mlx_lm.models.cache import KVCache, RotatingKVCache
+    from mlx_lm.models.cache import KVCache
 
     from vllm_mlx.scheduler import Scheduler
 
@@ -404,7 +404,7 @@ def test_live_cache_probe_accepts_capability_marked_shared_hybrid():
         language_model = _LanguageModel()
 
         def make_cache(self):
-            return [KVCache(), RotatingKVCache(max_size=8, keep=0)]
+            return [KVCache(), KVCache()]
 
     assert Scheduler._quantized_live_cache_incompatibility(_FakeModel()) is None
 

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -46,6 +46,35 @@ GEMMA4_UNIFIED_CONFIG = {
     "text_config": {"model_type": "gemma4_unified_text", "sliding_window": 1024},
 }
 
+GEMMA4_DENSE_HYBRID_CONFIG = {
+    "model_type": "gemma4_unified",
+    "text_config": {
+        "model_type": "gemma4_unified_text",
+        "sliding_window": 512,
+        "num_kv_shared_layers": 0,
+        "layer_types": [
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+    },
+}
+
+GEMMA4_SHARED_HYBRID_CONFIG = {
+    "model_type": "gemma4",
+    "text_config": {
+        "model_type": "gemma4_text",
+        "sliding_window": 512,
+        "num_kv_shared_layers": 2,
+        "layer_types": [
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+    },
+}
+
 # Full-attention control family (Qwen3.5-style): no sliding window, no MLA.
 SUPPORTED_CONFIG = {
     "model_type": "qwen3_5",
@@ -104,6 +133,28 @@ def test_gemma4_unified_explicit_request_is_rejected():
             model_name="gemma-4-12b-alias",
             hf_config=GEMMA4_UNIFIED_CONFIG,
         )
+
+
+@pytest.mark.parametrize("dtype", ["int8", "int4"])
+def test_dense_hybrid_explicit_request_allows_per_layer_quantization(dtype):
+    decision = resolve_kv_cache_dtype(
+        dtype,
+        explicit=True,
+        model_name="local-hybrid-checkpoint",
+        hf_config=GEMMA4_DENSE_HYBRID_CONFIG,
+    )
+    assert decision.dtype == dtype
+    assert decision.downgraded is False
+
+
+def test_cross_layer_shared_hybrid_defers_to_loaded_capability_probe():
+    decision = resolve_kv_cache_dtype(
+        "int8",
+        explicit=True,
+        model_name="local-shared-hybrid-checkpoint",
+        hf_config=GEMMA4_SHARED_HYBRID_CONFIG,
+    )
+    assert decision.dtype == "int8"
 
 
 @pytest.mark.parametrize("dtype", ["int8", "int4"])
@@ -281,7 +332,7 @@ def _scheduler_stub(explicit: bool):
 
 
 @pytest.mark.requires_mlx  # imports mlx_lm.models.cache + vllm_mlx.scheduler (mlx)
-def test_live_cache_probe_flags_rotating_cache():
+def test_live_cache_probe_accepts_plain_plus_rotating_hybrid():
     from mlx_lm.models.cache import KVCache, RotatingKVCache
 
     from vllm_mlx.scheduler import Scheduler
@@ -290,9 +341,121 @@ def test_live_cache_probe_flags_rotating_cache():
         def make_cache(self):
             return [KVCache(), RotatingKVCache(max_size=8, keep=0)]
 
+    assert Scheduler._quantized_live_cache_incompatibility(_FakeModel()) is None
+
+
+@pytest.mark.requires_mlx
+def test_live_cache_probe_rejects_cross_layer_shared_hybrid():
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from vllm_mlx.scheduler import Scheduler
+
+    class _FakeModel:
+        args = SimpleNamespace(num_kv_shared_layers=2)
+
+        def make_cache(self):
+            return [KVCache(), RotatingKVCache(max_size=8, keep=0)]
+
     assert (
         Scheduler._quantized_live_cache_incompatibility(_FakeModel())
-        == "RotatingKVCache"
+        == "cross-layer shared KV"
+    )
+
+
+@pytest.mark.requires_mlx
+def test_live_cache_probe_accepts_capability_marked_shared_hybrid():
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from vllm_mlx.scheduler import Scheduler
+
+    class _LanguageModel:
+        supports_quantized_shared_kv = True
+        config = SimpleNamespace(num_kv_shared_layers=2)
+
+    class _FakeModel:
+        language_model = _LanguageModel()
+
+        def make_cache(self):
+            return [KVCache(), RotatingKVCache(max_size=8, keep=0)]
+
+    assert Scheduler._quantized_live_cache_incompatibility(_FakeModel()) is None
+
+
+@pytest.mark.requires_mlx
+def test_live_cache_probe_rejects_attention_sinks_before_ready():
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from vllm_mlx.scheduler import Scheduler
+
+    class _Layer:
+        self_attn = SimpleNamespace(sinks=object())
+
+    class _Inner:
+        layers = [_Layer()]
+
+    class _FakeModel:
+        model = _Inner()
+
+        def make_cache(self):
+            return [KVCache(), RotatingKVCache(max_size=8, keep=0)]
+
+    reason = Scheduler._quantized_live_cache_incompatibility(_FakeModel())
+    assert reason is not None
+    assert "attention sinks" in reason
+
+    with pytest.raises(KVCacheQuantizationUnsupportedError, match="attention sinks"):
+        _scheduler_stub(explicit=True)._init_kv_quantization(_FakeModel())
+
+
+@pytest.mark.requires_mlx
+@pytest.mark.parametrize("bits", [4, 8])
+def test_init_quantization_reports_hybrid_component_policy(caplog, bits):
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    class _FakeModel:
+        args = SimpleNamespace(head_dim=64, num_kv_shared_layers=0)
+
+        def make_cache(self):
+            return [
+                RotatingKVCache(max_size=8, keep=0),
+                KVCache(),
+                RotatingKVCache(max_size=8, keep=0),
+            ]
+
+    sched = _scheduler_stub(explicit=True)
+    sched.config.kv_cache_quantization_bits = bits
+    with caplog.at_level(logging.INFO):
+        sched._init_kv_quantization(_FakeModel())
+    assert sched._kv_quant_live_disabled is False
+    assert sched._kv_quant_layout.quantizable_layers == 1
+    assert sched._kv_quant_layout.rotating_layers == 2
+    assert any(
+        f"1/3 full-attention layers use int{bits}" in record.message
+        and "2 bounded rotating layers remain bf16" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.requires_mlx
+def test_init_quantization_reports_shared_borrowers(caplog):
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    class _LanguageModel:
+        supports_quantized_shared_kv = True
+        config = SimpleNamespace(head_dim=64, num_kv_shared_layers=2)
+
+    class _FakeModel:
+        language_model = _LanguageModel()
+
+        def make_cache(self):
+            return [KVCache(), RotatingKVCache(max_size=8, keep=0)]
+
+    sched = _scheduler_stub(explicit=True)
+    with caplog.at_level(logging.INFO):
+        sched._init_kv_quantization(_FakeModel())
+    assert sched._kv_quant_layout.shared_borrower_layers == 2
+    assert any(
+        "2 cross-layer KV borrowers" in record.message for record in caplog.records
     )
 
 

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -147,6 +147,22 @@ def test_dense_hybrid_explicit_request_allows_per_layer_quantization(dtype):
     assert decision.downgraded is False
 
 
+def test_unqualified_hybrid_family_remains_rejected():
+    config = {
+        "model_type": "future_hybrid",
+        "sliding_window": 512,
+        "layer_types": ["sliding_attention", "full_attention"],
+    }
+
+    with pytest.raises(KVCacheQuantizationUnsupportedError):
+        resolve_kv_cache_dtype(
+            "int8",
+            explicit=True,
+            model_name="future-hybrid",
+            hf_config=config,
+        )
+
+
 def test_cross_layer_shared_hybrid_defers_to_loaded_capability_probe():
     decision = resolve_kv_cache_dtype(
         "int8",
@@ -451,6 +467,34 @@ def test_attention_probe_looks_through_non_decoder_wrapper_layers():
 
     assert "attention sinks" in Scheduler._quantized_attention_incompatibility(model)
 
+    model.layers = [SimpleNamespace(self_attn=SimpleNamespace())]
+    assert "attention sinks" in Scheduler._quantized_attention_incompatibility(model)
+
+
+@pytest.mark.requires_mlx
+def test_init_quantization_constructs_prompt_cache_once(monkeypatch):
+    from mlx_lm.models.cache import KVCache, make_prompt_cache
+
+    calls = 0
+
+    def _counted_make_prompt_cache(model):
+        nonlocal calls
+        calls += 1
+        return make_prompt_cache(model)
+
+    monkeypatch.setattr(
+        "mlx_lm.models.cache.make_prompt_cache", _counted_make_prompt_cache
+    )
+
+    class _FakeModel:
+        args = SimpleNamespace(head_dim=64)
+
+        def make_cache(self):
+            return [KVCache()]
+
+    _scheduler_stub(explicit=True)._init_kv_quantization(_FakeModel())
+    assert calls == 1
+
 
 @pytest.mark.requires_mlx
 def test_live_cache_probe_rejects_unknown_cache_type():
@@ -508,7 +552,7 @@ def test_batch_generator_legacy_constructor_fallback(monkeypatch):
     from vllm_mlx.request import SamplingParams
 
     calls = []
-    legacy_generator = object()
+    legacy_generator = SimpleNamespace(_make_new_cache=lambda: [])
 
     def _batch_generator(**kwargs):
         calls.append(kwargs)
@@ -531,8 +575,12 @@ def test_batch_generator_legacy_constructor_fallback(monkeypatch):
         prefill_step_size=1,
         spec_decode="none",
         enable_suffix_decoding=False,
-        kv_cache_quantization=False,
+        kv_cache_quantization=True,
+        kv_cache_turboquant=None,
+        kv_cache_quantization_bits=4,
     )
+    scheduler._kv_quant_live_disabled = False
+    scheduler._kv_quant_group_size = 32
 
     result = scheduler._create_batch_generator(SamplingParams(max_tokens=8))
 
@@ -540,6 +588,7 @@ def test_batch_generator_legacy_constructor_fallback(monkeypatch):
     assert len(calls) == 2
     assert "stream" in calls[0]
     assert "stream" not in calls[1]
+    assert scheduler._live_kv_quant == (32, 4)
 
 
 @pytest.mark.requires_mlx

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -435,6 +435,22 @@ def test_attention_probe_supports_alternate_attention_attribute_and_empty_layers
     model.model.layers = [_AttentionLayer()]
     assert "attention sinks" in Scheduler._quantized_attention_incompatibility(model)
 
+    model.model.layers = [SimpleNamespace(self_attn=SimpleNamespace())]
+    assert Scheduler._quantized_attention_incompatibility(model) is None
+
+
+@pytest.mark.requires_mlx
+def test_attention_probe_looks_through_non_decoder_wrapper_layers():
+    from vllm_mlx.scheduler import Scheduler
+
+    sink_layer = SimpleNamespace(self_attn=SimpleNamespace(sinks=object()))
+    model = SimpleNamespace(
+        layers=[],
+        model=SimpleNamespace(layers=[sink_layer]),
+    )
+
+    assert "attention sinks" in Scheduler._quantized_attention_incompatibility(model)
+
 
 @pytest.mark.requires_mlx
 def test_live_cache_probe_rejects_unknown_cache_type():
@@ -483,6 +499,47 @@ def test_live_cache_layout_negative_paths():
     assert Scheduler._quantized_live_cache_layout(_Shared()) is None
     assert Scheduler._quantized_live_cache_layout(_Unknown()) is None
     assert Scheduler._quantized_live_cache_layout(_RotatingOnly()) is None
+
+
+@pytest.mark.requires_mlx
+def test_batch_generator_legacy_constructor_fallback(monkeypatch):
+    """A runtime without the stream keyword still builds the same generator."""
+    import vllm_mlx.scheduler as scheduler_module
+    from vllm_mlx.request import SamplingParams
+
+    calls = []
+    legacy_generator = object()
+
+    def _batch_generator(**kwargs):
+        calls.append(kwargs)
+        if "stream" in kwargs:
+            raise TypeError("unexpected keyword argument 'stream'")
+        return legacy_generator
+
+    monkeypatch.setattr(scheduler_module, "BatchGenerator", _batch_generator)
+    monkeypatch.setattr(scheduler_module, "make_sampler", lambda **_: object())
+
+    scheduler = scheduler_module.Scheduler.__new__(scheduler_module.Scheduler)
+    scheduler.model = object()
+    scheduler.tokenizer = object()
+    scheduler._get_stop_tokens = lambda: set()
+    scheduler.memory_aware_cache = None
+    scheduler.model_config = None
+    scheduler.config = SimpleNamespace(
+        prefill_batch_size=1,
+        completion_batch_size=1,
+        prefill_step_size=1,
+        spec_decode="none",
+        enable_suffix_decoding=False,
+        kv_cache_quantization=False,
+    )
+
+    result = scheduler._create_batch_generator(SamplingParams(max_tokens=8))
+
+    assert result is legacy_generator
+    assert len(calls) == 2
+    assert "stream" in calls[0]
+    assert "stream" not in calls[1]
 
 
 @pytest.mark.requires_mlx

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -233,7 +233,7 @@ def test_serve_exits_before_load_for_explicit_gemma4_dtype(tmp_path, dtype):
     ],
 )
 def test_serve_command_maps_both_explicit_flag_shapes_to_exit_two(
-    tmp_path, flags, capsys
+    tmp_path, flags, capsys, monkeypatch
 ):
     """Exercise the in-process CLI exception mapping as well as subprocess E2E."""
     from vllm_mlx import cli
@@ -242,6 +242,18 @@ def test_serve_command_maps_both_explicit_flag_shapes_to_exit_two(
     model_dir.mkdir()
     (model_dir / "config.json").write_text(json.dumps(GEMMA4_UNIFIED_CONFIG))
     args = cli.build_parser().parse_args(["serve", str(model_dir), "--no-mllm", *flags])
+
+    # ``serve_command`` installs middleware before loading the model. Keep this
+    # in-process exception-mapping test independent of the process-global
+    # Starlette app, which may already have served requests in the full suite.
+    from vllm_mlx import server
+    from vllm_mlx.middleware import request_logging
+
+    monkeypatch.setattr(server, "configure_cors_from_env", lambda *_: [])
+    monkeypatch.setattr(server, "configure_trusted_hosts", lambda *_: None)
+    monkeypatch.setattr(
+        request_logging, "install_request_logging_middleware", lambda *_: None
+    )
 
     with pytest.raises(SystemExit) as exc_info:
         cli.serve_command(args)
@@ -408,6 +420,72 @@ def test_live_cache_probe_rejects_attention_sinks_before_ready():
 
 
 @pytest.mark.requires_mlx
+def test_attention_probe_supports_alternate_attention_attribute_and_empty_layers():
+    from vllm_mlx.scheduler import Scheduler
+
+    class _AttentionLayer:
+        attention = SimpleNamespace(attn_sink=object())
+
+    class _NoAttentionLayer:
+        pass
+
+    model = SimpleNamespace(model=SimpleNamespace(layers=[_NoAttentionLayer()]))
+    assert Scheduler._quantized_attention_incompatibility(model) is None
+
+    model.model.layers = [_AttentionLayer()]
+    assert "attention sinks" in Scheduler._quantized_attention_incompatibility(model)
+
+
+@pytest.mark.requires_mlx
+def test_live_cache_probe_rejects_unknown_cache_type():
+    from vllm_mlx.scheduler import Scheduler
+
+    class _UnknownCache:
+        pass
+
+    class _FakeModel:
+        def make_cache(self):
+            return [_UnknownCache()]
+
+    assert (
+        Scheduler._quantized_live_cache_incompatibility(_FakeModel()) == "_UnknownCache"
+    )
+
+
+@pytest.mark.requires_mlx
+def test_live_cache_layout_negative_paths():
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from vllm_mlx.scheduler import Scheduler
+
+    class _Broken:
+        def make_cache(self):
+            raise ValueError("stub")
+
+    class _Shared:
+        args = SimpleNamespace(num_kv_shared_layers=1)
+
+        def make_cache(self):
+            return [KVCache()]
+
+    class _UnknownCache:
+        pass
+
+    class _Unknown:
+        def make_cache(self):
+            return [_UnknownCache()]
+
+    class _RotatingOnly:
+        def make_cache(self):
+            return [RotatingKVCache(max_size=8, keep=0)]
+
+    assert Scheduler._quantized_live_cache_layout(_Broken()) is None
+    assert Scheduler._quantized_live_cache_layout(_Shared()) is None
+    assert Scheduler._quantized_live_cache_layout(_Unknown()) is None
+    assert Scheduler._quantized_live_cache_layout(_RotatingOnly()) is None
+
+
+@pytest.mark.requires_mlx
 @pytest.mark.parametrize("bits", [4, 8])
 def test_init_quantization_reports_hybrid_component_policy(caplog, bits):
     from mlx_lm.models.cache import KVCache, RotatingKVCache
@@ -553,6 +631,13 @@ def test_serve_command_maps_runtime_backstop_to_exit_two(tmp_path, monkeypatch, 
     monkeypatch.setattr(cli, "_check_memory_capacity", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         server, "configure_model_residency", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(server, "configure_cors_from_env", lambda *_: [])
+    monkeypatch.setattr(server, "configure_trusted_hosts", lambda *_: None)
+    from vllm_mlx.middleware import request_logging
+
+    monkeypatch.setattr(
+        request_logging, "install_request_logging_middleware", lambda *_: None
     )
     monkeypatch.setattr(
         server, "load_model", lambda *args, **kwargs: (_ for _ in ()).throw(error)

--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -15,6 +15,8 @@ so two invariants are checked:
    comparison is bit-exact (max-abs-diff == 0), not merely "close".
 """
 
+import sys
+
 import pytest
 
 pytest.importorskip("mlx")
@@ -56,6 +58,19 @@ def _max_abs(a, b):
 def _deq(cache, triple):
     """Dequantize an update_and_fetch return (quantized triples, #1751)."""
     return _dequantize(list(triple), cache._q_group_size, cache._q_bits)
+
+
+def test_supported_cache_types_without_optional_vision_runtime(monkeypatch):
+    """The base install keeps mlx-lm cache support without mlx-vlm."""
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from vllm_mlx.quantized_batch_cache import supported_kv_cache_types
+
+    monkeypatch.setitem(sys.modules, "mlx_vlm.models.cache", None)
+    plain, rotating = supported_kv_cache_types()
+
+    assert plain == (KVCache,)
+    assert rotating == (RotatingKVCache,)
 
 
 def _ref_attention_fp32(queries, k, v, mask):

--- a/tests/test_quantized_batch_cache.py
+++ b/tests/test_quantized_batch_cache.py
@@ -2,8 +2,8 @@
 
 Strategy
 --------
-``QuantizedBatchKVCache`` stores quantized KV but returns bf16 (dequant-on-read),
-so two invariants are checked:
+``QuantizedBatchKVCache`` stores quantized KV and returns packed triples to the
+fused quantized-attention dispatcher, so three invariants are checked:
 
 1. **Bookkeeping is bit-exact vs BatchKVCache.** ``offset`` / ``left_padding`` /
    ``_idx`` / ``make_mask`` / ``nbytes>`` structure never touch quantization, so
@@ -13,6 +13,10 @@ so two invariants are checked:
    axis is 1:1 with tokens in the packed tensor, the value returned for a written
    chunk is exactly ``dequantize(quantize(chunk))`` — deterministic, so the
    comparison is bit-exact (max-abs-diff == 0), not merely "close".
+
+3. **Model attention takes the fused packed path.** The public attention
+   dispatcher sees the cache's ``bits``/``group_size`` metadata and invokes
+   quantized SDPA without materializing the full BF16 history.
 """
 
 import sys
@@ -991,6 +995,46 @@ def test_cache_exposes_quantized_dispatch_attrs():
     q.update_and_fetch(k, k)
     # group size auto-adjusted for head_dim=96 must show through the attr
     assert q.group_size == 32
+
+
+def test_public_attention_dispatch_consumes_packed_cache(monkeypatch):
+    """The model-facing dispatcher must select quantized SDPA for this cache."""
+    import mlx_lm.models.base as mlx_base
+
+    q = QuantizedBatchKVCache([0], group_size=32, bits=8)
+    keys = mx.random.normal((1, 2, 8, 64)).astype(mx.bfloat16)
+    values = mx.random.normal((1, 2, 8, 64)).astype(mx.bfloat16)
+    packed_keys, packed_values = q.update_and_fetch(keys, values)
+    queries = mx.random.normal((1, 2, 1, 64)).astype(mx.bfloat16)
+
+    original = mlx_base.quantized_scaled_dot_product_attention
+    calls = []
+
+    def _recording_quantized_attention(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        mlx_base,
+        "quantized_scaled_dot_product_attention",
+        _recording_quantized_attention,
+    )
+    output = mlx_base.scaled_dot_product_attention(
+        queries,
+        packed_keys,
+        packed_values,
+        cache=q,
+        scale=1.0,
+        mask=None,
+    )
+    mx.eval(output)
+
+    assert calls
+    assert calls[0][0][1] is packed_keys
+    assert calls[0][0][2] is packed_values
+    assert calls[0][1]["group_size"] == q.group_size
+    assert calls[0][1]["bits"] == q.bits
+    assert output.shape == queries.shape
 
 
 def test_fused_qsdpa_matches_dequant_reference_batched_gqa():

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -217,6 +217,13 @@ def _supports_hybrid_partial_quantization(
     separately verifies cache classes and cross-layer sharing capability
     before the server reports ready.
     """
+    if not isinstance(hf_config, dict) or hf_config.get("model_type") not in {
+        "gemma4",
+        "gemma4_assistant",
+        "gemma4_unified",
+    }:
+        return False
+
     for cfg in _candidate_configs(hf_config):
         layer_types = cfg.get("layer_types")
         if not isinstance(layer_types, list) or not layer_types:

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -12,25 +12,15 @@ Three user-facing dtypes:
   workloads, used as the reasoning/code profile.
 * ``int4`` — 4-bit ``QuantizedKVCache``. Smallest KV footprint.
 
-The R15 rollout defaulted to int4 on the theory that Apple Silicon
-decode is memory-bandwidth-bound, so a 4×-smaller KV cache should
-speed up every decode step. The live serve path
-(``QuantizedBatchKVCache``, #1197) implements quantization as
-dequant-on-read — it materializes full-precision K/V every decode
-step — so the bandwidth win never materializes and per-token cost
-GROWS with context instead: measured on qwen3.5-4b at 16k context,
-bf16 134.6 tok/s vs int4 98.2 (-27%) vs int8 86.1 (-36%); the
-short-context numbers that motivated the int4 default (#910,
-292-token prompts) could not see this. Until the read path uses a
-fused quantized-attention kernel, quantized KV is a memory/quality
-trade-off the operator must opt into, not a free speedup (#1853).
+The live serve path uses packed K/V with fused quantized attention. KV
+quantization remains an explicit memory/quality trade-off: it reduces resident
+cache bytes but is not assumed to improve latency on every model or context.
 
 Unsupported-family safelist:
 
-* Sliding-window attention (Gemma 3/4, GPT-OSS) — the rotating buffer
-  can't tolerate arbitrary-boundary quant blocks; on Gemma 4 the
-  quantized cache reaches the KV-shared text layers as raw tuples and
-  every request fails (#78).
+* Pure sliding-window attention — rotating buffers cannot tolerate arbitrary
+  quant-block boundaries. Hybrid layouts are handled per layer: compatible
+  full-attention caches are quantized while bounded rotating caches stay BF16.
 * Multi-head Latent Attention (DeepSeek V3+, Kimi K2.5) — the K
   projection is already compressed; quantizing on top compounds error.
 
@@ -211,6 +201,34 @@ def _is_sliding_window(
     return any(pat in needle for pat in _SLIDING_WINDOW_PATTERNS)
 
 
+def _supports_hybrid_partial_quantization(
+    hf_config: dict[str, Any] | None,
+) -> bool:
+    """Whether config proves a safe full-attention + rotating split.
+
+    Quantized rotating caches are not supported, but a hybrid model does not
+    need them in order to reduce its long-context footprint: exact full-
+    attention ``KVCache`` layers can be quantized independently while bounded
+    sliding-window layers remain BF16.  Require an explicit per-layer layout;
+    a scalar ``sliding_window`` alone cannot prove that any full-attention
+    component exists.
+
+    This is only the config-level admission check. The loaded-model probe
+    separately verifies cache classes and cross-layer sharing capability
+    before the server reports ready.
+    """
+    for cfg in _candidate_configs(hf_config):
+        layer_types = cfg.get("layer_types")
+        if not isinstance(layer_types, list) or not layer_types:
+            continue
+        normalized = {value.lower() for value in layer_types if isinstance(value, str)}
+        has_full = "full_attention" in normalized
+        has_sliding = any("sliding" in value for value in normalized)
+        if has_full and has_sliding:
+            return True
+    return False
+
+
 def _is_mla(
     *,
     model_name: str,
@@ -285,9 +303,13 @@ def quantized_kv_unsupported_reason(
         hf_config=hf_config,
         alias_metadata=alias_metadata,
     ):
+        if _supports_hybrid_partial_quantization(hf_config):
+            return None
         return (
             "sliding-window attention (rotating KV buffers are "
-            "incompatible with QuantizedKVCache block boundaries)"
+            "incompatible with QuantizedKVCache block boundaries, and the "
+            "config does not prove an independently quantizable full-attention "
+            "component without cross-layer KV sharing)"
         )
     if _is_mla(
         model_name=model_name or "",
@@ -409,9 +431,8 @@ def resolve_kv_cache_dtype(
         reason = "bf16 selected (no QuantizedKVCache wrap)"
     else:
         reason = (
-            f"{requested} selected (operator override; dequant-on-read "
-            f"costs O(context) per decode step — #1853); "
-            f"model={model_name or hf_path or 'unknown'} not in safelist"
+            f"{requested} selected (operator override; packed live KV with "
+            f"fused quantized attention); model={model_name or hf_path or 'unknown'}"
         )
 
     return KVCacheDtypeDecision(

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -162,7 +162,7 @@ def _read_model_config(model_path: str | Path) -> dict | None:
         return None
     try:
         config = json.loads(config_path.read_text())
-        return config
+        return config if isinstance(config, dict) else None
     except Exception:
         return None
 

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -283,6 +283,14 @@ def gemma4_family_kind(model_path: str | Path) -> str | None:
     return None
 
 
+def _has_cross_layer_kv_sharing(config: object) -> bool:
+    """Return whether a config declares a positive integer borrower count."""
+    if not isinstance(config, dict):
+        return False
+    shared = config.get("num_kv_shared_layers", 0)
+    return isinstance(shared, int) and not isinstance(shared, bool) and shared > 0
+
+
 def gemma4_load_plan(model_path: str | Path) -> tuple[str | None, bool]:
     """Return ``(family_kind, needs_shared_kv_loader)`` from one config read.
 
@@ -303,12 +311,7 @@ def gemma4_load_plan(model_path: str | Path) -> tuple[str | None, bool]:
     else:
         return None, False
     text_config = config.get("text_config", config)
-    shared = (
-        text_config.get("num_kv_shared_layers", 0)
-        if isinstance(text_config, dict)
-        else 0
-    )
-    return kind, isinstance(shared, int) and not isinstance(shared, bool) and shared > 0
+    return kind, _has_cross_layer_kv_sharing(text_config)
 
 
 class Gemma4TextWrapper(nn.Module):
@@ -410,7 +413,7 @@ def _resolve_gemma4_text_classes(text_config: dict | None = None):
     """Return ``(TextConfig, LanguageModel)`` for the NON-unified ``gemma4``
     arch — upstream ``mlx_vlm.models.gemma4`` when importable, else the
     vendored copy (dataclass-identical, no ``[vision]`` extra needed)."""
-    if isinstance(text_config, dict) and text_config.get("num_kv_shared_layers", 0) > 0:
+    if _has_cross_layer_kv_sharing(text_config):
         from vllm_mlx.models.gemma4_vendored import config as _v_cfg
         from vllm_mlx.models.gemma4_vendored import language as _v_lang
 
@@ -463,7 +466,7 @@ def _resolve_gemma4_unified_text_classes(text_config: dict | None = None):
     vendored copy are unavailable, which cannot happen because the
     vendored copy ships inside the wheel.
     """
-    if isinstance(text_config, dict) and text_config.get("num_kv_shared_layers", 0) > 0:
+    if _has_cross_layer_kv_sharing(text_config):
         from vllm_mlx.models.gemma4_vendored import config as _v_cfg
         from vllm_mlx.models.gemma4_vendored import language as _v_lang
 

--- a/vllm_mlx/models/gemma4_text.py
+++ b/vllm_mlx/models/gemma4_text.py
@@ -130,8 +130,8 @@ def _path_matches_any_suffix(path: str, suffixes: set[str]) -> bool:
     return False
 
 
-def _read_model_type(model_path: str | Path) -> str | None:
-    """Read the top-level ``model_type`` from a model's ``config.json``.
+def _read_model_config(model_path: str | Path) -> dict | None:
+    """Read a model's ``config.json`` without resolving weight shards.
 
     Returns ``None`` when the config is unreachable or unparseable so
     callers can treat "can't tell" as "not this family".
@@ -162,9 +162,15 @@ def _read_model_type(model_path: str | Path) -> str | None:
         return None
     try:
         config = json.loads(config_path.read_text())
-        return config.get("model_type", "")
+        return config
     except Exception:
         return None
+
+
+def _read_model_type(model_path: str | Path) -> str | None:
+    """Read the top-level ``model_type`` from a model's ``config.json``."""
+    config = _read_model_config(model_path)
+    return config.get("model_type", "") if config is not None else None
 
 
 # Model_types the Gemma 4 text loader path claims. This is a deliberate
@@ -277,6 +283,34 @@ def gemma4_family_kind(model_path: str | Path) -> str | None:
     return None
 
 
+def gemma4_load_plan(model_path: str | Path) -> tuple[str | None, bool]:
+    """Return ``(family_kind, needs_shared_kv_loader)`` from one config read.
+
+    Current native Gemma 4 classes discard the producer cache object when a
+    later layer reuses its K/V tensors.  That loses the quantization metadata
+    required by the attention dispatcher.  Checkpoints with an explicit
+    cross-layer sharing split therefore use Rapid's text loader, whose cache
+    handoff preserves that metadata.  Dense checkpoints keep the native path.
+    """
+    config = _read_model_config(model_path)
+    if config is None:
+        return None, False
+    model_type = config.get("model_type", "")
+    if model_type in _GEMMA4_UNIFIED_MODEL_TYPES:
+        kind = "unified"
+    elif model_type in _GEMMA4_NONUNIFIED_MODEL_TYPES:
+        kind = "nonunified"
+    else:
+        return None, False
+    text_config = config.get("text_config", config)
+    shared = (
+        text_config.get("num_kv_shared_layers", 0)
+        if isinstance(text_config, dict)
+        else 0
+    )
+    return kind, isinstance(shared, int) and not isinstance(shared, bool) and shared > 0
+
+
 class Gemma4TextWrapper(nn.Module):
     """Wraps mlx-vlm's Gemma4 LanguageModel for mlx-lm compatibility.
 
@@ -372,10 +406,15 @@ class Gemma4TextWrapper(nn.Module):
 # the fresh-install path working with zero extras.
 
 
-def _resolve_gemma4_text_classes():
+def _resolve_gemma4_text_classes(text_config: dict | None = None):
     """Return ``(TextConfig, LanguageModel)`` for the NON-unified ``gemma4``
     arch — upstream ``mlx_vlm.models.gemma4`` when importable, else the
     vendored copy (dataclass-identical, no ``[vision]`` extra needed)."""
+    if isinstance(text_config, dict) and text_config.get("num_kv_shared_layers", 0) > 0:
+        from vllm_mlx.models.gemma4_vendored import config as _v_cfg
+        from vllm_mlx.models.gemma4_vendored import language as _v_lang
+
+        return _v_cfg.TextConfig, _v_lang.LanguageModel
     try:
         from mlx_vlm.models.gemma4.config import TextConfig
         from mlx_vlm.models.gemma4.language import LanguageModel
@@ -392,7 +431,7 @@ def _resolve_gemma4_text_classes():
         return _v_cfg.TextConfig, _v_lang.LanguageModel
 
 
-def _resolve_gemma4_unified_text_classes():
+def _resolve_gemma4_unified_text_classes(text_config: dict | None = None):
     """Return ``(TextConfig, LanguageModel)`` for the ``gemma4_unified`` arch.
 
     Prefer upstream ``mlx_vlm.models.gemma4_unified`` when mlx-vlm is
@@ -424,6 +463,11 @@ def _resolve_gemma4_unified_text_classes():
     vendored copy are unavailable, which cannot happen because the
     vendored copy ships inside the wheel.
     """
+    if isinstance(text_config, dict) and text_config.get("num_kv_shared_layers", 0) > 0:
+        from vllm_mlx.models.gemma4_vendored import config as _v_cfg
+        from vllm_mlx.models.gemma4_vendored import language as _v_lang
+
+        return _v_cfg.TextConfig, _v_lang.LanguageModel
     try:
         from mlx_vlm.models.gemma4_unified import LanguageModel
         from mlx_vlm.models.gemma4_unified.config import TextConfig
@@ -727,7 +771,7 @@ def _load_gemma4_text_impl(
     # (e.g. ``gemma4_assistant``) instead of a coarser default.
     routed_model_type = config.get("model_type") or default_model_type
 
-    TextConfig, LanguageModel = resolve_classes()
+    TextConfig, LanguageModel = resolve_classes(text_config)
 
     tc = TextConfig.from_dict(text_config)
 

--- a/vllm_mlx/models/gemma4_vendored/language.py
+++ b/vllm_mlx/models/gemma4_vendored/language.py
@@ -252,6 +252,7 @@ class Attention(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         shared_kv: Optional[tuple] = None,
+        shared_cache: Optional[Any] = None,
         offset: Optional[Any] = None,
     ) -> mx.array:
         B, L, _ = x.shape
@@ -261,7 +262,9 @@ class Attention(nn.Module):
 
         if shared_kv is not None:
             keys, values = shared_kv
+            attention_cache = shared_cache
         else:
+            attention_cache = cache
             keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
 
             # k_eq_v: values from raw k_proj (before k_norm)
@@ -286,7 +289,12 @@ class Attention(nn.Module):
         queries = self.rope(queries, offset=offset)
 
         output = scaled_dot_product_attention(
-            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            queries,
+            keys,
+            values,
+            cache=attention_cache,
+            scale=self.scale,
+            mask=mask,
         )
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
 
@@ -361,13 +369,19 @@ class DecoderLayer(nn.Module):
         cache: Optional[Any] = None,
         per_layer_input: Optional[mx.array] = None,
         shared_kv: Optional[tuple] = None,
+        shared_cache: Optional[Any] = None,
         offset: Optional[Any] = None,
     ) -> mx.array:
         residual = x
 
         h = self.input_layernorm(x)
         h, shared_kv, offset = self.self_attn(
-            h, mask, cache, shared_kv=shared_kv, offset=offset
+            h,
+            mask,
+            cache,
+            shared_kv=shared_kv,
+            shared_cache=shared_cache,
+            offset=offset,
         )
         h = self.post_attention_layernorm(h)
         h = residual + h
@@ -661,7 +675,7 @@ class Gemma4TextModel(nn.Module):
             per_layer_inputs = [None] * len(self.layers)
 
         capture_set = set(capture_layer_ids) if capture_layer_ids else set()
-        intermediates = [(None, None)] * len(self.layers)
+        intermediates = [(None, None, None)] * len(self.layers)
         for idx, (layer, c, m, prev_idx, pli) in enumerate(
             zip(
                 self.layers,
@@ -671,17 +685,27 @@ class Gemma4TextModel(nn.Module):
                 per_layer_inputs,
             )
         ):
-            kvs, offset = intermediates[prev_idx]
+            kvs, offset, shared_cache = intermediates[prev_idx]
             h, kvs, offset = layer(
-                h, m, c, per_layer_input=pli, shared_kv=kvs, offset=offset
+                h,
+                m,
+                c,
+                per_layer_input=pli,
+                shared_kv=kvs,
+                shared_cache=shared_cache,
+                offset=offset,
             )
-            intermediates[idx] = (kvs, offset)
+            intermediates[idx] = (
+                kvs,
+                offset,
+                c if c is not None else shared_cache,
+            )
             if hidden_sink is not None and idx in capture_set:
                 hidden_sink.append(h)
 
         if shared_kv_sink is not None:
             for idx, layer in enumerate(self.layers):
-                kvs, _ = intermediates[idx]
+                kvs, _, _ = intermediates[idx]
                 if kvs is not None:
                     shared_kv_sink[layer.layer_type] = kvs
 
@@ -702,6 +726,10 @@ class Gemma4TextModel(nn.Module):
 
 
 class LanguageModel(nn.Module):
+    # Borrower layers receive the producer cache metadata alongside shared K/V,
+    # preserving quantized-attention dispatch without updating the cache twice.
+    supports_quantized_shared_kv = True
+
     def __init__(self, config: TextConfig):
         super().__init__()
         self.config = config

--- a/vllm_mlx/models/gemma4_vendored/language.py
+++ b/vllm_mlx/models/gemma4_vendored/language.py
@@ -686,6 +686,7 @@ class Gemma4TextModel(nn.Module):
             )
         ):
             kvs, offset, shared_cache = intermediates[prev_idx]
+            borrows_kv = kvs is not None
             h, kvs, offset = layer(
                 h,
                 m,
@@ -698,7 +699,7 @@ class Gemma4TextModel(nn.Module):
             intermediates[idx] = (
                 kvs,
                 offset,
-                c if c is not None else shared_cache,
+                shared_cache if borrows_kv else c,
             )
             if hidden_sink is not None and idx in capture_set:
                 hidden_sink.append(h)

--- a/vllm_mlx/models/gemma4_vendored/language.py
+++ b/vllm_mlx/models/gemma4_vendored/language.py
@@ -252,8 +252,8 @@ class Attention(nn.Module):
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
         shared_kv: Optional[tuple] = None,
-        shared_cache: Optional[Any] = None,
         offset: Optional[Any] = None,
+        shared_cache: Optional[Any] = None,
     ) -> mx.array:
         B, L, _ = x.shape
 
@@ -369,8 +369,8 @@ class DecoderLayer(nn.Module):
         cache: Optional[Any] = None,
         per_layer_input: Optional[mx.array] = None,
         shared_kv: Optional[tuple] = None,
-        shared_cache: Optional[Any] = None,
         offset: Optional[Any] = None,
+        shared_cache: Optional[Any] = None,
     ) -> mx.array:
         residual = x
 

--- a/vllm_mlx/quantized_batch_cache.py
+++ b/vllm_mlx/quantized_batch_cache.py
@@ -1,4 +1,4 @@
-"""Quantized, continuous-batching KV cache (dequant-on-read).
+"""Quantized, continuous-batching KV cache (fused packed-KV reads).
 
 Background (#1197)
 ------------------
@@ -78,6 +78,25 @@ from mlx_lm.models.cache import (  # noqa: E402
     create_causal_mask,
     dynamic_roll,
 )
+
+
+def supported_kv_cache_types() -> tuple[tuple[type, ...], tuple[type, ...]]:
+    """Return exact plain and rotating KV cache classes installed locally.
+
+    mlx-lm and mlx-vlm expose separate classes with the same names.  Keeping
+    their discovery here gives install, prefix normalization, and the
+    scheduler's structural capability probe one authoritative definition.
+    """
+    from mlx_lm.models.cache import RotatingKVCache
+
+    plain: tuple[type, ...] = (KVCache,)
+    rotating: tuple[type, ...] = (RotatingKVCache,)
+    try:
+        from mlx_vlm.models.cache import KVCache as VLMKVCache
+        from mlx_vlm.models.cache import RotatingKVCache as VLMRotatingKVCache
+    except ImportError:
+        return plain, rotating
+    return plain + (VLMKVCache,), rotating + (VLMRotatingKVCache,)
 
 
 def _quantize(x: mx.array, group_size: int, bits: int) -> list[mx.array]:
@@ -637,8 +656,9 @@ def install_quantized_batch_cache(
     :class:`QuantizedBatchKVCache`) is therefore a single, minimal instance-level
     hook — no mlx-lm internals are patched.
 
-    Only exact top-level ``KVCache`` layers are swapped. Everything else keeps
-    its bf16 behavior:
+    Only exact top-level ``KVCache`` layers are swapped. This deliberately
+    supports hybrid per-layer layouts: full-attention layers use packed KV while
+    bounded rotating layers keep their bf16 behavior.
 
     * ``RotatingKVCache`` (sliding-window / ``max_kv_size``) — quantized batched
       sliding-window is NYI upstream (``BatchRotatingKVCache`` raises NYI).
@@ -669,9 +689,11 @@ def install_quantized_batch_cache(
         # instead of the server wedging.
         return False
 
+    plain_kv_types, _ = supported_kv_cache_types()
+
     def _quantized_make_new_cache():
         return [
-            _QuantizableKVCache(group_size, bits) if type(c) is KVCache else c
+            _QuantizableKVCache(group_size, bits) if type(c) in plain_kv_types else c
             for c in orig_make_new_cache()
         ]
 
@@ -862,9 +884,11 @@ def normalize_caches_for_quantization(caches: list, group_size: int, bits: int) 
     ``RotatingKVCache`` / hybrid / ``CacheList`` layers pass through untouched
     (see that function for why ``CacheList`` models stay bf16).
     """
+    plain_kv_types, _ = supported_kv_cache_types()
+
     out = []
     for c in caches:
-        if type(c) is KVCache:
+        if type(c) in plain_kv_types:
             q = _QuantizableKVCache(group_size, bits)
             q.keys, q.values, q.offset = c.keys, c.values, c.offset
             out.append(q)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4346,31 +4346,142 @@ class Scheduler:
     #: Sentinel for a model whose cache layout could not be probed at all.
     _KV_CACHE_UNPROBEABLE = "unprobeable"
 
+    @dataclass(frozen=True)
+    class _QuantizedLiveCacheLayout:
+        quantizable_layers: int
+        rotating_layers: int
+        total_layers: int
+        shared_borrower_layers: int = 0
+
+    @staticmethod
+    def _quantized_attention_incompatibility(model) -> str | None:
+        """Return a structural attention feature unsupported by fused QSDPA."""
+        layer_owners = [
+            model,
+            getattr(model, "model", None),
+            getattr(model, "language_model", None),
+            getattr(getattr(model, "language_model", None), "model", None),
+        ]
+        for owner in layer_owners:
+            layers = getattr(owner, "layers", None)
+            if not isinstance(layers, (list, tuple)):
+                continue
+            for layer in layers:
+                attention = getattr(layer, "self_attn", None)
+                if attention is None:
+                    attention = getattr(layer, "attention", None)
+                if attention is None:
+                    continue
+                if (
+                    getattr(attention, "sinks", None) is not None
+                    or getattr(attention, "attn_sink", None) is not None
+                ):
+                    return (
+                        "attention sinks require a fused quantized-attention "
+                        "kernel that is unavailable in this MLX runtime"
+                    )
+            # The first concrete decoder stack is authoritative.
+            return None
+        return None
+
     @classmethod
     def _quantized_live_cache_incompatibility(cls, model) -> str | None:
         """Structural capability probe for the quantized live cache (#78).
 
         Asks the model what caches it actually builds — no family names,
-        no config heuristics. Returns ``None`` when every cache is a
-        plain ``KVCache`` (verified quantized read path), the offending
-        type name otherwise (``RotatingKVCache`` for sliding windows,
-        ``ArraysCache``/``MambaCache`` for hybrids), or
+        no config heuristics. Returns ``None`` for an all-plain layout or a
+        verified mixture of plain ``KVCache`` and bounded ``RotatingKVCache``;
+        rotating components remain bf16. Returns the offending type name for
+        other layouts (``ArraysCache``/``MambaCache``), or
         :data:`_KV_CACHE_UNPROBEABLE` when no cache list could be built.
         Backstops the config-level safelist for models whose HF config
         was not readable at CLI time (fresh download).
         """
         try:
-            from mlx_lm.models.cache import KVCache, make_prompt_cache
+            from mlx_lm.models.cache import make_prompt_cache
 
             caches = make_prompt_cache(model)
         except Exception:
             return cls._KV_CACHE_UNPROBEABLE
         if not caches:
             return cls._KV_CACHE_UNPROBEABLE
-        for c in caches:
-            if type(c) is not KVCache:
-                return type(c).__name__
+        attention_reason = cls._quantized_attention_incompatibility(model)
+        if attention_reason is not None:
+            return attention_reason
+        from .quantized_batch_cache import supported_kv_cache_types
+
+        plain_kv_types, rotating_types = supported_kv_cache_types()
+        quantizable = sum(type(c) in plain_kv_types for c in caches)
+        rotating = sum(type(c) in rotating_types for c in caches)
+        unsupported = [
+            type(c).__name__
+            for c in caches
+            if type(c) not in plain_kv_types and type(c) not in rotating_types
+        ]
+        if unsupported:
+            return unsupported[0]
+        if quantizable == 0:
+            return "RotatingKVCache" if rotating else cls._KV_CACHE_UNPROBEABLE
+        if cls._has_unsupported_cross_layer_kv_sharing(model):
+            return "cross-layer shared KV"
         return None
+
+    @staticmethod
+    def _cross_layer_kv_sharing_count(model) -> int:
+        """Return the configured number of cache-borrowing layers."""
+        candidates = [
+            model,
+            getattr(model, "args", None),
+            getattr(model, "config", None),
+            getattr(model, "language_model", None),
+            getattr(getattr(model, "language_model", None), "args", None),
+            getattr(getattr(model, "language_model", None), "config", None),
+        ]
+        for candidate in candidates:
+            value = getattr(candidate, "num_kv_shared_layers", None)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                return value
+        return 0
+
+    @classmethod
+    def _has_unsupported_cross_layer_kv_sharing(cls, model) -> bool:
+        """Whether sharing loses metadata required for quantized attention."""
+        if cls._cross_layer_kv_sharing_count(model) == 0:
+            return False
+        language_model = getattr(model, "language_model", None)
+        return not bool(
+            getattr(model, "supports_quantized_shared_kv", False)
+            or getattr(language_model, "supports_quantized_shared_kv", False)
+        )
+
+    @classmethod
+    def _quantized_live_cache_layout(cls, model):
+        """Return the verified per-component live-cache layout, if usable."""
+        try:
+            from mlx_lm.models.cache import make_prompt_cache
+
+            caches = make_prompt_cache(model)
+        except Exception:
+            return None
+        if not caches or cls._has_unsupported_cross_layer_kv_sharing(model):
+            return None
+        from .quantized_batch_cache import supported_kv_cache_types
+
+        plain_kv_types, rotating_types = supported_kv_cache_types()
+        if any(
+            type(c) not in plain_kv_types and type(c) not in rotating_types
+            for c in caches
+        ):
+            return None
+        quantizable = sum(type(c) in plain_kv_types for c in caches)
+        if quantizable == 0:
+            return None
+        return cls._QuantizedLiveCacheLayout(
+            quantizable_layers=quantizable,
+            rotating_layers=sum(type(c) in rotating_types for c in caches),
+            total_layers=len(caches),
+            shared_borrower_layers=cls._cross_layer_kv_sharing_count(model),
+        )
 
     def _init_kv_quantization(self, model) -> None:
         """Resolve the LIVE cache's group size + install gate (#1197).
@@ -4417,22 +4528,36 @@ class Scheduler:
                         "the model's KV-cache layout could not be probed, so "
                         "a supported quantized read path cannot be verified"
                         if unprobeable
-                        else f"the model builds a {incompatible_cache} KV "
-                        f"cache (sliding-window/hybrid attention) with no "
-                        f"supported quantized read path"
+                        else f"the loaded model is incompatible: {incompatible_cache}"
                     ),
                 )
             if not unprobeable:
                 self._kv_quant_live_disabled = True
                 logger.warning(
-                    "[kv-cache] live KV quantization disabled: model builds a "
-                    "%s cache (sliding-window/hybrid attention) with no "
-                    "supported quantized read path; serving a bf16 live cache.",
+                    "[kv-cache] live KV quantization disabled: %s; serving a "
+                    "bf16 live cache.",
                     incompatible_cache,
                 )
                 return
             # Unprobeable + auto-selected: the head-dim probe below keeps
             # the pre-#78 disable behavior.
+
+        self._kv_quant_layout = self._quantized_live_cache_layout(model)
+        if self._kv_quant_layout is not None and self._kv_quant_layout.rotating_layers:
+            logger.info(
+                "[kv-cache] hybrid partial quantization: %d/%d full-attention "
+                "layers use int%d; %d bounded rotating layers remain bf16",
+                self._kv_quant_layout.quantizable_layers,
+                self._kv_quant_layout.total_layers,
+                getattr(self.config, "kv_cache_quantization_bits", 8),
+                self._kv_quant_layout.rotating_layers,
+            )
+            if self._kv_quant_layout.shared_borrower_layers:
+                logger.info(
+                    "[kv-cache] %d cross-layer KV borrowers reuse producer "
+                    "caches and allocate no independent KV",
+                    self._kv_quant_layout.shared_borrower_layers,
+                )
 
         from .quantized_batch_cache import (
             probe_kv_head_dims,
@@ -4509,8 +4634,9 @@ class Scheduler:
 
         # ``--kv-cache-dtype int8/int4`` must reach the LIVE continuous-batching
         # KV cache, not just the retained prefix cache (#1197). Swap the
-        # generator's plain ``BatchKVCache`` for a quantized, dequant-on-read
-        # ``QuantizedBatchKVCache``. TurboQuant has its own path, so this only
+        # generator's plain ``BatchKVCache`` for a packed
+        # ``QuantizedBatchKVCache`` consumed by fused quantized attention.
+        # TurboQuant has its own path, so this only
         # runs for the plain quantization toggle. The head_dim-compatible group
         # size (and the disable-on-incompatible decision) were resolved once in
         # __init__ so the live and retained caches never diverge.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4366,14 +4366,12 @@ class Scheduler:
             layers = getattr(owner, "layers", None)
             if not isinstance(layers, (list, tuple)):
                 continue
-            inspected_attention = False
             for layer in layers:
                 attention = getattr(layer, "self_attn", None)
                 if attention is None:
                     attention = getattr(layer, "attention", None)
                 if attention is None:
                     continue
-                inspected_attention = True
                 if (
                     getattr(attention, "sinks", None) is not None
                     or getattr(attention, "attn_sink", None) is not None
@@ -4382,16 +4380,13 @@ class Scheduler:
                         "attention sinks require a fused quantized-attention "
                         "kernel that is unavailable in this MLX runtime"
                     )
-            # An outer wrapper may expose an empty or unrelated ``layers``
-            # collection. Only an attention-bearing decoder stack is
-            # authoritative; otherwise keep looking through wrapped owners.
-            if inspected_attention:
-                return None
         return None
 
     @classmethod
-    def _quantized_live_cache_incompatibility(cls, model) -> str | None:
-        """Structural capability probe for the quantized live cache (#78).
+    def _quantized_live_cache_probe(
+        cls, model
+    ) -> tuple[str | None, "Scheduler._QuantizedLiveCacheLayout | None"]:
+        """Probe incompatibility and layout from one cache construction (#78).
 
         Asks the model what caches it actually builds — no family names,
         no config heuristics. Returns ``None`` for an all-plain layout or a
@@ -4407,12 +4402,12 @@ class Scheduler:
 
             caches = make_prompt_cache(model)
         except Exception:
-            return cls._KV_CACHE_UNPROBEABLE
+            return cls._KV_CACHE_UNPROBEABLE, None
         if not caches:
-            return cls._KV_CACHE_UNPROBEABLE
+            return cls._KV_CACHE_UNPROBEABLE, None
         attention_reason = cls._quantized_attention_incompatibility(model)
         if attention_reason is not None:
-            return attention_reason
+            return attention_reason, None
         from .quantized_batch_cache import supported_kv_cache_types
 
         plain_kv_types, rotating_types = supported_kv_cache_types()
@@ -4424,12 +4419,24 @@ class Scheduler:
             if type(c) not in plain_kv_types and type(c) not in rotating_types
         ]
         if unsupported:
-            return unsupported[0]
+            return unsupported[0], None
         if quantizable == 0:
-            return "RotatingKVCache" if rotating else cls._KV_CACHE_UNPROBEABLE
+            reason = "RotatingKVCache" if rotating else cls._KV_CACHE_UNPROBEABLE
+            return reason, None
         if cls._has_unsupported_cross_layer_kv_sharing(model):
-            return "cross-layer shared KV"
-        return None
+            return "cross-layer shared KV", None
+        return None, cls._QuantizedLiveCacheLayout(
+            quantizable_layers=quantizable,
+            rotating_layers=rotating,
+            total_layers=len(caches),
+            shared_borrower_layers=cls._cross_layer_kv_sharing_count(model),
+        )
+
+    @classmethod
+    def _quantized_live_cache_incompatibility(cls, model) -> str | None:
+        """Return only the compatibility result for focused callers/tests."""
+        reason, _ = cls._quantized_live_cache_probe(model)
+        return reason
 
     @staticmethod
     def _cross_layer_kv_sharing_count(model) -> int:
@@ -4461,32 +4468,9 @@ class Scheduler:
 
     @classmethod
     def _quantized_live_cache_layout(cls, model):
-        """Return the verified per-component live-cache layout, if usable."""
-        try:
-            from mlx_lm.models.cache import make_prompt_cache
-
-            caches = make_prompt_cache(model)
-        except Exception:
-            return None
-        if not caches or cls._has_unsupported_cross_layer_kv_sharing(model):
-            return None
-        from .quantized_batch_cache import supported_kv_cache_types
-
-        plain_kv_types, rotating_types = supported_kv_cache_types()
-        if any(
-            type(c) not in plain_kv_types and type(c) not in rotating_types
-            for c in caches
-        ):
-            return None
-        quantizable = sum(type(c) in plain_kv_types for c in caches)
-        if quantizable == 0:
-            return None
-        return cls._QuantizedLiveCacheLayout(
-            quantizable_layers=quantizable,
-            rotating_layers=sum(type(c) in rotating_types for c in caches),
-            total_layers=len(caches),
-            shared_borrower_layers=cls._cross_layer_kv_sharing_count(model),
-        )
+        """Return only the verified layout for focused callers/tests."""
+        _, layout = cls._quantized_live_cache_probe(model)
+        return layout
 
     def _init_kv_quantization(self, model) -> None:
         """Resolve the LIVE cache's group size + install gate (#1197).
@@ -4516,7 +4500,9 @@ class Scheduler:
         ):
             return
 
-        incompatible_cache = self._quantized_live_cache_incompatibility(model)
+        incompatible_cache, self._kv_quant_layout = self._quantized_live_cache_probe(
+            model
+        )
         if incompatible_cache is not None:
             unprobeable = incompatible_cache == self._KV_CACHE_UNPROBEABLE
             if getattr(self.config, "kv_cache_dtype_explicit", False):
@@ -4547,7 +4533,6 @@ class Scheduler:
             # Unprobeable + auto-selected: the head-dim probe below keeps
             # the pre-#78 disable behavior.
 
-        self._kv_quant_layout = self._quantized_live_cache_layout(model)
         if self._kv_quant_layout is not None and self._kv_quant_layout.rotating_layers:
             logger.info(
                 "[kv-cache] hybrid partial quantization: %d/%d full-attention "

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4542,12 +4542,15 @@ class Scheduler:
                 getattr(self.config, "kv_cache_quantization_bits", 8),
                 self._kv_quant_layout.rotating_layers,
             )
-            if self._kv_quant_layout.shared_borrower_layers:
-                logger.info(
-                    "[kv-cache] %d cross-layer KV borrowers reuse producer "
-                    "caches and allocate no independent KV",
-                    self._kv_quant_layout.shared_borrower_layers,
-                )
+        if (
+            self._kv_quant_layout is not None
+            and self._kv_quant_layout.shared_borrower_layers
+        ):
+            logger.info(
+                "[kv-cache] %d cross-layer KV borrowers reuse producer "
+                "caches and allocate no independent KV",
+                self._kv_quant_layout.shared_borrower_layers,
+            )
 
         from .quantized_batch_cache import (
             probe_kv_head_dims,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -4366,12 +4366,14 @@ class Scheduler:
             layers = getattr(owner, "layers", None)
             if not isinstance(layers, (list, tuple)):
                 continue
+            inspected_attention = False
             for layer in layers:
                 attention = getattr(layer, "self_attn", None)
                 if attention is None:
                     attention = getattr(layer, "attention", None)
                 if attention is None:
                     continue
+                inspected_attention = True
                 if (
                     getattr(attention, "sinks", None) is not None
                     or getattr(attention, "attn_sink", None) is not None
@@ -4380,8 +4382,11 @@ class Scheduler:
                         "attention sinks require a fused quantized-attention "
                         "kernel that is unavailable in this MLX runtime"
                     )
-            # The first concrete decoder stack is authoritative.
-            return None
+            # An outer wrapper may expose an empty or unrelated ``layers``
+            # collection. Only an attention-bearing decoder stack is
+            # authoritative; otherwise keep looking through wrapped owners.
+            if inspected_attention:
+                return None
         return None
 
     @classmethod
@@ -4634,9 +4639,8 @@ class Scheduler:
 
         # ``--kv-cache-dtype int8/int4`` must reach the LIVE continuous-batching
         # KV cache, not just the retained prefix cache (#1197). Swap the
-        # generator's plain ``BatchKVCache`` for a packed
-        # ``QuantizedBatchKVCache`` consumed by fused quantized attention.
-        # TurboQuant has its own path, so this only
+        # generator's plain ``BatchKVCache`` for packed ``QuantizedBatchKVCache``
+        # storage consumed by fused quantized attention. TurboQuant only
         # runs for the plain quantization toggle. The head_dim-compatible group
         # size (and the disable-on-incompatible decision) were resolved once in
         # __init__ so the live and retained caches never diverge.

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1579,12 +1579,31 @@ def _load_model_with_fallback_impl(
     # classification through the native-load fallback so a remote repo's
     # config isn't fetched twice and a transient second lookup can't
     # flip the loader choice (see #509).
-    from ..models.gemma4_text import (
-        gemma4_family_kind,
-    )
+    from ..models.gemma4_text import gemma4_load_plan
 
-    gemma4_kind = gemma4_family_kind(model_name)  # "unified" | "nonunified" | None
+    gemma4_kind, gemma4_shared_kv = gemma4_load_plan(model_name)
     if gemma4_kind is not None:
+        # Cross-layer shared KV must retain the producer cache object so
+        # quantized-attention metadata reaches borrower layers.  The native
+        # loader currently passes only the raw K/V payload, so route this
+        # structural variant through our capable text loader.  Dense Gemma 4
+        # remains on the native path.
+        if gemma4_shared_kv:
+            if gemma4_kind == "unified":
+                from ..models.gemma4_text import load_gemma4_unified_text
+
+                logger.info(
+                    "Gemma 4 cross-layer shared KV uses the metadata-preserving "
+                    "unified text loader"
+                )
+                return load_gemma4_unified_text(model_name, tokenizer_config)
+
+            from ..models.gemma4_text import load_gemma4_text
+
+            logger.info(
+                "Gemma 4 cross-layer shared KV uses the metadata-preserving text loader"
+            )
+            return load_gemma4_text(model_name, tokenizer_config)
         try:
             # Try native mlx-lm load first (0.31+)
             model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)


### PR DESCRIPTION
## Summary

- quantize full-attention KV components while bounded rotating components remain BF16
- preserve quantization metadata across Gemma 4 cross-layer KV sharing
- make int8/int4 work through continuous batching, prefix restore, and mlx-lm/mlx-vlm cache namespaces
- reject attention-sink layouts before ready until the runtime has a genuinely fused compatible kernel

Part of #2967

## User impact

Memory-constrained Gemma 4 users can opt into `--kv-cache-dtype int8` or `int4` without the previous healthy-server/all-requests-503 failure. Startup reports exact quantized, rotating, and shared-borrower layer counts. Layouts that cannot deliver a production-quality packed-KV read fail before readiness with an actionable error.

## Design precedent

Mature serving engines manage hybrid attention as separate cache components with per-layer precision capability. This adapts that pattern: unbounded full-attention components may use packed KV, bounded rotating components keep their native representation, and unsupported attention features fail closed. It deliberately avoids a custom quantized ring-buffer codec.

## Verification

- `178 passed`: Gemma routing/shared-KV, dtype gate, hybrid layout, quantized batching/filter/trim/restore tests
- Ruff check and format check clean
- Python compileall clean
- diff check clean
- Gemma 4 E2B real model: int8 + int4 completed 12K-token wrap-crossing prompts; int8 completed concurrent 4K/6K requests
- Gemma 4 E2B prefix reuse: 11,008 cached tokens, 1.55s cold -> 0.22s warm, identical `ECHO` output
- Gemma 4 12B real model: int8/int4 completed 8K; int8 completed 32K and concurrent requests; 32K peak 10.77 GB vs BF16 10.98 GB
- GPT-OSS 20B negative qualification: a non-fused sink experiment raised active memory 14.52 -> 29.30 GB and slowed 32K+256 from 21.6s -> 36.5s, so production now rejects this layout before ready instead of shipping a negative optimization

## Non-goals

- no custom quantized rotating-cache codec
- no dependency or model-weight changes
- no default dtype change