### PR TITLE
fix(mac): accept live video capability contracts

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -92,7 +92,11 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         }
 
         struct InputReferenceLimit: Decodable, Sendable, Hashable {
-            let accepted: Bool
+            /// Older servers advertised an explicit acceptance flag. Current
+            /// servers advertise support by including this limits object, so
+            /// a missing flag means accepted while an explicit false remains
+            /// authoritative for backwards compatibility.
+            let accepted: Bool?
             let maximumBytes: Int
             let formats: [String]
 
@@ -100,6 +104,8 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
                 case accepted, formats
                 case maximumBytes = "maximum_bytes"
             }
+
+            var isAccepted: Bool { accepted ?? true }
         }
 
         let size: SizeLimit
@@ -137,7 +143,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
     let limits: Limits
 
     var acceptedReferenceMIMETypes: Set<String> {
-        guard let input = limits.inputReference, input.accepted else { return [] }
+        guard let input = limits.inputReference, input.isAccepted else { return [] }
         return Set(input.formats.compactMap { format in
             switch format.lowercased() {
             case "jpeg", "jpg", "image/jpeg": "image/jpeg"
@@ -212,7 +218,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
 
     var referenceMaximumBytes: Int {
         guard let inputReference = limits.inputReference,
-              inputReference.accepted,
+              inputReference.isAccepted,
               inputReference.maximumBytes > 0 else { return 0 }
         return min(inputReference.maximumBytes, VideoClient.maxReferenceBytes)
     }
@@ -240,7 +246,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         let workload = limits.workload
         let validInput = limits.inputReference.map {
             $0.maximumBytes >= 0
-                && (!$0.accepted || ($0.maximumBytes > 0 && !acceptedReferenceMIMETypes.isEmpty))
+                && (!$0.isAccepted || ($0.maximumBytes > 0 && !acceptedReferenceMIMETypes.isEmpty))
         } ?? true
         guard !model.isEmpty,
               !family.isEmpty,
@@ -259,7 +265,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               frames.offset <= frames.maximum,
               workload.metric == "pixel_frames",
               workload.maximum > 0,
-              workload.dimensionRounding == "multiple_of_64",
+              workloadDimensionMultiple != nil,
               validInput else {
             throw VideoClientError.invalidResponse
         }
@@ -272,9 +278,11 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               seconds > 0,
               limits.fps.default > 0 else { return false }
         // Workload normalization is a separate server contract from the
-        // request-size alignment. This client validates only multiple_of_64.
-        guard let width = Self.roundUp(dimensions.width, to: 64),
-              let height = Self.roundUp(dimensions.height, to: 64) else { return false }
+        // request-size alignment. Apply the live server's workload rounding
+        // contract independently of the model's accepted request dimensions.
+        guard let multiple = workloadDimensionMultiple,
+              let width = Self.roundUp(dimensions.width, to: multiple),
+              let height = Self.roundUp(dimensions.height, to: multiple) else { return false }
         let frameStep = max(1, limits.frames.step)
         let frameOffset = limits.frames.offset
         guard frameOffset >= 0 else { return false }
@@ -295,6 +303,15 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         let (pixelCount, pixelOverflow) = width.multipliedReportingOverflow(by: height)
         let (workload, workloadOverflow) = pixelCount.multipliedReportingOverflow(by: frames)
         return !pixelOverflow && !workloadOverflow && workload <= limits.workload.maximum
+    }
+
+    private var workloadDimensionMultiple: Int? {
+        switch limits.workload.dimensionRounding {
+        case "none": 1
+        case "ceil_to_32": 32
+        case "ceil_to_64", "multiple_of_64": 64
+        default: nil
+        }
     }
 
     private static func parseSize(_ value: String) -> (width: Int, height: Int)? {

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -59,7 +59,7 @@ struct VideoClientTests {
     func unsupportedRoundingFailsClosed() async {
         let client = makeClient()
         let json = Self.capabilitiesJSON.replacingOccurrences(
-            of: #""dimension_rounding":"multiple_of_64""#,
+            of: #""dimension_rounding":"ceil_to_64""#,
             with: #""dimension_rounding":"floor""#
         )
         VideoStubProtocol.response = (200, Data(json.utf8))
@@ -67,6 +67,20 @@ struct VideoClientTests {
         await #expect(throws: VideoClientError.invalidResponse) {
             _ = try await client.capabilities(port: 8123, bearer: nil)
         }
+    }
+
+    @Test("Shipped workload rounding contracts are accepted", arguments: [
+        "none", "ceil_to_32", "ceil_to_64",
+    ])
+    func shippedRoundingContractsAreAccepted(_ rounding: String) async throws {
+        let client = makeClient()
+        let json = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""dimension_rounding":"ceil_to_64""#,
+            with: #""dimension_rounding":"\#(rounding)""#
+        )
+        VideoStubProtocol.response = (200, Data(json.utf8))
+
+        _ = try await client.capabilities(port: 8123, bearer: nil)
     }
 
     @Test("Workload uses 64-pixel rounding independently of size alignment")
@@ -92,7 +106,10 @@ struct VideoClientTests {
         #expect(value.supportsImageInput)
         #expect(value.acceptedReferenceMIMETypes == ["image/jpeg"])
 
-        let rejected = jpegOnly.replacingOccurrences(of: #""accepted":true"#, with: #""accepted":false"#)
+        let rejected = jpegOnly.replacingOccurrences(
+            of: #""maximum_bytes":20971520"#,
+            with: #""accepted":false,"maximum_bytes":20971520"#
+        )
         let rejectedValue = try JSONDecoder().decode(
             VideoCapabilities.self, from: Data(rejected.utf8)
         )
@@ -323,8 +340,8 @@ struct VideoClientTests {
         "seconds":{"minimum":1,"maximum":20,"default":4},
         "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
         "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
-        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"},
-        "input_reference":{"accepted":true,"maximum_bytes":20971520,"formats":["jpeg","png","webp"]}
+        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"ceil_to_64"},
+        "input_reference":{"maximum_bytes":20971520,"maximum_pixels":16777216,"formats":["jpeg","png","webp"]}
       },
       "controls":{}
     }


### PR DESCRIPTION
## Why

The 0.13.4 Desktop Video workspace rejected every live packaged server capability response as invalid. The Swift client still required the prototype `input_reference.accepted` field and only recognized the prototype `multiple_of_64` workload rounding value, while the shipped server advertises support by including the input limits object and returns `none`, `ceil_to_32`, or `ceil_to_64` by video family.

## Scope

- Decode the current server-authoritative input-reference contract while preserving an explicit legacy `accepted: false`.
- Accept and apply the three workload-rounding values emitted by shipped video families.
- Keep unknown rounding values fail-closed.
- Cover the live response shape and legacy rejection behavior with focused Swift tests.

## Non-goals

- No server API, video runtime, model policy, memory limit, generation UI, or cancellation behavior changes.
- No expansion of the experimental Video feature set.

## Acceptance

- A packaged Desktop build can start the cached Wan video model, load capabilities, expose valid controls, and complete a real text-to-video job.
- The Swift client accepts all three rounding contracts currently emitted by the server and rejects unknown values.
- An explicit legacy `accepted: false` still disables image input.

## Design precedent

The server response remains the authoritative capabilities contract. The client maps only the finite values the shipped server emits, preserves backwards-compatible explicit rejection, and fails closed on unknown future values instead of guessing.

## Verification

- `swift test --no-parallel --filter Video` — 38 passed.
- `git diff --check` — passed.
- Real packaged-app dogfood on Apple M3 Ultra: started cached `wan2.2-ti2v-5b-q8`, decoded live capabilities, exposed Text/Image controls, and completed a 1-second 512×512 H.264 video at 24 fps (25 frames).
- The same packaged 0.13.4 app without this patch reproduced `The video server returned an invalid response.`

Fixes #2969

## AI assistance disclosure

Codex identified the client/server schema mismatch, implemented the bounded compatibility fix and focused tests, and exercised the patched client against the packaged 0.13.4 runtime and a real local video model. The resulting diff and evidence were reviewed for scope, compatibility, and release risk.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Directly affected tests pass locally
- [x] Real packaged Desktop path verified
- [x] Documentation impact reviewed; no user documentation change required
- [x] No breaking changes to the public server API
