### PR TITLE
fix(scheduler): bound per-step decode output chain on hybrid lanes (#2834)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,7 @@ jobs:
             tests/test_speculative_request_policy.py \
             tests/test_deepseek_v4_vendored.py \
             tests/test_dspark_scheduler.py \
+            tests/test_scheduler_recurrent_cache_materialization.py \
             tests/test_prefix_cache_persistence.py \
             tests/test_prefix_boundary_path_parity.py \
             tests/test_prompt_cache_snapshot.py \

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -622,42 +622,57 @@ def test_output_chain_collection_failure_escalates_after_limit(monkeypatch):
     assert scheduler._recurrent_output_chain_failures == limit
 
 
-def test_failure_counter_resets_when_recurrent_lane_goes_inactive(monkeypatch):
-    """#2834 (codex r7): the output-chain failure counter is scoped to an
-    ACTIVE recurrent lane. A streak accumulated on one recurrent request must
-    NOT cascade into a later one across an idle/dense interval — otherwise a
-    NEW request could hit the escalation limit on its FIRST failure, failing a
-    lane that was never actually broken. The dense/no-recurrent-state early
-    returns clear the counter."""
+def test_failure_counter_resets_when_recurrent_lane_changes(monkeypatch):
+    """#2834 (codex r7 r8#1/#2): the output-chain failure counter is scoped to
+    the ACTIVE generation batch. A streak accumulated on one recurrent request
+    must NOT cascade into a later one when the batch IDENTITY changes — via a
+    dense interval OR a DIRECT recurrent->recurrent replacement — otherwise a
+    new request could hit the escalation limit on its FIRST failure, failing a
+    lane that was never actually broken. One persistent scheduler is reused
+    and its generation batch is replaced in place, so the test exercises the
+    identity-tracking reset rather than depending on separate instances."""
     limit = scheduler_module._RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
 
     monkeypatch.setattr(scheduler_module.mx, "eval", _detaching_eval)
 
-    def _recurrent_scheduler(layer):
-        scheduler = Scheduler.__new__(Scheduler)
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._recurrent_output_chain_failures = 0
+    scheduler._recurrent_output_chain_batch = None
+
+    def _recurrent(layer):
+        # Replace the active batch IN PLACE on the SAME scheduler: a direct
+        # batch-identity change without an intervening idle/dense step.
         scheduler.batch_generator = _OutputGenerator(_RaisingOutputBatch([layer]))
-        scheduler._recurrent_output_chain_failures = 0
-        return scheduler
+
+    def _dense():
+        # All-trimmable lane on the SAME scheduler.
+        scheduler.batch_generator = _Generator([_Layer(trimmable=True)])
 
     # --- recurrent lane with a persistently-raising output surface ---
-    scheduler = _recurrent_scheduler(_OutputRecurrentLayer())
+    _recurrent(_OutputRecurrentLayer())
     for _ in range(limit - 1):
         scheduler._materialize_active_recurrent_cache()
     assert scheduler._recurrent_output_chain_failures == limit - 1
 
-    # --- the lane goes inactive (all-trimmable / dense batch) ---
-    dense_scheduler = _scheduler_with([_Layer(trimmable=True)])
-    dense_scheduler._recurrent_output_chain_failures = limit - 1  # stale streak
-    assert dense_scheduler._materialize_active_recurrent_cache() == 0
-    # Dense period cleared the stale counter (codex r7).
-    assert dense_scheduler._recurrent_output_chain_failures == 0
+    # --- DIRECT recurrent->recurrent replacement must reset the streak ---
+    _recurrent(_OutputRecurrentLayer())  # new batch identity on the same lane
+    scheduler._materialize_active_recurrent_cache()
+    assert scheduler._recurrent_output_chain_failures == 1  # fresh streak
 
-    # --- a NEW recurrent request starts on a fresh counter ---
-    fresh = _recurrent_scheduler(_OutputRecurrentLayer())
-    fresh._materialize_active_recurrent_cache()
-    # First failure of the new lane must NOT inherit the old streak: it sits at
-    # 1, well below the escalation limit.
-    assert fresh._recurrent_output_chain_failures == 1
+    # --- a NONZERO streak, then go dense: dense period must reset ---
+    # (Not all the way to limit-1 again — a fresh counter of 1 plus (limit-1)
+    # more would overflow into escalation. Two failures is enough to prove the
+    # dense reset clears a nonzero streak.)
+    scheduler._materialize_active_recurrent_cache()
+    assert scheduler._recurrent_output_chain_failures == 2
+    _dense()
+    assert scheduler._materialize_active_recurrent_cache() == 0
+    assert scheduler._recurrent_output_chain_failures == 0
+
+    # --- back to a NEW recurrent batch: first failure is fresh (never limit) ---
+    _recurrent(_OutputRecurrentLayer())
+    scheduler._materialize_active_recurrent_cache()
+    assert scheduler._recurrent_output_chain_failures == 1
 
 
 class _RaisingOutputBatch(_OutputBatch):

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -510,14 +510,16 @@ class _GeneratorNoOut:
 
 
 def test_output_chain_failure_escalates_after_limit(monkeypatch):
-    """#2834 (codex r1 BLOCKING): a persistent output-chain realize failure
-    must escalate, not silently concede to an unbounded output graph.
+    """#2834 (codex r1+r2 converge): a persistent OUTPUT-chain realize failure
+    must escalate, not silently concede to an unbounded output graph — while a
+    cache-state failure must propagate IMMEDIATELY (never suppressed).
 
-    If evaluating the per-step output chain keeps failing while the cache-state
-    barrier keeps succeeding, logging-and-returning forever would recreate
-    exactly the Metal-handle exhaustion this fix targets. After
-    ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT`` consecutive failures the lane must
-    raise so the incompatibility surfaces instead of drifting toward 499000.
+    The barrier realizes cache state first, unguarded, then the output chain in
+    a guarded block. So: (a) a failing output chain while cache state succeeds
+    retries and escalates after ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT``; (b) a
+    failing cache state propagates on the very first barrier. Modelling the two
+    independently is what round-2 codex demanded — under the earlier combined
+    single-eval design this test could not express either correctly.
     """
     recurrent = _OutputRecurrentLayer()
     batch = _OutputBatch([recurrent])
@@ -525,31 +527,43 @@ def test_output_chain_failure_escalates_after_limit(monkeypatch):
     scheduler = Scheduler.__new__(Scheduler)
     scheduler.batch_generator = generator
     scheduler._recurrent_output_chain_failures = 0
-
-    calls = []
     limit = scheduler_module._RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
 
-    def always_fail(value):
-        calls.append(value)
+    cache_head = recurrent.head
+
+    # --- (a) cache-state succeeds, output-chain fails persistently ---
+    def fail_only_outputs(value):
+        # The cache-state eval realizes ``states`` = [[recurrent.head]]
+        # (layer.state returns a one-element list). Every other realizable
+        # tensor is part of the per-step output chain. Succeed (and detach)
+        # the cache-head eval; fail any output-chain realize.
+        values = value if isinstance(value, list) else [value]
+        if values == [[cache_head]]:
+            _detaching_eval(value)
+            return
         raise RuntimeError("simulated persistent output-chain eval failure")
 
-    monkeypatch.setattr(scheduler_module.mx, "eval", always_fail)
+    monkeypatch.setattr(scheduler_module.mx, "eval", fail_only_outputs)
 
-    # The first |limit-1| failures are tolerated (transient/missing surface).
     for _ in range(limit - 1):
         assert scheduler._materialize_active_recurrent_cache() is not None
     assert scheduler._recurrent_output_chain_failures == limit - 1
 
-    # The |limit|-th consecutive failure escalates (raises) instead of
-    # continuing to accumulate the unbounded graph.
-    with pytest.raises(RuntimeError, match="simulated persistent"):
+    with pytest.raises(RuntimeError, match="simulated persistent output-chain"):
         scheduler._materialize_active_recurrent_cache()
     assert scheduler._recurrent_output_chain_failures == limit
 
-    # A later successful realization resets the counter so the lane can
-    # recover if the transient condition clears.
+    # Recover: a later successful realize resets the counter.
     monkeypatch.setattr(
         scheduler_module.mx, "eval", lambda value: _detaching_eval(value)
     )
     scheduler._materialize_active_recurrent_cache()
     assert scheduler._recurrent_output_chain_failures == 0
+
+    # --- (b) cache-state failure propagates immediately (unguarded) ---
+    def fail_cache(value):
+        raise RuntimeError("simulated cache-state eval failure")
+
+    monkeypatch.setattr(scheduler_module.mx, "eval", fail_cache)
+    with pytest.raises(RuntimeError, match="simulated cache-state"):
+        scheduler._materialize_active_recurrent_cache()

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -693,3 +693,135 @@ class _RaisingOutputBatch(_OutputBatch):
         self.prompt_cache = cache
         self._next_logprobs = [_OutputNode(), _OutputNode()]
         self._token_context = [_TokenBuffer(), _TokenBuffer()]
+
+
+class _OnlyRaisingNextTokensBatch(_OutputBatch):
+    """An output batch where EVERY surface is missing except ``_next_tokens``,
+    which raises on access. The collector gathers NO outputs while recording a
+    collection_error — exercising the 'nothing collectible AND a surface
+    raised' escalation branch (codex r4/r5: the cache-state barrier already
+    fired in the caller, so escalation is safe)."""
+
+    @property
+    def _next_tokens(self):
+        raise RuntimeError("simulated only-raising output surface")
+
+    def __init__(self, cache):
+        self.prompt_cache = cache
+        self._next_logprobs = None
+        self._token_context = None
+
+
+def test_output_chain_nothing_collectible_and_surface_raised_escalates(monkeypatch):
+    """#2834 (coverage): when the collector gathers ZERO outputs AND a surface
+    raised on access, ``_retry_materialize_output_chain`` must escalate
+    (nothing was realized by mB, so the only thing keeping the graph bounded is
+    escalating) — not silently clear the counter as if it were a clean no-op."""
+    recurrent = _OutputRecurrentLayer()
+    batch = _OnlyRaisingNextTokensBatch([recurrent])
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = _OutputGenerator(batch)
+    scheduler._recurrent_output_chain_failures = 0
+    limit = scheduler_module._RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
+
+    monkeypatch.setattr(scheduler_module.mx, "eval", _detaching_eval)
+
+    for _ in range(limit - 1):
+        assert scheduler._materialize_active_recurrent_cache() is not None
+    assert scheduler._recurrent_output_chain_failures == limit - 1
+
+    with pytest.raises(
+        scheduler_module._RecurrentOutputChainError, match="Metal handle"
+    ):
+        scheduler._materialize_active_recurrent_cache()
+
+
+class _ScalarLogprobsRaisingContextBatch(_OutputBatch):
+    """Covers the two remaining collector branches: (1) a scalar (non-list)
+    ``_next_logprobs`` value is appended directly; (2) a ``TokenBuffer`` whose
+    ``tokens`` accessor raises is recorded as a collection error rather than an
+    absent surface — while the valid buffer and scalar logprobs still reach
+    ``mx.eval`` (never discard a collectible output chain, r6#2)."""
+
+    def __init__(self, cache):
+        self.prompt_cache = cache
+        self._next_tokens = _OutputNode()
+        self._next_logprobs = _OutputNode()  # scalar, not a list
+        self._token_context = [_TokenBufferWithRaisingTokens(), _TokenBuffer()]
+
+
+class _TokenBufferWithRaisingTokens(_TokenBuffer):
+    @property
+    def tokens(self):
+        raise RuntimeError("simulated TokenBuffer.tokens access failure")
+
+
+def test_collector_scalar_logprobs_and_raising_token_buffer(monkeypatch):
+    """#2834 (coverage): the collector must (a) append a scalar ``_next_logprobs``
+    value and (b) treat a raising ``TokenBuffer.tokens`` as a collection error
+    (not absence) — while still realizing the valid scalar logprobs and the
+    valid token buffer. The raising surface routes into the escalation counter;
+    the valid outputs are NOT discarded."""
+    recurrent = _OutputRecurrentLayer()
+    batch = _ScalarLogprobsRaisingContextBatch([recurrent])
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = _OutputGenerator(batch)
+    scheduler._recurrent_output_chain_failures = 0
+
+    evals = []
+
+    def eval_and_record(value):
+        evals.append(value)
+        return _detaching_eval(value)
+
+    monkeypatch.setattr(scheduler_module.mx, "eval", eval_and_record)
+
+    # One step: valid outputs (scalar logprobs + valid buffer tokens) are
+    # realized, and the raising surface feeds the escalation counter (to 1,
+    # below the limit so no raise).
+    result = scheduler._materialize_active_recurrent_cache()
+    assert scheduler._recurrent_output_chain_failures == 1
+
+    # The cache-state barrier fired ([[head]]), and the collected outputs were
+    # realized even though one surface raised (r6#2).
+    realized = [v for v in evals if v != [[recurrent.head]]]
+    assert realized, "expected the collected output chain to be realized"
+    flattened = []
+    for v in realized:
+        flattened.extend(v if isinstance(v, list) else [v])
+    assert id(batch._next_logprobs) in {id(x) for x in flattened}
+    assert id(batch._token_context[1]._buf) in {id(x) for x in flattened}
+
+
+def test_materialize_with_no_batch_generator_resets_counter(monkeypatch):
+    """#2834 (coverage): with NO active lane, the barrier clears any failure
+    counter left by a prior recurrent request and returns 0 — so a NEW request
+    never inherits a stale streak (codex r7)."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._recurrent_output_chain_failures = 5
+    scheduler._recurrent_output_chain_batch = object()
+    scheduler.batch_generator = None
+
+    assert scheduler._materialize_active_recurrent_cache() == 0
+    assert scheduler._recurrent_output_chain_failures == 0
+    assert scheduler._recurrent_output_chain_batch is None
+
+
+def test_materialize_with_empty_cache_resets_counter(monkeypatch):
+    """#2834 (coverage): a generation batch with NO ``prompt_cache`` (falsy)
+    is nothing to materialize — the barrier clears a stale failure streak and
+    returns without touching the output chain."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._recurrent_output_chain_failures = 3
+    scheduler._recurrent_output_chain_batch = object()
+    scheduler.batch_generator = _OutputGenerator(_OutputBatch([]))  # empty cache
+
+    assert scheduler._materialize_active_recurrent_cache() == 0
+    # The empty cache means nothing was materialized: the stale streak is
+    # cleared so a NEW request never inherits it, and the batch-identity
+    # tracking now points at the new (empty-cache) batch.
+    assert scheduler._recurrent_output_chain_failures == 0
+    assert (
+        scheduler._recurrent_output_chain_batch
+        is scheduler.batch_generator._generation_batch
+    )

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -589,11 +589,21 @@ def test_output_chain_collection_failure_escalates_after_limit(monkeypatch):
     limit = scheduler_module._RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
 
     # Cache-state realize succeeds; the output-chain surface is uncollectable.
-    monkeypatch.setattr(scheduler_module.mx, "eval", _detaching_eval)
+    # Record every value handed to mx.eval so we can assert the cache-state
+    # barrier still fires on each collection-failed step (codex r5) — it must
+    # not be skipped for up to `limit` intervals while collection escalates.
+    cache_state_evals = []
+
+    def eval_and_record(value):
+        cache_state_evals.append(value)
+        return _detaching_eval(value)
+
+    monkeypatch.setattr(scheduler_module.mx, "eval", eval_and_record)
 
     for _ in range(limit - 1):
         assert scheduler._materialize_active_recurrent_cache() is not None
     assert scheduler._recurrent_output_chain_failures == limit - 1
+    assert len(cache_state_evals) == limit - 1  # cache-state realized every step
 
     with pytest.raises(
         scheduler_module._RecurrentOutputChainError, match="Metal handle"

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -588,22 +588,32 @@ def test_output_chain_collection_failure_escalates_after_limit(monkeypatch):
     scheduler._recurrent_output_chain_failures = 0
     limit = scheduler_module._RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
 
-    # Cache-state realize succeeds; the output-chain surface is uncollectable.
+    # Cache-state realize succeeds; the ``_next_tokens`` surface is
+    # uncollectable while ``_next_logprobs`` / ``token_context`` stay valid.
     # Record every value handed to mx.eval so we can assert the cache-state
-    # barrier still fires on each collection-failed step (codex r5) — it must
-    # not be skipped for up to `limit` intervals while collection escalates.
-    cache_state_evals = []
+    # barrier (`[[head]]`) still fires on each collection-failed step (codex
+    # r5/r6) — it must not be skipped for up to `limit` intervals while
+    # collection escalates — and that the valid partial outputs ARE realized
+    # every step (r6#2: never discard a collectible output chain).
+    evals = []
 
     def eval_and_record(value):
-        cache_state_evals.append(value)
+        evals.append(value)
         return _detaching_eval(value)
 
     monkeypatch.setattr(scheduler_module.mx, "eval", eval_and_record)
 
+    cache_head = recurrent.head
     for _ in range(limit - 1):
         assert scheduler._materialize_active_recurrent_cache() is not None
     assert scheduler._recurrent_output_chain_failures == limit - 1
-    assert len(cache_state_evals) == limit - 1  # cache-state realized every step
+    # The cache-state eval (states = [[head]]) fired on EVERY step.
+    assert evals.count([[cache_head]]) == limit - 1
+    # The valid partial outputs (any non-cache-state realize) were realized
+    # every step too — not discarded because one surface raised (r6#2).
+    output_evals = [v for v in evals if v != [[cache_head]]]
+    assert len(output_evals) == limit - 1
+    assert all(isinstance(v, list) and v for v in output_evals)
 
     with pytest.raises(
         scheduler_module._RecurrentOutputChainError, match="Metal handle"

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -549,7 +549,9 @@ def test_output_chain_failure_escalates_after_limit(monkeypatch):
         assert scheduler._materialize_active_recurrent_cache() is not None
     assert scheduler._recurrent_output_chain_failures == limit - 1
 
-    with pytest.raises(RuntimeError, match="simulated persistent output-chain"):
+    with pytest.raises(
+        scheduler_module._RecurrentOutputChainError, match="Metal handle"
+    ):
         scheduler._materialize_active_recurrent_cache()
     assert scheduler._recurrent_output_chain_failures == limit
 
@@ -567,3 +569,54 @@ def test_output_chain_failure_escalates_after_limit(monkeypatch):
     monkeypatch.setattr(scheduler_module.mx, "eval", fail_cache)
     with pytest.raises(RuntimeError, match="simulated cache-state"):
         scheduler._materialize_active_recurrent_cache()
+
+
+def test_output_chain_collection_failure_escalates_after_limit(monkeypatch):
+    """#2834 (codex r4): a persistently RAISING output surface — as opposed to
+    a merely ABSENT one — must feed the same escalation counter. Before r4,
+    ``_collect_recurrent_outputs`` swallowed a raising ``_next_*`` /
+    ``TokenBuffer.tokens`` access as if the surface were absent, the barrier
+    saw ``collection_failed=False`` and no outputs, cleared the counter every
+    step, and a persistently-uncollectable output chain never reached the
+    escalation limit — the exact unbounded chain this barrier exists to bound.
+    """
+    recurrent = _OutputRecurrentLayer()
+    batch = _RaisingOutputBatch([recurrent])
+    generator = _OutputGenerator(batch)
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = generator
+    scheduler._recurrent_output_chain_failures = 0
+    limit = scheduler_module._RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
+
+    # Cache-state realize succeeds; the output-chain surface is uncollectable.
+    monkeypatch.setattr(scheduler_module.mx, "eval", _detaching_eval)
+
+    for _ in range(limit - 1):
+        assert scheduler._materialize_active_recurrent_cache() is not None
+    assert scheduler._recurrent_output_chain_failures == limit - 1
+
+    with pytest.raises(
+        scheduler_module._RecurrentOutputChainError, match="Metal handle"
+    ):
+        scheduler._materialize_active_recurrent_cache()
+    assert scheduler._recurrent_output_chain_failures == limit
+
+
+class _RaisingOutputBatch(_OutputBatch):
+    """An output batch whose ``_next_tokens`` accessor raises on every read —
+    modelling a persistent mlx-lm patch-level incompatibility on that surface
+    while ``layer.state`` (the cache-state barrier) stays fully intact.
+
+    The base ``__init__`` assigns ``self._next_tokens`` directly, which the
+    read-only property forbids, so this subclass wires its own surfaces (and
+    the ``_token_context`` buffers ``advance_outputs`` mutates) without ever
+    assigning ``_next_tokens``."""
+
+    @property
+    def _next_tokens(self):
+        raise RuntimeError("simulated persistent output-surface access failure")
+
+    def __init__(self, cache):
+        self.prompt_cache = cache
+        self._next_logprobs = [_OutputNode(), _OutputNode()]
+        self._token_context = [_TokenBuffer(), _TokenBuffer()]

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -507,3 +507,49 @@ class _NoOutputBatch:
 class _GeneratorNoOut:
     def __init__(self, batch):
         self._generation_batch = batch
+
+
+def test_output_chain_failure_escalates_after_limit(monkeypatch):
+    """#2834 (codex r1 BLOCKING): a persistent output-chain realize failure
+    must escalate, not silently concede to an unbounded output graph.
+
+    If evaluating the per-step output chain keeps failing while the cache-state
+    barrier keeps succeeding, logging-and-returning forever would recreate
+    exactly the Metal-handle exhaustion this fix targets. After
+    ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT`` consecutive failures the lane must
+    raise so the incompatibility surfaces instead of drifting toward 499000.
+    """
+    recurrent = _OutputRecurrentLayer()
+    batch = _OutputBatch([recurrent])
+    generator = _OutputGenerator(batch)
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = generator
+    scheduler._recurrent_output_chain_failures = 0
+
+    calls = []
+    limit = scheduler_module._RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
+
+    def always_fail(value):
+        calls.append(value)
+        raise RuntimeError("simulated persistent output-chain eval failure")
+
+    monkeypatch.setattr(scheduler_module.mx, "eval", always_fail)
+
+    # The first |limit-1| failures are tolerated (transient/missing surface).
+    for _ in range(limit - 1):
+        assert scheduler._materialize_active_recurrent_cache() is not None
+    assert scheduler._recurrent_output_chain_failures == limit - 1
+
+    # The |limit|-th consecutive failure escalates (raises) instead of
+    # continuing to accumulate the unbounded graph.
+    with pytest.raises(RuntimeError, match="simulated persistent"):
+        scheduler._materialize_active_recurrent_cache()
+    assert scheduler._recurrent_output_chain_failures == limit
+
+    # A later successful realization resets the counter so the lane can
+    # recover if the transient condition clears.
+    monkeypatch.setattr(
+        scheduler_module.mx, "eval", lambda value: _detaching_eval(value)
+    )
+    scheduler._materialize_active_recurrent_cache()
+    assert scheduler._recurrent_output_chain_failures == 0

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -326,3 +326,184 @@ def test_step_arms_barrier_on_idle_to_active_edge(monkeypatch):
     assert "barrier" not in events[tail:]  # depth 63 < 64, no second barrier yet
     scheduler.step()  # depth reaches 64
     assert events[-3:] == ["next", "barrier", "responses"]
+
+
+class _OutputNode:
+    """Models a lazily-scheduled decode OUTPUT tensor (issue #2834).
+
+    ``parent`` models the MLX lazy-graph reference an ``async_eval`` output
+    retains to the prior step: on a recurrent/hybrid lane ``gb._next_tokens`` /
+    ``_next_logprobs`` / ``token_context`` are re-scheduled by the forward each
+    step and are NOT detached unless someone evaluates them. The #1834 barrier
+    only realizes ``layer.state``, so this separate output chain can grow
+    unboundedly and exhaust Metal's 499000-handle ceiling even though the cache
+    state stays bounded.
+    """
+
+    def __init__(self, parent=None):
+        self.parent = parent
+
+
+class _TokenBuffer:
+    """Models mlx_lm's ``TokenBuffer`` — the logits-processor
+    ``token_context`` accumulator whose lazily grown buffer feeds ``_step``'s
+    ``async_eval``."""
+
+    def __init__(self):
+        self._buf = _OutputNode()
+
+    @property
+    def tokens(self):
+        return self._buf
+
+
+class _OutputBatch:
+    """A recurrent generation batch exposing the per-step output chain the
+    scheduler's barrier must realize."""
+
+    def __init__(self, cache):
+        self.prompt_cache = cache
+        self._next_tokens = _OutputNode()
+        self._next_logprobs = [_OutputNode(), _OutputNode()]
+        self._token_context = [_TokenBuffer(), _TokenBuffer()]
+
+    def advance_outputs(self):
+        # One recurrent decode step: every output re-references the prior step.
+        self._next_tokens = _OutputNode(self._next_tokens)
+        self._next_logprobs = [_OutputNode(p) for p in self._next_logprobs]
+        for tc in self._token_context:
+            tc._buf = _OutputNode(tc._buf)
+
+
+class _OutputGenerator:
+    def __init__(self, batch):
+        self._generation_batch = batch
+
+
+class _OutputRecurrentLayer:
+    def __init__(self):
+        self.head = _OutputNode()
+
+    def is_trimmable(self):
+        return False
+
+    @property
+    def state(self):
+        return [self.head]
+
+
+def _detaching_eval(values, seen=None):
+    """A monkeypatched ``mx.eval`` that detaches every graph it is handed —
+    exactly like a real realization pass — and records what it received."""
+    if seen is None:
+        seen = []
+    if not isinstance(values, (list, tuple)):
+        values = [values]
+    for v in values:
+        seen.append(v)
+        if isinstance(v, (list, tuple)):
+            _detaching_eval(v, seen=seen)
+            continue
+        node = v
+        while hasattr(node, "parent") and node.parent is not None:
+            node.parent = None
+            node = node.parent
+    return len(values)
+
+
+def test_recurrent_barrier_realizes_per_step_output_chain(monkeypatch):
+    """#2834 regression: the hybrid barrier must realize the per-step decode
+    OUTPUT chain (``_next_tokens`` / ``_next_logprobs`` / ``token_context``),
+    not just ``layer.state``. Before the fix this chain was never evaluated, so
+    it grew unboundedly; after the fix the barrier detaches it on the SAME
+    cadence as the cache state."""
+    recurrent = _OutputRecurrentLayer()
+    batch = _OutputBatch([recurrent])
+    generator = _OutputGenerator(batch)
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = generator
+
+    seen = []
+    monkeypatch.setattr(
+        scheduler_module.mx,
+        "eval",
+        lambda *a, **k: _detaching_eval(*a, seen=seen),
+    )
+
+    # Build an unbounded output chain exactly the way a running recurrent
+    # model would: many decode steps with no intervening realization.
+    for _ in range(1_000):
+        batch.advance_outputs()
+
+    # The chain is deep before the barrier (the bug state).
+    assert _chain_length(batch._next_tokens) > 900
+
+    scheduler._materialize_active_recurrent_cache()
+
+    # The barrier realized the cache state AND detached the output chain.
+    assert _chain_length(batch._next_tokens) == 1
+    for lp in batch._next_logprobs:
+        assert _chain_length(lp) == 1
+    for tc in batch._token_context:
+        assert _chain_length(tc._buf) == 1
+
+    # Every output surface was handed to mx.eval at least once.
+    seen_kinds = {id(v) for v in seen}
+    assert id(batch._next_tokens) in seen_kinds
+    for lp in batch._next_logprobs:
+        assert id(lp) in seen_kinds
+    for tc in batch._token_context:
+        assert id(tc._buf) in seen_kinds
+
+
+def test_dense_batch_barrier_does_not_touch_output_chain(monkeypatch):
+    """The dense no-per-token-eval guarantee must hold for the OUTPUT chain
+    too: on a dense (all-trimmable) lane the barrier returns before reaching
+    the output-chain realization, so it influences none of the batch's
+    ``_next_*`` / ``token_context`` tensors."""
+    dense = _Layer(trimmable=True)
+    batch = _OutputBatch([dense])
+    generator = _OutputGenerator(batch)
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = generator
+
+    for _ in range(200):
+        batch.advance_outputs()
+    deep = _chain_length(batch._next_tokens)
+    assert deep > 100
+
+    evals = []
+    monkeypatch.setattr(scheduler_module.mx, "eval", lambda value: evals.append(value))
+
+    assert scheduler._materialize_active_recurrent_cache() == 0
+    assert evals == []
+    # The output chain is untouched — dense lanes never realize it per step.
+    assert _chain_length(batch._next_tokens) == deep
+
+
+def test_barrier_tolerates_missing_output_surface(monkeypatch):
+    """Hot-path safety: the output-chain passthrough must not raise when the
+    batch lacks the per-step output attributes (older mlx-lm surfaces) or holds
+    None placeholders — and it must never suppress the cache-state eval."""
+    layer = _Layer(trimmable=False)
+    batch = _NoOutputBatch([layer])
+    generator = _GeneratorNoOut(batch)
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.batch_generator = generator
+
+    evals = []
+    monkeypatch.setattr(scheduler_module.mx, "eval", lambda value: evals.append(value))
+
+    assert scheduler._materialize_active_recurrent_cache() == 1
+    assert evals == [[[layer.head]]]  # cache-state barrier still fired
+
+
+class _NoOutputBatch:
+    def __init__(self, cache):
+        self.prompt_cache = cache
+        # Deliberately NO _next_tokens / _next_logprobs / _token_context.
+
+
+class _GeneratorNoOut:
+    def __init__(self, batch):
+        self._generation_batch = batch

--- a/tests/test_scheduler_recurrent_cache_materialization.py
+++ b/tests/test_scheduler_recurrent_cache_materialization.py
@@ -622,6 +622,44 @@ def test_output_chain_collection_failure_escalates_after_limit(monkeypatch):
     assert scheduler._recurrent_output_chain_failures == limit
 
 
+def test_failure_counter_resets_when_recurrent_lane_goes_inactive(monkeypatch):
+    """#2834 (codex r7): the output-chain failure counter is scoped to an
+    ACTIVE recurrent lane. A streak accumulated on one recurrent request must
+    NOT cascade into a later one across an idle/dense interval — otherwise a
+    NEW request could hit the escalation limit on its FIRST failure, failing a
+    lane that was never actually broken. The dense/no-recurrent-state early
+    returns clear the counter."""
+    limit = scheduler_module._RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
+
+    monkeypatch.setattr(scheduler_module.mx, "eval", _detaching_eval)
+
+    def _recurrent_scheduler(layer):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.batch_generator = _OutputGenerator(_RaisingOutputBatch([layer]))
+        scheduler._recurrent_output_chain_failures = 0
+        return scheduler
+
+    # --- recurrent lane with a persistently-raising output surface ---
+    scheduler = _recurrent_scheduler(_OutputRecurrentLayer())
+    for _ in range(limit - 1):
+        scheduler._materialize_active_recurrent_cache()
+    assert scheduler._recurrent_output_chain_failures == limit - 1
+
+    # --- the lane goes inactive (all-trimmable / dense batch) ---
+    dense_scheduler = _scheduler_with([_Layer(trimmable=True)])
+    dense_scheduler._recurrent_output_chain_failures = limit - 1  # stale streak
+    assert dense_scheduler._materialize_active_recurrent_cache() == 0
+    # Dense period cleared the stale counter (codex r7).
+    assert dense_scheduler._recurrent_output_chain_failures == 0
+
+    # --- a NEW recurrent request starts on a fresh counter ---
+    fresh = _recurrent_scheduler(_OutputRecurrentLayer())
+    fresh._materialize_active_recurrent_cache()
+    # First failure of the new lane must NOT inherit the old streak: it sits at
+    # 1, well below the escalation limit.
+    assert fresh._recurrent_output_chain_failures == 1
+
+
 class _RaisingOutputBatch(_OutputBatch):
     """An output batch whose ``_next_tokens`` accessor raises on every read —
     modelling a persistent mlx-lm patch-level incompatibility on that surface

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -9253,55 +9253,58 @@ class Scheduler:
         # above, so this dense no-sync guarantee is untouched.
         #
         # Ordering + single-barrier (codex r1, r2, r3 converge): collection is
-        # host-only, then cache-state AND output chain are realized together in
-        # ONE ``mx.eval`` — a single device barrier on the happy path for both
-        # graphs (r3 wanted no doubled sync). But a combined eval cannot tell
-        # WHICH tensor failed, and the cache-state realize is the
-        # proven-necessary barrier that MUST NOT be suppressible (r2). So on
-        # exception we re-eval ``states`` alone to classify: if that ALSO fails
-        # the lane is genuinely broken and the cache-state failure propagates
-        # immediately; if only the output chain failed it is the NEW #2834
-        # surface and goes through guarded retry/escalation. Dense lanes never
-        # reach here, so no per-token eval is added to a dense batch.
+        # Attribution (codex r2 + r6#1): a SINGLE combined ``mx.eval`` cannot
+        # say which tensors failed, and attributing by re-evaluating ``states``
+        # after a combined failure is unsound — the first call may have
+        # partially realized state, or a state failure may be transient, so a
+        # cache-state failure could be misattributed to the outputs and
+        # silently suppressed for up to ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT``
+        # intervals. So the two graphs are realized SEPARATELY:
+        #
+        #   mA) cache-state realize is UNGUARDED and first — the proven-necessary
+        #       #1834 barrier; any cache-state failure propagates immediately
+        #       (r2) and is attributable to the cache (r6#1).
+        #   mB) the output-chain realize is GUARDED below — attributable to the
+        #       NEW #2834 surface alone, with retry/escalation.
+        #
+        # Firing two back-to-back synchronous ``mx.eval`` on one device stream
+        # does not meaningfully double the barrier: it runs every 8 decode
+        # steps on hybrid lanes only, and the second call finds the device
+        # already drained from the first. Dense lanes never reach here, so no
+        # per-token eval is added to a dense batch.
         outputs, collection_failed = self._collect_recurrent_outputs(generation_batch)
+        mx.eval(states)  # mA: unguarded, immediately-propagating cache barrier
         self._retry_materialize_output_chain(
-            states, outputs, collection_failed=collection_failed
+            outputs, collection_failed=collection_failed
         )
         return len(states)
 
     def _retry_materialize_output_chain(
-        self, states, outputs, *, collection_failed: bool = False
+        self, outputs, *, collection_failed: bool = False
     ) -> int:
         """Realize the per-step decode output chain (guarded retry/escalation).
 
-        The caller has already collected ``outputs`` (host-side) and hands us
-        both ``states`` and ``outputs`` so we realize them in ONE ``mx.eval`` —
-        a single device barrier covering both halves of the lazy graph on the
-        happy path (codex r3). Because a combined eval cannot say WHICH tensor
-        failed, the ``except`` re-evaluates ``states`` alone to classify:
+        The caller has ALREADY realized the cache state (unguarded, mA) and
+        hands us the collected ``outputs`` to realize SEPARATELY, so the
+        output-chain barrier is attributable to the NEW #2834 surface alone
+        (codex r6#1 — no combined eval that could misattribute a cache-state
+        failure). This surface is version-sensitive (``mlx_lm`` ``TokenBuffer``
+        / ``_next_*`` shapes), so a realize failure retries and escalates after
+        ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT`` consecutive misses rather
+        than hard-crashing or silently conceding to an unbounded output graph
+        (codex r1, r3).
 
-          * states re-eval also fails  -> hard cache-state failure; the
-            proven-necessary #1834 barrier must not be suppressed, so it
-            propagates immediately (codex r2).
-          * states re-eval succeeds     -> the failure was the NEW #2834
-            output-chain surface; it is version-sensitive (``mlx_lm``
-            ``TokenBuffer`` / ``_next_*`` shapes), so it retries and escalates
-            after ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT`` consecutive misses
-            rather than hard-crashing or silently conceding to an unbounded
-            output graph (codex r1, r3).
-
-        ``collection_failed`` (codex r4) is the host-side analogue: an output
-        attribute whose ACCESS raised (not one that is merely absent) is a
-        collection failure for that surface and must feed the SAME
-        escalation counter — otherwise a persistently-raising surface would
-        read as "no outputs", clear the counter every step, and the unbounded
-        chain it exists to bound would never escalate.
+        ``collection_failed`` (codex r4/r6#2) means some output attribute's
+        ACCESS raised (not merely absent). The successfully-collected outputs
+        are still REALIZED here — a valid ``_next_logprobs`` / token-context
+        chain is never discarded (r6#2) — and then the inaccessible surface
+        counts through the SAME escalation counter, else a persistently-raising
+        surface would read as "no outputs", clear the counter every step, and
+        the unbounded chain it exists to bound would never escalate.
 
         On success the dereference counter resets so a cleared transient
-        recovers. Realizing with an empty/absent output list that DID collect
-        cleanly (a batch genuinely exposing no output tensors) is fine: the
-        cache-state half already realized, and the combined eval is just
-        ``mx.eval(states)``.
+        recovers. A cleanly-collected empty output list is a no-op that clears
+        the counter (the cache-state barrier already fired in the caller).
         """
 
         def _escalate(failure: Exception | None = None) -> int:
@@ -9333,46 +9336,29 @@ class Scheduler:
             )
             return 0
 
-        if collection_failed:
-            # An output surface raised on ACCESS — indistinguishable from a
-            # realize failure for the purpose of bounding the chain, so route
-            # it through the same escalation path (codex r4). The cache-state
-            # barrier is NOT realized by the caller, so realize it HERE first
-            # (unguarded — a cache-state failure must propagate immediately,
-            # r2), else this edge puts up to 7 intervals between cache-state
-            # realizations and regresses the #1834 invariant (codex r5).
+        if outputs:
+            # Realize the successfully-collected output chain (mB, attributable
+            # to outputs alone). Cache state was already realized by the caller.
             try:
-                mx.eval(states)
-            except Exception:
-                raise
+                mx.eval(outputs)
+            except Exception as exc:
+                return _escalate(exc)
+            if not collection_failed:
+                self._recurrent_output_chain_failures = 0
+                return len(outputs)
+            # Some surface was inaccessible, but what we gathered is now
+            # realized — never discard it (r6#2). Escalate for the surface
+            # whose access raised (r4).
             return _escalate()
 
-        if not outputs:
-            # No output tensors exposed (and collection was clean): still
-            # realize the cache state. This is the same barrier #1834 already
-            # issued — not a doubled sync.
-            try:
-                mx.eval(states)
-            except Exception:
-                # No output surface to absorb the blame; a cache-state failure
-                # must propagate (r2).
-                raise
-            self._recurrent_output_chain_failures = 0
-            return 0
+        if collection_failed:
+            # Nothing collectible AND a surface raised on access: escalate
+            # (cache state was already realized by the caller, r5).
+            return _escalate()
 
-        try:
-            mx.eval([*states, *outputs])  # single device barrier (r3)
-        except Exception as exc:
-            # Classify the failure: if the cache-state half is broken too, that
-            # is the proven-necessary barrier and must propagate, not count as a
-            # retryable output-chain miss (r2).
-            try:
-                mx.eval(states)
-            except Exception:
-                raise
-            return _escalate(exc)
+        # Cleanly empty: nothing to realize; cache-state barrier already fired.
         self._recurrent_output_chain_failures = 0
-        return len(outputs)
+        return 0
 
     def _collect_recurrent_outputs(self, generation_batch) -> tuple[list, bool]:
         """Collect the per-step decode output chain tensors, returning

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -168,6 +168,16 @@ _RECURRENT_MATERIALIZE_MAX_INTERVAL = 64
 _RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT = 8
 
 
+class _RecurrentOutputChainError(RuntimeError):
+    """Raised when a recurrent lane's per-step decode output chain cannot be
+    realized (or, codex r4, even collected) ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT``
+    consecutive times. The barrier exists so the lazy per-step graph cannot grow
+    to Metal's 499000-handle ceiling (#2834/#2836); a persistent failure means
+    that safety guarantee is no longer upheld, so the lane fails rather than
+    silently continuing toward unbounded handle growth.
+    """
+
+
 def _pflash_compressed(request: Request) -> bool:
     """Whether PFlash replaced this request's prompt with a compressed
     subsequence. Used to gate every prefix-cache store/fetch site so the
@@ -9253,11 +9263,15 @@ class Scheduler:
         # immediately; if only the output chain failed it is the NEW #2834
         # surface and goes through guarded retry/escalation. Dense lanes never
         # reach here, so no per-token eval is added to a dense batch.
-        outputs = self._collect_recurrent_outputs(generation_batch)
-        self._retry_materialize_output_chain(states, outputs)
+        outputs, collection_failed = self._collect_recurrent_outputs(generation_batch)
+        self._retry_materialize_output_chain(
+            states, outputs, collection_failed=collection_failed
+        )
         return len(states)
 
-    def _retry_materialize_output_chain(self, states, outputs) -> int:
+    def _retry_materialize_output_chain(
+        self, states, outputs, *, collection_failed: bool = False
+    ) -> int:
         """Realize the per-step decode output chain (guarded retry/escalation).
 
         The caller has already collected ``outputs`` (host-side) and hands us
@@ -9276,39 +9290,60 @@ class Scheduler:
             rather than hard-crashing or silently conceding to an unbounded
             output graph (codex r1, r3).
 
+        ``collection_failed`` (codex r4) is the host-side analogue: an output
+        attribute whose ACCESS raised (not one that is merely absent) is a
+        collection failure for that surface and must feed the SAME
+        escalation counter — otherwise a persistently-raising surface would
+        read as "no outputs", clear the counter every step, and the unbounded
+        chain it exists to bound would never escalate.
+
         On success the dereference counter resets so a cleared transient
-        recovers. Realizing with an empty/outputs-only list (a batch currently
-        exposing no output tensors) is fine: the cache-state half already
-        realized, and the combined eval is just ``mx.eval(states)``.
+        recovers. Realizing with an empty/absent output list that DID collect
+        cleanly (a batch genuinely exposing no output tensors) is fine: the
+        cache-state half already realized, and the combined eval is just
+        ``mx.eval(states)``.
         """
 
-        def _escalate() -> int:
+        def _escalate(failure: Exception | None = None) -> int:
             self._recurrent_output_chain_failures += 1
             if (
                 self._recurrent_output_chain_failures
                 >= _RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
             ):
                 logger.error(
-                    "[recurrent-output-chain] %d consecutive realize-failures; "
-                    "a persistent incompatibility is leaving the per-step "
-                    "decode output chain unbounded. Failing the lane rather "
-                    "than drifting toward Metal handle exhaustion.",
+                    "[recurrent-output-chain] %d consecutive realize/collect "
+                    "failures; a persistent incompatibility is leaving the "
+                    "per-step decode output chain unbounded. Failing the lane "
+                    "rather than drifting toward Metal handle exhaustion.",
                     self._recurrent_output_chain_failures,
                 )
-                raise
+                raise _RecurrentOutputChainError(
+                    "recurrent decode output chain could not be realized "
+                    f"{self._recurrent_output_chain_failures} consecutive "
+                    "times; failing the lane rather than drifting toward "
+                    "Metal handle exhaustion"
+                ) from failure
             logger.warning(
-                "[recurrent-output-chain] realize failed (attempt %d/%d); the "
-                "cache-state barrier already realized this step's state so the "
-                "graph stays bounded this interval, but a recurring failure "
-                "will escalate.",
+                "[recurrent-output-chain] realize/collect failed (attempt "
+                "%d/%d); the cache-state barrier already realized this step's "
+                "state so the graph stays bounded this interval, but a "
+                "recurring failure will escalate.",
                 self._recurrent_output_chain_failures,
                 _RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT,
             )
             return 0
 
+        if collection_failed:
+            # An output surface raised on ACCESS — indistinguishable from a
+            # realize failure for the purpose of bounding the chain, so route
+            # it through the same escalation path (codex r4). Cache-state was
+            # already realized by the caller, so this step is still bounded.
+            return _escalate()
+
         if not outputs:
-            # No output tensors exposed: still realize the cache state. This is
-            # the same barrier #1834 already issued — not a doubled sync.
+            # No output tensors exposed (and collection was clean): still
+            # realize the cache state. This is the same barrier #1834 already
+            # issued — not a doubled sync.
             try:
                 mx.eval(states)
             except Exception:
@@ -9320,7 +9355,7 @@ class Scheduler:
 
         try:
             mx.eval([*states, *outputs])  # single device barrier (r3)
-        except Exception:
+        except Exception as exc:
             # Classify the failure: if the cache-state half is broken too, that
             # is the proven-necessary barrier and must propagate, not count as a
             # retryable output-chain miss (r2).
@@ -9328,66 +9363,69 @@ class Scheduler:
                 mx.eval(states)
             except Exception:
                 raise
-            return _escalate()
+            return _escalate(exc)
         self._recurrent_output_chain_failures = 0
         return len(outputs)
 
-    def _collect_recurrent_outputs(self, generation_batch) -> list:
-        """Best-effort collect the per-step decode output chain tensors.
+    def _collect_recurrent_outputs(self, generation_batch) -> tuple[list, bool]:
+        """Collect the per-step decode output chain tensors, returning
+        ``(outputs, collection_failed)``.
 
         Mirrors the cache-state barrier for the OTHER half of the lazy graph
         that #1834 did not cover: the tensors ``mlx_lm generate._step`` hands
         to ``mx.async_eval(self._next_tokens, self._next_logprobs,
         token_context)``. On dense batches every layer is trimmable, so the
         caller returns before ever reaching this — no per-token host sync on a
-        dense lane.
+        dense lane. Collection only (the caller realizes).
 
-        Collection only (the caller realizes). The attribute surface varies
-        across mlx-lm patch levels, so each optional surface is individually
-        guarded: a single version-mismatched ``TokenBuffer.tokens`` property
-        raising is skipped for that item rather than failing the whole batch.
-        A batch that exposes nothing simply contributes nothing, and the
-        cache-state barrier still fires.
+        The attribute surface varies across mlx-lm patch levels, so each
+        optional surface must be tolerated. Critically (codex r4), GENUINELY
+        ABSENT attributes are not failures, but an attribute whose ACCESS
+        RAISED is — a persistently-raising surface would otherwise read as
+        "no outputs", the barrier would clear its escalation counter each step,
+        and the unbounded chain it exists to bound would never escalate.
+        ``collection_failed`` is set when any surface access raised, so the
+        caller can route it into the same retry/escalation path as a realize
+        failure. ``_safe`` returns ``(value, errored)`` to tell the two apart.
         """
         outputs: list = []
+        collection_failed = False
 
-        def _safe(attr) -> object:
+        def _safe(attr) -> tuple[object, bool]:
             try:
-                return getattr(generation_batch, attr, None)
+                return getattr(generation_batch, attr, None), False
             except Exception:
-                return None
+                return None, True
 
-        try:
-            next_tokens = _safe("_next_tokens")
-            if next_tokens is not None:
-                outputs.append(next_tokens)
-        except Exception:
-            pass
+        next_tokens, errored = _safe("_next_tokens")
+        collection_failed = collection_failed or errored
+        if next_tokens is not None:
+            outputs.append(next_tokens)
 
-        try:
-            next_logprobs = _safe("_next_logprobs")
-            if isinstance(next_logprobs, (list, tuple)):
-                for lp in next_logprobs:
-                    if lp is not None:
-                        outputs.append(lp)
-            elif next_logprobs is not None:
-                outputs.append(next_logprobs)
-        except Exception:
-            pass
+        next_logprobs, errored = _safe("_next_logprobs")
+        collection_failed = collection_failed or errored
+        if isinstance(next_logprobs, (list, tuple)):
+            for lp in next_logprobs:
+                if lp is not None:
+                    outputs.append(lp)
+        elif next_logprobs is not None:
+            outputs.append(next_logprobs)
 
-        try:
-            token_context = _safe("_token_context") or None
-            if isinstance(token_context, (list, tuple)):
-                for tc in token_context:
-                    try:
-                        tok = getattr(tc, "tokens", None)
-                    except Exception:
-                        tok = None
-                    if tok is not None:
-                        outputs.append(tok)
-        except Exception:
-            pass
-        return outputs
+        token_context, errored = _safe("_token_context")
+        collection_failed = collection_failed or errored
+        if isinstance(token_context, (list, tuple)):
+            for tc in token_context:
+                try:
+                    tok = getattr(tc, "tokens", None)
+                except Exception:
+                    # A TokenBuffer whose ``tokens`` accessor raises is a
+                    # collection failure for that surface, not an absent one.
+                    collection_failed = True
+                    tok = None
+                if tok is not None:
+                    outputs.append(tok)
+
+        return outputs, collection_failed
 
     def get_request(self, request_id: str) -> Request | None:
         """Get a request by ID."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -9239,23 +9239,50 @@ class Scheduler:
         # nodes each step, so the output chain can grow unboundedly and hit
         # Metal's 499000-handle ceiling even though ``layer.state`` stays
         # bounded (the #1834 math caps cache-state alone at ~71 units, ~150x
-        # below the ceiling). Realize the output chain on the SAME depth
-        # interval below (same barrier cadence, same host sync) so it cannot
-        # grow. Dense lanes already returned at ``if not states`` above, so
-        # this dense no-sync guarantee is untouched.
+        # below the ceiling). Dense lanes already returned at ``if not states``
+        # above, so this dense no-sync guarantee is untouched.
         #
-        # Collect the output chain and realize it in the same ``mx.eval`` as
-        # the cache states: two separate ``mx.eval`` calls would double the
-        # barrier's host-synchronization cost on the decode hot path (codex
-        # r1 BLOCKING). ``_collect_recurrent_outputs`` never evaluates and
-        # never throws on a transient shape mismatch; if a *persistent*
-        # incompatibility prevents realizing the chain at all, the escalated
-        # EngineError propagates instead of silently conceding to the unbounded
-        # graph this barrier exists to prevent (codex r1 BLOCKING).
+        # Ordering + single-barrier (codex r1, r2, r3 converge): collection is
+        # host-only, then cache-state AND output chain are realized together in
+        # ONE ``mx.eval`` — a single device barrier on the happy path for both
+        # graphs (r3 wanted no doubled sync). But a combined eval cannot tell
+        # WHICH tensor failed, and the cache-state realize is the
+        # proven-necessary barrier that MUST NOT be suppressible (r2). So on
+        # exception we re-eval ``states`` alone to classify: if that ALSO fails
+        # the lane is genuinely broken and the cache-state failure propagates
+        # immediately; if only the output chain failed it is the NEW #2834
+        # surface and goes through guarded retry/escalation. Dense lanes never
+        # reach here, so no per-token eval is added to a dense batch.
         outputs = self._collect_recurrent_outputs(generation_batch)
-        try:
-            mx.eval([*states, *outputs])
-        except Exception:
+        self._retry_materialize_output_chain(states, outputs)
+        return len(states)
+
+    def _retry_materialize_output_chain(self, states, outputs) -> int:
+        """Realize the per-step decode output chain (guarded retry/escalation).
+
+        The caller has already collected ``outputs`` (host-side) and hands us
+        both ``states`` and ``outputs`` so we realize them in ONE ``mx.eval`` —
+        a single device barrier covering both halves of the lazy graph on the
+        happy path (codex r3). Because a combined eval cannot say WHICH tensor
+        failed, the ``except`` re-evaluates ``states`` alone to classify:
+
+          * states re-eval also fails  -> hard cache-state failure; the
+            proven-necessary #1834 barrier must not be suppressed, so it
+            propagates immediately (codex r2).
+          * states re-eval succeeds     -> the failure was the NEW #2834
+            output-chain surface; it is version-sensitive (``mlx_lm``
+            ``TokenBuffer`` / ``_next_*`` shapes), so it retries and escalates
+            after ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT`` consecutive misses
+            rather than hard-crashing or silently conceding to an unbounded
+            output graph (codex r1, r3).
+
+        On success the dereference counter resets so a cleared transient
+        recovers. Realizing with an empty/outputs-only list (a batch currently
+        exposing no output tensors) is fine: the cache-state half already
+        realized, and the combined eval is just ``mx.eval(states)``.
+        """
+
+        def _escalate() -> int:
             self._recurrent_output_chain_failures += 1
             if (
                 self._recurrent_output_chain_failures
@@ -9277,12 +9304,36 @@ class Scheduler:
                 self._recurrent_output_chain_failures,
                 _RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT,
             )
-            return len(states)
+            return 0
+
+        if not outputs:
+            # No output tensors exposed: still realize the cache state. This is
+            # the same barrier #1834 already issued — not a doubled sync.
+            try:
+                mx.eval(states)
+            except Exception:
+                # No output surface to absorb the blame; a cache-state failure
+                # must propagate (r2).
+                raise
+            self._recurrent_output_chain_failures = 0
+            return 0
+
+        try:
+            mx.eval([*states, *outputs])  # single device barrier (r3)
+        except Exception:
+            # Classify the failure: if the cache-state half is broken too, that
+            # is the proven-necessary barrier and must propagate, not count as a
+            # retryable output-chain miss (r2).
+            try:
+                mx.eval(states)
+            except Exception:
+                raise
+            return _escalate()
         self._recurrent_output_chain_failures = 0
-        return len(states)
+        return len(outputs)
 
     def _collect_recurrent_outputs(self, generation_batch) -> list:
-        """Return the per-step decode output chain tensors of a batch.
+        """Best-effort collect the per-step decode output chain tensors.
 
         Mirrors the cache-state barrier for the OTHER half of the lazy graph
         that #1834 did not cover: the tensors ``mlx_lm generate._step`` hands
@@ -9291,31 +9342,51 @@ class Scheduler:
         caller returns before ever reaching this — no per-token host sync on a
         dense lane.
 
-        Collection only (no evaluation): the caller realizes the gathered
-        tensors together with the cache states in a single ``mx.eval``. The
-        attribute surface varies across mlx-lm patch levels, so any shape the
-        batch exposes is tolerated without raising; a batch with no exposed
-        output tensors simply contributes nothing, and the cache-state barrier
-        still fires.
+        Collection only (the caller realizes). The attribute surface varies
+        across mlx-lm patch levels, so each optional surface is individually
+        guarded: a single version-mismatched ``TokenBuffer.tokens`` property
+        raising is skipped for that item rather than failing the whole batch.
+        A batch that exposes nothing simply contributes nothing, and the
+        cache-state barrier still fires.
         """
-        # ``_next_tokens`` is a single batch array (or None pre-sampling).
-        next_tokens = getattr(generation_batch, "_next_tokens", None)
         outputs: list = []
-        if next_tokens is not None:
-            outputs.append(next_tokens)
-        # ``_next_logprobs`` is a list of per-row arrays.
-        next_logprobs = getattr(generation_batch, "_next_logprobs", None)
-        if isinstance(next_logprobs, (list, tuple)):
-            outputs.extend(lp for lp in next_logprobs if lp is not None)
-        elif next_logprobs is not None:
-            outputs.append(next_logprobs)
-        # ``_token_context`` is a list of TokenBuffer objects whose lazily
-        # grown buffer is the per-step ``token_context`` async_eval lives on.
-        # Realize each buffer slice so the concat chain detaches.
-        for tc in getattr(generation_batch, "_token_context", None) or []:
-            tok = getattr(tc, "tokens", None)
-            if tok is not None:
-                outputs.append(tok)
+
+        def _safe(attr) -> object:
+            try:
+                return getattr(generation_batch, attr, None)
+            except Exception:
+                return None
+
+        try:
+            next_tokens = _safe("_next_tokens")
+            if next_tokens is not None:
+                outputs.append(next_tokens)
+        except Exception:
+            pass
+
+        try:
+            next_logprobs = _safe("_next_logprobs")
+            if isinstance(next_logprobs, (list, tuple)):
+                for lp in next_logprobs:
+                    if lp is not None:
+                        outputs.append(lp)
+            elif next_logprobs is not None:
+                outputs.append(next_logprobs)
+        except Exception:
+            pass
+
+        try:
+            token_context = _safe("_token_context") or None
+            if isinstance(token_context, (list, tuple)):
+                for tc in token_context:
+                    try:
+                        tok = getattr(tc, "tokens", None)
+                    except Exception:
+                        tok = None
+                    if tok is not None:
+                        outputs.append(tok)
+        except Exception:
+            pass
         return outputs
 
     def get_request(self, request_id: str) -> Request | None:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -160,6 +160,12 @@ _RECURRENT_CACHE_MATERIALIZE_INTERVAL = 8
 # ~150× below the 499000-handle ceiling — only UNBOUNDED chains exhaust Metal.
 _RECURRENT_MATERIALIZE_HANDLE_BUDGET = 64
 _RECURRENT_MATERIALIZE_MAX_INTERVAL = 64
+# Consecutive realize-failures of the per-step output chain (issue #2834) that
+# must be tolerated as a transient/missing-surface before the lane escalates.
+# A persistent failure means the very chain this barrier exists to bound is
+# not being detached — continuing to log-and-return would silently concede to
+# the Metal-handle exhaustion the fix targets.
+_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT = 8
 
 
 def _pflash_compressed(request: Request) -> bool:
@@ -3638,6 +3644,11 @@ class Scheduler:
     # a deep low-batch chain materializes immediately when concurrency rises
     # instead of waiting for the next global-step multiple.
     _recurrent_chain_depth = 0
+    # Consecutive realize-failures of the per-step decode output chain (issue
+    # #2834). Reset on success; when it reaches
+    # ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT`` the lane escalates rather than
+    # silently conceding to an unbounded output graph.
+    _recurrent_output_chain_failures = 0
     # Running-sequence count at the previous barrier check. An idle->active
     # edge (this was 0, now >0) arms the barrier so a sequence admitted to a
     # fresh OR long-idle scheduler materializes its prefill-inherited graph
@@ -9219,7 +9230,6 @@ class Scheduler:
                     states.append(state)
         if not states:
             return 0
-        mx.eval(states)
         # Issue #2834/#2836: realizing ``layer.state`` bounds the *cache-state*
         # lazy graph, but the per-step decode OUTPUT chain is a separate graph
         # surface. ``mlx_lm generate._step`` schedules ``self._next_tokens``,
@@ -9233,55 +9243,80 @@ class Scheduler:
         # interval below (same barrier cadence, same host sync) so it cannot
         # grow. Dense lanes already returned at ``if not states`` above, so
         # this dense no-sync guarantee is untouched.
-        self._materialize_recurrent_output_chain(generation_batch)
+        #
+        # Collect the output chain and realize it in the same ``mx.eval`` as
+        # the cache states: two separate ``mx.eval`` calls would double the
+        # barrier's host-synchronization cost on the decode hot path (codex
+        # r1 BLOCKING). ``_collect_recurrent_outputs`` never evaluates and
+        # never throws on a transient shape mismatch; if a *persistent*
+        # incompatibility prevents realizing the chain at all, the escalated
+        # EngineError propagates instead of silently conceding to the unbounded
+        # graph this barrier exists to prevent (codex r1 BLOCKING).
+        outputs = self._collect_recurrent_outputs(generation_batch)
+        try:
+            mx.eval([*states, *outputs])
+        except Exception:
+            self._recurrent_output_chain_failures += 1
+            if (
+                self._recurrent_output_chain_failures
+                >= _RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT
+            ):
+                logger.error(
+                    "[recurrent-output-chain] %d consecutive realize-failures; "
+                    "a persistent incompatibility is leaving the per-step "
+                    "decode output chain unbounded. Failing the lane rather "
+                    "than drifting toward Metal handle exhaustion.",
+                    self._recurrent_output_chain_failures,
+                )
+                raise
+            logger.warning(
+                "[recurrent-output-chain] realize failed (attempt %d/%d); the "
+                "cache-state barrier already realized this step's state so the "
+                "graph stays bounded this interval, but a recurring failure "
+                "will escalate.",
+                self._recurrent_output_chain_failures,
+                _RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT,
+            )
+            return len(states)
+        self._recurrent_output_chain_failures = 0
         return len(states)
 
-    def _materialize_recurrent_output_chain(self, generation_batch) -> int:
-        """Realize the per-step decode output chain on a recurrent lane.
+    def _collect_recurrent_outputs(self, generation_batch) -> list:
+        """Return the per-step decode output chain tensors of a batch.
 
         Mirrors the cache-state barrier for the OTHER half of the lazy graph
         that #1834 did not cover: the tensors ``mlx_lm generate._step`` hands
         to ``mx.async_eval(self._next_tokens, self._next_logprobs,
         token_context)``. On dense batches every layer is trimmable, so the
-        caller never reaches here — this realizes no per-token host sync on a
+        caller returns before ever reaching this — no per-token host sync on a
         dense lane.
 
-        Everything below is guarded: the attribute surface varies across mlx-lm
-        patch levels and this runs on the engine hot path, so any shape the
-        batch exposes must be tolerated. Failures here are isolated (the caller
-        already computed the cache state) so a passthrough defect cannot
-        silently disable the cache-state barrier.
+        Collection only (no evaluation): the caller realizes the gathered
+        tensors together with the cache states in a single ``mx.eval``. The
+        attribute surface varies across mlx-lm patch levels, so any shape the
+        batch exposes is tolerated without raising; a batch with no exposed
+        output tensors simply contributes nothing, and the cache-state barrier
+        still fires.
         """
-        try:
-            # ``_next_tokens`` is a single batch array (or None pre-sampling).
-            next_tokens = getattr(generation_batch, "_next_tokens", None)
-            outputs: list = []
-            if next_tokens is not None:
-                outputs.append(next_tokens)
-            # ``_next_logprobs`` is a list of per-row arrays.
-            next_logprobs = getattr(generation_batch, "_next_logprobs", None)
-            if isinstance(next_logprobs, (list, tuple)):
-                outputs.extend(lp for lp in next_logprobs if lp is not None)
-            elif next_logprobs is not None:
-                outputs.append(next_logprobs)
-            # ``_token_context`` is a list of TokenBuffer objects whose lazily
-            # grown buffer is the per-step ``token_context`` async_eval lives
-            # on. Realize each buffer slice so the concat chain detaches.
-            for tc in getattr(generation_batch, "_token_context", None) or []:
-                tok = getattr(tc, "tokens", None)
-                if tok is not None:
-                    outputs.append(tok)
-            if not outputs:
-                return 0
-            mx.eval(outputs)
-            return len(outputs)
-        except Exception:
-            logger.exception(
-                "[recurrent-output-chain] passthrough failed; the cache-state "
-                "barrier already realized this step's state so the graph "
-                "remains bounded this interval"
-            )
-            return 0
+        # ``_next_tokens`` is a single batch array (or None pre-sampling).
+        next_tokens = getattr(generation_batch, "_next_tokens", None)
+        outputs: list = []
+        if next_tokens is not None:
+            outputs.append(next_tokens)
+        # ``_next_logprobs`` is a list of per-row arrays.
+        next_logprobs = getattr(generation_batch, "_next_logprobs", None)
+        if isinstance(next_logprobs, (list, tuple)):
+            outputs.extend(lp for lp in next_logprobs if lp is not None)
+        elif next_logprobs is not None:
+            outputs.append(next_logprobs)
+        # ``_token_context`` is a list of TokenBuffer objects whose lazily
+        # grown buffer is the per-step ``token_context`` async_eval lives on.
+        # Realize each buffer slice so the concat chain detaches.
+        for tc in getattr(generation_batch, "_token_context", None) or []:
+            tok = getattr(tc, "tokens", None)
+            if tok is not None:
+                outputs.append(tok)
+        return outputs
 
     def get_request(self, request_id: str) -> Request | None:
         """Get a request by ID."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -9209,12 +9209,17 @@ class Scheduler:
         """
         batch_generator = self.batch_generator
         if batch_generator is None:
+            # No active lane: clear any failure counter left by a prior
+            # recurrent request so a NEW request never inherits a stale streak
+            # (codex r7). Failures are scoped to an ACTIVE recurrent lane.
+            self._recurrent_output_chain_failures = 0
             return 0
         generation_batch = getattr(batch_generator, "_generation_batch", None)
         if generation_batch is None:
             generation_batch = getattr(batch_generator, "active_batch", None)
         cache = getattr(generation_batch, "prompt_cache", None)
         if not cache:
+            self._recurrent_output_chain_failures = 0
             return 0
 
         states = []
@@ -9239,6 +9244,12 @@ class Scheduler:
                 if state is not None:
                     states.append(state)
         if not states:
+            # No recurrent state to materialize (all-trimmable/dense lane): the
+            # output-chain failure counter is scoped to an ACTIVE recurrent
+            # lane, so clear any streak left by a prior recurrent request —
+            # a dense period must not let stale failures cascade into a new
+            # recurrent request (codex r7).
+            self._recurrent_output_chain_failures = 0
             return 0
         # Issue #2834/#2836: realizing ``layer.state`` bounds the *cache-state*
         # lazy graph, but the per-step decode OUTPUT chain is a separate graph

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -9220,7 +9220,68 @@ class Scheduler:
         if not states:
             return 0
         mx.eval(states)
+        # Issue #2834/#2836: realizing ``layer.state`` bounds the *cache-state*
+        # lazy graph, but the per-step decode OUTPUT chain is a separate graph
+        # surface. ``mlx_lm generate._step`` schedules ``self._next_tokens``,
+        # ``self._next_logprobs`` and the logits-processor ``token_context``
+        # via ``mx.async_eval`` but does not detach them from the prior step —
+        # on a recurrent/hybrid lane the forward pass re-invokes those async
+        # nodes each step, so the output chain can grow unboundedly and hit
+        # Metal's 499000-handle ceiling even though ``layer.state`` stays
+        # bounded (the #1834 math caps cache-state alone at ~71 units, ~150x
+        # below the ceiling). Realize the output chain on the SAME depth
+        # interval below (same barrier cadence, same host sync) so it cannot
+        # grow. Dense lanes already returned at ``if not states`` above, so
+        # this dense no-sync guarantee is untouched.
+        self._materialize_recurrent_output_chain(generation_batch)
         return len(states)
+
+    def _materialize_recurrent_output_chain(self, generation_batch) -> int:
+        """Realize the per-step decode output chain on a recurrent lane.
+
+        Mirrors the cache-state barrier for the OTHER half of the lazy graph
+        that #1834 did not cover: the tensors ``mlx_lm generate._step`` hands
+        to ``mx.async_eval(self._next_tokens, self._next_logprobs,
+        token_context)``. On dense batches every layer is trimmable, so the
+        caller never reaches here — this realizes no per-token host sync on a
+        dense lane.
+
+        Everything below is guarded: the attribute surface varies across mlx-lm
+        patch levels and this runs on the engine hot path, so any shape the
+        batch exposes must be tolerated. Failures here are isolated (the caller
+        already computed the cache state) so a passthrough defect cannot
+        silently disable the cache-state barrier.
+        """
+        try:
+            # ``_next_tokens`` is a single batch array (or None pre-sampling).
+            next_tokens = getattr(generation_batch, "_next_tokens", None)
+            outputs: list = []
+            if next_tokens is not None:
+                outputs.append(next_tokens)
+            # ``_next_logprobs`` is a list of per-row arrays.
+            next_logprobs = getattr(generation_batch, "_next_logprobs", None)
+            if isinstance(next_logprobs, (list, tuple)):
+                outputs.extend(lp for lp in next_logprobs if lp is not None)
+            elif next_logprobs is not None:
+                outputs.append(next_logprobs)
+            # ``_token_context`` is a list of TokenBuffer objects whose lazily
+            # grown buffer is the per-step ``token_context`` async_eval lives
+            # on. Realize each buffer slice so the concat chain detaches.
+            for tc in getattr(generation_batch, "_token_context", None) or []:
+                tok = getattr(tc, "tokens", None)
+                if tok is not None:
+                    outputs.append(tok)
+            if not outputs:
+                return 0
+            mx.eval(outputs)
+            return len(outputs)
+        except Exception:
+            logger.exception(
+                "[recurrent-output-chain] passthrough failed; the cache-state "
+                "barrier already realized this step's state so the graph "
+                "remains bounded this interval"
+            )
+            return 0
 
     def get_request(self, request_id: str) -> Request | None:
         """Get a request by ID."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -9336,8 +9336,15 @@ class Scheduler:
         if collection_failed:
             # An output surface raised on ACCESS — indistinguishable from a
             # realize failure for the purpose of bounding the chain, so route
-            # it through the same escalation path (codex r4). Cache-state was
-            # already realized by the caller, so this step is still bounded.
+            # it through the same escalation path (codex r4). The cache-state
+            # barrier is NOT realized by the caller, so realize it HERE first
+            # (unguarded — a cache-state failure must propagate immediately,
+            # r2), else this edge puts up to 7 intervals between cache-state
+            # realizations and regresses the #1834 invariant (codex r5).
+            try:
+                mx.eval(states)
+            except Exception:
+                raise
             return _escalate()
 
         if not outputs:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3659,6 +3659,13 @@ class Scheduler:
     # ``_RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT`` the lane escalates rather than
     # silently conceding to an unbounded output graph.
     _recurrent_output_chain_failures = 0
+    # The generation batch ``_recurrent_output_chain_failures`` is scoped to.
+    # The failure streak belongs to ONE active recurrent lane; when the active
+    # batch identity CHANGES (idle -> recurrent, dense -> recurrent, or direct
+    # recurrent -> recurrent replacement) the counter must reset so a new
+    # request never inherits a stale streak (codex r7, r8#1). Reset on success
+    # and whenever this identity changes.
+    _recurrent_output_chain_batch = None
     # Running-sequence count at the previous barrier check. An idle->active
     # edge (this was 0, now >0) arms the barrier so a sequence admitted to a
     # fresh OR long-idle scheduler materializes its prefill-inherited graph
@@ -9213,12 +9220,24 @@ class Scheduler:
             # recurrent request so a NEW request never inherits a stale streak
             # (codex r7). Failures are scoped to an ACTIVE recurrent lane.
             self._recurrent_output_chain_failures = 0
+            self._recurrent_output_chain_batch = None
             return 0
         generation_batch = getattr(batch_generator, "_generation_batch", None)
         if generation_batch is None:
             generation_batch = getattr(batch_generator, "active_batch", None)
+        # The failure streak is scoped to the ACTIVE generation batch. If the
+        # batch IDENTITY changed (idle -> recurrent, dense -> recurrent, or a
+        # direct recurrent->recurrent replacement), the counter belongs to a
+        # different geometry and must reset — otherwise a new request could
+        # inherit a stale streak and fail on its FIRST collection error (codex
+        # r7, r8#1). Everything after this point is the SAME batch, so the
+        # counter persists across its own consecutive failures.
+        if generation_batch is not self._recurrent_output_chain_batch:
+            self._recurrent_output_chain_failures = 0
+            self._recurrent_output_chain_batch = generation_batch
         cache = getattr(generation_batch, "prompt_cache", None)
         if not cache:
+            # No cache on the (possibly new) batch: nothing to materialize.
             self._recurrent_output_chain_failures = 0
             return 0
 
@@ -9250,6 +9269,7 @@ class Scheduler:
             # a dense period must not let stale failures cascade into a new
             # recurrent request (codex r7).
             self._recurrent_output_chain_failures = 0
+            self._recurrent_output_chain_batch = None
             return 0
         # Issue #2834/#2836: realizing ``layer.state`` bounds the *cache-state*
         # lazy graph, but the per-step decode OUTPUT chain is a separate graph
@@ -9283,15 +9303,13 @@ class Scheduler:
         # steps on hybrid lanes only, and the second call finds the device
         # already drained from the first. Dense lanes never reach here, so no
         # per-token eval is added to a dense batch.
-        outputs, collection_failed = self._collect_recurrent_outputs(generation_batch)
+        outputs, collection_error = self._collect_recurrent_outputs(generation_batch)
         mx.eval(states)  # mA: unguarded, immediately-propagating cache barrier
-        self._retry_materialize_output_chain(
-            outputs, collection_failed=collection_failed
-        )
+        self._retry_materialize_output_chain(outputs, collection_error=collection_error)
         return len(states)
 
     def _retry_materialize_output_chain(
-        self, outputs, *, collection_failed: bool = False
+        self, outputs, *, collection_error: Exception | None = None
     ) -> int:
         """Realize the per-step decode output chain (guarded retry/escalation).
 
@@ -9305,13 +9323,16 @@ class Scheduler:
         than hard-crashing or silently conceding to an unbounded output graph
         (codex r1, r3).
 
-        ``collection_failed`` (codex r4/r6#2) means some output attribute's
-        ACCESS raised (not merely absent). The successfully-collected outputs
-        are still REALIZED here — a valid ``_next_logprobs`` / token-context
-        chain is never discarded (r6#2) — and then the inaccessible surface
-        counts through the SAME escalation counter, else a persistently-raising
-        surface would read as "no outputs", clear the counter every step, and
-        the unbounded chain it exists to bound would never escalate.
+        ``collection_error`` (codex r4/r6#2) is the first output attribute
+        whose ACCESS raised (not merely absent), or ``None``. The
+        successfully-collected outputs are still REALIZED here — a valid
+        ``_next_logprobs`` / token-context chain is never discarded (r6#2) —
+        and then the inaccessible surface counts through the SAME escalation
+        counter, else a persistently-raising surface would read as "no
+        outputs", clear the counter every step, and the unbounded chain it
+        exists to bound would never escalate. The original exception is chained
+        into ``_RecurrentOutputChainError`` so the log names the failing
+        surface (codex r8#3).
 
         On success the dereference counter resets so a cleared transient
         recovers. A cleanly-collected empty output list is a no-op that clears
@@ -9328,8 +9349,10 @@ class Scheduler:
                     "[recurrent-output-chain] %d consecutive realize/collect "
                     "failures; a persistent incompatibility is leaving the "
                     "per-step decode output chain unbounded. Failing the lane "
-                    "rather than drifting toward Metal handle exhaustion.",
+                    "rather than drifting toward Metal handle exhaustion. "
+                    "Last failure: %r",
                     self._recurrent_output_chain_failures,
+                    failure,
                 )
                 raise _RecurrentOutputChainError(
                     "recurrent decode output chain could not be realized "
@@ -9341,9 +9364,10 @@ class Scheduler:
                 "[recurrent-output-chain] realize/collect failed (attempt "
                 "%d/%d); the cache-state barrier already realized this step's "
                 "state so the graph stays bounded this interval, but a "
-                "recurring failure will escalate.",
+                "recurring failure will escalate. Last failure: %r",
                 self._recurrent_output_chain_failures,
                 _RECURRENT_OUTPUT_CHAIN_FAILURE_LIMIT,
+                failure,
             )
             return 0
 
@@ -9354,26 +9378,28 @@ class Scheduler:
                 mx.eval(outputs)
             except Exception as exc:
                 return _escalate(exc)
-            if not collection_failed:
+            if collection_error is None:
                 self._recurrent_output_chain_failures = 0
                 return len(outputs)
             # Some surface was inaccessible, but what we gathered is now
             # realized — never discard it (r6#2). Escalate for the surface
-            # whose access raised (r4).
-            return _escalate()
+            # whose access raised (r4), chaining its exception (r8#3).
+            return _escalate(collection_error)
 
-        if collection_failed:
+        if collection_error is not None:
             # Nothing collectible AND a surface raised on access: escalate
             # (cache state was already realized by the caller, r5).
-            return _escalate()
+            return _escalate(collection_error)
 
         # Cleanly empty: nothing to realize; cache-state barrier already fired.
         self._recurrent_output_chain_failures = 0
         return 0
 
-    def _collect_recurrent_outputs(self, generation_batch) -> tuple[list, bool]:
+    def _collect_recurrent_outputs(
+        self, generation_batch
+    ) -> tuple[list, Exception | None]:
         """Collect the per-step decode output chain tensors, returning
-        ``(outputs, collection_failed)``.
+        ``(outputs, collection_error)``.
 
         Mirrors the cache-state barrier for the OTHER half of the lazy graph
         that #1834 did not cover: the tensors ``mlx_lm generate._step`` hands
@@ -9388,26 +9414,33 @@ class Scheduler:
         RAISED is — a persistently-raising surface would otherwise read as
         "no outputs", the barrier would clear its escalation counter each step,
         and the unbounded chain it exists to bound would never escalate.
-        ``collection_failed`` is set when any surface access raised, so the
-        caller can route it into the same retry/escalation path as a realize
-        failure. ``_safe`` returns ``(value, errored)`` to tell the two apart.
+        ``collection_error`` is the FIRST surface access that raised (or
+        ``None``), so the caller can route it into the same retry/escalation
+        path as a realize failure AND chain the original exception into
+        escalation (codex r8#3 nit — the log names the failing surface).
+        ``_safe`` returns ``(value, exception)`` to tell the two apart.
         """
         outputs: list = []
-        collection_failed = False
+        collection_error: Exception | None = None
 
-        def _safe(attr) -> tuple[object, bool]:
+        def _safe(attr) -> tuple[object, Exception | None]:
             try:
-                return getattr(generation_batch, attr, None), False
-            except Exception:
-                return None, True
+                return getattr(generation_batch, attr, None), None
+            except Exception as exc:
+                return None, exc
 
-        next_tokens, errored = _safe("_next_tokens")
-        collection_failed = collection_failed or errored
+        def _note_error(exc: Exception | None) -> None:
+            nonlocal collection_error
+            if exc is not None and collection_error is None:
+                collection_error = exc
+
+        next_tokens, exc = _safe("_next_tokens")
+        _note_error(exc)
         if next_tokens is not None:
             outputs.append(next_tokens)
 
-        next_logprobs, errored = _safe("_next_logprobs")
-        collection_failed = collection_failed or errored
+        next_logprobs, exc = _safe("_next_logprobs")
+        _note_error(exc)
         if isinstance(next_logprobs, (list, tuple)):
             for lp in next_logprobs:
                 if lp is not None:
@@ -9415,21 +9448,21 @@ class Scheduler:
         elif next_logprobs is not None:
             outputs.append(next_logprobs)
 
-        token_context, errored = _safe("_token_context")
-        collection_failed = collection_failed or errored
+        token_context, exc = _safe("_token_context")
+        _note_error(exc)
         if isinstance(token_context, (list, tuple)):
             for tc in token_context:
                 try:
                     tok = getattr(tc, "tokens", None)
-                except Exception:
+                except Exception as tok_exc:
                     # A TokenBuffer whose ``tokens`` accessor raises is a
                     # collection failure for that surface, not an absent one.
-                    collection_failed = True
+                    _note_error(tok_exc)
                     tok = None
                 if tok is not None:
                     outputs.append(tok)
 
-        return outputs, collection_failed
+        return outputs, collection_error
 
     def get_request(self, request_id: str) -> Request | None:
         """Get a request by ID."""


### PR DESCRIPTION
Closes #2834. Related #2836 (same root cause on the hybrid Qwen3.6-35B recurring `Resource limit (499000)`).

## Why

#1834's recurrent-cache barrier realizes only `layer.state` (cache-state lazy graph), bounding it to ~71 units — ~150× below Metal's 499000-handle ceiling. Issue #2834/#2836 still crash at ~55/day steady-state because the **per-step decode OUTPUT chain** — `gb._next_tokens`, `gb._next_logprobs`, and the logits-processor `token_context` that `mlx_lm generate._step` schedules via `mx.async_eval(...)` — is a separate lazy-graph surface the barrier never touches. On a recurrent/hybrid lane the forward re-invokes those async nodes each step, so the output chain grows unboundedly and exhausts Metal even though cache state stays flat (byte accounting flat, handle count grows).

## Fix

Extend `_materialize_active_recurrent_cache()` to call a sibling `_materialize_recurrent_output_chain(generation_batch)` that realizes `_next_tokens`, `_next_logprobs`, and each `TokenBuffer.tokens` in `_token_context` — on the **same depth interval** as the existing barrier (no extra host-sync frequency). Dense lanes return at the existing `if not states` guard before reaching the passthrough, so the **dense per-token no-sync guarantee is preserved**. The passthrough is defensive across mlx-lm patch levels and failure-isolated (cannot disable the cache-state barrier).

## Test

`test_recurrent_barrier_realizes_per_step_output_chain` builds a 1000-step output chain and proves the barrier detaches it — **fails before this change (assert 1001 == 1), passes after**. Dense-lane no-touch + missing-surface tolerance tests included. 14/14 tests in the materialization file pass; surrounding scheduler suites no-regression green; ruff clean.

## Known limits / follow-ups

- **On-device validation pending**: the fix's correctness is established from the mechanism + #1834's own math, not measured on a live hybrid model (no model in this offline env). The reporter (reports-svg) offered to run a patched build on their M5 Max production workload — will validate the handle-count reduction end-to-end.
- MLLM/audio lane (`vllm_mlx/mllm_batch_generator.py` ~1741) does its own `async_eval` with no barrier; if hybrid VLM serving is in scope it deserves the same treatment (separate follow-up, not this PR).