### PR TITLE
fix(pr_validate): don't BLOCK external PRs that only enroll a test (#2522)

### DIFF
--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -72,9 +72,23 @@ def _is_hook_file(path: str) -> bool:
     return any(path == p or path.startswith(p) for p in HOOK_PATHS)
 
 
-# A roster-enrollment line in a CI workflow file: `tests/<name>.py \` — the
-# exact shape the explicit test roster asks a contributor to add (issue #2522).
-_ROSTER_LINE = re.compile(r"^\s*tests/[^\s\\]+\.py\s+\\?\s*$")
+# A roster-enrollment line in the explicit CI test command.  Keep the path
+# grammar deliberately narrower than a shell token: allowing characters such
+# as ``$()``, quotes, ``;`` or ``..`` here would turn the exception itself into
+# a workflow-code injection bypass.
+_ROSTER_LINE = re.compile(
+    r"^(?P<indent>\s+)(?P<path>tests/[A-Za-z0-9_./-]+\.py)\s+\\?\s*$"
+)
+
+
+def _safe_roster_path(line: str, files_changed: set[str]) -> bool:
+    """Return whether *line* names a test file added by this PR."""
+    match = _ROSTER_LINE.fullmatch(line)
+    if match is None:
+        return False
+    path = match.group("path")
+    parts = Path(path).parts
+    return ".." not in parts and path in files_changed
 
 
 def _roster_only_workflow_files(files_changed: list[str], diff: str) -> set[str]:
@@ -89,7 +103,9 @@ def _roster_only_workflow_files(files_changed: list[str], diff: str) -> set[str]
     else (removed lines, non-roster edits) is NOT roster-only and stays
     BLOCKING (issue #2522)."""
     workflow_files = {f for f in files_changed if f.startswith(".github/workflows/")}
-    if not workflow_files:
+    # The exception is for this repository's one explicit Python test roster,
+    # not for arbitrary workflow files containing a roster-looking shell line.
+    if workflow_files != {".github/workflows/ci.yml"}:
         return set()
 
     # Accumulate the *content* lines (with +/-/space marker) per workflow file.
@@ -118,7 +134,8 @@ def _roster_only_workflow_files(files_changed: list[str], diff: str) -> set[str]
         # A pure append has NO removed lines; context lines are unchanged
         # neighboring list entries (the wrapper is safe). So roster-only ==
         # not removing anything AND every added line is a roster enrollment.
-        if all(_ROSTER_LINE.match(ln[1:]) for ln in added):
+        changed = set(files_changed)
+        if all(_safe_roster_path(ln[1:], changed) for ln in added):
             roster_only.add(path)
     return roster_only
 
@@ -225,7 +242,8 @@ class SupplyChainStep(Step):
                 added = [
                     ln[1:]
                     for ln in diff.splitlines()
-                    if ln.startswith("+") and _ROSTER_LINE.match(ln[1:])
+                    if ln.startswith("+")
+                    and _safe_roster_path(ln[1:], set(ctx.files_changed))
                 ]
                 detail = " Roster-only test enrollment: " + ", ".join(
                     f"`{a.strip()}`" for a in added

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -72,6 +72,57 @@ def _is_hook_file(path: str) -> bool:
     return any(path == p or path.startswith(p) for p in HOOK_PATHS)
 
 
+# A roster-enrollment line in a CI workflow file: `tests/<name>.py \` — the
+# exact shape the explicit test roster asks a contributor to add (issue #2522).
+_ROSTER_LINE = re.compile(r"^\s*tests/[^\s\\]+\.py\s+\\?\s*$")
+
+
+def _roster_only_workflow_files(files_changed: list[str], diff: str) -> set[str]:
+    """Return the workflow files whose diff is PURELY a test-roster enrollment.
+
+    Enrolling a new test in the explicit CI roster (adding
+    ``tests/<name>.py \\`` to the list in ``.github/workflows/ci.yml``) is the
+    expected shape of a "I added a test" contribution. A workflow edit that is
+    ONLY such additions — no removed lines, no other added/modified lines in any
+    workflow file — is not a supply-chain risk and, for an external author,
+    should not ``[BLOCKING]``. Any workflow file whose diff contains anything
+    else (removed lines, non-roster edits) is NOT roster-only and stays
+    BLOCKING (issue #2522)."""
+    workflow_files = {f for f in files_changed if f.startswith(".github/workflows/")}
+    if not workflow_files:
+        return set()
+
+    # Accumulate the *content* lines (with +/-/space marker) per workflow file.
+    per_file: dict[str, list[str]] = {f: [] for f in workflow_files}
+    cur_path = ""
+    for line in diff.splitlines():
+        if line.startswith("diff --git a/"):
+            cur_path = line.split(" b/", 1)[-1]
+            continue
+        if cur_path not in per_file:
+            continue
+        if line.startswith(("+++ ", "--- ", "@@")):
+            continue  # hunk headers
+        marker = line[:1]
+        if marker in ("+", "-", " "):
+            per_file[cur_path].append(line)
+
+    roster_only: set[str] = set()
+    for path, content in per_file.items():
+        added = [ln for ln in content if ln.startswith("+")]
+        removed = [ln for ln in content if ln.startswith("-")]
+        if removed:
+            continue  # anything deleted from a workflow file is NOT roster-only
+        if not added:
+            continue  # no actual change tracked (blank/file-empty hunk)
+        # A pure append has NO removed lines; context lines are unchanged
+        # neighboring list entries (the wrapper is safe). So roster-only ==
+        # not removing anything AND every added line is a roster enrollment.
+        if all(_ROSTER_LINE.match(ln[1:]) for ln in added):
+            roster_only.add(path)
+    return roster_only
+
+
 # Backwards-compatibility alias — the dep-declaration matcher now
 # lives in ``_test_env.is_dep_declaration_file`` (shared with
 # ``test_env_check``); kept as a constant here so existing call
@@ -152,10 +203,36 @@ class SupplyChainStep(Step):
         if hook_files:
             # Even an "innocent-looking" hook change is worth surfacing.
             # External-author + hook change = strong reason to read.
-            severity = "BLOCKING" if ctx.is_external_author else "warning"
+            #
+            # Exception (issue #2522): a workflow edit that is PURELY
+            # enrolling a new test in the explicit CI roster
+            # (``tests/<name>.py \`` added, nothing else in any workflow
+            # file) is the expected shape of a "I added a test" contribution.
+            # It stays surfaced as a WARNING (with the added lines) but does
+            # not BLOCK an external author. Any other workflow edit — removed
+            # lines, non-roster edits, edits to non-workflow hook files —
+            # keeps BLOCKING.
+            roster_only = _roster_only_workflow_files(ctx.files_changed, diff)
+            external_hooks = [f for f in hook_files if f not in roster_only]
+            if external_hooks and ctx.is_external_author:
+                severity = "BLOCKING"
+            else:
+                severity = "warning"
+            detail = ""
+            if severity == "warning" and roster_only:
+                # Include the roster-enrollment lines (the diff hunk) so the
+                # human still inspects exactly what was added (issue #2522).
+                added = [
+                    ln[1:]
+                    for ln in diff.splitlines()
+                    if ln.startswith("+") and _ROSTER_LINE.match(ln[1:])
+                ]
+                detail = " Roster-only test enrollment: " + ", ".join(
+                    f"`{a.strip()}`" for a in added
+                )
             findings.append(
                 f"[{severity}] modifies install/CI hook(s): {hook_files}. "
-                "These run unattended; review every line."
+                "These run unattended; review every line." + detail
             )
 
         # 2. Suspicious patterns in ADDED lines (not removed — removed

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the pr_validate ``supply_chain`` step, focusing on the
+test-roster-enrollment exception (issue #2522).
+
+Issue #2522: external PRs that ONLY enroll a test in the explicit CI roster
+(``tests/<name>.py \\`` added to a ``.github/workflows/`` list, nothing else
+changed in any workflow file) must be surfaced as a WARNING — with the added
+lines — not ``[BLOCKING]``. Any other workflow edit by an external author stays
+BLOCKING.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.pr_validate.context import Context
+from scripts.pr_validate.steps.supply_chain import SupplyChainStep
+
+
+@pytest.fixture
+def ctx_factory(tmp_path):
+    """A Context pre-wired with a diff file + changed-files plus external or
+    internal author, without requiring the real GitHub fetch."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+
+    def _make(
+        files_changed: list[str],
+        diff_text: str,
+        *,
+        external: bool = True,
+    ) -> Context:
+        diff_path = tmp_path / "pr.diff"
+        diff_path.write_text(diff_text)
+        ctx = Context(pr_number=1)
+        ctx.files_changed = list(files_changed)
+        ctx.diff_path = str(diff_path)
+        ctx.pr_is_external = external
+        return ctx
+
+    return _make
+
+
+def _run(ctx) -> object:
+    return SupplyChainStep().run(ctx)
+
+
+ROSTER_ONLY_DIFF = """\
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -470 +470,2 @@
+             tests/test_suffix_decoding.py \\
++            tests/test_new_lane_contract.py \\
+"""
+
+MIXED_DIFF = """\
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -470 +470,2 @@
+             tests/test_suffix_decoding.py \\
++            tests/test_new_lane_contract.py \\
++            - uses: actions/checkout@not-a-pinned-sha \\
+"""
+
+
+class TestRosterOnlyEnrollment:
+    def test_external_roster_only_is_warning_not_blocking(self, ctx_factory):
+        """#2522: an external author adding only ``tests/<name>.py \\`` to the
+        roster must NOT be [BLOCKING] — it's the expected shape of a
+        'I added a test' contribution."""
+        ctx = ctx_factory(
+            [".github/workflows/ci.yml"],
+            ROSTER_ONLY_DIFF,
+            external=True,
+        )
+        result = _run(ctx)
+        assert result.status == "pass", result.summary
+        # Surface it as a warning listing the enrollment line.
+        body = "\n".join(result.findings)
+        assert "[BLOCKING]" not in body
+        assert "modifies install/CI hook(s)" in body
+        assert "tests/test_new_lane_contract.py" in body
+
+    def test_external_mixed_roster_plus_edit_stays_blocking(self, ctx_factory):
+        """#2522: a workflow edit that ALSO changes something non-roster
+        (e.g. an unpinned action) must remain [BLOCKING] for an external
+        author."""
+        ctx = ctx_factory(
+            [".github/workflows/ci.yml"],
+            MIXED_DIFF,
+            external=True,
+        )
+        result = _run(ctx)
+        assert result.status == "fail", result.summary
+        assert any("[BLOCKING]" in f for f in result.findings)
+
+    def test_external_unpinned_action_change_stays_blocking(self, ctx_factory):
+        """#2522: a non-roster workflow change (unpinned action line) with no
+        roster enrollment at all remains BLOCKING."""
+        diff = """\
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -49 +49 @@
+-            - uses: actions/checkout@v4
++            - uses: actions/checkout@main
+"""
+        ctx = ctx_factory(
+            [".github/workflows/ci.yml"],
+            diff,
+            external=True,
+        )
+        result = _run(ctx)
+        assert result.status == "fail", result.summary
+        assert any("[BLOCKING]" in f for f in result.findings)
+
+    def test_internal_author_roster_only_is_warning(self, ctx_factory):
+        """#2522 regression: even for an INTERNAL author the roster-only
+        change is surfaced as a warning (not silently swallowed), but the
+        status stays pass."""
+        ctx = ctx_factory(
+            [".github/workflows/ci.yml"],
+            ROSTER_ONLY_DIFF,
+            external=False,
+        )
+        result = _run(ctx)
+        assert result.status == "pass", result.summary
+        assert "modifies install/CI hook(s)" in "\n".join(result.findings)
+
+    def test_non_workflow_hook_change_stays_blocking_for_external(self, ctx_factory):
+        """#2522: the roster-only exception applies ONLY to workflow roster
+        enrollment; a conftest.py hook change by an external author stays
+        BLOCKING."""
+        ctx = ctx_factory(
+            ["tests/conftest.py"],
+            "diff --git a/tests/conftest.py b/tests/conftest.py\n"
+            "--- a/tests/conftest.py\n+++ b/tests/conftest.py\n"
+            "@@ -1 +1 @@\n-x\n+y\n",
+            external=True,
+        )
+        result = _run(ctx)
+        assert result.status == "fail", result.summary
+        assert any("[BLOCKING]" in f for f in result.findings)

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -126,9 +126,7 @@ diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
     )
     def test_shell_or_traversal_path_stays_blocking(self, ctx_factory, unsafe_path):
         """A roster-looking line must not become a shell-injection bypass."""
-        diff = ROSTER_ONLY_DIFF.replace(
-            "tests/test_new_lane_contract.py", unsafe_path
-        )
+        diff = ROSTER_ONLY_DIFF.replace("tests/test_new_lane_contract.py", unsafe_path)
         ctx = ctx_factory(
             [".github/workflows/ci.yml", unsafe_path],
             diff,

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -70,7 +70,7 @@ class TestRosterOnlyEnrollment:
         roster must NOT be [BLOCKING] — it's the expected shape of a
         'I added a test' contribution."""
         ctx = ctx_factory(
-            [".github/workflows/ci.yml"],
+            [".github/workflows/ci.yml", "tests/test_new_lane_contract.py"],
             ROSTER_ONLY_DIFF,
             external=True,
         )
@@ -87,7 +87,7 @@ class TestRosterOnlyEnrollment:
         (e.g. an unpinned action) must remain [BLOCKING] for an external
         author."""
         ctx = ctx_factory(
-            [".github/workflows/ci.yml"],
+            [".github/workflows/ci.yml", "tests/test_new_lane_contract.py"],
             MIXED_DIFF,
             external=True,
         )
@@ -107,8 +107,56 @@ diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
 +            - uses: actions/checkout@main
 """
         ctx = ctx_factory(
-            [".github/workflows/ci.yml"],
+            [".github/workflows/ci.yml", "tests/test_new_lane_contract.py"],
             diff,
+            external=True,
+        )
+        result = _run(ctx)
+        assert result.status == "fail", result.summary
+        assert any("[BLOCKING]" in f for f in result.findings)
+
+    @pytest.mark.parametrize(
+        "unsafe_path",
+        (
+            "tests/../payload.py",
+            "tests/test_ok.py;curl.py",
+            "tests/$(payload).py",
+            "tests/'payload'.py",
+        ),
+    )
+    def test_shell_or_traversal_path_stays_blocking(self, ctx_factory, unsafe_path):
+        """A roster-looking line must not become a shell-injection bypass."""
+        diff = ROSTER_ONLY_DIFF.replace(
+            "tests/test_new_lane_contract.py", unsafe_path
+        )
+        ctx = ctx_factory(
+            [".github/workflows/ci.yml", unsafe_path],
+            diff,
+            external=True,
+        )
+        result = _run(ctx)
+        assert result.status == "fail", result.summary
+        assert any("[BLOCKING]" in f for f in result.findings)
+
+    def test_roster_path_not_added_by_pr_stays_blocking(self, ctx_factory):
+        """The exception applies to a contributed test, not an arbitrary line."""
+        ctx = ctx_factory(
+            [".github/workflows/ci.yml"],
+            ROSTER_ONLY_DIFF,
+            external=True,
+        )
+        result = _run(ctx)
+        assert result.status == "fail", result.summary
+        assert any("[BLOCKING]" in f for f in result.findings)
+
+    def test_other_workflow_roster_lookalike_stays_blocking(self, ctx_factory):
+        """Only the explicit ci.yml roster is eligible for the exception."""
+        other = ROSTER_ONLY_DIFF.replace(
+            ".github/workflows/ci.yml", ".github/workflows/release.yml"
+        )
+        ctx = ctx_factory(
+            [".github/workflows/release.yml", "tests/test_new_lane_contract.py"],
+            other,
             external=True,
         )
         result = _run(ctx)


### PR DESCRIPTION
## What
Issue #2522: an external contributor who adds a test to the explicit CI test roster (`tests/<name>.py \` in `.github/workflows/ci.yml`) was hit with a `[BLOCKING]` supply-chain finding for touching a hook path — forcing a maintainer to hand-accept. Enrolling a test is the **expected** shape of a "I added a test" contribution.

## Why it's safe / what changes
- `_roster_only_workflow_files()` classifies a workflow diff as **roster-only** when it: removes nothing, and every added line is a roster-enrollment line (`tests/<name>.py [\\]`).
- A roster-only workflow change by an **external author** is now surfaced as a **WARNING that includes the added lines**, not `[BLOCKING]`.
- **Any other** workflow edit stays `[BLOCKING]` for external authors: removed lines, non-roster additions, unpinned-action changes, or edits to non-workflow hook files (`tests/conftest.py`, `Makefile`, `Formula/`, etc.).

## Tests
New `tests/test_pr_validate_supply_chain.py` covers:
- external roster-only → WARNING (pass), lists the enrollment line
- external mixed (roster + non-roster edit) → BLOCKING
- external unpinned-action-only change → BLOCKING
- internal-author roster-only → WARNING
- external `tests/conftest.py` change → BLOCKING (exception is workflow-roster-only)

11 focused supply-chain tests pass; ruff + mypy clean.

## Status
**READY for review — NOT enqueued** (parked per operator directive; user enqueues tomorrow morning).

Closes #2522.

## Harbor review hardening

The warning exception is restricted to `.github/workflows/ci.yml`, conservative `tests/*.py` paths with no shell metacharacters or traversal, and a named test file present in the PR. Negative controls keep malformed paths, unchanged test paths, mixed edits, and other workflow files BLOCKING.

## Design precedent

Security exceptions should be positive allowlists over the smallest known-safe grammar, with adversarial negative controls. This keeps the default workflow-hook policy fail-closed.