### PR TITLE
feat(models): add --search and --modality to narrow the catalog (#2355)

### DIFF
--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -225,6 +225,19 @@ def test_modality_audio_count_does_not_crash(capsys):
     assert "Models [audio]" in out
 
 
+def test_modality_audio_count_tolerates_a_broken_audio_registry(capsys, monkeypatch):
+    """#2355 (coverage): a broken/missing audio registry must not crash the
+    modality count — the guarded fallback yields 0 aliases and the title
+    still renders."""
+    import sys
+    import types
+
+    broken = types.ModuleType("vllm_mlx.audio.registry")
+    monkeypatch.setitem(sys.modules, "vllm_mlx.audio.registry", broken)
+    out = _capture(capsys, modality="audio")
+    assert "Models [audio] (0 aliases)" in out
+
+
 def test_default_view_preserves_full_catalog_and_recipe_pointer(capsys):
     """#2355 regression: no filters keeps the full catalog AND points the
     user to the recipe command for RAM-fit recommendations."""

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -186,6 +186,10 @@ def test_modality_audio_shows_only_audio_section(capsys):
     assert "[audio:" in out or "Audio models" in out
     # Text chat aliases (e.g. qwen3-0.6b) must NOT appear.
     assert not any(ln.lstrip().startswith("qwen3-0.6b") for ln in out.splitlines())
+    # The other tagged sections must be blanked too — audio-only really is
+    # audio-only (codex r5 BLOCKING).
+    assert "Video models" not in out
+    assert "Image models" not in out
 
 
 def test_modality_video_gen_shows_video_section(capsys):
@@ -231,6 +235,44 @@ def test_modality_audio_count_does_not_crash(capsys):
     section actually shown without crashing on the audio registry."""
     out = _capture(capsys, modality="audio")
     assert "Models [audio]" in out
+
+
+def test_broken_audio_registry_propagates_a_genuine_bug(capsys, monkeypatch):
+    """#2355 (codex r5 NIT): a REAL bug in the audio registry must surface
+    loudly, not be silently swallowed into a misleading empty catalog. Only
+    the expectable 'registry unavailable / malformed' failures (absent module,
+    missing file, bad JSON) degrade — anything else propagates."""
+    import json
+
+    import pytest
+
+    from vllm_mlx import model_aliases as ma
+    from vllm_mlx.audio import registry as audio_registry
+
+    # Patch list_profiles so the text table is minimal and deterministic.
+    monkeypatch.setattr(
+        ma, "list_profiles", lambda: {"qwen3-0.6b": ma.AliasProfile(hf_path="x/q")}
+    )
+
+    # list_audio_aliases raises a GENUINE bug (RuntimeError) — not a
+    # registry-format failure — so it must propagate, not degrade to [].
+    monkeypatch.setattr(
+        audio_registry,
+        "list_audio_aliases",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        _capture(capsys)
+
+    # A malformed aliases.json (JSONDecodeError, a ValueError subclass) is an
+    # expectable format failure and still degrades: the text table renders.
+    monkeypatch.setattr(
+        audio_registry,
+        "list_audio_aliases",
+        lambda: (_ for _ in ()).throw(json.JSONDecodeError("bad", "doc", 0)),
+    )
+    out = _capture(capsys)
+    assert "qwen3-0.6b" in out  # text table intact despite broken audio registry
 
 
 def test_modality_audio_count_tolerates_a_broken_audio_registry(capsys, monkeypatch):

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -204,6 +204,27 @@ def test_modality_image_gen_shows_image_section(capsys):
     assert not any(ln.lstrip().startswith("qwen3-0.6b") for ln in out.splitlines())
 
 
+def test_modality_text_restricts_to_text_chat(capsys):
+    """#2355 (codex review #1): ``--modality text`` must show ONLY the text
+    chat table — the video / image / audio sections are blanked so the view
+    really is text-only (unlike the default full catalog)."""
+    out = _capture(capsys, modality="text")
+    assert "Models [text]" in out
+    # A text chat alias appears.
+    assert any(ln.lstrip().startswith("qwen3-0.6b") for ln in out.splitlines())
+    # Tagged sections are suppressed.
+    assert "Video models" not in out
+    assert "Image models" not in out
+    assert "Audio models" not in out
+
+
+def test_modality_audio_count_does_not_crash(capsys):
+    """#2355 (codex review #3): the modality title count must reflect the
+    section actually shown without crashing on the audio registry."""
+    out = _capture(capsys, modality="audio")
+    assert "Models [audio]" in out
+
+
 def test_default_view_preserves_full_catalog_and_recipe_pointer(capsys):
     """#2355 regression: no filters keeps the full catalog AND points the
     user to the recipe command for RAM-fit recommendations."""

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from vllm_mlx.cli import models_command
 from vllm_mlx.model_aliases import list_profiles
 
@@ -346,3 +348,18 @@ def test_default_view_preserves_full_catalog_and_recipe_pointer(capsys):
     out = _capture(capsys)
     assert "Available models" in out
     assert "recipe" in out  # discoverability pointer to recommendations
+
+
+@pytest.mark.parametrize("other_flag", ("json", "cached"))
+@pytest.mark.parametrize("filter_flag", ("search", "modality"))
+def test_filters_do_not_silently_noop_on_other_views(
+    capsys, other_flag, filter_flag
+):
+    """Accepted filter syntax must never return an unfiltered alternate view."""
+    args = {"cached": False, "json": False, "search": None, "modality": None}
+    args[other_flag] = True
+    args[filter_flag] = "qwen" if filter_flag == "search" else "text"
+    with pytest.raises(SystemExit) as exc:
+        models_command(SimpleNamespace(**args))
+    assert exc.value.code == 2
+    assert "cannot be combined" in capsys.readouterr().err

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -153,12 +153,20 @@ def test_search_narrows_to_matching_aliases(capsys):
     out = _capture(capsys, search="qwen3-0.6b")
     # The section title reflects the active search.
     assert "matching 'qwen3-0.6b'" in out
+    # The filter narrows to the matching slice: the qwen3-0.6b rows survive,
+    # and a KNOWN UNRELATED alias that exists in the real catalog must NOT
+    # leak through. Scoring presence/absence of concrete aliases (rather than
+    # parsing every table row) catches a filter that keeps the matches but
+    # also lets non-matching rows through (codex r4).
     lines = [ln for ln in out.splitlines() if ln.lstrip().startswith("qwen3-0.6b")]
-    # Only the qwen3-0.6b aliases (and nothing larger) survive the filter.
     ids = {ln.split()[0] for ln in lines}
-    assert "qwen3-0.6b" in ids
-    assert all(a.startswith("qwen3-0.6b") for a in ids)
     assert len(ids) >= 3  # 0.6b + 0.6b-4bit + 0.6b-8bit
+    # ``deepseek`` / ``gemma3`` aliases exist in the full catalog but must be
+    # filtered out by a ``qwen3-0.6b`` search.
+    for leaked in ("deepseek", "gemma3"):
+        assert not any(ln.lstrip().startswith(leaked) for ln in out.splitlines()), (
+            f"search 'qwen3-0.6b' leaked a {leaked} row"
+        )
 
 
 def test_search_ignores_case(capsys):
@@ -269,8 +277,14 @@ def test_whole_catalog_search_counts_tagged_matches(capsys, monkeypatch):
     )
 
     out = _capture(capsys, search="voodoo")
-    matches = [ln for ln in out.splitlines() if "voodoo" in ln]
-    assert any("voodoo" in ln for ln in matches)
+    # The single video-lane match must render as an actual ALIAS TABLE ROW
+    # (first column == ``voodoo-video``) in the video section — checking any
+    # line containing "voodoo" would also be satisfied by the title line
+    # "matching 'voodoo'" (codex r4).
+    video_rows = [
+        ln for ln in out.splitlines() if ln.lstrip().startswith("voodoo-video")
+    ]
+    assert video_rows, "voodoo-video table row must render under the search"
     # The title counts the single video-lane match, not ``(0 aliases)``.
     assert "matching 'voodoo' (1 aliases)" in out
 

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -352,9 +352,7 @@ def test_default_view_preserves_full_catalog_and_recipe_pointer(capsys):
 
 @pytest.mark.parametrize("other_flag", ("json", "cached"))
 @pytest.mark.parametrize("filter_flag", ("search", "modality"))
-def test_filters_do_not_silently_noop_on_other_views(
-    capsys, other_flag, filter_flag
-):
+def test_filters_do_not_silently_noop_on_other_views(capsys, other_flag, filter_flag):
     """Accepted filter syntax must never return an unfiltered alternate view."""
     args = {"cached": False, "json": False, "search": None, "modality": None}
     args[other_flag] = True

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -144,3 +144,57 @@ def test_longest_real_alias_does_not_overflow(capsys):
     assert after_alias.startswith(" "), (
         f"No padding between alias and Tools column for {longest_alias!r}"
     )
+
+
+def test_search_narrows_to_matching_aliases(capsys):
+    """#2355: ``--search`` is a case-insensitive alias substring match that
+    narrows the 200+-line catalog to the requested slice and retitles the
+    section with the term."""
+    out = _capture(capsys, search="qwen3-0.6b")
+    # The section title reflects the active search.
+    assert "matching 'qwen3-0.6b'" in out
+    lines = [ln for ln in out.splitlines() if ln.lstrip().startswith("qwen3-0.6b")]
+    # Only the qwen3-0.6b aliases (and nothing larger) survive the filter.
+    ids = {ln.split()[0] for ln in lines}
+    assert "qwen3-0.6b" in ids
+    assert all(a.startswith("qwen3-0.6b") for a in ids)
+    assert len(ids) >= 3  # 0.6b + 0.6b-4bit + 0.6b-8bit
+
+
+def test_search_ignores_case(capsys):
+    """#2355: the substring match is case-insensitive."""
+    out = _capture(capsys, search="Qwen3")
+    assert "matching 'Qwen3'" in out
+    # Some qwen rows survive (the filter is casefolded).
+    assert any(ln.lstrip().startswith("qwen3") for ln in out.splitlines())
+
+
+def test_modality_audio_shows_only_audio_section(capsys):
+    """#2355: ``--modality audio`` blanks the text chat table and shows
+    only the audio section — the terminal settles on the requested slice."""
+    out = _capture(capsys, modality="audio")
+    assert "Models [audio]" in out
+    # The audio section header is present.
+    assert "[audio:" in out or "Audio models" in out
+    # Text chat aliases (e.g. qwen3-0.6b) must NOT appear.
+    assert not any(ln.lstrip().startswith("qwen3-0.6b") for ln in out.splitlines())
+
+
+def test_modality_video_gen_shows_video_section(capsys):
+    """#2355: ``--modality video-gen`` shows the video section and hides
+    the text chat table + image section."""
+    out = _capture(capsys, modality="video-gen")
+    assert "Models [video-gen]" in out
+    assert "Video models" in out
+    # Image section must not be present (only the requested modality).
+    assert "Image models" not in out
+    # A text chat alias must not leak in.
+    assert not any(ln.lstrip().startswith("qwen3-0.6b") for ln in out.splitlines())
+
+
+def test_default_view_preserves_full_catalog_and_recipe_pointer(capsys):
+    """#2355 regression: no filters keeps the full catalog AND points the
+    user to the recipe command for RAM-fit recommendations."""
+    out = _capture(capsys)
+    assert "Available models" in out
+    assert "recipe" in out  # discoverability pointer to recommendations

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -238,6 +238,43 @@ def test_modality_audio_count_tolerates_a_broken_audio_registry(capsys, monkeypa
     assert "Models [audio] (0 aliases)" in out
 
 
+def test_whole_catalog_search_counts_tagged_matches(capsys, monkeypatch):
+    """#2355 (codex r3 BLOCKING): a ``--search`` with no ``--modality`` greps
+    the whole catalog, so the title count must include matches in the tagged
+    (video / image / audio) sections too. Before the fix, a search matching
+    only a tagged model printed its rows under a misleading ``(0 aliases)``."""
+    import sys
+    import types
+
+    from vllm_mlx import model_aliases
+    from vllm_mlx.model_aliases import AliasProfile
+
+    # A tiny controlled registry with one chat + one video-gen + one
+    # image-gen alias. ``voodoo`` is deliberately unique to the video lane.
+    monkeypatch.setattr(
+        model_aliases,
+        "list_profiles",
+        lambda: {
+            "qwen3-0.6b": AliasProfile(hf_path="x/qwen"),
+            "voodoo-video": AliasProfile(hf_path="x/voodoo", modality="video-gen"),
+            "photon-img": AliasProfile(hf_path="x/photon", modality="image-gen"),
+        },
+    )
+    # Blank the audio registry so the aggregate count is exactly the three
+    # aliases above (guarded import degrades to 0 aliases, not a crash).
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_mlx.audio.registry",
+        types.ModuleType("vllm_mlx.audio.registry"),
+    )
+
+    out = _capture(capsys, search="voodoo")
+    matches = [ln for ln in out.splitlines() if "voodoo" in ln]
+    assert any("voodoo" in ln for ln in matches)
+    # The title counts the single video-lane match, not ``(0 aliases)``.
+    assert "matching 'voodoo' (1 aliases)" in out
+
+
 def test_default_view_preserves_full_catalog_and_recipe_pointer(capsys):
     """#2355 regression: no filters keeps the full catalog AND points the
     user to the recipe command for RAM-fit recommendations."""

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -192,6 +192,18 @@ def test_modality_video_gen_shows_video_section(capsys):
     assert not any(ln.lstrip().startswith("qwen3-0.6b") for ln in out.splitlines())
 
 
+def test_modality_image_gen_shows_image_section(capsys):
+    """#2355: ``--modality image-gen`` shows the image section and hides
+    the text chat table + video section."""
+    out = _capture(capsys, modality="image-gen")
+    assert "Models [image-gen]" in out
+    assert "Image models" in out
+    # Video section must not be present (only the requested modality).
+    assert "Video models" not in out
+    # A text chat alias must not leak in.
+    assert not any(ln.lstrip().startswith("qwen3-0.6b") for ln in out.splitlines())
+
+
 def test_default_view_preserves_full_catalog_and_recipe_pointer(capsys):
     """#2355 regression: no filters keeps the full catalog AND points the
     user to the recipe command for RAM-fit recommendations."""

--- a/tests/test_models_command_layout.py
+++ b/tests/test_models_command_layout.py
@@ -177,6 +177,15 @@ def test_search_ignores_case(capsys):
     assert any(ln.lstrip().startswith("qwen3") for ln in out.splitlines())
 
 
+def test_search_title_shows_stripped_term(capsys):
+    """#2355 (codex r6 NIT): the title shows the stripped search term, not the
+    raw ``--search`` value — ``--search " qwen "`` matches ``qwen`` and the
+    title must claim ``'qwen'`` (not the literal ``' qwen '``)."""
+    out = _capture(capsys, search="  qwen3-0.6b  ")
+    assert "matching 'qwen3-0.6b'" in out
+    assert "matching '  qwen3-0.6b  '" not in out
+
+
 def test_modality_audio_shows_only_audio_section(capsys):
     """#2355: ``--modality audio`` blanks the text chat table and shows
     only the audio section — the terminal settles on the requested slice."""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6787,12 +6787,22 @@ def models_command(args):
     # modality request blanks it, and a search filters it, exactly like the
     # video/image sections above. Audio aliases live in their own registry
     # (``vllm_mlx/audio/aliases.json``), separate from the text profiles.
+    #
+    # Catch only the expectable "registry unavailable / malformed" failures
+    # (absent optional module or attribute, missing/unreadable aliases.json,
+    # malformed JSON). A genuine bug in ``list_audio_aliases`` itself (e.g. a
+    # TypeError) must surface loudly rather than silently render an empty
+    # audio catalog (codex r5 NIT). ``ImportError`` also covers the bare-module
+    # monkeypatch used by the broken-registry coverage test.
     try:
         from vllm_mlx.audio.registry import list_audio_aliases
-
-        _all_audio = list_audio_aliases()
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
         _all_audio = []
+    else:
+        try:
+            _all_audio = list_audio_aliases()
+        except (FileNotFoundError, OSError, ValueError):
+            _all_audio = []
     if modality and modality != "audio":
         audio_entries = []
     elif search_active:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6809,7 +6809,24 @@ def models_command(args):
             else len([e for e in audio_for_count if search_term in e.alias.casefold()])
         )
     else:
-        shown = len(profiles)
+        # Whole-catalog view (no modality filter) shows the text table AND
+        # any tagged sections (video / image / audio) that have entries.
+        # The title count must reflect every section actually shown — for a
+        # ``--search`` that matches only a tagged model, counting just the
+        # text table would print a misleading "(0 aliases)". (codex r3 BLOCKING)
+        shown = len(profiles) + len(video_profiles) + len(image_profiles)
+        try:
+            from vllm_mlx.audio.registry import list_audio_aliases
+
+            audio_for_count = list_audio_aliases()
+        except Exception:
+            audio_for_count = []
+        if not search_active:
+            shown += len(audio_for_count)
+        else:
+            shown += len(
+                [e for e in audio_for_count if search_term in e.alias.casefold()]
+            )
     print(f"  {title} ({shown} aliases)")
 
     # Alias width is computed from the actual registry so new long names
@@ -11997,8 +12014,9 @@ Examples:
         "--modality",
         choices=("text", "video-gen", "image-gen", "audio"),
         default=None,
-        help="Only list models of this modality (text chat models by "
-        "default; other aliases are split into their own tagged sections).",
+        help="Show only models of this modality (text, audio, video-gen, "
+        "image-gen). Omit the flag to show the full catalog: the text chat "
+        "table plus every tagged section.",
     )
     recipe_parser = subparsers.add_parser(
         "recipe", help="Recommend the smart and fast models for this Mac"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6815,17 +6815,18 @@ def models_command(args):
     elif modality == "audio":
         shown = len(audio_entries)
     else:
-        # Whole-catalog view (no modality filter) shows the text table AND
-        # any tagged sections (video / image / audio) that have entries.
-        # The title count must reflect every section actually shown — for a
-        # ``--search`` that matches only a tagged model, counting just the
-        # text table would print a misleading "(0 aliases)". (codex r3 BLOCKING)
-        shown = (
-            len(profiles)
-            + len(video_profiles)
-            + len(image_profiles)
-            + len(audio_entries)
-        )
+        shown = len(profiles)
+        if search_active:
+            # Whole-catalog ``--search`` shows the text table AND any tagged
+            # sections (video / image / audio) with matching entries. The
+            # title count must reflect every matching section — counting just
+            # the text table would print a misleading "(0 aliases)" for a
+            # search that matches only, say, a video model. (codex r3 BLOCKING)
+            # The default (no search) keeps the legacy contract: the top title
+            # counts the main text table and each tagged section carries its
+            # own ``(N aliases)`` sub-count.
+            shown = shown + len(video_profiles) + len(image_profiles)
+            shown += len(audio_entries)
     print(f"  {title} ({shown} aliases)")
 
     # Alias width is computed from the actual registry so new long names

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6738,6 +6738,10 @@ def models_command(args):
     # the full catalog + the existing recommendation pointer.
     search_term = (getattr(args, "search", None) or "").strip().casefold()
     search_active = bool(search_term)
+    # The title shows the stripped original (user-facing case preserved) so
+    # ``--search " qwen "`` doesn't claim it matched the literal ``' qwen '``
+    # while actually matching ``qwen`` (codex r6 NIT).
+    search_display = (getattr(args, "search", None) or "").strip()
     modality = getattr(args, "modality", None)
 
     def _matches_search(alias: str) -> bool:
@@ -6815,7 +6819,7 @@ def models_command(args):
     if modality:
         title = f"Models [{modality}]"
     if search_active:
-        title += f" matching '{args.search}'"
+        title += f" matching '{search_display}'"
     # The count reflects the section actually shown (a modality view empties
     # the text ``profiles`` but presents its own tagged section). (codex #3)
     if modality == "video-gen":

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -11958,8 +11958,8 @@ Examples:
         "--search",
         metavar="TERM",
         default=None,
-        help="Case-insensitive substring match against alias name and HF "
-        "repo. Narrows the 200+-line catalog to rows containing TERM "
+        help="Case-insensitive substring match against the alias name. "
+        "Narrows the 200+-line catalog to rows containing TERM "
         "(e.g. --search qwen picks only qwen aliases).",
     )
     models_parser.add_argument(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6728,8 +6728,58 @@ def models_command(args):
         for a, p in all_profiles.items()
         if a not in video_profiles and a not in image_profiles
     }
+
+    # #2355: narrow the 200+-line catalog so a new user isn't forced to
+    # grep it externally. ``--search`` is a case-insensitive substring match
+    # on the alias name; ``--modality`` restricts to a single tagged section
+    # (text chat, video-gen, image-gen, or audio). When a modality/scoped
+    # search is requested the OTHER sections are suppressed so the terminal
+    # settles on exactly the requested slice. The default (no flags) keeps
+    # the full catalog + the existing recommendation pointer.
+    search_term = (getattr(args, "search", None) or "").strip().casefold()
+    search_active = bool(search_term)
+    modality = getattr(args, "modality", None)
+
+    def _matches_search(alias: str) -> bool:
+        return not search_active or search_term in alias.casefold()
+
+    if modality and modality != "text":
+        # A non-text modality request: blank every OTHER section (text chat
+        # table + the tagged sections) and show only the requested one below
+        # (search applies within it).
+        profiles = {}
+        if modality == "video-gen":
+            video_profiles = {
+                a: p for a, p in video_profiles.items() if _matches_search(a)
+            }
+            image_profiles = {}
+        elif modality == "image-gen":
+            video_profiles = {}
+            image_profiles = {
+                a: p for a, p in image_profiles.items() if _matches_search(a)
+            }
+        elif modality == "audio":
+            video_profiles = {}
+            image_profiles = {}
+    else:
+        # text modality or no filter: apply search to the chat table and, if
+        # a search is active, to the tagged sections too (whole-catalog grep).
+        profiles = {a: p for a, p in profiles.items() if _matches_search(a)}
+        if search_active:
+            video_profiles = {
+                a: p for a, p in video_profiles.items() if _matches_search(a)
+            }
+            image_profiles = {
+                a: p for a, p in image_profiles.items() if _matches_search(a)
+            }
+
     print()
-    print(f"  Available models ({len(profiles)} aliases)")
+    title = "Available models"
+    if modality:
+        title = f"Models [{modality}]"
+    if search_active:
+        title += f" matching '{args.search}'"
+    print(f"  {title} ({len(profiles)} aliases)")
 
     # Alias width is computed from the actual registry so new long names
     # (e.g. ``deepseek-coder-v2-lite-16b-4bit``, 31 chars) don't push the
@@ -6847,6 +6897,13 @@ def models_command(args):
         # listing — silently degrade by skipping the audio section.
         audio_entries = []
 
+    # Search/modality gating for the audio section (mirrors the text/video/
+    # image sections above, #2355).
+    if modality and modality != "audio":
+        audio_entries = []
+    elif search_active:
+        audio_entries = [e for e in audio_entries if search_term in e.alias.casefold()]
+
     if audio_entries:
         audio_alias_width = max(
             24, max((len(e.alias) for e in audio_entries), default=0) + 2
@@ -6943,6 +7000,9 @@ def models_command(args):
         "  Size is an approximate download footprint (weight+tokenizer); "
         "“—” = unknown. The exact size is confirmed at pull time."
     )
+    print("  Narrow: `rapid-mlx models --search <term>` (alias match)")
+    print("          `rapid-mlx models --modality text|audio|video-gen|image-gen`")
+    print("  Pick a model: run `rapid-mlx recipe` for RAM-fit recommendations")
     print("  Tip: `rapid-mlx info <alias>` for the full per-model profile")
     print("       `rapid-mlx pull <alias>` to download")
     print("       `rapid-mlx chat <alias>` for an interactive REPL")
@@ -11893,6 +11953,21 @@ Examples:
         help="Emit the model list as machine-readable JSON instead of the "
         "human table (stable keys; pairs with --cached). Prefer this over "
         "scraping the text columns.",
+    )
+    models_parser.add_argument(
+        "--search",
+        metavar="TERM",
+        default=None,
+        help="Case-insensitive substring match against alias name and HF "
+        "repo. Narrows the 200+-line catalog to rows containing TERM "
+        "(e.g. --search qwen picks only qwen aliases).",
+    )
+    models_parser.add_argument(
+        "--modality",
+        choices=("text", "video-gen", "image-gen", "audio"),
+        default=None,
+        help="Only list models of this modality (text chat models by "
+        "default; other aliases are split into their own tagged sections).",
     )
     recipe_parser = subparsers.add_parser(
         "recipe", help="Recommend the smart and fast models for this Mac"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6781,6 +6781,25 @@ def models_command(args):
                 a: p for a, p in image_profiles.items() if _matches_search(a)
             }
 
+    # Load + filter the audio registry ONCE so the title count and the
+    # rendered section (below) share the same snapshot (codex r4 NIT) — a
+    # broken/missing registry degrades to [] (never a crash), a non-audio
+    # modality request blanks it, and a search filters it, exactly like the
+    # video/image sections above. Audio aliases live in their own registry
+    # (``vllm_mlx/audio/aliases.json``), separate from the text profiles.
+    try:
+        from vllm_mlx.audio.registry import list_audio_aliases
+
+        _all_audio = list_audio_aliases()
+    except Exception:
+        _all_audio = []
+    if modality and modality != "audio":
+        audio_entries = []
+    elif search_active:
+        audio_entries = [e for e in _all_audio if search_term in e.alias.casefold()]
+    else:
+        audio_entries = _all_audio
+
     print()
     title = "Available models"
     if modality:
@@ -6794,39 +6813,19 @@ def models_command(args):
     elif modality == "image-gen":
         shown = len(image_profiles)
     elif modality == "audio":
-        # ``audio_entries`` is computed below (after the text/video/image
-        # sections); import the audio registry here with the same guarded
-        # fallback so an absent/broken registry yields 0, not a crash.
-        try:
-            from vllm_mlx.audio.registry import list_audio_aliases
-
-            audio_for_count = list_audio_aliases()
-        except Exception:
-            audio_for_count = []
-        shown = (
-            len(audio_for_count)
-            if not search_active
-            else len([e for e in audio_for_count if search_term in e.alias.casefold()])
-        )
+        shown = len(audio_entries)
     else:
         # Whole-catalog view (no modality filter) shows the text table AND
         # any tagged sections (video / image / audio) that have entries.
         # The title count must reflect every section actually shown — for a
         # ``--search`` that matches only a tagged model, counting just the
         # text table would print a misleading "(0 aliases)". (codex r3 BLOCKING)
-        shown = len(profiles) + len(video_profiles) + len(image_profiles)
-        try:
-            from vllm_mlx.audio.registry import list_audio_aliases
-
-            audio_for_count = list_audio_aliases()
-        except Exception:
-            audio_for_count = []
-        if not search_active:
-            shown += len(audio_for_count)
-        else:
-            shown += len(
-                [e for e in audio_for_count if search_term in e.alias.casefold()]
-            )
+        shown = (
+            len(profiles)
+            + len(video_profiles)
+            + len(image_profiles)
+            + len(audio_entries)
+        )
     print(f"  {title} ({shown} aliases)")
 
     # Alias width is computed from the actual registry so new long names
@@ -6935,22 +6934,9 @@ def models_command(args):
     # they had to read the docs site. Now the audio registry
     # (vllm_mlx/audio/aliases.json) feeds the same table so
     # ``rapid-mlx models`` is the canonical "what can I serve?" view
-    # across every lane.
-    try:
-        from vllm_mlx.audio.registry import list_audio_aliases
-
-        audio_entries = list_audio_aliases()
-    except Exception:
-        # A malformed audio registry must NOT break the text alias
-        # listing — silently degrade by skipping the audio section.
-        audio_entries = []
-
-    # Search/modality gating for the audio section (mirrors the text/video/
-    # image sections above, #2355).
-    if modality and modality != "audio":
-        audio_entries = []
-    elif search_active:
-        audio_entries = [e for e in audio_entries if search_term in e.alias.casefold()]
+    # across every lane. ``audio_entries`` is already loaded + gated up
+    # above (before the title count) so the count and this table agree on
+    # the same snapshot (codex r4 NIT); nothing to re-load here.
 
     if audio_entries:
         audio_alias_width = max(

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6681,6 +6681,25 @@ def models_command(args):
     from vllm_mlx.model_aliases import list_profiles
     from vllm_mlx.model_sizes import format_size
 
+    search_display = (getattr(args, "search", None) or "").strip()
+    search_term = search_display.casefold()
+    search_active = bool(search_term)
+    modality = getattr(args, "modality", None)
+
+    # The narrowing contract currently targets the human available-models
+    # catalog.  Do not silently accept the flags on the cached or stable JSON
+    # surfaces and then return an unfiltered payload: that looks successful to
+    # scripts while doing the opposite of what the caller requested.
+    if (search_active or modality) and (
+        getattr(args, "json", False) or getattr(args, "cached", False)
+    ):
+        print(
+            "rapid-mlx models: --search/--modality cannot be combined with "
+            "--json or --cached",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
     # JSON mode emits ONLY the payload on stdout — no staleness banner, no
     # table — so a caller can pipe it straight into a parser.
     if getattr(args, "json", False):
@@ -6736,13 +6755,9 @@ def models_command(args):
     # search is requested the OTHER sections are suppressed so the terminal
     # settles on exactly the requested slice. The default (no flags) keeps
     # the full catalog + the existing recommendation pointer.
-    search_term = (getattr(args, "search", None) or "").strip().casefold()
-    search_active = bool(search_term)
     # The title shows the stripped original (user-facing case preserved) so
     # ``--search " qwen "`` doesn't claim it matched the literal ``' qwen '``
     # while actually matching ``qwen`` (codex r6 NIT).
-    search_display = (getattr(args, "search", None) or "").strip()
-    modality = getattr(args, "modality", None)
 
     def _matches_search(alias: str) -> bool:
         return not search_active or search_term in alias.casefold()
@@ -12009,7 +12024,9 @@ Examples:
         default=None,
         help="Case-insensitive substring match against the alias name. "
         "Narrows the 200+-line catalog to rows containing TERM "
-        "(e.g. --search qwen picks only qwen aliases).",
+        "(e.g. --search qwen picks only qwen aliases). Applies to the "
+        "human available-models table; cannot be combined with --json or "
+        "--cached.",
     )
     models_parser.add_argument(
         "--modality",
@@ -12017,7 +12034,8 @@ Examples:
         default=None,
         help="Show only models of this modality (text, audio, video-gen, "
         "image-gen). Omit the flag to show the full catalog: the text chat "
-        "table plus every tagged section.",
+        "table plus every tagged section. Applies to the human "
+        "available-models table; cannot be combined with --json or --cached.",
     )
     recipe_parser = subparsers.add_parser(
         "recipe", help="Recommend the smart and fast models for this Mac"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6743,10 +6743,17 @@ def models_command(args):
     def _matches_search(alias: str) -> bool:
         return not search_active or search_term in alias.casefold()
 
-    if modality and modality != "text":
+    if modality == "text":
+        # ``--modality text``: show ONLY the text chat table — blank every
+        # tagged section (video / image / audio) so the view really is
+        # text-only, unlike the default full catalog. (codex review #1)
+        profiles = {a: p for a, p in profiles.items() if _matches_search(a)}
+        video_profiles = {}
+        image_profiles = {}
+    elif modality in ("video-gen", "image-gen", "audio"):
         # A non-text modality request: blank every OTHER section (text chat
-        # table + the tagged sections) and show only the requested one below
-        # (search applies within it).
+        # table + the other tagged sections) and show only the requested one
+        # below (search applies within it).
         profiles = {}
         if modality == "video-gen":
             video_profiles = {
@@ -6758,12 +6765,13 @@ def models_command(args):
             image_profiles = {
                 a: p for a, p in image_profiles.items() if _matches_search(a)
             }
-        elif modality == "audio":
+        else:  # audio
             video_profiles = {}
             image_profiles = {}
     else:
-        # text modality or no filter: apply search to the chat table and, if
-        # a search is active, to the tagged sections too (whole-catalog grep).
+        # No modality filter (full catalog): apply search to the chat table
+        # and, if a search is active, to the tagged sections too
+        # (whole-catalog grep).
         profiles = {a: p for a, p in profiles.items() if _matches_search(a)}
         if search_active:
             video_profiles = {
@@ -6779,7 +6787,30 @@ def models_command(args):
         title = f"Models [{modality}]"
     if search_active:
         title += f" matching '{args.search}'"
-    print(f"  {title} ({len(profiles)} aliases)")
+    # The count reflects the section actually shown (a modality view empties
+    # the text ``profiles`` but presents its own tagged section). (codex #3)
+    if modality == "video-gen":
+        shown = len(video_profiles)
+    elif modality == "image-gen":
+        shown = len(image_profiles)
+    elif modality == "audio":
+        # ``audio_entries`` is computed below (after the text/video/image
+        # sections); import the audio registry here with the same guarded
+        # fallback so an absent/broken registry yields 0, not a crash.
+        try:
+            from vllm_mlx.audio.registry import list_audio_aliases
+
+            audio_for_count = list_audio_aliases()
+        except Exception:
+            audio_for_count = []
+        shown = (
+            len(audio_for_count)
+            if not search_active
+            else len([e for e in audio_for_count if search_term in e.alias.casefold()])
+        )
+    else:
+        shown = len(profiles)
+    print(f"  {title} ({shown} aliases)")
 
     # Alias width is computed from the actual registry so new long names
     # (e.g. ``deepseek-coder-v2-lite-16b-4bit``, 31 chars) don't push the


### PR DESCRIPTION
## What
Issue #2355: `rapid-mlx models` prints 267 lines (178 text aliases + audio/video/image tables) with no way to narrow it. A new user cannot filter by name or modality without external shell tools.

## Changes
- **`--search TERM`**: case-insensitive substring match on the alias name, applied across the text chat table and (when active) the tagged audio/video-gen/image-gen sections. The section title shows the active term (`Available models matching 'qwen'`).
- **`--modality text|audio|video-gen|image-gen`**: restrict to ONE tagged section and blank the others, so the terminal settles on the requested slice.
- **Default view unchanged**, plus a new discoverability pointer: `Pick a model: run 'rapid-mlx recipe' for RAM-fit recommendations`, plus the new `--search` / `--modality` hint lines.

## Verified
- `models --search qwen` → 56 aliases (from 180 text).
- `models --modality audio|video-gen|image-gen` → each shows ONLY its section.
- `models` (no flags) → full catalog + recipe pointer (no regression).
- 20 focused layout/filter tests pass, including four invalid-combination negative controls; ruff clean; mypy remains at the repository baseline.

## Status
**READY for review — NOT enqueued** (parked per operator directive; user reviews/enqueues tomorrow morning).

Closes #2355.

## Harbor review hardening

`--search` and `--modality` now reject combinations with `--json` or `--cached` instead of silently returning an unfiltered alternate view. Four negative-control combinations lock the exit-2 contract until those stable payload surfaces receive an explicit filtering design.

## Design precedent

Model discovery uses normalized, case-insensitive search with explicit modality facets. Filters must either apply consistently to an output surface or fail clearly; accepted-but-ignored CLI options are not a valid compatibility contract.