### PR TITLE
fix(desktop/video): accept the live video capabilities contract (#2969)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -183,7 +183,7 @@ enum DevSnapshot {
                     workload: .init(
                         metric: "pixel_frames",
                         maximum: 38_141_952,
-                        dimensionRounding: "multiple_of_64"
+                        dimensionRounding: "ceil_to_64"
                     )
                 )
             )

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -92,12 +92,15 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         }
 
         struct InputReferenceLimit: Decodable, Sendable, Hashable {
-            let accepted: Bool
+            // The live server contract (issue #2969) expresses support by the
+            // PRESENCE of ``input_reference`` with a valid reference limit —
+            // the retired ``accepted`` boolean is no longer sent. It must not
+            // be decoded, or an otherwise-healthy 200 response is rejected.
             let maximumBytes: Int
             let formats: [String]
 
             enum CodingKeys: String, CodingKey {
-                case accepted, formats
+                case formats
                 case maximumBytes = "maximum_bytes"
             }
         }
@@ -137,7 +140,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
     let limits: Limits
 
     var acceptedReferenceMIMETypes: Set<String> {
-        guard let input = limits.inputReference, input.accepted else { return [] }
+        guard let input = limits.inputReference else { return [] }
         return Set(input.formats.compactMap { format in
             switch format.lowercased() {
             case "jpeg", "jpg", "image/jpeg": "image/jpeg"
@@ -212,7 +215,6 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
 
     var referenceMaximumBytes: Int {
         guard let inputReference = limits.inputReference,
-              inputReference.accepted,
               inputReference.maximumBytes > 0 else { return 0 }
         return min(inputReference.maximumBytes, VideoClient.maxReferenceBytes)
     }
@@ -238,9 +240,11 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         let fps = limits.fps
         let frames = limits.frames
         let workload = limits.workload
+        // Live contract (issue #2969): ``input_reference`` is present exactly
+        // when image-input is supported, so a present-but-malformed reference
+        // limit (zero/negative bytes or no recognizable format) fails closed.
         let validInput = limits.inputReference.map {
-            $0.maximumBytes >= 0
-                && (!$0.accepted || ($0.maximumBytes > 0 && !acceptedReferenceMIMETypes.isEmpty))
+            $0.maximumBytes > 0 && !acceptedReferenceMIMETypes.isEmpty
         } ?? true
         guard !model.isEmpty,
               !family.isEmpty,
@@ -259,7 +263,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               frames.offset <= frames.maximum,
               workload.metric == "pixel_frames",
               workload.maximum > 0,
-              workload.dimensionRounding == "multiple_of_64",
+              Self.alignment(options: workload.dimensionRounding) != nil,
               validInput else {
             throw VideoClientError.invalidResponse
         }
@@ -272,9 +276,12 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               seconds > 0,
               limits.fps.default > 0 else { return false }
         // Workload normalization is a separate server contract from the
-        // request-size alignment. This client validates only multiple_of_64.
-        guard let width = Self.roundUp(dimensions.width, to: 64),
-              let height = Self.roundUp(dimensions.height, to: 64) else { return false }
+        // request-size alignment. Derive the alignment from the advertised
+        // dimension_rounding (ceil_to_32 / ceil_to_64 / none) instead of a
+        // hard-coded multiple-of-64 (issue #2969).
+        guard let alignment = Self.alignment(options: limits.workload.dimensionRounding),
+              let width = Self.roundUp(dimensions.width, to: alignment),
+              let height = Self.roundUp(dimensions.height, to: alignment) else { return false }
         let frameStep = max(1, limits.frames.step)
         let frameOffset = limits.frames.offset
         guard frameOffset >= 0 else { return false }
@@ -307,6 +314,20 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
 
     private static func contains(_ value: Int, minimum: Int, maximum: Int) -> Bool {
         minimum <= maximum && value >= minimum && value <= maximum
+    }
+
+    /// The pixel-alignment divisor implied by a server ``dimension_rounding``
+    /// token (issue #2969). The live server emits ``ceil_to_32`` (ltx-2.5),
+    /// ``ceil_to_64`` (Wan and the default lanes), and ``none`` (cogvideox-fun).
+    /// Any other token is unrecognized and fails closed by returning ``nil``,
+    /// preserving the previous reject-on-unknown behavior.
+    private static func alignment(options: String) -> Int? {
+        switch options {
+        case "ceil_to_64": 64
+        case "ceil_to_32": 32
+        case "none": 1
+        default: nil
+        }
     }
 
     private static func product(_ lhs: Int, _ rhs: Int) -> Int? {

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -59,7 +59,7 @@ struct VideoClientTests {
     func unsupportedRoundingFailsClosed() async {
         let client = makeClient()
         let json = Self.capabilitiesJSON.replacingOccurrences(
-            of: #""dimension_rounding":"multiple_of_64""#,
+            of: #""dimension_rounding":"ceil_to_64""#,
             with: #""dimension_rounding":"floor""#
         )
         VideoStubProtocol.response = (200, Data(json.utf8))
@@ -82,7 +82,25 @@ struct VideoClientTests {
         #expect(value.durationPresets(for: "592x592") == [1, 2])
     }
 
-    @Test("Image input follows advertised formats and acceptance")
+    @Test("Workload alignment follows the advertised ceil_to_32 / none tokens")
+    func workloadAlignmentFollowsServerToken() throws {
+        func withRounding(_ token: String) throws -> VideoCapabilities {
+            let json = Self.capabilitiesJSON.replacingOccurrences(
+                of: #""dimension_rounding":"ceil_to_64""#,
+                with: #""dimension_rounding":"\#(token)""#
+            )
+            return try JSONDecoder().decode(VideoCapabilities.self, from: Data(json.utf8))
+        }
+
+        // ceil_to_32 (ltx-2.5 lane) validates and rounds to 32.
+        let c32 = try withRounding("ceil_to_32")
+        #expect(c32.durationPresets(for: "592x592").count > 0)
+        // none (cogvideox-fun lane) validates with alignment 1.
+        let none = try withRounding("none")
+        #expect(none.durationPresets(for: "1280x720").count > 0)
+    }
+
+    @Test("Image input follows advertised formats; presence of input_reference enables it")
     func imageInputUsesCapabilityContract() throws {
         let jpegOnly = Self.capabilitiesJSON.replacingOccurrences(
             of: #"["jpeg","png","webp"]"#,
@@ -92,12 +110,38 @@ struct VideoClientTests {
         #expect(value.supportsImageInput)
         #expect(value.acceptedReferenceMIMETypes == ["image/jpeg"])
 
-        let rejected = jpegOnly.replacingOccurrences(of: #""accepted":true"#, with: #""accepted":false"#)
-        let rejectedValue = try JSONDecoder().decode(
-            VideoCapabilities.self, from: Data(rejected.utf8)
+        // Live contract (issue #2969): the PRESENCE of input_reference (with a
+        // valid limit), not a retired ``accepted`` boolean, expresses support.
+        // A MISSING input_reference must disable image input entirely.
+        let absent = #"""
+        {
+          "object":"video.capabilities","model":"ltx","modality":"video-gen","family":"ltx-2.3",
+          "modes":["text-to-video","image-to-video"],
+          "limits":{
+            "size":{"type":"range","width":{"minimum":256,"maximum":1920,"multiple_of":64},"height":{"minimum":256,"maximum":1920,"multiple_of":64},"also_supported":["1280x720","720x1280"]},
+            "seconds":{"minimum":1,"maximum":20,"default":4},
+            "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
+            "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
+            "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"ceil_to_64"}
+          },
+          "controls":{}
+        }
+        """#
+        let absentValue = try JSONDecoder().decode(
+            VideoCapabilities.self, from: Data(absent.utf8)
         )
-        #expect(!rejectedValue.supportsImageInput)
-        #expect(rejectedValue.acceptedReferenceMIMETypes.isEmpty)
+        #expect(!absentValue.supportsImageInput)
+        #expect(absentValue.acceptedReferenceMIMETypes.isEmpty)
+        #expect(absentValue.referenceMaximumBytes == 0)
+
+        // A present-but-malformed input_reference (zero bytes) fails closed in
+        // validated(): it advertises support but carries no usable limit.
+        let zeroBytes = jpegOnly.replacingOccurrences(
+            of: #""maximum_bytes":20971520"#, with: #""maximum_bytes":0"#
+        )
+        #expect(throws: VideoClientError.invalidResponse) {
+            _ = try JSONDecoder().decode(VideoCapabilities.self, from: Data(zeroBytes.utf8)).validated()
+        }
     }
 
     @Test("Reference MIME type is detected from bytes, not the filename")
@@ -323,8 +367,8 @@ struct VideoClientTests {
         "seconds":{"minimum":1,"maximum":20,"default":4},
         "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
         "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
-        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"},
-        "input_reference":{"accepted":true,"maximum_bytes":20971520,"formats":["jpeg","png","webp"]}
+        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"ceil_to_64"},
+        "input_reference":{"maximum_bytes":20971520,"maximum_pixels":1811939328,"formats":["jpeg","png","webp"]}
       },
       "controls":{}
     }

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -416,8 +416,8 @@ private actor VideoFakeClient: VideoClientProtocol {
         "seconds":{"minimum":1,"maximum":20,"default":4},
         "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
         "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
-        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"},
-        "input_reference":{"accepted":true,"maximum_bytes":20971520,"formats":["jpeg","png","webp"]}
+        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"ceil_to_64"},
+        "input_reference":{"maximum_bytes":20971520,"maximum_pixels":1811939328,"formats":["jpeg","png","webp"]}
       }
     }
     """#


### PR DESCRIPTION
Fixes **#2969** — the Desktop Video workspace rejected the server's healthy `/v1/videos/capabilities` 200 response ("The video server returned an invalid response"), keeping Generate disabled.

## Root cause
The Desktop decoder was frozen on two **retired** contract shapes while the live server (`vllm_mlx/routes/video.py` `capabilities`) had moved on:
- Decoder required `input_reference.accepted` (boolean); the server now expresses image support by the **presence** of `input_reference` with a valid `maximum_bytes`/`formats`. Decoding the retired key fails on the healthy payload.
- Decoder accepted only `dimension_rounding == "multiple_of_64"`; server now emits `ceil_to_32` (ltx-2.5), `ceil_to_64` (Wan + default), `none` (cogvideox-fun).

## Fix
- **Drop the retired `accepted` field** so the live payload decodes.
- **Gate image input on presence** of `input_reference` with `maximum_bytes > 0`.
- **`alignment()`** maps `dimension_rounding` tokens to their divisor in both `validated()` and `workloadAllows`; unrecognized tokens still fail closed.
- **Present-but-malformed** `input_reference` (zero/negative bytes, no recognizable format) fails closed in `validated()`.
- Update `DevSnapshot` fixture + `VideoClient`/`VideoGenViewModel` tests to the live contract; add `ceil_to_32`/`none` alignment coverage.

## Verification
- `swift build --target Rapid` clean.
- `VideoClient` (18 tests) + `VideoGenViewModel` (9 tests) + all video suites (38 tests) pass against the live contract.
- Full desktop suite's only failures are pre-existing timing/env flakes in untouched suites (Mermaid, SSEDeltaCoalescer, Resident-load, posix-spawn env) — none touch video capabilities.

**READY for review — NOT enqueued** (night ROI batch; user enqueues).