### PR TITLE
fix(cli): tier `serve --help` for first-time users

### DIFF
--- a/docs/engineering/decisions/2026-09-03-serve-help-tiers.md
+++ b/docs/engineering/decisions/2026-09-03-serve-help-tiers.md
@@ -1,0 +1,104 @@
+# `serve --help` is a first-run surface, not a flag dump
+
+Date: 2026-09-03
+Status: accepted
+Owner: Vector (CLI), with Harbor for the docs surface
+Issue: #2354
+
+## Context
+
+`rapid-mlx serve` accepts ~110 options. Rendering all of them produced a
+526-line `--help` (540 by 0.13.4) in which the flags a first-time user needs —
+model, host, port, authentication, logging, and how to connect — were
+interleaved with experimental scheduler and cache controls.
+
+The text also leaked maintainer context at users: internal module paths
+(`vllm_mlx.disk_stream_patch`, `vllm_mlx.registry`,
+`vllm_mlx.expert_cache.ExpertCache`), project phase labels (`R15-P1`,
+`R15 Phase 4`, `D-METAL-CAP`), an internal process reference (`SOP §10`),
+internal class names (`AliasProfile`, `HarmonyStreamingRouter`), and
+issue/PR back-references (`PR #649`, `#1853`, `#287`).
+
+## Decision
+
+`serve` help is tiered:
+
+- `rapid-mlx serve --help` renders the core tier only, in named sections
+  (`model`, `server`, `authentication and access`, `generation`,
+  `performance and memory`), plus an epilog carrying examples and the
+  connection contract (base URL, `/v1/models`, `/health`, bearer auth).
+- `rapid-mlx serve --help-all` renders every option, adding the
+  `advanced: *` sections (model loading, caching, KV cache, batching,
+  speculative decoding, long-prompt compression, vision, sampling defaults,
+  profile overrides, embeddings, deployment).
+- Help strings describe behavior and risk in Rapid-MLX terms. Implementation
+  history stays in code comments, `docs/reference/cli.md`, and git.
+
+The flag surface is unchanged. Every option still parses from any command
+line; only rendering is tiered.
+
+## Implementation
+
+`vllm_mlx/cli.py`:
+
+- `_SERVE_CORE_GROUPS` / `_SERVE_ADVANCED_GROUPS` are the single, reviewable
+  table of which tier a flag belongs to.
+- `_organize_serve_help()` runs after the last `serve` `add_argument` and
+  re-homes each action into its group, tagging advanced ones with
+  `action.rapid_mlx_advanced`.
+- `_ServeHelpFormatter` filters tagged actions at RENDER time — from both the
+  usage block and the option list. `_ServeHelpAllAction` swaps in
+  `_ServeFullHelpFormatter` and prints everything.
+
+### Why render-time filtering instead of `argparse.SUPPRESS`
+
+Rewriting `action.help` to `SUPPRESS` would hide advanced flags from
+`--help-all` too, and would break tests that introspect `action.help`
+(for example `tests/test_recurrent_prefill_auto_default.py`). Filtering in the
+formatter keeps one parser, one set of help strings, and two views.
+
+### Why a post-registration move instead of `group.add_argument`
+
+Threading a group object through ~110 `add_argument` call sites would spread
+the tier decision across ~1100 lines and make review of "what is hidden?"
+impossible. The table keeps that decision in one place. Only the help renderer
+reads `_group_actions`; parsing walks `parser._actions`, which is untouched.
+
+### Fail-open for new flags
+
+A flag missing from both tables stays in the default `options` section and
+remains visible. A new flag is never silently invisible; the line budget in
+`tests/test_serve_help_tiers.py` is what forces the tier decision.
+
+## Consequences
+
+- `serve --help` is 182 lines (was 540). `--help-all` is 590.
+- `rapid-mlx help serve` renders the same core tier.
+- Tests that scraped `serve --help` for advanced flags now read `--help-all`,
+  and additionally assert deprecated aliases are absent from *both* surfaces:
+  `test_speculative_config.py`, `test_dflash_integration.py`,
+  `test_ddtree_integration.py`, `test_mtp_spec_decode.py`,
+  `test_mtp_cli_wiring.py`, `test_cli_deprecated_noop_flags.py`,
+  `test_serve_listen_fd.py`.
+- `tests/test_serve_help_tiers.py` pins the budget, the core journey, the
+  connection contract, tier completeness, and the absence of internal tokens
+  on both surfaces.
+
+## Alternatives considered
+
+- **A separate `rapid-mlx serve --advanced-help` subcommand.** More surface to
+  document and complete; `--help-all` is the convention users already know
+  from other CLIs.
+- **Leaving help alone and only fixing the docs.** The docs were already
+  correct (`docs/reference/cli.md` groups every flag). The regression was the
+  terminal, which is where a first-time user actually looks.
+- **Deleting advanced flags from the CLI.** Out of scope and user-hostile:
+  operators depend on them.
+
+## Reproduce
+
+```bash
+rapid-mlx serve --help      | wc -l   # 182
+rapid-mlx serve --help-all  | wc -l   # 590
+python -m pytest tests/test_serve_help_tiers.py
+```

--- a/docs/engineering/decisions/README.md
+++ b/docs/engineering/decisions/README.md
@@ -10,3 +10,4 @@ alternatives considered, consequences, owner, and date.
 | 2026-08-22 | [Model management and performance decision SSOT](2026-08-22-model-management-performance-ssot.md) | Accepted direction; incremental rollout |
 | 2026-08-31 | [Community benchmark wire contract v1](2026-08-31-community-benchmark-wire-contract.md) | Accepted contract |
 | 2026-08-31 | [Community Benchmark local workspace](2026-08-31-community-benchmark-local-workspace.md) | Internal beta |
+| 2026-09-03 | [`serve --help` is a first-run surface](2026-09-03-serve-help-tiers.md) | Accepted |

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -24,9 +24,10 @@ rapid-mlx serve qwen3.5-9b-4bit --port 8000 --use-paged-cache
 
 ## Server Options
 
-The most consequential `rapid-mlx serve` flags. The exhaustive list — every
-flag visible in `rapid-mlx serve --help`, grouped by category — lives in the
-[CLI reference](../reference/cli.md#rapid-mlx-serve).
+The most consequential `rapid-mlx serve` flags. `rapid-mlx serve --help` shows
+the core startup options; `rapid-mlx serve --help-all` adds the advanced and
+experimental groups. The exhaustive list, grouped by category with defaults,
+lives in the [CLI reference](../reference/cli.md#rapid-mlx-serve).
 
 | Option | Description | Default |
 |--------|-------------|---------|

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -25,7 +25,13 @@
 | `rapid-mlx version` | Show version number |
 | `rapid-mlx help <cmd>` | Show help for a subcommand |
 
-Run `rapid-mlx <cmd> --help` for the full flag list of any subcommand.
+Run `rapid-mlx <cmd> --help` for the flag list of any subcommand. `serve`
+carries far more options than the rest, so its help is tiered: `--help` shows
+the common startup path (model, host, port, authentication, logging, and how to
+connect), and `rapid-mlx serve --help-all` adds the advanced and experimental
+groups (caching, KV-cache quantization, speculative decoding, prefill
+compression, profile overrides, deployment). Both surfaces list the same flags
+this page documents.
 
 `rapid-mlx models --cached --json` is the stable machine-readable cache
 inventory used by the Desktop app. Each row includes `repo`, `alias`,
@@ -62,8 +68,13 @@ rapid-mlx serve <model> [options]
 
 ### Options
 
-Every flag visible in `rapid-mlx serve --help`, grouped by category. Defaults
-are the argparse defaults from `vllm_mlx/cli.py`.
+Every flag accepted by `rapid-mlx serve`, grouped by category. Defaults are the
+argparse defaults from `vllm_mlx/cli.py`.
+
+The terminal help is tiered (issue #2354): `rapid-mlx serve --help` shows the
+core startup options only, and `rapid-mlx serve --help-all` prints every option
+below. Nothing is removed from the CLI — the tiering only affects what `--help`
+renders by default.
 
 #### Network and process
 

--- a/tests/test_cli_deprecated_noop_flags.py
+++ b/tests/test_cli_deprecated_noop_flags.py
@@ -157,15 +157,20 @@ def test_deprecated_flag_is_behaviorally_inert(flag, extra_argv, attr):
     "flag",
     [f[0] for f in _DEPRECATED_NOOP_FLAGS],
 )
-def test_deprecated_flag_hidden_from_help(flag):
+@pytest.mark.parametrize("surface", ["--help", "--help-all"])
+def test_deprecated_flag_hidden_from_help(flag, surface):
     """Deprecated no-op flags use ``argparse.SUPPRESS`` — they must not appear
-    in ``serve --help`` so we don't advertise dead knobs to new users."""
+    in ``serve --help`` so we don't advertise dead knobs to new users.
+
+    ``--help-all`` (issue #2354) is checked too: it reveals the advanced
+    tier, so a suppressed flag that regained a help string would surface
+    there first."""
     buf = io.StringIO()
     with (
-        patch.object(sys, "argv", ["rapid-mlx", "serve", "--help"]),
+        patch.object(sys, "argv", ["rapid-mlx", "serve", surface]),
         pytest.raises(SystemExit) as exc,
         redirect_stdout(buf),
     ):
         cli.main()
     assert exc.value.code == 0
-    assert flag not in buf.getvalue(), f"{flag} leaked into --help output"
+    assert flag not in buf.getvalue(), f"{flag} leaked into {surface} output"

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -17,8 +17,11 @@ def test_serve_parser_exposes_ddtree_speculative_config() -> None:
     import subprocess
     import sys
 
+    # ``--speculative-config`` is an advanced flag: issue #2354 moved it off
+    # the default help onto ``--help-all``. The deprecated ``--enable-ddtree``
+    # alias must stay hidden on BOTH surfaces.
     out = subprocess.run(
-        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help-all"],
         capture_output=True,
         text=True,
         timeout=30,
@@ -26,6 +29,15 @@ def test_serve_parser_exposes_ddtree_speculative_config() -> None:
     assert out.returncode == 0, out.stderr
     assert "--speculative-config" in out.stdout
     assert "--enable-ddtree" not in out.stdout
+
+    default_help = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert default_help.returncode == 0, default_help.stderr
+    assert "--enable-ddtree" not in default_help.stdout
 
 
 def _ddtree_cli_args(**overrides):

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -102,8 +102,11 @@ def test_serve_parser_exposes_speculative_config() -> None:
     import subprocess
     import sys
 
+    # ``--speculative-config`` is advanced: issue #2354 moved it off the
+    # default help onto ``--help-all``. The deprecated aliases must stay
+    # hidden on BOTH surfaces.
     out = subprocess.run(
-        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help-all"],
         capture_output=True,
         text=True,
         timeout=30,
@@ -117,6 +120,16 @@ def test_serve_parser_exposes_speculative_config() -> None:
     assert "[dflash]" in out.stdout, (
         "help text should reference the rapid-mlx[dflash] extras"
     )
+
+    default_help = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert default_help.returncode == 0, default_help.stderr
+    assert "--enable-dflash" not in default_help.stdout
+    assert "--spec-decode" not in default_help.stdout
 
 
 def _dflash_cli_args(**overrides):

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -178,8 +178,8 @@ def test_detect_sidecar_default_argument_matches_pre_0913_behaviour():
 # ---------------------------------------------------------------------------
 
 
-def _serve_help_stdout() -> str:
-    """Run ``python -m vllm_mlx.cli serve --help`` and return stdout.
+def _serve_help_stdout(flag: str = "--help") -> str:
+    """Run ``python -m vllm_mlx.cli serve <flag>`` and return stdout.
 
     Mirrors ``tests/test_dflash_spec_decode.py::_serve_help_stdout`` —
     same pattern lets us pin the flag without importing the giant CLI
@@ -189,7 +189,7 @@ def _serve_help_stdout() -> str:
     import sys
 
     proc = subprocess.run(
-        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", flag],
         capture_output=True,
         text=True,
         timeout=60,
@@ -199,11 +199,17 @@ def _serve_help_stdout() -> str:
 
 
 def test_cli_serve_help_hides_legacy_mtp_sidecar_flag():
-    """MTP sidecars are configured through ``--speculative-config`` only."""
-    text = _serve_help_stdout()
-    assert "--mtp-sidecar" not in text
-    assert "--mtp-max-k" not in text
-    assert "--mtp-disable-auto-k" not in text
+    """MTP sidecars are configured through ``--speculative-config`` only.
+
+    Both help surfaces are checked: ``--help-all`` (issue #2354) prints the
+    advanced tier, so a deprecated flag regaining a help string would show
+    up there even while the default help stays clean.
+    """
+    for surface in ("--help", "--help-all"):
+        text = _serve_help_stdout(surface)
+        assert "--mtp-sidecar" not in text
+        assert "--mtp-max-k" not in text
+        assert "--mtp-disable-auto-k" not in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -591,18 +591,19 @@ def test_cache_patch_is_idempotent():
 # ---------------------------------------------------------------------------
 
 
-def _serve_help_stdout() -> str:
-    """Run ``python -m vllm_mlx.cli serve --help`` and return stdout.
+def _serve_help_stdout(flag: str = "--help-all") -> str:
+    """Run ``python -m vllm_mlx.cli serve <flag>`` and return stdout.
 
     Mirrors :mod:`tests.test_kv_cache_dtype_cli` — the serve parser is
     inlined into ``main()``, so subprocess inspection is the canonical
-    way to assert that the flag landed.
+    way to assert that the flag landed. Defaults to ``--help-all``:
+    issue #2354 tiered the help, and speculative decoding is advanced.
     """
     import subprocess
     import sys
 
     proc = subprocess.run(
-        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", flag],
         capture_output=True,
         text=True,
         timeout=60,
@@ -644,24 +645,14 @@ def test_cli_spec_decode_flag_is_hidden_but_recognized():
 
 
 def test_cli_spec_decode_mtp_legacy_choice_absent_from_help():
-    """Deprecated ``--spec-decode mtp`` is absent, not merely hidden."""
-    import subprocess
-    import sys
+    """Deprecated ``--spec-decode mtp`` is absent, not merely hidden.
 
-    proc = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "vllm_mlx.cli",
-            "serve",
-            "--help",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert proc.returncode == 0, proc.stderr
-    assert "--spec-decode" not in proc.stdout
+    Checked on both help surfaces: ``--help-all`` (issue #2354) reveals the
+    advanced tier, so a deprecated flag leaking back would show up there
+    first.
+    """
+    for surface in ("--help", "--help-all"):
+        assert "--spec-decode" not in _serve_help_stdout(surface)
 
 
 def test_scheduler_config_default_spec_decode_is_none():

--- a/tests/test_serve_help_tiers.py
+++ b/tests/test_serve_help_tiers.py
@@ -96,6 +96,18 @@ def test_default_help_documents_the_connection_contract(default_help):
     assert "RAPID_MLX_API_KEY" in default_help
 
 
+def test_default_help_examples_do_not_advertise_unauthenticated_lan_binding(
+    default_help,
+):
+    examples = default_help.split("Examples:", 1)[1].split("Connecting:", 1)[0]
+    unsafe = [
+        line
+        for line in examples.splitlines()
+        if "--host 0.0.0.0" in line and "--api-key" not in line
+    ]
+    assert not unsafe, f"unauthenticated wildcard-bind example: {unsafe}"
+
+
 def test_default_help_points_at_the_advanced_surface(default_help):
     assert "--help-all" in default_help
     assert "docs/reference/cli.md" in default_help
@@ -225,6 +237,26 @@ def test_tiering_does_not_change_parsing():
     assert args.listen_fd == 7
     assert args.disk_stream is True
     assert args.pflash == "always"
+
+
+def test_help_all_does_not_change_later_help_rendering(capsys):
+    """A reusable parser must return to the default help tier after --help-all."""
+    pytest.importorskip("websockets")
+    from vllm_mlx.cli import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit) as full_exit:
+        parser.parse_args(["serve", "--help-all"])
+    full_help = capsys.readouterr().out
+
+    with pytest.raises(SystemExit) as default_exit:
+        parser.parse_args(["serve", "--help"])
+    default_help = capsys.readouterr().out
+
+    assert full_exit.value.code == 0
+    assert default_exit.value.code == 0
+    assert "--listen-fd" in full_help
+    assert "--listen-fd" not in default_help
 
 
 def test_every_tiered_flag_exists_on_the_serve_parser():

--- a/tests/test_serve_help_tiers.py
+++ b/tests/test_serve_help_tiers.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``serve --help`` stays a first-run surface (issue #2354).
+
+``rapid-mlx serve --help`` had grown to 526 lines: the flags a new user
+needs (model, host, port, auth, logging, how to connect) were mixed with
+experimental scheduler controls, internal module paths, project phase
+labels, and issue/PR numbers.
+
+These tests pin the contract that fixed it:
+
+* the DEFAULT help stays small and covers the common serve journey;
+* advanced/experimental flags are reachable through ``--help-all``;
+* neither surface leaks internal implementation history at the user.
+
+The flag surface itself is untouched — every option still parses. Only
+rendering is tiered, so ``--help-all`` remains the exhaustive reference.
+
+Help text is captured by subprocess (the convention in
+``tests/test_kv_cache_dtype_cli.py``): importing ``vllm_mlx.cli`` in
+process drags in the heavy model stack on some lanes.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+import pytest
+
+# Budget for the default help. The pre-fix surface was 526 lines; the
+# point of the tier split is that a new flag can no longer quietly
+# regrow it. Raising this number is a product decision, not a rubber
+# stamp: prefer tagging the new flag advanced in ``_SERVE_ADVANCED_GROUPS``.
+MAX_DEFAULT_HELP_LINES = 220
+
+
+def _serve_help(*flags: str) -> str:
+    proc = subprocess.run(
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", *flags],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+@pytest.fixture(scope="module")
+def default_help() -> str:
+    return _serve_help("--help")
+
+
+@pytest.fixture(scope="module")
+def full_help() -> str:
+    return _serve_help("--help-all")
+
+
+# ---------------------------------------------------------------------------
+# 1. The default surface stays small and answers the first-run questions
+# ---------------------------------------------------------------------------
+
+
+def test_default_help_fits_the_first_run_budget(default_help):
+    lines = default_help.splitlines()
+    assert len(lines) <= MAX_DEFAULT_HELP_LINES, (
+        f"serve --help grew to {len(lines)} lines (budget "
+        f"{MAX_DEFAULT_HELP_LINES}). Tag the new flag advanced in "
+        f"vllm_mlx/cli.py::_SERVE_ADVANCED_GROUPS instead of raising this."
+    )
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--host",
+        "--port",
+        "--api-key",
+        "--log-level",
+        "--served-model-name",
+        "--max-tokens",
+        "--timeout",
+    ],
+)
+def test_default_help_keeps_the_core_serve_journey(default_help, flag):
+    """The flags a first-time user needs must not be behind --help-all."""
+    assert flag in default_help
+
+
+def test_default_help_documents_the_connection_contract(default_help):
+    """A reader must learn where to point an OpenAI client and how to auth."""
+    assert "/v1" in default_help
+    assert "/v1/models" in default_help
+    assert "/health" in default_help
+    assert "Bearer" in default_help
+    assert "RAPID_MLX_API_KEY" in default_help
+
+
+def test_default_help_points_at_the_advanced_surface(default_help):
+    assert "--help-all" in default_help
+    assert "docs/reference/cli.md" in default_help
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--kv-cache-turboquant",
+        "--speculative-config",
+        "--pflash-stride-blocks",
+        "--metal-cap-kv-bytes-per-token",
+        "--prefix-cache-index",
+        "--force-openai-harmony-streaming",
+        "--listen-fd",
+        "--disk-stream",
+    ],
+)
+def test_default_help_defers_advanced_controls(default_help, flag):
+    assert flag not in default_help
+
+
+# ---------------------------------------------------------------------------
+# 2. --help-all stays the exhaustive reference
+# ---------------------------------------------------------------------------
+
+
+def test_help_all_lists_every_documented_serve_option(full_help):
+    """No option may be lost between the tiers.
+
+    ``--help-all`` must render every ``serve`` flag that carries a help
+    string; deliberately suppressed (deprecated) aliases stay hidden and
+    are pinned by ``tests/test_cli_deprecated_noop_flags.py``.
+    """
+    pytest.importorskip("websockets")  # build_parser registers `share`
+    import argparse
+
+    from vllm_mlx.cli import build_parser
+
+    serve_parser = next(
+        action.choices["serve"]
+        for action in build_parser()._actions
+        if getattr(action, "choices", None) and "serve" in action.choices
+    )
+    documented = {
+        opt
+        for action in serve_parser._actions
+        if action.help is not argparse.SUPPRESS
+        for opt in action.option_strings
+    }
+    missing = sorted(opt for opt in documented if opt not in full_help)
+    assert not missing, f"options missing from --help-all: {missing}"
+
+
+def test_help_all_is_a_superset_of_default_help(default_help, full_help):
+    assert len(full_help.splitlines()) > len(default_help.splitlines())
+    for flag in ("--host", "--port", "--api-key", "--max-tokens"):
+        assert flag in full_help
+
+
+def test_advanced_groups_are_rendered_as_named_sections(full_help):
+    """Advanced flags are grouped, not dumped into one wall of options."""
+    for title in (
+        "advanced: KV cache",
+        "advanced: speculative decoding",
+        "advanced: deployment",
+    ):
+        assert f"{title}:" in full_help
+
+
+# ---------------------------------------------------------------------------
+# 3. Help text speaks Rapid-MLX, not internal implementation history
+# ---------------------------------------------------------------------------
+
+# Substrings that mean "this sentence was written for a maintainer".
+_INTERNAL_TOKENS = (
+    "vllm_mlx.",  # internal module paths
+    "D-METAL-CAP",  # internal design-doc label
+    "SOP §",  # internal process reference
+    "AliasProfile",  # internal class name
+    "HarmonyStreamingRouter",  # internal class name
+    "ExpertCache",  # internal class name
+    "PortSweep",  # internal test-plan label
+)
+
+# Project phase labels (``R15-P1``, ``R15 Phase 4``) and issue/PR
+# back-references (``#1853``, ``PR #649``) belong in the docs and the
+# git history, not in a user's terminal.
+_INTERNAL_PATTERNS = (
+    re.compile(r"\bR\d+[- ](?:P\d+|Phase\b|#\d+)"),
+    re.compile(r"#\d{3,}"),
+)
+
+
+@pytest.mark.parametrize("surface", ["--help", "--help-all"])
+def test_help_text_carries_no_internal_implementation_detail(surface):
+    text = _serve_help(surface)
+    leaked = [token for token in _INTERNAL_TOKENS if token in text]
+    assert not leaked, f"serve {surface} leaks internal detail: {leaked}"
+
+    for pattern in _INTERNAL_PATTERNS:
+        found = pattern.findall(text)
+        assert not found, f"serve {surface} leaks internal references: {found}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Tiering is a rendering concern — parsing must be untouched
+# ---------------------------------------------------------------------------
+
+
+def test_tiering_does_not_change_parsing():
+    """Advanced flags still parse from the default (untiered) command line."""
+    pytest.importorskip("websockets")
+    from vllm_mlx.cli import build_parser
+
+    args = build_parser().parse_args(
+        [
+            "serve",
+            "some/model",
+            "--listen-fd",
+            "7",
+            "--disk-stream",
+            "--pflash",
+            "always",
+        ]
+    )
+    assert args.listen_fd == 7
+    assert args.disk_stream is True
+    assert args.pflash == "always"
+
+
+def test_every_tiered_flag_exists_on_the_serve_parser():
+    """The tier tables must not accumulate stale flag names."""
+    pytest.importorskip("websockets")
+    from vllm_mlx.cli import (
+        _SERVE_ADVANCED_GROUPS,
+        _SERVE_CORE_GROUPS,
+        build_parser,
+    )
+
+    serve_parser = next(
+        action.choices["serve"]
+        for action in build_parser()._actions
+        if getattr(action, "choices", None) and "serve" in action.choices
+    )
+    known = {opt for action in serve_parser._actions for opt in action.option_strings}
+
+    tiered = [flag for _, _, flags in _SERVE_CORE_GROUPS for flag in flags]
+    tiered += [flag for _, flags in _SERVE_ADVANCED_GROUPS for flag in flags]
+
+    unknown = sorted(flag for flag in tiered if flag not in known)
+    assert not unknown, f"tier table references non-existent flags: {unknown}"
+    assert len(tiered) == len(set(tiered)), "a flag is listed in two tiers"

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -796,11 +796,14 @@ def test_serve_command_resets_stale_bind_fields_between_invocations(
 
 
 def test_serve_listen_fd_help_documents_host_port_ignored(capsys):
-    """``rapid-mlx serve --help`` must mention that ``--host``/``--port``
+    """``rapid-mlx serve --help-all`` must mention that ``--host``/``--port``
     are ignored when ``--listen-fd`` is set. Operators reading the help
-    text need to know the precedence without diving into source."""
+    text need to know the precedence without diving into source.
+
+    Socket activation is a deployment-tier flag, so issue #2354 moved it
+    off the default help onto the ``--help-all`` surface."""
     with (
-        patch.object(sys, "argv", ["rapid-mlx", "serve", "--help"]),
+        patch.object(sys, "argv", ["rapid-mlx", "serve", "--help-all"]),
         pytest.raises(SystemExit) as exc,
     ):
         cli.main()

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -210,8 +210,11 @@ def test_spec_decoder_registry_lists_existing_backends() -> None:
 
 
 def test_serve_help_exposes_speculative_config() -> None:
+    """Speculative decoding is an advanced knob, so it lives on the
+    ``--help-all`` surface (issue #2354 moved it out of the default
+    ``serve --help``). It must stay discoverable there."""
     proc = subprocess.run(
-        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help"],
+        [sys.executable, "-m", "vllm_mlx.cli", "serve", "--help-all"],
         capture_output=True,
         text=True,
         timeout=30,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -10620,8 +10620,12 @@ class _ServeHelpAllAction(argparse.Action):
         )
 
     def __call__(self, parser, namespace, values, option_string=None):
-        parser.formatter_class = _ServeFullHelpFormatter
-        parser.print_help()
+        formatter_class = parser.formatter_class
+        try:
+            parser.formatter_class = _ServeFullHelpFormatter
+            parser.print_help()
+        finally:
+            parser.formatter_class = formatter_class
         parser.exit()
 
 
@@ -10727,7 +10731,7 @@ Examples:
 Examples:
   rapid-mlx serve qwen3.5-4b-4bit
   rapid-mlx serve qwen3.5-9b-4bit --port 8000 --api-key sk-local
-  rapid-mlx serve mlx-community/Qwen3.5-9B-4bit --host 0.0.0.0
+  rapid-mlx serve mlx-community/Qwen3.5-9B-4bit
 
 Connecting:
   Base URL   http://<host>:<port>/v1     (point any OpenAI client here)
@@ -11010,7 +11014,7 @@ are hidden here:
         help=(
             "Prefix-cache lookup index: 'radix' (default) uses a token trie "
             "for O(prefix_len) lookups and reports dedup-bytes-saved on "
-            "/metrics; 'hash' falls back to the legacy linear-scan path."
+            "/metrics; 'hash' falls back to bisect over sorted keys."
         ),
     )
     # KV cache quantization options

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2003,8 +2003,8 @@ def _add_pflash_args(parser) -> None:
         choices=["off", "auto", "always"],
         default=None,
         help="Enable PFlash long-prompt prefill compression "
-        "(off, auto, always). Default: 'always' for verified aliases "
-        "(Qwen3.5 / Qwen3.6 family per #287), 'off' for everything else.",
+        "(off, auto, always). Default: 'always' for bench-verified models "
+        "(Qwen3.5 / Qwen3.6 family), 'off' for everything else.",
     )
     parser.add_argument(
         "--pflash-threshold",
@@ -2017,10 +2017,10 @@ def _add_pflash_args(parser) -> None:
         type=float,
         default=None,
         help="Fraction of prompt tokens to keep when compressing. Unset lets "
-        "the engine resolve it: a per-alias ``pflash_keep_ratio`` override if "
-        "the alias pins one (e.g. 0.50 for a ternary arch), else the default "
-        "0.20 (the bench-validated profile in PR #649: TTFT 3.87x-8.5x, needle "
-        "recall 5/5). An explicit value here always wins.",
+        "the engine resolve it: the model profile's own ratio if it pins one "
+        "(e.g. 0.50 for a ternary architecture), else the bench-validated "
+        "default of 0.20 (TTFT 3.87x-8.5x, needle recall 5/5). An explicit "
+        "value here always wins.",
     )
     parser.add_argument(
         "--pflash-min-keep-tokens",
@@ -10369,6 +10369,311 @@ def _resolve_cli_version() -> str:
         return "dev"
 
 
+# ---------------------------------------------------------------------------
+# ``serve`` help tiering (issue #2354)
+#
+# ``serve`` carries ~110 flags. Rendering all of them in ``--help`` buried the
+# handful a first-time user actually needs (model, host, port, auth, logging)
+# under experimental scheduler and cache knobs. The flag surface itself is
+# unchanged — every option still parses exactly as before — but the DEFAULT
+# help renders only the core tier; ``--help-all`` renders everything.
+#
+# Grouping is data-driven (below) rather than sprinkled across the ~1100 lines
+# of ``add_argument`` calls, so the tier of a flag is reviewable in one place.
+# ---------------------------------------------------------------------------
+
+# (title, description, flags). Rendered by plain ``serve --help``.
+_SERVE_CORE_GROUPS: tuple[tuple[str, str | None, tuple[str, ...]], ...] = (
+    (
+        "model",
+        "Which model to load and how it is named over the API.",
+        (
+            "--served-model-name",
+            "--embedding-model",
+            "--enable-audio",
+        ),
+    ),
+    (
+        "server",
+        "Where the OpenAI-compatible endpoint listens.",
+        (
+            "--host",
+            "--port",
+            "--log-level",
+            "--timeout",
+        ),
+    ),
+    (
+        "authentication and access",
+        "Who may reach the server. Review these before leaving loopback.",
+        (
+            "--api-key",
+            "--cors-origins",
+            "--trusted-hosts",
+            "--rate-limit",
+            "--max-request-bytes",
+        ),
+    ),
+    (
+        "generation",
+        "Request-time behavior shared by every client.",
+        (
+            "--max-tokens",
+            "--reasoning-parser",
+            "--no-thinking",
+            "--enable-auto-tool-choice",
+            "--tool-call-parser",
+            "--mcp-config",
+        ),
+    ),
+    (
+        "performance and memory",
+        "The knobs worth reaching for first on a memory-tight Mac.",
+        (
+            "--max-num-seqs",
+            "--max-concurrent-requests",
+            "--kv-cache-dtype",
+            "--reasoning",
+            "--enable-prefix-cache",
+            "--disable-prefix-cache",
+            "--gpu-memory-utilization",
+        ),
+    ),
+)
+
+# (title, flags). Hidden from plain ``--help``; rendered by ``--help-all``.
+_SERVE_ADVANCED_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "advanced: model loading",
+        (
+            "--force-disk-check",
+            "--mllm",
+            "--no-mllm",
+            "--resident-memory-limit-gb",
+            "--resident-model-idle-ttl",
+            "--disk-stream",
+            "--disk-stream-cache-gb",
+        ),
+    ),
+    (
+        "advanced: prompt and response caching",
+        (
+            "--prefix-cache-size",
+            "--prefix-cache-index",
+            "--cache-memory-mb",
+            "--cache-memory-percent",
+            "--no-memory-aware-cache",
+            "--idle-cache-clear-seconds",
+            "--hybrid-cache-entries",
+            "--response-cache-entries",
+            "--pin-system-prompt",
+        ),
+    ),
+    (
+        "advanced: KV cache",
+        (
+            "--kv-cache-quantization",
+            "--kv-cache-quantization-bits",
+            "--kv-cache-quantization-group-size",
+            "--kv-cache-min-quantize-tokens",
+            "--kv-cache-turboquant",
+            "--kv-cache-turboquant-bits",
+            "--kv-cache-turboquant-group-size",
+            "--kv-disk-checkpoint-interval",
+            "--metal-cap-kv-bytes-per-token",
+            "--use-paged-cache",
+            "--paged-cache-block-size",
+            "--max-cache-blocks",
+        ),
+    ),
+    (
+        "advanced: batching and streaming",
+        (
+            "--prefill-batch-size",
+            "--completion-batch-size",
+            "--prefill-step-size",
+            "--stream-interval",
+            "--gc-control",
+            "--no-gc-control",
+        ),
+    ),
+    (
+        "advanced: speculative decoding",
+        ("--speculative-config",),
+    ),
+    (
+        "advanced: long-prompt compression",
+        (
+            "--pflash",
+            "--pflash-threshold",
+            "--pflash-keep-ratio",
+            "--pflash-min-keep-tokens",
+            "--pflash-sink-tokens",
+            "--pflash-tail-tokens",
+            "--pflash-block-size",
+            "--pflash-query-window",
+            "--pflash-stride-blocks",
+            "--pflash-include-tools",
+        ),
+    ),
+    (
+        "advanced: vision",
+        (
+            "--vision-prefill-token-budget",
+            "--vision-min-pixels",
+            "--vision-max-pixels",
+        ),
+    ),
+    (
+        "advanced: sampling defaults",
+        (
+            "--default-temperature",
+            "--default-top-p",
+            "--default-top-k",
+            "--default-min-p",
+            "--default-repetition-penalty",
+            "--default-presence-penalty",
+            "--default-frequency-penalty",
+        ),
+    ),
+    (
+        "advanced: model profile overrides",
+        (
+            "--no-tool-call-parser",
+            "--no-reasoning-parser",
+            "--enable-tool-logits-bias",
+            "--force-hybrid",
+            "--no-hybrid",
+            "--force-spec-decode",
+            "--no-spec-decode",
+            "--force-openai-harmony-streaming",
+            "--no-openai-harmony-streaming",
+            "--relocate-mid-conversation-system",
+        ),
+    ),
+    (
+        "advanced: embeddings",
+        (
+            "--embedding-max-length",
+            "--embedding-overflow-policy",
+        ),
+    ),
+    (
+        "advanced: deployment",
+        (
+            "--listen-fd",
+            "--watchdog-ppid",
+            "--video-output-dir",
+        ),
+    ),
+)
+
+
+class _ServeFullHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    """``serve`` help with every option, epilog kept verbatim."""
+
+
+class _ServeHelpFormatter(_ServeFullHelpFormatter):
+    """Default ``serve --help``: skips options tagged advanced.
+
+    Filtering happens at RENDER time (not by rewriting ``action.help`` to
+    ``argparse.SUPPRESS``), so the advanced help strings stay readable to
+    ``--help-all``, ``rapid-mlx help serve``, and tests that introspect
+    ``action.help`` directly.
+    """
+
+    @staticmethod
+    def _is_advanced(action) -> bool:
+        return bool(getattr(action, "rapid_mlx_advanced", False))
+
+    def add_usage(self, usage, actions, groups, prefix=None):
+        visible = [a for a in actions if not self._is_advanced(a)]
+        # Drop any mutually-exclusive group that lost a member: argparse
+        # renders those inline against the action list it was handed.
+        groups = [
+            g for g in groups if not any(self._is_advanced(a) for a in g._group_actions)
+        ]
+        super().add_usage(usage, visible, groups, prefix)
+
+    def add_argument(self, action):
+        if self._is_advanced(action):
+            return
+        super().add_argument(action)
+
+
+class _ServeHelpAllAction(argparse.Action):
+    """``--help-all``: print the complete option list, then exit 0."""
+
+    def __init__(
+        self,
+        option_strings,
+        dest=argparse.SUPPRESS,
+        default=argparse.SUPPRESS,
+        help=None,
+    ):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.formatter_class = _ServeFullHelpFormatter
+        parser.print_help()
+        parser.exit()
+
+
+def _move_action_to_group(parser, action, group) -> None:
+    """Re-home an already-registered *action* under *group*.
+
+    Only the help renderer reads ``_group_actions``; parsing walks
+    ``parser._actions``, which is untouched. Moving after registration (as
+    opposed to threading a group object through ~110 ``add_argument`` calls)
+    keeps the tier table as the single reviewable source of truth.
+    """
+    for existing in parser._action_groups:
+        if existing is not group and action in existing._group_actions:
+            existing._group_actions.remove(action)
+    if action not in group._group_actions:
+        group._group_actions.append(action)
+    action.container = group
+
+
+def _organize_serve_help(parser: argparse.ArgumentParser) -> None:
+    """Sort the ``serve`` options into core / advanced help sections.
+
+    Flags absent from both tables stay in the default ``options`` section and
+    remain visible: a newly added flag is never silently invisible. The
+    default-help size budget in ``tests/test_serve_help_tiers.py`` is what
+    forces the follow-up decision about where it belongs.
+    """
+    by_option = {
+        opt: action for action in parser._actions for opt in action.option_strings
+    }
+    claimed: set[int] = set()
+
+    def _assign(title, description, flags, advanced):
+        group = parser.add_argument_group(title, description)
+        for flag in flags:
+            action = by_option.get(flag)
+            if action is None or id(action) in claimed:
+                continue
+            if action.help is argparse.SUPPRESS:
+                # Hidden/deprecated aliases stay hidden on every surface.
+                continue
+            claimed.add(id(action))
+            _move_action_to_group(parser, action, group)
+            if advanced:
+                action.rapid_mlx_advanced = True
+
+    for title, description, flags in _SERVE_CORE_GROUPS:
+        _assign(title, description, flags, advanced=False)
+    for title, flags in _SERVE_ADVANCED_GROUPS:
+        _assign(title, None, flags, advanced=True)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Construct the full CLI parser (extracted from ``main`` so tests
     can assert effective flag defaults on the parsed namespace instead
@@ -10416,6 +10721,33 @@ Examples:
         "serve",
         help="Start OpenAI-compatible server",
         allow_abbrev=False,
+        description="Serve a local model over an OpenAI-compatible HTTP API.",
+        formatter_class=_ServeHelpFormatter,
+        epilog="""\
+Examples:
+  rapid-mlx serve qwen3.5-4b-4bit
+  rapid-mlx serve qwen3.5-9b-4bit --port 8000 --api-key sk-local
+  rapid-mlx serve mlx-community/Qwen3.5-9B-4bit --host 0.0.0.0
+
+Connecting:
+  Base URL   http://<host>:<port>/v1     (point any OpenAI client here)
+  Models     GET  /v1/models
+  Health     GET  /health
+  Auth       Authorization: Bearer <--api-key or $RAPID_MLX_API_KEY>
+
+This is the common path. Advanced and experimental options (KV-cache
+quantization, speculative decoding, prefill compression, profile overrides)
+are hidden here:
+
+  rapid-mlx serve --help-all      every option, grouped
+  docs/reference/cli.md           full reference with defaults
+  docs/guides/server.md           deployment and tuning guide
+""",
+    )
+    serve_parser.add_argument(
+        "--help-all",
+        action=_ServeHelpAllAction,
+        help="Show every option, including advanced and experimental ones",
     )
     serve_parser.add_argument(
         "model", nargs="?", type=str, help="Model to serve"
@@ -10450,11 +10782,11 @@ Examples:
         action="store_true",
         default=False,
         help=(
-            "Stream MoE routed-expert weights from disk instead of holding "
-            "them resident (opt-in). Loads the model lazily and installs "
-            "vllm_mlx.disk_stream_patch on every MoE layer before serving "
-            "starts. Only architectures registered in vllm_mlx.registry "
-            "are supported; an unregistered model_type fails at load time."
+            "Experimental. Stream mixture-of-experts weights from disk "
+            "instead of keeping them in memory, so a model larger than this "
+            "Mac's RAM can still be served — at a latency cost. Supported "
+            "only on known MoE architectures; anything else fails at load "
+            "time with an explicit error."
         ),
     )
     serve_parser.add_argument(
@@ -10462,9 +10794,9 @@ Examples:
         type=positive_finite_float,
         default=1.0,
         help=(
-            "Byte budget (GB) for the disk-stream expert LRU cache. Only "
-            "used when --disk-stream is set. Default: 1.0 GB, matching "
-            "vllm_mlx.expert_cache.ExpertCache's default."
+            "Memory budget (GB) for the disk-stream expert cache. Only "
+            "used when --disk-stream is set. Default: 1.0 GB. Raise it to "
+            "trade RAM for fewer disk reads."
         ),
     )
     serve_parser.add_argument(
@@ -10473,16 +10805,11 @@ Examples:
         default="127.0.0.1",
         help=(
             "Host to bind (default: 127.0.0.1, loopback-only). Pass "
-            '0.0.0.0 (or "") to expose the server on every '
-            "interface (LAN reachable) — only do this once the "
-            "bearer-auth posture has been reviewed. The wildcard "
-            "bind also widens the PortSweep collision window: macOS "
-            "lets a wildcard listener coexist with a more-specific "
-            "(127.0.0.1) listener on the same port, so a second "
-            "server may start and silently shadow the first on the "
-            "loopback path. The pre-flight bind check below probes "
-            "127.0.0.1 explicitly whenever --host is a wildcard "
-            "alias to keep that bypass closed."
+            '0.0.0.0 (or "") to expose the server on every interface, '
+            "reachable from the LAN — set --api-key first. Startup "
+            "refuses to bind a port another rapid-mlx server already "
+            "holds, including the loopback address behind a wildcard "
+            "bind."
         ),
     )
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
@@ -10548,7 +10875,7 @@ Examples:
             "requests start decoding sooner instead of all sharing one "
             "full-wave prefill — at an aggregate-throughput cost on large MoE "
             "models, where staggered rows carry ragged offsets that push "
-            "batched attention onto a slower path (see #1861)."
+            "batched attention onto a slower path."
         ),
     )
     serve_parser.add_argument(
@@ -10637,7 +10964,7 @@ Examples:
         default=0,
         metavar="BYTES",
         help=(
-            "Override the per-token KV-cache size the D-METAL-CAP admission "
+            "Override the per-token KV-cache size the memory admission "
             "gate projects, in bytes. 0 (default) auto-derives an "
             "architecture-aware fp16 figure. Set this when running a "
             "quantized KV cache (--kv-cache-turboquant / "
@@ -10681,10 +11008,9 @@ Examples:
         default="radix",
         choices=("radix", "hash"),
         help=(
-            "Prefix-cache lookup index: 'radix' (default, R15-P1) uses a "
-            "token trie for O(prefix_len) lookups and surfaces dedup-bytes-"
-            "saved on /metrics; 'hash' falls back to the legacy bisect-over-"
-            "sorted-keys path."
+            "Prefix-cache lookup index: 'radix' (default) uses a token trie "
+            "for O(prefix_len) lookups and reports dedup-bytes-saved on "
+            "/metrics; 'hash' falls back to the legacy linear-scan path."
         ),
     )
     # KV cache quantization options
@@ -10708,10 +11034,10 @@ Examples:
         default="bf16",
         choices=["bf16", "int8", "int4"],
         help=(
-            "KV cache dtype (R15 #300, default: bf16). int8/int4 shrink the "
+            "KV cache dtype (default: bf16). int8/int4 shrink the "
             "KV cache 2x/4x for memory-constrained hosts, but the live-cache "
             "dequant-on-read costs O(context) per decode step — measured "
-            "-27%% (int4) / -36%% (int8) at 16k context (#1853). "
+            "-27%% (int4) / -36%% (int8) at 16k context. "
             "An explicit int8/int4 on a sliding-window (Gemma 3/4, "
             "GPT-OSS) or MLA (DeepSeek V3+, Kimi K2.5) model is rejected "
             "before the server reports ready; only auto/profile-selected "
@@ -10778,7 +11104,7 @@ Examples:
         choices=["v4", "k8v4", "none"],
         help="Enable TurboQuant KV-cache compression. ``v4`` (default when "
         "the flag is bare) is V-only 3-4 bit Lloyd-Max with K in FP16; "
-        "``k8v4`` is the R15 Phase 4 mix — K at 8-bit Walsh-Hadamard + V at "
+        "``k8v4`` mixes K at 8-bit Walsh-Hadamard with V at "
         "4-bit Lloyd-Max (~4.6x KV compression on dense models); ``none`` "
         "is the explicit off-switch — overrides the alias-driven "
         "``turboquant_tier=k8v4_verified`` default so the operator can A/B "
@@ -10815,11 +11141,11 @@ Examples:
         default=0,
         help=(
             "Token interval at which the scheduler snapshots KV state to "
-            "~/.cache/rapid-mlx/kv_checkpoints/ (R15 #296). 0 (default) "
-            "disables. Write-only today: no engine path reloads the "
+            "~/.cache/rapid-mlx/kv_checkpoints/. 0 (default) "
+            "disables. Write-only today: nothing reloads the "
             "snapshots yet, and each one blocks decode for O(context) — "
-            "enable only for external tooling that consumes the files "
-            "(#1853). Pairs with the RAPID_MLX_KV_CHECKPOINT_MAX_BYTES "
+            "enable only for external tooling that consumes the files. "
+            "Pairs with the RAPID_MLX_KV_CHECKPOINT_MAX_BYTES "
             "env var (default 20 GiB) for the oldest-first disk-cap "
             "eviction policy."
         ),
@@ -10841,8 +11167,8 @@ Examples:
         dest="speculative_config",
         default=None,
         help=(
-            "vLLM-style speculative decoding JSON config. This frontend "
-            "parses method/model/num_speculative_tokens now. DFlash "
+            "Speculative decoding config, as vLLM-style JSON with "
+            "method/model/num_speculative_tokens. DFlash "
             "requires the rapid-mlx[dflash] extra and is available with "
             '\'{"method":"dflash"}\', DDTree with '
             '\'{"method":"ddtree"}\', and MTP with '
@@ -11236,8 +11562,8 @@ Examples:
             "granite/granite3, nemotron/nemotron3, xlam, functionary/meetkai, "
             "glm47/glm4, minimax/minimax_m2, harmony/gpt-oss/gpt_oss, "
             "gemma4/gemma_4, seed_oss/seed. "
-            "Run `python -c 'from vllm_mlx.tool_parsers import ToolParserManager;"
-            "print(sorted(ToolParserManager.tool_parsers))'` for the live list. "
+            "An unknown name is rejected at startup with the full list of "
+            "accepted values; see docs/guides/tool-calling.md. "
             "Required for --enable-auto-tool-choice."
         ),
     )
@@ -11259,9 +11585,9 @@ Examples:
         default=None,
         choices=reasoning_choices,
         help=(
-            "Enable reasoning content extraction with specified parser. "
-            "Extracts <think>...</think> tags into reasoning_content field. "
-            f"Options: {', '.join(reasoning_choices)}."
+            "Extract chain-of-thought into the reasoning_content field "
+            "(<think>...</think> tags) using the named parser. Auto-detected "
+            "from the model when omitted."
         ),
     )
     serve_parser.add_argument(
@@ -11290,9 +11616,9 @@ Examples:
         action="store_true",
         default=False,
         help=(
-            "Force-disable tool-call parser auto-detection from the alias "
-            "profile. Escape hatch (SOP §10) when AliasProfile's auto-"
-            "selected parser misfires for a specific deployment. Mutually "
+            "Force-disable tool-call parser auto-detection from the model "
+            "profile. Escape hatch for when the auto-selected parser "
+            "misfires for a specific deployment. Mutually "
             "exclusive with --tool-call-parser."
         ),
     )
@@ -11320,7 +11646,7 @@ Examples:
         default=False,
         help=(
             "Force-treat the model as a hybrid (linear-attention / Mamba) "
-            "architecture even when AliasProfile says otherwise. Disables "
+            "architecture even when the model profile says otherwise. Disables "
             "spec/suffix decode paths that are unsound on hybrids. "
             "Mutually exclusive with --no-hybrid."
         ),
@@ -11332,7 +11658,7 @@ Examples:
         default=False,
         help=(
             "Force-treat the model as non-hybrid (full attention) even when "
-            "AliasProfile says it's hybrid. Use when the profile mis-labels "
+            "the model profile says it's hybrid. Use when the profile mis-labels "
             "your model and you want spec/suffix decode enabled. "
             "Mutually exclusive with --force-hybrid."
         ),
@@ -11344,7 +11670,7 @@ Examples:
         default=False,
         help=(
             "Force-enable speculative-decode eligibility even when "
-            "AliasProfile says the model doesn't support it. Risky on "
+            "the model profile says it doesn't support it. Risky on "
             "hybrid models — use only when you've verified the profile "
             "is wrong. Mutually exclusive with --no-spec-decode."
         ),
@@ -11356,7 +11682,7 @@ Examples:
         default=False,
         help=(
             "Force-disable speculative-decode eligibility (suffix / MTP / "
-            "DFlash / DDTree) even when AliasProfile says the model supports it. "
+            "DFlash / DDTree) even when the model profile says it is supported. "
             "Mutually exclusive with --force-spec-decode."
         ),
     )
@@ -11372,9 +11698,9 @@ Examples:
         action="store_true",
         default=False,
         help=(
-            "Force-on: construct HarmonyStreamingRouter even when the "
-            "compat gate would reject. Use to debug a regression in the "
-            "gate itself; production should leave this off. Mutually "
+            "Force-on: use the OpenAI Harmony streaming parser even when "
+            "the compatibility check would reject this tokenizer. For "
+            "debugging that check; leave off in production. Mutually "
             "exclusive with --no-openai-harmony-streaming."
         ),
     )
@@ -11384,10 +11710,9 @@ Examples:
         action="store_true",
         default=False,
         help=(
-            "Force-off: skip the HarmonyStreamingRouter upgrade and use "
-            "the legacy custom harmony state machine even on matched-vocab "
-            "gpt-oss tokenizers. Escape hatch for a hypothetical false "
-            "positive in the compat gate. Mutually exclusive with "
+            "Force-off: keep the legacy harmony streaming path even on "
+            "gpt-oss tokenizers the compatibility check accepts. Escape "
+            "hatch for a false positive in that check. Mutually exclusive with "
             "--force-openai-harmony-streaming."
         ),
     )
@@ -11427,14 +11752,14 @@ Examples:
     serve_parser.add_argument(
         "--mllm",
         action="store_true",
-        help="Force load model as multimodal (vision) even if name doesn't match auto-detection patterns. Also DISABLES the automatic text-only fallback: normally a vision-config checkpoint that ships no usable vision tower auto-degrades to text-only serving (#1187); with --mllm it hard-fails instead so a deliberate demand for the vision lane is never silently downgraded.",
+        help="Force load model as multimodal (vision) even if name doesn't match auto-detection patterns. Also DISABLES the automatic text-only fallback: normally a vision-config checkpoint that ships no usable vision tower auto-degrades to text-only serving; with --mllm it hard-fails instead so a deliberate demand for the vision lane is never silently downgraded.",
     )
     serve_parser.add_argument(
         "--no-mllm",
         "--text-only",
         dest="no_mllm",
         action="store_true",
-        help="Force load model as text-only LLM even when auto-detection would route it to the multimodal/VLM path. Escape hatch for incomplete vision-tower checkpoints (#393) and text-only forks of multimodal architectures whose config.json still declares vision_config.",
+        help="Force load model as text-only LLM even when auto-detection would route it to the multimodal/VLM path. Escape hatch for incomplete vision-tower checkpoints and text-only forks of multimodal architectures whose config.json still declares vision_config.",
     )
     # Generation defaults
     serve_parser.add_argument(
@@ -11544,6 +11869,10 @@ Examples:
     # PFlash long-prompt prefill compression (#287). Off by default; see
     # vllm_mlx/pflash.py for the design and the prefix-cache bypass.
     _add_pflash_args(serve_parser)
+    # Split the (very large) serve flag surface into core / advanced help
+    # sections. Must run after the LAST serve add_argument call. Parsing is
+    # unaffected; only ``--help`` rendering changes (issue #2354).
+    _organize_serve_help(serve_parser)
     # Bench command
     bench_parser = subparsers.add_parser("bench", help="Run benchmark")
     bench_parser.add_argument(


### PR DESCRIPTION
## Why

  Fixes #2354.

  `rapid-mlx serve --help` had grown to 540 lines. Common startup options were mixed with experimental scheduler controls, internal module names, project labels, and issue/PR references, making the command difficult for first-time users to navigate.

  ## Scope

  - Make `rapid-mlx serve --help` show a focused 182-line core surface.
  - Add `rapid-mlx serve --help-all` as the exhaustive 590-line reference.
  - Group options by model, server, authentication, generation, performance, caching, deployment, and other advanced areas.
  - Add examples and the OpenAI-compatible connection contract.
  - Rewrite implementation-oriented help text in user-facing terms.
  - Keep deprecated compatibility flags hidden on both help surfaces.
  - Preserve parser behavior and all existing serve options.
  - Document the help-tier decision and update the CLI/server guides.
  - Avoid unauthenticated wildcard-bind examples and restore parser formatter state after `--help-all`.

  ## Non-goals

  - Removing or renaming existing CLI options.
  - Changing serve defaults or runtime behavior.
  - Redesigning help output for commands other than `serve`.

  ## Acceptance

  - `rapid-mlx serve --help` includes model, host, port, authentication, logging, and connection details.
  - Advanced and experimental options are omitted from default help.
  - `rapid-mlx serve --help-all` lists every non-suppressed serve option in named groups.
  - Both help surfaces exclude internal implementation history.
  - Advanced options continue to parse normally.
  - Reusing a parser after `--help-all` still produces the core default help.
  - Examples do not advertise unauthenticated LAN binding.

  ## Verification

  - `258 passed, 136 skipped` across the affected CLI and integration test files.
  - `tests/test_serve_help_tiers.py`: 27 passed.
  - Help generation verified on Python 3.10, 3.11, 3.12, and 3.13.
  - Default/full output verified at 182/590 lines.
  - `ruff check` passed.
  - `ruff format --check` passed.
  - `git diff --check` passed.
  - Skipped tests require MLX or MLX-VLM and were unavailable in the no-MLX test environment.

  ## Behaviour delta

  Before: `rapid-mlx serve --help` printed the complete 540-line option surface.

  After: `rapid-mlx serve --help` prints the 182-line common path, while `rapid-mlx serve --help-all` prints the complete 590-line grouped reference. Parsing and runtime defaults are unchanged.

  ## AI assistance disclosure

  Codex assisted with the CLI implementation, tests, documentation, branch review, and review-finding fixes. The output was verified with targeted regression tests, affected integration tests, cross-version CLI execution, lint, formatting, and diff checks.

  > By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated /  boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

  ## Checklist

  - [ ] Tests pass locally (`python3 -m pytest tests/ -x`)
  - [x] Lint passes (`ruff check && ruff format --check`)
  - [ ] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>`
  - [ ] If new tests touch a critical code path, I've spot-checked that they fail when the corresponding production line is broken
  - [x] Updated README/docs if applicable
  - [x] No breaking changes to existing API
