### PR TITLE
fix(serve): calm default startup logs; keep Ready/Connect the stable endpoint (#2356)

### DIFF
--- a/tests/test_serve_calm_startup_logs.py
+++ b/tests/test_serve_calm_startup_logs.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#2356 — a normal ``rapid-mlx serve`` must not bury the Ready/Connect block.
+
+A first ``serve <model> --port N`` interleaved the user-facing startup card
+with low-level INFO trace (per-cache auto-load counts, radix rebuild) and
+printed the KV-cache dtype decision twice, so the terminal never settled on a
+clear final next step. These tests pin the CALM startup-shape contract:
+
+  * The deferred post-ready prefix-cache auto-load and the radix rebuild
+    (which run on a background task scheduled AFTER the Ready banner) must log
+    at DEBUG, not INFO — otherwise they scroll the Ready/Connect block off the
+    terminal after it prints.
+  * The KV-cache dtype resolution must be surfaced exactly once
+    (``log_kv_cache_decision`` emits a single line, not a log line *and* a
+    duplicate ``print``).
+
+These are unit-level: they stub the engine/config/disk surfaces and assert on
+the captured log records, so no model weights need to boot.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import threading
+from contextlib import redirect_stdout
+
+
+def _stub_config_and_cache_dir(monkeypatch, *, entries: int = 1):
+    """Wire the module's ``get_config``/``get_cache_dir`` to stub surfaces so
+    ``load_prefix_cache_from_disk`` runs without touching the real cache dir.
+
+    Mirrors the stubbing already used by
+    ``tests/test_deferred_prefix_cache_load.py`` so the two files agree on the
+    injection seams. ``entries`` is the value ``load_cache_from_disk`` returns
+    (0 selects the "No ... found on disk" branch).
+    """
+    from vllm_mlx.runtime import cache as cache_mod
+
+    class _StubEngine:
+        def load_cache_from_disk(self, _path, *, protected_import):
+            return entries
+
+    class _Config:
+        engine = _StubEngine()
+
+    monkeypatch.setattr(cache_mod, "get_config", lambda: _Config())
+    monkeypatch.setattr(cache_mod, "get_cache_dir", lambda: "/tmp/calm-cache")
+    return cache_mod
+
+
+def _info_records(caplog) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+
+
+def test_post_ready_prefix_cache_load_lines_are_debug_not_info(monkeypatch, caplog):
+    """The background prefix-cache auto-load must NOT emit at INFO.
+
+    #2356: ``server._deferred_load_prefix_cache`` schedules this load AFTER
+    ``_cfg.ready = True`` and after the Ready banner prints. At INFO, the
+    ``[lifespan] Loading ...`` / ``Loaded N`` / ``No ... found`` lines landed
+    after the connect card and pushed it off the terminal. They are warm-start
+    detail, so they move to DEBUG.
+    """
+    from vllm_mlx.runtime import cache as cache_mod
+
+    cache_mod = _stub_config_and_cache_dir(monkeypatch)
+
+    with caplog.at_level(logging.INFO):
+        cache_mod.load_prefix_cache_from_disk()
+
+    # Default INFO output must be free of the post-ready per-boot chatter.
+    assert not any(
+        "prefix cache" in m or "prefix cache entries" in m
+        for m in _info_records(caplog)
+    ), (
+        "post-ready prefix-cache lines must be silent at INFO (#2356) but were "
+        f"logged:\n{caplog.text}"
+    )
+
+    # The detail is reachable at DEBUG (captured separately).
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        cache_mod.load_prefix_cache_from_disk()
+    assert "Loading prefix cache from /tmp/calm-cache" in caplog.text
+    assert "Loaded 1 prefix cache entries" in caplog.text
+
+
+def test_post_ready_prefix_cache_no_entries_branch_is_debug(monkeypatch, caplog):
+    """The ``No prefix cache entries found on disk`` branch is DEBUG too."""
+    from vllm_mlx.runtime import cache as cache_mod
+
+    cache_mod = _stub_config_and_cache_dir(monkeypatch, entries=0)
+
+    with caplog.at_level(logging.INFO):
+        cache_mod.load_prefix_cache_from_disk()
+    assert not any("No prefix cache entries found" in m for m in _info_records(caplog))
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        cache_mod.load_prefix_cache_from_disk()
+    assert "No prefix cache entries found on disk" in caplog.text
+
+
+def test_post_ready_radix_rebuild_is_debug_not_info(caplog):
+    """The radix-index rebuild (post-ready background task) must log at DEBUG.
+
+    Same class of offender: ``_load_radix_index_after_cache`` runs on the
+    deferred post-ready task, so its ``[radix] rebuilt index ...`` line used to
+    bury the Ready banner.
+    """
+    from vllm_mlx.runtime import cache as cache_mod
+
+    class _StubRadix:
+        def load(self, _path):
+            return None  # falsy → rebuild path fires
+
+        def rebuild_from_keys(self, _keys):
+            pass
+
+    class _StubCache:
+        _radix_index = _StubRadix()
+        _lock = threading.Lock()
+        _entries = {"k1": object()}
+
+    class _StubScheduler:
+        memory_aware_cache = _StubCache()
+
+    class _StubEngine:
+        scheduler = _StubScheduler()
+
+    with caplog.at_level(logging.INFO):
+        cache_mod._load_radix_index_after_cache(_StubEngine(), "/tmp/calm-cache")
+    assert "rebuilt index" not in caplog.text, (
+        f"radix rebuild must be silent at INFO (#2356) but was logged:\n{caplog.text}"
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        cache_mod._load_radix_index_after_cache(_StubEngine(), "/tmp/calm-cache")
+    assert "rebuilt index" in caplog.text
+
+
+def test_kv_cache_dtype_decision_logged_exactly_once(caplog):
+    """The KV-cache dtype decision surfaces exactly once.
+
+    #2356: ``log_kv_cache_decision`` used to emit the message twice — once as
+    ``logger.info`` (stderr) and again via ``print`` (stdout) — so a foreground
+    serve showed two identical dtype lines. It must now produce a single
+    emission (one INFO log record, nothing printed to stdout).
+    """
+    from vllm_mlx.kv_cache_dtype import (
+        KVCacheDtypeDecision,
+        log_kv_cache_decision,
+    )
+
+    decision = KVCacheDtypeDecision(
+        dtype="bf16",
+        reason="bf16 selected (no QuantizedKVCache wrap)",
+        downgraded=False,
+        requested="bf16",
+    )
+
+    buf = io.StringIO()
+    with caplog.at_level(logging.INFO), redirect_stdout(buf):
+        log_kv_cache_decision(decision, model_name="qwen3.5-4b")
+
+    matches = [r for r in caplog.records if "KV cache dtype:" in r.getMessage()]
+    assert len(matches) == 1, (
+        f"KV-cache dtype decision must be logged exactly once (#2356); got "
+        f"{len(matches)} INFO records:\n"
+        + "\n".join(r.getMessage() for r in caplog.records)
+    )
+    assert "KV cache dtype:" in matches[0].getMessage()
+    # The decision must not be double-emitted via a raw stdout print.
+    assert "KV cache dtype:" not in buf.getvalue(), (
+        "KV-cache dtype decision must not also be printed to stdout — that "
+        "doubles it on the terminal (#2356)."
+    )

--- a/vllm_mlx/kv_cache_dtype.py
+++ b/vllm_mlx/kv_cache_dtype.py
@@ -447,14 +447,17 @@ def dtype_to_quantization_bits(dtype: str) -> tuple[bool, int]:
 def log_kv_cache_decision(
     decision: KVCacheDtypeDecision, *, model_name: str | None = None
 ) -> None:
-    """Emit the operator-facing startup log line for a decision.
+    """Emit the operator-facing startup log line for a decision, exactly once.
 
     The log line is the operator's window into what
     ``resolve_kv_cache_dtype`` decided — without it, a downgrade from
-    int4 to bf16 looks like a perf regression. Always logged at INFO so
-    it survives in default deployments. Also prints to stdout for
-    parity with the existing CLI banners (operators run ``rapid-mlx
-    serve`` in foreground much more often than they ``journalctl`` it).
+    int4 to bf16 looks like a perf regression. It is a single ``logger.info``
+    emission: in a foreground ``rapid-mlx serve`` the root handler writes to
+    stderr (visible on the terminal), and in log-backed deployments the INFO
+    record survives into the log. The decision is surfaced exactly once —
+    #2356 flagged that a previous ``logger.info`` + ``print(msg)`` pair sent
+    the same line to the terminal twice (stderr and stdout), so a user's
+    startup card never settled on a single dtype line.
     """
     msg = f"KV cache dtype: {decision.dtype} — {decision.reason}"
     if model_name and model_name not in decision.reason:
@@ -462,4 +465,3 @@ def log_kv_cache_decision(
             f"KV cache dtype: {decision.dtype} (model={model_name}) — {decision.reason}"
         )
     logger.info(msg)
-    print(msg)

--- a/vllm_mlx/runtime/cache.py
+++ b/vllm_mlx/runtime/cache.py
@@ -73,7 +73,12 @@ def load_prefix_cache_from_disk() -> None:
         return
     try:
         d = get_cache_dir()
-        logger.info(f"[lifespan] Loading prefix cache from {d}")
+        # #2356: this auto-load runs on the deferred background task scheduled
+        # AFTER the Ready banner is printed (see server._deferred_load_prefix_cache).
+        # At INFO it scrolled the Ready/Connect block off the terminal; the
+        # per-boot cache counts are warm-start detail, so they live at DEBUG.
+        # Operator-requested explicit loads/imports surface their own feedback.
+        logger.debug(f"[lifespan] Loading prefix cache from {d}")
         # #1111 codex r3: the STARTUP auto-load must NOT protect reloaded
         # entries. ``save_to_disk`` persists ALL live entries — including
         # opportunistic (unprotected) non-trimmable ones — so protecting them on
@@ -83,9 +88,9 @@ def load_prefix_cache_from_disk() -> None:
         # only the EXPLICIT ``POST /v1/cache/import`` (#476) pins its entries.
         loaded = cfg.engine.load_cache_from_disk(d, protected_import=False)
         if loaded > 0:
-            logger.info(f"[lifespan] Loaded {loaded} prefix cache entries")
+            logger.debug(f"[lifespan] Loaded {loaded} prefix cache entries")
         else:
-            logger.info("[lifespan] No prefix cache entries found on disk")
+            logger.debug("[lifespan] No prefix cache entries found on disk")
         _load_radix_index_after_cache(cfg.engine, d)
     except Exception as e:
         logger.warning(f"[lifespan] Failed to load cache from disk: {e}", exc_info=True)
@@ -127,7 +132,10 @@ def _load_radix_index_after_cache(engine, cache_dir: str) -> None:
         )
         if not radix_matches_entries:
             radix.rebuild_from_keys(keys)
-            logger.info(f"[radix] rebuilt index from {len(keys)} loaded cache entries")
+            # #2356: runs on the deferred post-ready background task, so at INFO
+            # it buried the Ready banner. Radix rebuild is a warm-start
+            # accelerator detail, not a user-facing readiness signal.
+            logger.debug(f"[radix] rebuilt index from {len(keys)} loaded cache entries")
     except Exception as e:  # pragma: no cover — defensive
         logger.warning(f"[radix] rebuild_from_keys failed: {e}", exc_info=True)
 


### PR DESCRIPTION
## Why

A normal `rapid-mlx serve <model> --port N` buried the user's next step. The startup interleaved the user-facing card with low-level INFO trace, printed the KV-cache dtype decision twice, and kept printing lifecycle detail (prefix-cache auto-load, radix rebuild) AFTER the Ready/Connect banner — so the terminal never settled on a clear final instruction and a new user had to scroll to find the connection info.

Part of #2356.

## What

3 files, +198/−10.

1. **Stable final endpoint** (`vllm_mlx/runtime/cache.py`): the deferred post-ready background prefix-cache auto-load and radix rebuild ran on a task scheduled AFTER the Ready banner and scrolled it off the terminal. Their per-boot counts (`Loaded N prefix cache entries`, `No ... found`, `[radix] rebuilt index ...`) are warm-start detail → moved to **DEBUG**. Failure sites stay `WARNING`; operator-requested explicit loads keep their own user feedback.

2. **KV-cache dtype dedup** (`vllm_mlx/kv_cache_dtype.py`): `log_kv_cache_decision` emitted the same line twice — once as `logger.info` (stderr) and again via `print` (stdout). Removed the redundant `print`; the decision now surfaces exactly once.

3. **Tests** (`tests/test_serve_calm_startup_logs.py`, 4 cases): prefix-cache load lines silent at INFO / reachable at DEBUG; "No entries" branch DEBUG; radix rebuild silent at INFO / reachable at DEBUG; KV dtype decision logged exactly once with no duplicate stdout print. Unit-level stubs (mirroring `test_deferred_prefix_cache_load.py`) — no model boot.

## Scope / follow-up

Fixes the two most-visible defects: Ready/Connect scrolled away, and duplicated dtype line. The issue also asks to demote **warmup-period** per-kernel/allocator/scheduler INFO traces (GDN/MambaCache fusion install, UBC eviction, allocator limits); that is a broader ~15-file engine-log sweep with higher regression risk — deliberately a separate, individually-reviewed change. Uvicorn's own "Application startup complete" stays INFO (third-party logger; lowering it risks hiding real error visibility).

Verified locally: new tests + 36 related (deferred prefix cache, KV dtype) pass; ruff clean; mypy clean on changed files.

## Design precedent

Default operational logs retain readiness, decisions, and warnings while repetitive cache/index lifecycle detail remains available at DEBUG. This change applies that severity boundary narrowly; the broader startup-log inventory remains tracked by #2356.