### PR TITLE
fix(ci): wait for complete GUI catalog snapshot

### DIFF
--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -13,6 +13,11 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXHeading desc="Connect your agents, Connect any agent or editor that supports a local base URL. It's free and stays on your Mac." enabled=true
           AXScrollArea
+            AXStaticText value=text enabled=true
+            AXTextField id="ConnectTools.ServerPort.Field" value=empty enabled=true
+            AXButton id="ConnectTools.ServerPort.Save" desc="Save" enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
             AXHeading desc="Start here, Run a text model first. Rapid will then create a private local endpoint and ready-to-copy setup commands." enabled=true
             AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
             AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3655,7 +3655,8 @@ flow_catalog_integrity() {
     local management_ready=0
     for _ in {1..40}; do
         see_main "$OUT/catalog-model-management.json"
-        if jq -e 'any(.data.ui_elements[]?;
+        if jq -e '.data.walk.complete == true
+                  and any(.data.ui_elements[]?;
                           .identifier == "Settings.ModelManagement.LargestModel"
                           and ([.title // "", .value // "", .description // ""]
                                | join(" ") | contains("fake-image-alias")))' \
@@ -3667,8 +3668,6 @@ flow_catalog_integrity() {
     done
     [[ "$management_ready" == 1 ]] \
         || die "complete cross-modality Model Management inventory was not observed"
-    jq -e '.data.walk.complete == true' "$OUT/catalog-model-management.json" >/dev/null \
-        || die "could not completely observe Model Management"
     jq -e '.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.Row.fake-alias")' \
         "$OUT/catalog-model-management.json" >/dev/null \
         || die "Model Management inventory was not observed"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3646,7 +3646,27 @@ flow_catalog_integrity() {
     see_main "$OUT/catalog-settings.json"
     press "$OUT/catalog-settings.json" Settings.Category.modelManagement \
         "$OUT/catalog-open-mm.json"
-    see_main "$OUT/catalog-model-management.json"
+    # Opening the panel starts its own asynchronous, cross-modality catalog
+    # refresh. The chat picker above is not a completion barrier for that
+    # separate task: on a fast host it can expose the cached chat rows before
+    # the image inventory has joined the snapshot. Wait for the exact largest
+    # managed fixture this flow is about, rather than asserting against a
+    # partially rendered but otherwise complete accessibility tree.
+    local management_ready=0
+    for _ in {1..40}; do
+        see_main "$OUT/catalog-model-management.json"
+        if jq -e 'any(.data.ui_elements[]?;
+                          .identifier == "Settings.ModelManagement.LargestModel"
+                          and ([.title // "", .value // "", .description // ""]
+                               | join(" ") | contains("fake-image-alias")))' \
+               "$OUT/catalog-model-management.json" >/dev/null; then
+            management_ready=1
+            break
+        fi
+        sleep 0.25
+    done
+    [[ "$management_ready" == 1 ]] \
+        || die "complete cross-modality Model Management inventory was not observed"
     jq -e '.data.walk.complete == true' "$OUT/catalog-model-management.json" >/dev/null \
         || die "could not completely observe Model Management"
     jq -e '.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.Row.fake-alias")' \

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -557,6 +557,23 @@ def test_launch_baseline_waits_for_the_authoritative_integration_registry():
     assert 'see_main "$OUT/launch.json"' in flow[:settle]
 
 
+def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
+    flow = _harness_flow_body("flow_catalog_integrity")
+    open_panel = flow.index("Settings.Category.modelManagement")
+    wait_for_image = flow.index(
+        '.identifier == "Settings.ModelManagement.LargestModel"'
+    )
+    require_ready = flow.index(
+        '|| die "complete cross-modality Model Management inventory was not observed"'
+    )
+    semantic_assertion = flow.index(
+        '|| die "disk overview did not identify the largest managed model"'
+    )
+
+    assert open_panel < wait_for_image < require_ready < semantic_assertion
+    assert "for _ in {1..40}; do" in flow[open_panel:require_ready]
+
+
 @pytest.mark.parametrize("flow", SNAP_AUDIT_FLOWS)
 def test_semantic_control_audits_are_blocking_gui_ci(flow: str):
     """Each semantic audit is gated, and its failure leaves usable evidence.

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -567,6 +567,7 @@ def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
     )
     mark_ready = flow.index("management_ready=1", wait_for_image)
     break_loop = flow.index("break", mark_ready)
+    retry_delay = flow.index("sleep 0.25", break_loop)
     loop_end = flow.index("done", break_loop)
     require_ready = flow.index(
         '|| die "complete cross-modality Model Management inventory was not observed"'
@@ -582,6 +583,7 @@ def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
         < wait_for_image
         < mark_ready
         < break_loop
+        < retry_delay
         < loop_end
         < require_ready
         < semantic_assertion

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -560,9 +560,14 @@ def test_launch_baseline_waits_for_the_authoritative_integration_registry():
 def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
     flow = _harness_flow_body("flow_catalog_integrity")
     open_panel = flow.index("Settings.Category.modelManagement")
+    loop_start = flow.index("for _ in {1..40}; do", open_panel)
+    complete_walk = flow.index(".data.walk.complete == true", loop_start)
     wait_for_image = flow.index(
         '.identifier == "Settings.ModelManagement.LargestModel"'
     )
+    mark_ready = flow.index("management_ready=1", wait_for_image)
+    break_loop = flow.index("break", mark_ready)
+    loop_end = flow.index("done", break_loop)
     require_ready = flow.index(
         '|| die "complete cross-modality Model Management inventory was not observed"'
     )
@@ -570,8 +575,17 @@ def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
         '|| die "disk overview did not identify the largest managed model"'
     )
 
-    assert open_panel < wait_for_image < require_ready < semantic_assertion
-    assert "for _ in {1..40}; do" in flow[open_panel:require_ready]
+    assert (
+        open_panel
+        < loop_start
+        < complete_walk
+        < wait_for_image
+        < mark_ready
+        < break_loop
+        < loop_end
+        < require_ready
+        < semantic_assertion
+    )
 
 
 @pytest.mark.parametrize("flow", SNAP_AUDIT_FLOWS)

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -182,7 +182,7 @@ def test_serve_exits_before_load_for_explicit_gemma4_dtype(tmp_path, dtype):
     ],
 )
 def test_serve_command_maps_both_explicit_flag_shapes_to_exit_two(
-    tmp_path, flags, capsys
+    tmp_path, flags, capsys, monkeypatch
 ):
     """Exercise the in-process CLI exception mapping as well as subprocess E2E."""
     from vllm_mlx import cli
@@ -191,6 +191,18 @@ def test_serve_command_maps_both_explicit_flag_shapes_to_exit_two(
     model_dir.mkdir()
     (model_dir / "config.json").write_text(json.dumps(GEMMA4_UNIFIED_CONFIG))
     args = cli.build_parser().parse_args(["serve", str(model_dir), "--no-mllm", *flags])
+
+    # ``serve_command`` installs middleware before loading the model. Keep this
+    # in-process exception-mapping test independent of the process-global
+    # Starlette app, which may already have served requests in the full suite.
+    from vllm_mlx import server
+    from vllm_mlx.middleware import request_logging
+
+    monkeypatch.setattr(server, "configure_cors_from_env", lambda *_: [])
+    monkeypatch.setattr(server, "configure_trusted_hosts", lambda *_: None)
+    monkeypatch.setattr(
+        request_logging, "install_request_logging_middleware", lambda *_: None
+    )
 
     with pytest.raises(SystemExit) as exc_info:
         cli.serve_command(args)
@@ -390,6 +402,13 @@ def test_serve_command_maps_runtime_backstop_to_exit_two(tmp_path, monkeypatch, 
     monkeypatch.setattr(cli, "_check_memory_capacity", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         server, "configure_model_residency", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(server, "configure_cors_from_env", lambda *_: [])
+    monkeypatch.setattr(server, "configure_trusted_hosts", lambda *_: None)
+    from vllm_mlx.middleware import request_logging
+
+    monkeypatch.setattr(
+        request_logging, "install_request_logging_middleware", lambda *_: None
     )
     monkeypatch.setattr(
         server, "load_model", lambda *args, **kwargs: (_ for _ in ()).throw(error)


### PR DESCRIPTION
## Summary

- align the `launch-integrations` AX snapshot with the shipped Desktop server-port controls
- make `catalog-integrity` wait for a complete cross-modality storage summary instead of sampling a valid but partial catalog refresh
- lock the polling control flow with a focused harness contract
- isolate three in-process CLI error-mapping tests from the process-global server app so full-suite order cannot make middleware setup fail first

This repairs the two current-main GUI golden failures that dequeued #2970 in Mergify candidate #2976 and the current-main full-suite isolation failure exposed while validating this prerequisite. It does not change Desktop or engine product behavior.

## User impact

Mac merge candidates are no longer rejected because a newly opened Model Management panel was observed between its chat-cache result and its complete cross-modality snapshot. The launch journey also recognizes the intentional server-port controls already visible to users. Test order no longer hides the CLI error contract behind a reused server application's middleware lifecycle.

## Scope

Test harnesses and committed golden baseline only.

Non-goals: Desktop runtime behavior, engine/KV behavior, queue policy, or unrelated golden-flow changes.

## Design precedent

The GUI harness follows an outcome-based readiness contract: asynchronous UI tests wait for the exact stable state they intend to assert, then retain the independent complete-accessibility-walk requirement. The CLI tests isolate external process-global infrastructure so they exercise only the error mapping they claim to cover. Neither path uses fixed sleeps as proof or weakens its semantic assertion.

## Verification

- `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- 80 focused GUI harness, fixture, and Gemma CLI tests passed
- local release Desktop build passed
- `catalog-integrity` passed against the local current-main build on Studio
- `launch-integrations` passed against the same build; all 14 commands were non-empty
- updated launch snapshot matches the failed queue candidate's observed AX tree byte-for-byte
- ruff check/format and `git diff --check` passed
- Codex review of the GUI readiness change converged; exact-head review and full `pr_validate` are being rerun after the test-isolation addition

After this lands, unchanged #2970 can be requeued on a corrected main base.
