### PR TITLE
fix(ci): restore managed macOS GUI queue

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -331,7 +331,7 @@ jobs:
           codesign --verify --deep --strict "$app"
           mkdir -p "$ARTIFACT_DIR"
           ditto -c -k --keepParent "$app" "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip"
-          python ../../scripts/gui_app_artifact.py create \
+          python3 ../../scripts/gui_app_artifact.py create \
             --archive "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip" \
             --source-sha "$GITHUB_SHA" \
             --output "$ARTIFACT_DIR/manifest.json"
@@ -431,7 +431,7 @@ jobs:
           ARTIFACT_DIR: ${{ runner.temp }}/gui-app-artifact
         run: |
           set -euo pipefail
-          python ../../scripts/gui_app_artifact.py verify \
+          python3 ../../scripts/gui_app_artifact.py verify \
             --archive "$ARTIFACT_DIR/Rapid-MLX-Desktop.zip" \
             --manifest "$ARTIFACT_DIR/manifest.json" \
             --expected-source-sha "$GITHUB_SHA"

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -13,6 +13,11 @@ AXApplication title="Rapid-MLX"
         AXGroup subrole=AXHostingView
           AXHeading desc="Connect your agents, Connect any agent or editor that supports a local base URL. It's free and stays on your Mac." enabled=true
           AXScrollArea
+            AXStaticText value=text enabled=true
+            AXTextField id="ConnectTools.ServerPort.Field" value=empty enabled=true
+            AXButton id="ConnectTools.ServerPort.Save" desc="Save" enabled=false
+            AXStaticText value=text enabled=true
+            AXStaticText value=text enabled=true
             AXHeading desc="Start here, Run a text model first. Rapid will then create a private local endpoint and ready-to-copy setup commands." enabled=true
             AXPopUpButton id="ModelPickerBar.ModelMenu" desc="Model" help="Choose which model to run" value=text enabled=true
             AXButton id="ModelPickerBar.ModelInfo" desc="Show model details" help="Show model details" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -32,6 +32,7 @@ AXApplication title="Rapid-MLX"
       AXUnknown desc="Tokens per second: no data yet" enabled=true
       AXUnknown desc="CPU <percent>" enabled=true
       AXUnknown desc="GPU <gpu>" enabled=true
+      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
       AXGroup id="UpdateCard" desc="Rapid-MLX update <version> available" enabled=true
         AXStaticText value=text enabled=true
         AXStaticText value=text enabled=true
@@ -39,7 +40,6 @@ AXApplication title="Rapid-MLX"
         AXStaticText value=text enabled=true
         AXLink id="UpdateCard.ReleaseNotes" desc="View release notes" enabled=true
         AXBusyIndicator id="UpdateCard.Update" desc="Update in progress…" value=number enabled=false
-      AXUnknown desc="Memory <pressure>: <size> used out of <size>" enabled=true
       AXButton id="Footer.DesktopVersionPill" desc="Rapid-MLX <version> <update-state>" help="Rapid-MLX <version> <update-state>" enabled=true
     AXToolbar
       AXButton desc="Hide Sidebar" enabled=true

--- a/apps/rapid-mac/scripts/ax-baseline.py
+++ b/apps/rapid-mac/scripts/ax-baseline.py
@@ -22,7 +22,8 @@ What the normalizer keeps
   * ``AXEnabled``
   * the *kind* of ``AXValue`` — ``bool:true`` / ``bool:false`` for toggles,
     ``number`` / ``text`` / ``empty`` for everything else
-  * sibling order below the window level
+  * sibling order below the window level, except for narrowly identified
+    SwiftUI overlays whose AX position is known to vary by session
 
 What it drops or rewrites, and why
   * ``bounds`` — absolute screen coordinates move whenever the window opens at
@@ -276,6 +277,40 @@ def normalize_transient_overlay_children(children: list[Node]) -> list[Node]:
         if child.record.get("role") == "AXSplitGroup"
     )
     return remaining[:split_index] + overlay + remaining[split_index:]
+
+
+def normalize_update_overlay_children(children: list[Node]) -> list[Node]:
+    """Anchor the update overlay immediately before the footer version pill.
+
+    SwiftUI flattens the bottom-trailing ``UpdateCard`` overlay into the same
+    AX sibling list as the footer.  Managed macOS runners have returned that
+    identified overlay on either side of the live Memory gauge for identical
+    UI state.  The footer version pill is the stable, app-authored anchor that
+    follows both variants, so move only the uniquely identified overlay next
+    to it.  Duplicate overlays or a missing anchor remain unmodified and will
+    still produce a structural diff.
+    """
+    update_indexes = [
+        index
+        for index, child in enumerate(children)
+        if child.record.get("identifier") == "UpdateCard"
+    ]
+    pill_indexes = [
+        index
+        for index, child in enumerate(children)
+        if child.record.get("identifier") == "Footer.DesktopVersionPill"
+    ]
+    if len(update_indexes) != 1 or len(pill_indexes) != 1:
+        return children
+
+    update = children[update_indexes[0]]
+    remaining = [child for child in children if child is not update]
+    pill_index = next(
+        index
+        for index, child in enumerate(remaining)
+        if child.record.get("identifier") == "Footer.DesktopVersionPill"
+    )
+    return remaining[:pill_index] + [update] + remaining[pill_index:]
 
 
 def _subtree_has_identifier(node: Node, identifier: str) -> bool:
@@ -620,6 +655,7 @@ def render(root: Node, extra_tokens: tuple[str, ...]) -> list[str]:
         if node_is_toolbar:
             children = normalize_toolbar_children(children)
         children = normalize_transient_overlay_children(children)
+        children = normalize_update_overlay_children(children)
         for child in children:
             walk(
                 child, depth + 1, sort_children=False, parent_is_toolbar=node_is_toolbar

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3655,7 +3655,8 @@ flow_catalog_integrity() {
     local management_ready=0
     for _ in {1..40}; do
         see_main "$OUT/catalog-model-management.json"
-        if jq -e 'any(.data.ui_elements[]?;
+        if jq -e '.data.walk.complete == true
+                  and any(.data.ui_elements[]?;
                           .identifier == "Settings.ModelManagement.LargestModel"
                           and ([.title // "", .value // "", .description // ""]
                                | join(" ") | contains("fake-image-alias")))' \
@@ -3667,8 +3668,6 @@ flow_catalog_integrity() {
     done
     [[ "$management_ready" == 1 ]] \
         || die "complete cross-modality Model Management inventory was not observed"
-    jq -e '.data.walk.complete == true' "$OUT/catalog-model-management.json" >/dev/null \
-        || die "could not completely observe Model Management"
     jq -e '.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.Row.fake-alias")' \
         "$OUT/catalog-model-management.json" >/dev/null \
         || die "Model Management inventory was not observed"

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3646,7 +3646,27 @@ flow_catalog_integrity() {
     see_main "$OUT/catalog-settings.json"
     press "$OUT/catalog-settings.json" Settings.Category.modelManagement \
         "$OUT/catalog-open-mm.json"
-    see_main "$OUT/catalog-model-management.json"
+    # Opening the panel starts its own asynchronous, cross-modality catalog
+    # refresh. The chat picker above is not a completion barrier for that
+    # separate task: on a fast host it can expose the cached chat rows before
+    # the image inventory has joined the snapshot. Wait for the exact largest
+    # managed fixture this flow is about, rather than asserting against a
+    # partially rendered but otherwise complete accessibility tree.
+    local management_ready=0
+    for _ in {1..40}; do
+        see_main "$OUT/catalog-model-management.json"
+        if jq -e 'any(.data.ui_elements[]?;
+                          .identifier == "Settings.ModelManagement.LargestModel"
+                          and ([.title // "", .value // "", .description // ""]
+                               | join(" ") | contains("fake-image-alias")))' \
+               "$OUT/catalog-model-management.json" >/dev/null; then
+            management_ready=1
+            break
+        fi
+        sleep 0.25
+    done
+    [[ "$management_ready" == 1 ]] \
+        || die "complete cross-modality Model Management inventory was not observed"
     jq -e '.data.walk.complete == true' "$OUT/catalog-model-management.json" >/dev/null \
         || die "could not completely observe Model Management"
     jq -e '.data.ui_elements[]? | select(.identifier == "Settings.ModelManagement.Row.fake-alias")' \

--- a/tests/test_ax_baseline.py
+++ b/tests/test_ax_baseline.py
@@ -247,6 +247,75 @@ def test_unrelated_anonymous_scroll_area_after_search_panel_keeps_order_sensitiv
     assert ax_baseline.render(window_a, ()) != ax_baseline.render(window_b, ())
 
 
+def test_update_overlay_order_is_session_independent(ax_baseline):
+    memory = ax_baseline.Node(
+        {"role": "AXUnknown", "description": "Memory normal: 4 GB used out of 16 GB"}
+    )
+    update = ax_baseline.Node({"role": "AXGroup", "identifier": "UpdateCard"})
+    pill = ax_baseline.Node(
+        {"role": "AXButton", "identifier": "Footer.DesktopVersionPill"}
+    )
+    host_a = ax_baseline.Node({"role": "AXGroup", "identifier": "host"})
+    host_a.children = [update, memory, pill]
+    host_b = ax_baseline.Node({"role": "AXGroup", "identifier": "host"})
+    host_b.children = [memory, update, pill]
+    app_a = ax_baseline.Node({"role": "AXApplication"})
+    app_a.children = [host_a]
+    app_b = ax_baseline.Node({"role": "AXApplication"})
+    app_b.children = [host_b]
+
+    assert ax_baseline.render(app_a, ()) == ax_baseline.render(app_b, ())
+
+
+def test_update_overlay_does_not_hide_unrelated_sibling_reordering(ax_baseline):
+    first = ax_baseline.Node({"role": "AXUnknown", "identifier": "Footer.First"})
+    second = ax_baseline.Node({"role": "AXUnknown", "identifier": "Footer.Second"})
+    update = ax_baseline.Node({"role": "AXGroup", "identifier": "UpdateCard"})
+    pill = ax_baseline.Node(
+        {"role": "AXButton", "identifier": "Footer.DesktopVersionPill"}
+    )
+    host_a = ax_baseline.Node({"role": "AXGroup", "identifier": "host"})
+    host_a.children = [first, update, second, pill]
+    host_b = ax_baseline.Node({"role": "AXGroup", "identifier": "host"})
+    host_b.children = [second, update, first, pill]
+    app_a = ax_baseline.Node({"role": "AXApplication"})
+    app_a.children = [host_a]
+    app_b = ax_baseline.Node({"role": "AXApplication"})
+    app_b.children = [host_b]
+
+    assert ax_baseline.render(app_a, ()) != ax_baseline.render(app_b, ())
+
+
+@pytest.mark.parametrize("missing", ["update", "pill"])
+def test_update_overlay_requires_unique_pair(ax_baseline, missing):
+    update = ax_baseline.Node({"role": "AXGroup", "identifier": "UpdateCard"})
+    pill = ax_baseline.Node(
+        {"role": "AXButton", "identifier": "Footer.DesktopVersionPill"}
+    )
+    children = [update, pill]
+    if missing == "update":
+        children = [pill]
+    else:
+        children = [update]
+
+    assert ax_baseline.normalize_update_overlay_children(children) == children
+
+
+def test_duplicate_update_overlay_is_not_normalized(ax_baseline):
+    first_update = ax_baseline.Node(
+        {"role": "AXGroup", "identifier": "UpdateCard"}
+    )
+    second_update = ax_baseline.Node(
+        {"role": "AXGroup", "identifier": "UpdateCard"}
+    )
+    pill = ax_baseline.Node(
+        {"role": "AXButton", "identifier": "Footer.DesktopVersionPill"}
+    )
+    children = [first_update, pill, second_update]
+
+    assert ax_baseline.normalize_update_overlay_children(children) == children
+
+
 def test_scrollbar_subtree_is_ignored_but_scroll_area_remains(ax_baseline):
     area = ax_baseline.Node({"role": "AXScrollArea", "identifier": "Results"})
     bar = ax_baseline.Node({"role": "AXScrollBar", "value": 0.5})

--- a/tests/test_ax_baseline.py
+++ b/tests/test_ax_baseline.py
@@ -302,12 +302,8 @@ def test_update_overlay_requires_unique_pair(ax_baseline, missing):
 
 
 def test_duplicate_update_overlay_is_not_normalized(ax_baseline):
-    first_update = ax_baseline.Node(
-        {"role": "AXGroup", "identifier": "UpdateCard"}
-    )
-    second_update = ax_baseline.Node(
-        {"role": "AXGroup", "identifier": "UpdateCard"}
-    )
+    first_update = ax_baseline.Node({"role": "AXGroup", "identifier": "UpdateCard"})
+    second_update = ax_baseline.Node({"role": "AXGroup", "identifier": "UpdateCard"})
     pill = ax_baseline.Node(
         {"role": "AXButton", "identifier": "Footer.DesktopVersionPill"}
     )

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -557,6 +557,23 @@ def test_launch_baseline_waits_for_the_authoritative_integration_registry():
     assert 'see_main "$OUT/launch.json"' in flow[:settle]
 
 
+def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
+    flow = _harness_flow_body("flow_catalog_integrity")
+    open_panel = flow.index("Settings.Category.modelManagement")
+    wait_for_image = flow.index(
+        '.identifier == "Settings.ModelManagement.LargestModel"'
+    )
+    require_ready = flow.index(
+        '|| die "complete cross-modality Model Management inventory was not observed"'
+    )
+    semantic_assertion = flow.index(
+        '|| die "disk overview did not identify the largest managed model"'
+    )
+
+    assert open_panel < wait_for_image < require_ready < semantic_assertion
+    assert "for _ in {1..40}; do" in flow[open_panel:require_ready]
+
+
 @pytest.mark.parametrize("flow", SNAP_AUDIT_FLOWS)
 def test_semantic_control_audits_are_blocking_gui_ci(flow: str):
     """Each semantic audit is gated, and its failure leaves usable evidence.

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -567,6 +567,7 @@ def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
     )
     mark_ready = flow.index("management_ready=1", wait_for_image)
     break_loop = flow.index("break", mark_ready)
+    retry_delay = flow.index("sleep 0.25", break_loop)
     loop_end = flow.index("done", break_loop)
     require_ready = flow.index(
         '|| die "complete cross-modality Model Management inventory was not observed"'
@@ -582,6 +583,7 @@ def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
         < wait_for_image
         < mark_ready
         < break_loop
+        < retry_delay
         < loop_end
         < require_ready
         < semantic_assertion

--- a/tests/test_gui_control_behavior_contract.py
+++ b/tests/test_gui_control_behavior_contract.py
@@ -560,9 +560,14 @@ def test_launch_baseline_waits_for_the_authoritative_integration_registry():
 def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
     flow = _harness_flow_body("flow_catalog_integrity")
     open_panel = flow.index("Settings.Category.modelManagement")
+    loop_start = flow.index("for _ in {1..40}; do", open_panel)
+    complete_walk = flow.index(".data.walk.complete == true", loop_start)
     wait_for_image = flow.index(
         '.identifier == "Settings.ModelManagement.LargestModel"'
     )
+    mark_ready = flow.index("management_ready=1", wait_for_image)
+    break_loop = flow.index("break", mark_ready)
+    loop_end = flow.index("done", break_loop)
     require_ready = flow.index(
         '|| die "complete cross-modality Model Management inventory was not observed"'
     )
@@ -570,8 +575,17 @@ def test_catalog_integrity_waits_for_the_cross_modality_management_snapshot():
         '|| die "disk overview did not identify the largest managed model"'
     )
 
-    assert open_panel < wait_for_image < require_ready < semantic_assertion
-    assert "for _ in {1..40}; do" in flow[open_panel:require_ready]
+    assert (
+        open_panel
+        < loop_start
+        < complete_walk
+        < wait_for_image
+        < mark_ready
+        < break_loop
+        < loop_end
+        < require_ready
+        < semantic_assertion
+    )
 
 
 @pytest.mark.parametrize("flow", SNAP_AUDIT_FLOWS)

--- a/tests/test_kv_cache_gemma4_gate.py
+++ b/tests/test_kv_cache_gemma4_gate.py
@@ -182,7 +182,7 @@ def test_serve_exits_before_load_for_explicit_gemma4_dtype(tmp_path, dtype):
     ],
 )
 def test_serve_command_maps_both_explicit_flag_shapes_to_exit_two(
-    tmp_path, flags, capsys
+    tmp_path, flags, capsys, monkeypatch
 ):
     """Exercise the in-process CLI exception mapping as well as subprocess E2E."""
     from vllm_mlx import cli
@@ -191,6 +191,18 @@ def test_serve_command_maps_both_explicit_flag_shapes_to_exit_two(
     model_dir.mkdir()
     (model_dir / "config.json").write_text(json.dumps(GEMMA4_UNIFIED_CONFIG))
     args = cli.build_parser().parse_args(["serve", str(model_dir), "--no-mllm", *flags])
+
+    # ``serve_command`` installs middleware before loading the model. Keep this
+    # in-process exception-mapping test independent of the process-global
+    # Starlette app, which may already have served requests in the full suite.
+    from vllm_mlx import server
+    from vllm_mlx.middleware import request_logging
+
+    monkeypatch.setattr(server, "configure_cors_from_env", lambda *_: [])
+    monkeypatch.setattr(server, "configure_trusted_hosts", lambda *_: None)
+    monkeypatch.setattr(
+        request_logging, "install_request_logging_middleware", lambda *_: None
+    )
 
     with pytest.raises(SystemExit) as exc_info:
         cli.serve_command(args)
@@ -390,6 +402,13 @@ def test_serve_command_maps_runtime_backstop_to_exit_two(tmp_path, monkeypatch, 
     monkeypatch.setattr(cli, "_check_memory_capacity", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         server, "configure_model_residency", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(server, "configure_cors_from_env", lambda *_: [])
+    monkeypatch.setattr(server, "configure_trusted_hosts", lambda *_: None)
+    from vllm_mlx.middleware import request_logging
+
+    monkeypatch.setattr(
+        request_logging, "install_request_logging_middleware", lambda *_: None
     )
     monkeypatch.setattr(
         server, "load_model", lambda *args, **kwargs: (_ for _ in ()).throw(error)


### PR DESCRIPTION
## Why

The managed macOS queue exposed three independent CI portability failures after the runner migration: the image provides `python3` without an unversioned `python`; the GUI catalog assertion could race before all entries arrived; and SwiftUI exposed the identified update overlay on either side of the live Memory footer node across otherwise identical sessions. Because each split PR was tested in isolation, every Mergify candidate lacked another prerequisite and bisection repeatedly ejected healthy source PRs.

This intentionally consolidates the queue prerequisites into one exact-head candidate so the real six-shard GUI matrix can verify the foundation atomically.

Fixes #2986.
Fixes #3008.
Supersedes #2985.

## What

- invoke the GUI artifact helper with the portable `python3` executable at both producer and consumer boundaries;
- wait for the complete GUI model catalog before asserting its contents, with bounded polling and contract coverage;
- isolate the Gemma serve-error mapping test from shared application state;
- canonicalize only the uniquely identified `UpdateCard` overlay immediately before its stable `Footer.DesktopVersionPill` anchor;
- update the measured launch-integrations and update-card AX baselines.

## Design precedent

The AX normalizer already handles session-dependent placement for a uniquely identified SwiftUI overlay while preserving all unrelated authored sibling ordering. This change applies that same narrow, fail-visible pattern to the measured update-card case. It deliberately does not sort generic footer or window children.

## Scope

Allowed: GUI artifact interpreter portability, complete catalog polling, focused test isolation, and narrowly identified AX overlay normalization.

Non-goals: product UI behavior, runner selection, timeout policy, broad AX sorting, release/signing behavior, model catalog content, or user-visible update semantics.

## Verification

- `pytest -q tests/test_ax_baseline.py tests/test_ax_baseline_os_variance.py tests/test_gui_control_behavior_contract.py tests/test_kv_cache_gemma4_gate.py` (123 passed)
- both recorded Manzanita `update-busy` AX order variants normalize to the committed baseline
- `ruff check` and `ruff format --check` on all changed Python files
- `actionlint .github/workflows/rapid-mac-ci.yml`
- `git diff --check`
- exact-head `tests`, `desktop-tests`, and `version-bump-guard`: green
- `pr_validate`: MERGE-SAFE (21,411 passed, 108 skipped, 6 xfailed)
- pending: the Mergify candidate's real six-shard GUI matrix on Manzanita

## Risk and rollback

Risk is limited to test infrastructure. Duplicate/missing update-card anchors remain unnormalized, and unrelated sibling reordering remains regression-sensitive. Revert this PR to restore the prior queue behavior.

