### PR TITLE
fix(mac): prevent star prompt label truncation

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/GitHubStarPrompt.swift
@@ -73,7 +73,11 @@ struct GitHubStarPromptCard: View {
                 }
                 .padding(.trailing, 28)
 
-                HStack(spacing: RapidTheme.Space.sm) {
+                // Keep the primary action on its own row. Three actions no
+                // longer fit beside the leading icon at the card's 360pt
+                // minimum width, and allowing SwiftUI to compress them turns
+                // every label into an ellipsis.
+                VStack(spacing: RapidTheme.Space.sm) {
                     Button {
                         Task {
                             switch await prompt.attemptDirectStar() {
@@ -100,6 +104,7 @@ struct GitHubStarPromptCard: View {
                                     .font(.system(size: 10, weight: .semibold))
                             }
                         }
+                        .fixedSize(horizontal: true, vertical: false)
                         .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(RapidPrimaryButtonStyle(
@@ -114,31 +119,41 @@ struct GitHubStarPromptCard: View {
                     )
                     .accessibilityIdentifier("GitHub.Star.ValueMoment.Open")
 
-                    Button("Later") { prompt.deferPrompt() }
+                    HStack(spacing: RapidTheme.Space.sm) {
+                        Button { prompt.deferPrompt() } label: {
+                            Text("Later")
+                                .fixedSize(horizontal: true, vertical: false)
+                        }
                         .buttonStyle(RapidSecondaryButtonStyle(
+                            expands: true,
                             height: RapidTheme.ControlHeight.medium,
                             font: .system(size: 14, weight: .medium)
                         ))
-                        .frame(width: 84, height: RapidTheme.ControlHeight.medium)
+                        .frame(maxWidth: .infinity, minHeight: RapidTheme.ControlHeight.medium)
                         .disabled(prompt.isStarring)
                         .accessibilityIdentifier("GitHub.Star.ValueMoment.Later")
 
-                    Menu("Feedback") {
-                        Button("Bug report") {
-                            openURL(GitHubCommunity.feedbackBugReportURL)
+                        Menu {
+                            Button("Bug report") {
+                                openURL(GitHubCommunity.feedbackBugReportURL)
+                            }
+                            .accessibilityIdentifier("GitHub.Star.ValueMoment.BugReport")
+                            Button("Feature request") {
+                                openURL(GitHubCommunity.feedbackFeatureRequestURL)
+                            }
+                            .accessibilityIdentifier("GitHub.Star.ValueMoment.FeatureRequest")
+                        } label: {
+                            Text("Feedback")
+                                .fixedSize(horizontal: true, vertical: false)
                         }
-                        .accessibilityIdentifier("GitHub.Star.ValueMoment.BugReport")
-                        Button("Feature request") {
-                            openURL(GitHubCommunity.feedbackFeatureRequestURL)
-                        }
-                        .accessibilityIdentifier("GitHub.Star.ValueMoment.FeatureRequest")
+                        .buttonStyle(RapidSecondaryButtonStyle(
+                            expands: true,
+                            height: RapidTheme.ControlHeight.medium,
+                            font: .system(size: 14, weight: .medium)
+                        ))
+                        .frame(maxWidth: .infinity, minHeight: RapidTheme.ControlHeight.medium)
+                        .accessibilityIdentifier("GitHub.Star.ValueMoment.Feedback")
                     }
-                    .buttonStyle(RapidSecondaryButtonStyle(
-                        height: RapidTheme.ControlHeight.medium,
-                        font: .system(size: 14, weight: .medium)
-                    ))
-                    .frame(width: 84, height: RapidTheme.ControlHeight.medium)
-                    .accessibilityIdentifier("GitHub.Star.ValueMoment.Feedback")
                 }
             }
 

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -55,6 +55,20 @@ struct GitHubStarPromptTests {
             card.components(separatedBy: "expands: true").count - 1 == 3,
             "the primary action and second-row actions must fill their available rows"
         )
+        let primaryActionEnd = card.range(
+            of: ".accessibilityIdentifier(\"GitHub.Star.ValueMoment.Open\")"
+        )
+        let laterActionStart = card.range(of: "Button { prompt.deferPrompt() }")
+        if let primaryActionEnd, let laterActionStart,
+           primaryActionEnd.upperBound < laterActionStart.lowerBound {
+            let betweenActionRows = card[primaryActionEnd.upperBound..<laterActionStart.lowerBound]
+            #expect(
+                betweenActionRows.contains("HStack(spacing: RapidTheme.Space.sm) {"),
+                "Later and Feedback must begin in a separate row after the primary action"
+            )
+        } else {
+            Issue.record("could not locate the primary and secondary action boundaries")
+        }
         #expect(!card.contains(".frame(width: 84, height: RapidTheme.ControlHeight.medium)"))
         #expect(card.contains(".padding(14)"))
         #expect(content.contains(".padding(.trailing, 16)"))

--- a/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GitHubStarPromptTests.swift
@@ -46,7 +46,16 @@ struct GitHubStarPromptTests {
         #expect(card.contains("Text(\"Star on GitHub\")"))
         #expect(!card.contains("Text(\"Open GitHub\")"))
         #expect(card.contains(".frame(width: 360)"))
-        #expect(card.contains(".frame(width: 84, height: RapidTheme.ControlHeight.medium)"))
+        #expect(
+            card.components(separatedBy: ".fixedSize(horizontal: true, vertical: false)").count - 1
+                == 3,
+            "every visible action label must keep its intrinsic width"
+        )
+        #expect(
+            card.components(separatedBy: "expands: true").count - 1 == 3,
+            "the primary action and second-row actions must fill their available rows"
+        )
+        #expect(!card.contains(".frame(width: 84, height: RapidTheme.ControlHeight.medium)"))
         #expect(card.contains(".padding(14)"))
         #expect(content.contains(".padding(.trailing, 16)"))
         #expect(content.contains(".padding(.bottom, 40)"))


### PR DESCRIPTION
## Why

The post-value invitation placed three actions in one 302pt-wide row inside its compact card. SwiftUI compressed the labels to ellipses, so users could not read “Star on GitHub” or “Feedback” in the normal desktop layout.

## Scope

- Keep the existing 360pt card width and content hierarchy.
- Give the primary action its own full-width row.
- Place Later and Feedback in an equal-width secondary row.
- Preserve each visible action label’s intrinsic width.
- Strengthen the focused layout contract.

## Non-goals

- Changing prompt eligibility, cadence, dismissal, or direct-star behavior.
- Changing copy, destinations, accessibility identifiers, or other desktop surfaces.
- Fixing the separate repository-wide DevSnapshot environment injection failure.

## Acceptance

- Enjoying Rapid-MLX, its body copy, Star on GitHub, Later, and Feedback all render without truncation at the existing 360pt card width.
- The card still fits the minimum supported window width.
- Existing prompt interaction and accessibility behavior remains unchanged.

## Verification

- `swift test --filter 'GitHubStarPromptTests|GitHubStarPromptCoordinatorTests|AccessibilityIdentifierInventoryTests'` — 40 tests passed.
- `swift build -c release` — passed; only pre-existing compiler warnings were emitted.
- `pytest -q tests/test_gui_control_behavior_contract.py tests/test_gui_golden_ci_coverage.py` — 37 tests passed.
- Isolated dark-mode 360×220 ImageRenderer capture — all five text labels rendered in full.
- `git diff --check` and scoped generated-file/secret review — passed.

## Behaviour delta

Three compressed actions in one row → one full-width primary row plus two equal-width secondary actions, with all labels kept at intrinsic width.

## AI assistance disclosure

Codex implemented and reviewed both touched files. The result was verified through focused interaction/accessibility tests, a production Swift build, GUI contract tests, and an isolated visual render at the reported width and appearance.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.
