### PR TITLE
fix: complete Desktop video Community Benchmark validation

### DIFF
--- a/docs/engineering/operations/2026-09-03-community-benchmark-0.13.4-dogfood.md
+++ b/docs/engineering/operations/2026-09-03-community-benchmark-0.13.4-dogfood.md
@@ -1,0 +1,48 @@
+# Community Benchmark 0.13.4 dogfood
+
+## Scope
+
+Studio host, released `Rapid-MLX Desktop.app` 0.13.4 (build 170), Community
+Benchmark only. The embedded 0.13.4 CLI was used instead of an older CLI on
+`PATH`.
+
+## Reproduction
+
+```console
+/Applications/Rapid-MLX\ Desktop.app/Contents/Resources/rapid-mlx/bin/rapid-mlx benchmark catalog --json
+/Applications/Rapid-MLX\ Desktop.app/Contents/Resources/rapid-mlx/bin/rapid-mlx benchmark run qwen3.5-9b-4bit --json
+/Applications/Rapid-MLX\ Desktop.app/Contents/Resources/rapid-mlx/bin/rapid-mlx benchmark run qwen3.8-27b-4bit --json
+/Applications/Rapid-MLX\ Desktop.app/Contents/Resources/rapid-mlx/bin/rapid-mlx benchmark run flux2-klein-4b --json
+/Applications/Rapid-MLX\ Desktop.app/Contents/Resources/rapid-mlx/bin/rapid-mlx benchmark run wan2.2-ti2v-5b-q8 --json
+```
+
+Upload preview, explicit consent, receipt permissions, and idempotent retry were
+checked separately. The Desktop tab loaded CLI-created runs, cancelled a live
+run without leaving a child server, and shared an image result only after the
+confirmation sheet.
+
+## Findings
+
+- Text (9B and 27B) and 1024-square image runs completed and produced valid
+  atomic records.
+- Upload accepted the record, stored a mode-0600 receipt, and returned the same
+  submission on retry.
+- The registered Wan workload requested 832x480, while the route admitted only
+  64-aligned dimensions and two 720p compatibility sizes. The request therefore
+  failed before generation.
+- After admitting Wan's 832x480 output target, Desktop generated the video but
+  result validation failed because the deliberately minimal Desktop sidecar has
+  no imageio/OpenCV. It does ship a constrained FFmpeg executable.
+
+## Resolution and regression boundary
+
+Wan explicitly admits 832x480 while retaining existing alignment rules for
+other sizes. Video artifact validation falls back to the bundled FFmpeg stream
+probe when imageio is absent. The fallback reads dimensions, frame count, and
+frame rate without adding another media stack to the signed sidecar. Tests pin
+the route exception, capability advertisement, server error detail, and the
+imageio-free probe.
+
+Website publication is intentionally handled in a separate website change: raw
+atomic uploads contain private identity material and must not be exposed
+directly.

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -3247,6 +3247,22 @@ def test_system_ffmpeg_probe_uses_portable_null_muxer(
     assert "h264_videotoolbox" not in command
 
 
+def test_ffmpeg_environment_variable_does_not_imply_sidecar_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(local_runner.sys, "executable", "/usr/bin/python3")
+    assert local_runner._is_sidecar_bundled_ffmpeg("/usr/local/bin/ffmpeg") is False
+
+    monkeypatch.setattr(
+        local_runner.sys,
+        "executable",
+        "/Applications/Rapid.app/Contents/Resources/rapid-mlx/python/bin/python3.12",
+    )
+    assert local_runner._is_sidecar_bundled_ffmpeg(
+        "/Applications/Rapid.app/Contents/Resources/rapid-mlx/bin/ffmpeg"
+    )
+
+
 def test_probe_video_artifact_returns_worker_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -3208,7 +3208,10 @@ def test_bundled_ffmpeg_probe_has_no_second_artifact_and_a_timeout(
 
     assert captured["stdout"] is subprocess.DEVNULL
     assert captured["timeout"] == local_runner._VIDEO_ARTIFACT_PROBE_TIMEOUT_S
-    assert captured["command"][-1] == "pipe:1"
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[command.index("-c:v") + 1] == "h264_videotoolbox"
+    assert command[-1] == "pipe:1"
 
 
 def test_probe_video_artifact_returns_worker_payload(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -1764,6 +1764,21 @@ def test_video_request_failure_preserves_server_detail(
     }
 
 
+def test_local_request_failure_uses_bounded_fallback_for_non_json_error() -> None:
+    class NonJSONErrorResponse(_HTTPErrorResponse):
+        def json(self) -> dict:
+            raise ValueError("not JSON")
+
+    with pytest.raises(
+        RuntimeError,
+        match="video benchmark request failed with HTTP 400: "
+        "local server rejected the request",
+    ):
+        local_runner._raise_for_status(
+            NonJSONErrorResponse({}), phase="video benchmark request"
+        )
+
+
 def test_video_artifact_is_downloaded_and_probed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3261,6 +3276,35 @@ def test_ffmpeg_environment_variable_does_not_imply_sidecar_bundle(
     assert local_runner._is_sidecar_bundled_ffmpeg(
         "/Applications/Rapid.app/Contents/Resources/rapid-mlx/bin/ffmpeg"
     )
+
+
+def test_sidecar_ffmpeg_detection_fails_closed_on_unresolvable_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_runner.os.path,
+        "realpath",
+        lambda path: (_ for _ in ()).throw(OSError("unresolvable path")),
+    )
+    assert local_runner._is_sidecar_bundled_ffmpeg("/app/bin/ffmpeg") is False
+
+
+def test_video_probe_without_imageio_or_ffmpeg_explains_required_extra(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def import_without_imageio(name: str, *args: object, **kwargs: object):
+        if name == "imageio.v2":
+            raise ImportError("imageio unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_imageio)
+    monkeypatch.delenv("FFMPEG_BINARY", raising=False)
+    monkeypatch.setattr(local_runner.shutil, "which", lambda name: None)
+
+    with pytest.raises(RuntimeError, match=r"validation requires rapid-mlx\[video\]"):
+        local_runner._probe_video_artifact_unbounded("clip.mp4")
 
 
 def test_probe_video_artifact_returns_worker_payload(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -3193,6 +3193,24 @@ def test_bundled_ffmpeg_probe_rejects_unparseable_media(
         local_runner._probe_video_with_ffmpeg("clip.mp4", "/app/bin/ffmpeg")
 
 
+def test_bundled_ffmpeg_probe_has_no_second_artifact_and_a_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        captured.update(command=command, **kwargs)
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(local_runner.subprocess, "run", run)
+    with pytest.raises(RuntimeError, match="invalid MP4 artifact"):
+        local_runner._probe_video_with_ffmpeg("clip.mp4", "/app/bin/ffmpeg")
+
+    assert captured["stdout"] is subprocess.DEVNULL
+    assert captured["timeout"] == local_runner._VIDEO_ARTIFACT_PROBE_TIMEOUT_S
+    assert captured["command"][-1] == "pipe:1"
+
+
 def test_probe_video_artifact_returns_worker_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -3204,7 +3204,9 @@ def test_bundled_ffmpeg_probe_has_no_second_artifact_and_a_timeout(
 
     monkeypatch.setattr(local_runner.subprocess, "run", run)
     with pytest.raises(RuntimeError, match="invalid MP4 artifact"):
-        local_runner._probe_video_with_ffmpeg("clip.mp4", "/app/bin/ffmpeg")
+        local_runner._probe_video_with_ffmpeg(
+            "clip.mp4", "/app/bin/ffmpeg", desktop_bundle=True
+        )
 
     assert captured["stdout"] is subprocess.DEVNULL
     assert captured["timeout"] == local_runner._VIDEO_ARTIFACT_PROBE_TIMEOUT_S
@@ -3212,6 +3214,37 @@ def test_bundled_ffmpeg_probe_has_no_second_artifact_and_a_timeout(
     assert isinstance(command, list)
     assert command[command.index("-c:v") + 1] == "h264_videotoolbox"
     assert command[-1] == "pipe:1"
+
+
+def test_system_ffmpeg_probe_uses_portable_null_muxer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="",
+        stderr=(
+            "Stream #0:0: Video: h264, yuv420p, 832x480, 24 fps, 24 tbr\n"
+            "frame=   81 fps=0.0 q=-0.0 Lsize=N/A\n"
+        ),
+    )
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        captured["command"] = command
+        return completed
+
+    monkeypatch.setattr(local_runner.subprocess, "run", run)
+    assert local_runner._probe_video_with_ffmpeg("clip.mp4", "/usr/bin/ffmpeg") == (
+        832,
+        480,
+        81,
+        24.0,
+    )
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[-3:] == ["-f", "null", "-"]
+    assert "h264_videotoolbox" not in command
 
 
 def test_probe_video_artifact_returns_worker_payload(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -3166,7 +3166,9 @@ def test_video_probe_uses_bundled_ffmpeg_without_imageio(
             "frame=   81 fps=0.0 q=-1.0 Lsize=1KiB\n"
         ),
     )
-    monkeypatch.setattr(local_runner.subprocess, "run", lambda *args, **kwargs: completed)
+    monkeypatch.setattr(
+        local_runner.subprocess, "run", lambda *args, **kwargs: completed
+    )
 
     assert local_runner._probe_video_artifact_unbounded("clip.mp4") == (
         832,

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import builtins
 import contextlib
 import io
 import json
@@ -22,6 +23,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import requests
 
 from vllm_mlx.bench import _server
 from vllm_mlx.catalog import rcj_digest
@@ -69,6 +71,15 @@ class _Response:
 
     def json(self) -> dict:
         return self._payload
+
+
+class _HTTPErrorResponse(_Response):
+    status_code = 400
+
+    def raise_for_status(self) -> None:
+        response = requests.Response()
+        response.status_code = self.status_code
+        raise requests.HTTPError("400 Client Error", response=response)
 
 
 def _png_base64(width: int, height: int) -> str:
@@ -1719,6 +1730,40 @@ def test_run_local_executes_video_protocol_and_polls_to_completion(
     }
 
 
+def test_video_request_failure_preserves_server_detail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    archive = LocalRunArchive(tmp_path)
+    _mock_local_context(
+        monkeypatch, "video_generation", "mlx-community/example-video-model"
+    )
+
+    @contextlib.contextmanager
+    def serve(alias: str, **kwargs):
+        yield {"base_url": "http://local/v1"}
+
+    monkeypatch.setattr(_server, "serve", serve)
+    monkeypatch.setattr(
+        local_runner.requests,
+        "post",
+        lambda *args, **kwargs: _HTTPErrorResponse(
+            {"detail": "video width/height must be divisible by 64"}
+        ),
+    )
+
+    with pytest.raises(
+        local_runner.LocalBenchmarkError,
+        match="video benchmark request failed with HTTP 400: .*divisible by 64",
+    ) as error:
+        local_runner.run_local("example-video", archive=archive)
+
+    assert error.value.saved is True
+    assert error.value.run["outcome"] == {
+        "status": "failed",
+        "failure_code": "runtime_error",
+    }
+
+
 def test_video_artifact_is_downloaded_and_probed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3098,6 +3143,52 @@ def test_video_probe_translates_decoder_crashes(
 
     with pytest.raises(RuntimeError, match="invalid MP4 artifact"):
         local_runner._probe_video_artifact_unbounded("clip.mp4")
+
+
+def test_video_probe_uses_bundled_ffmpeg_without_imageio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def import_without_imageio(name: str, *args: object, **kwargs: object):
+        if name == "imageio.v2":
+            raise ImportError("Desktop intentionally omits imageio")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_imageio)
+    monkeypatch.setenv("FFMPEG_BINARY", "/app/rapid-mlx/bin/ffmpeg")
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="",
+        stderr=(
+            "Stream #0:0: Video: h264, yuv420p, 832x480, 24 fps, 24 tbr\n"
+            "frame=   81 fps=0.0 q=-1.0 Lsize=1KiB\n"
+        ),
+    )
+    monkeypatch.setattr(local_runner.subprocess, "run", lambda *args, **kwargs: completed)
+
+    assert local_runner._probe_video_artifact_unbounded("clip.mp4") == (
+        832,
+        480,
+        81,
+        24.0,
+    )
+
+
+def test_bundled_ffmpeg_probe_rejects_unparseable_media(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_runner.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="invalid data"
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid MP4 artifact"):
+        local_runner._probe_video_with_ffmpeg("clip.mp4", "/app/bin/ffmpeg")
 
 
 def test_probe_video_artifact_returns_worker_payload(

--- a/tests/test_video_capabilities.py
+++ b/tests/test_video_capabilities.py
@@ -130,6 +130,23 @@ async def test_wan_capabilities_include_registered_community_benchmark_size(
 
 
 @pytest.mark.asyncio
+async def test_wan_capabilities_require_aligned_canvas_area_for_benchmark_size(
+    monkeypatch,
+) -> None:
+    engine = SimpleNamespace(
+        model_name="Anes1032/Wan2.2-TI2V-5B-mlx-q8",
+        video_family="wan",
+        native_fps=24,
+        _wan_engine=SimpleNamespace(model_type="ti2v", max_area=832 * 512 - 1),
+    )
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+
+    body = await video.video_capabilities()
+
+    assert "832x480" not in body["limits"]["size"]["also_supported"]
+
+
+@pytest.mark.asyncio
 async def test_wan_capabilities_use_checkpoint_limits(monkeypatch) -> None:
     engine = SimpleNamespace(
         model_name="Anes1032/Wan2.2-TI2V-5B-mlx-q8",

--- a/tests/test_video_capabilities.py
+++ b/tests/test_video_capabilities.py
@@ -113,6 +113,23 @@ async def test_cogvideox_capabilities_report_fixed_mvp_shape(monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_wan_capabilities_include_registered_community_benchmark_size(
+    monkeypatch,
+) -> None:
+    engine = SimpleNamespace(
+        model_name="Anes1032/Wan2.2-TI2V-5B-mlx-q8",
+        video_family="wan",
+        native_fps=24,
+        _wan_engine=SimpleNamespace(model_type="ti2v", max_area=832 * 512),
+    )
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+
+    body = await video.video_capabilities()
+
+    assert "832x480" in body["limits"]["size"]["also_supported"]
+
+
+@pytest.mark.asyncio
 async def test_wan_capabilities_use_checkpoint_limits(monkeypatch) -> None:
     engine = SimpleNamespace(
         model_name="Anes1032/Wan2.2-TI2V-5B-mlx-q8",
@@ -126,7 +143,7 @@ async def test_wan_capabilities_use_checkpoint_limits(monkeypatch) -> None:
 
     assert body["modes"] == ["image-to-video"]
     assert body["limits"]["size"]["maximum_area"] == 901_120
-    assert body["limits"]["size"]["also_supported"] == []
+    assert body["limits"]["size"]["also_supported"] == ["832x480"]
     assert body["limits"]["fps"] == {
         "minimum": 24,
         "maximum": 24,
@@ -153,6 +170,7 @@ async def test_wan_only_lists_openai_sizes_accepted_after_alignment(
     assert body["limits"]["size"]["also_supported"] == [
         "1280x720",
         "720x1280",
+        "832x480",
     ]
 
 

--- a/tests/test_wan_video.py
+++ b/tests/test_wan_video.py
@@ -306,6 +306,55 @@ async def test_wan_job_uses_native_fps_and_async_video_contract(
 
 
 @pytest.mark.asyncio
+async def test_wan_route_accepts_registered_community_benchmark_size(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    class FakeWanEngine:
+        model_name = "Anes1032/Wan2.2-TI2V-5B-mlx-q8"
+        video_family = "wan"
+        native_fps = 24
+        _wan_engine = None
+
+        def validate_request(self, **kwargs):
+            captured["validated"] = kwargs
+
+        def generate(self, *, output_path: Path, **kwargs):
+            captured.update(kwargs)
+            output_path.write_bytes(b"mp4")
+
+    engine = FakeWanEngine()
+    engine._wan_engine = engine
+    monkeypatch.setattr(video, "_video_engine", lambda: engine)
+
+    created = await video.create_video(
+        prompt="ocean sunrise",
+        model="wan2.2-ti2v-5b-q8",
+        seconds="ignored",
+        size="832x480",
+        seed=9,
+        frames=81,
+        fps=24,
+        guidance_scale=5.0,
+        input_reference=None,
+    )
+    for _ in range(100):
+        current = await video.retrieve_video(created["id"])
+        if current["status"] == "completed":
+            break
+        await asyncio.sleep(0.01)
+
+    assert current["status"] == "completed"
+    assert current["size"] == "832x480"
+    assert captured["width"] == 832
+    assert captured["height"] == 512
+    assert captured["output_width"] == 832
+    assert captured["output_height"] == 480
+    await video.delete_video(created["id"])
+
+
+@pytest.mark.asyncio
 async def test_wan_route_rejects_non_native_fps(monkeypatch) -> None:
     class FakeWanEngine:
         model_name = "Anes1032/Wan2.2-TI2V-5B-mlx-q8"

--- a/vllm_mlx/community_bench/local_runner.py
+++ b/vllm_mlx/community_bench/local_runner.py
@@ -12,7 +12,10 @@ import math
 import multiprocessing
 import multiprocessing.process
 import os
+import re
+import shutil
 import signal
+import subprocess
 import tempfile
 import threading
 import time
@@ -32,6 +35,27 @@ _VIDEO_POLL_INTERVAL_S = 1.0
 _VIDEO_ARTIFACT_DOWNLOAD_TIMEOUT_S = 300.0
 _VIDEO_ARTIFACT_PROBE_TIMEOUT_S = 120.0
 _MAX_VIDEO_ARTIFACT_BYTES = 1024 * 1024 * 1024
+
+
+def _raise_for_status(response: requests.Response, *, phase: str) -> None:
+    """Preserve a bounded localhost API error instead of only its status line."""
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        detail: Any = None
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                detail = body.get("detail") or body.get("error")
+        except (requests.exceptions.JSONDecodeError, ValueError):
+            detail = None
+        if not isinstance(detail, str) or not detail.strip():
+            detail = "local server rejected the request"
+        detail = detail.strip()[:500]
+        raise RuntimeError(
+            f"{phase} failed with HTTP {response.status_code}: {detail}"
+        ) from exc
 
 
 class LocalBenchmarkError(RuntimeError):
@@ -112,13 +136,58 @@ def _validated_image_count(result: dict[str, Any], *, width: int, height: int) -
     return len(data)
 
 
+def _probe_video_with_ffmpeg(path: str, ffmpeg: str) -> tuple[int, int, int, float]:
+    """Probe an MP4 with the small FFmpeg binary shipped by Desktop.
+
+    Desktop deliberately omits imageio/OpenCV. A stream copy makes FFmpeg walk
+    every video packet without decoding or retaining a second media stack.
+    """
+
+    with tempfile.NamedTemporaryFile(prefix="rapid-probe-", suffix=".mp4") as copy:
+        result = subprocess.run(
+            [
+                ffmpeg,
+                "-hide_banner",
+                "-i",
+                path,
+                "-map",
+                "0:v:0",
+                "-c",
+                "copy",
+                "-f",
+                "mp4",
+                "-y",
+                copy.name,
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "LC_ALL": "C"},
+            check=False,
+        )
+    output = result.stderr
+    stream = re.search(
+        r"Stream #\S+.*Video:.*?\b(\d{2,5})x(\d{2,5})\b.*?\b([0-9.]+) fps\b",
+        output,
+    )
+    frame_matches = re.findall(r"\bframe=\s*(\d+)\b", output)
+    if result.returncode or stream is None or not frame_matches:
+        raise RuntimeError("video benchmark returned an invalid MP4 artifact")
+    return (
+        int(stream.group(1)),
+        int(stream.group(2)),
+        int(frame_matches[-1]),
+        float(stream.group(3)),
+    )
+
+
 def _probe_video_artifact_unbounded(path: str) -> tuple[int, int, int, float]:
     try:
         import imageio.v2 as imageio
-    except ImportError as exc:  # pragma: no cover - video extra owns this dependency
-        raise RuntimeError(
-            "video artifact validation requires rapid-mlx[video]"
-        ) from exc
+    except ImportError:
+        ffmpeg = os.environ.get("FFMPEG_BINARY") or shutil.which("ffmpeg")
+        if ffmpeg:
+            return _probe_video_with_ffmpeg(path, ffmpeg)
+        raise RuntimeError("video artifact validation requires rapid-mlx[video]")
 
     try:
         reader = imageio.get_reader(path, format="ffmpeg")
@@ -436,7 +505,7 @@ def _run_image(
         for index in range(total):
             started = time.perf_counter()
             response = requests.post(endpoint, json=payload, timeout=3600)
-            response.raise_for_status()
+            _raise_for_status(response, phase="image benchmark request")
             result = response.json()
             duration_ms = (time.perf_counter() - started) * 1000
             if result.get("cancelled", False):
@@ -490,7 +559,7 @@ def _run_video(
         response = requests.post(
             f"{server['base_url']}/videos", data=payload, timeout=30
         )
-        response.raise_for_status()
+        _raise_for_status(response, phase="video benchmark request")
         job = response.json()
         deadline = time.monotonic() + _VIDEO_JOB_TIMEOUT_S
         active_statuses = {"queued", "running", "in_progress", "processing"}
@@ -506,7 +575,7 @@ def _run_video(
                 f"{server['base_url']}/videos/{job['id']}",
                 timeout=min(10, max(0.001, deadline - time.monotonic())),
             )
-            response.raise_for_status()
+            _raise_for_status(response, phase="video benchmark status poll")
             job = response.json()
             status = str(job.get("status", "")).lower()
         if status in {"cancelled", "canceled"}:

--- a/vllm_mlx/community_bench/local_runner.py
+++ b/vllm_mlx/community_bench/local_runner.py
@@ -16,6 +16,7 @@ import re
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -187,6 +188,19 @@ def _probe_video_with_ffmpeg(
     )
 
 
+def _is_sidecar_bundled_ffmpeg(ffmpeg: str) -> bool:
+    """Return whether FFmpeg and this interpreter share the sidecar root."""
+
+    try:
+        ffmpeg_root = os.path.dirname(os.path.dirname(os.path.realpath(ffmpeg)))
+        python_root = os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.realpath(sys.executable)))
+        )
+        return ffmpeg_root == python_root
+    except (OSError, ValueError):
+        return False
+
+
 def _probe_video_artifact_unbounded(path: str) -> tuple[int, int, int, float]:
     try:
         import imageio.v2 as imageio
@@ -195,7 +209,7 @@ def _probe_video_artifact_unbounded(path: str) -> tuple[int, int, int, float]:
         ffmpeg = bundled_ffmpeg or shutil.which("ffmpeg")
         if ffmpeg:
             return _probe_video_with_ffmpeg(
-                path, ffmpeg, desktop_bundle=bundled_ffmpeg is not None
+                path, ffmpeg, desktop_bundle=_is_sidecar_bundled_ffmpeg(ffmpeg)
             )
         raise RuntimeError("video artifact validation requires rapid-mlx[video]")
 

--- a/vllm_mlx/community_bench/local_runner.py
+++ b/vllm_mlx/community_bench/local_runner.py
@@ -143,7 +143,7 @@ def _probe_video_with_ffmpeg(path: str, ffmpeg: str) -> tuple[int, int, int, flo
     every video packet without decoding or retaining a second media stack.
     """
 
-    with tempfile.NamedTemporaryFile(prefix="rapid-probe-", suffix=".mp4") as copy:
+    try:
         result = subprocess.run(
             [
                 ffmpeg,
@@ -154,16 +154,21 @@ def _probe_video_with_ffmpeg(path: str, ffmpeg: str) -> tuple[int, int, int, flo
                 "0:v:0",
                 "-c",
                 "copy",
+                "-movflags",
+                "frag_keyframe+empty_moov",
                 "-f",
                 "mp4",
-                "-y",
-                copy.name,
+                "pipe:1",
             ],
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
             env={**os.environ, "LC_ALL": "C"},
+            timeout=_VIDEO_ARTIFACT_PROBE_TIMEOUT_S,
             check=False,
         )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError("video benchmark returned an invalid MP4 artifact") from exc
     output = result.stderr
     stream = re.search(
         r"Stream #\S+.*Video:.*?\b(\d{2,5})x(\d{2,5})\b.*?\b([0-9.]+) fps\b",

--- a/vllm_mlx/community_bench/local_runner.py
+++ b/vllm_mlx/community_bench/local_runner.py
@@ -136,7 +136,9 @@ def _validated_image_count(result: dict[str, Any], *, width: int, height: int) -
     return len(data)
 
 
-def _probe_video_with_ffmpeg(path: str, ffmpeg: str) -> tuple[int, int, int, float]:
+def _probe_video_with_ffmpeg(
+    path: str, ffmpeg: str, *, desktop_bundle: bool = False
+) -> tuple[int, int, int, float]:
     """Probe an MP4 with the small FFmpeg binary shipped by Desktop.
 
     Desktop deliberately omits imageio/OpenCV. Decode and re-encode through its
@@ -145,14 +147,8 @@ def _probe_video_with_ffmpeg(path: str, ffmpeg: str) -> tuple[int, int, int, flo
     """
 
     try:
-        result = subprocess.run(
+        sink = (
             [
-                ffmpeg,
-                "-hide_banner",
-                "-i",
-                path,
-                "-map",
-                "0:v:0",
                 "-c:v",
                 "h264_videotoolbox",
                 "-movflags",
@@ -160,7 +156,12 @@ def _probe_video_with_ffmpeg(path: str, ffmpeg: str) -> tuple[int, int, int, flo
                 "-f",
                 "mp4",
                 "pipe:1",
-            ],
+            ]
+            if desktop_bundle
+            else ["-f", "null", "-"]
+        )
+        result = subprocess.run(
+            [ffmpeg, "-hide_banner", "-i", path, "-map", "0:v:0", *sink],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             text=True,
@@ -190,9 +191,12 @@ def _probe_video_artifact_unbounded(path: str) -> tuple[int, int, int, float]:
     try:
         import imageio.v2 as imageio
     except ImportError:
-        ffmpeg = os.environ.get("FFMPEG_BINARY") or shutil.which("ffmpeg")
+        bundled_ffmpeg = os.environ.get("FFMPEG_BINARY")
+        ffmpeg = bundled_ffmpeg or shutil.which("ffmpeg")
         if ffmpeg:
-            return _probe_video_with_ffmpeg(path, ffmpeg)
+            return _probe_video_with_ffmpeg(
+                path, ffmpeg, desktop_bundle=bundled_ffmpeg is not None
+            )
         raise RuntimeError("video artifact validation requires rapid-mlx[video]")
 
     try:

--- a/vllm_mlx/community_bench/local_runner.py
+++ b/vllm_mlx/community_bench/local_runner.py
@@ -139,8 +139,9 @@ def _validated_image_count(result: dict[str, Any], *, width: int, height: int) -
 def _probe_video_with_ffmpeg(path: str, ffmpeg: str) -> tuple[int, int, int, float]:
     """Probe an MP4 with the small FFmpeg binary shipped by Desktop.
 
-    Desktop deliberately omits imageio/OpenCV. A stream copy makes FFmpeg walk
-    every video packet without decoding or retaining a second media stack.
+    Desktop deliberately omits imageio/OpenCV. Decode and re-encode through its
+    constrained VideoToolbox FFmpeg to prove every frame is readable without
+    retaining a second media stack or a second artifact on disk.
     """
 
     try:
@@ -152,8 +153,8 @@ def _probe_video_with_ffmpeg(path: str, ffmpeg: str) -> tuple[int, int, int, flo
                 path,
                 "-map",
                 "0:v:0",
-                "-c",
-                "copy",
+                "-c:v",
+                "h264_videotoolbox",
                 "-movflags",
                 "frag_keyframe+empty_moov",
                 "-f",

--- a/vllm_mlx/routes/video.py
+++ b/vllm_mlx/routes/video.py
@@ -40,6 +40,10 @@ _VIDEO_JOB_SCHEMA_VERSION = 1
 _VIDEO_JOB_METADATA = "job.json"
 _MAX_VIDEO_JOB_METADATA_BYTES = 64 * 1024
 _VIDEO_ID_RE = re.compile(r"video_[0-9a-f]{32}\Z")
+# The registered Community Benchmark uses Wan's common 480p landscape target.
+# Wan renders through a 64-aligned working canvas and crops/scales to the
+# requested output, just like the OpenAI-compatible 720p exceptions below.
+_WAN_STANDARD_OUTPUT_SIZE = (832, 480)
 _jobs_lock = threading.Lock()
 _ephemeral_jobs_roots = {Path(tempfile.mkdtemp(prefix="rapid-mlx-videos-"))}
 _jobs_root = next(iter(_ephemeral_jobs_roots))
@@ -690,19 +694,25 @@ def _video_engine():
     return engine
 
 
-def _parse_size(value: str, *, multiple: int = 64) -> tuple[int, int]:
+def _parse_size(
+    value: str,
+    *,
+    multiple: int = 64,
+    also_supported: set[tuple[int, int]] | None = None,
+) -> tuple[int, int]:
     try:
         width, height = (int(part) for part in value.lower().split("x", 1))
     except (TypeError, ValueError) as exc:
         raise HTTPException(
             status_code=400, detail="size must be WIDTHxHEIGHT"
         ) from exc
-    openai_sizes = {(1280, 720), (720, 1280)}
+    exceptional_sizes = {(1280, 720), (720, 1280)}
+    exceptional_sizes.update(also_supported or ())
     is_model_aligned = width % multiple == 0 and height % multiple == 0
     if not (
         256 <= width <= 1920
         and 256 <= height <= 1920
-        and (is_model_aligned or (width, height) in openai_sizes)
+        and (is_model_aligned or (width, height) in exceptional_sizes)
     ):
         raise HTTPException(
             status_code=400,
@@ -741,7 +751,7 @@ def _video_capabilities(engine) -> dict:
             "i2v": ["image-to-video"],
             "ti2v": ["text-to-video", "image-to-video"],
         }.get(model_type, ["text-to-video", "image-to-video"])
-        openai_sizes = [(1280, 720), (720, 1280)]
+        openai_sizes = [(1280, 720), (720, 1280), _WAN_STANDARD_OUTPUT_SIZE]
         supported_openai_sizes = [
             f"{width}x{height}"
             for width, height in openai_sizes
@@ -1052,7 +1062,11 @@ async def create_video(
             )
         width, height = 672, 384
     else:
-        width, height = _parse_size(size, multiple=32 if is_ltx25 else 64)
+        width, height = _parse_size(
+            size,
+            multiple=32 if is_ltx25 else 64,
+            also_supported={_WAN_STANDARD_OUTPUT_SIZE} if is_wan else None,
+        )
     native_fps = 5 if is_cogvideox else getattr(engine, "native_fps", 24)
     request_fps = native_fps if fps is None else fps
     if not 1 <= request_fps <= 60:


### PR DESCRIPTION
## Scope

Community Benchmark video execution only: Wan 832x480 workload admission, imageio-free Desktop artifact validation, and useful localhost API errors. This does not redesign video generation, benchmark schemas, upload, GUI, or the website.

## Release dogfood evidence

0.13.4 on Studio exposed two blockers in sequence:
- the registered Wan workload requested 832x480 but the route rejected the non-64-aligned height
- after generation succeeded, the minimal signed Desktop sidecar could not validate MP4 output because it intentionally omits imageio/OpenCV

The fix admits only Wan 832x480 as an explicit compatibility target and falls back to the already bundled constrained FFmpeg for dimensions/frame-count/fps probing.

## Verification

- `python3.12 -m ruff check` on changed Python/test files
- 228 relevant pytest cases passed
- real bundled FFmpeg probe: 832x480, 81 frames, 24fps
- full patched Wan end-to-end dogfood in progress; result will be posted before queueing

Reviewer scope: validate only the Community Benchmark video request/probe path and its regression boundary; unrelated video architecture and broader benchmark product work are out of scope.