### PR TITLE
fix(ci): accept scrollbar-free transcript tail

### DIFF
--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -907,16 +907,20 @@ settle_transcript_at_bottom() {
                     and .bounds.height > .bounds.width
                     and .bounds.x > $compose_x)]
         | sort_by(.bounds.x) | .[0].bounds.x // empty' "$destination")"
-    [[ -n "$scroll_x" ]] \
-        || die "could not identify the transcript scrollbar beside the compose surface"
-    before_value="$(jq -r --argjson scroll_x "$scroll_x" '
-        [.data.ui_elements[]?
-         | select(.role == "AXScrollBar"
-                  and (.value | type) == "number"
-                  and ((.bounds.x - $scroll_x) | fabs) < 1)
-         | .value] | first // empty' "$destination")"
-    [[ -n "$before_value" ]] \
-        || die "transcript exposes no measurable scroll position before Jump to latest"
+    # AppKit does not expose an AXScrollBar when the completed transcript fits
+    # its viewport. That is a valid at-tail state, not a missing-control
+    # failure. Keep the correlated scrollbar when one exists; otherwise the
+    # stability loop below must prove the visible assistant tail twice.
+    if [[ -n "$scroll_x" ]]; then
+        before_value="$(jq -r --argjson scroll_x "$scroll_x" '
+            [.data.ui_elements[]?
+             | select(.role == "AXScrollBar"
+                      and (.value | type) == "number"
+                      and ((.bounds.x - $scroll_x) | fabs) < 1)
+             | .value] | first // empty' "$destination")"
+        [[ -n "$before_value" ]] \
+            || die "transcript exposes no measurable scroll position before Jump to latest"
+    fi
     if jq -e '.data.ui_elements[]?
               | select(.identifier == "Transcript.JumpToBottom")' \
         "$destination" >/dev/null; then
@@ -938,12 +942,15 @@ settle_transcript_at_bottom() {
     for _ in {1..60}; do
         see_main "$destination"
         local current_value tail_marker_visible tail_key=""
-        current_value="$(jq -r --argjson scroll_x "$scroll_x" '
-            [.data.ui_elements[]?
-             | select(.role == "AXScrollBar"
-                      and (.value | type) == "number"
-                      and ((.bounds.x - $scroll_x) | fabs) < 1)
-             | .value] | first // empty' "$destination")"
+        current_value=""
+        if [[ -n "$scroll_x" ]]; then
+            current_value="$(jq -r --argjson scroll_x "$scroll_x" '
+                [.data.ui_elements[]?
+                 | select(.role == "AXScrollBar"
+                          and (.value | type) == "number"
+                          and ((.bounds.x - $scroll_x) | fabs) < 1)
+                 | .value] | first // empty' "$destination")"
+        fi
         # AppKit may remove an overlay scrollbar once a short transcript fits
         # entirely inside its viewport. In that state, the last assistant
         # action row being fully visible is stronger physical evidence than a

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -395,6 +395,77 @@ def test_transcript_settler_accepts_stable_visible_tail_after_scrollbar_hides(tm
     assert completed.stdout.strip() == "3"
 
 
+def test_transcript_settler_accepts_short_reply_without_scrollbar(tmp_path):
+    """A fitting first reply can be at its tail before AppKit mounts any bar."""
+    source = HARNESS.read_text()
+    helper_body = source.split("settle_transcript_at_bottom() {", 1)[1].split("\n}", 1)[
+        0
+    ]
+    helper = f"settle_transcript_at_bottom() {{{helper_body}\n}}"
+
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "ui_elements": [
+                        {
+                            "role": "AXScrollArea",
+                            "bounds": {
+                                "x": 201,
+                                "y": 171,
+                                "width": 519,
+                                "height": 318,
+                            },
+                        },
+                        {
+                            "role": "AXButton",
+                            "identifier": "ChatView.Message.Retry.reply",
+                            "bounds": {
+                                "x": 277,
+                                "y": 383,
+                                "width": 24,
+                                "height": 24,
+                            },
+                        },
+                        {
+                            "role": "AXButton",
+                            "identifier": "ChatView.SendOrStopButton",
+                            "bounds": {
+                                "x": 658,
+                                "y": 546,
+                                "width": 28,
+                                "height": 28,
+                            },
+                        },
+                    ]
+                }
+            }
+        )
+    )
+
+    script = textwrap.dedent(
+        f"""
+        set -euo pipefail
+        fixture={str(fixture)!r}
+        calls=0
+        see_main() {{ cp "$fixture" "$1"; calls=$((calls + 1)); }}
+        press() {{ printf 'unexpected press\n' >&2; exit 98; }}
+        die() {{ printf '%s\n' "$*" >&2; exit 97; }}
+        sleep() {{ :; }}
+        {helper}
+        settle_transcript_at_bottom "$fixture.current.json" "$fixture.press.json"
+        printf '%s\n' "$calls"
+        """
+    )
+    completed = subprocess.run(
+        ["bash", "-c", script], capture_output=True, check=False, text=True
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "3"
+
+
 def test_transcript_settler_rechecks_after_a_stale_jump_press(tmp_path):
     """A vanished stale AX element still needs the physical tail proof."""
     source = HARNESS.read_text()


### PR DESCRIPTION
## Why

Mergify correctly isolated #2972 after the fresh-install GUI journey failed on candidate #3012. The completed one-line reply fit entirely inside the transcript viewport, so AppKit exposed the assistant tail but no AXScrollBar. The harness treated that valid state as a missing control and failed before applying its existing physical-tail proof.

## Fix

- Keep using the correlated scrollbar and numeric tail position whenever AppKit exposes one.
- When no scrollbar exists, require the final assistant action row to be fully visible inside the transcript for two consecutive AX snapshots.
- Preserve fail-closed behavior when neither a measurable scrollbar tail nor a stable visible assistant tail exists.

## Test

- python3 -m pytest -q tests/test_gui_preflight_contract.py (34 passed)
- bash -n apps/rapid-mac/scripts/gui-golden-flows.sh
- git diff HEAD^ --check
- Regression fixture mirrors candidate #3012 evidence: transcript AXScrollArea and Retry action visible, no AXScrollBar.

## Design precedent

Native macOS scroll views may omit overlay scrollbar accessibility nodes when content fits. The gate therefore validates the user-observable invariant—stable visibility of the transcript tail—rather than requiring an implementation-specific scrollbar node.

## Scope

This changes only the GUI golden-flow harness and its contract test. It does not alter Desktop product behavior, scheduler behavior, queue policy, timeouts, or retry policy.