### PR TITLE
fix(cache): accept safe indexed sidecar paths

### DIFF
--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1974,6 +1974,64 @@ def test_is_repo_cached_rejects_ambiguous_nested_manifest_paths(
     assert gate.is_repo_cached("user/ambiguous") is False
 
 
+@pytest.mark.parametrize(
+    "weight_map",
+    (
+        {"model.weight": None},
+        {"model.weight": "model.safetensors", "helper.weight": "helper.bin"},
+    ),
+)
+def test_is_repo_cached_rejects_malformed_manifest_values(
+    tmp_path, monkeypatch, weight_map
+):
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--malformed-index"
+    snap = repo_root / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "model.safetensors").write_bytes(b"model")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map})
+    )
+    _seed_refs_main(repo_root, "abc")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/malformed-index") is False
+
+
+def test_is_repo_cached_rejects_index_with_only_nested_sidecars(tmp_path, monkeypatch):
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--sidecar-only-index"
+    snap = repo_root / "snapshots" / "abc"
+    (snap / "sidecars").mkdir(parents=True)
+    (snap / "sidecars" / "helper.safetensors").write_bytes(b"helper")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"helper.weight": "sidecars/helper.safetensors"}})
+    )
+    _seed_refs_main(repo_root, "abc")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/sidecar-only-index") is False
+
+
+def test_snapshot_manifest_helpers_fail_closed_for_local_and_racing_files(
+    tmp_path, monkeypatch
+):
+    local_snapshot = tmp_path / "local-checkpoint"
+    local_snapshot.mkdir()
+    weight = local_snapshot / "model.safetensors"
+    weight.write_bytes(b"model")
+
+    assert gate._snapshot_repo_root(str(local_snapshot)) == str(local_snapshot)
+
+    monkeypatch.setattr(
+        gate.os.path, "getsize", MagicMock(side_effect=OSError("file vanished"))
+    )
+    assert (
+        gate._is_nonempty_snapshot_manifest_file(str(weight), str(local_snapshot))
+        is False
+    )
+
+
 def test_is_repo_cached_honours_resolved_revision_ref(tmp_path, monkeypatch):
     """Codex round-9 BLOCKING: an old complete snapshot must not mask
     the current incomplete one. After an interrupted ``snapshot_download``

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1781,6 +1781,111 @@ def test_is_repo_cached_rejects_path_traversal_in_index(tmp_path, monkeypatch):
     assert gate.is_repo_cached("user/escape") is False
 
 
+def test_is_repo_cached_accepts_manifest_declared_nested_sidecar(tmp_path, monkeypatch):
+    """A complete indexed checkpoint may declare auxiliary weights below it.
+
+    Model shards remain at the snapshot root where the text loader consumes
+    them; the nested file is a manifest-owned sidecar.  Mirror the real Hub
+    cache shape so this also proves symlinks into the owning repo's blobs are
+    accepted.
+    """
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--mlx-community--optiq"
+    snap = repo_root / "snapshots" / "abc"
+    blobs = repo_root / "blobs"
+    (snap / "optiq").mkdir(parents=True)
+    blobs.mkdir()
+    (snap / "config.json").write_text("{}")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "language_model.weight": "model-00001-of-00001.safetensors",
+                    "vision_tower.weight": "optiq/optiq_vision.safetensors",
+                }
+            }
+        )
+    )
+    root_blob = blobs / "root-shard"
+    sidecar_blob = blobs / "vision-sidecar"
+    root_blob.write_bytes(b"model")
+    sidecar_blob.write_bytes(b"vision")
+    (snap / "model-00001-of-00001.safetensors").symlink_to(root_blob)
+    (snap / "optiq" / "optiq_vision.safetensors").symlink_to(sidecar_blob)
+    _seed_refs_main(repo_root, "abc")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("mlx-community/optiq") is True
+
+    # The sidecar is part of the manifest closure, not optional decoration.
+    (snap / "optiq" / "optiq_vision.safetensors").unlink()
+    assert gate.is_repo_cached("mlx-community/optiq") is False
+
+
+def test_is_repo_cached_rejects_nested_sidecar_outside_owning_repo(
+    tmp_path, monkeypatch
+):
+    """A crafted nested symlink cannot borrow a file from another repo."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--nested-escape"
+    snap = repo_root / "snapshots" / "abc"
+    (snap / "sidecars").mkdir(parents=True)
+    (snap / "model.safetensors").write_bytes(b"model")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.weight": "model.safetensors",
+                    "helper.weight": "sidecars/helper.safetensors",
+                }
+            }
+        )
+    )
+    outside = tmp_path / "other-repo" / "blobs" / "helper"
+    outside.parent.mkdir(parents=True)
+    outside.write_bytes(b"helper")
+    (snap / "sidecars" / "helper.safetensors").symlink_to(outside)
+    _seed_refs_main(repo_root, "abc")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/nested-escape") is False
+
+
+@pytest.mark.parametrize(
+    "sidecar",
+    (
+        "sidecars/../helper.safetensors",
+        "sidecars/./helper.safetensors",
+        "sidecars//helper.safetensors",
+        r"sidecars\helper.safetensors",
+    ),
+)
+def test_is_repo_cached_rejects_ambiguous_nested_manifest_paths(
+    tmp_path, monkeypatch, sidecar
+):
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--ambiguous"
+    snap = repo_root / "snapshots" / "abc"
+    snap.mkdir(parents=True)
+    (snap / "model.safetensors").write_bytes(b"model")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.weight": "model.safetensors",
+                    "helper.weight": sidecar,
+                }
+            }
+        )
+    )
+    _seed_refs_main(repo_root, "abc")
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/ambiguous") is False
+
+
 def test_is_repo_cached_honours_resolved_revision_ref(tmp_path, monkeypatch):
     """Codex round-9 BLOCKING: an old complete snapshot must not mask
     the current incomplete one. After an interrupted ``snapshot_download``

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1885,6 +1885,34 @@ def test_is_repo_cached_rejects_symlinked_blob_store_anchor(tmp_path, monkeypatc
     assert gate.is_repo_cached("user/blob-anchor-escape") is False
 
 
+def test_is_repo_cached_rejects_symlinked_snapshot_anchor(tmp_path, monkeypatch):
+    """A revision directory cannot redirect the manifest into another repo."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--snapshot-anchor-escape"
+    snapshots = repo_root / "snapshots"
+    snapshots.mkdir(parents=True)
+    foreign_snap = cache_root / "models--other--repo" / "snapshots" / "foreign"
+    (foreign_snap / "sidecars").mkdir(parents=True)
+    (foreign_snap / "model.safetensors").write_bytes(b"model")
+    (foreign_snap / "sidecars" / "helper.safetensors").write_bytes(b"helper")
+    (foreign_snap / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.weight": "model.safetensors",
+                    "helper.weight": "sidecars/helper.safetensors",
+                }
+            }
+        )
+    )
+    (snapshots / "abc").symlink_to(foreign_snap)
+    _seed_refs_main(repo_root, "abc")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/snapshot-anchor-escape") is False
+
+
 @pytest.mark.parametrize(
     "sidecar",
     (

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1913,6 +1913,34 @@ def test_is_repo_cached_rejects_symlinked_snapshot_anchor(tmp_path, monkeypatch)
     assert gate.is_repo_cached("user/snapshot-anchor-escape") is False
 
 
+def test_is_repo_cached_rejects_current_revision_linked_to_old_revision(
+    tmp_path, monkeypatch
+):
+    """A same-repo snapshot redirect cannot make stale weights current."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--stale-snapshot"
+    old_snap = repo_root / "snapshots" / "old"
+    (old_snap / "sidecars").mkdir(parents=True)
+    (old_snap / "model.safetensors").write_bytes(b"old-model")
+    (old_snap / "sidecars" / "helper.safetensors").write_bytes(b"old-helper")
+    (old_snap / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.weight": "model.safetensors",
+                    "helper.weight": "sidecars/helper.safetensors",
+                }
+            }
+        )
+    )
+    (repo_root / "snapshots" / "current").symlink_to(old_snap)
+    _seed_refs_main(repo_root, "current")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/stale-snapshot") is False
+
+
 @pytest.mark.parametrize(
     "sidecar",
     (

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -1853,6 +1853,38 @@ def test_is_repo_cached_rejects_nested_sidecar_outside_owning_repo(
     assert gate.is_repo_cached("user/nested-escape") is False
 
 
+def test_is_repo_cached_rejects_symlinked_blob_store_anchor(tmp_path, monkeypatch):
+    """The owning repo cannot redirect its entire blob store to another repo."""
+    cache_root = tmp_path / "hf-cache"
+    repo_root = cache_root / "models--user--blob-anchor-escape"
+    snap = repo_root / "snapshots" / "abc"
+    (snap / "sidecars").mkdir(parents=True)
+    (snap / "model.safetensors").write_bytes(b"model")
+    (snap / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.weight": "model.safetensors",
+                    "helper.weight": "sidecars/helper.safetensors",
+                }
+            }
+        )
+    )
+    foreign_blobs = cache_root / "models--other--repo" / "blobs"
+    foreign_blobs.mkdir(parents=True)
+    helper = foreign_blobs / "helper"
+    helper.write_bytes(b"helper")
+    (repo_root / "blobs").symlink_to(foreign_blobs)
+    (snap / "sidecars" / "helper.safetensors").symlink_to(
+        repo_root / "blobs" / "helper"
+    )
+    _seed_refs_main(repo_root, "abc")
+
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.is_repo_cached("user/blob-anchor-escape") is False
+
+
 @pytest.mark.parametrize(
     "sidecar",
     (

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -645,7 +645,9 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
     Strategy:
       1. ``model.safetensors.index.json`` present → parse ``weight_map``
          and require every referenced shard to exist with non-zero
-         size. Codex round-4 BLOCKING #1.
+         size. Primary ``model*.safetensors`` shards must stay at the root
+         consumed by mlx-lm; safe nested paths are accepted for declared
+         auxiliary weights.
       2. Without an index, numbered ``model-N-of-M`` files must form the
          complete 1...M set. This covers an interrupted pull where one shard
          lands before the index file.
@@ -676,35 +678,32 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
             # know SOMETHING expects shards here; refuse to fall
             # through to the lax single-file probe.
             return False
-        shard_names = set(weight_map.values())
-        # Codex round-6 BLOCKING #2: validate the shard filenames
-        # themselves match the loader glob, not just that they exist.
-        # Codex round-7 BLOCKING #1: AND make sure the shard names
-        # don't escape ``snap_dir`` via ``..`` or an absolute path —
-        # ``mlx_lm`` only loads ``snap_dir/model*.safetensors``, so a
-        # validated basename pointing at ``../somewhere-else`` would
-        # otherwise pass while the loader sees nothing.
+        shard_values = weight_map.values()
+        if not all(isinstance(shard, str) for shard in shard_values):
+            return False
+        shard_names = set(shard_values)
+        has_root_model_shard = False
         for shard in shard_names:
-            if not isinstance(shard, str):
+            parts = _safe_safetensors_manifest_parts(shard)
+            if parts is None:
                 return False
-            # No directory traversal, no absolute paths, no nested
-            # subdirectories — the loader's glob is non-recursive on
-            # the snapshot root.
-            if (
-                os.path.isabs(shard)
-                or os.sep in shard
-                or "/" in shard
-                or ".." in shard.split("/")
-            ):
+
+            is_root_entry = len(parts) == 1
+            is_model_shard = _is_model_weight_filename(parts[-1])
+            # mlx-lm loads primary model weights only from the snapshot root.
+            # A manifest may also declare nested auxiliary safetensors (for
+            # example a quantizer-owned vision sidecar), but a nested
+            # ``model*.safetensors`` must not make an unloaded primary shard
+            # look usable.
+            if is_root_entry != is_model_shard:
                 return False
-            if not _is_model_weight_filename(shard):
+            has_root_model_shard = has_root_model_shard or is_root_entry
+
+            target = os.path.join(snap_dir, *parts)
+            if not _is_nonempty_snapshot_manifest_file(target, snap_dir):
                 return False
-            target = os.path.join(snap_dir, shard)
-            try:
-                if os.path.getsize(target) <= 0:
-                    return False
-            except OSError:
-                return False
+        if not has_root_model_shard:
+            return False
         # Codex round-7 BLOCKING #3: the loader globs every
         # ``model*.safetensors`` at the snapshot root — a stray
         # zero-byte ``model-extra.safetensors`` next to a valid
@@ -742,6 +741,58 @@ def _snapshot_is_complete(snap_dir: str) -> bool:
     except OSError:
         pass
     return False
+
+
+def _safe_safetensors_manifest_parts(value: object) -> tuple[str, ...] | None:
+    """Return safe POSIX-relative components for an indexed weight file.
+
+    Hub manifests use ``/`` regardless of the host platform.  Reject rather
+    than normalize ambiguous paths: an index is metadata, not authority to
+    escape its snapshot or reinterpret ``.``/empty components.
+    """
+    if not isinstance(value, str) or not value.endswith(".safetensors"):
+        return None
+    if not value or value.startswith("/") or "\\" in value:
+        return None
+    parts = tuple(value.split("/"))
+    if any(part in ("", ".", "..") for part in parts):
+        return None
+    return parts
+
+
+def _snapshot_repo_root(snap_dir: str) -> str:
+    """Return the owning Hub repo root, or ``snap_dir`` for local fixtures.
+
+    A normal Hub leaf is ``<repo>/snapshots/<revision>[/checkpoint]`` and its
+    files are symlinks into ``<repo>/blobs``.  Walking ancestors instead of
+    assuming a fixed depth also covers aliases that select a checkpoint
+    subdirectory.
+    """
+    current = os.path.abspath(snap_dir)
+    while True:
+        parent = os.path.dirname(current)
+        if os.path.basename(parent) == "snapshots":
+            return os.path.dirname(parent)
+        if parent == current:
+            return os.path.abspath(snap_dir)
+        current = parent
+
+
+def _is_nonempty_snapshot_manifest_file(path: str, snap_dir: str) -> bool:
+    """Accept a real snapshot file or its normal symlink into repo blobs."""
+    try:
+        if not os.path.isfile(path) or os.path.getsize(path) <= 0:
+            return False
+        snapshot_real = os.path.realpath(snap_dir)
+        blobs_real = os.path.realpath(
+            os.path.join(_snapshot_repo_root(snap_dir), "blobs")
+        )
+        target_real = os.path.realpath(path)
+        return target_real.startswith(snapshot_real + os.sep) or target_real.startswith(
+            blobs_real + os.sep
+        )
+    except OSError:
+        return False
 
 
 def _root_model_files_all_non_empty(snap_dir: str) -> bool:

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -784,7 +784,12 @@ def _is_nonempty_snapshot_manifest_file(path: str, snap_dir: str) -> bool:
         if not os.path.isfile(path) or os.path.getsize(path) <= 0:
             return False
         snapshot_real = os.path.realpath(snap_dir)
-        repo_root_real = os.path.realpath(_snapshot_repo_root(snap_dir))
+        repo_root = _snapshot_repo_root(snap_dir)
+        repo_root_real = os.path.realpath(repo_root)
+        if os.path.abspath(repo_root) != os.path.abspath(snap_dir):
+            snapshots_real = os.path.join(repo_root_real, "snapshots")
+            if not snapshot_real.startswith(snapshots_real + os.sep):
+                return False
         expected_blobs = os.path.join(repo_root_real, "blobs")
         blobs_real = os.path.realpath(expected_blobs)
         # The leaf may be a normal Hub symlink into ``blobs``; the blob-store

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -784,9 +784,13 @@ def _is_nonempty_snapshot_manifest_file(path: str, snap_dir: str) -> bool:
         if not os.path.isfile(path) or os.path.getsize(path) <= 0:
             return False
         snapshot_real = os.path.realpath(snap_dir)
-        blobs_real = os.path.realpath(
-            os.path.join(_snapshot_repo_root(snap_dir), "blobs")
-        )
+        repo_root_real = os.path.realpath(_snapshot_repo_root(snap_dir))
+        expected_blobs = os.path.join(repo_root_real, "blobs")
+        blobs_real = os.path.realpath(expected_blobs)
+        # The leaf may be a normal Hub symlink into ``blobs``; the blob-store
+        # anchor itself may not be rebound to another repository.
+        if blobs_real != expected_blobs:
+            return False
         target_real = os.path.realpath(path)
         return target_real.startswith(snapshot_real + os.sep) or target_real.startswith(
             blobs_real + os.sep

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -787,8 +787,11 @@ def _is_nonempty_snapshot_manifest_file(path: str, snap_dir: str) -> bool:
         repo_root = _snapshot_repo_root(snap_dir)
         repo_root_real = os.path.realpath(repo_root)
         if os.path.abspath(repo_root) != os.path.abspath(snap_dir):
-            snapshots_real = os.path.join(repo_root_real, "snapshots")
-            if not snapshot_real.startswith(snapshots_real + os.sep):
+            relative_snapshot = os.path.relpath(
+                os.path.abspath(snap_dir), os.path.abspath(repo_root)
+            )
+            expected_snapshot = os.path.join(repo_root_real, relative_snapshot)
+            if snapshot_real != expected_snapshot:
                 return False
         expected_blobs = os.path.join(repo_root_real, "blobs")
         blobs_real = os.path.realpath(expected_blobs)


### PR DESCRIPTION
## Why

Fixes #3018. Fully downloaded built-in OptiQ checkpoints whose index declares an auxiliary safetensors file below the snapshot root are incorrectly classified as uncached. Users are prompted to download the same multi-GB model again on every serve.

A current-repository audit found four affected built-in checkpoints. Two additional OptiQ aliases named in the report currently have flat manifests and are not affected.

## Scope

- Accept safe manifest-declared nested safetensors sidecars in the cache-completeness gate.
- Keep primary model shards constrained to the root path consumed by the text loader.
- Validate every declared file as non-empty and contained in the exact snapshot or the owning repository blob store.
- Add focused regression and path-containment tests.

## Non-goals

- No model loader, routing, alias, dependency, Desktop, or CI changes.
- No model-family or OptiQ-name special case.
- No change to download behavior for incomplete snapshots.

## Acceptance

- A complete Hub-cache-shaped checkpoint with root model shards plus a declared nested sidecar is recognized as cached.
- Missing or empty declared files remain incomplete.
- Absolute, traversal, ambiguous, nested-primary-shard, cross-repository, and stale-revision symlink paths remain rejected.
- Flat indexed and indexless checkpoint behavior remains unchanged.

## Design precedent

Established checkpoint loaders treat the index weight map as the authoritative set of repository-relative files, while separately constraining which files are primary loadable shards. This change adapts that split: validate the complete manifest closure, preserve the actual root-only primary-weight loading contract, and fail closed on ambiguous or escaping paths.

## Verification

- Reproduced the pre-fix false result with the reported root-shard plus nested-sidecar manifest shape.
- Audited all six reported built-in repositories; four currently publish the nested sidecar layout.
- python3.12 -m pytest -q tests/test_download_gate.py — 176 passed.
- python3.12 -m pytest -q tests/test_server_load_model_order.py tests/test_cli_models.py — 125 passed.
- python3.12 -m scripts.pr_validate.pr_validate 3020 -v — Codex review, lint, targeted tests, and full-unit passed; 21,506 passed, 108 skipped, 6 xfailed, 1 xpassed. The only initial scorecard failure was the self-referential unchecked item now completed below.
- python3.12 -m compileall -q vllm_mlx — passed.
- python3.12 -m ruff check vllm_mlx/_download_gate.py tests/test_download_gate.py — passed.
- python3.12 -m ruff format --check vllm_mlx/_download_gate.py tests/test_download_gate.py — passed.
- git diff --check — passed.

## Behaviour delta

A complete indexed cache with safe nested auxiliary safetensors: repeatedly treated as uncached → recognized as cached. Unsafe or incomplete manifests still fail closed.

## AI assistance disclosure

Codex implemented and reviewed both changed files. The result was verified against the issue reproduction, current published manifest shapes, four adversarial Codex rounds, focused cache/CLI/server tests, the full unit suite, formatting, lint, compilation, and diff checks.

## Checklist

- [x] Focused tests pass locally
- [x] Lint and format checks pass
- [x] Self-validated with pr_validate
- [x] Regression tests were checked against the pre-fix failure
- [x] No documentation change is needed for this corrective behavior
- [x] No breaking API change