### PR TITLE
fix(engine): cooperatively cancel buffered guided decoding

### DIFF
--- a/tests/headless_mlx/test_disconnect_guard_aborts_scheduler.py
+++ b/tests/headless_mlx/test_disconnect_guard_aborts_scheduler.py
@@ -31,6 +31,30 @@ import time
 
 import pytest
 
+
+def test_force_abort_prefers_live_guided_owner_over_text_scheduler():
+    """A guided id is not present in the text scheduler it bypasses."""
+    from vllm_mlx.service.helpers import _force_abort_request
+
+    class _Scheduler:
+        def abort_request(self, _request_id):
+            raise AssertionError("guided cancellation must not hit text scheduler")
+
+    class _Engine:
+        scheduler = _Scheduler()
+
+        def __init__(self):
+            self.aborted = []
+
+        def abort_guided_request(self, request_id):
+            self.aborted.append(request_id)
+            return True
+
+    engine = _Engine()
+    assert _force_abort_request(engine, ["chatcmpl-guided"]) is True
+    assert engine.aborted == ["chatcmpl-guided"]
+
+
 # ---------------------------------------------------------------------------
 # Stubs
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -22,15 +22,20 @@ Two contract tests:
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from vllm_mlx.api.errors import GuidedGenerationCancelledError
+from vllm_mlx.api.models import ChatCompletionRequest
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
 from vllm_mlx.routes.chat import router as chat_router
+from vllm_mlx.routes.chat import stream_chat_completion_guided
+from vllm_mlx.routes.health import cancel_request
 
 
 class _GuidedEngine:
@@ -122,6 +127,77 @@ def _parse_sse_events(text: str) -> tuple[list[dict], bool]:
         except json.JSONDecodeError:
             continue
     return events, saw_done
+
+
+@pytest.mark.asyncio
+async def test_guided_stream_publishes_cancellable_id_before_buffered_output():
+    """The first SSE event addresses live guided work, not completed work."""
+
+    class _CancellableGuidedEngine(_GuidedEngine):
+        def __init__(self):
+            super().__init__()
+            self.cancelled = asyncio.Event()
+            self.live_request_id: str | None = None
+
+        async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+            self.guided_calls.append(
+                {"messages": messages, "json_schema": json_schema, "kwargs": kwargs}
+            )
+            self.live_request_id = kwargs["request_id"]
+            kwargs["request_id_holder"][0] = self.live_request_id
+            kwargs["request_admitted_event"].set()
+            await self.cancelled.wait()
+            raise GuidedGenerationCancelledError()
+
+        def abort_guided_request(self, request_id: str) -> bool:
+            if request_id != self.live_request_id or self.cancelled.is_set():
+                return False
+            self.cancelled.set()
+            return True
+
+        async def abort_request(self, request_id: str) -> bool:
+            return self.abort_guided_request(request_id)
+
+    engine = _CancellableGuidedEngine()
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "emit json"}],
+    )
+    holder: list[str | None] = [None]
+    stream = stream_chat_completion_guided(
+        engine,
+        request.messages,
+        request,
+        {"type": "object"},
+        response_id="chatcmpl-" + "a" * 32,
+        strict_mode=True,
+        request_id_holder=holder,
+    )
+
+    first = json.loads((await anext(stream)).removeprefix("data: "))
+    request_id = first["id"]
+    assert request_id == "chatcmpl-" + "a" * 32
+    assert holder == [request_id]
+    assert engine.cancelled.is_set() is False
+
+    response = await cancel_request(request_id)
+    assert response == {
+        "object": "request.cancel",
+        "id": request_id,
+        "cancelled": True,
+    }
+
+    terminal = json.loads((await anext(stream)).removeprefix("data: "))
+    assert terminal["choices"][0]["finish_reason"] == "cancelled"
+    assert terminal["choices"][0]["delta"] == {}
+    assert await anext(stream) == "data: [DONE]\n\n"
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+    assert engine.stream_calls == [], "cancellation must never fall back unconstrained"
 
 
 _SCHEMA = {
@@ -415,6 +491,13 @@ def test_streaming_guided_fallback_preserves_id_and_created():
 
     ids = {e["id"] for e in events if "id" in e}
     createds = {e["created"] for e in events if "created" in e}
+    role_events = [
+        e
+        for e in events
+        for choice in e.get("choices", [])
+        if (choice.get("delta") or {}).get("role") == "assistant"
+    ]
+    assert len(role_events) == 1, "guided fallback must not duplicate the role frame"
     assert len(ids) == 1, (
         f"all chunks must share one id across the guided→unconstrained "
         f"fallback handoff; saw {ids}"

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -200,6 +200,65 @@ async def test_guided_stream_publishes_cancellable_id_before_buffered_output():
     assert engine.stream_calls == [], "cancellation must never fall back unconstrained"
 
 
+@pytest.mark.asyncio
+async def test_cancel_during_guided_to_scheduler_handoff_never_leaks_fallback():
+    """The public id stays owned until the fallback scheduler is admitted."""
+
+    class _HandoffEngine(_GuidedEngine):
+        def __init__(self):
+            super().__init__(raise_in_guided=True)
+            self.handoff_calls = 0
+            self.scheduler_aborts: list[str] = []
+
+        def finish_guided_handoff(self, request_id: str) -> bool:
+            assert request_id == "chatcmpl-handoff"
+            self.handoff_calls += 1
+            return True
+
+        async def stream_chat(self, messages, **kwargs):
+            self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+            kwargs["request_id_holder"][0] = kwargs["request_id"]
+            kwargs["request_admitted_event"].set()
+            yield GenerationOutput(
+                text="FALLBACK-MUST-NOT-LEAK",
+                new_text="FALLBACK-MUST-NOT-LEAK",
+                finished=True,
+                finish_reason="stop",
+            )
+
+        async def abort_request(self, request_id: str) -> bool:
+            self.scheduler_aborts.append(request_id)
+            return True
+
+    engine = _HandoffEngine()
+    request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "emit json"}],
+    )
+    holder: list[str | None] = [None]
+    stream = stream_chat_completion_guided(
+        engine,
+        request.messages,
+        request,
+        {"type": "object"},
+        response_id="chatcmpl-handoff",
+        request_id_holder=holder,
+    )
+
+    admission = json.loads((await anext(stream)).removeprefix("data: "))
+    assert admission["id"] == "chatcmpl-handoff"
+    terminal = json.loads((await anext(stream)).removeprefix("data: "))
+    assert terminal["choices"][0]["finish_reason"] == "cancelled"
+    assert await anext(stream) == "data: [DONE]\n\n"
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+    assert engine.handoff_calls == 1
+    assert engine.scheduler_aborts == ["chatcmpl-handoff"]
+    assert len(engine.stream_calls) == 1
+    assert engine.guided_calls[0]["kwargs"]["retain_guided_request_on_failure"] is True
+
+
 _SCHEMA = {
     "type": "object",
     "$defs": {

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -376,6 +376,118 @@ async def test_cancel_during_guided_to_scheduler_handoff_never_leaks_fallback():
     assert engine.guided_calls[0]["kwargs"]["retain_guided_request_on_failure"] is True
 
 
+@pytest.mark.asyncio
+async def test_closing_after_admission_cancels_unfinished_guided_task():
+    """Disconnect after ID publication cannot leave buffered work alive."""
+
+    class _BlockedGuidedEngine(_GuidedEngine):
+        def __init__(self):
+            super().__init__()
+            self.cancelled = asyncio.Event()
+
+        async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+            kwargs["request_admitted_event"].set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                self.cancelled.set()
+
+    engine = _BlockedGuidedEngine()
+    request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "emit json"}],
+    )
+    stream = stream_chat_completion_guided(
+        engine,
+        request.messages,
+        request,
+        {"type": "object"},
+        response_id="chatcmpl-close-after-admission",
+    )
+
+    await anext(stream)
+    await stream.aclose()
+    await asyncio.wait_for(engine.cancelled.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_fallback_await_finishes_retained_handoff():
+    """A disconnect before fallback admission releases the guided identity."""
+
+    class _BlockedFallbackEngine(_GuidedEngine):
+        def __init__(self):
+            super().__init__(raise_in_guided=True)
+            self.fallback_started = asyncio.Event()
+            self.handoffs = 0
+
+        async def stream_chat(self, messages, **kwargs):
+            self.fallback_started.set()
+            await asyncio.Event().wait()
+            yield  # pragma: no cover - establishes the async-generator shape
+
+        def finish_guided_handoff(self, request_id: str):
+            assert request_id == "chatcmpl-cancel-fallback"
+            self.handoffs += 1
+            return False
+
+    engine = _BlockedFallbackEngine()
+    request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "emit json"}],
+    )
+    stream = stream_chat_completion_guided(
+        engine,
+        request.messages,
+        request,
+        {"type": "object"},
+        response_id="chatcmpl-cancel-fallback",
+    )
+
+    await anext(stream)
+    pending = asyncio.create_task(anext(stream))
+    await asyncio.wait_for(engine.fallback_started.wait(), timeout=1)
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+
+    assert engine.handoffs == 1
+
+
+def test_nonstream_guided_user_cancel_is_not_model_replacement():
+    """An explicit cancel propagates through the ordinary cancellation path."""
+    import concurrent.futures
+
+    class _CancelledEngine(_GuidedEngine):
+        async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+            raise GuidedGenerationCancelledError()
+
+    cfg = reset_config()
+    cfg.engine = _CancelledEngine()
+    cfg.model_name = "test-model"
+    app = FastAPI()
+    app.include_router(chat_router)
+    client = TestClient(app)
+
+    with pytest.raises(concurrent.futures.CancelledError):
+        client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "emit json"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "result",
+                        "schema": {"type": "object"},
+                        "strict": False,
+                    },
+                },
+            },
+        )
+
+
 _SCHEMA = {
     "type": "object",
     "$defs": {

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -245,6 +245,54 @@ async def test_guided_stream_shutdown_consumes_exact_lifecycle_owner():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_during_retained_handoff_keeps_replacement_semantics():
+    """A retained guided owner carries shutdown cause through handoff."""
+    from types import SimpleNamespace
+
+    class _ShutdownHandoffEngine(_GuidedEngine):
+        def __init__(self):
+            super().__init__(raise_in_guided=True)
+            self.lifecycle_owner = object()
+            self.lifecycle_consumed = False
+
+        def finish_guided_handoff(self, _request_id: str):
+            return SimpleNamespace(
+                cancelled=True,
+                lifecycle_task=self.lifecycle_owner,
+            )
+
+        def consume_lifecycle_task_abort(self, task) -> bool:
+            if task is not self.lifecycle_owner or self.lifecycle_consumed:
+                return False
+            self.lifecycle_consumed = True
+            return True
+
+    engine = _ShutdownHandoffEngine()
+    reset_config().engine = engine
+    request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "emit json"}],
+    )
+    stream = stream_chat_completion_guided(
+        engine,
+        request.messages,
+        request,
+        {"type": "object"},
+        response_id="chatcmpl-" + "c" * 32,
+        strict_mode=True,
+    )
+
+    events = [event async for event in stream]
+
+    assert any('"code": "model_replacement"' in event for event in events)
+    assert all('"finish_reason":"cancelled"' not in event for event in events)
+    assert events[-1] == "data: [DONE]\n\n"
+    assert engine.lifecycle_consumed is True
+    assert engine.stream_calls == []
+
+
+@pytest.mark.asyncio
 async def test_cancel_during_guided_to_scheduler_handoff_never_leaks_fallback():
     """The public id stays owned until the fallback scheduler is admitted."""
 

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -201,6 +201,50 @@ async def test_guided_stream_publishes_cancellable_id_before_buffered_output():
 
 
 @pytest.mark.asyncio
+async def test_guided_stream_shutdown_consumes_exact_lifecycle_owner():
+    """Shutdown emits the model-replacement terminal and clears its ledger."""
+
+    class _ShutdownGuidedEngine(_GuidedEngine):
+        def __init__(self):
+            super().__init__()
+            self.lifecycle_owner = object()
+            self.lifecycle_consumed = False
+
+        async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+            kwargs["request_admitted_event"].set()
+            raise GuidedGenerationCancelledError(lifecycle_task=self.lifecycle_owner)
+
+        def consume_lifecycle_task_abort(self, task) -> bool:
+            if task is not self.lifecycle_owner or self.lifecycle_consumed:
+                return False
+            self.lifecycle_consumed = True
+            return True
+
+    engine = _ShutdownGuidedEngine()
+    reset_config().engine = engine
+    request = ChatCompletionRequest(
+        model="test-model",
+        stream=True,
+        messages=[{"role": "user", "content": "emit json"}],
+    )
+    stream = stream_chat_completion_guided(
+        engine,
+        request.messages,
+        request,
+        {"type": "object"},
+        response_id="chatcmpl-" + "b" * 32,
+        strict_mode=True,
+    )
+
+    events = [event async for event in stream]
+
+    assert any('"code": "model_replacement"' in event for event in events)
+    assert events[-1] == "data: [DONE]\n\n"
+    assert engine.lifecycle_consumed is True
+    assert engine.stream_calls == []
+
+
+@pytest.mark.asyncio
 async def test_cancel_during_guided_to_scheduler_handoff_never_leaks_fallback():
     """The public id stays owned until the fallback scheduler is admitted."""
 

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -301,14 +301,21 @@ async def test_cancel_during_guided_to_scheduler_handoff_never_leaks_fallback():
             super().__init__(raise_in_guided=True)
             self.handoff_calls = 0
             self.scheduler_aborts: list[str] = []
+            self.guided_owned = True
+            self.cancelled = False
+            self.fallback_started = asyncio.Event()
+            self.release_fallback = asyncio.Event()
 
         def finish_guided_handoff(self, request_id: str) -> bool:
             assert request_id == "chatcmpl-handoff"
             self.handoff_calls += 1
-            return True
+            self.guided_owned = False
+            return self.cancelled
 
         async def stream_chat(self, messages, **kwargs):
             self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+            self.fallback_started.set()
+            await self.release_fallback.wait()
             kwargs["request_id_holder"][0] = kwargs["request_id"]
             kwargs["request_admitted_event"].set()
             yield GenerationOutput(
@@ -319,10 +326,16 @@ async def test_cancel_during_guided_to_scheduler_handoff_never_leaks_fallback():
             )
 
         async def abort_request(self, request_id: str) -> bool:
+            if self.guided_owned:
+                self.cancelled = True
+                return True
             self.scheduler_aborts.append(request_id)
             return True
 
     engine = _HandoffEngine()
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
     request = ChatCompletionRequest(
         model="test-model",
         stream=True,
@@ -340,7 +353,15 @@ async def test_cancel_during_guided_to_scheduler_handoff_never_leaks_fallback():
 
     admission = json.loads((await anext(stream)).removeprefix("data: "))
     assert admission["id"] == "chatcmpl-handoff"
-    terminal = json.loads((await anext(stream)).removeprefix("data: "))
+    fallback_result = asyncio.create_task(anext(stream))
+    await engine.fallback_started.wait()
+    assert fallback_result.done() is False
+
+    response = await cancel_request("chatcmpl-handoff")
+    assert response["cancelled"] is True
+    engine.release_fallback.set()
+
+    terminal = json.loads((await fallback_result).removeprefix("data: "))
     assert terminal["choices"][0]["finish_reason"] == "cancelled"
     assert await anext(stream) == "data: [DONE]\n\n"
     with pytest.raises(StopAsyncIteration):

--- a/tests/test_chat_streaming_guided.py
+++ b/tests/test_chat_streaming_guided.py
@@ -363,7 +363,11 @@ async def test_cancel_during_guided_to_scheduler_handoff_never_leaks_fallback():
 
     terminal = json.loads((await fallback_result).removeprefix("data: "))
     assert terminal["choices"][0]["finish_reason"] == "cancelled"
-    assert await anext(stream) == "data: [DONE]\n\n"
+    assert terminal["choices"][0]["delta"] == {}
+    assert "FALLBACK-MUST-NOT-LEAK" not in json.dumps(terminal)
+    done = await anext(stream)
+    assert done == "data: [DONE]\n\n"
+    assert "FALLBACK-MUST-NOT-LEAK" not in done
     with pytest.raises(StopAsyncIteration):
         await anext(stream)
     assert engine.handoff_calls == 1

--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -767,6 +767,8 @@ class TestGuidedGenerationStepThread:
         engine._tokenizer.encode = MagicMock(return_value=[1])
         engine._model_load_executor = None
         engine._engine = None
+        engine._admission_lock = threading.Lock()
+        engine._lifecycle_aborted_tasks = set()
         engine._guided_requests_lock = threading.Lock()
         engine._guided_abort_events = {}
         engine._guided_stopping = False
@@ -782,8 +784,13 @@ class TestGuidedGenerationStepThread:
                 retain_guided_request_on_failure=True,
             )
 
-        assert engine.abort_guided_request("chatcmpl-handoff") is True
-        assert engine.finish_guided_handoff("chatcmpl-handoff") is True
+        owner = asyncio.current_task()
+        assert owner is not None
+        engine._abort_all_guided_requests()
+        outcome = engine.finish_guided_handoff("chatcmpl-handoff")
+        assert outcome.cancelled is True
+        assert outcome.lifecycle_task is owner
+        assert engine.consume_lifecycle_task_abort(owner) is True
         assert engine._guided_abort_events == {}
 
 

--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -749,6 +749,42 @@ class TestGuidedGenerationStepThread:
         finally:
             executor.shutdown(wait=True)
 
+    @pytest.mark.asyncio
+    async def test_guided_failure_retains_identity_until_fallback_handoff(
+        self, monkeypatch
+    ):
+        """Best-effort SSE has no unowned id window before admission."""
+        from vllm_mlx.engine import batched as batched_mod
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = True
+        engine._is_mllm = False
+        engine._model = MagicMock()
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+        engine._tokenizer.encode = MagicMock(return_value=[1])
+        engine._model_load_executor = None
+        engine._engine = None
+        engine._guided_requests_lock = threading.Lock()
+        engine._guided_abort_events = {}
+        engine._guided_stopping = False
+        monkeypatch.setattr(batched_mod, "HAS_GUIDED", True)
+        engine._run_guided_generation = MagicMock(return_value=None)
+
+        with pytest.raises(RuntimeError, match="produced no result"):
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id="chatcmpl-handoff",
+                raise_on_failure=True,
+                retain_guided_request_on_failure=True,
+            )
+
+        assert engine.abort_guided_request("chatcmpl-handoff") is True
+        assert engine.finish_guided_handoff("chatcmpl-handoff") is True
+        assert engine._guided_abort_events == {}
+
 
 class TestMLLMSchedulerStepThread:
     """#170 regression: MLLMScheduler must run every step on the mllm-step

--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -15,6 +15,7 @@ must be routed through the same worker via _run_on_step_thread().
 These tests exercise that machinery without spinning up a real model.
 """
 
+import asyncio
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -434,6 +435,8 @@ class TestGuidedGenerationStepThread:
             engine._tokenizer.encode = MagicMock(return_value=[1, 2])
             engine._model_load_executor = executor
             engine._engine = None
+            engine._guided_requests_lock = threading.Lock()
+            engine._guided_abort_events = {}
 
             # Force HAS_GUIDED True so supports_guided_generation passes.
             from vllm_mlx.engine import batched as batched_mod
@@ -442,8 +445,11 @@ class TestGuidedGenerationStepThread:
 
             captured: dict = {}
 
-            def fake_run_guided(prompt, json_schema, max_tokens, temperature):
+            def fake_run_guided(
+                prompt, json_schema, max_tokens, temperature, should_abort
+            ):
                 captured["thread"] = threading.current_thread().name
+                assert should_abort() is False
                 return '{"ok": true}'
 
             engine._run_guided_generation = fake_run_guided
@@ -454,8 +460,8 @@ class TestGuidedGenerationStepThread:
                 max_tokens=8,
                 temperature=0.0,
             )
-
             assert result.text == '{"ok": true}'
+            assert engine._guided_abort_events == {}
             assert captured["thread"].startswith("mlx-step-test"), (
                 f"_run_guided_generation ran on {captured['thread']!r}, "
                 "expected mlx-step worker. asyncio.to_thread() would dispatch "
@@ -479,6 +485,8 @@ class TestGuidedGenerationStepThread:
         engine._tokenizer.encode = MagicMock(return_value=[1])
         engine._model_load_executor = None
         engine._engine = None
+        engine._guided_requests_lock = threading.Lock()
+        engine._guided_abort_events = {}
 
         from vllm_mlx.engine import batched as batched_mod
 
@@ -486,8 +494,9 @@ class TestGuidedGenerationStepThread:
 
         called = {"n": 0}
 
-        def fake_run_guided(prompt, json_schema, max_tokens, temperature):
+        def fake_run_guided(prompt, json_schema, max_tokens, temperature, should_abort):
             called["n"] += 1
+            assert should_abort() is False
             return '{"ok": true}'
 
         engine._run_guided_generation = fake_run_guided
@@ -496,12 +505,12 @@ class TestGuidedGenerationStepThread:
             messages=[{"role": "user", "content": "hi"}],
             json_schema={"type": "object"},
         )
-
         # Should still execute (via asyncio default executor) even without
         # a mlx-step worker. Caller may then hit Stream(gpu, N), but the
         # dispatch itself must not crash.
         assert called["n"] == 1
         assert result.text == '{"ok": true}'
+        assert engine._guided_abort_events == {}
 
     @pytest.mark.asyncio
     async def test_raise_on_failure_skips_unconstrained_fallback(self, monkeypatch):
@@ -526,6 +535,8 @@ class TestGuidedGenerationStepThread:
         engine._tokenizer.encode = MagicMock(return_value=[1])
         engine._model_load_executor = None
         engine._engine = None
+        engine._guided_requests_lock = threading.Lock()
+        engine._guided_abort_events = {}
 
         from vllm_mlx.engine import batched as batched_mod
         from vllm_mlx.engine.base import GenerationOutput
@@ -559,6 +570,7 @@ class TestGuidedGenerationStepThread:
         )
         assert result.text == "FALLBACK"
         assert chat_calls["n"] == 1
+        assert engine._guided_abort_events == {}
 
         # Opt-in path: raises instead, self.chat is never called again.
         with pytest.raises(RuntimeError, match="Guided generation produced no result"):
@@ -568,6 +580,174 @@ class TestGuidedGenerationStepThread:
                 raise_on_failure=True,
             )
         assert chat_calls["n"] == 1  # unchanged — raise short-circuited self.chat
+        assert engine._guided_abort_events == {}
+
+    @pytest.mark.asyncio
+    async def test_public_abort_stops_guided_worker_and_cleans_identity(
+        self, monkeypatch
+    ):
+        """A guided id stays live until the executor cooperatively exits."""
+        import concurrent.futures
+        import time
+
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+        from vllm_mlx.engine import batched as batched_mod
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            engine = BatchedEngine.__new__(BatchedEngine)
+            engine._loaded = True
+            engine._is_mllm = False
+            engine._model = MagicMock()
+            engine._tokenizer = MagicMock()
+            engine._tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+            engine._tokenizer.encode = MagicMock(return_value=[1])
+            engine._model_load_executor = executor
+            engine._engine = None
+            engine._mllm_scheduler = None
+            engine._guided_requests_lock = threading.Lock()
+            engine._guided_abort_events = {}
+            monkeypatch.setattr(batched_mod, "HAS_GUIDED", True)
+
+            started = threading.Event()
+            stopped = threading.Event()
+
+            def fake_run_guided(
+                prompt, json_schema, max_tokens, temperature, should_abort
+            ):
+                started.set()
+                while not should_abort():
+                    time.sleep(0.001)
+                stopped.set()
+                raise GuidedGenerationCancelledError()
+
+            engine._run_guided_generation = fake_run_guided
+            holder: list[str | None] = [None]
+            admitted = asyncio.Event()
+            task = asyncio.create_task(
+                engine.generate_with_schema(
+                    messages=[{"role": "user", "content": "hi"}],
+                    json_schema={"type": "object"},
+                    request_id="chatcmpl-public-guided",
+                    request_id_holder=holder,
+                    request_admitted_event=admitted,
+                    raise_on_failure=True,
+                )
+            )
+
+            await asyncio.wait_for(admitted.wait(), timeout=1)
+            assert await asyncio.to_thread(started.wait, 1)
+            assert holder == ["chatcmpl-public-guided"]
+            assert "chatcmpl-public-guided" in engine._guided_abort_events
+            assert await engine.abort_request("chatcmpl-public-guided") is True
+            with pytest.raises(GuidedGenerationCancelledError):
+                await task
+            assert await asyncio.to_thread(stopped.wait, 1)
+            assert engine._guided_abort_events == {}
+            assert await engine.abort_request("chatcmpl-public-guided") is False
+        finally:
+            executor.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_async_task_cancel_publishes_worker_stop_token(self, monkeypatch):
+        """Cancelling the response task must not leave executor work running."""
+        import concurrent.futures
+        import time
+
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+        from vllm_mlx.engine import batched as batched_mod
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            engine = BatchedEngine.__new__(BatchedEngine)
+            engine._loaded = True
+            engine._is_mllm = False
+            engine._model = MagicMock()
+            engine._tokenizer = MagicMock()
+            engine._tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+            engine._tokenizer.encode = MagicMock(return_value=[1])
+            engine._model_load_executor = executor
+            engine._engine = None
+            engine._guided_requests_lock = threading.Lock()
+            engine._guided_abort_events = {}
+            monkeypatch.setattr(batched_mod, "HAS_GUIDED", True)
+
+            started = threading.Event()
+            stopped = threading.Event()
+
+            def fake_run_guided(
+                prompt, json_schema, max_tokens, temperature, should_abort
+            ):
+                started.set()
+                while not should_abort():
+                    time.sleep(0.001)
+                stopped.set()
+                raise GuidedGenerationCancelledError()
+
+            engine._run_guided_generation = fake_run_guided
+            task = asyncio.create_task(
+                engine.generate_with_schema(
+                    messages=[{"role": "user", "content": "hi"}],
+                    json_schema={"type": "object"},
+                    request_id="chatcmpl-disconnected-guided",
+                )
+            )
+            assert await asyncio.to_thread(started.wait, 1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert await asyncio.to_thread(stopped.wait, 1)
+            await asyncio.sleep(0)
+            assert engine._guided_abort_events == {}
+        finally:
+            executor.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_abort_after_final_model_call_still_suppresses_buffered_result(
+        self, monkeypatch
+    ):
+        """An accepted cancel wins the worker-complete/result-commit race."""
+        import concurrent.futures
+
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+        from vllm_mlx.engine import batched as batched_mod
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            engine = BatchedEngine.__new__(BatchedEngine)
+            engine._loaded = True
+            engine._is_mllm = False
+            engine._model = MagicMock()
+            engine._tokenizer = MagicMock()
+            engine._tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+            engine._tokenizer.encode = MagicMock(return_value=[1])
+            engine._model_load_executor = executor
+            engine._engine = None
+            engine._guided_requests_lock = threading.Lock()
+            engine._guided_abort_events = {}
+            monkeypatch.setattr(batched_mod, "HAS_GUIDED", True)
+
+            def fake_run_guided(
+                prompt, json_schema, max_tokens, temperature, should_abort
+            ):
+                # Simulate cancel landing after the final model call. The
+                # worker returns a valid buffer without another loop check.
+                assert engine.abort_guided_request("chatcmpl-final-race") is True
+                return '{"must_not_commit": true}'
+
+            engine._run_guided_generation = fake_run_guided
+            with pytest.raises(GuidedGenerationCancelledError):
+                await engine.generate_with_schema(
+                    messages=[{"role": "user", "content": "hi"}],
+                    json_schema={"type": "object"},
+                    request_id="chatcmpl-final-race",
+                )
+            assert engine._guided_abort_events == {}
+        finally:
+            executor.shutdown(wait=True)
 
 
 class TestMLLMSchedulerStepThread:

--- a/tests/test_engine_step_thread.py
+++ b/tests/test_engine_step_thread.py
@@ -641,8 +641,9 @@ class TestGuidedGenerationStepThread:
             assert holder == ["chatcmpl-public-guided"]
             assert "chatcmpl-public-guided" in engine._guided_abort_events
             assert await engine.abort_request("chatcmpl-public-guided") is True
-            with pytest.raises(GuidedGenerationCancelledError):
+            with pytest.raises(GuidedGenerationCancelledError) as cancelled:
                 await task
+            assert cancelled.value.lifecycle_task is task
             assert await asyncio.to_thread(stopped.wait, 1)
             assert engine._guided_abort_events == {}
             assert await engine.abort_request("chatcmpl-public-guided") is False

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -629,6 +629,62 @@ class TestConstrainedDecodeWithRealLLGuidance:
             "context-dependent fake model emitted the wrong planned tokens"
         )
 
+    def test_cancellation_is_observed_between_prefill_chunks(
+        self, wrapped_tokenizer, monkeypatch
+    ):
+        """Long-prompt cancellation stops before the next model chunk."""
+        import vllm_mlx.api.guided as guided
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+        target = '{"a":1}'
+        plan = wrapped_tokenizer._tokenizer.encode(target)
+        prompt = "prefill boundary " * 8
+        gen, _ = self._make_generator(wrapped_tokenizer, plan, prompt=prompt)
+        monkeypatch.setattr(guided, "_PREFILL_STEP_SIZE", 4)
+        checks = 0
+
+        def should_abort():
+            nonlocal checks
+            checks += 1
+            # Initial check, then the first chunk's pre/post checks.
+            return checks >= 3
+
+        with pytest.raises(GuidedGenerationCancelledError):
+            gen.generate_json_object(
+                prompt,
+                max_tokens=32,
+                temperature=0.0,
+                should_abort=should_abort,
+            )
+        assert checks == 3
+
+    def test_cancellation_is_observed_between_constrained_decode_steps(
+        self, wrapped_tokenizer
+    ):
+        """A committed constrained token cannot hide later cancellation."""
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+        target = '{"a":1}'
+        plan = wrapped_tokenizer._tokenizer.encode(target)
+        gen, _ = self._make_generator(wrapped_tokenizer, plan)
+        checks = 0
+
+        def should_abort():
+            nonlocal checks
+            checks += 1
+            # Initial + trailing-prefill checks, first loop entry, and the
+            # post-forward check after one constrained token was consumed.
+            return checks >= 5
+
+        with pytest.raises(GuidedGenerationCancelledError):
+            gen.generate_json_object(
+                "prompt",
+                max_tokens=32,
+                temperature=0.0,
+                should_abort=should_abort,
+            )
+        assert checks == 5
+
     def test_negative_control_first_token_mask(self, wrapped_tokenizer):
         """NEGATIVE CONTROL: under a JSON-object grammar the first-step
         allow-mask forbids a plain-text token (e.g. the word ``Sure``) and

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -473,12 +473,13 @@ class TestGuidedGenerator:
             def _decode_constrained(self, *, grammar, prompt, max_tokens, temperature):
                 return "legacy-ok"
 
+        class _MatcherStub:
+            @staticmethod
+            def grammar_from_json_schema(*_args, **_kwargs):
+                return object()
+
         monkeypatch.setattr(guided, "HAS_LLGUIDANCE", True)
-        monkeypatch.setattr(
-            guided.LLMatcher,
-            "grammar_from_json_schema",
-            lambda *_args, **_kwargs: object(),
-        )
+        monkeypatch.setattr(guided, "LLMatcher", _MatcherStub)
         generator = _LegacyGenerator(object(), object())
 
         assert (

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -493,6 +493,64 @@ class TestGuidedGenerator:
             == "legacy-ok"
         )
 
+    def test_generate_json_forwards_and_preserves_cancellation(self, monkeypatch):
+        """The public callback reaches decode and cancellation is never degraded."""
+        import vllm_mlx.api.guided as guided
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+        callback = lambda: True
+
+        class _MatcherStub:
+            @staticmethod
+            def grammar_from_json_schema(*_args, **_kwargs):
+                return object()
+
+        class _CancelledGenerator(guided.GuidedGenerator):
+            def _decode_constrained(self, **kwargs):
+                assert kwargs["should_abort"] is callback
+                raise GuidedGenerationCancelledError()
+
+        monkeypatch.setattr(guided, "HAS_LLGUIDANCE", True)
+        monkeypatch.setattr(guided, "LLMatcher", _MatcherStub)
+
+        with pytest.raises(GuidedGenerationCancelledError):
+            _CancelledGenerator(object(), object()).generate_json(
+                "hi",
+                {"type": "object"},
+                max_tokens=8,
+                temperature=0.0,
+                should_abort=callback,
+            )
+
+    def test_module_helper_forwards_and_preserves_cancellation(self, monkeypatch):
+        """The convenience helper keeps the same cooperative-cancel contract."""
+        import vllm_mlx.api.guided as guided
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+        callback = lambda: True
+
+        class _CancelledGenerator:
+            def __init__(self, _model, _tokenizer):
+                pass
+
+            def generate_json(self, **kwargs):
+                assert kwargs["should_abort"] is callback
+                raise GuidedGenerationCancelledError()
+
+        monkeypatch.setattr(guided, "HAS_LLGUIDANCE", True)
+        monkeypatch.setattr(guided, "GuidedGenerator", _CancelledGenerator)
+
+        with pytest.raises(GuidedGenerationCancelledError):
+            guided.generate_with_schema(
+                object(),
+                object(),
+                "hi",
+                {"type": "object"},
+                max_tokens=8,
+                temperature=0.0,
+                should_abort=callback,
+            )
+
     def test_degrades_gracefully_without_fast_tokenizer(self):
         """A tokenizer with no underlying fast (``._tokenizer``) tokenizer
         must NOT crash — ``_get_lltokenizer`` logs and returns None, and

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -465,6 +465,33 @@ class TestGuidedGenerator:
         finally:
             guided.HAS_LLGUIDANCE = original
 
+    def test_default_calls_preserve_legacy_decode_override_signature(self, monkeypatch):
+        """The optional cancellation callback does not break subclasses."""
+        import vllm_mlx.api.guided as guided
+
+        class _LegacyGenerator(guided.GuidedGenerator):
+            def _decode_constrained(self, *, grammar, prompt, max_tokens, temperature):
+                return "legacy-ok"
+
+        monkeypatch.setattr(guided, "HAS_LLGUIDANCE", True)
+        monkeypatch.setattr(
+            guided.LLMatcher,
+            "grammar_from_json_schema",
+            lambda *_args, **_kwargs: object(),
+        )
+        generator = _LegacyGenerator(object(), object())
+
+        assert (
+            generator.generate_json(
+                "hi", {"type": "object"}, max_tokens=8, temperature=0.0
+            )
+            == "legacy-ok"
+        )
+        assert (
+            generator.generate_json_object("hi", max_tokens=8, temperature=0.0)
+            == "legacy-ok"
+        )
+
     def test_degrades_gracefully_without_fast_tokenizer(self):
         """A tokenizer with no underlying fast (``._tokenizer``) tokenizer
         must NOT crash — ``_get_lltokenizer`` logs and returns None, and

--- a/tests/test_request_cancellation.py
+++ b/tests/test_request_cancellation.py
@@ -11,6 +11,35 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
+def _make_guided_engine(monkeypatch, run_guided, *, executor=None):
+    """Build the no-weights engine shape used by cancellation lifecycle tests."""
+    import threading
+
+    from vllm_mlx.engine import batched as batched_mod
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    monkeypatch.setattr(batched_mod, "HAS_GUIDED", True)
+    monkeypatch.setattr(
+        batched_mod, "shared_apply_chat_template", lambda *_a, **_k: "prompt"
+    )
+    engine = BatchedEngine.__new__(BatchedEngine)
+    engine._loaded = True
+    engine._is_mllm = False
+    engine._model_name = "test-model"
+    engine._model = MagicMock()
+    engine._tokenizer = MagicMock()
+    engine._tokenizer.encode = MagicMock(return_value=[1])
+    engine._model_load_executor = executor
+    engine._engine = None
+    engine._mllm_scheduler = None
+    engine._guided_requests_lock = threading.Lock()
+    engine._guided_abort_events = {}
+    engine._guided_owner_tasks = {}
+    engine._guided_stopping = False
+    engine._run_guided_generation = run_guided
+    return engine
+
+
 class _StubAsyncEngine:
     """Minimal async engine stub exposing ``abort_request`` as a coroutine."""
 
@@ -36,6 +65,296 @@ class _StubSyncMllmScheduler:
 
 
 class TestBatchedEngineAbortRouting:
+    def test_constructor_initializes_guided_lifecycle_state(self, monkeypatch):
+        from vllm_mlx.engine import batched as batched_mod
+
+        monkeypatch.setattr(batched_mod, "is_mllm_model", lambda _name: False)
+        engine = batched_mod.BatchedEngine("test-model", force_text=True)
+
+        assert engine._guided_abort_events == {}
+        assert engine._guided_owner_tasks == {}
+        assert engine._guided_stopping is False
+
+    def test_guided_registry_legacy_shapes_and_direct_abort(self):
+        """Lightweight embedders get lazy state without weakening cancellation."""
+        import asyncio
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._guided_requests_lock = threading.Lock()
+        engine._guided_abort_events = {}
+        event = threading.Event()
+        engine._register_guided_request("req", event)
+
+        assert engine._guided_owner_tasks == {}
+        assert engine.abort_guided_request("missing") is False
+        assert engine.abort_guided_request("req") is True
+        assert event.is_set()
+
+        owner = asyncio.new_event_loop().create_task(asyncio.sleep(0))
+        try:
+            engine._mark_lifecycle_aborted_tasks((owner,))
+            assert not hasattr(engine, "_lifecycle_aborted_tasks")
+
+            engine._admission_lock = threading.Lock()
+            engine._mark_lifecycle_aborted_tasks((owner,))
+            assert owner in engine._lifecycle_aborted_tasks
+        finally:
+            owner.cancel()
+            owner.get_loop().run_until_complete(
+                asyncio.gather(owner, return_exceptions=True)
+            )
+            owner.get_loop().close()
+
+    def test_guided_helpers_are_safe_before_runtime_initialization(self):
+        """Abort and handoff are harmless on legacy ``__new__`` engines."""
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+
+        event = threading.Event()
+        engine._register_guided_request("legacy", event)
+        assert engine._guided_abort_events == {"legacy": event}
+        assert engine._guided_owner_tasks == {}
+        assert engine._guided_stopping is False
+        assert engine._finish_guided_request("legacy", event) is False
+
+        assert engine.abort_guided_request("missing") is False
+        uninitialized = BatchedEngine.__new__(BatchedEngine)
+        uninitialized._abort_all_guided_requests()
+        outcome = uninitialized.finish_guided_handoff("missing")
+        assert outcome.cancelled is False
+        assert outcome.lifecycle_task is None
+
+    def test_guided_handoff_returns_owner_and_cancel_state(self):
+        import asyncio
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        loop = asyncio.new_event_loop()
+        owner = loop.create_task(asyncio.sleep(0))
+        try:
+            engine = BatchedEngine.__new__(BatchedEngine)
+            engine._guided_requests_lock = threading.Lock()
+            event = threading.Event()
+            event.set()
+            engine._guided_abort_events = {"req": event}
+            engine._guided_owner_tasks = {"req": owner}
+
+            outcome = engine.finish_guided_handoff("req")
+
+            assert outcome.cancelled is True
+            assert outcome.lifecycle_task is owner
+            assert engine._guided_abort_events == {}
+            assert engine._guided_owner_tasks == {}
+        finally:
+            owner.cancel()
+            loop.run_until_complete(asyncio.gather(owner, return_exceptions=True))
+            loop.close()
+
+    @pytest.mark.asyncio
+    async def test_guided_abort_precedes_scheduler_routing(self):
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._guided_requests_lock = threading.Lock()
+        event = threading.Event()
+        engine._guided_abort_events = {"req-guided": event}
+        engine._guided_owner_tasks = {}
+        engine._mllm_scheduler = _StubSyncMllmScheduler(returns=False)
+        engine._engine = _StubAsyncEngine(returns=False)
+
+        assert await engine.abort_request("req-guided") is True
+        assert event.is_set()
+        assert engine._mllm_scheduler.calls == []
+        assert engine._engine.calls == []
+
+    @pytest.mark.asyncio
+    async def test_start_reopens_guided_admission_and_stop_closes_it(self):
+        """Restart and shutdown own guided admission with the engine lifecycle."""
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._loaded = False
+        engine._is_mllm = False
+        engine._model_name = "test-model"
+        engine._guided_requests_lock = threading.Lock()
+        engine._guided_abort_events = {}
+        engine._guided_owner_tasks = {}
+        engine._guided_stopping = True
+        engine._validate_lane_capabilities = MagicMock()
+        engine._start_llm = AsyncMock()
+
+        await engine.start()
+        assert engine._guided_stopping is False
+
+        engine._mllm_scheduler = None
+        engine._engine = None
+        engine._model_load_executor = None
+        engine._processor = object()
+        engine._mllm_instance = object()
+        engine._engine_started = True
+        await engine.stop()
+        assert engine._guided_stopping is True
+        assert engine._loaded is False
+
+    @pytest.mark.asyncio
+    async def test_guided_admission_publication_is_best_effort(self, monkeypatch):
+        """A broken compatibility holder cannot prevent worker admission."""
+        import concurrent.futures
+
+        class _BrokenHolder:
+            def __setitem__(self, _index, _value):
+                raise RuntimeError("read-only holder")
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            engine = _make_guided_engine(
+                monkeypatch,
+                lambda **_kwargs: '{"ok": true}',
+                executor=executor,
+            )
+            admitted = MagicMock()
+
+            result = await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id_holder=_BrokenHolder(),
+                request_admitted_event=admitted,
+            )
+
+            assert result.text == '{"ok": true}'
+            admitted.set.assert_called_once_with()
+            assert engine._guided_abort_events == {}
+        finally:
+            executor.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_guided_submission_failure_releases_identity(self, monkeypatch):
+        class _RejectingExecutor:
+            def submit(self, *_args, **_kwargs):
+                raise RuntimeError("executor stopped")
+
+        engine = _make_guided_engine(
+            monkeypatch,
+            lambda **_kwargs: "unused",
+            executor=_RejectingExecutor(),
+        )
+
+        with pytest.raises(RuntimeError, match="executor stopped"):
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id="submission-failed",
+            )
+        assert engine._guided_abort_events == {}
+
+    @pytest.mark.asyncio
+    async def test_guided_worker_cancellation_preserves_lifecycle(self, monkeypatch):
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+        def cancelled(**_kwargs):
+            raise GuidedGenerationCancelledError()
+
+        engine = _make_guided_engine(monkeypatch, cancelled)
+
+        with pytest.raises(GuidedGenerationCancelledError) as exc:
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id="worker-cancelled",
+            )
+        assert exc.value.lifecycle_task is not None
+        assert engine._guided_abort_events == {}
+
+    @pytest.mark.asyncio
+    async def test_guided_worker_base_exception_releases_identity(self, monkeypatch):
+        class _WorkerFailure(BaseException):
+            pass
+
+        def fail(**_kwargs):
+            raise _WorkerFailure()
+
+        engine = _make_guided_engine(monkeypatch, fail)
+
+        with pytest.raises(_WorkerFailure):
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id="worker-failed",
+            )
+        assert engine._guided_abort_events == {}
+
+    @pytest.mark.asyncio
+    async def test_completed_cancelled_future_releases_identity(self, monkeypatch):
+        def cancel(**_kwargs):
+            raise asyncio.CancelledError()
+
+        import asyncio
+
+        engine = _make_guided_engine(monkeypatch, cancel)
+
+        with pytest.raises(asyncio.CancelledError):
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id="future-cancelled",
+            )
+        assert engine._guided_abort_events == {}
+
+    @pytest.mark.asyncio
+    async def test_retained_guided_failure_honors_accepted_abort(self, monkeypatch):
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+        engine = None
+
+        def abort_then_fail(**_kwargs):
+            assert engine is not None
+            assert engine.abort_guided_request("retained") is True
+            return None
+
+        engine = _make_guided_engine(monkeypatch, abort_then_fail)
+
+        with pytest.raises(GuidedGenerationCancelledError):
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id="retained",
+                raise_on_failure=True,
+                retain_guided_request_on_failure=True,
+            )
+        assert engine._guided_abort_events == {}
+
+    def test_run_guided_generation_never_degrades_cancellation(self, monkeypatch):
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+        from vllm_mlx.engine import batched as batched_mod
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        class _CancelledGenerator:
+            def __init__(self, _model, _tokenizer):
+                pass
+
+            def generate_json(self, **_kwargs):
+                raise GuidedGenerationCancelledError()
+
+        monkeypatch.setattr(batched_mod, "GuidedGenerator", _CancelledGenerator)
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._model = object()
+        engine._tokenizer = object()
+        engine._is_mllm = False
+
+        with pytest.raises(GuidedGenerationCancelledError):
+            engine._run_guided_generation("prompt", {}, 8, 0.0)
+
     def test_guided_registry_cleanup_is_instance_safe_and_shutdown_signals_all(self):
         """Late cleanup cannot remove a newer job reusing the same id."""
         import threading
@@ -197,6 +516,77 @@ class TestBaseEngineDefaultAbort:
         sentinel = object()
         result = await BaseEngine.abort_request(sentinel, "any")  # type: ignore[arg-type]
         assert result is False
+
+
+class TestGuidedRouteCancellationClassification:
+    """Explicit user cancellation stays distinct from model replacement."""
+
+    @staticmethod
+    def _cancelled_engine():
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+        from vllm_mlx.engine.base import GenerationOutput
+
+        class _CancelledEngine:
+            preserve_native_tool_format = False
+            is_mllm = False
+            tokenizer = None
+            supports_guided_generation = True
+
+            def build_prompt(self, messages, tools=None, enable_thinking=None):
+                return "prompt"
+
+            async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+                raise GuidedGenerationCancelledError()
+
+            async def chat(self, *, messages, **kwargs):
+                return GenerationOutput(text='{"value": 42}', finished=True)
+
+        return _CancelledEngine()
+
+    def test_responses_guided_user_cancel_propagates_cancelled_error(self):
+        import concurrent.futures
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from vllm_mlx.config import reset_config
+        from vllm_mlx.middleware.auth import rate_limiter
+        from vllm_mlx.routes.responses import router as responses_router
+
+        saved_enabled = rate_limiter.enabled
+        saved_rpm = rate_limiter.requests_per_minute
+        saved_requests = dict(rate_limiter._requests)
+        try:
+            rate_limiter.enabled = False
+            cfg = reset_config()
+            cfg.engine = self._cancelled_engine()
+            cfg.model_name = "test-model"
+            cfg.model_registry = None
+            cfg.no_thinking = True
+            app = FastAPI()
+            app.include_router(responses_router)
+            client = TestClient(app)
+            with pytest.raises(concurrent.futures.CancelledError):
+                client.post(
+                    "/v1/responses",
+                    json={
+                        "model": "test-model",
+                        "input": "emit json",
+                        "text": {
+                            "format": {
+                                "type": "json_schema",
+                                "name": "result",
+                                "schema": {"type": "object"},
+                                "strict": True,
+                            }
+                        },
+                    },
+                )
+        finally:
+            rate_limiter.enabled = saved_enabled
+            rate_limiter.requests_per_minute = saved_rpm
+            rate_limiter._requests.clear()
+            rate_limiter._requests.update(saved_requests)
 
 
 class TestCancelRequestEndpoint:

--- a/tests/test_request_cancellation.py
+++ b/tests/test_request_cancellation.py
@@ -51,12 +51,53 @@ class TestBatchedEngineAbortRouting:
         engine._finish_guided_request("req-guided", first)
         assert engine._guided_abort_events["req-guided"] is replacement
 
+        with pytest.raises(RuntimeError, match="already active"):
+            engine._register_guided_request("req-guided", threading.Event())
+
         engine._abort_all_guided_requests()
         assert first.is_set()
         assert replacement.is_set()
 
-        with pytest.raises(RuntimeError, match="already active"):
-            engine._register_guided_request("req-guided", threading.Event())
+        late = threading.Event()
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+        with pytest.raises(GuidedGenerationCancelledError):
+            engine._register_guided_request("req-late", late)
+        assert late.is_set()
+        assert "req-late" not in engine._guided_abort_events
+
+    def test_stop_and_registration_serialize_on_the_guided_lock(self):
+        """A registration waiting behind shutdown cannot miss its signal."""
+        import threading
+
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._guided_requests_lock = threading.Lock()
+        engine._guided_abort_events = {}
+        engine._guided_stopping = False
+        late = threading.Event()
+        started = threading.Event()
+        outcome: list[type[BaseException]] = []
+
+        def register_late() -> None:
+            started.set()
+            try:
+                engine._register_guided_request("req-late", late)
+            except BaseException as exc:
+                outcome.append(type(exc))
+
+        with engine._guided_requests_lock:
+            thread = threading.Thread(target=register_late)
+            thread.start()
+            assert started.wait(timeout=1)
+            engine._guided_stopping = True
+        thread.join(timeout=1)
+
+        assert outcome == [GuidedGenerationCancelledError]
+        assert late.is_set()
+        assert engine._guided_abort_events == {}
 
     @pytest.mark.asyncio
     async def test_routes_to_mllm_scheduler_when_present(self):

--- a/tests/test_request_cancellation.py
+++ b/tests/test_request_cancellation.py
@@ -36,6 +36,28 @@ class _StubSyncMllmScheduler:
 
 
 class TestBatchedEngineAbortRouting:
+    def test_guided_registry_cleanup_is_instance_safe_and_shutdown_signals_all(self):
+        """Late cleanup cannot remove a newer job reusing the same id."""
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._guided_requests_lock = threading.Lock()
+        first = threading.Event()
+        replacement = threading.Event()
+        engine._guided_abort_events = {"req-guided": replacement, "req-other": first}
+
+        engine._finish_guided_request("req-guided", first)
+        assert engine._guided_abort_events["req-guided"] is replacement
+
+        engine._abort_all_guided_requests()
+        assert first.is_set()
+        assert replacement.is_set()
+
+        with pytest.raises(RuntimeError, match="already active"):
+            engine._register_guided_request("req-guided", threading.Event())
+
     @pytest.mark.asyncio
     async def test_routes_to_mllm_scheduler_when_present(self):
         from vllm_mlx.engine.batched import BatchedEngine

--- a/tests/test_request_cancellation.py
+++ b/tests/test_request_cancellation.py
@@ -320,16 +320,22 @@ class TestBatchedEngineAbortRouting:
         import time
 
         started = threading.Event()
+        abort_seen = threading.Event()
+        release_worker = threading.Event()
         stopped = threading.Event()
 
         def cooperate(*, should_abort, **_kwargs):
             started.set()
             while not should_abort():
                 time.sleep(0.001)
+            abort_seen.set()
+            release_worker.wait()
             stopped.set()
             return None
 
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        engine = None
+        task = None
         try:
             engine = _make_guided_engine(monkeypatch, cooperate, executor=executor)
             task = asyncio.create_task(
@@ -343,6 +349,10 @@ class TestBatchedEngineAbortRouting:
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
+            assert await asyncio.to_thread(abort_seen.wait, 1)
+            assert "pending-worker" in engine._guided_abort_events
+
+            release_worker.set()
             assert await asyncio.to_thread(stopped.wait, 1)
             for _ in range(100):
                 if not engine._guided_abort_events:
@@ -350,7 +360,14 @@ class TestBatchedEngineAbortRouting:
                 await asyncio.sleep(0.001)
             assert engine._guided_abort_events == {}
         finally:
+            release_worker.set()
+            if engine is not None:
+                engine.abort_guided_request("pending-worker")
+            if task is not None and not task.done():
+                task.cancel()
             executor.shutdown(wait=True)
+            if task is not None:
+                await asyncio.gather(task, return_exceptions=True)
 
     @pytest.mark.asyncio
     async def test_retained_guided_failure_keeps_identity_for_handoff(

--- a/tests/test_request_cancellation.py
+++ b/tests/test_request_cancellation.py
@@ -312,6 +312,86 @@ class TestBatchedEngineAbortRouting:
         assert engine._guided_abort_events == {}
 
     @pytest.mark.asyncio
+    async def test_task_cancel_defers_cleanup_until_worker_finishes(self, monkeypatch):
+        """A live executor future owns the registry until its callback runs."""
+        import asyncio
+        import concurrent.futures
+        import threading
+        import time
+
+        started = threading.Event()
+        stopped = threading.Event()
+
+        def cooperate(*, should_abort, **_kwargs):
+            started.set()
+            while not should_abort():
+                time.sleep(0.001)
+            stopped.set()
+            return None
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            engine = _make_guided_engine(monkeypatch, cooperate, executor=executor)
+            task = asyncio.create_task(
+                engine.generate_with_schema(
+                    messages=[{"role": "user", "content": "hi"}],
+                    json_schema={"type": "object"},
+                    request_id="pending-worker",
+                )
+            )
+            assert await asyncio.to_thread(started.wait, 1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert await asyncio.to_thread(stopped.wait, 1)
+            for _ in range(100):
+                if not engine._guided_abort_events:
+                    break
+                await asyncio.sleep(0.001)
+            assert engine._guided_abort_events == {}
+        finally:
+            executor.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_retained_guided_failure_keeps_identity_for_handoff(
+        self, monkeypatch
+    ):
+        engine = _make_guided_engine(monkeypatch, lambda **_kwargs: None)
+
+        with pytest.raises(RuntimeError, match="produced no result"):
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id="retained-failure",
+                raise_on_failure=True,
+                retain_guided_request_on_failure=True,
+            )
+        assert "retained-failure" in engine._guided_abort_events
+        outcome = engine.finish_guided_handoff("retained-failure")
+        assert outcome.cancelled is False
+        assert engine._guided_abort_events == {}
+
+    @pytest.mark.asyncio
+    async def test_abort_after_worker_result_suppresses_commit(self, monkeypatch):
+        from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+        engine = None
+
+        def abort_then_return(**_kwargs):
+            assert engine is not None
+            assert engine.abort_guided_request("result-race") is True
+            return '{"must_not_commit": true}'
+
+        engine = _make_guided_engine(monkeypatch, abort_then_return)
+        with pytest.raises(GuidedGenerationCancelledError):
+            await engine.generate_with_schema(
+                messages=[{"role": "user", "content": "hi"}],
+                json_schema={"type": "object"},
+                request_id="result-race",
+            )
+        assert engine._guided_abort_events == {}
+
+    @pytest.mark.asyncio
     async def test_retained_guided_failure_honors_accepted_abort(self, monkeypatch):
         from vllm_mlx.api.errors import GuidedGenerationCancelledError
 

--- a/tests/test_request_cancellation.py
+++ b/tests/test_request_cancellation.py
@@ -47,6 +47,7 @@ class TestBatchedEngineAbortRouting:
         first = threading.Event()
         replacement = threading.Event()
         engine._guided_abort_events = {"req-guided": replacement, "req-other": first}
+        engine._guided_owner_tasks = {}
 
         engine._finish_guided_request("req-guided", first)
         assert engine._guided_abort_events["req-guided"] is replacement
@@ -74,8 +75,11 @@ class TestBatchedEngineAbortRouting:
         from vllm_mlx.engine.batched import BatchedEngine
 
         engine = BatchedEngine.__new__(BatchedEngine)
+        engine._admission_lock = threading.Lock()
+        engine._lifecycle_aborted_tasks = set()
         engine._guided_requests_lock = threading.Lock()
         engine._guided_abort_events = {}
+        engine._guided_owner_tasks = {}
         engine._guided_stopping = False
         late = threading.Event()
         started = threading.Event()
@@ -98,6 +102,32 @@ class TestBatchedEngineAbortRouting:
         assert outcome == [GuidedGenerationCancelledError]
         assert late.is_set()
         assert engine._guided_abort_events == {}
+
+    @pytest.mark.asyncio
+    async def test_shutdown_marks_guided_owner_in_real_lifecycle_ledger(self):
+        """Guided shutdown cancellation reaches the standard route 503 ledger."""
+        import asyncio
+        import threading
+
+        from vllm_mlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine.__new__(BatchedEngine)
+        engine._admission_lock = threading.Lock()
+        engine._lifecycle_aborted_tasks = set()
+        engine._guided_requests_lock = threading.Lock()
+        engine._guided_abort_events = {}
+        engine._guided_owner_tasks = {}
+        engine._guided_stopping = False
+        owner = asyncio.current_task()
+        assert owner is not None
+        abort_event = threading.Event()
+
+        engine._register_guided_request("req-guided", abort_event, owner)
+        engine._abort_all_guided_requests()
+
+        assert abort_event.is_set()
+        assert engine.consume_lifecycle_task_abort(owner) is True
+        assert engine.consume_lifecycle_task_abort(owner) is False
 
     @pytest.mark.asyncio
     async def test_routes_to_mllm_scheduler_when_present(self):

--- a/tests/test_response_format_json_schema_strict.py
+++ b/tests/test_response_format_json_schema_strict.py
@@ -1852,6 +1852,27 @@ def test_responses_strict_true_guided_failure_returns_502(_rate_limiter_state):
     assert snap["strict_violations_total"] == 1
 
 
+def test_responses_guided_cancellation_is_lifecycle_not_schema_failure(
+    _rate_limiter_state,
+):
+    """Shutdown cancellation never becomes a 502 or unconstrained retry."""
+    from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+    class _CancelledEngine(_Engine):
+        async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+            raise GuidedGenerationCancelledError()
+
+        def consume_lifecycle_task_abort(self, _task) -> bool:
+            return True
+
+    engine = _CancelledEngine(supports_guided=True)
+    client = _make_responses_client(engine, _rate_limiter_state)
+    resp = client.post("/v1/responses", json=_responses_payload(strict=True))
+    assert resp.status_code == 503, resp.text
+    assert engine.chat_calls == []
+    assert response_format_metrics.snapshot()["strict_violations_total"] == 0
+
+
 def test_strict_true_with_tools_returns_400_chat():
     """Codex r3 BLOCKING #2 hole — strict + tools: the existing
     ``if response_format and not request.tools`` guard around the
@@ -2413,6 +2434,25 @@ def test_strict_true_non_streaming_guided_raises_returns_502_no_fallback():
     snap = response_format_metrics.snapshot()
     assert snap["strict_requests_total"] == 1
     assert snap["strict_violations_total"] == 1
+
+
+def test_non_streaming_guided_cancellation_never_falls_back_unconstrained():
+    """A stopped guided worker propagates lifecycle cancellation only."""
+    from vllm_mlx.api.errors import GuidedGenerationCancelledError
+
+    class _CancelledEngine(_Engine):
+        def consume_lifecycle_task_abort(self, _task) -> bool:
+            return True
+
+    engine = _CancelledEngine(
+        supports_guided=True,
+        guided_raises=GuidedGenerationCancelledError(),
+    )
+    client = _make_client(engine)
+    resp = client.post("/v1/chat/completions", json=_payload(strict=False))
+    assert resp.status_code == 503, resp.text
+    assert engine.chat_calls == []
+    assert engine.stream_calls == []
 
 
 def test_strict_false_streaming_guided_raises_still_falls_back():

--- a/tests/test_response_format_json_schema_strict.py
+++ b/tests/test_response_format_json_schema_strict.py
@@ -1859,17 +1859,26 @@ def test_responses_guided_cancellation_is_lifecycle_not_schema_failure(
     from vllm_mlx.api.errors import GuidedGenerationCancelledError
 
     class _CancelledEngine(_Engine):
-        async def generate_with_schema(self, *, messages, json_schema, **kwargs):
-            raise GuidedGenerationCancelledError()
+        def __init__(self):
+            super().__init__(supports_guided=True)
+            self.lifecycle_owner = object()
+            self.lifecycle_consumed = False
 
-        def consume_lifecycle_task_abort(self, _task) -> bool:
+        async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+            raise GuidedGenerationCancelledError(lifecycle_task=self.lifecycle_owner)
+
+        def consume_lifecycle_task_abort(self, task) -> bool:
+            if task is not self.lifecycle_owner or self.lifecycle_consumed:
+                return False
+            self.lifecycle_consumed = True
             return True
 
-    engine = _CancelledEngine(supports_guided=True)
+    engine = _CancelledEngine()
     client = _make_responses_client(engine, _rate_limiter_state)
     resp = client.post("/v1/responses", json=_responses_payload(strict=True))
     assert resp.status_code == 503, resp.text
     assert engine.chat_calls == []
+    assert engine.lifecycle_consumed is True
     assert response_format_metrics.snapshot()["strict_violations_total"] == 0
 
 
@@ -2441,18 +2450,27 @@ def test_non_streaming_guided_cancellation_never_falls_back_unconstrained():
     from vllm_mlx.api.errors import GuidedGenerationCancelledError
 
     class _CancelledEngine(_Engine):
-        def consume_lifecycle_task_abort(self, _task) -> bool:
+        def __init__(self):
+            super().__init__(supports_guided=True)
+            self.lifecycle_owner = object()
+            self.lifecycle_consumed = False
+
+        async def generate_with_schema(self, *, messages, json_schema, **kwargs):
+            raise GuidedGenerationCancelledError(lifecycle_task=self.lifecycle_owner)
+
+        def consume_lifecycle_task_abort(self, task) -> bool:
+            if task is not self.lifecycle_owner or self.lifecycle_consumed:
+                return False
+            self.lifecycle_consumed = True
             return True
 
-    engine = _CancelledEngine(
-        supports_guided=True,
-        guided_raises=GuidedGenerationCancelledError(),
-    )
+    engine = _CancelledEngine()
     client = _make_client(engine)
     resp = client.post("/v1/chat/completions", json=_payload(strict=False))
     assert resp.status_code == 503, resp.text
     assert engine.chat_calls == []
     assert engine.stream_calls == []
+    assert engine.lifecycle_consumed is True
 
 
 def test_strict_false_streaming_guided_raises_still_falls_back():

--- a/vllm_mlx/api/errors.py
+++ b/vllm_mlx/api/errors.py
@@ -40,6 +40,15 @@ class GuidedSchemaCompileError(Exception):
     """
 
 
+class GuidedGenerationCancelledError(Exception):
+    """Internal control signal for cooperatively cancelled guided work.
+
+    This is deliberately distinct from an operational guided-decoder failure:
+    callers must terminate the request instead of falling back to unconstrained
+    generation after the client has cancelled its schema-constrained request.
+    """
+
+
 def guided_schema_compile_error_detail(
     exc: BaseException,
     param: str | None = None,

--- a/vllm_mlx/api/errors.py
+++ b/vllm_mlx/api/errors.py
@@ -48,6 +48,13 @@ class GuidedGenerationCancelledError(Exception):
     generation after the client has cancelled its schema-constrained request.
     """
 
+    def __init__(self, *, lifecycle_task: object | None = None) -> None:
+        super().__init__()
+        # When shutdown initiated the stop, this is the exact task entered in
+        # the engine's lifecycle ledger.  The guided worker may be nested under
+        # a disconnect guard, so consumers must not substitute current_task().
+        self.lifecycle_task = lifecycle_task
+
 
 def guided_schema_compile_error_detail(
     exc: BaseException,

--- a/vllm_mlx/api/guided.py
+++ b/vllm_mlx/api/guided.py
@@ -587,13 +587,15 @@ class GuidedGenerator:
                 schema_str,
                 overrides={"whitespace_flexible": True},
             )
-            return self._decode_constrained(
-                grammar=grammar,
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                should_abort=should_abort,
-            )
+            decode_kwargs: dict[str, Any] = {
+                "grammar": grammar,
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+            if should_abort is not None:
+                decode_kwargs["should_abort"] = should_abort
+            return self._decode_constrained(**decode_kwargs)
         except GuidedGenerationCancelledError:
             raise
         except GuidedSchemaCompileError:
@@ -646,13 +648,15 @@ class GuidedGenerator:
                 _JSON_OBJECT_SCHEMA,
                 overrides={"whitespace_flexible": True},
             )
-            return self._decode_constrained(
-                grammar=grammar,
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                should_abort=should_abort,
-            )
+            decode_kwargs: dict[str, Any] = {
+                "grammar": grammar,
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+            if should_abort is not None:
+                decode_kwargs["should_abort"] = should_abort
+            return self._decode_constrained(**decode_kwargs)
         except GuidedGenerationCancelledError:
             raise
         except Exception:

--- a/vllm_mlx/api/guided.py
+++ b/vllm_mlx/api/guided.py
@@ -27,6 +27,7 @@ Two constraint modes are supported, matching the two the OpenAI
 
 import json
 import logging
+from collections.abc import Callable
 from typing import Any
 
 # ``GuidedSchemaCompileError`` originally lived in THIS module; it now lives in
@@ -43,7 +44,7 @@ from typing import Any
 # ``from vllm_mlx.api.guided import *``. Adding an ``__all__`` would silently
 # hide every name not listed, breaking existing ``import *`` consumers; leaving
 # it off keeps all module-level public names exported.
-from .errors import GuidedSchemaCompileError
+from .errors import GuidedGenerationCancelledError, GuidedSchemaCompileError
 
 logger = logging.getLogger(__name__)
 
@@ -317,6 +318,7 @@ class GuidedGenerator:
         prompt: str,
         max_tokens: int,
         temperature: float,
+        should_abort: Callable[[], bool] | None = None,
     ) -> str | None:
         """Run an ``mlx_lm`` decode loop constrained by an llguidance grammar.
 
@@ -380,6 +382,12 @@ class GuidedGenerator:
         benign truncated-parse ``None``.
         """
         from mlx_lm.models.cache import make_prompt_cache
+
+        def check_cancelled() -> None:
+            if should_abort is not None and should_abort():
+                raise GuidedGenerationCancelledError()
+
+        check_cancelled()
 
         lltok = self._get_lltokenizer()
         if lltok is None:
@@ -451,17 +459,22 @@ class GuidedGenerator:
         #      generated token still sees full context.
         y = mx.array(prompt_ids)
         while y.size > _PREFILL_STEP_SIZE:
+            check_cancelled()
             model(y[:_PREFILL_STEP_SIZE][None], cache=cache)
             mx.eval([c.state for c in cache])
+            check_cancelled()
             y = y[_PREFILL_STEP_SIZE:]
             mx.clear_cache()
 
         # Trailing remainder (1 .. _PREFILL_STEP_SIZE tokens): this final
         # forward pass yields the last-token logits for the first sample.
+        check_cancelled()
         logits = model(y[None], cache=cache)[:, -1, :]
+        check_cancelled()
 
         generated: list[int] = []
         for _ in range(max_tokens):
+            check_cancelled()
             if matcher.is_stopped():
                 break
 
@@ -501,6 +514,7 @@ class GuidedGenerator:
             if matcher.is_stopped() or len(generated) >= max_tokens:
                 break
             logits = model(mx.array([tok])[None], cache=cache)[:, -1, :]
+            check_cancelled()
 
         # Only return output the grammar actually completed. ``is_accepting``
         # is True iff the matcher is in a state where the grammar is fully
@@ -519,6 +533,7 @@ class GuidedGenerator:
         json_schema: dict[str, Any],
         max_tokens: int = 256,
         temperature: float = 0.7,
+        should_abort: Callable[[], bool] | None = None,
     ) -> str | None:
         """Generate JSON output constrained to a schema.
 
@@ -577,7 +592,10 @@ class GuidedGenerator:
                 prompt=prompt,
                 max_tokens=max_tokens,
                 temperature=temperature,
+                should_abort=should_abort,
             )
+        except GuidedGenerationCancelledError:
+            raise
         except GuidedSchemaCompileError:
             # llguidance rejected the (structurally-valid) schema LAZILY at
             # matcher construction (``matcher.get_error()``) → operational.
@@ -599,6 +617,7 @@ class GuidedGenerator:
         prompt: str,
         max_tokens: int = 256,
         temperature: float = 0.7,
+        should_abort: Callable[[], bool] | None = None,
     ) -> str | None:
         """
         Generate any valid JSON object.
@@ -632,7 +651,10 @@ class GuidedGenerator:
                 prompt=prompt,
                 max_tokens=max_tokens,
                 temperature=temperature,
+                should_abort=should_abort,
             )
+        except GuidedGenerationCancelledError:
+            raise
         except Exception:
             logger.exception("JSON object generation failed")
             return None
@@ -682,6 +704,7 @@ def generate_with_schema(
     json_schema: dict[str, Any],
     max_tokens: int = 256,
     temperature: float = 0.7,
+    should_abort: Callable[[], bool] | None = None,
 ) -> str | None:
     """
     Convenience function for one-shot guided JSON generation.
@@ -693,6 +716,7 @@ def generate_with_schema(
         json_schema: JSON schema
         max_tokens: Maximum tokens
         temperature: Sampling temperature
+        should_abort: Optional callback that reports request cancellation.
 
     Returns:
         JSON string or None if guided generation unavailable/failed
@@ -702,12 +726,17 @@ def generate_with_schema(
 
     try:
         generator = GuidedGenerator(model, tokenizer)
-        return generator.generate_json(
-            prompt=prompt,
-            json_schema=json_schema,
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
+        generation_kwargs: dict[str, Any] = {
+            "prompt": prompt,
+            "json_schema": json_schema,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if should_abort is not None:
+            generation_kwargs["should_abort"] = should_abort
+        return generator.generate_json(**generation_kwargs)
+    except GuidedGenerationCancelledError:
+        raise
     except Exception as e:
         # ``generate_json`` already degrades EVERY failure (compile-reject
         # included) to ``None`` internally, so nothing schema-specific escapes

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -21,7 +21,7 @@ import time
 import uuid
 import weakref
 from collections.abc import AsyncIterator, Callable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import Any
 
 from ..api.errors import GuidedGenerationCancelledError
@@ -39,6 +39,15 @@ from .base import BaseEngine, GenerationOutput
 ADMISSION_ORPHAN_GRACE_SECONDS = 2.0
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _GuidedHandoffOutcome:
+    """Cancellation state retained while guided work transfers ownership."""
+
+    cancelled: bool
+    lifecycle_task: asyncio.Task | None
+
 
 # Tokenization can change across a message boundary once the following turn is
 # appended. Replay a negligible suffix so non-trimmable caches never snapshot
@@ -4132,21 +4141,24 @@ class BatchedEngine(BaseEngine):
             owner_tasks = tuple(getattr(self, "_guided_owner_tasks", {}).values())
         self._mark_lifecycle_aborted_tasks(owner_tasks)
 
-    def finish_guided_handoff(self, request_id: str) -> bool:
+    def finish_guided_handoff(self, request_id: str) -> _GuidedHandoffOutcome:
         """Transfer a retained guided identity to an admitted fallback.
 
-        Returns whether cancellation reached the guided owner before the
-        scheduler-backed fallback took ownership.
+        Returns cancellation plus the exact lifecycle owner so shutdown cannot
+        be misreported as an explicit client cancel during the transfer.
         """
 
         lock = getattr(self, "_guided_requests_lock", None)
         registry = getattr(self, "_guided_abort_events", None)
         if lock is None or registry is None:
-            return False
+            return _GuidedHandoffOutcome(cancelled=False, lifecycle_task=None)
         with lock:
             abort_event = registry.pop(request_id, None)
-            getattr(self, "_guided_owner_tasks", {}).pop(request_id, None)
-            return bool(abort_event is not None and abort_event.is_set())
+            owner_task = getattr(self, "_guided_owner_tasks", {}).pop(request_id, None)
+            return _GuidedHandoffOutcome(
+                cancelled=bool(abort_event is not None and abort_event.is_set()),
+                lifecycle_task=owner_task,
+            )
 
     async def generate_with_schema(
         self,

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -995,6 +995,7 @@ class BatchedEngine(BaseEngine):
         # that token only at safe prefill/decode boundaries.
         self._guided_requests_lock = threading.Lock()
         self._guided_abort_events: dict[str, threading.Event] = {}
+        self._guided_owner_tasks: dict[str, asyncio.Task] = {}
         self._guided_stopping = False
 
     @property
@@ -4037,7 +4038,10 @@ class BatchedEngine(BaseEngine):
         return HAS_GUIDED and not self._is_mllm
 
     def _register_guided_request(
-        self, request_id: str, abort_event: threading.Event
+        self,
+        request_id: str,
+        abort_event: threading.Event,
+        owner_task: asyncio.Task | None = None,
     ) -> None:
         # A few lightweight embedding/tests construct the engine through
         # ``__new__`` to avoid loading MLX. Production always initializes
@@ -4045,14 +4049,43 @@ class BatchedEngine(BaseEngine):
         if not hasattr(self, "_guided_requests_lock"):
             self._guided_requests_lock = threading.Lock()
             self._guided_abort_events = {}
+            self._guided_owner_tasks = {}
             self._guided_stopping = False
+        elif not hasattr(self, "_guided_owner_tasks"):
+            self._guided_owner_tasks = {}
         with self._guided_requests_lock:
             if getattr(self, "_guided_stopping", False):
                 abort_event.set()
-                raise GuidedGenerationCancelledError()
-            if request_id in self._guided_abort_events:
+                stopped = True
+            else:
+                stopped = False
+            if not stopped and request_id in self._guided_abort_events:
                 raise RuntimeError("guided request identity is already active")
-            self._guided_abort_events[request_id] = abort_event
+            if not stopped:
+                self._guided_abort_events[request_id] = abort_event
+                if owner_task is not None:
+                    self._guided_owner_tasks[request_id] = owner_task
+        if stopped:
+            self._mark_lifecycle_aborted_tasks((owner_task,))
+            raise GuidedGenerationCancelledError()
+
+    def _mark_lifecycle_aborted_tasks(
+        self, tasks: tuple[asyncio.Task | None, ...]
+    ) -> None:
+        """Publish engine-owned cancellation through the route lifecycle ledger."""
+
+        owners = tuple(task for task in tasks if task is not None)
+        if not owners:
+            return
+        lock = getattr(self, "_admission_lock", None)
+        if lock is None:
+            return
+        with lock:
+            aborted_tasks = getattr(self, "_lifecycle_aborted_tasks", None)
+            if aborted_tasks is None:
+                aborted_tasks = weakref.WeakSet()
+                self._lifecycle_aborted_tasks = aborted_tasks
+            aborted_tasks.update(owners)
 
     def _finish_guided_request(
         self, request_id: str, abort_event: threading.Event
@@ -4067,6 +4100,7 @@ class BatchedEngine(BaseEngine):
             if self._guided_abort_events.get(request_id) is abort_event:
                 was_aborted = abort_event.is_set()
                 self._guided_abort_events.pop(request_id, None)
+                getattr(self, "_guided_owner_tasks", {}).pop(request_id, None)
                 return was_aborted
         return abort_event.is_set()
 
@@ -4095,6 +4129,8 @@ class BatchedEngine(BaseEngine):
             self._guided_stopping = True
             for abort_event in registry.values():
                 abort_event.set()
+            owner_tasks = tuple(getattr(self, "_guided_owner_tasks", {}).values())
+        self._mark_lifecycle_aborted_tasks(owner_tasks)
 
     def finish_guided_handoff(self, request_id: str) -> bool:
         """Transfer a retained guided identity to an admitted fallback.
@@ -4109,6 +4145,7 @@ class BatchedEngine(BaseEngine):
             return False
         with lock:
             abort_event = registry.pop(request_id, None)
+            getattr(self, "_guided_owner_tasks", {}).pop(request_id, None)
             return bool(abort_event is not None and abort_event.is_set())
 
     async def generate_with_schema(
@@ -4190,7 +4227,11 @@ class BatchedEngine(BaseEngine):
             kwargs.pop("retain_guided_request_on_failure", False)
         )
         abort_event = threading.Event()
-        self._register_guided_request(request_id, abort_event)
+        self._register_guided_request(
+            request_id,
+            abort_event,
+            owner_task=asyncio.current_task(),
+        )
         if request_id_holder is not None:
             try:
                 request_id_holder[0] = request_id

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -20,10 +20,11 @@ import threading
 import time
 import uuid
 import weakref
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import replace
 from typing import Any
 
+from ..api.errors import GuidedGenerationCancelledError
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import (
     clean_output_text,
@@ -988,6 +989,12 @@ class BatchedEngine(BaseEngine):
         self._lifecycle_aborted_tasks: weakref.WeakSet[asyncio.Task] = weakref.WeakSet()
         self._generation_paused = False
         self._generation_pause_mode: str | None = None
+        # Guided decoding runs outside the continuous scheduler on the
+        # model-owning executor. Keep the same request-owned lifecycle shape:
+        # a public id maps to a thread-safe stop token, and the worker observes
+        # that token only at safe prefill/decode boundaries.
+        self._guided_requests_lock = threading.Lock()
+        self._guided_abort_events: dict[str, threading.Event] = {}
 
     @property
     def model_name(self) -> str:
@@ -2083,6 +2090,10 @@ class BatchedEngine(BaseEngine):
 
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
+        # Scheduler shutdown queues work on the same single model executor
+        # used by guided decoding. Signal guided jobs first so a long schema
+        # request cannot hold model unload behind it.
+        self._abort_all_guided_requests()
         if self._mllm_scheduler:
             await self._mllm_scheduler.stop()
             self._mllm_scheduler = None
@@ -3925,6 +3936,8 @@ class BatchedEngine(BaseEngine):
         """
         import inspect
 
+        if self.abort_guided_request(request_id):
+            return True
         if self._mllm_scheduler is not None:
             if error_kind is None:
                 return self._mllm_scheduler.abort_request(request_id)
@@ -4020,6 +4033,62 @@ class BatchedEngine(BaseEngine):
         """Check if guided generation is available."""
         return HAS_GUIDED and not self._is_mllm
 
+    def _register_guided_request(
+        self, request_id: str, abort_event: threading.Event
+    ) -> None:
+        # A few lightweight embedding/tests construct the engine through
+        # ``__new__`` to avoid loading MLX. Production always initializes
+        # these in ``__init__``; keep that legacy construction shape usable.
+        if not hasattr(self, "_guided_requests_lock"):
+            self._guided_requests_lock = threading.Lock()
+            self._guided_abort_events = {}
+        with self._guided_requests_lock:
+            if request_id in self._guided_abort_events:
+                raise RuntimeError("guided request identity is already active")
+            self._guided_abort_events[request_id] = abort_event
+
+    def _finish_guided_request(
+        self, request_id: str, abort_event: threading.Event
+    ) -> bool:
+        """Atomically commit completion and return whether cancellation won.
+
+        Removal is identity-checked so a late worker callback cannot remove a
+        newer request that reused the same public id.
+        """
+
+        with self._guided_requests_lock:
+            if self._guided_abort_events.get(request_id) is abort_event:
+                was_aborted = abort_event.is_set()
+                self._guided_abort_events.pop(request_id, None)
+                return was_aborted
+        return abort_event.is_set()
+
+    def abort_guided_request(self, request_id: str) -> bool:
+        """Synchronously publish cancellation to a live guided worker."""
+
+        lock = getattr(self, "_guided_requests_lock", None)
+        abort_events = getattr(self, "_guided_abort_events", None)
+        if lock is None or abort_events is None:
+            return False
+        with lock:
+            abort_event = abort_events.get(request_id)
+            if abort_event is None:
+                return False
+            abort_event.set()
+            return True
+
+    def _abort_all_guided_requests(self) -> None:
+        """Unblock the model-owning executor before engine shutdown."""
+
+        lock = getattr(self, "_guided_requests_lock", None)
+        registry = getattr(self, "_guided_abort_events", None)
+        if lock is None or registry is None:
+            return
+        with lock:
+            abort_events = tuple(registry.values())
+        for abort_event in abort_events:
+            abort_event.set()
+
     async def generate_with_schema(
         self,
         messages: list[dict[str, Any]],
@@ -4092,6 +4161,19 @@ class BatchedEngine(BaseEngine):
             chat_template_kwargs=chat_template_kwargs,
         )
 
+        request_id = kwargs.pop("request_id", None) or f"guided-{uuid.uuid4().hex}"
+        request_id_holder = kwargs.pop("request_id_holder", None)
+        request_admitted_event = kwargs.pop("request_admitted_event", None)
+        abort_event = threading.Event()
+        self._register_guided_request(request_id, abort_event)
+        if request_id_holder is not None:
+            try:
+                request_id_holder[0] = request_id
+            except Exception:
+                logger.debug("[guided] request_id_holder publish failed", exc_info=True)
+        if request_admitted_event is not None:
+            request_admitted_event.set()
+
         # Run guided generation on the mlx-step worker. The model was
         # loaded on _model_load_executor (#170 fix) and every later mx.eval
         # on its weights must come from that same thread — see the third-leg
@@ -4108,27 +4190,49 @@ class BatchedEngine(BaseEngine):
         # _inject_shared_model path), and its worker thread did NOT load the
         # model — using it would just trade one Stream(gpu, N) crash for another.
         loop = asyncio.get_running_loop()
-        if self._model_load_executor is not None:
-            result = await loop.run_in_executor(
-                self._model_load_executor,
-                functools.partial(
-                    self._run_guided_generation,
-                    prompt=prompt,
-                    json_schema=json_schema,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                ),
-            )
-        else:
-            # Best-effort fallback for sync/test paths. Will hit Stream(gpu, N)
-            # if the model lives on a real worker thread.
-            result = await asyncio.to_thread(
-                self._run_guided_generation,
-                prompt=prompt,
-                json_schema=json_schema,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
+        work = functools.partial(
+            self._run_guided_generation,
+            prompt=prompt,
+            json_schema=json_schema,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            should_abort=abort_event.is_set,
+        )
+        try:
+            if self._model_load_executor is not None:
+                future = loop.run_in_executor(self._model_load_executor, work)
+            else:
+                # Best-effort fallback for sync/test paths. Will hit Stream(gpu, N)
+                # if the model lives on a real worker thread.
+                future = asyncio.create_task(asyncio.to_thread(work))
+        except BaseException:
+            self._finish_guided_request(request_id, abort_event)
+            raise
+
+        # ``shield`` prevents an HTTP task cancellation from marking the
+        # executor future complete while its thread still owns MLX state.
+        was_aborted = False
+        try:
+            result = await asyncio.shield(future)
+        except asyncio.CancelledError:
+            abort_event.set()
+            raise
+        finally:
+            # Normal completion/failure atomically observes cancellation and
+            # releases the id before fallback can reuse it. If the response
+            # task exits while the shielded worker is still live, retain
+            # ownership and attach cleanup to actual worker completion.
+            if future.done():
+                was_aborted = self._finish_guided_request(request_id, abort_event)
+            else:
+                future.add_done_callback(
+                    lambda _future: self._finish_guided_request(request_id, abort_event)
+                )
+        # Close the worker-complete / result-commit race: unregistering and
+        # checking the stop token happened under one lock, so an abort either
+        # wins before commit or receives ``False`` after completion committed.
+        if was_aborted:
+            raise GuidedGenerationCancelledError()
 
         if result is None:
             # Fallback to standard generation. The streaming caller passes
@@ -4176,6 +4280,7 @@ class BatchedEngine(BaseEngine):
         json_schema: dict[str, Any],
         max_tokens: int,
         temperature: float,
+        should_abort: Callable[[], bool] | None = None,
     ) -> str | None:
         """Run guided generation synchronously (called from thread pool)."""
         try:
@@ -4189,7 +4294,10 @@ class BatchedEngine(BaseEngine):
                 json_schema=json_schema,
                 max_tokens=max_tokens,
                 temperature=temperature,
+                should_abort=should_abort,
             )
+        except GuidedGenerationCancelledError:
+            raise
         except Exception as e:
             # ``generate_json`` already degrades every failure — compile-reject
             # (structural validity is settled at the route boundary) and

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -4067,7 +4067,7 @@ class BatchedEngine(BaseEngine):
                     self._guided_owner_tasks[request_id] = owner_task
         if stopped:
             self._mark_lifecycle_aborted_tasks((owner_task,))
-            raise GuidedGenerationCancelledError()
+            raise GuidedGenerationCancelledError(lifecycle_task=owner_task)
 
     def _mark_lifecycle_aborted_tasks(
         self, tasks: tuple[asyncio.Task | None, ...]
@@ -4279,6 +4279,11 @@ class BatchedEngine(BaseEngine):
         # executor future complete while its thread still owns MLX state.
         try:
             result = await asyncio.shield(future)
+        except GuidedGenerationCancelledError as exc:
+            self._finish_guided_request(request_id, abort_event)
+            raise GuidedGenerationCancelledError(
+                lifecycle_task=asyncio.current_task()
+            ) from exc
         except asyncio.CancelledError:
             abort_event.set()
             if future.done():
@@ -4299,7 +4304,9 @@ class BatchedEngine(BaseEngine):
         if result is None and raise_on_failure and retain_request_on_failure:
             if abort_event.is_set():
                 self._finish_guided_request(request_id, abort_event)
-                raise GuidedGenerationCancelledError()
+                raise GuidedGenerationCancelledError(
+                    lifecycle_task=asyncio.current_task()
+                )
             raise RuntimeError(
                 "Guided generation produced no result "
                 "(llguidance import/grammar failure — see prior log)"
@@ -4312,7 +4319,7 @@ class BatchedEngine(BaseEngine):
         # checking the stop token happened under one lock, so an abort either
         # wins before commit or receives ``False`` after completion committed.
         if was_aborted:
-            raise GuidedGenerationCancelledError()
+            raise GuidedGenerationCancelledError(lifecycle_task=asyncio.current_task())
 
         if result is None:
             # Fallback to standard generation. The streaming caller passes

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -995,6 +995,7 @@ class BatchedEngine(BaseEngine):
         # that token only at safe prefill/decode boundaries.
         self._guided_requests_lock = threading.Lock()
         self._guided_abort_events: dict[str, threading.Event] = {}
+        self._guided_stopping = False
 
     @property
     def model_name(self) -> str:
@@ -1454,6 +1455,8 @@ class BatchedEngine(BaseEngine):
         else:
             await self._start_llm()
 
+        with self._guided_requests_lock:
+            self._guided_stopping = False
         self._loaded = True
         self._start_time = time.monotonic()
         logger.info(f"BatchedEngine loaded: {self._model_name} (mllm={self._is_mllm})")
@@ -4042,7 +4045,11 @@ class BatchedEngine(BaseEngine):
         if not hasattr(self, "_guided_requests_lock"):
             self._guided_requests_lock = threading.Lock()
             self._guided_abort_events = {}
+            self._guided_stopping = False
         with self._guided_requests_lock:
+            if getattr(self, "_guided_stopping", False):
+                abort_event.set()
+                raise GuidedGenerationCancelledError()
             if request_id in self._guided_abort_events:
                 raise RuntimeError("guided request identity is already active")
             self._guided_abort_events[request_id] = abort_event
@@ -4078,16 +4085,31 @@ class BatchedEngine(BaseEngine):
             return True
 
     def _abort_all_guided_requests(self) -> None:
-        """Unblock the model-owning executor before engine shutdown."""
+        """Close guided admission and unblock workers before shutdown."""
 
         lock = getattr(self, "_guided_requests_lock", None)
         registry = getattr(self, "_guided_abort_events", None)
         if lock is None or registry is None:
             return
         with lock:
-            abort_events = tuple(registry.values())
-        for abort_event in abort_events:
-            abort_event.set()
+            self._guided_stopping = True
+            for abort_event in registry.values():
+                abort_event.set()
+
+    def finish_guided_handoff(self, request_id: str) -> bool:
+        """Transfer a retained guided identity to an admitted fallback.
+
+        Returns whether cancellation reached the guided owner before the
+        scheduler-backed fallback took ownership.
+        """
+
+        lock = getattr(self, "_guided_requests_lock", None)
+        registry = getattr(self, "_guided_abort_events", None)
+        if lock is None or registry is None:
+            return False
+        with lock:
+            abort_event = registry.pop(request_id, None)
+            return bool(abort_event is not None and abort_event.is_set())
 
     async def generate_with_schema(
         self,
@@ -4164,6 +4186,9 @@ class BatchedEngine(BaseEngine):
         request_id = kwargs.pop("request_id", None) or f"guided-{uuid.uuid4().hex}"
         request_id_holder = kwargs.pop("request_id_holder", None)
         request_admitted_event = kwargs.pop("request_admitted_event", None)
+        retain_request_on_failure = bool(
+            kwargs.pop("retain_guided_request_on_failure", False)
+        )
         abort_event = threading.Event()
         self._register_guided_request(request_id, abort_event)
         if request_id_holder is not None:
@@ -4211,23 +4236,37 @@ class BatchedEngine(BaseEngine):
 
         # ``shield`` prevents an HTTP task cancellation from marking the
         # executor future complete while its thread still owns MLX state.
-        was_aborted = False
         try:
             result = await asyncio.shield(future)
         except asyncio.CancelledError:
             abort_event.set()
-            raise
-        finally:
-            # Normal completion/failure atomically observes cancellation and
-            # releases the id before fallback can reuse it. If the response
-            # task exits while the shielded worker is still live, retain
-            # ownership and attach cleanup to actual worker completion.
             if future.done():
-                was_aborted = self._finish_guided_request(request_id, abort_event)
+                self._finish_guided_request(request_id, abort_event)
             else:
                 future.add_done_callback(
                     lambda _future: self._finish_guided_request(request_id, abort_event)
                 )
+            raise
+        except BaseException:
+            self._finish_guided_request(request_id, abort_event)
+            raise
+
+        # Best-effort streaming may transfer this identity to the ordinary
+        # scheduler when guided decoding is operationally unavailable. Retain
+        # ownership until that scheduler confirms admission, eliminating an
+        # unowned cancel/404 interval.
+        if result is None and raise_on_failure and retain_request_on_failure:
+            if abort_event.is_set():
+                self._finish_guided_request(request_id, abort_event)
+                raise GuidedGenerationCancelledError()
+            raise RuntimeError(
+                "Guided generation produced no result "
+                "(llguidance import/grammar failure — see prior log)"
+            )
+
+        # Normal completion/failure atomically observes cancellation and
+        # releases the id before the result or fallback can commit.
+        was_aborted = self._finish_guided_request(request_id, abort_event)
         # Close the worker-complete / result-commit race: unregistering and
         # checking the stop token happened under one lock, so an abort either
         # wins before commit or receives ``False`` after completion committed.

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -16,7 +16,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 
-from ..api.errors import CHAT_RESPONSE_FORMAT_PARAM
+from ..api.errors import CHAT_RESPONSE_FORMAT_PARAM, GuidedGenerationCancelledError
 from ..api.models import (
     AssistantMessage,
     ChatCompletionChoice,
@@ -7780,9 +7780,10 @@ async def stream_chat_completion_guided(
         # ``self.chat(...)`` on guided-engine failure and returns a
         # buffered unconstrained ``GenerationOutput``. From this
         # helper's POV that looks like a successful guided result and
-        # we would emit one giant content chunk at the end —
-        # defeating SSE for clients/proxies that rely on early chunks
-        # (codex Round 2 finding).
+        # we would emit one giant content chunk at the end. The admission
+        # frame below deliberately carries no role or content; after it, a
+        # successful guided result remains buffered and strict failures still
+        # occur before any assistant content (codex Round 2 finding).
         # Codex r5 BLOCKING parity: prevent a kwargs collision with
         # the explicit ``raise_on_failure=True`` below. If ``kwargs``
         # ever contained ``raise_on_failure`` it would TypeError
@@ -7792,14 +7793,59 @@ async def stream_chat_completion_guided(
         # guided-generation failure (silent fallback to unconstrained
         # streaming, which IS the case strict callers cannot
         # tolerate). Sanitize so the strict caller OWNS the value.
-        _guided_kwargs = {k: v for k, v in kwargs.items() if k != "raise_on_failure"}
-        try:
-            output = await engine.generate_with_schema(
+        _guided_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in {"raise_on_failure", "request_id", "request_admitted_event"}
+        }
+        request_admitted_event = asyncio.Event()
+        guided_task = asyncio.create_task(
+            engine.generate_with_schema(
                 messages=messages,
                 json_schema=json_schema,
                 raise_on_failure=True,
+                request_id=response_id,
+                request_admitted_event=request_admitted_event,
                 **_guided_kwargs,
             )
+        )
+        admission_task = asyncio.create_task(request_admitted_event.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {guided_task, admission_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            # Production engines set the event immediately after registering
+            # the public id. Compatibility stubs may finish without an event;
+            # task completion is itself proof that no unaddressable live work
+            # remains, so publishing the stable id is still safe.
+            if guided_task in done and not admission_task.done():
+                admission_task.cancel()
+
+            # Publish the high-entropy identity before waiting for prefill or
+            # constrained decode. Clients can now pass this exact id to the
+            # existing /v1/requests/{id}/cancel endpoint.
+            # Admission frame: publish only the stable id with an empty delta.
+            # The role frame remains buffered until guided output has passed
+            # strict validation, preserving the existing error-before-content
+            # contract if decoding or post-validation later fails.
+            yield f"{_sse_prefix}{_sse_suffix}"
+            output = await guided_task
+        except GuidedGenerationCancelledError:
+            cancelled_chunk = ChatCompletionChunk(
+                id=response_id,
+                created=_sse_created,
+                model=_resolve_model_name(request.model),
+                choices=[
+                    ChatCompletionChunkChoice(
+                        delta=ChatCompletionChunkDelta(),
+                        finish_reason="cancelled",
+                    )
+                ],
+            )
+            yield f"data: {cancelled_chunk.model_dump_json(exclude_none=True)}\n\n"
+            yield "data: [DONE]\n\n"
+            return
         except Exception as guided_err:
             # Log only the schema's top-level shape, not the full body —
             # user-supplied schemas may embed PII (default values),
@@ -7876,6 +7922,11 @@ async def stream_chat_completion_guided(
             ):
                 yield chunk
             return
+        finally:
+            if not admission_task.done():
+                admission_task.cancel()
+            if not guided_task.done():
+                guided_task.cancel()
 
         content = output.text or ""
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -7793,9 +7793,38 @@ async def stream_chat_completion_guided(
                 "data: [DONE]\n\n",
             )
 
-        def _finish_guided_handoff() -> bool:
+        def _model_replacement_terminal_events() -> tuple[str, str]:
+            error_data = json.dumps(
+                {
+                    "error": {
+                        "message": "Request cancelled by model replacement",
+                        "type": "server_error",
+                        "code": "model_replacement",
+                    }
+                }
+            )
+            return f"data: {error_data}\n\n", "data: [DONE]\n\n"
+
+        def _finish_guided_handoff() -> tuple[bool, object | None]:
             finish = getattr(engine, "finish_guided_handoff", None)
-            return bool(callable(finish) and finish(response_id))
+            if not callable(finish):
+                return False, None
+            outcome = finish(response_id)
+            # Compatibility for lightweight engines implementing the earlier
+            # bool-returning internal hook.
+            if isinstance(outcome, bool):
+                return outcome, None
+            return bool(getattr(outcome, "cancelled", False)), getattr(
+                outcome, "lifecycle_task", None
+            )
+
+        def _handoff_cancel_terminal_events(
+            lifecycle_task: object | None,
+        ) -> tuple[str, str]:
+            exc = GuidedGenerationCancelledError(lifecycle_task=lifecycle_task)
+            if _consume_guided_lifecycle_cancel(engine, exc):
+                return _model_replacement_terminal_events()
+            return _cancelled_terminal_events()
 
         # Run guided generation buffered. If it raises, fall through to
         # the unconstrained streaming helper — this preserves request
@@ -7865,17 +7894,8 @@ async def stream_chat_completion_guided(
             output = await guided_task
         except GuidedGenerationCancelledError as exc:
             if _consume_guided_lifecycle_cancel(engine, exc):
-                error_data = json.dumps(
-                    {
-                        "error": {
-                            "message": "Request cancelled by model replacement",
-                            "type": "server_error",
-                            "code": "model_replacement",
-                        }
-                    }
-                )
-                yield f"data: {error_data}\n\n"
-                yield "data: [DONE]\n\n"
+                for event in _model_replacement_terminal_events():
+                    yield event
                 return
             for event in _cancelled_terminal_events():
                 yield event
@@ -7906,8 +7926,9 @@ async def stream_chat_completion_guided(
             # (mirror of the post-decode shape) + DONE, and DO NOT
             # enter the unconstrained fallback.
             if strict_mode:
-                if _finish_guided_handoff():
-                    for event in _cancelled_terminal_events():
+                was_cancelled, lifecycle_task = _finish_guided_handoff()
+                if was_cancelled:
+                    for event in _handoff_cancel_terminal_events(lifecycle_task):
                         yield event
                     return
                 incr_strict_violation()
@@ -7965,11 +7986,13 @@ async def stream_chat_completion_guided(
                         # The fallback helper publishes its first chunk only
                         # after scheduler admission. Transfer ownership under
                         # the guided-registry lock before exposing that chunk.
-                        was_cancelled = _finish_guided_handoff()
+                        was_cancelled, lifecycle_task = _finish_guided_handoff()
                         handoff_finished = True
                         if was_cancelled:
                             await engine.abort_request(response_id)
-                            for event in _cancelled_terminal_events():
+                            for event in _handoff_cancel_terminal_events(
+                                lifecycle_task
+                            ):
                                 yield event
                             return
                     yield chunk

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -10,8 +10,8 @@ import re
 import threading
 import time
 import uuid
-from collections.abc import AsyncIterator
-from typing import Any
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
@@ -7969,15 +7969,18 @@ async def stream_chat_completion_guided(
             # tracks the completion id across the guided→unconstrained
             # handoff sees two different ids/timestamps for what is
             # logically one request (DeepSeek pr_validate round 5).
-            fallback_stream = stream_chat_completion(
-                engine,
-                messages,
-                request,
-                response_id=response_id,
-                created=_sse_created,
-                request_id=response_id,
-                caller_agent=caller_agent,
-                **kwargs,
+            fallback_stream = cast(
+                AsyncGenerator[str, None],
+                stream_chat_completion(
+                    engine,
+                    messages,
+                    request,
+                    response_id=response_id,
+                    created=_sse_created,
+                    request_id=response_id,
+                    caller_agent=caller_agent,
+                    **kwargs,
+                ),
             )
             handoff_finished = False
             try:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -86,6 +86,7 @@ from ..service.helpers import (
     _build_prompt_with_thinking_compat,
     _build_usage,
     _check_admission_or_503,
+    _consume_guided_lifecycle_cancel,
     _disconnect_guard,
     _effective_enable_thinking,
     _extract_streaming_token_logprobs,
@@ -5271,6 +5272,11 @@ async def _create_chat_completion_impl(
             except GuidedGenerationCancelledError as exc:
                 # Engine-owned cancellation is lifecycle control, never a
                 # guided failure eligible for unconstrained fallback.
+                if _consume_guided_lifecycle_cancel(engine, exc):
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Request cancelled by model replacement",
+                    ) from exc
                 raise asyncio.CancelledError() from exc
             except HTTPException:
                 raise
@@ -7857,7 +7863,20 @@ async def stream_chat_completion_guided(
             # contract if decoding or post-validation later fails.
             yield f"{_sse_prefix}{_sse_suffix}"
             output = await guided_task
-        except GuidedGenerationCancelledError:
+        except GuidedGenerationCancelledError as exc:
+            if _consume_guided_lifecycle_cancel(engine, exc):
+                error_data = json.dumps(
+                    {
+                        "error": {
+                            "message": "Request cancelled by model replacement",
+                            "type": "server_error",
+                            "code": "model_replacement",
+                        }
+                    }
+                )
+                yield f"data: {error_data}\n\n"
+                yield "data: [DONE]\n\n"
+                return
             for event in _cancelled_terminal_events():
                 yield event
             return

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5268,6 +5268,10 @@ async def _create_chat_completion_impl(
                     raw_request,
                     timeout=timeout,
                 )
+            except GuidedGenerationCancelledError as exc:
+                # Engine-owned cancellation is lifecycle control, never a
+                # guided failure eligible for unconstrained fallback.
+                raise asyncio.CancelledError() from exc
             except HTTPException:
                 raise
             except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
@@ -7766,6 +7770,27 @@ async def stream_chat_completion_guided(
         )
         _sse_suffix = "}}]}\n\n"
 
+        def _cancelled_terminal_events() -> tuple[str, str]:
+            chunk = ChatCompletionChunk(
+                id=response_id,
+                created=_sse_created,
+                model=_resolve_model_name(request.model),
+                choices=[
+                    ChatCompletionChunkChoice(
+                        delta=ChatCompletionChunkDelta(),
+                        finish_reason="cancelled",
+                    )
+                ],
+            )
+            return (
+                f"data: {chunk.model_dump_json(exclude_none=True)}\n\n",
+                "data: [DONE]\n\n",
+            )
+
+        def _finish_guided_handoff() -> bool:
+            finish = getattr(engine, "finish_guided_handoff", None)
+            return bool(callable(finish) and finish(response_id))
+
         # Run guided generation buffered. If it raises, fall through to
         # the unconstrained streaming helper — this preserves request
         # liveness (constraints best-effort, response always emitted)
@@ -7798,6 +7823,7 @@ async def stream_chat_completion_guided(
             for k, v in kwargs.items()
             if k not in {"raise_on_failure", "request_id", "request_admitted_event"}
         }
+        _guided_kwargs["retain_guided_request_on_failure"] = True
         request_admitted_event = asyncio.Event()
         guided_task = asyncio.create_task(
             engine.generate_with_schema(
@@ -7832,19 +7858,8 @@ async def stream_chat_completion_guided(
             yield f"{_sse_prefix}{_sse_suffix}"
             output = await guided_task
         except GuidedGenerationCancelledError:
-            cancelled_chunk = ChatCompletionChunk(
-                id=response_id,
-                created=_sse_created,
-                model=_resolve_model_name(request.model),
-                choices=[
-                    ChatCompletionChunkChoice(
-                        delta=ChatCompletionChunkDelta(),
-                        finish_reason="cancelled",
-                    )
-                ],
-            )
-            yield f"data: {cancelled_chunk.model_dump_json(exclude_none=True)}\n\n"
-            yield "data: [DONE]\n\n"
+            for event in _cancelled_terminal_events():
+                yield event
             return
         except Exception as guided_err:
             # Log only the schema's top-level shape, not the full body —
@@ -7872,6 +7887,10 @@ async def stream_chat_completion_guided(
             # (mirror of the post-decode shape) + DONE, and DO NOT
             # enter the unconstrained fallback.
             if strict_mode:
+                if _finish_guided_handoff():
+                    for event in _cancelled_terminal_events():
+                        yield event
+                    return
                 incr_strict_violation()
                 logger.warning(
                     "Strict json_schema streaming guided generation "
@@ -7910,7 +7929,7 @@ async def stream_chat_completion_guided(
             # tracks the completion id across the guided→unconstrained
             # handoff sees two different ids/timestamps for what is
             # logically one request (DeepSeek pr_validate round 5).
-            async for chunk in stream_chat_completion(
+            fallback_stream = stream_chat_completion(
                 engine,
                 messages,
                 request,
@@ -7919,8 +7938,26 @@ async def stream_chat_completion_guided(
                 request_id=response_id,
                 caller_agent=caller_agent,
                 **kwargs,
-            ):
-                yield chunk
+            )
+            handoff_finished = False
+            try:
+                async for chunk in fallback_stream:
+                    if not handoff_finished:
+                        # The fallback helper publishes its first chunk only
+                        # after scheduler admission. Transfer ownership under
+                        # the guided-registry lock before exposing that chunk.
+                        was_cancelled = _finish_guided_handoff()
+                        handoff_finished = True
+                        if was_cancelled:
+                            await engine.abort_request(response_id)
+                            for event in _cancelled_terminal_events():
+                                yield event
+                            return
+                    yield chunk
+            finally:
+                if not handoff_finished:
+                    _finish_guided_handoff()
+                await fallback_stream.aclose()
             return
         finally:
             if not admission_task.done():

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -90,6 +90,7 @@ from ..service.helpers import (
     _build_usage,
     _check_admission_or_503,
     _client_signalled_reasoning_intent,
+    _consume_guided_lifecycle_cancel,
     _disconnect_guard,
     _effective_enable_thinking,
     _extract_thinking_from_request,
@@ -1728,6 +1729,11 @@ async def _non_stream(
             except GuidedGenerationCancelledError as exc:
                 # Engine-owned cancellation is lifecycle control, never a
                 # strict-schema failure and never eligible for fallback.
+                if _consume_guided_lifecycle_cancel(engine, exc):
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Request cancelled by model replacement",
+                    ) from exc
                 raise asyncio.CancelledError() from exc
             except Exception as guided_err:
                 logger.warning(

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -27,7 +27,7 @@ from collections.abc import AsyncIterator, Mapping
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 
-from ..api.errors import RESPONSES_TEXT_FORMAT_PARAM
+from ..api.errors import RESPONSES_TEXT_FORMAT_PARAM, GuidedGenerationCancelledError
 from ..api.models import (
     AssistantMessage,
     ChatCompletionChoice,
@@ -1725,6 +1725,10 @@ async def _non_stream(
                 # belongs to the route's standard cancellation
                 # path, not the strict contract.
                 raise
+            except GuidedGenerationCancelledError as exc:
+                # Engine-owned cancellation is lifecycle control, never a
+                # strict-schema failure and never eligible for fallback.
+                raise asyncio.CancelledError() from exc
             except Exception as guided_err:
                 logger.warning(
                     "Guided generation failed mid-await on /v1/responses "

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -3687,6 +3687,18 @@ def _force_abort_request(engine, request_id_holder) -> bool:
     if not request_id:
         return False
     try:
+        # Guided decoding is intentionally outside the continuous scheduler,
+        # but it still exposes the same public request identity. Give its
+        # thread-safe stop-token registry first refusal; otherwise resolving
+        # the text scheduler would return False for the guided id and prevent
+        # disconnect cleanup from reaching the actual owner.
+        abort_guided = getattr(engine, "abort_guided_request", None)
+        if callable(abort_guided) and abort_guided(request_id):
+            logger.info(
+                "[disconnect_guard] force-abort guided request %s -> True",
+                str(request_id)[:12],
+            )
+            return True
         sync_abort = _resolve_sync_scheduler_for_abort(engine)
         if sync_abort is not None:
             result = sync_abort(request_id)

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -167,6 +167,14 @@ def _raise_lifecycle_cancel_or_reraise(engine, exc: asyncio.CancelledError) -> N
     raise exc
 
 
+def _consume_guided_lifecycle_cancel(engine, exc) -> bool:
+    """Consume shutdown ownership carried by a guided cancellation signal."""
+
+    task = getattr(exc, "lifecycle_task", None)
+    consume_abort = getattr(engine, "consume_lifecycle_task_abort", None)
+    return bool(task is not None and callable(consume_abort) and consume_abort(task))
+
+
 def _raise_backpressure_503(exc: Exception) -> None:
     """Convert ``BackpressureError`` from the scheduler into HTTP 503
     with a Retry-After header (RFC 9110 §10.2.4).


### PR DESCRIPTION
## Summary

- expose the stable public request ID before buffered guided prefill/decode begins
- keep guided request cancellation state in the engine and check it at safe prefill/decode boundaries
- terminate cancelled strict-schema streams without content or unconstrained fallback
- release guided identities safely across success, failure, disconnect, shutdown, and final-result races

## User benefit

Structured-output and tool workflows can now stop long guided requests promptly. A disconnected or explicitly cancelled client no longer leaves buffered schema generation monopolizing the model executor, and cancellation can never leak a late result or silently switch to unconstrained output.

## Scope

Engine-owned guided request lifecycle, the existing public cancellation/disconnect wiring, guided SSE admission/termination behavior, and focused regression tests.

## Non-goals

No scheduler redesign, protocol endpoint changes, sampling changes, telemetry expansion, model changes, or dependency updates.

## Design precedent

Mature inference schedulers treat cancellation as engine-owned request state: publish an addressable request identity at admission, record abort state centrally, observe it at safe scheduling or compute boundaries, and resolve abort before output commit. This change adapts that pattern to Rapid-MLX's buffered guided path. Because MLX execution is not safely preemptible inside a dispatched operation, checks occur before and after chunked prefill calls and decode steps. Completion and cancellation are serialized under the request registry lock so exactly one outcome commits.

## Verification

- exact-head focused suite: 194 passed
- worker-cleanup ordering regression: 30 consecutive passes
- clean Python 3.12 full suite on the production-identical test-only parent: 21,498 passed, 122 skipped, 22 deselected, 6 xfailed, 1 xpassed
- changed production-line coverage: 100% (252/252)
- `pr_validate`: MERGE-SAFE on the exact head
- exact-head hosted Apple Silicon, Desktop, lint, type-check, engine-contract, version-guard, and merge-lane checks passed
- Ruff check, Ruff format check, and `git diff --check` passed

## Checklist

- [x] User-visible need validated
- [x] Reference-first architecture review completed
- [x] Cancellation races covered by tests
- [x] No secrets, generated files, or unrelated edits
- [x] User path exercised through the public cancellation route
- [x] Independent Codex review converged (13 requests; exact-head LGTM)

Fixes #2399
