### PR TITLE
feat(benchmark): show contributor identity after sharing

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -2,6 +2,10 @@ import Darwin
 import Foundation
 import SwiftUI
 
+private let communityBenchmarkLeaderboardURL = URL(
+    string: "https://rapidmlx.com/leaderboard"
+)!
+
 struct CommunityBenchmarkModel: Identifiable, Hashable {
     let entry: ModelEntry
     let task: ModelTask
@@ -674,9 +678,10 @@ struct CommunityBenchmarkView: View {
             } else {
                 Link(
                     "View Community Benchmark",
-                    destination: URL(string: "https://rapidmlx.com/leaderboard")!
+                    destination: communityBenchmarkLeaderboardURL
                 )
-                .buttonStyle(.borderedProminent)
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("CommunityBenchmark.Share.Leaderboard")
             }
             Text("Thanks for helping other Mac users choose models with real-world evidence.")
                 .font(.callout)

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -112,12 +112,29 @@ private struct CommunityBenchmarkResults: Decodable {
     let receipts: [String: CommunityBenchmarkReceipt]?
 }
 
-private struct CommunityBenchmarkReceipt: Decodable {
+struct CommunityBenchmarkContributor: Decodable, Equatable {
+    let name: String
+    let tag: String
+
+    var displayName: String { "\(name) ·\(tag)" }
+
+    var profileURL: URL? {
+        var components = URLComponents(string: "https://rapidmlx.com")
+        components?.path = "/leaderboard/contributors/\(name)-\(tag)"
+        return components?.url
+    }
+}
+
+struct CommunityBenchmarkReceipt: Decodable, Identifiable {
     let submissionID: String
     let alreadyExists: Bool
     let acceptedAt: String
+    let contributor: CommunityBenchmarkContributor?
+
+    var id: String { submissionID }
 
     enum CodingKeys: String, CodingKey {
+        case contributor
         case submissionID = "submission_id"
         case alreadyExists = "already_exists"
         case acceptedAt = "accepted_at"
@@ -555,6 +572,7 @@ struct CommunityBenchmarkView: View {
     @State private var shareTask: Task<Void, Never>?
     @State private var shareCandidate: CommunityBenchmarkUploadPreview?
     @State private var sharingRunID: String?
+    @State private var shareSuccess: CommunityBenchmarkReceipt?
     @State private var receipts: [String: CommunityBenchmarkReceipt] = [:]
     @State private var benchmarkMetadata: [String: CommunityBenchmarkCatalogModel] = [:]
     @State private var benchmarkCLIAvailable = false
@@ -627,6 +645,51 @@ struct CommunityBenchmarkView: View {
             .padding(24)
             .frame(minWidth: 680, minHeight: 600)
         }
+        .sheet(item: $shareSuccess, content: shareSuccessSheet)
+    }
+
+    private func shareSuccessSheet(_ receipt: CommunityBenchmarkReceipt) -> some View {
+        VStack(spacing: 18) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 44))
+                .foregroundStyle(.green)
+                .accessibilityHidden(true)
+            Text(receipt.alreadyExists ? "Already on the map" : "You added a point to the map")
+                .font(.title2.weight(.semibold))
+            if let contributor = receipt.contributor {
+                VStack(spacing: 6) {
+                    Text("Your Community Benchmark identity")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(contributor.displayName)
+                        .font(.system(.headline, design: .monospaced))
+                        .textSelection(.enabled)
+                        .accessibilityIdentifier("CommunityBenchmark.Share.Identity")
+                }
+                if let url = contributor.profileURL {
+                    Link("View my contributions", destination: url)
+                        .buttonStyle(.borderedProminent)
+                        .accessibilityIdentifier("CommunityBenchmark.Share.Profile")
+                }
+            } else {
+                Link(
+                    "View Community Benchmark",
+                    destination: URL(string: "https://rapidmlx.com/leaderboard")!
+                )
+                .buttonStyle(.borderedProminent)
+            }
+            Text("Thanks for helping other Mac users choose models with real-world evidence.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Done") { shareSuccess = nil }
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("CommunityBenchmark.Share.Done")
+        }
+        .padding(32)
+        .frame(width: 440)
+        .frame(minHeight: 330)
+        .accessibilityIdentifier("CommunityBenchmark.Share.Success")
     }
 
     private var header: some View {
@@ -714,10 +777,22 @@ struct CommunityBenchmarkView: View {
                         Spacer()
                         VStack(alignment: .trailing, spacing: 5) {
                             Text(result.duration ?? result.outcome.status.capitalized)
-                            if receipts[result.id] != nil {
+                            if let receipt = receipts[result.id] {
                                 Label("Shared", systemImage: "checkmark.circle.fill")
                                     .font(.caption)
                                     .foregroundStyle(.green)
+                                if let contributor = receipt.contributor,
+                                   let url = contributor.profileURL
+                                {
+                                    Link(contributor.displayName, destination: url)
+                                        .font(.caption.monospaced())
+                                        .accessibilityLabel(
+                                            "View contributions by \(contributor.displayName)"
+                                        )
+                                        .accessibilityIdentifier(
+                                            "CommunityBenchmark.Contributor.\(result.id)"
+                                        )
+                                }
                             } else {
                                 Button(sharingRunID == result.id ? "Sharing…" : "Share") {
                                     prepareShare(result)
@@ -833,10 +908,9 @@ struct CommunityBenchmarkView: View {
                         message: "The benchmark was not uploaded."
                     )
                 }
-                if response.receiptSaved {
-                    receipts[preview.runID] = response.receipt
-                } else {
-                    await refreshResults()
+                receipts[preview.runID] = response.receipt
+                shareSuccess = response.receipt
+                if !response.receiptSaved {
                     errorMessage = "Uploaded, but Rapid couldn’t save the local receipt."
                 }
             } catch is CancellationError {

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -123,9 +123,17 @@ struct CommunityBenchmarkContributor: Decodable, Equatable {
     var displayName: String { "\(name) ·\(tag)" }
 
     var profileURL: URL? {
-        var components = URLComponents(string: "https://rapidmlx.com")
-        components?.path = "/leaderboard/contributors/\(name)-\(tag)"
-        return components?.url
+        // Percent-encode the identifier so an embedded "/" in a server-assigned
+        // name/tag cannot become a path separator — mirrors the CLI client's
+        // urllib `quote(f"{name}-{tag}", safe="-")`. (Nothing but ASCII
+        // alphanumerics, "_", ".", "-", "~" stays literal; everything else is
+        // percent-encoded, so the joined slug is safe to drop into a URL path.)
+        var allowed = CharacterSet.alphanumerics
+        allowed.formUnion(CharacterSet(charactersIn: "_.-~"))
+        let encoded = ("\(name)-\(tag)").addingPercentEncoding(
+            withAllowedCharacters: allowed
+        ) ?? ""
+        return URL(string: "https://rapidmlx.com/leaderboard/contributors/\(encoded)")
     }
 }
 
@@ -922,11 +930,12 @@ struct CommunityBenchmarkView: View {
                         message: "The benchmark was not uploaded."
                     )
                 }
-                receipts[preview.runID] = response.receipt
-                shareSuccess = response.receipt
-                if !response.receiptSaved {
+                if response.receiptSaved {
+                    receipts[preview.runID] = response.receipt
+                } else {
                     errorMessage = "Uploaded, but Rapid couldn’t save the local receipt."
                 }
+                shareSuccess = response.receipt
             } catch is CancellationError {
                 // Navigation cancelled the upload command and its subprocess.
             } catch {

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -136,6 +136,18 @@ struct CommunityBenchmarkReceipt: Decodable, Identifiable {
     let contributor: CommunityBenchmarkContributor?
 
     var id: String { submissionID }
+    var contributionLinkTitle: String {
+        contributor?.displayName ?? "View Community Benchmark"
+    }
+
+    var contributionURL: URL {
+        contributor?.profileURL ?? communityBenchmarkLeaderboardURL
+    }
+
+    var contributionAccessibilityLabel: String {
+        contributor.map { "View contributions by \($0.displayName)" }
+            ?? "View Community Benchmark"
+    }
 
     enum CodingKeys: String, CodingKey {
         case contributor
@@ -786,18 +798,15 @@ struct CommunityBenchmarkView: View {
                                 Label("Shared", systemImage: "checkmark.circle.fill")
                                     .font(.caption)
                                     .foregroundStyle(.green)
-                                if let contributor = receipt.contributor,
-                                   let url = contributor.profileURL
-                                {
-                                    Link(contributor.displayName, destination: url)
-                                        .font(.caption.monospaced())
-                                        .accessibilityLabel(
-                                            "View contributions by \(contributor.displayName)"
-                                        )
-                                        .accessibilityIdentifier(
-                                            "CommunityBenchmark.Contributor.\(result.id)"
-                                        )
-                                }
+                                Link(
+                                    receipt.contributionLinkTitle,
+                                    destination: receipt.contributionURL
+                                )
+                                .font(.caption.monospaced())
+                                .accessibilityLabel(receipt.contributionAccessibilityLabel)
+                                .accessibilityIdentifier(
+                                    "CommunityBenchmark.Contributor.\(result.id)"
+                                )
                             } else {
                                 Button(sharingRunID == result.id ? "Sharing…" : "Share") {
                                     prepareShare(result)

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -219,6 +219,21 @@ struct CommunityBenchmarkModelTests {
         )
     }
 
+    @Test("Contributor profile URL percent-encodes embedded slashes in the identity")
+    func contributorProfileURLPercentEncodesSlash() {
+        let contributor = CommunityBenchmarkContributor(
+            name: "modest/slate+wombat",
+            tag: "5 4"
+        )
+        // Mirrors the CLI client's urllib quote(f"{name}-{tag}", safe="-"): every
+        // character outside [A-Za-z0-9_.~-] is percent-encoded, so "/" cannot be
+        // interpreted as a path separator and the lone segment round-trips.
+        #expect(
+            contributor.profileURL?.absoluteString
+                == "https://rapidmlx.com/leaderboard/contributors/modest%2Fslate%2Bwombat-5%204"
+        )
+    }
+
     @Test("Desktop decodes contributor identity and older anonymous receipts")
     func contributorReceiptDecoding() throws {
         let full = try JSONDecoder().decode(

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -234,7 +234,7 @@ struct CommunityBenchmarkModelTests {
         )
     }
 
-    @Test("Desktop decodes contributor identity and older anonymous receipts")
+    @Test("Desktop decodes contributor identity and valid anonymous receipts")
     func contributorReceiptDecoding() throws {
         let full = try JSONDecoder().decode(
             CommunityBenchmarkReceipt.self,
@@ -249,15 +249,15 @@ struct CommunityBenchmarkModelTests {
         )
         #expect(full.contributionLinkTitle == "modest-slate-wombat ·545")
 
-        let legacy = try JSONDecoder().decode(
+        let anonymous = try JSONDecoder().decode(
             CommunityBenchmarkReceipt.self,
             from: Data(
-                #"{"submission_id":"00000000-0000-4000-8000-000000000001","already_exists":true,"accepted_at":"2026-09-01T20:00:00Z"}"#.utf8
+                #"{"submission_id":"00000000-0000-4000-8000-000000000001","already_exists":true,"accepted_at":"2026-09-01T20:00:00Z","contributor":null}"#.utf8
             )
         )
-        #expect(legacy.contributor == nil)
-        #expect(legacy.contributionURL.absoluteString == "https://rapidmlx.com/leaderboard")
-        #expect(legacy.contributionLinkTitle == "View Community Benchmark")
+        #expect(anonymous.contributor == nil)
+        #expect(anonymous.contributionURL.absoluteString == "https://rapidmlx.com/leaderboard")
+        #expect(anonymous.contributionLinkTitle == "View Community Benchmark")
     }
 
     @Test("Benchmark pipe capture bounds stdout heads and stderr tails")

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -205,6 +205,39 @@ struct CommunityBenchmarkModelTests {
         )
     }
 
+    @Test("Contributor receipt produces the public profile identity")
+    func contributorProfileIdentity() throws {
+        let contributor = CommunityBenchmarkContributor(
+            name: "modest-slate-wombat",
+            tag: "545"
+        )
+
+        #expect(contributor.displayName == "modest-slate-wombat ·545")
+        #expect(
+            contributor.profileURL?.absoluteString
+                == "https://rapidmlx.com/leaderboard/contributors/modest-slate-wombat-545"
+        )
+    }
+
+    @Test("Desktop decodes contributor identity and older anonymous receipts")
+    func contributorReceiptDecoding() throws {
+        let full = try JSONDecoder().decode(
+            CommunityBenchmarkReceipt.self,
+            from: Data(
+                #"{"submission_id":"00000000-0000-4000-8000-000000000001","already_exists":false,"accepted_at":"2026-09-01T20:00:00Z","contributor":{"name":"modest-slate-wombat","tag":"545"}}"#.utf8
+            )
+        )
+        #expect(full.contributor?.displayName == "modest-slate-wombat ·545")
+
+        let legacy = try JSONDecoder().decode(
+            CommunityBenchmarkReceipt.self,
+            from: Data(
+                #"{"submission_id":"00000000-0000-4000-8000-000000000001","already_exists":true,"accepted_at":"2026-09-01T20:00:00Z"}"#.utf8
+            )
+        )
+        #expect(legacy.contributor == nil)
+    }
+
     @Test("Benchmark pipe capture bounds stdout heads and stderr tails")
     func boundedPipeCapture() throws {
         let headPipe = Pipe()

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -228,6 +228,11 @@ struct CommunityBenchmarkModelTests {
             )
         )
         #expect(full.contributor?.displayName == "modest-slate-wombat ·545")
+        #expect(
+            full.contributionURL.absoluteString
+                == "https://rapidmlx.com/leaderboard/contributors/modest-slate-wombat-545"
+        )
+        #expect(full.contributionLinkTitle == "modest-slate-wombat ·545")
 
         let legacy = try JSONDecoder().decode(
             CommunityBenchmarkReceipt.self,
@@ -236,6 +241,8 @@ struct CommunityBenchmarkModelTests {
             )
         )
         #expect(legacy.contributor == nil)
+        #expect(legacy.contributionURL.absoluteString == "https://rapidmlx.com/leaderboard")
+        #expect(legacy.contributionLinkTitle == "View Community Benchmark")
     }
 
     @Test("Benchmark pipe capture bounds stdout heads and stderr tails")

--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -129,6 +129,12 @@ run digest. The client verifies that the returned receipt digest identifies the
 exact uploaded payload before marking a result shared. Atomic rows remain
 outside the legacy public aggregation path.
 
+The receipt's server-assigned contributor `name` and `tag` close the feedback
+loop after consent: CLI prints the public identity and contributor-page URL;
+Desktop presents the identity immediately after upload and keeps the page link
+on the local result. Clients construct the website route from those two atomic
+fields rather than adding a presentation URL to the strict receipt schema.
+
 Model-identity resolution, public aggregation, campaign prompts, rewards, and
 leaderboard growth mechanics remain later work. The ingestion boundary accepts
 the current unresolved identities deliberately; it never upgrades them to

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -907,6 +907,11 @@ def test_share_cli_text_reports_cancel_and_unsaved_existing_acceptance(
     assert community_cli.benchmark_command(args) == 0
     output = capsys.readouterr().out
     assert "already uploaded" in output
+    assert "You contributed as rapid-silver-otter ·abc." in output
+    assert (
+        "https://rapidmlx.com/leaderboard/contributors/rapid-silver-otter-abc"
+        in output
+    )
     assert "local receipt could not be saved" in output
 
 

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -913,6 +913,22 @@ def test_share_cli_text_reports_cancel_and_unsaved_existing_acceptance(
     )
     assert "local receipt could not be saved" in output
 
+    anonymous_receipt = {**receipt, "contributor": None}
+    anonymous_acceptance = atomic_upload.AtomicUploadAcceptance(
+        receipt=anonymous_receipt,
+        install_id="012345abcdef",
+        payload_digest=anonymous_receipt["run_digest"],
+    )
+    monkeypatch.setattr(
+        community_cli,
+        "upload_run",
+        lambda local_run, **kwargs: anonymous_acceptance,
+    )
+    assert community_cli.benchmark_command(args) == 0
+    output = capsys.readouterr().out
+    assert "You contributed as" not in output
+    assert "View Community Benchmark: https://rapidmlx.com/leaderboard" in output
+
 
 def test_unknown_run_model_returns_structured_unsaved_cli_error(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -909,8 +909,7 @@ def test_share_cli_text_reports_cancel_and_unsaved_existing_acceptance(
     assert "already uploaded" in output
     assert "You contributed as rapid-silver-otter ·abc." in output
     assert (
-        "https://rapidmlx.com/leaderboard/contributors/rapid-silver-otter-abc"
-        in output
+        "https://rapidmlx.com/leaderboard/contributors/rapid-silver-otter-abc" in output
     )
     assert "local receipt could not be saved" in output
 

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -874,6 +874,10 @@ def test_share_cli_text_reports_cancel_and_unsaved_existing_acceptance(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     run = _text_run()
+    assert (
+        community_cli._contributor_profile({"contributor": {"name": "", "tag": "abc"}})
+        is None
+    )
 
     class Archive:
         def get(self, run_id: str):

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -6,10 +6,31 @@ from __future__ import annotations
 import json
 import sys
 from typing import Any
+from urllib.parse import quote
 
 from .atomic_upload import preview_run, upload_run
 from .local_runner import LocalBenchmarkError, run_local
 from .workspace import LocalRunArchive, benchmark_catalog, plan_for_alias
+
+_CONTRIBUTOR_BASE_URL = "https://rapidmlx.com/leaderboard/contributors"
+
+
+def _contributor_profile(receipt: dict[str, Any]) -> tuple[str, str] | None:
+    """Return the server-assigned public identity and its board URL."""
+
+    contributor = receipt.get("contributor")
+    if not isinstance(contributor, dict):
+        return None
+    name, tag = contributor.get("name"), contributor.get("tag")
+    if (
+        not isinstance(name, str)
+        or not name
+        or not isinstance(tag, str)
+        or not tag
+    ):
+        return None
+    slug = quote(f"{name}-{tag}", safe="-")
+    return f"{name} ·{tag}", f"{_CONTRIBUTOR_BASE_URL}/{slug}"
 
 
 def _print_json(value: Any) -> None:
@@ -141,6 +162,10 @@ def benchmark_command(args) -> int:
             receipt = value["receipt"]
             suffix = " (already uploaded)" if receipt["already_exists"] else ""
             print(f"Accepted benchmark {receipt['submission_id']}{suffix}.")
+            if profile := _contributor_profile(receipt):
+                identity, url = profile
+                print(f"You contributed as {identity}.")
+                print(f"View your contributions: {url}")
             if not value["receipt_saved"]:
                 print(
                     "Warning: the upload succeeded but its local receipt could not be saved."

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -22,12 +22,7 @@ def _contributor_profile(receipt: dict[str, Any]) -> tuple[str, str] | None:
     if not isinstance(contributor, dict):
         return None
     name, tag = contributor.get("name"), contributor.get("tag")
-    if (
-        not isinstance(name, str)
-        or not name
-        or not isinstance(tag, str)
-        or not tag
-    ):
+    if not isinstance(name, str) or not name or not isinstance(tag, str) or not tag:
         return None
     slug = quote(f"{name}-{tag}", safe="-")
     return f"{name} ·{tag}", f"{_CONTRIBUTOR_BASE_URL}/{slug}"

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -12,7 +12,8 @@ from .atomic_upload import preview_run, upload_run
 from .local_runner import LocalBenchmarkError, run_local
 from .workspace import LocalRunArchive, benchmark_catalog, plan_for_alias
 
-_CONTRIBUTOR_BASE_URL = "https://rapidmlx.com/leaderboard/contributors"
+_LEADERBOARD_URL = "https://rapidmlx.com/leaderboard"
+_CONTRIBUTOR_BASE_URL = f"{_LEADERBOARD_URL}/contributors"
 
 
 def _contributor_profile(receipt: dict[str, Any]) -> tuple[str, str] | None:
@@ -161,6 +162,8 @@ def benchmark_command(args) -> int:
                 identity, url = profile
                 print(f"You contributed as {identity}.")
                 print(f"View your contributions: {url}")
+            else:
+                print(f"View Community Benchmark: {_LEADERBOARD_URL}")
             if not value["receipt_saved"]:
                 print(
                     "Warning: the upload succeeded but its local receipt could not be saved."


### PR DESCRIPTION
## Why

Community Benchmark currently records a stable public pseudonym, but the CLI only says Accepted and Desktop only says Shared. The contributor cannot see the personal page their work created, so the upload flow loses its strongest participation feedback.

## Scope

Module: Community Benchmark client feedback only.

- Print the server-assigned pseudonym and personal contributor URL after a successful CLI share.
- Decode the existing receipt contributor in Desktop.
- Present an immediate success sheet with the identity and View my contributions link.
- Keep that identity link on shared rows after the sheet closes and across relaunches when the receipt was saved.
- Preserve a leaderboard fallback for valid receipts whose contributor is null.
- Document the client feedback contract.

## Non-goals

- No ingestion, storage, benchmark execution, ranking, pseudonym-generation, or schema changes.
- No emoji/avatar mapping in the client; that remains website presentation.
- No website deployment or campaign promotion.
- No changes outside Community Benchmark CLI/Desktop surfaces.

Website dependency: rapidmlx.com#116 must land before release dogfood so the production receipt remains compatible with the strict 0.13.4 schema. The visual contributor page work is separate in rapidmlx.com#117.

## Acceptance

- A successful CLI share prints both the server identity and its full contributor URL.
- A successful Desktop share immediately names the contributor and provides a clickable personal-page action.
- Shared Desktop rows retain the personal-page link.
- Duplicate shares identify themselves as already mapped.
- Valid receipts with a null contributor decode and use a general leaderboard link.
- The strict receipt wire schema stays byte-for-byte unchanged.

## Verification

- Python 3.12: 240 Community Benchmark workspace/proto tests passed.
- Swift: CommunityBenchmarkModelTests, 17 tests passed.
- ruff check passed on touched Python files.
- git diff --check passed.
- Codex Review round 4: LGTM. pr_validate: MERGE-SAFE, 21,510 tests passed.

## Behaviour delta

Successful share feedback: opaque Accepted/Shared state -> server-assigned public identity plus direct personal contribution page, persisted on Desktop result rows.

## AI assistance disclosure

Codex wrote the scoped CLI, SwiftUI, tests, and decision-note changes. I reviewed the complete diff, verified strict receipt compatibility and legacy receipt fallback, and ran the Python and Swift test suites listed above.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally (targeted suites pass; full pr_validate pending)
- [x] Lint passes (ruff check on touched Python files)
- [x] Self-validated with python3 -m scripts.pr_validate.pr_validate <PR#>
- [x] If new tests touch a critical code path, spot-checked
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API

## Author

