### PR TITLE
fix(mac): accept the current live video capabilities contract (#2969)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -183,7 +183,7 @@ enum DevSnapshot {
                     workload: .init(
                         metric: "pixel_frames",
                         maximum: 38_141_952,
-                        dimensionRounding: "multiple_of_64"
+                        dimensionRounding: "ceil_to_64"
                     )
                 )
             )

--- a/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/VideoView.swift
@@ -14,7 +14,8 @@ enum VideoReferenceLoader {
     static func load(
         from url: URL,
         fileManager: FileManager = .default,
-        maximumBytes: Int = VideoClient.maxReferenceBytes
+        maximumBytes: Int = VideoClient.maxReferenceBytes,
+        maximumPixels: Int? = nil
     ) throws -> Data {
         let (readLimit, overflowed) = maximumBytes.addingReportingOverflow(1)
         guard maximumBytes >= 0, !overflowed else {
@@ -36,6 +37,22 @@ enum VideoReferenceLoader {
         let data = try handle.read(upToCount: readLimit) ?? Data()
         guard data.count <= maximumBytes else {
             throw VideoReferenceLoaderError.tooLarge
+        }
+        if let maximumPixels {
+            guard maximumPixels > 0 else { throw VideoReferenceLoaderError.tooLarge }
+            let options = [kCGImageSourceShouldCache: false] as CFDictionary
+            guard let source = CGImageSourceCreateWithData(data as CFData, options),
+                  let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, options)
+                    as? [CFString: Any],
+                  let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+                  let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
+                  width > 0, height > 0 else {
+                throw VideoReferenceLoaderError.unsupportedFormat
+            }
+            let (pixelCount, overflowed) = width.multipliedReportingOverflow(by: height)
+            guard !overflowed, pixelCount <= maximumPixels else {
+                throw VideoReferenceLoaderError.tooLarge
+            }
         }
         return data
     }
@@ -591,15 +608,21 @@ struct VideoView: View {
     private func loadReference(_ url: URL) async {
         do {
             let maximumBytes = viewModel.referenceMaximumBytes
+            let maximumPixels = viewModel.referenceMaximumPixels
             let acceptedMIMETypes = viewModel.acceptedReferenceMIMETypes
             let (data, mime) = try await Task.detached(priority: .userInitiated) {
-                let data = try VideoReferenceLoader.load(from: url, maximumBytes: maximumBytes)
+                let data = try VideoReferenceLoader.load(
+                    from: url,
+                    maximumBytes: maximumBytes,
+                    maximumPixels: maximumPixels
+                )
                 guard let mime = VideoReferenceLoader.mimeType(for: data) else {
                     throw VideoReferenceLoaderError.unsupportedFormat
                 }
                 return (data, mime)
             }.value
             guard maximumBytes == viewModel.referenceMaximumBytes,
+                  maximumPixels == viewModel.referenceMaximumPixels,
                   acceptedMIMETypes == viewModel.acceptedReferenceMIMETypes else { return }
             guard acceptedMIMETypes.contains(mime) else {
                 viewModel.errorMessage = "Choose a valid JPEG, PNG, or WebP image."

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -95,21 +95,15 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
             /// `dimension_rounding` vocabulary (`none` -> raw dimensions,
             /// `ceil_to_32`, `ceil_to_64`).
             ///
-            /// An unrecognized constant is deliberately tolerated (fail-closed is
-            /// reserved for missing/malformed payloads, not for a new rounding
-            /// label) and falls back to the largest step this client currently
-            /// understands, 64. This keeps the payload valid while being
-            /// conservative with the workload estimate. A future constant larger
-            /// than 64 (e.g. `ceil_to_128`) could under-round here and admit a
-            /// preset the server rejects; that is an accepted UI-level tradeoff —
-            /// the server remains authoritative at request time, and we prefer
-            /// tolerance over dropping an otherwise healthy response.
-            var alignmentStep: Int {
+            /// Unknown values have no safe fallback: treating a future larger
+            /// alignment as 64 could under-count workload and expose a preset the
+            /// server must reject. Callers therefore fail closed on `nil`.
+            var alignmentStep: Int? {
                 switch dimensionRounding {
                 case "none": 1
                 case "ceil_to_32": 32
                 case "ceil_to_64": 64
-                default: 64
+                default: nil
                 }
             }
         }
@@ -326,13 +320,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               frames.offset <= frames.maximum,
               workload.metric == "pixel_frames",
               workload.maximum > 0,
-              // dimension_rounding must be a well-formed (non-empty, non-blank)
-              // string. A blank value is malformed and fails closed; a
-              // well-formed but unrecognized constant is tolerated (see
-              // WorkloadLimit.alignmentStep).
-              !workload.dimensionRounding.trimmingCharacters(
-                  in: .whitespacesAndNewlines
-              ).isEmpty,
+              workload.alignmentStep != nil,
               validInput else {
             throw VideoClientError.invalidResponse
         }
@@ -347,7 +335,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         // Workload normalization is a separate server contract from the
         // request-size alignment. The rounding step is taken from the
         // server-advertised dimension_rounding vocabulary (see WorkloadLimit).
-        let step = limits.workload.alignmentStep
+        guard let step = limits.workload.alignmentStep else { return false }
         guard let width = Self.roundUp(dimensions.width, to: step),
               let height = Self.roundUp(dimensions.height, to: step) else { return false }
         let frameStep = max(1, limits.frames.step)

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -118,11 +118,18 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
             let maximumBytes: Int
             let maximumPixels: Int?
             let formats: [String]
+            /// Legacy field from the retired contract. Absent for the current
+            /// server (which signals image-to-video support by the reference's
+            /// presence); honored here so a transitional server that still sends
+            /// `accepted: false` keeps image input disabled rather than enabling
+            /// it by ignoring the flag.
+            let accepted: Bool?
 
             enum CodingKeys: String, CodingKey {
                 case formats
                 case maximumBytes = "maximum_bytes"
                 case maximumPixels = "maximum_pixels"
+                case accepted
             }
         }
 
@@ -174,9 +181,11 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
 
     /// The `input_reference` limit is usable when the server advertises a
     /// positive byte budget, at least one image MIME type this client can
-    /// produce, and (when declared) a positive pixel ceiling.
+    /// produce, and (when declared) a positive pixel ceiling. A legacy
+    /// `accepted: false` (retired current-server field) explicitly disables it.
     private var usableReferenceLimits: Bool {
         guard let input = limits.inputReference,
+              input.accepted != false,
               input.maximumBytes > 0,
               !acceptedReferenceMIMETypes.isEmpty else { return false }
         return input.maximumPixels.map { $0 > 0 } ?? true
@@ -274,14 +283,19 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         let fps = limits.fps
         let frames = limits.frames
         let workload = limits.workload
-        // A present but unusable input_reference fails closed: it must carry a
-        // positive byte budget, at least one image MIME type, and (when sent) a
-        // positive pixel ceiling. Absent is fine — it simply means text-to-video.
-        let validInput = limits.inputReference.map {
-            $0.maximumBytes > 0
-                && !$0.formats.isEmpty
-                && !acceptedReferenceMIMETypes.isEmpty
-                && ($0.maximumPixels.map { $0 > 0 } ?? true)
+        // A present input_reference must be either usable, or explicitly
+        // disabled by a legacy `accepted: false` (a transitional server that
+        // still sends the retired flag). Any other present-but-unusable
+        // reference misses the byte/formats/pixel limits and fails closed;
+        // absent is fine — it simply means text-to-video.
+        let validInput = limits.inputReference.map { reference in
+            reference.accepted == false
+                || (
+                    reference.maximumBytes > 0
+                        && !reference.formats.isEmpty
+                        && !acceptedReferenceMIMETypes.isEmpty
+                        && (reference.maximumPixels.map { $0 > 0 } ?? true)
+                )
         } ?? true
         guard !model.isEmpty,
               !family.isEmpty,

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -89,16 +89,32 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
                 case metric, maximum
                 case dimensionRounding = "dimension_rounding"
             }
+
+            /// Alignment step applied to generation dimensions before the
+            /// pixel-workload budget is checked. Mirrors the server's
+            /// `dimension_rounding` vocabulary (`none` -> raw dimensions,
+            /// `ceil_to_32`, `ceil_to_64`). An unrecognized constant falls back
+            /// to the most conservative step (ceil to 64) so a newer server
+            /// rounding label remains safe without rejecting a healthy payload.
+            var alignmentStep: Int {
+                switch dimensionRounding {
+                case "none": 1
+                case "ceil_to_32": 32
+                case "ceil_to_64": 64
+                default: 64
+                }
+            }
         }
 
         struct InputReferenceLimit: Decodable, Sendable, Hashable {
-            let accepted: Bool
             let maximumBytes: Int
+            let maximumPixels: Int?
             let formats: [String]
 
             enum CodingKeys: String, CodingKey {
-                case accepted, formats
+                case formats
                 case maximumBytes = "maximum_bytes"
+                case maximumPixels = "maximum_pixels"
             }
         }
 
@@ -137,7 +153,7 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
     let limits: Limits
 
     var acceptedReferenceMIMETypes: Set<String> {
-        guard let input = limits.inputReference, input.accepted else { return [] }
+        guard let input = limits.inputReference else { return [] }
         return Set(input.formats.compactMap { format in
             switch format.lowercased() {
             case "jpeg", "jpg", "image/jpeg": "image/jpeg"
@@ -148,10 +164,17 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         })
     }
 
+    /// Image-to-video is enabled by the presence of a usable `input_reference`
+    /// limit object, not by a retired `accepted` boolean. The reference is
+    /// usable only when the server advertises a positive byte budget, at least
+    /// one image MIME type this client can produce, and (when declared) a
+    /// positive pixel ceiling.
     var supportsImageInput: Bool {
-        modes.contains(.imageToVideo)
-            && referenceMaximumBytes > 0
-            && !acceptedReferenceMIMETypes.isEmpty
+        guard modes.contains(.imageToVideo),
+              let input = limits.inputReference,
+              input.maximumBytes > 0,
+              !acceptedReferenceMIMETypes.isEmpty else { return false }
+        return input.maximumPixels.map { $0 > 0 } ?? true
     }
 
     /// Conservative, familiar output shapes. The API remains authoritative:
@@ -212,7 +235,6 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
 
     var referenceMaximumBytes: Int {
         guard let inputReference = limits.inputReference,
-              inputReference.accepted,
               inputReference.maximumBytes > 0 else { return 0 }
         return min(inputReference.maximumBytes, VideoClient.maxReferenceBytes)
     }
@@ -238,9 +260,14 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         let fps = limits.fps
         let frames = limits.frames
         let workload = limits.workload
+        // A present but unusable input_reference fails closed: it must carry a
+        // positive byte budget, at least one image MIME type, and (when sent) a
+        // positive pixel ceiling. Absent is fine — it simply means text-to-video.
         let validInput = limits.inputReference.map {
-            $0.maximumBytes >= 0
-                && (!$0.accepted || ($0.maximumBytes > 0 && !acceptedReferenceMIMETypes.isEmpty))
+            $0.maximumBytes > 0
+                && !$0.formats.isEmpty
+                && !acceptedReferenceMIMETypes.isEmpty
+                && ($0.maximumPixels.map { $0 > 0 } ?? true)
         } ?? true
         guard !model.isEmpty,
               !family.isEmpty,
@@ -259,7 +286,6 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               frames.offset <= frames.maximum,
               workload.metric == "pixel_frames",
               workload.maximum > 0,
-              workload.dimensionRounding == "multiple_of_64",
               validInput else {
             throw VideoClientError.invalidResponse
         }
@@ -272,9 +298,11 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               seconds > 0,
               limits.fps.default > 0 else { return false }
         // Workload normalization is a separate server contract from the
-        // request-size alignment. This client validates only multiple_of_64.
-        guard let width = Self.roundUp(dimensions.width, to: 64),
-              let height = Self.roundUp(dimensions.height, to: 64) else { return false }
+        // request-size alignment. The rounding step is taken from the
+        // server-advertised dimension_rounding vocabulary (see WorkloadLimit).
+        let step = limits.workload.alignmentStep
+        guard let width = Self.roundUp(dimensions.width, to: step),
+              let height = Self.roundUp(dimensions.height, to: step) else { return false }
         let frameStep = max(1, limits.frames.step)
         let frameOffset = limits.frames.offset
         guard frameOffset >= 0 else { return false }

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -167,7 +167,11 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
     let modes: [VideoModelCapability]
     let limits: Limits
 
-    var acceptedReferenceMIMETypes: Set<String> {
+    /// Image MIME types advertised by the reference, independent of whether the
+    /// reference is currently usable. Kept separate from the gated
+    /// ``acceptedReferenceMIMETypes`` so the usability checks (which read this)
+    /// do not depend on a gated value.
+    private var inputReferenceFormats: Set<String> {
         guard let input = limits.inputReference else { return [] }
         return Set(input.formats.compactMap { format in
             switch format.lowercased() {
@@ -187,8 +191,16 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         guard let input = limits.inputReference,
               input.accepted != false,
               input.maximumBytes > 0,
-              !acceptedReferenceMIMETypes.isEmpty else { return false }
+              !inputReferenceFormats.isEmpty else { return false }
         return input.maximumPixels.map { $0 > 0 } ?? true
+    }
+
+    /// The image MIME types this client accepts for a reference image.
+    /// Non-empty only while the reference is present AND usable, so an
+    /// explicitly disabled (legacy `accepted: false`) or malformed reference
+    /// never advertises supported formats.
+    var acceptedReferenceMIMETypes: Set<String> {
+        usableReferenceLimits ? inputReferenceFormats : []
     }
 
     /// Image-to-video is enabled by the presence of a usable `input_reference`

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -268,6 +268,14 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         return min(input.maximumBytes, VideoClient.maxReferenceBytes)
     }
 
+    /// Optional decoded-pixel ceiling advertised by the active server. Older
+    /// compatible servers omit it, in which case the byte limit remains the
+    /// only client-side bound and the server stays authoritative.
+    var referenceMaximumPixels: Int? {
+        guard let input = limits.inputReference, usableReferenceLimits else { return nil }
+        return input.maximumPixels
+    }
+
     func validated() throws -> Self {
         let size = limits.size
         let validDimension: (Limits.Dimension) -> Bool = {

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -300,6 +300,13 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
               frames.offset <= frames.maximum,
               workload.metric == "pixel_frames",
               workload.maximum > 0,
+              // dimension_rounding must be a well-formed (non-empty, non-blank)
+              // string. A blank value is malformed and fails closed; a
+              // well-formed but unrecognized constant is tolerated (see
+              // WorkloadLimit.alignmentStep).
+              !workload.dimensionRounding.trimmingCharacters(
+                  in: .whitespacesAndNewlines
+              ).isEmpty,
               validInput else {
             throw VideoClientError.invalidResponse
         }

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoClient.swift
@@ -93,9 +93,17 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
             /// Alignment step applied to generation dimensions before the
             /// pixel-workload budget is checked. Mirrors the server's
             /// `dimension_rounding` vocabulary (`none` -> raw dimensions,
-            /// `ceil_to_32`, `ceil_to_64`). An unrecognized constant falls back
-            /// to the most conservative step (ceil to 64) so a newer server
-            /// rounding label remains safe without rejecting a healthy payload.
+            /// `ceil_to_32`, `ceil_to_64`).
+            ///
+            /// An unrecognized constant is deliberately tolerated (fail-closed is
+            /// reserved for missing/malformed payloads, not for a new rounding
+            /// label) and falls back to the largest step this client currently
+            /// understands, 64. This keeps the payload valid while being
+            /// conservative with the workload estimate. A future constant larger
+            /// than 64 (e.g. `ceil_to_128`) could under-round here and admit a
+            /// preset the server rejects; that is an accepted UI-level tradeoff —
+            /// the server remains authoritative at request time, and we prefer
+            /// tolerance over dropping an otherwise healthy response.
             var alignmentStep: Int {
                 switch dimensionRounding {
                 case "none": 1
@@ -164,17 +172,20 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
         })
     }
 
-    /// Image-to-video is enabled by the presence of a usable `input_reference`
-    /// limit object, not by a retired `accepted` boolean. The reference is
-    /// usable only when the server advertises a positive byte budget, at least
-    /// one image MIME type this client can produce, and (when declared) a
-    /// positive pixel ceiling.
-    var supportsImageInput: Bool {
-        guard modes.contains(.imageToVideo),
-              let input = limits.inputReference,
+    /// The `input_reference` limit is usable when the server advertises a
+    /// positive byte budget, at least one image MIME type this client can
+    /// produce, and (when declared) a positive pixel ceiling.
+    private var usableReferenceLimits: Bool {
+        guard let input = limits.inputReference,
               input.maximumBytes > 0,
               !acceptedReferenceMIMETypes.isEmpty else { return false }
         return input.maximumPixels.map { $0 > 0 } ?? true
+    }
+
+    /// Image-to-video is enabled by the presence of a usable `input_reference`
+    /// limit object, not by a retired `accepted` boolean.
+    var supportsImageInput: Bool {
+        modes.contains(.imageToVideo) && usableReferenceLimits
     }
 
     /// Conservative, familiar output shapes. The API remains authoritative:
@@ -233,10 +244,13 @@ struct VideoCapabilities: Decodable, Sendable, Hashable {
             ? [limits.seconds.default] : []
     }
 
+    /// The usable byte budget for an input reference image. Returns 0 unless the
+    /// reference limit is fully usable (positive byte budget, at least one image
+    /// MIME type, and a positive pixel ceiling when declared) so a disabled or
+    /// malformed reference never exposes a positive budget to callers.
     var referenceMaximumBytes: Int {
-        guard let inputReference = limits.inputReference,
-              inputReference.maximumBytes > 0 else { return 0 }
-        return min(inputReference.maximumBytes, VideoClient.maxReferenceBytes)
+        guard let input = limits.inputReference, usableReferenceLimits else { return 0 }
+        return min(input.maximumBytes, VideoClient.maxReferenceBytes)
     }
 
     func validated() throws -> Self {

--- a/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Video/VideoGenViewModel.swift
@@ -108,6 +108,7 @@ final class VideoGenViewModel {
     var sizePresets: [String] { capabilities?.sizePresets ?? [] }
     var durationPresets: [Int] { capabilities?.durationPresets(for: size) ?? [] }
     var referenceMaximumBytes: Int { capabilities?.referenceMaximumBytes ?? 0 }
+    var referenceMaximumPixels: Int? { capabilities?.referenceMaximumPixels }
     var acceptedReferenceMIMETypes: Set<String> {
         capabilities?.acceptedReferenceMIMETypes ?? []
     }

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -146,6 +146,28 @@ struct VideoClientTests {
         #expect(value.acceptedReferenceMIMETypes.isEmpty)
     }
 
+    @Test("Legacy accepted:false keeps image input disabled without rejecting the payload")
+    func legacyAcceptedFalseDisablesImageInput() async throws {
+        // A transitional server may still send the retired `accepted` boolean.
+        // `accepted: false` must disable image input (not enable it by being
+        // ignored) yet must not reject the whole payload during skew.
+        let client = makeClient()
+        let json = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""input_reference":{"maximum_bytes":20971520,"maximum_pixels":16777216,"formats":["jpeg","png","webp"]}"#,
+            with: #""input_reference":{"accepted":false,"maximum_bytes":20971520,"formats":["jpeg","png","webp"]}"#
+        )
+        let decoded = try? JSONDecoder().decode(
+            VideoCapabilities.self, from: Data(json.utf8)
+        )
+        #expect(decoded.map { !$0.supportsImageInput } == true)
+
+        VideoStubProtocol.response = (200, Data(json.utf8))
+        let value = try await client.capabilities(port: 8123, bearer: nil)
+        #expect(!value.supportsImageInput)
+        #expect(value.referenceMaximumBytes == 0)
+        #expect(!value.sizePresets.isEmpty)
+    }
+
     @Test("Image input is disabled when reference limits are unusable")
     func imageInputDisabledWhenReferenceUnusable() async {
         // A zero byte budget leaves no usable reference limit, so image input is

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -55,18 +55,21 @@ struct VideoClientTests {
         }
     }
 
-    @Test("Unsupported workload rounding fails closed")
-    func unsupportedRoundingFailsClosed() async {
+    @Test("Unrecognized dimension_rounding string is tolerated, not fatal")
+    func unsupportedRoundingIsTolerated() async throws {
+        // The fail-closed rule is about missing/malformed payloads, not about a
+        // new rounding constant. An unknown value decodes and validates, and the
+        // workload budget uses the conservative 64-pixel fallback.
         let client = makeClient()
         let json = Self.capabilitiesJSON.replacingOccurrences(
-            of: #""dimension_rounding":"multiple_of_64""#,
+            of: #""dimension_rounding":"ceil_to_64""#,
             with: #""dimension_rounding":"floor""#
         )
         VideoStubProtocol.response = (200, Data(json.utf8))
 
-        await #expect(throws: VideoClientError.invalidResponse) {
-            _ = try await client.capabilities(port: 8123, bearer: nil)
-        }
+        let value = try await client.capabilities(port: 8123, bearer: nil)
+        #expect(!value.sizePresets.isEmpty)
+        #expect(!value.durationPresets(for: "512x512").isEmpty)
     }
 
     @Test("Workload uses 64-pixel rounding independently of size alignment")
@@ -82,22 +85,76 @@ struct VideoClientTests {
         #expect(value.durationPresets(for: "592x592") == [1, 2])
     }
 
-    @Test("Image input follows advertised formats and acceptance")
+    @Test("Image input is enabled by input_reference presence, not an accepted boolean")
     func imageInputUsesCapabilityContract() throws {
+        // The input_reference object has no `accepted` field in the current
+        // contract; its presence with usable limits enables image-to-video.
+        let value = try JSONDecoder().decode(
+            VideoCapabilities.self, from: Data(Self.capabilitiesJSON.utf8)
+        )
+        #expect(value.supportsImageInput)
+        #expect(value.acceptedReferenceMIMETypes == ["image/jpeg", "image/png", "image/webp"])
+        #expect(value.referenceMaximumBytes == 20 * 1024 * 1024)
+
+        // Limited formats narrow the accepted reference MIME types.
         let jpegOnly = Self.capabilitiesJSON.replacingOccurrences(
             of: #"["jpeg","png","webp"]"#,
             with: #"["jpeg"]"#
         )
-        let value = try JSONDecoder().decode(VideoCapabilities.self, from: Data(jpegOnly.utf8))
-        #expect(value.supportsImageInput)
-        #expect(value.acceptedReferenceMIMETypes == ["image/jpeg"])
-
-        let rejected = jpegOnly.replacingOccurrences(of: #""accepted":true"#, with: #""accepted":false"#)
-        let rejectedValue = try JSONDecoder().decode(
-            VideoCapabilities.self, from: Data(rejected.utf8)
+        let jpegValue = try JSONDecoder().decode(
+            VideoCapabilities.self, from: Data(jpegOnly.utf8)
         )
-        #expect(!rejectedValue.supportsImageInput)
-        #expect(rejectedValue.acceptedReferenceMIMETypes.isEmpty)
+        #expect(jpegValue.supportsImageInput)
+        #expect(jpegValue.acceptedReferenceMIMETypes == ["image/jpeg"])
+    }
+
+    @Test("Image input is disabled when input_reference is absent")
+    func imageInputDisabledWithoutReference() throws {
+        // Omit the input_reference object entirely (a video model that only
+        // supports text-to-video, like CogVideoX-Fun, never sends it).
+        // Replace the object with JSON null so the container stays well-formed;
+        // the optional decodes to nil, identical to the key being absent.
+        let json = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""input_reference":{"maximum_bytes":20971520,"maximum_pixels":16777216,"formats":["jpeg","png","webp"]}"#,
+            with: #""input_reference":null"#
+        )
+        let value = try JSONDecoder().decode(VideoCapabilities.self, from: Data(json.utf8))
+        #expect(value.limits.inputReference == nil)
+        #expect(!value.supportsImageInput)
+        #expect(value.referenceMaximumBytes == 0)
+        #expect(value.acceptedReferenceMIMETypes.isEmpty)
+    }
+
+    @Test("Image input is disabled when reference limits are unusable")
+    func imageInputDisabledWhenReferenceUnusable() async {
+        // A zero byte budget leaves no usable reference limit, so image input is
+        // disabled, and the payload itself fails closed on validation.
+        let client = makeClient()
+        let json = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""maximum_bytes":20971520"#,
+            with: #""maximum_bytes":0"#
+        )
+        let decoded = try! JSONDecoder().decode(
+            VideoCapabilities.self, from: Data(json.utf8)
+        )
+        #expect(!decoded.supportsImageInput)
+        VideoStubProtocol.response = (200, Data(json.utf8))
+        await #expect(throws: VideoClientError.invalidResponse) {
+            _ = try await client.capabilities(port: 8123, bearer: nil)
+        }
+    }
+
+    @Test("Current contract with ceil_to_64 rounding decodes to working video")
+    func currentContractDecodesToWorkingVideo() async throws {
+        let client = makeClient()
+        VideoStubProtocol.response = (200, Data(Self.capabilitiesJSON.utf8))
+
+        let value = try await client.capabilities(port: 8123, bearer: "secret")
+
+        #expect(value.modes == [.textToVideo, .imageToVideo])
+        #expect(!value.sizePresets.isEmpty)
+        #expect(!value.durationPresets(for: "512x512").isEmpty)
+        #expect(value.supportsImageInput)
     }
 
     @Test("Reference MIME type is detected from bytes, not the filename")
@@ -323,8 +380,8 @@ struct VideoClientTests {
         "seconds":{"minimum":1,"maximum":20,"default":4},
         "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
         "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
-        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"},
-        "input_reference":{"accepted":true,"maximum_bytes":20971520,"formats":["jpeg","png","webp"]}
+        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"ceil_to_64"},
+        "input_reference":{"maximum_bytes":20971520,"maximum_pixels":16777216,"formats":["jpeg","png","webp"]}
       },
       "controls":{}
     }

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -77,6 +77,22 @@ struct VideoClientTests {
         #expect(value.durationPresets(for: "592x592") == [1, 2])
     }
 
+    @Test("Malformed (blank) dimension_rounding fails closed")
+    func blankRoundingFailsClosed() async {
+        // An empty/blank rounding label is a malformed payload and rejects,
+        // unlike a well-formed but unrecognized constant (covered above).
+        let client = makeClient()
+        let json = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""dimension_rounding":"ceil_to_64""#,
+            with: #""dimension_rounding":""#
+        )
+        VideoStubProtocol.response = (200, Data(json.utf8))
+
+        await #expect(throws: VideoClientError.invalidResponse) {
+            _ = try await client.capabilities(port: 8123, bearer: nil)
+        }
+    }
+
     @Test("Workload uses 64-pixel rounding independently of size alignment")
     func workloadRoundingIsIndependent() throws {
         let json = Self.capabilitiesJSON

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -388,6 +388,25 @@ struct VideoClientTests {
         }
     }
 
+    @Test("Reference loader enforces the advertised decoded-pixel ceiling")
+    func referencePixelCeilingIsEnforced() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "rapid-video-reference-pixel-tests-\(UUID().uuidString)", isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = directory.appendingPathComponent("one-pixel.png")
+        let png = try #require(Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        ))
+        try png.write(to: source)
+
+        #expect(try VideoReferenceLoader.load(from: source, maximumPixels: 1) == png)
+        #expect(throws: VideoReferenceLoaderError.tooLarge) {
+            _ = try VideoReferenceLoader.load(from: source, maximumPixels: 0)
+        }
+    }
+
     @Test("Failed save leaves an existing destination untouched")
     func failedSavePreservesDestination() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -55,32 +55,26 @@ struct VideoClientTests {
         }
     }
 
-    @Test("Unrecognized dimension_rounding string is tolerated with a 64-pixel fallback")
-    func unsupportedRoundingIsTolerated() async throws {
-        // The fail-closed rule is about missing/malformed payloads, not about a
-        // new rounding constant. An unknown value decodes and validates, and the
-        // workload budget uses the conservative 64-pixel fallback.
-        //
-        // 592x592 is not a multiple of 64, so only the 64-pixel fallback excludes
-        // the 4 s preset: rounded up to 640x640, its 97-frame workload
-        // (39,731,200) exceeds the 38,141,952 budget. A laxer fallback
-        // (1/16/32) would leave 4 s inside the budget and yield [1, 2, 4],
-        // so asserting [1, 2] proves the 64-pixel fallback is applied.
+    @Test("Unrecognized dimension_rounding fails closed")
+    func unsupportedRoundingFailsClosed() async {
+        // A future alignment can be larger than the values this client knows.
+        // Guessing 64 would under-count workload for e.g. ceil_to_128, so an
+        // unknown value must reject the capabilities payload.
         let client = makeClient()
         let json = Self.capabilitiesJSON.replacingOccurrences(
             of: #""dimension_rounding":"ceil_to_64""#,
-            with: #""dimension_rounding":"floor""#
+            with: #""dimension_rounding":"ceil_to_128""#
         )
         VideoStubProtocol.response = (200, Data(json.utf8))
 
-        let value = try await client.capabilities(port: 8123, bearer: nil)
-        #expect(value.durationPresets(for: "592x592") == [1, 2])
+        await #expect(throws: VideoClientError.invalidResponse) {
+            _ = try await client.capabilities(port: 8123, bearer: nil)
+        }
     }
 
     @Test("Malformed (blank) dimension_rounding fails closed")
     func blankRoundingFailsClosed() async {
-        // An empty/blank rounding label is a malformed payload and rejects,
-        // unlike a well-formed but unrecognized constant (covered above).
+        // An empty/blank rounding label is malformed and rejects too.
         let client = makeClient()
         let json = Self.capabilitiesJSON.replacingOccurrences(
             of: #""dimension_rounding":"ceil_to_64""#,

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -55,11 +55,17 @@ struct VideoClientTests {
         }
     }
 
-    @Test("Unrecognized dimension_rounding string is tolerated, not fatal")
+    @Test("Unrecognized dimension_rounding string is tolerated with a 64-pixel fallback")
     func unsupportedRoundingIsTolerated() async throws {
         // The fail-closed rule is about missing/malformed payloads, not about a
         // new rounding constant. An unknown value decodes and validates, and the
         // workload budget uses the conservative 64-pixel fallback.
+        //
+        // 592x592 is not a multiple of 64, so only the 64-pixel fallback excludes
+        // the 4 s preset: rounded up to 640x640, its 97-frame workload
+        // (39,731,200) exceeds the 38,141,952 budget. A laxer fallback
+        // (1/16/32) would leave 4 s inside the budget and yield [1, 2, 4],
+        // so asserting [1, 2] proves the 64-pixel fallback is applied.
         let client = makeClient()
         let json = Self.capabilitiesJSON.replacingOccurrences(
             of: #""dimension_rounding":"ceil_to_64""#,
@@ -68,8 +74,7 @@ struct VideoClientTests {
         VideoStubProtocol.response = (200, Data(json.utf8))
 
         let value = try await client.capabilities(port: 8123, bearer: nil)
-        #expect(!value.sizePresets.isEmpty)
-        #expect(!value.durationPresets(for: "512x512").isEmpty)
+        #expect(value.durationPresets(for: "592x592") == [1, 2])
     }
 
     @Test("Workload uses 64-pixel rounding independently of size alignment")

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -165,23 +165,41 @@ struct VideoClientTests {
         let value = try await client.capabilities(port: 8123, bearer: nil)
         #expect(!value.supportsImageInput)
         #expect(value.referenceMaximumBytes == 0)
+        #expect(value.acceptedReferenceMIMETypes.isEmpty)
         #expect(!value.sizePresets.isEmpty)
     }
 
     @Test("Image input is disabled when reference limits are unusable")
     func imageInputDisabledWhenReferenceUnusable() async {
         // A zero byte budget leaves no usable reference limit, so image input is
-        // disabled, and the payload itself fails closed on validation.
+        // disabled (and no MIME types are advertised), and the payload itself
+        // fails closed on validation.
         let client = makeClient()
-        let json = Self.capabilitiesJSON.replacingOccurrences(
+        let zeroBytes = Self.capabilitiesJSON.replacingOccurrences(
             of: #""maximum_bytes":20971520"#,
             with: #""maximum_bytes":0"#
         )
-        let decoded = try! JSONDecoder().decode(
-            VideoCapabilities.self, from: Data(json.utf8)
+        let zeroValue = try! JSONDecoder().decode(
+            VideoCapabilities.self, from: Data(zeroBytes.utf8)
         )
-        #expect(!decoded.supportsImageInput)
-        VideoStubProtocol.response = (200, Data(json.utf8))
+        #expect(!zeroValue.supportsImageInput)
+        #expect(zeroValue.acceptedReferenceMIMETypes.isEmpty)
+        VideoStubProtocol.response = (200, Data(zeroBytes.utf8))
+        await #expect(throws: VideoClientError.invalidResponse) {
+            _ = try await client.capabilities(port: 8123, bearer: nil)
+        }
+
+        // A non-positive pixel ceiling is likewise unusable and fails closed.
+        let zeroPixels = Self.capabilitiesJSON.replacingOccurrences(
+            of: #""maximum_pixels":16777216"#,
+            with: #""maximum_pixels":0"#
+        )
+        let pixelsValue = try! JSONDecoder().decode(
+            VideoCapabilities.self, from: Data(zeroPixels.utf8)
+        )
+        #expect(!pixelsValue.supportsImageInput)
+        #expect(pixelsValue.acceptedReferenceMIMETypes.isEmpty)
+        VideoStubProtocol.response = (200, Data(zeroPixels.utf8))
         await #expect(throws: VideoClientError.invalidResponse) {
             _ = try await client.capabilities(port: 8123, bearer: nil)
         }

--- a/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoClientTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 @testable import Rapid
@@ -395,15 +396,25 @@ struct VideoClientTests {
         )
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
-        let source = directory.appendingPathComponent("one-pixel.png")
-        let png = try #require(Data(base64Encoded:
-            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        let source = directory.appendingPathComponent("two-pixel.png")
+        let bitmap = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 2,
+            pixelsHigh: 1,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
         ))
+        let png = try #require(bitmap.representation(using: .png, properties: [:]))
         try png.write(to: source)
 
-        #expect(try VideoReferenceLoader.load(from: source, maximumPixels: 1) == png)
+        #expect(try VideoReferenceLoader.load(from: source, maximumPixels: 2) == png)
         #expect(throws: VideoReferenceLoaderError.tooLarge) {
-            _ = try VideoReferenceLoader.load(from: source, maximumPixels: 0)
+            _ = try VideoReferenceLoader.load(from: source, maximumPixels: 1)
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/VideoGenViewModelTests.swift
@@ -416,8 +416,8 @@ private actor VideoFakeClient: VideoClientProtocol {
         "seconds":{"minimum":1,"maximum":20,"default":4},
         "fps":{"minimum":1,"maximum":60,"default":24,"fixed":false},
         "frames":{"minimum":9,"maximum":1201,"step":8,"offset":1},
-        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"multiple_of_64"},
-        "input_reference":{"accepted":true,"maximum_bytes":20971520,"formats":["jpeg","png","webp"]}
+        "workload":{"metric":"pixel_frames","maximum":38141952,"dimension_rounding":"ceil_to_64"},
+        "input_reference":{"maximum_bytes":20971520,"maximum_pixels":16777216,"formats":["jpeg","png","webp"]}
       }
     }
     """#


### PR DESCRIPTION
Fixes #2969

## Bug

The macOS Desktop Video workspace shows "The video server returned an invalid response" and keeps **Generate** disabled, because the Desktop client still parses a **retired** capabilities contract while the local Videos API server now serves the **current** contract. The decoder required `dimension_rounding == "multiple_of_64"` (never sent) and gated image-to-video on a retired `accepted` boolean, so a healthy response was rejected and i2v was always disabled.

This is a **Desktop-only fix** — the server contract in `vllm_mlx/routes/video.py` is correct and unchanged. No version/pyproject changes.

## Contract changes (aligned to the current server output)

1. **`dimension_rounding`** vocabulary is now `{"none", "ceil_to_32", "ceil_to_64"}` (never `multiple_of_64`). The client maps it to a workload-alignment step (`none`→raw, `ceil_to_32`→32, `ceil_to_64`→64) and stops rejecting the payload on it.
2. **`input_reference`** is now a plain object `{maximum_bytes, maximum_pixels, formats}` with **no** `accepted` field. Its **presence** (with usable limits) enables image-to-video. The decoder decodes the retired `accepted` boolean as optional `Bool?` for backward compatibility during client/server version skew: `accepted: false` keeps image input disabled (never silently enabling it), while an absent value means the current presence-based contract.
3. `maximum_pixels` (new field) participates in reference-limit validation and is enforced against decoded image dimensions before submission; arithmetic overflow and over-limit images fail closed. `referenceMaximumBytes` returns 0 when the reference is unusable.

## Acceptance criteria → implementation

- **(1) Accept current dimension_rounding vocabulary** — `WorkloadLimit.alignmentStep` maps `none/ceil_to_32/ceil_to_64` to the workload rounding step used by `workloadAllows` (mirroring the server's `alignment = 32 if ltx-2.5 else 64`). Unknown or blank values fail closed because a future larger alignment cannot safely fall back to 64 without under-counting workload.
- **(2) i2v = presence of a usable input_reference object** — `supportsImageInput`, `referenceMaximumBytes`, and `acceptedReferenceMIMETypes` enable i2v from a usable reference (presence-based, not `accepted == true`): `inputReference != nil && accepted != false && maximumBytes > 0 && !formats.isEmpty && (maximumPixels > 0 when declared) && modes contains image-to-video`. A legacy `accepted: false` disables i2v without rejecting the payload.
- **(3) Fail closed on malformed/unsupported payloads** — `validated()` keeps the existing invalid-response path and now rejects a present-but-unusable `input_reference` (zero byte budget, empty formats, non-positive pixel ceiling). `referenceMaximumBytes` returns 0 (no silent enable) for an unusable reference.
- **(4) Tests lock in the current contract** — see test plan; the Swift fixtures now use `ceil_to_64` and no `accepted`.
- **(5) Tests run** — 40 Video-related Swift tests pass (20 VideoClient + 9 VideoGenViewModel + foundation suites).
- **(6) Server untouched.**

## Test plan

- [x] Swift `--filter VideoClientTests` — 23/23 pass (unknown-rounding fail-closed + decoded-pixel ceiling)
- [x] Swift `--filter VideoGenViewModel` — 9/9 pass
- [x] Swift `--filter Video` (all 7 Video suites) — 40/40 pass
- [x] Contract fixture updated to current server output (`ceil_to_64`, no `accepted`, `maximum_pixels`) across VideoClient + VideoGenViewModel tests and DevSnapshot
- [x] Fail-closed tests for malformed ranges and unusable `input_reference` still pass
- [x] Harbor Codex review blocker addressed: unknown rounding values now fail closed; focused Swift tests pass. Full `pr_validate` is being refreshed on the exact head and its scorecard appears below.
- [x] No docs change (contract is implementation-internal between app and local server)
- [x] No breaking change to request creation or the create/list/delete/content paths

<!-- pr-validate-scorecard -->
