### PR TITLE
fix(pr_validate): warn (not block) roster-only workflow edits (#2522)

### DIFF
--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -140,19 +140,35 @@ def _roster_only_workflows(
     if not workflow_files:
         return set(), {}
 
+    # A roster enrollment is only meaningful for a test this PR NEWLY adds
+    # (issue #2522: "I added a test" → enroll it). Compute the newly-created
+    # files from the diff's ``new file mode`` markers so a PR that merely
+    # edits an existing test cannot get the downgrade.
+    new_files = _new_files(diff)
+    files_changed_set = set(files_changed)
+
     # Group added/removed content lines per workflow file.
     per_file: dict[str, dict[str, list[str]]] = {
         f: {"added": [], "removed": []} for f in workflow_files
     }
     cur_path = ""
+    in_hunk = False
     for line in diff.splitlines():
         if line.startswith("diff --git "):
             cur_path = line.split(" b/", 1)[-1] if " b/" in line else ""
+            in_hunk = False
+            continue
+        if line.startswith("@@"):
+            in_hunk = True  # everything after this is file content, not headers
             continue
         if cur_path not in per_file:
             continue
-        if line.startswith(("+++ ", "--- ", "@@")):
-            continue  # hunk / file headers
+        # ``--- /path`` and ``+++ /path`` are file headers ONLY before the
+        # first hunk. Inside a hunk a content line may itself begin with
+        # ``-- `` / ``++ `` (e.g. a removed ``-- flag`` line) and must be
+        # treated as a real change, not skipped as a header.
+        if not in_hunk and line.startswith(("--- ", "+++ ")):
+            continue
         marker = line[:1]
         if marker == "+":
             per_file[cur_path]["added"].append(line[1:])
@@ -171,8 +187,8 @@ def _roster_only_workflows(
         ok = True
         for content in block["added"]:
             p = _roster_addition_path(content)
-            # Must be a real roster token AND a test the PR itself adds.
-            if p is None or p not in files_changed:
+            # Must be a real roster token for a test this PR NEWLY adds.
+            if p is None or p not in new_files or p not in files_changed_set:
                 ok = False
                 break
             enrolled.append(p)
@@ -180,6 +196,28 @@ def _roster_only_workflows(
             roster_only.add(path)
             roster_additions[path] = enrolled
     return roster_only, roster_additions
+
+
+def _new_files(diff: str) -> set[str]:
+    """Return the repo-relative paths of files newly created in *diff*
+    (``new file mode`` markers). Used to require that a roster enrollment
+    point at a test this PR actually adds, not an existing one it edits."""
+    new_files: set[str] = set()
+    cur_path = ""
+    is_new = False
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            if is_new and cur_path:
+                new_files.add(cur_path)
+            cur_path = line.split(" b/", 1)[-1] if " b/" in line else ""
+            is_new = False
+            continue
+        if line.startswith("new file mode"):
+            is_new = True
+            continue
+    if is_new and cur_path:
+        new_files.add(cur_path)
+    return new_files
 
 
 # Backwards-compatibility alias — the dep-declaration matcher now

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -141,9 +141,12 @@ def _pytest_roster_lines(content: str) -> set[int]:
     """Return the (1-based) line numbers in *content* that are roster entries
     of the explicit pytest test list. This is the authoritative, ground-truth
     denominator: the contiguous ``tests/*.py \\`` continuation lines that
-    immediately follow a ``pytest \\`` command. Codex r1 round-3 — do not
-    trust hunk context (a long non-pytest file list would hide its opener);
-    verify each added line against the ACTUAL roster location in the file."""
+    follow a ``pytest \\`` command, PLUS an optional trailing terminal
+    ``tests/*.py`` (no backslash) — the last argument of a ``run: |`` block is
+    allowed to omit the shell continuation, and must still be a valid final
+    enrollment (codex r1 round-4). Codex r1 round-3 — do not trust hunk
+    context (a long non-pytest file list would hide its opener); verify each
+    added line against the ACTUAL roster location in the file."""
     roster: set[int] = set()
     lines = content.splitlines()
     i = 0
@@ -151,8 +154,13 @@ def _pytest_roster_lines(content: str) -> set[int]:
     while i < n:
         if _PYTEST_ROSTER_CMD.match(lines[i]):
             j = i + 1
+            # A run of continuing roster entries...
             while j < n and _ROSTER_CONTINUE_RE.match(lines[j]):
                 roster.add(j + 1)  # 1-based
+                j += 1
+            # ...optionally followed by one terminal entry (no continuation).
+            if j < n and _ROSTER_ENTRY_RE.match(lines[j]):
+                roster.add(j + 1)
                 j += 1
             i = j
         else:

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -95,15 +95,16 @@ def _is_hook_file(path: str) -> bool:
 # The path grammar is deliberately narrower than a shell token: allowing
 # ``$()``, quotes, ``;``, ``..`` etc. would let the exception itself become
 # a workflow-code injection bypass. Only a plain ``tests/<alnum>_./-`` token
-# with an optional trailing ``\`` continuation matches.
+# with a trailing ``\`` continuation matches.  Requiring the continuation is
+# intentional: this is a fail-closed exception for executable workflow files,
+# and the repository's explicit roster uses that canonical form.
 # ---------------------------------------------------------------------------
 
 _WORKFLOW_PREFIX = ".github/workflows/"
+_ROSTER_WORKFLOWS = frozenset({".github/workflows/ci.yml"})
 
 # A single roster-enrollment content line (leading ``+`` already stripped).
-_ROSTER_ENTRY_RE = re.compile(
-    r"^\s*(?P<path>tests/[A-Za-z0-9_./-]+\.py)(?P<cont>\s*\\)?\s*$"
-)
+_ROSTER_ENTRY_RE = re.compile(r"^\s*(?P<path>tests/[A-Za-z0-9_./-]+\.py)\s*\\\s*$")
 
 
 def _roster_addition_path(content: str) -> str | None:
@@ -141,12 +142,13 @@ def _pytest_roster_lines(content: str) -> set[int]:
     """Return the (1-based) line numbers in *content* that are roster entries
     of the explicit pytest test list. This is the authoritative, ground-truth
     denominator: the contiguous ``tests/*.py \\`` continuation lines that
-    follow a ``pytest \\`` command, PLUS an optional trailing terminal
-    ``tests/*.py`` (no backslash) — the last argument of a ``run: |`` block is
-    allowed to omit the shell continuation, and must still be a valid final
-    enrollment (codex r1 round-4). Codex r1 round-3 — do not trust hunk
-    context (a long non-pytest file list would hide its opener); verify each
-    added line against the ACTUAL roster location in the file."""
+    follow a ``pytest \\`` command.  The downgrade deliberately recognizes
+    only this canonical form.  Accepting a no-backslash line requires parsing
+    the remainder of the shell command correctly; getting that wrong can turn
+    following options into separate commands while suppressing review of an
+    executable workflow change.  Codex r1 round-3 — do not trust hunk context
+    (a long non-pytest file list would hide its opener); verify each added line
+    against the ACTUAL roster location in the file."""
     roster: set[int] = set()
     lines = content.splitlines()
     i = 0
@@ -157,16 +159,6 @@ def _pytest_roster_lines(content: str) -> set[int]:
             # A run of continuing roster entries...
             while j < n and _ROSTER_CONTINUE_RE.match(lines[j]):
                 roster.add(j + 1)  # 1-based
-                j += 1
-            # ...optionally followed by one TERMINAL entry (no continuation).
-            # A no-backslash line only ends the list legitimately when it is
-            # the genuine final argument: if another continuing roster entry
-            # immediately follows, the no-backslash line would cut the pytest
-            # command short and run later paths as separate commands — that is
-            # a behavior change, not an enrollment (codex r1 round-4).
-            if j < n and _ROSTER_ENTRY_RE.match(lines[j]):
-                if j + 1 >= n or not _ROSTER_CONTINUE_RE.match(lines[j + 1]):
-                    roster.add(j + 1)
                 j += 1
             i = j
         else:
@@ -196,7 +188,15 @@ def _roster_only_workflows(
     token added outside the real roster, a file we cannot verify) is absent
     from both — it stays [BLOCKING]."""
 
-    workflow_files = {f for f in files_changed if f.startswith(_WORKFLOW_PREFIX)}
+    # This is not a general exemption for pytest commands in workflow files.
+    # It applies only to the reviewed explicit Apple/MLX roster in ci.yml.
+    # Any other workflow remains an executable hook and therefore blocking for
+    # an external author.
+    workflow_files = {
+        f
+        for f in files_changed
+        if f.startswith(_WORKFLOW_PREFIX) and f in _ROSTER_WORKFLOWS
+    }
     if not workflow_files:
         return set(), {}
 

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -158,9 +158,15 @@ def _pytest_roster_lines(content: str) -> set[int]:
             while j < n and _ROSTER_CONTINUE_RE.match(lines[j]):
                 roster.add(j + 1)  # 1-based
                 j += 1
-            # ...optionally followed by one terminal entry (no continuation).
+            # ...optionally followed by one TERMINAL entry (no continuation).
+            # A no-backslash line only ends the list legitimately when it is
+            # the genuine final argument: if another continuing roster entry
+            # immediately follows, the no-backslash line would cut the pytest
+            # command short and run later paths as separate commands — that is
+            # a behavior change, not an enrollment (codex r1 round-4).
             if j < n and _ROSTER_ENTRY_RE.match(lines[j]):
-                roster.add(j + 1)
+                if j + 1 >= n or not _ROSTER_CONTINUE_RE.match(lines[j + 1]):
+                    roster.add(j + 1)
                 j += 1
             i = j
         else:

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -137,14 +137,28 @@ _ROSTER_CONTINUE_RE = re.compile(r"^\s*tests/[A-Za-z0-9_./-]+\.py\s*\\\s*$")
 _PYTEST_ROSTER_CMD = re.compile(r"^\s*pytest\b.*\\\s*$")
 
 
-def _roster_anchor(content: str) -> bool:
-    """True if *content* is a line that may legally sit directly above a
-    roster entry inside the explicit test list: either another roster entry
-    that CONTINUES (ends in ``\\``) or the ``pytest \\`` command that opens
-    the list."""
-    return bool(_ROSTER_CONTINUE_RE.match(content)) or bool(
-        _PYTEST_ROSTER_CMD.match(content)
-    )
+def _anchored_to_roster(lines: list[tuple[str, str, bool]], i: int) -> bool:
+    """True if the added line at index *i* sits inside the explicit pytest
+    test roster — i.e. the contiguous chain of ``tests/*.py \\`` lines above
+    it traces BACKWARD to a ``pytest \\`` opener, not to some other multiline
+    command (an uploader receiving test-file arguments, for example).
+
+    Walk backward through continuing roster entries; the chain terminates
+    correctly when it reaches a ``pytest \\`` opener, or when it runs off the
+    top of this file's visible diff while still inside roster entries (the
+    real end-of-roster append: the opener is lines above the hunk context).
+    It is rejected if the chain reaches a non-pytest, non-roster opener."""
+    j = i - 1
+    while j >= 0:
+        marker, content, first_in_hunk = lines[j]
+        if _PYTEST_ROSTER_CMD.match(content):
+            return True  # reached the `pytest \` opener
+        if not _ROSTER_CONTINUE_RE.match(content):
+            return False  # non-pytest, non-roster opener → not the roster list
+        if first_in_hunk:
+            return True  # block continues above the visible diff (the roster)
+        j -= 1
+    return False
 
 
 def _roster_only_workflows(
@@ -252,15 +266,15 @@ def _roster_only_workflows(
             if p not in new_files or p not in files_changed_set:
                 ok = False
                 break
-            # ...appended INTO the explicit roster list: the line directly
-            # above it (WITHIN the same hunk) is a roster entry or the
-            # opening ``pytest \`` command — never a top-level YAML scalar,
-            # an unrelated ``run:`` block, or a different region of the file.
+            # ...appended INTO the explicit pytest test roster: never a
+            # top-level YAML scalar, an unrelated ``run:`` block, or a
+            # different region of the file. The added line must not open its
+            # own hunk (no valid anchor), and its continuation chain must
+            # trace back to a ``pytest \`` opener.
             if first_in_hunk:
                 ok = False  # no valid in-hunk anchor; stay conservative
                 break
-            prev = block["lines"][i - 1][1]
-            if not _roster_anchor(prev):
+            if not _anchored_to_roster(block["lines"], i):
                 ok = False
                 break
             enrolled.append(p)

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -120,6 +120,22 @@ def _roster_addition_path(content: str) -> str | None:
     return path
 
 
+# A ``run: |``-block command line that opens a pytest test roster, e.g.
+# ``          pytest \``. An enrollment is only trusted when it is anchored to
+# the explicit roster list — i.e. the line directly above it is itself a
+# roster entry or the ``pytest`` command that starts the list (codex r1 #2).
+_PYTEST_ROSTER_CMD = re.compile(r"^\s*pytest(\s.*)?\\?\s*$")
+
+
+def _roster_anchor(content: str) -> bool:
+    """True if *content* is a line that may legally sit directly above a
+    roster entry inside the explicit test list: either another roster entry
+    or the ``pytest \\`` command that opens the list."""
+    return bool(_ROSTER_ENTRY_RE.match(content)) or bool(
+        _PYTEST_ROSTER_CMD.match(content)
+    )
+
+
 def _roster_only_workflows(
     diff: str, files_changed: set[str]
 ) -> tuple[set[str], dict[str, list[str]]]:
@@ -128,8 +144,8 @@ def _roster_only_workflows(
     Returns ``(roster_only, roster_additions)``:
 
     * ``roster_only`` — the set of workflow files whose ENTIRE diff is a
-      pure roster enrollment (only ``tests/<name>.py \\`` lines added, no
-      removed lines, no other change).
+      pure roster enrollment (only ``tests/<name>.py \\`` lines added to the
+      explicit test list, no removed lines, no other change).
     * ``roster_additions`` — ``{workflow_file: [test paths enrolled]}`` for
       those roster-only files, so the human gets the exact added lines.
 
@@ -147,9 +163,11 @@ def _roster_only_workflows(
     new_files = _new_files(diff)
     files_changed_set = set(files_changed)
 
-    # Group added/removed content lines per workflow file.
+    # Collect every kind of line (context / added / removed) per workflow file,
+    # in file order, so we can anchor an added roster line to the lines around
+    # it (the roster list) rather than accepting the token anywhere in YAML.
     per_file: dict[str, dict[str, list[str]]] = {
-        f: {"added": [], "removed": []} for f in workflow_files
+        f: {"lines": [], "added": [], "removed": []} for f in workflow_files
     }
     cur_path = ""
     in_hunk = False
@@ -170,10 +188,12 @@ def _roster_only_workflows(
         if not in_hunk and line.startswith(("--- ", "+++ ")):
             continue
         marker = line[:1]
-        if marker == "+":
-            per_file[cur_path]["added"].append(line[1:])
-        elif marker == "-":
-            per_file[cur_path]["removed"].append(line[1:])
+        if marker in (" ", "+", "-"):
+            per_file[cur_path]["lines"].append((marker, line[1:]))
+            if marker == "+":
+                per_file[cur_path]["added"].append(line[1:])
+            elif marker == "-":
+                per_file[cur_path]["removed"].append(line[1:])
 
     roster_only: set[str] = set()
     roster_additions: dict[str, list[str]] = {}
@@ -185,10 +205,22 @@ def _roster_only_workflows(
             continue  # no tracked change; stay conservative
         enrolled: list[str] = []
         ok = True
-        for content in block["added"]:
+        for i, (marker, content) in enumerate(block["lines"]):
+            if marker != "+":
+                continue
             p = _roster_addition_path(content)
-            # Must be a real roster token for a test this PR NEWLY adds.
-            if p is None or p not in new_files or p not in files_changed_set:
+            if p is None:
+                ok = False
+                break
+            # Must be a NEW test this PR adds...
+            if p not in new_files or p not in files_changed_set:
+                ok = False
+                break
+            # ...appended INTO the explicit roster list: the line directly
+            # above it is a roster entry or the opening ``pytest \`` command,
+            # not a top-level YAML scalar or an unrelated ``run:`` block.
+            prev = block["lines"][i - 1][1] if i > 0 else ""
+            if not _roster_anchor(prev):
                 ok = False
                 break
             enrolled.append(p)

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -138,6 +138,7 @@ _ROSTER_CONTINUE_RE = re.compile(r"^\s*tests/[A-Za-z0-9_./-]+\.py\s*\\\s*$")
 # the line directly above it is another (continuing) roster entry or this
 # opening command.
 _PYTEST_ROSTER_CMD = re.compile(r"^\s*pytest\b.*\\\s*$")
+_PYTEST_ROSTER_STEP = "- name: Run MLX-dependent tests"
 
 
 def _pytest_roster_lines(content: str) -> set[int]:
@@ -152,8 +153,25 @@ def _pytest_roster_lines(content: str) -> set[int]:
     verify each added line against the ACTUAL roster location in the file."""
     roster: set[int] = set()
     lines = content.splitlines()
-    i = 0
-    n = len(lines)
+    # Bind the exception to the one reviewed job step, not merely to any
+    # command spelling ``pytest`` somewhere in ci.yml.
+    step_indexes = [
+        idx for idx, line in enumerate(lines) if line.strip() == _PYTEST_ROSTER_STEP
+    ]
+    if len(step_indexes) != 1:
+        return roster
+    step_start = step_indexes[0]
+    step_indent = len(lines[step_start]) - len(lines[step_start].lstrip())
+    step_end = len(lines)
+    for idx in range(step_start + 1, len(lines)):
+        stripped = lines[idx].lstrip()
+        indent = len(lines[idx]) - len(stripped)
+        if stripped.startswith("- ") and indent <= step_indent:
+            step_end = idx
+            break
+
+    i = step_start + 1
+    n = step_end
     while i < n:
         if _PYTEST_ROSTER_CMD.match(lines[i]):
             command_indent = len(lines[i]) - len(lines[i].lstrip())

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -120,20 +120,29 @@ def _roster_addition_path(content: str) -> str | None:
     return path
 
 
+# An anchor roster line must CONTINUE the shell list — i.e. it ends with a
+# backslash continuation, exactly like every entry in the real roster. A
+# terminal ``tests/foo.py`` (no backslash) runs as its own command, so a
+# ``tests/new.py \`` following it would be a SECOND command, not another
+# pytest argument — that is not an enrollment (codex r1 round-2).
+_ROSTER_CONTINUE_RE = re.compile(r"^\s*tests/[A-Za-z0-9_./-]+\.py\s*\\\s*$")
+
 # The ``run: |``-block command that OPENS a pytest test roster, e.g.
 # ``          pytest \``. It must end with a continuation backslash: a
 # complete, non-continuing command like ``pytest -q`` runs as its own shell
 # invocation and does NOT open the multi-line ``tests/x.py \`` list (codex
 # r1 #2). An enrollment is only trusted when it is anchored to that list —
-# the line directly above it is another roster entry or this opening command.
+# the line directly above it is another (continuing) roster entry or this
+# opening command.
 _PYTEST_ROSTER_CMD = re.compile(r"^\s*pytest\b.*\\\s*$")
 
 
 def _roster_anchor(content: str) -> bool:
     """True if *content* is a line that may legally sit directly above a
     roster entry inside the explicit test list: either another roster entry
-    or the ``pytest \\`` command that opens the list."""
-    return bool(_ROSTER_ENTRY_RE.match(content)) or bool(
+    that CONTINUES (ends in ``\\``) or the ``pytest \\`` command that opens
+    the list."""
+    return bool(_ROSTER_CONTINUE_RE.match(content)) or bool(
         _PYTEST_ROSTER_CMD.match(content)
     )
 

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -72,6 +72,116 @@ def _is_hook_file(path: str) -> bool:
     return any(path == p or path.startswith(p) for p in HOOK_PATHS)
 
 
+# ---------------------------------------------------------------------------
+# Issue #2522 — the "roster-only workflow edit" exception.
+#
+# The explicit CI test roster in ``.github/workflows/ci.yml`` is a long
+# ``tests/test_*.py \`` (shell line-continuation) list. Enrolling a NEW test
+# in that list — ``+            tests/test_foo.py \`` and nothing else in any
+# workflow file — is the expected shape of "I added a test". Blocking it for
+# an external contributor is self-defeating: the gate blocks the exact
+# contribution it asks for.
+#
+# We therefore detect "roster-only" workflow edits: a workflow file counts
+# as roster-only when EVERY change in its diff is a pure ADDITION of a
+# ``tests/<name>.py`` roster entry (no removed lines, no other added or
+# modified lines). The overall hook finding is downgraded from [BLOCKING] to
+# [warning] ONLY when EVERY workflow file the PR touches is roster-only and
+# there are no other ``.github/workflows/`` edits of any other kind. Any
+# other workflow edit — a ``runs-on`` / ``step.run:`` change, a removed
+# line, a structural edit — or any non-workflow hook file (conftest.py,
+# Makefile, a dep file) keeps [BLOCKING] for external authors.
+#
+# The path grammar is deliberately narrower than a shell token: allowing
+# ``$()``, quotes, ``;``, ``..`` etc. would let the exception itself become
+# a workflow-code injection bypass. Only a plain ``tests/<alnum>_./-`` token
+# with an optional trailing ``\`` continuation matches.
+# ---------------------------------------------------------------------------
+
+_WORKFLOW_PREFIX = ".github/workflows/"
+
+# A single roster-enrollment content line (leading ``+`` already stripped).
+_ROSTER_ENTRY_RE = re.compile(
+    r"^\s*(?P<path>tests/[A-Za-z0-9_./-]+\.py)(?P<cont>\s*\\)?\s*$"
+)
+
+
+def _roster_addition_path(content: str) -> str | None:
+    """If *content* (a ``+`` line with the marker stripped) is a roster
+    enrollment of the form ``tests/<name>.py \\``, return the test path,
+    else ``None``. Rejects anything with traversal (``..``) — that would
+    be an injection, not an enrollment."""
+    m = _ROSTER_ENTRY_RE.match(content)
+    if m is None:
+        return None
+    path = m.group("path")
+    if ".." in Path(path).parts:
+        return None
+    return path
+
+
+def _roster_only_workflows(
+    diff: str, files_changed: set[str]
+) -> tuple[set[str], dict[str, list[str]]]:
+    """Classify every workflow file touched by the PR.
+
+    Returns ``(roster_only, roster_additions)``:
+
+    * ``roster_only`` — the set of workflow files whose ENTIRE diff is a
+      pure roster enrollment (only ``tests/<name>.py \\`` lines added, no
+      removed lines, no other change).
+    * ``roster_additions`` — ``{workflow_file: [test paths enrolled]}`` for
+      those roster-only files, so the human gets the exact added lines.
+
+    A workflow file in ``files_changed`` that fails any of those checks is
+    simply absent from both — it stays [BLOCKING]."""
+
+    workflow_files = {f for f in files_changed if f.startswith(_WORKFLOW_PREFIX)}
+    if not workflow_files:
+        return set(), {}
+
+    # Group added/removed content lines per workflow file.
+    per_file: dict[str, dict[str, list[str]]] = {
+        f: {"added": [], "removed": []} for f in workflow_files
+    }
+    cur_path = ""
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            cur_path = line.split(" b/", 1)[-1] if " b/" in line else ""
+            continue
+        if cur_path not in per_file:
+            continue
+        if line.startswith(("+++ ", "--- ", "@@")):
+            continue  # hunk / file headers
+        marker = line[:1]
+        if marker == "+":
+            per_file[cur_path]["added"].append(line[1:])
+        elif marker == "-":
+            per_file[cur_path]["removed"].append(line[1:])
+
+    roster_only: set[str] = set()
+    roster_additions: dict[str, list[str]] = {}
+    for path, block in per_file.items():
+        # Anything deleted from a workflow file is NOT roster-only (#2522).
+        if block["removed"]:
+            continue
+        if not block["added"]:
+            continue  # no tracked change; stay conservative
+        enrolled: list[str] = []
+        ok = True
+        for content in block["added"]:
+            p = _roster_addition_path(content)
+            # Must be a real roster token AND a test the PR itself adds.
+            if p is None or p not in files_changed:
+                ok = False
+                break
+            enrolled.append(p)
+        if ok:
+            roster_only.add(path)
+            roster_additions[path] = enrolled
+    return roster_only, roster_additions
+
+
 # Backwards-compatibility alias — the dep-declaration matcher now
 # lives in ``_test_env.is_dep_declaration_file`` (shared with
 # ``test_env_check``); kept as a constant here so existing call
@@ -152,10 +262,44 @@ class SupplyChainStep(Step):
         if hook_files:
             # Even an "innocent-looking" hook change is worth surfacing.
             # External-author + hook change = strong reason to read.
-            severity = "BLOCKING" if ctx.is_external_author else "warning"
+            #
+            # Issue #2522 exception: an external PR that ONLY enrolls a new
+            # test into the explicit CI roster (pure ``tests/<name>.py \``
+            # additions, no removed lines, no other workflow edit) is the
+            # expected shape of a "I added a test" contribution. Downgrade
+            # that to a WARNING (still surfaced, with the added lines) so it
+            # doesn't BLOCK the behavior the gate is meant to encourage. Any
+            # other workflow edit, or any non-workflow hook file modified
+            # alongside, keeps [BLOCKING] for external authors.
+            roster_only, roster_additions = _roster_only_workflows(
+                diff, set(ctx.files_changed)
+            )
+            roster_downgrade = bool(
+                ctx.is_external_author
+                and hook_files
+                and all(f.startswith(_WORKFLOW_PREFIX) for f in hook_files)
+                and all(f in roster_only for f in hook_files)
+            )
+            severity = (
+                "warning"
+                if roster_downgrade
+                else ("BLOCKING" if ctx.is_external_author else "warning")
+            )
+            detail = ""
+            if roster_downgrade:
+                # Include the exact enrolled test paths (diff hunk) so the
+                # human still inspects what was added (issue #2522).
+                added = sorted(
+                    {  # flatten, dedupe, sort for a stable message
+                        p for paths in roster_additions.values() for p in paths
+                    }
+                )
+                detail = " Roster-only test enrollment: " + ", ".join(
+                    f"`{p}`" for p in added
+                )
             findings.append(
                 f"[{severity}] modifies install/CI hook(s): {hook_files}. "
-                "These run unattended; review every line."
+                "These run unattended; review every line." + detail
             )
 
         # 2. Suspicious patterns in ADDED lines (not removed — removed

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -137,45 +137,50 @@ _ROSTER_CONTINUE_RE = re.compile(r"^\s*tests/[A-Za-z0-9_./-]+\.py\s*\\\s*$")
 _PYTEST_ROSTER_CMD = re.compile(r"^\s*pytest\b.*\\\s*$")
 
 
-def _anchored_to_roster(lines: list[tuple[str, str, bool]], i: int) -> bool:
-    """True if the added line at index *i* sits inside the explicit pytest
-    test roster — i.e. the contiguous chain of ``tests/*.py \\`` lines above
-    it traces BACKWARD to a ``pytest \\`` opener, not to some other multiline
-    command (an uploader receiving test-file arguments, for example).
-
-    Walk backward through continuing roster entries; the chain terminates
-    correctly when it reaches a ``pytest \\`` opener, or when it runs off the
-    top of this file's visible diff while still inside roster entries (the
-    real end-of-roster append: the opener is lines above the hunk context).
-    It is rejected if the chain reaches a non-pytest, non-roster opener."""
-    j = i - 1
-    while j >= 0:
-        marker, content, first_in_hunk = lines[j]
-        if _PYTEST_ROSTER_CMD.match(content):
-            return True  # reached the `pytest \` opener
-        if not _ROSTER_CONTINUE_RE.match(content):
-            return False  # non-pytest, non-roster opener → not the roster list
-        if first_in_hunk:
-            return True  # block continues above the visible diff (the roster)
-        j -= 1
-    return False
+def _pytest_roster_lines(content: str) -> set[int]:
+    """Return the (1-based) line numbers in *content* that are roster entries
+    of the explicit pytest test list. This is the authoritative, ground-truth
+    denominator: the contiguous ``tests/*.py \\`` continuation lines that
+    immediately follow a ``pytest \\`` command. Codex r1 round-3 — do not
+    trust hunk context (a long non-pytest file list would hide its opener);
+    verify each added line against the ACTUAL roster location in the file."""
+    roster: set[int] = set()
+    lines = content.splitlines()
+    i = 0
+    n = len(lines)
+    while i < n:
+        if _PYTEST_ROSTER_CMD.match(lines[i]):
+            j = i + 1
+            while j < n and _ROSTER_CONTINUE_RE.match(lines[j]):
+                roster.add(j + 1)  # 1-based
+                j += 1
+            i = j
+        else:
+            i += 1
+    return roster
 
 
 def _roster_only_workflows(
-    diff: str, files_changed: set[str]
+    diff: str, files_changed: set[str], head_content: dict[str, str]
 ) -> tuple[set[str], dict[str, list[str]]]:
     """Classify every workflow file touched by the PR.
+
+    ``head_content`` must map each modified workflow path to its HEAD file
+    text (the full file the diff will produce once merged) — used to verify
+    that each added roster line lands inside the ACTUAL pytest roster, rather
+    than trusting diff hunk context.
 
     Returns ``(roster_only, roster_additions)``:
 
     * ``roster_only`` — the set of workflow files whose ENTIRE diff is a
       pure roster enrollment (only ``tests/<name>.py \\`` lines added to the
-      explicit test list, no removed lines, no other change).
+      explicit pytest test list, no removed lines, no other change).
     * ``roster_additions`` — ``{workflow_file: [test paths enrolled]}`` for
       those roster-only files, so the human gets the exact added lines.
 
-    A workflow file in ``files_changed`` that fails any of those checks is
-    simply absent from both — it stays [BLOCKING]."""
+    A workflow file that fails any check (removed lines, metadata, a roster
+    token added outside the real roster, a file we cannot verify) is absent
+    from both — it stays [BLOCKING]."""
 
     workflow_files = {f for f in files_changed if f.startswith(_WORKFLOW_PREFIX)}
     if not workflow_files:
@@ -187,15 +192,18 @@ def _roster_only_workflows(
     # edits an existing test cannot get the downgrade.
     new_files = _new_files(diff)
     files_changed_set = set(files_changed)
+    # Authoritative roster line numbers, from the actual HEAD file.
+    roster_lines = {
+        path: _pytest_roster_lines(head_content[path])
+        for path in workflow_files
+        if path in head_content
+    }
 
     # Collect every kind of line (context / added / removed) per workflow file,
-    # in file order, so we can anchor an added roster line to the lines around
-    # it (the roster list) rather than accepting the token anywhere in YAML.
-    # Each entry is ``(marker, content, first_in_hunk)`` — the flag lets us
-    # refuse an anchor that would cross a ``@@`` hunk boundary (the line above
-    # may be a different region of the file).
-    per_file: dict[str, dict[str, list[tuple[str, str, bool]]]] = {
-        f: {"lines": [], "added": [], "removed": []} for f in workflow_files
+    # tracking each added line's absolute NEW-file line number (from the @@
+    # hunk headers) so we can match it against the real roster location.
+    per_file: dict[str, dict[str, list]] = {
+        f: {"added": [], "removed": []} for f in workflow_files
     }
     # Workflow diffs carrying extended metadata (rename/copy/mode change) are
     # structural, not roster enrollments — a roster-only ``+tests/x.py \``
@@ -203,7 +211,7 @@ def _roster_only_workflows(
     metadata_files: set[str] = set()
     cur_path = ""
     in_hunk = False
-    first_in_hunk = False
+    new_lineno = 0
     for line in diff.splitlines():
         if line.startswith("diff --git "):
             cur_path = line.split(" b/", 1)[-1] if " b/" in line else ""
@@ -212,8 +220,10 @@ def _roster_only_workflows(
         if cur_path not in per_file:
             continue
         if line.startswith("@@"):
-            in_hunk = True  # everything after this is file content, not headers
-            first_in_hunk = True
+            # @@ -a,b +c,d @@ → the first new-file line is c.
+            in_hunk = True
+            m = re.search(r"\+(\d+)", line)
+            new_lineno = int(m.group(1)) if m else 0
             continue
         # Extended diff metadata lines (no + / - / space marker): a rename,
         # copy, or mode change of the workflow file itself is disqualifying.
@@ -237,12 +247,13 @@ def _roster_only_workflows(
         if not in_hunk and line.startswith(("--- ", "+++ ")):
             continue
         marker = line[:1]
-        per_file[cur_path]["lines"].append((marker, line[1:], first_in_hunk))
-        first_in_hunk = False
         if marker == "+":
-            per_file[cur_path]["added"].append(line[1:])
+            per_file[cur_path]["added"].append((new_lineno, line[1:]))
+            new_lineno += 1  # an added line occupies a new-file position
         elif marker == "-":
             per_file[cur_path]["removed"].append(line[1:])
+        elif marker == " ":
+            new_lineno += 1  # a context line also occupies a new-file position
 
     roster_only: set[str] = set()
     roster_additions: dict[str, list[str]] = {}
@@ -253,28 +264,21 @@ def _roster_only_workflows(
             continue
         if not block["added"]:
             continue  # no tracked change; stay conservative
+        # We must be able to verify the file against its real roster; without
+        # head content we cannot prove the additions are roster-only.
+        if path not in roster_lines:
+            continue
         enrolled: list[str] = []
         ok = True
-        for i, (marker, content, first_in_hunk) in enumerate(block["lines"]):
-            if marker != "+":
-                continue
+        for lineno, content in block["added"]:
             p = _roster_addition_path(content)
-            if p is None:
+            # A real roster token for a test this PR NEWLY adds...
+            if p is None or p not in new_files or p not in files_changed_set:
                 ok = False
                 break
-            # Must be a NEW test this PR adds...
-            if p not in new_files or p not in files_changed_set:
-                ok = False
-                break
-            # ...appended INTO the explicit pytest test roster: never a
-            # top-level YAML scalar, an unrelated ``run:`` block, or a
-            # different region of the file. The added line must not open its
-            # own hunk (no valid anchor), and its continuation chain must
-            # trace back to a ``pytest \`` opener.
-            if first_in_hunk:
-                ok = False  # no valid in-hunk anchor; stay conservative
-                break
-            if not _anchored_to_roster(block["lines"], i):
+            # ...placed at a line that is ACTUALLY a pytest-roster entry in the
+            # merged file (ground truth, not hunk context).
+            if lineno not in roster_lines[path]:
                 ok = False
                 break
             enrolled.append(p)
@@ -395,8 +399,18 @@ class SupplyChainStep(Step):
             # doesn't BLOCK the behavior the gate is meant to encourage. Any
             # other workflow edit, or any non-workflow hook file modified
             # alongside, keeps [BLOCKING] for external authors.
+            # Build the HEAD content of each modified workflow file (the PR
+            # head is checked out in the working tree) so roster-only can be
+            # verified against the file's ACTUAL pytest roster, not diff hunk
+            # context (codex r1 round-3).
+            head_content: dict[str, str] = {}
+            for wf in ctx.files_changed:
+                if wf.startswith(_WORKFLOW_PREFIX):
+                    p = ctx.repo_root / wf
+                    if p.is_file():
+                        head_content[wf] = p.read_text()
             roster_only, roster_additions = _roster_only_workflows(
-                diff, set(ctx.files_changed)
+                diff, set(ctx.files_changed), head_content
             )
             roster_downgrade = bool(
                 ctx.is_external_author

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -120,11 +120,13 @@ def _roster_addition_path(content: str) -> str | None:
     return path
 
 
-# A ``run: |``-block command line that opens a pytest test roster, e.g.
-# ``          pytest \``. An enrollment is only trusted when it is anchored to
-# the explicit roster list — i.e. the line directly above it is itself a
-# roster entry or the ``pytest`` command that starts the list (codex r1 #2).
-_PYTEST_ROSTER_CMD = re.compile(r"^\s*pytest(\s.*)?\\?\s*$")
+# The ``run: |``-block command that OPENS a pytest test roster, e.g.
+# ``          pytest \``. It must end with a continuation backslash: a
+# complete, non-continuing command like ``pytest -q`` runs as its own shell
+# invocation and does NOT open the multi-line ``tests/x.py \`` list (codex
+# r1 #2). An enrollment is only trusted when it is anchored to that list —
+# the line directly above it is another roster entry or this opening command.
+_PYTEST_ROSTER_CMD = re.compile(r"^\s*pytest\b.*\\\s*$")
 
 
 def _roster_anchor(content: str) -> bool:
@@ -166,11 +168,15 @@ def _roster_only_workflows(
     # Collect every kind of line (context / added / removed) per workflow file,
     # in file order, so we can anchor an added roster line to the lines around
     # it (the roster list) rather than accepting the token anywhere in YAML.
-    per_file: dict[str, dict[str, list[str]]] = {
+    # Each entry is ``(marker, content, first_in_hunk)`` — the flag lets us
+    # refuse an anchor that would cross a ``@@`` hunk boundary (the line above
+    # may be a different region of the file).
+    per_file: dict[str, dict[str, list[tuple[str, str, bool]]]] = {
         f: {"lines": [], "added": [], "removed": []} for f in workflow_files
     }
     cur_path = ""
     in_hunk = False
+    first_in_hunk = False
     for line in diff.splitlines():
         if line.startswith("diff --git "):
             cur_path = line.split(" b/", 1)[-1] if " b/" in line else ""
@@ -178,6 +184,7 @@ def _roster_only_workflows(
             continue
         if line.startswith("@@"):
             in_hunk = True  # everything after this is file content, not headers
+            first_in_hunk = True
             continue
         if cur_path not in per_file:
             continue
@@ -189,7 +196,8 @@ def _roster_only_workflows(
             continue
         marker = line[:1]
         if marker in (" ", "+", "-"):
-            per_file[cur_path]["lines"].append((marker, line[1:]))
+            per_file[cur_path]["lines"].append((marker, line[1:], first_in_hunk))
+            first_in_hunk = False
             if marker == "+":
                 per_file[cur_path]["added"].append(line[1:])
             elif marker == "-":
@@ -205,7 +213,7 @@ def _roster_only_workflows(
             continue  # no tracked change; stay conservative
         enrolled: list[str] = []
         ok = True
-        for i, (marker, content) in enumerate(block["lines"]):
+        for i, (marker, content, first_in_hunk) in enumerate(block["lines"]):
             if marker != "+":
                 continue
             p = _roster_addition_path(content)
@@ -217,9 +225,13 @@ def _roster_only_workflows(
                 ok = False
                 break
             # ...appended INTO the explicit roster list: the line directly
-            # above it is a roster entry or the opening ``pytest \`` command,
-            # not a top-level YAML scalar or an unrelated ``run:`` block.
-            prev = block["lines"][i - 1][1] if i > 0 else ""
+            # above it (WITHIN the same hunk) is a roster entry or the
+            # opening ``pytest \`` command — never a top-level YAML scalar,
+            # an unrelated ``run:`` block, or a different region of the file.
+            if first_in_hunk:
+                ok = False  # no valid in-hunk anchor; stay conservative
+                break
+            prev = block["lines"][i - 1][1]
             if not _roster_anchor(prev):
                 ok = False
                 break

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -402,13 +402,21 @@ class SupplyChainStep(Step):
             # Build the HEAD content of each modified workflow file (the PR
             # head is checked out in the working tree) so roster-only can be
             # verified against the file's ACTUAL pytest roster, not diff hunk
-            # context (codex r1 round-3).
+            # context (codex r1 round-3). Only external authors need this
+            # (internal writers already get [warning]); a file that cannot be
+            # read is treated as NOT roster-only → BLOCKING, never a crash.
             head_content: dict[str, str] = {}
-            for wf in ctx.files_changed:
-                if wf.startswith(_WORKFLOW_PREFIX):
-                    p = ctx.repo_root / wf
-                    if p.is_file():
-                        head_content[wf] = p.read_text()
+            if ctx.is_external_author:
+                for wf in ctx.files_changed:
+                    if not wf.startswith(_WORKFLOW_PREFIX):
+                        continue
+                    try:
+                        p = ctx.repo_root / wf
+                        if p.is_file():
+                            head_content[wf] = p.read_text()
+                    except (OSError, UnicodeDecodeError):
+                        # Unreadable workflow → cannot prove roster-only.
+                        continue
             roster_only, roster_additions = _roster_only_workflows(
                 diff, set(ctx.files_changed), head_content
             )

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -95,16 +95,18 @@ def _is_hook_file(path: str) -> bool:
 # The path grammar is deliberately narrower than a shell token: allowing
 # ``$()``, quotes, ``;``, ``..`` etc. would let the exception itself become
 # a workflow-code injection bypass. Only a plain ``tests/<alnum>_./-`` token
-# with a trailing ``\`` continuation matches.  Requiring the continuation is
-# intentional: this is a fail-closed exception for executable workflow files,
-# and the repository's explicit roster uses that canonical form.
+# with an optional trailing ``\`` continuation matches. A no-continuation
+# entry is accepted only when it is proven to be the final command argument at
+# the end of its YAML literal block; see ``_pytest_roster_lines``.
 # ---------------------------------------------------------------------------
 
 _WORKFLOW_PREFIX = ".github/workflows/"
 _ROSTER_WORKFLOWS = frozenset({".github/workflows/ci.yml"})
 
 # A single roster-enrollment content line (leading ``+`` already stripped).
-_ROSTER_ENTRY_RE = re.compile(r"^\s*(?P<path>tests/[A-Za-z0-9_./-]+\.py)\s*\\\s*$")
+_ROSTER_ENTRY_RE = re.compile(
+    r"^\s*(?P<path>tests/[A-Za-z0-9_./-]+\.py)(?P<cont>\s*\\)?\s*$"
+)
 
 
 def _roster_addition_path(content: str) -> str | None:
@@ -142,23 +144,37 @@ def _pytest_roster_lines(content: str) -> set[int]:
     """Return the (1-based) line numbers in *content* that are roster entries
     of the explicit pytest test list. This is the authoritative, ground-truth
     denominator: the contiguous ``tests/*.py \\`` continuation lines that
-    follow a ``pytest \\`` command.  The downgrade deliberately recognizes
-    only this canonical form.  Accepting a no-backslash line requires parsing
-    the remainder of the shell command correctly; getting that wrong can turn
-    following options into separate commands while suppressing review of an
-    executable workflow change.  Codex r1 round-3 — do not trust hunk context
-    (a long non-pytest file list would hide its opener); verify each added line
-    against the ACTUAL roster location in the file."""
+    follow a ``pytest \\`` command, plus a no-backslash final test only when
+    the next nonblank source line has left that YAML literal block (or EOF was
+    reached). Looking merely for another test is unsafe: following pytest
+    options would become separate shell commands. Codex r1 round-3 — do not
+    trust hunk context (a long non-pytest file list would hide its opener);
+    verify each added line against the ACTUAL roster location in the file."""
     roster: set[int] = set()
     lines = content.splitlines()
     i = 0
     n = len(lines)
     while i < n:
         if _PYTEST_ROSTER_CMD.match(lines[i]):
+            command_indent = len(lines[i]) - len(lines[i].lstrip())
             j = i + 1
             # A run of continuing roster entries...
             while j < n and _ROSTER_CONTINUE_RE.match(lines[j]):
                 roster.add(j + 1)  # 1-based
+                j += 1
+            # A final test may omit ``\`` only when it genuinely ends the
+            # literal shell block. Any later nonblank line at the command's
+            # indentation or deeper is another command/argument in that block.
+            if j < n and _ROSTER_ENTRY_RE.match(lines[j]):
+                next_nonblank = j + 1
+                while next_nonblank < n and not lines[next_nonblank].strip():
+                    next_nonblank += 1
+                left_literal_block = next_nonblank >= n or (
+                    len(lines[next_nonblank]) - len(lines[next_nonblank].lstrip())
+                    < command_indent
+                )
+                if left_literal_block:
+                    roster.add(j + 1)
                 j += 1
             i = j
         else:

--- a/scripts/pr_validate/steps/supply_chain.py
+++ b/scripts/pr_validate/steps/supply_chain.py
@@ -183,6 +183,10 @@ def _roster_only_workflows(
     per_file: dict[str, dict[str, list[tuple[str, str, bool]]]] = {
         f: {"lines": [], "added": [], "removed": []} for f in workflow_files
     }
+    # Workflow diffs carrying extended metadata (rename/copy/mode change) are
+    # structural, not roster enrollments — a roster-only ``+tests/x.py \``
+    # cannot accompany a rename or a mode change of the workflow file itself.
+    metadata_files: set[str] = set()
     cur_path = ""
     in_hunk = False
     first_in_hunk = False
@@ -191,11 +195,26 @@ def _roster_only_workflows(
             cur_path = line.split(" b/", 1)[-1] if " b/" in line else ""
             in_hunk = False
             continue
+        if cur_path not in per_file:
+            continue
         if line.startswith("@@"):
             in_hunk = True  # everything after this is file content, not headers
             first_in_hunk = True
             continue
-        if cur_path not in per_file:
+        # Extended diff metadata lines (no + / - / space marker): a rename,
+        # copy, or mode change of the workflow file itself is disqualifying.
+        if line[:1] not in (" ", "+", "-"):
+            if line.startswith(
+                (
+                    "rename from ",
+                    "rename to ",
+                    "copy from ",
+                    "copy to ",
+                    "old mode ",
+                    "new mode ",
+                )
+            ):
+                metadata_files.add(cur_path)
             continue
         # ``--- /path`` and ``+++ /path`` are file headers ONLY before the
         # first hunk. Inside a hunk a content line may itself begin with
@@ -204,19 +223,19 @@ def _roster_only_workflows(
         if not in_hunk and line.startswith(("--- ", "+++ ")):
             continue
         marker = line[:1]
-        if marker in (" ", "+", "-"):
-            per_file[cur_path]["lines"].append((marker, line[1:], first_in_hunk))
-            first_in_hunk = False
-            if marker == "+":
-                per_file[cur_path]["added"].append(line[1:])
-            elif marker == "-":
-                per_file[cur_path]["removed"].append(line[1:])
+        per_file[cur_path]["lines"].append((marker, line[1:], first_in_hunk))
+        first_in_hunk = False
+        if marker == "+":
+            per_file[cur_path]["added"].append(line[1:])
+        elif marker == "-":
+            per_file[cur_path]["removed"].append(line[1:])
 
     roster_only: set[str] = set()
     roster_additions: dict[str, list[str]] = {}
     for path, block in per_file.items():
-        # Anything deleted from a workflow file is NOT roster-only (#2522).
-        if block["removed"]:
+        # Anything deleted from (or structurally altered with) a workflow file
+        # is NOT roster-only (#2522).
+        if block["removed"] or path in metadata_files:
             continue
         if not block["added"]:
             continue  # no tracked change; stay conservative

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -440,10 +440,10 @@ def test_mid_list_no_backslash_entry_is_not_roster_only():
     assert roster_only == set()
 
 
-def test_terminal_roster_entry_without_backslash_is_enrollment():
-    """Regression (codex r1 round-4): the final roster entry of a ``run: |``
-    block may omit the shell continuation backslash; it is still a valid
-    enrollment and must be recognized by the ground-truth roster detection."""
+def test_terminal_roster_entry_without_backslash_stays_blocking():
+    """The workflow exception is fail-closed: even a genuinely terminal
+    no-backslash entry is outside the canonical roster form and stays subject
+    to maintainer review."""
     from scripts.pr_validate.steps.supply_chain import _pytest_roster_lines
 
     head = (
@@ -457,7 +457,7 @@ def test_terminal_roster_entry_without_backslash_is_enrollment():
         "            tests/test_alpha.py \\\n"
         "            tests/test_terminal.py\n"
     )
-    # A no-backslash final entry added at the same position (roster only).
+    # A no-backslash final entry added at the same position.
     diff = (
         "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
         "--- a/.github/workflows/ci.yml\n"
@@ -467,11 +467,12 @@ def test_terminal_roster_entry_without_backslash_is_enrollment():
         "+            tests/test_appended.py\n"
     )
     lines = _pytest_roster_lines(head)
-    # alpha (line 8) is continuing; terminal (line 9) has no backslash.
-    assert 9 in lines
+    # alpha (line 8) is continuing; terminal (line 9) has no backslash and is
+    # deliberately outside the narrow exception.
+    assert 9 not in lines
 
-    # End-to-end: a no-backslash added line at that terminal position is a
-    # valid roster enrollment (with a genuinely new test file).
+    # End-to-end: the no-backslash edit stays blocking even though the test is
+    # genuinely new.
     newfile = (
         "diff --git a/tests/test_appended.py b/tests/test_appended.py\n"
         "new file mode 100644\n"
@@ -486,8 +487,79 @@ def test_terminal_roster_entry_without_backslash_is_enrollment():
         {".github/workflows/ci.yml", "tests/test_appended.py"},
         {".github/workflows/ci.yml": head},
     )
-    assert roster_only == {".github/workflows/ci.yml"}
-    assert additions[".github/workflows/ci.yml"] == ["tests/test_appended.py"]
+    assert roster_only == set()
+    assert additions == {}
+
+
+def test_no_backslash_before_pytest_options_stays_blocking():
+    """Regression: a missing continuation before existing pytest options
+    terminates pytest and turns those options into shell commands.  It must
+    never receive the roster-only downgrade."""
+    from scripts.pr_validate.steps.supply_chain import _pytest_roster_lines
+
+    path = "tests/test_new_external.py"
+    head = (
+        "pytest \\\n"
+        "  tests/test_existing.py \\\n"
+        f"  {path}\n"
+        "  -v --tb=short \\\n"
+        "  --cov=rapid_mlx\n"
+    )
+    line = 3
+    assert line not in _pytest_roster_lines(head)
+
+    newfile = (
+        f"diff --git a/{path} b/{path}\n"
+        "new file mode 100644\n"
+        "--- /dev/null\n"
+        f"+++ b/{path}\n"
+        "@@ -0,0 +1 @@\n"
+        "+pass\n"
+    )
+    workflow = (
+        "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
+        "--- a/.github/workflows/ci.yml\n"
+        "+++ b/.github/workflows/ci.yml\n"
+        "@@ -2 +3,2 @@\n"
+        f"+  {path}\n"
+        "   -v --tb=short \\\n"
+    )
+    roster_only, additions = _roster_only_workflows(
+        newfile + workflow,
+        {".github/workflows/ci.yml", path},
+        {".github/workflows/ci.yml": head},
+    )
+    assert roster_only == set()
+    assert additions == {}
+
+
+def test_other_workflow_pytest_roster_stays_blocking():
+    """The narrow exception belongs only to ci.yml's reviewed Apple/MLX
+    roster, not arbitrary pytest commands in other executable workflows."""
+    workflow_path = ".github/workflows/rapid-mac-ci.yml"
+    test_path = "tests/test_new_external.py"
+    head = f"pytest \\\n  {test_path} \\\n  -q\n"
+    diff = (
+        f"diff --git a/{test_path} b/{test_path}\n"
+        "new file mode 100644\n"
+        "--- /dev/null\n"
+        f"+++ b/{test_path}\n"
+        "@@ -0,0 +1 @@\n"
+        "+pass\n"
+        f"diff --git a/{workflow_path} b/{workflow_path}\n"
+        f"--- a/{workflow_path}\n"
+        f"+++ b/{workflow_path}\n"
+        "@@ -1 +2,2 @@\n"
+        f"+  {test_path} \\\n"
+        "   -q\n"
+    )
+    roster_only, additions = _roster_only_workflows(
+        diff,
+        {workflow_path, test_path},
+        {workflow_path: head},
+    )
+    assert roster_only == set()
+    assert additions == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -386,6 +386,56 @@ def test_new_files_detects_created_file():
     assert _ENROLLED in new
 
 
+def test_terminal_roster_entry_without_backslash_is_enrollment():
+    """Regression (codex r1 round-4): the final roster entry of a ``run: |``
+    block may omit the shell continuation backslash; it is still a valid
+    enrollment and must be recognized by the ground-truth roster detection."""
+    from scripts.pr_validate.steps.supply_chain import _pytest_roster_lines
+
+    head = (
+        "name: CI\n"
+        "jobs:\n"
+        "  t:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: |\n"
+        "          pytest \\\n"
+        "            tests/test_alpha.py \\\n"
+        "            tests/test_terminal.py\n"
+    )
+    # A no-backslash final entry added at the same position (roster only).
+    diff = (
+        "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
+        "--- a/.github/workflows/ci.yml\n"
+        "+++ b/.github/workflows/ci.yml\n"
+        "@@ -8 +8,2 @@\n"
+        "            tests/test_alpha.py \\\n"
+        "+            tests/test_appended.py\n"
+    )
+    lines = _pytest_roster_lines(head)
+    # alpha (line 8) is continuing; terminal (line 9) has no backslash.
+    assert 9 in lines
+
+    # End-to-end: a no-backslash added line at that terminal position is a
+    # valid roster enrollment (with a genuinely new test file).
+    newfile = (
+        "diff --git a/tests/test_appended.py b/tests/test_appended.py\n"
+        "new file mode 100644\n"
+        "index 0000000..1111111\n"
+        "--- /dev/null\n"
+        "+++ b/tests/test_appended.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+pass\n"
+    )
+    roster_only, additions = _roster_only_workflows(
+        newfile + diff,
+        {".github/workflows/ci.yml", "tests/test_appended.py"},
+        {".github/workflows/ci.yml": head},
+    )
+    assert roster_only == {".github/workflows/ci.yml"}
+    assert additions[".github/workflows/ci.yml"] == ["tests/test_appended.py"]
+
+
 # ---------------------------------------------------------------------------
 # SupplyChainStep.run — the gate behavior
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -182,6 +182,20 @@ index 1111111..2222222 100644
 +            {_ENROLLED} \\
 """
 
+# Regression for codex r1 round-2: the preceding roster entry that anchors an
+# added line must CONTINUE (end in ``\\``). Here the preceding entry has no
+# backslash — a shell terminal — so the added ``tests/foo.py \\`` after it
+# would be a SECOND command, not a pytest argument. Not an enrollment.
+_TERMINAL_ANCHOR_DIFF = f"""\
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -441 +441,2 @@
+             tests/test_mllm_hybrid_probe.py
++            {_ENROLLED} \\
+"""
+
 
 def _ctx(
     diff: str,
@@ -279,6 +293,16 @@ def test_non_continuing_pytest_command_not_roster_only(tmp_path):
     multi-line roster and must not be treated as an enrollment."""
     roster_only, _ = _roster_only_workflows(
         _NON_CONTINUING_PYTEST_DIFF, {_WORKFLOW, _ENROLLED}
+    )
+    assert roster_only == set()
+
+
+def test_terminal_anchor_entry_not_roster_only(tmp_path):
+    """Regression (codex r1 round-2): an added ``tests/foo.py \\`` line whose
+    preceding roster entry does NOT end in a continuation backslash runs as a
+    separate shell command, so it is not a pytest argument / enrollment."""
+    roster_only, _ = _roster_only_workflows(
+        _TERMINAL_ANCHOR_DIFF, {_WORKFLOW, _ENROLLED}
     )
     assert roster_only == set()
 

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -28,10 +28,25 @@ from scripts.pr_validate.steps.supply_chain import (
 # The test file an external "I added a test" PR enrolls.
 _ENROLLED = "tests/test_serving_lane_reason_contract.py"
 
+# The diff of the NEWLY-created test file being enrolled (``new file mode``
+# makes it count as a fresh contribution — required for the downgrade).
+_NEW_TEST_DIFF = f"""\
+diff --git a/{_ENROLLED} b/{_ENROLLED}
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/{_ENROLLED}
+@@ -0,0 +1,3 @@
++"\"test contract run on the new lane\"\"
++from test_stuff import run
+
+"""
+
 # A unified diff adding ONE line to the Linux test roster in ci.yml — the
-# exact "encourage me" case from issue #2522 / PR #2514.
+# exact "encourage me" case from issue #2522 / PR #2514. Includes the new
+# test file so the enrollment points at a genuinely new contribution.
 _ROSTER_ONLY_DIFF = f"""\
-diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
 index 1111111..2222222 100644
 --- a/.github/workflows/ci.yml
 +++ b/.github/workflows/ci.yml
@@ -43,7 +58,7 @@ index 1111111..2222222 100644
 # Same roster addition PLUS a real structural edit to the same workflow
 # (swapping ``runs-on``) — a mixed case that must still BLOCK.
 _MIXED_DIFF = f"""\
-diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
 index 1111111..2222222 100644
 --- a/.github/workflows/ci.yml
 +++ b/.github/workflows/ci.yml
@@ -64,6 +79,42 @@ index 1111111..2222222 100644
 @@ -80 +80 @@
 -            runs-on: ubuntu-latest
 +            runs-on: macos-14
+"""
+
+# A "roster-only" diff that ALSO removes a line whose content begins with
+# ``-- ``, so the diff line starts ``--- ``, colliding with the file-header
+# marker. The parser must NOT drop that removed line once inside the hunk —
+# otherwise a structural change gets misclassified as roster-only and
+# downgraded (regression for codex r1 finding #1).
+_COLLIDING_HEADER_DIFF = f"""\
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -8 +8,0 @@
+--- --quiet-node
+@@ -441 +442,2 @@
+             tests/test_mllm_hybrid_probe.py \\
++            {_ENROLLED} \\
+"""
+
+# An enrollment of an EXISTING (modified, not new) test file — must NOT get
+# the downgrade, because the exemption is for "I added a new test".
+_MODIFIED_TEST_DIFF = """\
+diff --git a/tests/test_existing.py b/tests/test_existing.py
+index 1111111..2222222 100644
+--- a/tests/test_existing.py
++++ b/tests/test_existing.py
+@@ -1 +1 @@
+-import os
++import os  # touched, not new
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -441 +441,2 @@
+             tests/test_mllm_hybrid_probe.py \\
++            tests/test_existing.py \\
 """
 
 _WORKFLOW = ".github/workflows/ci.yml"
@@ -115,6 +166,35 @@ def test_mixed_edit_not_roster_only(tmp_path):
 def test_arbitrary_workflow_edit_not_roster_only(tmp_path):
     roster_only, _ = _roster_only_workflows(_ARBITRARY_DIFF, {_WORKFLOW})
     assert roster_only == set()
+
+
+def test_removed_line_colliding_with_header_marker_not_roster_only(tmp_path):
+    """Regression (codex r1 #1): a removed line whose content begins with
+    ``-- `` produces a diff line starting ``--- ``, which must be treated as
+    a real removed change once inside the hunk — NOT skipped as a file header.
+    Otherwise a workflow with an additional structural change could be
+    misclassified as roster-only."""
+    roster_only, _ = _roster_only_workflows(
+        _COLLIDING_HEADER_DIFF, {_WORKFLOW, _ENROLLED}
+    )
+    assert roster_only == set()
+
+
+def test_enrolling_modified_existing_test_not_roster_only(tmp_path):
+    """Regression (codex r1 #2): the downgrade is for a NEWLY added test, so
+    enrolling a test this PR merely edits must not qualify."""
+    roster_only, _ = _roster_only_workflows(
+        _MODIFIED_TEST_DIFF, {_WORKFLOW, "tests/test_existing.py"}
+    )
+    assert roster_only == set()
+
+
+def test_new_files_detects_created_file():
+    from scripts.pr_validate.steps.supply_chain import _new_files
+
+    assert _NEW_TEST_DIFF.split("diff --git a/")[1]  # sanity: top block is the new file
+    new = _new_files(_ROSTER_ONLY_DIFF)
+    assert _ENROLLED in new
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -410,6 +410,29 @@ def test_external_roster_only_is_warning_not_blocking(tmp_path):
     assert _ENROLLED in hook
 
 
+def test_external_roster_only_unreadable_workflow_stays_blocking(tmp_path, monkeypatch):
+    """Regression (codex r1 round-3): if the workflow file cannot be read
+    (missing / decode / permission), validation must NOT crash and must
+    conservatively treat the change as NOT roster-only → [BLOCKING]."""
+    real_read_text = Path.read_text
+
+    def _flaky(self, *a, **k):
+        if ".github/workflows/" in str(self).replace("\\", "/"):
+            raise OSError("denied")
+        return real_read_text(self, *a, **k)
+
+    monkeypatch.setattr("scripts.pr_validate.steps.supply_chain.Path.read_text", _flaky)
+    ctx = _ctx(
+        _ROSTER_ONLY_DIFF,
+        [_WORKFLOW, _ENROLLED],
+        external=True,
+        tmp_path=tmp_path,
+    )
+    result = SupplyChainStep().run(ctx)  # must not raise
+    assert result.status == "fail"
+    assert "[BLOCKING]" in " ".join(result.findings)
+
+
 def test_internal_roster_only_is_warning(tmp_path):
     """An internal author's roster-only change is already a warning (the
     default); the fix must not regress it."""

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -202,7 +202,6 @@ index 1111111..2222222 100644
 _MODE_CHANGE_DIFF = f"""\
 {_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
 old mode 100644
-new mode 100755
 index 1111111..2222222 100644
 --- a/.github/workflows/ci.yml
 +++ b/.github/workflows/ci.yml
@@ -224,6 +223,23 @@ index 1111111..2222222 100644
 @@ -441 +441,2 @@
              tests/test_mllm_hybrid_probe.py \\
 +            {_ENROLLED} \\
+"""
+
+# Regression for codex r1 round-2 (non-pytest command anchor): the added
+# ``tests/foo.py \\`` sits inside a DIFFERENT multiline command (an uploader
+# receiving test-file arguments), not the pytest roster. Its continuation
+# chain traces back to ``upload-artifact \\`` — not a ``pytest \\`` opener —
+# so it must NOT be downgraded.
+_NON_PYTEST_COMMAND_DIFF = f"""\
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -198,4 +198,5 @@
+             upload-artifact \\
+               tests/test_asset_1.py \\
+               tests/test_asset_2.py \\
++              {_ENROLLED} \\
 """
 
 
@@ -350,6 +366,16 @@ def test_rename_with_roster_addition_not_roster_only(tmp_path):
     roster-only enrollment even combined with a roster addition."""
     roster_only, _ = _roster_only_workflows(
         _RENAME_DIFF, {_WORKFLOW, "tests/test_serving_lane_reason_contract.py"}
+    )
+    assert roster_only == set()
+
+
+def test_non_pytest_command_chain_not_roster_only(tmp_path):
+    """Regression (codex r1 round-2): an added ``tests/foo.py \\`` line whose
+    continuation chain is rooted at a NON-pytest command (an uploader) is not
+    a roster enrollment and must NOT be downgraded."""
+    roster_only, _ = _roster_only_workflows(
+        _NON_PYTEST_COMMAND_DIFF, {_WORKFLOW, _ENROLLED}
     )
     assert roster_only == set()
 

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -386,6 +386,60 @@ def test_new_files_detects_created_file():
     assert _ENROLLED in new
 
 
+def test_mid_list_no_backslash_entry_is_not_roster_only():
+    """Regression (codex r1 round-4): a no-backslash ``tests/x.py`` line
+    sandwiched BEFORE an existing continuing roster entry would cut the
+    pytest command short and run later paths as separate commands — it is
+    not a terminal enrollment and must NOT be downgraded."""
+    from scripts.pr_validate.steps.supply_chain import _pytest_roster_lines
+
+    head = (
+        "name: CI\n"
+        "jobs:\n"
+        "  t:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: |\n"
+        "          pytest \\\n"
+        "            tests/test_alpha.py \\\n"
+        "            tests/test_mid.py\n"  # no backslash
+        "            tests/test_beta.py \\\n"
+    )
+    lines = _pytest_roster_lines(head)
+    # line 9 (the sandwiched no-backslash entry) must NOT count as a genuine
+    # roster terminal (it would cut the pytest command and run beta as a
+    # separate command).
+    assert 9 not in lines
+
+    # End-to-end: adding that no-backslash line at position 9 is not a valid
+    # enrollment and stays BLOCKING (the path is new, but the position is not
+    # a genuine roster terminal). The added test must be "new" to isolate the
+    # position check.
+    newfile = (
+        "diff --git a/tests/test_mid.py b/tests/test_mid.py\n"
+        "new file mode 100644\n"
+        "index 0000000..9999999\n"
+        "--- /dev/null\n"
+        "+++ b/tests/test_mid.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+pass\n"
+    )
+    inserted = (
+        "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
+        "--- a/.github/workflows/ci.yml\n"
+        "+++ b/.github/workflows/ci.yml\n"
+        "@@ -8 +9,3 @@\n"
+        "+            tests/test_mid.py\n"
+        "             tests/test_beta.py \\\n"
+    )
+    roster_only, _ = _roster_only_workflows(
+        newfile + inserted,
+        {".github/workflows/ci.yml", "tests/test_mid.py"},
+        {".github/workflows/ci.yml": head},
+    )
+    assert roster_only == set()
+
+
 def test_terminal_roster_entry_without_backslash_is_enrollment():
     """Regression (codex r1 round-4): the final roster entry of a ``run: |``
     block may omit the shell continuation backslash; it is still a valid

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -135,6 +135,53 @@ index 1111111..2222222 100644
  jobs:
 """
 
+# A second new test file, enrolled alongside the primary one — used by the
+# hunk-boundary fixture below so BOTH hunks carry a fully-legitimate
+# new-file enrollment under the (buggy) flat-list logic.
+_OTHER_NEW = "tests/test_first_new.py"
+_OTHER_NEW_DIFF = f"""\
+diff --git a/{_OTHER_NEW} b/{_OTHER_NEW}
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/{_OTHER_NEW}
+@@ -0,0 +1 @@
++pass
+
+"""
+
+# Regression for codex r1 #2 (hunk boundaries): the FIRST added line of a
+# later hunk is anchored ONLY if we ignore hunk boundaries. Hunk 1 is a real
+# roster append (context `tests/...py \` + added entry); hunk 2's first line
+# is a roster-shaped token placed OUTSIDE the roster — under the buggy flat
+# list it would inherit hunk 1's roster anchor and be misclassified. The new
+# code rejects any added line that opens its own hunk.
+_HUNK_BOUNDARY_DIFF = f"""\
+{_NEW_TEST_DIFF}{_OTHER_NEW_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -441 +441,2 @@
+             tests/test_mllm_hybrid_probe.py \\
++            {_OTHER_NEW} \\
+@@ -1 +2,2 @@
++            {_ENROLLED} \\
+"""
+
+# Regression for codex r1 #2 (opening pytest command must continue): a line
+# following a plain ``pytest -q`` (NO trailing backslash) runs as its own
+# shell command and does NOT open the multi-line roster, so an added
+# ``tests/foo.py \`` after it is not an enrollment.
+_NON_CONTINUING_PYTEST_DIFF = f"""\
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -354,1 +354,2 @@
+          pytest -q
++            {_ENROLLED} \\
+"""
+
 
 def _ctx(
     diff: str,
@@ -211,6 +258,27 @@ def test_roster_token_outside_roster_list_not_roster_only(tmp_path):
     though the token and new-file checks pass — it must NOT be downgraded."""
     roster_only, _ = _roster_only_workflows(
         _NON_ROSTER_CONTEXT_DIFF, {_WORKFLOW, _ENROLLED}
+    )
+    assert roster_only == set()
+
+
+def test_hunk_boundary_not_roster_only(tmp_path):
+    """Regression (codex r1 #2 / hunk boundaries): a roster token that is the
+    FIRST added line of its own hunk must not inherit an anchor from the
+    previous hunk's final roster line. Without this, a token placed outside
+    the roster could be misclassified and downgraded."""
+    roster_only, _ = _roster_only_workflows(
+        _HUNK_BOUNDARY_DIFF, {_WORKFLOW, _ENROLLED, _OTHER_NEW}
+    )
+    assert roster_only == set()
+
+
+def test_non_continuing_pytest_command_not_roster_only(tmp_path):
+    """Regression (codex r1 #2): an added ``tests/foo.py \\`` line directly
+    after a `pytest -q` command with NO continuation backslash is not in the
+    multi-line roster and must not be treated as an enrollment."""
+    roster_only, _ = _roster_only_workflows(
+        _NON_CONTINUING_PYTEST_DIFF, {_WORKFLOW, _ENROLLED}
     )
     assert roster_only == set()
 

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -119,6 +119,22 @@ index 1111111..2222222 100644
 
 _WORKFLOW = ".github/workflows/ci.yml"
 
+# A NEW test is genuinely added, but its ``tests/foo.py \`` line is inserted
+# at the top of the workflow file (NOT inside the explicit ``pytest \`` test
+# roster). It must NOT qualify as roster-only — the token alone, outside the
+# roster list, is not an enrollment (codex r1 #2).
+_NON_ROSTER_CONTEXT_DIFF = f"""\
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1,3 +1,4 @@
+ name: CI
+ on: [push]
++tests/test_serving_lane_reason_contract.py \\
+ jobs:
+"""
+
 
 def _ctx(
     diff: str,
@@ -185,6 +201,16 @@ def test_enrolling_modified_existing_test_not_roster_only(tmp_path):
     enrolling a test this PR merely edits must not qualify."""
     roster_only, _ = _roster_only_workflows(
         _MODIFIED_TEST_DIFF, {_WORKFLOW, "tests/test_existing.py"}
+    )
+    assert roster_only == set()
+
+
+def test_roster_token_outside_roster_list_not_roster_only(tmp_path):
+    """Regression (codex r1 #2): a ``tests/foo.py \\`` line added at the top of
+    the workflow (outside the `pytest \\` roster) is not an enrollment, even
+    though the token and new-file checks pass — it must NOT be downgraded."""
+    roster_only, _ = _roster_only_workflows(
+        _NON_ROSTER_CONTEXT_DIFF, {_WORKFLOW, _ENROLLED}
     )
     assert roster_only == set()
 

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -32,8 +32,9 @@ from scripts.pr_validate.steps.supply_chain import (
 # parser tests validate against the same ground truth the step reads at run
 # time. If the roster ever moves, these tests fail loudly and the fixtures
 # must be re-synced.
+_REPO = Path(__file__).resolve().parents[1]
 _WORKFLOW_HEAD = {
-    ".github/workflows/ci.yml": Path(".github/workflows/ci.yml").read_text(),
+    ".github/workflows/ci.yml": (_REPO / ".github/workflows/ci.yml").read_text(),
 }
 
 # The test file an external "I added a test" PR enrolls.
@@ -399,17 +400,18 @@ def test_mid_list_no_backslash_entry_is_not_roster_only():
         "  t:\n"
         "    runs-on: ubuntu-latest\n"
         "    steps:\n"
-        "      - run: |\n"
+        "      - name: Run MLX-dependent tests\n"
+        "        run: |\n"
         "          pytest \\\n"
         "            tests/test_alpha.py \\\n"
         "            tests/test_mid.py\n"  # no backslash
         "            tests/test_beta.py \\\n"
     )
     lines = _pytest_roster_lines(head)
-    # line 9 (the sandwiched no-backslash entry) must NOT count as a genuine
+    # line 10 (the sandwiched no-backslash entry) must NOT count as a genuine
     # roster terminal (it would cut the pytest command and run beta as a
     # separate command).
-    assert 9 not in lines
+    assert 10 not in lines
 
     # End-to-end: adding that no-backslash line at position 9 is not a valid
     # enrollment and stays BLOCKING (the path is new, but the position is not
@@ -428,7 +430,7 @@ def test_mid_list_no_backslash_entry_is_not_roster_only():
         "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
         "--- a/.github/workflows/ci.yml\n"
         "+++ b/.github/workflows/ci.yml\n"
-        "@@ -8 +9,3 @@\n"
+        "@@ -9 +10,2 @@\n"
         "+            tests/test_mid.py\n"
         "             tests/test_beta.py \\\n"
     )
@@ -450,7 +452,8 @@ def test_terminal_roster_entry_without_backslash_is_enrollment():
         "  t:\n"
         "    runs-on: ubuntu-latest\n"
         "    steps:\n"
-        "      - run: |\n"
+        "      - name: Run MLX-dependent tests\n"
+        "        run: |\n"
         "          pytest \\\n"
         "            tests/test_alpha.py \\\n"
         "            tests/test_terminal.py\n"
@@ -460,14 +463,14 @@ def test_terminal_roster_entry_without_backslash_is_enrollment():
         "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
         "--- a/.github/workflows/ci.yml\n"
         "+++ b/.github/workflows/ci.yml\n"
-        "@@ -8 +8,2 @@\n"
+        "@@ -9 +9,2 @@\n"
         "            tests/test_alpha.py \\\n"
         "+            tests/test_appended.py\n"
     )
     lines = _pytest_roster_lines(head)
-    # alpha (line 8) is continuing; terminal (line 9) has no backslash but is
+    # alpha (line 9) is continuing; terminal (line 10) has no backslash but is
     # the genuine end of the literal block.
-    assert 9 in lines
+    assert 10 in lines
 
     # End-to-end: the genuinely terminal no-backslash edit is an enrollment.
     newfile = (
@@ -496,13 +499,15 @@ def test_no_backslash_before_pytest_options_stays_blocking():
 
     path = "tests/test_new_external.py"
     head = (
-        "pytest \\\n"
-        "  tests/test_existing.py \\\n"
-        f"  {path}\n"
-        "  -v --tb=short \\\n"
-        "  --cov=rapid_mlx\n"
+        "- name: Run MLX-dependent tests\n"
+        "  run: |\n"
+        "    pytest \\\n"
+        "      tests/test_existing.py \\\n"
+        f"      {path}\n"
+        "      -v --tb=short \\\n"
+        "      --cov=rapid_mlx\n"
     )
-    line = 3
+    line = 5
     assert line not in _pytest_roster_lines(head)
 
     newfile = (
@@ -517,7 +522,7 @@ def test_no_backslash_before_pytest_options_stays_blocking():
         "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
         "--- a/.github/workflows/ci.yml\n"
         "+++ b/.github/workflows/ci.yml\n"
-        "@@ -2 +3,2 @@\n"
+        "@@ -4 +5,2 @@\n"
         f"+  {path}\n"
         "   -v --tb=short \\\n"
     )
@@ -528,6 +533,20 @@ def test_no_backslash_before_pytest_options_stays_blocking():
     )
     assert roster_only == set()
     assert additions == {}
+
+
+def test_unrelated_pytest_step_in_ci_stays_blocking():
+    """Matching command syntax elsewhere in ci.yml is not privileged."""
+    from scripts.pr_validate.steps.supply_chain import _pytest_roster_lines
+
+    head = (
+        "- name: Some other tests\n"
+        "  run: |\n"
+        "    pytest \\\n"
+        "      tests/test_unrelated.py \\\n"
+        "      -q\n"
+    )
+    assert _pytest_roster_lines(head) == set()
 
 
 def test_other_workflow_pytest_roster_stays_blocking():

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the supply-chain step's roster-only workflow exception (#2522).
+
+Issue #2522: an external contributor who adds a NEW test and enrolls it in
+the explicit CI test roster (appending ``tests/<name>.py \\`` to the list in
+``.github/workflows/ci.yml``) was getting ``[BLOCKING]`` — the gate was
+blocking the exact contribution it exists to encourage. The fix downgrades a
+PURELY roster-only workflow edit (only ``tests/<name>.py \\`` lines added, no
+removed lines, no other workflow edit) from ``[BLOCKING]`` to ``[warning]``
+for external authors, while keeping every other external workflow edit at
+``[BLOCKING]``.
+
+These tests are the contract that drove the change. The roster-only path and
+the mixed / arbitrary paths must stay distinct.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.pr_validate.context import Context
+from scripts.pr_validate.steps.supply_chain import (
+    _WORKFLOW_PREFIX,
+    SupplyChainStep,
+    _roster_only_workflows,
+)
+
+# The test file an external "I added a test" PR enrolls.
+_ENROLLED = "tests/test_serving_lane_reason_contract.py"
+
+# A unified diff adding ONE line to the Linux test roster in ci.yml — the
+# exact "encourage me" case from issue #2522 / PR #2514.
+_ROSTER_ONLY_DIFF = f"""\
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -441 +441,2 @@
+             tests/test_mllm_hybrid_probe.py \\
++            {_ENROLLED} \\
+"""
+
+# Same roster addition PLUS a real structural edit to the same workflow
+# (swapping ``runs-on``) — a mixed case that must still BLOCK.
+_MIXED_DIFF = f"""\
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -80 +80 @@
+-            runs-on: ubuntu-latest
++            runs-on: macos-14
+@@ -441 +441,2 @@
+             tests/test_mllm_hybrid_probe.py \\
++            {_ENROLLED} \\
+"""
+
+# An arbitrary workflow edit alone (no roster) — must still BLOCK.
+_ARBITRARY_DIFF = """\
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -80 +80 @@
+-            runs-on: ubuntu-latest
++            runs-on: macos-14
+"""
+
+_WORKFLOW = ".github/workflows/ci.yml"
+
+
+def _ctx(
+    diff: str,
+    files_changed: list[str],
+    *,
+    external: bool,
+    tmp_path: pytest.TempPathFactory,
+) -> Context:
+    """A context pointing at a tmpfile diff with the given file set. Pytest
+    runs from the repo root (which has pyproject.toml), so Context's
+    ``__post_init__`` repo-root check is satisfied without chdir."""
+    ctx = Context(pr_number=999, repo="x/y")
+    ctx.pr_is_external = external
+    ctx.files_changed = files_changed
+    diff_path = tmp_path / "pr.diff"
+    diff_path.write_text(diff)
+    ctx.diff_path = str(diff_path)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# _roster_only_workflows — the pure parser
+# ---------------------------------------------------------------------------
+
+
+def test_roster_only_classifies_single_addition(tmp_path):
+    roster_only, additions = _roster_only_workflows(
+        _ROSTER_ONLY_DIFF, {_WORKFLOW, _ENROLLED}
+    )
+    assert roster_only == {_WORKFLOW}
+    assert additions[_WORKFLOW] == [_ENROLLED]
+
+
+def test_roster_only_addition_not_in_files_changed_stays_blocking(tmp_path):
+    # The roster line names a test the PR did NOT add — not an enrollment.
+    roster_only, _ = _roster_only_workflows(_ROSTER_ONLY_DIFF, {_WORKFLOW})
+    assert roster_only == set()
+
+
+def test_mixed_edit_not_roster_only(tmp_path):
+    roster_only, _ = _roster_only_workflows(_MIXED_DIFF, {_WORKFLOW, _ENROLLED})
+    assert roster_only == set()
+
+
+def test_arbitrary_workflow_edit_not_roster_only(tmp_path):
+    roster_only, _ = _roster_only_workflows(_ARBITRARY_DIFF, {_WORKFLOW})
+    assert roster_only == set()
+
+
+# ---------------------------------------------------------------------------
+# SupplyChainStep.run — the gate behavior
+# ---------------------------------------------------------------------------
+
+
+def test_external_roster_only_is_warning_not_blocking(tmp_path):
+    """Acceptance criterion 1: roster-only external change → warning with the
+    enrolled hunk, NOT [BLOCKING]."""
+    ctx = _ctx(
+        _ROSTER_ONLY_DIFF,
+        [_WORKFLOW, _ENROLLED],
+        external=True,
+        tmp_path=tmp_path,
+    )
+    result = SupplyChainStep().run(ctx)
+    # Warnings only → the step passes (does not gate).
+    assert result.status == "pass"
+    assert "[BLOCKING]" not in " ".join(result.findings)
+    hook = next(f for f in result.findings if "install/CI hook" in f)
+    assert "[warning]" in hook
+    # The diff hunk (enrolled path) must be surfaced for human eyeballs.
+    assert _ENROLLED in hook
+
+
+def test_internal_roster_only_is_warning(tmp_path):
+    """An internal author's roster-only change is already a warning (the
+    default); the fix must not regress it."""
+    ctx = _ctx(
+        _ROSTER_ONLY_DIFF,
+        [_WORKFLOW, _ENROLLED],
+        external=False,
+        tmp_path=tmp_path,
+    )
+    result = SupplyChainStep().run(ctx)
+    assert result.status == "pass"
+    assert "[BLOCKING]" not in " ".join(result.findings)
+
+
+def test_external_mixed_roster_plus_edit_still_blocking(tmp_path):
+    """Acceptance criterion 2 / mixed case: roster addition + a real workflow
+    edit keeps [BLOCKING]."""
+    ctx = _ctx(
+        _MIXED_DIFF,
+        [_WORKFLOW, _ENROLLED],
+        external=True,
+        tmp_path=tmp_path,
+    )
+    result = SupplyChainStep().run(ctx)
+    assert result.status == "fail"
+    assert "[BLOCKING]" in " ".join(result.findings)
+
+
+def test_external_arbitrary_workflow_edit_still_blocking(tmp_path):
+    """Acceptance criterion 2: any other workflow edit alone stays BLOCKING."""
+    ctx = _ctx(
+        _ARBITRARY_DIFF,
+        [_WORKFLOW],
+        external=True,
+        tmp_path=tmp_path,
+    )
+    result = SupplyChainStep().run(ctx)
+    assert result.status == "fail"
+    assert "[BLOCKING]" in " ".join(result.findings)
+
+
+def test_external_roster_plus_nonworkflow_hook_still_blocking(tmp_path):
+    """The exception is scoped to workflow files: a roster-only ci.yml edit
+    PLUS a change to a non-workflow hook (conftest.py) must still BLOCK."""
+    conftest_diff = (
+        _ROSTER_ONLY_DIFF
+        + """\
+diff --git a/conftest.py b/conftest.py
+index 3333333..4444444 100644
+--- a/conftest.py
++++ b/conftest.py
+@@ -1 +1,2 @@
+ import os
++import subprocess
+"""
+    )
+    ctx = _ctx(
+        conftest_diff,
+        [_WORKFLOW, _ENROLLED, "conftest.py"],
+        external=True,
+        tmp_path=tmp_path,
+    )
+    result = SupplyChainStep().run(ctx)
+    assert result.status == "fail"
+    assert "[BLOCKING]" in " ".join(result.findings)
+
+
+def test_roster_only_prefix_constant_is_workflow_scope():
+    """The exception deliberately targets the workflow tree, matching the
+    issue's "explicit roster list in .github/workflows/ci.yml" framing."""
+    assert _WORKFLOW_PREFIX == ".github/workflows/"

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -196,6 +196,36 @@ index 1111111..2222222 100644
 +            {_ENROLLED} \\
 """
 
+# Regression for codex r1 round-2: extended diff metadata on the workflow
+# (here a mode change) is structural and disqualifies a file even when it also
+# carries a valid roster addition.
+_MODE_CHANGE_DIFF = f"""\
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+old mode 100644
+new mode 100755
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -441 +441,2 @@
+             tests/test_mllm_hybrid_probe.py \\
++            {_ENROLLED} \\
+"""
+
+# Regression for codex r1 round-2: a rename of the workflow file, even with a
+# roster addition, is not a roster-only enrollment.
+_RENAME_DIFF = f"""\
+{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/renamed.yml
+similarity index 99%
+rename from .github/workflows/ci.yml
+rename to .github/workflows/renamed.yml
+index 1111111..2222222 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/renamed.yml
+@@ -441 +441,2 @@
+             tests/test_mllm_hybrid_probe.py \\
++            {_ENROLLED} \\
+"""
+
 
 def _ctx(
     diff: str,
@@ -303,6 +333,23 @@ def test_terminal_anchor_entry_not_roster_only(tmp_path):
     separate shell command, so it is not a pytest argument / enrollment."""
     roster_only, _ = _roster_only_workflows(
         _TERMINAL_ANCHOR_DIFF, {_WORKFLOW, _ENROLLED}
+    )
+    assert roster_only == set()
+
+
+def test_mode_change_with_roster_addition_not_roster_only(tmp_path):
+    """Regression (codex r1 round-2): a mode change on the workflow file is
+    structural, so even with a valid-looking roster addition the file must
+    not be downgraded."""
+    roster_only, _ = _roster_only_workflows(_MODE_CHANGE_DIFF, {_WORKFLOW, _ENROLLED})
+    assert roster_only == set()
+
+
+def test_rename_with_roster_addition_not_roster_only(tmp_path):
+    """Regression (codex r1 round-2): renaming the workflow file is not a
+    roster-only enrollment even combined with a roster addition."""
+    roster_only, _ = _roster_only_workflows(
+        _RENAME_DIFF, {_WORKFLOW, "tests/test_serving_lane_reason_contract.py"}
     )
     assert roster_only == set()
 

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -16,6 +16,8 @@ the mixed / arbitrary paths must stay distinct.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from scripts.pr_validate.context import Context
@@ -24,6 +26,15 @@ from scripts.pr_validate.steps.supply_chain import (
     SupplyChainStep,
     _roster_only_workflows,
 )
+
+# HEAD content of the real workflow roster, read from the working tree. The
+# fixtures below are line-tuned to it (roster spans 432-487), so the pure
+# parser tests validate against the same ground truth the step reads at run
+# time. If the roster ever moves, these tests fail loudly and the fixtures
+# must be re-synced.
+_WORKFLOW_HEAD = {
+    ".github/workflows/ci.yml": Path(".github/workflows/ci.yml").read_text(),
+}
 
 # The test file an external "I added a test" PR enrolls.
 _ENROLLED = "tests/test_serving_lane_reason_contract.py"
@@ -182,21 +193,7 @@ index 1111111..2222222 100644
 +            {_ENROLLED} \\
 """
 
-# Regression for codex r1 round-2: the preceding roster entry that anchors an
-# added line must CONTINUE (end in ``\\``). Here the preceding entry has no
-# backslash — a shell terminal — so the added ``tests/foo.py \\`` after it
-# would be a SECOND command, not a pytest argument. Not an enrollment.
-_TERMINAL_ANCHOR_DIFF = f"""\
-{_NEW_TEST_DIFF}diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
-index 1111111..2222222 100644
---- a/.github/workflows/ci.yml
-+++ b/.github/workflows/ci.yml
-@@ -441 +441,2 @@
-             tests/test_mllm_hybrid_probe.py
-+            {_ENROLLED} \\
-"""
-
-# Regression for codex r1 round-2: extended diff metadata on the workflow
+# Regression for codex r1 round-3: extended diff metadata on the workflow
 # (here a mode change) is structural and disqualifies a file even when it also
 # carries a valid roster addition.
 _MODE_CHANGE_DIFF = f"""\
@@ -269,7 +266,7 @@ def _ctx(
 
 def test_roster_only_classifies_single_addition(tmp_path):
     roster_only, additions = _roster_only_workflows(
-        _ROSTER_ONLY_DIFF, {_WORKFLOW, _ENROLLED}
+        _ROSTER_ONLY_DIFF, {_WORKFLOW, _ENROLLED}, _WORKFLOW_HEAD
     )
     assert roster_only == {_WORKFLOW}
     assert additions[_WORKFLOW] == [_ENROLLED]
@@ -277,17 +274,23 @@ def test_roster_only_classifies_single_addition(tmp_path):
 
 def test_roster_only_addition_not_in_files_changed_stays_blocking(tmp_path):
     # The roster line names a test the PR did NOT add — not an enrollment.
-    roster_only, _ = _roster_only_workflows(_ROSTER_ONLY_DIFF, {_WORKFLOW})
+    roster_only, _ = _roster_only_workflows(
+        _ROSTER_ONLY_DIFF, {_WORKFLOW}, _WORKFLOW_HEAD
+    )
     assert roster_only == set()
 
 
 def test_mixed_edit_not_roster_only(tmp_path):
-    roster_only, _ = _roster_only_workflows(_MIXED_DIFF, {_WORKFLOW, _ENROLLED})
+    roster_only, _ = _roster_only_workflows(
+        _MIXED_DIFF, {_WORKFLOW, _ENROLLED}, _WORKFLOW_HEAD
+    )
     assert roster_only == set()
 
 
 def test_arbitrary_workflow_edit_not_roster_only(tmp_path):
-    roster_only, _ = _roster_only_workflows(_ARBITRARY_DIFF, {_WORKFLOW})
+    roster_only, _ = _roster_only_workflows(
+        _ARBITRARY_DIFF, {_WORKFLOW}, _WORKFLOW_HEAD
+    )
     assert roster_only == set()
 
 
@@ -298,7 +301,7 @@ def test_removed_line_colliding_with_header_marker_not_roster_only(tmp_path):
     Otherwise a workflow with an additional structural change could be
     misclassified as roster-only."""
     roster_only, _ = _roster_only_workflows(
-        _COLLIDING_HEADER_DIFF, {_WORKFLOW, _ENROLLED}
+        _COLLIDING_HEADER_DIFF, {_WORKFLOW, _ENROLLED}, _WORKFLOW_HEAD
     )
     assert roster_only == set()
 
@@ -307,7 +310,7 @@ def test_enrolling_modified_existing_test_not_roster_only(tmp_path):
     """Regression (codex r1 #2): the downgrade is for a NEWLY added test, so
     enrolling a test this PR merely edits must not qualify."""
     roster_only, _ = _roster_only_workflows(
-        _MODIFIED_TEST_DIFF, {_WORKFLOW, "tests/test_existing.py"}
+        _MODIFIED_TEST_DIFF, {_WORKFLOW, "tests/test_existing.py"}, _WORKFLOW_HEAD
     )
     assert roster_only == set()
 
@@ -317,7 +320,7 @@ def test_roster_token_outside_roster_list_not_roster_only(tmp_path):
     the workflow (outside the `pytest \\` roster) is not an enrollment, even
     though the token and new-file checks pass — it must NOT be downgraded."""
     roster_only, _ = _roster_only_workflows(
-        _NON_ROSTER_CONTEXT_DIFF, {_WORKFLOW, _ENROLLED}
+        _NON_ROSTER_CONTEXT_DIFF, {_WORKFLOW, _ENROLLED}, _WORKFLOW_HEAD
     )
     assert roster_only == set()
 
@@ -328,7 +331,7 @@ def test_hunk_boundary_not_roster_only(tmp_path):
     previous hunk's final roster line. Without this, a token placed outside
     the roster could be misclassified and downgraded."""
     roster_only, _ = _roster_only_workflows(
-        _HUNK_BOUNDARY_DIFF, {_WORKFLOW, _ENROLLED, _OTHER_NEW}
+        _HUNK_BOUNDARY_DIFF, {_WORKFLOW, _ENROLLED, _OTHER_NEW}, _WORKFLOW_HEAD
     )
     assert roster_only == set()
 
@@ -338,17 +341,7 @@ def test_non_continuing_pytest_command_not_roster_only(tmp_path):
     after a `pytest -q` command with NO continuation backslash is not in the
     multi-line roster and must not be treated as an enrollment."""
     roster_only, _ = _roster_only_workflows(
-        _NON_CONTINUING_PYTEST_DIFF, {_WORKFLOW, _ENROLLED}
-    )
-    assert roster_only == set()
-
-
-def test_terminal_anchor_entry_not_roster_only(tmp_path):
-    """Regression (codex r1 round-2): an added ``tests/foo.py \\`` line whose
-    preceding roster entry does NOT end in a continuation backslash runs as a
-    separate shell command, so it is not a pytest argument / enrollment."""
-    roster_only, _ = _roster_only_workflows(
-        _TERMINAL_ANCHOR_DIFF, {_WORKFLOW, _ENROLLED}
+        _NON_CONTINUING_PYTEST_DIFF, {_WORKFLOW, _ENROLLED}, _WORKFLOW_HEAD
     )
     assert roster_only == set()
 
@@ -357,7 +350,9 @@ def test_mode_change_with_roster_addition_not_roster_only(tmp_path):
     """Regression (codex r1 round-2): a mode change on the workflow file is
     structural, so even with a valid-looking roster addition the file must
     not be downgraded."""
-    roster_only, _ = _roster_only_workflows(_MODE_CHANGE_DIFF, {_WORKFLOW, _ENROLLED})
+    roster_only, _ = _roster_only_workflows(
+        _MODE_CHANGE_DIFF, {_WORKFLOW, _ENROLLED}, _WORKFLOW_HEAD
+    )
     assert roster_only == set()
 
 
@@ -365,17 +360,20 @@ def test_rename_with_roster_addition_not_roster_only(tmp_path):
     """Regression (codex r1 round-2): renaming the workflow file is not a
     roster-only enrollment even combined with a roster addition."""
     roster_only, _ = _roster_only_workflows(
-        _RENAME_DIFF, {_WORKFLOW, "tests/test_serving_lane_reason_contract.py"}
+        _RENAME_DIFF,
+        {_WORKFLOW, "tests/test_serving_lane_reason_contract.py"},
+        _WORKFLOW_HEAD,
     )
     assert roster_only == set()
 
 
-def test_non_pytest_command_chain_not_roster_only(tmp_path):
-    """Regression (codex r1 round-2): an added ``tests/foo.py \\`` line whose
-    continuation chain is rooted at a NON-pytest command (an uploader) is not
-    a roster enrollment and must NOT be downgraded."""
+def test_non_roster_line_not_roster_only(tmp_path):
+    """Regression (codex r1 round-3): an added ``tests/foo.py \\`` line whose
+    target line number is NOT an actual pytest-roster entry in the merged file
+    (e.g. inside an unrelated multiline command an uploader) is not an
+    enrollment — verified against ground truth, not hunk context."""
     roster_only, _ = _roster_only_workflows(
-        _NON_PYTEST_COMMAND_DIFF, {_WORKFLOW, _ENROLLED}
+        _NON_PYTEST_COMMAND_DIFF, {_WORKFLOW, _ENROLLED}, _WORKFLOW_HEAD
     )
     assert roster_only == set()
 

--- a/tests/test_pr_validate_supply_chain.py
+++ b/tests/test_pr_validate_supply_chain.py
@@ -440,10 +440,8 @@ def test_mid_list_no_backslash_entry_is_not_roster_only():
     assert roster_only == set()
 
 
-def test_terminal_roster_entry_without_backslash_stays_blocking():
-    """The workflow exception is fail-closed: even a genuinely terminal
-    no-backslash entry is outside the canonical roster form and stays subject
-    to maintainer review."""
+def test_terminal_roster_entry_without_backslash_is_enrollment():
+    """A genuine final argument at the end of the literal block is safe."""
     from scripts.pr_validate.steps.supply_chain import _pytest_roster_lines
 
     head = (
@@ -467,12 +465,11 @@ def test_terminal_roster_entry_without_backslash_stays_blocking():
         "+            tests/test_appended.py\n"
     )
     lines = _pytest_roster_lines(head)
-    # alpha (line 8) is continuing; terminal (line 9) has no backslash and is
-    # deliberately outside the narrow exception.
-    assert 9 not in lines
+    # alpha (line 8) is continuing; terminal (line 9) has no backslash but is
+    # the genuine end of the literal block.
+    assert 9 in lines
 
-    # End-to-end: the no-backslash edit stays blocking even though the test is
-    # genuinely new.
+    # End-to-end: the genuinely terminal no-backslash edit is an enrollment.
     newfile = (
         "diff --git a/tests/test_appended.py b/tests/test_appended.py\n"
         "new file mode 100644\n"
@@ -487,8 +484,8 @@ def test_terminal_roster_entry_without_backslash_stays_blocking():
         {".github/workflows/ci.yml", "tests/test_appended.py"},
         {".github/workflows/ci.yml": head},
     )
-    assert roster_only == set()
-    assert additions == {}
+    assert roster_only == {".github/workflows/ci.yml"}
+    assert additions[".github/workflows/ci.yml"] == ["tests/test_appended.py"]
 
 
 def test_no_backslash_before_pytest_options_stays_blocking():


### PR DESCRIPTION
## Why

Fixes #2522. The pr_validate `supply_chain` step flags ANY external-author PR that edits `.github/workflows/` as `[BLOCKING]`. But adding a new test legitimately does exactly what the explicit Apple/MLX test roster in `.github/workflows/ci.yml` asks for — appending one line (`tests/test_*.py \`) to enroll the test — and gets auto-blocked. The gate blocks the exact contribution it exists to encourage, forcing manual merges for every external "I added a test" PR.

## Scope

- `scripts/pr_validate/steps/supply_chain.py`: detect a "roster-only" workflow edit and downgrade the external-author hook finding from `[BLOCKING]` to `[warning]` (surfacing the enrolled test paths) in that narrow case.
- `tests/test_pr_validate_supply_chain.py`: new unit tests (repo `tests/` convention).

## Non-goals

- Not a general downgrade of workflow scrutiny: any non-roster workflow edit, removed/deleted line, structural edit (rename/copy/mode change), or any non-workflow hook file modified alongside (conftest.py, Makefile, dep files) still `[BLOCKING]` for external authors.
- Internal-author behavior unchanged (already `warning`).

## Acceptance

Maps 1:1 to issue #2522:
1. **Roster-only external change → warning (with hunk), not `[BLOCKING]`** — `test_external_roster_only_is_warning_not_blocking`.
2. **Any other workflow edit stays `[BLOCKING]`** — `test_external_arbitrary_workflow_edit_still_blocking`; `test_external_mixed_roster_plus_edit_still_blocking` (roster + `runs-on` change); `test_external_roster_plus_nonworkflow_hook_still_blocking` (roster + conftest change).
3. **Unit test covers roster-only AND mixed** — covered above.

### Roster-only rule (precisely)

For EACH modified workflow file, the change is roster-only only when ALL of:
- every diff line is a pure ADDITION matching `^\s*tests/[A-Za-z0-9_./-]+\.py\s*\\?\s*$` (optional trailing `\`), with NO removed lines and NO rename/copy/mode metadata;
- the enrolled path is a test this PR NEWLY creates (`new file mode`);
- the added line lands at a line that is ACTUALLY a pytest-roster entry in the merged file — verified against the real `.github/workflows/ci.yml` (ground truth, not hunk context): the contiguous `tests/*.py \` lines following a `pytest \` opener, plus the genuine final (no-backslash) entry;
- a no-backslash line is only a valid terminal entry if no continuing roster entry follows it (a sandwiched no-backslash insert is a behavior change → BLOCKING).

Downgrade fires ONLY when ALL hook files touched are workflow files and ALL are roster-only. Any other case → `[BLOCKING]`. Unreadable workflow / internal-author cases are handled conservatively (BLOCKING / existing warning).

## Verification

- [x] `python3 -m pytest tests/test_pr_validate_supply_chain.py` → 22 passed
- [x] `python3 -m pytest tests/test_pr_validate_*.py` → 359 passed (no pr_validate regressions)
- [x] `ruff check` on both changed files → clean
- [x] `ruff format --check` on both changed files → clean
- [x] Self-validated with pr_validate on this PR: fetch / test_plan / cl_description / supply_chain / test_env / review_vocabulary / **codex_review** / lint / targeted_tests all **OK**; targeted_tests 22 passed.
- [x] Spot-check: hand-traced roster-only vs mixed vs arbitrary vs metadata vs ground-truth diffs through `_roster_only_workflows`.
- full_unit note: the `full_unit` step fails 8 tests (`test_glm5_*`, `test_no_mllm_flag.py`, `test_pflash_cli_wiring.py`) in the LOCAL shared venv due to a pre-existing `mlx-vlm==0.6.17` version mismatch — confirmed identical on clean `origin/main` in the same venv. This PR touches only `scripts/pr_validate/steps/supply_chain.py` (+ its test), which those tests never import, so it is not a regression from this change.
- No breaking change / docs not needed (internal tooling behavior only).

## Behaviour delta

- External author: `[BLOCKING]` on any `.github/workflows/` edit → `[warning]` ONLY for a purely roster-only test-enrollment edit; every other workflow edit stays `[BLOCKING]`.

## AI assistance disclosure

Implementation and tests written by Claude (this agent) per operator-assigned issue #2522, refined through pr_validate's own codex adversarial review (each finding addressed with a regression test), and validated as listed above.

## Checklist

- [x] Tests pass locally
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with pr_validate (codex_review clean; fix its own findings across 7 rounds)