### PR TITLE
fix(server): synthesise schema-valid args for forced named calls (#2502)

### DIFF
--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -97,16 +97,17 @@ class TestSalvageForcedScalarArguments:
         assert json.loads(out) == {"degrees": 72}
 
     def test_fractional_float_rejected_for_integer_prop(self):
-        # A non-integer float would fail integer validation → refuse to salvage.
+        # A non-integral float would fail integer validation → refuse to salvage.
         int_tool = _tool("temperature", ["degrees"], ptype="integer")
         assert (
             _salvage_forced_scalar_arguments("temperature", "72.5", [int_tool]) is None
         )
-        # An integral float is still a FLOAT, whose json.loads parse may have
-        # already lost precision on large values — fail closed rather than
-        # int()-coerce (codex BLOCKING). Only a genuine JSON integer salvages.
+        # An INTEGRAL float is a valid JSON-Schema integer and the downstream
+        # jsonschema validator accepts it; serialize it verbatim (no lossy
+        # int()-coercion).
         assert (
-            _salvage_forced_scalar_arguments("temperature", "72.0", [int_tool]) is None
+            _salvage_forced_scalar_arguments("temperature", "72.0", [int_tool])
+            == '{"degrees": 72.0}'
         )
         assert (
             _salvage_forced_scalar_arguments("temperature", "72", [int_tool])

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#2502 — a concrete forced named tool call must yield schema-valid arguments
+when the small model emits the bare required value, while preserving the #1256
+fail-closed 422 for genuinely invalid generations.
+
+Repro (from the issue): ``tool_choice={"type":"function","function":{"name":
+"weather"}}`` against a JSON-schema tool whose ``parameters`` require ``city``.
+Qwen3.5-4B-4bit (Hermes parser) forced onto that tool emits ``"arguments":
+"San Francisco"`` — a bare scalar, not ``{"city": "San Francisco"}``. The
+forced-choice repair collapsed that to ``"{}"`` and the #1256 schema gate 422'd
+on the missing required ``city``; a more imperative re-prompt happened to work.
+
+Fix (schema-aware scalar salvage): when the target tool is an OBJECT-schema tool
+with EXACTLY ONE required property and the recovered ``arguments`` is a bare
+scalar whose type matches that property, synthesise ``{<prop>: <value>}``.
+Gated tightly — multi/zero-required schemas, type mismatches, JSON ``null``,
+arrays, and broken-object fragments all still fail closed exactly as before.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from vllm_mlx.routes.chat import (
+    _forced_synth_schema_error,
+    _recover_bare_scalar_from_raw,
+    _repair_forced_call_arguments,
+    _salvage_forced_scalar_arguments,
+    _synthesize_forced_tool_call,
+)
+
+
+def _tool(
+    name: str,
+    required: list[str] | None,
+    *,
+    ptype: str = "string",
+    props: dict | None = None,
+):
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": props or {required[0]: {"type": ptype}},
+    }
+    if required is not None:
+        schema["required"] = required
+    return SimpleNamespace(
+        type="function", function={"name": name, "parameters": schema}
+    )
+
+
+def _no_required_schema():
+    return SimpleNamespace(
+        type="function",
+        function={
+            "name": "ping",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    )
+
+
+_WEATHER = _tool("weather", ["city"])  # single required STRING prop
+_ADD = _tool("add", ["a", "b"], ptype="integer")  # multi-required
+_NUM = _tool("temperature", ["degrees"], ptype="number")  # single required NUMBER
+_OBJ_ARR = SimpleNamespace(
+    type="function",
+    function={
+        "name": "obj",
+        "parameters": {
+            "type": "object",
+            "properties": {"a": {"type": "integer"}},
+        },
+    },
+)
+
+
+# =====================================================================
+# Unit: _salvage_forced_scalar_arguments (the gated decision core)
+# =====================================================================
+
+
+class TestSalvageForcedScalarArguments:
+    def test_bare_string_maps_single_required_string_prop(self):
+        out = _salvage_forced_scalar_arguments("weather", "San Francisco", [_WEATHER])
+        assert out == '{"city": "San Francisco"}'
+
+    def test_json_string_value_maps_single_required_string_prop(self):
+        out = _salvage_forced_scalar_arguments("weather", '"SF"', [_WEATHER])
+        assert out == '{"city": "SF"}'
+
+    def test_number_maps_single_required_number_prop(self):
+        out = _salvage_forced_scalar_arguments("temperature", "72.5", [_NUM])
+        assert out == '{"degrees": 72.5}'
+
+    def test_integer_maps_number_prop(self):
+        out = _salvage_forced_scalar_arguments("temperature", "72", [_NUM])
+        assert json.loads(out) == {"degrees": 72}
+
+    def test_multi_required_never_guesses(self):
+        assert _salvage_forced_scalar_arguments("add", "7", [_ADD]) is None
+
+    def test_no_required_never_guesses(self):
+        assert _salvage_forced_scalar_arguments("ping", "x", [_no_required_schema()]) is None
+
+    def test_type_mismatch_never_guesses(self):
+        # Number scalar cannot satisfy a required STRING property.
+        assert _salvage_forced_scalar_arguments("weather", "42", [_WEATHER]) is None
+
+    def test_null_never_guesses(self):
+        # Explicit JSON ``null`` is a real value, not a salvageable scalar.
+        assert _salvage_forced_scalar_arguments("weather", "null", [_WEATHER]) is None
+
+    def test_array_never_guesses(self):
+        assert _salvage_forced_scalar_arguments("weather", "[1,2]", [_WEATHER]) is None
+
+    def test_object_value_never_guesses(self):
+        assert _salvage_forced_scalar_arguments("weather", "{}", [_WEATHER]) is None
+        assert (
+            _salvage_forced_scalar_arguments(
+                "weather", '{"city": "SF"}', [_WEATHER]
+            )
+            is None
+        )
+
+    def test_empty_arguments_never_guesses(self):
+        assert _salvage_forced_scalar_arguments("weather", "", [_WEATHER]) is None
+        assert _salvage_forced_scalar_arguments("weather", None, [_WEATHER]) is None
+
+    def test_broken_object_fragment_never_guesses_as_string(self):
+        # A fragment that was clearly aiming at a JSON object must not be mapped
+        # onto a string property — it fails closed instead.
+        assert (
+            _salvage_forced_scalar_arguments(
+                "weather", '{"unbalanced": ', [_WEATHER]
+            )
+            is None
+        )
+        assert (
+            _salvage_forced_scalar_arguments("weather", "[bad", [_WEATHER]) is None
+        )
+
+    def test_unknown_tool_never_guesses(self):
+        assert _salvage_forced_scalar_arguments("other", "x", [_WEATHER]) is None
+
+    def test_boolean_prop(self):
+        flag = _tool("toggle", ["on"], ptype="boolean")
+        assert _salvage_forced_scalar_arguments("toggle", "true", [flag]) == '{"on": true}'
+        # A string cannot satisfy a boolean prop.
+        assert _salvage_forced_scalar_arguments("toggle", "yes", [flag]) is None
+        # A bool must not be coerced to a NUMBER prop.
+        assert _salvage_forced_scalar_arguments("temperature", "true", [_NUM]) is None
+
+
+# =====================================================================
+# _forced_synth_schema_error: salvage succeeds (no 422) where appropriate,
+# and genuinely invalid cases still fail closed with the existing message.
+# =====================================================================
+
+
+class TestForcedSynthSchemaErrorWithSalvage:
+    def test_bare_string_now_valid_for_single_required_string_prop(self):
+        # NEW: no longer a false 422.
+        assert (
+            _forced_synth_schema_error("weather", "San Francisco", [_WEATHER])
+            is None
+        )
+
+    def test_json_string_now_valid_for_single_required_string_prop(self):
+        assert _forced_synth_schema_error("weather", '"SF"', [_WEATHER]) is None
+
+    def test_number_now_valid_for_single_required_number_prop(self):
+        assert _forced_synth_schema_error("temperature", "72", [_NUM]) is None
+
+    def test_missing_required_multi_still_422(self):
+        err = _forced_synth_schema_error("add", "{}", [_ADD])
+        assert err is not None
+        assert "required" in err.lower() or "1256" in err
+
+    def test_scalar_violating_type_still_422(self):
+        # Number scalar against a required STRING prop → no salvage → 422.
+        assert _forced_synth_schema_error("weather", "42", [_WEATHER]) is not None
+
+    def test_null_still_422(self):
+        # Explicit null offers nothing to salvage (codex r3 preserved).
+        assert _forced_synth_schema_error("weather", "null", [_WEATHER]) is not None
+
+    def test_array_against_object_schema_still_422(self):
+        assert _forced_synth_schema_error("obj", "[1,2]", [_OBJ_ARR]) is not None
+
+    def test_broken_object_fragment_still_422(self):
+        # A fragment that looks like a broken object is not a salvageable
+        # scalar; it keeps failing closed (regression guard).
+        assert (
+            _forced_synth_schema_error("weather", '{"unbalanced": ', [_WEATHER])
+            is not None
+        )
+
+    def test_valid_object_unchanged(self):
+        assert _forced_synth_schema_error("weather", '{"city": "SF"}', [_WEATHER]) is None
+
+
+# =====================================================================
+# _synthesize_forced_tool_call: produces a schema-valid object for a bare scalar
+# =====================================================================
+
+
+class TestSynthesizeForcedToolCallScalar:
+    def test_direct_bare_scalar_with_tools_synthesizes_valid_object(self):
+        call = _synthesize_forced_tool_call(
+            "weather", "San Francisco", tools=[_WEATHER]
+        )
+        assert call.function.name == "weather"
+        assert json.loads(call.function.arguments) == {"city": "San Francisco"}
+
+    def test_direct_bare_scalar_no_tools_keeps_default(self):
+        # Without the schema we must NOT guess — keep the caller's argument.
+        call = _synthesize_forced_tool_call("weather", "San Francisco")
+        assert call.function.arguments == "San Francisco"
+
+    def test_recovery_from_raw_scalar_emission(self):
+        raw = '<tool_call>{"name": "weather", "arguments": "New York"}'
+        call = _synthesize_forced_tool_call("weather", raw_text=raw, tools=[_WEATHER])
+        assert json.loads(call.function.arguments) == {"city": "New York"}
+
+    def test_multi_required_never_guesses_in_synthesis(self):
+        # tools has multi-required → no salvage → unchanged ("{}" default).
+        call = _synthesize_forced_tool_call("add", raw_text="", tools=[_ADD])
+        assert call.function.arguments == "{}"
+
+    def test_recovered_object_still_preferred(self):
+        # A recoverable object beats scalar salvage.
+        raw = '<tool_call>{"name": "weather", "arguments": {"city": "LA"}}'
+        call = _synthesize_forced_tool_call("weather", raw_text=raw, tools=[_WEATHER])
+        assert json.loads(call.function.arguments) == {"city": "LA"}
+
+
+# =====================================================================
+# _repair_forced_call_arguments (the live repro path): writes the valid object
+# back onto the wire; genuinely invalid cases still 422.
+# =====================================================================
+
+
+def _call(arguments):
+    return SimpleNamespace(
+        id="call_x",
+        type="function",
+        function=SimpleNamespace(name="weather", arguments=arguments),
+    )
+
+
+class TestRepairForcedCallArgumentsScalar:
+    def test_bare_scalar_repairs_to_schema_valid_object(self):
+        tc = _call("San Francisco")
+        err = _repair_forced_call_arguments([tc], "", "weather", [_WEATHER])
+        assert err is None
+        assert json.loads(tc.function.arguments) == {"city": "San Francisco"}
+
+    def test_multi_required_invalid_still_returns_error(self):
+        tc = _call("1")  # actually ends up "1" against add
+        tc.function.name = "add"
+        err = _repair_forced_call_arguments([tc], "", "add", [_ADD])
+        assert err is not None
+        assert tc.function.arguments == "{}"
+
+    def test_no_required_still_repairs_to_empty_object(self):
+        tc = _call("1")
+        err = _repair_forced_call_arguments([tc], "", "ping", [_no_required_schema()])
+        assert err is None
+        assert tc.function.arguments == "{}"
+
+
+# =====================================================================
+# _recover_bare_scalar_from_raw: bounded scalar recovery from response text
+# =====================================================================
+
+
+class TestRecoverBareScalarFromRaw:
+    def test_extracts_quoted_scalar_in_envelope(self):
+        raw = '<tool_call>{"name": "weather", "arguments": "San Francisco"}'
+        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") == '"San Francisco"'
+
+    def test_extracts_unquoted_number_in_envelope(self):
+        raw = '<tool_call>{"name": "temperature", "arguments": 72}'
+        assert _recover_bare_scalar_from_raw(raw, expected_name="temperature") == "72"
+
+    def test_ignores_object_argument(self):
+        raw = '<tool_call>{"name": "weather", "arguments": {"city": "SF"}}'
+        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") is None
+
+    def test_ignores_mismatched_name(self):
+        raw = '<tool_call>{"name": "other", "arguments": "San Francisco"}'
+        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") is None
+
+    def test_ignores_null(self):
+        raw = '<tool_call>{"name": "weather", "arguments": null}'
+        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") is None
+
+    def test_empty_or_none_returns_none(self):
+        assert _recover_bare_scalar_from_raw(None) is None
+        assert _recover_bare_scalar_from_raw("") is None

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -371,6 +371,32 @@ class TestRecoverBareScalarFromRaw:
             )
             is None
         )
+        # codex round-4: a colon or stray angle-bracket is NOT a valid terminator.
+        assert (
+            _recover_bare_scalar_from_raw(
+                '<tool_call>{"name": "x", "arguments": "SF": garbage}',
+                expected_name="x",
+            )
+            is None
+        )
+        assert (
+            _recover_bare_scalar_from_raw(
+                '<tool_call>{"name": "x", "arguments": 72<junk}', expected_name="x"
+            )
+            is None
+        )
+
+    def test_multiple_matching_candidates_is_ambiguous_none(self):
+        # codex round-4: two scalar candidates pairing with the SAME target name
+        # is ambiguous — fail closed (None) rather than pick the last.
+        raw = (
+            '<tool_call>{"name": "weather", "arguments": "SF"}'
+            '{"name": "weather", "arguments": "NY"}'
+        )
+        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") is None
+        # A single candidate still resolves.
+        raw2 = '<tool_call>{"name": "weather", "arguments": "SF"}'
+        assert _recover_bare_scalar_from_raw(raw2, expected_name="weather") == '"SF"'
 
     def test_name_pairing_decodes_json_escapes(self):
         # codex NIT: any valid JSON string escape decodes for the pairing check.

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -175,6 +175,33 @@ class TestSalvageForcedScalarArguments:
     def test_unknown_tool_never_guesses(self):
         assert _salvage_forced_scalar_arguments("other", "x", [_WEATHER]) is None
 
+    def test_malformed_schema_never_guesses_or_crashes(self):
+        # codex round-8: a malformed client schema must fail closed, not crash.
+        bad_props = SimpleNamespace(
+            type="function",
+            function={
+                "name": "x",
+                "parameters": {
+                    "type": "object",
+                    "properties": [],  # a list, not a dict
+                    "required": ["a"],
+                },
+            },
+        )
+        bad_required = SimpleNamespace(
+            type="function",
+            function={
+                "name": "x",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"a": {"type": "integer"}},
+                    "required": [["a"]],  # non-string sole entry
+                },
+            },
+        )
+        assert _salvage_forced_scalar_arguments("x", "7", [bad_props]) is None
+        assert _salvage_forced_scalar_arguments("x", "7", [bad_required]) is None
+
     def test_boolean_prop(self):
         flag = _tool("toggle", ["on"], ptype="boolean")
         assert (

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -176,6 +176,21 @@ class TestSalvageForcedScalarArguments:
     def test_unknown_tool_never_guesses(self):
         assert _salvage_forced_scalar_arguments("other", "x", [_WEATHER]) is None
 
+    def test_dict_tool_shape_is_supported(self):
+        tool = {"type": "function", "function": _WEATHER.function}
+        assert _salvage_forced_scalar_arguments("weather", "Paris", [tool]) == (
+            '{"city": "Paris"}'
+        )
+
+    def test_exotic_property_type_never_guesses(self):
+        array_tool = _tool("collect", ["items"], ptype="array")
+        assert (
+            _salvage_forced_scalar_arguments("collect", "value", [array_tool]) is None
+        )
+
+    def test_non_string_argument_object_never_guesses(self):
+        assert _salvage_forced_scalar_arguments("weather", object(), [_WEATHER]) is None
+
     def test_malformed_schema_never_guesses_or_crashes(self):
         # codex round-8: a malformed client schema must fail closed, not crash.
         bad_props = SimpleNamespace(
@@ -212,6 +227,11 @@ class TestSalvageForcedScalarArguments:
         assert _salvage_forced_scalar_arguments("toggle", "yes", [flag]) is None
         # A bool must not be coerced to a NUMBER prop.
         assert _salvage_forced_scalar_arguments("temperature", "true", [_NUM]) is None
+        int_tool = _tool("count", ["value"], ptype="integer")
+        assert _salvage_forced_scalar_arguments("count", "true", [int_tool]) is None
+
+    def test_string_never_coerces_to_number(self):
+        assert _salvage_forced_scalar_arguments("temperature", "warm", [_NUM]) is None
 
 
 # =====================================================================

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -97,15 +97,19 @@ class TestSalvageForcedScalarArguments:
         assert json.loads(out) == {"degrees": 72}
 
     def test_fractional_float_rejected_for_integer_prop(self):
-        # codex NIT round-5: a non-integer float would fail integer validation;
-        # refuse to salvage it (fail closed).
+        # A non-integer float would fail integer validation → refuse to salvage.
         int_tool = _tool("temperature", ["degrees"], ptype="integer")
         assert (
             _salvage_forced_scalar_arguments("temperature", "72.5", [int_tool]) is None
         )
-        # An integral float is fine.
+        # An integral float is still a FLOAT, whose json.loads parse may have
+        # already lost precision on large values — fail closed rather than
+        # int()-coerce (codex BLOCKING). Only a genuine JSON integer salvages.
         assert (
-            _salvage_forced_scalar_arguments("temperature", "72.0", [int_tool])
+            _salvage_forced_scalar_arguments("temperature", "72.0", [int_tool]) is None
+        )
+        assert (
+            _salvage_forced_scalar_arguments("temperature", "72", [int_tool])
             == '{"degrees": 72}'
         )
 
@@ -148,6 +152,17 @@ class TestSalvageForcedScalarArguments:
             is None
         )
         assert _salvage_forced_scalar_arguments("weather", "[bad", [_WEATHER]) is None
+
+    def test_legit_string_with_colon_is_accepted(self):
+        # codex round-6: a bare string containing ':' is not necessarily a broken
+        # object — e.g. a URL. Only STRUCTURAL-LED text is rejected.
+        url_tool = _tool("lookup", ["url"], ptype="string")
+        assert (
+            _salvage_forced_scalar_arguments(
+                "lookup", "https://example.com", [url_tool]
+            )
+            == '{"url": "https://example.com"}'
+        )
 
     def test_unknown_tool_never_guesses(self):
         assert _salvage_forced_scalar_arguments("other", "x", [_WEATHER]) is None

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -308,6 +308,27 @@ class TestRecoverBareScalarFromRaw:
         raw = '<tool_call>{"name": "x", "arguments" garbage, "foo": 7}'
         assert _recover_bare_scalar_from_raw(raw, expected_name="x") is None
 
+    def test_rejects_malformed_value_prefixes(self):
+        # codex BLOCKING: ``72oops`` / ``trueish`` must NOT be truncated to a
+        # valid-looking scalar prefix.
+        assert (
+            _recover_bare_scalar_from_raw(
+                '<tool_call>{"name": "x", "arguments": 72oops}', expected_name="x"
+            )
+            is None
+        )
+        assert (
+            _recover_bare_scalar_from_raw(
+                '<tool_call>{"name": "x", "arguments": trueish}', expected_name="x"
+            )
+            is None
+        )
+
+    def test_name_pairing_decodes_json_escapes(self):
+        # codex NIT: any valid JSON string escape decodes for the pairing check.
+        raw = '<tool_call>{"name": "we\\u0061ther", "arguments": "SF"}'
+        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") == '"SF"'
+
     def test_pairing_uses_nearest_preceding_name_in_multi_call_span(self):
         # codex BLOCKING #1: two calls in one span — the second scalar must pair
         # with the SECOND tool ("other"), not the span's first ("weather").
@@ -319,11 +340,11 @@ class TestRecoverBareScalarFromRaw:
         # a string scalar, and 1 is a number but pairs with weather... both here).
         recovered = _recover_bare_scalar_from_raw(raw, expected_name="other")
         assert recovered == '"San Francisco"'
-        # Searching for the first tool yields None (its scalar is numeric "1",
-        # which is still returned as a scalar — so pairing must gate it too).
-        # Verify pairing does NOT let the first tool's scalar attach to "other".
-        bad = _recover_bare_scalar_from_raw(raw, expected_name="weather")
-        assert bad in ("1", None)  # "weather" owns the first, numeric scalar
+        # Searching for the first tool yields ITS OWN numeric scalar "1" — the
+        # names in a multi-call span must not cross-attach.
+        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") == "1"
+        # A name that is not present pairs with nothing.
+        assert _recover_bare_scalar_from_raw(raw, expected_name="nope") is None
 
 
 class TestSalvageRejectsNonFinite:

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -122,6 +122,19 @@ class TestSalvageForcedScalarArguments:
         out = _salvage_forced_scalar_arguments("temperature", "72", [_NUM])
         assert json.loads(out) == {"degrees": 72}
 
+    def test_fractional_float_rejected_for_integer_prop(self):
+        # codex NIT round-5: a non-integer float would fail integer validation;
+        # refuse to salvage it (fail closed).
+        int_tool = _tool("temperature", ["degrees"], ptype="integer")
+        assert (
+            _salvage_forced_scalar_arguments("temperature", "72.5", [int_tool]) is None
+        )
+        # An integral float is fine.
+        assert (
+            _salvage_forced_scalar_arguments("temperature", "72.0", [int_tool])
+            == '{"degrees": 72}'
+        )
+
     def test_multi_required_never_guesses(self):
         assert _salvage_forced_scalar_arguments("add", "7", [_ADD]) is None
 

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -152,6 +152,14 @@ class TestSalvageForcedScalarArguments:
             is None
         )
         assert _salvage_forced_scalar_arguments("weather", "[bad", [_WEATHER]) is None
+        # A whitespace-prefixed broken fragment also fails closed (codex).
+        assert (
+            _salvage_forced_scalar_arguments("weather", '  {"unbalanced": ', [_WEATHER])
+            is None
+        )
+        assert (
+            _salvage_forced_scalar_arguments("weather", "  [bad,", [_WEATHER]) is None
+        )
 
     def test_legit_string_with_colon_is_accepted(self):
         # codex round-6: a bare string containing ':' is not necessarily a broken

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -25,35 +25,9 @@ from typing import Any
 
 from vllm_mlx.routes.chat import (
     _forced_synth_schema_error,
-    _recover_bare_scalar_from_raw,
     _repair_forced_call_arguments,
     _salvage_forced_scalar_arguments,
     _synthesize_forced_tool_call,
-)
-
-# DeepSeek-style tool-call wire delimiters (begin / end), matching the route's
-# ``_WIRE_OPENERS`` / ``_WIRE_CLOSERS`` byte-for-byte.
-_BEGIN_MARKER = (
-    "<"
-    + chr(0xFF5C)
-    + "tool"
-    + chr(0x2581)
-    + "calls"
-    + chr(0x2581)
-    + "begin"
-    + chr(0xFF5C)
-    + ">"
-)
-_END_MARKER = (
-    "<"
-    + chr(0xFF5C)
-    + "tool"
-    + chr(0x2581)
-    + "calls"
-    + chr(0x2581)
-    + "end"
-    + chr(0xFF5C)
-    + ">"
 )
 
 
@@ -256,10 +230,14 @@ class TestSynthesizeForcedToolCallScalar:
         call = _synthesize_forced_tool_call("weather", "San Francisco")
         assert call.function.arguments == "San Francisco"
 
-    def test_recovery_from_raw_scalar_emission(self):
+    def test_raw_text_scalar_not_guessed_in_synthesis(self):
+        # Raw-text scalar recovery is deliberately conservative (excluded) — the
+        # verified #2502 path is the parser-SURFACED scalar repair; synthesising
+        # a scalar out of free-form text risks structural-parse edge cases, so
+        # with the default ``"{}"`` arguments we keep the fallback unchanged.
         raw = '<tool_call>{"name": "weather", "arguments": "New York"}'
         call = _synthesize_forced_tool_call("weather", raw_text=raw, tools=[_WEATHER])
-        assert json.loads(call.function.arguments) == {"city": "New York"}
+        assert call.function.arguments == "{}"
 
     def test_multi_required_never_guesses_in_synthesis(self):
         # tools has multi-required → no salvage → unchanged ("{}" default).
@@ -306,132 +284,6 @@ class TestRepairForcedCallArgumentsScalar:
         err = _repair_forced_call_arguments([tc], "", "ping", [_no_required_schema()])
         assert err is None
         assert tc.function.arguments == "{}"
-
-
-# =====================================================================
-# _recover_bare_scalar_from_raw: bounded scalar recovery from response text
-# =====================================================================
-
-
-class TestRecoverBareScalarFromRaw:
-    def test_extracts_quoted_scalar_in_envelope(self):
-        raw = '<tool_call>{"name": "weather", "arguments": "San Francisco"}'
-        assert (
-            _recover_bare_scalar_from_raw(raw, expected_name="weather")
-            == '"San Francisco"'
-        )
-
-    def test_extracts_unquoted_number_in_envelope(self):
-        raw = '<tool_call>{"name": "temperature", "arguments": 72}'
-        assert _recover_bare_scalar_from_raw(raw, expected_name="temperature") == "72"
-
-    def test_ignores_object_argument(self):
-        raw = '<tool_call>{"name": "weather", "arguments": {"city": "SF"}}'
-        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") is None
-
-    def test_ignores_mismatched_name(self):
-        raw = '<tool_call>{"name": "other", "arguments": "San Francisco"}'
-        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") is None
-
-    def test_ignores_null(self):
-        raw = '<tool_call>{"name": "weather", "arguments": null}'
-        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") is None
-
-    def test_empty_or_none_returns_none(self):
-        assert _recover_bare_scalar_from_raw(None) is None
-        assert _recover_bare_scalar_from_raw("") is None
-
-    def test_begin_end_marker_wire_format_recovers_scalar(self):
-        # codex BLOCKING (round 3): the begin marker must not also be treated as
-        # a closer, or no scalar inside this wire format would recover. The begin
-        # (more) and end (尽) markers are the DeepSeek-style tool-call delimiters.
-        begin = _BEGIN_MARKER
-        end = _END_MARKER
-        raw = begin + '{"name": "weather", "arguments": "SF"}' + end
-        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") == '"SF"'
-
-    def test_rejects_colon_with_intervening_garbage(self):
-        # codex BLOCKING #2: the key must be immediately followed by a colon.
-        raw = '<tool_call>{"name": "x", "arguments" garbage, "foo": 7}'
-        assert _recover_bare_scalar_from_raw(raw, expected_name="x") is None
-
-    def test_rejects_malformed_value_prefixes(self):
-        # codex BLOCKING: ``72oops`` / ``trueish`` must NOT be truncated to a
-        # valid-looking scalar prefix.
-        assert (
-            _recover_bare_scalar_from_raw(
-                '<tool_call>{"name": "x", "arguments": 72oops}', expected_name="x"
-            )
-            is None
-        )
-        assert (
-            _recover_bare_scalar_from_raw(
-                '<tool_call>{"name": "x", "arguments": trueish}', expected_name="x"
-            )
-            is None
-        )
-        # Trailing garbage after whitespace is also rejected.
-        assert (
-            _recover_bare_scalar_from_raw(
-                '<tool_call>{"name": "x", "arguments": 72 oops}', expected_name="x"
-            )
-            is None
-        )
-        assert (
-            _recover_bare_scalar_from_raw(
-                '<tool_call>{"name": "x", "arguments": "SF" garbage}',
-                expected_name="x",
-            )
-            is None
-        )
-        # codex round-4: a colon or stray angle-bracket is NOT a valid terminator.
-        assert (
-            _recover_bare_scalar_from_raw(
-                '<tool_call>{"name": "x", "arguments": "SF": garbage}',
-                expected_name="x",
-            )
-            is None
-        )
-        assert (
-            _recover_bare_scalar_from_raw(
-                '<tool_call>{"name": "x", "arguments": 72<junk}', expected_name="x"
-            )
-            is None
-        )
-
-    def test_multiple_matching_candidates_is_ambiguous_none(self):
-        # codex round-4: two scalar candidates pairing with the SAME target name
-        # is ambiguous — fail closed (None) rather than pick the last.
-        raw = (
-            '<tool_call>{"name": "weather", "arguments": "SF"}'
-            '{"name": "weather", "arguments": "NY"}'
-        )
-        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") is None
-        # A single candidate still resolves.
-        raw2 = '<tool_call>{"name": "weather", "arguments": "SF"}'
-        assert _recover_bare_scalar_from_raw(raw2, expected_name="weather") == '"SF"'
-
-    def test_name_pairing_decodes_json_escapes(self):
-        # codex NIT: any valid JSON string escape decodes for the pairing check.
-        raw = '<tool_call>{"name": "we\\u0061ther", "arguments": "SF"}'
-        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") == '"SF"'
-
-    def test_pairing_uses_nearest_preceding_name_in_multi_call_span(self):
-        # codex BLOCKING #1: two calls in one span — the second scalar must pair
-        # with the SECOND tool ("other"), not the span's first ("weather").
-        raw = (
-            '<tool_call>{"name": "weather", "arguments": 1}'
-            '{"name": "other", "arguments": "San Francisco"}'
-        )
-        # Searching for the FIRST tool's scalar yields nothing (only "other" has
-        # a string scalar, and 1 is a number but pairs with weather... both here).
-        recovered = _recover_bare_scalar_from_raw(raw, expected_name="other")
-        assert recovered == '"San Francisco"'
-        # Searching for the first tool yields ITS OWN numeric scalar "1" — the
-        # names in a multi-call span must not cross-attach.
-        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") == "1"
-        # A name that is not present pairs with nothing.
-        assert _recover_bare_scalar_from_raw(raw, expected_name="nope") is None
 
 
 class TestSalvageRejectsNonFinite:

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -31,6 +31,31 @@ from vllm_mlx.routes.chat import (
     _synthesize_forced_tool_call,
 )
 
+# DeepSeek-style tool-call wire delimiters (begin / end), matching the route's
+# ``_WIRE_OPENERS`` / ``_WIRE_CLOSERS`` byte-for-byte.
+_BEGIN_MARKER = (
+    "<"
+    + chr(0xFF5C)
+    + "tool"
+    + chr(0x2581)
+    + "calls"
+    + chr(0x2581)
+    + "begin"
+    + chr(0xFF5C)
+    + ">"
+)
+_END_MARKER = (
+    "<"
+    + chr(0xFF5C)
+    + "tool"
+    + chr(0x2581)
+    + "calls"
+    + chr(0x2581)
+    + "end"
+    + chr(0xFF5C)
+    + ">"
+)
+
 
 def _tool(
     name: str,
@@ -303,6 +328,15 @@ class TestRecoverBareScalarFromRaw:
         assert _recover_bare_scalar_from_raw(None) is None
         assert _recover_bare_scalar_from_raw("") is None
 
+    def test_begin_end_marker_wire_format_recovers_scalar(self):
+        # codex BLOCKING (round 3): the begin marker must not also be treated as
+        # a closer, or no scalar inside this wire format would recover. The begin
+        # (more) and end (尽) markers are the DeepSeek-style tool-call delimiters.
+        begin = _BEGIN_MARKER
+        end = _END_MARKER
+        raw = begin + '{"name": "weather", "arguments": "SF"}' + end
+        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") == '"SF"'
+
     def test_rejects_colon_with_intervening_garbage(self):
         # codex BLOCKING #2: the key must be immediately followed by a colon.
         raw = '<tool_call>{"name": "x", "arguments" garbage, "foo": 7}'
@@ -320,6 +354,20 @@ class TestRecoverBareScalarFromRaw:
         assert (
             _recover_bare_scalar_from_raw(
                 '<tool_call>{"name": "x", "arguments": trueish}', expected_name="x"
+            )
+            is None
+        )
+        # Trailing garbage after whitespace is also rejected.
+        assert (
+            _recover_bare_scalar_from_raw(
+                '<tool_call>{"name": "x", "arguments": 72 oops}', expected_name="x"
+            )
+            is None
+        )
+        assert (
+            _recover_bare_scalar_from_raw(
+                '<tool_call>{"name": "x", "arguments": "SF" garbage}',
+                expected_name="x",
             )
             is None
         )

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -101,7 +101,10 @@ class TestSalvageForcedScalarArguments:
         assert _salvage_forced_scalar_arguments("add", "7", [_ADD]) is None
 
     def test_no_required_never_guesses(self):
-        assert _salvage_forced_scalar_arguments("ping", "x", [_no_required_schema()]) is None
+        assert (
+            _salvage_forced_scalar_arguments("ping", "x", [_no_required_schema()])
+            is None
+        )
 
     def test_type_mismatch_never_guesses(self):
         # Number scalar cannot satisfy a required STRING property.
@@ -117,9 +120,7 @@ class TestSalvageForcedScalarArguments:
     def test_object_value_never_guesses(self):
         assert _salvage_forced_scalar_arguments("weather", "{}", [_WEATHER]) is None
         assert (
-            _salvage_forced_scalar_arguments(
-                "weather", '{"city": "SF"}', [_WEATHER]
-            )
+            _salvage_forced_scalar_arguments("weather", '{"city": "SF"}', [_WEATHER])
             is None
         )
 
@@ -131,21 +132,19 @@ class TestSalvageForcedScalarArguments:
         # A fragment that was clearly aiming at a JSON object must not be mapped
         # onto a string property — it fails closed instead.
         assert (
-            _salvage_forced_scalar_arguments(
-                "weather", '{"unbalanced": ', [_WEATHER]
-            )
+            _salvage_forced_scalar_arguments("weather", '{"unbalanced": ', [_WEATHER])
             is None
         )
-        assert (
-            _salvage_forced_scalar_arguments("weather", "[bad", [_WEATHER]) is None
-        )
+        assert _salvage_forced_scalar_arguments("weather", "[bad", [_WEATHER]) is None
 
     def test_unknown_tool_never_guesses(self):
         assert _salvage_forced_scalar_arguments("other", "x", [_WEATHER]) is None
 
     def test_boolean_prop(self):
         flag = _tool("toggle", ["on"], ptype="boolean")
-        assert _salvage_forced_scalar_arguments("toggle", "true", [flag]) == '{"on": true}'
+        assert (
+            _salvage_forced_scalar_arguments("toggle", "true", [flag]) == '{"on": true}'
+        )
         # A string cannot satisfy a boolean prop.
         assert _salvage_forced_scalar_arguments("toggle", "yes", [flag]) is None
         # A bool must not be coerced to a NUMBER prop.
@@ -162,8 +161,7 @@ class TestForcedSynthSchemaErrorWithSalvage:
     def test_bare_string_now_valid_for_single_required_string_prop(self):
         # NEW: no longer a false 422.
         assert (
-            _forced_synth_schema_error("weather", "San Francisco", [_WEATHER])
-            is None
+            _forced_synth_schema_error("weather", "San Francisco", [_WEATHER]) is None
         )
 
     def test_json_string_now_valid_for_single_required_string_prop(self):
@@ -197,7 +195,9 @@ class TestForcedSynthSchemaErrorWithSalvage:
         )
 
     def test_valid_object_unchanged(self):
-        assert _forced_synth_schema_error("weather", '{"city": "SF"}', [_WEATHER]) is None
+        assert (
+            _forced_synth_schema_error("weather", '{"city": "SF"}', [_WEATHER]) is None
+        )
 
 
 # =====================================================================
@@ -278,7 +278,10 @@ class TestRepairForcedCallArgumentsScalar:
 class TestRecoverBareScalarFromRaw:
     def test_extracts_quoted_scalar_in_envelope(self):
         raw = '<tool_call>{"name": "weather", "arguments": "San Francisco"}'
-        assert _recover_bare_scalar_from_raw(raw, expected_name="weather") == '"San Francisco"'
+        assert (
+            _recover_bare_scalar_from_raw(raw, expected_name="weather")
+            == '"San Francisco"'
+        )
 
     def test_extracts_unquoted_number_in_envelope(self):
         raw = '<tool_call>{"name": "temperature", "arguments": 72}'
@@ -299,3 +302,38 @@ class TestRecoverBareScalarFromRaw:
     def test_empty_or_none_returns_none(self):
         assert _recover_bare_scalar_from_raw(None) is None
         assert _recover_bare_scalar_from_raw("") is None
+
+    def test_rejects_colon_with_intervening_garbage(self):
+        # codex BLOCKING #2: the key must be immediately followed by a colon.
+        raw = '<tool_call>{"name": "x", "arguments" garbage, "foo": 7}'
+        assert _recover_bare_scalar_from_raw(raw, expected_name="x") is None
+
+    def test_pairing_uses_nearest_preceding_name_in_multi_call_span(self):
+        # codex BLOCKING #1: two calls in one span — the second scalar must pair
+        # with the SECOND tool ("other"), not the span's first ("weather").
+        raw = (
+            '<tool_call>{"name": "weather", "arguments": 1}'
+            '{"name": "other", "arguments": "San Francisco"}'
+        )
+        # Searching for the FIRST tool's scalar yields nothing (only "other" has
+        # a string scalar, and 1 is a number but pairs with weather... both here).
+        recovered = _recover_bare_scalar_from_raw(raw, expected_name="other")
+        assert recovered == '"San Francisco"'
+        # Searching for the first tool yields None (its scalar is numeric "1",
+        # which is still returned as a scalar — so pairing must gate it too).
+        # Verify pairing does NOT let the first tool's scalar attach to "other".
+        bad = _recover_bare_scalar_from_raw(raw, expected_name="weather")
+        assert bad in ("1", None)  # "weather" owns the first, numeric scalar
+
+
+class TestSalvageRejectsNonFinite:
+    def test_non_finite_float_never_salvages(self):
+        # codex BLOCKING #3: NaN/Infinity are not strict JSON — never emit them.
+        assert _salvage_forced_scalar_arguments("temperature", "NaN", [_NUM]) is None
+        assert (
+            _salvage_forced_scalar_arguments("temperature", "Infinity", [_NUM]) is None
+        )
+        assert (
+            _salvage_forced_scalar_arguments("temperature", "72.5", [_NUM])
+            == '{"degrees": 72.5}'
+        )

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3055,7 +3055,9 @@ def _salvage_forced_scalar_arguments(
         # accepted (codex); ``{"unbalanced": ...`` / ``["bad`` are rejected.
         if not isinstance(arguments, str) or not arguments.strip():
             return None
-        if arguments[0] in '{}["':
+        # Inspect the first NON-WHITESPACE char so a whitespace-prefixed broken
+        # object/array fragment (`  {"unbalanced": ...`) still fails closed.
+        if arguments.lstrip()[0] in '{}["':
             return None
         value = arguments
     elif isinstance(decoded, (str, int, float, bool)):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2982,12 +2982,16 @@ def _recover_bare_scalar_from_raw(
         block = text[lo:marker]
 
         last: re.Match | None = None
-        for m in re.finditer(r"\"name\"\s*:\s*\"([^\"]*)\"", block):
+        for m in re.finditer(r'"name"\s*:\s*("(?:[^"\\]|\\.)*")', block):
             last = m
         if last is None:
             return False
-        # Decode common JSON escapes for a fair comparison.
-        decoded = last.group(1).replace("\\u005f", "_")
+        # Decode the complete JSON string literal so ALL valid JSON escapes
+        # (\\, \", \uXXXX ...) compare fairly (codex NIT), not just _.
+        try:
+            decoded = json.loads(last.group(1))
+        except (ValueError, TypeError):
+            return False
         return decoded == expected_name
 
     # Scan every ``"arguments"`` marker; prefer the LAST candidate inside a
@@ -3026,6 +3030,7 @@ def _recover_bare_scalar_from_raw(
             if end >= len(rest):
                 continue
             scalar = rest[: end + 1]
+            after = end + 1
         elif ch == "{":
             continue  # object — not our concern here
         elif ch == "[":
@@ -3042,6 +3047,13 @@ def _recover_bare_scalar_from_raw(
                 scalar = token
             else:
                 continue
+            after = j
+        # Fail closed on malformed values: a bare scalar must be followed by a
+        # JSON/structural terminator (`,` `}` `]` whitespace or a wire closer),
+        # never a stray alphanumeric (`"arguments": 72oops` / `trueish`).
+        terminated = after >= len(rest) or rest[after] in " \t\r\n,}]:/>"
+        if not terminated:
+            continue
         # Ensure the scalar re-parses to a scalar (never an object/array/null).
         try:
             v = json.loads(scalar)

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3105,7 +3105,7 @@ def _salvage_forced_scalar_arguments(
         if isinstance(value, bool):
             return json.dumps({prop: value})
         return None
-    return None
+    return None  # pragma: no cover - ptype was exhaustively restricted above
 
 
 def _forced_synth_schema_error(name: str, arguments: str | None, tools) -> str | None:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2850,12 +2850,28 @@ def _repair_forced_call_arguments(tool_calls, raw_text, target, tools):
     # NEXT TO valid ones the recovery would lift a VALID call's
     # arguments into the broken one (codex r3). Ambiguous cases repair
     # to "{}".
-    recovered = (
+    retrieved = (
         _recover_partial_tool_args(raw_text, expected_name=target)
         if len(broken) == 1 and len(tool_calls or []) == 1
         else None
     )
-    repaired = recovered if recovered is not None else "{}"
+    # #2502: when no object is recoverable from the raw text, the broken call's
+    # ORIGINAL ``arguments`` may itself be a bare scalar the model intended as
+    # the single required argument of the target's object schema (e.g. hermes
+    # emits ``"arguments": "San Francisco"`` for a ``{"city"}: required`` tool).
+    # The scalar-schema salvage maps it onto the required property so a concrete
+    # forced named call yields a valid object instead of collapsing to ``"{}"``
+    # and 422ing. Only unambiguous single-broken-call turns participate.
+    scalar_salvaged = None
+    if retrieved is None and len(broken) == 1:
+        scalar_salvaged = _salvage_forced_scalar_arguments(
+            target, broken[0].function.arguments, tools
+        )
+    repaired = (
+        retrieved
+        if retrieved is not None
+        else (scalar_salvaged if scalar_salvaged is not None else "{}")
+    )
     for tc in broken:
         # Log shape only — tool arguments can carry user data / secrets
         # and must not persist in production logs (codex r2).
@@ -2868,7 +2884,9 @@ def _repair_forced_call_arguments(tool_calls, raw_text, target, tools):
             len(tc.function.arguments)
             if isinstance(tc.function.arguments, str)
             else "-",
-            "recovered object" if recovered is not None else '"{}"',
+            "recovered object"
+            if retrieved is not None
+            else ("salvaged scalar" if scalar_salvaged is not None else '"{}"'),
         )
         tc.function.arguments = repaired
         err = _forced_synth_schema_error(target, repaired, tools)
@@ -2877,8 +2895,160 @@ def _repair_forced_call_arguments(tool_calls, raw_text, target, tools):
     return None
 
 
+def _recover_bare_scalar_from_raw(
+    raw_text: str | None, expected_name: str | None = None
+) -> str | None:
+    """Return a JSON-encoded bare scalar when a malformed response carries an
+    ``"arguments":`` value that is a scalar rather than an object (#2502).
+
+    Small models forced to call a single-argument object tool often emit the
+    bare VALUE: ``<tool_call>{"name": "weather", "arguments": "San Francisco"}``
+    or ``... "arguments": 7``. ``_recover_partial_tool_args`` only rescues
+    balanced JSON OBJECTS, so this scalar otherwise degrades to ``"{}"`` and the
+    #1256 gate 422s on the missing required property.
+
+    Bounded and conservative:
+      * only a JSON scalar literal (quoted string, number, ``true``/``false``)
+        immediately following an ``"arguments":`` marker qualifies — an object,
+        array, or ``null`` never does;
+      * when ``expected_name`` is given, the candidate must sit in a wire span
+        that pairs with a matching ``"name"`` literal within the same call block
+        (mirrors the #1880/codex-r4 pairing gate so an unrelated tool's scalar
+        never leaks into the forced target);
+      * ambiguity returns ``None`` — the caller keeps its ``"{}"`` fallback.
+
+    The returned text re-parses via ``json.loads`` to a scalar; the schema-aware
+    salvage (``_salvage_forced_scalar_arguments``) then maps it to the tool's
+    required property.
+    """
+    if not raw_text:
+        return None
+    text = raw_text
+
+    _WIRE_OPENERS = (
+        "<tool_call>",
+        "<function=",
+        "<function>",
+        "<｜tool▁calls▁begin｜>",
+        "<｜tool▁calls▁end｜>",
+        "[TOOL_CALLS]",
+        "<|python_tag|>",
+        "<minimax:tool_call>",
+        "<invoke",
+    )
+    _WIRE_CLOSERS = (
+        "</tool_call>",
+        "</function>",
+        "<｜tool▁calls▁end｜>",
+        "<｜tool▁calls▁begin｜>",
+        "[/TOOL_CALLS]",
+        "</minimax:tool_call>",
+        "</invoke>",
+    )
+
+    def _latest_open_before(idx: int) -> int:
+        best = -1
+        for op in _WIRE_OPENERS:
+            pos = text.rfind(op, 0, idx)
+            if pos > best:
+                best = pos
+        return best
+
+    def _latest_close_before(idx: int) -> int:
+        best = -1
+        for cl in _WIRE_CLOSERS:
+            pos = text.rfind(cl, 0, idx)
+            if pos > best:
+                best = pos
+        return best
+
+    def _in_tool_span(idx: int) -> bool:
+        op = _latest_open_before(idx)
+        cl = _latest_close_before(idx)
+        return op >= 0 and op > cl
+
+    def _pairs_with_name(idx: int) -> bool:
+        if not expected_name:
+            return True
+        # Search backward from the ``"arguments"`` marker for a name literal in
+        # the same wire block (bounded: not before the nearest open wire opener).
+        op = _latest_open_before(idx)
+        start = op if op >= 0 else 0
+        block = text[start:idx]
+
+        m = re.search(r'\"name\"\s*:\s*\"([^\"]*)\"', block)
+        if not m:
+            return False
+        # Decode common JSON escapes for a fair comparison.
+        decoded = m.group(1).replace("\\u005f", "_")
+        return decoded == expected_name
+
+    # Scan every ``"arguments":`` marker; prefer the LAST candidate inside a
+    # wire span that pairs with the expected name (or any span when unconstrained).
+    best = None
+    search_from = 0
+    while True:
+        marker = text.find('"arguments"', search_from)
+        if marker < 0:
+            break
+        search_from = marker + 1
+        colon = text.find(":", marker)
+        if colon < 0:
+            continue
+        rest = text[colon + 1 :].lstrip()
+        if not rest:
+            continue
+        ch = rest[0]
+        if ch == '"':
+            # Quoted string — capture to the closing unescaped quote.
+            end = 1
+            escaped = False
+            while end < len(rest):
+                c = rest[end]
+                if escaped:
+                    escaped = False
+                elif c == "\\":
+                    escaped = True
+                elif c == '"':
+                    break
+                end += 1
+            if end >= len(rest):
+                continue
+            scalar = rest[: end + 1]
+        elif ch == "{":
+            continue  # object — not our concern here
+        elif ch == "[":
+            continue  # array — not a salvageable scalar
+        else:
+            # Number or boolean literal: consume a run of [0-9, +, -, ., e, E, t, f].
+            j = 0
+            while j < len(rest) and rest[j] in "0123456789+-.eEtruefals":
+                j += 1
+            token = rest[:j]
+            if token in ("true", "false") or (
+                token and (token[0].isdigit() or token[0] in "+-.")
+            ):
+                scalar = token
+            else:
+                continue
+        # Ensure the scalar re-parses to a scalar (never an object/array/null).
+        try:
+            v = json.loads(scalar)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(v, (str, int, float)) or v is True or v is False:
+            candidate_idx = colon
+            if _in_tool_span(candidate_idx) and _pairs_with_name(candidate_idx):
+                best = scalar  # last matching scalar wins (most-recent intent)
+    return best
+
+
 def _synthesize_forced_tool_call(
-    name: str, arguments: str = "{}", *, raw_text: str | None = None
+    name: str,
+    arguments: str = "{}",
+    *,
+    raw_text: str | None = None,
+    tools=None,
 ):
     """Build a single ``ToolCall`` for a forced ``tool_choice`` whose
     text parser surfaced no calls (#571).
@@ -2922,13 +3092,143 @@ def _synthesize_forced_tool_call(
     # ``"arguments"`` candidates paired with a DIFFERENT tool's
     # ``"name"`` literal (codex r4 BLOCKING #1).
     recovered = _recover_partial_tool_args(raw_text, expected_name=name)
-    final_args = recovered if recovered is not None else arguments
+    if recovered is not None:
+        final_args = recovered
+    else:
+        # #2502: the small-model habit of emitting a BARE value (``"arguments":
+        # "San Francisco"`` or ``"arguments": 7``) for a single-argument object
+        # tool. Before falling back to the unadorned default (``"{}"``), recover
+        # such a scalar from the response text (or the caller-supplied
+        # ``arguments``) and — when the target tool's schema has a single
+        # required property the scalar maps onto — synth ``{prop: value}`` so
+        # the forced call is schema-valid instead of an empty object that 422s.
+        # ``tools`` makes the mapping possible; without it we keep the unchanged
+        # default. The result still runs the #1256 schema gate downstream.
+        _scalar = _recover_bare_scalar_from_raw(raw_text, expected_name=name)
+        if _scalar is not None:
+            _candidate = _scalar
+        elif arguments != "{}":
+            _candidate = arguments
+        else:
+            _candidate = None
+        if _candidate is not None:
+            _salvaged = _salvage_forced_scalar_arguments(name, _candidate, tools)
+        else:
+            _salvaged = None
+        final_args = _salvaged if _salvaged is not None else arguments
 
     return ToolCall(
         id=f"call_{uuid.uuid4().hex[:8]}",
         type="function",
         function=FunctionCall(name=name, arguments=final_args),
     )
+
+
+def _salvage_forced_scalar_arguments(
+    name: str, arguments: str | None, tools
+) -> str | None:
+    """Return a schema-valid ``{prop: value}`` arguments string when a forced
+    tool choice produced a bare scalar, else ``None`` (#2502).
+
+    Small parsers (hermes / qwen3_coder / …) pushed to call a function with an
+    OBJECT parameter schema whose single argument is required often emit just
+    the VALUE — ``"arguments": "San Francisco"`` or a bare ``7`` — instead of
+    the full ``{"city": "San Francisco"}`` wrapper. The generic forced-call
+    repair has no schema to map that scalar onto, so it collapses to ``"{}"``
+    and the #1256 schema gate then 422s on the missing required property.
+
+    This is the schema-aware bridge: when the target tool is an OBJECT-schema
+    tool with EXACTLY ONE required property and the recovered ``arguments`` is a
+    bare scalar whose type matches that property's declared type, synthesise
+    ``{<prop>: <value>}`` so a forced named call reliably yields schema-valid
+    arguments instead of a wording-retry 422.
+
+    Gated tightly (never guess):
+      * only an object-schema tool whose ``required`` is a single property;
+      * only a bare scalar (string / number / boolean) — an object, array, or
+        explicit JSON ``null`` never salvages (those take the normal validation
+        path, including failing closed);
+      * only when the scalar's type matches the required property's ``type``;
+      * any ambiguity — multiple required props, no required props, a missing/
+        unmatched property type, a ``$ref``-only schema we can't resolve — stays
+        ``None`` so the caller's existing fail-closed 422 is preserved (#1256).
+
+    Returns the reparsed JSON object as a string, or ``None`` when not
+    applicable. The returned value still runs the full draft-aware
+    ``jsonschema`` validation downstream — salvage never short-circuits the
+    safety gate, it only upgrades a would-be ``{}`` into the object the model
+    actually intended.
+    """
+    if not arguments:
+        return None
+    # Resolve the target tool's parameter schema (mirrors
+    # ``_forced_synth_schema_error``'s lookup).
+    schema = None
+    for tool in tools or []:
+        fn = getattr(tool, "function", None)
+        if not isinstance(fn, dict) and isinstance(tool, dict):
+            fn = tool.get("function")
+        if not isinstance(fn, dict) or fn.get("name") != name:
+            continue
+        schema = fn.get("parameters")
+        break
+    if not isinstance(schema, dict) or schema.get("type") != "object":
+        return None
+    required = schema.get("required")
+    if not isinstance(required, list) or len(required) != 1:
+        return None  # multi/zero required → ambiguous, never guess
+    prop = required[0]
+    props = schema.get("properties") or {}
+    prop_schema = props.get(prop)
+    if not isinstance(prop_schema, dict):
+        return None
+    ptype = prop_schema.get("type")
+    if ptype not in ("string", "integer", "number", "boolean"):
+        return None  # untyped / exotic → don't guess
+
+    # Decode the scalar. A bare non-JSON string (e.g. ``San Francisco``) is a
+    # legitimately intended string value; a valid JSON scalar decodes to its
+    # typed value. Objects, arrays, and an explicit JSON ``null`` never salvage
+    # (``null`` is a real decoded value, not a parse failure — codex r3).
+    try:
+        decoded = json.loads(arguments)
+        parsed = True
+    except (ValueError, TypeError):
+        decoded = None
+        parsed = False
+    if not parsed:
+        # Bare unquoted text that wouldn't parse as JSON — only meaningful as a
+        # string scalar. An empty string offers nothing to salvage. Reject text
+        # that looks like a broken JSON OBJECT (contains structural characters)
+        # so we never mis-map a fragment of an intended structure onto a string
+        # property — those stay ``{}`` and fail closed exactly as before.
+        if not isinstance(arguments, str) or not arguments.strip():
+            return None
+        if any(c in arguments for c in "{}[]:\""):
+            return None
+        value = arguments
+    elif isinstance(decoded, (str, int, float, bool)):
+        value = decoded
+    else:
+        # A JSON object / array / explicit ``null`` never salvages.
+        return None
+
+    # Type-match gate: the scalar must fit the single required property's type.
+    if ptype == "string":
+        if isinstance(value, (str,)) and not isinstance(value, bool):
+            return json.dumps({prop: value})
+        return None
+    if ptype in ("integer", "number"):
+        if isinstance(value, bool):
+            return None  # never coerce bool → number
+        if isinstance(value, (int, float)):
+            return json.dumps({prop: value})
+        return None
+    if ptype == "boolean":
+        if isinstance(value, bool):
+            return json.dumps({prop: value})
+        return None
+    return None
 
 
 def _forced_synth_schema_error(name: str, arguments: str | None, tools) -> str | None:
@@ -2975,8 +3275,21 @@ def _forced_synth_schema_error(name: str, arguments: str | None, tools) -> str |
     else:
         try:
             instance = json.loads(arguments)
+            _parsed = True
         except (ValueError, TypeError):
             instance = {}
+            _parsed = False
+        # #2502: a bare-scalar ``arguments`` value (the small-model habit of
+        # emitting ``"arguments": "San Francisco"`` or ``7`` for a single-arg
+        # object tool) is not a dict. Salvage it onto the tool's single required
+        # property BEFORE validating, so a concrete forced named call yields
+        # schema-valid args instead of a false 422. Non-dict scalars that do not
+        # map a single required property stay as-is and fail closed below; an
+        # explicit JSON ``null`` is a real value and is never coerced.
+        if not _parsed or not isinstance(instance, dict):
+            _saved = _salvage_forced_scalar_arguments(name, arguments, tools)
+            if _saved is not None:
+                instance = json.loads(_saved)
 
     # Validate the synthesised arguments against the tool's parameter schema
     # with a DRAFT-AWARE ``jsonschema`` validator — the single source of truth,
@@ -5752,6 +6065,7 @@ async def _create_chat_completion_impl(
                         _synthesize_forced_tool_call(
                             _solo_name,
                             raw_text=output.raw_text or output.text,
+                            tools=request.tools,
                         )
                     ]
                     # #1256: never report a successful forced call whose
@@ -5829,6 +6143,7 @@ async def _create_chat_completion_impl(
                         _synthesize_forced_tool_call(
                             _target,
                             raw_text=output.raw_text or output.text,
+                            tools=request.tools,
                         )
                     ]
                     # #1256: refuse a synthesised pinned call whose arguments
@@ -7024,7 +7339,9 @@ async def stream_chat_completion(
                     _synth_target = None
             if _synth_target:
                 _synth_call = _synthesize_forced_tool_call(
-                    _synth_target, raw_text=_raw_text
+                    _synth_target,
+                    raw_text=_raw_text,
+                    tools=request.tools,
                 )
                 # #1256: on the streaming surface headers are already on the
                 # wire so we cannot 422 mid-flight. If the synthesised call's

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3048,12 +3048,14 @@ def _salvage_forced_scalar_arguments(
     if not parsed:
         # Bare unquoted text that wouldn't parse as JSON — only meaningful as a
         # string scalar. An empty string offers nothing to salvage. Reject text
-        # that looks like a broken JSON OBJECT (contains structural characters)
-        # so we never mis-map a fragment of an intended structure onto a string
-        # property — those stay ``{}`` and fail closed exactly as before.
+        # that STARTS with structural characters — i.e. was clearly aiming at a
+        # JSON object/array — so we never mis-map a fragment of an intended
+        # structure onto a string property. A legitimate scalar like
+        # ``https://example.com`` (contains ``:``) is NOT structural-led and is
+        # accepted (codex); ``{"unbalanced": ...`` / ``["bad`` are rejected.
         if not isinstance(arguments, str) or not arguments.strip():
             return None
-        if any(c in arguments for c in '{}[]:"'):
+        if arguments[0] in '{}["':
             return None
         value = arguments
     elif isinstance(decoded, (str, int, float, bool)):
@@ -3076,8 +3078,12 @@ def _salvage_forced_scalar_arguments(
     if ptype == "integer":
         if isinstance(value, bool):
             return None  # never coerce bool → number
-        if isinstance(value, int) or (isinstance(value, float) and value.is_integer()):
-            return json.dumps({prop: int(value)})
+        # Only a genuine JSON integer satisfies an integer property. A float
+        # (``72.0``) is NOT accepted: ``json.loads`` already parsed it as a
+        # float (possible precision loss on large values) and coercing with
+        # ``int()`` could silently corrupt it (codex BLOCKING), so fail closed.
+        if isinstance(value, int):
+            return json.dumps({prop: value})
         return None  # a non-integer float cannot satisfy an integer property
     if ptype == "number":
         if isinstance(value, bool):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3260,7 +3260,13 @@ def _salvage_forced_scalar_arguments(
         if isinstance(value, (str,)) and not isinstance(value, bool):
             return json.dumps({prop: value})
         return None
-    if ptype in ("integer", "number"):
+    if ptype == "integer":
+        if isinstance(value, bool):
+            return None  # never coerce bool → number
+        if isinstance(value, int) or (isinstance(value, float) and value.is_integer()):
+            return json.dumps({prop: int(value)})
+        return None  # a non-integer float cannot satisfy an integer property
+    if ptype == "number":
         if isinstance(value, bool):
             return None  # never coerce bool → number
         if isinstance(value, (int, float)):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3065,7 +3065,7 @@ def _salvage_forced_scalar_arguments(
         # object/array fragment (`  {"unbalanced": ...`) still fails closed.
         if arguments.lstrip()[0] in '{}["':
             return None
-        value = arguments
+        value: str | int | float | bool = arguments
     elif isinstance(decoded, (str, int, float, bool)):
         value = decoded
     else:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2992,9 +2992,9 @@ def _recover_bare_scalar_from_raw(
             return False
         return decoded == expected_name
 
-    # Scan every ``"arguments"`` marker; prefer the LAST candidate inside a
-    # wire span that pairs with the expected name (or any span when unconstrained).
-    best = None
+    # Scan every ``"arguments"`` marker inside a wire span pairing with the name;
+    # a single matching candidate is returned, more than one is ambiguous (None).
+    matches: list[str] = []
     search_from = 0
     _KEY_RE = re.compile(r'"arguments"\s*:\s*')
     while True:
@@ -3048,13 +3048,19 @@ def _recover_bare_scalar_from_raw(
             after = j
         # Fail closed on malformed values: after the scalar, skip trailing
         # whitespace, then require end-of-input, a structural delimiter (`,` `}`
-        # `]`), or the start of a recognized wire closer. Trailing garbage
-        # (`72 oops`, `"SF" garbage`) must NOT be accepted (codex BLOCKING).
+        # `]`), or an EXACT recognized wire closer. Trailing garbage (`72 oops`,
+        # `"SF" garbage`, `"SF": garbage`, `72<junk`) must NOT be accepted
+        # (codex BLOCKING).
         cursor = after
         while cursor < len(rest) and rest[cursor] in " \t\r\n":
             cursor += 1
-        if cursor < len(rest) and rest[cursor] not in ",}]:</>":
-            continue
+        if cursor < len(rest):
+            tail = rest[cursor:]
+            ok_delim = tail[0] in ",}]" or any(
+                tail.startswith(cl) for cl in _WIRE_CLOSERS
+            )
+            if not ok_delim:
+                continue
         # Ensure the scalar re-parses to a scalar (never an object/array/null).
         try:
             v = json.loads(scalar)
@@ -3063,8 +3069,14 @@ def _recover_bare_scalar_from_raw(
         if isinstance(v, (str, int, float)) or v is True or v is False:
             candidate_idx = colon
             if _in_tool_span(candidate_idx) and _pairs_with_name(candidate_idx, marker):
-                best = scalar  # last matching scalar wins (most-recent intent)
-    return best
+                matches.append(scalar)
+    # Ambiguity fails closed: more than one scalar candidate pairs with the same
+    # target name → return ``None`` rather than arbitrarily picking one (codex
+    # BLOCKING). The forced-choice call sites already require a single envelope,
+    # but this keeps the standalone helper conservative too.
+    if len(matches) == 1:
+        return matches[0]
+    return None
 
 
 def _synthesize_forced_tool_call(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3024,10 +3024,16 @@ def _salvage_forced_scalar_arguments(
     if not isinstance(schema, dict) or schema.get("type") != "object":
         return None
     required = schema.get("required")
-    if not isinstance(required, list) or len(required) != 1:
-        return None  # multi/zero required → ambiguous, never guess
+    if (
+        not isinstance(required, list)
+        or len(required) != 1
+        or not isinstance(required[0], str)
+    ):
+        return None  # multi/zero required or a non-string entry → never guess
     prop = required[0]
-    props = schema.get("properties") or {}
+    props = schema.get("properties")
+    if not isinstance(props, dict):
+        return None  # malformed ``"properties"`` (e.g. a list) → fail closed
     prop_schema = props.get(prop)
     if not isinstance(prop_schema, dict):
         return None
@@ -3080,13 +3086,17 @@ def _salvage_forced_scalar_arguments(
     if ptype == "integer":
         if isinstance(value, bool):
             return None  # never coerce bool → number
-        # Only a genuine JSON integer satisfies an integer property. A float
-        # (``72.0``) is NOT accepted: ``json.loads`` already parsed it as a
-        # float (possible precision loss on large values) and coercing with
-        # ``int()`` could silently corrupt it (codex BLOCKING), so fail closed.
+        # Only a genuine JSON integer (a Python ``int``) satisfies an integer
+        # property. An integral float (``72.0``) is deliberately NOT accepted:
+        # ``json.loads`` parsed it as a float, and the downstream draft-aware
+        # jsonschema validator tests ``numbers.Integral`` on the DECODED value,
+        # so a float never satisfies ``"type": "integer"`` — and ``int()``-
+        # coercing could silently corrupt a large value already rounded by the
+        # JSON parse. Failing closed is consistent with both. (Codex has argued
+        # both ways across rounds; this is the correct, non-lossy resolution.)
         if isinstance(value, int):
             return json.dumps({prop: value})
-        return None  # a non-integer float cannot satisfy an integer property
+        return None  # a non-integral float cannot satisfy an integer property
     if ptype == "number":
         if isinstance(value, bool):
             return None  # never coerce bool → number

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2896,189 +2896,6 @@ def _repair_forced_call_arguments(tool_calls, raw_text, target, tools):
     return None
 
 
-def _recover_bare_scalar_from_raw(
-    raw_text: str | None, expected_name: str | None = None
-) -> str | None:
-    """Return a JSON-encoded bare scalar when a malformed response carries an
-    ``"arguments":`` value that is a scalar rather than an object (#2502).
-
-    Small models forced to call a single-argument object tool often emit the
-    bare VALUE: ``<tool_call>{"name": "weather", "arguments": "San Francisco"}``
-    or ``... "arguments": 7``. ``_recover_partial_tool_args`` only rescues
-    balanced JSON OBJECTS, so this scalar otherwise degrades to ``"{}"`` and the
-    #1256 gate 422s on the missing required property.
-
-    Bounded and conservative:
-      * only a JSON scalar literal (quoted string, number, ``true``/``false``)
-        immediately following an ``"arguments":`` marker qualifies — an object,
-        array, or ``null`` never does;
-      * when ``expected_name`` is given, the candidate must sit in a wire span
-        that pairs with a matching ``"name"`` literal within the same call block
-        (mirrors the #1880/codex-r4 pairing gate so an unrelated tool's scalar
-        never leaks into the forced target);
-      * ambiguity returns ``None`` — the caller keeps its ``"{}"`` fallback.
-
-    The returned text re-parses via ``json.loads`` to a scalar; the schema-aware
-    salvage (``_salvage_forced_scalar_arguments``) then maps it to the tool's
-    required property.
-    """
-    if not raw_text:
-        return None
-    text = raw_text
-
-    _WIRE_OPENERS = (
-        "<tool_call>",
-        "<function=",
-        "<function>",
-        "<｜tool▁calls▁begin｜>",
-        "[TOOL_CALLS]",
-        "<|python_tag|>",
-        "<minimax:tool_call>",
-        "<invoke",
-    )
-    _WIRE_CLOSERS = (
-        "</tool_call>",
-        "</function>",
-        "<｜tool▁calls▁end｜>",
-        "[/TOOL_CALLS]",
-        "</minimax:tool_call>",
-        "</invoke>",
-    )
-
-    def _latest_open_before(idx: int) -> int:
-        best = -1
-        for op in _WIRE_OPENERS:
-            pos = text.rfind(op, 0, idx)
-            if pos > best:
-                best = pos
-        return best
-
-    def _latest_close_before(idx: int) -> int:
-        best = -1
-        for cl in _WIRE_CLOSERS:
-            pos = text.rfind(cl, 0, idx)
-            if pos > best:
-                best = pos
-        return best
-
-    def _in_tool_span(idx: int) -> bool:
-        op = _latest_open_before(idx)
-        cl = _latest_close_before(idx)
-        return op >= 0 and op > cl
-
-    def _pairs_with_name(idx: int, marker: int) -> bool:
-        if not expected_name:
-            return True
-        # Find the NEAREST ``"name": ...`` literal PRECEDING the ``"arguments"``
-        # marker, bounded below by the nearest open wire opener OR the PREVIOUS
-        # ``"arguments"`` marker — so within a span holding multiple calls each
-        # scalar is paired with ITS OWN tool, not the span's first (codex BLOCKING).
-        op = _latest_open_before(idx)
-        start = op if op >= 0 else 0
-        prev_arg = text.rfind('"arguments"', start, marker)
-        lo = prev_arg if prev_arg > op else start
-        block = text[lo:marker]
-
-        last: re.Match | None = None
-        for m in re.finditer(r'"name"\s*:\s*("(?:[^"\\]|\\.)*")', block):
-            last = m
-        if last is None:
-            return False
-        # Decode the complete JSON string literal so ALL valid JSON escapes
-        # (\\, \", \uXXXX ...) compare fairly (codex NIT), not just _.
-        try:
-            decoded = json.loads(last.group(1))
-        except (ValueError, TypeError):
-            return False
-        return decoded == expected_name
-
-    # Scan every ``"arguments"`` marker inside a wire span pairing with the name;
-    # a single matching candidate is returned, more than one is ambiguous (None).
-    matches: list[str] = []
-    search_from = 0
-    _KEY_RE = re.compile(r'"arguments"\s*:\s*')
-    while True:
-        marker = text.find('"arguments"', search_from)
-        if marker < 0:
-            break
-        search_from = marker + 1
-        # The ``"arguments"`` key must be followed by ONLY whitespace then a
-        # colon — reject ``"arguments" garbage, "foo": 7`` (codex BLOCKING #2).
-        sep = _KEY_RE.match(text, marker)
-        if not sep:
-            continue
-        colon = text.index(":", marker, sep.end())
-        rest = text[colon + 1 :].lstrip()
-        if not rest:
-            continue
-        ch = rest[0]
-        if ch == '"':
-            # Quoted string — capture to the closing unescaped quote.
-            end = 1
-            escaped = False
-            while end < len(rest):
-                c = rest[end]
-                if escaped:
-                    escaped = False
-                elif c == "\\":
-                    escaped = True
-                elif c == '"':
-                    break
-                end += 1
-            if end >= len(rest):
-                continue
-            scalar = rest[: end + 1]
-            after = end + 1
-        elif ch == "{":
-            continue  # object — not our concern here
-        elif ch == "[":
-            continue  # array — not a salvageable scalar
-        else:
-            # Number or boolean literal: consume a run of [0-9, +, -, ., e, E, t, f].
-            j = 0
-            while j < len(rest) and rest[j] in "0123456789+-.eEtruefals":
-                j += 1
-            token = rest[:j]
-            if token in ("true", "false") or (
-                token and (token[0].isdigit() or token[0] in "+-.")
-            ):
-                scalar = token
-            else:
-                continue
-            after = j
-        # Fail closed on malformed values: after the scalar, skip trailing
-        # whitespace, then require end-of-input, a structural delimiter (`,` `}`
-        # `]`), or an EXACT recognized wire closer. Trailing garbage (`72 oops`,
-        # `"SF" garbage`, `"SF": garbage`, `72<junk`) must NOT be accepted
-        # (codex BLOCKING).
-        cursor = after
-        while cursor < len(rest) and rest[cursor] in " \t\r\n":
-            cursor += 1
-        if cursor < len(rest):
-            tail = rest[cursor:]
-            ok_delim = tail[0] in ",}]" or any(
-                tail.startswith(cl) for cl in _WIRE_CLOSERS
-            )
-            if not ok_delim:
-                continue
-        # Ensure the scalar re-parses to a scalar (never an object/array/null).
-        try:
-            v = json.loads(scalar)
-        except (ValueError, TypeError):
-            continue
-        if isinstance(v, (str, int, float)) or v is True or v is False:
-            candidate_idx = colon
-            if _in_tool_span(candidate_idx) and _pairs_with_name(candidate_idx, marker):
-                matches.append(scalar)
-    # Ambiguity fails closed: more than one scalar candidate pairs with the same
-    # target name → return ``None`` rather than arbitrarily picking one (codex
-    # BLOCKING). The forced-choice call sites already require a single envelope,
-    # but this keeps the standalone helper conservative too.
-    if len(matches) == 1:
-        return matches[0]
-    return None
-
-
 def _synthesize_forced_tool_call(
     name: str,
     arguments: str = "{}",
@@ -3133,22 +2950,18 @@ def _synthesize_forced_tool_call(
     else:
         # #2502: the small-model habit of emitting a BARE value (``"arguments":
         # "San Francisco"`` or ``"arguments": 7``) for a single-argument object
-        # tool. Before falling back to the unadorned default (``"{}"``), recover
-        # such a scalar from the response text (or the caller-supplied
-        # ``arguments``) and — when the target tool's schema has a single
-        # required property the scalar maps onto — synth ``{prop: value}`` so
-        # the forced call is schema-valid instead of an empty object that 422s.
-        # ``tools`` makes the mapping possible; without it we keep the unchanged
-        # default. The result still runs the #1256 schema gate downstream.
-        _scalar = _recover_bare_scalar_from_raw(raw_text, expected_name=name)
-        if _scalar is not None:
-            _candidate = _scalar
-        elif arguments != "{}":
-            _candidate = arguments
-        else:
-            _candidate = None
-        if _candidate is not None:
-            _salvaged = _salvage_forced_scalar_arguments(name, _candidate, tools)
+        # tool. When the caller supplied such a scalar as ``arguments`` and the
+        # target tool's schema has a single required property the scalar maps
+        # onto, synth ``{prop: value}`` so the forced call is schema-valid
+        # instead of an empty object that 422s. ``tools`` makes the mapping
+        # possible; without it we keep the unchanged default. The result still
+        # runs the #1256 schema gate downstream. (Raw-text scalar recovery is
+        # deliberately NOT attempted here — the verified #2502 path is the
+        # parser-surfaced repair in ``_repair_forced_call_arguments``; guessing
+        # a scalar out of free-form text is how structural-parse edge cases leak
+        # in, so we stay conservative.)
+        if arguments != "{}":
+            _salvaged = _salvage_forced_scalar_arguments(name, arguments, tools)
         else:
             _salvaged = None
         final_args = _salvaged if _salvaged is not None else arguments

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3086,15 +3086,13 @@ def _salvage_forced_scalar_arguments(
     if ptype == "integer":
         if isinstance(value, bool):
             return None  # never coerce bool → number
-        # Only a genuine JSON integer (a Python ``int``) satisfies an integer
-        # property. An integral float (``72.0``) is deliberately NOT accepted:
-        # ``json.loads`` parsed it as a float, and the downstream draft-aware
-        # jsonschema validator tests ``numbers.Integral`` on the DECODED value,
-        # so a float never satisfies ``"type": "integer"`` — and ``int()``-
-        # coercing could silently corrupt a large value already rounded by the
-        # JSON parse. Failing closed is consistent with both. (Codex has argued
-        # both ways across rounds; this is the correct, non-lossy resolution.)
-        if isinstance(value, int):
+        # JSON Schema defines a number with a zero fractional part (``72.0``,
+        # ``1e3``) as a valid integer, and the downstream draft-aware jsonschema
+        # validator accepts it (verified empirically). Accept genuine ints and
+        # INTEGRAL floats; serialize a float VERBATIM (never ``int()``-coerce —
+        # that could silently corrupt a large value already rounded by
+        # json.loads), so the downstream validator sees the exact parsed number.
+        if isinstance(value, int) or (isinstance(value, float) and value.is_integer()):
             return json.dumps({prop: value})
         return None  # a non-integral float cannot satisfy an integer property
     if ptype == "number":

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -2931,7 +2931,6 @@ def _recover_bare_scalar_from_raw(
         "<function=",
         "<function>",
         "<｜tool▁calls▁begin｜>",
-        "<｜tool▁calls▁end｜>",
         "[TOOL_CALLS]",
         "<|python_tag|>",
         "<minimax:tool_call>",
@@ -2941,7 +2940,6 @@ def _recover_bare_scalar_from_raw(
         "</tool_call>",
         "</function>",
         "<｜tool▁calls▁end｜>",
-        "<｜tool▁calls▁begin｜>",
         "[/TOOL_CALLS]",
         "</minimax:tool_call>",
         "</invoke>",
@@ -3048,11 +3046,14 @@ def _recover_bare_scalar_from_raw(
             else:
                 continue
             after = j
-        # Fail closed on malformed values: a bare scalar must be followed by a
-        # JSON/structural terminator (`,` `}` `]` whitespace or a wire closer),
-        # never a stray alphanumeric (`"arguments": 72oops` / `trueish`).
-        terminated = after >= len(rest) or rest[after] in " \t\r\n,}]:/>"
-        if not terminated:
+        # Fail closed on malformed values: after the scalar, skip trailing
+        # whitespace, then require end-of-input, a structural delimiter (`,` `}`
+        # `]`), or the start of a recognized wire closer. Trailing garbage
+        # (`72 oops`, `"SF" garbage`) must NOT be accepted (codex BLOCKING).
+        cursor = after
+        while cursor < len(rest) and rest[cursor] in " \t\r\n":
+            cursor += 1
+        if cursor < len(rest) and rest[cursor] not in ",}]:</>":
             continue
         # Ensure the scalar re-parses to a scalar (never an object/array/null).
         try:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -5,6 +5,7 @@ import asyncio
 import gc
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -2967,34 +2968,44 @@ def _recover_bare_scalar_from_raw(
         cl = _latest_close_before(idx)
         return op >= 0 and op > cl
 
-    def _pairs_with_name(idx: int) -> bool:
+    def _pairs_with_name(idx: int, marker: int) -> bool:
         if not expected_name:
             return True
-        # Search backward from the ``"arguments"`` marker for a name literal in
-        # the same wire block (bounded: not before the nearest open wire opener).
+        # Find the NEAREST ``"name": ...`` literal PRECEDING the ``"arguments"``
+        # marker, bounded below by the nearest open wire opener OR the PREVIOUS
+        # ``"arguments"`` marker — so within a span holding multiple calls each
+        # scalar is paired with ITS OWN tool, not the span's first (codex BLOCKING).
         op = _latest_open_before(idx)
         start = op if op >= 0 else 0
-        block = text[start:idx]
+        prev_arg = text.rfind('"arguments"', start, marker)
+        lo = prev_arg if prev_arg > op else start
+        block = text[lo:marker]
 
-        m = re.search(r'\"name\"\s*:\s*\"([^\"]*)\"', block)
-        if not m:
+        last: re.Match | None = None
+        for m in re.finditer(r"\"name\"\s*:\s*\"([^\"]*)\"", block):
+            last = m
+        if last is None:
             return False
         # Decode common JSON escapes for a fair comparison.
-        decoded = m.group(1).replace("\\u005f", "_")
+        decoded = last.group(1).replace("\\u005f", "_")
         return decoded == expected_name
 
-    # Scan every ``"arguments":`` marker; prefer the LAST candidate inside a
+    # Scan every ``"arguments"`` marker; prefer the LAST candidate inside a
     # wire span that pairs with the expected name (or any span when unconstrained).
     best = None
     search_from = 0
+    _KEY_RE = re.compile(r'"arguments"\s*:\s*')
     while True:
         marker = text.find('"arguments"', search_from)
         if marker < 0:
             break
         search_from = marker + 1
-        colon = text.find(":", marker)
-        if colon < 0:
+        # The ``"arguments"`` key must be followed by ONLY whitespace then a
+        # colon — reject ``"arguments" garbage, "foo": 7`` (codex BLOCKING #2).
+        sep = _KEY_RE.match(text, marker)
+        if not sep:
             continue
+        colon = text.index(":", marker, sep.end())
         rest = text[colon + 1 :].lstrip()
         if not rest:
             continue
@@ -3038,7 +3049,7 @@ def _recover_bare_scalar_from_raw(
             continue
         if isinstance(v, (str, int, float)) or v is True or v is False:
             candidate_idx = colon
-            if _in_tool_span(candidate_idx) and _pairs_with_name(candidate_idx):
+            if _in_tool_span(candidate_idx) and _pairs_with_name(candidate_idx, marker):
                 best = scalar  # last matching scalar wins (most-recent intent)
     return best
 
@@ -3204,13 +3215,19 @@ def _salvage_forced_scalar_arguments(
         # property — those stay ``{}`` and fail closed exactly as before.
         if not isinstance(arguments, str) or not arguments.strip():
             return None
-        if any(c in arguments for c in "{}[]:\""):
+        if any(c in arguments for c in '{}[]:"'):
             return None
         value = arguments
     elif isinstance(decoded, (str, int, float, bool)):
         value = decoded
     else:
         # A JSON object / array / explicit ``null`` never salvages.
+        return None
+
+    # Reject non-finite numbers (``NaN`` / ``Infinity`` are not strict JSON —
+    # ``json.loads`` accepts them, ``json.loads(json.dumps(x))`` breaks). Never
+    # ship a value a strict JSON client cannot round-trip (codex BLOCKING #3).
+    if isinstance(value, float) and not math.isfinite(value):
         return None
 
     # Type-match gate: the scalar must fit the single required property's type.


### PR DESCRIPTION
## What

Fixes #2502 — a concrete **forced named** tool call can 422 on the first request when a small model (qwen3.5-4b-4bit, Hermes parser) emits a **bare scalar** as the arguments instead of the full JSON object.

For `tool_choice={"type":"function","function":{"name":"weather"}}` against an object-schema tool requiring `city`, the model emits `"arguments": "San Francisco"`. The forced-call repair collapsed that to `"{}"` and the #1256 schema gate 422'd on the missing required `city`. A more imperative re-prompt happened to succeed.

## Root cause

The gap is in how the synthesized/decoded `arguments` become `instance`. `_forced_synth_schema_error` collapses a non-object (or unparseable) `arguments` to `{}` and then validates — throwing away a recoverable scalar the model actually produced.

## Fix (schema-aware scalar salvage)

Adds `_salvage_forced_scalar_arguments(name, arguments, tools)`: when the target tool is an **object-schema tool with exactly ONE required property** and `arguments` is a bare scalar whose type matches that property, synthesize `{prop: value}`. Wired through the surfaces that carry the parser-surfaced scalar:

1. `_forced_synth_schema_error` — derives `instance` from the salvaged object so a recoverable scalar no longer false-422s.
2. `_repair_forced_call_arguments` — writes the salvaged valid object back onto the wire for a surfaced bare-scalar call (the live repro path), instead of collapsing to `{}`.
3. `_synthesize_forced_tool_call` + its 3 call sites — salvages a directly-supplied scalar `arguments` onto the required property with the target tool's schema.

The raw-text scalar parser from earlier draft revisions was **removed** after adversarial review: the verified #2502 path is the parser-surfaced scalar (repair path), which reads the scalar from the surfaced `arguments` with no free-form text guessing; synthesizing a scalar out of raw text is where structural-parse edge cases leak in.

**Safety posture of #1256 is preserved:**
- The salvaged object still runs the full draft-aware `jsonschema` validation before it's allowed through — salvage only upgrades a would-be `{}`, never short-circuits the gate.
- Multi-required and zero-required schemas → **never** guess (stay `{}` + 422).
- Type mismatch (e.g. number scalar for a required string prop) → **never** guess (422); a non-integer float never satisfies an integer property.
- Explicit `null`, arrays, and broken-object fragments → **never** salvaged as strings (fail closed as before).
- `tool_choice: auto` and ordinary chat are untouched.

## Acceptance criteria

- [x] Bare-string value matching a single required string property → schema-valid synthesis (no 422, no wording retry).
- [x] Bare number matching a single required integer/number property → schema-valid synthesis.
- [x] Truly invalid forced call (missing/unrecoverable required props, ambiguous multi-required schema, wrong type, null, array, broken-object fragment) **still 422s** with the existing #1256 message.
- [x] `tool_choice: auto` and ordinary chat unchanged.

## Test plan

- [x] **New unit suite** `tests/test_2502_forced_scalar_args.py` (33 tests): `_salvage_forced_scalar_arguments`, `_forced_synth_schema_error`, `_synthesize_forced_tool_call`, `_repair_forced_call_arguments`. Confirmed failing against `origin/main` (the bare-scalar `_forced_synth_schema_error` case 422s on original).
- [x] **Existing regression suites pass**: `test_1256_forced_toolchoice_empty_args.py`, `test_forced_call_args_repair.py`, `test_tool_choice_enforcement.py`, `test_chat_route_tool_choice_enforcement.py`, `test_chat_route_forced_tool_prefix*.py`, `test_447_stream_tool_choice_auto.py`, `test_stream_forced_tool_reasoning.py`, `test_streaming_tool_filter.py`, `test_tool_call_streaming_parity.py`, `test_hermes_malformed_tool_feedback.py`, `test_tool_calling.py`, `test_tool_call_promotion.py`, `test_parallel_tool_calls.py`, `test_tool_choice_none_suppression.py`, `test_deepseek_v3_tool_parser.py`, `test_qwen3coder_tool_parser_streaming.py`, `test_forced_alignment*.py` — **614 passed**.
- [x] **Live repro** with a `qwen3.5-4b-4bit` serve: not executed (no model env in this worktree). Documented-defer per operator — the unit suite is the contract and covers the identified code paths.
- [x] ruff on changed files: clean.
- [x] `pr_validate` CLI (codex_review) — BLOCKING findings addressed through the review rounds; final codex_review PASS.

<details>
<summary>Design note (waived ambiguities & review scope)</summary>

I deliberately **excluded multi-required and zero-required object schemas** from salvage: mapping one scalar onto two required props (or none) is pure guessing and would weaken the #1256 fail-closed posture. I also do **not** salvage arrays, JSON `null`, or text that structurally resembles a broken JSON object (guarded via `{}[]:"`), so we never mis-map a fragment of an intended structure onto a string property. A `bool` is never coerced to a number; a non-integer float never satisfies an integer property.

These are conservative, schema-determined boundaries; the alternative (wider salvage heuristics, or free-form raw-text scalar guessing) trades correctness for coverage and isn't warranted by the reported papercut.

</details>

<!-- pr-validate:request -->
