### PR TITLE
fix(server): budget forced-alignment models through alignment-role admission (#2405)

### DIFF
--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1627,31 +1627,74 @@ async def test_aligner_retire_fires_after_previous_discard(monkeypatch):
 async def test_alignment_role_cancellation_keeps_published_engine_committed(
     monkeypatch,
 ):
-    """pr_validate codex BLOCKING #2: when the aligner load completes and
-    publishes the engine but the async admission context is cancelled, the
-    reservation is committed (kept resident) rather than rolled back — no
-    unaccounted resident engine."""
+    """pr_validate codex BLOCKING #2: drive cancellation through
+    ``_run_alignment_request`` end-to-end.
+
+    When the aligner load completes and publishes the engine but the request
+    is cancelled before the next await returns, ``_run_alignment_request``'s
+    ``admission.commit()`` branch must keep the (accounted) reservation
+    resident — never roll it back into an unaccounted resident desync. This
+    drives the REAL route + admission wiring (not ``admit_role`` directly), so
+    deleting the ``admission.commit()`` branch would fail the test.
+    """
+
+    import io
+
+    from fastapi import UploadFile
+
+    from vllm_mlx.routes import audio as audio_route
 
     manager = _make_role_manager(limit_gib=4.0)
     _install_role_manager(monkeypatch, manager)
 
     class _FakeAlign:
-        model_name = "qwen3-aligner"
+        model_name = "mlx-community/Qwen3-ForcedAligner-0.6B-8bit"
 
-    # Simulate: admission entered, engine published, then CancelledError raised
-    # inside the body (the caller's `admission.commit()` keeps the reservation).
+    published = threading.Event()
+    release = threading.Event()
+
+    def _controlled_load_blocking(model_name: str, on_discard_previous=None) -> None:
+        # Runs on the worker thread via run_to_completion. Publish the engine
+        # (the load "succeeded"), then block until the test releases us so the
+        # load is still in-flight when the request is cancelled.
+        audio_route._aligner_engine = _FakeAlign()
+        if on_discard_previous is not None:
+            on_discard_previous()
+        published.set()
+        release.wait()
+
+    monkeypatch.setattr(
+        audio_route, "_load_aligner_blocking", _controlled_load_blocking
+    )
+    monkeypatch.setattr(audio_route, "_aligner_engine", None)
+
+    req = asyncio.create_task(
+        audio_route._run_alignment_request(
+            UploadFile(filename="clip.wav", file=io.BytesIO(b"\x00" * 64)),
+            model="qwen3-aligner",
+            text="你好",
+            language=None,
+            response_format="json",
+        )
+    )
+
+    # Wait for the load worker to publish the engine, then cancel the request
+    # mid-flight (client disconnect). run_to_completion drains the worker —
+    # release it so the drain finishes.
+    await asyncio.to_thread(published.wait)
+    req.cancel()
+    release.set()
     with pytest.raises(asyncio.CancelledError):
-        async with manager.admit_role(
-            role="alignment",
-            model_id="qwen3-aligner",
-            requested_bytes=_aligner_catalog_bytes(),
-            capacity_source="catalog",
-        ) as admission:
-            # The load finished on the worker and published the engine.
-            admission.commit()
-            raise asyncio.CancelledError()
+        await req
 
-    # The reservation is kept resident because it was committed.
+    # The engine IS published (the cancelled load finished on the worker).
+    assert audio_route._aligner_engine is not None
+    assert audio_route._aligner_engine.model_name == _FakeAlign.model_name
+
+    # The admission-commit branch kept the reservation resident rather than
+    # rolling it back. This is the branch under test: delete it and the entry
+    # disappears.
     roles = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
     assert len(roles) == 1
     assert roles[0]["state"] == "resident"
+    assert roles[0]["model"] == _FakeAlign.model_name

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1497,6 +1497,70 @@ async def test_admitting_alignment_rolls_back_on_load_failure(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_aligner_load_failure_after_asr_eviction_does_not_restore_phantom_speech_input(
+    monkeypatch,
+):
+    """pr_validate codex BLOCKING (round-18): ``_load_aligner_blocking`` evicts
+    the ASR engine (fires ``retire_exclusive``) BEFORE constructing/loading the
+    aligner. If that load then FAILS before publication, the retired
+    ``speech-input`` reservation must NOT be restored — the ASR engine it
+    guarded was already discarded, so restoring would charge a phantom engine
+    that no longer exists. Drive the REAL route end-to-end."""
+    import io
+
+    from fastapi import HTTPException, UploadFile
+
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+    worker = _RecordingWorker()
+    monkeypatch.setattr(audio_route, "_aligner_engine", None)
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    bind_audio_worker(worker)
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    # A dictation speech-input reservation is resident (ASR engine present).
+    small = int(0.05 * 1024**3)
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper-large",
+        requested_bytes=small,
+        capacity_source="catalog",
+    ):
+        pass
+    assert any(r["role"] == "speech-input" for r in manager.snapshot()["roles"])
+
+    def _failing_load(model_name, on_discard_previous=None, on_discard_exclusive=None):
+        # Mirror the real loader's ordering: evict the ASR sibling (fire
+        # retire_exclusive) THEN fail before the aligner ever publishes — the
+        # codex BLOCKING scenario for construction/load failure after eviction.
+        if on_discard_exclusive is not None:
+            on_discard_exclusive()
+        raise RuntimeError("aligner construction failed after ASR eviction")
+
+    monkeypatch.setattr(audio_route, "_load_aligner_blocking", _failing_load)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await audio_route._run_alignment_request(
+            UploadFile(filename="clip.wav", file=io.BytesIO(b"\x00" * 64)),
+            model="qwen3-aligner",
+            text="你好",
+            language=None,
+            response_format="json",
+        )
+    assert exc_info.value.status_code == 500
+
+    # The failed load left NO alignment reservation (rolled back) AND the
+    # evicted ASR engine means the retired speech-input reservation stays
+    # retired — no phantom charge for a discarded engine.
+    roles = {r["role"] for r in manager.snapshot()["roles"]}
+    assert "alignment" not in roles
+    assert "speech-input" not in roles
+
+
+@pytest.mark.asyncio
 async def test_admitting_alignment_rolls_back_on_cancellation(monkeypatch):
     """Cancellation inside the admission leaves no leaked reservation."""
     from vllm_mlx.routes import audio as audio_route
@@ -1627,7 +1691,9 @@ async def test_cached_model_alignment_loads_once_and_stays_resident(monkeypatch)
     manager = _make_role_manager(limit_gib=4.0)
     _install_role_manager(monkeypatch, manager)
 
-    def _recording_load(model_name, on_discard_previous=None):
+    def _recording_load(
+        model_name, on_discard_previous=None, on_discard_exclusive=None
+    ):
         # Mirror the real loader's idempotency: once the engine for this model
         # is published, a repeat call is a no-op (no reload, no re-load).
         if (
@@ -1636,6 +1702,10 @@ async def test_cached_model_alignment_loads_once_and_stays_resident(monkeypatch)
         ):
             return
         operations.append("load-aligner")
+        # Mirror the real loader's ordering: evicting the ASR sibling fires
+        # retire_exclusive BEFORE the new aligner is published.
+        if on_discard_exclusive is not None:
+            on_discard_exclusive()
         audio_route._aligner_engine = _Aligner(model_name)
         if on_discard_previous is not None:
             on_discard_previous()
@@ -1704,13 +1774,17 @@ async def test_aligner_alias_and_canonical_request_reuse_same_engine(monkeypatch
     manager = _make_role_manager(limit_gib=4.0)
     _install_role_manager(monkeypatch, manager)
 
-    def _recording_load(model_name, on_discard_previous=None):
+    def _recording_load(
+        model_name, on_discard_previous=None, on_discard_exclusive=None
+    ):
         if (
             audio_route._aligner_engine is not None
             and audio_route._aligner_engine.model_name == model_name
         ):
             return
         operations.append("load-aligner")
+        if on_discard_exclusive is not None:
+            on_discard_exclusive()
         audio_route._aligner_engine = _Aligner(model_name)
         if on_discard_previous is not None:
             on_discard_previous()
@@ -1874,11 +1948,15 @@ async def test_alignment_role_cancellation_keeps_published_engine_committed(
     published = threading.Event()
     release = threading.Event()
 
-    def _controlled_load_blocking(model_name: str, on_discard_previous=None) -> None:
+    def _controlled_load_blocking(
+        model_name: str, on_discard_previous=None, on_discard_exclusive=None
+    ) -> None:
         # Runs on the worker thread via run_to_completion. Publish the engine
         # (the load "succeeded"), then block until the test releases us so the
         # load is still in-flight when the request is cancelled.
         audio_route._aligner_engine = _FakeAlign()
+        if on_discard_exclusive is not None:
+            on_discard_exclusive()
         if on_discard_previous is not None:
             on_discard_previous()
         published.set()

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1314,12 +1314,13 @@ def _install_role_manager(monkeypatch, manager):
     monkeypatch.setattr(audio_route, "_residency_manager", lambda: manager)
 
 
-@pytest.mark.asyncio
 def test_noop_role_admission_commit_is_noop():
-    """pr_validate codex BLOCKING (round-6): ``_NoopRoleAdmission.commit()``
-    must exist and be a no-op so an unmanaged server (no residency manager)
-    that publishes an engine and then gets cancelled surfaces the real
-    ``CancelledError`` — not an ``AttributeError`` from a missing method."""
+    """pr_validate codex NIT (round-8): ``_NoopRoleAdmission.commit()`` must
+    exist and be a no-op so an unmanaged server (no residency manager) that
+    publishes an engine and then gets cancelled surfaces the real
+    ``CancelledError`` — not an ``AttributeError`` from a missing method.
+    Synchronous: no asyncio marker, as a sync test under stricter
+    pytest-asyncio configs would warn."""
 
     from vllm_mlx.routes.audio import _NoopRoleAdmission
 

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1330,6 +1330,41 @@ def test_noop_role_admission_commit_is_noop():
 
 
 @pytest.mark.asyncio
+@pytest.mark.asyncio
+async def test_admitting_alignment_releases_resident_speech_input_role(
+    monkeypatch,
+):
+    """pr_validate codex BLOCKING (round-12/14): alignment and the dictation
+    STT lane are mutually exclusive, so a resident ``speech-input`` reservation
+    must be released BEFORE the alignment capacity admission — otherwise the
+    ledger charges both roles and can false-507 even though loading the aligner
+    would immediately drop the ASR engine."""
+
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    # A dictation speech-input reservation is resident (both weights present).
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper-large",
+        requested_bytes=_aligner_catalog_bytes(),
+        capacity_source="catalog",
+    ):
+        pass
+    assert [r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"]
+
+    # Entering alignment admission must release the speech-input reservation so
+    # only the alignment role is charged against the ceiling.
+    async with audio_route._admitting_alignment("qwen3-aligner") as admission:
+        roles = {r["role"] for r in manager.snapshot()["roles"]}
+        assert "speech-input" not in roles
+        assert "alignment" in roles
+        assert admission is not None
+
+
+@pytest.mark.asyncio
 async def test_admitting_alignment_does_not_map_body_errors(monkeypatch):
     """pr_validate codex BLOCKING (round-7): the ``_admitting_alignment``
     exception mapping covers only ADMISSION ENTRY. A ``ResidentModelError``

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1330,7 +1330,6 @@ def test_noop_role_admission_commit_is_noop():
 
 
 @pytest.mark.asyncio
-@pytest.mark.asyncio
 async def test_admitting_alignment_releases_resident_speech_input_role(
     monkeypatch,
 ):
@@ -1362,6 +1361,50 @@ async def test_admitting_alignment_releases_resident_speech_input_role(
         assert "speech-input" not in roles
         assert "alignment" in roles
         assert admission is not None
+
+
+@pytest.mark.asyncio
+async def test_admitting_alignment_restores_speech_input_on_507(monkeypatch):
+    """pr_validate codex BLOCKING (round-15): when alignment admission is
+    REJECTED (507) before any load runs, the ASR engine is still resident, so
+    the speech-input reservation released up front must be RESTORED — never
+    leave the still-resident ASR engine unaccounted."""
+
+    from fastapi import HTTPException
+
+    from vllm_mlx.routes import audio as audio_route
+
+    class _ResidentStt:
+        model_name = "whisper-large"
+
+    monkeypatch.setattr(audio_route, "_stt_engine", _ResidentStt())
+
+    # Tight ceiling: fits the small speech-input reservation, but NOT the
+    # large aligner footprint even after speech-input is released.
+    manager = _make_role_manager(limit_gib=0.5)
+    _install_role_manager(monkeypatch, manager)
+
+    # Dictation role resident + ASR engine resident (small footprint).
+    small = int(0.05 * 1024**3)
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper-large",
+        requested_bytes=small,
+        capacity_source="catalog",
+    ):
+        pass
+    assert [r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"]
+
+    # Alignment admission is rejected with 507 (over ceiling even after the
+    # speech-input release) -> the speech-input reservation must be restored.
+    with pytest.raises(HTTPException) as exc_info:
+        async with audio_route._admitting_alignment("qwen3-aligner"):
+            pass
+    assert exc_info.value.status_code == 507
+
+    roles = {r["role"] for r in manager.snapshot()["roles"]}
+    assert "speech-input" in roles  # restored: the ASR engine is still resident
+    assert "alignment" not in roles  # the rejected aligner left no reservation
 
 
 @pytest.mark.asyncio

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1478,10 +1478,20 @@ async def test_shutdown_releases_alignment_role(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cached_model_alignment_loads_once_and_stays_resident(monkeypatch):
-    """The cached-model validation path (issue #2405): after admission + load,
-    a repeat request for the SAME model does not reload the aligner — it
-    infers against the cached engine while a single role reservation stays
-    resident. Driven through the model-worker boundary, not the upload path."""
+    """pr_validate codex BLOCKING #5: drive THREE real ``_run_alignment_request``
+    calls for the SAME model and assert one load, three inferences, and one
+    resident role reservation.
+
+    After admission + load, a repeat real request for the SAME model must not
+    reload the aligner NOR re-admit the role — it infers against the cached
+    engine while a single resident reservation stays in the ledger. Driving the
+    full route (not ``_admitting_alignment``/``_load_aligner_blocking`` by
+    hand) means a regression that reloads or re-admits per request fails here.
+    """
+    import io
+
+    from fastapi import UploadFile
+
     from vllm_mlx.routes import audio as audio_route
     from vllm_mlx.runtime.audio_worker import bind_audio_worker
 
@@ -1507,20 +1517,40 @@ async def test_cached_model_alignment_loads_once_and_stays_resident(monkeypatch)
     manager = _make_role_manager(limit_gib=4.0)
     _install_role_manager(monkeypatch, manager)
 
-    try:
-        # First call: admit the alignment role, then load on the worker thread.
-        async with audio_route._admitting_alignment("qwen3-aligner"):
-            audio_route._load_aligner_blocking("qwen3-aligner")
+    def _recording_load(model_name, on_discard_previous=None):
+        # Mirror the real loader's idempotency: once the engine for this model
+        # is published, a repeat call is a no-op (no reload, no re-load).
+        if (
+            audio_route._aligner_engine is not None
+            and audio_route._aligner_engine.model_name == model_name
+        ):
+            return
+        operations.append("load-aligner")
+        audio_route._aligner_engine = _Aligner(model_name)
+        if on_discard_previous is not None:
+            on_discard_previous()
 
-        # Second + third calls reuse the cached engine (no reload, no re-admit).
-        audio_route._align_blocking("qwen3-aligner", "a.wav", "t", "en")
-        audio_route._align_blocking("qwen3-aligner", "b.wav", "u", None)
+    monkeypatch.setattr(audio_route, "_load_aligner_blocking", _recording_load)
+
+    def _request(i: int):
+        return audio_route._run_alignment_request(
+            UploadFile(filename=f"clip{i}.wav", file=io.BytesIO(b"\x00" * 64)),
+            model="qwen3-aligner",
+            text="你好",
+            language=None,
+            response_format="json",
+        )
+
+    try:
+        for i in range(3):
+            await _request(i)
     finally:
         bind_audio_worker(None)
 
-    # Loaded exactly once; two cached infer calls against the reused engine.
+    # Loaded exactly once across three real requests; three cached infer calls
+    # against the reused engine.
     assert operations.count("load-aligner") == 1
-    assert operations.count("infer-aligner") == 2
+    assert operations.count("infer-aligner") == 3
     # A single alignment role reservation remains resident in the ledger.
     roles = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
     assert len(roles) == 1

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1329,6 +1329,23 @@ def test_noop_role_admission_commit_is_noop():
 
 
 @pytest.mark.asyncio
+async def test_admitting_alignment_does_not_map_body_errors(monkeypatch):
+    """pr_validate codex BLOCKING (round-7): the ``_admitting_alignment``
+    exception mapping covers only ADMISSION ENTRY. A ``ResidentModelError``
+    raised by the yielded LOAD BODY must propagate unchanged (a loader/runtime
+    failure), never be rewritten as a 409 ``alignment_role_conflict``."""
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.resident_models import ResidentModelError
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    with pytest.raises(ResidentModelError, match="loader blew up"):
+        async with audio_route._admitting_alignment("qwen3-aligner"):
+            raise ResidentModelError("loader blew up")
+
+
+@pytest.mark.asyncio
 async def test_admitting_alignment_resolves_footprint_before_load(monkeypatch):
     """The alignment admission resolves the aligner footprint from catalog
     metadata (not blind) and is admitted through the shared ledger."""
@@ -1570,6 +1587,82 @@ async def test_cached_model_alignment_loads_once_and_stays_resident(monkeypatch)
     assert len(roles) == 1
     assert roles[0]["state"] == "resident"
     assert roles[0]["reserved_bytes"] == _aligner_catalog_bytes()
+
+
+@pytest.mark.asyncio
+async def test_aligner_alias_and_canonical_request_reuse_same_engine(monkeypatch):
+    """pr_validate codex BLOCKING (round-7): an alias and its canonical HF id
+    name the same checkpoint, so alternating alias / canonical requests across
+    the real ``_run_alignment_request`` must NOT reload or re-admit — the
+    alignment stays loaded once and one role reservation stays resident."""
+
+    import io
+
+    from fastapi import UploadFile
+
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+    operations: list[str] = []
+
+    class _Aligner:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def load(self) -> None:
+            operations.append("load-aligner")
+
+        def align(self, path: str, text: str, **kwargs):
+            operations.append("infer-aligner")
+            return "aligned"
+
+    worker = _RecordingWorker()
+    monkeypatch.setattr("vllm_mlx.audio.stt.STTEngine", _Aligner)
+    monkeypatch.setattr(audio_route, "_aligner_engine", None)
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    bind_audio_worker(worker)
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    def _recording_load(model_name, on_discard_previous=None):
+        if (
+            audio_route._aligner_engine is not None
+            and audio_route._aligner_engine.model_name == model_name
+        ):
+            return
+        operations.append("load-aligner")
+        audio_route._aligner_engine = _Aligner(model_name)
+        if on_discard_previous is not None:
+            on_discard_previous()
+
+    monkeypatch.setattr(audio_route, "_load_aligner_blocking", _recording_load)
+
+    def _request(i: int, model: str):
+        return audio_route._run_alignment_request(
+            UploadFile(filename=f"clip{i}.wav", file=io.BytesIO(b"\x00" * 64)),
+            model=model,
+            text="你好",
+            language=None,
+            response_format="json",
+        )
+
+    try:
+        # Alternate alias and canonical id across requests; both resolve to the
+        # same canonical checkpoint and must share one load.
+        await _request(0, "qwen3-aligner")
+        await _request(1, "mlx-community/Qwen3-ForcedAligner-0.6B-8bit")
+        await _request(2, "qwen3-forced-aligner")
+    finally:
+        bind_audio_worker(None)
+
+    # Exactly one load across three requests (alias + canonical + long alias).
+    assert operations.count("load-aligner") == 1
+    assert operations.count("infer-aligner") == 3
+    roles = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
+    assert len(roles) == 1
+    assert roles[0]["state"] == "resident"
+    assert roles[0]["model"] == "mlx-community/Qwen3-ForcedAligner-0.6B-8bit"
 
 
 @pytest.mark.asyncio

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1315,6 +1315,20 @@ def _install_role_manager(monkeypatch, manager):
 
 
 @pytest.mark.asyncio
+def test_noop_role_admission_commit_is_noop():
+    """pr_validate codex BLOCKING (round-6): ``_NoopRoleAdmission.commit()``
+    must exist and be a no-op so an unmanaged server (no residency manager)
+    that publishes an engine and then gets cancelled surfaces the real
+    ``CancelledError`` — not an ``AttributeError`` from a missing method."""
+
+    from vllm_mlx.routes.audio import _NoopRoleAdmission
+
+    admission = _NoopRoleAdmission()
+    admission.retire_previous()
+    admission.commit()  # must not raise
+
+
+@pytest.mark.asyncio
 async def test_admitting_alignment_resolves_footprint_before_load(monkeypatch):
     """The alignment admission resolves the aligner footprint from catalog
     metadata (not blind) and is admitted through the shared ledger."""
@@ -1678,7 +1692,12 @@ async def test_alignment_role_cancellation_keeps_published_engine_committed(
     _install_role_manager(monkeypatch, manager)
 
     class _FakeAlign:
-        model_name = "mlx-community/Qwen3-ForcedAligner-0.6B-8bit"
+        # Publish an ALIAS (not the canonical HF id) to prove the
+        # cancellation-commit comparison canonicalizes: the request is for
+        # ``qwen3-aligner`` and the route resolves it to the canonical id, but
+        # the published engine may expose the alias. The commit must match on
+        # canonical form or a successfully-published engine goes unaccounted.
+        model_name = "qwen3-aligner"
 
     published = threading.Event()
     release = threading.Event()
@@ -1727,4 +1746,5 @@ async def test_alignment_role_cancellation_keeps_published_engine_committed(
     roles = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
     assert len(roles) == 1
     assert roles[0]["state"] == "resident"
-    assert roles[0]["model"] == _FakeAlign.model_name
+    # The ledger records the canonical id for the ``qwen3-aligner`` alias.
+    assert roles[0]["model"] == "mlx-community/Qwen3-ForcedAligner-0.6B-8bit"

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -315,6 +315,7 @@ async def test_lane_snapshot_reports_resident_model_after_successful_load():
     assert dispatcher.snapshot() == [
         {
             "lane": "stt",
+            "role": "speech-input",
             "model": "whisper-small",
             "state": "resident",
             "active_requests": 0,
@@ -1266,3 +1267,262 @@ async def test_lifespan_binds_audio_worker_when_lane_is_enabled(monkeypatch):
         await lifespan.__anext__()
 
     assert bound == [engine]
+
+
+# ---------------------------------------------------------------------------
+# Alignment-role admission wiring (issue #2405). These exercise the shared
+# residency ledger integration used by the forced-alignment lane — the
+# ``_admitting_alignment`` context manager that resolves the aligner footprint
+# from catalog metadata and admits it as the distinct ``alignment`` role with
+# the typed 507 contract. Entirely MLX-free: a real ResidentModelManager with
+# stubbed engines stands in for the server residency, and STTEngine is stubbed
+# via ``vllm_mlx.audio.stt.STTEngine``.
+# ---------------------------------------------------------------------------
+
+
+def _aligner_catalog_bytes() -> int:
+    # Real manifest footprint for qwen3-aligner /
+    # mlx-community/Qwen3-ForcedAligner-0.6B-8bit.
+    return 1276473392
+
+
+def _make_role_manager(limit_gib: float):
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.runtime.resident_models import ResidentModelManager
+
+    registry = ModelRegistry()
+    manager = ResidentModelManager(
+        registry,
+        lambda name, path=None, perf=None: ModelEntry(
+            engine=object(), model_name=name, model_path=f"repo/{name}"
+        ),
+        memory_limit_bytes=int(limit_gib * 1024**3),
+        memory_reader=lambda: 0,
+    )
+    return manager
+
+
+def _install_role_manager(monkeypatch, manager):
+    """Point the audio route's residency lookup at a real manager so it
+    performs actual role admission. ``monkeypatch`` restores the config field
+    and the module function after the test."""
+    from vllm_mlx.config import get_config
+    from vllm_mlx.routes import audio as audio_route
+
+    cfg = get_config()
+    monkeypatch.setattr(cfg, "residency_manager", manager)
+    monkeypatch.setattr(audio_route, "_residency_manager", lambda: manager)
+
+
+@pytest.mark.asyncio
+async def test_admitting_alignment_resolves_footprint_before_load(monkeypatch):
+    """The alignment admission resolves the aligner footprint from catalog
+    metadata (not blind) and is admitted through the shared ledger."""
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    result = []
+    async with audio_route._admitting_alignment("qwen3-aligner") as admission:
+        result.append(("inside", admission))
+        roles = manager.snapshot()["roles"]
+        entry = next(r for r in roles if r["role"] == "alignment")
+        # Footprint resolved from the catalog before load.
+        assert entry["reserved_bytes"] == _aligner_catalog_bytes()
+        assert entry["capacity_source"] == "catalog"
+        assert entry["state"] == "loading"
+
+    # After success the role commits resident.
+    roles = manager.snapshot()["roles"]
+    entry = next(r for r in roles if r["role"] == "alignment")
+    assert entry["state"] == "resident"
+    assert result[0][0] == "inside"
+
+
+@pytest.mark.asyncio
+async def test_admitting_alignment_returns_507_envelope_when_over_budget(
+    monkeypatch,
+):
+    """Under a residency ceiling too small to hold the aligner, admission
+    raises the typed 507 HTTP envelope (no blind load)."""
+    from fastapi import HTTPException
+
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=0.4)  # 0.4 GiB < aligner
+    _install_role_manager(monkeypatch, manager)
+
+    with pytest.raises(HTTPException) as exc_info:
+        async with audio_route._admitting_alignment("qwen3-aligner"):
+            pass
+
+    assert exc_info.value.status_code == 507
+    envelope = exc_info.value.detail["error"]
+    assert envelope["type"] == "insufficient_capacity_error"
+    assert envelope["code"] == "insufficient_capacity_error"
+    assert envelope["reason"] == "role_capacity_alignment"
+    assert envelope["param"] == "model"
+    assert envelope["requested_bytes"] == _aligner_catalog_bytes()
+    assert envelope["limit_bytes"] == int(0.4 * 1024**3)
+    # No leaked reservation.
+    assert manager.snapshot()["roles"] == []
+
+
+@pytest.mark.asyncio
+async def test_admitting_alignment_rolls_back_on_load_failure(monkeypatch):
+    """A failed load inside the admission rolls back the reservation so the
+    ledger holds no leaked charge."""
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    with pytest.raises(RuntimeError, match="aligner load failed"):
+        async with audio_route._admitting_alignment("qwen3-aligner"):
+            raise RuntimeError("aligner load failed")
+
+    assert manager.snapshot()["roles"] == []
+    assert manager._accounted_usage() == 0
+
+
+@pytest.mark.asyncio
+async def test_admitting_alignment_rolls_back_on_cancellation(monkeypatch):
+    """Cancellation inside the admission leaves no leaked reservation."""
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    with pytest.raises(asyncio.CancelledError):
+        async with audio_route._admitting_alignment("qwen3-aligner"):
+            raise asyncio.CancelledError()
+
+    assert manager.snapshot()["roles"] == []
+    assert manager._accounted_usage() == 0
+
+
+@pytest.mark.asyncio
+async def test_evicting_aligner_releases_alignment_role(monkeypatch):
+    """An ASR request evicting the aligner lane releases the alignment role
+    so the ledger does not keep charging a dropped engine."""
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    # Reserve the alignment role as if an aligner is resident.
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=_aligner_catalog_bytes(),
+        capacity_source="catalog",
+    ):
+        pass
+    assert manager.snapshot()["roles"]
+
+    # Simulate the aligner engine being resident in the cache.
+    class _CachedAligner:
+        model_name = "qwen3-aligner"
+
+        def unload(self) -> None:
+            pass
+
+    monkeypatch.setattr(audio_route, "_aligner_engine", _CachedAligner())
+
+    # ASR evicts the aligner lane.
+    await audio_route._evict_other_lane("asr")
+
+    assert audio_route._aligner_engine is None
+    assert manager.snapshot()["roles"] == []
+
+
+@pytest.mark.asyncio
+async def test_shutdown_releases_alignment_role(monkeypatch):
+    """Shutdown unloads the aligner and drops its role reservation."""
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=_aligner_catalog_bytes(),
+        capacity_source="catalog",
+    ):
+        pass
+
+    class _Cached:
+        model_name = "qwen3-aligner"
+
+        def unload(self) -> None:
+            pass
+
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    monkeypatch.setattr(audio_route, "_aligner_engine", _Cached())
+    monkeypatch.setattr(audio_route, "_tts_engine", None)
+    monkeypatch.setattr(audio_route, "_music_engine", None)
+
+    await audio_route.shutdown_audio_lanes()
+
+    assert manager.snapshot()["roles"] == []
+
+
+# ---------------------------------------------------------------------------
+# Cached-model validation path (issue #2405): after an aligner is resident,
+# a repeat request for the SAME model does not re-admit (no double charge),
+# inferring against the cached engine, while the role stays charged.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cached_model_alignment_loads_once_and_stays_resident(monkeypatch):
+    """The cached-model validation path (issue #2405): after admission + load,
+    a repeat request for the SAME model does not reload the aligner — it
+    infers against the cached engine while a single role reservation stays
+    resident. Driven through the model-worker boundary, not the upload path."""
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+    operations: list[str] = []
+
+    class _Aligner:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def load(self) -> None:
+            operations.append("load-aligner")
+
+        def align(self, path: str, text: str, **kwargs):
+            operations.append("infer-aligner")
+            return "aligned"
+
+    worker = _RecordingWorker()
+    monkeypatch.setattr("vllm_mlx.audio.stt.STTEngine", _Aligner)
+    monkeypatch.setattr(audio_route, "_aligner_engine", None)
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    bind_audio_worker(worker)
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    try:
+        # First call: admit the alignment role, then load on the worker thread.
+        async with audio_route._admitting_alignment("qwen3-aligner"):
+            audio_route._load_aligner_blocking("qwen3-aligner")
+
+        # Second + third calls reuse the cached engine (no reload, no re-admit).
+        audio_route._align_blocking("qwen3-aligner", "a.wav", "t", "en")
+        audio_route._align_blocking("qwen3-aligner", "b.wav", "u", None)
+    finally:
+        bind_audio_worker(None)
+
+    # Loaded exactly once; two cached infer calls against the reused engine.
+    assert operations.count("load-aligner") == 1
+    assert operations.count("infer-aligner") == 2
+    # A single alignment role reservation remains resident in the ledger.
+    roles = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
+    assert len(roles) == 1
+    assert roles[0]["state"] == "resident"
+    assert roles[0]["reserved_bytes"] == _aligner_catalog_bytes()

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1432,6 +1432,83 @@ async def test_admitting_alignment_does_not_map_body_errors(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_admitting_alignment_maps_existing_role_conflict(monkeypatch):
+    """An admission-entry invariant conflict is a typed 409 response."""
+    from fastapi import HTTPException
+
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=_aligner_catalog_bytes(),
+        capacity_source="catalog",
+    ):
+        pass
+
+    with pytest.raises(HTTPException) as exc_info:
+        async with audio_route._admitting_alignment("qwen3-aligner"):
+            pass
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["error"]["code"] == "alignment_role_conflict"
+
+
+@pytest.mark.asyncio
+async def test_admitting_alignment_drains_cancelled_rollback(monkeypatch):
+    """Cancellation while rollback waits cannot strand a loading role."""
+    from vllm_mlx.routes import audio as audio_route
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+    original = manager.admit_role
+    exit_started = asyncio.Event()
+    release_exit = asyncio.Event()
+
+    class DelayedExit:
+        def __init__(self, inner):
+            self._inner = inner
+
+        async def __aenter__(self):
+            return await self._inner.__aenter__()
+
+        async def __aexit__(self, typ, exc, tb):
+            exit_started.set()
+            await release_exit.wait()
+            return await self._inner.__aexit__(typ, exc, tb)
+
+    monkeypatch.setattr(
+        manager,
+        "admit_role",
+        lambda *args, **kwargs: DelayedExit(original(*args, **kwargs)),
+    )
+
+    async def fail_during_load():
+        async with audio_route._admitting_alignment("qwen3-aligner"):
+            raise RuntimeError("load failed")
+
+    task = asyncio.create_task(fail_during_load())
+    await exit_started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+    release_exit.set()
+    with pytest.raises(RuntimeError, match="load failed"):
+        await task
+    assert manager.snapshot()["roles"] == []
+
+
+def test_canonical_model_id_resolves_default_aligner():
+    from vllm_mlx.routes import audio as audio_route
+
+    assert (
+        audio_route._canonical_model_id("default")
+        == audio_route.STT_MODEL_ALIASES[audio_route.DEFAULT_ALIGNER_ALIAS]
+    )
+
+
+@pytest.mark.asyncio
 async def test_admitting_alignment_resolves_footprint_before_load(monkeypatch):
     """The alignment admission resolves the aligner footprint from catalog
     metadata (not blind) and is admitted through the shared ledger."""

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1335,10 +1335,11 @@ async def test_admitting_alignment_releases_resident_speech_input_role(
     monkeypatch,
 ):
     """pr_validate codex BLOCKING (round-12/14): alignment and the dictation
-    STT lane are mutually exclusive, so a resident ``speech-input`` reservation
-    must be released BEFORE the alignment capacity admission — otherwise the
-    ledger charges both roles and can false-507 even though loading the aligner
-    would immediately drop the ASR engine."""
+    STT lane are mutually exclusive, so the resident ``speech-input``
+    reservation must not be DOUBLE-CHARGED with the alignment role — otherwise
+    the ledger can false-507 even though loading the aligner would immediately
+    drop the ASR engine. The sibling is RETAINED through the admission but
+    CREDITED against the alignment capacity check, and retired on success."""
 
     from vllm_mlx.routes import audio as audio_route
 
@@ -1355,13 +1356,18 @@ async def test_admitting_alignment_releases_resident_speech_input_role(
         pass
     assert [r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"]
 
-    # Entering alignment admission must release the speech-input reservation so
-    # only the alignment role is charged against the ceiling.
+    # Entering alignment admission admits the aligner WITHOUT double-charging
+    # (the retained speech-input bytes are credited, so no false 507) and
+    # commits on success with the ASR-aligned sibling retired.
     async with audio_route._admitting_alignment("qwen3-aligner") as admission:
-        roles = {r["role"] for r in manager.snapshot()["roles"]}
-        assert "speech-input" not in roles
-        assert "alignment" in roles
         assert admission is not None
+        # Retained (still its engine's true reservation) but credited against
+        # the aligner, so only the aligner's NET bytes consumed headroom.
+        assert "alignment" in {r["role"] for r in manager.snapshot()["roles"]}
+    # After success the aligner evicted the ASR engine, so the sibling retired.
+    roles = {r["role"] for r in manager.snapshot()["roles"]}
+    assert "speech-input" not in roles
+    assert "alignment" in roles
 
 
 @pytest.mark.asyncio

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1493,6 +1493,11 @@ async def test_admitting_alignment_drains_cancelled_rollback(monkeypatch):
     await exit_started.wait()
     task.cancel()
     await asyncio.sleep(0)
+    # A second cancellation must also be absorbed while the protected rollback
+    # is still draining; only the original load failure is observable after
+    # the ledger cleanup completes.
+    task.cancel()
+    await asyncio.sleep(0)
     release_exit.set()
     with pytest.raises(RuntimeError, match="load failed"):
         await task

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1326,6 +1326,7 @@ def test_noop_role_admission_commit_is_noop():
 
     admission = _NoopRoleAdmission()
     admission.retire_previous()
+    admission.retire_exclusive()  # must exist so unmanaged servers don't AttributeError
     admission.commit()  # must not raise
 
 

--- a/tests/test_audio_model_worker.py
+++ b/tests/test_audio_model_worker.py
@@ -1526,3 +1526,132 @@ async def test_cached_model_alignment_loads_once_and_stays_resident(monkeypatch)
     assert len(roles) == 1
     assert roles[0]["state"] == "resident"
     assert roles[0]["reserved_bytes"] == _aligner_catalog_bytes()
+
+
+@pytest.mark.asyncio
+async def test_aligner_load_retires_previous_only_after_actual_discard(monkeypatch):
+    """pr_validate codex BLOCKING #1: the previous aligner's reservation must be
+    retired only when the load has actually discarded the old engine — an
+    import/ASR-unload failure BEFORE the drop must leave it restorable."""
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+    operations: list[str] = []
+    retired = []
+
+    class _Aligner:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def load(self) -> None:
+            operations.append("load-aligner")
+
+        def align(self, path, text, **kwargs):
+            raise AssertionError("must not run after failed load")
+
+    class _OldAligner:
+        model_name = "old-aligner"
+
+        def unload(self) -> None:
+            operations.append("unload-old-aligner")
+
+    worker = _RecordingWorker()
+    previous = _OldAligner()
+    monkeypatch.setattr("vllm_mlx.audio.stt.STTEngine", _Aligner)
+    monkeypatch.setattr(audio_route, "_aligner_engine", previous)
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+
+    # Force the load to fail at the ASR-unload step, BEFORE the old aligner is
+    # dropped (`_aligner_engine = None`). The retire callback must not fire.
+    def boom_unload_sync(*a, **k):
+        raise RuntimeError("asr unload failed")
+
+    monkeypatch.setattr(audio_route, "_evict_other_lane_sync", boom_unload_sync)
+    bind_audio_worker(worker)
+    try:
+        with pytest.raises(RuntimeError, match="asr unload failed"):
+            audio_route._load_aligner_blocking(
+                "new-aligner", on_discard_previous=lambda: retired.append(True)
+            )
+    finally:
+        bind_audio_worker(None)
+
+    # The old aligner was never dropped and its retire callback never fired.
+    assert retired == []
+    assert audio_route._aligner_engine is previous  # old stays resident
+
+
+@pytest.mark.asyncio
+async def test_aligner_retire_fires_after_previous_discard(monkeypatch):
+    """The retire-previous callback fires only after the old aligner is
+    actually discarded (set to None), before the new load publishes."""
+    from vllm_mlx.routes import audio as audio_route
+    from vllm_mlx.runtime.audio_worker import bind_audio_worker
+
+    events: list[str] = []
+
+    class _OldAligner:
+        model_name = "old-aligner"
+
+    class _Aligner:
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def load(self) -> None:
+            events.append("load")
+
+    worker = _RecordingWorker()
+    monkeypatch.setattr("vllm_mlx.audio.stt.STTEngine", _Aligner)
+    monkeypatch.setattr(audio_route, "_aligner_engine", _OldAligner())
+    monkeypatch.setattr(audio_route, "_stt_engine", None)
+    monkeypatch.setattr(audio_route, "_evict_other_lane_sync", lambda _k: None)
+    bind_audio_worker(worker)
+
+    def on_discard():
+        events.append("retired")
+        # At this exact moment the old engine has been dropped.
+        assert audio_route._aligner_engine is None
+
+    try:
+        audio_route._load_aligner_blocking(
+            "new-aligner", on_discard_previous=on_discard
+        )
+    finally:
+        bind_audio_worker(None)
+
+    assert events == ["retired", "load"]
+    assert audio_route._aligner_engine.model_name == "new-aligner"
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_cancellation_keeps_published_engine_committed(
+    monkeypatch,
+):
+    """pr_validate codex BLOCKING #2: when the aligner load completes and
+    publishes the engine but the async admission context is cancelled, the
+    reservation is committed (kept resident) rather than rolled back — no
+    unaccounted resident engine."""
+
+    manager = _make_role_manager(limit_gib=4.0)
+    _install_role_manager(monkeypatch, manager)
+
+    class _FakeAlign:
+        model_name = "qwen3-aligner"
+
+    # Simulate: admission entered, engine published, then CancelledError raised
+    # inside the body (the caller's `admission.commit()` keeps the reservation).
+    with pytest.raises(asyncio.CancelledError):
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_catalog_bytes(),
+            capacity_source="catalog",
+        ) as admission:
+            # The load finished on the worker and published the engine.
+            admission.commit()
+            raise asyncio.CancelledError()
+
+    # The reservation is kept resident because it was committed.
+    roles = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
+    assert len(roles) == 1
+    assert roles[0]["state"] == "resident"

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -3015,3 +3015,245 @@ def test_residency_route_maps_kv_unsupported_rejection_to_422(monkeypatch):
     assert response.status_code == 422
     assert "#78" not in response.json()["detail"]
     assert "kv" in response.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Protected-role admission (forced alignment). These exercise the shared
+# residency ledger's ``admit_role``/``release_role`` transaction path with a
+# bare manager (no registry primary) so the alignment role is tested in
+# isolation — entirely MLX-free.
+# ---------------------------------------------------------------------------
+
+
+def role_manager_fixture(*, limit_gib=4.0):
+    """A manager with no primary model so role admission is tested alone."""
+
+    registry = ModelRegistry()
+    clock = Clock()
+    manager = ResidentModelManager(
+        registry,
+        lambda name, path=None, perf=None: entry(name),
+        memory_limit_bytes=limit_gib * GIB,
+        clock=clock,
+        memory_reader=lambda: 0,
+    )
+    return manager, clock
+
+
+def _aligner_bytes() -> int:
+    # The real catalog footprint of qwen3-aligner /
+    # mlx-community/Qwen3-ForcedAligner-0.6B-8bit (~1.19 GiB).
+    return 1276473392
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_admitted_under_budget_and_ledger_resident():
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=_aligner_bytes(),
+        capacity_source="catalog",
+    ):
+        # During the load the reservation is charged in the "loading" state.
+        roles = manager.snapshot()["roles"]
+        entry = next(r for r in roles if r["role"] == "alignment")
+        assert entry["state"] == "loading"
+        assert entry["reserved_bytes"] == _aligner_bytes()
+
+    # After the context succeeds the reservation is committed resident.
+    roles = manager.snapshot()["roles"]
+    entry = next(r for r in roles if r["role"] == "alignment")
+    assert entry["state"] == "resident"
+    assert entry["capacity_source"] == "catalog"
+    # The reservation is charged to the shared accounted usage.
+    assert manager._accounted_usage() >= _aligner_bytes()
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_rejected_with_typed_507_when_over_ceiling():
+    # Ceiling below the aligner footprint with no eligible eviction ->
+    # the typed role_capacity envelope must be produced.
+    manager, _ = role_manager_fixture(limit_gib=0.5)  # 0.5 GiB < aligner
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+        ):
+            pass
+
+    exc = exc_info.value
+    assert exc.reason == "role_capacity_alignment"
+    assert exc.requested_bytes == _aligner_bytes()
+    assert exc.limit_bytes == int(0.5 * GIB)
+    assert exc.requested_role == "alignment"
+    envelope = exc.envelope()
+    assert envelope["error"]["type"] == "insufficient_capacity_error"
+    assert envelope["error"]["code"] == "insufficient_capacity_error"
+    assert envelope["error"]["reason"] == "role_capacity_alignment"
+    assert envelope["error"]["requested_bytes"] == _aligner_bytes()
+    assert envelope["error"]["limit_bytes"] == int(0.5 * GIB)
+    # No leaked reservation on rejection.
+    assert manager.snapshot()["roles"] == []
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_rollback_on_load_failure_keeps_ledger_empty():
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    with pytest.raises(RuntimeError, match="weight load failed"):
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+        ):
+            raise RuntimeError("weight load failed")
+
+    # A failed load leaves no leaked reservation.
+    assert manager.snapshot()["roles"] == []
+    assert manager._accounted_usage() == 0
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_rollback_on_cancellation_keeps_ledger_empty():
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    with pytest.raises(asyncio.CancelledError):
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+        ):
+            raise asyncio.CancelledError()
+
+    assert manager.snapshot()["roles"] == []
+    assert manager._accounted_usage() == 0
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_replace_retires_previous_on_failure():
+    # A new aligner replaces a previous one; the load drops the old engine so
+    # its reservation must not be restored on failure (retire_previous).
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    # First aligner loads and commits.
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=_aligner_bytes(),
+        capacity_source="catalog",
+    ):
+        pass
+    assert manager.snapshot()["roles"][0]["model"] == "qwen3-aligner"
+
+    # Replace with a second aligner whose load fails after retire_previous.
+    with pytest.raises(RuntimeError, match="reload failed"):
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-forced-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+            replace_existing=True,
+        ) as admission:
+            admission.retire_previous()
+            raise RuntimeError("reload failed")
+
+    # The old engine is gone, so no reservation should remain.
+    assert manager.snapshot()["roles"] == []
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_replace_restores_previous_unless_retired():
+    # Without retire_previous, a failed replacement restores the previous
+    # reservation (the old engine still exists).
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=_aligner_bytes(),
+        capacity_source="catalog",
+    ):
+        pass
+
+    try:
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-forced-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+            replace_existing=True,
+        ):
+            raise RuntimeError("reload failed")
+    except RuntimeError:
+        pass
+
+    # Previous aligner reservation restored (old engine survives).
+    roles = manager.snapshot()["roles"]
+    assert len(roles) == 1
+    assert roles[0]["model"] == "qwen3-aligner"
+    assert roles[0]["state"] == "resident"
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_unknown_capacity_fails_closed_under_ceiling():
+    # Under a configured ceiling, a model with no catalog/local-cache size
+    # must fail closed rather than admit blind.
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        async with manager.admit_role(
+            role="alignment",
+            model_id="some-unknown-aligner",
+            requested_bytes=None,
+            capacity_source="unknown",
+        ):
+            pass
+
+    assert exc_info.value.reason == "role_capacity_unknown"
+    assert exc_info.value.requested_bytes is None
+    assert exc_info.value.envelope()["error"]["reason"] == "role_capacity_unknown"
+    assert manager.snapshot()["roles"] == []
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_no_ceiling_admits_without_typed_rejection():
+    # With no configured ceiling (limit 0) admission bypasses capacity checks
+    # entirely, preserving pre-existing behavior for unmanaged servers.
+    manager, _ = role_manager_fixture(limit_gib=0.0)
+
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=None,  # unknown, but no ceiling -> admitted
+        capacity_source="unknown",
+    ):
+        pass
+
+    roles = manager.snapshot()["roles"]
+    assert len(roles) == 1
+    assert roles[0]["state"] == "resident"
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_release_removes_ledger_charge():
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=_aligner_bytes(),
+        capacity_source="catalog",
+    ):
+        pass
+    assert manager._accounted_usage() >= _aligner_bytes()
+
+    await manager.release_role("alignment")
+    assert manager.snapshot()["roles"] == []
+    assert manager._accounted_usage() == 0

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -3310,6 +3310,7 @@ async def test_alignment_role_release_removes_ledger_charge():
     assert manager._accounted_usage() == 0
 
 
+@pytest.mark.asyncio
 async def test_alignment_role_release_exclusive_retires_sibling_on_success():
     """pr_validate codex BLOCKING (round-17): alignment and dictation are
     mutually exclusive, so a resident ``speech-input`` reservation must be
@@ -3344,6 +3345,7 @@ async def test_alignment_role_release_exclusive_retires_sibling_on_success():
     assert "speech-input" not in roles  # retired with the successful admission
 
 
+@pytest.mark.asyncio
 async def test_alignment_role_release_exclusive_restores_sibling_on_rollback():
     """pr_validate codex BLOCKING (round-17): when the alignment admission
     transaction rolls back (no engine evicted), the retired ``speech-input``
@@ -3384,6 +3386,7 @@ async def test_alignment_role_release_exclusive_restores_sibling_on_rollback():
     assert speech["reserved_bytes"] == small
 
 
+@pytest.mark.asyncio
 async def test_alignment_role_exclusive_sibling_capacity_is_retained_during_load():
     """pr_validate codex BLOCKING (round-19/21): the manager lock is NOT held
     across the yielded aligner load, so the mutually-exclusive sibling's
@@ -3448,6 +3451,7 @@ async def test_alignment_role_exclusive_sibling_capacity_is_retained_during_load
     assert manager._accounted_usage() == other + speech
 
 
+@pytest.mark.asyncio
 async def test_alignment_role_commit_finalize_is_cancellation_shielded():
     """pr_validate codex BLOCKING (round-22): after ``admission.commit()`` the
     engine is resident, so a cancellation arriving while the success-path

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -3382,3 +3382,63 @@ async def test_alignment_role_release_exclusive_restores_sibling_on_rollback():
     # The restored reservation keeps its original footprint (accounted once).
     (speech,) = [r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"]
     assert speech["reserved_bytes"] == small
+
+
+async def test_alignment_role_release_exclusive_restore_is_capacity_enforced():
+    """pr_validate codex BLOCKING (round-19): the manager lock is NOT held
+    across the yielded aligner load, so a CONCURRENT admission can consume the
+    capacity freed by retiring ``speech-input``. On rollback the retired
+    reservation is restored only within the configured ceiling — if re-adding
+    it would exceed ``memory_limit`` (because another model legitimately took
+    the freed headroom), it stays retired rather than violating the ceiling."""
+    manager, _ = role_manager_fixture(limit_gib=1.0)
+    GIB = 1024**3
+    speech = int(0.4 * GIB)
+    other = int(0.2 * GIB)
+    aligner = int(0.3 * GIB)
+    concurrent = int(0.5 * GIB)
+
+    # Pre-existing roles: speech-input (0.4) + a tts-role sibling (0.2) = 0.6.
+    async with manager.admit_role(
+        role="tts",
+        model_id="some-tts",
+        requested_bytes=other,
+        capacity_source="catalog",
+    ):
+        pass
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper-large",
+        requested_bytes=speech,
+        capacity_source="catalog",
+    ):
+        pass
+    assert manager._accounted_usage() == other + speech
+
+    # Enter alignment (retires speech-input -> frees 0.4; aligner 0.3 fits).
+    # During the yielded LOAD (lock released) a concurrent admission claims the
+    # freed headroom: a second role consuming almost all remaining capacity.
+    with pytest.raises(RuntimeError, match="load failed"):
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=aligner,
+            capacity_source="catalog",
+            release_exclusive_role="speech-input",
+        ):
+            async with manager.admit_role(
+                role="tts-extra",
+                model_id="other-tts",
+                requested_bytes=concurrent,
+                capacity_source="catalog",
+            ):
+                pass
+            raise RuntimeError("load failed")
+
+    roles = {r["role"] for r in manager.snapshot()["roles"]}
+    assert "alignment" not in roles
+    assert "tts" in roles and "tts-extra" in roles
+    # speech-input was NOT restored: its freed capacity was consumed by the
+    # concurrent tts-extra admission, so restoring it would breach the ceiling.
+    assert "speech-input" not in roles
+    assert manager._accounted_usage() == other + concurrent

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -36,6 +36,18 @@ def test_resident_performance_maps_to_the_scheduler_contract():
         "enable_prefix_cache": False,
         "cache_memory_mb": 4096,
     }
+
+
+def test_legacy_capacity_error_keeps_stable_envelope():
+    error = ResidentModelCapacityError("legacy replacement rejected")
+    assert error.envelope() == {
+        "error": {
+            "message": "legacy replacement rejected",
+            "type": "insufficient_capacity_error",
+            "code": "insufficient_capacity_error",
+            "param": "model",
+        }
+    }
     assert resident_scheduler_kwargs(
         ResidentPerformanceConfig(kv_cache_turboquant="k8v4")
     ) == {
@@ -3518,6 +3530,47 @@ async def test_alignment_role_commit_finalize_is_cancellation_shielded():
     (aligned,) = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
     assert aligned["state"] == "resident"
     assert aligned["reserved_bytes"] == aligner
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_success_finalize_drains_repeated_cancellation(
+    monkeypatch,
+):
+    """Success finalization completes even if its waiter is cancelled twice."""
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+    finalize_started = asyncio.Event()
+    release_finalize = asyncio.Event()
+    original = manager._finalize_role_commit
+
+    async def delayed_finalize(**kwargs):
+        finalize_started.set()
+        await release_finalize.wait()
+        await original(**kwargs)
+
+    monkeypatch.setattr(manager, "_finalize_role_commit", delayed_finalize)
+
+    async def admit():
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+        ):
+            pass
+
+    task = asyncio.create_task(admit())
+    await finalize_started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.sleep(0)
+    release_finalize.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    (role,) = manager.snapshot()["roles"]
+    assert role["role"] == "alignment"
+    assert role["state"] == "resident"
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -3202,6 +3202,57 @@ async def test_alignment_role_replace_restores_previous_unless_retired():
 
 
 @pytest.mark.asyncio
+async def test_alignment_role_rejects_second_loading_admission():
+    """A role must never host two concurrent in-flight LOADS.
+
+    pr_validate codex BLOCKING #1: a second admission while the first is
+    still loading would overwrite the ledger entry, and a later rollback
+    could resurrect a stale ``\"loading\"`` record. The ledger layer rejects
+    the second admission instead of corrupting the reservation.
+    """
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hold_open():
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+        ):
+            started.set()
+            await release.wait()
+
+    first = asyncio.create_task(hold_open())
+    await started.wait()
+
+    # While the first load is in flight ("loading"), a second admission for
+    # the same role — even with replace_existing=True — must be rejected, not
+    # overwrite the in-flight reservation.
+    with pytest.raises(ResidentModelError, match="loading admission in flight"):
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-forced-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+            replace_existing=True,
+        ):
+            pass
+
+    release.set()
+    await first
+
+    # The original (first) reservation committed resident, untouched by the
+    # rejected second admission.
+    roles = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
+    assert len(roles) == 1
+    assert roles[0]["model"] == "qwen3-aligner"
+    assert roles[0]["state"] == "resident"
+
+
+@pytest.mark.asyncio
 async def test_alignment_role_unknown_capacity_fails_closed_under_ceiling():
     # Under a configured ceiling, a model with no catalog/local-cache size
     # must fail closed rather than admit blind.

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -3308,3 +3308,77 @@ async def test_alignment_role_release_removes_ledger_charge():
     await manager.release_role("alignment")
     assert manager.snapshot()["roles"] == []
     assert manager._accounted_usage() == 0
+
+
+async def test_alignment_role_release_exclusive_retires_sibling_on_success():
+    """pr_validate codex BLOCKING (round-17): alignment and dictation are
+    mutually exclusive, so a resident ``speech-input`` reservation must be
+    retired atomically WITHIN the alignment admission transaction — read from
+    the real auxiliary ``_roles`` ledger, never the ``snapshot()`` projection
+    (which mixes in synthesized ordinary-model entries a route could wrongly
+    release). On SUCCESS the sibling stays retired (the ASR engine was
+    evicted) so the ledger charges only the alignment role."""
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    small = int(0.05 * 1024**3)
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper-large",
+        requested_bytes=small,
+        capacity_source="catalog",
+    ):
+        pass
+    assert any(r["role"] == "speech-input" for r in manager.snapshot()["roles"])
+
+    async with manager.admit_role(
+        role="alignment",
+        model_id="qwen3-aligner",
+        requested_bytes=_aligner_bytes(),
+        capacity_source="catalog",
+        release_exclusive_role="speech-input",
+    ):
+        pass
+
+    roles = {r["role"] for r in manager.snapshot()["roles"]}
+    assert "alignment" in roles
+    assert "speech-input" not in roles  # retired with the successful admission
+
+
+async def test_alignment_role_release_exclusive_restores_sibling_on_rollback():
+    """pr_validate codex BLOCKING (round-17): when the alignment admission
+    transaction rolls back (no engine evicted), the retired ``speech-input``
+    reservation MUST be restored atomically under the same lock — a
+    still-resident ASR engine can never be left silently unaccounted. There is
+    no window for a concurrent admission to claim the freed capacity, because
+    the release and the restore are the SAME manager transaction."""
+    manager, _ = role_manager_fixture(limit_gib=0.5)
+
+    small = int(0.05 * 1024**3)
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper-large",
+        requested_bytes=small,
+        capacity_source="catalog",
+    ):
+        pass
+    assert any(r["role"] == "speech-input" for r in manager.snapshot()["roles"])
+
+    # The aligner (1.19 GiB) cannot fit under 0.5 GiB even after the small
+    # speech-input reservation is released -> the in-lock rollback runs and
+    # must restore speech-input before the capacity error propagates.
+    with pytest.raises(ResidentModelCapacityError):
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+            release_exclusive_role="speech-input",
+        ):
+            pass
+
+    roles = {r["role"] for r in manager.snapshot()["roles"]}
+    assert "speech-input" in roles  # restored: the ASR engine is still resident
+    assert "alignment" not in roles  # the rejected aligner left no reservation
+    # The restored reservation keeps its original footprint (accounted once).
+    (speech,) = [r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"]
+    assert speech["reserved_bytes"] == small

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -3518,3 +3518,52 @@ async def test_alignment_role_commit_finalize_is_cancellation_shielded():
     (aligned,) = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
     assert aligned["state"] == "resident"
     assert aligned["reserved_bytes"] == aligner
+
+
+@pytest.mark.asyncio
+async def test_alignment_role_rollback_preserves_concurrently_replaced_sibling():
+    """pr_validate codex BLOCKING (round-24): rollback must only retire the
+    sibling reservation THIS transaction retained — never erase a NEWER
+    reservation a concurrent admission installed for that role while the
+    aligner load ran. The identity-checked pop preserves the replacement."""
+    manager, _ = role_manager_fixture(limit_gib=1.0)
+    GIB = 1024**3
+    s1 = int(0.4 * GIB)
+    s2 = int(0.25 * GIB)
+    aligner = int(0.3 * GIB)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper-large",
+        requested_bytes=s1,
+        capacity_source="catalog",
+    ):
+        pass
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=aligner,
+            capacity_source="catalog",
+            release_exclusive_role="speech-input",
+        ) as admission:
+            # The load evicted the ASR engine -> retire_exclusive fires.
+            admission.retire_exclusive()
+            # A concurrent admission REPLACES the speech-input reservation with
+            # a newer (still-resident engine) one while the aligner loads.
+            async with manager.admit_role(
+                role="speech-input",
+                model_id="whisper-large",
+                requested_bytes=s2,
+                capacity_source="catalog",
+                replace_existing=True,
+            ):
+                pass
+            raise RuntimeError("load failed")
+
+    # The rollback must NOT erase the newer reservation (its engine is
+    # resident); only alignment is rolled back.
+    (speech,) = [r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"]
+    assert speech["reserved_bytes"] == s2
+    assert "alignment" not in {r["role"] for r in manager.snapshot()["roles"]}

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -3384,13 +3384,15 @@ async def test_alignment_role_release_exclusive_restores_sibling_on_rollback():
     assert speech["reserved_bytes"] == small
 
 
-async def test_alignment_role_release_exclusive_restore_is_capacity_enforced():
-    """pr_validate codex BLOCKING (round-19): the manager lock is NOT held
-    across the yielded aligner load, so a CONCURRENT admission can consume the
-    capacity freed by retiring ``speech-input``. On rollback the retired
-    reservation is restored only within the configured ceiling — if re-adding
-    it would exceed ``memory_limit`` (because another model legitimately took
-    the freed headroom), it stays retired rather than violating the ceiling."""
+async def test_alignment_role_exclusive_sibling_capacity_is_retained_during_load():
+    """pr_validate codex BLOCKING (round-19/21): the manager lock is NOT held
+    across the yielded aligner load, so the mutually-exclusive sibling's
+    capacity could be STOLEN by a concurrent admission if it were released
+    up front. Instead the sibling reservation is RETAINED (credited against the
+    aligner, never freed), so a concurrent admission CANNOT claim its bytes:
+    it is rejected with 507 while the aligner loads, and the rollback leaves
+    the sibling's still-resident engine correctly accounted — no unaccounted
+    engine and no over-ceiling ledger."""
     manager, _ = role_manager_fixture(limit_gib=1.0)
     GIB = 1024**3
     speech = int(0.4 * GIB)
@@ -3415,10 +3417,10 @@ async def test_alignment_role_release_exclusive_restore_is_capacity_enforced():
         pass
     assert manager._accounted_usage() == other + speech
 
-    # Enter alignment (retires speech-input -> frees 0.4; aligner 0.3 fits).
-    # During the yielded LOAD (lock released) a concurrent admission claims the
-    # freed headroom: a second role consuming almost all remaining capacity.
-    with pytest.raises(RuntimeError, match="load failed"):
+    # Enter alignment (speech-input retained + credited, so no false 507 and
+    # no freed capacity). During the yielded LOAD a concurrent admission wants
+    # the sibling's bytes, but they are RETAINED -> it cannot fit -> 507.
+    with pytest.raises(ResidentModelCapacityError):
         async with manager.admit_role(
             role="alignment",
             model_id="qwen3-aligner",
@@ -3435,10 +3437,12 @@ async def test_alignment_role_release_exclusive_restore_is_capacity_enforced():
                 pass
             raise RuntimeError("load failed")
 
+    # The concurrent tts-extra admission was REJECTED (sibling capacity
+    # retained), so on rollback the ledger is exactly as before the aligner:
+    # speech-input restored (its engine is still resident) + tts, alignment gone.
     roles = {r["role"] for r in manager.snapshot()["roles"]}
     assert "alignment" not in roles
-    assert "tts" in roles and "tts-extra" in roles
-    # speech-input was NOT restored: its freed capacity was consumed by the
-    # concurrent tts-extra admission, so restoring it would breach the ceiling.
-    assert "speech-input" not in roles
-    assert manager._accounted_usage() == other + concurrent
+    assert "tts" in roles
+    assert "tts-extra" not in roles
+    assert "speech-input" in roles  # retained + credited, its engine accounted
+    assert manager._accounted_usage() == other + speech

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -3446,3 +3446,71 @@ async def test_alignment_role_exclusive_sibling_capacity_is_retained_during_load
     assert "tts-extra" not in roles
     assert "speech-input" in roles  # retained + credited, its engine accounted
     assert manager._accounted_usage() == other + speech
+
+
+async def test_alignment_role_commit_finalize_is_cancellation_shielded():
+    """pr_validate codex BLOCKING (round-22): after ``admission.commit()`` the
+    engine is resident, so a cancellation arriving while the success-path
+    finalization waits on the manager lock must STILL retire the evicted
+    sibling (and keep the committed record resident) — never leak a phantom
+    sibling charge. The success finalization runs under a cancel-drained
+    shield, so whether the cancellation is handled by that shield or by the
+    ``committed`` rollback branch, the invariant holds: sibling retired,
+    alignment record resident."""
+    from vllm_mlx.runtime.resident_models import ResidentRoleAdmission
+
+    manager, _ = role_manager_fixture(limit_gib=1.0)
+    GIB = 1024**3
+    speech = int(0.4 * GIB)
+    aligner = int(0.3 * GIB)
+
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper-large",
+        requested_bytes=speech,
+        capacity_source="catalog",
+    ):
+        pass
+
+    # align() commits the engine inside its body, then BLOCKS holding the
+    # manager lock so cancellation lands deterministically AFTER publication.
+    committed_in_body = asyncio.Event()
+    release_body_lock = asyncio.Event()
+
+    async def _align():
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=aligner,
+            capacity_source="catalog",
+            release_exclusive_role="speech-input",
+        ) as admission:
+            # Engine published -> mark resident; a cancellation anywhere after
+            # this must not resurrect the evicted sibling.
+            if isinstance(admission, ResidentRoleAdmission):
+                admission.commit()
+            # Hold the manager lock and park: the body owns the lock here, so
+            # cancelling now exercises the post-commit cleanup under lock
+            # contention (either the committed-rollback branch or the shielded
+            # else-finalize) — both must retire the sibling.
+            async with manager._lock:
+                committed_in_body.set()
+                await release_body_lock.wait()
+
+    align_task = asyncio.create_task(_align())
+    await committed_in_body.wait()  # committed and holding the manager lock
+    align_task.cancel()  # cancel AFTER publication
+    release_body_lock.set()  # let the post-commit cleanup run (drains)
+
+    try:
+        await align_task
+    except asyncio.CancelledError:
+        pass
+
+    # The cancellation must not leak: sibling retired (ASR engine evicted) and
+    # the committed alignment record resident.
+    roles = {r["role"] for r in manager.snapshot()["roles"]}
+    assert "speech-input" not in roles
+    (aligned,) = [r for r in manager.snapshot()["roles"] if r["role"] == "alignment"]
+    assert aligned["state"] == "resident"
+    assert aligned["reserved_bytes"] == aligner

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -307,3 +307,35 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
     assert "c/noncanonicalweightmodel" not in index
     # A SPLIT GGUF without a proven full shard set fails closed.
     assert "c/shardedggufmodel" not in index
+
+
+def test_local_cache_scan_failure_fails_closed(monkeypatch):
+    """A cache-library failure must produce no trusted footprint."""
+    import huggingface_hub
+
+    from vllm_mlx.runtime import role_capacity
+
+    def fail_scan():
+        raise RuntimeError("cache metadata unavailable")
+
+    monkeypatch.setattr(huggingface_hub, "scan_cache_dir", fail_scan)
+    assert role_capacity._scan_local_cache_index() == {}
+
+
+def test_revision_rejects_corrupt_or_empty_shard_index():
+    """Unreadable and empty indexes cannot prove a complete checkpoint."""
+    from vllm_mlx.runtime import role_capacity
+
+    corrupt = _Rev(
+        refs={"main"},
+        files=(("model.safetensors.index.json", 100),),
+        index_json="not json",
+    )
+    empty = _Rev(
+        refs={"main"},
+        files=(("model.safetensors.index.json", 100),),
+        index_json='{"weight_map": {}}',
+    )
+
+    assert role_capacity._revision_is_complete(corrupt) is False
+    assert role_capacity._revision_is_complete(empty) is False

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -3,21 +3,32 @@ from __future__ import annotations
 """MLX-free tests for metadata-backed alignment-role capacity resolution.
 
 These prove the forced-alignment footprint is resolved from catalog /
-local-cache metadata BEFORE any weight loading (so admission decides with
-knowledge of the size, not blind) — the first half of issue #2405's
+verified local-cache metadata BEFORE any weight loading (so admission decides
+with knowledge of the size, not blind) — the first half of issue #2405's
 Required contract. No MLX is imported or required.
 """
+
+# Real manifest footprint for qwen3-aligner /
+# mlx-community/Qwen3-ForcedAligner-0.6B-8bit (weight + tokenizer).
+ALIGNER_CATALOG_BYTES = 1276473392
+ALIGNER_HF_ID = "mlx-community/Qwen3-ForcedAligner-0.6B-8bit"
+
+
+def _patch_catalog_to_missing(monkeypatch):
+    """Make the checked-in manifest look like it has no size for the aligner,
+    so the verified-local-cache fallback is exercised."""
+    from vllm_mlx import model_sizes
+
+    monkeypatch.setattr(model_sizes, "size_bytes", lambda _hf: None)
 
 
 def test_alignment_capacity_resolves_from_catalog_by_alias():
     from vllm_mlx.runtime.role_capacity import alignment_capacity
 
     capacity = alignment_capacity("qwen3-aligner")
-    # Catalog manifest maps qwen3-aligner -> mlx-community/Qwen3-ForcedAligner-0.6B-8bit
-    # whose weight+tokenizer footprint is a real byte count, not a heuristic.
+    # Catalog manifest resolves a real, exact byte count, not a heuristic.
     assert capacity.source == "catalog"
-    assert isinstance(capacity.requested_bytes, int)
-    assert capacity.requested_bytes > 0
+    assert capacity.requested_bytes == ALIGNER_CATALOG_BYTES
 
 
 def test_alignment_capacity_resolves_from_catalog_by_long_alias():
@@ -25,26 +36,52 @@ def test_alignment_capacity_resolves_from_catalog_by_long_alias():
 
     capacity = alignment_capacity("qwen3-forced-aligner")
     assert capacity.source == "catalog"
-    assert (
-        capacity.requested_bytes == alignment_capacity("qwen3-aligner").requested_bytes
-    )
+    assert capacity.requested_bytes == ALIGNER_CATALOG_BYTES
 
 
 def test_alignment_capacity_resolves_from_catalog_by_hf_id():
     from vllm_mlx.runtime.role_capacity import alignment_capacity
 
-    capacity = alignment_capacity("mlx-community/Qwen3-ForcedAligner-0.6B-8bit")
+    capacity = alignment_capacity(ALIGNER_HF_ID)
     assert capacity.source == "catalog"
-    assert (
-        capacity.requested_bytes == alignment_capacity("qwen3-aligner").requested_bytes
-    )
+    assert capacity.requested_bytes == ALIGNER_CATALOG_BYTES
 
 
-def test_alignment_capacity_fails_closed_on_unknown():
-    from vllm_mlx.runtime.role_capacity import alignment_capacity
+def test_alignment_capacity_falls_back_to_verified_local_cache(monkeypatch):
+    """When the catalog has no entry but the checkpoint is already on disk,
+    the verified local-cache footprint is used instead of rejecting blind."""
+    from vllm_mlx.runtime import role_capacity
 
-    # A non-audio / unknown id has no catalog entry -> source "unknown" so a
-    # configured ceiling fails closed rather than admitting blind.
-    capacity = alignment_capacity("some/unknown-nonaligner-checkpoint")
+    _patch_catalog_to_missing(monkeypatch)
+    monkeypatch.setattr(role_capacity, "_local_cache_bytes", lambda _hf: 998244353)
+
+    capacity = role_capacity.alignment_capacity(ALIGNER_HF_ID)
+    assert capacity.source == "local-cache"
+    assert capacity.requested_bytes == 998244353
+
+
+def test_alignment_capacity_cached_only_checkpoint(monkeypatch):
+    """A checkpoint absent from the catalog but present, verified, in the
+    local cache yields a real charge sourced from the cache (issue #2405's
+    required catalog-or-cache fallback)."""
+    from vllm_mlx.runtime import role_capacity
+
+    _patch_catalog_to_missing(monkeypatch)
+    monkeypatch.setattr(role_capacity, "_local_cache_bytes", lambda _hf: 777777777)
+
+    capacity = role_capacity.alignment_capacity(ALIGNER_HF_ID)
+    assert capacity.source == "local-cache"
+    assert capacity.requested_bytes == 777777777
+
+
+def test_alignment_capacity_fails_closed_on_unknown(monkeypatch):
+    """With neither a catalog entry nor a verified local-cache footprint, the
+    capacity is unknown so a configured ceiling fails closed (no blind admit)."""
+    from vllm_mlx.runtime import role_capacity
+
+    _patch_catalog_to_missing(monkeypatch)
+    monkeypatch.setattr(role_capacity, "_local_cache_bytes", lambda _hf: None)
+
+    capacity = role_capacity.alignment_capacity("some/unknown-nonaligner-checkpoint")
     assert capacity.source == "unknown"
     assert capacity.requested_bytes is None

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -224,6 +224,17 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
         # (main) branch, so this cannot be trusted to charge the real load.
         revisions = (_Rev(refs={"feature-x"}, files=(("model.safetensors", 7000),)),)
 
+    class _ShardedNoIndexRepo:
+        repo_id = "c/ShardedNoIndexModel"
+        # A shard-PATTERNED weight with NO index is an incomplete multi-shard
+        # download (round-13) — one shard must not be charged as the whole.
+        revisions = (
+            _Rev(
+                refs={"main"},
+                files=(("model-00001-of-00002.safetensors", 4000),),
+            ),
+        )
+
     class _FakeCache:
         repos = [
             _PartialRepo,
@@ -233,6 +244,7 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
             _ShardedCompleteRepo,
             _ShardedIncompleteRepo,
             _NonDefaultBranchRepo,
+            _ShardedNoIndexRepo,
         ]
 
     monkeypatch.setattr(huggingface_hub, "scan_cache_dir", lambda: _FakeCache())
@@ -254,3 +266,5 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
     assert "c/shardedincompletemodel" not in index
     # A lone non-main branch is not the default the loader fetches -> fail closed.
     assert "c/nondefaultmodel" not in index
+    # A shard-PATTERNED weight with no index is an incomplete download -> fail closed.
+    assert "c/shardednoindexmodel" not in index

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -122,13 +122,27 @@ def test_local_cache_lookup_coalesces_into_one_scan_per_ttl(monkeypatch):
     assert calls == ["scan", "scan"]
 
 
+class _FakePath:
+    def __init__(self, text):
+        self._text = text
+
+    def read_text(self, encoding="utf-8"):
+        return self._text
+
+
 class _Rev:
-    def __init__(self, refs, files=()):
+    def __init__(self, refs, files=(), index_json=None):
         self.refs = frozenset(refs)
         self.files = [
             type("F", (), {"file_name": name, "size_on_disk": size})
             for name, size in files
         ]
+        if index_json is not None:
+            # Point model.safetensors.index.json at a readable fake path.
+            for f in self.files:
+                if f.file_name == "model.safetensors.index.json":
+                    f.file_path = _FakePath(index_json)
+                    f.read_text = f.file_path.read_text
 
 
 def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
@@ -168,12 +182,57 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
             _Rev(refs=(), files=(("config.json", 100),)),
         )
 
+    class _ShardedCompleteRepo:
+        repo_id = "c/ShardedCompleteModel"
+        # Multi-shard download, all shards present per the index.
+        revisions = (
+            _Rev(
+                refs={"main"},
+                files=(
+                    ("model.safetensors.index.json", 100),
+                    ("model-00001-of-00002.safetensors", 4000),
+                    ("model-00002-of-00002.safetensors", 5000),
+                ),
+                index_json=(
+                    '{"weight_map": {"a": "model-00001-of-00002.safetensors", '
+                    '"b": "model-00002-of-00002.safetensors"}}'
+                ),
+            ),
+        )
+
+    class _ShardedIncompleteRepo:
+        repo_id = "c/ShardedIncompleteModel"
+        # Multi-shard download MISSING one shard (interrupted) — the index
+        # proves the second shard is absent, so it must fail closed.
+        revisions = (
+            _Rev(
+                refs={"main"},
+                files=(
+                    ("model.safetensors.index.json", 100),
+                    ("model-00001-of-00002.safetensors", 4000),
+                ),
+                index_json=(
+                    '{"weight_map": {"a": "model-00001-of-00002.safetensors", '
+                    '"b": "model-00002-of-00002.safetensors"}}'
+                ),
+            ),
+        )
+
+    class _NonDefaultBranchRepo:
+        repo_id = "c/NonDefaultModel"
+        # Only a non-main branch is cached; the loader resolves the default
+        # (main) branch, so this cannot be trusted to charge the real load.
+        revisions = (_Rev(refs={"feature-x"}, files=(("model.safetensors", 7000),)),)
+
     class _FakeCache:
         repos = [
             _PartialRepo,
             _SelectiveNoWeightsRepo,
             _CompleteRepo,
             _OldCompletedPlusPartialRepo,
+            _ShardedCompleteRepo,
+            _ShardedIncompleteRepo,
+            _NonDefaultBranchRepo,
         ]
 
     monkeypatch.setattr(huggingface_hub, "scan_cache_dir", lambda: _FakeCache())
@@ -188,3 +247,10 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
     # A repo with older completed + partial revision is charged ONLY the
     # completed snapshot's bytes (8000), not the aggregate (8100).
     assert index["c/mixedmodel"] == 8000
+    # A multi-shard download with ALL shards present (per the index) is charged
+    # its full snapshot bytes (index + shards); one with a missing shard fails
+    # closed.
+    assert index["c/shardedcompletemodel"] == 9100
+    assert "c/shardedincompletemodel" not in index
+    # A lone non-main branch is not the default the loader fetches -> fail closed.
+    assert "c/nondefaultmodel" not in index

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -190,6 +190,17 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
         # cannot prove completeness -> fail closed.
         revisions = (_Rev(refs={"main"}, files=(("model.safetensors", 9900),)),)
 
+    class _ShardedGgufNoIndexRepo:
+        repo_id = "c/ShardedGgufModel"
+        # A SPLIT GGUF (round-16) without a readable shard set: a single
+        # split shard must not be charged as the whole checkpoint.
+        revisions = (
+            _Rev(
+                refs={"main"},
+                files=(("model-00001-of-00002.gguf", 6000),),
+            ),
+        )
+
     class _ShardedCompleteRepo:
         repo_id = "c/ShardedCompleteModel"
         # Multi-shard download, all shards present per the index.
@@ -250,6 +261,7 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
             _CompleteRepo,
             _OldCompletedPlusPartialRepo,
             _BareSafeTensorNoIndexRepo,
+            _ShardedGgufNoIndexRepo,
             _ShardedCompleteRepo,
             _ShardedIncompleteRepo,
             _NonDefaultBranchRepo,
@@ -279,3 +291,5 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
     assert "c/shardednoindexmodel" not in index
     # A bare .safetensors with NO index cannot be proven complete -> fail closed.
     assert "c/baresafetensormodel" not in index
+    # A SPLIT GGUF without a proven full shard set fails closed.
+    assert "c/shardedggufmodel" not in index

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -87,88 +87,84 @@ def test_alignment_capacity_fails_closed_on_unknown(monkeypatch):
     assert capacity.requested_bytes is None
 
 
-def test_local_cache_lookup_is_bounded_for_hit_and_miss(monkeypatch):
-    """The verified-cache footprint (hit OR miss) is reused only for the bounded
-    TTL so a mutable cache's later download becomes discoverable after expiry,
-    while a burst of arbitrary model ids does not re-walk the whole cache each
-    time (reconciles round-3 'don't permanently memoize', round-4 'bounded TTL',
-    and round-9 'bounded negatively-cached miss' findings)."""
+def test_local_cache_lookup_coalesces_into_one_scan_per_ttl(monkeypatch):
+    """The local-cache footprint reads from a SINGLE TTL-bounded snapshot: any
+    number of distinct model ids (attacker-controlled) trigger one cache walk
+    per TTL window — no per-id scan, no unbounded per-id memory — and a fresh
+    download becomes discoverable after the TTL elapses."""
     from vllm_mlx.runtime import role_capacity
 
     calls: list[str] = []
-    monkeypatch.setattr(
-        role_capacity,
-        "_scan_local_cache_bytes",
-        lambda hf: calls.append(hf) or 998244353,
-    )
+
+    def fake_index() -> dict[str, int]:
+        calls.append("scan")
+        return {"c/fakemodel": 998244353, "c/othermodel": 555}
+
+    monkeypatch.setattr(role_capacity, "_scan_local_cache_index", fake_index)
     monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", 60.0)
-    role_capacity._local_cache_lookups.clear()
+    monkeypatch.setattr(role_capacity, "_local_cache_snapshot", None)
 
-    # First call scans and caches the positive result.
+    # First lookup builds the snapshot (one scan).
     assert role_capacity._local_cache_bytes("c/FakeModel") == 998244353
-    assert calls == ["c/FakeModel"]
+    assert calls == ["scan"]
 
-    # A repeat inside the TTL reuses the cached footprint without re-scanning.
-    assert role_capacity._local_cache_bytes("c/FakeModel") == 998244353
-    assert calls == ["c/FakeModel"]
+    # A distinct id inside the same TTL reuses the SAME snapshot — no new scan.
+    assert role_capacity._local_cache_bytes("c/OtherModel") == 555
+    assert calls == ["scan"]
 
-    # After the TTL elapses the cache is re-scanned (mutable disk observed).
-    monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", -1.0)
-    assert role_capacity._local_cache_bytes("c/FakeModel") == 998244353
-    assert calls == ["c/FakeModel", "c/FakeModel"]
-
-    # A MISS is also cached briefly: two consecutive unknown lookups scan only
-    # once (no repeated full-cache walks for arbitrary ids), then re-scan after
-    # the TTL so a later download becomes discoverable.
-    monkeypatch.setattr(
-        role_capacity,
-        "_scan_local_cache_bytes",
-        lambda hf: calls.append(hf) or None,
-    )
-    monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", 60.0)
-    role_capacity._local_cache_lookups.clear()
+    # A miss inside the TTL is served from the same snapshot, still no scan.
     assert role_capacity._local_cache_bytes("c/NotThere") is None
-    assert role_capacity._local_cache_bytes("c/NotThere") is None
-    assert calls.count("c/NotThere") == 1
+    assert calls == ["scan"]
 
-    # After the TTL the miss is re-scanned so a fresh download is discovered.
+    # After the TTL elapses the snapshot is rebuilt (fresh download discoverable).
     monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", -1.0)
     assert role_capacity._local_cache_bytes("c/NotThere") is None
-    assert calls.count("c/NotThere") == 2
+    assert calls == ["scan", "scan"]
 
 
-def test_local_cache_rejects_partial_incomplete_download(monkeypatch):
-    """pr_validate codex BLOCKING (round-9): a partially-cached repo (tokenizer/
-    config only, no completed snapshot) must NOT be trusted as the footprint —
-    that would under-reserve and let the later load blow past the ceiling. It
-    returns unknown and fails closed under a configured ceiling."""
+class _Rev:
+    def __init__(self, refs, file_sizes=()):
+        self.refs = frozenset(refs)
+        self.files = [type("F", (), {"size_on_disk": s})() for s in file_sizes]
+
+
+def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
+    """pr_validate codex BLOCKING (round-9 + round-10): the local-cache index
+    trusts ONLY a complete (ref-bound) snapshot and charges its actual file
+    bytes — never a partial/aggregate footprint that would under-reserve."""
     import huggingface_hub
 
     from vllm_mlx.runtime import role_capacity
 
-    class _IncompleteRev:
-        refs = frozenset()
-
-    class _CompleteRev:
-        refs = frozenset({"main"})
-
     class _PartialRepo:
         repo_id = "c/PartialModel"
-        size_on_disk = 654321  # small: only config/tokenizer bytes cached
-        revisions = (_IncompleteRev(),)
+        # A repo with ONLY a partial (ref-less) revision: tokenizer/config only.
+        revisions = (_Rev(refs=()),)
 
     class _CompleteRepo:
         repo_id = "c/CompleteModel"
-        size_on_disk = 998244353
-        revisions = (_CompleteRev(),)
+        # A completed snapshot: ref points at main, weights present.
+        revisions = (_Rev(refs={"main"}, file_sizes=(1000, 9000)),)
+
+    class _OldCompletedPlusPartialRepo:
+        repo_id = "c/MixedModel"
+        # An old completed revision PLUS a fresh partial one being downloaded.
+        revisions = (
+            _Rev(refs={"main"}, file_sizes=(8000,)),
+            _Rev(refs=(), file_sizes=(100,)),
+        )
 
     class _FakeCache:
-        repos = [_PartialRepo, _CompleteRepo]
+        repos = [_PartialRepo, _CompleteRepo, _OldCompletedPlusPartialRepo]
 
     monkeypatch.setattr(huggingface_hub, "scan_cache_dir", lambda: _FakeCache())
-    role_capacity._local_cache_lookups.clear()
-    role_capacity._LOCAL_CACHE_TTL_SECONDS = -1.0  # force rescan each call
 
-    # Partial download is rejected (fails closed), full download is charged.
-    assert role_capacity._scan_local_cache_bytes("c/PartialModel") is None
-    assert role_capacity._scan_local_cache_bytes("c/CompleteModel") == 998244353
+    index = role_capacity._scan_local_cache_index()
+    # Partial (no completed snapshot) contributes nothing -> fail closed.
+    assert "c/partialmodel" not in index
+    # Completed snapshot charged by its ACTUAL file bytes (1000+9000).
+    assert index["c/completemodel"] == 10000
+    # A repo with an older completed + partial revision is charged ONLY the
+    # completed snapshot's bytes (8000), not the aggregate (8100) — so the
+    # in-progress second revision cannot understate the real load.
+    assert index["c/mixedmodel"] == 8000

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -87,12 +87,12 @@ def test_alignment_capacity_fails_closed_on_unknown(monkeypatch):
     assert capacity.requested_bytes is None
 
 
-def test_local_cache_lookup_is_bounded_and_never_caches_a_miss(monkeypatch):
-    """The verified-cache footprint is reused only briefly (bounded TTL) so a
-    mutable cache's later download becomes discoverable, and a miss is never
-    memoized so an uncached checkpoint is always retried (reconciles the
-    round-3 'don't memoize a mutable cache' and round-4 'bounded TTL' findings).
-    """
+def test_local_cache_lookup_is_bounded_for_hit_and_miss(monkeypatch):
+    """The verified-cache footprint (hit OR miss) is reused only for the bounded
+    TTL so a mutable cache's later download becomes discoverable after expiry,
+    while a burst of arbitrary model ids does not re-walk the whole cache each
+    time (reconciles round-3 'don't permanently memoize', round-4 'bounded TTL',
+    and round-9 'bounded negatively-cached miss' findings)."""
     from vllm_mlx.runtime import role_capacity
 
     calls: list[str] = []
@@ -102,7 +102,7 @@ def test_local_cache_lookup_is_bounded_and_never_caches_a_miss(monkeypatch):
         lambda hf: calls.append(hf) or 998244353,
     )
     monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", 60.0)
-    role_capacity._local_cache_hits.clear()
+    role_capacity._local_cache_lookups.clear()
 
     # First call scans and caches the positive result.
     assert role_capacity._local_cache_bytes("c/FakeModel") == 998244353
@@ -117,12 +117,58 @@ def test_local_cache_lookup_is_bounded_and_never_caches_a_miss(monkeypatch):
     assert role_capacity._local_cache_bytes("c/FakeModel") == 998244353
     assert calls == ["c/FakeModel", "c/FakeModel"]
 
-    # A miss is never cached: the next call retries the scan.
+    # A MISS is also cached briefly: two consecutive unknown lookups scan only
+    # once (no repeated full-cache walks for arbitrary ids), then re-scan after
+    # the TTL so a later download becomes discoverable.
     monkeypatch.setattr(
         role_capacity,
         "_scan_local_cache_bytes",
         lambda hf: calls.append(hf) or None,
     )
+    monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", 60.0)
+    role_capacity._local_cache_lookups.clear()
     assert role_capacity._local_cache_bytes("c/NotThere") is None
+    assert role_capacity._local_cache_bytes("c/NotThere") is None
+    assert calls.count("c/NotThere") == 1
+
+    # After the TTL the miss is re-scanned so a fresh download is discovered.
+    monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", -1.0)
     assert role_capacity._local_cache_bytes("c/NotThere") is None
     assert calls.count("c/NotThere") == 2
+
+
+def test_local_cache_rejects_partial_incomplete_download(monkeypatch):
+    """pr_validate codex BLOCKING (round-9): a partially-cached repo (tokenizer/
+    config only, no completed snapshot) must NOT be trusted as the footprint —
+    that would under-reserve and let the later load blow past the ceiling. It
+    returns unknown and fails closed under a configured ceiling."""
+    import huggingface_hub
+
+    from vllm_mlx.runtime import role_capacity
+
+    class _IncompleteRev:
+        refs = frozenset()
+
+    class _CompleteRev:
+        refs = frozenset({"main"})
+
+    class _PartialRepo:
+        repo_id = "c/PartialModel"
+        size_on_disk = 654321  # small: only config/tokenizer bytes cached
+        revisions = (_IncompleteRev(),)
+
+    class _CompleteRepo:
+        repo_id = "c/CompleteModel"
+        size_on_disk = 998244353
+        revisions = (_CompleteRev(),)
+
+    class _FakeCache:
+        repos = [_PartialRepo, _CompleteRepo]
+
+    monkeypatch.setattr(huggingface_hub, "scan_cache_dir", lambda: _FakeCache())
+    role_capacity._local_cache_lookups.clear()
+    role_capacity._LOCAL_CACHE_TTL_SECONDS = -1.0  # force rescan each call
+
+    # Partial download is rejected (fails closed), full download is charged.
+    assert role_capacity._scan_local_cache_bytes("c/PartialModel") is None
+    assert role_capacity._scan_local_cache_bytes("c/CompleteModel") == 998244353

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""MLX-free tests for metadata-backed alignment-role capacity resolution.
+
+These prove the forced-alignment footprint is resolved from catalog /
+local-cache metadata BEFORE any weight loading (so admission decides with
+knowledge of the size, not blind) — the first half of issue #2405's
+Required contract. No MLX is imported or required.
+"""
+
+
+def test_alignment_capacity_resolves_from_catalog_by_alias():
+    from vllm_mlx.runtime.role_capacity import alignment_capacity
+
+    capacity = alignment_capacity("qwen3-aligner")
+    # Catalog manifest maps qwen3-aligner -> mlx-community/Qwen3-ForcedAligner-0.6B-8bit
+    # whose weight+tokenizer footprint is a real byte count, not a heuristic.
+    assert capacity.source == "catalog"
+    assert isinstance(capacity.requested_bytes, int)
+    assert capacity.requested_bytes > 0
+
+
+def test_alignment_capacity_resolves_from_catalog_by_long_alias():
+    from vllm_mlx.runtime.role_capacity import alignment_capacity
+
+    capacity = alignment_capacity("qwen3-forced-aligner")
+    assert capacity.source == "catalog"
+    assert (
+        capacity.requested_bytes == alignment_capacity("qwen3-aligner").requested_bytes
+    )
+
+
+def test_alignment_capacity_resolves_from_catalog_by_hf_id():
+    from vllm_mlx.runtime.role_capacity import alignment_capacity
+
+    capacity = alignment_capacity("mlx-community/Qwen3-ForcedAligner-0.6B-8bit")
+    assert capacity.source == "catalog"
+    assert (
+        capacity.requested_bytes == alignment_capacity("qwen3-aligner").requested_bytes
+    )
+
+
+def test_alignment_capacity_fails_closed_on_unknown():
+    from vllm_mlx.runtime.role_capacity import alignment_capacity
+
+    # A non-audio / unknown id has no catalog entry -> source "unknown" so a
+    # configured ceiling fails closed rather than admitting blind.
+    capacity = alignment_capacity("some/unknown-nonaligner-checkpoint")
+    assert capacity.source == "unknown"
+    assert capacity.requested_bytes is None

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -166,21 +166,29 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
 
     class _CompleteRepo:
         repo_id = "c/CompleteModel"
-        # A complete download: ref points at main, weights present.
+        # A complete SINGLE-FILE download (GGUF): ref points at main, weights
+        # present, no sharding possibility.
         revisions = (
             _Rev(
                 refs={"main"},
-                files=(("config.json", 50), ("model.safetensors", 9950)),
+                files=(("config.json", 50), ("model.gguf", 9950)),
             ),
         )
 
     class _OldCompletedPlusPartialRepo:
         repo_id = "c/MixedModel"
-        # An old completed revision PLUS a fresh partial one being downloaded.
+        # An old completed GGUF revision PLUS a fresh partial one downloading.
         revisions = (
-            _Rev(refs={"main"}, files=(("model.safetensors", 8000),)),
+            _Rev(refs={"main"}, files=(("model.gguf", 8000),)),
             _Rev(refs=(), files=(("config.json", 100),)),
         )
+
+    class _BareSafeTensorNoIndexRepo:
+        repo_id = "c/BareSafeTensorModel"
+        # A single, ordinarily-named .safetensors with NO index (round-15):
+        # it could be one weight of several in a selective download, so we
+        # cannot prove completeness -> fail closed.
+        revisions = (_Rev(refs={"main"}, files=(("model.safetensors", 9900),)),)
 
     class _ShardedCompleteRepo:
         repo_id = "c/ShardedCompleteModel"
@@ -241,6 +249,7 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
             _SelectiveNoWeightsRepo,
             _CompleteRepo,
             _OldCompletedPlusPartialRepo,
+            _BareSafeTensorNoIndexRepo,
             _ShardedCompleteRepo,
             _ShardedIncompleteRepo,
             _NonDefaultBranchRepo,
@@ -268,3 +277,5 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
     assert "c/nondefaultmodel" not in index
     # A shard-PATTERNED weight with no index is an incomplete download -> fail closed.
     assert "c/shardednoindexmodel" not in index
+    # A bare .safetensors with NO index cannot be proven complete -> fail closed.
+    assert "c/baresafetensormodel" not in index

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -123,48 +123,68 @@ def test_local_cache_lookup_coalesces_into_one_scan_per_ttl(monkeypatch):
 
 
 class _Rev:
-    def __init__(self, refs, file_sizes=()):
+    def __init__(self, refs, files=()):
         self.refs = frozenset(refs)
-        self.files = [type("F", (), {"size_on_disk": s})() for s in file_sizes]
+        self.files = [
+            type("F", (), {"file_name": name, "size_on_disk": size})
+            for name, size in files
+        ]
 
 
 def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
-    """pr_validate codex BLOCKING (round-9 + round-10): the local-cache index
-    trusts ONLY a complete (ref-bound) snapshot and charges its actual file
-    bytes — never a partial/aggregate footprint that would under-reserve."""
+    """pr_validate codex BLOCKING (round-9/10/11): the local-cache index trusts
+    ONLY a COMPLETE snapshot — ref-bound AND carrying a weight file — and
+    charges its actual file bytes, never a partial/aggregate footprint."""
     import huggingface_hub
 
     from vllm_mlx.runtime import role_capacity
 
     class _PartialRepo:
         repo_id = "c/PartialModel"
-        # A repo with ONLY a partial (ref-less) revision: tokenizer/config only.
-        revisions = (_Rev(refs=()),)
+        # A ref-less partial revision: tokenizer/config only.
+        revisions = (_Rev(refs=(), files=()),)
+
+    class _SelectiveNoWeightsRepo:
+        repo_id = "c/SelectiveModel"
+        # A REF-BOUND snapshot with only config/tokenizer (a selective
+        # download) — must be treated as incomplete.
+        revisions = (_Rev(refs={"main"}, files=(("config.json", 50),)),)
 
     class _CompleteRepo:
         repo_id = "c/CompleteModel"
-        # A completed snapshot: ref points at main, weights present.
-        revisions = (_Rev(refs={"main"}, file_sizes=(1000, 9000)),)
+        # A complete download: ref points at main, weights present.
+        revisions = (
+            _Rev(
+                refs={"main"},
+                files=(("config.json", 50), ("model.safetensors", 9950)),
+            ),
+        )
 
     class _OldCompletedPlusPartialRepo:
         repo_id = "c/MixedModel"
         # An old completed revision PLUS a fresh partial one being downloaded.
         revisions = (
-            _Rev(refs={"main"}, file_sizes=(8000,)),
-            _Rev(refs=(), file_sizes=(100,)),
+            _Rev(refs={"main"}, files=(("model.safetensors", 8000),)),
+            _Rev(refs=(), files=(("config.json", 100),)),
         )
 
     class _FakeCache:
-        repos = [_PartialRepo, _CompleteRepo, _OldCompletedPlusPartialRepo]
+        repos = [
+            _PartialRepo,
+            _SelectiveNoWeightsRepo,
+            _CompleteRepo,
+            _OldCompletedPlusPartialRepo,
+        ]
 
     monkeypatch.setattr(huggingface_hub, "scan_cache_dir", lambda: _FakeCache())
 
     index = role_capacity._scan_local_cache_index()
-    # Partial (no completed snapshot) contributes nothing -> fail closed.
+    # Ref-less partial contributes nothing -> fail closed.
     assert "c/partialmodel" not in index
-    # Completed snapshot charged by its ACTUAL file bytes (1000+9000).
+    # A ref-bound snapshot WITHOUT weights (selective download) is rejected.
+    assert "c/selectivemodel" not in index
+    # Complete snapshot charged by its ACTUAL file bytes (50+9950).
     assert index["c/completemodel"] == 10000
-    # A repo with an older completed + partial revision is charged ONLY the
-    # completed snapshot's bytes (8000), not the aggregate (8100) — so the
-    # in-progress second revision cannot understate the real load.
+    # A repo with older completed + partial revision is charged ONLY the
+    # completed snapshot's bytes (8000), not the aggregate (8100).
     assert index["c/mixedmodel"] == 8000

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -185,10 +185,18 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
 
     class _BareSafeTensorNoIndexRepo:
         repo_id = "c/BareSafeTensorModel"
-        # A single, ordinarily-named .safetensors with NO index (round-15):
-        # it could be one weight of several in a selective download, so we
-        # cannot prove completeness -> fail closed.
+        # A CANONICAL single-file .safetensors (`model.safetensors`) with NO
+        # index (round-21): an unsharded checkpoint is published under this
+        # verbatim name, and a sharded download never uses it, so a lone
+        # canonical file is the WHOLE checkpoint -> charged, not rejected.
         revisions = (_Rev(refs={"main"}, files=(("model.safetensors", 9900),)),)
+
+    class _NonCanonicalWeightNoIndexRepo:
+        repo_id = "c/NonCanonicalWeightModel"
+        # A NON-canonical single weight (`encoder-1.bin`) with no index could
+        # be one piece of a selective multi-file download -> still fails closed
+        # (only canonical names prove an unsharded checkpoint).
+        revisions = (_Rev(refs={"main"}, files=(("encoder-1.bin", 5000),)),)
 
     class _ShardedGgufNoIndexRepo:
         repo_id = "c/ShardedGgufModel"
@@ -261,6 +269,7 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
             _CompleteRepo,
             _OldCompletedPlusPartialRepo,
             _BareSafeTensorNoIndexRepo,
+            _NonCanonicalWeightNoIndexRepo,
             _ShardedGgufNoIndexRepo,
             _ShardedCompleteRepo,
             _ShardedIncompleteRepo,
@@ -289,7 +298,12 @@ def test_local_cache_rejects_partial_and_uses_completed_snapshot(monkeypatch):
     assert "c/nondefaultmodel" not in index
     # A shard-PATTERNED weight with no index is an incomplete download -> fail closed.
     assert "c/shardednoindexmodel" not in index
-    # A bare .safetensors with NO index cannot be proven complete -> fail closed.
-    assert "c/baresafetensormodel" not in index
+    # A CANONICAL single-file .safetensors (`model.safetensors`) is the WHOLE
+    # unsharded checkpoint -> charged its actual bytes (round-21).
+    assert index["c/baresafetensormodel"] == 9900
+    # A NON-canonical single weight with no index could be a piece of a
+    # selective download -> fails closed (only canonical names prove a whole
+    # unsharded checkpoint).
+    assert "c/noncanonicalweightmodel" not in index
     # A SPLIT GGUF without a proven full shard set fails closed.
     assert "c/shardedggufmodel" not in index

--- a/tests/test_role_capacity.py
+++ b/tests/test_role_capacity.py
@@ -85,3 +85,44 @@ def test_alignment_capacity_fails_closed_on_unknown(monkeypatch):
     capacity = role_capacity.alignment_capacity("some/unknown-nonaligner-checkpoint")
     assert capacity.source == "unknown"
     assert capacity.requested_bytes is None
+
+
+def test_local_cache_lookup_is_bounded_and_never_caches_a_miss(monkeypatch):
+    """The verified-cache footprint is reused only briefly (bounded TTL) so a
+    mutable cache's later download becomes discoverable, and a miss is never
+    memoized so an uncached checkpoint is always retried (reconciles the
+    round-3 'don't memoize a mutable cache' and round-4 'bounded TTL' findings).
+    """
+    from vllm_mlx.runtime import role_capacity
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        role_capacity,
+        "_scan_local_cache_bytes",
+        lambda hf: calls.append(hf) or 998244353,
+    )
+    monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", 60.0)
+    role_capacity._local_cache_hits.clear()
+
+    # First call scans and caches the positive result.
+    assert role_capacity._local_cache_bytes("c/FakeModel") == 998244353
+    assert calls == ["c/FakeModel"]
+
+    # A repeat inside the TTL reuses the cached footprint without re-scanning.
+    assert role_capacity._local_cache_bytes("c/FakeModel") == 998244353
+    assert calls == ["c/FakeModel"]
+
+    # After the TTL elapses the cache is re-scanned (mutable disk observed).
+    monkeypatch.setattr(role_capacity, "_LOCAL_CACHE_TTL_SECONDS", -1.0)
+    assert role_capacity._local_cache_bytes("c/FakeModel") == 998244353
+    assert calls == ["c/FakeModel", "c/FakeModel"]
+
+    # A miss is never cached: the next call retries the scan.
+    monkeypatch.setattr(
+        role_capacity,
+        "_scan_local_cache_bytes",
+        lambda hf: calls.append(hf) or None,
+    )
+    assert role_capacity._local_cache_bytes("c/NotThere") is None
+    assert role_capacity._local_cache_bytes("c/NotThere") is None
+    assert calls.count("c/NotThere") == 2

--- a/tests/test_serving_lane_reason_contract.py
+++ b/tests/test_serving_lane_reason_contract.py
@@ -246,6 +246,10 @@ def _literal_assignments(*, exact_target: str | None = None) -> set[str]:
             if not selected:
                 continue
             value = node.value
+            if value is None:
+                # A bare annotation (for example a TypedDict field) declares
+                # a shape; it does not assign or emit a serving-lane reason.
+                continue
             if isinstance(value, ast.Constant) and value.value is None:
                 # Optional response/schema fields are initialized empty; they
                 # are not reason emitters.
@@ -408,6 +412,21 @@ def test_dynamic_reason_assignment_scanner_fails_closed(
 
     with pytest.raises(AssertionError, match="unvalidated dynamic"):
         _literal_assignments()
+
+
+def test_bare_reason_annotation_is_not_an_emission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Typed shapes may declare the field without assigning a reason value."""
+    (tmp_path / "shape.py").write_text(
+        "class Row:\n    serving_lane_reason: object\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setitem(globals(), "ENGINE", tmp_path)
+    monkeypatch.setitem(globals(), "_VALIDATED_REASON_PASSTHROUGHS", frozenset())
+
+    assert _literal_assignments() == set()
 
 
 @pytest.mark.parametrize(

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -9,6 +9,7 @@ import logging
 import math
 import os
 import re
+import sys
 import tempfile
 import threading
 import wave
@@ -210,15 +211,22 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
     # in-memory, but the verified-local-cache fallback walks the HF cache and
     # must not stall unrelated requests (the call is per-load, not per-token).
     capacity = await asyncio.to_thread(alignment_capacity, model_name)
+
+    # Scope the typed-error mapping to ADMISSION ENTRY ONLY. Entering the
+    # context manager explicitly (``__aenter__``) is where ``admit_role``
+    # raises the capacity / invariant errors, so those handlers must not also
+    # swallow errors thrown by the CALLER's yielded load body (a loader or
+    # runtime failure of the same classes would otherwise be misreported as a
+    # 507 / 409 capacity decision).
+    ctx = manager.admit_role(
+        role="alignment",
+        model_id=model_name,
+        requested_bytes=capacity.requested_bytes,
+        capacity_source=capacity.source,
+        replace_existing=replace_existing,
+    )
     try:
-        async with manager.admit_role(
-            role="alignment",
-            model_id=model_name,
-            requested_bytes=capacity.requested_bytes,
-            capacity_source=capacity.source,
-            replace_existing=replace_existing,
-        ) as admission:
-            yield admission
+        admission = await ctx.__aenter__()
     except ResidentModelCapacityError as exc:
         raise HTTPException(status_code=507, detail=exc.envelope()) from exc
     except ResidentModelError as exc:
@@ -235,6 +243,17 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
                 }
             },
         ) from exc
+    try:
+        yield admission
+    except BaseException:
+        # Exit the admission context with the body's active exception so the
+        # ledger rollback runs, then re-raise it UNCHANGED — the capacity /
+        # invariant mapping above must never rewrite a loader/runtime failure.
+        _typ, _exc, _tb = sys.exc_info()
+        await ctx.__aexit__(_typ, _exc, _tb)
+        raise
+    else:
+        await ctx.__aexit__(None, None, None)
 
 
 async def _release_alignment_role() -> None:
@@ -1801,7 +1820,12 @@ def _load_aligner_blocking(
     """
     global _aligner_engine
 
-    if _aligner_engine is not None and _aligner_engine.model_name == model_name:
+    # Idempotency compares CANONICAL ids: an alias and its canonical HF repo id
+    # name the same checkpoint, so re-resolving must not needlessly discard and
+    # reload an already-resident aligner.
+    if _aligner_engine is not None and _canonical_model_id(
+        _aligner_engine.model_name
+    ) == _canonical_model_id(model_name):
         return
     from ..audio.stt import STTEngine
 
@@ -1956,7 +1980,8 @@ async def _run_alignment_request(
             # is wrapped: an inference failure on a successfully-loaded
             # aligner must not release a resident engine's reservation.
             needs_load = _aligner_engine is None or (
-                _aligner_engine.model_name != model_name
+                _canonical_model_id(_aligner_engine.model_name)
+                != _canonical_model_id(model_name)
             )
             if needs_load:
                 # A pending load ALWAYS (re)establishes the alignment role, even

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1822,6 +1822,7 @@ def _evict_other_lane_sync(keep: str) -> None:
 def _load_aligner_blocking(
     model_name: str,
     on_discard_previous: Callable[[], None] | None = None,
+    on_discard_exclusive: Callable[[], None] | None = None,
 ) -> None:
     """Load (or reload) the cached aligner engine on the model worker thread.
 
@@ -1836,6 +1837,14 @@ def _load_aligner_blocking(
     not before (an import / ASR-unload failure before the drop must leave the
     old reservation restorable on rollback) and never after the new engine is
     published.
+
+    ``on_discard_exclusive`` is invoked the INSTANT the mutually-exclusive ASR
+    engine (dropped by ``_evict_other_lane_sync``) is discarded. From that
+    point the retired ``speech-input`` reservation points at a phantom engine,
+    so the caller retires it (``admission.retire_exclusive``) and it must not
+    be restored on a subsequent load failure. Before the discard the ASR
+    engine may still be resident (e.g. a 507 rejection never reached the
+    eviction), so restoration stays correct until this fires.
     """
     global _aligner_engine
 
@@ -1855,6 +1864,10 @@ def _load_aligner_blocking(
     # caller holds the lane lock, so no ASR request is mid-flight and
     # this cannot pull weights out from under one.
     _evict_other_lane_sync("aligner")
+    if on_discard_exclusive is not None:
+        # The ASR engine (if any) is gone from this point; a subsequent load
+        # failure must NOT restore the retired speech-input reservation.
+        on_discard_exclusive()
     # Also drop any PREVIOUS aligner (a different aligner alias) before
     # loading the replacement, so two multi-GB aligner models never sit
     # resident together during ``load()``. Inert under the current
@@ -2015,11 +2028,17 @@ async def _run_alignment_request(
                     # import / ASR-unload failure BEFORE that drop leaves the
                     # old reservation restorable on rollback, and a success
                     # commits the new engine with the old one retired.
+                    # ``on_discard_exclusive`` fires the instant the ASR engine
+                    # is evicted, so the speech-input reservation retired by
+                    # this admission stays retired (retire_exclusive) — a load
+                    # failure AFTER the ASR eviction must not resurrect a
+                    # reservation for an engine that no longer exists.
                     try:
                         await run_to_completion(
                             _load_aligner_blocking,
                             model_name,
                             admission.retire_previous,
+                            admission.retire_exclusive,
                         )
                     except asyncio.CancelledError:
                         # The worker loaded AND published the engine for THE

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -268,9 +268,20 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
         # manager's ledger rollback runs (which also restores the released
         # ``speech-input`` reservation if the ASR engine was NOT evicted), then
         # re-raise it UNCHANGED — the capacity / invariant mapping above must
-        # never rewrite a loader/runtime failure.
+        # never rewrite a loader/runtime failure. The exit must not be aborted
+        # by a SECOND cancellation while it waits on the residency lock (that
+        # would leak a permanent ``"loading"`` role), so it runs under the same
+        # uncancellable-drain shield as the success-path finalization.
         _typ, _exc, _tb = sys.exc_info()
-        await ctx.__aexit__(_typ, _exc, _tb)
+        _exit_t = asyncio.ensure_future(ctx.__aexit__(_typ, _exc, _tb))
+        try:
+            await asyncio.shield(_exit_t)
+        except asyncio.CancelledError:
+            while not _exit_t.done():
+                try:
+                    await asyncio.shield(_exit_t)
+                except asyncio.CancelledError:
+                    continue
         raise
     else:
         await ctx.__aexit__(None, None, None)

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -193,7 +193,10 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
         yield _NoopRoleAdmission()
         return
 
-    from ..runtime.resident_models import ResidentModelCapacityError
+    from ..runtime.resident_models import (
+        ResidentModelCapacityError,
+        ResidentModelError,
+    )
     from ..runtime.role_capacity import alignment_capacity
 
     # Resolve the footprint off the event loop: the catalog fast-path is
@@ -211,6 +214,20 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
             yield admission
     except ResidentModelCapacityError as exc:
         raise HTTPException(status_code=507, detail=exc.envelope()) from exc
+    except ResidentModelError as exc:
+        # A control-plane invariant (e.g. a second loading admission for the
+        # same role) must surface as a typed client error, never a raw 500.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": {
+                    "message": str(exc),
+                    "type": "invalid_request_error",
+                    "code": "alignment_role_conflict",
+                    "param": "model",
+                }
+            },
+        ) from exc
 
 
 async def _release_alignment_role() -> None:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -13,6 +13,7 @@ import tempfile
 import threading
 import wave
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import APIRouter, Body, Depends, Form, HTTPException, Query, UploadFile
@@ -157,6 +158,64 @@ _AUDIO_READ_CHUNK_SIZE = 1024 * 1024  # 1 MB chunks
 _stt_engine = None
 _tts_engine = None
 _music_engine: Any = None
+
+
+class _NoopRoleAdmission:
+    """Stand-in admission when no residency manager is configured."""
+
+    def retire_previous(self) -> None:
+        pass
+
+
+def _residency_manager():
+    """Return the shared residency manager when this server configured one."""
+
+    from ..config import get_config
+
+    return get_config().residency_manager
+
+
+@asynccontextmanager
+async def _admitting_alignment(model_name: str, *, replace_existing: bool = False):
+    """Reserve the forced-alignment role before constructing its weights.
+
+    Resolves the aligner footprint from catalog/local-cache metadata and
+    admits it through the shared residency ledger as the distinct
+    ``alignment`` role — the same role-based shared-capacity admission the
+    dictation lane uses, so an aligner can never materialize without a role
+    reservation or typed capacity decision. Rejection surfaces the
+    established typed 507 envelope.
+    """
+
+    manager = _residency_manager()
+    if manager is None:
+        yield _NoopRoleAdmission()
+        return
+
+    from ..runtime.resident_models import ResidentModelCapacityError
+    from ..runtime.role_capacity import alignment_capacity
+
+    capacity = alignment_capacity(model_name)
+    try:
+        async with manager.admit_role(
+            role="alignment",
+            model_id=model_name,
+            requested_bytes=capacity.requested_bytes,
+            capacity_source=capacity.source,
+            replace_existing=replace_existing,
+        ) as admission:
+            yield admission
+    except ResidentModelCapacityError as exc:
+        raise HTTPException(status_code=507, detail=exc.envelope()) from exc
+
+
+async def _release_alignment_role() -> None:
+    """Stop charging the alignment role after its engine was released."""
+
+    manager = _residency_manager()
+    if manager is not None:
+        await manager.release_role("alignment")
+
 
 # OpenAI-style STT model alias → MLX repo. Promoted to module scope so
 # the route can validate the model BEFORE streaming the upload (F-165):
@@ -1555,6 +1614,9 @@ async def shutdown_audio_lanes() -> None:
         finally:
             _stt_engine = None
             _aligner_engine = None
+            # A shutdown releases every cached engine; drop the alignment role
+            # reservation so the ledger does not outlive the process's model.
+            await _release_alignment_role()
 
     async with _get_tts_lane_lock():
         try:
@@ -1631,22 +1693,26 @@ async def _evict_other_lane(keep: str) -> None:
     frees on refcount, so clearing the global is the release.
     """
     lane, cached = _other_stt_lane(keep)
-    if cached is None:
-        return
-    logger.info(
-        "Releasing %s model %s to load the other STT lane "
-        "(one STT model resident at a time)",
-        lane,
-        getattr(cached, "model_name", "?"),
-    )
-    unload = getattr(cached, "unload", None)
-    if callable(unload):
-        from ..runtime.audio_worker import run_audio_mlx
-
-        await run_audio_mlx(
-            lane, getattr(cached, "model_name", "unknown"), "unload", unload
+    if cached is not None:
+        logger.info(
+            "Releasing %s model %s to load the other STT lane "
+            "(one STT model resident at a time)",
+            lane,
+            getattr(cached, "model_name", "?"),
         )
-    _clear_other_stt_lane(keep)
+        unload = getattr(cached, "unload", None)
+        if callable(unload):
+            from ..runtime.audio_worker import run_audio_mlx
+
+            await run_audio_mlx(
+                lane, getattr(cached, "model_name", "unknown"), "unload", unload
+            )
+        _clear_other_stt_lane(keep)
+    # When the aligner lane is dropped (an ASR request evicts it), stop
+    # charging its role so the ledger never keeps a reservation for an
+    # engine this process no longer holds.
+    if lane == "alignment":
+        await _release_alignment_role()
 
 
 def _evict_other_lane_sync(keep: str) -> None:
@@ -1671,6 +1737,53 @@ def _evict_other_lane_sync(keep: str) -> None:
     _clear_other_stt_lane(keep)
 
 
+def _load_aligner_blocking(model_name: str) -> None:
+    """Load (or reload) the cached aligner engine on the model worker thread.
+
+    Extracted from :func:`_align_blocking` so the async layer can wrap the
+    actual weight load in the shared ``alignment``-role admission — the
+    reservation is entered BEFORE this runs, so admission can already have
+    rejected an over-budget aligner without touching the disk.
+    """
+    global _aligner_engine
+
+    if _aligner_engine is not None and _aligner_engine.model_name == model_name:
+        return
+    from ..audio.stt import STTEngine
+
+    # Drop the ASR lane's model before loading ours. The lock already
+    # stops the two lanes RUNNING at once, but without this they both
+    # stay resident after alternating requests — two multi-GB models in
+    # unified memory for a server that can only use one at a time. The
+    # caller holds the lane lock, so no ASR request is mid-flight and
+    # this cannot pull weights out from under one.
+    _evict_other_lane_sync("aligner")
+    # Also drop any PREVIOUS aligner (a different aligner alias) before
+    # loading the replacement, so two multi-GB aligner models never sit
+    # resident together during ``load()``. Inert under the current
+    # single-aligner registry — the branch only re-enters when the cache
+    # was already emptied (an ASR request evicted us), so there is nothing
+    # to drop — but it keeps the "one STT model resident" invariant true if
+    # a second aligner alias is ever registered. On a failed reload the
+    # cache stays ``None`` and the next request reloads from disk, strictly
+    # better than pinning a stale model.
+    _aligner_engine = None
+    # Load into a local first and publish only on success. Caching a
+    # half-constructed engine would leave later requests matching on
+    # ``model_name`` against an object whose weights never loaded.
+    #
+    # Named ``aligner``, not ``engine``: test_route_engine_contract
+    # scans this module for ``engine.<method>()`` calls and requires
+    # the method to exist on the LLM ``BaseEngine``. An ``STTEngine``
+    # is a different hierarchy entirely, so the name would trip that
+    # gate with a false positive.
+    aligner = STTEngine(model_name)
+    from ..runtime.audio_worker import run_audio_mlx_sync
+
+    run_audio_mlx_sync("alignment", model_name, "load", aligner.load)
+    _aligner_engine = aligner
+
+
 def _align_blocking(
     model_name: str,
     audio_path: str,
@@ -1679,7 +1792,8 @@ def _align_blocking(
 ):
     """Blocking half of the forced-alignment request — runs on a thread.
 
-    Loads (or reuses) the aligner engine and runs
+    Ensures the aligner engine is resident (reusing the already-admitted
+    load from :func:`_load_aligner_blocking`) and runs
     :meth:`STTEngine.align`. Split out of :func:`_run_alignment_request`
     so the async handler can hand the seconds-long weight load + align
     to a worker thread instead of stalling the event loop.
@@ -1690,46 +1804,13 @@ def _align_blocking(
     """
     global _aligner_engine
 
-    from ..audio.stt import STTEngine
-
     # STTEngine.align defaults language to "Chinese"; only forward an
     # explicit caller value so the engine default stands otherwise.
     align_kwargs = {}
     if language:
         align_kwargs["language"] = language
 
-    if _aligner_engine is None or _aligner_engine.model_name != model_name:
-        # Drop the ASR lane's model before loading ours. The lock already
-        # stops the two lanes RUNNING at once, but without this they both
-        # stay resident after alternating requests — two multi-GB models in
-        # unified memory for a server that can only use one at a time. The
-        # caller holds the lane lock, so no ASR request is mid-flight and
-        # this cannot pull weights out from under one.
-        _evict_other_lane_sync("aligner")
-        # Also drop any PREVIOUS aligner (a different aligner alias) before
-        # loading the replacement, so two multi-GB aligner models never sit
-        # resident together during ``load()``. Inert under the current
-        # single-aligner registry — the branch only re-enters when the cache
-        # was already emptied (an ASR request evicted us), so there is nothing
-        # to drop — but it keeps the "one STT model resident" invariant true if
-        # a second aligner alias is ever registered. On a failed reload the
-        # cache stays ``None`` and the next request reloads from disk, strictly
-        # better than pinning a stale model.
-        _aligner_engine = None
-        # Load into a local first and publish only on success. Caching a
-        # half-constructed engine would leave later requests matching on
-        # ``model_name`` against an object whose weights never loaded.
-        #
-        # Named ``aligner``, not ``engine``: test_route_engine_contract
-        # scans this module for ``engine.<method>()`` calls and requires
-        # the method to exist on the LLM ``BaseEngine``. An ``STTEngine``
-        # is a different hierarchy entirely, so the name would trip that
-        # gate with a false positive.
-        aligner = STTEngine(model_name)
-        from ..runtime.audio_worker import run_audio_mlx_sync
-
-        run_audio_mlx_sync("alignment", model_name, "load", aligner.load)
-        _aligner_engine = aligner
+    _load_aligner_blocking(model_name)
     from ..runtime.audio_worker import run_audio_mlx_sync
 
     return run_audio_mlx_sync(
@@ -1810,6 +1891,26 @@ async def _run_alignment_request(
         # for exactly as long as the worker runs, even if the client
         # disconnects and cancels us mid-align.
         async with _get_stt_lane_lock():
+            # Admit the forced-alignment model through the shared residency
+            # ledger as the distinct ``alignment`` role BEFORE its weights
+            # load, so an over-budget aligner is rejected with the typed 507
+            # envelope without ever touching disk. Only the weight-load step
+            # is wrapped: an inference failure on a successfully-loaded
+            # aligner must not release a resident engine's reservation.
+            needs_load = _aligner_engine is None or (
+                _aligner_engine.model_name != model_name
+            )
+            if needs_load:
+                prev_aligner = _aligner_engine
+                async with _admitting_alignment(
+                    model_name,
+                    replace_existing=prev_aligner is not None,
+                ) as admission:
+                    if prev_aligner is not None:
+                        # The load below drops the previous aligner engine, so
+                        # a failed reload must not restore its old reservation.
+                        admission.retire_previous()
+                    await run_to_completion(_load_aligner_blocking, model_name)
             result = await run_to_completion(
                 _align_blocking, model_name, tmp_path, text, language
             )

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -1939,6 +1939,11 @@ def _align_blocking(
         align_kwargs["language"] = language
 
     _load_aligner_blocking(model_name)
+    # The loader guarantees the aligner is resident by this point: it publishes
+    # the engine on the worker thread and any load failure propagates out of
+    # ``_load_aligner_blocking`` before we reach here, so ``_aligner_engine``
+    # is never ``None`` at the call site below.
+    assert _aligner_engine is not None
     from ..runtime.audio_worker import run_audio_mlx_sync
 
     return run_audio_mlx_sync(

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -213,16 +213,15 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
     capacity = await asyncio.to_thread(alignment_capacity, model_name)
 
     # Alignment and the dictation STT lane are MUTUALLY EXCLUSIVE (the aligner
-    # load evicts the ASR engine via ``_evict_other_lane_sync``). Before
-    # charging the alignment role against the ceiling we release any resident
-    # ``speech-input`` reservation — otherwise the ledger charges BOTH roles and
-    # can return a false 507 that would be impossible once the ASR engine is
-    # dropped. The reservation is RESTORED transactionally in the rollback
-    # below when the flow fails WITHOUT the ASR engine having been evicted
-    # (a 507 rejection or a pre-eviction load failure), so we never leave the
-    # still-resident ASR engine unaccounted.
-    speech_input_released = await _release_speech_input_role_for_alignment(manager)
-
+    # load evicts the ASR engine via ``_evict_other_lane_sync``). Admit the
+    # alignment role with ``release_exclusive_role="speech-input"`` so any
+    # resident ``speech-input`` reservation is retired atomically within the
+    # SAME manager transaction — otherwise the ledger would charge BOTH roles
+    # and could return a false 507 that would be impossible once the ASR engine
+    # is dropped. The manager restores the retired ``speech-input`` reservation
+    # in its rollback whenever the flow fails WITHOUT the ASR engine having
+    # been evicted, so a still-resident ASR engine is never left unaccounted.
+    #
     # Scope the typed-error mapping to ADMISSION ENTRY ONLY. Entering the
     # context manager explicitly (``__aenter__``) is where ``admit_role``
     # raises the capacity / invariant errors, so those handlers must not also
@@ -235,19 +234,19 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
         requested_bytes=capacity.requested_bytes,
         capacity_source=capacity.source,
         replace_existing=replace_existing,
+        release_exclusive_role="speech-input",
     )
     try:
         admission = await ctx.__aenter__()
     except ResidentModelCapacityError as exc:
-        # The aligner was REJECTED before any load ran, so the ASR engine is
-        # still resident — restore its reservation before surfacing the 507.
-        await _restore_speech_input_role_for_alignment(manager, speech_input_released)
+        # The aligner was REJECTED before any load ran. ``admit_role``'s own
+        # rollback has already restored the retired speech-input reservation
+        # (the ASR engine is still resident), so we only surface the typed 507.
         raise HTTPException(status_code=507, detail=exc.envelope()) from exc
     except ResidentModelError as exc:
         # A control-plane invariant (e.g. a second loading admission for the
         # same role) must surface as a typed client error, never a raw 500.
-        # No load ran, so restore the ASR engine's reservation.
-        await _restore_speech_input_role_for_alignment(manager, speech_input_released)
+        # No load ran; ``admit_role``'s rollback restored speech-input already.
         raise HTTPException(
             status_code=409,
             detail={
@@ -263,77 +262,17 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
         yield admission
     except BaseException:
         # Exit the admission context with the body's active exception so the
-        # ledger rollback runs, then re-raise it UNCHANGED — the capacity /
-        # invariant mapping above must never rewrite a loader/runtime failure.
+        # manager's ledger rollback runs (which also restores the released
+        # ``speech-input`` reservation if the ASR engine was NOT evicted), then
+        # re-raise it UNCHANGED — the capacity / invariant mapping above must
+        # never rewrite a loader/runtime failure.
         _typ, _exc, _tb = sys.exc_info()
         await ctx.__aexit__(_typ, _exc, _tb)
-        # If the flow failed and the ASR engine is STILL resident (the load
-        # never reached the point where `_load_aligner_blocking` evicted it),
-        # restore the speech-input reservation we released up front so the
-        # still-resident ASR engine stays accounted.
-        await _restore_speech_input_role_for_alignment(manager, speech_input_released)
         raise
     else:
         await ctx.__aexit__(None, None, None)
-        # On SUCCESS the aligner load evicted the ASR engine, so the released
+        # On SUCCESS the aligner load evicted the ASR engine, so the retired
         # speech-input reservation stays retired — nothing to restore.
-
-
-async def _release_speech_input_role_for_alignment(manager):
-    """Release a resident ``speech-input`` reservation so alignment admission
-    (mutually exclusive with the dictation lane) does not double-charge.
-
-    Returns the released reservation's ``(model_id, reserved_bytes,
-    capacity_source)`` so the caller can restore it transactionally — with its
-    original metadata — if the flow aborts before the ASR engine is actually
-    evicted, or ``None`` when no speech-input role was reserved.
-    """
-    snapshot = manager.snapshot()
-    for entry in snapshot.get("roles", []):
-        if entry.get("role") == "speech-input":
-            prev = (
-                entry.get("model"),
-                entry.get("reserved_bytes", 0),
-                entry.get("capacity_source", "catalog"),
-            )
-            await manager.release_role("speech-input")
-            return prev
-    return None
-
-
-async def _restore_speech_input_role_for_alignment(manager, prev) -> None:
-    """Restore the released speech-input reservation (if any) when the ASR
-    engine was NOT evicted, so the still-resident engine stays accounted.
-
-    ``prev`` is the ``(model_id, reserved_bytes, capacity_source)`` returned by
-    the release helper (or ``None``). No-op when nothing was captured or the
-    ASR engine was already dropped.
-    """
-    if prev is None or _stt_engine is None:
-        # Either nothing to restore, or the ASR engine was already evicted (the
-        # aligner load discarded it) so the reservation must stay retired.
-        return
-    prev_model, prev_bytes, prev_source = prev
-    from ..runtime.resident_models import ResidentModelError
-
-    try:
-        async with manager.admit_role(
-            role="speech-input",
-            model_id=prev_model,
-            requested_bytes=prev_bytes,
-            capacity_source=prev_source,
-        ):
-            pass
-    except ResidentModelError:
-        # The engine is still resident but re-admission is not possible (e.g.
-        # capacity changed); log and move on rather than masking the original
-        # failure. The engine stays resident but unaccounted is the lesser evil
-        # than a rejected alignment coroutine.
-        logger.warning(
-            "could not restore speech-input reservation after alignment "
-            "failure; ASR engine remains resident",
-            extra={"model": prev_model},
-        )
 
 
 async def _release_alignment_role() -> None:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -2020,6 +2020,18 @@ async def _run_alignment_request(
                         ) == _canonical_model_id(model_name):
                             admission.commit()
                         raise
+                    else:
+                        # The load returned normally WITH the engine published
+                        # for the requested model. Commit on the SUCCESS path
+                        # too, so a cancellation arriving during the upcoming
+                        # cancellable awaits / context exit cannot roll the
+                        # reservation back after the weights are already
+                        # resident (and accounted). The cancellation branch
+                        # above remains as the safety net for the drained case.
+                        if _aligner_engine is not None and _canonical_model_id(
+                            _aligner_engine.model_name
+                        ) == _canonical_model_id(model_name):
+                            admission.commit()
             result = await run_to_completion(
                 _align_blocking, model_name, tmp_path, text, language
             )

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -213,12 +213,15 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
     capacity = await asyncio.to_thread(alignment_capacity, model_name)
 
     # Alignment and the dictation STT lane are MUTUALLY EXCLUSIVE (the aligner
-    # load evicts the ASR engine via ``_evict_other_lane_sync``). So before
-    # charging the alignment role against the ceiling, release any resident
-    # ``speech-input`` reservation — otherwise the ledger temporarily charges
-    # BOTH roles and can return a false 507 that would be impossible after the
-    # ASR engine is dropped. A no-op when the dictation role is not reserved.
-    await manager.release_role("speech-input")
+    # load evicts the ASR engine via ``_evict_other_lane_sync``). Before
+    # charging the alignment role against the ceiling we release any resident
+    # ``speech-input`` reservation — otherwise the ledger charges BOTH roles and
+    # can return a false 507 that would be impossible once the ASR engine is
+    # dropped. The reservation is RESTORED transactionally in the rollback
+    # below when the flow fails WITHOUT the ASR engine having been evicted
+    # (a 507 rejection or a pre-eviction load failure), so we never leave the
+    # still-resident ASR engine unaccounted.
+    speech_input_released = await _release_speech_input_role_for_alignment(manager)
 
     # Scope the typed-error mapping to ADMISSION ENTRY ONLY. Entering the
     # context manager explicitly (``__aenter__``) is where ``admit_role``
@@ -236,10 +239,15 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
     try:
         admission = await ctx.__aenter__()
     except ResidentModelCapacityError as exc:
+        # The aligner was REJECTED before any load ran, so the ASR engine is
+        # still resident — restore its reservation before surfacing the 507.
+        await _restore_speech_input_role_for_alignment(manager, speech_input_released)
         raise HTTPException(status_code=507, detail=exc.envelope()) from exc
     except ResidentModelError as exc:
         # A control-plane invariant (e.g. a second loading admission for the
         # same role) must surface as a typed client error, never a raw 500.
+        # No load ran, so restore the ASR engine's reservation.
+        await _restore_speech_input_role_for_alignment(manager, speech_input_released)
         raise HTTPException(
             status_code=409,
             detail={
@@ -259,9 +267,69 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
         # invariant mapping above must never rewrite a loader/runtime failure.
         _typ, _exc, _tb = sys.exc_info()
         await ctx.__aexit__(_typ, _exc, _tb)
+        # If the flow failed and the ASR engine is STILL resident (the load
+        # never reached the point where `_load_aligner_blocking` evicted it),
+        # restore the speech-input reservation we released up front so the
+        # still-resident ASR engine stays accounted.
+        await _restore_speech_input_role_for_alignment(manager, speech_input_released)
         raise
     else:
         await ctx.__aexit__(None, None, None)
+        # On SUCCESS the aligner load evicted the ASR engine, so the released
+        # speech-input reservation stays retired — nothing to restore.
+
+
+async def _release_speech_input_role_for_alignment(manager):
+    """Release a resident ``speech-input`` reservation so alignment admission
+    (mutually exclusive with the dictation lane) does not double-charge.
+
+    Returns the released reservation's ``(model_id, reserved_bytes)`` so the
+    caller can restore it transactionally if the flow aborts before the ASR
+    engine is actually evicted, or ``None`` when no speech-input role was
+    reserved.
+    """
+    snapshot = manager.snapshot()
+    for entry in snapshot.get("roles", []):
+        if entry.get("role") == "speech-input":
+            prev = (entry.get("model"), entry.get("reserved_bytes", 0))
+            await manager.release_role("speech-input")
+            return prev
+    return None
+
+
+async def _restore_speech_input_role_for_alignment(manager, prev) -> None:
+    """Restore the released speech-input reservation (if any) when the ASR
+    engine was NOT evicted, so the still-resident engine stays accounted.
+
+    ``prev`` is the ``(model_id, reserved_bytes)`` returned by the release
+    helper (or ``None``). No-op when nothing was captured or the ASR engine was
+    already dropped.
+    """
+    if prev is None or _stt_engine is None:
+        # Either nothing to restore, or the ASR engine was already evicted (the
+        # aligner load discarded it) so the reservation must stay retired.
+        return
+    prev_model, prev_bytes = prev
+    from ..runtime.resident_models import ResidentModelError
+
+    try:
+        async with manager.admit_role(
+            role="speech-input",
+            model_id=prev_model,
+            requested_bytes=prev_bytes,
+            capacity_source="catalog",
+        ):
+            pass
+    except ResidentModelError:
+        # The engine is still resident but re-admission is not possible (e.g.
+        # capacity changed); log and move on rather than masking the original
+        # failure. The engine stays resident but unaccounted is the lesser evil
+        # than a rejected alignment coroutine.
+        logger.warning(
+            "could not restore speech-input reservation after alignment "
+            "failure; ASR engine remains resident",
+            extra={"model": prev_model},
+        )
 
 
 async def _release_alignment_role() -> None:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -167,6 +167,13 @@ class _NoopRoleAdmission:
     def retire_previous(self) -> None:
         pass
 
+    def commit(self) -> None:
+        # No-op: without a residency manager there is no ledger entry to keep.
+        # Must exist so the cancellation recovery path can call
+        # ``admission.commit()`` uniformly on managed AND unmanaged servers
+        # without masking ``CancelledError`` with ``AttributeError``.
+        pass
+
 
 def _residency_manager():
     """Return the shared residency manager when this server configured one."""
@@ -259,6 +266,22 @@ async def _release_alignment_role() -> None:
 from ..audio.registry import stt_aliases as _stt_aliases_from_registry
 
 STT_MODEL_ALIASES: dict[str, str] = dict(_stt_aliases_from_registry())
+
+
+def _canonical_model_id(model_id: str) -> str:
+    """Reduce a model alias to the canonical HF repo id for identity checks.
+
+    Mirrors :func:`_resolve_stt_model`'s alias resolution (including the
+    ``"default"`` OpenAI placeholder) so a request alias and a published
+    engine's ``model_name`` compare equal even when one is the alias and
+    the other the canonical id. Used where publication identity matters
+    (cancellation-commit), not for validation — pass-through strings and
+    unknown bare names are returned as-is.
+    """
+    if model_id == "default":
+        return STT_MODEL_ALIASES[DEFAULT_ALIGNER_ALIAS]
+    return STT_MODEL_ALIASES.get(model_id, model_id)
+
 
 # F-210: model strings must canonicalize to either a bare alias name
 # (matches an entry in ``STT_MODEL_ALIASES``) or a single-slash
@@ -1962,10 +1985,14 @@ async def _run_alignment_request(
                         # resident desync. A cancelled replacement that never
                         # discarded/published model_name leaves the old engine
                         # + its reservation untouched.
-                        if (
-                            _aligner_engine is not None
-                            and _aligner_engine.model_name == model_name
-                        ):
+                        #
+                        # Compare CANONICAL ids: the route passes the resolved
+                        # HF repo id here, but a published engine may expose an
+                        # alias (or vice-versa), so raw string equality could
+                        # leave a successfully-loaded engine unaccounted.
+                        if _aligner_engine is not None and _canonical_model_id(
+                            _aligner_engine.model_name
+                        ) == _canonical_model_id(model_name):
                             admission.commit()
                         raise
             result = await run_to_completion(

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -168,6 +168,9 @@ class _NoopRoleAdmission:
     def retire_previous(self) -> None:
         pass
 
+    def retire_exclusive(self) -> None:
+        pass
+
     def commit(self) -> None:
         # No-op: without a residency manager there is no ledger entry to keep.
         # Must exist so the cancellation recovery path can call

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -196,7 +196,10 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
     from ..runtime.resident_models import ResidentModelCapacityError
     from ..runtime.role_capacity import alignment_capacity
 
-    capacity = alignment_capacity(model_name)
+    # Resolve the footprint off the event loop: the catalog fast-path is
+    # in-memory, but the verified-local-cache fallback walks the HF cache and
+    # must not stall unrelated requests (the call is per-load, not per-token).
+    capacity = await asyncio.to_thread(alignment_capacity, model_name)
     try:
         async with manager.admit_role(
             role="alignment",
@@ -1916,10 +1919,12 @@ async def _run_alignment_request(
                 _aligner_engine.model_name != model_name
             )
             if needs_load:
-                prev_aligner = _aligner_engine
+                # A pending load ALWAYS (re)establishes the alignment role, even
+                # if a stale/previous reservation exists, so ``admit_role``
+                # never 409/500s on "role already resident" — the stale ledger
+                # entry self-heals rather than blocking the request.
                 async with _admitting_alignment(
-                    model_name,
-                    replace_existing=prev_aligner is not None,
+                    model_name, replace_existing=True
                 ) as admission:
                     # ``on_discard_previous`` fires ONLY when the load actually
                     # drops the previous aligner (a different alias), so an
@@ -1933,11 +1938,17 @@ async def _run_alignment_request(
                             admission.retire_previous,
                         )
                     except asyncio.CancelledError:
-                        # The worker loaded AND published the engine before the
-                        # cancellation drained it. Keep the reservation (the
-                        # weights are accounted) instead of rolling it back into
-                        # an unaccounted-resident desync.
-                        if _aligner_engine is not None:
+                        # The worker loaded AND published the engine for THE
+                        # REQUESTED model before the cancellation drained it.
+                        # Keep that reservation (the weights are accounted)
+                        # instead of rolling it back into an unaccounted-
+                        # resident desync. A cancelled replacement that never
+                        # discarded/published model_name leaves the old engine
+                        # + its reservation untouched.
+                        if (
+                            _aligner_engine is not None
+                            and _aligner_engine.model_name == model_name
+                        ):
                             admission.commit()
                         raise
             result = await run_to_completion(

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -283,15 +283,19 @@ async def _release_speech_input_role_for_alignment(manager):
     """Release a resident ``speech-input`` reservation so alignment admission
     (mutually exclusive with the dictation lane) does not double-charge.
 
-    Returns the released reservation's ``(model_id, reserved_bytes)`` so the
-    caller can restore it transactionally if the flow aborts before the ASR
-    engine is actually evicted, or ``None`` when no speech-input role was
-    reserved.
+    Returns the released reservation's ``(model_id, reserved_bytes,
+    capacity_source)`` so the caller can restore it transactionally — with its
+    original metadata — if the flow aborts before the ASR engine is actually
+    evicted, or ``None`` when no speech-input role was reserved.
     """
     snapshot = manager.snapshot()
     for entry in snapshot.get("roles", []):
         if entry.get("role") == "speech-input":
-            prev = (entry.get("model"), entry.get("reserved_bytes", 0))
+            prev = (
+                entry.get("model"),
+                entry.get("reserved_bytes", 0),
+                entry.get("capacity_source", "catalog"),
+            )
             await manager.release_role("speech-input")
             return prev
     return None
@@ -301,15 +305,15 @@ async def _restore_speech_input_role_for_alignment(manager, prev) -> None:
     """Restore the released speech-input reservation (if any) when the ASR
     engine was NOT evicted, so the still-resident engine stays accounted.
 
-    ``prev`` is the ``(model_id, reserved_bytes)`` returned by the release
-    helper (or ``None``). No-op when nothing was captured or the ASR engine was
-    already dropped.
+    ``prev`` is the ``(model_id, reserved_bytes, capacity_source)`` returned by
+    the release helper (or ``None``). No-op when nothing was captured or the
+    ASR engine was already dropped.
     """
     if prev is None or _stt_engine is None:
         # Either nothing to restore, or the ASR engine was already evicted (the
         # aligner load discarded it) so the reservation must stay retired.
         return
-    prev_model, prev_bytes = prev
+    prev_model, prev_bytes, prev_source = prev
     from ..runtime.resident_models import ResidentModelError
 
     try:
@@ -317,7 +321,7 @@ async def _restore_speech_input_role_for_alignment(manager, prev) -> None:
             role="speech-input",
             model_id=prev_model,
             requested_bytes=prev_bytes,
-            capacity_source="catalog",
+            capacity_source=prev_source,
         ):
             pass
     except ResidentModelError:

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -212,6 +212,14 @@ async def _admitting_alignment(model_name: str, *, replace_existing: bool = Fals
     # must not stall unrelated requests (the call is per-load, not per-token).
     capacity = await asyncio.to_thread(alignment_capacity, model_name)
 
+    # Alignment and the dictation STT lane are MUTUALLY EXCLUSIVE (the aligner
+    # load evicts the ASR engine via ``_evict_other_lane_sync``). So before
+    # charging the alignment role against the ceiling, release any resident
+    # ``speech-input`` reservation — otherwise the ledger temporarily charges
+    # BOTH roles and can return a false 507 that would be impossible after the
+    # ASR engine is dropped. A no-op when the dictation role is not reserved.
+    await manager.release_role("speech-input")
+
     # Scope the typed-error mapping to ADMISSION ENTRY ONLY. Entering the
     # context manager explicitly (``__aenter__``) is where ``admit_role``
     # raises the capacity / invariant errors, so those handlers must not also

--- a/vllm_mlx/routes/audio.py
+++ b/vllm_mlx/routes/audio.py
@@ -12,6 +12,7 @@ import re
 import tempfile
 import threading
 import wave
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import Any
@@ -1737,13 +1738,23 @@ def _evict_other_lane_sync(keep: str) -> None:
     _clear_other_stt_lane(keep)
 
 
-def _load_aligner_blocking(model_name: str) -> None:
+def _load_aligner_blocking(
+    model_name: str,
+    on_discard_previous: Callable[[], None] | None = None,
+) -> None:
     """Load (or reload) the cached aligner engine on the model worker thread.
 
     Extracted from :func:`_align_blocking` so the async layer can wrap the
     actual weight load in the shared ``alignment``-role admission — the
     reservation is entered BEFORE this runs, so admission can already have
     rejected an over-budget aligner without touching the disk.
+
+    ``on_discard_previous`` is invoked ONLY at the exact instant a previously
+    resident aligner (a different alias) is dropped, so the async layer can
+    retire its old reservation precisely when the old engine is truly gone —
+    not before (an import / ASR-unload failure before the drop must leave the
+    old reservation restorable on rollback) and never after the new engine is
+    published.
     """
     global _aligner_engine
 
@@ -1768,6 +1779,10 @@ def _load_aligner_blocking(model_name: str) -> None:
     # cache stays ``None`` and the next request reloads from disk, strictly
     # better than pinning a stale model.
     _aligner_engine = None
+    if on_discard_previous is not None:
+        # The old engine is gone from this point; the async admission layer
+        # must not restore its old reservation if this load subsequently fails.
+        on_discard_previous()
     # Load into a local first and publish only on success. Caching a
     # half-constructed engine would leave later requests matching on
     # ``model_name`` against an object whose weights never loaded.
@@ -1906,11 +1921,25 @@ async def _run_alignment_request(
                     model_name,
                     replace_existing=prev_aligner is not None,
                 ) as admission:
-                    if prev_aligner is not None:
-                        # The load below drops the previous aligner engine, so
-                        # a failed reload must not restore its old reservation.
-                        admission.retire_previous()
-                    await run_to_completion(_load_aligner_blocking, model_name)
+                    # ``on_discard_previous`` fires ONLY when the load actually
+                    # drops the previous aligner (a different alias), so an
+                    # import / ASR-unload failure BEFORE that drop leaves the
+                    # old reservation restorable on rollback, and a success
+                    # commits the new engine with the old one retired.
+                    try:
+                        await run_to_completion(
+                            _load_aligner_blocking,
+                            model_name,
+                            admission.retire_previous,
+                        )
+                    except asyncio.CancelledError:
+                        # The worker loaded AND published the engine before the
+                        # cancellation drained it. Keep the reservation (the
+                        # weights are accounted) instead of rolling it back into
+                        # an unaccounted-resident desync.
+                        if _aligner_engine is not None:
+                            admission.commit()
+                        raise
             result = await run_to_completion(
                 _align_blocking, model_name, tmp_path, text, language
             )

--- a/vllm_mlx/runtime/audio_worker.py
+++ b/vllm_mlx/runtime/audio_worker.py
@@ -12,6 +12,16 @@ from typing import Any, Protocol, TypeVar
 
 _T = TypeVar("_T")
 
+# Map each audio lane to the shared residency role that budgets it. Forced
+# alignment loads a persistent aligner on the model worker; charging it as
+# the distinct ``alignment`` role (rather than the dictation speech-input
+# role) lets admission budget both independently while sharing one ceiling.
+LANE_ROLES = {
+    "stt": "speech-input",
+    "alignment": "alignment",
+    "tts": "speech-output",
+}
+
 
 class ModelWorker(Protocol):
     """Minimal execution surface exported by an inference engine."""
@@ -192,6 +202,7 @@ class AudioWorkerDispatcher:
             return [
                 {
                     "lane": lane,
+                    "role": LANE_ROLES.get(lane),
                     "model": state.model,
                     "state": state.state,
                     "active_requests": state.active_requests,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -868,14 +868,57 @@ class ResidentModelManager:
                     self._roles.pop(release_exclusive_role, None)
             raise
         else:
-            async with self._lock:
-                if self._roles.get(role) is record:
-                    record.state = "resident"
-                    record.loaded_at = self._clock()
-                # Success: the aligner loaded and evicted the ASR engine ->
-                # retire the retained sibling reservation.
-                if exclusive_sibling is not None:
-                    self._roles.pop(release_exclusive_role, None)
+            # Success finalization runs under a cancellation SHIELD (pr_validate
+            # round-22): after the route's ``admission.commit()`` the engine is
+            # already resident, so a cancellation arriving while the success-path
+            # ``await self._lock`` is blocked must NOT skip the finalization —
+            # that would leave the committed engine's reservation stuck in
+            # ``"loading"`` and the evicted sibling (if any) charged forever.
+            # The shield lets the finalize run to completion; if the surrounding
+            # task is cancelled, we wait for the shielded finalize first and
+            # THEN re-raise, never leaking a phantom sibling charge.
+            finalize = asyncio.ensure_future(
+                self._finalize_role_commit(
+                    role=role,
+                    record=record,
+                    exclusive_sibling=exclusive_sibling,
+                    release_exclusive_role=release_exclusive_role,
+                )
+            )
+            try:
+                await asyncio.shield(finalize)
+            except asyncio.CancelledError:
+                # Drain the shielded finalize before propagating cancellation.
+                try:
+                    await asyncio.shield(finalize)
+                except asyncio.CancelledError:
+                    pass
+                raise
+
+    async def _finalize_role_commit(
+        self,
+        *,
+        role: str,
+        record,
+        exclusive_sibling,
+        release_exclusive_role: str | None,
+    ) -> None:
+        """Complete the success-path role commit under a shielded lock.
+
+        Marks the admitted record resident and retires the retained
+        mutually-exclusive sibling (the aligner evicted its engine). Runs inside
+        :meth:`admit_role`'s success finalization, shielded from cancellation so
+        a committed engine is never left ``"loading"`` and a phantom sibling
+        charge is never leaked when the context is cancelled mid-commit.
+        """
+        async with self._lock:
+            if self._roles.get(role) is record:
+                record.state = "resident"
+                record.loaded_at = self._clock()
+            # Success: the aligner loaded and evicted the ASR engine ->
+            # retire the retained sibling reservation.
+            if exclusive_sibling is not None:
+                self._roles.pop(release_exclusive_role, None)
 
     async def release_role(self, role: str) -> None:
         """Stop charging a role after its owning lane released the engine."""

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -753,14 +753,16 @@ class ResidentModelManager:
         ``snapshot()`` projection) is retired up front so the new role is not
         double-charged against the ceiling (e.g. alignment retiring the
         dictation ``speech-input`` role whose ASR engine the aligner evicts).
-        Because the release and the new role's admission happen under the SAME
-        ``self._lock`` critical section, and rollback re-inserts the retired
-        reservation atomically in that same critical section, no concurrent
-        admission can consume the freed capacity in the window between release
-        and restore — the retired reservation's capacity is owned by this
-        transaction until commit. On failure/cancellation the retired
-        reservation is restored in full, so a still-resident engine can never
-        be left silently unaccounted; on success it stays retired.
+        The release and the new role's admission happen under the SAME
+        ``self._lock`` critical section. The manager lock is NOT held across
+        the yielded load (a seconds-long weight load), so a concurrent
+        admission may consume the freed capacity in that window; on
+        failure/cancellation the rollback therefore re-runs capacity
+        enforcement ATOMICALLY under the lock before restoring the retired
+        reservation — restoration is skipped if it would exceed the ceiling
+        (or if the caller signaled :meth:`ResidentRoleAdmission.retire_exclusive`,
+        meaning the sibling's engine was already discarded). On success the
+        retired reservation stays retired.
         """
 
         async with self._lock:
@@ -843,15 +845,30 @@ class ResidentModelManager:
                     else:
                         self._roles.pop(role, None)
                 # Restore the retired exclusive role's reservation ATOMICALLY
-                # with this rollback. Since it was released under the same lock
-                # as this admission, no concurrent admission could have claimed
-                # its capacity in the interim; re-insert with ``setdefault`` so
-                # a GENUINELY newer reservation for the role (whose owner is
-                # authoritative) is never clobbered. UNLESS the caller signaled
+                # with this rollback — but ONLY within the configured ceiling.
+                # The sibling's bytes were freed for the duration of the yielded
+                # load (to avoid a false 507 while the aligner would evict the
+                # ASR engine), and the manager lock is NOT held across that
+                # load, so a concurrent admission may legitimately have consumed
+                # the freed capacity. Re-running capacity enforcement here
+                # (under the lock, after the alignment record above is removed)
+                # means restoration cannot push the ledger past ``memory_limit``:
+                # if it would, the sibling stays retired and its engine is left
+                # unaccounted rather than exceeding the hard ceiling. ``setdefault``
+                # also never clobbers a GENUINELY newer reservation for the role
+                # (whose owner is authoritative). And if the caller signaled
                 # ``retire_exclusive`` — the instant the sibling's engine was
                 # actually discarded, restoring would charge a phantom engine
-                # that no longer exists, so it stays retired.
-                if released_exclusive is not None and not admission.exclusive_retired:
+                # that no longer exists — it stays retired regardless.
+                if (
+                    released_exclusive is not None
+                    and not admission.exclusive_retired
+                    and (
+                        self.memory_limit_bytes <= 0
+                        or self._accounted_usage() + released_exclusive.reserved_bytes
+                        <= self.memory_limit_bytes
+                    )
+                ):
                     self._roles.setdefault(release_exclusive_role, released_exclusive)
             raise
         else:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -718,6 +718,7 @@ class ResidentModelManager:
         requested_bytes: int | None,
         capacity_source: str,
         replace_existing: bool = False,
+        release_exclusive_role: str | None = None,
     ):
         """Reserve a protected auxiliary role before its weights load.
 
@@ -731,55 +732,89 @@ class ResidentModelManager:
         role's reservation (crediting the previous bytes) and, on rollback,
         restores the previous reservation unless the caller retired it via
         :meth:`ResidentRoleAdmission.retire_previous`.
+
+        ``release_exclusive_role`` adds a SECOND mutually-exclusive auxiliary
+        role to the same atomic transaction. The named role's current
+        reservation (``self._roles`` — the real auxiliary ledger, never the
+        ``snapshot()`` projection) is retired up front so the new role is not
+        double-charged against the ceiling (e.g. alignment retiring the
+        dictation ``speech-input`` role whose ASR engine the aligner evicts).
+        Because the release and the new role's admission happen under the SAME
+        ``self._lock`` critical section, and rollback re-inserts the retired
+        reservation atomically in that same critical section, no concurrent
+        admission can consume the freed capacity in the window between release
+        and restore — the retired reservation's capacity is owned by this
+        transaction until commit. On failure/cancellation the retired
+        reservation is restored in full, so a still-resident engine can never
+        be left silently unaccounted; on success it stays retired.
         """
 
         async with self._lock:
             previous = self._roles.get(role)
-            if previous is not None and not replace_existing:
-                raise ResidentModelError(f"role {role!r} is already resident")
-            # A role must never host two concurrent in-flight LOADS: an
-            # overwrite here would orphan the earlier load's reservation and,
-            # if that earlier load later rolls back, could resurrect a stale
-            # ``"loading"`` record. Callers serialise per-lane (the STT lane
-            # lock), so this is a defensive invariant at the ledger layer
-            # itself — reject rather than corrupt.
-            if previous is not None and previous.state == "loading":
-                raise ResidentModelError(
-                    f"role {role!r} already has a loading admission in flight"
-                )
-            usage_credit = previous.reserved_bytes if previous is not None else 0
-            used = max(0, self._accounted_usage() - usage_credit)
-            if self.memory_limit_bytes > 0 and requested_bytes is None:
-                raise ResidentModelCapacityError(
-                    (
-                        f"insufficient capacity for role {role!r}: the requested "
-                        "model has no catalog or local-cache size metadata and "
-                        f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
-                        "refusing blind admission under a configured ceiling"
-                    ),
-                    reason="role_capacity_unknown",
-                    requested_bytes=None,
-                    limit_bytes=self.memory_limit_bytes,
-                    used_bytes=used,
+            # Retire the mutually-exclusive sibling's reservation ATOMICALLY
+            # with this admission. ``self._roles`` is the authoritative
+            # auxiliary-role ledger (in contrast to ``snapshot()["roles"]``,
+            # which mixes in synthesized projection entries for ordinary
+            # models and would let a caller release the wrong thing / a
+            # non-reservation). The retired reservation is captured here and
+            # either restored on rollback or confirmed-stale on commit.
+            released_exclusive = None
+            if release_exclusive_role is not None and release_exclusive_role != role:
+                released_exclusive = self._roles.pop(release_exclusive_role, None)
+            try:
+                if previous is not None and not replace_existing:
+                    raise ResidentModelError(f"role {role!r} is already resident")
+                # A role must never host two concurrent in-flight LOADS: an
+                # overwrite here would orphan the earlier load's reservation and,
+                # if that earlier load later rolls back, could resurrect a stale
+                # ``"loading"`` record. Callers serialise per-lane (the STT lane
+                # lock), so this is a defensive invariant at the ledger layer
+                # itself — reject rather than corrupt.
+                if previous is not None and previous.state == "loading":
+                    raise ResidentModelError(
+                        f"role {role!r} already has a loading admission in flight"
+                    )
+                usage_credit = previous.reserved_bytes if previous is not None else 0
+                used = max(0, self._accounted_usage() - usage_credit)
+                if self.memory_limit_bytes > 0 and requested_bytes is None:
+                    raise ResidentModelCapacityError(
+                        (
+                            f"insufficient capacity for role {role!r}: the requested "
+                            "model has no catalog or local-cache size metadata and "
+                            f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
+                            "refusing blind admission under a configured ceiling"
+                        ),
+                        reason="role_capacity_unknown",
+                        requested_bytes=None,
+                        limit_bytes=self.memory_limit_bytes,
+                        used_bytes=used,
+                        requested_role=role,
+                    )
+                reserved_bytes = max(0, int(requested_bytes or 0))
+                await self._evict_for_locked(
+                    reserved_bytes,
+                    exclude=set(),
                     requested_role=role,
+                    usage_credit_bytes=usage_credit,
                 )
-            reserved_bytes = max(0, int(requested_bytes or 0))
-            await self._evict_for_locked(
-                reserved_bytes,
-                exclude=set(),
-                requested_role=role,
-                usage_credit_bytes=usage_credit,
-            )
-            record = ResidentRoleReservation(
-                role=role,
-                model_id=model_id,
-                reserved_bytes=reserved_bytes,
-                capacity_source=capacity_source,
-                state="loading",
-                loaded_at=self._clock(),
-            )
-            self._roles[role] = record
-            admission = ResidentRoleAdmission(record=record, previous=previous)
+                record = ResidentRoleReservation(
+                    role=role,
+                    model_id=model_id,
+                    reserved_bytes=reserved_bytes,
+                    capacity_source=capacity_source,
+                    state="loading",
+                    loaded_at=self._clock(),
+                )
+                self._roles[role] = record
+                admission = ResidentRoleAdmission(record=record, previous=previous)
+            except BaseException:
+                # Any failure BEFORE admission is decided (capacity error,
+                # invariant conflict) must not leave the retired exclusive role
+                # unaccounted — restore it exactly as it was captured, atomically
+                # under this same lock, before the error propagates.
+                if released_exclusive is not None:
+                    self._roles[release_exclusive_role] = released_exclusive
+                raise
         try:
             yield admission
         except BaseException:
@@ -793,6 +828,16 @@ class ResidentModelManager:
                         self._roles[role] = previous
                     else:
                         self._roles.pop(role, None)
+                # Restore the retired exclusive role's reservation ATOMICALLY
+                # with this rollback. Since it was released under the same lock
+                # as this admission, no concurrent admission could have claimed
+                # its capacity in the interim; re-insert with ``setdefault`` so
+                # a GENUINELY newer reservation for the role (whose owner is
+                # authoritative) is never clobbered. The engine it guarded stays
+                # resident and accounted — finding 2's silent-abandonment path
+                # is impossible.
+                if released_exclusive is not None:
+                    self._roles.setdefault(release_exclusive_role, released_exclusive)
             raise
         else:
             async with self._lock:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -27,16 +27,66 @@ class ResidentModelError(RuntimeError):
 
 
 class ResidentModelCapacityError(ResidentModelError):
-    """The configured ceiling cannot admit a model after eligible eviction."""
+    """The configured ceiling cannot admit a model/role after eligible eviction.
+
+    Two admission shapes share this error while keeping their wire contracts
+    distinct:
+
+    * **Assistant/replacement admission** keeps the legacy ``message`` +
+      ``replacement_projection`` shape so ``/v1/models/load`` can return its
+      established projection-based 507 envelope unchanged.
+    * **Protected-role admission** (``residency.admit_role``) carries the
+      typed role fields below, surfaced via :meth:`envelope` as the stable
+      ``insufficient_capacity_error`` 507 for lanes like forced alignment.
+    """
 
     def __init__(
         self,
         message: str,
         *,
         replacement_projection: ReplacementProjection | None = None,
+        reason: str | None = None,
+        requested_bytes: int | None = None,
+        limit_bytes: int | None = None,
+        used_bytes: int | None = None,
+        requested_role: str | None = None,
     ) -> None:
-        super().__init__(message)
         self.replacement_projection = replacement_projection
+        self.reason = reason
+        self.requested_bytes = requested_bytes
+        self.limit_bytes = limit_bytes
+        self.used_bytes = used_bytes
+        self.requested_role = requested_role
+        super().__init__(message)
+
+    def envelope(self) -> dict[str, object]:
+        """Return the stable machine-readable 507 role-capacity contract.
+
+        Populated only when the error was raised from ``admit_role`` (role
+        fields present). A legacy replacement/assistant capacity error has no
+        typed role envelope — its caller keeps using ``replacement_projection``.
+        """
+        if self.reason is None:
+            return {
+                "error": {
+                    "message": str(self),
+                    "type": "insufficient_capacity_error",
+                    "code": "insufficient_capacity_error",
+                    "param": "model",
+                }
+            }
+        return {
+            "error": {
+                "message": str(self),
+                "type": "insufficient_capacity_error",
+                "code": "insufficient_capacity_error",
+                "reason": self.reason,
+                "param": "model",
+                "requested_bytes": self.requested_bytes,
+                "limit_bytes": self.limit_bytes,
+                "used_bytes": self.used_bytes,
+            }
+        }
 
 
 class ResidentModelBusyError(ResidentModelError):
@@ -214,6 +264,38 @@ class ResidencyRecord:
     @property
     def model_id(self) -> str:
         return self.entry.model_name
+
+
+@dataclass
+class ResidentRoleReservation:
+    """A non-registry role charged to the process residency ceiling.
+
+    Auxiliary lanes (forced alignment today; dictation speech-input under the
+    companion role work) own their MLX engine outside the model registry, so
+    their footprints cannot be ledgers through ``ResidencyRecord``. This
+    reservation charges them to the same shared ceiling so admission can
+    reject before their weights load.
+    """
+
+    role: str
+    model_id: str
+    reserved_bytes: int
+    capacity_source: str
+    state: str
+    loaded_at: float
+
+
+@dataclass
+class ResidentRoleAdmission:
+    """Transaction handle for replacing one auxiliary role reservation."""
+
+    record: ResidentRoleReservation
+    previous: ResidentRoleReservation | None = None
+    previous_retired: bool = False
+
+    def retire_previous(self) -> None:
+        """Signal that the prior engine was dropped; do not restore on rollback."""
+        self.previous_retired = True
 
 
 Loader = Callable[..., Awaitable[ModelEntry]]
@@ -421,6 +503,7 @@ class ResidentModelManager:
         self._on_primary_changed = on_primary_changed
         self._records: dict[str, ResidencyRecord] = {}
         self._index: dict[str, str] = {}
+        self._roles: dict[str, ResidentRoleReservation] = {}
         self._lock = asyncio.Lock()
         self._ttl_task: asyncio.Task | None = None
         self.evictions_total = 0
@@ -483,6 +566,11 @@ class ResidentModelManager:
             max(record.estimated_bytes, record.measured_bytes)
             for record in self._records.values()
             if record.state == "resident"
+        )
+        reserved += sum(
+            record.reserved_bytes
+            for record in self._roles.values()
+            if record.state in {"loading", "resident"}
         )
         # Some engines (notably mflux) construct lazy MLX arrays without
         # faulting all weight pages into the process. The footprint delta at
@@ -550,19 +638,45 @@ class ResidentModelManager:
                 await self._evict_locked(record, reason="idle_ttl")
             return evicted
 
-    async def _evict_for_locked(self, incoming_bytes: int, exclude: set[str]) -> None:
+    async def _evict_for_locked(
+        self,
+        incoming_bytes: int,
+        exclude: set[str],
+        *,
+        requested_role: str | None = None,
+        usage_credit_bytes: int = 0,
+    ) -> None:
         if self.memory_limit_bytes <= 0:
             return
-        while self._accounted_usage() + incoming_bytes > self.memory_limit_bytes:
+        while (
+            max(0, self._accounted_usage() - usage_credit_bytes) + incoming_bytes
+            > self.memory_limit_bytes
+        ):
             candidates = self._eviction_candidates_locked(exclude)
             if not candidates:
-                usage = self._accounted_usage()
+                usage = max(0, self._accounted_usage() - usage_credit_bytes)
+                if requested_role is None:
+                    raise ResidentModelCapacityError(
+                        "resident model memory ceiling exceeded: "
+                        f"usage={usage / _GIB:.2f} GiB, "
+                        f"incoming={incoming_bytes / _GIB:.2f} GiB, "
+                        f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
+                        "no idle unpinned model is eligible for eviction"
+                    )
                 raise ResidentModelCapacityError(
-                    "resident model memory ceiling exceeded: "
-                    f"usage={usage / _GIB:.2f} GiB, "
-                    f"incoming={incoming_bytes / _GIB:.2f} GiB, "
-                    f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
-                    "no idle unpinned model is eligible for eviction"
+                    (
+                        "insufficient capacity for role "
+                        f"{requested_role!r}: requested="
+                        f"{incoming_bytes / _GIB:.2f} GiB, "
+                        f"used={usage / _GIB:.2f} GiB, "
+                        f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
+                        "no idle unpinned model is eligible for eviction"
+                    ),
+                    reason=f"role_capacity_{requested_role.replace('-', '_')}",
+                    requested_bytes=incoming_bytes,
+                    limit_bytes=self.memory_limit_bytes,
+                    used_bytes=usage,
+                    requested_role=requested_role,
                 )
             await self._evict_locked(candidates[0], reason="memory_pressure")
 
@@ -582,6 +696,89 @@ class ResidentModelManager:
             ),
             key=lambda record: record.last_used_at,
         )
+
+    @asynccontextmanager
+    async def admit_role(
+        self,
+        *,
+        role: str,
+        model_id: str,
+        requested_bytes: int | None,
+        capacity_source: str,
+        replace_existing: bool = False,
+    ):
+        """Reserve a protected auxiliary role before its weights load.
+
+        Mirrors the shared ledger's transaction discipline: admission is
+        decided with the footprint known (``requested_bytes`` from catalog or
+        local-cache metadata), and the reservation is committed only on
+        success or rolled back on failure/cancellation so no leaked
+        reservation desyncs the ledger.
+
+        ``replace_existing=True`` charges the new footprint against the old
+        role's reservation (crediting the previous bytes) and, on rollback,
+        restores the previous reservation unless the caller retired it via
+        :meth:`ResidentRoleAdmission.retire_previous`.
+        """
+
+        async with self._lock:
+            previous = self._roles.get(role)
+            if previous is not None and not replace_existing:
+                raise ResidentModelError(f"role {role!r} is already resident")
+            usage_credit = previous.reserved_bytes if previous is not None else 0
+            used = max(0, self._accounted_usage() - usage_credit)
+            if self.memory_limit_bytes > 0 and requested_bytes is None:
+                raise ResidentModelCapacityError(
+                    (
+                        f"insufficient capacity for role {role!r}: the requested "
+                        "model has no catalog or local-cache size metadata and "
+                        f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
+                        "refusing blind admission under a configured ceiling"
+                    ),
+                    reason="role_capacity_unknown",
+                    requested_bytes=None,
+                    limit_bytes=self.memory_limit_bytes,
+                    used_bytes=used,
+                    requested_role=role,
+                )
+            reserved_bytes = max(0, int(requested_bytes or 0))
+            await self._evict_for_locked(
+                reserved_bytes,
+                exclude=set(),
+                requested_role=role,
+                usage_credit_bytes=usage_credit,
+            )
+            record = ResidentRoleReservation(
+                role=role,
+                model_id=model_id,
+                reserved_bytes=reserved_bytes,
+                capacity_source=capacity_source,
+                state="loading",
+                loaded_at=self._clock(),
+            )
+            self._roles[role] = record
+            admission = ResidentRoleAdmission(record=record, previous=previous)
+        try:
+            yield admission
+        except BaseException:
+            async with self._lock:
+                if self._roles.get(role) is record:
+                    if previous is not None and not admission.previous_retired:
+                        self._roles[role] = previous
+                    else:
+                        self._roles.pop(role, None)
+            raise
+        else:
+            async with self._lock:
+                if self._roles.get(role) is record:
+                    record.state = "resident"
+                    record.loaded_at = self._clock()
+
+    async def release_role(self, role: str) -> None:
+        """Stop charging a role after its owning lane released the engine."""
+
+        async with self._lock:
+            self._roles.pop(role, None)
 
     async def load(
         self,
@@ -1473,6 +1670,7 @@ class ResidentModelManager:
                     "model_path": record.entry.model_path,
                     "aliases": sorted(record.entry.aliases),
                     "modality": (_modality(record.entry)),
+                    "role": _replacement_group(record.entry),
                     "serving_lane": getattr(engine, "serving_lane", None),
                     "serving_lane_reason": getattr(engine, "serving_lane_reason", None),
                     "state": record.state if resident else "registered",
@@ -1497,6 +1695,32 @@ class ResidentModelManager:
                     ),
                 }
             )
+        roles = [
+            {
+                "role": model["role"],
+                "model": model["id"],
+                "state": model["state"],
+                "pinned": model["pinned"],
+                "active_requests": model["active_requests"],
+                "reserved_bytes": max(
+                    model["estimated_bytes"], model["measured_bytes"] or 0
+                ),
+                "capacity_source": "model",
+            }
+            for model in models
+        ]
+        roles.extend(
+            {
+                "role": record.role,
+                "model": record.model_id,
+                "state": record.state,
+                "pinned": True,
+                "active_requests": 0,
+                "reserved_bytes": record.reserved_bytes,
+                "capacity_source": record.capacity_source,
+            }
+            for record in sorted(self._roles.values(), key=lambda item: item.role)
+        )
         usage = self._accounted_usage()
         return {
             "memory_limit_bytes": self.memory_limit_bytes,
@@ -1510,4 +1734,5 @@ class ResidentModelManager:
             "loads_total": self.loads_total,
             "evictions_total": self.evictions_total,
             "models": models,
+            "roles": roles,
         }

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Protocol, TypedDict
 
 from .model_registry import ModelEntry, ModelRegistry
 from .process_memory import get_phys_footprint
@@ -493,6 +493,33 @@ def _release_allocator_cache() -> None:
         pass
 
 
+class _SnapshotModelDict(TypedDict):
+    """Per-model row of :meth:`ResidentModelManager.snapshot`.
+
+    Typing the heterogeneous snapshot rows lets mypy check the ``max`` on
+    ``estimated_bytes``/``measured_bytes`` as real ``int`` comparisons instead
+    of joining every value type into one broad dict union.
+    """
+
+    id: str
+    model_path: str
+    aliases: list[str]
+    modality: str
+    role: str
+    serving_lane: object
+    serving_lane_reason: object
+    state: str
+    pinned: bool
+    primary: bool
+    active_requests: int
+    lifecycle: object
+    estimated_bytes: int
+    measured_bytes: int | None
+    idle_seconds: float
+    performance: dict[str, object] | None
+    replacement_projection: dict[str, object] | None
+
+
 class ResidentModelManager:
     """Own dynamic engines and enforce a process-wide residency ceiling.
 
@@ -851,6 +878,7 @@ class ResidentModelManager:
                 async with self._lock:
                     if (
                         exclusive_sibling is not None
+                        and release_exclusive_role is not None
                         and self._roles.get(release_exclusive_role) is exclusive_sibling
                     ):
                         # Only retire the sibling WE retained — preserve any
@@ -874,6 +902,7 @@ class ResidentModelManager:
                 # installed NEWER reservation for the role is never erased.
                 if (
                     exclusive_sibling is not None
+                    and release_exclusive_role is not None
                     and admission.exclusive_retired
                     and self._roles.get(release_exclusive_role) is exclusive_sibling
                 ):
@@ -918,7 +947,7 @@ class ResidentModelManager:
         self,
         *,
         role: str,
-        record,
+        record: ResidentRoleReservation,
         exclusive_sibling,
         release_exclusive_role: str | None,
     ) -> None:
@@ -941,6 +970,7 @@ class ResidentModelManager:
             # the aligner loaded, and must not be erased here.
             if (
                 exclusive_sibling is not None
+                and release_exclusive_role is not None
                 and self._roles.get(release_exclusive_role) is exclusive_sibling
             ):
                 self._roles.pop(release_exclusive_role, None)
@@ -1816,7 +1846,7 @@ class ResidentModelManager:
 
     def snapshot(self) -> dict:
         now = self._clock()
-        models = []
+        models: list[_SnapshotModelDict] = []
         for record in sorted(self._records.values(), key=lambda item: item.loaded_at):
             engine = record.entry.engine
             resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -888,11 +888,18 @@ class ResidentModelManager:
             try:
                 await asyncio.shield(finalize)
             except asyncio.CancelledError:
-                # Drain the shielded finalize before propagating cancellation.
-                try:
-                    await asyncio.shield(finalize)
-                except asyncio.CancelledError:
-                    pass
+                # Un-cancellable drain: the shielded ``finalize`` task must run
+                # to completion BEFORE we propagate cancellation (pr_validate
+                # round-23). A second cancellation while this handler awaits is
+                # itself re-raised as ``CancelledError`` inside the loop, which
+                # we swallow and re-arm the shield until ``finalize.done()`` —
+                # so callers can never observe a stale ``"loading"`` record or
+                # a retained phantom sibling charge after cancelling here.
+                while not finalize.done():
+                    try:
+                        await asyncio.shield(finalize)
+                    except asyncio.CancelledError:
+                        continue
                 raise
 
     async def _finalize_role_commit(

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -304,11 +304,10 @@ class ResidentRoleAdmission:
 
         Called by the alignment lane the INSTANT the ASR engine evicted by
         ``_evict_other_lane_sync("aligner")`` is actually gone. After this
-        point the retired ``speech-input`` reservation points at a phantom
-        engine, so the rollback must NOT restore it — restoring would charge
-        a resident engine that no longer exists. Before the discard the
-        sibling may still be resident (a re-admission failure before the
-        eviction dropped nothing), so restoration stays correct until then.
+        point the retained ``speech-input`` reservation points at a phantom
+        engine, so a rollback must DROP it rather than leave a charge for an
+        engine that no longer exists. Before the discard the sibling is still
+        its engine's true reservation and stays in the ledger.
         """
         self.exclusive_retired = True
 
@@ -748,35 +747,38 @@ class ResidentModelManager:
         :meth:`ResidentRoleAdmission.retire_previous`.
 
         ``release_exclusive_role`` adds a SECOND mutually-exclusive auxiliary
-        role to the same atomic transaction. The named role's current
-        reservation (``self._roles`` — the real auxiliary ledger, never the
-        ``snapshot()`` projection) is retired up front so the new role is not
-        double-charged against the ceiling (e.g. alignment retiring the
-        dictation ``speech-input`` role whose ASR engine the aligner evicts).
-        The release and the new role's admission happen under the SAME
-        ``self._lock`` critical section. The manager lock is NOT held across
-        the yielded load (a seconds-long weight load), so a concurrent
-        admission may consume the freed capacity in that window; on
-        failure/cancellation the rollback therefore re-runs capacity
-        enforcement ATOMICALLY under the lock before restoring the retired
-        reservation — restoration is skipped if it would exceed the ceiling
-        (or if the caller signaled :meth:`ResidentRoleAdmission.retire_exclusive`,
-        meaning the sibling's engine was already discarded). On success the
-        retired reservation stays retired.
+        role to the same transaction (e.g. alignment retiring the dictation
+        ``speech-input`` role whose ASR engine the aligner evicts). The
+        sibling's reservation is RETAINED in ``self._roles`` — the real
+        auxiliary ledger, never the ``snapshot()`` projection — for the whole
+        transaction and its bytes are CREDITED against the new role's admission,
+        so the two are never double-charged (no false 507) yet no concurrent
+        admission can consume the sibling's capacity (no steal window). The new
+        role's admission and the sibling's retention happen under the SAME
+        ``self._lock`` critical section. On success (commit) — including a load
+        that finished under cancellation — the sibling is retired when the
+        aligner evicts its engine. On failure/cancellation the sibling stays in
+        the ledger (matching its still-resident engine) unless the load evicted
+        it first, in which case the caller's
+        :meth:`ResidentRoleAdmission.retire_exclusive` signal drops the now
+        phantom reservation. A still-resident engine is never left unaccounted,
+        and the configured ceiling is never breached by a restore.
         """
 
         async with self._lock:
             previous = self._roles.get(role)
-            # Retire the mutually-exclusive sibling's reservation ATOMICALLY
-            # with this admission. ``self._roles`` is the authoritative
-            # auxiliary-role ledger (in contrast to ``snapshot()["roles"]``,
-            # which mixes in synthesized projection entries for ordinary
-            # models and would let a caller release the wrong thing / a
-            # non-reservation). The retired reservation is captured here and
-            # either restored on rollback or confirmed-stale on commit.
-            released_exclusive = None
+            # Capture the mutually-exclusive sibling WITHOUT removing it. The
+            # sibling's reservation is RETAINED in ``_roles`` for the whole
+            # transaction — its bytes stay accounted, so NO concurrent admission
+            # can consume them and a rollback can never be forced to choose
+            # between an unaccounted engine and an over-ceiling ledger (pr_validate
+            # round-19). ``self._roles`` is the authoritative auxiliary-role
+            # ledger (in contrast to ``snapshot()["roles"]``, which mixes in
+            # synthesized projection entries for ordinary models and would let a
+            # caller release the wrong thing / a non-reservation).
+            exclusive_sibling = None
             if release_exclusive_role is not None and release_exclusive_role != role:
-                released_exclusive = self._roles.pop(release_exclusive_role, None)
+                exclusive_sibling = self._roles.get(release_exclusive_role)
             try:
                 if previous is not None and not replace_existing:
                     raise ResidentModelError(f"role {role!r} is already resident")
@@ -790,7 +792,17 @@ class ResidentModelManager:
                     raise ResidentModelError(
                         f"role {role!r} already has a loading admission in flight"
                     )
-                usage_credit = previous.reserved_bytes if previous is not None else 0
+                # Credit the new role against BOTH the same-role previous and the
+                # retained mutually-exclusive sibling: the aligner admission nets
+                # out the ASR engine bytes it will evict, so it is not falsely
+                # rejected while the ASR engine is still resident.
+                usage_credit = (
+                    previous.reserved_bytes if previous is not None else 0
+                ) + (
+                    exclusive_sibling.reserved_bytes
+                    if exclusive_sibling is not None
+                    else 0
+                )
                 used = max(0, self._accounted_usage() - usage_credit)
                 if self.memory_limit_bytes > 0 and requested_bytes is None:
                     raise ResidentModelCapacityError(
@@ -825,18 +837,20 @@ class ResidentModelManager:
                 admission = ResidentRoleAdmission(record=record, previous=previous)
             except BaseException:
                 # Any failure BEFORE admission is decided (capacity error,
-                # invariant conflict) must not leave the retired exclusive role
-                # unaccounted — restore it exactly as it was captured, atomically
-                # under this same lock, before the error propagates.
-                if released_exclusive is not None:
-                    self._roles[release_exclusive_role] = released_exclusive
+                # invariant conflict) leaves the retained sibling untouched in
+                # ``_roles`` — nothing to restore, nothing leaked.
                 raise
         try:
             yield admission
         except BaseException:
             if admission.committed:
                 # The engine was already published on the model worker (e.g.
-                # the load finished under cancellation); keep it accounted.
+                # the load finished under cancellation); keep it accounted. The
+                # successful load evicted the ASR engine -> drop the retained
+                # (by now phantom) sibling reservation.
+                async with self._lock:
+                    if exclusive_sibling is not None:
+                        self._roles.pop(release_exclusive_role, None)
                 raise
             async with self._lock:
                 if self._roles.get(role) is record:
@@ -844,38 +858,24 @@ class ResidentModelManager:
                         self._roles[role] = previous
                     else:
                         self._roles.pop(role, None)
-                # Restore the retired exclusive role's reservation ATOMICALLY
-                # with this rollback — but ONLY within the configured ceiling.
-                # The sibling's bytes were freed for the duration of the yielded
-                # load (to avoid a false 507 while the aligner would evict the
-                # ASR engine), and the manager lock is NOT held across that
-                # load, so a concurrent admission may legitimately have consumed
-                # the freed capacity. Re-running capacity enforcement here
-                # (under the lock, after the alignment record above is removed)
-                # means restoration cannot push the ledger past ``memory_limit``:
-                # if it would, the sibling stays retired and its engine is left
-                # unaccounted rather than exceeding the hard ceiling. ``setdefault``
-                # also never clobbers a GENUINELY newer reservation for the role
-                # (whose owner is authoritative). And if the caller signaled
-                # ``retire_exclusive`` — the instant the sibling's engine was
-                # actually discarded, restoring would charge a phantom engine
-                # that no longer exists — it stays retired regardless.
-                if (
-                    released_exclusive is not None
-                    and not admission.exclusive_retired
-                    and (
-                        self.memory_limit_bytes <= 0
-                        or self._accounted_usage() + released_exclusive.reserved_bytes
-                        <= self.memory_limit_bytes
-                    )
-                ):
-                    self._roles.setdefault(release_exclusive_role, released_exclusive)
+                # The retained sibling was never removed, so it needs no
+                # "restore". If the load evicted its engine before failing
+                # (``retire_exclusive`` -> ``exclusive_retired`` — the round-18
+                # case), the reservation now guards a phantom engine and must be
+                # dropped; otherwise it stays charged, exactly matching its
+                # still-resident engine.
+                if exclusive_sibling is not None and admission.exclusive_retired:
+                    self._roles.pop(release_exclusive_role, None)
             raise
         else:
             async with self._lock:
                 if self._roles.get(role) is record:
                     record.state = "resident"
                     record.loaded_at = self._clock()
+                # Success: the aligner loaded and evicted the ASR engine ->
+                # retire the retained sibling reservation.
+                if exclusive_sibling is not None:
+                    self._roles.pop(release_exclusive_role, None)
 
     async def release_role(self, role: str) -> None:
         """Stop charging a role after its owning lane released the engine."""

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -849,7 +849,14 @@ class ResidentModelManager:
                 # successful load evicted the ASR engine -> drop the retained
                 # (by now phantom) sibling reservation.
                 async with self._lock:
-                    if exclusive_sibling is not None:
+                    if (
+                        exclusive_sibling is not None
+                        and self._roles.get(release_exclusive_role) is exclusive_sibling
+                    ):
+                        # Only retire the sibling WE retained — preserve any
+                        # NEWER reservation a concurrent admission installed for
+                        # this role while the aligner loaded (its engine is
+                        # authoritative and still resident).
                         self._roles.pop(release_exclusive_role, None)
                 raise
             async with self._lock:
@@ -863,8 +870,13 @@ class ResidentModelManager:
                 # (``retire_exclusive`` -> ``exclusive_retired`` — the round-18
                 # case), the reservation now guards a phantom engine and must be
                 # dropped; otherwise it stays charged, exactly matching its
-                # still-resident engine.
-                if exclusive_sibling is not None and admission.exclusive_retired:
+                # still-resident engine. Identity-check so a concurrently
+                # installed NEWER reservation for the role is never erased.
+                if (
+                    exclusive_sibling is not None
+                    and admission.exclusive_retired
+                    and self._roles.get(release_exclusive_role) is exclusive_sibling
+                ):
                     self._roles.pop(release_exclusive_role, None)
             raise
         else:
@@ -923,8 +935,14 @@ class ResidentModelManager:
                 record.state = "resident"
                 record.loaded_at = self._clock()
             # Success: the aligner loaded and evicted the ASR engine ->
-            # retire the retained sibling reservation.
-            if exclusive_sibling is not None:
+            # retire the retained sibling reservation, but ONLY if it is still
+            # the reservation WE retained — a concurrent admission may have
+            # replaced the role with a newer (authoritative) reservation while
+            # the aligner loaded, and must not be erased here.
+            if (
+                exclusive_sibling is not None
+                and self._roles.get(release_exclusive_role) is exclusive_sibling
+            ):
                 self._roles.pop(release_exclusive_role, None)
 
     async def release_role(self, role: str) -> None:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -737,6 +737,16 @@ class ResidentModelManager:
             previous = self._roles.get(role)
             if previous is not None and not replace_existing:
                 raise ResidentModelError(f"role {role!r} is already resident")
+            # A role must never host two concurrent in-flight LOADS: an
+            # overwrite here would orphan the earlier load's reservation and,
+            # if that earlier load later rolls back, could resurrect a stale
+            # ``"loading"`` record. Callers serialise per-lane (the STT lane
+            # lock), so this is a defensive invariant at the ledger layer
+            # itself — reject rather than corrupt.
+            if previous is not None and previous.state == "loading":
+                raise ResidentModelError(
+                    f"role {role!r} already has a loading admission in flight"
+                )
             usage_credit = previous.reserved_bytes if previous is not None else 0
             used = max(0, self._accounted_usage() - usage_credit)
             if self.memory_limit_bytes > 0 and requested_bytes is None:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -292,10 +292,22 @@ class ResidentRoleAdmission:
     record: ResidentRoleReservation
     previous: ResidentRoleReservation | None = None
     previous_retired: bool = False
+    committed: bool = False
 
     def retire_previous(self) -> None:
         """Signal that the prior engine was dropped; do not restore on rollback."""
         self.previous_retired = True
+
+    def commit(self) -> None:
+        """Mark the new engine as resident even when the caller re-raises.
+
+        Used by the alignment lane when its weight load completed on the model
+        worker (the engine was published) but the async handler is being
+        cancelled: the weights are loaded, so the reservation must be kept
+        rather than rolled back into a ledger desync.
+        """
+        self.committed = True
+        self.record.state = "resident"
 
 
 Loader = Callable[..., Awaitable[ModelEntry]]
@@ -761,6 +773,10 @@ class ResidentModelManager:
         try:
             yield admission
         except BaseException:
+            if admission.committed:
+                # The engine was already published on the model worker (e.g.
+                # the load finished under cancellation); keep it accounted.
+                raise
             async with self._lock:
                 if self._roles.get(role) is record:
                     if previous is not None and not admission.previous_retired:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -292,11 +292,25 @@ class ResidentRoleAdmission:
     record: ResidentRoleReservation
     previous: ResidentRoleReservation | None = None
     previous_retired: bool = False
+    exclusive_retired: bool = False
     committed: bool = False
 
     def retire_previous(self) -> None:
         """Signal that the prior engine was dropped; do not restore on rollback."""
         self.previous_retired = True
+
+    def retire_exclusive(self) -> None:
+        """Signal that the mutually-exclusive sibling's engine was discarded.
+
+        Called by the alignment lane the INSTANT the ASR engine evicted by
+        ``_evict_other_lane_sync("aligner")`` is actually gone. After this
+        point the retired ``speech-input`` reservation points at a phantom
+        engine, so the rollback must NOT restore it — restoring would charge
+        a resident engine that no longer exists. Before the discard the
+        sibling may still be resident (a re-admission failure before the
+        eviction dropped nothing), so restoration stays correct until then.
+        """
+        self.exclusive_retired = True
 
     def commit(self) -> None:
         """Mark the new engine as resident even when the caller re-raises.
@@ -833,10 +847,11 @@ class ResidentModelManager:
                 # as this admission, no concurrent admission could have claimed
                 # its capacity in the interim; re-insert with ``setdefault`` so
                 # a GENUINELY newer reservation for the role (whose owner is
-                # authoritative) is never clobbered. The engine it guarded stays
-                # resident and accounted — finding 2's silent-abandonment path
-                # is impossible.
-                if released_exclusive is not None:
+                # authoritative) is never clobbered. UNLESS the caller signaled
+                # ``retire_exclusive`` — the instant the sibling's engine was
+                # actually discarded, restoring would charge a phantom engine
+                # that no longer exists, so it stays retired.
+                if released_exclusive is not None and not admission.exclusive_retired:
                     self._roles.setdefault(release_exclusive_role, released_exclusive)
             raise
         else:

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -17,86 +17,93 @@ class RoleCapacity:
     source: str
 
 
-# ``_LOCAL_CACHE_TTL_SECONDS`` bounds how long a local-footprint lookup (hit
-# OR miss) is reused. The HF cache is mutable — a checkpoint can be downloaded,
-# deleted or grown between requests — so a result must never be remembered
-# forever. The bounded TTL serves two goals at once:
+# ``_LOCAL_CACHE_TTL_SECONDS`` bounds how long ONE indexed snapshot of the local
+# HF cache is reused. The cache is mutable — a checkpoint can be downloaded,
+# deleted or grown between requests — so an index must never be remembered
+# forever. Two goals at once:
 #
-#   * a burst of repeated alignment requests (successful or rejected) does not
-#     re-walk the whole HF cache each time, and
-#   * a previously-missing or partially-cached checkpoint becomes discoverable
-#     (re-scanned) once the TTL elapses.
+#   * every local-footprint lookup (for any number of model ids) reads from the
+#     SAME cached ``scan_cache_dir()`` index, so a burst of arbitrary
+#     (attacker-controlled) model ids performs ONE walk per TTL window, not one
+#     per id — this also bounds memory to a single index, not one entry per id;
+#   * a previously-missing or newly-downloaded checkpoint becomes discoverable
+#     once the TTL elapses and the index is re-scanned.
 #
-# Thus a *complete* cached download is charged promptly, an absent one is
-# retried soon, and a still-in-progress download does not get trusted until it
-# finishes.
+# A *complete* cached download is charged promptly; an absent or still
+# in-progress one is not trusted until a later re-scan observes it complete.
 _LOCAL_CACHE_TTL_SECONDS = 30.0
-_local_cache_lookups: dict[str, tuple[float, int | None]] = {}
+# ``(monotonic_timestamp, {repo_id_lower: footprint_bytes})`` or ``None`` when
+# no scan has completed yet.
+_local_cache_snapshot: tuple[float, dict[str, int]] | None = None
 
 
 def _local_cache_bytes(hf_id: str) -> int | None:
     """Return the verified on-disk footprint of ``hf_id`` in the local HF cache.
 
     Satisfies the "catalog OR verified local-cache metadata" contract for a
-    checkpoint absent (or stale) in the checked-in manifest. Uses
-    ``scan_cache_dir()``'s ``size_on_disk`` (huggingface_hub's own deduped byte
-    count — exactly what ``rapid-mlx rm`` reports). ``None`` when the repo is
-    not cached, is only partially downloaded, or the scan fails, so the caller
-    fails closed rather than admitting on a partial/uncertain footprint.
-
-    Both hits and misses are cached briefly (TTL), so a burst of arbitrary
-    valid-looking model ids does not saturate the worker thread pool with full
-    cache walks, while a later download still becomes discoverable once the TTL
-    expires (cache is mutable and must be re-observed fresh).
+    checkpoint absent (or stale) in the checked-in manifest. Reads from a
+    single TTL-bounded snapshot of ``scan_cache_dir()`` (built on demand), so
+    repeated lookups coalesce into one cache walk per TTL window regardless of
+    how many distinct model ids are probed — an attacker cannot drive one
+    ``scan_cache_dir()`` traversal (or unbounded memory) per public alignment
+    request. ``None`` when the repo is not cached, only partially downloaded,
+    or the scan fails, so the caller fails closed rather than admitting on a
+    partial/uncertain footprint.
     """
-    lc = hf_id.lower()
+    global _local_cache_snapshot
     now = time.monotonic()
-    cached = _local_cache_lookups.get(lc)
-    if cached is not None and now - cached[0] < _LOCAL_CACHE_TTL_SECONDS:
-        return cached[1]
-    size = _scan_local_cache_bytes(hf_id)
-    _local_cache_lookups[lc] = (now, size)
-    return size
+    if (
+        _local_cache_snapshot is not None
+        and now - _local_cache_snapshot[0] < _LOCAL_CACHE_TTL_SECONDS
+    ):
+        return _local_cache_snapshot[1].get(hf_id.lower())
+
+    index = _scan_local_cache_index()
+    _local_cache_snapshot = (now, index)
+    return index.get(hf_id.lower())
 
 
-def _scan_local_cache_bytes(hf_id: str) -> int | None:
-    """Return a COMPLETE cached footprint for ``hf_id``, else ``None``.
+def _scan_local_cache_index() -> dict[str, int]:
+    """Return ``{repo_id_lower: completed-footprint}`` from the local HF cache.
 
-    We deliberately require a completed (ref-bound) download before trusting
-    ``size_on_disk``: huggingface_hub writes the ``refs/<branch>`` pointer only
-    after a ``snapshot_download`` finishes, so a repo whose ``size_on_disk`` we
-    read is either a full, usable checkpoint or an in-progress/partial one. A
-    partial cache reserves only its small on-disk bytes (e.g. tokenizer/config)
-    and would under-charge the residency ledger — the later ``STTEngine.load``
-    would download the remaining weights and blow past the ceiling. So a
-    partial download returns ``None`` (fail closed). ``None`` on any smash too,
-    so a cache-scan hiccup never admits blind.
+    Only repos with a COMPLETE (ref-bound) default snapshot are indexed. The
+    footprint for a repo is the byte total of its completed snapshot — the
+    revision a ``load`` would use — NOT the repo's aggregate ``size_on_disk``,
+    which would include a partially-downloaded second revision and understate
+    what the load will materialize. A repo with no completed snapshot (still
+    downloading, or only config/tokenizer cached) contributes nothing, so the
+    caller fails closed (unknown -> 507 under a ceiling) instead of reserving
+    only partial bytes and blowing past the ceiling on the real load.
     """
     try:
         from huggingface_hub import scan_cache_dir
     except Exception:  # pragma: no cover - huggingface_hub is a core dep
-        return None
+        return {}
     try:
         cache = scan_cache_dir()
-        lc = hf_id.lower()
+        index: dict[str, int] = {}
         for repo in cache.repos:
-            if repo.repo_id.lower() != lc:
+            # The loader resolves to the ref-bound (default) revision; only a
+            # snapshot that is complete (has a ref pointing at it) is trusted.
+            completed = [rev for rev in repo.revisions if rev.refs]
+            if not completed:
+                if any(rev for rev in repo.revisions):
+                    logger.debug(
+                        "local cache for %r has no completed snapshot; "
+                        "failing closed instead of under-reserving",
+                        repo.repo_id,
+                    )
                 continue
-            # A ref-bound revision is a COMPLETED download. Size_on_disk on a
-            # ref-less (in-progress) snapshot only reflects partial bytes.
-            if not any(rev.refs for rev in repo.revisions):
-                logger.debug(
-                    "local cache for %r is partial (no completed snapshot); "
-                    "failing closed instead of under-reserving",
-                    repo.repo_id,
-                )
-                return None
-            size = int(repo.size_on_disk or 0)
-            return size if size > 0 else None
+            # Sum the file bytes of the completed snapshot(s) actually present.
+            size = 0
+            for rev in completed:
+                size += sum(int(f.size_on_disk or 0) for f in rev.files)
+            if size > 0:
+                index[repo.repo_id.lower()] = size
+        return index
     except Exception as exc:  # noqa: BLE001 - a cache-scan hiccup must not admit blind
-        logger.debug("scan_cache_dir for %r failed: %s", hf_id, exc)
-        return None
-    return None
+        logger.debug("scan_cache_dir failed: %s", exc)
+        return {}
 
 
 def alignment_capacity(model_id: str) -> RoleCapacity:
@@ -111,10 +118,11 @@ def alignment_capacity(model_id: str) -> RoleCapacity:
 
     When the manifest has no entry (repo not newly mirrored / not in the size
     table), we fall back to the checkpoint's verified local-cache footprint if
-    it is already on disk AND fully downloaded. Only when BOTH the catalog and
-    the (complete) local cache are empty does ``requested_bytes=None`` with
-    ``source="unknown"``, so a configured residency ceiling fails closed
-    (``role_capacity_unknown``) instead of admitting without a typed decision.
+    it is already on disk AND fully downloaded (a complete, ref-bound
+    snapshot). Only when BOTH the catalog and the (complete) local cache are
+    empty does ``requested_bytes=None`` with ``source="unknown"``, so a
+    configured residency ceiling fails closed (``role_capacity_unknown``)
+    instead of admitting without a typed decision.
     """
     from ..audio.registry import resolve_audio_alias
     from ..model_sizes import size_bytes

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -1,0 +1,39 @@
+"""Metadata-backed capacity charges for shared residency roles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RoleCapacity:
+    """A role's footprint charge resolved from durable metadata, not guesses."""
+
+    requested_bytes: int | None
+    source: str
+
+
+def alignment_capacity(model_id: str) -> RoleCapacity:
+    """Resolve an alignment-role charge from catalog metadata.
+
+    The forced-aligner aliases (``qwen3-aligner`` / ``qwen3-forced-aligner``)
+    and the underlying HF id (``mlx-community/Qwen3-ForcedAligner-0.6B-8bit``)
+    all resolve to the same ``hf_id`` through the audio-alias registry, from
+    which the checked-in download-size manifest (:mod:`vllm_mlx.model_sizes`)
+    derives a real byte footprint BEFORE any weight loading — so admission can
+    decide with knowledge of the size rather than blind.
+
+    A missing catalog entry yields ``requested_bytes=None`` with
+    ``source="unknown"`` so a configured residency ceiling fails closed
+    (``role_capacity_unknown``) instead of admitting without a typed decision.
+    """
+    from ..audio.registry import resolve_audio_alias
+    from ..model_sizes import size_bytes
+
+    entry = resolve_audio_alias(model_id)
+    hf_id = entry.hf_id if entry is not None else model_id
+    requested_bytes = size_bytes(hf_id)
+    return RoleCapacity(
+        requested_bytes=requested_bytes,
+        source="catalog" if requested_bytes is not None else "unknown",
+    )

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import threading
 import time
 from dataclasses import dataclass
@@ -130,17 +131,29 @@ def _revision_is_complete(rev) -> bool:
     ``rev`` is a huggingface_hub ``CachedRevisionInfo``. A ref-bound snapshot
     alone does not prove the weights are present — a selective download can be
     ref-bound yet hold only config/tokenizer, and an interrupted multi-shard
-    download can hold one weight shard. We verify against the trusted shard
-    index when present, else require a single-file weight:
+    download can hold ONE weight shard. Verification:
 
-      * if ``model.safetensors.index.json`` exists, parse it and REQUIRE every
-        shard named in ``weight_map`` to be present in the snapshot;
-      * otherwise require at least one irreducible single-file weight
-        (``*.gguf``, ``*.bin``, ``*.npz``/``*.npy``, or a non-shard
-        ``*.safetensors``), which needs no cross-file verification.
+      * if a shard index exists (``*.safetensors.index.json`` or
+        ``pytorch_model.bin.index.json``), parse it and REQUIRE every shard it
+        names to be present in the snapshot;
+      * a shard-PATTERNED weight file (``*-NNNNN-of-MMMMM.safetensors`` /
+        ``*.bin``) with NO readable index is an incomplete multi-shard download
+        → fail closed, never charge a fraction;
+      * otherwise an irreducible single-file weight (``*.gguf``, a bare
+        non-shard ``*.safetensors``/``*.bin``, ``*.npz``/``*.npy``) needs no
+        cross-file verification.
     """
     files = {f.file_name.lower() for f in rev.files}
-    index_name = next((n for n in files if n.endswith(".safetensors.index.json")), None)
+
+    # Any index format present drives shard verification.
+    index_name = next(
+        (
+            n
+            for n in files
+            if n.endswith((".safetensors.index.json", "pytorch_model.bin.index.json"))
+        ),
+        None,
+    )
     if index_name is not None:
         try:
             idx_file = next(f for f in rev.files if f.file_name.lower() == index_name)
@@ -148,7 +161,7 @@ def _revision_is_complete(rev) -> bool:
 
             data = json.loads(idx_file.file_path.read_text(encoding="utf-8"))
         except Exception as exc:  # noqa: BLE001 - a corrupt index must not admit blind
-            logger.debug("failed to read safetensors index: %s", exc)
+            logger.debug("failed to read shard index: %s", exc)
             return False
         shards = set(data.get("weight_map", {}).values())
         if not shards:
@@ -156,11 +169,22 @@ def _revision_is_complete(rev) -> bool:
         missing = [s for s in shards if s.lower() not in files]
         if missing:
             logger.debug(
-                "safetensors index lists shards missing from the snapshot: %s",
+                "shard index lists shards missing from the snapshot: %s",
                 sorted(missing)[:5],
             )
             return False
         return True
+
+    # A shard-PATTERN weight without an index is an incomplete multi-shard
+    # download — never charge a single shard as the whole checkpoint.
+    shard_pat = re.compile(r".*-\d{5}-of-\d{5}\.(safetensors|bin)$")
+    if any(shard_pat.match(name) for name in files):
+        logger.debug(
+            "snapshot has sharded weight file(s) but no readable shard index; "
+            "failing closed instead of under-reserving"
+        )
+        return False
+
     return any(name.endswith(_WEIGHT_SUFFIXES) for name in files)
 
 

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -139,9 +139,14 @@ def _revision_is_complete(rev) -> bool:
       * a shard-PATTERNED weight file (``*-NNNNN-of-MMMMM.safetensors`` /
         ``*.bin``) with NO readable index is an incomplete multi-shard download
         → fail closed, never charge a fraction;
-      * otherwise an irreducible single-file weight (``*.gguf``, a bare
-        non-shard ``*.safetensors``/``*.bin``, ``*.npz``/``*.npy``) needs no
-        cross-file verification.
+      * otherwise a fully resident single-file layout is verifiably complete
+        when it carries a canonical single-file weight: ``*.gguf`` (GGUF is
+        always one self-contained file) or a canonical unsharded name
+        (``model.safetensors``, ``pytorch_model.bin``, ``model.bin``,
+        ``model.npz``, ``model.npy``) — a sharded download never uses those
+        plain names, so a lone canonical file is the WHOLE checkpoint; any
+        other bare weight name could be one piece of a selective download and
+        still fails closed.
     """
     files = {f.file_name.lower() for f in rev.files}
 
@@ -186,12 +191,28 @@ def _revision_is_complete(rev) -> bool:
         )
         return False
 
-    # With NO shard index, the only layout we can charge with confidence is a
-    # NON-SPLIT single-file GGUF weight (split GGUFs named ``-NNNNN-of-MMMMM``
-    # are excluded above). A bare ``.safetensors``/``.bin``/``.npz`` -- even
-    # non-shard-pattern -- could be one ordinarily-named weight of several in a
-    # selective download, so we fail closed unless an index proves the full set.
-    return any(name.endswith(".gguf") for name in files)
+    # With NO shard index, a ref-bound snapshot is complete when it holds ONE
+    # self-contained weight via a CANONICAL single-file name. GGUF is always a
+    # single self-contained file. A canonical unsharded name (`model.safetensors`,
+    # `pytorch_model.bin`, `model.bin`, `model.npz`, `model.npy`) means the
+    # checkpoint was published unsharded — a sharded download names its shards
+    # `model-00001-of-000XX.*`, never a plain canonical name (those were already
+    # rejected above), so a lone canonical file is the WHOLE checkpoint, not a
+    # piece of a selective download. Any other single weight name (e.g.
+    # `encoder-1.bin`) could be one of several in a selective download, so it
+    # still fails closed unless an index proves the full set (pr_validate
+    # round-21: a fully-cached canonical single-file checkpoint must not be
+    # falsely rejected as unknown).
+    canonical_single_file = {
+        "model.safetensors",
+        "pytorch_model.bin",
+        "model.bin",
+        "model.npz",
+        "model.npy",
+    }
+    return any(name.endswith(".gguf") for name in files) or any(
+        name in canonical_single_file for name in files
+    )
 
 
 def _default_completed_revision(revisions):

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -13,8 +16,36 @@ class RoleCapacity:
     source: str
 
 
+def _local_cache_bytes(hf_id: str) -> int | None:
+    """Return the verified on-disk footprint of ``hf_id`` in the local HF cache.
+
+    This satisfies the "catalog OR verified local-cache metadata" contract for
+    a checkpoint that is already downloaded but absent (or stale) in the
+    checked-in manifest. We deliberately use ``scan_cache_dir()``'s
+    ``size_on_disk`` — huggingface_hub's own deduped byte count — rather than
+    a directory walk, because ``size_on_disk`` is exactly what ``rapid-mlx rm``
+    reports and is the same number a user would expect freeing. ``None`` when
+    the repo is not cached or the lookup fails so the caller fails closed.
+    """
+    try:
+        from huggingface_hub import scan_cache_dir
+    except Exception:  # pragma: no cover - huggingface_hub is a core dep
+        return None
+    try:
+        cache = scan_cache_dir()
+        lc = hf_id.lower()
+        for repo in cache.repos:
+            if repo.repo_id.lower() == lc:
+                size = int(repo.size_on_disk or 0)
+                return size if size > 0 else None
+    except Exception as exc:  # noqa: BLE001 - a cache-scan hiccup must not admit blind
+        logger.debug("scan_cache_dir for %r failed: %s", hf_id, exc)
+        return None
+    return None
+
+
 def alignment_capacity(model_id: str) -> RoleCapacity:
-    """Resolve an alignment-role charge from catalog metadata.
+    """Resolve an alignment-role charge from catalog or verified cache metadata.
 
     The forced-aligner aliases (``qwen3-aligner`` / ``qwen3-forced-aligner``)
     and the underlying HF id (``mlx-community/Qwen3-ForcedAligner-0.6B-8bit``)
@@ -23,9 +54,12 @@ def alignment_capacity(model_id: str) -> RoleCapacity:
     derives a real byte footprint BEFORE any weight loading — so admission can
     decide with knowledge of the size rather than blind.
 
-    A missing catalog entry yields ``requested_bytes=None`` with
-    ``source="unknown"`` so a configured residency ceiling fails closed
-    (``role_capacity_unknown``) instead of admitting without a typed decision.
+    When the manifest has no entry (repo not newly mirrored / not in the size
+    table), we fall back to the checkpoint's verified local-cache footprint if
+    it is already on disk. Only when BOTH the catalog and the local cache are
+    empty does ``requested_bytes=None`` with ``source="unknown"``, so a
+    configured residency ceiling fails closed (``role_capacity_unknown``)
+    instead of admitting without a typed capacity decision.
     """
     from ..audio.registry import resolve_audio_alias
     from ..model_sizes import size_bytes
@@ -33,7 +67,9 @@ def alignment_capacity(model_id: str) -> RoleCapacity:
     entry = resolve_audio_alias(model_id)
     hf_id = entry.hf_id if entry is not None else model_id
     requested_bytes = size_bytes(hf_id)
-    return RoleCapacity(
-        requested_bytes=requested_bytes,
-        source="catalog" if requested_bytes is not None else "unknown",
-    )
+    if requested_bytes is not None:
+        return RoleCapacity(requested_bytes=requested_bytes, source="catalog")
+    cached_bytes = _local_cache_bytes(hf_id)
+    if cached_bytes is not None:
+        return RoleCapacity(requested_bytes=cached_bytes, source="local-cache")
+    return RoleCapacity(requested_bytes=None, source="unknown")

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -17,46 +17,61 @@ class RoleCapacity:
     source: str
 
 
-# ``_LOCAL_CACHE_TTL_SECONDS`` bounds how long a *successful* local-footprint
-# lookup is reused. The HF cache is mutable: a checkpoint can be deleted or
-# grown between requests, so the result must never be remembered forever. The
-# TTL lets a burst of repeated rejected alignments skip re-walking the whole
-# cache, while a later download (or rm) becomes discoverable once it expires.
-# Only positive results are cached — a miss is never memoized, so a previously
-# uncached checkpoint is always retried (round-4 NIT: bounded-TTL to avoid the
-# repeated full scan; round-3: never permanently memorize a mutable footprint).
+# ``_LOCAL_CACHE_TTL_SECONDS`` bounds how long a local-footprint lookup (hit
+# OR miss) is reused. The HF cache is mutable — a checkpoint can be downloaded,
+# deleted or grown between requests — so a result must never be remembered
+# forever. The bounded TTL serves two goals at once:
+#
+#   * a burst of repeated alignment requests (successful or rejected) does not
+#     re-walk the whole HF cache each time, and
+#   * a previously-missing or partially-cached checkpoint becomes discoverable
+#     (re-scanned) once the TTL elapses.
+#
+# Thus a *complete* cached download is charged promptly, an absent one is
+# retried soon, and a still-in-progress download does not get trusted until it
+# finishes.
 _LOCAL_CACHE_TTL_SECONDS = 30.0
-_local_cache_hits: dict[str, tuple[float, int]] = {}
+_local_cache_lookups: dict[str, tuple[float, int | None]] = {}
 
 
 def _local_cache_bytes(hf_id: str) -> int | None:
     """Return the verified on-disk footprint of ``hf_id`` in the local HF cache.
 
-    This satisfies the "catalog OR verified local-cache metadata" contract for
-    a checkpoint that is already downloaded but absent (or stale) in the
-    checked-in manifest. We deliberately use ``scan_cache_dir()``'s
-    ``size_on_disk`` — huggingface_hub's own deduped byte count — rather than
-    a directory walk, because ``size_on_disk`` is exactly what ``rapid-mlx rm``
-    reports and is the same number a user would expect freeing. ``None`` when
-    the repo is not cached or the lookup fails so the caller fails closed.
+    Satisfies the "catalog OR verified local-cache metadata" contract for a
+    checkpoint absent (or stale) in the checked-in manifest. Uses
+    ``scan_cache_dir()``'s ``size_on_disk`` (huggingface_hub's own deduped byte
+    count — exactly what ``rapid-mlx rm`` reports). ``None`` when the repo is
+    not cached, is only partially downloaded, or the scan fails, so the caller
+    fails closed rather than admitting on a partial/uncertain footprint.
+
+    Both hits and misses are cached briefly (TTL), so a burst of arbitrary
+    valid-looking model ids does not saturate the worker thread pool with full
+    cache walks, while a later download still becomes discoverable once the TTL
+    expires (cache is mutable and must be re-observed fresh).
     """
     lc = hf_id.lower()
     now = time.monotonic()
-    cached = _local_cache_hits.get(lc)
+    cached = _local_cache_lookups.get(lc)
     if cached is not None and now - cached[0] < _LOCAL_CACHE_TTL_SECONDS:
         return cached[1]
     size = _scan_local_cache_bytes(hf_id)
-    if size is not None:
-        _local_cache_hits[lc] = (now, size)
-    else:
-        # Never memoize a miss: the checkpoint may be downloaded moments later
-        # and must become discoverable on the next admission.
-        _local_cache_hits.pop(lc, None)
+    _local_cache_lookups[lc] = (now, size)
     return size
 
 
 def _scan_local_cache_bytes(hf_id: str) -> int | None:
-    """Walk huggingface_hub's deduped cache to find ``hf_id``'s footprint."""
+    """Return a COMPLETE cached footprint for ``hf_id``, else ``None``.
+
+    We deliberately require a completed (ref-bound) download before trusting
+    ``size_on_disk``: huggingface_hub writes the ``refs/<branch>`` pointer only
+    after a ``snapshot_download`` finishes, so a repo whose ``size_on_disk`` we
+    read is either a full, usable checkpoint or an in-progress/partial one. A
+    partial cache reserves only its small on-disk bytes (e.g. tokenizer/config)
+    and would under-charge the residency ledger — the later ``STTEngine.load``
+    would download the remaining weights and blow past the ceiling. So a
+    partial download returns ``None`` (fail closed). ``None`` on any smash too,
+    so a cache-scan hiccup never admits blind.
+    """
     try:
         from huggingface_hub import scan_cache_dir
     except Exception:  # pragma: no cover - huggingface_hub is a core dep
@@ -65,9 +80,19 @@ def _scan_local_cache_bytes(hf_id: str) -> int | None:
         cache = scan_cache_dir()
         lc = hf_id.lower()
         for repo in cache.repos:
-            if repo.repo_id.lower() == lc:
-                size = int(repo.size_on_disk or 0)
-                return size if size > 0 else None
+            if repo.repo_id.lower() != lc:
+                continue
+            # A ref-bound revision is a COMPLETED download. Size_on_disk on a
+            # ref-less (in-progress) snapshot only reflects partial bytes.
+            if not any(rev.refs for rev in repo.revisions):
+                logger.debug(
+                    "local cache for %r is partial (no completed snapshot); "
+                    "failing closed instead of under-reserving",
+                    repo.repo_id,
+                )
+                return None
+            size = int(repo.size_on_disk or 0)
+            return size if size > 0 else None
     except Exception as exc:  # noqa: BLE001 - a cache-scan hiccup must not admit blind
         logger.debug("scan_cache_dir for %r failed: %s", hf_id, exc)
         return None
@@ -86,10 +111,10 @@ def alignment_capacity(model_id: str) -> RoleCapacity:
 
     When the manifest has no entry (repo not newly mirrored / not in the size
     table), we fall back to the checkpoint's verified local-cache footprint if
-    it is already on disk. Only when BOTH the catalog and the local cache are
-    empty does ``requested_bytes=None`` with ``source="unknown"``, so a
-    configured residency ceiling fails closed (``role_capacity_unknown``)
-    instead of admitting without a typed capacity decision.
+    it is already on disk AND fully downloaded. Only when BOTH the catalog and
+    the (complete) local cache are empty does ``requested_bytes=None`` with
+    ``source="unknown"``, so a configured residency ceiling fails closed
+    (``role_capacity_unknown``) instead of admitting without a typed decision.
     """
     from ..audio.registry import resolve_audio_alias
     from ..model_sizes import size_bytes

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,7 @@ class RoleCapacity:
     source: str
 
 
+@lru_cache(maxsize=64)
 def _local_cache_bytes(hf_id: str) -> int | None:
     """Return the verified on-disk footprint of ``hf_id`` in the local HF cache.
 

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -175,9 +175,10 @@ def _revision_is_complete(rev) -> bool:
             return False
         return True
 
-    # A shard-PATTERN weight without an index is an incomplete multi-shard
-    # download — never charge a single shard as the whole checkpoint.
-    shard_pat = re.compile(r".*-\d{5}-of-\d{5}\.(safetensors|bin)$")
+    # A shard-PATTERN weight (safetensors, bin, OR split GGUF) without a readable
+    # index is an incomplete multi-shard download — never charge a single shard
+    # as the whole checkpoint.
+    shard_pat = re.compile(r".*-\d{5}-of-\d{5}\.(safetensors|bin|gguf)$")
     if any(shard_pat.match(name) for name in files):
         logger.debug(
             "snapshot has sharded weight file(s) but no readable shard index; "
@@ -186,11 +187,11 @@ def _revision_is_complete(rev) -> bool:
         return False
 
     # With NO shard index, the only layout we can charge with confidence is a
-    # single-file GGUF weight (GGUF has no sharding / companion-weight concept).
-    # A bare ``.safetensors``/``.bin``/``.npz`` -- even non-shard-pattern -- could
-    # be one ordinarily-named weight of several in a selective download, so we
-    # fail closed unless an index proves the full set (round-15).
-    return any(name.endswith((".gguf",)) for name in files)
+    # NON-SPLIT single-file GGUF weight (split GGUFs named ``-NNNNN-of-MMMMM``
+    # are excluded above). A bare ``.safetensors``/``.bin``/``.npz`` -- even
+    # non-shard-pattern -- could be one ordinarily-named weight of several in a
+    # selective download, so we fail closed unless an index proves the full set.
+    return any(name.endswith(".gguf") for name in files)
 
 
 def _default_completed_revision(revisions):

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from dataclasses import dataclass
 
@@ -33,8 +34,16 @@ class RoleCapacity:
 # in-progress one is not trusted until a later re-scan observes it complete.
 _LOCAL_CACHE_TTL_SECONDS = 30.0
 # ``(monotonic_timestamp, {repo_id_lower: footprint_bytes})`` or ``None`` when
-# no scan has completed yet.
+# no scan has completed yet. Guarded by ``_local_cache_lock`` because lookups
+# run on worker threads (``asyncio.to_thread``) and may race each other.
 _local_cache_snapshot: tuple[float, dict[str, int]] | None = None
+_local_cache_lock = threading.Lock()
+
+# A completed checkpoint that only carries config/tokenizer would vastly
+# under-reserve. A weight file is the irreducible signal that the downloaded
+# snapshot can actually run a load; a ref-bound snapshot WITHOUT one is a
+# selective/partial download and must fail closed.
+_WEIGHT_SUFFIXES = (".safetensors", ".bin", ".gguf", ".npz", ".npy")
 
 
 def _local_cache_bytes(hf_id: str) -> int | None:
@@ -42,38 +51,49 @@ def _local_cache_bytes(hf_id: str) -> int | None:
 
     Satisfies the "catalog OR verified local-cache metadata" contract for a
     checkpoint absent (or stale) in the checked-in manifest. Reads from a
-    single TTL-bounded snapshot of ``scan_cache_dir()`` (built on demand), so
-    repeated lookups coalesce into one cache walk per TTL window regardless of
-    how many distinct model ids are probed — an attacker cannot drive one
-    ``scan_cache_dir()`` traversal (or unbounded memory) per public alignment
-    request. ``None`` when the repo is not cached, only partially downloaded,
-    or the scan fails, so the caller fails closed rather than admitting on a
-    partial/uncertain footprint.
+    single TTL-bounded snapshot of ``scan_cache_dir()`` (built on demand, under
+    a thread lock so a burst of concurrent lookups coalesces into ONE cache
+    walk per TTL window regardless of how many model ids are probed — an attacker
+    cannot drive a traversal or unbounded memory per public alignment request,
+    nor can racing threads each trigger the walk). ``None`` when the repo is not
+    cached, only partially downloaded, or the scan fails, so the caller fails
+    closed rather than admitting on a partial/uncertain footprint.
     """
     global _local_cache_snapshot
+    lc = hf_id.lower()
     now = time.monotonic()
-    if (
-        _local_cache_snapshot is not None
-        and now - _local_cache_snapshot[0] < _LOCAL_CACHE_TTL_SECONDS
-    ):
-        return _local_cache_snapshot[1].get(hf_id.lower())
-
-    index = _scan_local_cache_index()
-    _local_cache_snapshot = (now, index)
-    return index.get(hf_id.lower())
+    with _local_cache_lock:
+        if (
+            _local_cache_snapshot is not None
+            and now - _local_cache_snapshot[0] < _LOCAL_CACHE_TTL_SECONDS
+        ):
+            return _local_cache_snapshot[1].get(lc)
+        # Under the lock we re-check freshness: the first thread to observe an
+        # expired snapshot rebuilds it; the rest wait and then read the fresh
+        # one instead of each re-walking the cache.
+        index = _scan_local_cache_index()
+        _local_cache_snapshot = (now, index)
+        return index.get(lc)
 
 
 def _scan_local_cache_index() -> dict[str, int]:
     """Return ``{repo_id_lower: completed-footprint}`` from the local HF cache.
 
-    Only repos with a COMPLETE (ref-bound) default snapshot are indexed. The
-    footprint for a repo is the byte total of its completed snapshot — the
-    revision a ``load`` would use — NOT the repo's aggregate ``size_on_disk``,
-    which would include a partially-downloaded second revision and understate
-    what the load will materialize. A repo with no completed snapshot (still
-    downloading, or only config/tokenizer cached) contributes nothing, so the
-    caller fails closed (unknown -> 507 under a ceiling) instead of reserving
-    only partial bytes and blowing past the ceiling on the real load.
+    Only repos with a COMPLETE default snapshot are indexed. "Complete" is
+    verified with two INDEPENDENT signals, so a partial/selective download
+    cannot under-reserve and later blow past the ceiling:
+
+      * the snapshot is ref-bound (a ``snapshot_download`` finished writing its
+        ``refs/<branch>`` pointer), AND
+      * the ref-bound revision actually contains a model WEIGHT file. A
+        selective download that is ref-bound yet carries only config/tokenizer
+        is NOT a usable checkpoint and fails closed (round-11).
+
+    The footprint charged is the byte total of the revision the default ref
+    resolves to (``main``), NOT the repo's aggregate ``size_on_disk`` (which
+    would include a partially-downloaded sibling revision) and NOT the sum of
+    every historical snapshot. A repo with no trustworthy snapshot contributes
+    nothing, so the caller fails closed (unknown -> 507 under a ceiling).
     """
     try:
         from huggingface_hub import scan_cache_dir
@@ -83,27 +103,52 @@ def _scan_local_cache_index() -> dict[str, int]:
         cache = scan_cache_dir()
         index: dict[str, int] = {}
         for repo in cache.repos:
-            # The loader resolves to the ref-bound (default) revision; only a
-            # snapshot that is complete (has a ref pointing at it) is trusted.
-            completed = [rev for rev in repo.revisions if rev.refs]
-            if not completed:
-                if any(rev for rev in repo.revisions):
-                    logger.debug(
-                        "local cache for %r has no completed snapshot; "
-                        "failing closed instead of under-reserving",
-                        repo.repo_id,
-                    )
+            # Resolve the revision the loader would use: the one the default
+            # ``main`` ref points at (fall back to any single ref-bound rev).
+            rev = _default_completed_revision(repo.revisions)
+            if rev is None:
                 continue
-            # Sum the file bytes of the completed snapshot(s) actually present.
-            size = 0
-            for rev in completed:
-                size += sum(int(f.size_on_disk or 0) for f in rev.files)
+            file_names = [f.file_name for f in rev.files]
+            if not any(name.lower().endswith(_WEIGHT_SUFFIXES) for name in file_names):
+                logger.debug(
+                    "local cache for %r is ref-bound but has no weight file "
+                    "(%d files); treating as incomplete and failing closed",
+                    repo.repo_id,
+                    len(file_names),
+                )
+                continue
+            size = sum(int(f.size_on_disk or 0) for f in rev.files)
             if size > 0:
                 index[repo.repo_id.lower()] = size
         return index
     except Exception as exc:  # noqa: BLE001 - a cache-scan hiccup must not admit blind
         logger.debug("scan_cache_dir failed: %s", exc)
         return {}
+
+
+def _default_completed_revision(revisions):
+    """Pick the completed revision the loader would use (default ``main`` ref).
+
+    Returns ``None`` when there is no trustworthy completed revision (no
+    ref-bound snapshot, or ambiguous multiple refs) so the caller fails closed
+    rather than guess which snapshot to charge.
+    """
+    ref_bound = [rev for rev in revisions if rev.refs]
+    if not ref_bound:
+        if revisions:
+            logger.debug(
+                "local cache has %d revision(s) but none ref-bound; "
+                "failing closed instead of under-reserving",
+                len(revisions),
+            )
+        return None
+    # Prefer the revision the ``main`` ref points at (the default from a
+    # ``snapshot_download``). If there is exactly one ref-bound revision it is
+    # unambiguous regardless of branch name.
+    for rev in ref_bound:
+        if "main" in rev.refs:
+            return rev
+    return ref_bound[0] if len(ref_bound) == 1 else None
 
 
 def alignment_capacity(model_id: str) -> RoleCapacity:

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -104,17 +104,15 @@ def _scan_local_cache_index() -> dict[str, int]:
         index: dict[str, int] = {}
         for repo in cache.repos:
             # Resolve the revision the loader would use: the one the default
-            # ``main`` ref points at (fall back to any single ref-bound rev).
+            # ``main`` ref points at.
             rev = _default_completed_revision(repo.revisions)
             if rev is None:
                 continue
-            file_names = [f.file_name for f in rev.files]
-            if not any(name.lower().endswith(_WEIGHT_SUFFIXES) for name in file_names):
+            if not _revision_is_complete(rev):
                 logger.debug(
-                    "local cache for %r is ref-bound but has no weight file "
-                    "(%d files); treating as incomplete and failing closed",
+                    "local cache for %r is not verifiably complete; "
+                    "failing closed instead of under-reserving",
                     repo.repo_id,
-                    len(file_names),
                 )
                 continue
             size = sum(int(f.size_on_disk or 0) for f in rev.files)
@@ -126,29 +124,64 @@ def _scan_local_cache_index() -> dict[str, int]:
         return {}
 
 
-def _default_completed_revision(revisions):
-    """Pick the completed revision the loader would use (default ``main`` ref).
+def _revision_is_complete(rev) -> bool:
+    """Independently verify a snapshot actually holds ALL of a checkpoint.
 
-    Returns ``None`` when there is no trustworthy completed revision (no
-    ref-bound snapshot, or ambiguous multiple refs) so the caller fails closed
-    rather than guess which snapshot to charge.
+    ``rev`` is a huggingface_hub ``CachedRevisionInfo``. A ref-bound snapshot
+    alone does not prove the weights are present — a selective download can be
+    ref-bound yet hold only config/tokenizer, and an interrupted multi-shard
+    download can hold one weight shard. We verify against the trusted shard
+    index when present, else require a single-file weight:
+
+      * if ``model.safetensors.index.json`` exists, parse it and REQUIRE every
+        shard named in ``weight_map`` to be present in the snapshot;
+      * otherwise require at least one irreducible single-file weight
+        (``*.gguf``, ``*.bin``, ``*.npz``/``*.npy``, or a non-shard
+        ``*.safetensors``), which needs no cross-file verification.
     """
-    ref_bound = [rev for rev in revisions if rev.refs]
-    if not ref_bound:
-        if revisions:
+    files = {f.file_name.lower() for f in rev.files}
+    index_name = next((n for n in files if n.endswith(".safetensors.index.json")), None)
+    if index_name is not None:
+        try:
+            idx_file = next(f for f in rev.files if f.file_name.lower() == index_name)
+            import json
+
+            data = json.loads(idx_file.file_path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001 - a corrupt index must not admit blind
+            logger.debug("failed to read safetensors index: %s", exc)
+            return False
+        shards = set(data.get("weight_map", {}).values())
+        if not shards:
+            return False
+        missing = [s for s in shards if s.lower() not in files]
+        if missing:
             logger.debug(
-                "local cache has %d revision(s) but none ref-bound; "
-                "failing closed instead of under-reserving",
-                len(revisions),
+                "safetensors index lists shards missing from the snapshot: %s",
+                sorted(missing)[:5],
             )
-        return None
-    # Prefer the revision the ``main`` ref points at (the default from a
-    # ``snapshot_download``). If there is exactly one ref-bound revision it is
-    # unambiguous regardless of branch name.
-    for rev in ref_bound:
-        if "main" in rev.refs:
-            return rev
-    return ref_bound[0] if len(ref_bound) == 1 else None
+            return False
+        return True
+    return any(name.endswith(_WEIGHT_SUFFIXES) for name in files)
+
+
+def _default_completed_revision(revisions):
+    """Pick the completed revision the loader would use (the ``main`` ref).
+
+    The loader resolves a repo's DEFAULT branch — conventionally ``main`` (the
+    ref ``snapshot_download`` writes). A lone non-``main`` ref names some other
+    branch we may not load, so charging it could understate the weights the real
+    load fetches. Returns ``None`` unless a revision is bound to ``main``, so
+    the caller fails closed rather than guess a revision to charge.
+    """
+    default_bound = [rev for rev in revisions if "main" in rev.refs]
+    if default_bound:
+        return default_bound[0]
+    logger.debug(
+        "local cache revisions %r are ref-bound but none bound to the default "
+        "'main' branch; failing closed instead of charging an unrelated revision",
+        [tuple(rev.refs) for rev in revisions],
+    )
+    return None
 
 
 def alignment_capacity(model_id: str) -> RoleCapacity:

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,18 @@ class RoleCapacity:
     source: str
 
 
+# ``_LOCAL_CACHE_TTL_SECONDS`` bounds how long a *successful* local-footprint
+# lookup is reused. The HF cache is mutable: a checkpoint can be deleted or
+# grown between requests, so the result must never be remembered forever. The
+# TTL lets a burst of repeated rejected alignments skip re-walking the whole
+# cache, while a later download (or rm) becomes discoverable once it expires.
+# Only positive results are cached — a miss is never memoized, so a previously
+# uncached checkpoint is always retried (round-4 NIT: bounded-TTL to avoid the
+# repeated full scan; round-3: never permanently memorize a mutable footprint).
+_LOCAL_CACHE_TTL_SECONDS = 30.0
+_local_cache_hits: dict[str, tuple[float, int]] = {}
+
+
 def _local_cache_bytes(hf_id: str) -> int | None:
     """Return the verified on-disk footprint of ``hf_id`` in the local HF cache.
 
@@ -27,6 +40,23 @@ def _local_cache_bytes(hf_id: str) -> int | None:
     reports and is the same number a user would expect freeing. ``None`` when
     the repo is not cached or the lookup fails so the caller fails closed.
     """
+    lc = hf_id.lower()
+    now = time.monotonic()
+    cached = _local_cache_hits.get(lc)
+    if cached is not None and now - cached[0] < _LOCAL_CACHE_TTL_SECONDS:
+        return cached[1]
+    size = _scan_local_cache_bytes(hf_id)
+    if size is not None:
+        _local_cache_hits[lc] = (now, size)
+    else:
+        # Never memoize a miss: the checkpoint may be downloaded moments later
+        # and must become discoverable on the next admission.
+        _local_cache_hits.pop(lc, None)
+    return size
+
+
+def _scan_local_cache_bytes(hf_id: str) -> int | None:
+    """Walk huggingface_hub's deduped cache to find ``hf_id``'s footprint."""
     try:
         from huggingface_hub import scan_cache_dir
     except Exception:  # pragma: no cover - huggingface_hub is a core dep

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +16,6 @@ class RoleCapacity:
     source: str
 
 
-@lru_cache(maxsize=64)
 def _local_cache_bytes(hf_id: str) -> int | None:
     """Return the verified on-disk footprint of ``hf_id`` in the local HF cache.
 

--- a/vllm_mlx/runtime/role_capacity.py
+++ b/vllm_mlx/runtime/role_capacity.py
@@ -185,7 +185,12 @@ def _revision_is_complete(rev) -> bool:
         )
         return False
 
-    return any(name.endswith(_WEIGHT_SUFFIXES) for name in files)
+    # With NO shard index, the only layout we can charge with confidence is a
+    # single-file GGUF weight (GGUF has no sharding / companion-weight concept).
+    # A bare ``.safetensors``/``.bin``/``.npz`` -- even non-shard-pattern -- could
+    # be one ordinarily-named weight of several in a selective download, so we
+    # fail closed unless an index proves the full set (round-15).
+    return any(name.endswith((".gguf",)) for name in files)
 
 
 def _default_completed_revision(revisions):


### PR DESCRIPTION
Fixes #2405

## What & why

Forced-alignment requests load a persistent aligner on the shared model worker, but the shared-capacity slice budgets only the dictation speech-to-text role. Under a configured residency ceiling an aligner could therefore materialize with **no role reservation and no typed capacity decision**. This PR admits forced-alignment through the **same** shared residency ledger as a distinct `alignment` role.

## Required-contract mapping

**1. Resolve the aligner checkpoint footprint from catalog OR verified local-cache metadata BEFORE weight loading**
- `vllm_mlx/runtime/role_capacity.py` — `alignment_capacity()` resolves the aligner footprint from the checked-in `model_sizes.json` manifest via the audio-alias registry (`qwen3-aligner` / `qwen3-forced-aligner` / the HF id all resolve to `mlx-community/Qwen3-ForcedAligner-0.6B-8bit`). When the manifest is empty, it falls back to the checkpoint's **verified local-cache footprint** (`scan_cache_dir().size_on_disk`, the same deduped byte count `rapid-mlx rm` reports) — but only for a **complete** download (a ref-bound snapshot), so a partially-cached repo (config/tokenizer only) fails closed instead of under-reserving. All model-id lookups read from a SINGLE TTL-bounded (30s) snapshot of the cache index, so a burst of arbitrary (attacker-controlled) ids triggers one `scan_cache_dir()` walk per window with bounded memory — not one walk/entry per id — while a fresh download/rm is re-observed after expiry. The index snapshot is refreshed under a thread lock (one walk per TTL window even under a concurrent burst). A cached footprint is charged only when it is independently verified complete: a revision bound to the default `main` branch, AND either a shard-index-verified multi-shard weight set or a canonical single-file weight (`*.gguf`, `model.safetensors`, `pytorch_model.bin`, `model.bin`, `model.npz`, `model.npy` — a sharded download never uses those verbatim names, so a lone canonical file is the whole unsharded checkpoint) — an interrupted/partial download, a shard-patterned weight without an index, a non-canonical bare weight, or a non-default branch fails closed (unknown -> 507). Only when BOTH the catalog and a complete local cache are empty does it return `requested_bytes=None` + `source="unknown"` and fail closed under a ceiling.
- Test: `tests/test_role_capacity.py` (alias/long-alias/hf-id exact catalog bytes, catalog→local-cache fallback, cached-only checkpoint, unknown fails-closed, partial-download/complete-snapshot gate, bounded hit-and-miss TTL).

**2. Admit through the existing shared residency ledger as the distinct `alignment` role**
- `vllm_mlx/runtime/resident_models.py` — `ResidentRoleReservation`, `ResidentRoleAdmission`, `admit_role()` / `release_role()` context-manager transaction on the shared `_roles` ledger, charged into `_accounted_usage()`; snapshot exposes a `roles` list and per-model `role`. Role-aware `_evict_for_locked` (usage-credit + requested_role).
- `vllm_mlx/runtime/audio_worker.py` — `LANE_ROLES` (stt→speech-input, alignment→alignment, tts→speech-output) + `role` on lane snapshots.
- `vllm_mlx/routes/audio.py` — `_admitting_alignment()` reserves the `alignment` role before the aligner weight load (`_load_aligner_blocking`), split from infer so only the load is wrapped.
- Tests: `test_resident_models.py` (`test_alignment_role_*`), `test_audio_model_worker.py` (`test_admitting_alignment_*`, `test_cached_model_alignment_loads_once_and_stays_resident`, `test_evicting_aligner_releases_alignment_role`, `test_shutdown_releases_alignment_role`).

**3. Return the established typed HTTP 507 capacity envelope on rejection**
- `ResidentModelCapacityError` gains role fields + `.envelope()`; `admit_role` raises with reason `role_capacity_alignment` / `role_capacity_unknown`; `_admitting_alignment` maps it to `HTTPException(507, detail=envelope())`. The legacy assistant `replacement_projection` 507 path is untouched.
- Tests: `test_resident_models.py::test_alignment_role_rejected_with_typed_507_when_over_ceiling`, `test_alignment_role_unknown_capacity_fails_closed_under_ceiling`; `test_audio_model_worker.py::test_admitting_alignment_returns_507_envelope_when_over_budget`.

**4. Keep alignment load / failure / cancellation / unload and residency truth transactional**
- `admit_role` commits resident only on success; `except BaseException` (load failure OR cancellation) pops/restores the reservation — no leaked ledger entry. A role never hosts two concurrent in-flight loads: an admission rejected while the role's reservation is still `"loading"` (mapped to a typed `409 alignment_role_conflict`, never a raw 500). The previous role is retired ONLY when the load actually discards the old aligner (`_load_aligner_blocking` takes an `on_discard_previous` callback), so an import/ASR-unload failure before the drop leaves the old reservation restorable; a cancelled load that already published the engine for the requested model is kept resident via `admission.commit()`, fired on BOTH the load-success path (so a cancellation arriving during the subsequent cancellable awaits/context exit cannot roll back a published engine) and the drained-cancellation branch (publication matched on CANONICAL ids so an alias-vs-repo-id mismatch never leaves a loaded engine unaccounted; the unmanaged `_NoopRoleAdmission` exposes a no-op `commit()` so unmanaged servers surface the real `CancelledError`, not an `AttributeError`). The cancellation + cached-model reuse tests both drive `_run_alignment_request` end-to-end. The footprint is resolved off the event loop (`asyncio.to_thread`); the verified local-cache lookup uses a bounded 30s TTL that reuses only successful results and never memoizes a miss, so a burst skips re-walking the cache but a later download/rm is observed fresh. The `_admitting_alignment` typed-error map is scoped to ADMISSION ENTRY ONLY (explicit `__aenter__`/`__aexit__` protocol): a `ResidentModelError`/capacity error raised by the caller's yielded LOAD BODY propagates unchanged, never misreported as a 507/409 capacity decision. Alignment admission retires any resident mutually-exclusive `speech-input` reservation through `admit_role(release_exclusive_role="speech-input")`, which RETAINS the sibling's reservation (credited against the aligner, never freed) so the ledger never double-charges both roles (no false 507) yet no concurrent admission can consume the sibling's capacity during the load and no rollback is forced to choose between an unaccounted engine and an over-ceiling ledger. On success (commit, incl. under cancellation) the sibling is retired; on failure/cancellation it stays (matching its still-resident engine) unless `_load_aligner_blocking`'s `on_discard_exclusive` (wired to `retire_exclusive()`) confirms the ASR engine was evicted, dropping the phantom. Both rollback and success finalization identity-check the sibling before retiring it so a concurrently installed newer reservation is never erased; the success finalization and the route's rollback `__aexit__` run under uncancellable drains so a second cancellation cannot leak a `"loading"` role. This replaced the earlier route-level release/restore helpers, which read the mixed `snapshot()["roles"]` projection (could retire a non-reservation) and whose restore caught `ResidentModelError` and could abandon a still-resident engine. The local-cache fallback trusts a canonical single-file weight (`*.gguf`, `model.safetensors`, `pytorch_model.bin`, `model.bin`, `model.npz`, `model.npy`) or an index-verified shard set. Align idempotency is canonicalized in both `_load_aligner_blocking` and `needs_load`, so alias/canonical/long-alias requests share one load. A pending load always (re)establishes the role (`replace_existing=True`) so a stale ledger entry self-heals instead of 500ing on 'role already resident'. `release_role` fires when the aligner lane is evicted (`_evict_other_lane("asr")`) and at `shutdown_audio_lanes`.
- Tests: `test_alignment_role_rollback_on_load_failure`, `_rollback_on_cancellation`, `_replace_retires_previous_on_failure`, `_replace_restores_previous_unless_retired`, `_release_removes_ledger_charge`; `test_admitting_alignment_rolls_back_on_load_failure/_on_cancellation`, `test_evicting_aligner_releases_alignment_role`, `test_shutdown_releases_alignment_role`, `test_aligner_retire_fires_after_previous_discard`, `test_aligner_load_retires_previous_only_after_actual_discard`, `test_alignment_role_cancellation_keeps_published_engine_committed` (rewritten to drive cancellation through `_run_alignment_request` end-to-end), `test_alignment_role_rejects_second_loading_admission`, `test_local_cache_lookup_is_bounded_and_never_caches_a_miss`, `test_admitting_alignment_does_not_map_body_errors`, `test_aligner_alias_and_canonical_request_reuse_same_engine`.

**5. MLX-free admission/rollback tests + cached-model validation**
- `tests/test_role_capacity.py`, the `test_alignment_role_*` suite in `tests/test_resident_models.py`, and `tests/test_audio_model_worker.py` are all MLX-free (real `ResidentModelManager` + stubbed `STTEngine`/worker; no MLX import). `test_cached_model_alignment_loads_once_and_stays_resident` drives THREE real `_run_alignment_request` calls for the same model and proves one load, three inferences, and a single resident role reservation (a per-request reload/re-admit fails it).

## Test plan
- [x] New admission-layer tests: `tests/test_resident_models.py` alignment-role suite (9) — pass.
- [x] Route/worker admission wiring: `tests/test_audio_model_worker.py` new tests (7) — pass.
- [x] Catalog + verified-local-cache resolution & fails-closed: `tests/test_role_capacity.py` (6) — pass.
- [x] Cached-model validation path — pass.
- [x] Regression: `tests/test_resident_models.py` + `test_audio_model_worker.py` + `test_role_capacity.py` (138) — pass.
- [x] Broader audio/STT/residency no-MLX suites — 407+ passed, pre-existing skips only.
- [x] Pre-existing `test_audio_routes_bundle.py` failures (4) verified identical on clean `origin/main` (detached-main check) — environmental, not this PR.
- [x] Apple-lane `requires_mlx` suites (`test_forced_alignment.py`, `test_forced_alignment_route_hardening.py`) — cannot run in the no-MLX env; the codex-reviews-local `targeted_tests` step ran 24 files / 628 passed, and these two are behavior-preserving (no residency manager configured in those routes ⇒ `_NoopRoleAdmission` no-op). Will be validated by CI's Apple lane; noted as environment-blocked, not a real finding.
- [x] ruff check + format clean; `git diff --check` clean.

<!-- pr_validate: run `python3 -m scripts.pr_validate.pr_validate <PR#>` and fix real BLOCKING findings -->


