### PR TITLE
feat(desktop): gate Community Benchmark as experimental

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,12 @@ can actually understand.
 
 ## [Unreleased]
 
+### Changed
+
+- The Desktop Community Benchmark workspace is now an opt-in experimental
+  feature. Enable it in Settings → Experimental Features to reveal its sidebar
+  destination; the CLI benchmark workflow remains available independently.
+
 ## [0.13.4] — 2026-09-02
 
 Rapid-MLX 0.13.4 makes qualified local models faster under concurrent work,

--- a/apps/rapid-mac/Sources/Rapid/CommunityBenchmark/CommunityBenchmarkFeatureConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/CommunityBenchmark/CommunityBenchmarkFeatureConfig.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// User-controlled opt-in for the Community Benchmark workspace.
+///
+/// The benchmark runner remains installed and the CLI remains available when
+/// this is off. This preference controls Desktop discoverability only: the
+/// sidebar destination is absent until the user enables it in Settings.
+enum CommunityBenchmarkFeatureConfig {
+    static let enabledKey = "Rapid.experimental.communityBenchmarkEnabled"
+    static let defaultEnabled = false
+
+    static func isEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enabledKey) as? Bool ?? defaultEnabled
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -97,11 +97,17 @@ enum DevSnapshot {
         if ProcessInfo.processInfo.environment["RAPID_DEV_SIDEBAR_ONLY"] == "1" {
             let videoEnabled = ProcessInfo.processInfo.environment["RAPID_DEV_VIDEO_ENABLED"] == "1"
                 || VideoFeatureConfig.isEnabled()
+            let communityBenchmarkEnabled = ProcessInfo.processInfo.environment[
+                "RAPID_DEV_COMMUNITY_BENCHMARK_ENABLED"
+            ] == "1" || CommunityBenchmarkFeatureConfig.isEnabled()
             func sidebar() -> AnyView {
                 AnyView(
                     SidebarView(
-                        selection: .constant(.video),
+                        selection: .constant(
+                            communityBenchmarkEnabled ? .benchmark : .video
+                        ),
                         videoGenerationEnabled: videoEnabled,
+                        communityBenchmarkEnabled: communityBenchmarkEnabled,
                         chat: chat,
                         onNewChat: {},
                         onSelectConversation: { _ in }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -100,6 +100,8 @@ struct ContentView: View {
     @State private var section: SidebarSection = .chat
     @AppStorage(VideoFeatureConfig.enabledKey)
     private var videoGenerationEnabled = VideoFeatureConfig.defaultEnabled
+    @AppStorage(CommunityBenchmarkFeatureConfig.enabledKey)
+    private var communityBenchmarkEnabled = CommunityBenchmarkFeatureConfig.defaultEnabled
     /// Window-level conversation search, opened from the toolbar.
     @State private var showConversationSearch = false
     // Was @SceneStorage. Moved to @AppStorage so the View menu command in
@@ -565,6 +567,7 @@ struct ContentView: View {
                 SidebarView(
                     selection: $section,
                     videoGenerationEnabled: videoGenerationEnabled,
+                    communityBenchmarkEnabled: communityBenchmarkEnabled,
                     chat: chat,
                 onNewChat: {
                     chat.newConversation()
@@ -653,6 +656,14 @@ struct ContentView: View {
                     .padding(.bottom, 40)
                     .zIndex(20)
             }
+        }
+        .onChange(of: communityBenchmarkEnabled) { _, enabled in
+            // Match Video's experimental gate: closing the destination while
+            // it is selected returns to a reachable, non-experimental page.
+            section = Self.sectionAfterCommunityBenchmarkGateChange(
+                current: section,
+                enabled: enabled
+            )
         }
     }
 
@@ -1139,15 +1150,19 @@ struct ContentView: View {
                 onReadinessAction: performReadinessAction
             )
         case .benchmark:
-            CommunityBenchmarkView(
-                catalog: catalogEntries,
-                binary: server.binaryPath,
-                prepareServer: { try await server.prepareForCommunityBenchmark() },
-                releaseServer: { server.finishCommunityBenchmark($0) },
-                retainServerDuringDeferredReap: {
-                    server.retainCommunityBenchmarkDuringDeferredReap($0)
-                }
-            )
+            if communityBenchmarkEnabled {
+                CommunityBenchmarkView(
+                    catalog: catalogEntries,
+                    binary: server.binaryPath,
+                    prepareServer: { try await server.prepareForCommunityBenchmark() },
+                    releaseServer: { server.finishCommunityBenchmark($0) },
+                    retainServerDuringDeferredReap: {
+                        server.retainCommunityBenchmarkDuringDeferredReap($0)
+                    }
+                )
+            } else {
+                mainArea
+            }
         }
     }
 
@@ -1351,6 +1366,14 @@ struct ContentView: View {
         enabled: Bool
     ) -> SidebarSection {
         !enabled && current == .video ? .chat : current
+    }
+
+    /// Route recovery for the Community Benchmark experimental gate.
+    static func sectionAfterCommunityBenchmarkGateChange(
+        current: SidebarSection,
+        enabled: Bool
+    ) -> SidebarSection {
+        !enabled && current == .benchmark ? .chat : current
     }
 
     /// The chat catalog intentionally omits every media row, so aliases from

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -47,6 +47,8 @@ struct SettingsView: View {
     @State private var restartingSetup = false
     @AppStorage(VideoFeatureConfig.enabledKey)
     private var videoGenerationEnabled = VideoFeatureConfig.defaultEnabled
+    @AppStorage(CommunityBenchmarkFeatureConfig.enabledKey)
+    private var communityBenchmarkEnabled = CommunityBenchmarkFeatureConfig.defaultEnabled
 
     /// Stable reference shared by the sidebar and detail canvas. Keeping the
     /// frequently-mutated category outside this large view's value state means
@@ -531,6 +533,17 @@ struct SettingsView: View {
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
                 .accessibilityIdentifier("Settings.Experimental.VideoGenerationToggle")
+
+                SettingsRowDivider()
+
+                Toggle(isOn: $communityBenchmarkEnabled) {
+                    SettingsRowLabel(
+                        title: "Enable Community Benchmark",
+                        description: "Shows the Community Benchmark tab for reproducible local model measurements. Results stay on this Mac unless you explicitly preview and share them."
+                    )
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityIdentifier("Settings.Experimental.CommunityBenchmarkToggle")
             }
         }
         .accessibilityIdentifier("Settings.Experimental.Panel")

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -36,6 +36,9 @@ struct SidebarView: View {
     /// Video is intentionally opt-in because its models require substantially
     /// more unified memory than the app's everyday chat and media workflows.
     var videoGenerationEnabled: Bool = false
+    /// Community Benchmark is an internal-beta workspace and stays out of the
+    /// everyday navigation until the user explicitly opts in.
+    var communityBenchmarkEnabled: Bool = false
     /// The chat model — source of the conversation history list + the
     /// active conversation id (for highlighting).
     @Bindable var chat: ChatViewModel
@@ -195,13 +198,15 @@ struct SidebarView: View {
                 action: { selection = .launch }
             )
             .accessibilityIdentifier("Sidebar.Launch")
-            row(
-                title: "Community Benchmark",
-                systemImage: "gauge.with.dots.needle.50percent",
-                isSelected: selection == .benchmark,
-                action: { selection = .benchmark }
-            )
-            .accessibilityIdentifier("Sidebar.CommunityBenchmark")
+            if communityBenchmarkEnabled {
+                row(
+                    title: "Community Benchmark",
+                    systemImage: "gauge.with.dots.needle.50percent",
+                    isSelected: selection == .benchmark,
+                    action: { selection = .benchmark }
+                )
+                .accessibilityIdentifier("Sidebar.CommunityBenchmark")
+            }
 
             // Folders can exist before any conversation does (create one, then
             // file into it), so an empty history no longer means an empty rail.

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -200,11 +200,15 @@ struct SidebarView: View {
             .accessibilityIdentifier("Sidebar.Launch")
             if communityBenchmarkEnabled {
                 row(
-                    title: "Community Benchmark",
+                    // Keep the rail readable at the app's 720 pt minimum
+                    // width. The destination itself retains the full
+                    // "Community Benchmark" page title.
+                    title: "Benchmarks",
                     systemImage: "gauge.with.dots.needle.50percent",
                     isSelected: selection == .benchmark,
                     action: { selection = .benchmark }
                 )
+                .accessibilityLabel("Community Benchmark")
                 .accessibilityIdentifier("Sidebar.CommunityBenchmark")
             }
 

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkFeatureGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkFeatureGateTests.swift
@@ -54,6 +54,8 @@ struct CommunityBenchmarkFeatureGateTests {
         #expect(settings.contains("@AppStorage(CommunityBenchmarkFeatureConfig.enabledKey)"))
         #expect(settings.contains("Settings.Experimental.CommunityBenchmarkToggle"))
         #expect(sidebar.contains("if communityBenchmarkEnabled"))
+        #expect(sidebar.contains("title: \"Benchmarks\""))
+        #expect(sidebar.contains(".accessibilityLabel(\"Community Benchmark\")"))
         #expect(sidebar.contains("Sidebar.CommunityBenchmark"))
         #expect(content.contains("communityBenchmarkEnabled: communityBenchmarkEnabled"))
         #expect(content.contains("if communityBenchmarkEnabled"))

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkFeatureGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkFeatureGateTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Experimental Community Benchmark gate", .serialized)
+struct CommunityBenchmarkFeatureGateTests {
+    private static var sourceRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // RapidTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // package root
+    }
+
+    @Test("Community Benchmark is opt-in when no preference exists")
+    func defaultsOff() throws {
+        let suite = "rapid.community-benchmark-gate-tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(!CommunityBenchmarkFeatureConfig.isEnabled(in: defaults))
+        defaults.set(true, forKey: CommunityBenchmarkFeatureConfig.enabledKey)
+        #expect(CommunityBenchmarkFeatureConfig.isEnabled(in: defaults))
+    }
+
+    @MainActor
+    @Test("Disabling while Community Benchmark is active returns to Chat")
+    func disablingRecoversNavigation() {
+        #expect(
+            ContentView.sectionAfterCommunityBenchmarkGateChange(
+                current: .benchmark,
+                enabled: false
+            ) == .chat
+        )
+        #expect(
+            ContentView.sectionAfterCommunityBenchmarkGateChange(
+                current: .benchmark,
+                enabled: true
+            ) == .benchmark
+        )
+        #expect(
+            ContentView.sectionAfterCommunityBenchmarkGateChange(
+                current: .images,
+                enabled: false
+            ) == .images
+        )
+    }
+
+    @Test("Desktop wires one preference through Settings, sidebar, and detail routing")
+    func desktopWiring() throws {
+        let settings = try source("Sources/Rapid/UI/SettingsView.swift")
+        let sidebar = try source("Sources/Rapid/UI/SidebarView.swift")
+        let content = try source("Sources/Rapid/UI/ContentView.swift")
+
+        #expect(settings.contains("@AppStorage(CommunityBenchmarkFeatureConfig.enabledKey)"))
+        #expect(settings.contains("Settings.Experimental.CommunityBenchmarkToggle"))
+        #expect(sidebar.contains("if communityBenchmarkEnabled"))
+        #expect(sidebar.contains("Sidebar.CommunityBenchmark"))
+        #expect(content.contains("communityBenchmarkEnabled: communityBenchmarkEnabled"))
+        #expect(content.contains("if communityBenchmarkEnabled"))
+    }
+
+    private func source(_ relativePath: String) throws -> String {
+        try String(
+            contentsOf: Self.sourceRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+}

--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -115,6 +115,12 @@ derived protocol and download state, one local run/stop action, then recent
 local results. There is no home-page campaign card and no button repeated on
 every model card in the internal beta.
 
+During the internal beta, Desktop keeps the Community Benchmark destination
+behind Settings → Experimental Features and defaults it off. Enabling the
+preference reveals the sidebar destination immediately; disabling it while the
+page is active returns navigation to Chat. This gate affects Desktop
+discoverability only: it does not remove the local runner, archive, or CLI.
+
 If CLI metadata loading is unavailable, Desktop's legacy fallback is
 conservative: chat remains usable, while image/video rows without atomic
 capability evidence are hidden. Atomic video rows still require a registered


### PR DESCRIPTION
## Summary

- make the Desktop Community Benchmark workspace opt-in and hidden by default
- expose one persistent toggle under Settings → Experimental Features, matching the existing Video feature gate
- recover navigation to Chat if the user disables the feature while its page is active
- keep the CLI, local runner, archive, upload, and website behavior unchanged

## Module and scope

**Module:** `apps/rapid-mac` Desktop navigation/settings only, plus the existing Community Benchmark decision note.

**In scope:** preference key/default, Settings toggle, sidebar visibility, detail-route guard, route recovery, focused test/snapshot seam.

**Out of scope:** benchmark protocols, execution, uploads, server APIs, model registry, website/leaderboard, campaign mechanics, and unrelated Desktop cleanup. Please keep review within this boundary.

## Verification

- `swift test --filter CommunityBenchmarkFeatureGateTests` — 3/3 pass
- `swift test --filter VideoFeatureGateTests` — 3/3 pass
- `bash scripts/build.sh` — pass; ad-hoc Desktop app assembled
- dev snapshot harness, gate off/on — verified Community Benchmark absent by default and present when enabled
- full `swift test` — new suite passes; repository-wide run reported existing timing-sensitive failures across subprocess, Mermaid/WebKit, SSE, resident-load, and video polling suites when run concurrently (3436 tests, 22 issues); a focused runtime-probe rerun reduced to one unrelated missing-marker timing failure

## Rollback

Revert this PR. The existing Community Benchmark page and CLI remain intact; only Desktop discoverability is gated.