### PR TITLE
fix(mtp): keep ordinary tool requests on verified decode

### DIFF
--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2847,6 +2847,75 @@ def test_generator_rejection_discards_later_tool_guard_state():
     assert processor.interventions == 0
 
 
+def test_tool_guard_ordinary_decode_still_uses_committed_output():
+    """The refactored ordinary entry point retains its scheduler-owned history."""
+    from vllm_mlx.repetition_guard import AgentRepetitionLogitsProcessor
+
+    pattern = list(range(12))
+    processor = AgentRepetitionLogitsProcessor(pattern * 5)
+    logits = processor(mx.array([999]), mx.zeros((1, 32)))
+    mx.eval(logits)
+    assert float(logits[0, pattern[0]].item()) == float("-inf")
+
+
+def test_generator_restores_tool_guard_state_when_target_processor_raises():
+    """A verify-time processor exception restores the pre-proposal boundary."""
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    class FusedDraftModel(_MockedQwen35Model):
+        def mtp_greedy(self, hidden, next_token_ids, mtp_cache):
+            del mtp_cache
+            batch, positions = next_token_ids.shape
+            tokens = []
+            for _ in range(positions):
+                tokens.append(self._mtp[self._mtp_cursor])
+                self._mtp_cursor += 1
+            return (
+                mx.array([tokens] * batch, dtype=mx.uint32),
+                mx.zeros((batch, positions, hidden.shape[-1])),
+            )
+
+    class RaisingTransactionalProcessor:
+        def __init__(self):
+            self.state = 0
+            self.armed = False
+
+        def __call__(self, _tokens, logits):
+            return logits
+
+        def mtp_apply(self, _tentative, logits):
+            self.state += 1
+            if self.armed:
+                raise RuntimeError("sentinel target processor failure")
+            return logits
+
+        def mtp_snapshot_state(self):
+            return self.state
+
+        def mtp_restore_state(self, state):
+            self.state = state
+
+    processor = RaisingTransactionalProcessor()
+    gen = mtp_generate_step(
+        mx.array([1], dtype=mx.uint32),
+        FusedDraftModel([7, 11, 13], [11]),
+        max_tokens=3,
+        max_k=1,
+        logits_processors=[processor],
+        initial_tokens=[1],
+        disable_auto_k=True,
+        accept_counter=MTPAcceptCounter(),
+    )
+
+    assert next(gen)[0] == 7
+    assert processor.state == 1
+    processor.armed = True
+    with pytest.raises(RuntimeError, match="sentinel target processor failure"):
+        next(gen)
+    assert processor.state == 1
+
+
 def test_quantized_argmax_matches_materialized_qlinear_logits():
     """The fused greedy kernel must select the exact qlinear argmax."""
     import mlx.nn as nn

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2763,6 +2763,90 @@ def test_generator_fixed_k3_accepts_three_drafts_in_one_verify():
     assert snap.accepts == 3
 
 
+@pytest.mark.parametrize(
+    ("max_k", "committed", "drafts", "targets", "intervention_position"),
+    [
+        (2, list(range(24)) + list(range(23)), [23, 0], [23, 0, 7], 1),
+        (3, list(range(24)) + list(range(22)), [22, 23, 0], [22, 23, 0, 7], 2),
+    ],
+)
+def test_generator_commits_tool_guard_state_only_as_tokens_are_delivered(
+    max_k, committed, drafts, targets, intervention_position
+):
+    """K=2/K=3 verification cannot commit a not-yet-delivered guard hit."""
+    from vllm_mlx.repetition_guard import AgentRepetitionLogitsProcessor
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    near_loop = list(range(24)) + list(range(25 - max_k))
+
+    def start():
+        history = list(committed)
+        processor = AgentRepetitionLogitsProcessor(history)
+        gen = mtp_generate_step(
+            mx.array([1], dtype=mx.uint32),
+            _MockedQwen35Model([7, *targets], drafts),
+            max_tokens=max_k + 2,
+            max_k=max_k,
+            logits_processors=[processor],
+            initial_tokens=[1],
+            disable_auto_k=True,
+            accept_counter=MTPAcceptCounter(),
+        )
+        assert next(gen)[0] == 7
+        # The first sample above is committed before the generator is resumed.
+        history[:] = near_loop
+        return gen, processor
+
+    # Cancelling before the later intervention position must leave the guard
+    # exactly at the last delivered prefix.
+    cancelled, cancelled_processor = start()
+    for position in range(intervention_position):
+        token, _lp, from_draft = next(cancelled)
+        assert token == drafts[position]
+        assert from_draft is True
+        assert cancelled_processor.interventions == 0
+    cancelled.close()
+    assert cancelled_processor.interventions == 0
+
+    # Delivering that same position commits the intervention exactly once.
+    gen, processor = start()
+    for _ in range(intervention_position):
+        next(gen)
+    token, _lp, from_draft = next(gen)
+    assert from_draft is True
+    assert token != 0  # the loop-extending target/draft token was masked
+    assert processor.interventions == 1
+
+
+def test_generator_rejection_discards_later_tool_guard_state():
+    """A guard hit on a rejected K=3 suffix never consumes its safety cap."""
+    from vllm_mlx.repetition_guard import AgentRepetitionLogitsProcessor
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    pattern = list(range(24))
+    committed = pattern + pattern[:-2]
+    processor = AgentRepetitionLogitsProcessor(committed)
+    # Target rejects d1 immediately, but its batched rows still evaluate the
+    # later d1+d2 prefix that would otherwise arm the repetition guard.
+    gen = mtp_generate_step(
+        mx.array([1], dtype=mx.uint32),
+        _MockedQwen35Model([7, 9, 23, 0, 7], [22, 23, 0]),
+        max_tokens=2,
+        max_k=3,
+        logits_processors=[processor],
+        initial_tokens=[1],
+        disable_auto_k=True,
+        accept_counter=MTPAcceptCounter(),
+    )
+
+    assert next(gen)[0] == 7
+    token, _lp, from_draft = next(gen)
+    assert (token, from_draft) == (9, False)
+    assert processor.interventions == 0
+
+
 def test_quantized_argmax_matches_materialized_qlinear_logits():
     """The fused greedy kernel must select the exact qlinear argmax."""
     import mlx.nn as nn

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -753,6 +753,39 @@ class TestScheduleWaitingInsertDispatch:
             )
         )
 
+    def test_real_schedule_registers_tool_guard_as_transactional_mtp_safe(self):
+        """An ordinary tools request keeps MTP without admitting other processors."""
+        from vllm_mlx.repetition_guard import AgentRepetitionLogitsProcessor
+
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        request = Request(
+            request_id="req-tool-mtp-admission",
+            prompt="ignored",
+            prompt_token_ids=[10, 20, 30, 40],
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+        request.has_tools = True
+        request.prefix_boundary = 99
+        scheduler.waiting.append(request)
+
+        batch_generator = MagicMock()
+        batch_generator.insert_segments.return_value = [103]
+        scheduler.batch_generator = batch_generator
+        scheduler._ensure_batch_generator = MagicMock(return_value=True)
+        scheduler._get_request_sampler = MagicMock(return_value=MagicMock())
+        scheduler._register_uid_processors = MagicMock()
+
+        assert scheduler._schedule_waiting() == [request]
+
+        admitted = batch_generator.insert_segments.call_args.kwargs[
+            "logits_processors"
+        ][0]
+        assert len(admitted) == 1
+        assert isinstance(admitted[0], AgentRepetitionLogitsProcessor)
+        assert tuple(admitted) == request._mtp_safe_logits_processors
+
     def _build_dispatch_args(
         self,
         prefix_boundary: int,

--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -75,6 +75,26 @@ def test_logits_processor_masks_predicted_token_once():
     assert processor.interventions == 1
 
 
+def test_mtp_processor_state_restores_rejected_tentative_intervention():
+    pattern = list(range(24))
+    committed = pattern + pattern[:-2]
+    processor = AgentRepetitionLogitsProcessor(committed)
+    logits = mx.zeros((1, 32))
+    boundary = processor.mtp_snapshot_state()
+
+    # Two tentative tokens complete the second 24-token copy, so the next
+    # token would start the third copy and must be blocked on this branch.
+    processed = processor.mtp_apply(mx.array(pattern[-2:]), logits)
+    mx.eval(processed)
+    assert float(processed[0, pattern[0]].item()) == float("-inf")
+    assert processor.interventions == 1
+
+    processor.mtp_restore_state(boundary)
+    assert processor.interventions == 0
+    assert processor.last_match is None
+    assert processor._last_intervention_length == -1
+
+
 def test_ignores_short_stutter_and_near_repeat():
     assert detect_repeated_token_suffix([7] * 200) is None
     pattern = list(range(12))

--- a/vllm_mlx/repetition_guard.py
+++ b/vllm_mlx/repetition_guard.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from math import ceil
+from typing import cast
 
 import mlx.core as mx
 
@@ -183,7 +184,7 @@ class AgentRepetitionLogitsProcessor:
         tentative_count = int(tentative_token_ids.size)
         if len(self.output_token_ids) + tentative_count < 48:
             return logits
-        tentative = [int(token) for token in tentative_token_ids.tolist()]
+        tentative = cast(list[int], tentative_token_ids.tolist())
         return self._apply([*self.output_token_ids, *tentative], logits)
 
     def mtp_snapshot_state(

--- a/vllm_mlx/repetition_guard.py
+++ b/vllm_mlx/repetition_guard.py
@@ -147,13 +147,13 @@ class AgentRepetitionLogitsProcessor:
         self.last_match: RepetitionIntervention | None = None
         self._last_intervention_length = -1
 
-    def __call__(self, _tokens: mx.array, logits: mx.array) -> mx.array:
+    def _apply(self, history: Sequence[int], logits: mx.array) -> mx.array:
         if self.interventions >= self.max_interventions:
             return logits
-        history_length = len(self.output_token_ids)
+        history_length = len(history)
         if history_length == self._last_intervention_length:
             return logits
-        match = predict_repeated_token_suffix(self.output_token_ids)
+        match = predict_repeated_token_suffix(history)
         if match is None:
             return logits
         token_id = match.blocked_token_id
@@ -164,3 +164,39 @@ class AgentRepetitionLogitsProcessor:
         self._last_intervention_length = history_length
         token_mask = mx.arange(logits.shape[-1]) == token_id
         return mx.where(token_mask[None, :], -mx.inf, logits)
+
+    def __call__(self, _tokens: mx.array, logits: mx.array) -> mx.array:
+        """Apply against scheduler-committed output during ordinary decode."""
+
+        return self._apply(self.output_token_ids, logits)
+
+    def mtp_apply(self, tentative_token_ids: mx.array, logits: mx.array) -> mx.array:
+        """Apply against committed output plus one tentative MTP prefix.
+
+        The generator passes only draft tokens preceding the position being
+        sampled.  Keeping the committed list scheduler-owned avoids treating a
+        repeated user prompt as generated output.  The common path returns
+        before materializing MLX tokens: no supported loop can arm below 48
+        output tokens with the guard's production thresholds.
+        """
+
+        tentative_count = int(tentative_token_ids.size)
+        if len(self.output_token_ids) + tentative_count < 48:
+            return logits
+        tentative = [int(token) for token in tentative_token_ids.tolist()]
+        return self._apply([*self.output_token_ids, *tentative], logits)
+
+    def mtp_snapshot_state(
+        self,
+    ) -> tuple[int, RepetitionIntervention | None, int]:
+        """Return all mutable state owned by speculative verification."""
+
+        return self.interventions, self.last_match, self._last_intervention_length
+
+    def mtp_restore_state(
+        self,
+        state: tuple[int, RepetitionIntervention | None, int],
+    ) -> None:
+        """Restore a previously captured speculative boundary."""
+
+        self.interventions, self.last_match, self._last_intervention_length = state

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -199,11 +199,12 @@ class Request:
     # parser state after the prompt has explicitly closed it.
     suppressed_tokens_logits_processor: Any | None = None
 
-    # Exact standard-penalty processors installed for this request. The MTP
-    # handoff accepts a processor row only when every live object is identical
-    # to this tuple; grammar, tool, reasoning, and arbitrary custom processors
-    # therefore fail closed instead of entering speculative execution without
-    # a rollback contract. Populated by Scheduler at batch admission.
+    # Exact processors admitted to MTP for this request: standard history-only
+    # penalties plus any processor with an engine-owned speculative transaction
+    # contract. The handoff accepts a row only when every live object is
+    # identical to this tuple; grammar, reasoning, suppression, tool-bias, and
+    # arbitrary custom processors therefore fail closed. Populated by Scheduler
+    # at batch admission.
     _mtp_safe_logits_processors: tuple[Any, ...] = field(
         default_factory=tuple, init=False, repr=False
     )

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -8012,6 +8012,7 @@ class Scheduler:
             # hard-stop below.  The processor is deliberately tool-request
             # only and masks a single predicted token only after the output is
             # one full copy short of the conservative abort threshold.
+            _loop_breaker = None
             if request.has_tools:
                 _loop_breaker = AgentRepetitionLogitsProcessor(request.output_token_ids)
                 request._repetition_logits_processor = _loop_breaker
@@ -8060,7 +8061,7 @@ class Scheduler:
             # reasoning, suppression, tool-bias, and unknown processors
             # fail-closed at the GenerationBatch handoff.
             request._mtp_safe_logits_processors = tuple(
-                ([request._repetition_logits_processor] if request.has_tools else [])
+                ([_loop_breaker] if _loop_breaker is not None else [])
                 + penalty_processors
             )
             # Generation-time thinking-token budget (force-close </think>).

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1275,11 +1275,12 @@ def _install_mtp_vendored(
       through because the vendored generator does not yet accept a request-
       local PRNG key.
 
-    * The standard repetition / presence / frequency penalty processors are
-      passed through with the exact mlx-lm token history at the handoff seam.
-      Custom, grammar, tool, and reasoning-budget processors still fall
-      through because their mutable state needs an explicit speculative
-      rollback contract.
+    * Standard repetition / presence / frequency penalties use the exact
+      mlx-lm token history at the handoff seam. Ordinary tool requests may
+      additionally carry Rapid's agent repetition guard: it owns an explicit
+      tentative-prefix snapshot/restore contract. Grammar, tool-bias,
+      reasoning-budget, suppression, and unknown custom processors still fall
+      through.
 
     * On the very first ``_step`` call we short-circuit and return the
       token that mlx-lm's fresh ``GenerationBatch.__init__._step()``
@@ -1516,10 +1517,9 @@ def _install_mtp_vendored(
 
         The scheduler owns the authoritative ``SamplingParams`` object and the
         exact per-row processor list installed into mlx-lm. Only processors
-        explicitly marked as the standard penalty list at request insertion
-        may cross this seam; identity comparison prevents a future custom
-        processor with the same list length from being mistaken for a safe
-        one.
+        explicitly admitted at request insertion may cross this seam; identity
+        comparison prevents a future custom processor with the same list
+        length from being mistaken for a safe one.
         """
         if uid_to_request_id is None or requests is None:
             return None, "request metadata is unavailable"
@@ -8053,10 +8053,16 @@ class Scheduler:
                     frequency_context_size=4096,
                 )
                 request_processors.extend(penalty_processors)
-            # MTP may reuse only this exact standard-penalty list. Identity
-            # (not processor count or type-name heuristics) is the fail-closed
-            # contract at the GenerationBatch handoff.
-            request._mtp_safe_logits_processors = tuple(penalty_processors)
+            # MTP may reuse only this exact ordered list.  Standard penalties
+            # are history-derived, and the tool repetition guard exposes an
+            # explicit tentative-prefix snapshot/restore contract. Identity
+            # (not processor count or type-name heuristics) keeps grammar,
+            # reasoning, suppression, tool-bias, and unknown processors
+            # fail-closed at the GenerationBatch handoff.
+            request._mtp_safe_logits_processors = tuple(
+                ([request._repetition_logits_processor] if request.has_tools else [])
+                + penalty_processors
+            )
             # Generation-time thinking-token budget (force-close </think>).
             # Appended LAST so its force-close mask (all but </think> -> -inf)
             # has final say over any penalty/grammar bias in the same step;

--- a/vllm_mlx/spec_decode/mtp/generator.py
+++ b/vllm_mlx/spec_decode/mtp/generator.py
@@ -500,11 +500,41 @@ def mtp_generate_step(
         kv_bits=kv_bits,
     )
 
-    def _process_and_sample(tokens, logits, xtc_draw=None):
+    transactional_processors = tuple(
+        processor
+        for processor in (logits_processors or ())
+        if callable(getattr(processor, "mtp_snapshot_state", None))
+        and callable(getattr(processor, "mtp_restore_state", None))
+        and callable(getattr(processor, "mtp_apply", None))
+    )
+    transactional_processor_ids = {
+        id(processor) for processor in transactional_processors
+    }
+
+    def _snapshot_processor_state():
+        return tuple(
+            (processor, processor.mtp_snapshot_state())
+            for processor in transactional_processors
+        )
+
+    def _restore_processor_state(snapshot) -> None:
+        for processor, state in snapshot:
+            processor.mtp_restore_state(state)
+
+    def _process_and_sample(tokens, logits, xtc_draw=None, *, tentative_tokens=None):
         if logits_processors:
             logits = logits[None]
             for processor in logits_processors:
-                logits = processor(tokens, logits)
+                mtp_apply = getattr(processor, "mtp_apply", None)
+                if id(processor) in transactional_processor_ids:
+                    tentative = (
+                        tentative_tokens
+                        if tentative_tokens is not None
+                        else mx.array([], dtype=mx.uint32)
+                    )
+                    logits = mtp_apply(tentative, logits)
+                else:
+                    logits = processor(tokens, logits)
             logits = logits.squeeze(0)
         logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
         if _filter_chain:
@@ -614,8 +644,16 @@ def mtp_generate_step(
             if mc.is_trimmable():
                 mc.trim(n_to_drop)
 
-    def _step_backbone(yy, prev, n_predict=1, n_confirmed=0, xtc_draw=None):
-        """Run backbone on ``yy`` and return (tokens, logprobs, accept_lps, hidden, prev)."""
+    def _step_backbone(
+        yy,
+        prev,
+        n_predict=1,
+        n_confirmed=0,
+        xtc_draw=None,
+        *,
+        capture_processor_states=False,
+    ):
+        """Run backbone and optionally retain each processor position boundary."""
         with mx.stream(generation_stream):
             logits, hidden = model(
                 yy[None],
@@ -628,6 +666,7 @@ def mtp_generate_step(
             toks: list = []
             lps: list = []
             accept_lps: list = []
+            processor_states: list = []
             for i in range(n_predict):
                 if logits_processors:
                     prev = (
@@ -638,20 +677,36 @@ def mtp_generate_step(
                 # Shared XTC draw only for position 0 (verify position).
                 draw = xtc_draw if i == 0 else None
                 tok, lp, alp = _process_and_sample(
-                    prev, logits[:, i, :].squeeze(0), draw
+                    prev,
+                    logits[:, i, :].squeeze(0),
+                    draw,
+                    # ``yy[0]`` is the last committed token. Positions after
+                    # it are the tentative prefix visible at verify row i.
+                    tentative_tokens=yy[1 : i + 1],
                 )
                 toks.append(tok)
                 lps.append(lp)
                 accept_lps.append(alp)
+                if capture_processor_states:
+                    processor_states.append(_snapshot_processor_state())
             return (
                 mx.stack(toks),
                 mx.stack(lps),
                 mx.stack(accept_lps),
                 hidden,
                 prev,
+                processor_states,
             )
 
-    def _step_mtp(hidden_last, main_tok, prev, *, cache_commit=None, want_hidden=False):
+    def _step_mtp(
+        hidden_last,
+        main_tok,
+        prev,
+        *,
+        cache_commit=None,
+        want_hidden=False,
+        tentative_tokens=None,
+    ):
         """Run MTP head and return draft state.
 
         Returns ``(draft_tok, draft_lp, draft_accept_lp, xtc_draw, drafter_hidden_or_None)``.
@@ -704,7 +759,10 @@ def mtp_generate_step(
                 tokens_for_proc = prev
             xtc_draw = _uniform() if _xtc_cell is not None else None
             draft_tok, draft_lp, draft_accept_lp = _process_and_sample(
-                tokens_for_proc, mtp_logits, xtc_draw
+                tokens_for_proc,
+                mtp_logits,
+                xtc_draw,
+                tentative_tokens=tentative_tokens,
             )
         return draft_tok, draft_lp, draft_accept_lp, xtc_draw, drafter_hidden_last
 
@@ -764,6 +822,7 @@ def mtp_generate_step(
         # see ``prev + d2`` (omitting both), which weakens repetition/presence/
         # frequency penalties precisely when K > 1.
         chain_prev = prev
+        chain_tentative = mx.array([], dtype=mx.uint32)
         cur_hidden = hidden_last
         cur_commit = cache_commit
         for _k in range(K):
@@ -773,6 +832,7 @@ def mtp_generate_step(
                 chain_prev,
                 cache_commit=cur_commit,
                 want_hidden=_mtp_supports_hidden and K >= 2,
+                tentative_tokens=chain_tentative,
             )
             # Keep the draft chain on-device.  ``prev_tok`` is consumed as an
             # MLX array by the next head call; forcing ``mx.eval`` here adds
@@ -789,6 +849,7 @@ def mtp_generate_step(
                     if chain_prev is not None
                     else prev_tok.reshape(-1)
                 )
+                chain_tentative = mx.concatenate([chain_tentative, d_tok.reshape(-1)])
             prev_tok = d_tok
             # Drafter-hidden cascade: swap in the drafter's own
             # ``post_projection(h)`` for the next iteration's hidden
@@ -951,7 +1012,13 @@ def mtp_generate_step(
         """``_step_mtp_chain`` with its wall time held for the next round."""
         nonlocal pending_draft_ms
         _t0 = time.perf_counter()
-        result = _step_mtp_chain(*args, **kwargs)
+        boundary = _snapshot_processor_state()
+        try:
+            result = _step_mtp_chain(*args, **kwargs)
+        finally:
+            # Draft-side interventions shape q(d), but only target-verified,
+            # user-delivered positions may advance processor state.
+            _restore_processor_state(boundary)
         elapsed = time.perf_counter() - _t0
         pending_draft_ms = elapsed * 1000.0
         _timing_add("draft_seconds", elapsed)
@@ -1006,7 +1073,7 @@ def mtp_generate_step(
             # Round K=0 (either bootstrap or a park). Plain backbone
             # forward emits ONE committed token.
             # -------------------------------------------------------
-            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
+            toks, lps, accept_lps, hidden, prev_tokens, _ = _step_backbone(
                 y, prev_tokens, n_predict=1
             )
             mx.eval(toks)
@@ -1097,15 +1164,31 @@ def mtp_generate_step(
             )
             y_with_drafts = mx.concatenate([y, drafts_arr])
 
-            toks, lps, accept_lps, hidden, prev_tokens = _step_backbone(
-                y_with_drafts,
-                prev_tokens,
-                n_predict=k_len + 1,
-                # Any positive value activates per-position SSM snapshots;
-                # k_len preserves the legacy K=1 boundary semantics too.
-                n_confirmed=k_len,
-                xtc_draw=first_xtc_draw,
-            )
+            processor_boundary = _snapshot_processor_state()
+            try:
+                (
+                    toks,
+                    lps,
+                    accept_lps,
+                    hidden,
+                    prev_tokens,
+                    processor_position_states,
+                ) = _step_backbone(
+                    y_with_drafts,
+                    prev_tokens,
+                    n_predict=k_len + 1,
+                    # Any positive value activates per-position SSM snapshots;
+                    # k_len preserves the legacy K=1 boundary semantics too.
+                    n_confirmed=k_len,
+                    xtc_draw=first_xtc_draw,
+                    capture_processor_states=True,
+                )
+            except BaseException:
+                _restore_processor_state(processor_boundary)
+                raise
+            # Verification computes every target row eagerly, but none is
+            # committed until its token is actually delivered below.
+            _restore_processor_state(processor_boundary)
 
             # One independent uniform per speculative position. Reusing one
             # scalar across K positions preserves each isolated acceptance
@@ -1190,6 +1273,7 @@ def mtp_generate_step(
                     _rollback_verify_round(
                         k_len - accepted_count, verify_size=k_len + 1
                     )
+                _restore_processor_state(processor_boundary)
                 raise
 
             # Bump attempts by K (one per draft position considered).
@@ -1241,6 +1325,7 @@ def mtp_generate_step(
 
             # Emit the accepted drafts (capped at EOS position when set).
             for i in range(accepted_count):
+                _restore_processor_state(processor_position_states[i])
                 accept_counter.record_accept(tokens_saved=1)
                 ntoks += 1
                 draft_id = int(draft_ids[i])
@@ -1271,6 +1356,7 @@ def mtp_generate_step(
                     _sync_prompt_lookup_history(hidden, y, drafts_arr, accepted_count)
                 ntoks += 1
                 _remember_generated(bonus_id)
+                _restore_processor_state(processor_position_states[k_len])
                 yield bonus_id, lps[k_len], False
                 if ntoks >= max_tokens:
                     return
@@ -1301,6 +1387,7 @@ def mtp_generate_step(
 
                 ntoks += 1
                 _remember_generated(verify_tok_id)
+                _restore_processor_state(processor_position_states[accepted_count])
                 # ``lps[position]`` is the full target-model logprob row, not
                 # a scalar attached to the independently pre-sampled
                 # ``toks[position]``.  Indexing this row later with the emitted


### PR DESCRIPTION
## Intent

Let ordinary tool-bearing requests retain target-verified MTP acceleration without removing Rapid's agent repetition-loop protection or treating arbitrary stateful logits processors as safe.

Fixes #2886.

## Scope

- give `AgentRepetitionLogitsProcessor` an explicit tentative-prefix snapshot/restore contract;
- keep draft-side processor mutations provisional;
- commit the processor state for each target-verified token only when that token is delivered;
- admit the exact repetition-guard object alongside the existing standard penalty processors;
- cover K=2/K=3 acceptance, rejection, cancellation, admission, and unchanged loop protection.

## Non-goals

- grammar-constrained tool decoding;
- reasoning-budget, suppression, tool-bias, or unknown custom processor admission;
- continuous-MTP tool termination semantics;
- model-specific exceptions, dependency changes, or CI changes.

## Design precedent

Mature serving engines keep tool parsing downstream of accepted output and apply supported constraints at each target-verification position. MLX-native speculative runtimes with mutable processors preserve a state boundary per candidate position and restore only the accepted boundary after rejection. This change adapts that established transaction shape to Rapid's existing target-cache commit/rollback seam instead of adding a parallel scheduler or a broad “processor is safe” marker.

The scheduler continues to compare processor objects by exact identity. Only the existing history-derived penalties and Rapid's repetition guard cross the MTP seam; every unproven processor combination continues to use ordinary decoding.

## User-side verification

On Studio, from this exact branch with cached weights and offline Hub mode:

```bash
RAPID_MLX_CONSTRAIN_TOOLS=0 HF_HUB_OFFLINE=1 python3.12 -m vllm_mlx.cli serve qwen3.5-4b-4bit \
  --speculative-config '{"method":"mtp","model":"mlx-community/Qwen3.5-4B-MTP-4bit","num_speculative_tokens":3,"disable_auto_k":true}' \
  --no-thinking --host 127.0.0.1 --port 8465
```

A real forced `get_weather` request returned `tool_calls` with schema-valid arguments `{"city":"Beijing"}` and `finish_reason="tool_calls"`. Metrics recorded 12 MTP proposals, 5 accepts, and 5 saved tokens. The same request under `--no-spec-decode --no-mllm` returned the same tool name and arguments (request-generated call IDs excluded).

## Tests

- `ruff check` — pass
- `ruff format --check` — pass
- CLI/config fidelity audit — pass
- focused engine tests: 277 passed
- real cached Qwen3.5-4B + matching 4-bit MTP sidecar tool request — pass, 5 accepted proposals
- `make smoke`: lint/format/audit passed; the repository's fixed 300-second unit timeout stopped the 21,575-test suite at 44% with no test failure

Mutation proof: removing the accepted-position processor-state restore made `test_generator_commits_tool_guard_state_only_as_tokens_are_delivered` fail (`interventions` stayed 0 instead of committing exactly once). Restoring the production line returned the test to green.

## Risk and rollback

The behavior is limited to tool requests whose complete live processor row exactly matches the admitted guard/penalty tuple. Any grammar, reasoning, suppression, tool-bias, or unknown processor preserves the current fail-closed fallback. Reverting this PR returns those ordinary tool requests to plain decode.
