### PR TITLE
fix(residency): track post-commit engine cleanup across cancellation

### DIFF
--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -2315,6 +2315,38 @@ async def test_explicit_unload_propagates_stop_failure():
 
 
 @pytest.mark.asyncio
+async def test_explicit_unload_reports_cancelled_raw_cleanup():
+    """A cancelled manager-owned cleanup remains charged and fails explicitly."""
+    registry = ModelRegistry()
+    engine = BlockingStopLifecycleEngine()
+    target = entry("chat-target", engine)
+    registry.add(target)
+    manager = ResidentModelManager(registry, AsyncMock(), memory_reader=lambda: 0)
+    manager._index_record(
+        ResidencyRecord(
+            entry=target,
+            estimated_bytes=2 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    unload = asyncio.create_task(manager.unload("chat-target"))
+    await engine.stop_started.wait()
+    retirement = manager._retiring[id(engine)]
+    assert retirement.task is not None
+    retirement.task.cancel()
+
+    with pytest.raises(
+        ResidentModelError, match="retirement cleanup cancelled before completion"
+    ):
+        await unload
+
+    assert retirement.state == "failed"
+    assert _accounted_bytes(manager, "chat-target") == 2 * GIB
+
+
+@pytest.mark.asyncio
 async def test_ttl_does_not_report_failed_cleanup_as_evicted():
     registry = ModelRegistry()
     engine = FailingStopLifecycleEngine()
@@ -2369,6 +2401,26 @@ async def test_shutdown_reports_every_failed_cleanup_after_draining_all():
     assert all(
         manager._retiring[id(engine)].state == "failed" for engine in engines.values()
     )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_reports_failure_without_a_preserved_cause(monkeypatch):
+    """The aggregate error remains useful for cause-less cleanup failures."""
+    manager = ResidentModelManager(
+        ModelRegistry(), AsyncMock(), memory_reader=lambda: 0
+    )
+    monkeypatch.setattr(
+        manager,
+        "_cleanup_failures",
+        lambda _identities: [("chat-target", "cleanup interrupted", None)],
+    )
+
+    with pytest.raises(
+        ResidentModelError, match="chat-target: cleanup interrupted"
+    ) as caught:
+        await manager.shutdown()
+
+    assert caught.value.__cause__ is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1938,6 +1938,16 @@ async def test_task_cancel_during_sibling_cleanup_reopens_remaining_sibling():
     blocking_engine = BlockingStopLifecycleEngine()
     blocking = entry("chat-blocking", blocking_engine)
     remaining_engine = FakeLifecycleEngine()
+    resume_started = asyncio.Event()
+    resume_release = asyncio.Event()
+
+    async def blocking_resume() -> dict:
+        resume_started.set()
+        await resume_release.wait()
+        remaining_engine.paused = False
+        return remaining_engine.lifecycle_status()
+
+    remaining_engine.resume_generation = blocking_resume
     remaining = entry("chat-remaining", remaining_engine)
     registry.add(primary, is_default=True)
     registry.add(blocking)
@@ -1964,6 +1974,14 @@ async def test_task_cancel_during_sibling_cleanup_reopens_remaining_sibling():
     await blocking_engine.stop_started.wait()
 
     replacement.cancel()
+    await resume_started.wait()
+    # A second cancellation during rollback recovery must not strand the
+    # unretired sibling paused. The original cancellation is delayed until the
+    # manager-owned recovery finishes.
+    replacement.cancel()
+    await asyncio.sleep(0)
+    assert replacement.done() is False
+    resume_release.set()
     with pytest.raises(asyncio.CancelledError):
         await replacement
 
@@ -2175,9 +2193,8 @@ async def test_cancel_secondary_replace_keeps_sibling_charged_and_cleaned():
 
 
 @pytest.mark.asyncio
-async def test_suspended_stop_does_not_block_snapshot_lease_or_unrelated_op():
-    """LOCK SAFETY: a suspended stop() in the background must not block a
-    snapshot, a lease on an unrelated resident model, or another op."""
+async def test_suspended_stop_does_not_block_lease_or_unrelated_op():
+    """LOCK SAFETY: suspended stop must not block unrelated manager ops."""
     registry = ModelRegistry()
     primary_engine = BlockingStopLifecycleEngine()
     primary = entry("chat-old", primary_engine)
@@ -2206,7 +2223,8 @@ async def test_suspended_stop_does_not_block_snapshot_lease_or_unrelated_op():
     )
     await primary_engine.stop_started.wait()
 
-    # Snapshot must not block.
+    # The synchronous snapshot remains observable during suspended cleanup;
+    # the async operations below are the assertions that the lock is free.
     manager.snapshot()
 
     # A lease on the UNRELATED resident model must not be blocked by the

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1997,12 +1997,8 @@ async def test_existing_target_cancel_reopens_unretired_sibling():
     # The old primary is already owned by retirement, but the later sibling
     # stays routable and must be reopened rather than left paused indefinitely.
     assert registry.default_name == "chat-target"
-    assert "chat-primary" not in {
-        model.model_name for model in registry.list_entries()
-    }
-    assert "chat-remaining" in {
-        model.model_name for model in registry.list_entries()
-    }
+    assert "chat-primary" not in {model.model_name for model in registry.list_entries()}
+    assert "chat-remaining" in {model.model_name for model in registry.list_entries()}
     assert remaining_engine.paused is False
 
     primary_engine.stop_release.set()

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -479,11 +479,12 @@ class BlockingStopLifecycleEngine(FakeLifecycleEngine):
     def __init__(self) -> None:
         super().__init__()
         self.stop_started = asyncio.Event()
+        self.stop_release = asyncio.Event()
 
     async def stop(self) -> None:
         self.stopped = True
         self.stop_started.set()
-        await asyncio.Event().wait()
+        await self.stop_release.wait()
 
 
 class Clock:
@@ -1233,7 +1234,12 @@ async def test_evict_first_stop_failure_finishes_handoff_as_primary_absent():
     handoff.commit.assert_called_once_with(None)
     handoff.rollback.assert_not_called()
     assert registry.default_name is None
-    assert manager.snapshot()["models"] == []
+    # The evict-first failure propagates, but the engine is NOT silently freed:
+    # it is durably tracked as cleanup-failed and its bytes stay charged.
+    snapshot_models = manager.snapshot()["models"]
+    assert [item["id"] for item in snapshot_models] == ["chat-old"]
+    assert snapshot_models[0]["state"] == "failed"
+    assert snapshot_models[0]["cleanup_failed"] == "stop failed"
 
 
 @pytest.mark.asyncio
@@ -1282,7 +1288,15 @@ async def test_evict_first_sibling_stop_failure_preserves_primary_publication():
     assert primary_engine.stopped is False
     assert primary_engine.paused is False
     assert registry.default_name == "chat-primary"
-    assert [item["id"] for item in manager.snapshot()["models"]] == ["chat-primary"]
+    # The sibling's cleanup failed and is durably tracked (bytes charged), while
+    # the healthy primary stays published and un-touched.
+    ids = {item["id"] for item in manager.snapshot()["models"]}
+    assert ids == {"chat-primary", "chat-sibling"}
+    sibling_row = next(
+        item for item in manager.snapshot()["models"] if item["id"] == "chat-sibling"
+    )
+    assert sibling_row["state"] == "failed"
+    assert sibling_row["cleanup_failed"] == "stop failed"
 
 
 @pytest.mark.asyncio
@@ -1800,8 +1814,16 @@ async def test_committed_replacement_does_not_rollback_to_stopped_sibling(caplog
     assert replacement.primary is True
     assert registry.default_name == "chat-new"
     assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
-    assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
-    assert "Failed to stop replaced model 'chat-sibling'" in caplog.text
+    # The failed sibling is durably tracked as cleanup-failed (not resurrected
+    # as a route, but never silently freed) with its bytes still charged.
+    ids = {item["id"] for item in manager.snapshot()["models"]}
+    assert ids == {"chat-new", "chat-sibling"}
+    sibling_row = next(
+        item for item in manager.snapshot()["models"] if item["id"] == "chat-sibling"
+    )
+    assert sibling_row["state"] == "failed"
+    assert sibling_row["cleanup_failed"] == "stop failed"
+    assert "Failed to clean up resident model 'chat-sibling'" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1839,9 +1861,19 @@ async def test_primary_stop_failure_keeps_committed_replacement_routable(
     assert replacement.primary is True
     assert registry.default_name == "chat-new"
     assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
-    assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
+    # The old primary's cleanup failed and is durably tracked (bytes charged),
+    # never silently freed, while the committed new route stays authoritative.
+    assert {item["id"] for item in manager.snapshot()["models"]} == {
+        "chat-new",
+        "chat-old",
+    }
+    old_row = next(
+        item for item in manager.snapshot()["models"] if item["id"] == "chat-old"
+    )
+    assert old_row["state"] == "failed"
+    assert old_row["cleanup_failed"] == "stop failed"
     assert handoff_events == ["commit:chat-new"]
-    assert "Failed to stop replaced primary 'chat-old'" in caplog.text
+    assert "Failed to clean up resident model 'chat-old'" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1870,7 +1902,18 @@ async def test_task_cancel_after_primary_commit_preserves_new_route():
     assert registry.default_name == "chat-new"
     assert registry.get_engine("chat-new") is loaded["chat-new"]
     assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
-    assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
+    # The old engine's stop was suspended when the caller cancelled; it must stay
+    # durably tracked as retiring (bytes charged) until a later shutdown rejoins
+    # and drains its cleanup -- the old route is never resurrected.
+    assert {item["id"] for item in manager.snapshot()["models"]} == {
+        "chat-new",
+        "chat-old",
+    }
+    old_row = next(
+        item for item in manager.snapshot()["models"] if item["id"] == "chat-old"
+    )
+    assert old_row["state"] == "retiring"
+    assert "cleanup_failed" in old_row and old_row["cleanup_failed"] is None
 
 
 @pytest.mark.asyncio
@@ -1947,6 +1990,293 @@ async def test_wait_replacement_retires_drained_engine_with_http_lease_finalizin
 
     assert old_engine.stopped is True
     assert registry.default_name == "chat-new"
+
+
+# --- Issue #2383: post-commit retirement is durably tracked across ------------
+# cancellation. These assert the engine stays memory-charged + snapshot-visible
+# until its stop()/allocator cleanup finishes or fails truthfully, while the lock
+# stays free during a suspended stop.
+
+
+def _accounted_bytes(manager: ResidentModelManager, model_id: str) -> int:
+    """Sum the retired/resident model's reserved bytes as snapshot would."""
+    for retirement in manager._retiring.values():
+        if retirement.record.model_id == model_id:
+            return max(
+                retirement.record.estimated_bytes, retirement.record.measured_bytes
+            )
+    record = manager._records.get(model_id)
+    if record is not None:
+        return max(record.estimated_bytes, record.measured_bytes)
+    return 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_primary_replace_keeps_old_bytes_charged_until_cleanup():
+    """PRIMARY replacement: suspended old stop keeps bytes charged; cancel then
+    release the stop proves eventual cleanup with no old-route resurrection."""
+    registry = ModelRegistry()
+    old_engine = BlockingStopLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+    loaded: dict[str, FakeEngine] = {}
+
+    async def loader(name: str, path: str | None, performance=None):
+        loaded[name] = FakeEngine()
+        return entry(name, loaded[name])
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await old_engine.stop_started.wait()
+
+    # The new route is already authoritative before cancellation.
+    assert registry.default_name == "chat-new"
+    old_row = next(
+        item for item in manager.snapshot()["models"] if item["id"] == "chat-old"
+    )
+    assert old_row["state"] == "retiring"
+    # During suspension the old engine's bytes are STILL charged.
+    assert _accounted_bytes(manager, "chat-old") == 4 * GIB
+    joined = _accounted_bytes(manager, "chat-old")
+    assert joined > 0
+
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    # Still retiring (suspended), bytes still charged, no resurrection.
+    assert registry.default_name == "chat-new"
+    assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
+    assert _accounted_bytes(manager, "chat-old") == 4 * GIB
+
+    # Release the suspended stop and drain via shutdown -> cleanup completes,
+    # bytes disappear, old engine no longer visible.
+    old_engine.stop_release.set()
+    await asyncio.wait_for(manager.shutdown(), timeout=1)
+    assert {item["id"] for item in manager.snapshot()["models"]} == {"chat-new"}
+    assert _accounted_bytes(manager, "chat-old") == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_secondary_replace_keeps_sibling_charged_and_cleaned():
+    """SECONDARY replacement: a non-primary replacement candidate suspended in
+    stop() keeps bytes charged, and completes cleanup on release."""
+    registry = ModelRegistry()
+    primary_engine = FakeLifecycleEngine()
+    primary = entry("chat-primary", primary_engine)
+    old_engine = BlockingStopLifecycleEngine()
+    old_secondary = entry("chat-secondary", old_engine)
+    registry.add(primary, is_default=True)
+    registry.add(old_secondary)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=old_secondary,
+            estimated_bytes=2 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    # The old PRIMARY is retired first (fast), then the suspended SECONDARY.
+    await old_engine.stop_started.wait()
+
+    # The replacement group commits: chat-new becomes the new primary; the
+    # suspended secondary candidate is retired but still reports as being
+    # cleaned up, with its bytes charged.
+    assert registry.default_name == "chat-new"
+    assert _accounted_bytes(manager, "chat-secondary") == 2 * GIB
+    secondary_row = next(
+        item for item in manager.snapshot()["models"] if item["id"] == "chat-secondary"
+    )
+    assert secondary_row["state"] == "retiring"
+
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    # Sibling still retiring + charged until its stop is released.
+    assert _accounted_bytes(manager, "chat-secondary") == 2 * GIB
+
+    old_engine.stop_release.set()
+    await asyncio.wait_for(manager.shutdown(), timeout=1)
+    assert "chat-secondary" not in {item["id"] for item in manager.snapshot()["models"]}
+    assert _accounted_bytes(manager, "chat-secondary") == 0
+
+
+@pytest.mark.asyncio
+async def test_suspended_stop_does_not_block_snapshot_lease_or_unrelated_op():
+    """LOCK SAFETY: a suspended stop() in the background must not block a
+    snapshot, a lease on an unrelated resident model, or another op."""
+    registry = ModelRegistry()
+    primary_engine = BlockingStopLifecycleEngine()
+    primary = entry("chat-old", primary_engine)
+    unrelated_engine = FakeLifecycleEngine()
+    unrelated = entry("chat-unrelated", unrelated_engine)
+    registry.add(primary, is_default=True)
+    registry.add(unrelated)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=unrelated,
+            estimated_bytes=2 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    # Kick off a replacement that suspends the old primary's stop().
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await primary_engine.stop_started.wait()
+
+    # Snapshot must not block.
+    manager.snapshot()
+
+    # A lease on the UNRELATED resident model must not be blocked by the
+    # suspended stop() -- it needs the manager lock, which must be free.
+    got_lease = False
+    async with asyncio.timeout(1):
+        async with manager.lease("chat-unrelated"):
+            got_lease = True
+    assert got_lease is True
+
+    # A non-conflicting set_pinned on the unrelated model must also proceed.
+    await asyncio.wait_for(manager.set_pinned("chat-unrelated", True), timeout=1)
+
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+    primary_engine.stop_release.set()
+    await asyncio.wait_for(manager.shutdown(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_failed_stop_exposes_cleanup_failed_and_keeps_bytes_charged():
+    """FAILURE: stop() raises -> snapshot exposes cleanup_failed, bytes stay
+    charged, route stays retired, and retry/shutdown behaves explicitly."""
+    registry = ModelRegistry()
+    old_engine = FailingStopLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    await manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+
+    # Route retired, failed cleanup exposed, bytes still charged.
+    assert registry.default_name == "chat-new"
+    assert [item.model_name for item in registry.list_entries()] == ["chat-new"]
+    failed_row = next(
+        item for item in manager.snapshot()["models"] if item["id"] == "chat-old"
+    )
+    assert failed_row["state"] == "failed"
+    assert failed_row["cleanup_failed"] == "stop failed"
+    assert _accounted_bytes(manager, "chat-old") == 4 * GIB
+
+    # A later shutdown reports rather than silently claims the bytes free: the
+    # failed record remains observable.
+    await manager.shutdown()
+    assert _accounted_bytes(manager, "chat-old") == 4 * GIB
+    assert failed_row["state"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_unload_shutdown_race_stops_engine_exactly_once():
+    """IDEMPOTENCY: unload + shutdown for the same engine calls stop() exactly
+    once (the second retirement joins the in-flight cleanup, never double-stops)."""
+    registry = ModelRegistry()
+    primary_engine = FakeLifecycleEngine()
+    primary = entry("chat-primary", primary_engine)
+    target_engine = BlockingStopLifecycleEngine()
+    target = entry("chat-target", target_engine)
+    registry.add(primary, is_default=True)
+    registry.add(target)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    manager._index_record(
+        ResidencyRecord(
+            entry=target,
+            estimated_bytes=2 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    # Start an unload that suspends the target's stop().
+    unload_task = asyncio.create_task(manager.unload("chat-target"))
+    await target_engine.stop_started.wait()
+
+    # A concurrent shutdown must not call stop() again on the same engine; it
+    # joins the in-flight cleanup.
+    shutdown_task = asyncio.create_task(manager.shutdown())
+    await asyncio.sleep(0)
+
+    target_engine.stop_release.set()
+    await asyncio.wait_for(asyncio.gather(unload_task, shutdown_task), timeout=1)
+
+    assert target_engine.stopped is True
+    assert _accounted_bytes(manager, "chat-target") == 0
+
+
+@pytest.mark.asyncio
+async def test_suspended_stop_cancellation_latency_stays_bounded():
+    """CANCELLATION LATENCY: a cancelled caller returns promptly (not blocked on
+    the suspended stop), while cleanup continues to completion when released."""
+    registry = ModelRegistry()
+    old_engine = BlockingStopLifecycleEngine()
+    primary = entry("chat-old", old_engine)
+    registry.add(primary, is_default=True)
+
+    async def loader(name: str, path: str | None, performance=None):
+        return entry(name)
+
+    manager = ResidentModelManager(registry, loader, memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+
+    replacement = asyncio.create_task(
+        manager.load("chat-new", replace_group="assistant", replace_mode="wait")
+    )
+    await old_engine.stop_started.wait()
+
+    # Bounded wait proves the cancellation propagates promptly even though the
+    # stop is still suspended (events + wait_for, never sleep-as-sync).
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(replacement, timeout=1)
+
+    # Cleanup is still in flight (suspended); bytes remain charged.
+    assert _accounted_bytes(manager, "chat-old") == 4 * GIB
+    # Release and drain.
+    old_engine.stop_release.set()
+    await asyncio.wait_for(manager.shutdown(), timeout=1)
+    assert _accounted_bytes(manager, "chat-old") == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -2211,14 +2211,14 @@ async def test_suspended_stop_does_not_block_snapshot_lease_or_unrelated_op():
 
     # A lease on the UNRELATED resident model must not be blocked by the
     # suspended stop() -- it needs the manager lock, which must be free.
-    got_lease = False
-    async with asyncio.timeout(1):
+    async def use_unrelated_model() -> None:
         async with manager.lease("chat-unrelated"):
-            got_lease = True
-    assert got_lease is True
+            pass
 
-    # A non-conflicting set_pinned on the unrelated model must also proceed.
-    await asyncio.wait_for(manager.set_pinned("chat-unrelated", True), timeout=1)
+        # A non-conflicting set_pinned on the unrelated model must also proceed.
+        await manager.set_pinned("chat-unrelated", True)
+
+    await asyncio.wait_for(use_unrelated_model(), timeout=1)
 
     replacement.cancel()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1994,7 +1994,11 @@ async def test_task_cancel_during_sibling_cleanup_reopens_remaining_sibling():
 
 
 @pytest.mark.asyncio
-async def test_existing_target_cancel_reopens_unretired_sibling():
+async def test_existing_target_cancel_reopens_unretired_sibling(monkeypatch):
+    # This contract is about cancellation ownership, not allocator latency.
+    monkeypatch.setattr(
+        "vllm_mlx.runtime.resident_models._release_allocator_cache", lambda: None
+    )
     registry = ModelRegistry()
     primary_engine = BlockingStopLifecycleEngine()
     primary = entry("chat-primary", primary_engine)
@@ -2193,8 +2197,11 @@ async def test_cancel_secondary_replace_keeps_sibling_charged_and_cleaned():
 
 
 @pytest.mark.asyncio
-async def test_suspended_stop_does_not_block_lease_or_unrelated_op():
+async def test_suspended_stop_does_not_block_lease_or_unrelated_op(monkeypatch):
     """LOCK SAFETY: suspended stop must not block unrelated manager ops."""
+    monkeypatch.setattr(
+        "vllm_mlx.runtime.resident_models._release_allocator_cache", lambda: None
+    )
     registry = ModelRegistry()
     primary_engine = BlockingStopLifecycleEngine()
     primary = entry("chat-old", primary_engine)

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -480,8 +480,10 @@ class BlockingStopLifecycleEngine(FakeLifecycleEngine):
         super().__init__()
         self.stop_started = asyncio.Event()
         self.stop_release = asyncio.Event()
+        self.stop_calls = 0
 
     async def stop(self) -> None:
+        self.stop_calls += 1
         self.stopped = True
         self.stop_started.set()
         await self.stop_release.wait()
@@ -2284,9 +2286,114 @@ async def test_unload_shutdown_race_stops_engine_exactly_once():
 
     target_engine.stop_release.set()
     await asyncio.wait_for(asyncio.gather(unload_task, shutdown_task), timeout=1)
-
+    assert target_engine.stop_calls == 1
     assert target_engine.stopped is True
     assert _accounted_bytes(manager, "chat-target") == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_does_not_poison_later_retirement_join():
+    registry = ModelRegistry()
+    engine = BlockingStopLifecycleEngine()
+    target = entry("chat-target", engine)
+    registry.add(target)
+    manager = ResidentModelManager(registry, AsyncMock(), memory_reader=lambda: 0)
+    record = ResidencyRecord(
+        entry=target,
+        estimated_bytes=2 * GIB,
+        loaded_at=0,
+        last_used_at=0,
+    )
+    manager._index_record(record)
+
+    async with manager._lock:
+        first_waiter = manager._begin_evict_locked(record, reason="explicit")
+    await engine.stop_started.wait()
+    first_waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_waiter
+
+    async with manager._lock:
+        second_waiter = manager._begin_evict_locked(record, reason="shutdown")
+    assert second_waiter.cancelled() is False
+
+    engine.stop_release.set()
+    await asyncio.wait_for(second_waiter, timeout=1)
+    assert engine.stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_shutdown_does_not_cancel_manager_owned_retirement():
+    registry = ModelRegistry()
+    engine = BlockingStopLifecycleEngine()
+    target = entry("chat-target", engine)
+    registry.add(target)
+    manager = ResidentModelManager(registry, AsyncMock(), memory_reader=lambda: 0)
+    record = ResidencyRecord(
+        entry=target,
+        estimated_bytes=2 * GIB,
+        loaded_at=0,
+        last_used_at=0,
+    )
+    manager._index_record(record)
+
+    async with manager._lock:
+        first_waiter = manager._begin_evict_locked(record, reason="explicit")
+    await engine.stop_started.wait()
+    first_waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_waiter
+
+    shutdown = asyncio.create_task(manager.shutdown())
+    await asyncio.sleep(0)
+    shutdown.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await shutdown
+
+    retirement = manager._retiring[id(engine)]
+    assert retirement.task is not None
+    assert retirement.task.cancelled() is False
+
+    engine.stop_release.set()
+    await asyncio.wait_for(manager.shutdown(), timeout=1)
+    assert engine.stop_calls == 1
+    assert id(engine) not in manager._retiring
+
+
+@pytest.mark.asyncio
+async def test_retirement_does_not_remove_replacement_that_reuses_old_alias():
+    registry = ModelRegistry()
+    old_engine = BlockingStopLifecycleEngine()
+    old = entry("chat-old", old_engine)
+    registry.add(old, is_default=True)
+    manager = ResidentModelManager(registry, AsyncMock(), memory_reader=lambda: 0)
+    old_record = manager.register_primary(old, estimated_bytes=2 * GIB)
+
+    replacement = entry("chat-new")
+    replacement.aliases.add("chat-old")
+    registry.add(replacement, is_default=True)
+    replacement_record = ResidencyRecord(
+        entry=replacement,
+        estimated_bytes=2 * GIB,
+        loaded_at=1,
+        last_used_at=1,
+        pinned=True,
+        primary=True,
+    )
+    manager._index_record(replacement_record)
+
+    async with manager._lock:
+        cleanup = manager._begin_evict_locked(old_record, reason="replace_assistant")
+    await old_engine.stop_started.wait()
+
+    assert registry.get_entry("chat-old") is replacement
+    assert manager._canonical("chat-old") == "chat-new"
+
+    old_engine.stop_release.set()
+    await asyncio.wait_for(cleanup, timeout=1)
+    assert registry.get_entry("chat-old") is replacement
+    assert registry.list_entries() == [replacement]
+    assert manager._records["chat-new"] is replacement_record
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -475,6 +475,18 @@ class FailingStopLifecycleEngine(FakeLifecycleEngine):
         raise RuntimeError("stop failed")
 
 
+class FailOnceStopLifecycleEngine(FakeLifecycleEngine):
+    def __init__(self) -> None:
+        super().__init__()
+        self.stop_calls = 0
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        if self.stop_calls == 1:
+            raise RuntimeError("transient stop failure")
+        self.stopped = True
+
+
 class BlockingStopLifecycleEngine(FakeLifecycleEngine):
     def __init__(self) -> None:
         super().__init__()
@@ -2246,7 +2258,40 @@ async def test_failed_stop_exposes_cleanup_failed_and_keeps_bytes_charged():
     # failed record remains observable.
     await manager.shutdown()
     assert _accounted_bytes(manager, "chat-old") == 4 * GIB
-    assert failed_row["state"] == "failed"
+    current_row = next(
+        item for item in manager.snapshot()["models"] if item["id"] == "chat-old"
+    )
+    assert current_row["state"] == "failed"
+    assert current_row["cleanup_failed"] == "stop failed"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_retries_a_completed_failed_retirement():
+    registry = ModelRegistry()
+    engine = FailOnceStopLifecycleEngine()
+    target = entry("chat-target", engine)
+    registry.add(target)
+    manager = ResidentModelManager(registry, AsyncMock(), memory_reader=lambda: 0)
+    record = ResidencyRecord(
+        entry=target,
+        estimated_bytes=2 * GIB,
+        loaded_at=0,
+        last_used_at=0,
+    )
+    manager._index_record(record)
+
+    async with manager._lock:
+        first_attempt = manager._begin_evict_locked(record, reason="explicit")
+    await first_attempt
+    assert engine.stop_calls == 1
+    assert manager._retiring[id(engine)].state == "failed"
+    assert _accounted_bytes(manager, "chat-target") == 2 * GIB
+
+    await manager.shutdown()
+    assert engine.stop_calls == 2
+    assert engine.stopped is True
+    assert id(engine) not in manager._retiring
+    assert _accounted_bytes(manager, "chat-target") == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -2254,15 +2254,96 @@ async def test_failed_stop_exposes_cleanup_failed_and_keeps_bytes_charged():
     assert failed_row["cleanup_failed"] == "stop failed"
     assert _accounted_bytes(manager, "chat-old") == 4 * GIB
 
-    # A later shutdown reports rather than silently claims the bytes free: the
-    # failed record remains observable.
-    await manager.shutdown()
+    # A later shutdown reports rather than silently claiming success or the
+    # bytes free: the failed record remains observable.
+    with pytest.raises(ResidentModelError, match="chat-old: stop failed"):
+        await manager.shutdown()
     assert _accounted_bytes(manager, "chat-old") == 4 * GIB
     current_row = next(
         item for item in manager.snapshot()["models"] if item["id"] == "chat-old"
     )
     assert current_row["state"] == "failed"
     assert current_row["cleanup_failed"] == "stop failed"
+
+
+@pytest.mark.asyncio
+async def test_explicit_unload_propagates_stop_failure():
+    registry = ModelRegistry()
+    engine = FailingStopLifecycleEngine()
+    target = entry("chat-target", engine)
+    registry.add(target)
+    manager = ResidentModelManager(registry, AsyncMock(), memory_reader=lambda: 0)
+    manager._index_record(
+        ResidencyRecord(
+            entry=target,
+            estimated_bytes=2 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await manager.unload("chat-target")
+
+    assert manager._retiring[id(engine)].state == "failed"
+    assert _accounted_bytes(manager, "chat-target") == 2 * GIB
+
+
+@pytest.mark.asyncio
+async def test_ttl_does_not_report_failed_cleanup_as_evicted():
+    registry = ModelRegistry()
+    engine = FailingStopLifecycleEngine()
+    target = entry("chat-target", engine)
+    registry.add(target)
+    manager = ResidentModelManager(
+        registry,
+        AsyncMock(),
+        idle_ttl_seconds=60,
+        memory_reader=lambda: 0,
+        clock=lambda: 61,
+    )
+    manager._index_record(
+        ResidencyRecord(
+            entry=target,
+            estimated_bytes=2 * GIB,
+            loaded_at=0,
+            last_used_at=0,
+        )
+    )
+
+    assert await manager.evict_expired() == []
+    assert manager._retiring[id(engine)].state == "failed"
+    assert _accounted_bytes(manager, "chat-target") == 2 * GIB
+
+
+@pytest.mark.asyncio
+async def test_shutdown_reports_every_failed_cleanup_after_draining_all():
+    registry = ModelRegistry()
+    manager = ResidentModelManager(registry, AsyncMock(), memory_reader=lambda: 0)
+    engines = {}
+    for model_id in ("chat-a", "chat-b"):
+        engine = FailingStopLifecycleEngine()
+        engines[model_id] = engine
+        target = entry(model_id, engine)
+        registry.add(target)
+        manager._index_record(
+            ResidencyRecord(
+                entry=target,
+                estimated_bytes=2 * GIB,
+                loaded_at=0,
+                last_used_at=0,
+            )
+        )
+
+    with pytest.raises(ResidentModelError) as caught:
+        await manager.shutdown()
+
+    assert "chat-a: stop failed" in str(caught.value)
+    assert "chat-b: stop failed" in str(caught.value)
+    assert all(engine.stopped is True for engine in engines.values())
+    assert all(
+        manager._retiring[id(engine)].state == "failed" for engine in engines.values()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -1962,6 +1962,54 @@ async def test_task_cancel_during_sibling_cleanup_reopens_remaining_sibling():
 
 
 @pytest.mark.asyncio
+async def test_existing_target_cancel_reopens_unretired_sibling():
+    registry = ModelRegistry()
+    primary_engine = BlockingStopLifecycleEngine()
+    primary = entry("chat-primary", primary_engine)
+    target_engine = FakeLifecycleEngine()
+    target = entry("chat-target", target_engine)
+    remaining_engine = FakeLifecycleEngine()
+    remaining = entry("chat-remaining", remaining_engine)
+    for model in (primary, target, remaining):
+        registry.add(model, is_default=model is primary)
+
+    manager = ResidentModelManager(registry, AsyncMock(), memory_reader=lambda: 0)
+    manager.register_primary(primary, estimated_bytes=4 * GIB)
+    for model in (target, remaining):
+        manager._index_record(
+            ResidencyRecord(
+                entry=model,
+                estimated_bytes=2 * GIB,
+                loaded_at=0,
+                last_used_at=0,
+            )
+        )
+
+    replacement = asyncio.create_task(
+        manager.load("chat-target", replace_group="assistant", replace_mode="wait")
+    )
+    await primary_engine.stop_started.wait()
+
+    replacement.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await replacement
+
+    # The old primary is already owned by retirement, but the later sibling
+    # stays routable and must be reopened rather than left paused indefinitely.
+    assert registry.default_name == "chat-target"
+    assert "chat-primary" not in {
+        model.model_name for model in registry.list_entries()
+    }
+    assert "chat-remaining" in {
+        model.model_name for model in registry.list_entries()
+    }
+    assert remaining_engine.paused is False
+
+    primary_engine.stop_release.set()
+    await asyncio.wait_for(manager.shutdown(), timeout=1)
+
+
+@pytest.mark.asyncio
 async def test_wait_replacement_retires_drained_engine_with_http_lease_finalizing():
     registry = ModelRegistry()
     old_engine = FakeLifecycleEngine()

--- a/vllm_mlx/runtime/model_registry.py
+++ b/vllm_mlx/runtime/model_registry.py
@@ -105,6 +105,24 @@ class ModelRegistry:
         logger.info(f"Unregistered model '{canonical}'")
         return entry
 
+    def remove_if_entry(self, name: str, expected: ModelEntry) -> ModelEntry | None:
+        """Unregister ``expected`` only while it still owns its canonical slot.
+
+        Replacement publication may reuse an old model name or alias before
+        the old engine finishes retiring. Remove the hidden old canonical
+        entry by identity while preserving routes reassigned to the replacement.
+        """
+        canonical = expected.model_name
+        if canonical != name or self._entries.get(canonical) is not expected:
+            return None
+        entry = self._entries.pop(canonical)
+        for key in [key for key, value in self._index.items() if value == canonical]:
+            self._index.pop(key, None)
+        if self._default == canonical:
+            self._default = next(iter(self._entries), None)
+        logger.info("Unregistered model %r by identity", canonical)
+        return entry
+
     def get_engine(self, model_name: str | None = None) -> object:
         """Get the engine for a model name. Falls back to default.
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -7,7 +7,7 @@ import gc
 import logging
 import re
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Protocol, TypedDict
@@ -705,28 +705,37 @@ class ResidentModelManager:
             except asyncio.CancelledError:
                 pass
 
-        cleanups: list[asyncio.Future] = []
+        cleanups: dict[int, asyncio.Future] = {}
         async with self._lock:
+            existing_retirements = list(self._retiring.values())
             dynamic = [
                 record for record in self._records.values() if not record.primary
             ]
             for record in dynamic:
-                cleanups.append(
-                    self._begin_evict_locked(record, reason="shutdown", count=False)
+                cleanups[id(record.entry.engine)] = self._begin_evict_locked(
+                    record, reason="shutdown", count=False
                 )
             # Join any retirement already in flight (spawned offline by a prior
             # cancelled or replaced operation) so shutdown drains them too.
-            cleanups.extend(
-                self._begin_evict_locked(
+            for retirement in existing_retirements:
+                cleanups[id(retirement.record.entry.engine)] = self._begin_evict_locked(
                     retirement.record,
                     reason="shutdown",
                     count=False,
                 )
-                for retirement in list(self._retiring.values())
-            )
         # Drain every retirement OUTSIDE the lock: a suspended stop must never
         # hold self._lock while unrelated residency operations are waiting.
-        await self._await_cleanups(cleanups)
+        await self._await_cleanups(list(cleanups.values()))
+        failures = self._cleanup_failures(cleanups)
+        if failures:
+            details = "; ".join(
+                f"{model_id}: {message}" for model_id, message, _error in failures
+            )
+            error = ResidentModelError(f"resident model cleanup failed: {details}")
+            first_cause = failures[0][2]
+            if first_cause is not None:
+                raise error from first_cause
+            raise error
 
     async def _ttl_loop(self) -> None:
         interval = min(60.0, max(1.0, self.idle_ttl_seconds / 4.0))
@@ -738,6 +747,7 @@ class ResidentModelManager:
         if self.idle_ttl_seconds <= 0:
             return []
         cleanups: list[asyncio.Future] = []
+        attempted: list[tuple[str, int]] = []
         async with self._lock:
             now = self._clock()
             expired = sorted(
@@ -754,9 +764,15 @@ class ResidentModelManager:
             )
             evicted = []
             for record in expired:
-                evicted.append(record.model_id)
+                attempted.append((record.model_id, id(record.entry.engine)))
                 cleanups.append(self._begin_evict_locked(record, reason="idle_ttl"))
         await self._await_cleanups(cleanups)
+        failed = {
+            identity for _model_id, identity in attempted if identity in self._retiring
+        }
+        evicted.extend(
+            model_id for model_id, identity in attempted if identity not in failed
+        )
         return evicted
 
     async def _evict_for_locked(
@@ -1873,11 +1889,19 @@ class ResidentModelManager:
                 raise ResidentModelError("pinned models cannot be unloaded")
             if record.active_requests or not _engine_is_idle(record.entry.engine):
                 raise ResidentModelBusyError("model is serving an active request")
+            identity = id(record.entry.engine)
             cleanup = self._begin_evict_locked(record, reason="explicit")
         # Await cleanup OUTSIDE the lock: a suspended stop() must not hold the
         # manager lock while unrelated residency operations run. The shield lets
         # a caller cancellation propagate promptly while cleanup continues.
         await self._await_cleanups([cleanup])
+        retirement = self._retiring.get(identity)
+        if retirement is not None and retirement.state == "failed":
+            if retirement.cleanup_error is not None:
+                raise retirement.cleanup_error
+            raise ResidentModelError(
+                retirement.cleanup_failed or "resident model cleanup failed"
+            )
 
     def _begin_evict_locked(
         self,
@@ -2012,6 +2036,24 @@ class ResidentModelManager:
         """Await retirement cleanup completions (call OUTSIDE self._lock)."""
         if cleanups:
             await asyncio.gather(*cleanups)
+
+    def _cleanup_failures(
+        self, identities: Iterable[int]
+    ) -> list[tuple[str, str, BaseException | None]]:
+        """Return truthful failures for attempted engine identities."""
+        failures = []
+        for identity in identities:
+            retirement = self._retiring.get(identity)
+            if retirement is None or retirement.state != "failed":
+                continue
+            failures.append(
+                (
+                    retirement.record.model_id,
+                    retirement.cleanup_failed or "retirement cleanup failed",
+                    retirement.cleanup_error,
+                )
+            )
+        return failures
 
     async def _retire_sequentially(
         self, plan: list[tuple[ResidencyRecord, str]]

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -267,6 +267,40 @@ class ResidencyRecord:
 
 
 @dataclass
+class _Retirement:
+    """Manager-owned record of an engine that stopped being routable but whose
+    stop()/allocator cleanup has not yet completed (or failed truthfully).
+
+    A retirement is keyed by the engine object identity (``id(engine)``), not
+    the model alias, because distinct engines may legitimately share an alias
+    across a replacement. While present in ``ResidentModelManager._retiring``
+    the record stays memory-charged (see ``_accounted_usage``) so nobody claims
+    freed bytes before the cleanup actually finishes.
+    """
+
+    record: ResidencyRecord
+    reason: str
+    count: bool
+    # "retiring" while the offline cleanup task runs, "failed" once stop() has
+    # raised and a truthful cleanup_failed note has been recorded. The record
+    # only leaves _retiring on success or shutdown drain.
+    state: str = "retiring"
+    cleanup_failed: str | None = None
+    # The original stop() exception (retained so an under-lock caller that needs
+    # the failure propagated -- evict-first admission -- can re-raise it) while
+    # keeping the record + bytes charged either way.
+    cleanup_error: BaseException | None = None
+    task: asyncio.Task | None = None
+    shield: asyncio.Future | None = None
+
+
+def _sanitize_error(exc: Exception) -> str:
+    """Bounded, single-line snapshot of an engine cleanup failure."""
+    text = str(exc).strip() or type(exc).__name__
+    return text[:500]
+
+
+@dataclass
 class ResidentRoleReservation:
     """A non-registry role charged to the process residency ceiling.
 
@@ -518,6 +552,7 @@ class _SnapshotModelDict(TypedDict):
     idle_seconds: float
     performance: dict[str, object] | None
     replacement_projection: dict[str, object] | None
+    cleanup_failed: str | None
 
 
 class ResidentModelManager:
@@ -556,6 +591,10 @@ class ResidentModelManager:
         self._records: dict[str, ResidencyRecord] = {}
         self._index: dict[str, str] = {}
         self._roles: dict[str, ResidentRoleReservation] = {}
+        # Engine identity -> in-flight retirement. The engine bytes stay
+        # charged to _accounted_usage() and visible in snapshot() until the
+        # offline cleanup task completes or fails truthfully.
+        self._retiring: dict[int, _Retirement] = {}
         self._lock = asyncio.Lock()
         self._ttl_task: asyncio.Task | None = None
         self.evictions_total = 0
@@ -619,6 +658,12 @@ class ResidentModelManager:
             for record in self._records.values()
             if record.state == "resident"
         )
+        # Retiring engines are no longer routable but their stop() has not
+        # finished (or failed), so their bytes must not be reported free.
+        reserved += sum(
+            max(retirement.record.estimated_bytes, retirement.record.measured_bytes)
+            for retirement in self._retiring.values()
+        )
         reserved += sum(
             record.reserved_bytes
             for record in self._roles.values()
@@ -654,12 +699,25 @@ class ResidentModelManager:
             except asyncio.CancelledError:
                 pass
 
+        cleanups: list[asyncio.Future] = []
         async with self._lock:
             dynamic = [
                 record for record in self._records.values() if not record.primary
             ]
             for record in dynamic:
-                await self._evict_locked(record, reason="shutdown", count=False)
+                cleanups.append(
+                    self._begin_evict_locked(record, reason="shutdown", count=False)
+                )
+            # Join any retirement already in flight (spawned offline by a prior
+            # cancelled or replaced operation) so shutdown drains them too.
+            cleanups.extend(
+                task
+                for task in (retirement.task for retirement in self._retiring.values())
+                if task is not None
+            )
+        # Drain every retirement OUTSIDE the lock: a suspended stop must never
+        # hold self._lock while unrelated residency operations are waiting.
+        await self._await_cleanups(cleanups)
 
     async def _ttl_loop(self) -> None:
         interval = min(60.0, max(1.0, self.idle_ttl_seconds / 4.0))
@@ -670,6 +728,7 @@ class ResidentModelManager:
     async def evict_expired(self) -> list[str]:
         if self.idle_ttl_seconds <= 0:
             return []
+        cleanups: list[asyncio.Future] = []
         async with self._lock:
             now = self._clock()
             expired = sorted(
@@ -687,8 +746,9 @@ class ResidentModelManager:
             evicted = []
             for record in expired:
                 evicted.append(record.model_id)
-                await self._evict_locked(record, reason="idle_ttl")
-            return evicted
+                cleanups.append(self._begin_evict_locked(record, reason="idle_ttl"))
+        await self._await_cleanups(cleanups)
+        return evicted
 
     async def _evict_for_locked(
         self,
@@ -1003,6 +1063,8 @@ class ResidentModelManager:
         if memory_policy not in {"keep_then_commit", "evict_first_if_needed"}:
             raise ResidentModelError(f"unsupported memory policy {memory_policy!r}")
 
+        retirement_plan: list[tuple[ResidencyRecord, str]] = []
+        paused_engines: list[object] = []
         async with self._lock:
             canonical = self._canonical(model_name)
             if canonical is not None:
@@ -1034,9 +1096,10 @@ class ResidentModelManager:
                         )
                         did_reload = True
                         if group is not None:
-                            await self._commit_group_replacement_locked(
+                            reload_plan = await self._commit_group_replacement_locked(
                                 existing_record, group, reload_candidates
                             )
+                            retirement_plan.extend(reload_plan)
                     except BaseException:
                         await self._resume_engines(reload_paused_engines)
                         raise
@@ -1044,190 +1107,212 @@ class ResidentModelManager:
                 if pin:
                     existing_record.pinned = True
                 if group is not None and not did_reload:
-                    await self._replace_group_locked(
-                        existing_record, group, replace_mode
+                    retirement_plan.extend(
+                        await self._replace_group_locked(
+                            existing_record, group, replace_mode
+                        )
                     )
-                return existing_record
-
-            record: ResidencyRecord | None = None
-            candidates: list[ResidencyRecord] = []
-            paused_engines: list[object] = []
-            destructive_handoff: PrimaryHandoffLease | None = None
-            destructive_primary = False
-            destructive_primary_publish_attempted = False
-            destructive_replacement = False
-            projection: ReplacementProjection | None = None
-            try:
-                if replace_group is not None:
-                    if resolved_group is not None and resolved_group != replace_group:
-                        raise ResidentModelError(
-                            f"model {model_name!r} belongs to replacement group "
-                            f"{resolved_group!r}, not {replace_group!r}"
-                        )
-                    if replace_mode == "reject":
-                        # Preserve the established busy-before-capacity
-                        # contract without evicting anything: the zero-timeout
-                        # pause closes admission while the projection is read.
-                        (
-                            candidates,
-                            paused_engines,
-                        ) = await self._quiesce_replacement_group_locked(
-                            replace_group, replace_mode
-                        )
-                    else:
-                        candidates = self._replacement_candidates_locked(
-                            replace_group,
-                            replace_mode=replace_mode,
-                        )
-                    projection = self._replacement_projection_locked(
-                        estimate,
-                        candidates,
-                        (
-                            memory_policy
-                            if resolved_group == replace_group
-                            else "keep_then_commit"
-                        ),
-                    )
-                    if projection.reason == "role_capacity_insufficient_after_eviction":
-                        raise ResidentModelCapacityError(
-                            "resident model memory ceiling exceeded after projected "
-                            "assistant replacement",
-                            replacement_projection=projection,
-                        )
-                    evict_first = projection.strategy == "evict_first"
-                    if evict_first:
-                        if replace_mode != "reject":
+                result = existing_record
+            else:
+                record: ResidencyRecord | None = None
+                candidates: list[ResidencyRecord] = []
+                destructive_handoff: PrimaryHandoffLease | None = None
+                destructive_primary = False
+                destructive_primary_publish_attempted = False
+                destructive_replacement = False
+                projection: ReplacementProjection | None = None
+                try:
+                    if replace_group is not None:
+                        if (
+                            resolved_group is not None
+                            and resolved_group != replace_group
+                        ):
+                            raise ResidentModelError(
+                                f"model {model_name!r} belongs to replacement group "
+                                f"{resolved_group!r}, not {replace_group!r}"
+                            )
+                        if replace_mode == "reject":
+                            # Preserve the established busy-before-capacity
+                            # contract without evicting anything: the zero-timeout
+                            # pause closes admission while the projection is read.
                             (
                                 candidates,
                                 paused_engines,
                             ) = await self._quiesce_replacement_group_locked(
                                 replace_group, replace_mode
                             )
-                        (
-                            destructive_handoff,
-                            destructive_primary,
-                        ) = await self._evict_replacement_before_load_locked(
-                            candidates,
-                            replace_group,
-                        )
-                        destructive_replacement = True
-                        paused_engines = []
-                    elif paused_engines:
-                        await self._resume_engines(paused_engines)
-                        paused_engines = []
-                await self._evict_for_locked(
-                    estimate,
-                    exclude={model_name, *(item.model_id for item in candidates)},
-                )
-                before = self._read_memory()
-                if image_mode is None:
-                    entry = await self.loader(model_name, model_path, performance)
-                else:
-                    entry = await self.loader(
-                        model_name, model_path, performance, image_mode
-                    )
-                now = self._clock()
-                after = self._read_memory()
-                delta = max(0, after - before) if before and after else 0
-                record = ResidencyRecord(
-                    entry=entry,
-                    estimated_bytes=estimate,
-                    measured_bytes=delta,
-                    loaded_at=now,
-                    last_used_at=now,
-                    pinned=pin,
-                    performance=performance,
-                    replacement_projection=projection,
-                )
-                group = _effective_replace_group(record.entry, replace_group)
-                if destructive_replacement:
-                    record.primary = destructive_primary
-                    if destructive_primary:
-                        record.pinned = True
-                elif replace_group is not None:
-                    if replace_mode != "reject":
-                        (
-                            candidates,
-                            paused_engines,
-                        ) = await self._quiesce_replacement_group_locked(
-                            replace_group,
-                            replace_mode,
-                        )
-                    else:
-                        paused_engines = await self._quiesce_records_locked(
-                            candidates,
-                            replace_mode,
-                        )
-                elif group is not None and replace_group is None:
-                    candidates, paused_engines = await self._quiesce_group_locked(
-                        record, group, replace_mode
-                    )
-                # Keep the replacement private until the old inference engines
-                # have reached the policy boundary. Publication only makes the
-                # already-quiesced replacement visible to residency readers.
-                self.registry.add(entry, is_default=record.primary)
-                self._index_record(record)
-                self.loads_total += 1
-                if destructive_primary and self._on_primary_changed is not None:
-                    destructive_primary_publish_attempted = True
-                    self._on_primary_changed(entry)
-                await self._evict_for_locked(
-                    0,
-                    exclude={
-                        record.model_id,
-                        *(item.model_id for item in candidates),
-                    },
-                )
-                if destructive_handoff is not None:
-                    destructive_handoff.commit(entry)
-                    destructive_handoff = None
-                if group is not None and not destructive_replacement:
-                    await self._commit_group_replacement_locked(
-                        record, group, candidates
-                    )
-            except _CommittedReplacementCancelled:
-                # Routing already names the new target. Preserve that truth,
-                # reopen any sibling engines not yet retired, and propagate
-                # cancellation without treating the target as a failed load.
-                await self._resume_engines(paused_engines)
-                raise
-            except BaseException:
-                # Once the loader returns, this manager owns the engine.  A
-                # later admission/replacement failure must not leave a model
-                # resident even though the control-plane request was rejected.
-                try:
-                    if record is not None and record.model_id in self._records:
-                        await self._evict_locked(
-                            record, reason="load_rollback", count=False
-                        )
-                    elif record is not None:
-                        stop = getattr(record.entry.engine, "stop", None)
-                        if callable(stop):
-                            result = stop()
-                            if asyncio.iscoroutine(result):
-                                await result
-                        _release_allocator_cache()
-                finally:
-                    if (
-                        destructive_primary_publish_attempted
-                        and self._on_primary_changed is not None
-                    ):
-                        # Removing the rejected target may auto-promote an
-                        # unrelated secondary. A failed primary publication
-                        # has no valid default until a later load succeeds.
-                        self.registry.clear_default()
-                        try:
-                            self._on_primary_changed(None)
-                        except BaseException:
-                            logger.exception(
-                                "Failed to clear rejected replacement primary"
+                        else:
+                            candidates = self._replacement_candidates_locked(
+                                replace_group,
+                                replace_mode=replace_mode,
                             )
+                        projection = self._replacement_projection_locked(
+                            estimate,
+                            candidates,
+                            (
+                                memory_policy
+                                if resolved_group == replace_group
+                                else "keep_then_commit"
+                            ),
+                        )
+                        if (
+                            projection.reason
+                            == "role_capacity_insufficient_after_eviction"
+                        ):
+                            raise ResidentModelCapacityError(
+                                "resident model memory ceiling exceeded after projected "
+                                "assistant replacement",
+                                replacement_projection=projection,
+                            )
+                        evict_first = projection.strategy == "evict_first"
+                        if evict_first:
+                            if replace_mode != "reject":
+                                (
+                                    candidates,
+                                    paused_engines,
+                                ) = await self._quiesce_replacement_group_locked(
+                                    replace_group, replace_mode
+                                )
+                            (
+                                destructive_handoff,
+                                destructive_primary,
+                            ) = await self._evict_replacement_before_load_locked(
+                                candidates,
+                                replace_group,
+                            )
+                            destructive_replacement = True
+                            paused_engines = []
+                        elif paused_engines:
+                            await self._resume_engines(paused_engines)
+                            paused_engines = []
+                    await self._evict_for_locked(
+                        estimate,
+                        exclude={model_name, *(item.model_id for item in candidates)},
+                    )
+                    before = self._read_memory()
+                    if image_mode is None:
+                        entry = await self.loader(model_name, model_path, performance)
+                    else:
+                        entry = await self.loader(
+                            model_name, model_path, performance, image_mode
+                        )
+                    now = self._clock()
+                    after = self._read_memory()
+                    delta = max(0, after - before) if before and after else 0
+                    record = ResidencyRecord(
+                        entry=entry,
+                        estimated_bytes=estimate,
+                        measured_bytes=delta,
+                        loaded_at=now,
+                        last_used_at=now,
+                        pinned=pin,
+                        performance=performance,
+                        replacement_projection=projection,
+                    )
+                    group = _effective_replace_group(record.entry, replace_group)
+                    if destructive_replacement:
+                        record.primary = destructive_primary
+                        if destructive_primary:
+                            record.pinned = True
+                    elif replace_group is not None:
+                        if replace_mode != "reject":
+                            (
+                                candidates,
+                                paused_engines,
+                            ) = await self._quiesce_replacement_group_locked(
+                                replace_group,
+                                replace_mode,
+                            )
+                        else:
+                            paused_engines = await self._quiesce_records_locked(
+                                candidates,
+                                replace_mode,
+                            )
+                    elif group is not None and replace_group is None:
+                        candidates, paused_engines = await self._quiesce_group_locked(
+                            record, group, replace_mode
+                        )
+                    # Keep the replacement private until the old inference engines
+                    # have reached the policy boundary. Publication only makes the
+                    # already-quiesced replacement visible to residency readers.
+                    self.registry.add(entry, is_default=record.primary)
+                    self._index_record(record)
+                    self.loads_total += 1
+                    if destructive_primary and self._on_primary_changed is not None:
+                        destructive_primary_publish_attempted = True
+                        self._on_primary_changed(entry)
+                    await self._evict_for_locked(
+                        0,
+                        exclude={
+                            record.model_id,
+                            *(item.model_id for item in candidates),
+                        },
+                    )
                     if destructive_handoff is not None:
-                        destructive_handoff.commit(None)
-                    if not destructive_replacement:
-                        await self._resume_engines(paused_engines)
-                raise
-            return record
+                        destructive_handoff.commit(entry)
+                        destructive_handoff = None
+                    if group is not None and not destructive_replacement:
+                        retirement_plan.extend(
+                            await self._commit_group_replacement_locked(
+                                record, group, candidates
+                            )
+                        )
+                except _CommittedReplacementCancelled:
+                    # Routing already names the new target. Preserve that truth,
+                    # reopen any sibling engines not yet retired, and propagate
+                    # cancellation without treating the target as a failed load.
+                    await self._resume_engines(paused_engines)
+                    raise
+                except BaseException:
+                    # Once the loader returns, this manager owns the engine.  A
+                    # later admission/replacement failure must not leave a model
+                    # resident even though the control-plane request was rejected.
+                    try:
+                        if record is not None and record.model_id in self._records:
+                            await self._evict_locked(
+                                record, reason="load_rollback", count=False
+                            )
+                        elif record is not None:
+                            stop = getattr(record.entry.engine, "stop", None)
+                            if callable(stop):
+                                result = stop()
+                                if asyncio.iscoroutine(result):
+                                    await result
+                            _release_allocator_cache()
+                    finally:
+                        if (
+                            destructive_primary_publish_attempted
+                            and self._on_primary_changed is not None
+                        ):
+                            # Removing the rejected target may auto-promote an
+                            # unrelated secondary. A failed primary publication
+                            # has no valid default until a later load succeeds.
+                            self.registry.clear_default()
+                            try:
+                                self._on_primary_changed(None)
+                            except BaseException:
+                                logger.exception(
+                                    "Failed to clear rejected replacement primary"
+                                )
+                        if destructive_handoff is not None:
+                            destructive_handoff.commit(None)
+                        if not destructive_replacement:
+                            await self._resume_engines(paused_engines)
+                    raise
+                result = record
+        # Lock released. Drive post-commit retirement OUTSIDE the lock: each
+        # retirement enqueues under a brief lock scope but awaits its cleanup
+        # outside it, so a suspended stop() cannot block snapshot/lease/other
+        # operations. Caller cancellation is the cancellation-after-commit case
+        # the issue pins down: preserve the committed route, reopen any siblings
+        # not yet retired, and surface _CommittedReplacementCancelled while the
+        # shielded cleanup continues in the background.
+        try:
+            await self._retire_sequentially(retirement_plan)
+        except asyncio.CancelledError as exc:
+            await self._resume_engines(paused_engines)
+            raise _CommittedReplacementCancelled from exc
+        return result
 
     def _replacement_projection_locked(
         self,
@@ -1551,7 +1636,7 @@ class ResidentModelManager:
         target: ResidencyRecord,
         group: str,
         replace_mode: str = "reject",
-    ) -> None:
+    ) -> list[tuple[ResidencyRecord, str]]:
         """Make ``target`` the sole unpinned model in a lifecycle group.
 
         The desktop uses the ``assistant`` group for its chat picker: changing
@@ -1559,13 +1644,18 @@ class ResidentModelManager:
         image engines remain resident. A protected startup assistant hands its
         primary role to the replacement before the old engine is stopped, so
         legacy health/cache routes never retain a reference to unloaded weights.
+
+        Returns the ordered replacement retirement plan (never executed under
+        the lock); the caller drives it outside ``self._lock``.
         """
 
         candidates, paused_engines = await self._quiesce_group_locked(
             target, group, replace_mode
         )
         try:
-            await self._commit_group_replacement_locked(target, group, candidates)
+            return await self._commit_group_replacement_locked(
+                target, group, candidates
+            )
         except BaseException:
             await self._resume_engines(paused_engines)
             raise
@@ -1685,8 +1775,16 @@ class ResidentModelManager:
         target: ResidencyRecord,
         group: str,
         candidates: list[ResidencyRecord],
-    ) -> None:
-        """Apply the existing primary/audio handoff to quiesced engines."""
+    ) -> list[tuple[ResidencyRecord, str]]:
+        """Apply the existing primary/audio handoff to quiesced engines.
+
+        Commits the new route and returns an ORDERED retirement plan (the
+        replaced engines to retire, primary first) WITHOUT enqueuing their
+        cleanup. The caller (`load`) drives :meth:`_retire_sequentially`
+        OUTSIDE ``self._lock`` so a suspended stop never holds the lock and a
+        caller cancellation before a later sibling is retired leaves that
+        sibling routable (it gets reopened rather than resigned to cleanup).
+        """
 
         old_primary = next((record for record in candidates if record.primary), None)
         handoff = None
@@ -1731,46 +1829,19 @@ class ResidentModelManager:
             # so no stop-attempted engine can truthfully be restored as primary.
             if handoff is not None:
                 handoff.commit(target.entry)
+            # Return the ordered retirement plan (primary first). Each is
+            # already quiesced before commit, so stopping one cannot resurrect a
+            # dead route or undo the committed primary handoff. Left unresigned
+            # (unretired) on caller cancellation, so later siblings stay
+            # routable and get reopened by the caller.
+            plan: list[tuple[ResidencyRecord, str]] = []
             if old_primary is not None:
-                try:
-                    await self._evict_locked(
-                        old_primary,
-                        reason=f"replace_{group}",
-                    )
-                except asyncio.CancelledError as exc:
-                    logger.warning(
-                        "Primary retirement cancelled after routing commit: %r",
-                        old_primary.model_id,
-                    )
-                    raise _CommittedReplacementCancelled from exc
-                except Exception:
-                    logger.exception(
-                        "Failed to stop replaced primary %r after routing commit",
-                        old_primary.model_id,
-                    )
-            # Finish retiring secondary candidates as non-failing cleanup: each
-            # is already quiesced and removed from routing before stop(), so a
-            # cleanup failure may leak resources but cannot resurrect a dead
-            # route or undo the committed primary handoff.
+                plan.append((old_primary, f"replace_{group}"))
             for record in candidates:
                 if record is old_primary:
                     continue
-                try:
-                    await self._evict_locked(
-                        record,
-                        reason=f"replace_{group}",
-                    )
-                except asyncio.CancelledError as exc:
-                    logger.warning(
-                        "Replacement cleanup cancelled after routing commit: %r",
-                        record.model_id,
-                    )
-                    raise _CommittedReplacementCancelled from exc
-                except Exception:
-                    logger.exception(
-                        "Failed to stop replaced model %r after routing retirement",
-                        record.model_id,
-                    )
+                plan.append((record, f"replace_{group}"))
+            return plan
 
     async def set_pinned(self, model_name: str, pinned: bool) -> ResidencyRecord:
         async with self._lock:
@@ -1794,7 +1865,47 @@ class ResidentModelManager:
                 raise ResidentModelError("pinned models cannot be unloaded")
             if record.active_requests or not _engine_is_idle(record.entry.engine):
                 raise ResidentModelBusyError("model is serving an active request")
-            await self._evict_locked(record, reason="explicit")
+            cleanup = self._begin_evict_locked(record, reason="explicit")
+        # Await cleanup OUTSIDE the lock: a suspended stop() must not hold the
+        # manager lock while unrelated residency operations run. The shield lets
+        # a caller cancellation propagate promptly while cleanup continues.
+        await self._await_cleanups([cleanup])
+
+    def _begin_evict_locked(
+        self,
+        record: ResidencyRecord,
+        *,
+        reason: str,
+        count: bool = True,
+    ) -> asyncio.Future:
+        """Lock-held retirement phase: unroute + enqueue offline cleanup.
+
+        Returns a shield around the offline cleanup task. Callers MUST await
+        this OUTSIDE ``self._lock`` (see the retirement design contract) so a
+        suspended stop never blocks snapshot/leases/other operations. Repeated
+        retirement of the same engine identity joins the in-flight task instead
+        of calling ``stop()`` twice.
+        """
+        if record.active_requests:
+            raise ResidentModelBusyError("model is serving an active request")
+        identity = id(record.entry.engine)
+        existing = self._retiring.get(identity)
+        if existing is not None and existing.shield is not None:
+            # Idempotent retirement: an overlapping caller wants the same
+            # engine gone. Unroute this (possibly sibling) record's alias, but
+            # join the existing cleanup -- never double-stop the engine.
+            self.registry.remove(record.model_id)
+            self._drop_record(record.model_id)
+            return existing.shield
+        record.state = "retiring"
+        self.registry.remove(record.model_id)
+        self._drop_record(record.model_id)
+        retirement = _Retirement(record=record, reason=reason, count=count)
+        task = asyncio.create_task(self._cleanup_retired(identity, retirement))
+        retirement.task = task
+        retirement.shield = asyncio.shield(task)
+        self._retiring[identity] = retirement
+        return retirement.shield
 
     async def _evict_locked(
         self,
@@ -1803,20 +1914,99 @@ class ResidentModelManager:
         reason: str,
         count: bool = True,
     ) -> None:
-        if record.active_requests:
-            raise ResidentModelBusyError("model is serving an active request")
-        record.state = "evicting"
-        self.registry.remove(record.model_id)
-        self._drop_record(record.model_id)
-        stop = getattr(record.entry.engine, "stop", None)
-        if callable(stop):
-            result = stop()
-            if asyncio.iscoroutine(result):
-                await result
-        _release_allocator_cache()
-        if count:
+        """Retire and await cleanup while the caller continues to hold the lock.
+
+        Used only by capacity-admission / rollback paths that need the freed
+        bytes back before they can proceed (evict-first, load rollback). The
+        replacement-commit, unload, shutdown and TTL paths use
+        :meth:`_begin_evict_locked` and await OUTSIDE the lock instead. Idle
+        engines used here stop immediately (never a suspended BlockingStop, so
+        holding the lock here does not stall unrelated residency work).
+
+        Unlike :meth:`_retire_sequentially` (which treats a cleanup failure as a
+        non-fatal recorded ``cleanup_failed``), an evict-first admission cannot
+        safely proceed when the old engine did not actually free its memory, so
+        a failed cleanup is re-raised here -- while the failed-retirement record
+        and its byte charge are retained (never claimed free).
+        """
+        shield = self._begin_evict_locked(record, reason=reason, count=count)
+        identity = id(record.entry.engine)
+        await shield
+        retirement = self._retiring.get(identity)
+        if retirement is not None and retirement.cleanup_error is not None:
+            raise retirement.cleanup_error
+
+    async def _cleanup_retired(self, identity: int, retirement: _Retirement) -> None:
+        """Offline (lock-free) cleanup owning stop() + allocator cache release.
+
+        Never runs under ``self._lock``: it owns the engine's stop() and cache
+        release, then removes the retirement record atomically on success, or
+        records a truthful ``cleanup_failed`` state (bytes stay charged).
+        """
+        engine = retirement.record.entry.engine
+        try:
+            stop = getattr(engine, "stop", None)
+            if callable(stop):
+                result = stop()
+                if asyncio.iscoroutine(result):
+                    await result
+            _release_allocator_cache()
+        except asyncio.CancelledError:
+            # The offline task itself was cancelled (extreme: someone awaited
+            # the raw task). Leave it tracked + charged so a later shutdown
+            # re-joins it rather than leaking the engine silently.
+            retirement.state = "failed"
+            retirement.cleanup_failed = "retirement cleanup cancelled before completion"
+            return
+        except Exception as exc:
+            retirement.state = "failed"
+            retirement.cleanup_failed = _sanitize_error(exc)
+            retirement.cleanup_error = exc
+            logger.warning(
+                "Failed to clean up resident model %r (%s): %s",
+                retirement.record.model_id,
+                retirement.reason,
+                retirement.cleanup_failed,
+            )
+            return
+        if retirement.count:
             self.evictions_total += 1
-        logger.info("Evicted resident model %r (%s)", record.model_id, reason)
+        self._finish_retirement(identity, retirement)
+
+    def _finish_retirement(self, identity: int, retirement: _Retirement) -> None:
+        """Atomically drop a completed retirement; no await so event-loop-safe."""
+        current = self._retiring.get(identity)
+        if current is retirement:
+            del self._retiring[identity]
+        logger.info(
+            "Evicted resident model %r (%s)",
+            retirement.record.model_id,
+            retirement.reason,
+        )
+
+    async def _await_cleanups(
+        self, cleanups: list[asyncio.Future | asyncio.Task]
+    ) -> None:
+        """Await retirement cleanup completions (call OUTSIDE self._lock)."""
+        if cleanups:
+            await asyncio.gather(*cleanups)
+
+    async def _retire_sequentially(
+        self, plan: list[tuple[ResidencyRecord, str]]
+    ) -> None:
+        """Drive an ordered retirement plan outside ``self._lock``.
+
+        Each record is enqueued under a short lock scope (unrouted + moved to
+        the retirement ledger) and its cleanup is awaited OUTSIDE the lock, so a
+        suspended ``stop()`` never holds the lock. If the caller is cancelled
+        between records, the loop stops and any not-yet-retired record stays
+        routable (its caller reopens it), while the already-enqueued cleanup
+        continues shielded in the background.
+        """
+        for record, reason in plan:
+            async with self._lock:
+                shield = self._begin_evict_locked(record, reason=reason)
+            await shield
 
     @asynccontextmanager
     async def lease(self, model_name: str):
@@ -1847,7 +2037,10 @@ class ResidentModelManager:
     def snapshot(self) -> dict:
         now = self._clock()
         models: list[_SnapshotModelDict] = []
-        for record in sorted(self._records.values(), key=lambda item: item.loaded_at):
+
+        def push_model(
+            record: ResidencyRecord, retirement: _Retirement | None = None
+        ) -> None:
             engine = record.entry.engine
             resident = not hasattr(engine, "is_resident") or bool(engine.is_resident)
             engine_active = _engine_active_requests(engine)
@@ -1865,37 +2058,52 @@ class ResidentModelManager:
                     int(lifecycle.get("running_requests", 0) or 0),
                     int(lifecycle.get("queued_requests", 0) or 0),
                 )
-            models.append(
-                {
-                    "id": record.model_id,
-                    "model_path": record.entry.model_path,
-                    "aliases": sorted(record.entry.aliases),
-                    "modality": (_modality(record.entry)),
-                    "role": _replacement_group(record.entry),
-                    "serving_lane": getattr(engine, "serving_lane", None),
-                    "serving_lane_reason": getattr(engine, "serving_lane_reason", None),
-                    "state": record.state if resident else "registered",
-                    "pinned": record.pinned,
-                    "primary": record.primary,
-                    # A manager lease and a scheduler request describe
-                    # overlapping lifetimes for dynamic engines, so use the
-                    # larger count rather than double-counting. Primary traffic
-                    # has no manager lease and is supplied by the scheduler.
-                    "active_requests": active_requests,
-                    "lifecycle": lifecycle,
-                    "estimated_bytes": record.estimated_bytes,
-                    "measured_bytes": record.measured_bytes or None,
-                    "idle_seconds": max(0.0, now - record.last_used_at),
-                    "performance": (
-                        record.performance.payload() if record.performance else None
-                    ),
-                    "replacement_projection": (
-                        record.replacement_projection.payload()
-                        if record.replacement_projection
-                        else None
-                    ),
-                }
-            )
+            state = record.state if resident else "registered"
+            if retirement is not None:
+                # A retiring engine is no longer routable but its bytes are
+                # still held until cleanup finishes or fails truthfully. Surface
+                # the actual cleanup state so nobody mistakes it for resident.
+                state = retirement.state
+            row: _SnapshotModelDict = {
+                "id": record.model_id,
+                "model_path": record.entry.model_path,
+                "aliases": sorted(record.entry.aliases),
+                "modality": (_modality(record.entry)),
+                "role": _replacement_group(record.entry),
+                "serving_lane": getattr(engine, "serving_lane", None),
+                "serving_lane_reason": getattr(engine, "serving_lane_reason", None),
+                "state": state,
+                "pinned": record.pinned,
+                "primary": record.primary,
+                # A manager lease and a scheduler request describe
+                # overlapping lifetimes for dynamic engines, so use the
+                # larger count rather than double-counting. Primary traffic
+                # has no manager lease and is supplied by the scheduler.
+                "active_requests": active_requests,
+                "lifecycle": lifecycle,
+                "estimated_bytes": record.estimated_bytes,
+                "measured_bytes": record.measured_bytes or None,
+                "idle_seconds": max(0.0, now - record.last_used_at),
+                "performance": (
+                    record.performance.payload() if record.performance else None
+                ),
+                "replacement_projection": (
+                    record.replacement_projection.payload()
+                    if record.replacement_projection
+                    else None
+                ),
+                "cleanup_failed": (
+                    retirement.cleanup_failed if retirement is not None else None
+                ),
+            }
+            models.append(row)
+
+        for record in sorted(self._records.values(), key=lambda item: item.loaded_at):
+            push_model(record)
+        for retirement in sorted(
+            self._retiring.values(), key=lambda item: item.record.loaded_at
+        ):
+            push_model(retirement.record, retirement)
         roles = [
             {
                 "role": model["role"],

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -765,7 +765,7 @@ class ResidentModelManager:
                 ),
                 key=lambda record: record.last_used_at,
             )
-            evicted = []
+            evicted: list[str] = []
             for record in expired:
                 attempted.append((record.model_id, id(record.entry.engine)))
                 cleanups.append(self._begin_evict_locked(record, reason="idle_ttl"))

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -2019,10 +2019,7 @@ class ResidentModelManager:
                 # back to load().
                 first_unretired = index + 1 if retirement_started else index
                 await self._resume_engines(
-                    [
-                        pending.entry.engine
-                        for pending, _ in plan[first_unretired:]
-                    ]
+                    [pending.entry.engine for pending, _ in plan[first_unretired:]]
                 )
                 raise
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -717,9 +717,12 @@ class ResidentModelManager:
             # Join any retirement already in flight (spawned offline by a prior
             # cancelled or replaced operation) so shutdown drains them too.
             cleanups.extend(
-                asyncio.shield(task)
-                for task in (retirement.task for retirement in self._retiring.values())
-                if task is not None
+                self._begin_evict_locked(
+                    retirement.record,
+                    reason="shutdown",
+                    count=False,
+                )
+                for retirement in list(self._retiring.values())
             )
         # Drain every retirement OUTSIDE the lock: a suspended stop must never
         # hold self._lock while unrelated residency operations are waiting.
@@ -1895,12 +1898,27 @@ class ResidentModelManager:
             raise ResidentModelBusyError("model is serving an active request")
         identity = id(record.entry.engine)
         existing = self._retiring.get(identity)
-        if existing is not None and existing.task is not None:
+        if existing is not None:
             # Idempotent retirement: an overlapping caller wants the same
             # engine gone. Unroute this (possibly sibling) record's alias, but
             # join the existing cleanup -- never double-stop the engine.
             self.registry.remove_if_entry(record.model_id, record.entry)
             self._drop_record_if_same(record)
+            if (
+                existing.state == "failed"
+                and existing.task is not None
+                and existing.task.done()
+            ):
+                # A completed failed attempt owns no running cleanup. Explicit
+                # retry/shutdown may safely start one new attempt while keeping
+                # the same retirement record and byte charge authoritative.
+                existing.state = "retiring"
+                existing.cleanup_failed = None
+                existing.cleanup_error = None
+                existing.task = asyncio.create_task(
+                    self._cleanup_retired(identity, existing)
+                )
+            assert existing.task is not None
             return asyncio.shield(existing.task)
         record.state = "retiring"
         self.registry.remove_if_entry(record.model_id, record.entry)

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -1310,7 +1310,6 @@ class ResidentModelManager:
         try:
             await self._retire_sequentially(retirement_plan)
         except asyncio.CancelledError as exc:
-            await self._resume_engines(paused_engines)
             raise _CommittedReplacementCancelled from exc
         return result
 
@@ -2003,10 +2002,29 @@ class ResidentModelManager:
         routable (its caller reopens it), while the already-enqueued cleanup
         continues shielded in the background.
         """
-        for record, reason in plan:
-            async with self._lock:
-                shield = self._begin_evict_locked(record, reason=reason)
-            await shield
+        for index, (record, reason) in enumerate(plan):
+            retirement_started = False
+            try:
+                async with self._lock:
+                    shield = self._begin_evict_locked(record, reason=reason)
+                    retirement_started = True
+                await shield
+            except asyncio.CancelledError:
+                # The current record belongs to the shielded cleanup once
+                # _begin_evict_locked succeeds; reopening it would race stop().
+                # Records not reached yet are still routable but remain paused
+                # from the group quiesce, so reopen exactly that suffix. Keeping
+                # this ownership here also covers existing-target and reload
+                # branches, which do not expose their local paused-engine list
+                # back to load().
+                first_unretired = index + 1 if retirement_started else index
+                await self._resume_engines(
+                    [
+                        pending.entry.engine
+                        for pending, _ in plan[first_unretired:]
+                    ]
+                )
+                raise
 
     @asynccontextmanager
     async def lease(self, model_name: str):

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -295,7 +295,10 @@ class _Retirement:
 
 def _sanitize_error(exc: Exception) -> str:
     """Bounded, single-line snapshot of an engine cleanup failure."""
-    text = str(exc).strip() or type(exc).__name__
+    printable = "".join(
+        character if character.isprintable() else " " for character in str(exc)
+    )
+    text = " ".join(printable.split()) or type(exc).__name__
     return text[:500]
 
 
@@ -1794,6 +1797,18 @@ class ResidentModelManager:
                         "Failed to resume a model engine after replacement rollback"
                     )
 
+    async def _resume_engines_before_cancelling(self, engines: list[object]) -> None:
+        """Finish rollback recovery even if the caller is cancelled repeatedly."""
+        recovery = asyncio.create_task(self._resume_engines(engines))
+        while not recovery.done():
+            try:
+                await asyncio.shield(recovery)
+            except asyncio.CancelledError:
+                # Preserve cancellation at the outer call site, but do not let
+                # repeated cancellation strand an unretired sibling paused.
+                continue
+        recovery.result()
+
     async def _commit_group_replacement_locked(
         self,
         target: ResidencyRecord,
@@ -2083,7 +2098,7 @@ class ResidentModelManager:
                 # branches, which do not expose their local paused-engine list
                 # back to load().
                 first_unretired = index + 1 if retirement_started else index
-                await self._resume_engines(
+                await self._resume_engines_before_cancelling(
                     [pending.entry.engine for pending, _ in plan[first_unretired:]]
                 )
                 raise

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -291,7 +291,6 @@ class _Retirement:
     # keeping the record + bytes charged either way.
     cleanup_error: BaseException | None = None
     task: asyncio.Task | None = None
-    shield: asyncio.Future | None = None
 
 
 def _sanitize_error(exc: Exception) -> str:
@@ -622,6 +621,13 @@ class ResidentModelManager:
             self._index.pop(key, None)
         return record
 
+    def _drop_record_if_same(self, record: ResidencyRecord) -> bool:
+        """Drop manager routing only while ``record`` still owns its key."""
+        if self._records.get(record.model_id) is not record:
+            return False
+        self._drop_record(record.model_id)
+        return True
+
     def register_primary(
         self, entry: ModelEntry, *, estimated_bytes: int | None = None
     ) -> ResidencyRecord:
@@ -711,7 +717,7 @@ class ResidentModelManager:
             # Join any retirement already in flight (spawned offline by a prior
             # cancelled or replaced operation) so shutdown drains them too.
             cleanups.extend(
-                task
+                asyncio.shield(task)
                 for task in (retirement.task for retirement in self._retiring.values())
                 if task is not None
             )
@@ -1889,22 +1895,21 @@ class ResidentModelManager:
             raise ResidentModelBusyError("model is serving an active request")
         identity = id(record.entry.engine)
         existing = self._retiring.get(identity)
-        if existing is not None and existing.shield is not None:
+        if existing is not None and existing.task is not None:
             # Idempotent retirement: an overlapping caller wants the same
             # engine gone. Unroute this (possibly sibling) record's alias, but
             # join the existing cleanup -- never double-stop the engine.
-            self.registry.remove(record.model_id)
-            self._drop_record(record.model_id)
-            return existing.shield
+            self.registry.remove_if_entry(record.model_id, record.entry)
+            self._drop_record_if_same(record)
+            return asyncio.shield(existing.task)
         record.state = "retiring"
-        self.registry.remove(record.model_id)
-        self._drop_record(record.model_id)
+        self.registry.remove_if_entry(record.model_id, record.entry)
+        self._drop_record_if_same(record)
         retirement = _Retirement(record=record, reason=reason, count=count)
         task = asyncio.create_task(self._cleanup_retired(identity, retirement))
         retirement.task = task
-        retirement.shield = asyncio.shield(task)
         self._retiring[identity] = retirement
-        return retirement.shield
+        return asyncio.shield(task)
 
     async def _evict_locked(
         self,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -1285,12 +1285,6 @@ class ResidentModelManager:
                                 record, group, candidates
                             )
                         )
-                except _CommittedReplacementCancelled:
-                    # Routing already names the new target. Preserve that truth,
-                    # reopen any sibling engines not yet retired, and propagate
-                    # cancellation without treating the target as a failed load.
-                    await self._resume_engines(paused_engines)
-                    raise
                 except BaseException:
                     # Once the loader returns, this manager owns the engine.  A
                     # later admission/replacement failure must not leave a model


### PR DESCRIPTION
## Why

A cancellation after replacement routing commits can leave the retired engine partially alive but absent from routing and memory accounting. Repeated switches can therefore retain MLX resources until process exit and create unexpected memory pressure.

Fixes #2383

## Scope

- Introduce a manager-owned retirement ledger keyed by engine identity.
- Keep retiring or cleanup-failed engines charged and visible until cleanup succeeds.
- Move post-commit stop work outside the residency lock while shielding it from repeated caller cancellation.
- Make explicit unload, TTL reporting, and shutdown surface cleanup truthfully.
- Drain in-flight retirements during shutdown and permit a failed cleanup to be retried.
- Add deterministic primary and secondary cancellation, cleanup-failure, accounting, and lock-progress tests.

## Non-goals

No capacity-policy, scheduler, cache, Desktop, model-heuristic, or release-plumbing changes.

## Acceptance

- The committed replacement remains authoritative when its caller is cancelled.
- Cancellation reaches the caller promptly while old-engine cleanup continues; repeated cancellation cannot strand an unretired sibling paused.
- Memory accounting does not claim retired engine bytes free before cleanup completes.
- Cleanup does not hold the residency lock.
- Explicit unload raises a stop failure, TTL lists only successful evictions, and shutdown drains all attempts before reporting aggregated failures.
- Primary and secondary retirement paths are covered deterministically across Python 3.10+.

## Design precedent

The implementation follows the established owner-task pattern for cancellation-safe asynchronous work: the control plane retains a strong reference to each background task, callers await a shielded view, cleanup completion removes the owned record, and shutdown joins remaining tasks. The routing identity and resource-accounting state remain separate so publication can commit without falsely declaring resources released.

## Verification

- `python3.12 -m pytest tests/test_resident_models.py tests/test_model_registry.py -q` — 117 passed.
- Hosted timing regressions repeated 10/10 locally after isolating allocator latency.
- `pr_validate` non-review gates: 21,674 passed, 108 skipped, 6 xfailed; Qwen3.5, Qwen3.6, and Harmony model lanes passed.
- DiffusionGemma smoke failure reproduced identically on clean current main `7f34f5d2c`; tracked separately in #3038.
- Ruff, format, exact diff check, and exact-head type-check pass.
- Codex review reached the 10-round repository cap. All round-10 findings are fixed and dispositioned in the PR thread; no round 11 requested. Human-owner post-cap disposition is pending.

## Behaviour delta

Before: caller cancellation after route commit could orphan a partially alive engine outside residency accounting, and some cleanup callers could report success despite retained resources.

After: route commit remains authoritative, retirement continues under manager ownership, resources remain charged until truthful completion, and cleanup failures are reported by the initiating control-plane operation.

## AI assistance disclosure

Claude implemented the initial production and test changes. Harbor reviewed and corrected the diff against the issue contract and reference patterns, ran focused/full/model validation, and dispositioned all independent review and CI findings before queue entry.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For AI-assisted sections, I have identified them above and can describe how I verified them.

## Checklist

- [x] Focused tests pass locally
- [x] Lint passes
- [x] New critical-path tests cover the changed retirement contract
- [x] No docs update required
- [x] No breaking API changes
