### PR TITLE
feat(residency): add closed role and typed capacity envelope

### DIFF
--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -4370,6 +4370,9 @@ def test_role_enum_accepts_canonical_underscore_aliases():
     ):
         assert ResidentRole.coerce(role).value == wire
 
+    with pytest.raises(ResidentModelError, match="invalid role"):
+        ResidentRole.coerce(7)  # type: ignore[arg-type]
+
 
 @pytest.mark.asyncio
 async def test_role_aliases_share_one_canonical_ledger_key():

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -4451,6 +4451,41 @@ async def test_capacity_507_envelope_carries_full_role_contract():
 
 
 @pytest.mark.asyncio
+async def test_capacity_507_envelope_includes_registered_assistant_role():
+    registry = ModelRegistry()
+    assistant = entry("assistant-model")
+    registry.add(assistant, is_default=True)
+    manager = ResidentModelManager(
+        registry,
+        lambda name, path=None, perf=None: entry(name),
+        memory_limit_bytes=1 * GIB,
+        memory_reader=lambda: 0,
+    )
+    manager.register_primary(assistant, estimated_bytes=int(0.8 * GIB))
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=int(0.3 * GIB),
+            capacity_source="catalog",
+        ):
+            pass
+
+    envelope = exc_info.value.envelope()["error"]
+    assert envelope["used_bytes"] == int(0.8 * GIB)
+    assert envelope["resident_roles"] == [
+        {
+            "role": "assistant",
+            "model_id": "assistant-model",
+            "reserved_bytes": int(0.8 * GIB),
+            "state": "resident",
+        }
+    ]
+    assert envelope["recovery_actions"] == ["unload_assistant"]
+
+
+@pytest.mark.asyncio
 async def test_alignment_replace_conflict_reports_recovery_actions():
     # The capacity rejection for the alignment role must pair its
     # requested_role with the role-appropriate recovery actions.

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -16,6 +16,7 @@ from vllm_mlx.runtime.resident_models import (
     ResidentModelError,
     ResidentModelManager,
     ResidentPerformanceConfig,
+    ResidentRole,
     resident_scheduler_kwargs,
 )
 
@@ -4099,9 +4100,9 @@ async def test_alignment_role_exclusive_sibling_capacity_is_retained_during_load
     aligner = int(0.3 * GIB)
     concurrent = int(0.5 * GIB)
 
-    # Pre-existing roles: speech-input (0.4) + a tts-role sibling (0.2) = 0.6.
+    # Pre-existing roles: speech-input (0.4) + a speech-output sibling (0.2) = 0.6.
     async with manager.admit_role(
-        role="tts",
+        role="speech-output",
         model_id="some-tts",
         requested_bytes=other,
         capacity_source="catalog",
@@ -4128,21 +4129,22 @@ async def test_alignment_role_exclusive_sibling_capacity_is_retained_during_load
             release_exclusive_role="speech-input",
         ):
             async with manager.admit_role(
-                role="tts-extra",
-                model_id="other-tts",
+                role="image-generation",
+                model_id="other-gen",
                 requested_bytes=concurrent,
                 capacity_source="catalog",
             ):
                 pass
             raise RuntimeError("load failed")
 
-    # The concurrent tts-extra admission was REJECTED (sibling capacity
+    # The concurrent image-generation admission was REJECTED (sibling capacity
     # retained), so on rollback the ledger is exactly as before the aligner:
-    # speech-input restored (its engine is still resident) + tts, alignment gone.
+    # speech-input restored (its engine is still resident) + speech-output,
+    # alignment gone.
     roles = {r["role"] for r in manager.snapshot()["roles"]}
     assert "alignment" not in roles
-    assert "tts" in roles
-    assert "tts-extra" not in roles
+    assert "speech-output" in roles
+    assert "image-generation" not in roles
     assert "speech-input" in roles  # retained + credited, its engine accounted
     assert manager._accounted_usage() == other + speech
 
@@ -4304,3 +4306,231 @@ async def test_alignment_role_rollback_preserves_concurrently_replaced_sibling()
     (speech,) = [r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"]
     assert speech["reserved_bytes"] == s2
     assert "alignment" not in {r["role"] for r in manager.snapshot()["roles"]}
+
+
+# ---------------------------------------------------------------------------
+# Engine-layer contract for #2305: closed role enum + typed capacity envelope.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_closed_role_enum_rejects_unknown_and_admits_all_six():
+    # The six roles the shared residency lifecycle owns are all admissible.
+    manager, _ = role_manager_fixture(limit_gib=16.0)
+    for role in (
+        "assistant",
+        "speech-input",
+        "speech-output",
+        "alignment",
+        "image-generation",
+        "video-generation",
+    ):
+        async with manager.admit_role(
+            role=role,
+            model_id=f"model-{role}",
+            requested_bytes=int(0.1 * GIB),
+            capacity_source="catalog",
+        ):
+            pass
+    resident = {r["role"] for r in manager.snapshot()["roles"]}
+    assert resident == {
+        "assistant",
+        "speech-input",
+        "speech-output",
+        "alignment",
+        "image-generation",
+        "video-generation",
+    }
+
+    # An arbitrary/unknown role string must be rejected at the ledger gate with
+    # a clear error — never silently admitted into the closed set.
+    with pytest.raises(ResidentModelError, match="unknown resident role"):
+        async with manager.admit_role(
+            role="tts-extra",
+            model_id="whatever",
+            requested_bytes=int(0.1 * GIB),
+            capacity_source="catalog",
+        ):
+            pass
+
+    # release_role is gated by the same closed set.
+    with pytest.raises(ResidentModelError, match="unknown resident role"):
+        await manager.release_role("no-such-role")
+
+
+def test_role_enum_accepts_canonical_underscore_aliases():
+    # Callers may use the snake_case canonical names (speech_input,
+    # speech_output, image_generation, video_generation) and the closed enum
+    # coerces them to the authoritative dash-form wire values.
+    for role, wire in (
+        ("speech_input", "speech-input"),
+        ("speech_output", "speech-output"),
+        ("image_generation", "image-generation"),
+        ("video_generation", "video-generation"),
+    ):
+        assert ResidentRole.coerce(role).value == wire
+
+
+@pytest.mark.asyncio
+async def test_capacity_507_envelope_carries_full_role_contract():
+    # A capacity rejection must surface the stable machine fields #2306 will
+    # parse: requested_role, the live resident_roles ledger, recovery_actions,
+    # and the requested/used/limit bytes.
+    manager, _ = role_manager_fixture(limit_gib=1.0)
+    small = int(0.2 * GIB)
+
+    # Seed a resident speech-output role so the ledger is non-empty.
+    async with manager.admit_role(
+        role="speech-output",
+        model_id="some-tts",
+        requested_bytes=small,
+        capacity_source="catalog",
+    ):
+        pass
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+        ):
+            pass
+
+    exc = exc_info.value
+    assert exc.requested_role == "alignment"
+    envelope = exc.envelope()["error"]
+    assert envelope["type"] == "insufficient_capacity_error"
+    assert envelope["requested_role"] == "alignment"
+    assert envelope["requested_bytes"] == _aligner_bytes()
+    assert envelope["limit_bytes"] == int(1.0 * GIB)
+    assert envelope["used_bytes"] > 0
+    # The live ledger is reflected in the envelope (speech-output resident).
+    resident = envelope["resident_roles"]
+    assert resident == [
+        {
+            "role": "speech-output",
+            "model_id": "some-tts",
+            "reserved_bytes": small,
+            "state": "resident",
+        }
+    ]
+    # Alignment's server-declared recovery actions.
+    assert envelope["recovery_actions"] == ["unload_assistant"]
+
+
+@pytest.mark.asyncio
+async def test_alignment_replace_conflict_reports_recovery_actions():
+    # The capacity rejection for the alignment role must pair its
+    # requested_role with the role-appropriate recovery actions.
+    manager, _ = role_manager_fixture(limit_gib=0.5)
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=_aligner_bytes(),
+            capacity_source="catalog",
+        ):
+            pass
+
+    envelope = exc_info.value.envelope()["error"]
+    assert envelope["requested_role"] == "alignment"
+    assert envelope["recovery_actions"] == ["unload_assistant"]
+
+
+@pytest.mark.asyncio
+async def test_recovery_actions_are_role_appropriate():
+    # recovery_actions is data-driven per role: speech-input gets the three
+    # actions; speech-output only stop_speech_output; assistant none.
+    async def envelope_for_role(role):
+        manager, _ = role_manager_fixture(limit_gib=0.1)
+        with pytest.raises(ResidentModelCapacityError) as exc_info:
+            async with manager.admit_role(
+                role=role,
+                model_id=f"model-{role}",
+                requested_bytes=int(1.0 * GIB),  # far over the tiny ceiling
+                capacity_source="catalog",
+            ):
+                pass
+        return exc_info.value.envelope()["error"]
+
+    assert (await envelope_for_role("speech-input"))["recovery_actions"] == [
+        "select_smaller_speech_input",
+        "stop_speech_output",
+        "unload_assistant",
+    ]
+    assert (await envelope_for_role("speech-output"))["recovery_actions"] == [
+        "stop_speech_output"
+    ]
+    assert (await envelope_for_role("alignment"))["recovery_actions"] == [
+        "unload_assistant"
+    ]
+    # Assistant has no server-declared recovery actions.
+    assert (await envelope_for_role("assistant"))["recovery_actions"] == []
+
+
+@pytest.mark.asyncio
+async def test_role_telemetry_consistent_across_success_rollback_cancel():
+    # The role ledger stays consistent across the full lifecycle: an admitted
+    # role commits resident; a failed load rolls back to empty; a cancellation
+    # also leaves no leaked reservation (all deterministic — no real sleeps).
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    # Success: commits to resident.
+    async with manager.admit_role(
+        role="speech-input",
+        model_id="whisper",
+        requested_bytes=int(0.3 * GIB),
+        capacity_source="catalog",
+    ):
+        pass
+    (entry,) = [
+        r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"
+    ]
+    assert entry["state"] == "resident"
+    assert entry["reserved_bytes"] == int(0.3 * GIB)
+
+    # Rollback on failure: the new role is not left in the ledger.
+    with pytest.raises(RuntimeError, match="boom"):
+        async with manager.admit_role(
+            role="speech-output",
+            model_id="tts",
+            requested_bytes=int(0.3 * GIB),
+            capacity_source="catalog",
+        ):
+            raise RuntimeError("boom")
+    assert "speech-output" not in {r["role"] for r in manager.snapshot()["roles"]}
+
+    # Cancellation: no leaked reservation.
+    with pytest.raises(asyncio.CancelledError):
+        async with manager.admit_role(
+            role="speech-output",
+            model_id="tts",
+            requested_bytes=int(0.3 * GIB),
+            capacity_source="catalog",
+        ):
+            raise asyncio.CancelledError()
+    assert "speech-output" not in {r["role"] for r in manager.snapshot()["roles"]}
+
+    # release_role drops a committed reservation so the snapshot is consistent.
+    await manager.release_role("speech-input")
+    assert "speech-input" not in {r["role"] for r in manager.snapshot()["roles"]}
+
+
+@pytest.mark.asyncio
+async def test_release_role_unknown_rejected_after_valid_release_works():
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+    async with manager.admit_role(
+        role="speech-output",
+        model_id="tts",
+        requested_bytes=int(0.3 * GIB),
+        capacity_source="catalog",
+    ):
+        pass
+    # Valid release succeeds.
+    await manager.release_role("speech-output")
+    assert "speech-output" not in {r["role"] for r in manager.snapshot()["roles"]}
+    # Unknown release is gated by the closed enum.
+    with pytest.raises(ResidentModelError, match="unknown resident role"):
+        await manager.release_role("speech-output-extra")

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -4549,6 +4549,53 @@ async def test_capacity_507_envelope_includes_charged_retirement(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("resident_role", "requested_role", "admission_options"),
+    [
+        ("speech-output", "speech-output", {"replace_existing": True}),
+        (
+            "speech-input",
+            "alignment",
+            {"release_exclusive_role": "speech-input"},
+        ),
+    ],
+)
+async def test_capacity_507_used_bytes_remain_actual_when_role_is_credited(
+    resident_role, requested_role, admission_options
+):
+    manager, _ = role_manager_fixture(limit_gib=1.0)
+    resident_bytes = int(0.8 * GIB)
+    async with manager.admit_role(
+        role=resident_role,
+        model_id="resident-model",
+        requested_bytes=resident_bytes,
+        capacity_source="catalog",
+    ):
+        pass
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        async with manager.admit_role(
+            role=requested_role,
+            model_id="oversized-replacement",
+            requested_bytes=int(1.1 * GIB),
+            capacity_source="catalog",
+            **admission_options,
+        ):
+            pass
+
+    envelope = exc_info.value.envelope()["error"]
+    assert envelope["used_bytes"] == resident_bytes
+    assert envelope["resident_roles"] == [
+        {
+            "role": resident_role,
+            "model_id": "resident-model",
+            "reserved_bytes": resident_bytes,
+            "state": "resident",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_alignment_replace_conflict_reports_recovery_actions():
     # The capacity rejection for the alignment role must pair its
     # requested_role with the role-appropriate recovery actions.

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -4372,6 +4372,37 @@ def test_role_enum_accepts_canonical_underscore_aliases():
 
 
 @pytest.mark.asyncio
+async def test_role_aliases_share_one_canonical_ledger_key():
+    manager, _ = role_manager_fixture(limit_gib=4.0)
+
+    async with manager.admit_role(
+        role="speech_input",
+        model_id="asr",
+        requested_bytes=int(0.3 * GIB),
+        capacity_source="catalog",
+    ):
+        pass
+
+    roles = manager.snapshot()["roles"]
+    assert [row["role"] for row in roles] == ["speech-input"]
+
+    # The dash and underscore spellings are one logical role, not two ledger
+    # slots that could be admitted and charged independently.
+    with pytest.raises(ResidentModelError, match="already resident"):
+        async with manager.admit_role(
+            role="speech-input",
+            model_id="other-asr",
+            requested_bytes=int(0.3 * GIB),
+            capacity_source="catalog",
+        ):
+            pass
+
+    # Release accepts either spelling and removes the canonical reservation.
+    await manager.release_role("speech_input")
+    assert manager.snapshot()["roles"] == []
+
+
+@pytest.mark.asyncio
 async def test_capacity_507_envelope_carries_full_role_contract():
     # A capacity rejection must surface the stable machine fields #2306 will
     # parse: requested_role, the live resident_roles ledger, recovery_actions,

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -4516,9 +4516,7 @@ async def test_role_telemetry_consistent_across_success_rollback_cancel():
         capacity_source="catalog",
     ):
         pass
-    (entry,) = [
-        r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"
-    ]
+    (entry,) = [r for r in manager.snapshot()["roles"] if r["role"] == "speech-input"]
     assert entry["state"] == "resident"
     assert entry["reserved_bytes"] == int(0.3 * GIB)
 

--- a/tests/test_resident_models.py
+++ b/tests/test_resident_models.py
@@ -4489,6 +4489,66 @@ async def test_capacity_507_envelope_includes_registered_assistant_role():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cleanup_state", ["retiring", "failed"])
+async def test_capacity_507_envelope_includes_charged_retirement(
+    cleanup_state, monkeypatch
+):
+    monkeypatch.setattr(
+        "vllm_mlx.runtime.resident_models._release_allocator_cache", lambda: None
+    )
+    registry = ModelRegistry()
+    engine = BlockingStopLifecycleEngine()
+    assistant = entry("retiring-assistant", engine)
+    registry.add(assistant)
+    manager = ResidentModelManager(
+        registry,
+        AsyncMock(),
+        memory_limit_bytes=1 * GIB,
+        memory_reader=lambda: 0,
+    )
+    record = ResidencyRecord(
+        entry=assistant,
+        estimated_bytes=int(0.8 * GIB),
+        loaded_at=0,
+        last_used_at=0,
+    )
+    manager._index_record(record)
+
+    async with manager._lock:
+        cleanup = manager._begin_evict_locked(record, reason="explicit")
+    await engine.stop_started.wait()
+    retirement = manager._retiring[id(engine)]
+    if cleanup_state == "failed":
+        assert retirement.task is not None
+        retirement.task.cancel()
+        await cleanup
+
+    with pytest.raises(ResidentModelCapacityError) as exc_info:
+        async with manager.admit_role(
+            role="alignment",
+            model_id="qwen3-aligner",
+            requested_bytes=int(0.3 * GIB),
+            capacity_source="catalog",
+        ):
+            pass
+
+    envelope = exc_info.value.envelope()["error"]
+    assert envelope["used_bytes"] == int(0.8 * GIB)
+    assert envelope["resident_roles"] == [
+        {
+            "role": "assistant",
+            "model_id": "retiring-assistant",
+            "reserved_bytes": int(0.8 * GIB),
+            "state": cleanup_state,
+        }
+    ]
+
+    if cleanup_state == "retiring":
+        engine.stop_release.set()
+        await cleanup
+
+
+@pytest.mark.asyncio
 async def test_alignment_replace_conflict_reports_recovery_actions():
     # The capacity rejection for the alignment role must pair its
     # requested_role with the role-appropriate recovery actions.

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -99,10 +99,8 @@ _ALLOWED_RECOVERY_ACTIONS: dict[ResidentRole, tuple[str, ...]] = {
 }
 
 
-def _recovery_actions_for(role: ResidentRole | None) -> list[str]:
-    """Return the server-declared recovery actions for a role (empty if none)."""
-    if role is None:
-        return []
+def _recovery_actions_for(role: ResidentRole) -> list[str]:
+    """Return the server-declared recovery actions for a validated role."""
     return list(_ALLOWED_RECOVERY_ACTIONS[role])
 
 
@@ -845,7 +843,7 @@ class ResidentModelManager:
             key=lambda item: (str(item["role"]), str(item["model_id"])),
         )
 
-    def _recovery_actions_for(self, role: ResidentRole | None) -> list[str]:
+    def _recovery_actions_for(self, role: ResidentRole) -> list[str]:
         """Return the server-declared recovery actions for a role."""
         return _recovery_actions_for(role)
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -1020,8 +1020,18 @@ class ResidentModelManager:
         # read the ledger under a role the lifecycle does not own.
         coerced_role = self._coerce_role(role)
         assert coerced_role is not None  # role is required for role admission
-        if release_exclusive_role is not None and release_exclusive_role != role:
-            self._coerce_role(release_exclusive_role)
+        # Store only the enum wire value.  Merely validating an accepted alias
+        # is insufficient: keeping ``speech_input`` as a dictionary key would
+        # let a later ``speech-input`` admission create a second reservation
+        # for the same logical role, and release through the other spelling
+        # would miss it.
+        role = coerced_role.value
+        coerced_exclusive_role = self._coerce_role(release_exclusive_role)
+        release_exclusive_role = (
+            coerced_exclusive_role.value
+            if coerced_exclusive_role is not None
+            else None
+        )
 
         async with self._lock:
             previous = self._roles.get(role)
@@ -1214,9 +1224,10 @@ class ResidentModelManager:
         # Gate release against the closed enum too: an unknown role must not be
         # silently popped (which would imply the lifecycle owned a lane it never
         # defined), keeping ``_roles`` consistent with the closed role set.
-        self._coerce_role(role)
+        coerced_role = self._coerce_role(role)
+        assert coerced_role is not None  # role is required for release
         async with self._lock:
-            self._roles.pop(role, None)
+            self._roles.pop(coerced_role.value, None)
 
     async def load(
         self,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import enum
 import gc
 import logging
 import re
@@ -24,6 +25,95 @@ _QUANT_RE = re.compile(r"(?<!\d)(2|3|4|6|8|16)[-]?bit", re.IGNORECASE)
 
 class ResidentModelError(RuntimeError):
     """Base class for resident-model control-plane failures."""
+
+
+class ResidentRole(str, enum.Enum):
+    """Closed set of roles the shared residency lifecycle can budget.
+
+    The shared process residency ceiling is owned by the manager and must be
+    able to reject an unsafe admission *before* any weights load, with a
+    conflict that names the resident roles involved. Non-exhaustive open
+    strings would let an unknown lane charge the ceiling or let a consumer
+    guess at roles that were never defined, so every role string entering
+    :meth:`ResidentModelManager.admit_role` / ``release_role`` is coerced to
+    this closed enum before touching the ledger.
+
+    Wire values preserve the legacy reservation strings (``"alignment"`` and
+    the dash-form ``"speech-input"`` used by the forced-alignment route's
+    ``release_exclusive_role``) so existing callers keep working unchanged.
+    """
+
+    ASSISTANT = "assistant"
+    SPEECH_INPUT = "speech-input"
+    SPEECH_OUTPUT = "speech-output"
+    ALIGNMENT = "alignment"
+    IMAGE_GENERATION = "image-generation"
+    VIDEO_GENERATION = "video-generation"
+
+    @classmethod
+    def coerce(cls, value: ResidentRole | str | None) -> ResidentRole | None:
+        """Validate a role string against the closed set.
+
+        Accepts a ``ResidentRole`` member, a member's dash-form wire value, or
+        the canonical underscore alias (e.g. ``speech_input``); raises
+        ``ResidentModelError`` for any other string rather than silently
+        admitting an unknown lane. ``None`` (the assistant/replacement path)
+        maps to ``None``.
+        """
+        if value is None or isinstance(value, ResidentRole):
+            return value
+        if not isinstance(value, str):
+            raise ResidentModelError(
+                f"invalid role {value!r}: expected one of "
+                f"{sorted(member.value for member in cls)}"
+            )
+        member = cls(value) if value in cls._value2member_map_ else _ROLE_INPUT_ALIASES.get(value)
+        if member is None:
+            raise ResidentModelError(
+                f"unknown resident role {value!r}: must be one of "
+                f"{sorted(member.value for member in cls)}"
+            )
+        return member
+
+
+# Server-declared VALID recovery actions per role, the stable contract the
+# typed 507 envelope exposes so the downstream UX (#2306) can offer the user
+# concrete, actionable choices instead of guessing at capacity or deriving
+# roles from model aliases. Owned here (data-driven) rather than re-derived
+# by callers; the manager pulls from this one table.
+_ALLOWED_RECOVERY_ACTIONS: dict[ResidentRole, tuple[str, ...]] = {
+    ResidentRole.SPEECH_INPUT: (
+        "select_smaller_speech_input",
+        "stop_speech_output",
+        "unload_assistant",
+    ),
+    ResidentRole.SPEECH_OUTPUT: ("stop_speech_output",),
+    ResidentRole.ALIGNMENT: ("unload_assistant",),
+    ResidentRole.ASSISTANT: (),
+    ResidentRole.IMAGE_GENERATION: (),
+    ResidentRole.VIDEO_GENERATION: (),
+}
+
+
+def _recovery_actions_for(role: ResidentRole | None) -> list[str]:
+    """Return the server-declared recovery actions for a role (empty if none)."""
+    if role is None:
+        return []
+    return list(_ALLOWED_RECOVERY_ACTIONS[role])
+
+
+# Canonical underscore aliases accepted on role input (e.g. ``speech_input``)
+# alongside the dash-form wire values, so callers may use either without
+# silently inventing a role. Kept OUTSIDE the enum class: a ``str``-mixin enum
+# auto-converts a class-level dict of strings into an unexpected member.
+_ROLE_INPUT_ALIASES: dict[str, ResidentRole] = {
+    "assistant": ResidentRole.ASSISTANT,
+    "speech_input": ResidentRole.SPEECH_INPUT,
+    "speech_output": ResidentRole.SPEECH_OUTPUT,
+    "alignment": ResidentRole.ALIGNMENT,
+    "image_generation": ResidentRole.IMAGE_GENERATION,
+    "video_generation": ResidentRole.VIDEO_GENERATION,
+}
 
 
 class ResidentModelCapacityError(ResidentModelError):
@@ -50,6 +140,8 @@ class ResidentModelCapacityError(ResidentModelError):
         limit_bytes: int | None = None,
         used_bytes: int | None = None,
         requested_role: str | None = None,
+        resident_roles: list[dict[str, object]] | None = None,
+        recovery_actions: list[str] | None = None,
     ) -> None:
         self.replacement_projection = replacement_projection
         self.reason = reason
@@ -57,6 +149,8 @@ class ResidentModelCapacityError(ResidentModelError):
         self.limit_bytes = limit_bytes
         self.used_bytes = used_bytes
         self.requested_role = requested_role
+        self.resident_roles = resident_roles
+        self.recovery_actions = recovery_actions
         super().__init__(message)
 
     def envelope(self) -> dict[str, object]:
@@ -65,6 +159,11 @@ class ResidentModelCapacityError(ResidentModelError):
         Populated only when the error was raised from ``admit_role`` (role
         fields present). A legacy replacement/assistant capacity error has no
         typed role envelope — its caller keeps using ``replacement_projection``.
+
+        The role envelope is ADDITIVE-SAFE: consumers that cannot parse the
+        newer role fields keep working from ``reason``/bytes, while consumers
+        that can parse them use ``requested_role`` / ``resident_roles`` /
+        ``recovery_actions`` without guessing capacity or deriving roles.
         """
         if self.reason is None:
             return {
@@ -75,18 +174,20 @@ class ResidentModelCapacityError(ResidentModelError):
                     "param": "model",
                 }
             }
-        return {
-            "error": {
-                "message": str(self),
-                "type": "insufficient_capacity_error",
-                "code": "insufficient_capacity_error",
-                "reason": self.reason,
-                "param": "model",
-                "requested_bytes": self.requested_bytes,
-                "limit_bytes": self.limit_bytes,
-                "used_bytes": self.used_bytes,
-            }
+        envelope: dict[str, object] = {
+            "message": str(self),
+            "type": "insufficient_capacity_error",
+            "code": "insufficient_capacity_error",
+            "reason": self.reason,
+            "param": "model",
+            "requested_bytes": self.requested_bytes,
+            "limit_bytes": self.limit_bytes,
+            "used_bytes": self.used_bytes,
+            "requested_role": self.requested_role,
+            "resident_roles": self.resident_roles if self.resident_roles is not None else [],
+            "recovery_actions": self.recovery_actions if self.recovery_actions is not None else [],
         }
+        return {"error": envelope}
 
 
 class ResidentModelBusyError(ResidentModelError):
@@ -685,6 +786,37 @@ class ResidentModelManager:
         # force until the actual process footprint grows past it.
         return max(measured, reserved)
 
+    def _coerce_role(self, role: str | ResidentRole | None) -> ResidentRole | None:
+        """Validate a role against the closed enum before it touches the ledger.
+
+        Central location so every role string entering ``admit_role`` /
+        ``release_role`` — and thus ``self._roles`` — is checked against the
+        closed set rather than silently accepted.
+        """
+        return ResidentRole.coerce(role)
+
+    def _resident_roles_snapshot(self) -> list[dict[str, object]]:
+        """Snapshot the live auxiliary-role ledger for the typed 507 envelope.
+
+        Drawn from ``self._roles`` (the authoritative auxiliary reservation
+        ledger) with the stable fields the downstream UX renders: role,
+        model_id, reserved_bytes, state. Sorted deterministically by role so
+        the machine contract is order-stable regardless of admission order.
+        """
+        return [
+            {
+                "role": record.role,
+                "model_id": record.model_id,
+                "reserved_bytes": record.reserved_bytes,
+                "state": record.state,
+            }
+            for record in sorted(self._roles.values(), key=lambda item: item.role)
+        ]
+
+    def _recovery_actions_for(self, role: ResidentRole | None) -> list[str]:
+        """Return the server-declared recovery actions for a role."""
+        return _recovery_actions_for(role)
+
     def contains(self, model_name: str) -> bool:
         return self._canonical(model_name) is not None
 
@@ -803,6 +935,7 @@ class ResidentModelManager:
                         f"limit={self.memory_limit_bytes / _GIB:.2f} GiB; "
                         "no idle unpinned model is eligible for eviction"
                     )
+                coerced_role = self._coerce_role(requested_role)
                 raise ResidentModelCapacityError(
                     (
                         "insufficient capacity for role "
@@ -817,6 +950,8 @@ class ResidentModelManager:
                     limit_bytes=self.memory_limit_bytes,
                     used_bytes=usage,
                     requested_role=requested_role,
+                    resident_roles=self._resident_roles_snapshot(),
+                    recovery_actions=self._recovery_actions_for(coerced_role),
                 )
             await self._evict_locked(candidates[0], reason="memory_pressure")
 
@@ -880,6 +1015,14 @@ class ResidentModelManager:
         and the configured ceiling is never breached by a restore.
         """
 
+        # Validate every role string against the closed enum BEFORE it touches
+        # the ledger: an unknown lane must never charge the shared ceiling or
+        # read the ledger under a role the lifecycle does not own.
+        coerced_role = self._coerce_role(role)
+        assert coerced_role is not None  # role is required for role admission
+        if release_exclusive_role is not None and release_exclusive_role != role:
+            self._coerce_role(release_exclusive_role)
+
         async with self._lock:
             previous = self._roles.get(role)
             # Capture the mutually-exclusive sibling WITHOUT removing it. The
@@ -932,6 +1075,8 @@ class ResidentModelManager:
                         limit_bytes=self.memory_limit_bytes,
                         used_bytes=used,
                         requested_role=role,
+                        resident_roles=self._resident_roles_snapshot(),
+                        recovery_actions=self._recovery_actions_for(coerced_role),
                     )
                 reserved_bytes = max(0, int(requested_bytes or 0))
                 await self._evict_for_locked(
@@ -1066,6 +1211,10 @@ class ResidentModelManager:
     async def release_role(self, role: str) -> None:
         """Stop charging a role after its owning lane released the engine."""
 
+        # Gate release against the closed enum too: an unknown role must not be
+        # silently popped (which would imply the lifecycle owned a lane it never
+        # defined), keeping ``_roles`` consistent with the closed role set.
+        self._coerce_role(role)
         async with self._lock:
             self._roles.pop(role, None)
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -804,22 +804,46 @@ class ResidentModelManager:
         return ResidentRole.coerce(role)
 
     def _resident_roles_snapshot(self) -> list[dict[str, object]]:
-        """Snapshot the live auxiliary-role ledger for the typed 507 envelope.
+        """Snapshot every live role charged by the typed 507 envelope.
 
-        Drawn from ``self._roles`` (the authoritative auxiliary reservation
-        ledger) with the stable fields the downstream UX renders: role,
-        model_id, reserved_bytes, state. Sorted deterministically by role so
-        the machine contract is order-stable regardless of admission order.
+        Capacity accounting combines registry-backed models in ``_records``
+        with auxiliary reservations in ``_roles``. The conflict envelope must
+        describe that same set; otherwise it can recommend unloading the
+        assistant while omitting the assistant from ``resident_roles``.
         """
-        return [
+
+        def model_role(record: ResidencyRecord) -> str:
+            group = _replacement_group(record.entry)
+            return {
+                "image-gen": ResidentRole.IMAGE_GENERATION.value,
+                "video-gen": ResidentRole.VIDEO_GENERATION.value,
+            }.get(group, group)
+
+        model_roles = [
+            {
+                "role": model_role(record),
+                "model_id": record.model_id,
+                "reserved_bytes": max(
+                    record.estimated_bytes,
+                    record.measured_bytes,
+                ),
+                "state": record.state,
+            }
+            for record in self._records.values()
+        ]
+        auxiliary_roles = [
             {
                 "role": record.role,
                 "model_id": record.model_id,
                 "reserved_bytes": record.reserved_bytes,
                 "state": record.state,
             }
-            for record in sorted(self._roles.values(), key=lambda item: item.role)
+            for record in self._roles.values()
         ]
+        return sorted(
+            [*model_roles, *auxiliary_roles],
+            key=lambda item: (str(item["role"]), str(item["model_id"])),
+        )
 
     def _recovery_actions_for(self, role: ResidentRole | None) -> list[str]:
         """Return the server-declared recovery actions for a role."""

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -829,6 +829,18 @@ class ResidentModelManager:
             }
             for record in self._records.values()
         ]
+        retiring_roles = [
+            {
+                "role": model_role(retirement.record),
+                "model_id": retirement.record.model_id,
+                "reserved_bytes": max(
+                    retirement.record.estimated_bytes,
+                    retirement.record.measured_bytes,
+                ),
+                "state": retirement.state,
+            }
+            for retirement in self._retiring.values()
+        ]
         auxiliary_roles = [
             {
                 "role": record.role,
@@ -839,7 +851,7 @@ class ResidentModelManager:
             for record in self._roles.values()
         ]
         return sorted(
-            [*model_roles, *auxiliary_roles],
+            [*model_roles, *retiring_roles, *auxiliary_roles],
             key=lambda item: (str(item["role"]), str(item["model_id"])),
         )
 

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -978,6 +978,7 @@ class ResidentModelManager:
                         "no idle unpinned model is eligible for eviction"
                     )
                 coerced_role = self._coerce_role(requested_role)
+                assert coerced_role is not None
                 raise ResidentModelCapacityError(
                     (
                         "insufficient capacity for role "

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -67,7 +67,11 @@ class ResidentRole(str, enum.Enum):
                 f"invalid role {value!r}: expected one of "
                 f"{sorted(member.value for member in cls)}"
             )
-        member = cls(value) if value in cls._value2member_map_ else _ROLE_INPUT_ALIASES.get(value)
+        member = (
+            cls(value)
+            if value in cls._value2member_map_
+            else _ROLE_INPUT_ALIASES.get(value)
+        )
         if member is None:
             raise ResidentModelError(
                 f"unknown resident role {value!r}: must be one of "
@@ -184,8 +188,12 @@ class ResidentModelCapacityError(ResidentModelError):
             "limit_bytes": self.limit_bytes,
             "used_bytes": self.used_bytes,
             "requested_role": self.requested_role,
-            "resident_roles": self.resident_roles if self.resident_roles is not None else [],
-            "recovery_actions": self.recovery_actions if self.recovery_actions is not None else [],
+            "resident_roles": self.resident_roles
+            if self.resident_roles is not None
+            else [],
+            "recovery_actions": self.recovery_actions
+            if self.recovery_actions is not None
+            else [],
         }
         return {"error": envelope}
 
@@ -1028,9 +1036,7 @@ class ResidentModelManager:
         role = coerced_role.value
         coerced_exclusive_role = self._coerce_role(release_exclusive_role)
         release_exclusive_role = (
-            coerced_exclusive_role.value
-            if coerced_exclusive_role is not None
-            else None
+            coerced_exclusive_role.value if coerced_exclusive_role is not None else None
         )
 
         async with self._lock:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -968,7 +968,7 @@ class ResidentModelManager:
         ):
             candidates = self._eviction_candidates_locked(exclude)
             if not candidates:
-                usage = max(0, self._accounted_usage() - usage_credit_bytes)
+                usage = self._accounted_usage()
                 if requested_role is None:
                     raise ResidentModelCapacityError(
                         "resident model memory ceiling exceeded: "
@@ -1111,7 +1111,7 @@ class ResidentModelManager:
                     if exclusive_sibling is not None
                     else 0
                 )
-                used = max(0, self._accounted_usage() - usage_credit)
+                used = self._accounted_usage()
                 if self.memory_limit_bytes > 0 and requested_bytes is None:
                     raise ResidentModelCapacityError(
                         (


### PR DESCRIPTION
## Why

Auxiliary engine admission currently accepts open role strings and returns insufficient-capacity data without a complete typed description of the requested and resident roles. That forces later speech-role consumers to guess at lifecycle roles and recovery actions.

Part of #2305

## Scope

- Add a closed ResidentRole enum with validated legacy wire aliases.
- Reject unknown roles before they touch the residency ledger.
- Extend role-capacity errors with requested_role, resident_roles, and server-declared recovery_actions.
- Add deterministic contracts for role coercion, stable envelopes, and rollback compatibility.

## Non-goals

This L1 foundation does not implement auxiliary audio engine loading, idle TTL, Desktop conflict presentation, silent assistant eviction, or claim to complete #2305.

## Acceptance

- Every auxiliary role entering admission or release belongs to the closed role set.
- Existing dash-form role values remain compatible.
- A typed 507 capacity envelope names the requested role, live role reservations, and allowed recovery actions.
- Existing assistant replacement envelopes remain unchanged.
- Invalid role input cannot mutate the residency ledger.

## Design precedent

The design uses a closed string enum at the control-plane boundary, accepts only explicit compatibility aliases, and keeps recovery actions in one server-owned table. This mirrors established scheduler and worker-role contracts where routing roles are enumerated and invalid values fail before resource mutation.

## Verification

- python3.12 -m pytest tests/test_resident_models.py -q — 100 passed
- python3.12 -m ruff check vllm_mlx/runtime/resident_models.py tests/test_resident_models.py — passed
- git diff --check — passed
- Independent Codex review and pr_validate pending on the PR exact head.

## Behaviour delta

Before: auxiliary roles were open strings and role-capacity 507 responses omitted the resident-role and recovery-action contract.

After: role admission is closed and validated, and capacity failures expose a stable typed envelope while preserving legacy assistant replacement behavior.

## AI assistance disclosure

Claude implemented the production and test changes. Harbor found and fixed alias-key divergence, then reviewed the diff against this bounded L1 contract and reference patterns, ran focused tests and lint, and will independently validate it with Codex review, pr_validate, and exact-head CI before queue entry.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For AI-assisted sections, I have identified them above and can describe how I verified them.

## Checklist

- [x] Focused tests pass locally
- [x] Lint passes
- [x] New critical-path tests cover the changed role contract
- [x] No docs update required for this internal L1
- [x] No breaking API changes