### PR TITLE
feat(mac): add one-click model unload

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -19,6 +19,9 @@ can actually understand.
 
 ### Added
 - `/metrics` now breaks MTP speculative decoding down per verify call: `rapid_mlx_spec_decode_verify_calls_total`, `..._correction_tokens_total`, `..._bonus_tokens_total`, and per-depth `..._drafted_by_depth_total{depth=}` / `..._accepted_by_depth_total{depth=}` alongside the existing attempts/accepts counters, so a workload that loses with MTP can be attributed to wrong drafts, verify cost, or rollback churn. The continuous-batching MTP route (the default for tier-verified aliases) now feeds these counters too; previously it bypassed them and every `rapid_mlx_spec_decode_*` series stayed at 0. (#3155)
+- **One-click model unload in Desktop.** The resident-memory footer now has an
+  eject control that releases loaded models when the server is idle, while
+  protecting active chat and API responses from accidental interruption.
 
 ### Changed
 - The Desktop app now honours the same `RAPID_MLX_TELEMETRY=0` kill switch as
@@ -43,7 +46,6 @@ can actually understand.
   UTC stamp. The model menu groups recommended-for-this-Mac models first, then
   downloaded ones. While a run is measuring, the tab names the model, scope,
   expected duration, and an elapsed clock.
-
 ## [0.13.4] — 2026-09-02
 
 Rapid-MLX 0.13.4 makes qualified local models faster under concurrent work,

--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -20,8 +20,9 @@ can actually understand.
 ### Added
 - `/metrics` now breaks MTP speculative decoding down per verify call: `rapid_mlx_spec_decode_verify_calls_total`, `..._correction_tokens_total`, `..._bonus_tokens_total`, and per-depth `..._drafted_by_depth_total{depth=}` / `..._accepted_by_depth_total{depth=}` alongside the existing attempts/accepts counters, so a workload that loses with MTP can be attributed to wrong drafts, verify cost, or rollback churn. The continuous-batching MTP route (the default for tier-verified aliases) now feeds these counters too; previously it bypassed them and every `rapid_mlx_spec_decode_*` series stayed at 0. (#3155)
 - **One-click model unload in Desktop.** The resident-memory footer now has an
-  eject control that releases loaded models when the server is idle, while
-  protecting active chat and API responses from accidental interruption.
+  eject control that releases loaded models when the server is idle. It checks
+  the sidecar's latest reported request state before stopping and disables
+  itself during a visible active response.
 
 ### Changed
 - The Desktop app now honours the same `RAPID_MLX_TELEMETRY=0` kill switch as

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -90,6 +90,60 @@ enum DevSnapshot {
         snapshotPerfDefaults.removePersistentDomain(forName: "rapid.dev-snapshot.perf")
         let snapshotPerfConfig = ModelPerfConfigStore(defaults: snapshotPerfDefaults)
 
+        if ProcessInfo.processInfo.environment["RAPID_DEV_RESIDENCY_ONLY"] == "1" {
+            let model = ResidentModelStatus(
+                id: "qwen3.5-4b-4bit",
+                modelPath: "mlx-community/qwen3.5-4b-4bit",
+                aliases: ["qwen3.5-4b-4bit"],
+                modality: "text",
+                state: "resident",
+                pinned: true,
+                primary: true,
+                activeRequests: 0,
+                estimatedBytes: 6_335_076_762,
+                measuredBytes: nil,
+                idleSeconds: 12
+            )
+            let previewServer = ServerManager(
+                testingState: .ready(alias: model.id),
+                binaryPath: URL(fileURLWithPath: "/usr/bin/true"),
+                residency: ModelResidencySnapshot(
+                    memoryLimitBytes: 15_032_385_536,
+                    memoryUsedBytes: 6_335_076_762,
+                    memoryAvailableBytes: 8_697_308_774,
+                    idleTTLSeconds: 900,
+                    loadsTotal: 1,
+                    evictionsTotal: 0,
+                    models: [model]
+                )
+            )
+            func sidebar() -> AnyView {
+                AnyView(
+                    SidebarView(
+                        selection: .constant(.chat),
+                        chat: chat,
+                        onNewChat: {},
+                        onSelectConversation: { _ in },
+                        server: previewServer
+                    )
+                    .frame(width: SidebarView.columnIdealWidth, height: 640)
+                    .background(RapidTheme.surfaceSidebar)
+                    .tint(RapidTheme.brandAmber)
+                )
+            }
+            let size = CGSize(width: SidebarView.columnIdealWidth, height: 640)
+            renderHosted(
+                sidebar(), size: size, appearance: .aqua,
+                to: "\(dir)/resident-unload-sidebar-light.png"
+            )
+            renderHosted(
+                sidebar(), size: size, appearance: .darkAqua,
+                to: "\(dir)/resident-unload-sidebar-dark.png"
+            )
+            NSApp.terminate(nil)
+            return
+        }
+
         // Focused gate regression: render only the shipping sidebar and quit.
         // The full snapshot matrix is intentionally broad and takes minutes;
         // this lane gives feature-gate work a fast, deterministic visual proof

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -3552,6 +3552,10 @@ final class ServerManager {
         reason: String?, cancelMonitor: Bool = true
     ) async -> pid_t? {
         guard let process = child else { return nil }
+        let clearsResumeAlias = Self.shouldClearLastServedAlias(
+            expectedStop: reason == nil,
+            preservingLastServedAlias: preservingLastServedAliasDuringStop
+        )
         let alias: String
         switch state {
         case .starting(let a), .ready(let a), .crashed(let a, _):
@@ -3620,6 +3624,11 @@ final class ServerManager {
             // ``handleChildExit`` may not get a chance to run if
             // the termination handler is starved by app teardown.
             OwnedServerRecord.clear()
+            if clearsResumeAlias {
+                (sessionDefaults ?? .standard).removeObject(
+                    forKey: Self.lastServedAliasKey
+                )
+            }
             if let message = reason {
                 state = .crashed(alias: alias, message: message)
             } else {
@@ -3715,7 +3724,7 @@ final class ServerManager {
                 expectedStop: wasExpected,
                 preservingLastServedAlias: preservedLastServedAlias
             ) {
-                UserDefaults.standard.removeObject(forKey: Self.lastServedAliasKey)
+                (sessionDefaults ?? .standard).removeObject(forKey: Self.lastServedAliasKey)
             }
             return
         }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -3211,6 +3211,27 @@ final class ServerManager {
         _ = await stop(preservingLastServedAlias: false)
     }
 
+    enum ResidentUnloadResult: Equatable, Sendable {
+        case stopped
+        case busy
+        case unavailable
+    }
+
+    /// Release the resident pool only after asking the live sidecar for its
+    /// freshest request counts. The sidecar does not expose an atomic drain
+    /// operation, so this is deliberately an advisory last-moment guard: a
+    /// request that arrives after the response is still subject to an explicit
+    /// user stop, exactly like the existing model-switch confirmation path.
+    func unloadResidentModelsIfIdle() async -> ResidentUnloadResult {
+        guard await refreshResidency() else { return .unavailable }
+        guard !residency.models.contains(where: { $0.activeRequests > 0 }) else {
+            return .busy
+        }
+        _ = await stop(preservingLastServedAlias: false)
+        guard case .stopped = state else { return .unavailable }
+        return .stopped
+    }
+
     /// Reserve the server lifecycle for a local Community Benchmark and
     /// return only after no embedded model process can contend for unified
     /// memory. A start already inside its short spawn critical section is

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -3227,7 +3227,11 @@ final class ServerManager {
         guard !residency.models.contains(where: { $0.activeRequests > 0 }) else {
             return .busy
         }
-        guard !residency.audioLanes.contains(where: { ($0.activeRequests ?? 0) > 0 }) else {
+        let residentAudio = residency.audioLanes.filter { $0.state == "resident" }
+        guard !residentAudio.contains(where: { $0.activeRequests == nil }) else {
+            return .unavailable
+        }
+        guard !residentAudio.contains(where: { ($0.activeRequests ?? 0) > 0 }) else {
             return .busy
         }
         // This is an explicit unload, so clear the persisted auto-resume alias.

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -3227,6 +3227,13 @@ final class ServerManager {
         guard !residency.models.contains(where: { $0.activeRequests > 0 }) else {
             return .busy
         }
+        guard !residency.audioLanes.contains(where: { ($0.activeRequests ?? 0) > 0 }) else {
+            return .busy
+        }
+        // This is an explicit unload, so clear the persisted auto-resume alias.
+        // ContentView owns the current picker selection independently; keeping
+        // that in-memory selection supplies the immediate Start recovery action
+        // without surprising the user by reloading on their next app launch.
         _ = await stop(preservingLastServedAlias: false)
         guard case .stopped = state else { return .unavailable }
         return .stopped

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerResidency.swift
@@ -148,6 +148,21 @@ struct ResidentAudioLaneStatus: Codable, Sendable, Equatable {
     let lane: String
     let model: String?
     let state: String
+    let activeRequests: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case lane
+        case model
+        case state
+        case activeRequests = "active_requests"
+    }
+
+    init(lane: String, model: String?, state: String, activeRequests: Int? = nil) {
+        self.lane = lane
+        self.model = model
+        self.state = state
+        self.activeRequests = activeRequests
+    }
 
     func matches(modelPath: String) -> Bool {
         model == modelPath && state == "resident"

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -643,7 +643,8 @@ struct ContentView: View {
                     chat.selectConversation(id)
                     section = .chat
                 },
-                server: server
+                server: server,
+                hasActiveModelWork: hasActiveModelWork
             )
             // v1.0: the rail paints an explicit warm surface rather than
             // inheriting the system sidebar material. The material is a
@@ -722,22 +723,28 @@ struct ContentView: View {
         }
     }
 
-    private var starPromptPresentationContext: GitHubStarPromptCoordinator.PresentationContext {
+    private var hasActiveModelWork: Bool {
         let dictationIsBusy: Bool = switch dictation.phase {
         case .preparingModel, .starting, .recording, .transcribing: true
         case .off, .idle: false
         }
+
+        return chat.isStreaming
+            || imageGen.isGenerating
+            || audio.isBusy
+            || video.hasLiveActiveJobs
+            || video.isSubmitting
+            || video.isPreparing
+            || dictationIsBusy
+    }
+
+    private var starPromptPresentationContext: GitHubStarPromptCoordinator.PresentationContext {
         let campaignIsVisible = campaign.map {
             !UserDefaults.standard.bool(forKey: $0.dismissalKey)
         } ?? false
 
         return .init(
-            isBusy: chat.isStreaming
-                || imageGen.isGenerating
-                || video.hasLiveActiveJobs
-                || video.isSubmitting
-                || video.isPreparing
-                || dictationIsBusy,
+            isBusy: hasActiveModelWork,
             hasBlockingSurface: quickstartVisible
                 || deferredTelemetryConsent.isPresented
                 || campaignIsVisible

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -663,7 +663,10 @@ struct SidebarView: View {
                 set: { if !$0 { residentUnloadNotice = nil } }
             )
         ) {
-            Button("OK") { residentUnloadNotice = nil }
+            Button("OK") {
+                residentUnloadNotice = nil
+            }
+            .accessibilityIdentifier("Sidebar.Residency.UnloadNotice.OK")
         } message: {
             Text(residentUnloadNotice ?? "")
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -61,6 +61,10 @@ struct SidebarView: View {
     /// Optional in isolated snapshot fixtures; the shipping ContentView passes
     /// it so residency and the enforced memory ceiling remain visible globally.
     var server: ServerManager? = nil
+    /// Test seam for driving the real accessibility control without spawning a
+    /// sidecar. Production leaves this nil and uses ServerManager's guarded
+    /// resident-pool unload path.
+    var onUnloadResidentModels: (() async -> Void)? = nil
 
     /// The "now" the date buckets are computed against. Rolled forward by
     /// ``dayBoundaryTicker`` at each midnight so an open, untouched sidebar
@@ -127,6 +131,11 @@ struct SidebarView: View {
     /// the opposite of Archived, which is collapsed by default precisely
     /// because its whole purpose is getting rows out of the way.
     @State private var collapsedFolderIDs: Set<UUID> = []
+
+    /// Covers the short fresh-residency check before ServerManager enters its
+    /// own stop state, keeping repeated eject clicks out and making that work
+    /// visible instead of leaving an apparently inert button.
+    @State private var isUnloadingResidentModels = false
 
     /// The folder-name prompt currently on screen, if any.
     ///
@@ -510,6 +519,8 @@ struct SidebarView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("Sidebar.Residency")
 
             HStack(spacing: RapidTheme.Space.xs) {
                 if snapshot.memoryLimitBytes > 0 {
@@ -576,7 +587,7 @@ struct SidebarView: View {
     ) -> some View {
         let hasActiveRequests = snapshot.models.contains { $0.activeRequests > 0 }
         let disabled = Self.residentUnloadDisabled(
-            isOperating: server.isOperating,
+            isOperating: server.isOperating || isUnloadingResidentModels,
             chatIsStreaming: chat.isStreaming,
             hasActiveRequests: hasActiveRequests
         )
@@ -586,10 +597,19 @@ struct SidebarView: View {
         )
 
         return Button {
-            Task { await server.stop() }
+            Task {
+                guard !isUnloadingResidentModels else { return }
+                isUnloadingResidentModels = true
+                defer { isUnloadingResidentModels = false }
+                if let onUnloadResidentModels {
+                    await onUnloadResidentModels()
+                } else {
+                    _ = await server.unloadResidentModelsIfIdle()
+                }
+            }
         } label: {
             Group {
-                if server.isOperating {
+                if server.isOperating || isUnloadingResidentModels {
                     ProgressView()
                         .controlSize(.mini)
                 } else {
@@ -605,7 +625,7 @@ struct SidebarView: View {
         .disabled(disabled)
         .help(
             Self.residentUnloadHelp(
-                isOperating: server.isOperating,
+                isOperating: server.isOperating || isUnloadingResidentModels,
                 hasActiveResponse: chat.isStreaming || hasActiveRequests,
                 enabledLabel: label
             )

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -277,7 +277,8 @@ struct SidebarView: View {
             if let server, !server.residency.models.isEmpty {
                 residencyFooter(
                     server.residency,
-                    preferredAlias: server.servingAlias
+                    preferredAlias: server.servingAlias,
+                    server: server
                 )
             }
         }
@@ -487,7 +488,8 @@ struct SidebarView: View {
 
     private func residencyFooter(
         _ snapshot: ModelResidencySnapshot,
-        preferredAlias: String?
+        preferredAlias: String?,
+        server: ServerManager
     ) -> some View {
         VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
             HStack(spacing: RapidTheme.Space.xs) {
@@ -498,18 +500,32 @@ struct SidebarView: View {
                     .font(RapidFont.caption)
                     .foregroundStyle(.secondary)
                 Spacer(minLength: 4)
-                Text(memorySummary(snapshot))
+                Text(
+                    Self.memorySummary(
+                        usedBytes: snapshot.memoryUsedBytes,
+                        limitBytes: snapshot.memoryLimitBytes
+                    )
+                )
                     .font(.system(size: 10, weight: .medium, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
 
-            if snapshot.memoryLimitBytes > 0 {
-                ProgressView(
-                    value: min(1, Double(snapshot.memoryUsedBytes) / Double(snapshot.memoryLimitBytes))
-                )
-                .controlSize(.mini)
-                .tint(RapidTheme.brandAmber)
+            HStack(spacing: RapidTheme.Space.xs) {
+                if snapshot.memoryLimitBytes > 0 {
+                    ProgressView(
+                        value: min(
+                            1,
+                            Double(snapshot.memoryUsedBytes) / Double(snapshot.memoryLimitBytes)
+                        )
+                    )
+                    .controlSize(.mini)
+                    .tint(RapidTheme.brandAmber)
+                } else {
+                    Spacer(minLength: 0)
+                }
+
+                residentUnloadButton(snapshot: snapshot, server: server)
             }
 
             ForEach(snapshot.models.prefix(4)) { model in
@@ -543,13 +559,98 @@ struct SidebarView: View {
                 .fill(RapidTheme.hairline)
                 .frame(height: 1)
         }
-        .accessibilityIdentifier("Sidebar.Residency")
+        // Deliberately no accessibility modifier on this container: SwiftUI
+        // propagates container metadata and would mask the eject button and
+        // model-row semantics. The visible "Resident" heading names the group.
     }
 
-    private func memorySummary(_ snapshot: ModelResidencySnapshot) -> String {
-        let used = Self.formatBytes(snapshot.memoryUsedBytes)
-        guard snapshot.memoryLimitBytes > 0 else { return used }
-        return "\(used) / \(Self.formatBytes(snapshot.memoryLimitBytes))"
+    /// One visible release valve for the whole resident-memory pool. The
+    /// startup model is intentionally pinned by the engine, so presenting a
+    /// per-row eject action would be dishonest: ejecting that row means
+    /// stopping the resident runtime and therefore releasing every model it
+    /// owns. Keeping the control beside the aggregate memory bar makes that
+    /// scope clear and avoids shortening model names in the narrow rail.
+    private func residentUnloadButton(
+        snapshot: ModelResidencySnapshot,
+        server: ServerManager
+    ) -> some View {
+        let hasActiveRequests = snapshot.models.contains { $0.activeRequests > 0 }
+        let disabled = Self.residentUnloadDisabled(
+            isOperating: server.isOperating,
+            chatIsStreaming: chat.isStreaming,
+            hasActiveRequests: hasActiveRequests
+        )
+        let label = Self.residentUnloadLabel(
+            modelCount: snapshot.models.count,
+            memoryUsedBytes: snapshot.memoryUsedBytes
+        )
+
+        return Button {
+            Task { await server.stop() }
+        } label: {
+            Group {
+                if server.isOperating {
+                    ProgressView()
+                        .controlSize(.mini)
+                } else {
+                    Image(systemName: "eject.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+            }
+            .frame(width: 22, height: 22)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(disabled ? .tertiary : .secondary)
+        .disabled(disabled)
+        .help(
+            Self.residentUnloadHelp(
+                isOperating: server.isOperating,
+                hasActiveResponse: chat.isStreaming || hasActiveRequests,
+                enabledLabel: label
+            )
+        )
+        .accessibilityLabel(label)
+        .accessibilityIdentifier("Sidebar.Residency.Unload")
+    }
+
+    nonisolated static func residentUnloadDisabled(
+        isOperating: Bool,
+        chatIsStreaming: Bool,
+        hasActiveRequests: Bool
+    ) -> Bool {
+        isOperating || chatIsStreaming || hasActiveRequests
+    }
+
+    nonisolated static func residentUnloadHelp(
+        isOperating: Bool,
+        hasActiveResponse: Bool,
+        enabledLabel: String
+    ) -> String {
+        if isOperating { return "Unloading models…" }
+        if hasActiveResponse {
+            return "Stop the active response before unloading models"
+        }
+        return enabledLabel
+    }
+
+    nonisolated static func residentUnloadLabel(
+        modelCount: Int,
+        memoryUsedBytes: UInt64
+    ) -> String {
+        let subject = modelCount == 1 ? "model" : "all models"
+        return "Unload \(subject) and free \(formatBytes(memoryUsedBytes))"
+    }
+
+    nonisolated static func memorySummary(usedBytes: UInt64, limitBytes: UInt64) -> String {
+        let used = Self.formatBytes(usedBytes)
+        guard limitBytes > 0 else { return used }
+        let limit = Self.formatBytes(limitBytes)
+        if let unit = used.split(separator: " ").last,
+           limit.hasSuffix(" \(unit)") {
+            return "\(used.dropLast(unit.count + 1)) / \(limit)"
+        }
+        return "\(used) / \(limit)"
     }
 
     nonisolated private static func formatBytes(_ bytes: UInt64) -> String {

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -61,6 +61,10 @@ struct SidebarView: View {
     /// Optional in isolated snapshot fixtures; the shipping ContentView passes
     /// it so residency and the enforced memory ceiling remain visible globally.
     var server: ServerManager? = nil
+    /// True while any model-backed surface is doing user-visible work. The
+    /// unload control must not offer to tear down the shared runtime merely
+    /// because the active work is outside Chat.
+    var hasActiveModelWork: Bool = false
     /// Test seam for driving the real accessibility control without spawning a
     /// sidecar. Production leaves this nil and uses ServerManager's guarded
     /// resident-pool unload path.
@@ -610,7 +614,7 @@ struct SidebarView: View {
         let hasActiveRequests = Self.hasActiveResidentRequests(snapshot)
         let disabled = Self.residentUnloadDisabled(
             isOperating: server.isOperating || isUnloadingResidentModels,
-            chatIsStreaming: chat.isStreaming,
+            hasActiveModelWork: hasActiveModelWork,
             hasActiveRequests: hasActiveRequests
         )
         let label = Self.residentUnloadLabel(
@@ -650,7 +654,7 @@ struct SidebarView: View {
         .help(
             Self.residentUnloadHelp(
                 isOperating: server.isOperating || isUnloadingResidentModels,
-                hasActiveResponse: chat.isStreaming || hasActiveRequests,
+                hasActiveResponse: hasActiveModelWork || hasActiveRequests,
                 enabledLabel: label
             )
         )
@@ -703,10 +707,10 @@ struct SidebarView: View {
 
     nonisolated static func residentUnloadDisabled(
         isOperating: Bool,
-        chatIsStreaming: Bool,
+        hasActiveModelWork: Bool,
         hasActiveRequests: Bool
     ) -> Bool {
-        isOperating || chatIsStreaming || hasActiveRequests
+        isOperating || hasActiveModelWork || hasActiveRequests
     }
 
     nonisolated static func residentUnloadHelp(

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -136,6 +136,7 @@ struct SidebarView: View {
     /// own stop state, keeping repeated eject clicks out and making that work
     /// visible instead of leaving an apparently inert button.
     @State private var isUnloadingResidentModels = false
+    @State private var residentUnloadNotice: String?
 
     /// The folder-name prompt currently on screen, if any.
     ///
@@ -283,7 +284,7 @@ struct SidebarView: View {
 
             Spacer(minLength: 0)
 
-            if let server, !server.residency.models.isEmpty {
+            if let server, Self.hasResidentWorkloads(server.residency) {
                 residencyFooter(
                     server.residency,
                     preferredAlias: server.servingAlias,
@@ -556,6 +557,27 @@ struct SidebarView: View {
                 }
                 .accessibilityIdentifier("Sidebar.ResidentModel.\(model.id)")
             }
+
+            ForEach(
+                snapshot.audioLanes.filter { $0.state == "resident" }.prefix(4),
+                id: \.lane
+            ) { lane in
+                HStack(spacing: RapidTheme.Space.xs) {
+                    Image(systemName: "waveform")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 12)
+                    Text(lane.model ?? lane.lane.uppercased())
+                        .font(RapidFont.caption)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 4)
+                    Text(lane.lane.uppercased())
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityIdentifier("Sidebar.ResidentAudio.\(lane.lane)")
+            }
         }
         .padding(.horizontal, RapidTheme.Space.sm)
         .padding(.top, RapidTheme.Space.md)
@@ -585,14 +607,14 @@ struct SidebarView: View {
         snapshot: ModelResidencySnapshot,
         server: ServerManager
     ) -> some View {
-        let hasActiveRequests = snapshot.models.contains { $0.activeRequests > 0 }
+        let hasActiveRequests = Self.hasActiveResidentRequests(snapshot)
         let disabled = Self.residentUnloadDisabled(
             isOperating: server.isOperating || isUnloadingResidentModels,
             chatIsStreaming: chat.isStreaming,
             hasActiveRequests: hasActiveRequests
         )
         let label = Self.residentUnloadLabel(
-            modelCount: snapshot.models.count,
+            modelCount: Self.residentWorkloadCount(snapshot),
             memoryUsedBytes: snapshot.memoryUsedBytes
         )
 
@@ -604,7 +626,9 @@ struct SidebarView: View {
                 if let onUnloadResidentModels {
                     await onUnloadResidentModels()
                 } else {
-                    _ = await server.unloadResidentModelsIfIdle()
+                    residentUnloadNotice = Self.residentUnloadMessage(
+                        for: await server.unloadResidentModelsIfIdle()
+                    )
                 }
             }
         } label: {
@@ -632,6 +656,46 @@ struct SidebarView: View {
         )
         .accessibilityLabel(label)
         .accessibilityIdentifier("Sidebar.Residency.Unload")
+        .alert(
+            "Models are still loaded",
+            isPresented: Binding(
+                get: { residentUnloadNotice != nil },
+                set: { if !$0 { residentUnloadNotice = nil } }
+            )
+        ) {
+            Button("OK") { residentUnloadNotice = nil }
+        } message: {
+            Text(residentUnloadNotice ?? "")
+        }
+    }
+
+    nonisolated static func hasResidentWorkloads(_ snapshot: ModelResidencySnapshot) -> Bool {
+        residentWorkloadCount(snapshot) > 0
+    }
+
+    nonisolated static func residentWorkloadCount(_ snapshot: ModelResidencySnapshot) -> Int {
+        snapshot.models.filter { $0.state != "evicting" }.count
+            + snapshot.audioLanes.filter { $0.state == "resident" }.count
+    }
+
+    nonisolated static func hasActiveResidentRequests(
+        _ snapshot: ModelResidencySnapshot
+    ) -> Bool {
+        snapshot.models.contains { $0.activeRequests > 0 }
+            || snapshot.audioLanes.contains { ($0.activeRequests ?? 0) > 0 }
+    }
+
+    nonisolated static func residentUnloadMessage(
+        for result: ServerManager.ResidentUnloadResult
+    ) -> String? {
+        switch result {
+        case .stopped:
+            nil
+        case .busy:
+            "A request is still using the models. Stop it, then try again."
+        case .unavailable:
+            "Rapid couldn't confirm that the models were idle. Wait a moment, then try again."
+        }
     }
 
     nonisolated static func residentUnloadDisabled(

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -13,13 +13,12 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
@@ -13,13 +13,12 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
@@ -20,13 +20,12 @@ AXApplication title="Rapid-MLX"
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -13,13 +13,12 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.post-value-consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.post-value-consent.txt
@@ -20,13 +20,12 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="Say hello in one short sentence." enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.lfm2.5-1b-4bit" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.lfm2.5-1b-4bit" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.lfm2.5-1b-4bit" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -8,13 +8,12 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
           AXProgressIndicator value=number enabled=true
-          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Stop the active response before unloading models" enabled=false
           AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
           AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
           AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -8,13 +8,12 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXButton id="Images.Result.Edit" desc="Edit" help="Edit image" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -10,7 +10,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
           AXProgressIndicator value=number enabled=true
-          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Stop the active response before unloading models" enabled=false
           AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
           AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
           AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -8,13 +8,12 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXBusyIndicator value=number enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -13,13 +13,12 @@ AXApplication title="Rapid-MLX"
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true
             AXPopUpButton id="Sidebar.Conversation.Menu.<uuid>" desc="Conversation actions" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden crash marker" enabled=true
-          AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXProgressIndicator id="Sidebar.Residency" value=number enabled=true
-          AXImage id="Sidebar.Residency" desc="Lock" enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
-          AXStaticText id="Sidebar.Residency" value=text enabled=true
+          AXProgressIndicator value=number enabled=true
+          AXButton id="Sidebar.Residency.Unload" desc="Unload model and free <size>" help="Unload model and free <size>" enabled=true
+          AXImage id="Sidebar.ResidentModel.<model>" desc="Lock" enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
+          AXStaticText id="Sidebar.ResidentModel.<model>" value=text enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXScrollArea

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -506,7 +506,7 @@ struct CoreWorkspaceVisualFoundationTests {
                 "Sidebar.Audio",
                 "Sidebar.Video",
                 "Sidebar.Launch",
-                "Sidebar.Residency",
+                "Sidebar.Residency.Unload",
                 "Toolbar.SearchChats",
                 "Sidebar.DeleteConversation.Confirm",
                 "Sidebar.DeleteConversation.Keep",

--- a/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CoreWorkspaceVisualFoundationTests.swift
@@ -506,6 +506,7 @@ struct CoreWorkspaceVisualFoundationTests {
                 "Sidebar.Audio",
                 "Sidebar.Video",
                 "Sidebar.Launch",
+                "Sidebar.Residency",
                 "Sidebar.Residency.Unload",
                 "Toolbar.SearchChats",
                 "Sidebar.DeleteConversation.Confirm",

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -256,12 +256,17 @@ struct ModelResidencyTests {
     }
 
     @Test("Resident unload stops after a fresh idle response")
-    func residentUnloadStopsFreshIdleServer() async {
+    func residentUnloadStopsFreshIdleServer() async throws {
         var client = ServerResidencyClient()
         client.session = IdleResidencyProtocol.session()
+        let suite = "ResidentUnloadStopsFreshIdleServer.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set("current-model", forKey: SessionModelRestore.chatAliasStorageKey)
         let server = ServerManager(
             testingState: .ready(alias: "current-model"),
-            residency: .empty
+            residency: .empty,
+            sessionDefaults: defaults
         )
         server._testSetResidencyClient(client)
         server._testInstallChild(ProcessGroupChild.testStub())
@@ -269,10 +274,7 @@ struct ModelResidencyTests {
         #expect(await server.unloadResidentModelsIfIdle() == .stopped)
         #expect(server.state == .stopped)
         #expect(server.residency.activeRequests(for: "current-model") == 0)
-        #expect(ServerManager.shouldClearLastServedAlias(
-            expectedStop: true,
-            preservingLastServedAlias: false
-        ), "explicit eject must not auto-resume the model on next app launch")
+        #expect(ServerManager.lastServedAlias(defaults: defaults) == nil)
     }
 
     @Test("Resident unload also refuses a busy audio lane")

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -112,9 +112,15 @@ struct ModelResidencyTests {
             ResidentAudioLaneStatus(
                 lane: "stt",
                 model: "mlx-community/whisper-small-mlx",
-                state: "resident"
+                state: "resident",
+                activeRequests: 0
             ),
-            ResidentAudioLaneStatus(lane: "tts", model: nil, state: "registered")
+            ResidentAudioLaneStatus(
+                lane: "tts",
+                model: nil,
+                state: "registered",
+                activeRequests: 0
+            )
         ])
         #expect(snapshot.containsResidentAudioLane(
             modelPath: "mlx-community/whisper-small-mlx"
@@ -263,6 +269,26 @@ struct ModelResidencyTests {
         #expect(await server.unloadResidentModelsIfIdle() == .stopped)
         #expect(server.state == .stopped)
         #expect(server.residency.activeRequests(for: "current-model") == 0)
+        #expect(ServerManager.shouldClearLastServedAlias(
+            expectedStop: true,
+            preservingLastServedAlias: false
+        ), "explicit eject must not auto-resume the model on next app launch")
+    }
+
+    @Test("Resident unload also refuses a busy audio lane")
+    func residentUnloadRefusesFreshBusyAudioState() async {
+        var client = ServerResidencyClient()
+        client.session = BusyAudioResidencyProtocol.session()
+        let server = ServerManager(
+            testingState: .ready(alias: "current-model"),
+            residency: .empty
+        )
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+
+        #expect(await server.unloadResidentModelsIfIdle() == .busy)
+        #expect(server.state == .ready(alias: "current-model"))
+        #expect(server.residency.audioLanes.first?.activeRequests == 1)
     }
 
     @Test(
@@ -1012,6 +1038,29 @@ private final class IdleResidencyProtocol: URLProtocol, @unchecked Sendable {
 
     override func startLoading() {
         let payload = #"{"memory_limit_bytes":10,"memory_used_bytes":1,"memory_available_bytes":9,"idle_ttl_seconds":60,"loads_total":1,"evictions_total":0,"models":[{"id":"current-model","model_path":"test/current-model","aliases":[],"modality":"text","state":"resident","pinned":true,"primary":true,"active_requests":0,"estimated_bytes":1,"measured_bytes":null,"idle_seconds":0}],"audio_lanes":[]}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private final class BusyAudioResidencyProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BusyAudioResidencyProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override func startLoading() {
+        let payload = #"{"memory_limit_bytes":10,"memory_used_bytes":1,"memory_available_bytes":9,"idle_ttl_seconds":60,"loads_total":1,"evictions_total":0,"models":[],"audio_lanes":[{"lane":"tts","model":"test/voice","state":"resident","active_requests":1}]}"#.data(using: .utf8)!
         let response = HTTPURLResponse(
             url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
         )!

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -233,6 +233,38 @@ struct ModelResidencyTests {
         #expect(ModelSwitchConfirmationPreference.isEnabled(in: defaults))
     }
 
+    @Test("Resident unload refreshes request state and refuses a busy server")
+    func residentUnloadRefusesFreshBusyState() async {
+        var client = ServerResidencyClient()
+        client.session = BusyResidencyProtocol.session()
+        let server = ServerManager(
+            testingState: .ready(alias: "current-model"),
+            residency: .empty
+        )
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+
+        #expect(await server.unloadResidentModelsIfIdle() == .busy)
+        #expect(server.state == .ready(alias: "current-model"))
+        #expect(server.residency.activeRequests(for: "current-model") == 1)
+    }
+
+    @Test("Resident unload stops after a fresh idle response")
+    func residentUnloadStopsFreshIdleServer() async {
+        var client = ServerResidencyClient()
+        client.session = IdleResidencyProtocol.session()
+        let server = ServerManager(
+            testingState: .ready(alias: "current-model"),
+            residency: .empty
+        )
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+
+        #expect(await server.unloadResidentModelsIfIdle() == .stopped)
+        #expect(server.state == .stopped)
+        #expect(server.residency.activeRequests(for: "current-model") == 0)
+    }
+
     @Test(
         "Cancelling an active-request model switch leaves the live model untouched",
         .timeLimit(.minutes(1))
@@ -957,6 +989,29 @@ private final class BusyResidencyProtocol: URLProtocol, @unchecked Sendable {
 
     override func startLoading() {
         let payload = #"{"memory_limit_bytes":10,"memory_used_bytes":1,"memory_available_bytes":9,"idle_ttl_seconds":60,"loads_total":1,"evictions_total":0,"models":[{"id":"current-model","model_path":"test/current-model","aliases":[],"modality":"text","state":"resident","pinned":true,"primary":true,"active_requests":1,"estimated_bytes":1,"measured_bytes":null,"idle_seconds":0}],"audio_lanes":[]}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private final class IdleResidencyProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [IdleResidencyProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override func startLoading() {
+        let payload = #"{"memory_limit_bytes":10,"memory_used_bytes":1,"memory_available_bytes":9,"idle_ttl_seconds":60,"loads_total":1,"evictions_total":0,"models":[{"id":"current-model","model_path":"test/current-model","aliases":[],"modality":"text","state":"resident","pinned":true,"primary":true,"active_requests":0,"estimated_bytes":1,"measured_bytes":null,"idle_seconds":0}],"audio_lanes":[]}"#.data(using: .utf8)!
         let response = HTTPURLResponse(
             url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
         )!

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -293,6 +293,22 @@ struct ModelResidencyTests {
         #expect(server.residency.audioLanes.first?.activeRequests == 1)
     }
 
+    @Test("Resident unload fails closed when audio request state is unavailable")
+    func residentUnloadRefusesUnknownAudioState() async {
+        var client = ServerResidencyClient()
+        client.session = UnknownAudioResidencyProtocol.session()
+        let server = ServerManager(
+            testingState: .ready(alias: "current-model"),
+            residency: .empty
+        )
+        server._testSetResidencyClient(client)
+        server._testInstallChild(ProcessGroupChild.testStub())
+
+        #expect(await server.unloadResidentModelsIfIdle() == .unavailable)
+        #expect(server.state == .ready(alias: "current-model"))
+        #expect(server.residency.audioLanes.first?.activeRequests == nil)
+    }
+
     @Test(
         "Cancelling an active-request model switch leaves the live model untouched",
         .timeLimit(.minutes(1))
@@ -1063,6 +1079,29 @@ private final class BusyAudioResidencyProtocol: URLProtocol, @unchecked Sendable
 
     override func startLoading() {
         let payload = #"{"memory_limit_bytes":10,"memory_used_bytes":1,"memory_available_bytes":9,"idle_ttl_seconds":60,"loads_total":1,"evictions_total":0,"models":[],"audio_lanes":[{"lane":"tts","model":"test/voice","state":"resident","active_requests":1}]}"#.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private final class UnknownAudioResidencyProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [UnknownAudioResidencyProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    override func startLoading() {
+        let payload = #"{"memory_limit_bytes":10,"memory_used_bytes":1,"memory_available_bytes":9,"idle_ttl_seconds":60,"loads_total":1,"evictions_total":0,"models":[],"audio_lanes":[{"lane":"tts","model":"test/voice","state":"resident"}]}"#.data(using: .utf8)!
         let response = HTTPURLResponse(
             url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
         )!

--- a/apps/rapid-mac/Tests/RapidTests/SidebarResidentUnloadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarResidentUnloadTests.swift
@@ -1,0 +1,82 @@
+import Testing
+@testable import Rapid
+
+@Suite("Sidebar resident unload")
+struct SidebarResidentUnloadTests {
+    @Test("Memory summary keeps one shared unit in the narrow sidebar")
+    func compactMemorySummary() {
+        let gib = UInt64(1) << 30
+        #expect(
+            SidebarView.memorySummary(
+                usedBytes: 6 * gib,
+                limitBytes: 204 * gib
+            ) == "6 / 204 GB"
+        )
+    }
+
+    @Test("Unload is available only while the resident pool is idle")
+    func disabledState() {
+        #expect(!SidebarView.residentUnloadDisabled(
+            isOperating: false,
+            chatIsStreaming: false,
+            hasActiveRequests: false
+        ))
+        #expect(SidebarView.residentUnloadDisabled(
+            isOperating: true,
+            chatIsStreaming: false,
+            hasActiveRequests: false
+        ))
+        #expect(SidebarView.residentUnloadDisabled(
+            isOperating: false,
+            chatIsStreaming: true,
+            hasActiveRequests: false
+        ))
+        #expect(SidebarView.residentUnloadDisabled(
+            isOperating: false,
+            chatIsStreaming: false,
+            hasActiveRequests: true
+        ))
+    }
+
+    @Test("Accessible copy names the scope and memory released")
+    func accessibleCopy() {
+        let gib = UInt64(1) << 30
+        #expect(
+            SidebarView.residentUnloadLabel(
+                modelCount: 1,
+                memoryUsedBytes: 6 * gib
+            ) == "Unload model and free 6 GB"
+        )
+        #expect(
+            SidebarView.residentUnloadLabel(
+                modelCount: 2,
+                memoryUsedBytes: 10 * gib
+            ) == "Unload all models and free 10 GB"
+        )
+    }
+
+    @Test("Help explains blocked and in-progress states")
+    func helpCopy() {
+        #expect(
+            SidebarView.residentUnloadHelp(
+                isOperating: false,
+                hasActiveResponse: false,
+                enabledLabel: "Unload model and free 6 GB"
+            ) == "Unload model and free 6 GB"
+        )
+        #expect(
+            SidebarView.residentUnloadHelp(
+                isOperating: false,
+                hasActiveResponse: true,
+                enabledLabel: "unused"
+            ) == "Stop the active response before unloading models"
+        )
+        #expect(
+            SidebarView.residentUnloadHelp(
+                isOperating: true,
+                hasActiveResponse: true,
+                enabledLabel: "unused"
+            ) == "Unloading models…"
+        )
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/SidebarResidentUnloadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarResidentUnloadTests.swift
@@ -1,8 +1,90 @@
+import SwiftUI
 import Testing
 @testable import Rapid
 
 @Suite("Sidebar resident unload")
 struct SidebarResidentUnloadTests {
+    @MainActor
+    private final class UnloadProbe {
+        var calls = 0
+    }
+
+    private func residentSnapshot(activeRequests: Int = 0) -> ModelResidencySnapshot {
+        let gib = UInt64(1) << 30
+        return ModelResidencySnapshot(
+            memoryLimitBytes: 14 * gib,
+            memoryUsedBytes: 6 * gib,
+            memoryAvailableBytes: 8 * gib,
+            idleTTLSeconds: 900,
+            loadsTotal: 1,
+            evictionsTotal: 0,
+            models: [
+                ResidentModelStatus(
+                    id: "qwen3.5-4b-4bit",
+                    modelPath: "mlx-community/qwen3.5-4b-4bit",
+                    aliases: ["qwen3.5-4b-4bit"],
+                    modality: "text",
+                    state: "resident",
+                    pinned: true,
+                    primary: true,
+                    activeRequests: activeRequests,
+                    estimatedBytes: 6 * gib,
+                    measuredBytes: nil,
+                    idleSeconds: 12
+                ),
+            ]
+        )
+    }
+
+    @MainActor
+    @Test("The AX eject control invokes unload when idle and rejects a busy press")
+    func controlWiring() async throws {
+        let chat = ChatViewModel(persistsConversations: false)
+        let probe = UnloadProbe()
+        let idleServer = ServerManager(
+            testingState: .ready(alias: "qwen3.5-4b-4bit"),
+            residency: residentSnapshot()
+        )
+        let idleStage = GoldenStage(
+            SidebarView(
+                selection: .constant(.chat),
+                chat: chat,
+                onNewChat: {},
+                onSelectConversation: { _ in },
+                server: idleServer,
+                onUnloadResidentModels: { probe.calls += 1 }
+            )
+            .frame(width: SidebarView.columnIdealWidth, height: 640)
+        )
+
+        try await idleStage.waitForIdentifier("Sidebar.Residency")
+        try await idleStage.waitForIdentifier("Sidebar.Residency.Unload")
+        try idleStage.press("Sidebar.Residency.Unload")
+        try await idleStage.wait(for: "the unload action") { probe.calls == 1 }
+
+        let busyServer = ServerManager(
+            testingState: .ready(alias: "qwen3.5-4b-4bit"),
+            residency: residentSnapshot(activeRequests: 1)
+        )
+        let busyStage = GoldenStage(
+            SidebarView(
+                selection: .constant(.chat),
+                chat: chat,
+                onNewChat: {},
+                onSelectConversation: { _ in },
+                server: busyServer,
+                onUnloadResidentModels: { probe.calls += 1 }
+            )
+            .frame(width: SidebarView.columnIdealWidth, height: 640)
+        )
+
+        try await busyStage.waitForIdentifier("Sidebar.Residency.Unload")
+        #expect(throws: GoldenStage.StageError.self) {
+            try busyStage.press("Sidebar.Residency.Unload")
+        }
+        #expect(probe.calls == 1)
+    }
+
     @Test("Memory summary keeps one shared unit in the narrow sidebar")
     func compactMemorySummary() {
         let gib = UInt64(1) << 30

--- a/apps/rapid-mac/Tests/RapidTests/SidebarResidentUnloadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarResidentUnloadTests.swift
@@ -9,7 +9,11 @@ struct SidebarResidentUnloadTests {
         var calls = 0
     }
 
-    private func residentSnapshot(activeRequests: Int = 0) -> ModelResidencySnapshot {
+    private func residentSnapshot(
+        activeRequests: Int = 0,
+        includeTextModel: Bool = true,
+        audioActiveRequests: Int? = nil
+    ) -> ModelResidencySnapshot {
         let gib = UInt64(1) << 30
         return ModelResidencySnapshot(
             memoryLimitBytes: 14 * gib,
@@ -18,7 +22,7 @@ struct SidebarResidentUnloadTests {
             idleTTLSeconds: 900,
             loadsTotal: 1,
             evictionsTotal: 0,
-            models: [
+            models: includeTextModel ? [
                 ResidentModelStatus(
                     id: "qwen3.5-4b-4bit",
                     modelPath: "mlx-community/qwen3.5-4b-4bit",
@@ -32,7 +36,15 @@ struct SidebarResidentUnloadTests {
                     measuredBytes: nil,
                     idleSeconds: 12
                 ),
-            ]
+            ] : [],
+            audioLanes: audioActiveRequests.map {
+                [ResidentAudioLaneStatus(
+                    lane: "tts",
+                    model: "test/voice",
+                    state: "resident",
+                    activeRequests: $0
+                )]
+            } ?? []
         )
     }
 
@@ -83,6 +95,58 @@ struct SidebarResidentUnloadTests {
             try busyStage.press("Sidebar.Residency.Unload")
         }
         #expect(probe.calls == 1)
+
+        let busyAudioServer = ServerManager(
+            testingState: .ready(alias: "qwen3.5-4b-4bit"),
+            residency: residentSnapshot(audioActiveRequests: 1)
+        )
+        let busyAudioStage = GoldenStage(
+            SidebarView(
+                selection: .constant(.chat),
+                chat: chat,
+                onNewChat: {},
+                onSelectConversation: { _ in },
+                server: busyAudioServer,
+                onUnloadResidentModels: { probe.calls += 1 }
+            )
+            .frame(width: SidebarView.columnIdealWidth, height: 640)
+        )
+
+        try await busyAudioStage.waitForIdentifier("Sidebar.Residency.Unload")
+        #expect(throws: GoldenStage.StageError.self) {
+            try busyAudioStage.press("Sidebar.Residency.Unload")
+        }
+        #expect(probe.calls == 1)
+    }
+
+    @Test("Audio-only residency stays visible and participates in busy state")
+    func audioResidencyPresentation() {
+        let idle = residentSnapshot(
+            includeTextModel: false,
+            audioActiveRequests: 0
+        )
+        let busy = residentSnapshot(
+            includeTextModel: false,
+            audioActiveRequests: 1
+        )
+
+        #expect(SidebarView.hasResidentWorkloads(idle))
+        #expect(SidebarView.residentWorkloadCount(idle) == 1)
+        #expect(!SidebarView.hasActiveResidentRequests(idle))
+        #expect(SidebarView.hasActiveResidentRequests(busy))
+    }
+
+    @Test("Unload result copy explains a refused or unavailable stop")
+    func resultCopy() {
+        #expect(SidebarView.residentUnloadMessage(for: .stopped) == nil)
+        #expect(
+            SidebarView.residentUnloadMessage(for: .busy)
+                == "A request is still using the models. Stop it, then try again."
+        )
+        #expect(
+            SidebarView.residentUnloadMessage(for: .unavailable)
+                == "Rapid couldn't confirm that the models were idle. Wait a moment, then try again."
+        )
     }
 
     @Test("Memory summary keeps one shared unit in the narrow sidebar")

--- a/apps/rapid-mac/Tests/RapidTests/SidebarResidentUnloadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidebarResidentUnloadTests.swift
@@ -164,22 +164,22 @@ struct SidebarResidentUnloadTests {
     func disabledState() {
         #expect(!SidebarView.residentUnloadDisabled(
             isOperating: false,
-            chatIsStreaming: false,
+            hasActiveModelWork: false,
             hasActiveRequests: false
         ))
         #expect(SidebarView.residentUnloadDisabled(
             isOperating: true,
-            chatIsStreaming: false,
+            hasActiveModelWork: false,
             hasActiveRequests: false
         ))
         #expect(SidebarView.residentUnloadDisabled(
             isOperating: false,
-            chatIsStreaming: true,
+            hasActiveModelWork: true,
             hasActiveRequests: false
         ))
         #expect(SidebarView.residentUnloadDisabled(
             isOperating: false,
-            chatIsStreaming: false,
+            hasActiveModelWork: false,
             hasActiveRequests: true
         ))
     }

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -5183,12 +5183,14 @@ flow_audio_readiness() {
     local speech_resident=0
     for ((i=0; i<120; i++)); do
         see_main "$OUT/speech-resident.json"
-        if jq -e '.data.ui_elements as $elements
-                  | any(range(1; $elements | length);
-                        $elements[.].identifier == "Sidebar.Residency"
-                        and $elements[.].value == "fake-qwen3-tts"
-                        and $elements[. - 1].identifier == "Sidebar.Residency"
-                        and $elements[. - 1].description == "Lock")' \
+        if jq -e '[.data.ui_elements[]?
+                   | select(.identifier == "Sidebar.ResidentModel.fake-qwen3-tts")]
+                  | (any(.[];
+                         .role == "AXImage"
+                         and .description == "Lock"))
+                    and (any(.[];
+                             .role == "AXStaticText"
+                             and .value == "fake-qwen3-tts"))' \
                  "$OUT/speech-resident.json" >/dev/null; then
             speech_resident=1; break
         fi

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -1697,21 +1697,26 @@ def test_audio_baseline_waits_for_residency_poll_to_settle():
     flow = (
         HARNESS.read_text().split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]
     )
-    correlated_row = "any(range(1; $elements | length);"
-    resident_alias = '$elements[.].value == "fake-qwen3-tts"'
-    resident_lock = '$elements[. - 1].description == "Lock"'
+    resident_identifier = (
+        '.identifier == "Sidebar.ResidentModel.fake-qwen3-tts"'
+    )
+    resident_alias = '.value == "fake-qwen3-tts"'
+    resident_lock = '.role == "AXImage"'
+    pinned_state = '.description == "Lock"'
     settled_guard = '[[ "$speech_resident" == 1 ]]'
     launch_check = 'press "$OUT/speech-resident.json" Sidebar.Launch'
     return_to_audio = 'press "$OUT/launch-from-audio.json" Sidebar.Audio'
     switch = 'press "$OUT/audio-after-launch.json" Audio.Mode.Dictation'
-    assert correlated_row in flow
+    assert resident_identifier in flow
     assert resident_alias in flow
     assert resident_lock in flow
+    assert pinned_state in flow
     assert settled_guard in flow
     assert launch_check in flow
     assert return_to_audio in flow
     assert switch in flow
     assert flow.index(resident_alias) < flow.index(launch_check)
     assert flow.index(resident_lock) < flow.index(launch_check)
+    assert flow.index(pinned_state) < flow.index(launch_check)
     assert flow.index(settled_guard) < flow.index(launch_check)
     assert flow.index(launch_check) < flow.index(return_to_audio) < flow.index(switch)

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -1697,9 +1697,7 @@ def test_audio_baseline_waits_for_residency_poll_to_settle():
     flow = (
         HARNESS.read_text().split("flow_audio_readiness() {", 1)[1].split("\n}", 1)[0]
     )
-    resident_identifier = (
-        '.identifier == "Sidebar.ResidentModel.fake-qwen3-tts"'
-    )
+    resident_identifier = '.identifier == "Sidebar.ResidentModel.fake-qwen3-tts"'
     resident_alias = '.value == "fake-qwen3-tts"'
     resident_lock = '.role == "AXImage"'
     pinned_state = '.description == "Lock"'


### PR DESCRIPTION
## Why

Desktop shows resident model memory but offers no discoverable way to release it. On memory-constrained Macs, users currently have to quit the app or know an indirect server control.

## Scope

- Add one aggregate eject control beside the sidebar resident-memory bar, including audio-only resident pools.
- Refresh live residency before stopping and refuse currently reported busy text or audio lanes.
- Disable unload during visible active work, show progress, and explain busy/unavailable outcomes instead of silently no-oping.
- Keep the current-session model picker selection so the existing Start action reloads it.
- Keep the narrow memory summary readable and expose stable, separate group/button accessibility identifiers.
- Add focused ServerManager, persistence, wire-decode, AX interaction, logic, and deterministic light/dark snapshot coverage.

## Non-goals

- No engine or public API changes.
- No per-model eviction semantics; the primary model is engine-pinned, so the UI truthfully releases the whole resident pool.
- No new atomic server drain protocol. Like the existing model-switch guard, the fresh request-count check is advisory; an external request arriving after that response remains subject to the users explicit stop action.
- No persisted auto-resume after eject. Current picker selection and the persisted last-served alias are deliberately different: Start stays convenient in the current session, but reopening Rapid must not silently consume the memory the user explicitly freed.

## Acceptance

- A loaded text or audio-only model has a visible eject icon in the Resident footer.
- One click refreshes residency and, when idle, terminates the local serving process, removes the Resident footer, keeps the current picker choice, and exposes the existing Start recovery action.
- A freshly reported active text or audio request refuses the unload; known active work disables the control; race/fetch failures receive explicit explanatory UI.
- The explicit eject clears the persisted auto-resume alias, so the model remains unloaded across an app relaunch.
- Memory copy and model names remain untruncated at the verified sidebar width in light and dark appearances.
- VoiceOver/GUI automation can independently address Sidebar.Residency and Sidebar.Residency.Unload.

## Verification

- swift test focused unload/residency/accessibility set (passed)
- ./scripts/desktop-test-timeout.sh (3444 tests in 298 suites passed on exact head)
- pr_validate on exact head: MERGE-SAFE, Codex found no blocking issues; 21667 passed, 108 skipped, 22 deselected, 6 xfailed, 1 xpassed
- bash scripts/build.sh (release app assembled)
- codesign --verify --deep --strict on the local app bundle
- Live dogfood with qwen3.5-4b-4bit: unload exited the 3.1 GB resident sidecar, removed the footer, retained the current picker choice, and showed Start
- Inspected deterministic sidebar captures in light and dark mode after the final UI changes; fixed a 204 GB capacity truncation found during dogfood
- git diff --check

## Behaviour delta

Desktop resident models: visible memory status with no unload action → one-click aggregate unload with fresh advisory text/audio busy checks, explicit failure feedback, and reversible current-session Start recovery.

## AI assistance disclosure

Codex wrote and self-reviewed the Desktop UI, guarded lifecycle method, focused tests, snapshot seam, and changelog entry. Verification included the full Swift suite, pr_validate with Codex review, a packaged release build, signature validation, light/dark visual inspection, and a real model load/unload cycle.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Checklist

- [x] Desktop tests pass locally on exact head
- [x] pr_validate exact-head verdict is MERGE-SAFE; all review findings addressed
- [x] Guard paths cover busy/idle text, busy audio, persistence, feedback, and real AX interaction
- [x] Updated Desktop changelog
- [x] No breaking changes to existing API

## Author

