### PR TITLE
fix(api): map reasoning_effort onto a template's native levels (#3043)

### DIFF
--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -104,10 +104,19 @@ nothing more.
 - `max_output_tokens` → `max_tokens`
 - `reasoning.effort` (or the top-level `reasoning_effort` shorthand) →
   rapid-mlx's thinking controls: `"none"` disables thinking
-  (`chat_template_kwargs.enable_thinking=false`); `minimal` / `low` /
-  `medium` / `high` set the matching `reasoning_max_tokens` tier cap.
-  Explicit client knobs on the same dimension always win. Values are
-  validated against the OpenAI closed set (garbage → 400).
+  (`chat_template_kwargs.enable_thinking=false`). A graded value
+  (`minimal` / `low` / `medium` / `high` / `xhigh`) is translated one of
+  two ways, chosen from the served chat template:
+  - templates that publish their own effort vocabulary (Qwen3.8 accepts
+    `low` / `medium` / `xhigh`) get the nearest native level written into
+    the prompt — `low` → `low`, `medium` → `medium`, `high` → `xhigh`,
+    `minimal` → `low` — and no token cap;
+  - every other thinking model gets the matching `reasoning_max_tokens`
+    tier cap (256 / 512 / 2048 / 8192 / 24000).
+  Explicit client knobs on the same dimension always win
+  (`chat_template_kwargs.reasoning_effort`, `reasoning_max_tokens`,
+  `enable_thinking`). Values are validated against the closed set
+  (garbage → 400).
 - `input_image` content blocks → Chat `image_url` parts (needs a
   multimodal model to do anything useful)
 - SSE: the streaming lifecycle events Codex parses

--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -233,6 +233,16 @@ Use `reasoning_max_tokens` to stop a model from over-thinking, and pair it with 
 
 If `reasoning_max_tokens` is unset, the model decides how long to think.
 
+### `reasoning_effort` (OpenAI-style)
+
+The OpenAI `reasoning_effort` knob (`none` / `minimal` / `low` / `medium` / `high` / `xhigh`, also `reasoning.effort` on `/v1/responses`) is translated per model:
+
+- `none` turns thinking off (`chat_template_kwargs.enable_thinking=false`).
+- On a model whose chat template has its own effort vocabulary (Qwen3.8 accepts `low` / `medium` / `xhigh`), the nearest native level is written into the prompt and **no** token cap is added: `low` → `low`, `medium` → `medium`, `high` → `xhigh`, `minimal` → `low`.
+- On every other thinking model the value becomes a `reasoning_max_tokens` cap: `minimal` 256, `low` 512, `medium` 2048, `high` 8192, `xhigh` 24000.
+
+Explicit knobs on the same dimension always win: `chat_template_kwargs.reasoning_effort` over the mapped level, `reasoning_max_tokens` over the tier cap, `enable_thinking` over `none`.
+
 ## Backward Compatibility
 
 When `--reasoning-parser` is not specified, the server behaves as before:

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -1,0 +1,819 @@
+# SPDX-License-Identifier: Apache-2.0
+"""#3043 — graded ``reasoning_effort`` maps onto a template's native levels.
+
+Qwen3.8's chat template validates ``reasoning_effort`` against
+``('xhigh', 'medium', 'low')`` and defaults to ``xhigh``. Before #3043 the
+OpenAI ``reasoning_effort`` knob never reached that variable: every graded
+value became a ``reasoning_max_tokens`` cap, so ``reasoning_effort="low"``
+rendered the template's *xhigh* instruction ("think carefully through the
+task…") and was then force-closed at 512 thinking tokens — the prompt and
+the budget contradicted each other — while ``xhigh`` itself was a 400.
+
+This file pins the post-fix contract:
+
+  1. Detection is data-driven from the template source: only a template
+     that *validates* ``reasoning_effort`` against a literal set publishes
+     a vocabulary. Harmony (interpolation only) and North Mini Code
+     (``== "none"`` sentinel) do not, and keep the token-cap fallback.
+  2. Mapping ranks both sides on the OpenAI ladder, uses a native value
+     verbatim when the template accepts it, and rounds ties *up*.
+  3. ``maybe_apply_reasoning_effort`` writes the native level into
+     ``chat_template_kwargs`` and layers no cap; an explicit client
+     ``chat_template_kwargs.reasoning_effort`` wins; templates without a
+     vocabulary (Qwen3.5 / 3.6, Gemma 4, …) and callers that pass no
+     template keep the pre-#3043 cap tiers byte-for-byte.
+  4. The mapped value is always one the real Jinja template accepts
+     (rendered through jinja2 with the checkpoint's own validation clause).
+  5. ``xhigh`` is accepted on both OpenAI surfaces and sits in the cap
+     table for templates that need the fallback.
+  6. End to end through ``/v1/chat/completions`` and ``/v1/responses`` with
+     an engine whose tokenizer serves the Qwen3.8 template: ``engine.chat``
+     receives the native level and *no* ``reasoning_max_tokens`` cap (so the
+     request never grows a budget logits processor and stays MTP-eligible),
+     while the same request against an on/off-only template keeps the cap.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from vllm_mlx.api.models import (
+    _VALID_REASONING_EFFORTS,
+    OPENAI_REASONING_EFFORT_TO_MAX_TOKENS,
+    ChatCompletionRequest,
+)
+from vllm_mlx.api.responses_models import ResponsesRequest
+from vllm_mlx.config import reset_config
+from vllm_mlx.engine.base import GenerationOutput
+from vllm_mlx.middleware.exception_handlers import install_exception_handlers
+from vllm_mlx.service.helpers import (
+    maybe_apply_reasoning_effort,
+    served_chat_template,
+)
+from vllm_mlx.utils.chat_template import (
+    REASONING_EFFORT_LADDER,
+    detect_native_reasoning_effort_levels,
+    map_reasoning_effort_to_native,
+)
+
+# Verbatim validation + instruction clause from
+# rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX ``chat_template.jinja`` (2026-09-04).
+# Kept as a fixture so the contract is pinned against the real shape, not a
+# hand-simplified one; the trailing user/assistant turn is the minimal
+# scaffolding needed to render it standalone.
+QWEN38_TEMPLATE = """\
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+    {%- if resolved_reasoning_effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- if reasoning_instructions %}
+    {{- '<|im_start|>system\\n' + reasoning_instructions + '<|im_end|>\\n' }}
+{%- endif %}
+{%- for message in messages %}
+    {{- '<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>\\n' }}
+{%- endfor %}
+{{- '<|im_start|>assistant\\n' }}
+{%- if enable_thinking is defined and enable_thinking is false %}
+    {{- '<think>\\n\\n</think>\\n\\n' }}
+{%- else %}
+    {{- '<think>\\n' }}
+{%- endif %}
+"""
+
+# Hy3 shape: validates against a list literal that includes a non-ladder
+# name (``no_think``).
+HY3_TEMPLATE_CLAUSE = (
+    "{%- if not reasoning_effort is defined or reasoning_effort not in "
+    "['high', 'low', 'no_think'] %}{%- set reasoning_effort = 'no_think' %}{%- endif %}"
+)
+
+# GPT-OSS / Harmony shape: interpolates the value, never validates it.
+HARMONY_TEMPLATE_CLAUSE = (
+    '{%- if reasoning_effort is not defined %}{%- set reasoning_effort = "medium" %}'
+    '{%- endif %}{{- "Reasoning: " + reasoning_effort + "\\n\\n" }}'
+)
+
+# North Mini Code shape: a single-sentinel comparison, no vocabulary.
+NORTH_TEMPLATE_CLAUSE = (
+    "{%- set reasoning = reasoning if reasoning is not undefined else "
+    '(false if reasoning_effort is defined and reasoning_effort | lower == "none" '
+    "else true) -%}"
+)
+
+# Qwen3.5 / 3.6 / Gemma 4 shape: only an on/off switch.
+ENABLE_THINKING_ONLY_TEMPLATE = (
+    "{%- if enable_thinking is defined and not enable_thinking %}"
+    "{{- '<think>\\n\\n</think>\\n\\n' }}{%- endif %}"
+)
+
+
+def _request(**overrides):
+    base = dict(
+        reasoning_effort=None,
+        chat_template_kwargs=None,
+        enable_thinking=None,
+        reasoning_max_tokens=None,
+        tools=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# (1) Detection is data-driven from the template source
+# ---------------------------------------------------------------------------
+
+
+class TestDetectNativeLevels:
+    def test_qwen38_publishes_its_vocabulary_in_template_order(self):
+        assert detect_native_reasoning_effort_levels(QWEN38_TEMPLATE) == (
+            "xhigh",
+            "medium",
+            "low",
+        )
+
+    def test_hy3_list_literal_is_detected(self):
+        assert detect_native_reasoning_effort_levels(HY3_TEMPLATE_CLAUSE) == (
+            "high",
+            "low",
+            "no_think",
+        )
+
+    def test_harmony_interpolation_only_publishes_nothing(self):
+        """Harmony renders whatever it is given; it never validates, so it
+        does not declare a vocabulary and keeps the cap fallback."""
+        assert detect_native_reasoning_effort_levels(HARMONY_TEMPLATE_CLAUSE) is None
+
+    def test_north_mini_code_sentinel_compare_publishes_nothing(self):
+        assert detect_native_reasoning_effort_levels(NORTH_TEMPLATE_CLAUSE) is None
+
+    def test_enable_thinking_only_template_publishes_nothing(self):
+        assert (
+            detect_native_reasoning_effort_levels(ENABLE_THINKING_ONLY_TEMPLATE) is None
+        )
+
+    @pytest.mark.parametrize("template", [None, "", 42])
+    def test_absent_or_foreign_template_publishes_nothing(self, template):
+        assert detect_native_reasoning_effort_levels(template) is None
+
+    def test_dict_template_prefers_tool_use_variant_when_tools_given(self):
+        template = {
+            "default": ENABLE_THINKING_ONLY_TEMPLATE,
+            "tool_use": QWEN38_TEMPLATE,
+        }
+        assert detect_native_reasoning_effort_levels(template) is None
+        assert detect_native_reasoning_effort_levels(
+            template, tools=[{"type": "function"}]
+        ) == ("xhigh", "medium", "low")
+
+    def test_default_filter_between_name_and_membership_is_tolerated(self):
+        clause = "{% if reasoning_effort|default('low') not in ['low', 'high'] %}"
+        assert detect_native_reasoning_effort_levels(clause) == ("low", "high")
+
+    def test_duplicate_literals_collapse(self):
+        clause = "{% if reasoning_effort in ('low', 'low', 'high') %}"
+        assert detect_native_reasoning_effort_levels(clause) == ("low", "high")
+
+
+# ---------------------------------------------------------------------------
+# (2) Mapping ranks both sides on the OpenAI ladder
+# ---------------------------------------------------------------------------
+
+
+class TestMapToNative:
+    QWEN38 = ("xhigh", "medium", "low")
+
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("minimal", "low"),
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "xhigh"),
+            ("xhigh", "xhigh"),
+        ],
+    )
+    def test_qwen38_mapping(self, effort, expected):
+        assert map_reasoning_effort_to_native(effort, self.QWEN38) == expected
+
+    def test_high_rounds_up_to_the_template_ceiling(self):
+        """``high`` is equidistant from ``medium`` and ``xhigh`` on the
+        ladder; a client asking for the top of OpenAI's range wants the
+        template's ceiling, so ties round up."""
+        assert map_reasoning_effort_to_native("high", ("low", "medium", "xhigh")) == (
+            "xhigh"
+        )
+
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("minimal", "low"),
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("xhigh", "high"),
+        ],
+    )
+    def test_harmony_shaped_vocabulary_maps_identity_and_clamps(self, effort, expected):
+        assert (
+            map_reasoning_effort_to_native(effort, ("low", "medium", "high"))
+            == expected
+        )
+
+    def test_hy3_ignores_non_ladder_names_but_still_maps(self):
+        levels = ("high", "low", "no_think")
+        assert map_reasoning_effort_to_native("low", levels) == "low"
+        assert map_reasoning_effort_to_native("medium", levels) == "high"
+        assert map_reasoning_effort_to_native("xhigh", levels) == "high"
+
+    def test_unknown_effort_name_is_unmapped(self):
+        assert map_reasoning_effort_to_native("banana", self.QWEN38) is None
+
+    def test_vocabulary_without_ladder_names_is_unmapped(self):
+        assert map_reasoning_effort_to_native("high", ("no_think", "think")) is None
+
+    def test_none_is_never_a_native_level(self):
+        """``none`` is the on/off dimension (``enable_thinking=False``),
+        never a template level — even if a template happened to list it."""
+        assert "none" not in REASONING_EFFORT_LADDER
+        assert map_reasoning_effort_to_native("none", self.QWEN38) is None
+
+
+# ---------------------------------------------------------------------------
+# (3) Helper contract: native level in, no cap on top
+# ---------------------------------------------------------------------------
+
+
+class TestHelperWithNativeTemplate:
+    @pytest.mark.parametrize(
+        ("effort", "native"),
+        [
+            ("minimal", "low"),
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "xhigh"),
+            ("xhigh", "xhigh"),
+        ],
+    )
+    def test_graded_writes_native_level_and_no_cap(self, effort, native):
+        req = _request(reasoning_effort=effort)
+        assert maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE) is True
+        assert req.chat_template_kwargs == {"reasoning_effort": native}
+        assert req.reasoning_max_tokens is None
+        assert req.enable_thinking is None
+
+    def test_none_still_disables_thinking_on_native_template(self):
+        req = _request(reasoning_effort="none")
+        assert maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE) is True
+        assert req.chat_template_kwargs == {"enable_thinking": False}
+        assert req.reasoning_max_tokens is None
+
+    def test_explicit_client_template_kwarg_wins_and_no_cap_is_layered(self):
+        req = _request(
+            reasoning_effort="high",
+            chat_template_kwargs={"reasoning_effort": "low"},
+        )
+        assert maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE) is False
+        assert req.chat_template_kwargs == {"reasoning_effort": "low"}
+        assert req.reasoning_max_tokens is None
+
+    def test_merge_preserves_forward_compat_keys(self):
+        req = _request(
+            reasoning_effort="low",
+            chat_template_kwargs={"future_key": "x", "enable_thinking": True},
+        )
+        assert maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE) is True
+        assert req.chat_template_kwargs == {
+            "future_key": "x",
+            "enable_thinking": True,
+            "reasoning_effort": "low",
+        }
+
+    def test_explicit_cap_is_orthogonal_to_the_native_level(self):
+        """A client that sets both ``reasoning_effort`` and its own
+        ``reasoning_max_tokens`` drives two dimensions: the prompt level is
+        still translated and the explicit cap is left exactly as sent."""
+        req = _request(reasoning_effort="high", reasoning_max_tokens=1000)
+        assert maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE) is True
+        assert req.chat_template_kwargs == {"reasoning_effort": "xhigh"}
+        assert req.reasoning_max_tokens == 1000
+
+    def test_idempotent_second_call(self):
+        req = _request(reasoning_effort="high")
+        assert maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE) is True
+        assert maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE) is False
+        assert req.chat_template_kwargs == {"reasoning_effort": "xhigh"}
+        assert req.reasoning_max_tokens is None
+
+    def test_tools_variant_of_dict_template_is_consulted(self):
+        template = {
+            "default": ENABLE_THINKING_ONLY_TEMPLATE,
+            "tool_use": QWEN38_TEMPLATE,
+        }
+        req = _request(reasoning_effort="low", tools=[{"type": "function"}])
+        assert maybe_apply_reasoning_effort(req, chat_template=template) is True
+        assert req.chat_template_kwargs == {"reasoning_effort": "low"}
+        assert req.reasoning_max_tokens is None
+
+
+class TestHelperFallbackUnchanged:
+    """Templates without a vocabulary, and callers that pass no template,
+    keep the pre-#3043 ``reasoning_max_tokens`` tiers byte-for-byte."""
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh"])
+    def test_enable_thinking_only_template_keeps_cap_tiers(self, effort):
+        req = _request(reasoning_effort=effort)
+        assert (
+            maybe_apply_reasoning_effort(
+                req, chat_template=ENABLE_THINKING_ONLY_TEMPLATE
+            )
+            is True
+        )
+        assert req.chat_template_kwargs is None
+        assert req.reasoning_max_tokens == OPENAI_REASONING_EFFORT_TO_MAX_TOKENS[effort]
+
+    @pytest.mark.parametrize("template", [None, "", HARMONY_TEMPLATE_CLAUSE])
+    def test_no_template_or_harmony_keeps_cap(self, template):
+        req = _request(reasoning_effort="high")
+        assert maybe_apply_reasoning_effort(req, chat_template=template) is True
+        assert req.chat_template_kwargs is None
+        assert req.reasoning_max_tokens == 8192
+
+    def test_legacy_positional_call_signature_still_works(self):
+        req = _request(reasoning_effort="medium")
+        assert maybe_apply_reasoning_effort(req) is True
+        assert req.reasoning_max_tokens == 2048
+
+    def test_none_on_cap_template_disables_thinking(self):
+        req = _request(reasoning_effort="none")
+        assert (
+            maybe_apply_reasoning_effort(
+                req, chat_template=ENABLE_THINKING_ONLY_TEMPLATE
+            )
+            is True
+        )
+        assert req.chat_template_kwargs == {"enable_thinking": False}
+
+    def test_explicit_cap_wins_on_cap_template(self):
+        req = _request(reasoning_effort="high", reasoning_max_tokens=64)
+        assert (
+            maybe_apply_reasoning_effort(
+                req, chat_template=ENABLE_THINKING_ONLY_TEMPLATE
+            )
+            is False
+        )
+        assert req.reasoning_max_tokens == 64
+
+
+class TestServedChatTemplateAccessor:
+    def test_reads_tokenizer_chat_template(self):
+        engine = SimpleNamespace(
+            tokenizer=SimpleNamespace(chat_template=QWEN38_TEMPLATE)
+        )
+        assert served_chat_template(engine) == QWEN38_TEMPLATE
+
+    @pytest.mark.parametrize(
+        "engine",
+        [
+            SimpleNamespace(),
+            SimpleNamespace(tokenizer=None),
+            SimpleNamespace(tokenizer=SimpleNamespace()),
+            None,
+        ],
+    )
+    def test_missing_tokenizer_or_template_is_none(self, engine):
+        assert served_chat_template(engine) is None
+
+
+# ---------------------------------------------------------------------------
+# (4) The mapped value is always one the real template accepts
+# ---------------------------------------------------------------------------
+
+
+def _render_qwen38(**template_kwargs) -> str:
+    """Render the verbatim Qwen3.8 clause through jinja2 the way
+    ``transformers`` does (``raise_exception`` bound as a global)."""
+    jinja2 = pytest.importorskip("jinja2")
+
+    def raise_exception(message):
+        raise jinja2.exceptions.TemplateError(message)
+
+    env = jinja2.Environment(trim_blocks=True, lstrip_blocks=True)
+    env.globals["raise_exception"] = raise_exception
+    return env.from_string(QWEN38_TEMPLATE).render(
+        messages=[{"role": "user", "content": "hi"}], **template_kwargs
+    )
+
+
+class TestRealTemplateRender:
+    def test_unmapped_openai_value_is_rejected_by_the_template(self):
+        """The pre-#3043 failure shape: forwarding ``high`` verbatim raises
+        inside the template (this is what surfaced as a 400 Chat template
+        error). The mapping exists precisely so this never happens."""
+        jinja2 = pytest.importorskip("jinja2")
+        with pytest.raises(
+            jinja2.exceptions.TemplateError, match="Unexpected reasoning effort high"
+        ):
+            _render_qwen38(reasoning_effort="high")
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh"])
+    def test_every_mapped_value_renders(self, effort):
+        req = _request(reasoning_effort=effort)
+        maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE)
+        rendered = _render_qwen38(**req.chat_template_kwargs)
+        assert rendered.endswith("<|im_start|>assistant\n<think>\n")
+
+    def test_low_renders_the_brief_instruction(self):
+        req = _request(reasoning_effort="low")
+        maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE)
+        rendered = _render_qwen38(**req.chat_template_kwargs)
+        assert "Reasoning effort is set to low. Keep your thinking brief" in rendered
+        assert "xhigh" not in rendered
+
+    def test_high_renders_the_xhigh_instruction(self):
+        req = _request(reasoning_effort="high")
+        maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE)
+        rendered = _render_qwen38(**req.chat_template_kwargs)
+        assert "Reasoning effort is set to xhigh. Please think carefully" in rendered
+
+    def test_medium_renders_no_instruction_line(self):
+        req = _request(reasoning_effort="medium")
+        maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE)
+        rendered = _render_qwen38(**req.chat_template_kwargs)
+        assert "Reasoning effort is set to" not in rendered
+        assert rendered.endswith("<|im_start|>assistant\n<think>\n")
+
+    def test_none_renders_the_empty_think_block(self):
+        req = _request(reasoning_effort="none")
+        maybe_apply_reasoning_effort(req, chat_template=QWEN38_TEMPLATE)
+        rendered = _render_qwen38(**req.chat_template_kwargs)
+        assert rendered.endswith("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+        assert "Reasoning effort is set to" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# (5) ``xhigh`` on both OpenAI surfaces + cap table
+# ---------------------------------------------------------------------------
+
+
+class TestXhighSchema:
+    def test_xhigh_is_in_the_closed_set(self):
+        assert "xhigh" in _VALID_REASONING_EFFORTS
+
+    def test_xhigh_cap_tier_matches_anthropic(self):
+        from vllm_mlx.api.anthropic_models import (
+            ANTHROPIC_EFFORT_TO_REASONING_MAX_TOKENS,
+        )
+
+        assert OPENAI_REASONING_EFFORT_TO_MAX_TOKENS["xhigh"] == 24000
+        assert (
+            OPENAI_REASONING_EFFORT_TO_MAX_TOKENS["xhigh"]
+            == ANTHROPIC_EFFORT_TO_REASONING_MAX_TOKENS["xhigh"]
+        )
+
+    def test_cap_tiers_stay_monotonic_with_xhigh(self):
+        caps = [
+            OPENAI_REASONING_EFFORT_TO_MAX_TOKENS[e]
+            for e in ("minimal", "low", "medium", "high", "xhigh")
+        ]
+        assert caps == sorted(caps) and len(set(caps)) == len(caps)
+
+    def test_chat_request_accepts_xhigh(self):
+        req = ChatCompletionRequest(
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="xhigh",
+        )
+        assert req.reasoning_effort == "xhigh"
+
+    def test_responses_request_accepts_xhigh_top_level_and_nested(self):
+        top = ResponsesRequest(model="m", input="hi", reasoning_effort="xhigh")
+        assert top.reasoning_effort == "xhigh"
+        nested = ResponsesRequest(model="m", input="hi", reasoning={"effort": "xhigh"})
+        assert nested.reasoning == {"effort": "xhigh"}
+
+    def test_garbage_still_400s_at_schema(self):
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                reasoning_effort="xxhigh",
+            )
+
+
+# ---------------------------------------------------------------------------
+# (6) Route level: the engine sees the native level, never a cap
+# ---------------------------------------------------------------------------
+
+
+class _RouteEngine:
+    """Thinking-model-shaped mock whose tokenizer serves ``chat_template``
+    and which records the kwargs the route forwards to ``engine.chat``."""
+
+    preserve_native_tool_format = False
+    is_mllm = False
+    supports_guided_generation = False
+    supports_tool_calls = True
+
+    def __init__(self, chat_template):
+        self.tokenizer = (
+            SimpleNamespace(chat_template=chat_template)
+            if chat_template is not None
+            else None
+        )
+        self.chat_calls: list[dict] = []
+
+    def build_prompt(self, messages, tools=None, enable_thinking=None):
+        return "PROMPT"
+
+    async def chat(self, messages=None, **kwargs):
+        self.chat_calls.append({"messages": messages, "kwargs": kwargs})
+        return GenerationOutput(
+            text="ok",
+            new_text="ok",
+            prompt_tokens=4,
+            completion_tokens=2,
+            finished=True,
+            finish_reason="stop",
+        )
+
+    @property
+    def kwargs(self) -> dict:
+        assert self.chat_calls, "engine.chat was not called"
+        return self.chat_calls[0]["kwargs"]
+
+
+@pytest.fixture
+def _rate_limiter_state():
+    from vllm_mlx.middleware.auth import rate_limiter
+
+    saved_enabled = rate_limiter.enabled
+    saved_rpm = rate_limiter.requests_per_minute
+    saved_requests = dict(rate_limiter._requests)
+    rate_limiter.enabled = False
+    rate_limiter.requests_per_minute = 60
+    rate_limiter._requests.clear()
+    yield rate_limiter
+    rate_limiter.enabled = saved_enabled
+    rate_limiter.requests_per_minute = saved_rpm
+    rate_limiter._requests.clear()
+    rate_limiter._requests.update(saved_requests)
+
+
+@pytest.fixture
+def _chat_cap_probe():
+    """Record the ``reasoning_max_tokens`` the chat route hands its
+    generation-time budget builder. ``None`` means no cap was translated, so
+    no ``ReasoningBudgetLogitsProcessor`` can ever be built for the request
+    (the builder is the only place one is created on this surface)."""
+    seen: list = []
+
+    def _probe(engine, request, cfg, messages, resolved_thinking, **_kw):
+        seen.append(getattr(request, "reasoning_max_tokens", None))
+        return None
+
+    with patch(
+        "vllm_mlx.routes.chat._build_reasoning_budget_processor", side_effect=_probe
+    ):
+        yield seen
+
+
+@pytest.fixture
+def _responses_cap_probe():
+    """Record the ``reasoning_max_tokens`` the responses route hands its
+    post-hoc finalizer (the generic cap is enforced post-hoc on this surface)."""
+    import vllm_mlx.routes.responses as responses_mod
+
+    seen: list = []
+    original = responses_mod._finalize_content_and_reasoning
+
+    def _probe(*args, **kwargs):
+        seen.append(kwargs.get("reasoning_max_tokens"))
+        return original(*args, **kwargs)
+
+    with patch(
+        "vllm_mlx.routes.responses._finalize_content_and_reasoning",
+        side_effect=_probe,
+    ):
+        yield seen
+
+
+def _client(engine: _RouteEngine, *, surface: str) -> TestClient:
+    if surface == "chat":
+        from vllm_mlx.routes.chat import router
+    else:
+        from vllm_mlx.routes.responses import router
+
+    cfg = reset_config()
+    cfg.engine = engine
+    cfg.model_name = "test-model"
+    cfg.model_registry = None
+    cfg.no_thinking = False
+    cfg.reasoning_parser_name = "qwen3"
+
+    app = FastAPI()
+    install_exception_handlers(app)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _chat_body(**extra) -> dict:
+    body = {
+        "model": "test-model",
+        "max_tokens": 80,
+        "messages": [{"role": "user", "content": "In 8 words, what is rapid-mlx?"}],
+    }
+    body.update(extra)
+    return body
+
+
+def _responses_body(**extra) -> dict:
+    body = {
+        "model": "test-model",
+        "max_output_tokens": 80,
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "In 8 words, what is rapid-mlx?"}
+                ],
+            }
+        ],
+    }
+    body.update(extra)
+    return body
+
+
+class TestChatRouteNativeLevel:
+    @pytest.mark.parametrize(
+        ("effort", "native"),
+        [("low", "low"), ("medium", "medium"), ("high", "xhigh"), ("xhigh", "xhigh")],
+    )
+    def test_graded_reaches_engine_as_template_level_without_cap(
+        self, _rate_limiter_state, _chat_cap_probe, effort, native
+    ):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        resp = _client(engine, surface="chat").post(
+            "/v1/chat/completions", json=_chat_body(reasoning_effort=effort)
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.kwargs.get("chat_template_kwargs") == {"reasoning_effort": native}
+        # No cap was translated, so no budget processor can be built: the
+        # request stays on the MTP-eligible path (#3044 is about the cap path).
+        assert _chat_cap_probe == [None]
+        assert "reasoning_budget_logits_processor" not in engine.kwargs
+        # ``reasoning_effort`` is an explicit reasoning signal: the casual-chat
+        # auto-disable must step aside so the native level actually applies.
+        assert engine.kwargs.get("enable_thinking") is not False
+
+    def test_client_template_kwarg_wins_over_reasoning_effort(
+        self, _rate_limiter_state, _chat_cap_probe
+    ):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        resp = _client(engine, surface="chat").post(
+            "/v1/chat/completions",
+            json=_chat_body(
+                reasoning_effort="high",
+                chat_template_kwargs={"reasoning_effort": "low"},
+            ),
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.kwargs.get("chat_template_kwargs") == {"reasoning_effort": "low"}
+        assert _chat_cap_probe == [None]
+
+    def test_none_still_switches_thinking_off(
+        self, _rate_limiter_state, _chat_cap_probe
+    ):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        resp = _client(engine, surface="chat").post(
+            "/v1/chat/completions", json=_chat_body(reasoning_effort="none")
+        )
+        assert resp.status_code == 200, resp.text
+        ctk = engine.kwargs.get("chat_template_kwargs") or {}
+        assert ctk.get("enable_thinking") is False
+        assert "reasoning_effort" not in ctk
+        assert _chat_cap_probe == [None]
+
+    def test_on_off_only_template_keeps_the_cap(
+        self, _rate_limiter_state, _chat_cap_probe
+    ):
+        engine = _RouteEngine(ENABLE_THINKING_ONLY_TEMPLATE)
+        resp = _client(engine, surface="chat").post(
+            "/v1/chat/completions", json=_chat_body(reasoning_effort="high")
+        )
+        assert resp.status_code == 200, resp.text
+        assert "reasoning_effort" not in (
+            engine.kwargs.get("chat_template_kwargs") or {}
+        )
+        assert _chat_cap_probe == [8192]
+
+    def test_engine_without_tokenizer_keeps_the_cap(
+        self, _rate_limiter_state, _chat_cap_probe
+    ):
+        engine = _RouteEngine(None)
+        resp = _client(engine, surface="chat").post(
+            "/v1/chat/completions", json=_chat_body(reasoning_effort="low")
+        )
+        assert resp.status_code == 200, resp.text
+        assert _chat_cap_probe == [512]
+
+    def test_unknown_effort_is_a_400_not_a_template_error(self, _rate_limiter_state):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        resp = _client(engine, surface="chat").post(
+            "/v1/chat/completions", json=_chat_body(reasoning_effort="ultra")
+        )
+        assert resp.status_code == 400, resp.text
+        assert not engine.chat_calls
+
+
+class TestResponsesRouteNativeLevel:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"reasoning": {"effort": "high"}},
+            {"reasoning_effort": "high"},
+        ],
+        ids=["nested-reasoning.effort", "top-level-reasoning_effort"],
+    )
+    def test_high_reaches_engine_as_xhigh_without_cap(
+        self, _rate_limiter_state, _responses_cap_probe, body
+    ):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        resp = _client(engine, surface="responses").post(
+            "/v1/responses", json=_responses_body(**body)
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.kwargs.get("chat_template_kwargs") == {
+            "reasoning_effort": "xhigh"
+        }
+        assert _responses_cap_probe == [None]
+        assert "reasoning_budget_logits_processor" not in engine.kwargs
+        assert engine.kwargs.get("enable_thinking") is not False
+
+    def test_xhigh_is_accepted_on_the_nested_field(self, _rate_limiter_state):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        resp = _client(engine, surface="responses").post(
+            "/v1/responses", json=_responses_body(reasoning={"effort": "xhigh"})
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.kwargs.get("chat_template_kwargs") == {
+            "reasoning_effort": "xhigh"
+        }
+
+    def test_client_template_kwarg_wins(
+        self, _rate_limiter_state, _responses_cap_probe
+    ):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        resp = _client(engine, surface="responses").post(
+            "/v1/responses",
+            json=_responses_body(
+                reasoning={"effort": "high"},
+                chat_template_kwargs={"reasoning_effort": "medium"},
+            ),
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.kwargs.get("chat_template_kwargs") == {
+            "reasoning_effort": "medium"
+        }
+        assert _responses_cap_probe == [None]
+
+    def test_client_template_kwargs_reach_the_engine_at_all(self, _rate_limiter_state):
+        """Regression guard for the /v1/responses passthrough itself: before
+        #3043 the route resolved ``enable_thinking`` from the client's
+        ``chat_template_kwargs`` but never forwarded the dict to the engine,
+        so any other template variable silently vanished on this surface."""
+        engine = _RouteEngine(ENABLE_THINKING_ONLY_TEMPLATE)
+        resp = _client(engine, surface="responses").post(
+            "/v1/responses",
+            json=_responses_body(chat_template_kwargs={"custom_flag": True}),
+        )
+        assert resp.status_code == 200, resp.text
+        assert engine.kwargs.get("chat_template_kwargs", {}).get("custom_flag") is True
+
+    def test_on_off_only_template_keeps_the_cap(
+        self, _rate_limiter_state, _responses_cap_probe
+    ):
+        engine = _RouteEngine(ENABLE_THINKING_ONLY_TEMPLATE)
+        resp = _client(engine, surface="responses").post(
+            "/v1/responses", json=_responses_body(reasoning={"effort": "medium"})
+        )
+        assert resp.status_code == 200, resp.text
+        assert "reasoning_effort" not in (
+            engine.kwargs.get("chat_template_kwargs") or {}
+        )
+        assert _responses_cap_probe == [2048]

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -353,11 +353,78 @@ class TestDetectionRequiresAValidationBlock:
     def test_derivation_in_an_enclosing_block_counts(self):
         clause = (
             "{%- if enable_thinking %}{%- set r = reasoning_effort %}"
-            "{%- for m in messages %}"
+            "{%- if tools %}"
             "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
-            "{%- endfor %}{%- endif %}"
+            "{%- endif %}{%- endif %}"
         )
         assert detect_native_reasoning_effort_levels(clause) == ("a",)
+
+    def test_and_conjunct_does_not_guarantee_rejection(self):
+        """Codex r4: with ``strict and …`` the branch is skipped when
+        ``strict`` is false, so the membership test proves nothing."""
+        clause = (
+            "{%- if strict and reasoning_effort not in ('a', 'b') %}"
+            "{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_overwritten_derivation_is_forgotten(self):
+        """Codex r4: ``set r = reasoning_effort`` then ``set r = 'c'``."""
+        clause = (
+            "{%- set r = reasoning_effort %}{%- set r = 'c' %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_conditionally_overwritten_derivation_is_forgotten(self):
+        """A Jinja ``if`` body leaks its assignments, so the overwrite may
+        have happened."""
+        clause = (
+            "{%- set r = reasoning_effort %}"
+            "{%- if x %}{%- set r = 'c' %}{%- endif %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_block_assignment_overwrite_is_forgotten(self):
+        clause = (
+            "{%- set r = reasoning_effort %}{%- set r %}c{%- endset %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_loop_variable_shadowing_is_forgotten(self):
+        clause = (
+            "{%- for reasoning_effort in efforts %}{%- endfor %}"
+            "{%- if reasoning_effort not in ['a'] %}{{ raise_exception('z') }}"
+            "{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_macro_body_is_not_searched(self):
+        """Codex r4: a macro that is never invoked proves nothing."""
+        clause = (
+            "{%- macro check() %}{%- if reasoning_effort not in ['a'] %}"
+            "{{ raise_exception('z') }}{%- endif %}{%- endmacro %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_call_block_body_is_not_searched(self):
+        clause = (
+            "{%- macro wrap() %}{{ caller() }}{%- endmacro %}"
+            "{%- call wrap() %}{%- if reasoning_effort not in ['a'] %}"
+            "{{ raise_exception('z') }}{%- endif %}{%- endcall %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_loop_body_is_not_searched(self):
+        """A loop may run zero times, so a validation inside it may never
+        execute."""
+        clause = (
+            "{%- for m in messages %}{%- if reasoning_effort not in ['a'] %}"
+            "{{ raise_exception('z') }}{%- endif %}{%- endfor %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
 
     def test_unrelated_membership_first_in_the_condition_is_skipped(self):
         """Codex r3: every conjunct/disjunct is inspected, not just the first."""

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -181,12 +181,87 @@ class TestDetectNativeLevels:
         ) == ("xhigh", "medium", "low")
 
     def test_default_filter_between_name_and_membership_is_tolerated(self):
-        clause = "{% if reasoning_effort|default('low') not in ['low', 'high'] %}"
+        clause = (
+            "{% if reasoning_effort|default('low') not in ['low', 'high'] %}"
+            "{{ raise_exception('x') }}{% endif %}"
+        )
         assert detect_native_reasoning_effort_levels(clause) == ("low", "high")
 
     def test_duplicate_literals_collapse(self):
-        clause = "{% if reasoning_effort in ('low', 'low', 'high') %}"
+        clause = (
+            "{% if reasoning_effort not in ('low', 'low', 'high') %}"
+            "{{ raise_exception('x') }}{% endif %}"
+        )
         assert detect_native_reasoning_effort_levels(clause) == ("low", "high")
+
+
+class TestDetectionRequiresAValidationBlock:
+    """Codex r1 BLOCKING: a bare membership test is not a declaration. A
+    template that merely *branches* on a subset must not have that subset
+    mistaken for its accepted vocabulary (``medium`` would be upgraded and
+    lose its cap). Only ``not in (...)`` guarded by ``raise_exception`` or a
+    ``set`` of the tested variable counts."""
+
+    def test_positive_subset_branch_is_not_a_vocabulary(self):
+        clause = "{%- if reasoning_effort in ('high', 'xhigh') %}deep{%- endif %}"
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_negative_branch_without_rejection_is_not_a_vocabulary(self):
+        clause = (
+            "{%- if reasoning_effort not in ('high', 'xhigh') %}shallow{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_rejection_block_declares(self):
+        clause = (
+            "{%- if reasoning_effort not in ('a', 'b') %}"
+            "{{- raise_exception('bad') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
+    def test_defaulting_block_declares(self):
+        clause = (
+            "{%- if not reasoning_effort is defined or reasoning_effort not in ['a', 'b'] %}"
+            "{%- set reasoning_effort = 'a' %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
+    def test_setting_an_unrelated_variable_does_not_declare(self):
+        clause = (
+            "{%- if reasoning_effort not in ['a', 'b'] %}"
+            "{%- set other = 'a' %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_rejection_in_a_later_block_does_not_leak_backwards(self):
+        clause = (
+            "{%- if reasoning_effort not in ['a'] %}x{%- endif %}"
+            "{%- if y %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_elif_terminates_the_block_body(self):
+        clause = (
+            "{%- if reasoning_effort not in ['a'] %}x"
+            "{%- elif z %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_whitespace_control_and_derived_variable(self):
+        clause = (
+            "{%- set resolved_reasoning_effort = reasoning_effort|default('b') -%}"
+            "{%- if resolved_reasoning_effort not in ('a', 'b') -%}"
+            "{{- raise_exception('bad') -}}{%- endif -%}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
+    def test_first_validation_block_wins_over_a_later_branch(self):
+        clause = QWEN38_TEMPLATE + "{%- if reasoning_effort in ('zzz',) %}q{%- endif %}"
+        assert detect_native_reasoning_effort_levels(clause) == (
+            "xhigh",
+            "medium",
+            "low",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -536,6 +611,7 @@ class _RouteEngine:
             else None
         )
         self.chat_calls: list[dict] = []
+        self.stream_calls: list[dict] = []
 
     def build_prompt(self, messages, tools=None, enable_thinking=None):
         return "PROMPT"
@@ -551,10 +627,27 @@ class _RouteEngine:
             finish_reason="stop",
         )
 
+    async def stream_chat(self, messages=None, **kwargs):
+        self.stream_calls.append({"messages": messages, "kwargs": kwargs})
+        for i, piece in enumerate(("o", "k")):
+            yield GenerationOutput(
+                text="ok"[: i + 1],
+                new_text=piece,
+                prompt_tokens=4 if i == 0 else 0,
+                completion_tokens=i + 1,
+                finished=i == 1,
+                finish_reason="stop" if i == 1 else None,
+            )
+
     @property
     def kwargs(self) -> dict:
         assert self.chat_calls, "engine.chat was not called"
         return self.chat_calls[0]["kwargs"]
+
+    @property
+    def stream_kwargs(self) -> dict:
+        assert self.stream_calls, "engine.stream_chat was not called"
+        return self.stream_calls[0]["kwargs"]
 
 
 @pytest.fixture
@@ -817,3 +910,60 @@ class TestResponsesRouteNativeLevel:
             engine.kwargs.get("chat_template_kwargs") or {}
         )
         assert _responses_cap_probe == [2048]
+
+
+class TestStreamingRoutesNativeLevel:
+    """Codex r1 NIT: the streaming builders on both surfaces are separate
+    code paths (``/v1/responses`` had its own ``chat_kwargs`` block that
+    dropped ``chat_template_kwargs``), so exercise them through SSE."""
+
+    def test_chat_stream_forwards_native_level(
+        self, _rate_limiter_state, _chat_cap_probe
+    ):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        with _client(engine, surface="chat").stream(
+            "POST",
+            "/v1/chat/completions",
+            json=_chat_body(reasoning_effort="high", stream=True),
+        ) as resp:
+            assert resp.status_code == 200
+            body = "".join(resp.iter_text())
+        assert "data: [DONE]" in body
+        assert engine.stream_kwargs.get("chat_template_kwargs") == {
+            "reasoning_effort": "xhigh"
+        }
+        assert "reasoning_budget_logits_processor" not in engine.stream_kwargs
+        assert _chat_cap_probe == [None]
+
+    def test_responses_stream_forwards_native_level(self, _rate_limiter_state):
+        engine = _RouteEngine(QWEN38_TEMPLATE)
+        with _client(engine, surface="responses").stream(
+            "POST",
+            "/v1/responses",
+            json=_responses_body(reasoning={"effort": "low"}, stream=True),
+        ) as resp:
+            assert resp.status_code == 200
+            body = "".join(resp.iter_text())
+        assert "response.completed" in body
+        assert engine.stream_kwargs.get("chat_template_kwargs") == {
+            "reasoning_effort": "low"
+        }
+        assert "reasoning_budget_logits_processor" not in engine.stream_kwargs
+
+    def test_responses_stream_forwards_client_template_kwargs(
+        self, _rate_limiter_state
+    ):
+        engine = _RouteEngine(ENABLE_THINKING_ONLY_TEMPLATE)
+        with _client(engine, surface="responses").stream(
+            "POST",
+            "/v1/responses",
+            json=_responses_body(
+                chat_template_kwargs={"custom_flag": True}, stream=True
+            ),
+        ) as resp:
+            assert resp.status_code == 200
+            "".join(resp.iter_text())
+        assert (
+            engine.stream_kwargs.get("chat_template_kwargs", {}).get("custom_flag")
+            is True
+        )

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -426,13 +426,103 @@ class TestDetectionRequiresAValidationBlock:
         )
         assert detect_native_reasoning_effort_levels(clause) is None
 
-    def test_unrelated_membership_first_in_the_condition_is_skipped(self):
-        """Codex r3: every conjunct/disjunct is inspected, not just the first."""
+    def test_unrelated_disjunct_disqualifies_the_test(self):
+        """Codex r5: ``mode not in ['x'] or …`` enters the block for a valid
+        effort whenever ``mode`` is off, so the set proves nothing."""
         clause = (
             "{%- if mode not in ['x'] or reasoning_effort not in ['a', 'b'] %}"
             "{{ raise_exception('z') }}{%- endif %}"
         )
+        assert detect_native_reasoning_effort_levels(clause) is None
+        clause = (
+            "{%- if debug or reasoning_effort not in ['a', 'b'] %}"
+            "{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    @pytest.mark.parametrize(
+        "guard",
+        [
+            "not reasoning_effort is defined",
+            "reasoning_effort is undefined",
+            "reasoning_effort is none",
+            "not reasoning_effort",
+        ],
+    )
+    def test_definedness_guard_disjunct_is_allowed(self, guard):
+        clause = (
+            "{%- if " + guard + " or reasoning_effort not in ['a', 'b'] %}"
+            "{%- set reasoning_effort = 'a' %}{%- endif %}"
+        )
         assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
+    def test_definedness_guard_on_another_variable_disqualifies(self):
+        clause = (
+            "{%- if not mode is defined or reasoning_effort not in ['a', 'b'] %}"
+            "{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_elif_after_an_effort_dependent_test_is_path_constrained(self):
+        """Codex r5: reached only when ``reasoning_effort != 'x'``, so the
+        accepted set is really ``{'x'} ∪ [...]``."""
+        clause = (
+            "{%- if reasoning_effort == 'x' %}ok"
+            "{%- elif reasoning_effort not in ['a'] %}{{ raise_exception('z') }}"
+            "{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_nested_validation_under_an_effort_dependent_branch_is_skipped(self):
+        clause = (
+            "{%- if reasoning_effort == 'x' %}ok{%- else %}"
+            "{%- if reasoning_effort not in ['a'] %}{{ raise_exception('z') }}"
+            "{%- endif %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_assignment_inside_a_skipped_branch_still_forgets(self):
+        clause = (
+            "{%- set r = reasoning_effort %}"
+            "{%- if reasoning_effort == 'x' %}{%- set r = 'c' %}{%- endif %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "reasoning_effort == 'high'",
+            "'a' if reasoning_effort in ['x'] else 'b'",
+            "reasoning_effort | replace('x', 'a')",
+            "reasoning_effort | upper",
+            "reasoning_effort ~ ''",
+            "[reasoning_effort]",
+        ],
+    )
+    def test_domain_changing_derivation_does_not_count(self, expr):
+        """Codex r5: mentioning ``reasoning_effort`` is not deriving from it."""
+        clause = (
+            "{%- set r = " + expr + " %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "reasoning_effort",
+            "reasoning_effort | default('a')",
+            "reasoning_effort | trim | lower",
+            "reasoning_effort | string",
+        ],
+    )
+    def test_value_preserving_derivation_counts(self, expr):
+        clause = (
+            "{%- set r = " + expr + " %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a",)
 
     def test_conditional_raise_expression_does_not_count(self):
         """Codex r3: ``{{ raise_exception(...) if strict else '' }}`` may

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -352,7 +352,8 @@ class TestDetectionRequiresAValidationBlock:
 
     def test_derivation_in_an_enclosing_block_counts(self):
         clause = (
-            "{%- if enable_thinking %}{%- set r = reasoning_effort %}"
+            "{%- if enable_thinking is undefined or enable_thinking is true %}"
+            "{%- set r = reasoning_effort %}"
             "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
             "{%- endif %}"
         )
@@ -370,6 +371,12 @@ class TestDetectionRequiresAValidationBlock:
             "{%- if enable_thinking %}{%- if tools %}"
             "{%- if reasoning_effort not in ['low', 'high'] %}"
             "{{ raise_exception('bad') }}{%- endif %}{%- endif %}{%- endif %}",
+            "{%- if enable_thinking %}"
+            "{%- if reasoning_effort not in ['low', 'high'] %}"
+            "{{ raise_exception('bad') }}{%- endif %}{%- endif %}",
+            "{%- if enable_thinking is true %}"
+            "{%- if reasoning_effort not in ['low', 'high'] %}"
+            "{{ raise_exception('bad') }}{%- endif %}{%- endif %}",
         ],
     )
     def test_path_conditional_validation_does_not_publish_globally(self, clause):
@@ -388,8 +395,7 @@ class TestDetectionRequiresAValidationBlock:
     )
     def test_template_local_raise_exception_binding_fails_closed(self, binding):
         clause = (
-            binding
-            + "{%- if reasoning_effort not in ['low', 'high'] %}"
+            binding + "{%- if reasoning_effort not in ['low', 'high'] %}"
             "{{ raise_exception('bad') }}{%- endif %}"
         )
         assert detect_native_reasoning_effort_levels(clause) is None
@@ -645,11 +651,19 @@ class TestDetectionRequiresAValidationBlock:
 
     def test_validation_in_an_elif_test_counts(self):
         clause = (
-            "{%- if not enable_thinking %}off"
+            "{%- if enable_thinking is false %}off"
             "{%- elif reasoning_effort not in ['a', 'b'] %}{{ raise_exception('z') }}"
             "{%- endif %}"
         )
         assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
+    def test_bare_falsey_enable_thinking_branch_does_not_prove_elif_reachable(self):
+        clause = (
+            "{%- if not enable_thinking %}off"
+            "{%- elif reasoning_effort not in ['a', 'b'] %}{{ raise_exception('z') }}"
+            "{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
 
     def test_first_validation_block_wins_over_a_later_branch(self):
         clause = QWEN38_TEMPLATE + "{%- if reasoning_effort in ('zzz',) %}q{%- endif %}"

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -657,6 +657,14 @@ class TestDetectionRequiresAValidationBlock:
         )
         assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
 
+    def test_validation_in_enabled_else_branch_counts(self):
+        clause = (
+            "{%- if enable_thinking is false %}off{%- else %}"
+            "{%- if reasoning_effort not in ['a', 'b'] %}"
+            "{{ raise_exception('z') }}{%- endif %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
     def test_bare_falsey_enable_thinking_branch_does_not_prove_elif_reachable(self):
         clause = (
             "{%- if not enable_thinking %}off"

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -353,11 +353,46 @@ class TestDetectionRequiresAValidationBlock:
     def test_derivation_in_an_enclosing_block_counts(self):
         clause = (
             "{%- if enable_thinking %}{%- set r = reasoning_effort %}"
-            "{%- if tools %}"
             "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
-            "{%- endif %}{%- endif %}"
+            "{%- endif %}"
         )
         assert detect_native_reasoning_effort_levels(clause) == ("a",)
+
+    @pytest.mark.parametrize(
+        "clause",
+        [
+            "{%- if legacy_mode %}fixed-xhigh{%- else %}"
+            "{%- if reasoning_effort not in ['low', 'high'] %}"
+            "{{ raise_exception('bad') }}{%- endif %}{%- endif %}",
+            "{%- if legacy_mode %}fixed-xhigh"
+            "{%- elif reasoning_effort not in ['low', 'high'] %}"
+            "{{ raise_exception('bad') }}{%- endif %}",
+            "{%- if enable_thinking %}{%- if tools %}"
+            "{%- if reasoning_effort not in ['low', 'high'] %}"
+            "{{ raise_exception('bad') }}{%- endif %}{%- endif %}{%- endif %}",
+        ],
+    )
+    def test_path_conditional_validation_does_not_publish_globally(self, clause):
+        """A vocabulary is not global when an unrelated runtime branch can
+        skip its validation while reasoning remains enabled."""
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    @pytest.mark.parametrize(
+        "binding",
+        [
+            "{%- macro raise_exception(message) %}ok{%- endmacro %}",
+            "{%- set raise_exception = harmless %}",
+            "{%- import 'helpers.jinja' as raise_exception %}",
+            "{%- from 'helpers.jinja' import harmless as raise_exception %}",
+        ],
+    )
+    def test_template_local_raise_exception_binding_fails_closed(self, binding):
+        clause = (
+            binding
+            + "{%- if reasoning_effort not in ['low', 'high'] %}"
+            "{{ raise_exception('bad') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
 
     def test_and_conjunct_does_not_guarantee_rejection(self):
         """Codex r4: with ``strict and …`` the branch is skipped when
@@ -819,6 +854,37 @@ class TestServedChatTemplateAccessor:
     def test_reads_tokenizer_chat_template(self):
         engine = SimpleNamespace(
             tokenizer=SimpleNamespace(chat_template=QWEN38_TEMPLATE)
+        )
+        assert served_chat_template(engine) == QWEN38_TEMPLATE
+
+    def test_reads_the_processor_template_used_by_a_multimodal_engine(self):
+        processor_template = HY3_TEMPLATE_CLAUSE
+        engine = SimpleNamespace(
+            _is_mllm=True,
+            _processor=SimpleNamespace(
+                chat_template=processor_template,
+                apply_chat_template=lambda *args, **kwargs: None,
+            ),
+            tokenizer=SimpleNamespace(chat_template=QWEN38_TEMPLATE),
+        )
+        assert served_chat_template(engine) == processor_template
+
+    @pytest.mark.parametrize(
+        "processor",
+        [
+            SimpleNamespace(chat_template=HY3_TEMPLATE_CLAUSE),
+            SimpleNamespace(apply_chat_template=lambda *args, **kwargs: None),
+            SimpleNamespace(
+                chat_template=None,
+                apply_chat_template=lambda *args, **kwargs: None,
+            ),
+        ],
+    )
+    def test_multimodal_processor_without_a_usable_template_falls_back(self, processor):
+        engine = SimpleNamespace(
+            _is_mllm=True,
+            _processor=processor,
+            tokenizer=SimpleNamespace(chat_template=QWEN38_TEMPLATE),
         )
         assert served_chat_template(engine) == QWEN38_TEMPLATE
 

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -508,6 +508,65 @@ class TestDetectionRequiresAValidationBlock:
         )
         assert detect_native_reasoning_effort_levels(clause) is None
 
+    def test_a_bare_effort_test_makes_the_branch_path_constrained(self):
+        clause = (
+            "{%- if reasoning_effort %}"
+            "{%- if reasoning_effort not in ['a'] %}{{ raise_exception('z') }}"
+            "{%- endif %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    @pytest.mark.parametrize(
+        "clause",
+        [
+            # the membership's left side is not a value-preserving name
+            "{%- if (reasoning_effort | upper) not in ['A'] %}"
+            "{{ raise_exception('z') }}{%- endif %}",
+            "{%- if 'x' not in ['a'] %}{{ raise_exception('z') }}{%- endif %}",
+            # the set mixes in a non-string / non-literal item
+            "{%- if reasoning_effort not in ['a', 1] %}"
+            "{{ raise_exception('z') }}{%- endif %}",
+            "{%- if reasoning_effort not in ['a', other] %}"
+            "{{ raise_exception('z') }}{%- endif %}",
+        ],
+    )
+    def test_ill_formed_membership_tests_publish_nothing(self, clause):
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    @pytest.mark.parametrize(
+        "rebind",
+        [
+            # tuple unpacking on the path
+            "{%- set r, q = 'c', 'd' %}",
+            # tuple unpacking inside a skipped (effort-dependent) branch
+            "{%- if reasoning_effort == 'x' %}{%- set r, q = 'c', 'd' %}{%- endif %}",
+            # names bound by import / from-import (str and alias-tuple targets)
+            "{%- import 'x.jinja' as r %}",
+            "{%- from 'x.jinja' import r %}",
+            "{%- from 'x.jinja' import q as r %}",
+            # a tuple loop target
+            "{%- for r, q in items %}{%- endfor %}",
+        ],
+    )
+    def test_every_rebinding_shape_forgets_the_derived_name(self, rebind):
+        clause = (
+            "{%- set r = reasoning_effort %}" + rebind + "{%- if r not in ['a'] %}"
+            "{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_without_jinja2_detection_publishes_nothing(self, monkeypatch):
+        from vllm_mlx.utils import chat_template as module
+
+        monkeypatch.setattr(module, "_jinja_nodes", lambda: (None, None))
+        module._template_parser.cache_clear()
+        module._native_reasoning_effort_levels_for_source.cache_clear()
+        try:
+            assert detect_native_reasoning_effort_levels(QWEN38_TEMPLATE) is None
+        finally:
+            module._template_parser.cache_clear()
+            module._native_reasoning_effort_levels_for_source.cache_clear()
+
     @pytest.mark.parametrize(
         "expr",
         [

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -328,6 +328,78 @@ class TestDetectionRequiresAValidationBlock:
         )
         assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
 
+    def test_conditional_derivation_does_not_count(self):
+        """Codex r3: an assignment inside a sibling ``if`` may not have run."""
+        clause = (
+            "{%- if x %}{%- set r = reasoning_effort %}{%- endif %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_later_derivation_does_not_count(self):
+        clause = (
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+            "{%- set r = reasoning_effort %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_derivation_inside_a_loop_does_not_leak(self):
+        clause = (
+            "{%- for m in messages %}{%- set r = reasoning_effort %}{%- endfor %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_derivation_in_an_enclosing_block_counts(self):
+        clause = (
+            "{%- if enable_thinking %}{%- set r = reasoning_effort %}"
+            "{%- for m in messages %}"
+            "{%- if r not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+            "{%- endfor %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a",)
+
+    def test_unrelated_membership_first_in_the_condition_is_skipped(self):
+        """Codex r3: every conjunct/disjunct is inspected, not just the first."""
+        clause = (
+            "{%- if mode not in ['x'] or reasoning_effort not in ['a', 'b'] %}"
+            "{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
+    def test_conditional_raise_expression_does_not_count(self):
+        """Codex r3: ``{{ raise_exception(...) if strict else '' }}`` may
+        never raise."""
+        clause = (
+            "{%- if reasoning_effort not in ['a'] %}"
+            "{{ raise_exception('bad') if strict else '' }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_default_outside_the_vocabulary_does_not_count(self):
+        """Codex r3: ``set reasoning_effort = 'unsupported'`` proves nothing
+        about which values the template accepts."""
+        clause = (
+            "{%- if reasoning_effort not in ['a', 'b'] %}"
+            "{%- set reasoning_effort = 'unsupported' %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_non_literal_default_does_not_count(self):
+        clause = (
+            "{%- if reasoning_effort not in ['a', 'b'] %}"
+            "{%- set reasoning_effort = fallback %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_validation_in_an_elif_test_counts(self):
+        clause = (
+            "{%- if not enable_thinking %}off"
+            "{%- elif reasoning_effort not in ['a', 'b'] %}{{ raise_exception('z') }}"
+            "{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
     def test_first_validation_block_wins_over_a_later_branch(self):
         clause = QWEN38_TEMPLATE + "{%- if reasoning_effort in ('zzz',) %}q{%- endif %}"
         assert detect_native_reasoning_effort_levels(clause) == (

--- a/tests/test_native_reasoning_effort_levels.py
+++ b/tests/test_native_reasoning_effort_levels.py
@@ -196,11 +196,13 @@ class TestDetectNativeLevels:
 
 
 class TestDetectionRequiresAValidationBlock:
-    """Codex r1 BLOCKING: a bare membership test is not a declaration. A
+    """Codex r1/r2 BLOCKING: a bare membership test is not a declaration. A
     template that merely *branches* on a subset must not have that subset
     mistaken for its accepted vocabulary (``medium`` would be upgraded and
-    lose its cap). Only ``not in (...)`` guarded by ``raise_exception`` or a
-    ``set`` of the tested variable counts."""
+    lose its cap). The proof is made on the Jinja AST: ``<var> not in
+    (...)`` where ``<var>`` derives from ``reasoning_effort``, with an
+    unconditional ``raise_exception`` or ``set <var>`` at the top level of
+    the block body."""
 
     def test_positive_subset_branch_is_not_a_vocabulary(self):
         clause = "{%- if reasoning_effort in ('high', 'xhigh') %}deep{%- endif %}"
@@ -252,6 +254,77 @@ class TestDetectionRequiresAValidationBlock:
             "{%- set resolved_reasoning_effort = reasoning_effort|default('b') -%}"
             "{%- if resolved_reasoning_effort not in ('a', 'b') -%}"
             "{{- raise_exception('bad') -}}{%- endif -%}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
+
+    def test_rejection_nested_under_an_inner_condition_is_not_unconditional(self):
+        """Codex r2: a ``raise_exception`` that only fires under a further
+        ``if`` inside the block may never fire, so the set is not proven."""
+        clause = (
+            "{%- if reasoning_effort not in ['a'] %}"
+            "{%- if strict %}{{ raise_exception('z') }}{%- endif %}"
+            "{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_unrelated_variable_with_a_similar_name_does_not_count(self):
+        """Codex r2: ``my_reasoning_effort`` is not derived from the request
+        knob, so validating it says nothing about ``reasoning_effort``."""
+        clause = (
+            "{%- set my_reasoning_effort = 'a' %}"
+            "{%- if my_reasoning_effort not in ['a', 'b'] %}"
+            "{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_variable_derived_through_a_chain_counts(self):
+        clause = (
+            "{%- set r1 = reasoning_effort %}{%- set r2 = r1 | lower %}"
+            "{%- if r2 not in ['a'] %}{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == ("a",)
+
+    def test_negated_positive_membership_is_left_alone(self):
+        clause = (
+            "{%- if not (reasoning_effort in ['a', 'b']) %}"
+            "{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_non_literal_set_is_not_a_vocabulary(self):
+        clause = (
+            "{%- if reasoning_effort not in allowed %}"
+            "{{ raise_exception('z') }}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_validation_nested_under_enable_thinking_counts(self):
+        """Qwen3.8 validates only while thinking is on; the vocabulary still
+        applies whenever the level matters."""
+        clause = (
+            "{%- if enable_thinking is undefined or enable_thinking is true %}"
+            "{%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}"
+            "{%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}"
+            "{{- raise_exception('bad') }}{%- endif %}{%- endif %}"
+        )
+        assert detect_native_reasoning_effort_levels(clause) == (
+            "xhigh",
+            "medium",
+            "low",
+        )
+
+    def test_unparseable_template_publishes_nothing(self):
+        clause = "{% if reasoning_effort not in ['a'] %}{{ raise_exception('x') }}"
+        assert detect_native_reasoning_effort_levels(clause) is None
+
+    def test_transformers_generation_tag_is_parsed(self):
+        """HF templates may wrap assistant turns in ``{% generation %}``
+        (transformers' assistant-mask extension); the detector must not
+        choke on it."""
+        clause = (
+            "{%- for m in messages %}{% generation %}{{ m.content }}{% endgeneration %}"
+            "{%- endfor %}{%- if reasoning_effort not in ('a', 'b') %}"
+            "{{ raise_exception('x') }}{%- endif %}"
         )
         assert detect_native_reasoning_effort_levels(clause) == ("a", "b")
 

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -535,15 +535,19 @@ def _validate_seed(v) -> int | None:
 # was added Aug 2025 alongside ``low``/``medium``/``high``; ``none`` is
 # the rapid-mlx-specific "suppress thinking entirely" alias that the
 # desktop UI surfaces, kept here so SDK clients that learned it don't
-# 400. Anthropic Claude's ``thinking.type`` enum is intentionally NOT
-# included — that's a different surface (the Anthropic adapter handles
-# its own translation).
+# 400. ``xhigh`` (#3043) is the ceiling Qwen3.8's chat template ships as
+# its default and Anthropic's ``output_config.effort`` already accepts;
+# without it an OpenAI-SDK client could never ask that model for the
+# level it advertises. Anthropic Claude's ``thinking.type`` enum is
+# intentionally NOT included — that's a different surface (the
+# Anthropic adapter handles its own translation).
 _VALID_REASONING_EFFORTS: tuple[str, ...] = (
     "none",
     "minimal",
     "low",
     "medium",
     "high",
+    "xhigh",
 )
 
 #: Route-layer translation of the graded OpenAI ``reasoning_effort`` values
@@ -554,13 +558,20 @@ _VALID_REASONING_EFFORTS: tuple[str, ...] = (
 #: the Anthropic surface's ``ANTHROPIC_EFFORT_TO_REASONING_MAX_TOKENS`` tiers
 #: (low=512, medium=2048, high=8192) so the same effort name yields the same
 #: reasoning budget regardless of which API dialect it arrived on; ``minimal``
-#: (OpenAI-only, gpt-5 era) sits one tier below ``low``. Module-scoped so
-#: tests import + assert against the same table the helper uses.
+#: (OpenAI-only, gpt-5 era) sits one tier below ``low`` and ``xhigh`` reuses
+#: the Anthropic 24000 tier. This table is the FALLBACK for templates that
+#: expose no native effort vocabulary; a template that validates
+#: ``reasoning_effort`` against a literal set (Qwen3.8) gets the graded value
+#: mapped onto that set instead — see
+#: ``utils.chat_template.detect_native_reasoning_effort_levels`` (#3043).
+#: Module-scoped so tests import + assert against the same table the helper
+#: uses.
 OPENAI_REASONING_EFFORT_TO_MAX_TOKENS: dict[str, int] = {
     "minimal": 256,
     "low": 512,
     "medium": 2048,
     "high": 8192,
+    "xhigh": 24000,
 }
 
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -121,6 +121,7 @@ from ..service.helpers import (
     maybe_auto_disable_thinking_for_casual_chat,
     maybe_auto_disable_thinking_for_tools,
     repair_messages_fit_context,
+    served_chat_template,
 )
 
 logger = logging.getLogger(__name__)
@@ -4387,13 +4388,17 @@ async def _create_chat_completion_impl(
     # ``reasoning_effort="none"`` request registers its enable_thinking
     # preference first (the tool auto-disable then no-ops on it) and a
     # graded value lands its ``reasoning_max_tokens`` cap from one source.
-    if maybe_apply_reasoning_effort(request):
+    if maybe_apply_reasoning_effort(
+        request, chat_template=served_chat_template(engine)
+    ):
         logger.info(
-            "#448 reasoning_effort=%s translated on /v1/chat/completions "
-            "(none→enable_thinking=False; minimal/low/medium/high→"
-            "reasoning_max_tokens tier). Explicit client enable_thinking / "
-            "reasoning_max_tokens always wins.",
+            "#448/#3043 reasoning_effort=%s translated on /v1/chat/completions "
+            "(template reasoning_effort=%s, reasoning_max_tokens=%s). "
+            "Explicit client enable_thinking / chat_template_kwargs."
+            "reasoning_effort / reasoning_max_tokens always wins.",
             request.reasoning_effort,
+            (request.chat_template_kwargs or {}).get("reasoning_effort"),
+            request.reasoning_max_tokens,
         )
 
     # R12-T1F (0.8.16 operator dogfood) — auto-disable thinking when

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -116,6 +116,7 @@ from ..service.helpers import (
     maybe_auto_disable_thinking_for_casual_chat,
     maybe_auto_disable_thinking_for_tools,
     repair_messages_fit_context,
+    served_chat_template,
 )
 
 logger = logging.getLogger(__name__)
@@ -1239,13 +1240,17 @@ async def create_response(request: Request):
         # its enable_thinking preference first (the tool auto-disable then
         # no-ops on it) and a graded value lands its reasoning_max_tokens
         # cap from one source. Explicit client knobs always win.
-        if maybe_apply_reasoning_effort(openai_request):
+        if maybe_apply_reasoning_effort(
+            openai_request, chat_template=served_chat_template(engine)
+        ):
             logger.info(
-                "#448 reasoning_effort=%s translated on /v1/responses "
-                "(none→enable_thinking=False; minimal/low/medium/high→"
-                "reasoning_max_tokens tier). Explicit client enable_thinking "
-                "/ reasoning_max_tokens always wins.",
+                "#448/#3043 reasoning_effort=%s translated on /v1/responses "
+                "(template reasoning_effort=%s, reasoning_max_tokens=%s). "
+                "Explicit client enable_thinking / chat_template_kwargs."
+                "reasoning_effort / reasoning_max_tokens always wins.",
                 openai_request.reasoning_effort,
+                (openai_request.chat_template_kwargs or {}).get("reasoning_effort"),
+                openai_request.reasoning_max_tokens,
             )
 
         # R12-T1F (0.8.16 operator dogfood) — auto-disable thinking
@@ -1351,12 +1356,17 @@ async def create_response(request: Request):
             openai_request.max_tokens is None
             and not get_config().default_max_tokens_is_explicit
         )
+        # Count the prompt with the same template variables the engine will
+        # render with (parity with the chat route's guard; #3043 may have just
+        # merged a native ``reasoning_effort`` level into the dict).
+        _resp_ctk = getattr(openai_request, "chat_template_kwargs", None) or None
         _resp_ctx_prompt_tokens = enforce_context_length_for_messages(
             engine,
             _ctx_messages,
             tools=openai_request.tools,
             max_tokens=None if _resp_implicit_max_tokens else _resp_resolved_max_tokens,
             enable_thinking=_resp_resolved_thinking,
+            chat_template_kwargs=_resp_ctk,
         )
         if _resp_implicit_max_tokens:
             if _resp_ctx_prompt_tokens is None:
@@ -1370,6 +1380,7 @@ async def create_response(request: Request):
                     tools=openai_request.tools,
                     max_tokens=_resp_resolved_max_tokens,
                     enable_thinking=_resp_resolved_thinking,
+                    chat_template_kwargs=_resp_ctk,
                 )
             else:
                 _resp_resolved_max_tokens = (
@@ -1574,6 +1585,14 @@ async def _non_stream(
     resolved_thinking = _resolve_enable_thinking(openai_request)
     if resolved_thinking is not None:
         chat_kwargs["enable_thinking"] = resolved_thinking
+    # Forward client ``chat_template_kwargs`` to the engine (#2474 wired only
+    # the chat surface; here the dict was dropped, so the native
+    # ``reasoning_effort`` level #3043 merges in never reached the template).
+    # ``enable_thinking`` is resolved above; the engine-side merge never
+    # overwrites server-resolved keys.
+    ctk = getattr(openai_request, "chat_template_kwargs", None)
+    if isinstance(ctk, dict) and ctk:
+        chat_kwargs["chat_template_kwargs"] = ctk
     _attach_deepseek_no_think_suppression(
         engine,
         cfg,
@@ -2812,6 +2831,14 @@ async def _stream_responses(
         resolved_thinking = _resolve_enable_thinking(openai_request)
         if resolved_thinking is not None:
             chat_kwargs["enable_thinking"] = resolved_thinking
+        # Forward client ``chat_template_kwargs`` to the engine (#2474 wired only
+        # the chat surface; here the dict was dropped, so the native
+        # ``reasoning_effort`` level #3043 merges in never reached the template).
+        # ``enable_thinking`` is resolved above; the engine-side merge never
+        # overwrites server-resolved keys.
+        ctk = getattr(openai_request, "chat_template_kwargs", None)
+        if isinstance(ctk, dict) and ctk:
+            chat_kwargs["chat_template_kwargs"] = ctk
         _attach_deepseek_no_think_suppression(
             engine,
             cfg,

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -2103,12 +2103,21 @@ def _client_signalled_reasoning_intent(*sources) -> bool:
 def served_chat_template(engine):
     """Return the chat template ``engine`` renders prompts with, or ``None``.
 
-    Whatever the tokenizer exposes as ``chat_template`` (Jinja string,
-    ``{"default": ..., "tool_use": ...}`` dict, or nothing). Read-only
-    accessor so route code that needs template *capabilities* (native
-    reasoning-effort vocabulary, thinking-prefix shape) shares one
-    definition of "the served template" with the prompt renderer.
+    For a multimodal engine, prefer the processor template under the same
+    conditions as ``BatchedEngine._apply_chat_template``; otherwise use the
+    tokenizer template.  The value may be a Jinja string, a
+    ``{"default": ..., "tool_use": ...}`` dict, or ``None``.  Keeping this
+    selection aligned with the renderer is required before route code can use
+    template capabilities to remove a fallback reasoning cap.
     """
+    processor = getattr(engine, "_processor", None)
+    if (
+        getattr(engine, "_is_mllm", False)
+        and processor
+        and hasattr(processor, "apply_chat_template")
+        and getattr(processor, "chat_template", None)
+    ):
+        return processor.chat_template
     tokenizer = getattr(engine, "tokenizer", None)
     return getattr(tokenizer, "chat_template", None)
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -57,6 +57,10 @@ from ..config import get_config
 from ..engine import BaseEngine, GenerationOutput
 from ..errors import BackpressureError
 from ..tool_parsers import ToolParserManager
+from ..utils.chat_template import (
+    detect_native_reasoning_effort_levels,
+    map_reasoning_effort_to_native,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2096,9 +2100,22 @@ def _client_signalled_reasoning_intent(*sources) -> bool:
     return False
 
 
-def maybe_apply_reasoning_effort(request) -> bool:
+def served_chat_template(engine):
+    """Return the chat template ``engine`` renders prompts with, or ``None``.
+
+    Whatever the tokenizer exposes as ``chat_template`` (Jinja string,
+    ``{"default": ..., "tool_use": ...}`` dict, or nothing). Read-only
+    accessor so route code that needs template *capabilities* (native
+    reasoning-effort vocabulary, thinking-prefix shape) shares one
+    definition of "the served template" with the prompt renderer.
+    """
+    tokenizer = getattr(engine, "tokenizer", None)
+    return getattr(tokenizer, "chat_template", None)
+
+
+def maybe_apply_reasoning_effort(request, *, chat_template=None) -> bool:
     """Translate the OpenAI ``reasoning_effort`` knob into rapid-mlx's
-    native reasoning controls at the route layer (issue #448).
+    native reasoning controls at the route layer (issue #448, #3043).
 
     The schema layer (``_validate_reasoning_effort_field`` on
     ``ChatCompletionRequest`` / ``ResponsesRequest``) only *validates*
@@ -2118,7 +2135,18 @@ def maybe_apply_reasoning_effort(request) -> bool:
         ``REASONING_CUTOFF_SENTINEL`` injected into ``content`` — corrupting
         the field it re-feeds verbatim into the next turn. Suppressing the
         reasoning at the source means the truncation scenario never arises.
-      * ``reasoning_effort in {minimal, low, medium, high}`` → set
+      * graded ``reasoning_effort`` on a template that publishes its own
+        effort vocabulary (Qwen3.8 validates ``reasoning_effort`` against
+        ``('xhigh', 'medium', 'low')``) → merge the nearest native level into
+        ``chat_template_kwargs["reasoning_effort"]`` so the *prompt* carries
+        the request (``low`` → "keep your thinking brief", ``high`` →
+        ``xhigh``). No token cap is layered on top: before #3043 a
+        ``low`` request rendered the template's ``xhigh`` instruction and
+        was then force-closed at 512 thinking tokens — the instruction and
+        the budget contradicted each other. ``chat_template`` is the served
+        template (see :func:`served_chat_template`); pass ``None`` and this
+        branch is skipped.
+      * graded ``reasoning_effort`` on any other template → set
         ``request.reasoning_max_tokens`` to the matching tier from
         ``OPENAI_REASONING_EFFORT_TO_MAX_TOKENS`` (a subtractive cap on how
         long the model may think before answering).
@@ -2134,8 +2162,11 @@ def maybe_apply_reasoning_effort(request) -> bool:
         wins. A ``reasoning_max_tokens`` cap is orthogonal to ``none``:
         thinking-off makes the cap moot, so ``none`` still applies (it does
         NOT yield to a cap).
-      * the graded path controls the budget dimension, so it yields to an
-        explicit ``reasoning_max_tokens`` cap and does not touch
+      * the native-level path controls the prompt dimension, so it yields
+        to an explicit ``chat_template_kwargs.reasoning_effort`` and does
+        not touch ``enable_thinking`` or ``reasoning_max_tokens``.
+      * the graded cap path controls the budget dimension, so it yields to
+        an explicit ``reasoning_max_tokens`` cap and does not touch
         ``enable_thinking``.
 
     MUST run BEFORE ``maybe_auto_disable_thinking_for_tools`` so a
@@ -2166,7 +2197,33 @@ def maybe_apply_reasoning_effort(request) -> bool:
         _mark_thinking_auto_disabled(request)
         return True
 
-    # Graded effort (minimal/low/medium/high) → ``reasoning_max_tokens``
+    # Graded effort on a template with a native effort vocabulary → the
+    # nearest native level travels in ``chat_template_kwargs`` (#3043).
+    # ``enable_thinking`` / ``tools`` are server-resolved keys the renderer
+    # never lets a client override, so merging only ``reasoning_effort``
+    # here cannot clobber anything the route resolves later.
+    levels = (
+        detect_native_reasoning_effort_levels(
+            chat_template, tools=getattr(request, "tools", None)
+        )
+        if chat_template
+        else None
+    )
+    if levels:
+        native = map_reasoning_effort_to_native(effort, levels)
+        if native is not None:
+            ctk = getattr(request, "chat_template_kwargs", None)
+            merged_ctk = dict(ctk) if isinstance(ctk, dict) else {}
+            if "reasoning_effort" in merged_ctk:
+                # The client already drives the template variable directly
+                # (#2474 passthrough) — same dimension, the explicit value
+                # wins and no cap is layered on top.
+                return False
+            merged_ctk["reasoning_effort"] = native
+            request.chat_template_kwargs = merged_ctk
+            return True
+
+    # Graded effort (minimal/low/medium/high/xhigh) → ``reasoning_max_tokens``
     # tier (a subtractive cap on how long the model may think), unless the
     # client already set an explicit cap (which wins). Graded effort does
     # NOT force ``enable_thinking`` on — it is itself a reasoning-intent

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1161,27 +1161,51 @@ REASONING_EFFORT_LADDER: tuple[str, ...] = (
     "xhigh",
 )
 
-# A template that *validates* ``reasoning_effort`` against a literal set,
-# e.g. Qwen3.8's
-#   ``{%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}``
-# declares its native effort vocabulary. Only that shape counts as a
-# declaration: Harmony merely interpolates the value ("Reasoning: medium")
-# and North Mini Code compares against a single sentinel (``== "none"``),
-# so neither publishes a level set and both keep the token-cap fallback.
-_REASONING_EFFORT_LEVEL_SET_RE = re.compile(
-    r"reasoning_effort\s*(?:\|\s*default\([^)]*\))?\s+(?:not\s+)?in\s*"
-    r"[\(\[]([^\)\]]*)[\)\]]"
+# A template declares its native effort vocabulary only when it *validates*
+# ``reasoning_effort`` against a literal set: an ``{% if <var> not in (...) %}``
+# whose block body either rejects the value (``raise_exception(...)``, Qwen3.8)
+# or replaces it with a default (``{% set <var> = ... %}``, Hy3). Nothing else
+# counts — Harmony merely interpolates the value ("Reasoning: medium"), North
+# Mini Code compares against a single ``"none"`` sentinel, and a template that
+# just *branches* on a subset (``{% if reasoning_effort in ('high', 'xhigh') %}``)
+# says nothing about which values it accepts — so all of those keep the
+# token-cap fallback. The membership test may sit anywhere inside the ``if``
+# condition (Hy3 prefixes ``not reasoning_effort is defined or``), and the
+# tested variable may be a derived one (Qwen3.8's ``resolved_reasoning_effort``).
+_REASONING_EFFORT_VALIDATION_RE = re.compile(
+    r"\{%-?\s*if\s+(?P<cond>[^%]*?"
+    r"\b(?P<var>\w*reasoning_effort)\s*(?:\|\s*default\([^)]*\))?"
+    r"\s+not\s+in\s*[\(\[](?P<levels>[^\)\]]*)[\)\]]"
+    r"[^%]*?)%\}"
+    r"(?P<body>.*?)"
+    r"\{%-?\s*(?:elif|else|endif)\b",
+    re.DOTALL,
 )
 _REASONING_EFFORT_LITERAL_RE = re.compile(r"""['"]([A-Za-z_][A-Za-z0-9_]*)['"]""")
+_RAISE_EXCEPTION_RE = re.compile(r"\braise_exception\s*\(")
+
+
+def _validation_body_rejects_or_defaults(body: str, var: str) -> bool:
+    if _RAISE_EXCEPTION_RE.search(body):
+        return True
+    # ``{%- set reasoning_effort = 'no_think' %}`` — the template replaces an
+    # out-of-vocabulary value with one of its own, which is a validation too.
+    return re.search(r"\{%-?\s*set\s+" + re.escape(var) + r"\s*=", body) is not None
 
 
 @functools.lru_cache(maxsize=64)
 def _native_reasoning_effort_levels_for_source(template: str) -> tuple[str, ...] | None:
-    match = _REASONING_EFFORT_LEVEL_SET_RE.search(template)
-    if match is None:
-        return None
-    levels = tuple(dict.fromkeys(_REASONING_EFFORT_LITERAL_RE.findall(match.group(1))))
-    return levels or None
+    for match in _REASONING_EFFORT_VALIDATION_RE.finditer(template):
+        if not _validation_body_rejects_or_defaults(
+            match.group("body"), match.group("var")
+        ):
+            continue
+        levels = tuple(
+            dict.fromkeys(_REASONING_EFFORT_LITERAL_RE.findall(match.group("levels")))
+        )
+        if levels:
+            return levels
+    return None
 
 
 def detect_native_reasoning_effort_levels(

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1163,20 +1163,25 @@ REASONING_EFFORT_LADDER: tuple[str, ...] = (
 
 # A template declares its native effort vocabulary only when it *validates*
 # ``reasoning_effort`` against a literal set. Proven on the Jinja AST by a
-# forward, scope-aware walk (codex #3048 r1–r3), never by pattern matching:
+# forward, scope-aware walk (codex #3048 r1–r4), never by pattern matching:
 #
-#   * an ``{% if <var> not in ('a', 'b') %}`` test where ``<var>`` is
-#     ``reasoning_effort`` itself or a variable assigned — earlier in the
-#     same or an enclosing block, so it is guaranteed to have run — from an
-#     expression that references it (Qwen3.8's ``resolved_reasoning_effort``).
-#     An assignment inside a sibling ``if`` / ``for`` body, or one that comes
-#     later, does not count. The membership test may be any conjunct or
-#     disjunct of the condition (Hy3 prefixes ``not reasoning_effort is
-#     defined or``) but never sits under ``not``;
-#   * whose block body — at its top level, not inside a nested statement or a
-#     conditional expression — either is a bare ``{{ raise_exception(...) }}``
-#     (Qwen3.8) or re-assigns ``<var>`` to a *literal from that same set*
-#     (Hy3's ``{% set reasoning_effort = 'no_think' %}``).
+#   * the walk follows the render path from the template root through
+#     ``if`` / ``elif`` / ``else`` branches only — a branch may be gated on
+#     unrelated state (Qwen3.8 validates only while thinking is on, which is
+#     exactly when the level matters) — and never enters loops, macros, call
+#     blocks or any other deferred / possibly-zero-iteration scope;
+#   * ``<var>`` is ``reasoning_effort`` itself or a name assigned earlier on
+#     that path from an expression referencing it (Qwen3.8's
+#     ``resolved_reasoning_effort``). A later assignment that does not
+#     reference a derived name — anywhere, including a sibling ``if`` body,
+#     which leaks in Jinja — forgets the name for good;
+#   * the test is ``{% if <var> not in ('a', 'b') %}``, possibly as a disjunct
+#     of an ``or`` (Hy3 prefixes ``not reasoning_effort is defined or``; the
+#     branch is entered whenever the membership fails) but never under
+#     ``and`` or ``not``, which would make the rejection conditional;
+#   * the block body — at its top level — is a bare ``{{ raise_exception(...) }}``
+#     (Qwen3.8; a conditional expression does not count) or re-assigns
+#     ``<var>`` to a literal *from that same set* (Hy3's ``'no_think'``).
 #
 # Nothing else counts: Harmony merely interpolates the value, North Mini Code
 # compares against a single ``"none"`` sentinel, a template that just
@@ -1223,9 +1228,11 @@ def _references_any(expr, names: set[str], nodes) -> bool:
 
 
 def _not_in_memberships(expr, nodes):
-    """Yield every ``<x> not in <y>`` Compare inside ``expr``, looking through
-    ``and`` / ``or`` only (never ``not``, which inverts it)."""
-    if isinstance(expr, (nodes.And, nodes.Or)):
+    """Yield every ``<x> not in <y>`` Compare that, when true, guarantees the
+    branch is entered: the test itself or a disjunct of an ``or``. ``and``
+    and ``not`` are not looked through (they make the rejection conditional
+    or invert it)."""
+    if isinstance(expr, nodes.Or):
         yield from _not_in_memberships(expr.left, nodes)
         yield from _not_in_memberships(expr.right, nodes)
     elif (
@@ -1284,10 +1291,12 @@ def _body_unconditionally_rejects_or_defaults(
     return False
 
 
-def _validation_levels(if_node, derived: set[str], nodes) -> tuple[str, ...] | None:
+def _validation_levels(
+    if_node, derived: set[str], forgotten: set[str], nodes
+) -> tuple[str, ...] | None:
     for compare in _not_in_memberships(if_node.test, nodes):
         tested = _tested_name(compare.expr, nodes)
-        if tested is None or tested not in derived:
+        if tested is None or tested not in derived or tested in forgotten:
             continue
         levels = _literal_levels(compare.ops[0].expr, nodes)
         if levels is None:
@@ -1299,41 +1308,75 @@ def _validation_levels(if_node, derived: set[str], nodes) -> tuple[str, ...] | N
     return None
 
 
-def _walk_for_validation(stmts, derived: set[str], nodes) -> tuple[str, ...] | None:
-    """Forward walk of one statement list. ``derived`` is copied per block so
-    an assignment only counts for statements that follow it in the same or a
-    nested block — never for siblings of the block it sits in."""
+def _walk_for_validation(
+    stmts, derived: set[str], forgotten: set[str], nodes
+) -> tuple[str, ...] | None:
+    """Forward walk of one statement list along the render path.
+
+    ``derived`` is copied per block, so a name derived inside a branch only
+    counts for statements that follow it in that branch. ``forgotten`` is
+    shared for the whole walk: once a derived name is overwritten with a
+    non-derived value anywhere on the path it never counts again (a Jinja
+    ``if`` body leaks its assignments, so the overwrite may have happened).
+    """
     derived = set(derived)
     for stmt in stmts:
         if isinstance(stmt, nodes.Assign):
-            if isinstance(stmt.target, nodes.Name) and _references_any(
-                stmt.node, derived, nodes
-            ):
-                derived.add(stmt.target.name)
+            if isinstance(stmt.target, nodes.Name):
+                if _references_any(stmt.node, derived, nodes):
+                    derived.add(stmt.target.name)
+                else:
+                    derived.discard(stmt.target.name)
+                    forgotten.add(stmt.target.name)
+            else:
+                for name in stmt.target.find_all(nodes.Name):
+                    derived.discard(name.name)
+                    forgotten.add(name.name)
+            continue
+        if isinstance(stmt, nodes.AssignBlock):
+            if isinstance(stmt.target, nodes.Name):
+                derived.discard(stmt.target.name)
+                forgotten.add(stmt.target.name)
             continue
         if isinstance(stmt, nodes.If):
             branches = [stmt] + list(stmt.elif_)
             for branch in branches:
-                levels = _validation_levels(branch, derived, nodes)
+                levels = _validation_levels(branch, derived, forgotten, nodes)
                 if levels:
                     return levels
             for block in [branch.body for branch in branches] + [stmt.else_]:
-                levels = _walk_for_validation(block, derived, nodes)
+                levels = _walk_for_validation(block, derived, forgotten, nodes)
                 if levels:
                     return levels
             continue
-        # Any other statement with nested statement lists (for / with /
-        # filter / macro / call blocks, the parsed ``generation`` span, ...).
-        for _field, value in stmt.iter_fields():
-            if (
-                isinstance(value, list)
-                and value
-                and all(isinstance(item, nodes.Stmt) for item in value)
-            ):
-                levels = _walk_for_validation(value, derived, nodes)
-                if levels:
-                    return levels
+        # Loops, macros, call blocks, with / filter blocks, imports, the parsed
+        # ``generation`` span, ...: deferred or possibly-zero-iteration scopes
+        # are neither searched nor trusted to keep ``derived`` accurate —
+        # every name such a statement binds is forgotten.
+        for name in _bound_names(stmt, nodes):
+            derived.discard(name)
+            forgotten.add(name)
     return None
+
+
+def _bound_names(stmt, nodes) -> set[str]:
+    names: set[str] = set()
+    for field in ("target", "targets", "names"):
+        value = getattr(stmt, field, None)
+        if value is None:
+            continue
+        for item in value if isinstance(value, list) else [value]:
+            if isinstance(item, nodes.Name):
+                names.add(item.name)
+            elif isinstance(item, str):
+                names.add(item)
+            elif isinstance(item, tuple):
+                names.update(part for part in item if isinstance(part, str))
+            elif isinstance(item, nodes.Node):
+                names.update(n.name for n in item.find_all(nodes.Name))
+    if isinstance(stmt, nodes.Macro):
+        names.add(stmt.name)
+    return names
 
 
 @functools.lru_cache(maxsize=64)
@@ -1346,7 +1389,7 @@ def _native_reasoning_effort_levels_for_source(template: str) -> tuple[str, ...]
         tree = env.parse(template)
     except Exception:
         return None
-    return _walk_for_validation(tree.body, {"reasoning_effort"}, nodes)
+    return _walk_for_validation(tree.body, {"reasoning_effort"}, set(), nodes)
 
 
 def detect_native_reasoning_effort_levels(

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1324,6 +1324,56 @@ def _is_bare_raise(expr, nodes) -> bool:
     )
 
 
+def _binds_name(tree, name: str, nodes) -> bool:
+    """Whether template-local scope can shadow a trusted Jinja global."""
+    return any(name in _bound_names(node, nodes) for node in tree.find_all(nodes.Node))
+
+
+def _is_named_test(expr, variable: str, test: str, nodes) -> bool:
+    return bool(
+        isinstance(expr, nodes.Test)
+        and expr.name == test
+        and isinstance(expr.node, nodes.Name)
+        and expr.node.name == variable
+    )
+
+
+def _is_thinking_enabled_guard(expr, nodes) -> bool:
+    """A narrow guard whose body is relevant only while thinking is enabled.
+
+    Qwen3.8 places its effort validation under ``enable_thinking is undefined
+    or enable_thinking is true``.  Only that checkpoint shape (plus the direct
+    truthy spellings) is transparent to the validation proof; arbitrary outer
+    conditions would make the advertised vocabulary path-dependent.
+    """
+    if isinstance(expr, nodes.Name):
+        return bool(expr.name == "enable_thinking")
+    if _is_named_test(expr, "enable_thinking", "true", nodes):
+        return True
+    if isinstance(expr, nodes.Or):
+        parts = (expr.left, expr.right)
+        return any(
+            _is_named_test(part, "enable_thinking", "undefined", nodes)
+            for part in parts
+        ) and any(
+            _is_named_test(part, "enable_thinking", "true", nodes)
+            for part in parts
+        )
+    return False
+
+
+def _is_thinking_disabled_guard(expr, nodes) -> bool:
+    """A branch whose failure proves that thinking was not disabled."""
+    return bool(
+        (
+            isinstance(expr, nodes.Not)
+            and isinstance(expr.node, nodes.Name)
+            and expr.node.name == "enable_thinking"
+        )
+        or _is_named_test(expr, "enable_thinking", "false", nodes)
+    )
+
+
 def _body_unconditionally_rejects_or_defaults(
     body, tested: str, levels: tuple[str, ...], nodes
 ) -> bool:
@@ -1413,13 +1463,23 @@ def _walk_for_validation(
         if isinstance(stmt, nodes.If):
             branches = [stmt] + list(stmt.elif_)
             effort_dependent = False
+            # A validation in the first branch is unconditional at this
+            # statement.  A validation in a later ``elif`` is equally safe
+            # only when every earlier branch was the explicit
+            # thinking-disabled path; an unrelated earlier condition could
+            # bypass validation while the template still renders reasoning.
+            branch_path_is_safe = True
             for branch in branches:
-                if not effort_dependent:
+                if not effort_dependent and branch_path_is_safe:
                     levels = _validation_levels(branch, derived, forgotten, nodes)
                     if levels:
                         return levels
                 if _references_any(branch.test, derived - forgotten, nodes):
                     effort_dependent = True
+                branch_path_is_safe = (
+                    branch_path_is_safe
+                    and _is_thinking_disabled_guard(branch.test, nodes)
+                )
             blocks = [branch.body for branch in branches] + [stmt.else_]
             if effort_dependent:
                 # Path-constrained by the effort value: not searched, but any
@@ -1427,10 +1487,30 @@ def _walk_for_validation(
                 for block in blocks:
                     _forget_assignments_in(block, forgotten, nodes)
                 continue
-            for block in blocks:
-                levels = _walk_for_validation(block, derived, forgotten, nodes)
+            prior_branches_only_disable_thinking = True
+            searched_block_ids: set[int] = set()
+            for branch in branches:
+                if prior_branches_only_disable_thinking and _is_thinking_enabled_guard(
+                    branch.test, nodes
+                ):
+                    levels = _walk_for_validation(
+                        branch.body, derived, forgotten, nodes
+                    )
+                    searched_block_ids.add(id(branch.body))
+                    if levels:
+                        return levels
+                prior_branches_only_disable_thinking = (
+                    prior_branches_only_disable_thinking
+                    and _is_thinking_disabled_guard(branch.test, nodes)
+                )
+            if prior_branches_only_disable_thinking:
+                levels = _walk_for_validation(stmt.else_, derived, forgotten, nodes)
+                searched_block_ids.add(id(stmt.else_))
                 if levels:
                     return levels
+            for block in blocks:
+                if id(block) not in searched_block_ids:
+                    _forget_assignments_in(block, forgotten, nodes)
             continue
         # Loops, macros, call blocks, with / filter blocks, imports, the parsed
         # ``generation`` span, ...: deferred or possibly-zero-iteration scopes
@@ -1471,6 +1551,11 @@ def _native_reasoning_effort_levels_for_source(template: str) -> tuple[str, ...]
     try:
         tree = env.parse(template)
     except Exception:
+        return None
+    # ``raise_exception`` is trusted only as the throwing global installed by
+    # Transformers.  A local macro/import/assignment can shadow that name and
+    # turn an apparent rejection block into an ordinary successful render.
+    if _binds_name(tree, "raise_exception", nodes):
         return None
     return _walk_for_validation(tree.body, {"reasoning_effort"}, set(), nodes)
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -6,6 +6,7 @@ Handles enable_thinking, tools, and fallback logic for chat template rendering.
 """
 
 import copy
+import functools
 import json
 import logging
 import re
@@ -1147,6 +1148,89 @@ def _template_uses_reasoning_effort_without_enable_thinking(
         )
         for template in templates
     )
+
+
+#: OpenAI-shaped ``reasoning_effort`` ladder, weakest to strongest. Shared
+#: by :func:`map_reasoning_effort_to_native` so a graded name keeps its
+#: ordering no matter which subset a template happens to accept.
+REASONING_EFFORT_LADDER: tuple[str, ...] = (
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+)
+
+# A template that *validates* ``reasoning_effort`` against a literal set,
+# e.g. Qwen3.8's
+#   ``{%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}``
+# declares its native effort vocabulary. Only that shape counts as a
+# declaration: Harmony merely interpolates the value ("Reasoning: medium")
+# and North Mini Code compares against a single sentinel (``== "none"``),
+# so neither publishes a level set and both keep the token-cap fallback.
+_REASONING_EFFORT_LEVEL_SET_RE = re.compile(
+    r"reasoning_effort\s*(?:\|\s*default\([^)]*\))?\s+(?:not\s+)?in\s*"
+    r"[\(\[]([^\)\]]*)[\)\]]"
+)
+_REASONING_EFFORT_LITERAL_RE = re.compile(r"""['"]([A-Za-z_][A-Za-z0-9_]*)['"]""")
+
+
+@functools.lru_cache(maxsize=64)
+def _native_reasoning_effort_levels_for_source(template: str) -> tuple[str, ...] | None:
+    match = _REASONING_EFFORT_LEVEL_SET_RE.search(template)
+    if match is None:
+        return None
+    levels = tuple(dict.fromkeys(_REASONING_EFFORT_LITERAL_RE.findall(match.group(1))))
+    return levels or None
+
+
+def detect_native_reasoning_effort_levels(
+    template, *, tools: list[dict] | None = None
+) -> tuple[str, ...] | None:
+    """Return the effort vocabulary a chat template validates against.
+
+    ``template`` is whatever the tokenizer exposes as ``chat_template`` (a
+    Jinja string, a ``{"default": ..., "tool_use": ...}`` dict, or ``None``).
+    Returns the literal level set in template order (Qwen3.8 →
+    ``("xhigh", "medium", "low")``) or ``None`` when the template does not
+    declare one — the caller then falls back to the ``reasoning_max_tokens``
+    tier translation, exactly as before this detection existed.
+    """
+    for source in _chat_template_strings(template, tools=tools):
+        levels = _native_reasoning_effort_levels_for_source(source)
+        if levels:
+            return levels
+    return None
+
+
+def map_reasoning_effort_to_native(
+    effort: str, levels: tuple[str, ...] | list[str]
+) -> str | None:
+    """Pick the template-native level that best matches an OpenAI effort.
+
+    * A value the template already accepts is used verbatim.
+    * Otherwise both sides are ranked on :data:`REASONING_EFFORT_LADDER` and
+      the nearest native rank wins; ties round *up* (``high`` on a template
+      whose ceiling is ``xhigh`` means "as much as you have", not "medium").
+    * ``None`` when nothing can be ranked (unknown effort name, or a template
+      whose vocabulary shares no name with the ladder) — the caller keeps
+      the token-cap path. Non-ladder names inside an otherwise rankable set
+      (Hy3's ``no_think``) are simply ignored.
+    """
+    if effort in levels:
+        return effort
+    if effort not in REASONING_EFFORT_LADDER:
+        return None
+    ranked = [
+        (REASONING_EFFORT_LADDER.index(level), level)
+        for level in levels
+        if level in REASONING_EFFORT_LADDER
+    ]
+    if not ranked:
+        return None
+    target = REASONING_EFFORT_LADDER.index(effort)
+    _rank, native = min(ranked, key=lambda pair: (abs(pair[0] - target), -pair[0]))
+    return native
 
 
 def _is_gpt_oss_harmony_template(

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1342,36 +1342,25 @@ def _is_thinking_enabled_guard(expr, nodes) -> bool:
     """A narrow guard whose body is relevant only while thinking is enabled.
 
     Qwen3.8 places its effort validation under ``enable_thinking is undefined
-    or enable_thinking is true``.  Only that checkpoint shape (plus the direct
-    truthy spellings) is transparent to the validation proof; arbitrary outer
-    conditions would make the advertised vocabulary path-dependent.
+    or enable_thinking is true``.  Only that checkpoint shape is transparent
+    to the validation proof: a bare/truthy guard skips its body when the kwarg
+    is undefined, while arbitrary outer conditions make the advertised
+    vocabulary path-dependent.
     """
-    if isinstance(expr, nodes.Name):
-        return bool(expr.name == "enable_thinking")
-    if _is_named_test(expr, "enable_thinking", "true", nodes):
-        return True
     if isinstance(expr, nodes.Or):
         parts = (expr.left, expr.right)
         return any(
             _is_named_test(part, "enable_thinking", "undefined", nodes)
             for part in parts
         ) and any(
-            _is_named_test(part, "enable_thinking", "true", nodes)
-            for part in parts
+            _is_named_test(part, "enable_thinking", "true", nodes) for part in parts
         )
     return False
 
 
 def _is_thinking_disabled_guard(expr, nodes) -> bool:
     """A branch whose failure proves that thinking was not disabled."""
-    return bool(
-        (
-            isinstance(expr, nodes.Not)
-            and isinstance(expr.node, nodes.Name)
-            and expr.node.name == "enable_thinking"
-        )
-        or _is_named_test(expr, "enable_thinking", "false", nodes)
-    )
+    return _is_named_test(expr, "enable_thinking", "false", nodes)
 
 
 def _body_unconditionally_rejects_or_defaults(

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1254,14 +1254,14 @@ def _is_definedness_guard(expr, tested: str, nodes) -> bool:
     if isinstance(expr, nodes.Not):
         inner = expr.node
         if isinstance(inner, nodes.Name):
-            return inner.name == tested
-        return (
+            return bool(inner.name == tested)
+        return bool(
             isinstance(inner, nodes.Test)
             and inner.name == "defined"
             and isinstance(inner.node, nodes.Name)
             and inner.node.name == tested
         )
-    return (
+    return bool(
         isinstance(expr, nodes.Test)
         and expr.name in ("undefined", "none")
         and isinstance(expr.node, nodes.Name)

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1162,24 +1162,28 @@ REASONING_EFFORT_LADDER: tuple[str, ...] = (
 )
 
 # A template declares its native effort vocabulary only when it *validates*
-# ``reasoning_effort`` against a literal set. Proven on the Jinja AST, not by
-# pattern matching (codex #3048 r1/r2):
+# ``reasoning_effort`` against a literal set. Proven on the Jinja AST by a
+# forward, scope-aware walk (codex #3048 r1–r3), never by pattern matching:
 #
 #   * an ``{% if <var> not in ('a', 'b') %}`` test where ``<var>`` is
-#     ``reasoning_effort`` itself or a variable assigned from an expression
-#     that references it (Qwen3.8's ``resolved_reasoning_effort``); the test
-#     may be one disjunct/conjunct of a larger condition (Hy3 prefixes
-#     ``not reasoning_effort is defined or``) but never sits under ``not``;
-#   * whose block body — at its top level, not inside a nested ``if``/``for`` —
-#     either rejects (``{{ raise_exception(...) }}``, Qwen3.8) or replaces the
-#     value with a default (``{% set <var> = ... %}``, Hy3).
+#     ``reasoning_effort`` itself or a variable assigned — earlier in the
+#     same or an enclosing block, so it is guaranteed to have run — from an
+#     expression that references it (Qwen3.8's ``resolved_reasoning_effort``).
+#     An assignment inside a sibling ``if`` / ``for`` body, or one that comes
+#     later, does not count. The membership test may be any conjunct or
+#     disjunct of the condition (Hy3 prefixes ``not reasoning_effort is
+#     defined or``) but never sits under ``not``;
+#   * whose block body — at its top level, not inside a nested statement or a
+#     conditional expression — either is a bare ``{{ raise_exception(...) }}``
+#     (Qwen3.8) or re-assigns ``<var>`` to a *literal from that same set*
+#     (Hy3's ``{% set reasoning_effort = 'no_think' %}``).
 #
 # Nothing else counts: Harmony merely interpolates the value, North Mini Code
 # compares against a single ``"none"`` sentinel, a template that just
 # *branches* on a subset (``{% if reasoning_effort in ('high', 'xhigh') %}``)
-# says nothing about which values it accepts, and a rejection that is itself
-# conditional inside the block may never fire. All of those keep the
-# token-cap fallback, as does a template jinja2 cannot parse.
+# says nothing about which values it accepts, and a rejection that may not
+# fire proves nothing. All of those keep the token-cap fallback, as does a
+# template jinja2 cannot parse.
 
 
 def _jinja_nodes():
@@ -1212,43 +1216,24 @@ def _template_parser():
     return jinja2.Environment(extensions=["jinja2.ext.loopcontrols", _GenerationBlock])
 
 
-def _names_derived_from_reasoning_effort(tree, nodes) -> set[str]:
-    """``reasoning_effort`` plus every name ``{% set %}`` from an expression
-    that (transitively) references it, in document order."""
-    derived = {"reasoning_effort"}
-    assignments = [
-        (assign.target.name, assign.node)
-        for assign in tree.find_all(nodes.Assign)
-        if isinstance(assign.target, nodes.Name)
-    ]
-    changed = True
-    while changed:
-        changed = False
-        for target, expr in assignments:
-            if target in derived:
-                continue
-            referenced = [expr] if isinstance(expr, nodes.Name) else []
-            referenced.extend(expr.find_all(nodes.Name))
-            if any(name.name in derived for name in referenced):
-                derived.add(target)
-                changed = True
-    return derived
+def _references_any(expr, names: set[str], nodes) -> bool:
+    if isinstance(expr, nodes.Name) and expr.name in names:
+        return True
+    return any(name.name in names for name in expr.find_all(nodes.Name))
 
 
-def _not_in_membership(expr, nodes):
-    """Return the ``<x> not in <literal set>`` Compare inside ``expr``, looking
-    through ``and`` / ``or`` only (never ``not``, which inverts it)."""
+def _not_in_memberships(expr, nodes):
+    """Yield every ``<x> not in <y>`` Compare inside ``expr``, looking through
+    ``and`` / ``or`` only (never ``not``, which inverts it)."""
     if isinstance(expr, (nodes.And, nodes.Or)):
-        return _not_in_membership(expr.left, nodes) or _not_in_membership(
-            expr.right, nodes
-        )
-    if (
+        yield from _not_in_memberships(expr.left, nodes)
+        yield from _not_in_memberships(expr.right, nodes)
+    elif (
         isinstance(expr, nodes.Compare)
         and len(expr.ops) == 1
         and expr.ops[0].op == "notin"
     ):
-        return expr
-    return None
+        yield expr
 
 
 def _tested_name(expr, nodes) -> str | None:
@@ -1270,21 +1255,85 @@ def _literal_levels(expr, nodes) -> tuple[str, ...] | None:
     return levels or None
 
 
-def _body_unconditionally_rejects_or_defaults(body, tested: str, nodes) -> bool:
+def _is_bare_raise(expr, nodes) -> bool:
+    return (
+        isinstance(expr, nodes.Call)
+        and isinstance(expr.node, nodes.Name)
+        and expr.node.name == "raise_exception"
+    )
+
+
+def _body_unconditionally_rejects_or_defaults(
+    body, tested: str, levels: tuple[str, ...], nodes
+) -> bool:
     for stmt in body:
         if isinstance(stmt, nodes.Output) and any(
-            isinstance(call.node, nodes.Name) and call.node.name == "raise_exception"
-            for call in stmt.find_all(nodes.Call)
+            _is_bare_raise(item, nodes) for item in stmt.nodes
         ):
             return True
         if (
             isinstance(stmt, nodes.Assign)
             and isinstance(stmt.target, nodes.Name)
             and stmt.target.name == tested
+            and isinstance(stmt.node, nodes.Const)
+            and stmt.node.value in levels
         ):
             return True
-        # Anything nested (``if`` / ``for`` / ...) is conditional: skip it.
+        # Anything nested (``if`` / ``for`` / a conditional expression inside
+        # an output) may not run: it proves nothing.
     return False
+
+
+def _validation_levels(if_node, derived: set[str], nodes) -> tuple[str, ...] | None:
+    for compare in _not_in_memberships(if_node.test, nodes):
+        tested = _tested_name(compare.expr, nodes)
+        if tested is None or tested not in derived:
+            continue
+        levels = _literal_levels(compare.ops[0].expr, nodes)
+        if levels is None:
+            continue
+        if _body_unconditionally_rejects_or_defaults(
+            if_node.body, tested, levels, nodes
+        ):
+            return levels
+    return None
+
+
+def _walk_for_validation(stmts, derived: set[str], nodes) -> tuple[str, ...] | None:
+    """Forward walk of one statement list. ``derived`` is copied per block so
+    an assignment only counts for statements that follow it in the same or a
+    nested block — never for siblings of the block it sits in."""
+    derived = set(derived)
+    for stmt in stmts:
+        if isinstance(stmt, nodes.Assign):
+            if isinstance(stmt.target, nodes.Name) and _references_any(
+                stmt.node, derived, nodes
+            ):
+                derived.add(stmt.target.name)
+            continue
+        if isinstance(stmt, nodes.If):
+            branches = [stmt] + list(stmt.elif_)
+            for branch in branches:
+                levels = _validation_levels(branch, derived, nodes)
+                if levels:
+                    return levels
+            for block in [branch.body for branch in branches] + [stmt.else_]:
+                levels = _walk_for_validation(block, derived, nodes)
+                if levels:
+                    return levels
+            continue
+        # Any other statement with nested statement lists (for / with /
+        # filter / macro / call blocks, the parsed ``generation`` span, ...).
+        for _field, value in stmt.iter_fields():
+            if (
+                isinstance(value, list)
+                and value
+                and all(isinstance(item, nodes.Stmt) for item in value)
+            ):
+                levels = _walk_for_validation(value, derived, nodes)
+                if levels:
+                    return levels
+    return None
 
 
 @functools.lru_cache(maxsize=64)
@@ -1297,20 +1346,7 @@ def _native_reasoning_effort_levels_for_source(template: str) -> tuple[str, ...]
         tree = env.parse(template)
     except Exception:
         return None
-    derived = _names_derived_from_reasoning_effort(tree, nodes)
-    for if_node in tree.find_all(nodes.If):
-        compare = _not_in_membership(if_node.test, nodes)
-        if compare is None:
-            continue
-        tested = _tested_name(compare.expr, nodes)
-        if tested is None or tested not in derived:
-            continue
-        levels = _literal_levels(compare.ops[0].expr, nodes)
-        if levels is None:
-            continue
-        if _body_unconditionally_rejects_or_defaults(if_node.body, tested, nodes):
-            return levels
-    return None
+    return _walk_for_validation(tree.body, {"reasoning_effort"}, nodes)
 
 
 def detect_native_reasoning_effort_levels(

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1162,48 +1162,153 @@ REASONING_EFFORT_LADDER: tuple[str, ...] = (
 )
 
 # A template declares its native effort vocabulary only when it *validates*
-# ``reasoning_effort`` against a literal set: an ``{% if <var> not in (...) %}``
-# whose block body either rejects the value (``raise_exception(...)``, Qwen3.8)
-# or replaces it with a default (``{% set <var> = ... %}``, Hy3). Nothing else
-# counts — Harmony merely interpolates the value ("Reasoning: medium"), North
-# Mini Code compares against a single ``"none"`` sentinel, and a template that
-# just *branches* on a subset (``{% if reasoning_effort in ('high', 'xhigh') %}``)
-# says nothing about which values it accepts — so all of those keep the
-# token-cap fallback. The membership test may sit anywhere inside the ``if``
-# condition (Hy3 prefixes ``not reasoning_effort is defined or``), and the
-# tested variable may be a derived one (Qwen3.8's ``resolved_reasoning_effort``).
-_REASONING_EFFORT_VALIDATION_RE = re.compile(
-    r"\{%-?\s*if\s+(?P<cond>[^%]*?"
-    r"\b(?P<var>\w*reasoning_effort)\s*(?:\|\s*default\([^)]*\))?"
-    r"\s+not\s+in\s*[\(\[](?P<levels>[^\)\]]*)[\)\]]"
-    r"[^%]*?)%\}"
-    r"(?P<body>.*?)"
-    r"\{%-?\s*(?:elif|else|endif)\b",
-    re.DOTALL,
-)
-_REASONING_EFFORT_LITERAL_RE = re.compile(r"""['"]([A-Za-z_][A-Za-z0-9_]*)['"]""")
-_RAISE_EXCEPTION_RE = re.compile(r"\braise_exception\s*\(")
+# ``reasoning_effort`` against a literal set. Proven on the Jinja AST, not by
+# pattern matching (codex #3048 r1/r2):
+#
+#   * an ``{% if <var> not in ('a', 'b') %}`` test where ``<var>`` is
+#     ``reasoning_effort`` itself or a variable assigned from an expression
+#     that references it (Qwen3.8's ``resolved_reasoning_effort``); the test
+#     may be one disjunct/conjunct of a larger condition (Hy3 prefixes
+#     ``not reasoning_effort is defined or``) but never sits under ``not``;
+#   * whose block body — at its top level, not inside a nested ``if``/``for`` —
+#     either rejects (``{{ raise_exception(...) }}``, Qwen3.8) or replaces the
+#     value with a default (``{% set <var> = ... %}``, Hy3).
+#
+# Nothing else counts: Harmony merely interpolates the value, North Mini Code
+# compares against a single ``"none"`` sentinel, a template that just
+# *branches* on a subset (``{% if reasoning_effort in ('high', 'xhigh') %}``)
+# says nothing about which values it accepts, and a rejection that is itself
+# conditional inside the block may never fire. All of those keep the
+# token-cap fallback, as does a template jinja2 cannot parse.
 
 
-def _validation_body_rejects_or_defaults(body: str, var: str) -> bool:
-    if _RAISE_EXCEPTION_RE.search(body):
-        return True
-    # ``{%- set reasoning_effort = 'no_think' %}`` — the template replaces an
-    # out-of-vocabulary value with one of its own, which is a validation too.
-    return re.search(r"\{%-?\s*set\s+" + re.escape(var) + r"\s*=", body) is not None
+def _jinja_nodes():
+    try:
+        import jinja2
+        from jinja2 import nodes
+    except ImportError:  # pragma: no cover - jinja2 ships with transformers
+        return None, None
+    return jinja2, nodes
+
+
+@functools.lru_cache(maxsize=1)
+def _template_parser():
+    """A parse-only Jinja environment that accepts the tags HF chat templates
+    use: ``break`` / ``continue`` and transformers' ``{% generation %}``
+    span marker (parsed as a plain block; nothing is ever rendered here)."""
+    jinja2, nodes = _jinja_nodes()
+    if jinja2 is None:
+        return None
+    from jinja2.ext import Extension
+
+    class _GenerationBlock(Extension):
+        tags = {"generation"}
+
+        def parse(self, parser):
+            lineno = next(parser.stream).lineno
+            body = parser.parse_statements(("name:endgeneration",), drop_needle=True)
+            return nodes.Scope(body).set_lineno(lineno)
+
+    return jinja2.Environment(extensions=["jinja2.ext.loopcontrols", _GenerationBlock])
+
+
+def _names_derived_from_reasoning_effort(tree, nodes) -> set[str]:
+    """``reasoning_effort`` plus every name ``{% set %}`` from an expression
+    that (transitively) references it, in document order."""
+    derived = {"reasoning_effort"}
+    assignments = [
+        (assign.target.name, assign.node)
+        for assign in tree.find_all(nodes.Assign)
+        if isinstance(assign.target, nodes.Name)
+    ]
+    changed = True
+    while changed:
+        changed = False
+        for target, expr in assignments:
+            if target in derived:
+                continue
+            referenced = [expr] if isinstance(expr, nodes.Name) else []
+            referenced.extend(expr.find_all(nodes.Name))
+            if any(name.name in derived for name in referenced):
+                derived.add(target)
+                changed = True
+    return derived
+
+
+def _not_in_membership(expr, nodes):
+    """Return the ``<x> not in <literal set>`` Compare inside ``expr``, looking
+    through ``and`` / ``or`` only (never ``not``, which inverts it)."""
+    if isinstance(expr, (nodes.And, nodes.Or)):
+        return _not_in_membership(expr.left, nodes) or _not_in_membership(
+            expr.right, nodes
+        )
+    if (
+        isinstance(expr, nodes.Compare)
+        and len(expr.ops) == 1
+        and expr.ops[0].op == "notin"
+    ):
+        return expr
+    return None
+
+
+def _tested_name(expr, nodes) -> str | None:
+    """The variable a membership test inspects: ``x`` or ``x|default(...)``."""
+    if isinstance(expr, nodes.Filter) and expr.name == "default":
+        expr = expr.node
+    return expr.name if isinstance(expr, nodes.Name) else None
+
+
+def _literal_levels(expr, nodes) -> tuple[str, ...] | None:
+    if not isinstance(expr, (nodes.Tuple, nodes.List)):
+        return None
+    if not all(
+        isinstance(item, nodes.Const) and isinstance(item.value, str)
+        for item in expr.items
+    ):
+        return None
+    levels = tuple(dict.fromkeys(item.value for item in expr.items))
+    return levels or None
+
+
+def _body_unconditionally_rejects_or_defaults(body, tested: str, nodes) -> bool:
+    for stmt in body:
+        if isinstance(stmt, nodes.Output) and any(
+            isinstance(call.node, nodes.Name) and call.node.name == "raise_exception"
+            for call in stmt.find_all(nodes.Call)
+        ):
+            return True
+        if (
+            isinstance(stmt, nodes.Assign)
+            and isinstance(stmt.target, nodes.Name)
+            and stmt.target.name == tested
+        ):
+            return True
+        # Anything nested (``if`` / ``for`` / ...) is conditional: skip it.
+    return False
 
 
 @functools.lru_cache(maxsize=64)
 def _native_reasoning_effort_levels_for_source(template: str) -> tuple[str, ...] | None:
-    for match in _REASONING_EFFORT_VALIDATION_RE.finditer(template):
-        if not _validation_body_rejects_or_defaults(
-            match.group("body"), match.group("var")
-        ):
+    jinja2, nodes = _jinja_nodes()
+    env = _template_parser()
+    if jinja2 is None or env is None:
+        return None
+    try:
+        tree = env.parse(template)
+    except Exception:
+        return None
+    derived = _names_derived_from_reasoning_effort(tree, nodes)
+    for if_node in tree.find_all(nodes.If):
+        compare = _not_in_membership(if_node.test, nodes)
+        if compare is None:
             continue
-        levels = tuple(
-            dict.fromkeys(_REASONING_EFFORT_LITERAL_RE.findall(match.group("levels")))
-        )
-        if levels:
+        tested = _tested_name(compare.expr, nodes)
+        if tested is None or tested not in derived:
+            continue
+        levels = _literal_levels(compare.ops[0].expr, nodes)
+        if levels is None:
+            continue
+        if _body_unconditionally_rejects_or_defaults(if_node.body, tested, nodes):
             return levels
     return None
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1171,14 +1171,19 @@ REASONING_EFFORT_LADDER: tuple[str, ...] = (
 #     exactly when the level matters) — and never enters loops, macros, call
 #     blocks or any other deferred / possibly-zero-iteration scope;
 #   * ``<var>`` is ``reasoning_effort`` itself or a name assigned earlier on
-#     that path from an expression referencing it (Qwen3.8's
-#     ``resolved_reasoning_effort``). A later assignment that does not
-#     reference a derived name — anywhere, including a sibling ``if`` body,
-#     which leaks in Jinja — forgets the name for good;
-#   * the test is ``{% if <var> not in ('a', 'b') %}``, possibly as a disjunct
-#     of an ``or`` (Hy3 prefixes ``not reasoning_effort is defined or``; the
-#     branch is entered whenever the membership fails) but never under
-#     ``and`` or ``not``, which would make the rejection conditional;
+#     that path *value-preservingly* from it — a bare name or a
+#     ``default`` / ``trim`` / ``lower`` / ``string`` filter chain (Qwen3.8's
+#     ``resolved_reasoning_effort = reasoning_effort|default('xhigh')``); a
+#     comparison or conditional remap moves the value into another domain.
+#     Any other assignment to the name — anywhere on the path, including a
+#     sibling ``if`` body, which leaks in Jinja — forgets it for good;
+#   * branches whose own test, or a preceding sibling test, references a
+#     derived name are path-constrained by the effort value and not searched;
+#   * the test is ``{% if <var> not in ('a', 'b') %}``, alone or ``or``-ed only
+#     with definedness guards on the same variable (Hy3's ``not
+#     reasoning_effort is defined or …``) — never under ``and`` / ``not`` and
+#     never with an unrelated disjunct that could enter the block for a valid
+#     value;
 #   * the block body — at its top level — is a bare ``{{ raise_exception(...) }}``
 #     (Qwen3.8; a conditional expression does not count) or re-assigns
 #     ``<var>`` to a literal *from that same set* (Hy3's ``'no_think'``).
@@ -1227,27 +1232,76 @@ def _references_any(expr, names: set[str], nodes) -> bool:
     return any(name.name in names for name in expr.find_all(nodes.Name))
 
 
-def _not_in_memberships(expr, nodes):
-    """Yield every ``<x> not in <y>`` Compare that, when true, guarantees the
-    branch is entered: the test itself or a disjunct of an ``or``. ``and``
-    and ``not`` are not looked through (they make the rejection conditional
-    or invert it)."""
-    if isinstance(expr, nodes.Or):
-        yield from _not_in_memberships(expr.left, nodes)
-        yield from _not_in_memberships(expr.right, nodes)
-    elif (
-        isinstance(expr, nodes.Compare)
-        and len(expr.ops) == 1
-        and expr.ops[0].op == "notin"
-    ):
-        yield expr
+#: Filters that hand the value through unchanged for our purposes (the OpenAI
+#: effort names are lowercase ASCII words): ``x|default('xhigh')`` (Qwen3.8),
+#: ``x|trim``, ``x|lower``, ``x|string``. Anything else — a comparison, a
+#: conditional remap, ``replace`` — moves the value into another domain, so a
+#: set validated against *that* says nothing about ``reasoning_effort``.
+_VALUE_PRESERVING_FILTERS = frozenset({"default", "trim", "lower", "string"})
 
 
-def _tested_name(expr, nodes) -> str | None:
-    """The variable a membership test inspects: ``x`` or ``x|default(...)``."""
-    if isinstance(expr, nodes.Filter) and expr.name == "default":
+def _value_preserving_source(expr, nodes) -> str | None:
+    """Name of the variable ``expr`` carries through unchanged, or ``None``."""
+    while isinstance(expr, nodes.Filter) and expr.name in _VALUE_PRESERVING_FILTERS:
         expr = expr.node
     return expr.name if isinstance(expr, nodes.Name) else None
+
+
+def _is_definedness_guard(expr, tested: str, nodes) -> bool:
+    """``not x is defined`` / ``x is undefined`` / ``x is none`` / ``not x`` on
+    the tested variable: a disjunct that can only be true when there is no
+    value to validate, so it never lets a *valid* value into the block."""
+    if isinstance(expr, nodes.Not):
+        inner = expr.node
+        if isinstance(inner, nodes.Name):
+            return inner.name == tested
+        return (
+            isinstance(inner, nodes.Test)
+            and inner.name == "defined"
+            and isinstance(inner.node, nodes.Name)
+            and inner.node.name == tested
+        )
+    return (
+        isinstance(expr, nodes.Test)
+        and expr.name in ("undefined", "none")
+        and isinstance(expr.node, nodes.Name)
+        and expr.node.name == tested
+    )
+
+
+def _disjuncts(expr, nodes) -> list:
+    if isinstance(expr, nodes.Or):
+        return _disjuncts(expr.left, nodes) + _disjuncts(expr.right, nodes)
+    return [expr]
+
+
+def _guaranteed_membership(test, nodes):
+    """Return the single ``<x> not in <y>`` Compare whose failure alone enters
+    the block: the whole test, or one disjunct of an ``or`` whose every other
+    disjunct is a definedness guard on the same variable (Hy3's ``not
+    reasoning_effort is defined or reasoning_effort not in [...]``). ``and``,
+    ``not`` and unrelated disjuncts make the block reachable for valid values
+    or skippable for invalid ones, so they disqualify the test."""
+    parts = _disjuncts(test, nodes)
+    compares = [
+        part
+        for part in parts
+        if isinstance(part, nodes.Compare)
+        and len(part.ops) == 1
+        and part.ops[0].op == "notin"
+    ]
+    if len(compares) != 1:
+        return None
+    compare = compares[0]
+    tested = _value_preserving_source(compare.expr, nodes)
+    if tested is None:
+        return None
+    for part in parts:
+        if part is compare:
+            continue
+        if not _is_definedness_guard(part, tested, nodes):
+            return None
+    return compare, tested
 
 
 def _literal_levels(expr, nodes) -> tuple[str, ...] | None:
@@ -1294,18 +1348,31 @@ def _body_unconditionally_rejects_or_defaults(
 def _validation_levels(
     if_node, derived: set[str], forgotten: set[str], nodes
 ) -> tuple[str, ...] | None:
-    for compare in _not_in_memberships(if_node.test, nodes):
-        tested = _tested_name(compare.expr, nodes)
-        if tested is None or tested not in derived or tested in forgotten:
-            continue
-        levels = _literal_levels(compare.ops[0].expr, nodes)
-        if levels is None:
-            continue
-        if _body_unconditionally_rejects_or_defaults(
-            if_node.body, tested, levels, nodes
-        ):
-            return levels
+    found = _guaranteed_membership(if_node.test, nodes)
+    if found is None:
+        return None
+    compare, tested = found
+    if tested not in derived or tested in forgotten:
+        return None
+    levels = _literal_levels(compare.ops[0].expr, nodes)
+    if levels is None:
+        return None
+    if _body_unconditionally_rejects_or_defaults(if_node.body, tested, levels, nodes):
+        return levels
     return None
+
+
+def _forget_assignments_in(stmts, forgotten: set[str], nodes) -> None:
+    """Names assigned anywhere inside statements the walk does not enter may
+    have been overwritten (a Jinja ``if`` body leaks): forget them."""
+    for stmt in stmts:
+        assigns = [stmt] if isinstance(stmt, (nodes.Assign, nodes.AssignBlock)) else []
+        assigns.extend(stmt.find_all((nodes.Assign, nodes.AssignBlock)))
+        for assign in assigns:
+            if isinstance(assign.target, nodes.Name):
+                forgotten.add(assign.target.name)
+            else:
+                forgotten.update(n.name for n in assign.target.find_all(nodes.Name))
 
 
 def _walk_for_validation(
@@ -1318,12 +1385,17 @@ def _walk_for_validation(
     shared for the whole walk: once a derived name is overwritten with a
     non-derived value anywhere on the path it never counts again (a Jinja
     ``if`` body leaks its assignments, so the overwrite may have happened).
+    Branches whose own test, or a preceding sibling test, references a
+    derived name are not searched: a validation reached only when
+    ``reasoning_effort`` already failed or passed some other check is a
+    path-constrained one and would misstate the accepted set.
     """
     derived = set(derived)
     for stmt in stmts:
         if isinstance(stmt, nodes.Assign):
             if isinstance(stmt.target, nodes.Name):
-                if _references_any(stmt.node, derived, nodes):
+                source = _value_preserving_source(stmt.node, nodes)
+                if source is not None and source in derived and source not in forgotten:
                     derived.add(stmt.target.name)
                 else:
                     derived.discard(stmt.target.name)
@@ -1340,11 +1412,22 @@ def _walk_for_validation(
             continue
         if isinstance(stmt, nodes.If):
             branches = [stmt] + list(stmt.elif_)
+            effort_dependent = False
             for branch in branches:
-                levels = _validation_levels(branch, derived, forgotten, nodes)
-                if levels:
-                    return levels
-            for block in [branch.body for branch in branches] + [stmt.else_]:
+                if not effort_dependent:
+                    levels = _validation_levels(branch, derived, forgotten, nodes)
+                    if levels:
+                        return levels
+                if _references_any(branch.test, derived - forgotten, nodes):
+                    effort_dependent = True
+            blocks = [branch.body for branch in branches] + [stmt.else_]
+            if effort_dependent:
+                # Path-constrained by the effort value: not searched, but any
+                # assignment inside may still have leaked.
+                for block in blocks:
+                    _forget_assignments_in(block, forgotten, nodes)
+                continue
+            for block in blocks:
                 levels = _walk_for_validation(block, derived, forgotten, nodes)
                 if levels:
                     return levels


### PR DESCRIPTION
Closes #3043.

## Problem

Qwen3.8's chat template validates `reasoning_effort` against `('xhigh', 'medium', 'low')` and defaults to `xhigh`. The OpenAI `reasoning_effort` knob never reached that variable. Every graded value was translated into a `reasoning_max_tokens` cap, so `reasoning_effort="low"` rendered the template's *xhigh* instruction ("think carefully through the task…") and was then force-closed at 512 thinking tokens. The prompt and the budget contradicted each other, and the model's advertised `xhigh` level could not be requested at all (400 at the schema).

## Change

- **`utils/chat_template.py`**: `detect_native_reasoning_effort_levels` proves on the Jinja AST (jinja2 parse only, no render; cached per template string, ~4 ms cold) that a template *validates* `reasoning_effort` against a literal set. The walk follows the render path from the root through `if`/`elif`/`else` branches only (Qwen3.8 validates inside its `enable_thinking` block, which is exactly when the level matters) and never enters loops, macros, call blocks or other deferred scopes. A name counts as derived from `reasoning_effort` only when assigned earlier on that path *value-preservingly* from it, a bare name or a `default`/`trim`/`lower`/`string` filter chain (Qwen3.8's `resolved_reasoning_effort = reasoning_effort|default('xhigh')`); any other assignment to the name, anywhere on the path including a sibling `if` body (Jinja leaks those), forgets it for good. Branches whose own test or a preceding sibling test references a derived name are path-constrained by the effort value and are not searched. The test is `{% if <derived> not in ('a', 'b') %}`, alone or `or`-ed only with definedness guards on the same variable (Hy3's `not reasoning_effort is defined or …`), never under `and` or `not` and never with an unrelated disjunct, and its block body at top level is a bare `{{ raise_exception(...) }}` or re-assigns `<derived>` to a literal from that same set (Hy3's `'no_think'`). Everything else publishes nothing and keeps the cap fallback: a template that merely branches on a subset, a rejection that may not fire, a look-alike, overwritten or domain-transformed variable, a validation reachable only after another effort check, a default outside the set, Harmony (interpolation only), North Mini Code (single `"none"` sentinel), and anything jinja2 cannot parse. The parse-only environment accepts transformers' `{% generation %}` tag; all 33 templates in the local HF cache parse and only Qwen3.8 publishes a vocabulary. `map_reasoning_effort_to_native` uses a native value verbatim when the template accepts it, otherwise ranks both sides on the OpenAI ladder and rounds ties *up* (`high` on a `low/medium/xhigh` template → `xhigh`).
- **`service/helpers.py`**: `maybe_apply_reasoning_effort(request, chat_template=...)`. On a template with a vocabulary the nearest native level is merged into `chat_template_kwargs["reasoning_effort"]` and no cap is layered on top; an explicit client `chat_template_kwargs.reasoning_effort` wins. Templates without a vocabulary (Qwen3.5/3.6, Gemma 4, Nemotron, Ling…) and callers that pass no template keep the pre-existing tier caps byte-for-byte. `served_chat_template(engine)` is the shared accessor.
- **`api/models.py`**: `xhigh` joins the closed set, with a 24000 tier (same magnitude the Anthropic surface already uses) for templates that need the fallback.
- **`routes/chat.py`, `routes/responses.py`**: pass the served template; the log line now shows which translation fired.
- **`/v1/responses` passthrough fix**: the route resolved `enable_thinking` from the client's `chat_template_kwargs` but never forwarded the dict to `engine.chat` / `generate_with_schema` / `stream_chat` (#2474 wired only the chat surface). Without this the mapped level, and any client template variable, silently vanished on that surface. Both paths and the context guard now forward it.
- **Docs**: `docs/guides/reasoning.md` gains a `reasoning_effort` section; `docs/guides/codex-cli.md` describes the two translations.

Behaviour change to be aware of: Hy3 templates (`['high', 'low', 'no_think']`) also publish a vocabulary, so they now receive a native level (`minimal`/`low` → `low`, `medium`/`high`/`xhigh` → `high`) instead of a cap. Anthropic `output_config.effort` still uses the cap tiers; mapping it natively is a follow-up. The Desktop app and CLI do not surface `reasoning_effort` yet (they only have the on/off switch); that is out of scope here.

## Test plan

`tests/test_native_reasoning_effort_levels.py` (151 tests) pins detection across the Qwen3.8 / Hy3 / Harmony / North / on-off-only shapes and dict templates, the validation-block rule (subset branches, `not in` without rejection, unrelated `set`, rejection in a later / `elif` / nested-conditional block, a look-alike variable, a conditional / later / loop-scoped / overwritten / block-overwritten / skipped-branch-overwritten derivation, a comparison / conditional-remap / `replace` / `upper` / concat / list derivation, a loop variable shadowing the knob, an `and` conjunct, an unrelated `or` disjunct, a definedness guard on another variable, an `elif` after and a nested validation under an effort-dependent test, a validation inside a loop / macro / call block, a conditional `raise_exception` expression, a default outside the set, a non-literal default, a negated positive test, a non-literal or mixed set, a non-name membership subject, tuple / import / loop-target rebinding, an unparseable template and a missing jinja2 all publish nothing; whitespace-control, `default`/`trim`/`lower`/`string` derivation chains, an enclosing-block derivation, each of the four definedness-guard spellings as an `or` disjunct, an `elif` validation after an unrelated test, the Qwen3.8 enable_thinking nesting and a `{% generation %}` template do), the mapping table including the tie-up rule, the helper contract (native level in, no cap, client kwarg wins, explicit cap orthogonal, idempotent, tools variant), a jinja2 render of the verbatim Qwen3.8 clause proving every mapped value is accepted while a raw `high` raises, `xhigh` on both typed models, and route-level coverage on `/v1/chat/completions` and `/v1/responses` with an engine whose tokenizer serves the Qwen3.8 template (engine receives the native level, the budget builder sees `reasoning_max_tokens=None`, no `reasoning_budget_logits_processor` is installed, the on/off-only template still yields 8192/2048/512 caps, garbage is a 400), plus SSE streaming on both surfaces (`stream_chat` receives the mapped level; a client `chat_template_kwargs` reaches the streaming `/v1/responses` path). The related suites (`test_reasoning_effort_translation`, `test_chat_template_kwargs_passthrough`, `test_casual_chat_auto_disable_thinking`, `test_per_request_thinking_budget`) pass unchanged, 319 in total.

Real server on M3 Ultra, `qwen3.8-27b-4bit` (MTP sidecar) from this branch: `none` → 27 prompt tokens and no reasoning; `minimal`/`low` → 55 prompt tokens (the "keep your thinking brief" line); `medium` → 25 (no instruction line); `high`/`xhigh` → 67 (the xhigh line); `high` plus `chat_template_kwargs.reasoning_effort=low` → 55 (client wins); `ultra` → 400. `/v1/responses` with nested `reasoning.effort` and top-level `reasoning_effort` matches, streaming on both surfaces matches, the log shows `reasoning_max_tokens=None` for every graded request, and `/metrics` reports MTP still engaged at 79% draft acceptance over the run.
