### PR TITLE
feat(service): headless macOS service lifecycle CLI (#2859)

### DIFF
--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -38,6 +38,15 @@ rapid-mlx service install --service-user serveuser \
   --model qwen3.5-4b-4bit --dry-run
 ```
 
+Pass advanced non-secret server options after a `--` separator, for example
+`-- --max-num-seqs 4`. Use the service command's own `--host` and `--port`
+options for binding; secret-bearing flags are intentionally rejected.
+
+Changing an installed definition is explicit: run `service uninstall`, then
+`service install` with the new settings. Uninstalling preserves models, cache,
+and logs. The installer refuses to overwrite an existing plist because launchd
+would otherwise keep the old in-memory configuration until reboot.
+
 Day-to-day operations:
 
 ```bash

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -5,9 +5,63 @@ inference appliance. A system daemon starts after macOS boots and does not
 depend on a graphical login. This is the macOS equivalent of an enabled
 `systemd` service.
 
-> **Operational scope:** this guide uses the existing CLI and Apple's
-> `launchd`. Rapid-MLX does not yet install or manage the daemon for you. Test
-> the procedure while you still have physical or out-of-band access to the Mac.
+> **Operational scope:** `rapid-mlx service` (the supported way to set this
+> up) installs and manages the daemon for you in one command. The manual
+> runbook below remains as the fallback / recovery path and as the reference
+> for what the CLI produces. Test the procedure while you still have physical
+> or out-of-band access to the Mac.
+
+## Quickstart: `rapid-mlx service`
+
+Create a dedicated, non-administrator service account (shown as `serveuser`)
+and install Rapid-MLX there with the one-line installer, exactly as in
+[section 1](#1-prepare-the-service-account) below. Download the intended
+model once as that account. Then, from an administrator session:
+
+```bash
+sudo rapid-mlx service install \
+  --service-user serveuser \
+  --model qwen3.5-4b-4bit \
+  --host 127.0.0.1 --port 8000
+```
+
+`install` validates the service account, writes a deterministic,
+root-owned plist to `/Library/LaunchDaemons/com.rapidmlx.server.plist`,
+and bootstraps it into the system domain. It refuses to install onto an
+administrator or system account, refuses to embed a secret
+(`--api-key`) into the definition, and refuses when a server already
+answers on the target port (so it cannot silently race a Desktop-managed
+instance). Rehearse first without touching the machine:
+
+```bash
+rapid-mlx service install --service-user serveuser \
+  --model qwen3.5-4b-4bit --dry-run
+```
+
+Day-to-day operations:
+
+```bash
+rapid-mlx service status                 # registration / pid / health / logs
+rapid-mlx service status --json          # machine-readable
+rapid-mlx service logs                   # tail daemon logs
+rapid-mlx service logs --follow          # stream, across KeepAlive restarts
+sudo rapid-mlx service restart           # kickstart + wait until healthy
+```
+
+Remove the service (models, cache, and logs are left in place):
+
+```bash
+sudo rapid-mlx service uninstall         # bootout + remove plist
+rapid-mlx service uninstall --dry-run    # print the removal steps first
+```
+
+A full appliance acceptance test is [`scripts/headless_service_smoke.sh`](../scripts/headless_service_smoke.sh),
+which checks registration, process owner, liveness, readiness, model
+inventory, and a real one-token completion. Run it after any reboot test.
+
+> The CLI is macOS-only and requires an existing least-privilege account —
+> it intentionally does **not** create system users. Programmatic account
+> creation is out of scope for the first supported release.
 
 ## Before you begin
 
@@ -264,8 +318,9 @@ environment, or logs.
 
 ## Known limits
 
-- There is no `rapid-mlx service install` command yet; this is an operator-run
-  deployment.
+- `rapid-mlx service` requires a pre-existing non-administrator service
+  account and an administrator to run `install`/`uninstall`; it does not
+  create system users or rotate logs automatically.
 - Rapid-MLX does not rotate the two log files. Configure your existing log
   collector or rotation policy and monitor free disk space.
 - A full application update causes downtime while the daemon is booted out.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -531,7 +531,7 @@ existing non-administrator service account and (for `install`/`uninstall`/
 
 ```bash
 rapid-mlx service install --service-user USER --model MODEL \
-  [--host HOST] [--port PORT] [serve options...] [--dry-run]
+  [--host HOST] [--port PORT] [--dry-run] [-- SERVE_OPTIONS...]
 rapid-mlx service status [--json]
 rapid-mlx service logs [--follow] [--tail N]
 rapid-mlx service restart [--dry-run]
@@ -543,6 +543,9 @@ rapid-mlx service uninstall [--dry-run]
   bootstraps the daemon. It refuses an administrator/system account, a
   secret in the definition, and a target port that already has a server.
   `--dry-run` prints every step without changing anything.
+- Additional `serve` options must follow a `--` separator, for example
+  `-- --max-num-seqs 4`. Bind overrides and secret-bearing options are
+  rejected; use the service command's own `--host` and `--port` flags.
 - `status` reports launchd registration, PID and owner, the declared model
   and bind, endpoint (`/livez`/`/readyz`) health, and log paths.
 - `logs` tails the daemon's stdout/stderr logs (`--follow` streams across

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,7 @@
 | `rapid-mlx ps` | List running rapid-mlx servers |
 | `rapid-mlx share` | Expose a local model behind a public URL via rapidmlx.com |
 | `rapid-mlx launch` | One-shot bootstrap: patch an IDE/agent client config to use rapid-mlx |
+| `rapid-mlx service` | Install/inspect/remove the headless macOS system service (`install` `status` `logs` `restart` `uninstall`) |
 | `rapid-mlx connect` | Show the server's connection info and wire up a tool |
 | `rapid-mlx agents` | List, configure, and test agent integrations |
 | `rapid-mlx start` | Start an AI agent with a local model in one command |
@@ -521,7 +522,37 @@ rapid-mlx start opencode --model qwen3.5-9b-4bit --port 8123 --yes
 # Start a generic OpenAI-compatible endpoint (no agent config)
 rapid-mlx start
 ```
+## `rapid-mlx service`
 
+Manage Rapid-MLX as an unattended headless macOS system service (a launchd
+LaunchDaemon that boots before any GUI login). macOS-only; requires an
+existing non-administrator service account and (for `install`/`uninstall`/
+`restart`) root.
+
+```bash
+rapid-mlx service install --service-user USER --model MODEL \
+  [--host HOST] [--port PORT] [serve options...] [--dry-run]
+rapid-mlx service status [--json]
+rapid-mlx service logs [--follow] [--tail N]
+rapid-mlx service restart [--dry-run]
+rapid-mlx service uninstall [--dry-run]
+```
+
+- `install` validates the least-privilege service account, writes a
+  deterministic root-owned plist to `/Library/LaunchDaemons/`, and
+  bootstraps the daemon. It refuses an administrator/system account, a
+  secret in the definition, and a target port that already has a server.
+  `--dry-run` prints every step without changing anything.
+- `status` reports launchd registration, PID and owner, the declared model
+  and bind, endpoint (`/livez`/`/readyz`) health, and log paths.
+- `logs` tails the daemon's stdout/stderr logs (`--follow` streams across
+  KeepAlive restarts).
+- `restart` kickstarts the daemon and waits for readiness.
+- `uninstall` removes the launchd registration and plist only — models,
+  cache, and logs are never deleted.
+
+See [`docs/guides/headless-macos-service.md`](../guides/headless-macos-service.md)
+for the full appliance setup and recovery guidance.
 ## Environment Variables
 
 Operator-facing `RAPID_MLX_*` variables read by the server and CLI. A CLI

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -1264,6 +1264,34 @@ def test_is_admin_user_membership_false(monkeypatch):
     assert ins_mod.is_admin_user("serveuser") is False
 
 
+def test_is_admin_user_checks_effective_group_list(monkeypatch):
+    import grp
+    import pwd
+
+    monkeypatch.setattr(
+        grp, "getgrgid", lambda _gid: types.SimpleNamespace(gr_gid=80, gr_mem=[])
+    )
+    monkeypatch.setattr(pwd, "getpwnam", lambda _u: types.SimpleNamespace(pw_gid=20))
+    monkeypatch.setattr(ins_mod.os, "getgrouplist", lambda _u, _gid: [20, 80])
+    assert ins_mod.is_admin_user("serveuser") is True
+
+
+def test_is_admin_user_group_lookup_fallback(monkeypatch):
+    import grp
+    import pwd
+
+    monkeypatch.setattr(
+        grp, "getgrgid", lambda _gid: types.SimpleNamespace(gr_gid=80, gr_mem=[])
+    )
+    monkeypatch.setattr(pwd, "getpwnam", lambda _u: types.SimpleNamespace(pw_gid=80))
+    monkeypatch.setattr(
+        ins_mod.os,
+        "getgrouplist",
+        lambda *_args: (_ for _ in ()).throw(OSError("directory unavailable")),
+    )
+    assert ins_mod.is_admin_user("serveuser") is True
+
+
 def test_validate_service_account_empty_user():
     with pytest.raises(ins_mod.ServiceInstallError, match="required"):
         ins_mod.validate_service_account("")
@@ -1325,6 +1353,41 @@ def test_endpoint_health_live_200(monkeypatch):
     live, ready = st._endpoint_health("127.0.0.1", 8000)
     assert live is True
     assert ready is True
+
+
+def test_endpoint_health_probes_wildcard_bind_via_loopback(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    seen = []
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def settimeout(self, *a):
+            pass
+
+        def sendall(self, *a):
+            pass
+
+        def recv(self, n):
+            return b"HTTP/1.1 200 OK\r\n\r\n"
+
+    def _connect(address, **_kwargs):
+        seen.append(address)
+        return _Conn()
+
+    monkeypatch.setattr(socket, "create_connection", _connect)
+    monkeypatch.setattr(
+        ins_mod,
+        "_readyz_ready",
+        lambda host, port: seen.append((host, port)) or True,
+    )
+    assert st._endpoint_health("0.0.0.0", 8000) == (True, True)
+    assert seen == [("127.0.0.1", 8000), ("127.0.0.1", 8000)]
 
 
 def test_logs_follow_keyboard_interrupt(monkeypatch, tmp_path, capsys):
@@ -1523,3 +1586,91 @@ def test_stage_plist_uses_private_unpredictable_file(tmp_path, monkeypatch):
     finally:
         first.unlink()
         second.unlink()
+
+
+@pytest.mark.parametrize("unlink_fails", [False, True])
+def test_stage_plist_write_failure_closes_and_cleans(
+    tmp_path, monkeypatch, unlink_fails
+):
+    import os
+
+    import vllm_mlx.headless_service.install as ins
+
+    raw_path = tmp_path / "staged.plist"
+    fd = os.open(raw_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    monkeypatch.setattr(ins.tempfile, "mkstemp", lambda **_kwargs: (fd, str(raw_path)))
+
+    class _BadHandle:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            os.close(fd)
+
+        def write(self, _data):
+            raise RuntimeError("write failed")
+
+    monkeypatch.setattr(ins.os, "fdopen", lambda *_args, **_kwargs: _BadHandle())
+    real_unlink = ins.os.unlink
+    if unlink_fails:
+        monkeypatch.setattr(
+            ins.os, "unlink", lambda _path: (_ for _ in ()).throw(OSError("busy"))
+        )
+    with pytest.raises(RuntimeError, match="write failed"):
+        ins._stage_plist(b"data")
+    if unlink_fails:
+        monkeypatch.setattr(ins.os, "unlink", real_unlink)
+        raw_path.unlink()
+    else:
+        assert not raw_path.exists()
+
+
+def test_install_success_cleans_secure_staging_file(monkeypatch, tmp_path, capsys):
+    import shutil
+
+    import vllm_mlx.headless_service.install as ins
+
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "_port_busy", lambda _h, _p: False)
+    monkeypatch.setattr(ins, "is_root", lambda: True)
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+    monkeypatch.setattr(ins, "_wait_ready", lambda _h, _p, **_k: True)
+    monkeypatch.setattr(ins.tempfile, "tempdir", str(tmp_path))
+
+    def _fake_run(argv, check=True):
+        if argv[0] == "install":
+            shutil.copyfile(argv[-2], argv[-1])
+        return _FakeResult()
+
+    monkeypatch.setattr(ins, "_run", _fake_run)
+    code = ins.install_command(
+        _ns(dry_run=False, serve_args=["--", "--max-num-seqs", "4"])
+    )
+    assert code == 0
+    assert "Installed and running" in capsys.readouterr().out
+    assert not list(tmp_path.glob("rapid-mlx-service-*.plist"))
+
+
+def test_install_success_tolerates_staging_cleanup_failure(monkeypatch, tmp_path):
+    import vllm_mlx.headless_service.install as ins
+
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "_port_busy", lambda _h, _p: False)
+    monkeypatch.setattr(ins, "is_root", lambda: True)
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+    monkeypatch.setattr(ins, "_wait_ready", lambda _h, _p, **_k: True)
+    monkeypatch.setattr(ins, "_run", lambda *_a, **_k: _FakeResult())
+    staged = tmp_path / "private-stage.plist"
+    staged.write_bytes(b"plist")
+    monkeypatch.setattr(ins, "_stage_plist", lambda _buf: staged)
+    real_unlink = Path.unlink
+
+    def _fail_only_for_stage(self, *args, **kwargs):
+        if self == staged:
+            raise OSError("busy")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _fail_only_for_stage)
+    assert ins.install_command(_ns(dry_run=False)) == 0
+    assert staged.exists()
+    real_unlink(staged)

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -1,0 +1,1461 @@
+"""Tests for ``rapid-mlx service`` — the headless macOS service lifecycle.
+
+These tests are hermetic: they never touch launchd, the real account
+database (``pwd``/``grp``), or the real ``/Library/LaunchDaemons``. User
+accounts are simulated by monkeypatching ``pwd``/``grp``/``home_for_user``;
+mutations are exercised only through the pure generators and the
+``--dry-run`` surface.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.cli import build_parser
+from vllm_mlx.headless_service import common
+from vllm_mlx.headless_service import install as ins_mod
+from vllm_mlx.headless_service.plist import (
+    build_plist_dict,
+    parse_plist,
+    serialize_plist,
+)
+
+
+@pytest.fixture
+def plist_kwargs():
+    return dict(
+        label="com.rapidmlx.server",
+        user="serveuser",
+        executable="/Users/serveuser/.local/bin/rapid-mlx",
+        model="qwen3.5-4b-4bit",
+        home=Path("/Users/serveuser"),
+        log_dir=Path("/Users/serveuser/Library/Logs/Rapid-MLX"),
+        host="127.0.0.1",
+        port=8000,
+        serve_args=(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# plist generation — determinism + the documented safety contract.
+# ---------------------------------------------------------------------------
+
+
+def test_plist_is_deterministic(plist_kwargs):
+    a = serialize_plist(build_plist_dict(**plist_kwargs))
+    b = serialize_plist(build_plist_dict(**plist_kwargs))
+    assert a == b
+
+
+def test_plist_matches_documented_safety_contract(plist_kwargs):
+    """Same safety assertions as the static-template test
+    ``test_headless_service_assets`` but for the generated plist."""
+    parsed = build_plist_dict(**plist_kwargs)
+    assert parsed["Label"] == "com.rapidmlx.server"
+    assert parsed["UserName"] == "serveuser"
+    assert parsed["EnvironmentVariables"]["HOME"] == "/Users/serveuser"
+    assert parsed["ProgramArguments"][0].startswith("/Users/serveuser/")
+    host_idx = parsed["ProgramArguments"].index("--host")
+    assert parsed["ProgramArguments"][host_idx + 1] == "127.0.0.1"
+    assert parsed["KeepAlive"] is True
+    assert parsed["ThrottleInterval"] >= 10
+    assert parsed["Umask"] == 0o27
+    assert "ProcessType" not in parsed
+    assert "RAPID_MLX_API_KEY" not in parsed["EnvironmentVariables"]
+    assert parsed["StandardOutPath"] != parsed["StandardErrorPath"]
+
+
+def test_plist_argv_round_trips_serve_options(plist_kwargs):
+    plist_kwargs["serve_args"] = ("--max-num-seqs", "4")
+    argv = build_plist_dict(**plist_kwargs)["ProgramArguments"]
+    i = argv.index("--max-num-seqs")
+    assert argv[i + 1] == "4"
+
+
+def test_plist_xml_parse_round_trip(plist_kwargs):
+    parsed = parse_plist(serialize_plist(build_plist_dict(**plist_kwargs)))
+    assert parsed["Label"] == "com.rapidmlx.server"
+    assert parsed["UserName"] == "serveuser"
+
+
+# ---------------------------------------------------------------------------
+# CLI registration + dispatch.
+# ---------------------------------------------------------------------------
+
+
+def test_service_subcommand_registered():
+    parser = build_parser()
+    choices = parser._subparsers._group_actions[0].choices
+    assert "service" in choices
+
+
+def test_service_macos_guard():
+    """On non-darwin the service dispatch must refuse with a clear message."""
+
+    class FakeArgs:
+        command = "service"
+        service_command = "status"
+
+    # Simulate non-darwin by forcing sys.platform in the module check.
+    import vllm_mlx.headless_service.cli as svc_cli
+
+    real_platform = sys.platform
+    try:
+        sys.platform = "linux"
+        with pytest.raises(SystemExit) as ei:
+            svc_cli.service_command(FakeArgs())
+        assert ei.value.code == 2
+    finally:
+        sys.platform = real_platform
+
+
+# ---------------------------------------------------------------------------
+# Service-account validation (monkeypatched account DB).
+# ---------------------------------------------------------------------------
+
+
+def test_validate_rejects_missing_user(monkeypatch):
+    monkeypatch.setattr(ins_mod, "user_uid", staticmethod(lambda u: None))
+    with pytest.raises(ins_mod.ServiceInstallError, match="does not exist"):
+        ins_mod.validate_service_account("nope")
+
+
+def test_validate_rejects_root():
+    with pytest.raises(ins_mod.ServiceInstallError, match="root"):
+        ins_mod.validate_service_account("root")
+
+
+def test_validate_rejects_system_uid(monkeypatch):
+    monkeypatch.setattr(ins_mod, "user_uid", staticmethod(lambda u: 33))
+    # Patch home too: on some CI hosts the `_www` system user has no home dir,
+    # which would make the "does not exist" branch run first and change the
+    # error text. Keeping the home deterministic forces the system-uid branch.
+    monkeypatch.setattr(
+        common, "home_for_user", staticmethod(lambda u: Path(f"/var/{u}"))
+    )
+    with pytest.raises(ins_mod.ServiceInstallError, match="system account"):
+        ins_mod.validate_service_account("_www")
+
+
+def test_validate_rejects_admin(monkeypatch):
+    monkeypatch.setattr(ins_mod, "user_uid", staticmethod(lambda u: 503))
+    monkeypatch.setattr(ins_mod, "is_admin_user", staticmethod(lambda u: True))
+    monkeypatch.setattr(
+        common, "home_for_user", staticmethod(lambda u: Path("/Users/u"))
+    )
+    with pytest.raises(ins_mod.ServiceInstallError, match="admin"):
+        ins_mod.validate_service_account("bob")
+
+
+def test_validate_accepts_least_privilege(monkeypatch):
+    monkeypatch.setattr(ins_mod, "user_uid", staticmethod(lambda u: 503))
+    monkeypatch.setattr(ins_mod, "is_admin_user", staticmethod(lambda u: False))
+    monkeypatch.setattr(
+        common, "home_for_user", staticmethod(lambda u: Path("/Users/serveuser"))
+    )
+    # Should not raise.
+    ins_mod.validate_service_account("serveuser")
+
+
+# ---------------------------------------------------------------------------
+# Secret / port-race guards.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", ["--api-key", "--api-key=secret", "--api_key=secret"])
+def test_refuse_secret_flags(flag):
+    with pytest.raises(ins_mod.ServiceInstallError, match="API key"):
+        ins_mod.refuse_secret_flags((flag, "value"))
+
+
+def test_allow_non_secret_flags():
+    # No raise.
+    ins_mod.refuse_secret_flags(("--max-num-seqs", "4", "--use-paged-cache"))
+
+
+# ---------------------------------------------------------------------------
+# install --dry-run (no system mutation).
+# ---------------------------------------------------------------------------
+
+
+def _valid_user_monkeypatch(monkeypatch):
+    monkeypatch.setattr(
+        ins_mod, "user_uid", staticmethod(lambda u: 503 if u == "serveuser" else None)
+    )
+    monkeypatch.setattr(ins_mod, "is_admin_user", staticmethod(lambda u: False))
+    monkeypatch.setattr(
+        common,
+        "home_for_user",
+        staticmethod(lambda u: Path("/Users/serveuser") if u == "serveuser" else None),
+    )
+    # validate_service_account requires the service-user binary to exist.
+    monkeypatch.setattr(
+        ins_mod,
+        "resolve_executable",
+        staticmethod(lambda home: "/Users/serveuser/.local/bin/rapid-mlx"),
+    )
+
+
+def _ns(**over):
+    import types
+
+    base = dict(
+        service_command="install",
+        label=None,
+        model="qwen3.5-4b-4bit",
+        service_user="serveuser",
+        host="127.0.0.1",
+        port=8000,
+        serve_args=[],
+        dry_run=True,
+    )
+    base.update(over)
+    return types.SimpleNamespace(**base)
+
+
+def test_install_dry_run_prints_mutations_and_touches_nothing(monkeypatch, capsys):
+    _valid_user_monkeypatch(monkeypatch)
+    # Ensure no real port probe fires during dry-run.
+    monkeypatch.setattr(ins_mod, "_port_busy", staticmethod(lambda h, p: False))
+    code = ins_mod.install_command(_ns())
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "[DRY-RUN]" in out
+    assert "launchctl bootstrap system" in out
+    assert "install -o root -g wheel -m 644" in out
+    # Nothing must actually exist.
+    assert not Path("/Library/LaunchDaemons/com.rapidmlx.server.plist").exists()
+
+
+def test_install_without_service_user_errors(monkeypatch):
+    _valid_user_monkeypatch(monkeypatch)
+    code = ins_mod.install_command(_ns(service_user=None))
+    assert code == 1
+
+
+def test_install_refuses_admin_user(monkeypatch, capsys):
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins_mod, "is_admin_user", staticmethod(lambda u: True))
+    code = ins_mod.install_command(_ns())
+    assert code == 1
+    assert "administrator" in capsys.readouterr().err
+
+
+def test_install_refuses_port_race(monkeypatch, capsys):
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins_mod, "_port_busy", staticmethod(lambda h, p: True))
+    code = ins_mod.install_command(_ns())
+    assert code == 1
+    assert "already answers" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# uninstall --dry-run (no system mutation).
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_dry_run_prints_removal_and_touches_nothing(monkeypatch, capsys):
+    code = ins_mod.uninstall_command(_ns())
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "launchctl bootout system/com.rapidmlx.server" in out
+    assert "rm -f /Library/LaunchDaemons/com.rapidmlx.server.plist" in out
+    assert not Path("/Library/LaunchDaemons/com.rapidmlx.server.plist").exists()
+
+
+# ---------------------------------------------------------------------------
+# status --json shape.
+# ---------------------------------------------------------------------------
+
+
+def test_status_json_shape(monkeypatch, capsys):
+    from vllm_mlx.headless_service import status as st
+
+    monkeypatch.setattr(st, "_launchctl_print", staticmethod(lambda _label: None))
+    monkeypatch.setattr(st, "_read_installed_plist", staticmethod(lambda _label: None))
+    monkeypatch.setattr(
+        st, "_endpoint_health", staticmethod(lambda h, p: (False, False))
+    )
+    monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: False))
+
+    import types
+
+    ns = types.SimpleNamespace(
+        service_command="status",
+        label=None,
+        service_user=None,
+        host="127.0.0.1",
+        port=8000,
+        json=True,
+    )
+    code = st.status_command(ns)
+    assert code == 1  # not registered
+    data = json.loads(capsys.readouterr().out)
+    assert data["registered"] is False
+    assert data["pid"] is None
+    assert data["plist_present"] is False
+    assert set(data) >= {
+        "label",
+        "domain",
+        "registered",
+        "pid",
+        "model",
+        "livez",
+        "readyz",
+        "port",
+        "plist",
+        "log_dir",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Readiness probe correctness (matches the /readyz contract).
+# ---------------------------------------------------------------------------
+
+
+class _HttpResponder:
+    """A thread that answers raw HTTP on 127.0.0.1:0 the way rapid-mlx does."""
+
+    def __init__(self, status_line: bytes, body: bytes):
+        import socket as _s
+        import threading
+
+        self.sock = _s.socket(_s.AF_INET, _s.SOCK_STREAM)
+        self.sock.setsockopt(_s.SOL_SOCKET, _s.SO_REUSEADDR, 1)
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(1)
+        self.port = self.sock.getsockname()[1]
+        self.status_line = status_line
+        self.body = body
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+
+    def _serve(self):
+        conn, _ = self.sock.accept()
+        conn.settimeout(2)
+        try:
+            conn.recv(4096)
+            conn.sendall(
+                self.status_line
+                + b"\r\nContent-Length: "
+                + str(len(self.body)).encode()
+                + b"\r\n\r\n"
+                + self.body
+            )
+        finally:
+            conn.close()
+
+
+@pytest.mark.parametrize(
+    "status,body,expected",
+    [
+        (b"HTTP/1.1 200 OK", b'{"status":"healthy","ready":true}', True),
+        (
+            b"HTTP/1.1 503 Service Unavailable",
+            b'{"status":"draining","ready":false}',
+            False,
+        ),
+        # A bare 200 while the model is still loading must NOT count as ready.
+        (b"HTTP/1.1 200 OK", b'{"status":"healthy","ready":false}', False),
+        # Whitespace-tolerant: FastAPI compact vs pretty JSON.
+        (b"HTTP/1.1 200 OK", b'{"status": "healthy", "ready": true}', True),
+    ],
+)
+def test_readyz_ready_semantics(monkeypatch, status, body, expected):
+    from vllm_mlx.headless_service.install import _readyz_ready
+
+    srv = _HttpResponder(status, body)
+    try:
+        assert _readyz_ready("127.0.0.1", srv.port) is expected
+    finally:
+        srv.sock.close()
+
+
+# ---------------------------------------------------------------------------
+# launchd Label validation (path-traversal / injection hardening).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["../evil", "a b", "x/y", "x;rm", "$(x)", ""])
+def test_validate_label_rejects_unsafe(bad):
+    from vllm_mlx.headless_service.common import validate_label
+
+    with pytest.raises(ValueError):
+        validate_label(bad)
+
+
+@pytest.mark.parametrize("good", ["com.rapidmlx.server", "com.example-a1.b", "simple"])
+def test_validate_label_accepts_safe(good):
+    from vllm_mlx.headless_service.common import validate_label
+
+    assert validate_label(good) == good
+
+
+def test_service_dispatch_rejects_bad_label():
+    from vllm_mlx.headless_service.cli import service_command
+
+    class FakeArgs:
+        command = "service"
+        service_command = "status"
+        label = "../../etc/evil"
+
+    # Force darwin so the label-validation path (not the macOS-only guard)
+    # is what actually raises here, on every host.
+    real_platform = sys.platform
+    try:
+        sys.platform = "darwin"
+        with pytest.raises(SystemExit) as ei:
+            service_command(FakeArgs())
+        assert ei.value.code == 2
+    finally:
+        sys.platform = real_platform
+
+
+def test_service_dispatch_good_label_iterates_each_subcommand(monkeypatch):
+    """Dispatch forwards to the right *_command for each subcommand."""
+    import vllm_mlx.headless_service.cli as svc
+    from vllm_mlx.headless_service import install as disp_ins
+    from vllm_mlx.headless_service import logs as disp_logs
+    from vllm_mlx.headless_service import restart as disp_rest
+    from vllm_mlx.headless_service import status as disp_st
+
+    seen = {}
+
+    def _mk(name):
+        def _cmd(args):
+            seen[name] = args
+            return 0
+
+        return _cmd
+
+    monkeypatch.setattr(disp_ins, "install_command", _mk("install"))
+    monkeypatch.setattr(disp_st, "status_command", _mk("status"))
+    monkeypatch.setattr(disp_logs, "logs_command", _mk("logs"))
+    monkeypatch.setattr(disp_rest, "restart_command", _mk("restart"))
+    monkeypatch.setattr(disp_ins, "uninstall_command", _mk("uninstall"))
+
+    class FakeArgs:
+        label = "com.rapidmlx.server"
+
+    # Force darwin: on Linux CI the macOS-only guard fires before dispatch.
+    real_platform = sys.platform
+    try:
+        sys.platform = "darwin"
+        for name in ("install", "status", "logs", "restart", "uninstall"):
+            seen.clear()
+            fake = FakeArgs()
+            fake.service_command = name
+            svc.service_command(fake)  # code 0 → no SystemExit
+            assert seen.get(name) is fake, f"dispatch failed for {name}"
+    finally:
+        sys.platform = real_platform
+
+
+def test_service_dispatch_unknown_subcommand_errors(monkeypatch, capsys):
+    import vllm_mlx.headless_service.cli as svc
+
+    class FakeArgs:
+        label = None
+        service_command = "bogus"
+
+    # Force darwin so the macOS-only guard doesn't shadow the bad-command error.
+    real_platform = sys.platform
+    try:
+        sys.platform = "darwin"
+        with pytest.raises(SystemExit) as ei:
+            svc.service_command(FakeArgs())
+        assert ei.value.code == 2
+        assert (
+            "expected one of install/status/logs/restart/uninstall"
+            in capsys.readouterr().err
+        )
+    finally:
+        sys.platform = real_platform
+
+
+# ---------------------------------------------------------------------------
+# Reviewer fixes: rollback cleanliness, reinstall tolerance, exec requirement.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_executable_requires_service_user_binary(monkeypatch):
+    """The daemon must run the SERVICE account's binary, not the operator's."""
+    from vllm_mlx.headless_service.install import resolve_executable
+
+    # No /Users/serveuser/.local/bin/rapid-mlx exists on this machine.
+    with pytest.raises(ins_mod.ServiceInstallError, match="no Rapid-MLX binary"):
+        resolve_executable(Path("/Users/serveuser"))
+
+
+def test_serve_argv_splices_module_invocation(plist_kwargs):
+    """A ``-m vllm_mlx`` executable must be separate argv entries, never one
+    space-joined argv[0] (which launchd would fail to exec)."""
+    from vllm_mlx.headless_service.plist import serve_argv
+
+    argv = serve_argv(["/opt/venv/bin/python", "-m", "vllm_mlx"], "qwen3.5-4b-4bit")
+    assert argv[0] == "/opt/venv/bin/python"
+    assert argv[1] == "-m"
+    assert argv[2] == "vllm_mlx"
+
+
+def test_install_rollback_removes_plist_on_readiness_failure(monkeypatch, tmp_path):
+    """A failed readiness wait must remove the persistent plist so nothing
+    auto-starts on reboot (the 'rolled back' guarantee)."""
+    import vllm_mlx.headless_service.install as ins
+
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "_port_busy", staticmethod(lambda h, p: False))
+    monkeypatch.setattr(ins, "is_root", staticmethod(lambda: True))
+    # Point the plist directory at a temp dir (raw module constant patch).
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+    monkeypatch.setattr(ins, "_wait_ready", staticmethod(lambda h, p, **k: False))
+
+    # _run: emulate the real shell-outs enough that the rollback's `rm -f`
+    # actually deletes the persistent plist (the readiness wait is faked to
+    # fail). plutil/install/bootstrap return success so the only failure is
+    # the readiness wait.
+    def _fake_run(args, check=True):
+        if args and args[0] == "rm":
+            import os
+
+            for path in args[2:]:
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+        return _FakeResult()
+
+    monkeypatch.setattr(ins, "_run", _fake_run)
+    plist = tmp_path / "com.rapidmlx.server.plist"
+    plist.write_bytes(b"<failed-install-persisted>")
+
+    code = ins.install_command(_ns(dry_run=False))
+    assert code == 2
+    # The persistent plist must be gone after the rollback so nothing
+    # auto-starts on reboot.
+    assert not plist.exists()
+
+
+class _FakeResult:
+    returncode = 0
+    stdout = ""
+    stderr = "service already loaded"
+
+
+# ---------------------------------------------------------------------------
+# logs command — log-path resolution + tail invocation (subprocess patched).
+# ---------------------------------------------------------------------------
+
+
+def test_log_paths_from_installed_plist(monkeypatch, plist_kwargs, tmp_path):
+    """Prefers the plist-declared StandardOut/StandardError paths."""
+    import vllm_mlx.headless_service.logs as logs
+
+    plist = tmp_path / "com.rapidmlx.server.plist"
+    plist.write_bytes(serialize_plist(build_plist_dict(**plist_kwargs)))
+    monkeypatch.setattr(ins_mod, "_plist_path", staticmethod(lambda _l: plist))
+    out, err = logs._log_paths("com.rapidmlx.server", "serveuser")
+    assert out == Path("/Users/serveuser/Library/Logs/Rapid-MLX/server.stdout.log")
+    assert err == Path("/Users/serveuser/Library/Logs/Rapid-MLX/server.stderr.log")
+
+
+def test_log_paths_fallback_to_service_default(monkeypatch, tmp_path):
+    """No plist → fall back to the service account's default log dir."""
+    import vllm_mlx.headless_service.logs as logs
+
+    monkeypatch.setattr(
+        ins_mod, "_plist_path", staticmethod(lambda _l: tmp_path / "missing.plist")
+    )
+    monkeypatch.setattr(
+        logs,
+        "log_dir_for",
+        staticmethod(lambda u: Path(f"/Users/{u}/Library/Logs/Rapid-MLX")),
+    )
+    out, err = logs._log_paths("com.rapidmlx.server", "serveuser")
+    assert out.name == "server.stdout.log"
+    assert err.name == "server.stderr.log"
+
+
+def test_log_paths_returns_none_when_unknown(monkeypatch, tmp_path):
+    """No plist and no resolvable service default → None (→ hard error)."""
+    import vllm_mlx.headless_service.logs as logs
+
+    monkeypatch.setattr(
+        ins_mod, "_plist_path", staticmethod(lambda _l: tmp_path / "missing.plist")
+    )
+    monkeypatch.setattr(logs, "log_dir_for", staticmethod(lambda u: None))
+    assert logs._log_paths("com.rapidmlx.server", "serveuser") is None
+
+
+def test_logs_no_paths_errors(monkeypatch, capsys, tmp_path):
+    import vllm_mlx.headless_service.logs as logs
+
+    monkeypatch.setattr(logs, "_log_paths", staticmethod(lambda *a: None))
+    code = logs.logs_command(_ns())
+    assert code == 1
+    assert "no log paths known" in capsys.readouterr().err
+
+
+def _patched_logged_files(monkeypatch, tmp_path):
+    """Point _log_paths at two temp files; record subprocess.run calls."""
+    import vllm_mlx.headless_service.logs as logs
+
+    out_f = tmp_path / "out.log"
+    err_f = tmp_path / "err.log"
+    out_f.write_text("hello out\n")
+    err_f.write_text("hello err\n")
+    monkeypatch.setattr(
+        logs,
+        "_log_paths",
+        staticmethod(lambda *a: (out_f, err_f)),
+    )
+    calls = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        return _FakeResult()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    return out_f, err_f, calls
+
+
+def test_logs_tails_both_files(monkeypatch, tmp_path, capsys):
+    import vllm_mlx.headless_service.logs as logs
+
+    _, _, calls = _patched_logged_files(monkeypatch, tmp_path)
+    code = logs.logs_command(_ns())
+    assert code == 0
+    # Two tail invocations: stdout then stderr.
+    assert len(calls) == 2
+    assert calls[0][1] == "-n"
+    out = capsys.readouterr().out
+    assert "=== stdout:" in out
+    assert "=== stderr:" in out
+
+
+def test_logs_skips_missing_log_file(monkeypatch, tmp_path, capsys):
+    import vllm_mlx.headless_service.logs as logs
+
+    out_f, err_f, calls = _patched_logged_files(monkeypatch, tmp_path)
+    # Make stderr file absent → "not present" note, only one tail call.
+    err_f.unlink()
+    code = logs.logs_command(_ns())
+    assert code == 0
+    assert len(calls) == 1
+    assert "(stderr: not present" in capsys.readouterr().out
+
+
+def test_logs_tail_oserror(monkeypatch, tmp_path, capsys):
+    import subprocess as sp
+
+    import vllm_mlx.headless_service.logs as logs
+
+    out_f, err_f, _ = _patched_logged_files(monkeypatch, tmp_path)
+
+    def _boom(argv, **kwargs):
+        raise OSError("perm denied")
+
+    monkeypatch.setattr(sp, "run", _boom)
+    code = logs.logs_command(_ns())
+    assert code == 0
+    assert "cannot read" in capsys.readouterr().err
+
+
+def test_logs_follow_streams(monkeypatch, tmp_path, capsys):
+    import vllm_mlx.headless_service.logs as logs
+
+    _, _, calls = _patched_logged_files(monkeypatch, tmp_path)
+    code = logs.logs_command(_ns(follow=True))
+    assert code == 0
+    # --follow runs `tail -F <stdout> <stderr>` once.
+    assert len(calls) == 1
+    assert calls[0][1] == "-F"
+    assert len(calls[0]) == 4  # tail -F out err
+
+
+# ---------------------------------------------------------------------------
+# restart command — kickstart orchestration (subprocess/_wait_ready patched).
+# ---------------------------------------------------------------------------
+
+
+def test_declared_bind_parses_plist(monkeypatch, plist_kwargs, tmp_path):
+    import vllm_mlx.headless_service.restart as rest
+
+    plist = tmp_path / "com.rapidmlx.server.plist"
+    plist.write_bytes(serialize_plist(build_plist_dict(**plist_kwargs)))
+    monkeypatch.setattr(ins_mod, "_plist_path", staticmethod(lambda _l: plist))
+    assert rest._declared_bind("com.rapidmlx.server") == ("127.0.0.1", 8000)
+
+
+def test_declared_bind_none_when_missing_plist(monkeypatch, tmp_path):
+    import vllm_mlx.headless_service.restart as rest
+
+    monkeypatch.setattr(
+        ins_mod, "_plist_path", staticmethod(lambda _l: tmp_path / "nope.plist")
+    )
+    assert rest._declared_bind("com.rapidmlx.server") is None
+
+
+def test_declared_bind_none_on_bad_plist(monkeypatch, tmp_path):
+    import vllm_mlx.headless_service.restart as rest
+
+    plist = tmp_path / "com.rapidmlx.server.plist"
+    plist.write_bytes(b"<not a plist")
+    monkeypatch.setattr(ins_mod, "_plist_path", staticmethod(lambda _l: plist))
+    assert rest._declared_bind("com.rapidmlx.server") is None
+
+
+def test_restart_dry_run(monkeypatch, capsys):
+    import vllm_mlx.headless_service.restart as rest
+
+    monkeypatch.setattr(rest, "_declared_bind", staticmethod(lambda _l: None))
+    monkeypatch.setattr(rest, "_kickstart_status", staticmethod(lambda _l: 0))
+    code = rest.restart_command(_ns())
+    assert code == 0
+    assert "[DRY-RUN] would run: launchctl kickstart -k" in capsys.readouterr().out
+
+
+def test_restart_not_registered_errors(monkeypatch, capsys):
+    import vllm_mlx.headless_service.restart as rest
+
+    monkeypatch.setattr(rest, "_declared_bind", staticmethod(lambda _l: None))
+    monkeypatch.setattr(rest, "_kickstart_status", staticmethod(lambda _l: 1))
+    code = rest.restart_command(_ns())
+    assert code == 1
+    assert "is not registered" in capsys.readouterr().err
+
+
+def test_restart_happy_path(monkeypatch, capsys):
+    import vllm_mlx.headless_service.restart as rest
+
+    monkeypatch.setattr(
+        rest, "_declared_bind", staticmethod(lambda _l: ("127.0.0.1", 8123))
+    )
+    monkeypatch.setattr(rest, "_kickstart_status", staticmethod(lambda _l: 0))
+    monkeypatch.setattr(rest, "_wait_ready", staticmethod(lambda h, p, **k: True))
+    calls = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(argv)
+        return _FakeResult()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    code = rest.restart_command(_ns(dry_run=False))
+    assert code == 0
+    assert "healthy on 127.0.0.1:8123" in capsys.readouterr().out
+    assert calls[0][1] == "kickstart"
+
+
+def test_restart_kickstart_failure(monkeypatch, capsys):
+    import vllm_mlx.headless_service.restart as rest
+
+    monkeypatch.setattr(rest, "_declared_bind", staticmethod(lambda _l: None))
+    monkeypatch.setattr(rest, "_kickstart_status", staticmethod(lambda _l: 0))
+
+    def _fake_run(argv, **kwargs):
+        raise subprocess.CalledProcessError(1, argv)
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    code = rest.restart_command(_ns(dry_run=False))
+    assert code == 1
+    assert "kickstart failed" in capsys.readouterr().err
+
+
+def test_restart_ready_failure(monkeypatch, capsys):
+    import vllm_mlx.headless_service.restart as rest
+
+    monkeypatch.setattr(rest, "_declared_bind", staticmethod(lambda _l: None))
+    monkeypatch.setattr(rest, "_kickstart_status", staticmethod(lambda _l: 0))
+    monkeypatch.setattr(rest, "_wait_ready", staticmethod(lambda h, p, **k: False))
+    monkeypatch.setattr(subprocess, "run", staticmethod(lambda *a, **k: _FakeResult()))
+    code = rest.restart_command(_ns(dry_run=False))
+    assert code == 1
+    assert "did not become ready" in capsys.readouterr().err
+
+
+def test_kickstart_status_subprocess_error(monkeypatch):
+    import vllm_mlx.headless_service.restart as rest
+
+    def _boom(argv, **kwargs):
+        raise OSError("no launchctl")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    assert rest._kickstart_status("com.rapidmlx.server") == 1
+
+
+# ---------------------------------------------------------------------------
+# status command — richer aggregation + human rendering (parsers exercised).
+# ---------------------------------------------------------------------------
+
+
+def _fake_launchctl_print(pid=None, last_exit=None):
+    lines = ["com.rapidmlx.server = {", "    active count = 1"]
+    if pid is not None:
+        lines.append(f"    pid = {pid}")
+    if last_exit is not None:
+        lines.append(f"    last exit code = {last_exit}")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def test_parse_pid_and_last_exit():
+    import vllm_mlx.headless_service.status as st
+
+    out = _fake_launchctl_print(pid=4242, last_exit=0)
+    assert st._parse_pid(out) == 4242
+    assert st._parse_last_exit(out) == 0
+    assert st._parse_pid(None) is None
+    assert st._parse_pid("no pid here") is None
+    assert st._parse_last_exit(None) is None
+
+
+def test_collect_status_full_branch(monkeypatch, plist_kwargs, tmp_path):
+    """Registered + running + plist present + endpoint healthy."""
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        st,
+        "_launchctl_print",
+        staticmethod(lambda _l: _fake_launchctl_print(pid=4242, last_exit=0)),
+    )
+    plist = tmp_path / "com.rapidmlx.server.plist"
+    plist.write_bytes(serialize_plist(build_plist_dict(**plist_kwargs)))
+    monkeypatch.setattr(st, "_plist_path", staticmethod(lambda _l: plist))
+    monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
+    monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: True))
+    # Stub `ps -o user=` so the owner lookup is hermetic.
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        staticmethod(
+            lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="serveuser\n")
+        ),
+    )
+    monkeypatch.setattr(
+        st,
+        "log_dir_for",
+        staticmethod(lambda u: Path("/Users/u/Library/Logs/Rapid-MLX")),
+    )
+    data = st.collect_status(
+        label="com.rapidmlx.server", user="serveuser", host="127.0.0.1", port=8000
+    )
+    assert data["registered"] is True
+    assert data["pid"] == 4242
+    assert data["last_exit"] == 0
+    assert data["model"] == "qwen3.5-4b-4bit"
+    assert data["owner"] == "serveuser"
+    assert data["livez"] is True
+    assert data["readyz"] is True
+    assert data["port_open"] is True
+    assert data["plist_present"] is True
+    assert data["host"] == "127.0.0.1"
+    assert data["port"] == 8000
+    assert data["log_dir"]
+
+
+def test_status_command_json_and_exit_codes(monkeypatch, capsys):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        st, "_launchctl_print", staticmethod(lambda _l: _fake_launchctl_print(pid=9))
+    )
+    monkeypatch.setattr(st, "_read_installed_plist", staticmethod(lambda _l: None))
+    monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
+    monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: True))
+    ns = _ns(json=True)
+    assert st.status_command(ns) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["pid"] == 9
+
+    # Ready but no PID → not "up" → exit 1.
+    monkeypatch.setattr(
+        st, "_launchctl_print", staticmethod(lambda _l: _fake_launchctl_print(pid=None))
+    )
+    assert st.status_command(_ns(json=True)) == 1
+
+
+def test_render_human_lines():
+    import vllm_mlx.headless_service.status as st
+
+    s = {
+        "label": "com.rapidmlx.server",
+        "domain": "system",
+        "registered": True,
+        "pid": 42,
+        "owner": "serveuser",
+        "last_exit": 0,
+        "model": "qwen3.5-4b-4bit",
+        "host": "127.0.0.1",
+        "port": 8000,
+        "livez": True,
+        "readyz": True,
+        "port_open": True,
+        "plist": "/Library/LaunchDaemons/com.rapidmlx.server.plist",
+        "log_dir": "/Users/u/Library/Logs/Rapid-MLX",
+        "plist_present": True,
+    }
+    text = st._render_human(s)
+    assert "registered" in text
+    assert "pid:                   42 (as serveuser)" in text
+    assert "healthy" not in text
+
+    # Down + no pid + hint.
+    s2 = dict(
+        s,
+        pid=None,
+        owner=None,
+        registered=False,
+        last_exit=None,
+        model=None,
+        port_open=False,
+    )
+    text2 = st._render_human(s2)
+    assert "(no live process)" in text2
+    assert "not registered" in text2
+    assert "not registered — `rapid-mlx service install --dry-run`" in text2
+
+
+# ---------------------------------------------------------------------------
+# common helpers — account-DB fallthrough branches.
+# ---------------------------------------------------------------------------
+
+
+def test_common_home_for_user_missing(monkeypatch):
+    import pwd
+
+    class _NoPwd:
+        def getpwnam(self, user):
+            raise KeyError(user)
+
+    monkeypatch.setattr(pwd, "getpwnam", _NoPwd().getpwnam)
+    assert common.home_for_user("ghost") is None
+    assert common.user_uid("ghost") is None
+
+
+def test_common_log_dir_for_none_home(monkeypatch):
+    monkeypatch.setattr(common, "home_for_user", staticmethod(lambda u: None))
+    assert common.log_dir_for("ghost") is None
+
+
+def test_is_admin_user_missing_group(monkeypatch):
+    import grp
+
+    def _raise(*a):
+        raise KeyError("no group 80")
+
+    monkeypatch.setattr(grp, "getgrgid", _raise)
+    assert ins_mod.is_admin_user("serveuser") is False
+
+
+def test_logs_follow_tail_failure(monkeypatch, tmp_path, capsys):
+    import vllm_mlx.headless_service.logs as logs
+
+    _, _, _ = _patched_logged_files(monkeypatch, tmp_path)
+
+    def _boom(argv, **kwargs):
+        raise subprocess.CalledProcessError(1, argv)
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    code = logs.logs_command(_ns(follow=True))
+    assert code == 1
+    assert "tail failed" in capsys.readouterr().err
+
+
+def test_log_paths_ignores_corrupt_plist(monkeypatch, plist_kwargs, tmp_path):
+    """A corrupt installed plist must not crash _log_paths (falls through)."""
+    import vllm_mlx.headless_service.logs as logs
+
+    plist = tmp_path / "com.rapidmlx.server.plist"
+    plist.write_bytes(b"<not-a-plist")
+    monkeypatch.setattr(ins_mod, "_plist_path", staticmethod(lambda _l: plist))
+    monkeypatch.setattr(
+        logs,
+        "log_dir_for",
+        staticmethod(lambda u: Path(f"/Users/{u}/Library/Logs/Rapid-MLX")),
+    )
+    out, err = logs._log_paths("com.rapidmlx.server", "serveuser")
+    assert out.name == "server.stdout.log"
+
+
+def test_declared_bind_none_when_no_port(monkeypatch, plist_kwargs, tmp_path):
+    """A plist without a --port pair yields None (no reliable bind)."""
+    import vllm_mlx.headless_service.restart as rest
+
+    cfg = build_plist_dict(**plist_kwargs)
+    cfg["ProgramArguments"] = ["/bin/rapid-mlx", "serve", "qwen3.5-4b-4bit"]
+    plist = tmp_path / "com.rapidmlx.server.plist"
+    plist.write_bytes(serialize_plist(cfg))
+    monkeypatch.setattr(ins_mod, "_plist_path", staticmethod(lambda _l: plist))
+    assert rest._declared_bind("com.rapidmlx.server") is None
+
+
+def test_launchctl_print_returns_none_on_nonzero(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        staticmethod(lambda *a, **k: types.SimpleNamespace(returncode=5, stdout="x")),
+    )
+    assert st._launchctl_print("com.rapidmlx.server") is None
+
+
+def test_launchctl_print_returns_none_on_error(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    def _boom(argv, **kwargs):
+        raise OSError("no launchctl")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    assert st._launchctl_print("com.rapidmlx.server") is None
+
+
+def test_read_installed_plist_none_when_missing(monkeypatch, tmp_path):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        st, "_plist_path", staticmethod(lambda _l: tmp_path / "x.plist")
+    )
+    assert st._read_installed_plist("com.rapidmlx.server") is None
+
+
+def test_read_installed_plist_none_when_corrupt(monkeypatch, tmp_path):
+    import vllm_mlx.headless_service.status as st
+
+    plist = tmp_path / "x.plist"
+    plist.write_bytes(b"<not-a-plist")
+    monkeypatch.setattr(st, "_plist_path", staticmethod(lambda _l: plist))
+    assert st._read_installed_plist("com.rapidmlx.server") is None
+
+
+def test_endpoint_health_connection_error(monkeypatch):
+    import socket
+
+    import vllm_mlx.headless_service.status as st
+
+    def _boom(*a, **k):
+        raise OSError("refused")
+
+    monkeypatch.setattr(socket, "create_connection", _boom)
+    monkeypatch.setattr(ins_mod, "_readyz_ready", staticmethod(lambda h, p: False))
+    live, ready = st._endpoint_health("127.0.0.1", 1)
+    assert live is False
+    assert ready is False
+
+
+def test_status_owner_ps_error(monkeypatch, plist_kwargs, tmp_path):
+    """A failing `ps` owner lookup degrades to owner=None, not a crash."""
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        st, "_launchctl_print", staticmethod(lambda _l: _fake_launchctl_print(pid=7))
+    )
+    monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
+    monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: False))
+    plist = tmp_path / "com.rapidmlx.server.plist"
+    plist.write_bytes(serialize_plist(build_plist_dict(**plist_kwargs)))
+    monkeypatch.setattr(st, "_plist_path", staticmethod(lambda _l: plist))
+
+    def _boom(argv, **kwargs):
+        raise OSError("ps failed")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    data = st.collect_status(label="com.rapidmlx.server")
+    assert data["pid"] == 7
+    assert data["owner"] is None
+
+
+def test_status_command_human_branch(monkeypatch, capsys):
+    """Non-json status prints the human table (and returns 1 when down)."""
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        st, "_launchctl_print", staticmethod(lambda _l: _fake_launchctl_print())
+    )
+    monkeypatch.setattr(st, "_read_installed_plist", staticmethod(lambda _l: None))
+    monkeypatch.setattr(
+        st, "_endpoint_health", staticmethod(lambda h, p: (False, False))
+    )
+    monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: False))
+    code = st.status_command(_ns(json=False))
+    assert code == 1
+    text = capsys.readouterr().out
+    assert "launcher registration:" in text
+    # Down state surfaces in the human table.
+    assert "(no live process)" in text
+    assert "livez=down readyz=down port=closed" in text
+
+
+def test_resolve_executable_success(monkeypatch, tmp_path):
+    """A real executable under the service home resolves to that path."""
+    bin_dir = tmp_path / ".local" / "bin"
+    bin_dir.mkdir(parents=True)
+    exe = bin_dir / "rapid-mlx"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+    resolved = ins_mod.resolve_executable(Path(tmp_path))
+    assert resolved == str(exe)
+
+
+# ---------------------------------------------------------------------------
+# install.py remaining helpers — cache, build, port-busy, wait, uninstall.
+# ---------------------------------------------------------------------------
+
+
+def test_cache_root_present_branches(tmp_path):
+    home = tmp_path / "serveuser"
+    cache = home / ".cache" / "huggingface" / "hub"
+    assert ins_mod._cache_root_present(home, "org/model") is False
+    cache.mkdir(parents=True)
+    assert ins_mod._cache_root_present(home, "org/model") is False
+    (cache / "models--org--model").mkdir()
+    assert ins_mod._cache_root_present(home, "org/model") is True
+
+
+def test_build_plist_bytes_requires_resolvable_home(monkeypatch):
+    monkeypatch.setattr(common, "log_dir_for", staticmethod(lambda u: None))
+    with pytest.raises(ins_mod.ServiceInstallError, match="cannot resolve home"):
+        ins_mod._build_plist_bytes(
+            label="com.rapidmlx.server",
+            user="serveuser",
+            executable="/bin/rapid-mlx",
+            model="qwen3.5-4b-4bit",
+            home=Path("/Users/serveuser"),
+            host="127.0.0.1",
+            port=8000,
+            serve_args=(),
+        )
+
+
+def test_port_busy_true_when_answering(monkeypatch):
+    import socket
+
+    class _Sock:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        socket, "create_connection", staticmethod(lambda *a, **k: _Sock())
+    )
+    assert ins_mod._port_busy("127.0.0.1", 8000) is True
+
+
+def test_port_busy_false_on_connect_error(monkeypatch):
+    import socket
+
+    def _boom(*a, **k):
+        raise OSError("refused")
+
+    monkeypatch.setattr(socket, "create_connection", _boom)
+    assert ins_mod._port_busy("127.0.0.1", 1) is False
+
+
+def test_wait_ready_immediate(monkeypatch):
+    monkeypatch.setattr(ins_mod, "_readyz_ready", staticmethod(lambda h, p: True))
+    assert ins_mod._wait_ready("127.0.0.1", 1, timeout_s=5) is True
+
+
+def test_wait_ready_timeout(monkeypatch):
+    monkeypatch.setattr(ins_mod, "_readyz_ready", staticmethod(lambda h, p: False))
+    state = {"t": 0.0}
+
+    def _tick():
+        state["t"] += 1.0
+        return state["t"]
+
+    monkeypatch.setattr(
+        ins_mod, "time", types.SimpleNamespace(time=_tick, sleep=lambda s: None)
+    )
+    # time() advances past the (5s) deadline → loop ends → False.
+    assert ins_mod._wait_ready("127.0.0.1", 1, timeout_s=5) is False
+
+
+def test_uninstall_non_root_errors(monkeypatch, capsys):
+    monkeypatch.setattr(ins_mod, "is_root", staticmethod(lambda: False))
+    code = ins_mod.uninstall_command(_ns(dry_run=False))
+    assert code == 1
+    assert "requires root" in capsys.readouterr().err
+
+
+def test_uninstall_real_removes(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(ins_mod, "is_root", staticmethod(lambda: True))
+    monkeypatch.setattr(
+        ins_mod, "_plist_path", staticmethod(lambda _l: tmp_path / "x.plist")
+    )
+    monkeypatch.setattr(subprocess, "run", staticmethod(lambda *a, **k: _FakeResult()))
+    code = ins_mod.uninstall_command(_ns(dry_run=False))
+    assert code == 0
+    assert "uninstalled com.rapidmlx.server" in capsys.readouterr().out
+
+
+def test_uninstall_subprocess_failure(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(ins_mod, "is_root", staticmethod(lambda: True))
+    monkeypatch.setattr(
+        ins_mod, "_plist_path", staticmethod(lambda _l: tmp_path / "x.plist")
+    )
+
+    def _boom(argv, **kwargs):
+        raise subprocess.CalledProcessError(1, argv)
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    code = ins_mod.uninstall_command(_ns(dry_run=False))
+    assert code == 2
+    assert "uninstall failed" in capsys.readouterr().err
+
+
+def test_install_non_root_errors(monkeypatch, capsys):
+    """Real (non-dry-run) install without root refuses cleanly."""
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins_mod, "_port_busy", staticmethod(lambda h, p: False))
+    monkeypatch.setattr(ins_mod, "is_root", staticmethod(lambda: False))
+    code = ins_mod.install_command(_ns(dry_run=False))
+    assert code == 1
+    assert "requires root" in capsys.readouterr().err
+
+
+def test_is_root_direct():
+    # Non-root on CI hosts just exercises the comparison expression.
+    assert ins_mod.is_root() in (True, False)
+
+
+def test_is_admin_user_membership_false(monkeypatch):
+    import grp
+
+    def _group(*a):
+        return types.SimpleNamespace(gr_mem=["alice", "bob"])
+
+    monkeypatch.setattr(grp, "getgrgid", _group)
+    assert ins_mod.is_admin_user("serveuser") is False
+
+
+def test_validate_service_account_empty_user():
+    with pytest.raises(ins_mod.ServiceInstallError, match="required"):
+        ins_mod.validate_service_account("")
+
+
+def test_run_forwards_to_subprocess(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", staticmethod(lambda *a, **k: "ran"))
+    assert ins_mod._run(["echo", "hi"]) == "ran"
+
+
+def test_kickstart_status_success(monkeypatch):
+    import vllm_mlx.headless_service.restart as rest
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        staticmethod(lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="")),
+    )
+    assert rest._kickstart_status("com.rapidmlx.server") == 0
+
+
+def test_launchctl_print_success_returns_stdout(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        staticmethod(
+            lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="pid = 5")
+        ),
+    )
+    assert st._launchctl_print("com.rapidmlx.server") == "pid = 5"
+
+
+def test_endpoint_health_live_200(monkeypatch):
+    """_probe_live reads a 200 from /livez (socket sendall/recv path)."""
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def settimeout(self, *a):
+            pass
+
+        def sendall(self, *a):
+            pass
+
+        def recv(self, n):
+            return b"HTTP/1.1 200 OK\r\n\r\n"
+
+    monkeypatch.setattr(
+        socket, "create_connection", staticmethod(lambda *a, **k: _Conn())
+    )
+    monkeypatch.setattr(ins_mod, "_readyz_ready", staticmethod(lambda h, p: True))
+    live, ready = st._endpoint_health("127.0.0.1", 8000)
+    assert live is True
+    assert ready is True
+
+
+def test_logs_follow_keyboard_interrupt(monkeypatch, tmp_path, capsys):
+    import vllm_mlx.headless_service.logs as logs
+
+    _, _, _ = _patched_logged_files(monkeypatch, tmp_path)
+
+    def _kbi(argv, **kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(subprocess, "run", _kbi)
+    assert logs.logs_command(_ns(follow=True)) == 0
+
+
+def test_readyz_ready_connection_error():
+    """A refused /readyz probe is NOT ready (OSError branch)."""
+    from vllm_mlx.headless_service.install import _readyz_ready
+
+    # Port 1 on loopback is never listening → connection refused → False.
+    assert _readyz_ready("127.0.0.1", 1) is False
+
+
+def test_install_plutil_lint_failure_rolls_back(monkeypatch, tmp_path, capsys):
+    """A plutil -lint failure aborts the install cleanly (rollback)."""
+    ins = ins_mod
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "_port_busy", staticmethod(lambda h, p: False))
+    monkeypatch.setattr(ins, "is_root", staticmethod(lambda: True))
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+
+    def _fake_run(args, check=True):
+        if args[0] == "plutil":
+
+            class _Bad(_FakeResult):
+                returncode = 1
+                stderr = "invalid property list"
+
+            return _Bad()
+        return _FakeResult()
+
+    monkeypatch.setattr(ins, "_run", _fake_run)
+    code = ins.install_command(_ns(dry_run=False))
+    assert code == 2
+    assert "plutil -lint failed" in capsys.readouterr().err
+
+
+def test_install_bootstrap_hard_failure(monkeypatch, tmp_path, capsys):
+    """A bootstrap failure that is NOT 'already loaded' is a hard error."""
+    ins = ins_mod
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "_port_busy", staticmethod(lambda h, p: False))
+    monkeypatch.setattr(ins, "is_root", staticmethod(lambda: True))
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+
+    def _fake_run(args, check=True):
+        if args[0] == "plutil":
+            return _FakeResult()
+        if args[0] == "install":
+            return _FakeResult()
+        if args[0] == "launchctl" and args[1] == "bootstrap":
+
+            class _Bad(_FakeResult):
+                returncode = 8
+                stderr = "Bootstrap failed: 5: Input/output error"
+
+            return _Bad()
+        return _FakeResult()
+
+    monkeypatch.setattr(ins, "_run", _fake_run)
+    code = ins.install_command(_ns(dry_run=False))
+    assert code == 2
+    assert "bootstrap failed" in capsys.readouterr().err
+
+
+def test_install_generic_step_failure_rolls_back(monkeypatch, tmp_path, capsys):
+    """A non-ServiceInstallError during install prints info + returns 2."""
+    ins = ins_mod
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "_port_busy", staticmethod(lambda h, p: False))
+    monkeypatch.setattr(ins, "is_root", staticmethod(lambda: True))
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+    monkeypatch.setattr(ins, "_run", staticmethod(lambda *a, **k: _FakeResult()))
+
+    # _wait_ready raises a GENERIC exception (not ServiceInstallError) →
+    # the generic rollback branch (info: removed + install step failed).
+    def _boom(h, p, **k):
+        raise RuntimeError("readiness probe crashed")
+
+    monkeypatch.setattr(ins, "_wait_ready", _boom)
+    code = ins.install_command(_ns(dry_run=False))
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "info: removed" in err
+    assert "install step failed" in err
+
+
+def test_install_rollback_unlink_oserror(monkeypatch, tmp_path, capsys):
+    """staged.unlink() failing in rollback is tolerated (except OSError)."""
+    from pathlib import Path as _Path
+
+    ins = ins_mod
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "_port_busy", staticmethod(lambda h, p: False))
+    monkeypatch.setattr(ins, "is_root", staticmethod(lambda: True))
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+    monkeypatch.setattr(ins, "_run", staticmethod(lambda *a, **k: _FakeResult()))
+    monkeypatch.setattr(ins, "_wait_ready", staticmethod(lambda h, p, **k: False))
+
+    real_unlink = _Path.unlink
+
+    def _unlink_boom(self, *a, **k):
+        raise OSError("read-only")
+
+    monkeypatch.setattr(_Path, "unlink", _unlink_boom)
+    try:
+        code = ins.install_command(_ns(dry_run=False))
+    finally:
+        monkeypatch.setattr(_Path, "unlink", real_unlink)
+    assert code == 2
+    assert "rolled back" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Reviewer fixes: rollback cleanliness, reinstall tolerance, exec requirement.
+# ---------------------------------------------------------------------------
+
+
+def test_install_real_path_tolerates_already_loaded(monkeypatch, tmp_path):
+    """A reinstall where `launchctl bootstrap` reports 'already loaded' must
+    be accepted (documented reinstall grace), not fail as a bare CalledProcess
+    error — the tolerance must actually be reachable."""
+    import vllm_mlx.headless_service.install as ins
+
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "_port_busy", staticmethod(lambda h, p: False))
+    monkeypatch.setattr(ins, "is_root", staticmethod(lambda: True))
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+    monkeypatch.setattr(ins, "_wait_ready", staticmethod(lambda h, p, **k: True))
+
+    def _fake_run(args, check=True):
+        if args and args[0] == "launchctl" and args[1] == "bootstrap":
+            # launchd exits non-zero with "already loaded" on reinstall.
+            class _Already(_FakeResult):
+                returncode = 5
+                stderr = "service already loaded"
+
+            return _Already()
+        if args and args[0] == "rm":
+            import os
+
+            for path in args[2:]:
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+        return _FakeResult()
+
+    monkeypatch.setattr(ins, "_run", _fake_run)
+    code = ins.install_command(_ns(dry_run=False))
+    assert code == 0  # tolerated, not an error

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -96,6 +96,23 @@ def test_service_subcommand_registered():
     assert "service" in choices
 
 
+def test_service_install_parses_passthrough_after_separator():
+    args = build_parser().parse_args(
+        [
+            "service",
+            "install",
+            "--service-user",
+            "serveuser",
+            "--model",
+            "qwen3.5-4b-4bit",
+            "--",
+            "--max-num-seqs",
+            "4",
+        ]
+    )
+    assert args.serve_args == ["--", "--max-num-seqs", "4"]
+
+
 def test_service_macos_guard():
     """On non-darwin the service dispatch must refuse with a clear message."""
 
@@ -178,6 +195,12 @@ def test_refuse_secret_flags(flag):
 def test_allow_non_secret_flags():
     # No raise.
     ins_mod.refuse_secret_flags(("--max-num-seqs", "4", "--use-paged-cache"))
+
+
+@pytest.mark.parametrize("flag", ["--host", "--port=9000", "--listen-fd"])
+def test_refuse_passthrough_bind_overrides(flag):
+    with pytest.raises(ins_mod.ServiceInstallError, match="bind option"):
+        ins_mod.refuse_secret_flags((flag, "value"))
 
 
 # ---------------------------------------------------------------------------
@@ -522,6 +545,10 @@ def test_install_rollback_removes_plist_on_readiness_failure(monkeypatch, tmp_pa
     # fail). plutil/install/bootstrap return success so the only failure is
     # the readiness wait.
     def _fake_run(args, check=True):
+        if args and args[0] == "install":
+            import shutil
+
+            shutil.copyfile(args[-2], args[-1])
         if args and args[0] == "rm":
             import os
 
@@ -534,7 +561,6 @@ def test_install_rollback_removes_plist_on_readiness_failure(monkeypatch, tmp_pa
 
     monkeypatch.setattr(ins, "_run", _fake_run)
     plist = tmp_path / "com.rapidmlx.server.plist"
-    plist.write_bytes(b"<failed-install-persisted>")
 
     code = ins.install_command(_ns(dry_run=False))
     assert code == 2
@@ -1321,6 +1347,16 @@ def test_readyz_ready_connection_error():
     assert _readyz_ready("127.0.0.1", 1) is False
 
 
+@pytest.mark.parametrize(
+    ("bind", "probe"),
+    [("0.0.0.0", "127.0.0.1"), ("::", "::1"), ("[::]", "::1")],
+)
+def test_wildcard_bind_uses_connectable_probe_address(bind, probe):
+    from vllm_mlx.headless_service.install import _probe_host
+
+    assert _probe_host(bind) == probe
+
+
 def test_install_plutil_lint_failure_rolls_back(monkeypatch, tmp_path, capsys):
     """A plutil -lint failure aborts the install cleanly (rollback)."""
     ins = ins_mod
@@ -1426,10 +1462,8 @@ def test_install_rollback_unlink_oserror(monkeypatch, tmp_path, capsys):
 # ---------------------------------------------------------------------------
 
 
-def test_install_real_path_tolerates_already_loaded(monkeypatch, tmp_path):
-    """A reinstall where `launchctl bootstrap` reports 'already loaded' must
-    be accepted (documented reinstall grace), not fail as a bare CalledProcess
-    error — the tolerance must actually be reachable."""
+def test_install_real_path_rejects_already_loaded(monkeypatch, tmp_path, capsys):
+    """A hidden loaded job must not make a new plist look successfully active."""
     import vllm_mlx.headless_service.install as ins
 
     _valid_user_monkeypatch(monkeypatch)
@@ -1458,4 +1492,34 @@ def test_install_real_path_tolerates_already_loaded(monkeypatch, tmp_path):
 
     monkeypatch.setattr(ins, "_run", _fake_run)
     code = ins.install_command(_ns(dry_run=False))
-    assert code == 0  # tolerated, not an error
+    assert code == 2
+    assert "bootstrap failed" in capsys.readouterr().err
+
+
+def test_install_refuses_existing_plist_before_mutation(monkeypatch, tmp_path, capsys):
+    """Replacing a plist while launchd retains old argv creates split-brain."""
+    import vllm_mlx.headless_service.install as ins
+
+    _valid_user_monkeypatch(monkeypatch)
+    monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
+    (tmp_path / "com.rapidmlx.server.plist").write_text("existing")
+    code = ins.install_command(_ns(dry_run=False))
+    assert code == 1
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_stage_plist_uses_private_unpredictable_file(tmp_path, monkeypatch):
+    import stat
+
+    import vllm_mlx.headless_service.install as ins
+
+    monkeypatch.setattr(ins.tempfile, "tempdir", str(tmp_path))
+    first = ins._stage_plist(b"one")
+    second = ins._stage_plist(b"two")
+    try:
+        assert first != second
+        assert first.read_bytes() == b"one"
+        assert stat.S_IMODE(first.stat().st_mode) == 0o600
+    finally:
+        first.unlink()
+        second.unlink()

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -12560,6 +12560,15 @@ Examples:
 
     _register_launch(subparsers)
 
+    # Service subcommand — supported headless macOS service lifecycle
+    # (system LaunchDaemon). GH issue #2859. Lives in headless_service to
+    # stay distinct from vllm_mlx.service (the engine's helper/post-process
+    # layer). Registered after launch so the help ordering keeps the common
+    # interactive verbs first.
+    from vllm_mlx.headless_service.cli import register as _register_service
+
+    _register_service(subparsers)
+
     return parser
 
 
@@ -12897,10 +12906,14 @@ def main():
     # The doctor subcommand is exempt for historical reasons (and as a
     # belt-and-suspenders guard now that doctor doesn't take ``--model``):
     # an env-health probe should never trigger an alias→path lookup.
+    # ``service`` is exempt for the same class of reason: it embeds the
+    # model string verbatim into the plist and runs its own (dry-run safe,
+    # unit-testable) validation — it must not hard-fail here on an unknown
+    # alias nor swallow the user's spelling under a resolved HF path.
     if (
         hasattr(args, "model")
         and args.model
-        and getattr(args, "command", None) != "doctor"
+        and getattr(args, "command", None) not in ("doctor", "service")
     ):
         from vllm_mlx.model_aliases import RetiredModelAliasError, resolve_model
         from vllm_mlx.user_aliases import UserAliasError
@@ -13172,6 +13185,10 @@ def main():
         from vllm_mlx.launch.cli import launch_command
 
         launch_command(args)
+    elif args.command == "service":  # pragma: no cover - dispatch boundary
+        from vllm_mlx.headless_service.cli import service_command
+
+        service_command(args)
     elif (
         getattr(args, "command", None) is None
         and sys.stdout.isatty()

--- a/vllm_mlx/headless_service/__init__.py
+++ b/vllm_mlx/headless_service/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx service`` — supported headless macOS service lifecycle.
+
+Codifies the documented launchd contract for running Rapid-MLX as an
+unattended system daemon (the macOS analogue of an enabled ``systemd``
+service) behind commands an operator can run:
+
+* ``rapid-mlx service install`` — validate a least-privilege service
+  account and model, write a deterministic LaunchDaemon plist to
+  ``/Library/LaunchDaemons``, and bootstrap it.
+* ``rapid-mlx service status`` — launchd state / PID / endpoint health /
+  owner / log paths, in human or ``--json`` form.
+* ``rapid-mlx service logs`` — tail the daemon stdout/stderr logs.
+* ``rapid-mlx service restart`` — kickstart the daemon and wait for
+  readiness.
+* ``rapid-mlx service uninstall`` — ``bootout`` + remove the plist
+  without touching models, cache, or logs.
+
+This package is distinct from :mod:`vllm_mlx.service` (the engine's shared
+helpers + post-processing pipeline). See GH issue #2859 for motivation and
+the acceptance contract. The manual runbook that this command makes
+unnecessary remains documented in
+``docs/guides/headless-macos-service.md`` as a fallback/recovery path.
+"""

--- a/vllm_mlx/headless_service/cli.py
+++ b/vllm_mlx/headless_service/cli.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx service`` subcommand wiring.
+
+This module exposes:
+
+* :func:`register` — called from :mod:`vllm_mlx.cli` to wire the
+  ``service`` subparser (and its five subverebe parsers) onto the
+  top-level argparse tree.
+* :func:`service_command` — the argparse dispatch entry point.
+
+The subcommand has five shapes:
+
+* ``rapid-mlx service install [--service-user U] [--model M] [serve options]
+  [--dry-run]`` — validate + bootstrap the daemon.
+* ``rapid-mlx service status [--json]`` — launchd / pid / endpoint health.
+* ``rapid-mlx service logs [--follow] [--tail N]`` — tail daemon logs.
+* ``rapid-mlx service restart [--dry-run]`` — kickstart + wait health.
+* ``rapid-mlx service uninstall [--dry-run]`` — bootout + remove plist.
+
+``--dry-run`` is accepted on every mutating verb (install/restart/uninstall)
+so the operator can rehearse without touching the system; ``status``/``logs``
+are read-only and never take it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def register(subparsers) -> None:
+    """Wire up the ``service`` subcommand onto the top-level CLI parser.
+
+    Called from :mod:`vllm_mlx.cli` alongside the other
+    ``subparsers.add_parser(...)`` blocks, mirroring how ``launch`` is
+    wired. We keep the whole parser here (not in ``cli.py``) so the
+    sub-command surface lives with its implementation.
+    """
+    from ..cli import _port_arg
+
+    p = subparsers.add_parser(
+        "service",
+        help="Headless macOS service lifecycle (system LaunchDaemon)",
+        description=(
+            "Install, inspect, and remove Rapid-MLX as an unattended system "
+            "launchd daemon — the supported path for an always-on Mac mini "
+            "inference appliance that boots before any GUI login. "
+            "Sub-commands: install, status, logs, restart, uninstall."
+        ),
+    )
+    svc = p.add_subparsers(dest="service_command", help="Service sub-command")
+    svc.required = True
+
+    install = svc.add_parser(
+        "install",
+        help="Validate a least-privilege service account + model and install "
+        "the daemon",
+    )
+    install.add_argument(
+        "--service-user",
+        type=str,
+        required=True,
+        help="The dedicated least-privilege, NON-administrator service "
+        "account the daemon runs as (must already exist, e.g. serveuser). "
+        "Refused if root or an admin-group member.",
+    )
+    _add_bind_args(install, _port_arg)
+    install.add_argument(
+        "--model",
+        type=str,
+        default="qwen3.5-4b-4bit",
+        help="Model alias (or HF path) to serve, downloaded once by the "
+        "service account (default: qwen3.5-4b-4bit).",
+    )
+    install.add_argument(
+        "serve_args",
+        nargs="*",
+        help="Additional non-secret serve flags to embed in the plist, e.g. "
+        "--max-num-seqs 4. Secrets (--api-key) are refused.",
+    )
+    install.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print every install/validation step without changing anything.",
+    )
+
+    status = svc.add_parser("status", help="Report launchd/pid/endpoint health")
+    _add_service_account_args(status)
+    _add_bind_args(status, _port_arg)
+    status.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON status object.",
+    )
+
+    logs = svc.add_parser("logs", help="Tail the daemon stdout/stderr logs")
+    _add_service_account_args(logs)
+    logs.add_argument(
+        "--follow",
+        "-f",
+        action="store_true",
+        help="Stream new log lines (like tail -F), across KeepAlive restarts.",
+    )
+    logs.add_argument(
+        "--tail",
+        type=int,
+        default=200,
+        help="Lines per file to show without --follow (default: 200).",
+    )
+
+    restart = svc.add_parser(
+        "restart", help="Kickstart the daemon and wait until it is healthy"
+    )
+    _add_bind_args(restart, _port_arg)
+    restart.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the kickstart command without running it.",
+    )
+
+    uninstall = svc.add_parser(
+        "uninstall",
+        help="Remove the launchd registration and plist (never "
+        "deletes models/cache/logs without separate confirmation)",
+    )
+    uninstall.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the removal steps without running them.",
+    )
+
+    # Optional --label override is useful for multiple appliances; default
+    # (com.rapidmlx.server) matches the documented contract.
+    for sub in (install, status, logs, restart, uninstall):
+        sub.add_argument(
+            "--label",
+            type=str,
+            default=None,
+            help="launchd Label (default: com.rapidmlx.server).",
+        )
+
+
+def _add_service_account_args(p: argparse.ArgumentParser) -> None:
+    """The service account used for install/status/logs (needed to resolve
+    home/log paths for diagnostics)."""
+    p.add_argument(
+        "--service-user",
+        type=str,
+        default=None,
+        help="The dedicated least-privilege service account the daemon runs "
+        "as (e.g. serveuser).",
+    )
+
+
+def _add_bind_args(p: argparse.ArgumentParser, port_arg) -> None:
+    p.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Loopback bind host (default: 127.0.0.1).",
+    )
+    p.add_argument(
+        "--port",
+        type=port_arg,
+        default=8000,
+        help="Bind port (default: 8000). Must be in [1, 65535].",
+    )
+
+
+def service_command(args) -> None:
+    """Argparse dispatch for ``rapid-mlx service …``. Exits non-zero on a
+    user error via the individual command's return code."""
+    if sys.platform != "darwin":
+        print(
+            "error: `rapid-mlx service` is macOS-only (it manages a system "
+            "launchd daemon; launchd does not exist on this platform).",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    # Validate the launchd Label up front for every sub-command: it flows into
+    # the plist path, `launchctl`, and `rm`, so a malicious ``--label`` must
+    # never reach them (path-traversal / injection hardening).
+    label = getattr(args, "label", None)
+    if label is not None:
+        from .common import validate_label
+
+        try:
+            validate_label(label)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            raise SystemExit(2) from None
+    sub = getattr(args, "service_command", None)
+    if sub == "install":
+        from .install import install_command
+
+        code = install_command(args)
+    elif sub == "status":
+        from .status import status_command
+
+        code = status_command(args)
+    elif sub == "logs":
+        from .logs import logs_command
+
+        code = logs_command(args)
+    elif sub == "restart":
+        from .restart import restart_command
+
+        code = restart_command(args)
+    elif sub == "uninstall":
+        from .install import uninstall_command
+
+        code = uninstall_command(args)
+    else:
+        # argparse enforces a required service_command, so this is defensive.
+        print(
+            "error: expected one of install/status/logs/restart/uninstall",
+            file=sys.stderr,
+        )
+        code = 2
+    if code:
+        raise SystemExit(code)

--- a/vllm_mlx/headless_service/cli.py
+++ b/vllm_mlx/headless_service/cli.py
@@ -74,9 +74,9 @@ def register(subparsers) -> None:
     )
     install.add_argument(
         "serve_args",
-        nargs="*",
-        help="Additional non-secret serve flags to embed in the plist, e.g. "
-        "--max-num-seqs 4. Secrets (--api-key) are refused.",
+        nargs=argparse.REMAINDER,
+        help="Additional non-secret serve flags after a `--` separator, e.g. "
+        "`-- --max-num-seqs 4`. Secrets and bind overrides are refused.",
     )
     install.add_argument(
         "--dry-run",

--- a/vllm_mlx/headless_service/common.py
+++ b/vllm_mlx/headless_service/common.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared constants and path helpers for ``rapid-mlx service``.
+
+These are the concrete, documented defaults that the manual launchd
+runbook in ``docs/guides/headless-macos-service.md`` establishes. Keeping
+them here (not scattered across the sub-command modules) matches the
+"one source of truth" pattern the repo uses for model-recommendation data
+(``model_recommendations.json``) and keeps the deterministic plist and the
+diagnostic surface from drifting.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# The launchd Label. A system-domain daemon of this name is the contract
+# the docs + ``scripts/headless_service_smoke.sh`` already assume.
+DEFAULT_LABEL = "com.rapidmlx.server"
+
+# Default launchd domain. System-domain daemons start before and without
+# any GUI login — the whole point of #2859.
+DEFAULT_DOMAIN = "system"
+
+# Where system daemon plists live. Root-owned; writing here is what makes
+# the service a boot-persistent system LaunchDaemon (not a user daemon).
+LAUNCH_DAEMONS_DIR = Path("/Library/LaunchDaemons")
+
+# Relative log dir under the service account's home. Long-lived daemons
+# have no interactive session, so stdout+stderr go straight to these logs.
+LOG_RELATIVE_DIR = "Library/Logs/Rapid-MLX"
+STDOUT_LOG_NAME = "server.stdout.log"
+STDERR_LOG_NAME = "server.stderr.log"
+
+# Service-account paths established by the one-line installer + the guide:
+#   /Users/<u>/.local/bin/rapid-mlx   stable CLI symlink
+#   /Users/<u>/.rapid-mlx/            venv + app state
+#   /Users/<u>/.cache/huggingface/    model cache resolved from HOME
+DEFAULT_BIN = ".local/bin/rapid-mlx"
+APP_STATE_DIR = ".rapid-mlx"
+
+# Minimum uid for a dedicated service account. Real user accounts on macOS
+# start at 501; system accounts (root=_WHEEL 0-500) are never valid targets.
+MIN_USER_UID = 501
+
+# LaunchDaemons dir requires root to write; also used to gate dry-run vs
+# real mutation (a non-root caller cannot actually install).
+LAUNCH_DAEMONS_DIR_REQUIRES_ROOT = True
+
+
+def home_for_user(user: str) -> Path | None:
+    """Return the home directory for ``user``, or None if unknown.
+
+    Uses ``pwd.getpwnam`` (filesystem account database) so it works for
+    accounts that may never have logged into a GUI session — the service
+    account is exactly such a case. Returns None when the user does not
+    exist (caller should treat that as a hard error).
+    """
+    import pwd
+
+    try:
+        return Path(pwd.getpwnam(user).pw_dir)
+    except KeyError:
+        return None
+
+
+def user_uid(user: str) -> int | None:
+    """Return the numeric uid for ``user``, or None if the account is absent."""
+    import pwd
+
+    try:
+        return pwd.getpwnam(user).pw_uid
+    except KeyError:
+        return None
+
+
+def log_dir_for(user: str) -> Path | None:
+    """Absolute daemon log directory for a service account (or None)."""
+    home = home_for_user(user)
+    if home is None:
+        return None
+    return home / LOG_RELATIVE_DIR
+
+
+def validate_label(label: str) -> str:
+    """Validate a launchd Label, returning it unchanged.
+
+    Restricted to reverse-DNS-safe characters ``[A-Za-z0-9._-]`` — the same
+    constraint ``scripts/headless_service_smoke.sh`` already enforces on
+    ``RAPID_MLX_SERVICE_LABEL``. Guarantees a ``--label`` value can never
+    escape the LaunchDaemons directory (path traversal) or be joined into a
+    ``launchctl``/``rm`` argv as an unexpected token.
+    """
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", label):
+        raise ValueError(
+            f"invalid launchd Label {label!r}: only letters, digits, '.', "
+            "'_', '-' are allowed."
+        )
+    return label

--- a/vllm_mlx/headless_service/install.py
+++ b/vllm_mlx/headless_service/install.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -36,7 +37,8 @@ from .common import (
 )
 from .plist import build_plist_dict, serialize_plist
 
-FORBIDDEN_ARG_TOKENS = ("--api-key", "--api_key")
+FORBIDDEN_SECRET_ARG_TOKENS = ("--api-key", "--api_key")
+FORBIDDEN_BIND_ARG_TOKENS = ("--host", "--port", "--listen-fd")
 
 
 class ServiceInstallError(Exception):
@@ -55,12 +57,18 @@ def is_root() -> bool:
 def is_admin_user(user: str) -> bool:
     """Best-effort: is ``user`` a member of the local admin group (gid 80)?"""
     import grp
+    import pwd
 
     try:
         group = grp.getgrgid(80)
+        record = pwd.getpwnam(user)
     except KeyError:
         return False
-    return user in group.gr_mem
+    try:
+        return group.gr_gid in os.getgrouplist(user, record.pw_gid)
+    except OSError:
+        # Keep a conservative fallback for directory-service lookup failures.
+        return record.pw_gid == group.gr_gid or user in group.gr_mem
 
 
 def resolve_executable(home: Path) -> str:
@@ -126,12 +134,20 @@ def validate_service_account(user: str) -> None:
 def refuse_secret_flags(serve_args: tuple[str, ...]) -> None:
     """Reject serve flags that would embed a secret into argv/plist."""
     for tok in serve_args:
-        if tok.split("=", 1)[0] in FORBIDDEN_ARG_TOKENS:
+        option = tok.split("=", 1)[0]
+        if option in FORBIDDEN_SECRET_ARG_TOKENS:
             raise ServiceInstallError(
                 "refusing to put an API key in the service definition: argv "
                 "and plist EnvironmentVariables are visible to other local "
                 "processes. Bind to loopback and put a TLS-terminating "
                 "reverse proxy in front instead (the documented pattern)."
+            )
+        if option in FORBIDDEN_BIND_ARG_TOKENS:
+            raise ServiceInstallError(
+                f"refusing duplicate bind option {option!r} after `--`: use "
+                "the service install --host/--port options instead. "
+                "--listen-fd is incompatible with a launchd service that "
+                "does not configure socket activation."
             )
 
 
@@ -191,10 +207,19 @@ def _port_busy(host: str, port: int) -> bool:
     import socket
 
     try:
-        with socket.create_connection((host, port), timeout=1.0):
+        with socket.create_connection((_probe_host(host), port), timeout=1.0):
             return True
     except OSError:
         return False
+
+
+def _probe_host(bind_host: str) -> str:
+    """Return a connectable local address for a configured bind address."""
+    if bind_host == "0.0.0.0":
+        return "127.0.0.1"
+    if bind_host in {"::", "[::]"}:
+        return "::1"
+    return bind_host
 
 
 def _run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
@@ -205,18 +230,38 @@ def _mutation_list(
     *,
     label: str,
     plist_buf: bytes,
-    staged: Path,
     plist_path: Path,
     host: str,
     port: int,
 ) -> list[str]:
     return [
-        f"write staged plist {staged} ({len(plist_buf)} bytes)",
-        f"validate {staged} with plutil -lint",
-        f"install -o root -g wheel -m 644 {staged} -> {plist_path}",
+        f"write secure temporary plist ({len(plist_buf)} bytes, mode 600)",
+        "validate temporary plist with plutil -lint",
+        f"install -o root -g wheel -m 644 temporary plist -> {plist_path}",
         f"launchctl bootstrap {DEFAULT_DOMAIN} {plist_path}",
         f"poll {host}:{port}/readyz until ready (max 120s)",
     ]
+
+
+def _stage_plist(plist_buf: bytes) -> Path:
+    """Write ``plist_buf`` to an unguessable, owner-only temporary file.
+
+    ``rapid-mlx service install`` normally runs under sudo.  A predictable
+    path in a world-writable directory would let another local user place a
+    symlink there before the root process writes it.  ``mkstemp`` creates the
+    file atomically with O_EXCL and mode 0600, closing that overwrite path.
+    """
+    fd, raw_path = tempfile.mkstemp(prefix="rapid-mlx-service-", suffix=".plist")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(plist_buf)
+    except BaseException:
+        try:
+            os.unlink(raw_path)
+        except OSError:
+            pass
+        raise
+    return Path(raw_path)
 
 
 def _readyz_ready(host: str, port: int) -> bool:
@@ -231,7 +276,7 @@ def _readyz_ready(host: str, port: int) -> bool:
     import socket
 
     try:
-        with socket.create_connection((host, port), timeout=1.0) as sock:
+        with socket.create_connection((_probe_host(host), port), timeout=1.0) as sock:
             sock.settimeout(1.0)
             sock.sendall(b"GET /readyz HTTP/1.1\r\nHost: x\r\n\r\n")
             data = sock.recv(4096)
@@ -331,6 +376,8 @@ def install_command(args) -> int:
     host = getattr(args, "host", None) or "127.0.0.1"
     port = getattr(args, "port", None) or 8000
     serve_args = tuple(getattr(args, "serve_args", None) or ())
+    if serve_args[:1] == ("--",):
+        serve_args = serve_args[1:]
     dry_run = bool(getattr(args, "dry_run", False))
 
     # argparse marks --service-user required, but guard here too (direct calls
@@ -369,8 +416,20 @@ def install_command(args) -> int:
         port=port,
         serve_args=serve_args,
     )
-    staged = Path("/tmp") / f"{label}.plist"
     plist_path = _plist_path(label)
+
+    # Never silently replace a persistent definition.  A loaded job keeps
+    # using its old in-memory configuration even if its plist is overwritten,
+    # which would make a reinstall appear successful until the next reboot.
+    # Explicit uninstall+install is deterministic and preserves models/logs.
+    if plist_path.exists():
+        print(
+            f"error: {plist_path} already exists. Refusing an ambiguous "
+            "in-place reinstall; run `sudo rapid-mlx service uninstall` "
+            "first (models/cache/logs are preserved), then install again.",
+            file=sys.stderr,
+        )
+        return 1
 
     # Port-race guard: refuse before touching anything if a server already
     # listens on the target port (unknown owner — do not silently cohabit).
@@ -401,7 +460,6 @@ def install_command(args) -> int:
         for step in _mutation_list(
             label=label,
             plist_buf=plist_buf,
-            staged=staged,
             plist_path=plist_path,
             host=host,
             port=port,
@@ -425,7 +483,6 @@ def install_command(args) -> int:
     for step in _mutation_list(
         label=label,
         plist_buf=plist_buf,
-        staged=staged,
         plist_path=plist_path,
         host=host,
         port=port,
@@ -435,15 +492,17 @@ def install_command(args) -> int:
     # True transaction state: whether we've installed the persistent plist,
     # so a failure below can roll back BOTH the loaded job AND the plist
     # file (a plist left in /Library/LaunchDaemons auto-loads on reboot).
-    plist_installed = False
+    persistent_write_attempted = False
+    staged: Path | None = None
     try:
         # Stage + lint. check=False so a lint failure surfaces its specific
         # message instead of a generic "install step failed" traceback.
-        staged.write_bytes(plist_buf)
+        staged = _stage_plist(plist_buf)
         lint = _run(["plutil", "-lint", str(staged)], check=False)
         if lint.returncode != 0:
             raise ServiceInstallError(f"plutil -lint failed: {lint.stderr.strip()}")
         # Install root-owned, 0644.
+        persistent_write_attempted = True
         _run(
             [
                 "install",
@@ -457,22 +516,19 @@ def install_command(args) -> int:
                 str(plist_path),
             ]
         )
-        plist_installed = True
-        # Bootstrap into the system domain (boot-time autostart). check=False
-        # so we can distinguish "already loaded" (reinstall — fine) from a real
-        # bootstrap failure (error). launchctl exits non-zero on already-loaded.
+        # Bootstrap into the system domain (boot-time autostart). A job that is
+        # already loaded without its plist is still an inconsistent state, not
+        # a successful reinstall; fail and remove the newly installed plist.
         boot = _run(
             ["launchctl", "bootstrap", DEFAULT_DOMAIN, str(plist_path)],
             check=False,
         )
         if boot.returncode != 0:
             boot_err = boot.stderr.strip()
-            if "already loaded" not in boot_err.lower():
-                raise ServiceInstallError(f"launchctl bootstrap failed: {boot_err}")
+            raise ServiceInstallError(f"launchctl bootstrap failed: {boot_err}")
         # Wait for readiness; on failure roll back the load AND the plist so
         # nothing persists to auto-start on the next boot.
         if not _wait_ready(host, port):
-            _run(["launchctl", "bootout", f"{DEFAULT_DOMAIN}/{label}"], check=False)
             raise ServiceInstallError(
                 f"service did not become ready on {host}:{port} within 120s; "
                 f"rolled back. Check {home}/Library/Logs/Rapid-MLX/"
@@ -483,10 +539,18 @@ def install_command(args) -> int:
         # plist (never the models/data/logs), so a failed install cannot
         # leave a boot-persistent daemon behind.
         try:
-            staged.unlink()
+            if staged is not None:
+                staged.unlink()
         except OSError:
             pass
-        if plist_installed:
+        if persistent_write_attempted:
+            # A failed bootstrap can still leave a partially loaded job. Make
+            # rollback idempotent by always attempting bootout before removing
+            # the new persistent definition.
+            _run(
+                ["launchctl", "bootout", f"{DEFAULT_DOMAIN}/{label}"],
+                check=False,
+            )
             _run(["rm", "-f", str(plist_path)], check=False)
             if not isinstance(exc, ServiceInstallError):
                 print(
@@ -499,6 +563,15 @@ def install_command(args) -> int:
         else:
             print(f"error: install step failed: {exc}", file=sys.stderr)
         return 2
+
+    # The persistent root-owned copy is installed; the private staging file is
+    # no longer needed.  Failure to remove it is harmless but should not turn a
+    # healthy service into a reported install failure.
+    if staged is not None:
+        try:
+            staged.unlink()
+        except OSError:
+            pass
 
     print(f"Installed and running: {label} (model {model}, {host}:{port}).")
     print(

--- a/vllm_mlx/headless_service/install.py
+++ b/vllm_mlx/headless_service/install.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validation + transactional install for the headless service.
+
+``install`` is where most of the #2859 safety contract lives:
+
+* least-privilege service account (must exist, uid>500, not root/admin);
+* the install is transactional and, with ``--dry-run``, prints every
+  mutation and performs none;
+* a port-race guard refuses to install when a server already answers on
+  the target port (the "cannot silently cohabit with a Desktop-managed
+  server" criterion);
+* secrets (``--api-key``) are refused — a system-domain daemon boots before
+  login and must never carry a secret in argv or env;
+* the model must already be cached under the service account's HOME (the
+  documented workflow downloads once before the machine goes headless).
+
+We shell out to ``launchctl``/``install`` rather than raising a Python
+daemon, so the command surface stays exactly what the manual runbook
+already documented — this command just makes it safe and one-shot.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from .common import (
+    DEFAULT_DOMAIN,
+    DEFAULT_LABEL,
+    LAUNCH_DAEMONS_DIR,
+    log_dir_for,
+    user_uid,
+)
+from .plist import build_plist_dict, serialize_plist
+
+FORBIDDEN_ARG_TOKENS = ("--api-key", "--api_key")
+
+
+class ServiceInstallError(Exception):
+    """A user-facing install failure (rendered without a traceback)."""
+
+
+# ---------------------------------------------------------------------------
+# Pure validation helpers (no I/O) — exercised directly by tests.
+# ---------------------------------------------------------------------------
+
+
+def is_root() -> bool:
+    return os.geteuid() == 0
+
+
+def is_admin_user(user: str) -> bool:
+    """Best-effort: is ``user`` a member of the local admin group (gid 80)?"""
+    import grp
+
+    try:
+        group = grp.getgrgid(80)
+    except KeyError:
+        return False
+    return user in group.gr_mem
+
+
+def resolve_executable(home: Path) -> str:
+    """Resolve the daemon's executable against the SERVICE account's home.
+
+    The documented appliance installs Rapid-MLX into the service account's
+    own ``~/.local/bin/rapid-mlx`` (a stable symlink the one-line installer
+    creates). That — NOT the operator/admin's binary — is the only correct
+    thing for the daemon to execute (launchd runs it as the service user, so
+    a binary the service account cannot exec, or that belongs to another
+    account's install, would fail at runtime or run wrong code). We therefore
+    REQUIRE it: if the service user hasn't installed rapid-mlx yet, the
+    operator should run the one-line installer as that account (as the guide
+    directs) rather than silently embedding a wrong-owner binary.
+    """
+    candidate = home / ".local" / "bin" / "rapid-mlx"
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    raise ServiceInstallError(
+        f"no Rapid-MLX binary at {candidate} for the service account. Install "
+        "Rapid-MLX as the service account first (log in as it and run the "
+        "one-line installer; see docs/guides/headless-macos-service.md "
+        "'Prepare the service account'), then re-run install."
+    )
+
+
+def validate_service_account(user: str) -> None:
+    """Raise :class:`ServiceInstallError` unless ``user`` is a viable
+    least-privilege service account (exists, uid>500, not root, not admin)."""
+    from .common import home_for_user
+
+    if not user:
+        raise ServiceInstallError(
+            "a --service-user is required: the daemon runs as a dedicated, "
+            "least-privilege non-administrator account (create one first, "
+            "then pass its name)."
+        )
+    uid = user_uid(user)
+    if uid is None or home_for_user(user) is None:
+        raise ServiceInstallError(
+            f"service account {user!r} does not exist. Create a dedicated, "
+            "non-administrator local account first (see "
+            "docs/guides/headless-macos-service.md 'Prepare the service "
+            "account'), then re-run install."
+        )
+    if uid == 0 or user == "root":
+        raise ServiceInstallError(
+            "refusing to run the system service as root: a least-privilege "
+            "deployment requires a dedicated non-administrator account."
+        )
+    if uid < 501:
+        raise ServiceInstallError(
+            f"refusing to use system account {user!r} (uid {uid}) as the "
+            "service account."
+        )
+    if is_admin_user(user):
+        raise ServiceInstallError(
+            f"refusing to use administrator account {user!r}: the service "
+            "account must be non-privileged (not a member of the admin group)."
+        )
+
+
+def refuse_secret_flags(serve_args: tuple[str, ...]) -> None:
+    """Reject serve flags that would embed a secret into argv/plist."""
+    for tok in serve_args:
+        if tok.split("=", 1)[0] in FORBIDDEN_ARG_TOKENS:
+            raise ServiceInstallError(
+                "refusing to put an API key in the service definition: argv "
+                "and plist EnvironmentVariables are visible to other local "
+                "processes. Bind to loopback and put a TLS-terminating "
+                "reverse proxy in front instead (the documented pattern)."
+            )
+
+
+def _cache_root_present(home: Path, model: str) -> bool:
+    """Best-effort: is the HF cache dir for ``model`` present under ``home``?"""
+    cache_root = home / ".cache" / "huggingface" / "hub"
+    if not cache_root.is_dir():
+        return False
+    cache_id = model.replace("/", "--")
+    return (cache_root / f"models--{cache_id}").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Drive helpers — the actual install/rollback mutation steps.
+# ---------------------------------------------------------------------------
+
+
+def _plist_path(label: str) -> Path:
+    return LAUNCH_DAEMONS_DIR / f"{label}.plist"
+
+
+def _build_plist_bytes(
+    *,
+    label: str,
+    user: str,
+    executable: str,
+    model: str,
+    home: Path,
+    host: str,
+    port: int,
+    serve_args: tuple[str, ...],
+) -> bytes:
+    log_dir = log_dir_for(user)
+    if log_dir is None:
+        raise ServiceInstallError(f"cannot resolve home for service account {user!r}")
+    config = build_plist_dict(
+        label=label,
+        user=user,
+        executable=executable,
+        model=model,
+        home=home,
+        log_dir=log_dir,
+        host=host,
+        port=port,
+        serve_args=serve_args,
+    )
+    return serialize_plist(config)
+
+
+def _port_busy(host: str, port: int) -> bool:
+    """True if a TCP server already answers on ``(host, port)``.
+
+    A tiny loopback connect probe — no privileged syscalls. Guards the
+    "cannot silently race or cohabit with a Desktop-managed server on the
+    same port" acceptance criterion.
+    """
+    import socket
+
+    try:
+        with socket.create_connection((host, port), timeout=1.0):
+            return True
+    except OSError:
+        return False
+
+
+def _run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(args, check=check, capture_output=True, text=True)
+
+
+def _mutation_list(
+    *,
+    label: str,
+    plist_buf: bytes,
+    staged: Path,
+    plist_path: Path,
+    host: str,
+    port: int,
+) -> list[str]:
+    return [
+        f"write staged plist {staged} ({len(plist_buf)} bytes)",
+        f"validate {staged} with plutil -lint",
+        f"install -o root -g wheel -m 644 {staged} -> {plist_path}",
+        f"launchctl bootstrap {DEFAULT_DOMAIN} {plist_path}",
+        f"poll {host}:{port}/readyz until ready (max 120s)",
+    ]
+
+
+def _readyz_ready(host: str, port: int) -> bool:
+    """True when ``/readyz`` reports ready.
+
+    rapid-mlx ``/readyz`` returns HTTP 200 once the process is able to serve
+    (sets ``"ready": true`` in the body once the model is loaded; it returns
+    503 while draining). Matching the smoke script's contract, we require
+    BOTH an HTTP 200 status line AND a ``"ready": true`` in the body — a bare
+    200 during early boot (model still loading) does NOT count.
+    """
+    import socket
+
+    try:
+        with socket.create_connection((host, port), timeout=1.0) as sock:
+            sock.settimeout(1.0)
+            sock.sendall(b"GET /readyz HTTP/1.1\r\nHost: x\r\n\r\n")
+            data = sock.recv(4096)
+    except OSError:
+        return False
+    head, _, rest = data.partition(b"\r\n\r\n")
+    if b"200" not in head:
+        return False
+    # Compact JSON separators or pretty-printed — compare whitespace-free.
+    body = b"".join(rest.split()).lower()
+    return b'"ready":true' in body
+
+
+def _wait_ready(host: str, port: int, timeout_s: int = 120) -> bool:
+    """Poll ``/readyz`` until it reports ready or ``timeout_s`` elapses.
+
+    Mirrors the readiness loop in ``scripts/headless_service_smoke.sh`` so
+    the command and the smoke test agree on what "healthy" means.
+    """
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if _readyz_ready(host, port):
+            return True
+        time.sleep(1.0)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Uninstall — inverse of install. Never touches models/data/logs.
+# ---------------------------------------------------------------------------
+
+
+def uninstall_command(args) -> int:
+    """``rapid-mlx service uninstall`` — bootout + remove the plist.
+
+    Deliberately conservative: it ONLY removes the launchd registration and
+    the plist file. The model cache, virtual environment, and logs are left
+    untouched (the issue's "uninstall removes service registration without
+    deleting models or user data" criterion). ``--dry-run`` prints the exact
+    removal steps without performing them. Re-running after a partial
+    teardown is idempotent-safe (bootout tolerates a missing job).
+    """
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    dry_run = bool(getattr(args, "dry_run", False))
+    plist_path = _plist_path(label)
+
+    bootout_cmd = ["launchctl", "bootout", f"{DEFAULT_DOMAIN}/{label}"]
+    rm_cmd = ["rm", "-f", str(plist_path)]
+
+    if dry_run:
+        print(
+            "Dry run — would remove service registration (models/cache/logs "
+            "are NEVER touched):"
+        )
+        print(f"  [DRY-RUN] {' '.join(bootout_cmd)}")
+        print(f"  [DRY-RUN] {' '.join(rm_cmd)}")
+        if not plist_path.is_file():
+            print("  (service already absent — nothing to do)")
+        return 0
+
+    if not is_root():
+        print(
+            "error: removing a system LaunchDaemon requires root. Re-run "
+            f"with sudo (boots out {label} and removes {plist_path}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    # bootout first (so KeepAlive cannot respawn mid-teardown), tolerate a
+    # missing job, then remove the plist.
+    try:
+        subprocess.run(bootout_cmd, check=False, capture_output=True, text=True)
+        subprocess.run(rm_cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"error: uninstall failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"uninstalled {label}. Model cache and logs were left in place.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Command entry points.
+# ---------------------------------------------------------------------------
+
+
+def install_command(args) -> int:
+    """``rapid-mlx service install`` — validate + bootstrap the daemon.
+
+    Returns a process exit code (0 ok, 1 user error, 2 real failure).
+    """
+    from .common import home_for_user
+
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    model = getattr(args, "model", None) or "qwen3.5-4b-4bit"
+    user = getattr(args, "service_user", None)
+    host = getattr(args, "host", None) or "127.0.0.1"
+    port = getattr(args, "port", None) or 8000
+    serve_args = tuple(getattr(args, "serve_args", None) or ())
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    # argparse marks --service-user required, but guard here too (direct calls
+    # and dry-run tests bypass argparse): a clean error + mypy narrowing of
+    # ``user`` to ``str`` for every call below.
+    if not isinstance(user, str) or not user:
+        print(
+            "error: a --service-user is required: the daemon runs as a "
+            "dedicated, least-privilege non-administrator account (create one "
+            "first, then pass its name).",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        validate_service_account(user)
+        refuse_secret_flags(serve_args)
+        home = home_for_user(user)
+        assert home is not None
+        # Resolve the binary against the SERVICE account's home, not the
+        # operator's — the daemon runs as the service user and must execute
+        # that user's install of rapid-mlx. Raises ServiceInstallError if the
+        # service user hasn't installed it yet.
+        executable = resolve_executable(home)
+    except ServiceInstallError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    plist_buf = _build_plist_bytes(
+        label=label,
+        user=user,
+        executable=executable,
+        model=model,
+        home=home,
+        host=host,
+        port=port,
+        serve_args=serve_args,
+    )
+    staged = Path("/tmp") / f"{label}.plist"
+    plist_path = _plist_path(label)
+
+    # Port-race guard: refuse before touching anything if a server already
+    # listens on the target port (unknown owner — do not silently cohabit).
+    # This is a pre-flight *validation* outcome, so it fires in --dry-run
+    # too — the operator rehearsing should learn "this port is taken" as
+    # clearly as a real install would, rather than only at bootstrap time.
+    if _port_busy(host, port):
+        print(
+            f"error: a server already answers on {host}:{port}. Refusing to "
+            "install a service that would race/cohabit with it (it may be "
+            "Desktop-managed). Stop that server or choose another --port.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Model-cache check: warn (not fail) if the model isn't cached under the
+    # service account's HOME — the documented workflow pre-downloads it.
+    if not _cache_root_present(home, model):
+        print(
+            f"warning: model {model!r} not found in the service account's HF "
+            f"cache ({home}/.cache/huggingface/hub). Pre-download it as the "
+            "service account so the daemon can boot offline at first start.",
+            file=sys.stderr,
+        )
+
+    if dry_run:
+        print("Dry run — would perform these steps (no changes made):")
+        for step in _mutation_list(
+            label=label,
+            plist_buf=plist_buf,
+            staged=staged,
+            plist_path=plist_path,
+            host=host,
+            port=port,
+        ):
+            print(f"  [DRY-RUN] {step}")
+        print(f"  service account: {user} (uid {user_uid(user)})")
+        print(f"  executable: {executable}")
+        print(f"  model: {model}")
+        return 0
+
+    if not is_root():
+        print(
+            "error: installing a system LaunchDaemon requires root. Re-run "
+            f"with sudo (writes {plist_path} and bootstraps {label}). For a "
+            "rehearsal that changes nothing, pass --dry-run first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # -- Real install, transactional. --------------------------------------
+    for step in _mutation_list(
+        label=label,
+        plist_buf=plist_buf,
+        staged=staged,
+        plist_path=plist_path,
+        host=host,
+        port=port,
+    ):
+        print(f"  {step}")
+
+    # True transaction state: whether we've installed the persistent plist,
+    # so a failure below can roll back BOTH the loaded job AND the plist
+    # file (a plist left in /Library/LaunchDaemons auto-loads on reboot).
+    plist_installed = False
+    try:
+        # Stage + lint. check=False so a lint failure surfaces its specific
+        # message instead of a generic "install step failed" traceback.
+        staged.write_bytes(plist_buf)
+        lint = _run(["plutil", "-lint", str(staged)], check=False)
+        if lint.returncode != 0:
+            raise ServiceInstallError(f"plutil -lint failed: {lint.stderr.strip()}")
+        # Install root-owned, 0644.
+        _run(
+            [
+                "install",
+                "-o",
+                "root",
+                "-g",
+                "wheel",
+                "-m",
+                "644",
+                str(staged),
+                str(plist_path),
+            ]
+        )
+        plist_installed = True
+        # Bootstrap into the system domain (boot-time autostart). check=False
+        # so we can distinguish "already loaded" (reinstall — fine) from a real
+        # bootstrap failure (error). launchctl exits non-zero on already-loaded.
+        boot = _run(
+            ["launchctl", "bootstrap", DEFAULT_DOMAIN, str(plist_path)],
+            check=False,
+        )
+        if boot.returncode != 0:
+            boot_err = boot.stderr.strip()
+            if "already loaded" not in boot_err.lower():
+                raise ServiceInstallError(f"launchctl bootstrap failed: {boot_err}")
+        # Wait for readiness; on failure roll back the load AND the plist so
+        # nothing persists to auto-start on the next boot.
+        if not _wait_ready(host, port):
+            _run(["launchctl", "bootout", f"{DEFAULT_DOMAIN}/{label}"], check=False)
+            raise ServiceInstallError(
+                f"service did not become ready on {host}:{port} within 120s; "
+                f"rolled back. Check {home}/Library/Logs/Rapid-MLX/"
+                "server.stderr.log"
+            )
+    except Exception as exc:
+        # Best-effort rollback: remove the staged file AND the persistent
+        # plist (never the models/data/logs), so a failed install cannot
+        # leave a boot-persistent daemon behind.
+        try:
+            staged.unlink()
+        except OSError:
+            pass
+        if plist_installed:
+            _run(["rm", "-f", str(plist_path)], check=False)
+            if not isinstance(exc, ServiceInstallError):
+                print(
+                    f"info: removed {plist_path} to keep the failed install "
+                    "from auto-starting on reboot",
+                    file=sys.stderr,
+                )
+        if isinstance(exc, ServiceInstallError):
+            print(f"error: {exc}", file=sys.stderr)
+        else:
+            print(f"error: install step failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Installed and running: {label} (model {model}, {host}:{port}).")
+    print(
+        "Verify with `rapid-mlx service status` and after a reboot "
+        "`./scripts/headless_service_smoke.sh`."
+    )
+    return 0

--- a/vllm_mlx/headless_service/logs.py
+++ b/vllm_mlx/headless_service/logs.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx service logs`` — tail the daemon stdout/stderr logs.
+
+Simple and dependency-free: prints each log (stdout then stderr) up to a
+line cap, or streams both with ``--follow`` (which stays attached, like
+``tail -F``, so the operator sees the daemon restart across KeepAlive
+rebirths). Reading is read-only — it never touches the daemon.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from .common import DEFAULT_LABEL, STDERR_LOG_NAME, STDOUT_LOG_NAME, log_dir_for
+
+
+def _log_paths(label: str, user: str | None) -> tuple[Path, Path] | None:
+    """Resolve the two log paths. Prefers the installed plist's declared
+    paths (source of truth), falling back to the service account default."""
+    from .install import _plist_path
+    from .plist import parse_plist
+
+    plist_path = _plist_path(label)
+    if plist_path.is_file():
+        try:
+            config = parse_plist(plist_path.read_bytes())
+            out = config.get("StandardOutPath")
+            err = config.get("StandardErrorPath")
+            if out and err:
+                return Path(out), Path(err)
+        except Exception:
+            pass
+    if user:
+        log_dir = log_dir_for(user)
+        if log_dir is not None:
+            return log_dir / STDOUT_LOG_NAME, log_dir / STDERR_LOG_NAME
+    return None
+
+
+def logs_command(args) -> int:
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    user = getattr(args, "service_user", None)
+    follow = bool(getattr(args, "follow", False))
+    tail_n = int(getattr(args, "tail", None) or 200)
+
+    paths = _log_paths(label, user)
+    if paths is None:
+        print(
+            f"error: no log paths known for {label} — is it installed? "
+            "Run `rapid-mlx service status` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    out_path, err_path = paths
+    if follow:
+        try:
+            subprocess.run(["tail", "-F", str(out_path), str(err_path)], check=True)
+        except KeyboardInterrupt:
+            pass
+        except subprocess.CalledProcessError:
+            print("error: tail failed", file=sys.stderr)
+            return 1
+        return 0
+
+    for name, path in (("stdout", out_path), ("stderr", err_path)):
+        if not path.is_file():
+            print(f"({name}: not present: {path})")
+            continue
+        print(f"=== {name}: {path} ===")
+        try:
+            subprocess.run(["tail", "-n", str(tail_n), str(path)], check=False)
+        except OSError as exc:
+            print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(logs_command(sys.argv))

--- a/vllm_mlx/headless_service/plist.py
+++ b/vllm_mlx/headless_service/plist.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic LaunchDaemon plist generation for ``rapid-mlx service``.
+
+The generated plist is a strict, parameterised version of the documented
+template ``examples/launchd/com.rapidmlx.server.plist``, hardened by the
+same safety rules the manual runbook and ``tests/test_headless_service_
+assets.py`` already enforce:
+
+* binds to ``127.0.0.1`` loopback by default;
+* keeps secrets OUT of ``ProgramArguments`` and ``EnvironmentVariables``
+  (launchd can display configured env through ``launchctl print``, and
+  argv is visible to other local processes);
+* sets a mandatory ``HOME`` (the system domain does not inherit the GUI
+  session's environment — Hugging Face would otherwise fail to find the
+  service account's cache);
+* uses unconditional ``KeepAlive`` + a ``ThrottleInterval`` so a crash is
+  restarted but a broken config does not hot-spin faster than once/10s;
+* sends stdout and stderr to two distinct files.
+
+Generation is a pure function of ``(label, user, executable, model,
+serve_args, host, port, home, log_dir)`` — no I/O, no launchd calls — so
+tests can assert byte-determinism and the safety properties without ever
+touching the system.
+"""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+from .common import STDERR_LOG_NAME, STDOUT_LOG_NAME
+
+
+def _prepend_exec(argv: list[str], executable: str | list[str]) -> list[str]:
+    """Splice the executable (path, or path + invocation tokens) onto a argv.
+
+    ``executable`` may be either a single absolute path (the common case: the
+    symlink ``~/.local/bin/rapid-mlx``) or a list of argv tokens for a
+    module invocation (``[<python>, "-m", "vllm_mlx"]``). Every element is a
+    separate ProgramArguments entry — launchd/posix_spawn treats argv[0] as a
+    literal executable path, so we must never collapse a ``-m`` invocation
+    into a single space-joined string (which would not exist as a file).
+    """
+    if isinstance(executable, str):
+        argv.insert(0, executable)
+    else:
+        argv[0:0] = list(executable)
+    return argv
+
+
+def serve_argv(
+    executable: str | list[str],
+    model: str,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    serve_args: tuple[str, ...] | None = None,
+) -> list[str]:
+    """The daemon's ``ProgramArguments``.
+
+    The daemon boots through the ordinary ``rapid-mlx serve`` path — the
+    engine is already daemon-aware for non-interactive invocations (no
+    consent prompt when not on a TTY), so we get full serve-feature parity
+    for free without forking a second server entrypoint.
+
+    ``executable`` is either an absolute path or a ``[python, "-m",
+    "vllm_mlx"]``-style list (see :func:`_prepend_exec`).
+    ``serve_args`` are additional non-secret ``--flag value`` tokens (e.g.
+    ``--max-num-seqs 4``) passed straight through after ``--host/--port``.
+    """
+    argv = ["serve", model, "--host", host, "--port", str(port)]
+    if serve_args:
+        argv.extend(serve_args)
+    return _prepend_exec(argv, executable)
+
+
+def build_plist_dict(
+    *,
+    label: str,
+    user: str,
+    executable: str,
+    model: str,
+    home: Path,
+    log_dir: Path,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    serve_args: tuple[str, ...] | None = None,
+) -> dict:
+    """Build the plist dict for a system LaunchDaemon.
+
+    ``home`` is the service account's home dir (used for the mandatory
+    ``HOME`` env and the PATH prefix). ``log_dir`` is the absolute daemon
+    log directory. All paths are absolute — launchd does not expand ``$HOME``
+    or ``~`` in plist values.
+    """
+    environment: dict[str, str] = {
+        # Mandatory in the system launchd domain: without HOME, Hugging
+        # Face cannot resolve the service account's model cache.
+        "HOME": str(home),
+        "PATH": f"{home / '.local/bin'}:/usr/bin:/bin:/usr/sbin:/sbin",
+    }
+    return {
+        "Label": label,
+        "UserName": user,
+        "ProgramArguments": serve_argv(
+            executable, model, host=host, port=port, serve_args=serve_args
+        ),
+        "WorkingDirectory": str(home),
+        "EnvironmentVariables": environment,
+        # Unconditional KeepAlive = continuously enabled appliance. Use
+        # ``service restart`` (bootout/kickstart) before planned maintenance.
+        "KeepAlive": True,
+        # Prevent a broken config from re-spawning faster than once/10s.
+        "ThrottleInterval": 10,
+        "ExitTimeOut": 30,
+        # plist ints are decimal; 23 decimal == 027 octal — masks group/other
+        # write on files the daemon creates.
+        "Umask": 0o27,
+        "StandardOutPath": str(log_dir / STDOUT_LOG_NAME),
+        "StandardErrorPath": str(log_dir / STDERR_LOG_NAME),
+    }
+
+
+def serialize_plist(config: dict) -> bytes:
+    """Serialize a plist dict to deterministic XML bytes.
+
+    ``plistlib.dumps`` with ``fmt=FMT_XML`` is deterministic for a given
+    dict, so identical ``(label, user, executable, model, ...)`` inputs
+    yield byte-identical plists — the property the "no surprise diff on
+    reinstall" guarantee depends on.
+    """
+    return plistlib.dumps(config, fmt=plistlib.FMT_XML, sort_keys=True)
+
+
+def parse_plist(data: bytes) -> dict:
+    """Parse plist bytes back to a dict (used by status/uninstall to inspect
+    an installed plist without launching it)."""
+    parsed = plistlib.loads(data)
+    assert isinstance(parsed, dict)
+    return parsed

--- a/vllm_mlx/headless_service/restart.py
+++ b/vllm_mlx/headless_service/restart.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx service restart`` — kickstart the daemon and wait for health.
+
+``launchctl kickstart -k`` stops and restarts a loaded job regardless of
+KeepAlive (which would otherwise fight a manual restart). Afterward we poll
+the endpoint with the same readiness window the install path and the smoke
+script use, so "restart" means "ready," not merely "respawning."
+
+A service that is registered but currently down is ``kickstart -k``-ed the
+same way; a service that is not registered is a hard error telling the user
+to install first. ``--dry-run`` prints the command only.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from .common import DEFAULT_DOMAIN, DEFAULT_LABEL
+from .install import _wait_ready
+
+
+def _declared_bind(label: str) -> tuple[str, int] | None:
+    """The ``(host, port)`` the installed plist declares, if readable."""
+    from .install import _plist_path
+    from .plist import parse_plist
+
+    plist_path = _plist_path(label)
+    if not plist_path.is_file():
+        return None
+    try:
+        config = parse_plist(plist_path.read_bytes())
+    except Exception:
+        return None
+    argv = config.get("ProgramArguments") or []
+    host, port = None, None
+    for i, tok in enumerate(argv[:-1]):
+        if tok == "--host" and i + 1 < len(argv):
+            host = argv[i + 1]
+        if tok == "--port" and i + 1 < len(argv):
+            port = argv[i + 1]
+    if port is None:
+        return None
+    return (host or "127.0.0.1"), int(port)
+
+
+def _kickstart_status(label: str) -> int:
+    """``launchctl print`` exit code: 0 if the job is loaded in the domain."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"{DEFAULT_DOMAIN}/{label}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return 1
+    return result.returncode
+
+
+def restart_command(args) -> int:
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    host = getattr(args, "host", None) or "127.0.0.1"
+    port = getattr(args, "port", None) or 8000
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    # Resolve the actual bind from the installed plist so we wait on the right
+    # port (the service may have been installed on a non-default --port).
+    declared = _declared_bind(label)
+    if declared:
+        declared_host, declared_port = declared
+        host, port = declared_host, declared_port
+
+    if _kickstart_status(label) != 0:
+        print(
+            f"error: service {label} is not registered in the {DEFAULT_DOMAIN} "
+            "domain. Install it first with `rapid-mlx service install` "
+            "(or `--dry-run` to rehearse).",
+            file=sys.stderr,
+        )
+        return 1
+
+    cmd = ["launchctl", "kickstart", "-k", f"{DEFAULT_DOMAIN}/{label}"]
+    if dry_run:
+        print(f"[DRY-RUN] would run: {' '.join(cmd)}")
+        return 0
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except (subprocess.CalledProcessError, subprocess.SubprocessError) as exc:
+        print(f"error: kickstart failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not _wait_ready(host, port):
+        print(
+            f"error: service {label} did not become ready on {host}:{port} "
+            "within 120s after restart. Check `rapid-mlx service logs`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"restarted {label}; healthy on {host}:{port}.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(restart_command(sys.argv))

--- a/vllm_mlx/headless_service/status.py
+++ b/vllm_mlx/headless_service/status.py
@@ -107,8 +107,11 @@ def _endpoint_health(host: str, port: int) -> tuple[bool, bool]:
         except OSError:
             return False
 
-    from .install import _readyz_ready
+    from .install import _probe_host, _readyz_ready
 
+    probe_host = _probe_host(host)
+    if probe_host != host:
+        host = probe_host
     return _probe_live(), _readyz_ready(host, port)
 
 

--- a/vllm_mlx/headless_service/status.py
+++ b/vllm_mlx/headless_service/status.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx service status`` — actionable diagnostics for the daemon.
+
+Aggregates four independent sources of truth — the launchd registration,
+the live process, the installed plist, and the API endpoint — so a problem
+in any layer is surfaced rather than masked:
+
+* is the job registered in the system domain?
+* is a live PID running (and as whom)?
+* what model/port does the installed plist declare?
+* does the endpoint respond to /livez and /readyz?
+
+``--json`` emits a machine-readable object; the default is a compact
+human table mirroring the smoke-test vocabulary (registered / running /
+owner / model / port / healthy / log paths / last launchd exit).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from .common import (
+    DEFAULT_DOMAIN,
+    DEFAULT_LABEL,
+    log_dir_for,
+)
+from .install import _plist_path, _port_busy
+
+
+def _launchctl_print(label: str) -> str | None:
+    """Raw ``launchctl print <domain>/<label>`` output, or None if the job is
+    not registered."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"{DEFAULT_DOMAIN}/{label}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _parse_pid(print_out: str | None) -> int | None:
+    """Extract the job PID from ``launchctl print`` output (None if no live
+    process). Mirrors the smoke script's awk parse."""
+    if not print_out:
+        return None
+    for line in print_out.splitlines():
+        if line.strip().startswith("pid ="):
+            digits = "".join(ch for ch in line.split("=", 1)[1] if ch.isdigit())
+            if digits:
+                return int(digits)
+    return None
+
+
+def _parse_last_exit(print_out: str | None) -> int | None:
+    """Last exit status from ``launchctl print`` (None when absent)."""
+    if not print_out:
+        return None
+    for line in print_out.splitlines():
+        if "last exit code" in line.lower():
+            digits = "".join(ch for ch in line.split("=", 1)[1] if ch.isdigit())
+            if digits:
+                return int(digits)
+    return None
+
+
+def _read_installed_plist(label: str) -> dict | None:
+    """Parse the installed plist (None if not present)."""
+    path = _plist_path(label)
+    if not path.is_file():
+        return None
+    from .plist import parse_plist
+
+    try:
+        return parse_plist(path.read_bytes())
+    except Exception:
+        return None
+
+
+def _endpoint_health(host: str, port: int) -> tuple[bool, bool]:
+    """``(live, ready)`` for ``/livez`` and ``/readyz`` over HTTP.
+
+    ``live`` = the process is alive (``/livez`` returns 200 — it never means
+    "model ready"). ``ready`` = the model is loaded (``/readyz`` returns 200
+    AND ``"ready": true``), sharing the corrected ``install._readyz_ready``
+    so status, install, and restart all agree on "healthy". Best-effort via
+    a raw socket GET — no external HTTP client dependency.
+    """
+    import socket
+
+    def _probe_live() -> bool:
+        try:
+            with socket.create_connection((host, port), timeout=2.0) as sock:
+                sock.settimeout(2.0)
+                sock.sendall(
+                    b"GET /livez HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"
+                )
+                return b"200" in sock.recv(4096).split(b"\r\n", 1)[0]
+        except OSError:
+            return False
+
+    from .install import _readyz_ready
+
+    return _probe_live(), _readyz_ready(host, port)
+
+
+def collect_status(
+    *,
+    label: str = DEFAULT_LABEL,
+    user: str | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+) -> dict:
+    """Aggregate full service status into a plain dict (JSON-serializable)."""
+    print_out = _launchctl_print(label)
+    registered = print_out is not None
+    pid = _parse_pid(print_out)
+    last_exit = _parse_last_exit(print_out)
+    plist = _read_installed_plist(label)
+
+    model = port_declared = host_declared = None
+    if plist:
+        argv = plist.get("ProgramArguments") or []
+        # argv shape: [<bin>, "serve", <model>, ...]
+        if len(argv) >= 3 and argv[0].endswith("rapid-mlx"):
+            model = argv[2] if len(argv) > 2 else None
+            for i, tok in enumerate(argv[:-1]):
+                if tok == "--port" and i + 1 < len(argv):
+                    port_declared = argv[i + 1]
+                if tok == "--host" and i + 1 < len(argv):
+                    host_declared = argv[i + 1]
+
+    # Probe the bind the plist declares (fall back to CLI defaults) — probing
+    # the CLI default while the service actually listens elsewhere would report
+    # a false "down".
+    effective_host = host_declared or host
+    effective_port = int(port_declared) if port_declared else port
+    live, ready = _endpoint_health(effective_host, effective_port)
+
+    owner = None
+    if pid:
+        try:
+            out = subprocess.run(
+                ["ps", "-o", "user=", "-p", str(pid)],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            owner = out.stdout.strip() or None
+        except (subprocess.SubprocessError, OSError):
+            owner = None
+
+    log_dir = log_dir_for(user) if user else None
+    return {
+        "label": label,
+        "domain": DEFAULT_DOMAIN,
+        "registered": registered,
+        "pid": pid,
+        "owner": owner,
+        "last_exit": last_exit,
+        "model": model,
+        "host": effective_host,
+        "port": effective_port,
+        "livez": live,
+        "readyz": ready,
+        "port_open": _port_busy(effective_host, effective_port),
+        "plist": str(_plist_path(label)),
+        "log_dir": str(log_dir) if log_dir else None,
+        "plist_present": Path(_plist_path(label)).is_file(),
+    }
+
+
+def _render_human(s: dict) -> str:
+    lines = [
+        f"service {s['label']} ({s['domain']} domain)",
+        f"  launcher registration: {'installed' if s['plist_present'] else 'MISSING'}",
+        f"  launchd state:         {'registered' if s['registered'] else 'not registered'}",
+    ]
+    if s["pid"]:
+        owner = f" (as {s['owner']})" if s["owner"] else ""
+        lines.append(f"  pid:                   {s['pid']}{owner}")
+    else:
+        lines.append("  pid:                   (no live process)")
+    if s["last_exit"] is not None:
+        lines.append(f"  last launchd exit:     {s['last_exit']}")
+    if s["model"]:
+        lines.append(f"  model:                 {s['model']}")
+    lines.append(f"  endpoint:              http://{s['host']}:{s['port']}")
+    lines.append(
+        f"  health:                livez={'ok' if s['livez'] else 'down'} "
+        f"readyz={'ok' if s['readyz'] else 'down'} "
+        f"port={'open' if s['port_open'] else 'closed'}"
+    )
+    lines.append(f"  plist:                 {s['plist']}")
+    if s["log_dir"]:
+        lines.append(f"  logs:                  {s['log_dir']}/server.stdout.log")
+        lines.append(f"                         {s['log_dir']}/server.stderr.log")
+    if not s["registered"]:
+        lines.append(
+            "  hint: not registered — `rapid-mlx service install --dry-run` "
+            "shows the install plan."
+        )
+    return "\n".join(lines)
+
+
+def status_command(args) -> int:
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    user = getattr(args, "service_user", None)
+    host = getattr(args, "host", None) or "127.0.0.1"
+    port = getattr(args, "port", None) or 8000
+    data = collect_status(label=label, user=user, host=host, port=port)
+    if getattr(args, "json", False):
+        print(json.dumps(data, indent=2))
+    else:
+        print(_render_human(data))
+    # Non-zero exit when the service is not actually up (actionable for
+    # scripts that gate on health).
+    if not data["registered"] or not data["pid"] or not data["readyz"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(status_command(sys.argv))


### PR DESCRIPTION
Closes #2859 — officially support headless macOS service installation for always-on inference.

## What

Adds a first-class `rapid-mlx service` lifecycle for running Rapid-MLX as an unattended system LaunchDaemon that starts without a GUI login:

```text
rapid-mlx service install --service-user USER --model MODEL [--dry-run] [-- SERVE_OPTIONS...]
rapid-mlx service status [--json]
rapid-mlx service logs [--follow] [--tail N]
rapid-mlx service restart [--dry-run]
rapid-mlx service uninstall [--dry-run]
```

## Why

Always-on Mac inference hosts need a supported, inspectable service lifecycle instead of an operator-maintained plist. The command keeps the daemon least-privileged, makes failures actionable, and preserves models and logs during teardown.

## Acceptance criteria

- Requires an existing non-root, non-admin service account (uid >= 501).
- Generates a deterministic root-owned LaunchDaemon plist with explicit `HOME`, loopback binding by default, `KeepAlive`, throttling, umask 027, and separate logs.
- Refuses secrets in argv/plist, conflicting bind overrides, unsafe labels, occupied ports, and ambiguous in-place plist replacement.
- Stages the plist in an atomic, unpredictable mode-0600 temporary file before lint/install.
- Rolls back both a possibly loaded job and its persistent plist after bootstrap or readiness failure.
- Provides status, logs, restart, dry-run, and data-preserving uninstall operations.
- Treats wildcard binds as local loopback for readiness/collision probes.
- Documents setup, FileVault limitations, recovery, updates, and reboot verification.

## Design precedent

The implementation follows the platform's established system-service lifecycle: a deterministic configuration in the system launch domain, a dedicated unprivileged account, explicit bootstrap/bootout operations, readiness-based success, idempotent rollback, and operator-visible logs. Configuration replacement is deliberately uninstall-then-install because replacing a plist does not update a job already loaded in memory.

## Scope

Included: macOS LaunchDaemon lifecycle CLI, generated plist, diagnostics, focused tests, and operator documentation.

Not included: creating user accounts, embedding credentials, remote TLS/auth provisioning, deleting model/cache/log data, or changing inference-engine behavior.

## Validation

- [x] `python3.12 -m pytest -q tests/test_cli_service.py tests/test_headless_service_assets.py tests/test_docs_cli_defaults.py` — 124 passed
- [x] Focused changed-line coverage for the hardened install/status paths — 100%
- [x] `python3.12 -m ruff check vllm_mlx/headless_service tests/test_cli_service.py`
- [x] `python3.12 -m ruff format --check vllm_mlx/headless_service tests/test_cli_service.py`
- [x] `git diff --check`

Pending verification: exact-head hosted CI and the Mergify Mac candidate.

## Operator validation

Live system-domain bootstrap and reboot validation require sudo plus a real dedicated account, so they remain an operator acceptance step via `scripts/headless_service_smoke.sh`. The hermetic suite covers plist safety, account/secret/port/label guards, CLI parsing, dry-run, rollback, readiness, restart, status, logs, and uninstall without mutating the host.

Co-Authored-By: Claude <noreply@anthropic.com>
