### PR TITLE
fix(mtp): keep thinking-budget requests on speculative decode (#3044)

### DIFF
--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -2916,6 +2916,60 @@ def test_generator_restores_tool_guard_state_when_target_processor_raises():
     assert processor.state == 1
 
 
+def test_generator_budget_forces_think_end_on_the_verify_row_and_rolls_back_drafts():
+    """#3044: the thinking budget is a transactional MTP processor.
+
+    Budget of one think token, prompt seeded ``<think>``. The cold-start step
+    emits token 7 (1/1 spent). On the verify step the budget forces
+    ``</think>`` on row 0, so the draft (11) is rejected and ``</think>`` is
+    resampled; row 1 had tentatively counted the draft, and the generator's
+    restore to the accepted row-0 boundary must drop that count again.
+    """
+    from vllm_mlx.api.reasoning_budget import ReasoningBudgetLogitsProcessor
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    think_end = 5
+
+    class FusedDraftModel(_MockedQwen35Model):
+        def mtp_greedy(self, hidden, next_token_ids, mtp_cache):
+            del mtp_cache
+            batch, positions = next_token_ids.shape
+            tokens = []
+            for _ in range(positions):
+                tokens.append(self._mtp[self._mtp_cursor])
+                self._mtp_cursor += 1
+            return (
+                mx.array([tokens] * batch, dtype=mx.uint32),
+                mx.zeros((batch, positions, hidden.shape[-1])),
+            )
+
+    budget = ReasoningBudgetLogitsProcessor(think_end, 1, seeded_thinking=True)
+    gen = mtp_generate_step(
+        mx.array([1], dtype=mx.uint32),
+        FusedDraftModel([7, 11, 13, 20, 21], [11, 12, 14]),
+        max_tokens=3,
+        max_k=1,
+        logits_processors=[budget],
+        initial_tokens=[1],
+        disable_auto_k=True,
+        accept_counter=MTPAcceptCounter(),
+    )
+
+    emitted = [next(gen)[0], next(gen)[0]]
+    assert emitted == [7, think_end]
+    # Row 0's boundary (prompt + token 7 committed, 1/1 spent) is what
+    # survives; the rejected draft's tentative count (2/1) is gone.
+    assert budget._committed == budget._prompt_len + 1
+    assert budget._think_count == 1
+    assert budget._ended is False
+    # The delivered ``</think>`` is committed on the next step: generation
+    # phase, no further counting, the script's next target (20) passes.
+    assert next(gen)[0] == 20
+    assert budget._ended is True
+    assert budget._think_count == 1
+
+
 def test_quantized_argmax_matches_materialized_qlinear_logits():
     """The fused greedy kernel must select the exact qlinear argmax."""
     import mlx.nn as nn

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -825,6 +825,111 @@ class TestScheduleWaitingInsertDispatch:
         assert isinstance(admitted[1], AgentRepetitionLogitsProcessor)
         assert tuple(admitted) == request._mtp_safe_logits_processors
 
+    def test_real_schedule_registers_reasoning_budget_as_transactional_mtp_safe(self):
+        """A thinking-budget request keeps MTP: the budget joins the admitted row (#3044)."""
+        from vllm_mlx.api.reasoning_budget import ReasoningBudgetLogitsProcessor
+
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        budget = ReasoningBudgetLogitsProcessor(think_end_id=7, max_think_tokens=512)
+        request = Request(
+            request_id="req-reasoning-budget-mtp-admission",
+            prompt="ignored",
+            prompt_token_ids=[10, 20, 30, 40],
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+        request.reasoning_budget_logits_processor = budget
+        request.prefix_boundary = 99
+        scheduler.waiting.append(request)
+
+        batch_generator = MagicMock()
+        batch_generator.insert_segments.return_value = [105]
+        scheduler.batch_generator = batch_generator
+        scheduler._ensure_batch_generator = MagicMock(return_value=True)
+        scheduler._get_request_sampler = MagicMock(return_value=MagicMock())
+        scheduler._register_uid_processors = MagicMock()
+
+        assert scheduler._schedule_waiting() == [request]
+
+        admitted = batch_generator.insert_segments.call_args.kwargs[
+            "logits_processors"
+        ][0]
+        assert admitted == [budget]
+        assert tuple(admitted) == request._mtp_safe_logits_processors
+
+    def test_real_schedule_keeps_reasoning_budget_last_behind_the_tool_guard(self):
+        """Row order is the contract: guard first, budget last (its force mask wins)."""
+        from vllm_mlx.api.reasoning_budget import ReasoningBudgetLogitsProcessor
+        from vllm_mlx.repetition_guard import AgentRepetitionLogitsProcessor
+
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        budget = ReasoningBudgetLogitsProcessor(think_end_id=7, max_think_tokens=512)
+        request = Request(
+            request_id="req-reasoning-budget-tool-mtp-admission",
+            prompt="ignored",
+            prompt_token_ids=[10, 20, 30, 40],
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+        request.has_tools = True
+        request.reasoning_budget_logits_processor = budget
+        request.prefix_boundary = 99
+        scheduler.waiting.append(request)
+
+        batch_generator = MagicMock()
+        batch_generator.insert_segments.return_value = [106]
+        scheduler.batch_generator = batch_generator
+        scheduler._ensure_batch_generator = MagicMock(return_value=True)
+        scheduler._get_request_sampler = MagicMock(return_value=MagicMock())
+        scheduler._register_uid_processors = MagicMock()
+
+        assert scheduler._schedule_waiting() == [request]
+
+        admitted = batch_generator.insert_segments.call_args.kwargs[
+            "logits_processors"
+        ][0]
+        assert isinstance(admitted[0], AgentRepetitionLogitsProcessor)
+        assert admitted[1] is budget
+        assert tuple(admitted) == request._mtp_safe_logits_processors
+
+    def test_real_schedule_rejects_reasoning_budget_lookalike_from_mtp(self):
+        """Only the exact built-in budget type is MTP-safe; a subclass fails closed."""
+        from vllm_mlx.api.reasoning_budget import ReasoningBudgetLogitsProcessor
+
+        class _Lookalike(ReasoningBudgetLogitsProcessor):
+            pass
+
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        budget = _Lookalike(think_end_id=7, max_think_tokens=512)
+        request = Request(
+            request_id="req-reasoning-budget-lookalike-mtp-admission",
+            prompt="ignored",
+            prompt_token_ids=[10, 20, 30, 40],
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+        request.reasoning_budget_logits_processor = budget
+        request.prefix_boundary = 99
+        scheduler.waiting.append(request)
+
+        batch_generator = MagicMock()
+        batch_generator.insert_segments.return_value = [107]
+        scheduler.batch_generator = batch_generator
+        scheduler._ensure_batch_generator = MagicMock(return_value=True)
+        scheduler._get_request_sampler = MagicMock(return_value=MagicMock())
+        scheduler._register_uid_processors = MagicMock()
+
+        assert scheduler._schedule_waiting() == [request]
+
+        admitted = batch_generator.insert_segments.call_args.kwargs[
+            "logits_processors"
+        ][0]
+        assert admitted == [budget]
+        assert request._mtp_safe_logits_processors == ()
+
     def test_real_schedule_rejects_transactional_grammar_lookalike_from_mtp(self):
         """Named methods do not make an unknown stateful processor MTP-safe."""
         from vllm_mlx.repetition_guard import AgentRepetitionLogitsProcessor

--- a/tests/test_reasoning_budget_generation.py
+++ b/tests/test_reasoning_budget_generation.py
@@ -215,16 +215,20 @@ def test_mtp_force_inside_a_rejected_draft_row_is_rolled_back():
     out = proc.mtp_apply([1, 10, 11], mx.array([11]), mx.random.normal((1, 128)))
     assert int(mx.argmax(out[0]).item()) == THINK_END
     assert proc._think_count == 2
+    assert proc._force_logged is True  # the one-shot line fired tentatively
     # Target rejected the drafts: the boundary restores 0/2 and the force is
-    # gone; the cached row is harmless (rebuilt / reused when spent again).
+    # gone; the cached row is harmless (rebuilt / reused when spent again),
+    # and the log latch is re-armed so the committed force still logs once.
     proc.mtp_restore_state(boundary)
     assert proc._think_count == 0
+    assert proc._force_logged is False
     assert proc._phase([1, 12]) == "free"
     out = proc([1, 12], mx.random.normal((128,)))
     assert math.isfinite(out[0].item())  # untouched logits, no force
     # Spend it for real now: the same force row serves the committed path.
     out = proc([1, 12, 13], mx.random.normal((128,)))
     assert int(mx.argmax(out).item()) == THINK_END
+    assert proc._force_logged is True
 
 
 def test_force_mask_released_when_think_end_observed():

--- a/tests/test_reasoning_budget_generation.py
+++ b/tests/test_reasoning_budget_generation.py
@@ -204,6 +204,29 @@ def test_force_mask_makes_think_end_the_argmax():
     assert masked == 127  # all but the single kept column
 
 
+def test_mtp_force_inside_a_rejected_draft_row_is_rolled_back():
+    """#3044: under MTP the budget may spend itself on a tentative draft
+    prefix; restoring the pre-proposal boundary re-arms it and the next
+    ordinary step is ``free`` again with the force row rebuilt on demand."""
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 2, seeded_thinking=True)
+    _ = proc([1], mx.zeros((128,)))  # baseline, 0/2
+    boundary = proc.mtp_snapshot_state()
+    # Row 2 of a K=2 proposal: two tentative think tokens spend the budget.
+    out = proc.mtp_apply([1, 10, 11], mx.array([11]), mx.random.normal((1, 128)))
+    assert int(mx.argmax(out[0]).item()) == THINK_END
+    assert proc._think_count == 2
+    # Target rejected the drafts: the boundary restores 0/2 and the force is
+    # gone; the cached row is harmless (rebuilt / reused when spent again).
+    proc.mtp_restore_state(boundary)
+    assert proc._think_count == 0
+    assert proc._phase([1, 12]) == "free"
+    out = proc([1, 12], mx.random.normal((128,)))
+    assert math.isfinite(out[0].item())  # untouched logits, no force
+    # Spend it for real now: the same force row serves the committed path.
+    out = proc([1, 12, 13], mx.random.normal((128,)))
+    assert int(mx.argmax(out).item()) == THINK_END
+
+
 def test_force_mask_released_when_think_end_observed():
     # codex R14 nit: the cached OVERRIDE row must be dropped the moment </think>
     # is observed, not pinned through the whole answer. Force once (mask built),

--- a/tests/test_reasoning_budget_mtp.py
+++ b/tests/test_reasoning_budget_mtp.py
@@ -49,6 +49,7 @@ def test_snapshot_restore_round_trips_every_phase_counter():
     assert (proc._prompt_len, proc._committed, proc._think_count) == (3, 4, 1)
     assert proc._started is True
     assert proc._ended is False
+    assert proc._force_logged is False
     assert proc.mtp_snapshot_state() == boundary
 
 

--- a/tests/test_reasoning_budget_mtp.py
+++ b/tests/test_reasoning_budget_mtp.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``ReasoningBudgetLogitsProcessor`` as a transactional MTP processor (#3044).
+
+The continuous MTP lane admits a request only when its logits-processor row
+is, object for object, the scheduler's ``_mtp_safe_logits_processors``; a
+processor with per-request mutable state qualifies only by exposing the
+snapshot / restore / apply contract ``spec_decode/mtp/generator.py`` drives
+(see ``GrammarLogitsProcessor`` and ``AgentRepetitionLogitsProcessor``).
+Before #3044 the thinking budget exposed none of it, so every request that
+carried a ``reasoning_max_tokens`` cap (every graded ``reasoning_effort`` on
+a template without native levels) silently fell back to ordinary decode.
+
+These tests are pure phase-machine checks (no mlx): the budget's ``free`` and
+``generation`` phases return the incoming logits object untouched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from vllm_mlx.api.reasoning_budget import ReasoningBudgetLogitsProcessor
+
+THINK_END = 99
+THINK_START = 50
+PROMPT = [1, 2, 3]
+LOGITS = SimpleNamespace(shape=(1, 128))
+
+
+def _tentative(*ids: int) -> SimpleNamespace:
+    """The verifier's draft-prefix array: only ``size`` and ``tolist`` matter."""
+    return SimpleNamespace(size=len(ids), tolist=lambda: list(ids))
+
+
+def test_budget_exposes_the_generator_transaction_contract():
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 3)
+    assert callable(proc.mtp_apply)
+    assert callable(proc.mtp_snapshot_state)
+    assert callable(proc.mtp_restore_state)
+
+
+def test_snapshot_restore_round_trips_every_phase_counter():
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 3, seeded_thinking=True)
+    proc(PROMPT, LOGITS)
+    proc(PROMPT + [10], LOGITS)
+    boundary = proc.mtp_snapshot_state()
+    proc(PROMPT + [10, 11, THINK_END, 12], LOGITS)
+    assert proc._ended is True
+    proc.mtp_restore_state(boundary)
+    assert (proc._prompt_len, proc._committed, proc._think_count) == (3, 4, 1)
+    assert proc._started is True
+    assert proc._ended is False
+    assert proc.mtp_snapshot_state() == boundary
+
+
+def test_mtp_apply_walks_the_draft_prefix_tentatively_and_restore_rolls_back():
+    """Verification rows share ordinary decode's cumulative history; the
+    draft prefix advances the counters only until the generator restores the
+    target-accepted boundary."""
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 4, seeded_thinking=True)
+    proc(PROMPT, LOGITS)  # baseline the prompt like the first decode step
+    boundary = proc.mtp_snapshot_state()
+    # Row 0: the last committed token only. Rows 1..2: one and two drafts.
+    assert proc.mtp_apply(PROMPT + [10], _tentative(), LOGITS) is LOGITS
+    assert proc.mtp_apply(PROMPT + [10, 11], _tentative(11), LOGITS) is LOGITS
+    assert proc.mtp_apply(PROMPT + [10, 11, 12], _tentative(11, 12), LOGITS) is LOGITS
+    assert proc._think_count == 3
+    # One more tentative token would spend the budget (phase only: the force
+    # row itself needs real mlx logits and is covered by the mlx suite).
+    assert proc._phase(PROMPT + [10, 11, 12, 13]) == "force"
+    # Target rejected every draft: back to the pre-proposal boundary.
+    proc.mtp_restore_state(boundary)
+    assert proc._think_count == 0
+    assert proc._committed == len(PROMPT)
+    assert proc._phase(PROMPT + [10]) == "free"
+
+
+def test_restore_to_an_accepted_row_keeps_only_that_prefix():
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 4, seeded_thinking=True)
+    proc(PROMPT, LOGITS)
+    states = []
+    for row in ([10], [10, 11], [10, 11, 12]):
+        proc.mtp_apply(PROMPT + row, _tentative(*row[1:]), LOGITS)
+        states.append(proc.mtp_snapshot_state())
+    # One draft accepted: the boundary after row 1 becomes committed state.
+    proc.mtp_restore_state(states[1])
+    assert proc._think_count == 2
+    assert proc._committed == len(PROMPT) + 2
+    # The next ordinary steps continue from there: 4/4 spent → force.
+    assert proc._phase(PROMPT + [10, 11, 13]) == "free"
+    assert proc._phase(PROMPT + [10, 11, 13, 14]) == "force"
+
+
+def test_mtp_apply_uses_the_cumulative_history_not_the_tentative_arg():
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 3, seeded_thinking=True)
+    proc(PROMPT, LOGITS)
+    poisoned = SimpleNamespace(size=5, tolist=lambda: [THINK_END] * 5)
+    proc.mtp_apply(PROMPT + [10], poisoned, LOGITS)
+    assert proc._think_count == 1
+    assert proc._ended is False
+
+
+def test_generation_phase_is_inert_under_mtp_too():
+    proc = ReasoningBudgetLogitsProcessor(THINK_END, 3, seeded_thinking=True)
+    proc(PROMPT, LOGITS)
+    proc(PROMPT + [THINK_END], LOGITS)
+    assert proc._ended is True
+    assert proc.mtp_apply(PROMPT + [THINK_END, 20], _tentative(20), LOGITS) is LOGITS
+
+
+def test_emitting_template_transitions_inside_a_draft_row_and_rolls_back():
+    proc = ReasoningBudgetLogitsProcessor(
+        THINK_END, 3, think_start_id=THINK_START, seeded_thinking=False
+    )
+    proc(PROMPT, LOGITS)
+    boundary = proc.mtp_snapshot_state()
+    proc.mtp_apply(PROMPT + [THINK_START, 10], _tentative(10), LOGITS)
+    assert proc._started is True
+    assert proc._think_count == 1
+    proc.mtp_restore_state(boundary)
+    assert proc._started is False
+    assert proc._think_count == 0

--- a/vllm_mlx/api/reasoning_budget.py
+++ b/vllm_mlx/api/reasoning_budget.py
@@ -261,12 +261,15 @@ class ReasoningBudgetLogitsProcessor:
         """
         return self(token_ids, logits)
 
-    def mtp_snapshot_state(self) -> tuple[int | None, int, int, bool, bool]:
+    def mtp_snapshot_state(self) -> tuple[int | None, int, int, bool, bool, bool]:
         """Capture every phase counter speculative verification may advance.
 
-        The cached force row and the one-shot log latches are deliberately
-        left out: the row is rebuilt lazily from ``_ended``/``_think_count``
-        and the latches only de-duplicate log lines.
+        The "budget spent" log latch travels with the state: a force on a
+        draft row the target then rejects must not consume the one-shot
+        line, or the committed force would go unlogged. The cached force row
+        is rebuilt lazily from the counters, and the out-of-range latch
+        guards a static tokenizer/model mismatch that is true on every path,
+        so neither is snapshotted.
         """
         return (
             self._prompt_len,
@@ -274,9 +277,12 @@ class ReasoningBudgetLogitsProcessor:
             self._think_count,
             self._started,
             self._ended,
+            self._force_logged,
         )
 
-    def mtp_restore_state(self, state: tuple[int | None, int, int, bool, bool]) -> None:
+    def mtp_restore_state(
+        self, state: tuple[int | None, int, int, bool, bool, bool]
+    ) -> None:
         """Restore a pre-proposal or target-accepted phase boundary."""
         (
             self._prompt_len,
@@ -284,6 +290,7 @@ class ReasoningBudgetLogitsProcessor:
             self._think_count,
             self._started,
             self._ended,
+            self._force_logged,
         ) = state
 
     # ---- forced-distribution construction (cached per vocab width) ---------

--- a/vllm_mlx/api/reasoning_budget.py
+++ b/vllm_mlx/api/reasoning_budget.py
@@ -239,6 +239,53 @@ class ReasoningBudgetLogitsProcessor:
             return logits
         return self._force_distribution(logits)
 
+    # ---- MTP verification transaction (#3044) -------------------------------
+    #
+    # The continuous MTP lane admits a request only when every processor on
+    # its row is scheduler-vetted, and a processor with per-request mutable
+    # state is vetted only through this contract (``spec_decode/mtp/
+    # generator.py``; ``GrammarLogitsProcessor`` and the agent repetition
+    # guard implement the same one). Without it a ``reasoning_max_tokens``
+    # cap — every graded ``reasoning_effort`` on a template without native
+    # levels — silently dropped the request out of MTP.
+
+    def mtp_apply(self, token_ids: Any, _tentative_token_ids: Any, logits: Any) -> Any:
+        """Apply the budget to one cumulative speculative candidate row.
+
+        The verifier supplies the same cumulative history ordinary decode
+        does (prompt, committed output, then this row's draft prefix), so the
+        phase machine walks the draft prefix exactly as it would delivered
+        tokens. Generator-owned snapshots decide which of that temporary
+        state survives target acceptance, so the tentative array is not
+        consulted here.
+        """
+        return self(token_ids, logits)
+
+    def mtp_snapshot_state(self) -> tuple[int | None, int, int, bool, bool]:
+        """Capture every phase counter speculative verification may advance.
+
+        The cached force row and the one-shot log latches are deliberately
+        left out: the row is rebuilt lazily from ``_ended``/``_think_count``
+        and the latches only de-duplicate log lines.
+        """
+        return (
+            self._prompt_len,
+            self._committed,
+            self._think_count,
+            self._started,
+            self._ended,
+        )
+
+    def mtp_restore_state(self, state: tuple[int | None, int, int, bool, bool]) -> None:
+        """Restore a pre-proposal or target-accepted phase boundary."""
+        (
+            self._prompt_len,
+            self._committed,
+            self._think_count,
+            self._started,
+            self._ended,
+        ) = state
+
     # ---- forced-distribution construction (cached per vocab width) ---------
 
     def _force_distribution(self, logits: Any) -> Any:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1557,8 +1557,10 @@ def _install_mtp_vendored(
         #
         # Keep the positional fallback for standalone/benchmark callers that
         # do not own scheduler admission state. Production always passes the
-        # uid map; custom, grammar, tool, and reasoning processors remain in
-        # that authoritative list and therefore still fail closed below.
+        # uid map; every processor on the row is in that authoritative list,
+        # so anything the scheduler did not vet by identity (custom, tool-bias,
+        # suppression, unknown) still fails closed below, while the built-in
+        # grammar, tool guard and thinking budget (#3044) pass as themselves.
         row_processors: list[Any] = []
         if uid_to_request_processors is not None:
             row_processors = list(uid_to_request_processors.get(uid, ()))
@@ -8066,25 +8068,36 @@ class Scheduler:
                     frequency_context_size=4096,
                 )
                 request_processors.extend(penalty_processors)
-            # MTP may reuse only this exact ordered list. Standard penalties
-            # are history-derived; the built-in grammar and tool repetition
-            # guard expose explicit target-row snapshot/restore contracts.
-            # Identity (not processor count or type-name heuristics) keeps
-            # reasoning, suppression, tool-bias, and unknown processors
-            # fail-closed at the GenerationBatch handoff.
-            request._mtp_safe_logits_processors = tuple(
-                ([_mtp_grammar] if _mtp_grammar is not None else [])
-                + ([_loop_breaker] if _loop_breaker is not None else [])
-                + penalty_processors
-            )
             # Generation-time thinking-token budget (force-close </think>).
             # Appended LAST so its force-close mask (all but </think> -> -inf)
             # has final say over any penalty/grammar bias in the same step;
             # it is inert (returns logits unchanged) once thinking has ended,
             # so a chained grammar processor owns the generation phase.
             _rblp = getattr(request, "reasoning_budget_logits_processor", None)
+            _mtp_budget = None
             if _rblp is not None:
                 request_processors.append(_rblp)
+                # Same exact-type rule as the grammar above (#3044): the
+                # built-in budget implements the verifier's snapshot/restore/
+                # apply transaction; a subclass could override it, so a
+                # lookalike fails closed to ordinary decode.
+                from .api.reasoning_budget import ReasoningBudgetLogitsProcessor
+
+                if type(_rblp) is ReasoningBudgetLogitsProcessor:
+                    _mtp_budget = _rblp
+            # MTP may reuse only this exact ordered list. Standard penalties
+            # are history-derived; the built-in grammar, the tool repetition
+            # guard and the built-in thinking budget expose explicit
+            # target-row snapshot/restore contracts. Identity (not processor
+            # count or type-name heuristics) keeps suppression, tool-bias,
+            # and unknown processors fail-closed at the GenerationBatch
+            # handoff. Order mirrors ``request_processors`` exactly.
+            request._mtp_safe_logits_processors = tuple(
+                ([_mtp_grammar] if _mtp_grammar is not None else [])
+                + ([_loop_breaker] if _loop_breaker is not None else [])
+                + penalty_processors
+                + ([_mtp_budget] if _mtp_budget is not None else [])
+            )
             _stlp = getattr(request, "suppressed_tokens_logits_processor", None)
             if _stlp is not None:
                 request_processors.append(_stlp)


### PR DESCRIPTION
Closes #3044.

## Problem

The continuous MTP lane admits a request only when its logits-processor row is, object for object, the scheduler's `_mtp_safe_logits_processors` (`scheduler.py::_sampling_options_for_uid`). `ReasoningBudgetLogitsProcessor` was appended to the request row but never to that safe tuple, so every request carrying a `reasoning_max_tokens` cap was parked on plain decode with `[MTP-vendored] uid=… remains on plain decode: custom or stateful logits processor is active`. Since #448 that cap is what every graded `reasoning_effort` becomes on a template without native levels (Qwen3.5/3.6, Gemma 4, Nemotron, …), so the very requests Codex/agents send lost speculative decoding silently.

## Change

- **`api/reasoning_budget.py`**: the budget implements the verifier's transaction contract (`spec_decode/mtp/generator.py`; the same one `GrammarLogitsProcessor` and `AgentRepetitionLogitsProcessor` implement). `mtp_apply` walks the cumulative candidate row exactly like ordinary decode (the draft prefix is part of the history, the tentative array is not consulted); `mtp_snapshot_state` / `mtp_restore_state` carry the five phase counters (prompt baseline, committed, think count, started, ended) so a rejected draft's tentative count is rolled back and an accepted row's boundary becomes committed state. The "budget spent" log latch travels with that state so a force on a rejected draft row cannot consume the one-shot line before the committed force fires; the cached force row (rebuilt lazily from the counters) and the out-of-range latch (a static tokenizer/model mismatch, true on every path) stay out on purpose.
- **`scheduler.py`**: the exact built-in type joins the MTP-safe tuple, last, mirroring the request row order (its force mask keeps final say). A subclass fails closed exactly like a grammar lookalike. The stale identity-check comment that listed "reasoning" among the always-fail-closed processors is corrected.

Nothing changes for requests without a budget, and a budget request that also carries an unvetted processor (suppressed tokens, tool bias, custom) still falls back as before.

## Test plan

- `tests/test_prompt_cache_snapshot.py`: real `_schedule_waiting` admits `[budget]` as the MTP-safe row for a plain chat request, keeps it last behind the tool guard for a tools request, and leaves a subclass out of the safe tuple (the reproduction: the first of these fails on `main` with `_mtp_safe_logits_processors == ()`).
- `tests/test_reasoning_budget_mtp.py` (no mlx): the contract is present; snapshot/restore round-trips every counter; `mtp_apply` counts the draft prefix tentatively and a restore to the pre-proposal boundary or to an accepted row keeps exactly that prefix; the tentative array is ignored; the generation phase stays inert; an emitting template's `<think>` transition inside a draft row rolls back too.
- `tests/test_reasoning_budget_generation.py`: under mlx, a force spent on a rejected draft row is rolled back and the same force row later serves the committed path.
- `tests/test_mtp_spec_decode.py`: a mocked `mtp_generate_step` run with a one-token budget emits `7, </think>, 20`: the budget forces `</think>` on the verify row, the draft is rejected, only the accepted boundary survives (`committed == prompt + 1`, `think_count == 1`), and the next step commits the delivered `</think>`.
- 320 tests across those files plus `test_per_request_thinking_budget.py` pass.

Real server on M3 Ultra, `qwen3.8-27b-4bit` (MTP sidecar) served from this branch, fresh process so the MTP counters start at zero:

| request | `spec_decode_attempts_total` | `spec_decode_accepts_total` | reasoning | log |
|---|---|---|---|---|
| `reasoning_max_tokens=64`, `max_tokens=400`, greedy | 0 → 314 | 0 → 263 (84%) | 281 chars, cut by the budget, answer follows | no `remains on plain decode` line |
| same prompt twice concurrently (B>1, plain-decode control) | 314 → 314 | — | 272 chars each, cut at the same place | — |

The budget behaves identically on both lanes (the cut lands at the same point of the same greedy reasoning); `usage.completion_tokens_details.reasoning_tokens` reads 73 / 74 / 78 for those runs because `_build_usage` estimates it proportionally from characters, which is pre-existing accounting and unrelated to this change. `reasoning_max_tokens=0` is rejected by the schema (`must be >= 1`) as before.
