### PR TITLE
fix(chat-template): honour enable_thinking=false on templates with their own switch (#3045)

### DIFF
--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -243,6 +243,8 @@ The OpenAI `reasoning_effort` knob (`none` / `minimal` / `low` / `medium` / `hig
 
 Explicit knobs on the same dimension always win: `chat_template_kwargs.reasoning_effort` over the mapped level, `reasoning_max_tokens` over the tier cap, `enable_thinking` over `none`.
 
+A chat template that never reads `enable_thinking` but has its own on/off variable (Cohere's North Mini Code reads `reasoning`, default on) still turns off: a resolved `enable_thinking=false` (Desktop's default, `rapid-mlx chat` without `--think`, `reasoning_effort: none`) is passed as that variable. The template's switch is found from the variables it reads, not from the model name, and a request that already sets the switch or `reasoning_effort` in `chat_template_kwargs` keeps control.
+
 ## Backward Compatibility
 
 When `--reasoning-parser` is not specified, the server behaves as before:

--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -243,7 +243,7 @@ The OpenAI `reasoning_effort` knob (`none` / `minimal` / `low` / `medium` / `hig
 
 Explicit knobs on the same dimension always win: `chat_template_kwargs.reasoning_effort` over the mapped level, `reasoning_max_tokens` over the tier cap, `enable_thinking` over `none`.
 
-A chat template that never reads `enable_thinking` but has its own on/off variable (Cohere's North Mini Code reads `reasoning`, default on) still turns off: a resolved `enable_thinking=false` (Desktop's default, `rapid-mlx chat` without `--think`, `reasoning_effort: none`) is passed as that variable. The template's switch is found from the variables it reads, not from the model name, and a request that already sets the switch or `reasoning_effort` in `chat_template_kwargs` keeps control.
+A chat template that never reads `enable_thinking` but branches on its own boolean `reasoning` variable (Cohere's convention; North Mini Code defaults it to on) still turns off: a resolved `enable_thinking=false` (Desktop's default, `rapid-mlx chat` without `--think`, `reasoning_effort: none`) is passed as `reasoning=false`. `reasoning` is the only such switch recognised today; it is detected from the template's own reads and `if` tests, not from the model name, and a request that already sets `reasoning` or `reasoning_effort` in `chat_template_kwargs` keeps control.
 
 ## Backward Compatibility
 

--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -243,7 +243,7 @@ The OpenAI `reasoning_effort` knob (`none` / `minimal` / `low` / `medium` / `hig
 
 Explicit knobs on the same dimension always win: `chat_template_kwargs.reasoning_effort` over the mapped level, `reasoning_max_tokens` over the tier cap, `enable_thinking` over `none`.
 
-A chat template that never reads `enable_thinking` but branches on its own boolean `reasoning` variable (Cohere's convention; North Mini Code defaults it to on) still turns off: a resolved `enable_thinking=false` (Desktop's default, `rapid-mlx chat` without `--think`, `reasoning_effort: none`) is passed as `reasoning=false`. `reasoning` is the only such switch recognised today; it is detected from the template's own reads and `if` tests, not from the model name, and a request that already sets `reasoning` or `reasoning_effort` in `chat_template_kwargs` keeps control.
+A chat template that never reads `enable_thinking` but branches on its own boolean `reasoning` variable in an eagerly evaluated template scope (Cohere's convention; North Mini Code defaults it to on) still turns off: a resolved `enable_thinking=false` (Desktop's default, `rapid-mlx chat` without `--think`, `reasoning_effort: none`) is passed as `reasoning=false`. `reasoning` is the only such switch recognised today; it is detected from the template's own reads and reachable `if` tests, not from the model name. Deferred macro/call-block bodies and loops that may not execute do not establish a switch. A request that already sets `reasoning` or `reasoning_effort` in `chat_template_kwargs` keeps control.
 
 ## Backward Compatibility
 

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -18,7 +18,7 @@ import jinja2
 import pytest
 
 from vllm_mlx.utils.chat_template import (
-    _template_context_reads_for_source,
+    _template_context_facts_for_source,
     apply_chat_template,
     template_thinking_switch,
 )
@@ -100,7 +100,7 @@ class TestContextReads:
         ],
     )
     def test_bound_or_attribute_uses_are_not_reads(self, template):
-        assert "reasoning" not in _template_context_reads_for_source(template)
+        assert "reasoning" not in _template_context_facts_for_source(template)[0]
 
     @pytest.mark.parametrize(
         "template",
@@ -126,10 +126,13 @@ class TestContextReads:
         ],
     )
     def test_context_reads(self, template):
-        assert "reasoning" in _template_context_reads_for_source(template)
+        assert "reasoning" in _template_context_facts_for_source(template)[0]
 
     def test_unparseable_source_reads_nothing(self):
-        assert _template_context_reads_for_source("{% if reasoning %}") == frozenset()
+        assert _template_context_facts_for_source("{% if reasoning %}") == (
+            frozenset(),
+            frozenset(),
+        )
 
 
 class TestTemplateThinkingSwitch:
@@ -158,6 +161,16 @@ class TestTemplateThinkingSwitch:
             "{% if x %}a{% elif reasoning %}b{% endif %}",
             # read as data somewhere else too, but branched on as a boolean
             "{{ reasoning }}{% if reasoning %}x{% endif %}",
+            # North's shape: a definedness-guarded self-rebinding keeps the
+            # context value, so the later branch is on the knob
+            "{%- set reasoning = reasoning if reasoning is not undefined else true %}"
+            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = reasoning if reasoning is defined else true %}"
+            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = true if reasoning is undefined else reasoning %}"
+            "{% if reasoning %}x{% endif %}",
+            # the ``default`` filter idiom likewise
+            "{%- set reasoning = reasoning | default(true) %}{% if reasoning %}x{% endif %}",
         ],
     )
     def test_a_boolean_branch_on_a_context_read_is_a_switch(self, template):
@@ -178,6 +191,17 @@ class TestTemplateThinkingSwitch:
             "{% if reasoning.enabled %}x{% endif %}",
             # branched on the template's own local, not the context
             "{%- set reasoning = true %}{% if reasoning %}x{% endif %}",
+            # read as data, then shadowed by a local before the branch
+            "{{ reasoning }}{% set reasoning = true %}{% if reasoning %}x{% endif %}",
+            # a rebinding that does not preserve the value is a fresh local
+            "{%- set reasoning = reasoning if tools else true %}{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = reasoning | lower %}{% if reasoning %}x{% endif %}",
+            # a preserving rebinding of a name already shadowed stays shadowed
+            "{%- for reasoning in messages %}{% set reasoning = reasoning | default(1) %}"
+            "{% if reasoning %}x{% endif %}{%- endfor %}",
+            # the branch is inside a macro that binds the name
+            "{%- macro show(reasoning) %}{% if reasoning %}x{% endif %}{%- endmacro %}"
+            "{{ show(reasoning) }}",
             # branched on a loop variable of that name
             "{%- for reasoning in messages %}{% if reasoning %}x{% endif %}{%- endfor %}",
         ],
@@ -199,14 +223,12 @@ class TestTemplateThinkingSwitch:
     def test_without_jinja2_no_switch_is_reported(self, monkeypatch):
         from vllm_mlx.utils import chat_template as module
 
-        module._template_context_reads_for_source.cache_clear()
-        module._template_truthiness_tests_for_source.cache_clear()
+        module._template_context_facts_for_source.cache_clear()
         monkeypatch.setattr(module, "_jinja_nodes", lambda: (None, None))
         try:
             assert template_thinking_switch(NORTH_CLAUSE) is None
         finally:
-            module._template_context_reads_for_source.cache_clear()
-            module._template_truthiness_tests_for_source.cache_clear()
+            module._template_context_facts_for_source.cache_clear()
 
 
 class TestApplyChatTemplateOnNorth:

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -233,6 +233,13 @@ class TestTemplateThinkingSwitch:
             "{%- macro never() %}{% if false %}{{ caller() }}{% endif %}ok{% endmacro %}"
             "{{ reasoning | default('unset') }}"
             "{% call(x=('a' if reasoning else 'b')) never() %}{{ x }}{% endcall %}",
+            # every actual arm establishes a local before the later branch;
+            # an ``elif`` must not create an imaginary unbound fallthrough
+            "{{ reasoning | default('unset') }}"
+            "{% if x %}{% set reasoning=true %}"
+            "{% elif y %}{% set reasoning=false %}"
+            "{% else %}{% set reasoning=true %}{% endif %}"
+            "{% if reasoning %}on{% else %}off{% endif %}",
             # branched on a loop variable of that name
             "{%- for reasoning in messages %}{% if reasoning %}x{% endif %}{%- endfor %}",
         ],
@@ -367,6 +374,19 @@ class TestOtherTemplatesUnaffected:
         prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
         assert "reasoning" not in tok.received_kwargs
         assert prompt == "unsetok"
+
+    def test_complete_elif_chain_keeps_its_local_switch(self):
+        template = (
+            "{{ reasoning | default('unset') }}"
+            "{% if x %}{% set reasoning=true %}"
+            "{% elif y %}{% set reasoning=false %}"
+            "{% else %}{% set reasoning=true %}{% endif %}"
+            "{% if reasoning %}on{% else %}off{% endif %}"
+        )
+        tok = _RenderingTokenizer(template)
+        prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
+        assert "reasoning" not in tok.received_kwargs
+        assert prompt == "unseton"
 
     def test_enable_thinking_template_gets_no_reasoning_kwarg(self):
         tok = _RenderingTokenizer(ENABLE_THINKING_TEMPLATE)

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -240,6 +240,23 @@ class TestTemplateThinkingSwitch:
             "{% elif y %}{% set reasoning=false %}"
             "{% else %}{% set reasoning=true %}{% endif %}"
             "{% if reasoning %}on{% else %}off{% endif %}",
+            # constant-dead bodies cannot establish a live switch
+            "{{ reasoning | default('unset') }}"
+            "{% if false %}{% if reasoning %}x{% endif %}{% endif %}",
+            "{{ reasoning | default('unset') }}"
+            "{% if true %}x{% else %}{% if reasoning %}y{% endif %}{% endif %}",
+            "{{ reasoning | default('unset') }}"
+            "{% if not false %}x{% else %}{% if reasoning %}y{% endif %}{% endif %}",
+            "{{ reasoning | default('unset') }}"
+            "{% if 1 == 1 %}x{% else %}{% if reasoning %}y{% endif %}{% endif %}",
+            # a loop body that is not proven to execute cannot establish a
+            # live switch
+            "{{ reasoning | default('unset') }}"
+            "{% for x in [] %}{% if reasoning %}x{% endif %}{% endfor %}",
+            "{{ reasoning | default('unset') }}"
+            "{{ ('R' if reasoning else 'N') if false else '' }}",
+            "{{ reasoning | default('unset') }}"
+            "{% for x in [1] %}{% break %}{% if reasoning %}R{% endif %}{% endfor %}",
             # branched on a loop variable of that name
             "{%- for reasoning in messages %}{% if reasoning %}x{% endif %}{%- endfor %}",
         ],
@@ -387,6 +404,53 @@ class TestOtherTemplatesUnaffected:
         prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
         assert "reasoning" not in tok.received_kwargs
         assert prompt == "unseton"
+
+    @pytest.mark.parametrize(
+        ("template", "expected"),
+        [
+            (
+                "{{ reasoning | default('unset') }}"
+                "{% if false %}{% if reasoning %}x{% endif %}{% endif %}",
+                "unset",
+            ),
+            (
+                "{{ reasoning | default('unset') }}"
+                "{% if true %}x{% else %}{% if reasoning %}y{% endif %}{% endif %}",
+                "unsetx",
+            ),
+            (
+                "{{ reasoning | default('unset') }}"
+                "{% if not false %}x{% else %}{% if reasoning %}y{% endif %}{% endif %}",
+                "unsetx",
+            ),
+            (
+                "{{ reasoning | default('unset') }}"
+                "{% if 1 == 1 %}x{% else %}{% if reasoning %}y{% endif %}{% endif %}",
+                "unsetx",
+            ),
+            (
+                "{{ reasoning | default('unset') }}"
+                "{% for x in [] %}{% if reasoning %}x{% endif %}{% endfor %}",
+                "unset",
+            ),
+            (
+                "{{ reasoning | default('unset') }}"
+                "{{ ('R' if reasoning else 'N') if false else '' }}",
+                "unset",
+            ),
+            (
+                "{{ reasoning | default('unset') }}"
+                "{% for x in [1] %}{% break %}"
+                "{% if reasoning %}R{% endif %}{% endfor %}",
+                "unset",
+            ),
+        ],
+    )
+    def test_dead_branch_does_not_make_rendered_data_a_switch(self, template, expected):
+        tok = _RenderingTokenizer(template)
+        prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
+        assert "reasoning" not in tok.received_kwargs
+        assert prompt == expected
 
     def test_enable_thinking_template_gets_no_reasoning_kwarg(self):
         tok = _RenderingTokenizer(ENABLE_THINKING_TEMPLATE)

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -169,8 +169,16 @@ class TestTemplateThinkingSwitch:
             "{% if reasoning %}x{% endif %}",
             "{%- set reasoning = true if reasoning is undefined else reasoning %}"
             "{% if reasoning %}x{% endif %}",
-            # the ``default`` filter idiom likewise
+            "{%- set reasoning = reasoning if reasoning is not none else true %}"
+            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = true if reasoning is not defined else reasoning %}"
+            "{% if reasoning %}x{% endif %}",
+            # the ``default`` filter idiom likewise (a defined False survives)
             "{%- set reasoning = reasoning | default(true) %}{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = reasoning | default(true, false) %}"
+            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = reasoning | default(true, boolean=false) %}"
+            "{% if reasoning %}x{% endif %}",
         ],
     )
     def test_a_boolean_branch_on_a_context_read_is_a_switch(self, template):
@@ -196,6 +204,20 @@ class TestTemplateThinkingSwitch:
             # a rebinding that does not preserve the value is a fresh local
             "{%- set reasoning = reasoning if tools else true %}{% if reasoning %}x{% endif %}",
             "{%- set reasoning = reasoning | lower %}{% if reasoning %}x{% endif %}",
+            # the arm taken for a defined value does not carry the name
+            "{%- set reasoning = reasoning if reasoning is undefined else true %}"
+            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = true if reasoning is defined else reasoning %}"
+            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = reasoning if reasoning is none else true %}"
+            "{% if reasoning %}x{% endif %}",
+            # ``default`` with the boolean flag replaces a defined False
+            "{%- set reasoning = reasoning | default(true, true) %}"
+            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = reasoning | default(true, boolean=true) %}"
+            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = reasoning | default(true, boolean=flag) %}"
+            "{% if reasoning %}x{% endif %}",
             # a preserving rebinding of a name already shadowed stays shadowed
             "{%- for reasoning in messages %}{% set reasoning = reasoning | default(1) %}"
             "{% if reasoning %}x{% endif %}{%- endfor %}",

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -8,7 +8,8 @@ thinking block when it is false. Desktop's default (thinking off) and
 ``rapid-mlx chat`` without ``--think`` resolve ``enable_thinking=False``,
 which was silently inert for this family. ``apply_chat_template`` now maps
 that off flag onto the template's own switch, found by reading the Jinja AST
-for the variables the template actually consults.
+for the variables the template consults from its context and branches on as
+booleans.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ import jinja2
 import pytest
 
 from vllm_mlx.utils.chat_template import (
+    _template_context_reads_for_source,
     apply_chat_template,
     template_thinking_switch,
 )
@@ -68,18 +70,8 @@ class _RenderingTokenizer:
 MESSAGES = [{"role": "user", "content": "hi"}]
 
 
-class TestTemplateThinkingSwitch:
-    def test_north_reads_a_reasoning_switch(self):
-        assert template_thinking_switch(NORTH_CLAUSE) == "reasoning"
-
-    def test_enable_thinking_template_keeps_its_own_switch(self):
-        assert template_thinking_switch(ENABLE_THINKING_TEMPLATE) is None
-
-    def test_reads_of_both_prefer_enable_thinking(self):
-        assert template_thinking_switch(NORTH_CLAUSE + ENABLE_THINKING_TEMPLATE) is None
-
-    def test_harmony_style_effort_only_template_has_no_switch(self):
-        assert template_thinking_switch(HARMONY_LIKE_TEMPLATE) is None
+class TestContextReads:
+    """Which names a template reads from its render context (Jinja scoping)."""
 
     @pytest.mark.parametrize(
         "template",
@@ -107,24 +99,22 @@ class TestTemplateThinkingSwitch:
             "{%- with reasoning = 1 %}{{ reasoning }}{% endwith %}",
         ],
     )
-    def test_bound_or_attribute_uses_are_not_a_switch(self, template):
-        assert template_thinking_switch(template) is None
+    def test_bound_or_attribute_uses_are_not_reads(self, template):
+        assert "reasoning" not in _template_context_reads_for_source(template)
 
     @pytest.mark.parametrize(
         "template",
         [
             # North's own line: the read happens before the binding
-            "{%- set reasoning = reasoning if reasoning is not undefined else true %}"
-            "{% if reasoning %}x{% endif %}",
+            "{%- set reasoning = reasoning if reasoning is not undefined else true %}",
             # read after a loop that only shadowed it inside the body
-            "{%- for reasoning in messages %}{{ reasoning }}{%- endfor %}"
-            "{% if reasoning %}x{% endif %}",
+            "{%- for reasoning in messages %}{{ reasoning }}{%- endfor %}{{ reasoning }}",
             # read after a ``with`` block that only bound it inside
-            "{%- with reasoning = 1 %}{{ reasoning }}{% endwith %}{% if reasoning %}x{% endif %}",
+            "{%- with reasoning = 1 %}{{ reasoning }}{% endwith %}{{ reasoning }}",
             # bound in only one branch: the later read may still be the context
-            "{%- if x %}{% set reasoning = 1 %}{% endif %}{% if reasoning %}x{% endif %}",
+            "{%- if x %}{% set reasoning = 1 %}{% endif %}{{ reasoning }}",
             # read inside a macro body that does not bind it
-            "{%- macro show() %}{% if reasoning %}x{% endif %}{%- endmacro %}{{ show() }}",
+            "{%- macro show() %}{{ reasoning }}{%- endmacro %}{{ show() }}",
             # the loop's own filter clause
             "{%- for m in messages if reasoning %}{{ m }}{%- endfor %}",
             # a ``{% set %}`` whose value reads it inside a nested expression
@@ -135,18 +125,65 @@ class TestTemplateThinkingSwitch:
             "{%- with reasoning = reasoning %}{{ reasoning }}{% endwith %}",
         ],
     )
-    def test_context_reads_are_a_switch(self, template):
+    def test_context_reads(self, template):
+        assert "reasoning" in _template_context_reads_for_source(template)
+
+    def test_unparseable_source_reads_nothing(self):
+        assert _template_context_reads_for_source("{% if reasoning %}") == frozenset()
+
+
+class TestTemplateThinkingSwitch:
+    def test_north_reads_and_branches_on_reasoning(self):
+        assert template_thinking_switch(NORTH_CLAUSE) == "reasoning"
+
+    def test_enable_thinking_template_keeps_its_own_switch(self):
+        assert template_thinking_switch(ENABLE_THINKING_TEMPLATE) is None
+
+    def test_reads_of_both_prefer_enable_thinking(self):
+        assert template_thinking_switch(NORTH_CLAUSE + ENABLE_THINKING_TEMPLATE) is None
+
+    def test_harmony_style_effort_only_template_has_no_switch(self):
+        assert template_thinking_switch(HARMONY_LIKE_TEMPLATE) is None
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            # a bare truthiness test
+            "{% if reasoning %}<think>{% endif %}",
+            # its negation
+            "{% if not reasoning %}<think></think>{% endif %}",
+            # a conditional expression
+            "{{ '<think>' if reasoning else '<think></think>' }}",
+            # an elif branch
+            "{% if x %}a{% elif reasoning %}b{% endif %}",
+            # read as data somewhere else too, but branched on as a boolean
+            "{{ reasoning }}{% if reasoning %}x{% endif %}",
+        ],
+    )
+    def test_a_boolean_branch_on_a_context_read_is_a_switch(self, template):
         assert template_thinking_switch(template) == "reasoning"
 
-    def test_without_jinja2_no_switch_is_reported(self, monkeypatch):
-        from vllm_mlx.utils import chat_template as module
-
-        module._template_context_reads_for_source.cache_clear()
-        monkeypatch.setattr(module, "_jinja_nodes", lambda: (None, None))
-        try:
-            assert template_thinking_switch(NORTH_CLAUSE) is None
-        finally:
-            module._template_context_reads_for_source.cache_clear()
+    @pytest.mark.parametrize(
+        "template",
+        [
+            # rendered as data, never branched on
+            "{{ reasoning }}",
+            # only a definedness check
+            "{% if reasoning is defined %}x{% endif %}",
+            # compared against a value: not an on/off switch
+            "{% if reasoning == 'high' %}x{% endif %}",
+            # combined with something else (not a plain boolean test)
+            "{% if reasoning and tools %}x{% endif %}",
+            # branched on, but as an attribute
+            "{% if reasoning.enabled %}x{% endif %}",
+            # branched on the template's own local, not the context
+            "{%- set reasoning = true %}{% if reasoning %}x{% endif %}",
+            # branched on a loop variable of that name
+            "{%- for reasoning in messages %}{% if reasoning %}x{% endif %}{%- endfor %}",
+        ],
+    )
+    def test_data_definedness_or_local_uses_are_not_a_switch(self, template):
+        assert template_thinking_switch(template) is None
 
     def test_unparseable_and_missing_templates(self):
         assert template_thinking_switch("{% if reasoning %}") is None
@@ -158,6 +195,18 @@ class TestTemplateThinkingSwitch:
             )
             == "reasoning"
         )
+
+    def test_without_jinja2_no_switch_is_reported(self, monkeypatch):
+        from vllm_mlx.utils import chat_template as module
+
+        module._template_context_reads_for_source.cache_clear()
+        module._template_truthiness_tests_for_source.cache_clear()
+        monkeypatch.setattr(module, "_jinja_nodes", lambda: (None, None))
+        try:
+            assert template_thinking_switch(NORTH_CLAUSE) is None
+        finally:
+            module._template_context_reads_for_source.cache_clear()
+            module._template_truthiness_tests_for_source.cache_clear()
 
 
 class TestApplyChatTemplateOnNorth:

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -48,6 +48,15 @@ HARMONY_LIKE_TEMPLATE = (
     "{%- set effort = reasoning_effort | default('medium') %}"
     "Reasoning: {{ effort }}{%- for m in messages %}{{ m.content }}{%- endfor %}"
 )
+PLAIN_REASONING_TEMPLATE = (
+    "{%- for m in messages %}{{ m.content }}{%- endfor %}"
+    "{% if reasoning %}<think>{% else %}<think></think>{% endif %}"
+)
+HARMONY_REASONING_TEMPLATE = (
+    "{# <|start|><|channel|><|message|> #}"
+    "{% set reasoning = reasoning if reasoning is defined else true %}"
+    "{{ reasoning_effort }}:{% if reasoning %}on{% else %}off{% endif %}"
+)
 
 
 class _RenderingTokenizer:
@@ -383,6 +392,45 @@ class TestApplyChatTemplateOnNorth:
             chat_template_kwargs={"reasoning_effort": "none"},
         )
         assert prompt.endswith(NO_THINKING_PREFIX)
+
+    def test_none_effort_seeds_a_template_that_does_not_derive_it(self):
+        tok = _RenderingTokenizer(PLAIN_REASONING_TEMPLATE)
+        prompt = apply_chat_template(
+            tok,
+            MESSAGES,
+            enable_thinking=False,
+            chat_template_kwargs={"reasoning_effort": " NoNe "},
+        )
+        assert tok.received_kwargs["reasoning"] is False
+        assert prompt.endswith("<think></think>")
+
+    def test_non_none_effort_does_not_seed_plain_reasoning_switch(self):
+        tok = _RenderingTokenizer(PLAIN_REASONING_TEMPLATE)
+        apply_chat_template(
+            tok,
+            MESSAGES,
+            enable_thinking=False,
+            chat_template_kwargs={"reasoning_effort": "high"},
+        )
+        assert "reasoning" not in tok.received_kwargs
+
+    def test_explicit_reasoning_wins_over_none_effort_mapping(self):
+        tok = _RenderingTokenizer(PLAIN_REASONING_TEMPLATE)
+        prompt = apply_chat_template(
+            tok,
+            MESSAGES,
+            enable_thinking=False,
+            chat_template_kwargs={"reasoning_effort": "none", "reasoning": True},
+        )
+        assert tok.received_kwargs["reasoning"] is True
+        assert prompt.endswith("<think>")
+
+    def test_synthesized_low_effort_does_not_suppress_boolean_off_switch(self):
+        tok = _RenderingTokenizer(HARMONY_REASONING_TEMPLATE)
+        prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
+        assert tok.received_kwargs["reasoning_effort"] == "low"
+        assert tok.received_kwargs["reasoning"] is False
+        assert prompt == "low:off"
 
 
 class TestOtherTemplatesUnaffected:

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Template-native thinking switch for templates without ``enable_thinking`` (#3045).
+
+Cohere's North Mini Code template ignores ``enable_thinking``; its switch is
+a boolean ``reasoning`` (default on, also derived from
+``reasoning_effort == "none"``) and the generation prompt seeds an empty
+thinking block when it is false. Desktop's default (thinking off) and
+``rapid-mlx chat`` without ``--think`` resolve ``enable_thinking=False``,
+which was silently inert for this family. ``apply_chat_template`` now maps
+that off flag onto the template's own switch, found by reading the Jinja AST
+for the variables the template actually consults.
+"""
+
+from __future__ import annotations
+
+import jinja2
+import pytest
+
+from vllm_mlx.utils.chat_template import (
+    apply_chat_template,
+    template_thinking_switch,
+)
+
+# The verbatim control clauses of mlx-community/North-Mini-Code-1.0-4bit's
+# chat_template.jinja (the ``reasoning`` derivation and the generation
+# prompt), with a minimal message loop in between.
+NORTH_CLAUSE = (
+    "{%- set reasoning = reasoning if reasoning is not undefined else "
+    '(false if reasoning_effort is defined and reasoning_effort | lower == "none" '
+    "else true) %}"
+    "{%- for message in messages %}{{ message.role }}: {{ message.content }}\n"
+    "{%- endfor %}"
+    "{%- if add_generation_prompt -%}<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>"
+    "{% if reasoning %}<|START_THINKING|>{% else %}"
+    "<|START_THINKING|><|END_THINKING|>{% endif %}{%- endif %}"
+)
+THINKING_PREFIX = "<|CHATBOT_TOKEN|><|START_THINKING|>"
+NO_THINKING_PREFIX = "<|CHATBOT_TOKEN|><|START_THINKING|><|END_THINKING|>"
+
+ENABLE_THINKING_TEMPLATE = (
+    "{%- for m in messages %}{{ m.content }}{%- endfor %}"
+    "{%- if enable_thinking is defined and not enable_thinking %}<think></think>"
+    "{%- endif %}"
+)
+HARMONY_LIKE_TEMPLATE = (
+    "{%- set effort = reasoning_effort | default('medium') %}"
+    "Reasoning: {{ effort }}{%- for m in messages %}{{ m.content }}{%- endfor %}"
+)
+
+
+class _RenderingTokenizer:
+    """Applicator that renders its template with jinja2 like transformers does."""
+
+    def __init__(self, template):
+        self.chat_template = template
+        self.received_kwargs: dict | None = None
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.received_kwargs = dict(kwargs)
+        kwargs.pop("tokenize", None)
+        env = jinja2.Environment(extensions=["jinja2.ext.loopcontrols"])
+        return env.from_string(self.chat_template).render(messages=messages, **kwargs)
+
+    def encode(self, _text):
+        return [1, 2]
+
+
+MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+class TestTemplateThinkingSwitch:
+    def test_north_reads_a_reasoning_switch(self):
+        assert template_thinking_switch(NORTH_CLAUSE) == "reasoning"
+
+    def test_enable_thinking_template_keeps_its_own_switch(self):
+        assert template_thinking_switch(ENABLE_THINKING_TEMPLATE) is None
+
+    def test_reads_of_both_prefer_enable_thinking(self):
+        assert template_thinking_switch(NORTH_CLAUSE + ENABLE_THINKING_TEMPLATE) is None
+
+    def test_harmony_style_effort_only_template_has_no_switch(self):
+        assert template_thinking_switch(HARMONY_LIKE_TEMPLATE) is None
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            # attribute access on a message is not a context read
+            "{%- for m in messages %}{% if m.reasoning %}{{ m.reasoning }}{% endif %}"
+            "{%- endfor %}",
+            # a loop variable named ``reasoning`` shadows the context in its body
+            "{%- for reasoning in messages %}{{ reasoning }}{%- endfor %}",
+            # a macro argument named ``reasoning`` shadows the context in its body
+            "{%- macro show(reasoning) %}{{ reasoning }}{%- endmacro %}{{ show(1) }}",
+            # a call-block argument likewise
+            "{%- macro m(caller) %}{{ caller(1) }}{% endmacro %}"
+            "{%- call(reasoning) m() %}{{ reasoning }}{% endcall %}",
+            # assigned before being read: the template's own local, not a knob
+            "{%- set reasoning = true %}{% if reasoning %}x{% endif %}",
+            # a block assignment likewise
+            "{%- set reasoning %}yes{% endset %}{% if reasoning %}x{% endif %}",
+            # bound in every branch before the read
+            "{%- if x %}{% set reasoning = 1 %}{% else %}{% set reasoning = 0 %}"
+            "{%- endif %}{% if reasoning %}x{% endif %}",
+            # imported under that name
+            "{%- import 'x.jinja' as reasoning %}{{ reasoning.thing }}",
+            # a ``with`` binding, read only inside the block
+            "{%- with reasoning = 1 %}{{ reasoning }}{% endwith %}",
+        ],
+    )
+    def test_bound_or_attribute_uses_are_not_a_switch(self, template):
+        assert template_thinking_switch(template) is None
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            # North's own line: the read happens before the binding
+            "{%- set reasoning = reasoning if reasoning is not undefined else true %}"
+            "{% if reasoning %}x{% endif %}",
+            # read after a loop that only shadowed it inside the body
+            "{%- for reasoning in messages %}{{ reasoning }}{%- endfor %}"
+            "{% if reasoning %}x{% endif %}",
+            # read after a ``with`` block that only bound it inside
+            "{%- with reasoning = 1 %}{{ reasoning }}{% endwith %}{% if reasoning %}x{% endif %}",
+            # bound in only one branch: the later read may still be the context
+            "{%- if x %}{% set reasoning = 1 %}{% endif %}{% if reasoning %}x{% endif %}",
+            # read inside a macro body that does not bind it
+            "{%- macro show() %}{% if reasoning %}x{% endif %}{%- endmacro %}{{ show() }}",
+            # the loop's own filter clause
+            "{%- for m in messages if reasoning %}{{ m }}{%- endfor %}",
+            # a ``{% set %}`` whose value reads it inside a nested expression
+            "{%- set flags = namespace(on=reasoning) %}{{ flags.on }}",
+            # a macro default value is evaluated in the outer scope
+            "{%- macro show(on=reasoning) %}{{ on }}{%- endmacro %}{{ show() }}",
+            # a ``with`` value is evaluated in the outer scope
+            "{%- with reasoning = reasoning %}{{ reasoning }}{% endwith %}",
+        ],
+    )
+    def test_context_reads_are_a_switch(self, template):
+        assert template_thinking_switch(template) == "reasoning"
+
+    def test_without_jinja2_no_switch_is_reported(self, monkeypatch):
+        from vllm_mlx.utils import chat_template as module
+
+        module._template_context_reads_for_source.cache_clear()
+        monkeypatch.setattr(module, "_jinja_nodes", lambda: (None, None))
+        try:
+            assert template_thinking_switch(NORTH_CLAUSE) is None
+        finally:
+            module._template_context_reads_for_source.cache_clear()
+
+    def test_unparseable_and_missing_templates(self):
+        assert template_thinking_switch("{% if reasoning %}") is None
+        assert template_thinking_switch(None) is None
+        assert template_thinking_switch({"default": NORTH_CLAUSE}) == "reasoning"
+        assert (
+            template_thinking_switch(
+                {"tool_use": NORTH_CLAUSE, "default": "x"}, tools=[{}]
+            )
+            == "reasoning"
+        )
+
+
+class TestApplyChatTemplateOnNorth:
+    def test_thinking_off_seeds_an_empty_thinking_block(self):
+        tok = _RenderingTokenizer(NORTH_CLAUSE)
+        prompt = apply_chat_template(
+            tok, MESSAGES, enable_thinking=False, model_name="north-mini-code-4bit"
+        )
+        assert tok.received_kwargs["reasoning"] is False
+        assert prompt.endswith(NO_THINKING_PREFIX)
+
+    def test_thinking_on_keeps_the_template_default(self):
+        tok = _RenderingTokenizer(NORTH_CLAUSE)
+        prompt = apply_chat_template(
+            tok, MESSAGES, enable_thinking=True, model_name="north-mini-code-4bit"
+        )
+        assert "reasoning" not in tok.received_kwargs
+        assert prompt.endswith(THINKING_PREFIX)
+
+    def test_unset_thinking_defaults_on_for_this_family(self):
+        tok = _RenderingTokenizer(NORTH_CLAUSE)
+        prompt = apply_chat_template(tok, MESSAGES, model_name="north-mini-code-4bit")
+        assert tok.received_kwargs["enable_thinking"] is True
+        assert "reasoning" not in tok.received_kwargs
+        assert prompt.endswith(THINKING_PREFIX)
+
+    def test_desktop_shape_client_kwarg_off_is_honoured(self):
+        """Desktop sends ``chat_template_kwargs.enable_thinking=false``; the
+        route resolves it to ``enable_thinking=False`` before rendering."""
+        tok = _RenderingTokenizer(NORTH_CLAUSE)
+        prompt = apply_chat_template(
+            tok,
+            MESSAGES,
+            enable_thinking=False,
+            chat_template_kwargs={"enable_thinking": False},
+            model_name="north-mini-code-4bit",
+        )
+        assert prompt.endswith(NO_THINKING_PREFIX)
+
+    def test_explicit_client_reasoning_wins(self):
+        tok = _RenderingTokenizer(NORTH_CLAUSE)
+        prompt = apply_chat_template(
+            tok,
+            MESSAGES,
+            enable_thinking=False,
+            chat_template_kwargs={"reasoning": True},
+            model_name="north-mini-code-4bit",
+        )
+        assert tok.received_kwargs["reasoning"] is True
+        assert prompt.endswith(THINKING_PREFIX)
+
+    def test_explicit_client_reasoning_effort_wins(self):
+        tok = _RenderingTokenizer(NORTH_CLAUSE)
+        prompt = apply_chat_template(
+            tok,
+            MESSAGES,
+            enable_thinking=False,
+            chat_template_kwargs={"reasoning_effort": "high"},
+            model_name="north-mini-code-4bit",
+        )
+        assert "reasoning" not in tok.received_kwargs
+        assert prompt.endswith(THINKING_PREFIX)
+        tok = _RenderingTokenizer(NORTH_CLAUSE)
+        prompt = apply_chat_template(
+            tok,
+            MESSAGES,
+            enable_thinking=True,
+            chat_template_kwargs={"reasoning_effort": "none"},
+        )
+        assert prompt.endswith(NO_THINKING_PREFIX)
+
+
+class TestOtherTemplatesUnaffected:
+    def test_enable_thinking_template_gets_no_reasoning_kwarg(self):
+        tok = _RenderingTokenizer(ENABLE_THINKING_TEMPLATE)
+        prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
+        assert "reasoning" not in tok.received_kwargs
+        assert prompt.endswith("<think></think>")
+
+    def test_harmony_style_template_keeps_the_low_effort_path(self):
+        tok = _RenderingTokenizer(HARMONY_LIKE_TEMPLATE)
+        apply_chat_template(
+            tok, MESSAGES, enable_thinking=False, model_name="gpt-oss-20b"
+        )
+        assert "reasoning" not in tok.received_kwargs
+        assert tok.received_kwargs.get("reasoning_effort") == "low"

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -157,6 +157,10 @@ class TestTemplateThinkingSwitch:
             "{% if not reasoning %}<think></think>{% endif %}",
             # a conditional expression
             "{{ '<think>' if reasoning else '<think></think>' }}",
+            # a statically non-empty, unfiltered loop proves its body runs
+            "{% for x in [1] %}{% if reasoning %}x{% endif %}{% endfor %}",
+            # a statically empty, unfiltered loop proves its else arm runs
+            "{% for x in [] %}x{% else %}{% if reasoning %}y{% endif %}{% endfor %}",
             # an elif branch
             "{% if x %}a{% elif reasoning %}b{% endif %}",
             # read as data somewhere else too, but branched on as a boolean
@@ -257,6 +261,8 @@ class TestTemplateThinkingSwitch:
             "{{ ('R' if reasoning else 'N') if false else '' }}",
             "{{ reasoning | default('unset') }}"
             "{% for x in [1] %}{% break %}{% if reasoning %}R{% endif %}{% endfor %}",
+            "{{ reasoning | default('unset') }}"
+            "{% for x in items %}x{% else %}{% if reasoning %}R{% endif %}{% endfor %}",
             # branched on a loop variable of that name
             "{%- for reasoning in messages %}{% if reasoning %}x{% endif %}{%- endfor %}",
         ],
@@ -444,11 +450,22 @@ class TestOtherTemplatesUnaffected:
                 "{% if reasoning %}R{% endif %}{% endfor %}",
                 "unset",
             ),
+            (
+                "{{ reasoning | default('unset') }}"
+                "{% for x in items %}x{% else %}"
+                "{% if reasoning %}R{% endif %}{% endfor %}",
+                "unsetx",
+            ),
         ],
     )
     def test_dead_branch_does_not_make_rendered_data_a_switch(self, template, expected):
         tok = _RenderingTokenizer(template)
-        prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
+        prompt = apply_chat_template(
+            tok,
+            MESSAGES,
+            enable_thinking=False,
+            chat_template_kwargs={"items": [1]},
+        )
         assert "reasoning" not in tok.received_kwargs
         assert prompt == expected
 

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -224,6 +224,15 @@ class TestTemplateThinkingSwitch:
             # the branch is inside a macro that binds the name
             "{%- macro show(reasoning) %}{% if reasoning %}x{% endif %}{%- endmacro %}"
             "{{ show(reasoning) }}",
+            # macro bodies are deferred; an uncalled macro cannot prove that
+            # the template exposes a live switch
+            "{%- macro unused() %}{% if reasoning %}x{% endif %}{%- endmacro %}"
+            "{{ reasoning | default('unset') }}",
+            # call-block argument defaults are evaluated only if the callee
+            # invokes ``caller``; this callee deliberately never does
+            "{%- macro never() %}{% if false %}{{ caller() }}{% endif %}ok{% endmacro %}"
+            "{{ reasoning | default('unset') }}"
+            "{% call(x=('a' if reasoning else 'b')) never() %}{{ x }}{% endcall %}",
             # branched on a loop variable of that name
             "{%- for reasoning in messages %}{% if reasoning %}x{% endif %}{%- endfor %}",
         ],
@@ -338,6 +347,27 @@ class TestApplyChatTemplateOnNorth:
 
 
 class TestOtherTemplatesUnaffected:
+    def test_uncalled_macro_does_not_make_rendered_data_a_switch(self):
+        template = (
+            "{% macro unused() %}{% if reasoning %}x{% endif %}{% endmacro %}"
+            "{{ reasoning | default('unset') }}"
+        )
+        tok = _RenderingTokenizer(template)
+        prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
+        assert "reasoning" not in tok.received_kwargs
+        assert prompt == "unset"
+
+    def test_uninvoked_call_block_default_does_not_make_data_a_switch(self):
+        template = (
+            "{% macro never() %}{% if false %}{{ caller() }}{% endif %}ok{% endmacro %}"
+            "{{ reasoning | default('unset') }}"
+            "{% call(x=('a' if reasoning else 'b')) never() %}{{ x }}{% endcall %}"
+        )
+        tok = _RenderingTokenizer(template)
+        prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)
+        assert "reasoning" not in tok.received_kwargs
+        assert prompt == "unsetok"
+
     def test_enable_thinking_template_gets_no_reasoning_kwarg(self):
         tok = _RenderingTokenizer(ENABLE_THINKING_TEMPLATE)
         prompt = apply_chat_template(tok, MESSAGES, enable_thinking=False)

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -277,7 +277,8 @@ class TestTemplateThinkingSwitch:
             "{{ reasoning | default('unset') }}"
             "{% for x in [1] %}{% break %}{% if reasoning %}R{% endif %}{% endfor %}",
             "{{ reasoning | default('unset') }}"
-            "{% for x in [1] %}{% if true %}{% break %}{% endif %}"
+            "{% for x in [1] %}{% if true %}{% break %}"
+            "{% elif false %}{% continue %}{% endif %}"
             "{% if reasoning %}R{% endif %}{% endfor %}",
             "{{ reasoning | default('unset') }}"
             "{% for x in items %}x{% else %}{% if reasoning %}R{% endif %}{% endfor %}",
@@ -509,7 +510,8 @@ class TestOtherTemplatesUnaffected:
             ),
             (
                 "{{ reasoning | default('unset') }}"
-                "{% for x in [1] %}{% if true %}{% break %}{% endif %}"
+                "{% for x in [1] %}{% if true %}{% break %}"
+                "{% elif false %}{% continue %}{% endif %}"
                 "{% if reasoning %}R{% endif %}{% endfor %}",
                 "unset",
             ),

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -242,6 +242,20 @@ class TestTemplateThinkingSwitch:
             == "reasoning"
         )
 
+    @pytest.mark.parametrize("order", ["switch-first", "enable-thinking-first"])
+    def test_enable_thinking_in_any_selected_source_wins(self, monkeypatch, order):
+        """``_chat_template_strings`` selects one source today; should it ever
+        return several, a read of ``enable_thinking`` anywhere still wins."""
+        from vllm_mlx.utils import chat_template as module
+
+        sources = [NORTH_CLAUSE, ENABLE_THINKING_TEMPLATE]
+        if order == "enable-thinking-first":
+            sources.reverse()
+        monkeypatch.setattr(
+            module, "_chat_template_strings", lambda template, *, tools: sources
+        )
+        assert template_thinking_switch({"default": "x"}) is None
+
     def test_without_jinja2_no_switch_is_reported(self, monkeypatch):
         from vllm_mlx.utils import chat_template as module
 

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -159,6 +159,8 @@ class TestTemplateThinkingSwitch:
             "{{ '<think>' if reasoning else '<think></think>' }}",
             # a statically non-empty, unfiltered loop proves its body runs
             "{% for x in [1] %}{% if reasoning %}x{% endif %}{% endfor %}",
+            # tests reached before unconditional loop control remain live
+            "{% for x in [1] %}{% if reasoning %}x{% endif %}{% break %}{% endfor %}",
             # a statically empty, unfiltered loop proves its else arm runs
             "{% for x in [] %}x{% else %}{% if reasoning %}y{% endif %}{% endfor %}",
             # an elif branch
@@ -261,6 +263,9 @@ class TestTemplateThinkingSwitch:
             "{{ ('R' if reasoning else 'N') if false else '' }}",
             "{{ reasoning | default('unset') }}"
             "{% for x in [1] %}{% break %}{% if reasoning %}R{% endif %}{% endfor %}",
+            "{{ reasoning | default('unset') }}"
+            "{% for x in [1] %}{% if true %}{% break %}{% endif %}"
+            "{% if reasoning %}R{% endif %}{% endfor %}",
             "{{ reasoning | default('unset') }}"
             "{% for x in items %}x{% else %}{% if reasoning %}R{% endif %}{% endfor %}",
             # branched on a loop variable of that name
@@ -447,6 +452,12 @@ class TestOtherTemplatesUnaffected:
             (
                 "{{ reasoning | default('unset') }}"
                 "{% for x in [1] %}{% break %}"
+                "{% if reasoning %}R{% endif %}{% endfor %}",
+                "unset",
+            ),
+            (
+                "{{ reasoning | default('unset') }}"
+                "{% for x in [1] %}{% if true %}{% break %}{% endif %}"
                 "{% if reasoning %}R{% endif %}{% endfor %}",
                 "unset",
             ),

--- a/tests/test_template_thinking_switch.py
+++ b/tests/test_template_thinking_switch.py
@@ -145,6 +145,10 @@ class TestTemplateThinkingSwitch:
     def test_reads_of_both_prefer_enable_thinking(self):
         assert template_thinking_switch(NORTH_CLAUSE + ENABLE_THINKING_TEMPLATE) is None
 
+    def test_dead_enable_thinking_read_does_not_veto_live_switch(self):
+        template = NORTH_CLAUSE + "{% if false %}{{ enable_thinking }}{% endif %}"
+        assert template_thinking_switch(template) == "reasoning"
+
     def test_harmony_style_effort_only_template_has_no_switch(self):
         assert template_thinking_switch(HARMONY_LIKE_TEMPLATE) is None
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1658,22 +1658,30 @@ def _context_reads(
         _context_reads(node.iter, bound, nodes, reads, tests)
         inner = bound | _bound_names(node, nodes)
         body_tests: set[str] = set()
+        dead_reads: set[str] = set()
+        iterator_known = False
         body_proven_nonempty = False
         else_proven = False
-        if node.test is None:
-            try:
-                iterator_nonempty = bool(node.iter.as_const())
-                body_proven_nonempty = iterator_nonempty
-                else_proven = not iterator_nonempty
-            except Exception:
-                pass
+        try:
+            iterator_nonempty = bool(node.iter.as_const())
+            iterator_known = True
+            body_proven_nonempty = iterator_nonempty and node.test is None
+            else_proven = not iterator_nonempty
+        except Exception:
+            pass
         if node.test is not None:
-            _context_reads(node.test, inner, nodes, reads, body_tests)
+            _context_reads(
+                node.test,
+                inner,
+                nodes,
+                dead_reads if iterator_known and not iterator_nonempty else reads,
+                body_tests,
+            )
         _context_reads_all(
             node.body,
             inner,
             nodes,
-            reads,
+            dead_reads if iterator_known and not iterator_nonempty else reads,
             tests if body_proven_nonempty else body_tests,
         )
         # A loop ``else`` can establish a switch only when an unfiltered
@@ -1683,7 +1691,7 @@ def _context_reads(
             node.else_,
             bound,
             nodes,
-            reads,
+            dead_reads if body_proven_nonempty else reads,
             tests if else_proven else body_tests,
         )
         return bound
@@ -1695,23 +1703,27 @@ def _context_reads(
         after: list[frozenset[str]] = []
         fallthrough_possible = True
         deferred_tests: set[str] = set()
+        dead_reads: set[str] = set()
         for branch in [node, *node.elif_]:
             branch_tests = tests if fallthrough_possible else deferred_tests
+            branch_reads = reads if fallthrough_possible else dead_reads
             _record_truthiness_test(branch.test, bound, nodes, branch_tests)
-            _context_reads(branch.test, bound, nodes, reads, branch_tests)
+            _context_reads(branch.test, bound, nodes, branch_reads, branch_tests)
             truth = _constant_truthiness(branch.test, nodes)
             if fallthrough_possible and truth is not False:
                 after.append(
                     _context_reads_all(branch.body, bound, nodes, reads, tests)
                 )
             else:
-                _context_reads_all(branch.body, bound, nodes, reads, deferred_tests)
+                _context_reads_all(
+                    branch.body, bound, nodes, dead_reads, deferred_tests
+                )
             if fallthrough_possible and truth is True:
                 fallthrough_possible = False
         if fallthrough_possible:
             after.append(_context_reads_all(node.else_, bound, nodes, reads, tests))
         else:
-            _context_reads_all(node.else_, bound, nodes, reads, deferred_tests)
+            _context_reads_all(node.else_, bound, nodes, dead_reads, deferred_tests)
         return frozenset.intersection(*after)
     if isinstance(node, nodes.Macro):
         # A macro body is deferred until a call executes it.  Counting a
@@ -1762,11 +1774,12 @@ def _context_reads(
         _context_reads(node.test, bound, nodes, reads, tests)
         truth = _constant_truthiness(node.test, nodes)
         deferred_tests: set[str] = set()
+        dead_reads: set[str] = set()
         _context_reads(
             node.expr1,
             bound,
             nodes,
-            reads,
+            reads if truth is not False else dead_reads,
             tests if truth is not False else deferred_tests,
         )
         if node.expr2 is not None:
@@ -1774,7 +1787,7 @@ def _context_reads(
                 node.expr2,
                 bound,
                 nodes,
-                reads,
+                reads if truth is not True else dead_reads,
                 tests if truth is not True else deferred_tests,
             )
         return bound
@@ -1839,10 +1852,13 @@ def _context_reads_all(
 ) -> frozenset[str]:
     active_tests = tests
     deferred_tests: set[str] = set()
+    active_reads = reads
+    dead_reads: set[str] = set()
     for stmt in stmts:
-        bound = _context_reads(stmt, bound, nodes, reads, active_tests)
+        bound = _context_reads(stmt, bound, nodes, active_reads, active_tests)
         if _stmt_guarantees_loop_exit(stmt, nodes):
             active_tests = deferred_tests
+            active_reads = dead_reads
     return bound
 
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1759,13 +1759,17 @@ def template_thinking_switch(
     ``enable_thinking`` keeps that switch and yields ``None`` even if it also
     reads a recognised name.
     """
+    reads: set[str] = set()
+    tested: set[str] = set()
     for source in _chat_template_strings(template, tools=tools):
-        reads, tested = _template_context_facts_for_source(source)
-        if "enable_thinking" in reads:
-            return None
-        for switch in _TEMPLATE_THINKING_SWITCHES:
-            if switch in reads and switch in tested:
-                return switch
+        source_reads, source_tests = _template_context_facts_for_source(source)
+        reads |= source_reads
+        tested |= source_tests
+    if "enable_thinking" in reads:
+        return None
+    for switch in _TEMPLATE_THINKING_SWITCHES:
+        if switch in reads and switch in tested:
+            return switch
     return None
 
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1657,24 +1657,57 @@ def _context_reads(
     if isinstance(node, nodes.For):
         _context_reads(node.iter, bound, nodes, reads, tests)
         inner = bound | _bound_names(node, nodes)
+        body_tests: set[str] = set()
+        body_proven_nonempty = False
+        if node.test is None:
+            try:
+                body_proven_nonempty = bool(node.iter.as_const())
+            except Exception:
+                pass
         if node.test is not None:
-            _context_reads(node.test, inner, nodes, reads, tests)
-        _context_reads_all(node.body, inner, nodes, reads, tests)
-        _context_reads_all(node.else_, bound, nodes, reads, tests)
+            _context_reads(node.test, inner, nodes, reads, body_tests)
+        _context_reads_all(
+            node.body,
+            inner,
+            nodes,
+            reads,
+            body_tests,
+        )
+        # A loop ``else`` is dead only when an unfiltered iterable is
+        # statically known to contain at least one item.
+        _context_reads_all(
+            node.else_,
+            bound,
+            nodes,
+            reads,
+            body_tests if body_proven_nonempty else tests,
+        )
         return bound
     if isinstance(node, nodes.If):
-        _record_truthiness_test(node.test, bound, nodes, tests)
-        _context_reads(node.test, bound, nodes, reads, tests)
-        after = [_context_reads_all(node.body, bound, nodes, reads, tests)]
         # Jinja stores each ``elif`` as an ``If`` node whose ``else_`` is
         # empty, while the chain's real ``else`` stays on the outer node.
-        # Recursing into each branch would therefore add a fake fallthrough
-        # path and lose bindings made by every real arm of the chain.
-        for branch in node.elif_:
-            _record_truthiness_test(branch.test, bound, nodes, tests)
-            _context_reads(branch.test, bound, nodes, reads, tests)
-            after.append(_context_reads_all(branch.body, bound, nodes, reads, tests))
-        after.append(_context_reads_all(node.else_, bound, nodes, reads, tests))
+        # Evaluate the chain in order so bindings are joined across actual
+        # terminal paths and constant-dead arms cannot prove a live switch.
+        after: list[frozenset[str]] = []
+        fallthrough_possible = True
+        deferred_tests: set[str] = set()
+        for branch in [node, *node.elif_]:
+            branch_tests = tests if fallthrough_possible else deferred_tests
+            _record_truthiness_test(branch.test, bound, nodes, branch_tests)
+            _context_reads(branch.test, bound, nodes, reads, branch_tests)
+            truth = _constant_truthiness(branch.test, nodes)
+            if fallthrough_possible and truth is not False:
+                after.append(
+                    _context_reads_all(branch.body, bound, nodes, reads, tests)
+                )
+            else:
+                _context_reads_all(branch.body, bound, nodes, reads, deferred_tests)
+            if fallthrough_possible and truth is True:
+                fallthrough_possible = False
+        if fallthrough_possible:
+            after.append(_context_reads_all(node.else_, bound, nodes, reads, tests))
+        else:
+            _context_reads_all(node.else_, bound, nodes, reads, deferred_tests)
         return frozenset.intersection(*after)
     if isinstance(node, nodes.Macro):
         # A macro body is deferred until a call executes it.  Counting a
@@ -1722,6 +1755,25 @@ def _context_reads(
         return bound
     if isinstance(node, nodes.CondExpr):
         _record_truthiness_test(node.test, bound, nodes, tests)
+        _context_reads(node.test, bound, nodes, reads, tests)
+        truth = _constant_truthiness(node.test, nodes)
+        deferred_tests: set[str] = set()
+        _context_reads(
+            node.expr1,
+            bound,
+            nodes,
+            reads,
+            tests if truth is not False else deferred_tests,
+        )
+        if node.expr2 is not None:
+            _context_reads(
+                node.expr2,
+                bound,
+                nodes,
+                reads,
+                tests if truth is not True else deferred_tests,
+            )
+        return bound
     # Anything else (output, expressions, filter/scope blocks): evaluate the
     # children in order; bindings made inside stay inside.
     inner = bound | _bound_names(node, nodes)
@@ -1736,6 +1788,18 @@ def _record_truthiness_test(
     name = _truthiness_tested_name(test, nodes)
     if name is not None and name not in bound:
         tests.add(name)
+
+
+def _constant_truthiness(expr, nodes) -> bool | None:
+    """Jinja's compile-time truth value for a condition; unknown otherwise."""
+    try:
+        # ``as_const`` is Jinja's own side-effect-free constant folder.  It
+        # handles literal boolean expressions (``not false``, comparisons,
+        # ``and`` / ``or``) and raises ``Impossible`` for context-dependent
+        # expressions, which must remain conservatively reachable.
+        return bool(expr.as_const())
+    except Exception:
+        return None
 
 
 def _context_reads_all(

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -2198,6 +2198,12 @@ def apply_chat_template(
     if tools:
         template_kwargs["tools"] = tools
 
+    supplied_template_kwargs = chat_template_kwargs or {}
+    supplied_effort = supplied_template_kwargs.get("reasoning_effort")
+    supplied_effort_is_off = isinstance(supplied_effort, str) and (
+        supplied_effort.strip().lower() == "none"
+    )
+
     # Pass through client-supplied ``chat_template_kwargs`` keys (e.g.
     # ``reasoning_effort`` for Qwen3.8) into the template render. Server-
     # controlled keys (``tokenize``, ``add_generation_prompt``,
@@ -2206,7 +2212,7 @@ def apply_chat_template(
     # on templates that do not accept them; the error-driven fallback
     # below (and the ``reasoning_effort`` pop in the second retry) handles
     # that exactly as it does today.
-    for key, value in (chat_template_kwargs or {}).items():
+    for key, value in supplied_template_kwargs.items():
         if key in ("tokenize", "add_generation_prompt", "enable_thinking", "tools"):
             continue
         if key not in template_kwargs:
@@ -2232,9 +2238,13 @@ def apply_chat_template(
     # without ``--think`` actually turn reasoning off (#3045). Detection is
     # template-driven (the template reads the name from its context and
     # branches on it as a boolean), not a model-name match. A client that
-    # already passed the switch or ``reasoning_effort`` (the template derives
-    # ``reasoning`` from ``"none"``) keeps control.
-    if enable_thinking is False and "reasoning_effort" not in template_kwargs:
+    # already passed the switch keeps control. A non-``none``
+    # ``reasoning_effort`` also keeps control; ``none`` is the portable off
+    # value and must still seed a detected boolean switch for templates that
+    # do not derive the switch from effort themselves.
+    if enable_thinking is False and (
+        "reasoning_effort" not in supplied_template_kwargs or supplied_effort_is_off
+    ):
         switch = template_thinking_switch(
             getattr(template_applicator, "chat_template", None), tools=tools
         )

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1671,13 +1671,38 @@ def _context_reads(
         )
         after.append(_context_reads_all(node.else_, bound, nodes, reads, tests))
         return frozenset.intersection(*after)
-    if isinstance(node, (nodes.Macro, nodes.CallBlock)):
+    if isinstance(node, nodes.Macro):
+        # A macro body is deferred until a call executes it.  Counting a
+        # branch in an uncalled macro as a live template switch can inject a
+        # context value that changes unrelated output.  Proving reachability
+        # would require a Jinja call graph, so fail closed: retain its possible
+        # context reads (notably an ``enable_thinking`` read must still veto an
+        # adapter), but do not infer a live boolean switch from its body.
+        deferred_tests: set[str] = set()
         for default in node.defaults:
-            _context_reads(default, bound, nodes, reads, tests)
-        if isinstance(node, nodes.CallBlock):
-            _context_reads(node.call, bound, nodes, reads, tests)
+            _context_reads(default, bound, nodes, reads, deferred_tests)
         _context_reads_all(
-            node.body, bound | {arg.name for arg in node.args}, nodes, reads, tests
+            node.body,
+            bound | {arg.name for arg in node.args},
+            nodes,
+            reads,
+            deferred_tests,
+        )
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, nodes.CallBlock):
+        deferred_tests: set[str] = set()
+        for default in node.defaults:
+            _context_reads(default, bound, nodes, reads, deferred_tests)
+        _context_reads(node.call, bound, nodes, reads, tests)
+        # Whether the callee invokes ``caller`` is likewise not statically
+        # proven here.  Its body therefore cannot establish a live switch,
+        # though possible reads still participate in conservative vetoes.
+        _context_reads_all(
+            node.body,
+            bound | {arg.name for arg in node.args},
+            nodes,
+            reads,
+            deferred_tests,
         )
         return bound | _bound_names(node, nodes)
     if isinstance(node, (nodes.Import, nodes.FromImport)):
@@ -1751,9 +1776,12 @@ def template_thinking_switch(
     defaults to on or to ``reasoning_effort != "none"``, and seeds an empty
     thinking block when it is false). A name is a switch only when the
     template reads it from the render context and branches on it as a plain
-    boolean while it still carries the context value (a value-preserving
+    boolean while it still carries the context value in an eagerly evaluated
+    scope (a value-preserving
     ``set reasoning = reasoning if reasoning is not undefined else ...``
     keeps it; ``set reasoning = true`` makes the later branch a local one).
+    Deferred macro and call-block bodies are ignored unless a future detector
+    can prove their execution.
     A template that renders ``{{ reasoning }}`` as data or only asks
     ``reasoning is defined`` is left alone. A template that reads
     ``enable_thinking`` keeps that switch and yields ``None`` even if it also

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1702,11 +1702,11 @@ def _context_reads(
         # terminal paths and constant-dead arms cannot prove a live switch.
         after: list[frozenset[str]] = []
         fallthrough_possible = True
-        deferred_tests: set[str] = set()
-        dead_reads: set[str] = set()
+        if_deferred_tests: set[str] = set()
+        if_dead_reads: set[str] = set()
         for branch in [node, *node.elif_]:
-            branch_tests = tests if fallthrough_possible else deferred_tests
-            branch_reads = reads if fallthrough_possible else dead_reads
+            branch_tests = tests if fallthrough_possible else if_deferred_tests
+            branch_reads = reads if fallthrough_possible else if_dead_reads
             _record_truthiness_test(branch.test, bound, nodes, branch_tests)
             _context_reads(branch.test, bound, nodes, branch_reads, branch_tests)
             truth = _constant_truthiness(branch.test, nodes)
@@ -1716,14 +1716,16 @@ def _context_reads(
                 )
             else:
                 _context_reads_all(
-                    branch.body, bound, nodes, dead_reads, deferred_tests
+                    branch.body, bound, nodes, if_dead_reads, if_deferred_tests
                 )
             if fallthrough_possible and truth is True:
                 fallthrough_possible = False
         if fallthrough_possible:
             after.append(_context_reads_all(node.else_, bound, nodes, reads, tests))
         else:
-            _context_reads_all(node.else_, bound, nodes, dead_reads, deferred_tests)
+            _context_reads_all(
+                node.else_, bound, nodes, if_dead_reads, if_deferred_tests
+            )
         return frozenset.intersection(*after)
     if isinstance(node, nodes.Macro):
         # A macro body is deferred until a call executes it.  Counting a
@@ -1732,21 +1734,21 @@ def _context_reads(
         # would require a Jinja call graph, so fail closed: retain its possible
         # context reads (notably an ``enable_thinking`` read must still veto an
         # adapter), but do not infer a live boolean switch from its body.
-        deferred_tests: set[str] = set()
+        macro_deferred_tests: set[str] = set()
         for default in node.defaults:
-            _context_reads(default, bound, nodes, reads, deferred_tests)
+            _context_reads(default, bound, nodes, reads, macro_deferred_tests)
         _context_reads_all(
             node.body,
             bound | {arg.name for arg in node.args},
             nodes,
             reads,
-            deferred_tests,
+            macro_deferred_tests,
         )
         return bound | _bound_names(node, nodes)
     if isinstance(node, nodes.CallBlock):
-        deferred_tests: set[str] = set()
+        call_deferred_tests: set[str] = set()
         for default in node.defaults:
-            _context_reads(default, bound, nodes, reads, deferred_tests)
+            _context_reads(default, bound, nodes, reads, call_deferred_tests)
         _context_reads(node.call, bound, nodes, reads, tests)
         # Whether the callee invokes ``caller`` is likewise not statically
         # proven here.  Its body therefore cannot establish a live switch,
@@ -1756,7 +1758,7 @@ def _context_reads(
             bound | {arg.name for arg in node.args},
             nodes,
             reads,
-            deferred_tests,
+            call_deferred_tests,
         )
         return bound | _bound_names(node, nodes)
     if isinstance(node, (nodes.Import, nodes.FromImport)):
@@ -1773,22 +1775,22 @@ def _context_reads(
         _record_truthiness_test(node.test, bound, nodes, tests)
         _context_reads(node.test, bound, nodes, reads, tests)
         truth = _constant_truthiness(node.test, nodes)
-        deferred_tests: set[str] = set()
-        dead_reads: set[str] = set()
+        cond_deferred_tests: set[str] = set()
+        cond_dead_reads: set[str] = set()
         _context_reads(
             node.expr1,
             bound,
             nodes,
-            reads if truth is not False else dead_reads,
-            tests if truth is not False else deferred_tests,
+            reads if truth is not False else cond_dead_reads,
+            tests if truth is not False else cond_deferred_tests,
         )
         if node.expr2 is not None:
             _context_reads(
                 node.expr2,
                 bound,
                 nodes,
-                reads if truth is not True else dead_reads,
-                tests if truth is not True else deferred_tests,
+                reads if truth is not True else cond_dead_reads,
+                tests if truth is not True else cond_deferred_tests,
             )
         return bound
     # Anything else (output, expressions, filter/scope blocks): evaluate the

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1558,34 +1558,65 @@ def _truthiness_tested_name(test, nodes) -> str | None:
     return None
 
 
-def _is_definedness_test(expr, name: str, nodes) -> bool:
-    if isinstance(expr, nodes.Not):
-        expr = expr.node
-    return bool(
-        isinstance(expr, nodes.Test)
-        and expr.name in ("defined", "undefined", "none")
-        and isinstance(expr.node, nodes.Name)
-        and expr.node.name == name
+# Truth value of ``name is <test>`` when ``name`` holds a defined, non-None
+# value such as ``False``.
+_DEFINEDNESS_TESTS = {"defined": True, "undefined": False, "none": False}
+
+
+def _arm_taken_when_defined(test, name: str, nodes) -> str | None:
+    """Which arm of ``a if <test> else b`` runs when ``name`` is defined.
+
+    ``"expr1"`` / ``"expr2"`` for a definedness test on ``name`` (``defined``,
+    ``undefined``, ``none`` and their negations), ``None`` for any other
+    condition.
+    """
+    negated = isinstance(test, nodes.Not)
+    if negated:
+        test = test.node
+    if (
+        not isinstance(test, nodes.Test)
+        or test.name not in _DEFINEDNESS_TESTS
+        or not isinstance(test.node, nodes.Name)
+        or test.node.name != name
+    ):
+        return None
+    return "expr1" if _DEFINEDNESS_TESTS[test.name] != negated else "expr2"
+
+
+def _default_filter_keeps_false(expr, nodes) -> bool:
+    """``x | default(d)`` keeps a defined ``False``; ``default(d, true)`` or
+    ``default(d, boolean=true)`` replaces it."""
+    boolean = expr.args[1] if len(expr.args) > 1 else None
+    for kw in expr.kwargs:
+        if kw.key == "boolean":
+            boolean = kw.value
+    return boolean is None or bool(
+        isinstance(boolean, nodes.Const) and boolean.value is False
     )
 
 
 def _carries_context_value(expr, name: str, nodes) -> bool:
-    """Whether ``{% set name = expr %}`` keeps the context value of ``name``.
+    """Whether ``{% set name = expr %}`` keeps a defined context value of
+    ``name`` (including ``False``, the value the off switch injects).
 
     True for the idioms templates use to give a context variable a default:
-    ``name``, ``name | default(...)`` and ``name if name is (not) defined /
-    undefined else ...`` (either arm). Any other value is a fresh local.
+    ``name``, ``name | default(...)`` without the ``boolean`` flag, and
+    ``... if name is (not) defined / undefined / none else ...`` when the arm
+    taken for a defined value carries ``name``. Any other value is a fresh
+    local.
     """
     if isinstance(expr, nodes.Name):
         return bool(expr.ctx == "load" and expr.name == name)
     if isinstance(expr, nodes.Filter) and expr.name == "default":
-        return _carries_context_value(expr.node, name, nodes)
-    if isinstance(expr, nodes.CondExpr) and _is_definedness_test(
-        expr.test, name, nodes
-    ):
-        return _carries_context_value(expr.expr1, name, nodes) or (
-            expr.expr2 is not None and _carries_context_value(expr.expr2, name, nodes)
+        return _default_filter_keeps_false(expr, nodes) and _carries_context_value(
+            expr.node, name, nodes
         )
+    if isinstance(expr, nodes.CondExpr):
+        arm = _arm_taken_when_defined(expr.test, name, nodes)
+        if arm == "expr1":
+            return _carries_context_value(expr.expr1, name, nodes)
+        if arm == "expr2" and expr.expr2 is not None:
+            return _carries_context_value(expr.expr2, name, nodes)
     return False
 
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1638,24 +1638,64 @@ def _template_context_reads_for_source(template: str) -> frozenset[str]:
     return frozenset(reads)
 
 
+def _truthiness_tested_name(test, nodes) -> str | None:
+    """The variable a bare ``{% if x %}`` / ``{% if not x %}`` / ``a if x else b`` tests."""
+    if isinstance(test, nodes.Not):
+        test = test.node
+    if isinstance(test, nodes.Name) and test.ctx == "load":
+        return str(test.name)
+    return None
+
+
+@functools.lru_cache(maxsize=64)
+def _template_truthiness_tests_for_source(template: str) -> frozenset[str]:
+    """Names a template branches on as plain booleans (``if x``, ``if not x``,
+    ``... if x else ...``). ``x is defined``, ``x == "y"`` or ``x.flag`` do
+    not count: those consume ``x`` as something other than an on/off switch.
+    """
+    jinja2, nodes = _jinja_nodes()
+    env = _template_parser()
+    if jinja2 is None or env is None:
+        return frozenset()
+    try:
+        tree = env.parse(template)
+    except Exception:
+        return frozenset()
+    names: set[str] = set()
+    for node in tree.find_all((nodes.If, nodes.CondExpr)):
+        name = _truthiness_tested_name(node.test, nodes)
+        if name is not None:
+            names.add(name)
+    return frozenset(names)
+
+
+_TEMPLATE_THINKING_SWITCHES = ("reasoning",)
+
+
 def template_thinking_switch(
     template, *, tools: list[dict] | None = None
 ) -> str | None:
     """Name of a template's own on/off thinking variable when it is not
-    ``enable_thinking``.
+    ``enable_thinking``; ``None`` when the template has no such switch.
 
-    Cohere's North Mini Code template never consults ``enable_thinking``; it
-    reads a boolean ``reasoning`` (default on, also driven by
-    ``reasoning_effort == "none"``) and seeds an empty thinking block when it
-    is false. A template that reads ``enable_thinking`` keeps that switch and
-    yields ``None`` here even if it also reads ``reasoning``.
+    Recognised switches: ``reasoning`` (Cohere's convention; North Mini Code
+    never consults ``enable_thinking``, reads a boolean ``reasoning`` that
+    defaults to on or to ``reasoning_effort != "none"``, and seeds an empty
+    thinking block when it is false). A name is a switch only when the
+    template both reads it from the render context and branches on it as a
+    plain boolean somewhere; a template that renders ``{{ reasoning }}`` as
+    data or only asks ``reasoning is defined`` is left alone. A template that
+    reads ``enable_thinking`` keeps that switch and yields ``None`` even if it
+    also reads a recognised name.
     """
     for source in _chat_template_strings(template, tools=tools):
         reads = _template_context_reads_for_source(source)
         if "enable_thinking" in reads:
             return None
-        if "reasoning" in reads:
-            return "reasoning"
+        tested = _template_truthiness_tests_for_source(source)
+        for switch in _TEMPLATE_THINKING_SWITCHES:
+            if switch in reads and switch in tested:
+                return switch
     return None
 
 
@@ -1965,9 +2005,10 @@ def apply_chat_template(
     # (Cohere North Mini Code reads ``reasoning``, default on): a resolved off
     # flag becomes that switch, so Desktop's default and ``rapid-mlx chat``
     # without ``--think`` actually turn reasoning off (#3045). Detection is
-    # template-driven (the variables the template reads), not a model-name
-    # match. A client that already passed the switch or ``reasoning_effort``
-    # (the template derives ``reasoning`` from ``"none"``) keeps control.
+    # template-driven (the template reads the name from its context and
+    # branches on it as a boolean), not a model-name match. A client that
+    # already passed the switch or ``reasoning_effort`` (the template derives
+    # ``reasoning`` from ``"none"``) keeps control.
     if enable_thinking is False and "reasoning_effort" not in template_kwargs:
         switch = template_thinking_switch(
             getattr(template_applicator, "chat_template", None), tools=tools

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1666,9 +1666,14 @@ def _context_reads(
         _record_truthiness_test(node.test, bound, nodes, tests)
         _context_reads(node.test, bound, nodes, reads, tests)
         after = [_context_reads_all(node.body, bound, nodes, reads, tests)]
-        after.extend(
-            _context_reads(branch, bound, nodes, reads, tests) for branch in node.elif_
-        )
+        # Jinja stores each ``elif`` as an ``If`` node whose ``else_`` is
+        # empty, while the chain's real ``else`` stays on the outer node.
+        # Recursing into each branch would therefore add a fake fallthrough
+        # path and lose bindings made by every real arm of the chain.
+        for branch in node.elif_:
+            _record_truthiness_test(branch.test, bound, nodes, tests)
+            _context_reads(branch.test, bound, nodes, reads, tests)
+            after.append(_context_reads_all(branch.body, bound, nodes, reads, tests))
         after.append(_context_reads_all(node.else_, bound, nodes, reads, tests))
         return frozenset.intersection(*after)
     if isinstance(node, nodes.Macro):

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1549,6 +1549,116 @@ def _native_reasoning_effort_levels_for_source(template: str) -> tuple[str, ...]
     return _walk_for_validation(tree.body, {"reasoning_effort"}, set(), nodes)
 
 
+def _context_reads(
+    node, bound: frozenset[str], nodes, reads: set[str]
+) -> frozenset[str]:
+    """Collect the names ``node`` reads from the render context into ``reads``.
+
+    Walks in evaluation order with Jinja scoping: a ``set`` binds its target
+    only after its value is evaluated (so North's
+    ``set reasoning = reasoning if reasoning is not undefined else ...`` is a
+    context read), loop targets and macro / call-block arguments shadow the
+    context inside their body only, and a name bound in only some branches of
+    an ``if`` stays a context read afterwards. Attribute access
+    (``message.reasoning``) is never a context read. Returns the names bound
+    once ``node`` has run.
+    """
+    if isinstance(node, nodes.Name):
+        if node.ctx == "load" and node.name not in bound:
+            reads.add(node.name)
+        return bound
+    if isinstance(node, nodes.Assign):
+        _context_reads(node.node, bound, nodes, reads)
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, nodes.AssignBlock):
+        _context_reads_all(node.body, bound, nodes, reads)
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, nodes.For):
+        _context_reads(node.iter, bound, nodes, reads)
+        inner = bound | _bound_names(node, nodes)
+        if node.test is not None:
+            _context_reads(node.test, inner, nodes, reads)
+        _context_reads_all(node.body, inner, nodes, reads)
+        _context_reads_all(node.else_, bound, nodes, reads)
+        return bound
+    if isinstance(node, nodes.If):
+        _context_reads(node.test, bound, nodes, reads)
+        after = [_context_reads_all(node.body, bound, nodes, reads)]
+        after.extend(
+            _context_reads(branch, bound, nodes, reads) for branch in node.elif_
+        )
+        after.append(_context_reads_all(node.else_, bound, nodes, reads))
+        return frozenset.intersection(*after)
+    if isinstance(node, (nodes.Macro, nodes.CallBlock)):
+        for default in node.defaults:
+            _context_reads(default, bound, nodes, reads)
+        if isinstance(node, nodes.CallBlock):
+            _context_reads(node.call, bound, nodes, reads)
+        _context_reads_all(
+            node.body, bound | {arg.name for arg in node.args}, nodes, reads
+        )
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, (nodes.Import, nodes.FromImport)):
+        _context_reads(node.template, bound, nodes, reads)
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, nodes.With):
+        for value in node.values:
+            _context_reads(value, bound, nodes, reads)
+        _context_reads_all(node.body, bound | _bound_names(node, nodes), nodes, reads)
+        return bound
+    # Anything else (output, expressions, with/filter/scope blocks): evaluate
+    # the children in order; bindings made inside stay inside.
+    inner = bound | _bound_names(node, nodes)
+    for child in node.iter_child_nodes():
+        inner = _context_reads(child, inner, nodes, reads)
+    return bound
+
+
+def _context_reads_all(
+    stmts, bound: frozenset[str], nodes, reads: set[str]
+) -> frozenset[str]:
+    for stmt in stmts:
+        bound = _context_reads(stmt, bound, nodes, reads)
+    return bound
+
+
+@functools.lru_cache(maxsize=64)
+def _template_context_reads_for_source(template: str) -> frozenset[str]:
+    """Names a template reads from its render context (see ``_context_reads``)."""
+    jinja2, nodes = _jinja_nodes()
+    env = _template_parser()
+    if jinja2 is None or env is None:
+        return frozenset()
+    try:
+        tree = env.parse(template)
+    except Exception:
+        return frozenset()
+    reads: set[str] = set()
+    _context_reads_all(tree.body, frozenset(), nodes, reads)
+    return frozenset(reads)
+
+
+def template_thinking_switch(
+    template, *, tools: list[dict] | None = None
+) -> str | None:
+    """Name of a template's own on/off thinking variable when it is not
+    ``enable_thinking``.
+
+    Cohere's North Mini Code template never consults ``enable_thinking``; it
+    reads a boolean ``reasoning`` (default on, also driven by
+    ``reasoning_effort == "none"``) and seeds an empty thinking block when it
+    is false. A template that reads ``enable_thinking`` keeps that switch and
+    yields ``None`` here even if it also reads ``reasoning``.
+    """
+    for source in _chat_template_strings(template, tools=tools):
+        reads = _template_context_reads_for_source(source)
+        if "enable_thinking" in reads:
+            return None
+        if "reasoning" in reads:
+            return "reasoning"
+    return None
+
+
 def detect_native_reasoning_effort_levels(
     template, *, tools: list[dict] | None = None
 ) -> tuple[str, ...] | None:
@@ -1850,6 +1960,20 @@ def apply_chat_template(
         )
     ):
         template_kwargs.setdefault("reasoning_effort", "low")
+
+    # Templates with their own boolean switch and no ``enable_thinking``
+    # (Cohere North Mini Code reads ``reasoning``, default on): a resolved off
+    # flag becomes that switch, so Desktop's default and ``rapid-mlx chat``
+    # without ``--think`` actually turn reasoning off (#3045). Detection is
+    # template-driven (the variables the template reads), not a model-name
+    # match. A client that already passed the switch or ``reasoning_effort``
+    # (the template derives ``reasoning`` from ``"none"``) keeps control.
+    if enable_thinking is False and "reasoning_effort" not in template_kwargs:
+        switch = template_thinking_switch(
+            getattr(template_applicator, "chat_template", None), tools=tools
+        )
+        if switch is not None:
+            template_kwargs.setdefault(switch, False)
 
     # Hy3 chat_template.jinja defaults ``reasoning_effort=no_think`` which
     # empirically returns "France" instead of "Paris" on factual-recall

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1549,95 +1549,6 @@ def _native_reasoning_effort_levels_for_source(template: str) -> tuple[str, ...]
     return _walk_for_validation(tree.body, {"reasoning_effort"}, set(), nodes)
 
 
-def _context_reads(
-    node, bound: frozenset[str], nodes, reads: set[str]
-) -> frozenset[str]:
-    """Collect the names ``node`` reads from the render context into ``reads``.
-
-    Walks in evaluation order with Jinja scoping: a ``set`` binds its target
-    only after its value is evaluated (so North's
-    ``set reasoning = reasoning if reasoning is not undefined else ...`` is a
-    context read), loop targets and macro / call-block arguments shadow the
-    context inside their body only, and a name bound in only some branches of
-    an ``if`` stays a context read afterwards. Attribute access
-    (``message.reasoning``) is never a context read. Returns the names bound
-    once ``node`` has run.
-    """
-    if isinstance(node, nodes.Name):
-        if node.ctx == "load" and node.name not in bound:
-            reads.add(node.name)
-        return bound
-    if isinstance(node, nodes.Assign):
-        _context_reads(node.node, bound, nodes, reads)
-        return bound | _bound_names(node, nodes)
-    if isinstance(node, nodes.AssignBlock):
-        _context_reads_all(node.body, bound, nodes, reads)
-        return bound | _bound_names(node, nodes)
-    if isinstance(node, nodes.For):
-        _context_reads(node.iter, bound, nodes, reads)
-        inner = bound | _bound_names(node, nodes)
-        if node.test is not None:
-            _context_reads(node.test, inner, nodes, reads)
-        _context_reads_all(node.body, inner, nodes, reads)
-        _context_reads_all(node.else_, bound, nodes, reads)
-        return bound
-    if isinstance(node, nodes.If):
-        _context_reads(node.test, bound, nodes, reads)
-        after = [_context_reads_all(node.body, bound, nodes, reads)]
-        after.extend(
-            _context_reads(branch, bound, nodes, reads) for branch in node.elif_
-        )
-        after.append(_context_reads_all(node.else_, bound, nodes, reads))
-        return frozenset.intersection(*after)
-    if isinstance(node, (nodes.Macro, nodes.CallBlock)):
-        for default in node.defaults:
-            _context_reads(default, bound, nodes, reads)
-        if isinstance(node, nodes.CallBlock):
-            _context_reads(node.call, bound, nodes, reads)
-        _context_reads_all(
-            node.body, bound | {arg.name for arg in node.args}, nodes, reads
-        )
-        return bound | _bound_names(node, nodes)
-    if isinstance(node, (nodes.Import, nodes.FromImport)):
-        _context_reads(node.template, bound, nodes, reads)
-        return bound | _bound_names(node, nodes)
-    if isinstance(node, nodes.With):
-        for value in node.values:
-            _context_reads(value, bound, nodes, reads)
-        _context_reads_all(node.body, bound | _bound_names(node, nodes), nodes, reads)
-        return bound
-    # Anything else (output, expressions, with/filter/scope blocks): evaluate
-    # the children in order; bindings made inside stay inside.
-    inner = bound | _bound_names(node, nodes)
-    for child in node.iter_child_nodes():
-        inner = _context_reads(child, inner, nodes, reads)
-    return bound
-
-
-def _context_reads_all(
-    stmts, bound: frozenset[str], nodes, reads: set[str]
-) -> frozenset[str]:
-    for stmt in stmts:
-        bound = _context_reads(stmt, bound, nodes, reads)
-    return bound
-
-
-@functools.lru_cache(maxsize=64)
-def _template_context_reads_for_source(template: str) -> frozenset[str]:
-    """Names a template reads from its render context (see ``_context_reads``)."""
-    jinja2, nodes = _jinja_nodes()
-    env = _template_parser()
-    if jinja2 is None or env is None:
-        return frozenset()
-    try:
-        tree = env.parse(template)
-    except Exception:
-        return frozenset()
-    reads: set[str] = set()
-    _context_reads_all(tree.body, frozenset(), nodes, reads)
-    return frozenset(reads)
-
-
 def _truthiness_tested_name(test, nodes) -> str | None:
     """The variable a bare ``{% if x %}`` / ``{% if not x %}`` / ``a if x else b`` tests."""
     if isinstance(test, nodes.Not):
@@ -1647,26 +1558,152 @@ def _truthiness_tested_name(test, nodes) -> str | None:
     return None
 
 
+def _is_definedness_test(expr, name: str, nodes) -> bool:
+    if isinstance(expr, nodes.Not):
+        expr = expr.node
+    return bool(
+        isinstance(expr, nodes.Test)
+        and expr.name in ("defined", "undefined", "none")
+        and isinstance(expr.node, nodes.Name)
+        and expr.node.name == name
+    )
+
+
+def _carries_context_value(expr, name: str, nodes) -> bool:
+    """Whether ``{% set name = expr %}`` keeps the context value of ``name``.
+
+    True for the idioms templates use to give a context variable a default:
+    ``name``, ``name | default(...)`` and ``name if name is (not) defined /
+    undefined else ...`` (either arm). Any other value is a fresh local.
+    """
+    if isinstance(expr, nodes.Name):
+        return bool(expr.ctx == "load" and expr.name == name)
+    if isinstance(expr, nodes.Filter) and expr.name == "default":
+        return _carries_context_value(expr.node, name, nodes)
+    if isinstance(expr, nodes.CondExpr) and _is_definedness_test(
+        expr.test, name, nodes
+    ):
+        return _carries_context_value(expr.expr1, name, nodes) or (
+            expr.expr2 is not None and _carries_context_value(expr.expr2, name, nodes)
+        )
+    return False
+
+
+def _context_reads(
+    node, bound: frozenset[str], nodes, reads: set[str], tests: set[str]
+) -> frozenset[str]:
+    """Collect the names ``node`` reads from the render context into ``reads``
+    and the ones it branches on as plain booleans while unbound into ``tests``.
+
+    Walks in evaluation order with Jinja scoping: a ``set`` binds its target
+    only after its value is evaluated, loop targets and macro / call-block
+    arguments shadow the context inside their body only, and a name bound
+    in only some branches of an ``if`` stays a context read afterwards. A
+    value-preserving self-rebinding (``set x = x | default(...)``, North's
+    ``set reasoning = reasoning if reasoning is not undefined else ...``)
+    does not shadow: the local still carries the context value, so a later
+    ``{% if reasoning %}`` is a test of the context knob. Attribute access
+    (``message.reasoning``) is never a context read. Returns the names bound
+    once ``node`` has run.
+    """
+    if isinstance(node, nodes.Name):
+        if node.ctx == "load" and node.name not in bound:
+            reads.add(node.name)
+        return bound
+    if isinstance(node, nodes.Assign):
+        _context_reads(node.node, bound, nodes, reads, tests)
+        target = node.target
+        if (
+            isinstance(target, nodes.Name)
+            and target.name not in bound
+            and _carries_context_value(node.node, target.name, nodes)
+        ):
+            return bound
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, nodes.AssignBlock):
+        _context_reads_all(node.body, bound, nodes, reads, tests)
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, nodes.For):
+        _context_reads(node.iter, bound, nodes, reads, tests)
+        inner = bound | _bound_names(node, nodes)
+        if node.test is not None:
+            _context_reads(node.test, inner, nodes, reads, tests)
+        _context_reads_all(node.body, inner, nodes, reads, tests)
+        _context_reads_all(node.else_, bound, nodes, reads, tests)
+        return bound
+    if isinstance(node, nodes.If):
+        _record_truthiness_test(node.test, bound, nodes, tests)
+        _context_reads(node.test, bound, nodes, reads, tests)
+        after = [_context_reads_all(node.body, bound, nodes, reads, tests)]
+        after.extend(
+            _context_reads(branch, bound, nodes, reads, tests) for branch in node.elif_
+        )
+        after.append(_context_reads_all(node.else_, bound, nodes, reads, tests))
+        return frozenset.intersection(*after)
+    if isinstance(node, (nodes.Macro, nodes.CallBlock)):
+        for default in node.defaults:
+            _context_reads(default, bound, nodes, reads, tests)
+        if isinstance(node, nodes.CallBlock):
+            _context_reads(node.call, bound, nodes, reads, tests)
+        _context_reads_all(
+            node.body, bound | {arg.name for arg in node.args}, nodes, reads, tests
+        )
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, (nodes.Import, nodes.FromImport)):
+        _context_reads(node.template, bound, nodes, reads, tests)
+        return bound | _bound_names(node, nodes)
+    if isinstance(node, nodes.With):
+        for value in node.values:
+            _context_reads(value, bound, nodes, reads, tests)
+        _context_reads_all(
+            node.body, bound | _bound_names(node, nodes), nodes, reads, tests
+        )
+        return bound
+    if isinstance(node, nodes.CondExpr):
+        _record_truthiness_test(node.test, bound, nodes, tests)
+    # Anything else (output, expressions, filter/scope blocks): evaluate the
+    # children in order; bindings made inside stay inside.
+    inner = bound | _bound_names(node, nodes)
+    for child in node.iter_child_nodes():
+        inner = _context_reads(child, inner, nodes, reads, tests)
+    return bound
+
+
+def _record_truthiness_test(
+    test, bound: frozenset[str], nodes, tests: set[str]
+) -> None:
+    name = _truthiness_tested_name(test, nodes)
+    if name is not None and name not in bound:
+        tests.add(name)
+
+
+def _context_reads_all(
+    stmts, bound: frozenset[str], nodes, reads: set[str], tests: set[str]
+) -> frozenset[str]:
+    for stmt in stmts:
+        bound = _context_reads(stmt, bound, nodes, reads, tests)
+    return bound
+
+
 @functools.lru_cache(maxsize=64)
-def _template_truthiness_tests_for_source(template: str) -> frozenset[str]:
-    """Names a template branches on as plain booleans (``if x``, ``if not x``,
-    ``... if x else ...``). ``x is defined``, ``x == "y"`` or ``x.flag`` do
-    not count: those consume ``x`` as something other than an on/off switch.
+def _template_context_facts_for_source(
+    template: str,
+) -> tuple[frozenset[str], frozenset[str]]:
+    """``(names read from the render context, names branched on as plain
+    booleans while carrying the context value)``; see ``_context_reads``.
     """
     jinja2, nodes = _jinja_nodes()
     env = _template_parser()
     if jinja2 is None or env is None:
-        return frozenset()
+        return frozenset(), frozenset()
     try:
         tree = env.parse(template)
     except Exception:
-        return frozenset()
-    names: set[str] = set()
-    for node in tree.find_all((nodes.If, nodes.CondExpr)):
-        name = _truthiness_tested_name(node.test, nodes)
-        if name is not None:
-            names.add(name)
-    return frozenset(names)
+        return frozenset(), frozenset()
+    reads: set[str] = set()
+    tests: set[str] = set()
+    _context_reads_all(tree.body, frozenset(), nodes, reads, tests)
+    return frozenset(reads), frozenset(tests)
 
 
 _TEMPLATE_THINKING_SWITCHES = ("reasoning",)
@@ -1682,17 +1719,19 @@ def template_thinking_switch(
     never consults ``enable_thinking``, reads a boolean ``reasoning`` that
     defaults to on or to ``reasoning_effort != "none"``, and seeds an empty
     thinking block when it is false). A name is a switch only when the
-    template both reads it from the render context and branches on it as a
-    plain boolean somewhere; a template that renders ``{{ reasoning }}`` as
-    data or only asks ``reasoning is defined`` is left alone. A template that
-    reads ``enable_thinking`` keeps that switch and yields ``None`` even if it
-    also reads a recognised name.
+    template reads it from the render context and branches on it as a plain
+    boolean while it still carries the context value (a value-preserving
+    ``set reasoning = reasoning if reasoning is not undefined else ...``
+    keeps it; ``set reasoning = true`` makes the later branch a local one).
+    A template that renders ``{{ reasoning }}`` as data or only asks
+    ``reasoning is defined`` is left alone. A template that reads
+    ``enable_thinking`` keeps that switch and yields ``None`` even if it also
+    reads a recognised name.
     """
     for source in _chat_template_strings(template, tools=tools):
-        reads = _template_context_reads_for_source(source)
+        reads, tested = _template_context_facts_for_source(source)
         if "enable_thinking" in reads:
             return None
-        tested = _template_truthiness_tests_for_source(source)
         for switch in _TEMPLATE_THINKING_SWITCHES:
             if switch in reads and switch in tested:
                 return switch

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1669,17 +1669,12 @@ def _context_reads(
                 pass
         if node.test is not None:
             _context_reads(node.test, inner, nodes, reads, body_tests)
-        has_loop_control = any(
-            isinstance(stmt, (nodes.Break, nodes.Continue))
-            or any(stmt.find_all((nodes.Break, nodes.Continue)))
-            for stmt in node.body
-        )
         _context_reads_all(
             node.body,
             inner,
             nodes,
             reads,
-            tests if body_proven_nonempty and not has_loop_control else body_tests,
+            tests if body_proven_nonempty else body_tests,
         )
         # A loop ``else`` can establish a switch only when an unfiltered
         # iterable is statically known to be empty.  Dynamic iteration may
@@ -1811,11 +1806,43 @@ def _constant_truthiness(expr, nodes) -> bool | None:
         return None
 
 
+def _block_guarantees_loop_exit(stmts, nodes) -> bool:
+    """Whether sequential statements must reach a break or continue."""
+    return any(_stmt_guarantees_loop_exit(stmt, nodes) for stmt in stmts)
+
+
+def _stmt_guarantees_loop_exit(stmt, nodes) -> bool:
+    """Whether a statement exits its containing loop on every live path."""
+    if isinstance(stmt, (nodes.Break, nodes.Continue)):
+        return True
+    if isinstance(stmt, nodes.If):
+        exits: list[bool] = []
+        fallthrough_possible = True
+        for branch in [stmt, *stmt.elif_]:
+            if not fallthrough_possible:
+                break
+            truth = _constant_truthiness(branch.test, nodes)
+            if truth is not False:
+                exits.append(_block_guarantees_loop_exit(branch.body, nodes))
+            if truth is True:
+                fallthrough_possible = False
+        if fallthrough_possible:
+            exits.append(_block_guarantees_loop_exit(stmt.else_, nodes))
+        return bool(exits) and all(exits)
+    if isinstance(stmt, nodes.With):
+        return _block_guarantees_loop_exit(stmt.body, nodes)
+    return False
+
+
 def _context_reads_all(
     stmts, bound: frozenset[str], nodes, reads: set[str], tests: set[str]
 ) -> frozenset[str]:
+    active_tests = tests
+    deferred_tests: set[str] = set()
     for stmt in stmts:
-        bound = _context_reads(stmt, bound, nodes, reads, tests)
+        bound = _context_reads(stmt, bound, nodes, reads, active_tests)
+        if _stmt_guarantees_loop_exit(stmt, nodes):
+            active_tests = deferred_tests
     return bound
 
 

--- a/vllm_mlx/utils/chat_template.py
+++ b/vllm_mlx/utils/chat_template.py
@@ -1659,28 +1659,37 @@ def _context_reads(
         inner = bound | _bound_names(node, nodes)
         body_tests: set[str] = set()
         body_proven_nonempty = False
+        else_proven = False
         if node.test is None:
             try:
-                body_proven_nonempty = bool(node.iter.as_const())
+                iterator_nonempty = bool(node.iter.as_const())
+                body_proven_nonempty = iterator_nonempty
+                else_proven = not iterator_nonempty
             except Exception:
                 pass
         if node.test is not None:
             _context_reads(node.test, inner, nodes, reads, body_tests)
+        has_loop_control = any(
+            isinstance(stmt, (nodes.Break, nodes.Continue))
+            or any(stmt.find_all((nodes.Break, nodes.Continue)))
+            for stmt in node.body
+        )
         _context_reads_all(
             node.body,
             inner,
             nodes,
             reads,
-            body_tests,
+            tests if body_proven_nonempty and not has_loop_control else body_tests,
         )
-        # A loop ``else`` is dead only when an unfiltered iterable is
-        # statically known to contain at least one item.
+        # A loop ``else`` can establish a switch only when an unfiltered
+        # iterable is statically known to be empty.  Dynamic iteration may
+        # skip the else path for the current render.
         _context_reads_all(
             node.else_,
             bound,
             nodes,
             reads,
-            body_tests if body_proven_nonempty else tests,
+            tests if else_proven else body_tests,
         )
         return bound
     if isinstance(node, nodes.If):


### PR DESCRIPTION
Closes #3045. **Stacked on #3048** (the branch builds on `feat/3043-qwen38-native-reasoning-effort` and reuses its Jinja parser helpers). The PR targets `main` so CI runs; until #3048 merges the GitHub diff also shows #3048's commits, and it shrinks to this change alone once #3048 lands. Merge order: #3048 → this.

## Problem

Cohere's North Mini Code chat template never reads `enable_thinking`. Its switch is a boolean `reasoning` (`{%- set reasoning = reasoning if reasoning is not undefined else (false if reasoning_effort is defined and reasoning_effort | lower == "none" else true) %}`), and the generation prompt seeds `<|START_THINKING|><|END_THINKING|>` when it is false. Every way rapid-mlx turns thinking off resolves to `enable_thinking=False` (Desktop's default toggle sends `chat_template_kwargs.enable_thinking=false`, `rapid-mlx chat` without `--think`, `reasoning_effort: none`, the tool / casual-chat auto-disable gates), and North silently ignored all of them. The only working knob was the undocumented `chat_template_kwargs.reasoning=false`.

## Fix

`apply_chat_template` maps a resolved `enable_thinking=False` onto the template's own switch:

- `template_thinking_switch(template)` returns `"reasoning"` when the template reads `reasoning` from its render context **and** branches on it as a plain boolean (`{% if reasoning %}`, `{% if not reasoning %}`, `a if reasoning else b`) while it still carries the context value, and never reads `enable_thinking`; otherwise `None`. Both facts come from one scoped walk: North's `set reasoning = reasoning if reasoning is not undefined else …` (and the `x | default(...)` idiom) is a value-preserving self-rebinding that keeps the name a context knob, judged for a defined `False` specifically: the conditional's arm taken when the value is defined must carry the name, and `default(..., true)` / `boolean=true` (which replace a defined `False`) do not count; `set reasoning = true` or any other rebinding makes the later branch a local one. `reasoning` is the only recognised switch name (Cohere's convention). A template that renders `{{ reasoning }}` as data, only asks `reasoning is defined`, compares it to a value or branches on `reasoning.flag` is left alone. Templates that read `enable_thinking` (Qwen, Gemma, …) are untouched, GPT-OSS keeps its existing `reasoning_effort="low"` path.
- The reads come from the Jinja AST in evaluation order with Jinja scoping (`_context_reads`): `{% set x = <value> %}` binds only after its value is evaluated (so North's own line is a context read), `for` targets / macro and call-block arguments / `with` bindings shadow the context inside their body only, a name bound in only some `if` branches stays a context read, `message.reasoning` is attribute access and never counts. Model-name matching is not involved; a template that assigns `reasoning` before reading it is its own local and gets nothing.
- Precedence: a request that already passes the switch or `reasoning_effort` in `chat_template_kwargs` keeps control (`setdefault`, and the template derives `reasoning` from `reasoning_effort == "none"` itself).

Sweep of the 34 chat templates in this host's HF cache: only North reads `reasoning`; none of the others changes behaviour.

## Test plan

- `tests/test_template_thinking_switch.py` (new, 66 tests, no MLX): context-read semantics (North's line, macro defaults, loop filter, `with` values, partial `if` binding, nested expressions read; attribute access, loop / macro / call-block / `with` / import bindings, template-local and block assignment, both-branch binding not read), switch detection (bare / negated / conditional-expression / `elif` boolean tests and North's definedness-guarded or `default`-filtered self-rebinding are a switch; data use, `is defined`, comparison, compound condition, attribute branch, local / loop-variable / macro-argument branch, data read followed by a local rebinding, non-preserving rebindings are not; unparseable input, no jinja2), `apply_chat_template` on the verbatim North clauses (off flag → empty thinking block, on / unset → template default, Desktop request shape, explicit `reasoning` and `reasoning_effort` win), and unrelated templates (`enable_thinking` template gets no `reasoning` kwarg, Harmony-style template keeps the `low` path).
- Reproduction: on the base commit the same rendering with `enable_thinking=False` ends in `<|START_THINKING|>` (thinking on); with the fix it ends in `<|START_THINKING|><|END_THINKING|>`.
- Related suites green: `test_native_reasoning_effort_levels.py`, `test_chat_template_kwargs_passthrough.py`, `test_reasoning_effort_translation.py`, `test_casual_chat_auto_disable_thinking.py` (317 tests together with the new file).
- Local gate replicas: changed-lines coverage 100% (`diff-cover` against the base branch); mypy error count on `vllm_mlx/utils/chat_template.py` unchanged (13 → 13, repo total 308 → 308).
- Real server e2e on M3 Ultra, `north-mini-code-4bit` (`mlx-community/North-Mini-Code-1.0-4bit`), served from this worktree, `temperature=0`, prompt "Write a Python one-liner that reverses a string. Reply with just the code.":

| request | base branch (89dadf7a9) | this PR |
|---|---|---|
| Desktop default `chat_template_kwargs.enable_thinking=false` | reasoning 1493 chars, 436 completion tokens | reasoning empty, 7 tokens, content `s[::-1]` |
| same, streaming | – | 6 chunks, no reasoning deltas, content `s[::-1]` |
| top-level `enable_thinking: false` | – | reasoning empty, 7 tokens |
| `reasoning_effort: "none"` | reasoning 1493 chars, 436 tokens | reasoning empty, 7 tokens |
| no flag (casual-chat auto-disable gate fires) | reasoning 1493 chars, 436 tokens | reasoning empty, 7 tokens |
| `chat_template_kwargs.enable_thinking=true` (`--think`) | – | reasoning 1493 chars, content `reverse = lambda s: s[::-1]`, 436 tokens (unchanged path) |
| `chat_template_kwargs.reasoning=false` (old workaround) | reasoning empty, 7 tokens | reasoning empty, 7 tokens |
| `enable_thinking=false` + `chat_template_kwargs.reasoning=true` | – | reasoning on (client switch wins) |

Post-merge follow-up: none required; the release notes for the next version get a line from the docs PR.

## Docs

`docs/guides/reasoning.md`: one paragraph under `reasoning_effort` on templates that branch on their own `reasoning` switch (the only recognised name).

## Review rounds

- codex r1: BLOCKING — any unbound read of `reasoning` counted as a switch. Fixed: a switch now also needs a plain boolean branch on the name; data / `is defined` / comparison / attribute uses are excluded (7 new negative cases, 5 positive). NIT — docs claimed a broader capability than the single recognised name; wording narrowed.
- codex r2: BLOCKING — boolean tests were collected without scope and intersected with the global read set, so `{{ reasoning }}{% set reasoning = true %}{% if reasoning %}` was a switch. Fixed: tests are recorded inside the same scoped walk, only while the name is unbound or rebound by a value-preserving self-assignment (6 new negative cases, 4 positive).
- codex r3: BLOCKING ×2 — `default(d, true)` replaces a defined `False` and a conditional's arm was accepted without matching the definedness test. Fixed: `default` counts only without the `boolean` flag (or with a literal `false`), and the conditional must carry the name on the arm taken for a defined value (`defined` / `undefined` / `none` and negations resolved). 6 negative and 4 positive cases added.
- codex r4: BLOCKING — a dict template whose first selected source reads `reasoning` and a later one reads `enable_thinking` would return the switch early. `_chat_template_strings` selects a single source, so this is unreachable today; the loop now aggregates the facts of every selected source before deciding, and a two-source ordering test (monkeypatched selection) pins the rule.
