### PR TITLE
perf(qwen4): add opt-in block-sparse QSA prefill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,7 @@ jobs:
             tests/test_routing_groups_0131.py \
             tests/test_qwen4_exp_vendored.py \
             tests/test_qwen4_fused_gdn_decode.py \
+            tests/test_qsa_block_sparse.py \
             tests/test_mtp_cli_wiring.py \
             tests/test_continuous_mtp_routing.py \
             tests/test_continuous_self_mtp_mlx_backend.py \

--- a/.orca/flash-next-eval/benchmark.py
+++ b/.orca/flash-next-eval/benchmark.py
@@ -3,7 +3,8 @@
 
 Prompt construction and SSE accounting reuse ``scripts/bench_service_prefill.py``:
 exact tokenizer-counted prompts, first-visible-token TTFT, and server-reported
-token counts. Each context length is cold-cache, 256 decode tokens, three runs.
+token counts. Each requested context length is cold-cache, with a fixed decode
+budget and repetition count shared by every arm of a comparison.
 """
 
 from __future__ import annotations
@@ -138,14 +139,17 @@ def main() -> int:
     args = parser.parse_args()
 
     lengths = [int(value) for value in args.prompt_tokens.split(",")]
-    if lengths != [128, 2048, 8192, 32768]:
-        raise ValueError(
-            "launch methodology requires prompt lengths 128,2048,8192,32768"
-        )
-    if args.runs != 3 or args.decode_tokens != 256:
-        raise ValueError("launch methodology requires 3 runs and 256 decode tokens")
+    if not lengths or any(value <= 0 for value in lengths):
+        raise ValueError("prompt lengths must be positive integers")
+    if lengths != sorted(set(lengths)):
+        raise ValueError("prompt lengths must be unique and increasing")
+    if args.runs < 1 or args.decode_tokens < 1:
+        raise ValueError("runs and decode tokens must be positive")
     if args.dry_run:
-        print("READY: 4 prompt lengths x 3 cold-cache runs x 256 decode tokens")
+        print(
+            f"READY: {len(lengths)} prompt lengths x {args.runs} cold-cache runs "
+            f"x {args.decode_tokens} decode tokens"
+        )
         return 0
 
     from transformers import AutoTokenizer

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -15,13 +15,16 @@ for each MLX build before changing the default.
 
 ## Production-path contract
 
-Each QSA attention layer records cumulative `kernel_calls`, `declines`, and a
-complete `decline_reasons` histogram. `qwen4_qsa_block_sparse_stats(model)`
-aggregates the receipt without evaluating MLX arrays. Eligibility declines fail
-closed to dense attention. MLX kernel execution is lazy, so construction and
-execution errors surface through the engine's normal generation-error path;
-the route deliberately does not synchronize every layer to simulate an
-execution-time fallback.
+Each QSA attention layer records cumulative `route_constructions`, `declines`,
+and a complete `decline_reasons` histogram.
+`qwen4_qsa_block_sparse_stats(model)` aggregates the receipt without evaluating
+MLX arrays. A route construction proves selection of the sparse graph, not its
+successful execution; qualification must pair a positive construction delta
+with successful downstream request completion. Eligibility declines fail closed
+to dense attention. MLX kernel execution is lazy, so construction and execution
+errors surface through the engine's normal generation-error path; the route
+deliberately does not synchronize every layer to simulate an execution-time
+fallback.
 
 The Metal kernel clamps compact counts to their buffer capacities and skips
 out-of-range block starts and tail indices before reading K/V. Production inputs
@@ -167,5 +170,6 @@ than an exact-head promotion gate.
 The served campaign now supplies settled wall-time and peak-memory
 evidence at 16K, 32K, and 64K. Before automatic enablement, still require a
 fresh model-scale correctness comparison on the pinned release dependency
-build, the expected nonzero kernel-call count, and no unexpected decline
-reasons. Keep the feature opt-in while any of those requirements is missing.
+build, the expected nonzero route-construction delta paired with successful
+request completion, and no unexpected decline reasons. Keep the feature opt-in
+while any of those requirements is missing.

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -30,6 +30,9 @@ internal state from turning into an out-of-bounds GPU read without imposing a
 host synchronization. Before count-based dispatch, invalid compact entries are
 replaced with an out-of-range sentinel and sorted behind the valid prefix, so a
 future validity hole cannot substitute a padded index for a selected block.
+Block validity is represented structurally as one bit per complete block, while
+the incomplete tail retains per-token validity; a partially valid complete
+block cannot be represented at this boundary.
 
 The existing fused-GDN receipt now also retains every fallback reason instead
 of only the most recent reason per layer. Its end-to-end gate subtracts the

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -36,8 +36,8 @@ can call it.
 - MLX / mlx-lm / NumPy: 0.32.1 / 0.31.3 / 2.5.2
 - Precision: bf16 performance geometry; fp16 inputs with an fp64 NumPy oracle
   for the numerical probe; TF32 disabled before importing MLX
-- Warmup / samples: two warmups and five interleaved sparse/dense observations;
-  three warmups and 100 synchronized dispatch-floor observations
+- Warmup / samples: two warmups before each of five interleaved sparse/dense
+  observations; three warmups before 100 synchronized dispatch-floor observations
 - Artifact: `/tmp/qsa-qualification-production.json`, SHA-256
   `3eedcab197d6609a83279cac40b2b4e0796a6c94a2b8d487c720d79eff2fd821`
 

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -77,13 +77,13 @@ The dispatch floor is about 12% of the sparse call at this smallest admitted
 production geometry. This supports a coarse long-context gate and rejects a
 design that would split the same work into many launches.
 
-## Exact-head served dogfood
+## Served dogfood
 
 A follow-up campaign exercised the OpenAI-compatible streaming route against the
 immutable 98 GB `rapid-mlx/Qwen3.8-Flash-Next-4bit` snapshot at revision
 `dcf657e4acda2aae72da99cde65b6c491cd96998`. The baseline was
-`d6c50526a85d50346af4126c1dca9f149aaa9fbe`; the candidate was the exact PR
-head `c7371139ad4aa0edf5eacc3922243e9c0db91e03`. Both arms used the same M3
+`d6c50526a85d50346af4126c1dca9f149aaa9fbe`; the candidate was the reviewed
+kernel head `c7371139ad4aa0edf5eacc3922243e9c0db91e03`. Both arms used the same M3
 Ultra, dependency environment, prompt bytes, three-run order, cold prefix
 cache, 16-token decode budget, and Metal command-buffer settings.
 
@@ -138,6 +138,18 @@ This campaign is a performance and memory receipt, not a new model-quality
 gate. The earlier five-path output comparison and the focused fp64/Metal tests
 remain the correctness evidence for this default-off path.
 
+The subsequent adversarial review added only device-side malformed-input
+guards and removed a synchronous exception fallback that could not catch MLX's
+lazy execution errors. On the resulting code head
+`f1ec82bbf3ad0f478e2ad59d0960c3a07f8f9b6e`, the same isolated production
+geometry measured 1.487 ms sparse versus 3.348 ms dense (2.25x), with the exact
+same numerical errors reported above. The artifact is
+`/private/tmp/qsa-qualification-safety-guards.json`, SHA-256
+`15d6354b039801c39c1e155c72a16ef9e43da6b4f6f793a2bd7d74a4c0fbeab5`.
+A final served rerun completed three 16K samples and one 32K sample at the
+expected rates before a Metal recovery invalidated the remaining process state;
+those partial samples are not merged into the complete table.
+
 ## Earlier end-to-end evidence and remaining limit
 
 The repository's earlier M3 Ultra full-model campaign measured a 32K prompt at
@@ -147,7 +159,7 @@ paths. That campaign used the same kernel design but predates this rebased
 integration and its complete path receipts, so it is supporting evidence rather
 than an exact-head promotion gate.
 
-The exact-head served campaign now supplies settled wall-time and peak-memory
+The served campaign now supplies settled wall-time and peak-memory
 evidence at 16K, 32K, and 64K. Before automatic enablement, still require a
 fresh model-scale correctness comparison on the pinned release dependency
 build, the expected nonzero kernel-call count, and no unexpected decline

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -69,7 +69,68 @@ The dispatch floor is about 12% of the sparse call at this smallest admitted
 production geometry. This supports a coarse long-context gate and rejects a
 design that would split the same work into many launches.
 
-## Existing end-to-end evidence and limits
+## Exact-head served dogfood
+
+A follow-up campaign exercised the OpenAI-compatible streaming route against the
+immutable 98 GB `rapid-mlx/Qwen3.8-Flash-Next-4bit` snapshot at revision
+`dcf657e4acda2aae72da99cde65b6c491cd96998`. The baseline was
+`d6c50526a85d50346af4126c1dca9f149aaa9fbe`; the candidate was the exact PR
+head `c7371139ad4aa0edf5eacc3922243e9c0db91e03`. Both arms used the same M3
+Ultra, dependency environment, prompt bytes, three-run order, cold prefix
+cache, 16-token decode budget, and Metal command-buffer settings.
+
+The 98 GB parameter materialization intermittently tripped the macOS Metal
+watchdog, including on some launches with conservative command-buffer limits.
+The retained pair set both `MLX_MAX_OPS_PER_BUFFER=10` and
+`MLX_MAX_MB_PER_BUFFER=10`; these are qualification controls applied equally to
+both arms, not product defaults or a proven general watchdog workaround.
+Contended attempts and one run invalidated by an unrelated concurrent MLX job
+and GPU recovery were discarded before the clean pair below. Each retained arm
+completed without a new GPU recovery.
+
+| Prompt target | Baseline TTFT | Sparse TTFT | TTFT change | Baseline prefill | Sparse prefill | Prefill change | Decode change | Peak RSS baseline / sparse |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 16K | 20.125 s | 20.321 s | -0.98% | 812.3 tok/s | 804.5 tok/s | -0.97% | +0.58% | 54.080 / 54.085 GiB |
+| 32K | 45.684 s | 39.159 s | +14.28% | 716.5 tok/s | 835.9 tok/s | +16.66% | -0.56% | 54.091 / 54.096 GiB |
+| 64K | 116.040 s | 79.950 s | +31.10% | 564.5 tok/s | 819.3 tok/s | +45.14% | +0.86% | 54.113 / 54.111 GiB |
+
+Values are medians except peak RSS, which is the maximum. The 32K and 64K
+TTFT improvements are large and settled across all three observations. The 16K
+result is effectively flat but slightly negative, supporting the conservative
+opt-in status rather than automatic promotion at the current 16K boundary. Any
+future default-on policy should re-measure and select a higher crossover if the
+16K result remains negative. Decode stayed within one percent and peak RSS
+within 0.005 GiB.
+
+The result artifacts were written outside the repository and hashed before the
+server was shut down:
+
+- baseline: `/private/tmp/qsa-served-base-d6c50526-caps10-clean.json`, SHA-256
+  `bf76f01400241dabdb3a658963cb0e257af52c7ac77f2171e5cffcdc19df14c0`
+- candidate: `/private/tmp/qsa-served-candidate-c7371139-caps10.json`, SHA-256
+  `2af75b3c2b7389705ecbe945fa3fa0b81c1d0b0b6e71eb5de465ed1f066d99a9`
+
+The served harness uses exact tokenizer-counted prompts, clears the prefix
+cache before each request, records first-visible-delta TTFT and server-reported
+token counts, and samples the recursive server-process RSS every 50 ms. Run
+each arm from its own worktree with the environment above, then invoke:
+
+```bash
+.venv/bin/python .orca/flash-next-eval/benchmark.py \
+  --url http://127.0.0.1:8465/v1 \
+  --model rapid-mlx/Qwen3.8-Flash-Next-4bit \
+  --tokenizer-path "$SNAPSHOT" --server-pid "$SERVER_PID" \
+  --label "$ARM" --runs 3 --decode-tokens 16 \
+  --prompt-tokens 16384,32768,65536 \
+  --artifact-revision dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --rapid-sha "$RAPID_SHA" --output "$RESULT_JSON" --timeout 240
+```
+
+This campaign is a performance and memory receipt, not a new model-quality
+gate. The earlier five-path output comparison and the focused fp64/Metal tests
+remain the correctness evidence for this default-off path.
+
+## Earlier end-to-end evidence and remaining limit
 
 The repository's earlier M3 Ultra full-model campaign measured a 32K prompt at
 523.4 to 579.2 prefill tokens/s (+10.7%) and 62.539 to 56.516 seconds TTFT,
@@ -78,8 +139,8 @@ paths. That campaign used the same kernel design but predates this rebased
 integration and its complete path receipts, so it is supporting evidence rather
 than an exact-head promotion gate.
 
-Before automatic enablement, rerun the full served route at 16K, 32K, and 64K
-on the pinned release dependency build. Require three or more settled paired
-observations, stable stock output, the expected nonzero kernel-call count, no
-unexpected decline reasons, peak-memory evidence, and the model-scale
-correctness gate. Keep the feature opt-in if any requirement is missing.
+The exact-head served campaign now supplies settled wall-time and peak-memory
+evidence at 16K, 32K, and 64K. Before automatic enablement, still require a
+fresh model-scale correctness comparison on the pinned release dependency
+build, the expected nonzero kernel-call count, and no unexpected decline
+reasons. Keep the feature opt-in while any of those requirements is missing.

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -17,9 +17,17 @@ for each MLX build before changing the default.
 
 Each QSA attention layer records cumulative `kernel_calls`, `declines`, and a
 complete `decline_reasons` histogram. `qwen4_qsa_block_sparse_stats(model)`
-aggregates the receipt without evaluating MLX arrays. Synchronous construction
-or dispatch failures fail closed to dense attention and retain the exception
-class, not its potentially sensitive message.
+aggregates the receipt without evaluating MLX arrays. Eligibility declines fail
+closed to dense attention. MLX kernel execution is lazy, so construction and
+execution errors surface through the engine's normal generation-error path;
+the route deliberately does not synchronize every layer to simulate an
+execution-time fallback.
+
+The Metal kernel clamps compact counts to their buffer capacities and skips
+out-of-range block starts and tail indices before reading K/V. Production inputs
+come from the internal indexer, but the device-side guards prevent malformed
+internal state from turning into an out-of-bounds GPU read without imposing a
+host synchronization.
 
 The existing fused-GDN receipt now also retains every fallback reason instead
 of only the most recent reason per layer. Its end-to-end gate subtracts the

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -1,0 +1,85 @@
+# Qwen4 block-sparse QSA prefill qualification
+
+## Outcome
+
+Rapid-MLX now has an opt-in Metal path that consumes QSA's compact selected
+blocks directly during long-context prefill. It avoids rebuilding a dense mask
+and avoids visiting every physical K/V row. The route remains off by default
+behind `RAPID_MLX_QSA_BLOCK_SPARSE=1`; decode, training, short queries, short
+contexts, non-Metal systems, and unsupported layouts retain dense attention.
+
+This is deliberately not an automatic promotion. The sparse kernel changes the
+softmax reduction order relative to dense masked attention. A small fp64 probe
+is favorable, but model-scale correctness and performance must be requalified
+for each MLX build before changing the default.
+
+## Production-path contract
+
+Each QSA attention layer records cumulative `kernel_calls`, `declines`, and a
+complete `decline_reasons` histogram. `qwen4_qsa_block_sparse_stats(model)`
+aggregates the receipt without evaluating MLX arrays. Synchronous construction
+or dispatch failures fail closed to dense attention and retain the exception
+class, not its potentially sensitive message.
+
+The existing fused-GDN receipt now also retains every fallback reason instead
+of only the most recent reason per layer. Its end-to-end gate subtracts the
+cumulative histograms and requires the exact expected prefill fallback. A fast
+path is therefore not qualified merely because an engine-direct microbenchmark
+can call it.
+
+## Reproducible isolated measurement
+
+- Candidate: worktree diff on `origin/main@d6c50526a85d50346af4126c1dca9f149aaa9fbe`
+- Hardware: Apple M3 Ultra, 256 GiB unified memory
+- OS: macOS 26.5.2 (25F84)
+- Python: 3.12.13 from `.venv`
+- MLX / mlx-lm / NumPy: 0.32.1 / 0.31.3 / 2.5.2
+- Precision: bf16 performance geometry; fp16 inputs with an fp64 NumPy oracle
+  for the numerical probe; TF32 disabled before importing MLX
+- Warmup / samples: two warmups and five interleaved sparse/dense observations;
+  three warmups and 100 synchronized dispatch-floor observations
+- Artifact: `/tmp/qsa-qualification-production.json`, SHA-256
+  `3eedcab197d6609a83279cac40b2b4e0796a6c94a2b8d487c720d79eff2fd821`
+
+```bash
+MLX_ENABLE_TF32=0 .venv/bin/python \
+  scripts/bench_qwen4_qsa_block_sparse.py \
+  --query-length 64 --key-length 16384 \
+  --block-topk 512 --block-size 4 \
+  --query-heads 24 --kv-heads 2 --head-dim 256 \
+  --warmup 2 --repeats 5 --dispatch-repeats 100 \
+  --output /tmp/qsa-qualification-production.json
+```
+
+At 64 queries over 16,384 physical keys, selecting 2,048 tokens:
+
+| Measurement | Result |
+| --- | ---: |
+| Dense masked attention median | 2.828 ms |
+| Direct block-sparse median | 1.468 ms |
+| Isolated speedup | 1.93x |
+| Exact binary synchronized dispatch floor | 177.4 us median |
+| Sparse max absolute error vs fp64 | 0.000336 |
+| Dense max absolute error vs fp64 | 0.001031 |
+| Sparse RMS error vs fp64 | 0.000118 |
+| Dense RMS error vs fp64 | 0.000303 |
+| Sparse max absolute delta vs dense | 0.000977 |
+
+The dispatch floor is about 12% of the sparse call at this smallest admitted
+production geometry. This supports a coarse long-context gate and rejects a
+design that would split the same work into many launches.
+
+## Existing end-to-end evidence and limits
+
+The repository's earlier M3 Ultra full-model campaign measured a 32K prompt at
+523.4 to 579.2 prefill tokens/s (+10.7%) and 62.539 to 56.516 seconds TTFT,
+with unchanged decode and byte-identical normalized outputs over five user
+paths. That campaign used the same kernel design but predates this rebased
+integration and its complete path receipts, so it is supporting evidence rather
+than an exact-head promotion gate.
+
+Before automatic enablement, rerun the full served route at 16K, 32K, and 64K
+on the pinned release dependency build. Require three or more settled paired
+observations, stable stock output, the expected nonzero kernel-call count, no
+unexpected decline reasons, peak-memory evidence, and the model-scale
+correctness gate. Keep the feature opt-in if any requirement is missing.

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -27,7 +27,9 @@ The Metal kernel clamps compact counts to their buffer capacities and skips
 out-of-range block starts and tail indices before reading K/V. Production inputs
 come from the internal indexer, but the device-side guards prevent malformed
 internal state from turning into an out-of-bounds GPU read without imposing a
-host synchronization.
+host synchronization. Before count-based dispatch, invalid compact entries are
+replaced with an out-of-range sentinel and sorted behind the valid prefix, so a
+future validity hole cannot substitute a padded index for a selected block.
 
 The existing fused-GDN receipt now also retains every fallback reason instead
 of only the most recent reason per layer. Its end-to-end gate subtracts the

--- a/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
+++ b/docs/engineering/performance/2026-09-04-qwen4-qsa-block-sparse-prefill.md
@@ -154,6 +154,12 @@ geometry measured 1.487 ms sparse versus 3.348 ms dense (2.25x), with the exact
 same numerical errors reported above. The artifact is
 `/private/tmp/qsa-qualification-safety-guards.json`, SHA-256
 `15d6354b039801c39c1e155c72a16ef9e43da6b4f6f793a2bd7d74a4c0fbeab5`.
+After block-validity structuring, strict int32 input enforcement, and receipt
+renaming, code head `20df4f239c97ba107d6f180a0386f7cf396855f1`
+remeasured the geometry at 1.577 ms sparse versus 2.755 ms dense (1.75x), with
+the same numerical errors. That artifact is
+`/private/tmp/qsa-qualification-final-contract.json`, SHA-256
+`c5e7353e86eee32f683d0b6a1c52b51306350c5209ce7836b87022b9c77e2664`.
 A final served rerun completed three 16K samples and one 32K sample at the
 expected rates before a Metal recovery invalidated the remaining process state;
 those partial samples are not merged into the complete table.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -6,6 +6,7 @@ summary statistics, and limitations.
 
 ## Reports
 
+- [Qwen4 block-sparse QSA prefill qualification](2026-09-04-qwen4-qsa-block-sparse-prefill.md)
 - [Qwen4 fused GDN single-token decode](2026-09-01-qwen4-fused-gdn-decode.md)
 - [Gemma 4 12B engine comparison on M2 Pro](2026-08-21-gemma4-12b-engine-comparison.md)
 - [Qwen3.5-9B engine comparison on M2 Pro](2026-08-21-qwen3.5-9b-engine-comparison.md)

--- a/scripts/bench_metadata.py
+++ b/scripts/bench_metadata.py
@@ -48,6 +48,7 @@ JSON_BENCH_SCRIPTS = frozenset(
         "bench_engine_solo.py",
         "bench_qwen4_fused_gdn_decode.py",
         "bench_qwen4_fused_gdn_end_to_end.py",
+        "bench_qwen4_qsa_block_sparse.py",
         "bench_service_prefill.py",
         "bench_readme_refresh.py",
         "bench_suffix_decoding.py",

--- a/scripts/bench_qwen4_fused_gdn_end_to_end.py
+++ b/scripts/bench_qwen4_fused_gdn_end_to_end.py
@@ -40,6 +40,16 @@ def expected_path_counts(mode: str, fused_layers: int, generated_tokens: int):
     return fused_layers * (generated_tokens + 1), fused_layers
 
 
+def counter_delta(after: dict[str, int], before: dict[str, int]) -> dict[str, int]:
+    """Return non-zero per-reason deltas from cumulative path counters."""
+    reasons = set(before) | set(after)
+    return {
+        reason: delta
+        for reason in sorted(reasons)
+        if (delta := after.get(reason, 0) - before.get(reason, 0))
+    }
+
+
 def run(args):
     if args.max_tokens < 2:
         raise SystemExit("--max-tokens must be at least 2")
@@ -99,8 +109,14 @@ def run(args):
                 raise RuntimeError("decode timer did not advance")
             fused_calls = after["fused_calls"] - before["fused_calls"]
             fallbacks = after["fallbacks"] - before["fallbacks"]
+            fallback_reasons = counter_delta(
+                after["fallback_reasons"], before["fallback_reasons"]
+            )
             expected_fused_calls, expected_fallbacks = expected_path_counts(
                 mode, fused_layers, len(tokens)
+            )
+            expected_fallback_reasons = (
+                {"uninitialized cache": fused_layers} if mode == "fused" else {}
             )
             observations.append(
                 {
@@ -117,8 +133,11 @@ def run(args):
                     "expected_fused_calls": expected_fused_calls,
                     "fallbacks": fallbacks,
                     "expected_fallbacks": expected_fallbacks,
+                    "fallback_reasons": fallback_reasons,
+                    "expected_fallback_reasons": expected_fallback_reasons,
                     "path_counts_exact": fused_calls == expected_fused_calls
-                    and fallbacks == expected_fallbacks,
+                    and fallbacks == expected_fallbacks
+                    and fallback_reasons == expected_fallback_reasons,
                     "last_fallbacks": after["last_fallbacks"],
                 }
             )

--- a/scripts/bench_qwen4_qsa_block_sparse.py
+++ b/scripts/bench_qwen4_qsa_block_sparse.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Qualify Qwen4 block-sparse QSA latency, dispatch floor, and numerics."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import time
+from pathlib import Path
+
+import numpy as np
+
+try:
+    from scripts.bench_metadata import format_bench_json, write_bench_json
+except ImportError:  # direct `python scripts/bench_*.py` execution
+    from bench_metadata import format_bench_json, write_bench_json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--query-length", type=int, default=64)
+    parser.add_argument("--key-length", type=int, default=16_384)
+    parser.add_argument("--block-topk", type=int, default=512)
+    parser.add_argument("--block-size", type=int, default=4)
+    parser.add_argument("--query-heads", type=int, default=24)
+    parser.add_argument("--kv-heads", type=int, default=2)
+    parser.add_argument("--head-dim", type=int, default=256)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--dispatch-repeats", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=17)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def _validate_args(args) -> None:
+    positive = {
+        "query-length": args.query_length,
+        "key-length": args.key_length,
+        "block-topk": args.block_topk,
+        "block-size": args.block_size,
+        "query-heads": args.query_heads,
+        "kv-heads": args.kv_heads,
+        "head-dim": args.head_dim,
+        "repeats": args.repeats,
+        "dispatch-repeats": args.dispatch_repeats,
+    }
+    for name, value in positive.items():
+        if value < 1:
+            raise SystemExit(f"--{name} must be positive")
+    if args.warmup < 0:
+        raise SystemExit("--warmup must be non-negative")
+    if args.query_heads % args.kv_heads:
+        raise SystemExit("--query-heads must be divisible by --kv-heads")
+    if args.head_dim % 32:
+        raise SystemExit("--head-dim must be divisible by 32")
+    if args.block_topk * args.block_size > args.key_length:
+        raise SystemExit("selected blocks must fit inside --key-length")
+
+
+def _measure(call, evaluate, *, warmup: int, repeats: int) -> list[float]:
+    for _ in range(warmup):
+        evaluate(call())
+    samples = []
+    for _ in range(repeats):
+        started = time.perf_counter_ns()
+        evaluate(call())
+        samples.append((time.perf_counter_ns() - started) / 1_000_000)
+    return samples
+
+
+def _fp64_reference(queries, keys, values, selected_by_query):
+    output = np.zeros(queries.shape, dtype=np.float64)
+    head_dim = queries.shape[-1]
+    query_heads = queries.shape[1]
+    kv_heads = keys.shape[1]
+    heads_per_kv = query_heads // kv_heads
+    for query_index, selected in enumerate(selected_by_query):
+        for query_head in range(query_heads):
+            kv_head = query_head // heads_per_kv
+            scores = (
+                keys[0, kv_head, selected].astype(np.float64)
+                @ queries[0, query_head, query_index].astype(np.float64)
+            ) / np.sqrt(head_dim)
+            weights = np.exp(scores - scores.max())
+            weights /= weights.sum()
+            output[0, query_head, query_index] = (
+                weights[:, None] * values[0, kv_head, selected].astype(np.float64)
+            ).sum(axis=0)
+    return output
+
+
+def _numerics_probe(mx, block_sparse_attention):
+    rng = np.random.default_rng(29)
+    query_heads, kv_heads, query_length, key_length, head_dim = 2, 1, 2, 10, 32
+    block_size = 2
+    queries_np = rng.normal(size=(1, query_heads, query_length, head_dim)).astype(
+        np.float16
+    )
+    keys_np = rng.normal(size=(1, kv_heads, key_length, head_dim)).astype(np.float16)
+    values_np = rng.normal(size=(1, kv_heads, key_length, head_dim)).astype(np.float16)
+    block_starts_np = np.array([[[0, 4], [2, 6]]], dtype=np.int32)
+    block_counts_np = np.array([[2, 2]], dtype=np.int32)
+    tail_indices_np = np.array([[[8, 0], [8, 9]]], dtype=np.int32)
+    tail_counts_np = np.array([[1, 2]], dtype=np.int32)
+    selected = [np.array([0, 1, 4, 5, 8]), np.array([2, 3, 6, 7, 8, 9])]
+
+    queries = mx.array(queries_np)
+    keys = mx.array(keys_np)
+    values = mx.array(values_np)
+    sparse = block_sparse_attention(
+        queries,
+        keys,
+        values,
+        mx.array(block_starts_np),
+        mx.array(block_counts_np),
+        mx.array(tail_indices_np),
+        mx.array(tail_counts_np),
+        block_size=block_size,
+    )
+    dense_mask_np = np.zeros((1, 1, query_length, key_length), dtype=np.bool_)
+    for query_index, indices in enumerate(selected):
+        dense_mask_np[0, 0, query_index, indices] = True
+    dense_mask = mx.where(
+        mx.array(dense_mask_np),
+        mx.array(0.0, dtype=queries.dtype),
+        mx.array(-1e9, dtype=queries.dtype),
+    )
+    dense = mx.fast.scaled_dot_product_attention(
+        queries,
+        keys,
+        values,
+        scale=head_dim**-0.5,
+        mask=dense_mask,
+    )
+    mx.eval(sparse, dense)
+    reference = _fp64_reference(queries_np, keys_np, values_np, selected)
+    sparse_error = np.array(sparse).astype(np.float64) - reference
+    dense_error = np.array(dense).astype(np.float64) - reference
+    return {
+        "shape": [1, query_heads, query_length, head_dim],
+        "sparse_max_abs_error_vs_fp64": float(np.max(np.abs(sparse_error))),
+        "dense_max_abs_error_vs_fp64": float(np.max(np.abs(dense_error))),
+        "sparse_rms_error_vs_fp64": float(np.sqrt(np.mean(sparse_error**2))),
+        "dense_rms_error_vs_fp64": float(np.sqrt(np.mean(dense_error**2))),
+        "sparse_max_abs_delta_vs_dense": float(
+            np.max(np.abs(np.array(sparse) - np.array(dense)))
+        ),
+    }
+
+
+def run(args):
+    _validate_args(args)
+    if os.environ.get("MLX_ENABLE_TF32") != "0":
+        raise SystemExit(
+            "set MLX_ENABLE_TF32=0 before launch so the fp32 qualification "
+            "oracle is not silently reduced to TF32"
+        )
+
+    import mlx.core as mx
+
+    from vllm_mlx.kernels.qsa_block_sparse import (
+        block_sparse_attention,
+        block_sparse_layout_supported,
+    )
+
+    if not mx.metal.is_available():
+        raise SystemExit("QSA qualification requires an Apple Metal device")
+    if not block_sparse_layout_supported(
+        query_heads=args.query_heads,
+        kv_heads=args.kv_heads,
+        head_dim=args.head_dim,
+        block_size=args.block_size,
+        dtype=mx.bfloat16,
+    ):
+        raise SystemExit("requested QSA geometry is unsupported")
+
+    mx.random.seed(args.seed)
+    queries = mx.random.normal(
+        (1, args.query_heads, args.query_length, args.head_dim)
+    ).astype(mx.bfloat16)
+    keys = mx.random.normal((1, args.kv_heads, args.key_length, args.head_dim)).astype(
+        mx.bfloat16
+    )
+    values = mx.random.normal(
+        (1, args.kv_heads, args.key_length, args.head_dim)
+    ).astype(mx.bfloat16)
+    max_start = args.key_length - args.block_size
+    starts = np.linspace(
+        0,
+        max_start,
+        num=args.block_topk,
+        endpoint=True,
+        dtype=np.int32,
+    )
+    starts -= starts % args.block_size
+    starts = np.broadcast_to(
+        starts[None, None, :],
+        (1, args.query_length, args.block_topk),
+    ).copy()
+    block_starts = mx.array(starts)
+    block_counts = mx.full((1, args.query_length), args.block_topk, dtype=mx.int32)
+    tail_indices = mx.zeros((1, args.query_length, args.block_size), dtype=mx.int32)
+    tail_counts = mx.zeros((1, args.query_length), dtype=mx.int32)
+    token_indices = (
+        block_starts[..., None] + mx.arange(args.block_size)[None, None, None, :]
+    ).reshape(1, args.query_length, -1)
+    dense_mask = mx.zeros((1, args.query_length, args.key_length), dtype=mx.bool_)
+    dense_mask = mx.put_along_axis(
+        dense_mask,
+        token_indices,
+        mx.ones_like(token_indices, dtype=mx.bool_),
+        axis=-1,
+    )[:, None]
+    additive_mask = mx.where(
+        dense_mask,
+        mx.array(0.0, dtype=queries.dtype),
+        mx.array(-1e9, dtype=queries.dtype),
+    )
+    mx.eval(queries, keys, values, block_starts, additive_mask)
+
+    def sparse_call():
+        return block_sparse_attention(
+            queries,
+            keys,
+            values,
+            block_starts,
+            block_counts,
+            tail_indices,
+            tail_counts,
+            block_size=args.block_size,
+        )
+
+    def dense_call():
+        return mx.fast.scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            scale=args.head_dim**-0.5,
+            mask=additive_mask,
+        )
+
+    timings = {"sparse_ms": [], "dense_ms": []}
+    orders = (("dense_ms", dense_call), ("sparse_ms", sparse_call))
+    for repeat in range(args.repeats):
+        ordered = orders if repeat % 2 == 0 else tuple(reversed(orders))
+        for name, call in ordered:
+            timings[name].extend(_measure(call, mx.eval, warmup=args.warmup, repeats=1))
+
+    # Measure the launch floor of this exact compiled binary with its smallest
+    # supported useful geometry, synchronizing every call.
+    floor_q = mx.zeros((1, 1, 1, 32), dtype=mx.float16)
+    floor_kv = mx.zeros((1, 1, 2, 32), dtype=mx.float16)
+    floor_starts = mx.zeros((1, 1, 1), dtype=mx.int32)
+    floor_counts = mx.ones((1, 1), dtype=mx.int32)
+    floor_tail = mx.zeros((1, 1, 2), dtype=mx.int32)
+    floor_tail_counts = mx.zeros((1, 1), dtype=mx.int32)
+
+    def floor_call():
+        return block_sparse_attention(
+            floor_q,
+            floor_kv,
+            floor_kv,
+            floor_starts,
+            floor_counts,
+            floor_tail,
+            floor_tail_counts,
+            block_size=2,
+        )
+
+    floor_ms = _measure(
+        floor_call,
+        mx.eval,
+        warmup=max(args.warmup, 3),
+        repeats=args.dispatch_repeats,
+    )
+    medians = {name: statistics.median(values) for name, values in timings.items()}
+    return {
+        "geometry": {
+            "query_length": args.query_length,
+            "key_length": args.key_length,
+            "selected_tokens": args.block_topk * args.block_size,
+            "query_heads": args.query_heads,
+            "kv_heads": args.kv_heads,
+            "head_dim": args.head_dim,
+            "dtype": "bfloat16",
+        },
+        "timings_ms": timings,
+        "median_sparse_ms": medians["sparse_ms"],
+        "median_dense_ms": medians["dense_ms"],
+        "median_speedup": medians["dense_ms"] / medians["sparse_ms"],
+        "dispatch_floor": {
+            "binary": "rapid_qsa_block_sparse",
+            "synchronized_samples_ms": floor_ms,
+            "median_microseconds": statistics.median(floor_ms) * 1_000,
+        },
+        "numerics": _numerics_probe(mx, block_sparse_attention),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    result = run(args)
+    payload = format_bench_json(result, __file__, indent=2, sort_keys=True)
+    print(payload)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        write_bench_json(args.output, result, __file__, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bench_qwen4_fused_gdn.py
+++ b/tests/test_bench_qwen4_fused_gdn.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from scripts.bench_qwen4_fused_gdn_end_to_end import expected_path_counts
+from scripts.bench_qwen4_fused_gdn_end_to_end import counter_delta, expected_path_counts
 
 
 def test_expected_path_counts_prove_fused_execution_and_prefill_fallback():
@@ -13,3 +13,10 @@ def test_expected_path_counts_prove_fused_execution_and_prefill_fallback():
 def test_expected_path_counts_reject_unknown_mode():
     with pytest.raises(ValueError, match="unknown mode"):
         expected_path_counts("other", 36, 256)
+
+
+def test_counter_delta_preserves_complete_decline_histogram():
+    assert counter_delta(
+        {"uninitialized cache": 38, "speculative rollback": 7},
+        {"uninitialized cache": 2, "speculative rollback": 7},
+    ) == {"uninitialized cache": 36}

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -144,11 +144,12 @@ def test_apple_coverage_roster_contains_only_tracked_tests() -> None:
 
 
 def test_qwen4_fused_gdn_coverage_runs_on_apple_silicon() -> None:
-    """The Metal fast path must contribute to the changed-lines union."""
+    """Qwen4 Metal fast paths must contribute to the changed-lines union."""
     _, workflow = _workflow()
     apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
 
     assert "tests/test_qwen4_fused_gdn_decode.py" in apple_run
+    assert "tests/test_qsa_block_sparse.py" in apple_run
 
 
 def test_coverage_data_is_commit_bound_and_fail_closed() -> None:

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -157,6 +157,11 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # fires, which tier engages — none of that changes. Read by
         # ``moe_fusion.fuse_gate_up()`` only.
         "RAPID_MLX_MOE_GATE_UP_FUSION",
+        # Opt-in direct QSA block-sparse attention on an already-selected
+        # Qwen4-Exp model. This changes only the prefill kernel after a measured
+        # context crossover; model, parser, tier, and engine routing are
+        # unchanged. Unsupported layouts and the default path remain dense.
+        "RAPID_MLX_QSA_BLOCK_SPARSE",
         # Opt-out of the blocked-seq GDN prefill Metal kernel
         # (vllm_mlx/gdn_prefill.py). Same shape as DISABLE_FUSED_SAMPLER —
         # a kernel-selection perf toggle computing the exact same

--- a/tests/test_qsa_block_sparse.py
+++ b/tests/test_qsa_block_sparse.py
@@ -128,8 +128,29 @@ def _valid_kernel_inputs(*, query_heads=2, kv_heads=1, head_dim=32, dtype=mx.flo
     }
 
 
-def test_qsa_selection_rejects_non_block_aligned_validity():
+def test_qsa_selection_rejects_invalid_structural_validity():
     indices = mx.zeros((1, 2, 10), dtype=mx.int32)
+    with pytest.raises(ValueError, match="rank three"):
+        qwen4_exp._QSASelection(
+            token_indices=mx.zeros((2, 10), dtype=mx.int32),
+            block_valid=mx.ones((1, 2, 4), dtype=mx.bool_),
+            tail_valid=mx.ones((1, 2, 2), dtype=mx.bool_),
+            physical_kv_length=10,
+        )
+    with pytest.raises(ValueError, match="block validity"):
+        qwen4_exp._QSASelection(
+            token_indices=indices,
+            block_valid=mx.ones((1, 1, 4), dtype=mx.bool_),
+            tail_valid=mx.ones((1, 2, 2), dtype=mx.bool_),
+            physical_kv_length=10,
+        )
+    with pytest.raises(ValueError, match="tail validity"):
+        qwen4_exp._QSASelection(
+            token_indices=indices,
+            block_valid=mx.ones((1, 2, 4), dtype=mx.bool_),
+            tail_valid=mx.ones((1, 1, 2), dtype=mx.bool_),
+            physical_kv_length=10,
+        )
     with pytest.raises(ValueError, match="block geometry"):
         qwen4_exp._QSASelection(
             token_indices=indices,

--- a/tests/test_qsa_block_sparse.py
+++ b/tests/test_qsa_block_sparse.py
@@ -327,7 +327,7 @@ def test_qsa_attention_unsupported_layout_stays_dense(monkeypatch):
     }
 
 
-def test_qsa_attention_dispatch_failure_falls_back_with_histogram(monkeypatch):
+def test_qsa_attention_construction_failure_surfaces_without_false_receipt(monkeypatch):
     args = _args()
     attention = QSAAttention(args)
     attention.eval()
@@ -337,25 +337,39 @@ def test_qsa_attention_dispatch_failure_falls_back_with_histogram(monkeypatch):
     def fail_sparse(*_args, **_kwargs):
         raise RuntimeError("synthetic failure")
 
-    def fake_dense(queries, keys, values, *, cache, scale, mask):
-        del keys, values, cache, scale
-        assert mask.shape == (1, 1, 64, 16_448)
-        return mx.zeros_like(queries)
-
     monkeypatch.setattr(qwen4_exp, "block_sparse_attention", fail_sparse)
-    monkeypatch.setattr(qwen4_exp, "scaled_dot_product_attention", fake_dense)
-    output = attention(
-        mx.zeros((1, 64, args.hidden_size)),
-        [_FakeKVCache(), object()],
-        mask="causal",
-    )
-    mx.eval(output)
+    with pytest.raises(RuntimeError, match="synthetic failure"):
+        attention(
+            mx.zeros((1, 64, args.hidden_size)),
+            [_FakeKVCache(), object()],
+            mask="causal",
+        )
 
     assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
         "kernel_calls": 0,
-        "declines": 1,
-        "decline_reasons": {"kernel dispatch failed: RuntimeError": 1},
+        "declines": 0,
+        "decline_reasons": {},
     }
+
+
+@pytest.mark.skipif(
+    not mx.metal.is_available(), reason="QSA block-sparse kernel requires Metal"
+)
+@pytest.mark.parametrize("bad_block_start", [-8, 99, 2**31 - 1])
+@pytest.mark.parametrize("bad_count", [-1, 99])
+def test_qsa_kernel_bounds_malformed_counts_and_indices_on_device(
+    bad_block_start, bad_count
+):
+    inputs = _valid_kernel_inputs()
+    inputs.update(
+        block_starts=mx.array([[[bad_block_start]]], dtype=mx.int32),
+        block_counts=mx.array([[bad_count]], dtype=mx.int32),
+        tail_indices=mx.array([[[99, -1]]], dtype=mx.int32),
+        tail_counts=mx.array([[bad_count]], dtype=mx.int32),
+    )
+    output = qsa_block_sparse.block_sparse_attention(**inputs)
+    mx.eval(output)
+    np.testing.assert_array_equal(np.array(output), np.zeros(output.shape))
 
 
 @pytest.mark.skipif(

--- a/tests/test_qsa_block_sparse.py
+++ b/tests/test_qsa_block_sparse.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytest.importorskip("mlx_lm")
+pytestmark = pytest.mark.requires_mlx
+
+import vllm_mlx.models.qwen4_exp as qwen4_exp
+from vllm_mlx.kernels import qsa_block_sparse
+from vllm_mlx.models.qwen4_exp import QSAAttention, TextModelArgs
+
+
+def _args(**overrides) -> TextModelArgs:
+    values = {
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "vocab_size": 32,
+        "num_attention_heads": 24,
+        "num_key_value_heads": 2,
+        "head_dim": 256,
+        "linear_num_key_heads": 1,
+        "linear_num_value_heads": 3,
+        "linear_key_head_dim": 4,
+        "linear_value_head_dim": 4,
+        "linear_conv_kernel_dim": 3,
+        "num_experts": 4,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": 4,
+        "shared_expert_intermediate_size": 4,
+        "hc_count": 4,
+        "hc_lowrank": 3,
+        "layer_types": ["full_attention"],
+        "indexer_n_heads": 2,
+        "indexer_kv_heads": 1,
+        "indexer_head_dim": 64,
+        "indexer_budget": 8,
+        "indexer_compress_ratio": 2,
+        "ple_layer_ids": [],
+        "eos_token_id": 31,
+    }
+    values.update(overrides)
+    return TextModelArgs(**values)
+
+
+def test_qsa_gate_reports_each_decline_reason(monkeypatch):
+    monkeypatch.delenv(qsa_block_sparse.ENABLE_ENV, raising=False)
+    assert qsa_block_sparse.block_sparse_decline_reason(64, 16_384) == "disabled"
+
+    monkeypatch.setenv(qsa_block_sparse.ENABLE_ENV, "1")
+    assert (
+        qsa_block_sparse.block_sparse_decline_reason(64, 16_384, training=True)
+        == "training"
+    )
+    assert (
+        qsa_block_sparse.block_sparse_decline_reason(63, 16_384)
+        == "query below crossover"
+    )
+    assert (
+        qsa_block_sparse.block_sparse_decline_reason(64, 16_383)
+        == "physical KV below crossover"
+    )
+    monkeypatch.setattr(qsa_block_sparse.mx.metal, "is_available", lambda: False)
+    assert (
+        qsa_block_sparse.block_sparse_decline_reason(64, 16_384)
+        == "Metal runtime unavailable"
+    )
+
+
+def test_qsa_layout_gate_covers_threadgroup_and_gqa_limits():
+    assert qsa_block_sparse.block_sparse_layout_supported(
+        query_heads=24,
+        kv_heads=2,
+        head_dim=256,
+        block_size=4,
+        dtype=mx.bfloat16,
+    )
+    assert not qsa_block_sparse.block_sparse_layout_supported(
+        query_heads=65,
+        kv_heads=1,
+        head_dim=256,
+        block_size=4,
+        dtype=mx.bfloat16,
+    )
+    assert not qsa_block_sparse.block_sparse_layout_supported(
+        query_heads=24,
+        kv_heads=2,
+        head_dim=256,
+        block_size=128,
+        dtype=mx.bfloat16,
+    )
+
+
+class _FakeIndexer:
+    token_budget = 8
+    compress_ratio = 2
+    rope_theta = 10_000_000
+
+    def __call__(
+        self,
+        hidden_states,
+        cache,
+        *,
+        physical_kv_length,
+        record_rollback=False,
+    ):
+        del cache, record_rollback
+        length = int(hidden_states.shape[1])
+        # Deliberately unsorted to prove the kernel receives physical order.
+        block_tokens = mx.broadcast_to(
+            mx.array([8, 9, 0, 1, 4, 5, 12, 13], dtype=mx.int32),
+            (1, length, 8),
+        )
+        tail = mx.broadcast_to(mx.array([16, 17], dtype=mx.int32), (1, length, 2))
+        return qwen4_exp._QSASelection(
+            token_indices=mx.concatenate([block_tokens, tail], axis=-1),
+            valid=mx.ones((1, length, 10), dtype=mx.bool_),
+            physical_kv_length=physical_kv_length,
+        )
+
+
+class _FakeKVCache:
+    offset = 16_384
+    _idx = 16_384
+
+    def size(self):
+        return self._idx
+
+    def update_and_fetch(self, keys, values):
+        return keys, values
+
+
+def test_qsa_attention_routes_compact_selection_and_records_call(monkeypatch):
+    args = _args()
+    attention = QSAAttention(args)
+    attention.eval()
+    attention.indexer = _FakeIndexer()
+    monkeypatch.setenv(qsa_block_sparse.ENABLE_ENV, "1")
+    observed = []
+
+    def fake_sparse(
+        queries,
+        keys,
+        values,
+        block_starts,
+        block_counts,
+        tail_indices,
+        tail_counts,
+        *,
+        block_size,
+    ):
+        del keys, values
+        observed.append(
+            (
+                np.array(block_starts[0, 0]),
+                np.array(block_counts),
+                tail_indices.shape,
+                np.array(tail_counts),
+                block_size,
+            )
+        )
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(qwen4_exp, "block_sparse_attention", fake_sparse)
+    output = attention(
+        mx.zeros((1, 64, args.hidden_size)),
+        [_FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+
+    assert output.shape == (1, 64, args.hidden_size)
+    assert len(observed) == 1
+    starts, counts, tail_shape, tail_counts, block_size = observed[0]
+    np.testing.assert_array_equal(starts, [0, 4, 8, 12])
+    np.testing.assert_array_equal(counts, 4)
+    assert tail_shape == (1, 64, 2)
+    np.testing.assert_array_equal(tail_counts, 2)
+    assert block_size == 2
+    assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
+        "kernel_calls": 1,
+        "declines": 0,
+        "decline_reasons": {},
+    }
+
+
+def test_qsa_attention_disabled_control_stays_dense(monkeypatch):
+    args = _args()
+    attention = QSAAttention(args)
+    attention.eval()
+    attention.indexer = _FakeIndexer()
+    monkeypatch.delenv(qsa_block_sparse.ENABLE_ENV, raising=False)
+    sparse_called = False
+    dense_masks = []
+
+    def fail_if_sparse(*_args, **_kwargs):
+        nonlocal sparse_called
+        sparse_called = True
+        raise AssertionError("disabled route must not dispatch the sparse kernel")
+
+    def fake_dense(queries, keys, values, *, cache, scale, mask):
+        del keys, values, cache, scale
+        dense_masks.append(mask)
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(qwen4_exp, "block_sparse_attention", fail_if_sparse)
+    monkeypatch.setattr(qwen4_exp, "scaled_dot_product_attention", fake_dense)
+    output = attention(
+        mx.zeros((1, 64, args.hidden_size)),
+        [_FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output, *dense_masks)
+
+    assert not sparse_called
+    assert len(dense_masks) == 1
+    assert dense_masks[0].shape == (1, 1, 64, 16_448)
+    assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
+        "kernel_calls": 0,
+        "declines": 1,
+        "decline_reasons": {"disabled": 1},
+    }
+
+
+def test_qsa_attention_dispatch_failure_falls_back_with_histogram(monkeypatch):
+    args = _args()
+    attention = QSAAttention(args)
+    attention.eval()
+    attention.indexer = _FakeIndexer()
+    monkeypatch.setenv(qsa_block_sparse.ENABLE_ENV, "1")
+
+    def fail_sparse(*_args, **_kwargs):
+        raise RuntimeError("synthetic failure")
+
+    def fake_dense(queries, keys, values, *, cache, scale, mask):
+        del keys, values, cache, scale
+        assert mask.shape == (1, 1, 64, 16_448)
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(qwen4_exp, "block_sparse_attention", fail_sparse)
+    monkeypatch.setattr(qwen4_exp, "scaled_dot_product_attention", fake_dense)
+    output = attention(
+        mx.zeros((1, 64, args.hidden_size)),
+        [_FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+
+    assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
+        "kernel_calls": 0,
+        "declines": 1,
+        "decline_reasons": {"kernel dispatch failed: RuntimeError": 1},
+    }
+
+
+@pytest.mark.skipif(
+    not mx.metal.is_available(), reason="QSA block-sparse kernel requires Metal"
+)
+def test_qsa_block_sparse_matches_fp64_reference():
+    rng = np.random.default_rng(11)
+    batch = 2
+    query_heads = 4
+    kv_heads = 2
+    query_length = 2
+    key_length = 10
+    head_dim = 32
+    block_size = 2
+    queries_np = rng.normal(size=(batch, query_heads, query_length, head_dim)).astype(
+        np.float16
+    )
+    keys_np = rng.normal(size=(batch, kv_heads, key_length, head_dim)).astype(
+        np.float16
+    )
+    values_np = rng.normal(size=(batch, kv_heads, key_length, head_dim)).astype(
+        np.float16
+    )
+    block_starts_np = np.array([[[0, 4], [2, 6]], [[2, 4], [0, 6]]], dtype=np.int32)
+    block_counts_np = np.full((batch, query_length), 2, dtype=np.int32)
+    tail_indices_np = np.array([[[8, 0], [8, 9]], [[7, 0], [8, 9]]], dtype=np.int32)
+    tail_counts_np = np.array([[1, 2], [1, 2]], dtype=np.int32)
+
+    output = qsa_block_sparse.block_sparse_attention(
+        mx.array(queries_np),
+        mx.array(keys_np),
+        mx.array(values_np),
+        mx.array(block_starts_np),
+        mx.array(block_counts_np),
+        mx.array(tail_indices_np),
+        mx.array(tail_counts_np),
+        block_size=block_size,
+    )
+    mx.eval(output)
+
+    reference = np.zeros(output.shape, dtype=np.float64)
+    heads_per_kv = query_heads // kv_heads
+    for batch_index in range(batch):
+        for query_index in range(query_length):
+            selected = []
+            for start in block_starts_np[batch_index, query_index]:
+                selected.extend(range(int(start), int(start) + block_size))
+            selected.extend(
+                map(
+                    int,
+                    tail_indices_np[
+                        batch_index,
+                        query_index,
+                        : tail_counts_np[batch_index, query_index],
+                    ],
+                )
+            )
+            selected_array = np.array(selected)
+            for head in range(query_heads):
+                kv_head = head // heads_per_kv
+                scores = (
+                    keys_np[batch_index, kv_head, selected_array].astype(np.float64)
+                    @ queries_np[batch_index, head, query_index].astype(np.float64)
+                ) / np.sqrt(head_dim)
+                weights = np.exp(scores - scores.max())
+                weights /= weights.sum()
+                reference[batch_index, head, query_index] = (
+                    weights[:, None]
+                    * values_np[batch_index, kv_head, selected_array].astype(np.float64)
+                ).sum(axis=0)
+
+    np.testing.assert_allclose(np.array(output), reference, rtol=3e-3, atol=2e-3)

--- a/tests/test_qsa_block_sparse.py
+++ b/tests/test_qsa_block_sparse.py
@@ -161,6 +161,11 @@ def test_qsa_kernel_rejects_every_unsafe_shape_and_layout():
     rejected("tail counts", tail_counts=mx.zeros((1, 2), dtype=mx.int32))
     rejected("shapes are inconsistent", values=mx.zeros((1, 1, 3, 32)))
     rejected("same dtype", keys=mx.zeros((1, 1, 2, 32), dtype=mx.float32))
+    for name in ("block_starts", "block_counts", "tail_indices", "tail_counts"):
+        inputs = _valid_kernel_inputs()
+        inputs[name] = inputs[name].astype(mx.int64)
+        with pytest.raises(ValueError, match="must use int32"):
+            qsa_block_sparse.block_sparse_attention(**inputs)
 
     inputs = _valid_kernel_inputs(head_dim=33)
     with pytest.raises(ValueError, match="divisible by 32"):
@@ -249,7 +254,7 @@ class _FakeKVCache:
         return keys, values
 
 
-def test_qsa_attention_routes_compact_selection_and_records_call(monkeypatch):
+def test_qsa_attention_routes_compact_selection_and_records_construction(monkeypatch):
     args = _args()
     attention = QSAAttention(args)
     attention.eval()
@@ -297,7 +302,7 @@ def test_qsa_attention_routes_compact_selection_and_records_call(monkeypatch):
     np.testing.assert_array_equal(tail_counts, 2)
     assert block_size == 2
     assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
-        "kernel_calls": 1,
+        "route_constructions": 1,
         "declines": 0,
         "decline_reasons": {},
     }
@@ -381,7 +386,7 @@ def test_qsa_attention_disabled_control_stays_dense(monkeypatch):
     assert len(dense_masks) == 1
     assert dense_masks[0].shape == (1, 1, 64, 16_448)
     assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
-        "kernel_calls": 0,
+        "route_constructions": 0,
         "declines": 1,
         "decline_reasons": {"disabled": 1},
     }
@@ -412,7 +417,7 @@ def test_qsa_attention_unsupported_layout_stays_dense(monkeypatch):
     mx.eval(output)
 
     assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
-        "kernel_calls": 0,
+        "route_constructions": 0,
         "declines": 1,
         "decline_reasons": {"unsupported layout": 1},
     }
@@ -437,7 +442,7 @@ def test_qsa_attention_construction_failure_surfaces_without_false_receipt(monke
         )
 
     assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
-        "kernel_calls": 0,
+        "route_constructions": 0,
         "declines": 0,
         "decline_reasons": {},
     }

--- a/tests/test_qsa_block_sparse.py
+++ b/tests/test_qsa_block_sparse.py
@@ -90,6 +90,79 @@ def test_qsa_layout_gate_covers_threadgroup_and_gqa_limits():
         block_size=128,
         dtype=mx.bfloat16,
     )
+    assert not qsa_block_sparse.block_sparse_layout_supported(
+        query_heads=24,
+        kv_heads=0,
+        head_dim=256,
+        block_size=4,
+        dtype=mx.bfloat16,
+    )
+    assert not qsa_block_sparse.block_sparse_layout_supported(
+        query_heads=24,
+        kv_heads=2,
+        head_dim=255,
+        block_size=4,
+        dtype=mx.bfloat16,
+    )
+    assert not qsa_block_sparse.block_sparse_layout_supported(
+        query_heads=24,
+        kv_heads=2,
+        head_dim=256,
+        block_size=4,
+        dtype=mx.int32,
+    )
+
+
+def _valid_kernel_inputs(*, query_heads=2, kv_heads=1, head_dim=32, dtype=mx.float16):
+    queries = mx.zeros((1, query_heads, 1, head_dim), dtype=dtype)
+    keys = mx.zeros((1, kv_heads, 2, head_dim), dtype=dtype)
+    return {
+        "queries": queries,
+        "keys": keys,
+        "values": mx.zeros_like(keys),
+        "block_starts": mx.zeros((1, 1, 1), dtype=mx.int32),
+        "block_counts": mx.ones((1, 1), dtype=mx.int32),
+        "tail_indices": mx.zeros((1, 1, 2), dtype=mx.int32),
+        "tail_counts": mx.zeros((1, 1), dtype=mx.int32),
+        "block_size": 2,
+    }
+
+
+def test_qsa_kernel_rejects_every_unsafe_shape_and_layout():
+    def rejected(message, **overrides):
+        inputs = _valid_kernel_inputs()
+        inputs.update(overrides)
+        with pytest.raises(ValueError, match=message):
+            qsa_block_sparse.block_sparse_attention(**inputs)
+
+    rejected("rank four", queries=mx.zeros((1, 1, 32)))
+    rejected("positive", block_size=0)
+    rejected("block starts", block_starts=mx.zeros((1, 2, 1), dtype=mx.int32))
+    rejected("block counts", block_counts=mx.zeros((1, 2), dtype=mx.int32))
+    rejected("tail indices", tail_indices=mx.zeros((1, 1, 1), dtype=mx.int32))
+    rejected("tail counts", tail_counts=mx.zeros((1, 2), dtype=mx.int32))
+    rejected("shapes are inconsistent", values=mx.zeros((1, 1, 3, 32)))
+    rejected("same dtype", keys=mx.zeros((1, 1, 2, 32), dtype=mx.float32))
+
+    inputs = _valid_kernel_inputs(head_dim=33)
+    with pytest.raises(ValueError, match="divisible by 32"):
+        qsa_block_sparse.block_sparse_attention(**inputs)
+
+    inputs = _valid_kernel_inputs(kv_heads=0)
+    with pytest.raises(ValueError, match="at least one KV head"):
+        qsa_block_sparse.block_sparse_attention(**inputs)
+
+    inputs = _valid_kernel_inputs(query_heads=3, kv_heads=2)
+    with pytest.raises(ValueError, match="divisible by KV heads"):
+        qsa_block_sparse.block_sparse_attention(**inputs)
+
+    inputs = _valid_kernel_inputs(query_heads=33)
+    with pytest.raises(ValueError, match="at most 32"):
+        qsa_block_sparse.block_sparse_attention(**inputs)
+
+    inputs = _valid_kernel_inputs(dtype=mx.int32)
+    with pytest.raises(ValueError, match="layout is unsupported"):
+        qsa_block_sparse.block_sparse_attention(**inputs)
 
 
 class _FakeIndexer:
@@ -220,6 +293,37 @@ def test_qsa_attention_disabled_control_stays_dense(monkeypatch):
         "kernel_calls": 0,
         "declines": 1,
         "decline_reasons": {"disabled": 1},
+    }
+
+
+def test_qsa_attention_unsupported_layout_stays_dense(monkeypatch):
+    args = _args()
+    attention = QSAAttention(args)
+    attention.eval()
+    attention.indexer = _FakeIndexer()
+    monkeypatch.setenv(qsa_block_sparse.ENABLE_ENV, "1")
+    monkeypatch.setattr(qwen4_exp, "block_sparse_layout_supported", lambda **_: False)
+
+    def fail_if_sparse(*_args, **_kwargs):
+        raise AssertionError("unsupported layout must not dispatch the sparse kernel")
+
+    def fake_dense(queries, keys, values, *, cache, scale, mask):
+        del keys, values, cache, scale, mask
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(qwen4_exp, "block_sparse_attention", fail_if_sparse)
+    monkeypatch.setattr(qwen4_exp, "scaled_dot_product_attention", fake_dense)
+    output = attention(
+        mx.zeros((1, 64, args.hidden_size)),
+        [_FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+
+    assert qwen4_exp.qwen4_qsa_block_sparse_stats(attention) == {
+        "kernel_calls": 0,
+        "declines": 1,
+        "decline_reasons": {"unsupported layout": 1},
     }
 
 

--- a/tests/test_qsa_block_sparse.py
+++ b/tests/test_qsa_block_sparse.py
@@ -193,6 +193,32 @@ class _FakeIndexer:
         )
 
 
+class _GappedFakeIndexer(_FakeIndexer):
+    def __call__(
+        self,
+        hidden_states,
+        cache,
+        *,
+        physical_kv_length,
+        record_rollback=False,
+    ):
+        selection = super().__call__(
+            hidden_states,
+            cache,
+            physical_kv_length=physical_kv_length,
+            record_rollback=record_rollback,
+        )
+        length = int(hidden_states.shape[1])
+        validity = mx.array(
+            [True, True, False, False, True, True, False, False, False, True]
+        )
+        return qwen4_exp._QSASelection(
+            token_indices=selection.token_indices,
+            valid=mx.broadcast_to(validity, (1, length, validity.size)),
+            physical_kv_length=physical_kv_length,
+        )
+
+
 class _FakeKVCache:
     offset = 16_384
     _idx = 16_384
@@ -256,6 +282,52 @@ def test_qsa_attention_routes_compact_selection_and_records_call(monkeypatch):
         "declines": 0,
         "decline_reasons": {},
     }
+
+
+def test_qsa_attention_compacts_gapped_validity_before_counted_dispatch(monkeypatch):
+    args = _args()
+    attention = QSAAttention(args)
+    attention.eval()
+    attention.indexer = _GappedFakeIndexer()
+    monkeypatch.setenv(qsa_block_sparse.ENABLE_ENV, "1")
+    observed = []
+
+    def fake_sparse(
+        queries,
+        keys,
+        values,
+        block_starts,
+        block_counts,
+        tail_indices,
+        tail_counts,
+        *,
+        block_size,
+    ):
+        del keys, values, block_size
+        mx.eval(block_starts, block_counts, tail_indices, tail_counts)
+        observed.append(
+            (
+                np.array(block_starts[0, 0]),
+                np.array(block_counts),
+                np.array(tail_indices[0, 0]),
+                np.array(tail_counts),
+            )
+        )
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(qwen4_exp, "block_sparse_attention", fake_sparse)
+    output = attention(
+        mx.zeros((1, 64, args.hidden_size)),
+        [_FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+
+    starts, block_counts, tails, tail_counts = observed[0]
+    np.testing.assert_array_equal(starts, [4, 8, 16_448, 16_448])
+    np.testing.assert_array_equal(block_counts, 2)
+    np.testing.assert_array_equal(tails, [17, 16_448])
+    np.testing.assert_array_equal(tail_counts, 1)
 
 
 def test_qsa_attention_disabled_control_stays_dense(monkeypatch):

--- a/tests/test_qsa_block_sparse.py
+++ b/tests/test_qsa_block_sparse.py
@@ -128,6 +128,24 @@ def _valid_kernel_inputs(*, query_heads=2, kv_heads=1, head_dim=32, dtype=mx.flo
     }
 
 
+def test_qsa_selection_rejects_non_block_aligned_validity():
+    indices = mx.zeros((1, 2, 10), dtype=mx.int32)
+    with pytest.raises(ValueError, match="block geometry"):
+        qwen4_exp._QSASelection(
+            token_indices=indices,
+            block_valid=mx.ones((1, 2, 3), dtype=mx.bool_),
+            tail_valid=mx.ones((1, 2, 2), dtype=mx.bool_),
+            physical_kv_length=10,
+        )
+    with pytest.raises(ValueError, match="must be boolean"):
+        qwen4_exp._QSASelection(
+            token_indices=indices,
+            block_valid=mx.ones((1, 2, 4), dtype=mx.int32),
+            tail_valid=mx.ones((1, 2, 2), dtype=mx.bool_),
+            physical_kv_length=10,
+        )
+
+
 def test_qsa_kernel_rejects_every_unsafe_shape_and_layout():
     def rejected(message, **overrides):
         inputs = _valid_kernel_inputs()
@@ -188,7 +206,8 @@ class _FakeIndexer:
         tail = mx.broadcast_to(mx.array([16, 17], dtype=mx.int32), (1, length, 2))
         return qwen4_exp._QSASelection(
             token_indices=mx.concatenate([block_tokens, tail], axis=-1),
-            valid=mx.ones((1, length, 10), dtype=mx.bool_),
+            block_valid=mx.ones((1, length, 4), dtype=mx.bool_),
+            tail_valid=mx.ones((1, length, 2), dtype=mx.bool_),
             physical_kv_length=physical_kv_length,
         )
 
@@ -209,12 +228,12 @@ class _GappedFakeIndexer(_FakeIndexer):
             record_rollback=record_rollback,
         )
         length = int(hidden_states.shape[1])
-        validity = mx.array(
-            [True, True, False, False, True, True, False, False, False, True]
-        )
         return qwen4_exp._QSASelection(
             token_indices=selection.token_indices,
-            valid=mx.broadcast_to(validity, (1, length, validity.size)),
+            block_valid=mx.broadcast_to(
+                mx.array([True, False, True, False]), (1, length, 4)
+            ),
+            tail_valid=mx.broadcast_to(mx.array([False, True]), (1, length, 2)),
             physical_kv_length=physical_kv_length,
         )
 

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -914,8 +914,9 @@ def test_qsa_vectorized_mask_preserves_budget_tail_and_causality():
         physical_kv_length=65,
     )
     assert selected is not None
-    mx.eval(selected)
-    mask = np.array(selected[0, 0])
+    dense_mask = selected.dense_mask()
+    mx.eval(dense_mask)
+    mask = np.array(dense_mask[0, 0])
 
     expected_counts = []
     for position in range(65):
@@ -1015,7 +1016,8 @@ def test_qsa_sparse_scores_use_one_reference_batched_matmul(monkeypatch):
         cache,
         physical_kv_length=6,
     )
-    mx.eval(selected)
+    assert selected is not None
+    mx.eval(selected.token_indices, selected.valid)
     assert shapes == [
         (
             (args.indexer_n_heads, 6, args.indexer_head_dim),

--- a/tests/test_qwen4_fused_gdn_decode.py
+++ b/tests/test_qwen4_fused_gdn_decode.py
@@ -374,9 +374,17 @@ def test_resident_switch_preserves_weights_and_defaults_stock():
     layer.fused_gdn_decode_calls = 3
     layer.fused_gdn_decode_fallbacks = 2
     layer.fused_gdn_decode_last_fallback = "Metal runtime unavailable"
+    layer.fused_gdn_decode_fallback_reasons = {
+        "uninitialized cache": 1,
+        "Metal runtime unavailable": 1,
+    }
     assert qwen4_exp.qwen4_fused_gdn_stats(layer) == {
         "fused_calls": 3,
         "fallbacks": 2,
+        "fallback_reasons": {
+            "uninitialized cache": 1,
+            "Metal runtime unavailable": 1,
+        },
         "last_fallbacks": {"Metal runtime unavailable": 1},
     }
 
@@ -412,6 +420,10 @@ def test_uninitialized_and_speculative_cache_do_not_probe_metal():
     )
     assert result is None
     assert layer.fused_gdn_decode_last_fallback == "speculative rollback"
+    assert layer.fused_gdn_decode_fallback_reasons == {
+        "uninitialized cache": 1,
+        "speculative rollback": 1,
+    }
 
 
 def test_sharded_layer_falls_back_before_probe():

--- a/vllm_mlx/kernels/qsa_block_sparse.py
+++ b/vllm_mlx/kernels/qsa_block_sparse.py
@@ -256,6 +256,20 @@ def block_sparse_attention(
         raise ValueError("QSA tail indices must have shape [batch, query, block_size]")
     if tuple(tail_counts.shape) != expected_rows:
         raise ValueError("QSA tail counts must have shape [batch, query]")
+    compact_arrays = {
+        "block starts": block_starts,
+        "block counts": block_counts,
+        "tail indices": tail_indices,
+        "tail counts": tail_counts,
+    }
+    invalid_dtypes = [
+        name for name, array in compact_arrays.items() if array.dtype != mx.int32
+    ]
+    if invalid_dtypes:
+        raise ValueError(
+            "QSA compact indices and counts must use int32: "
+            + ", ".join(invalid_dtypes)
+        )
     block_topk = int(block_starts.shape[-1])
     if key_batch != batch or key_dim != head_dim or values.shape != keys.shape:
         raise ValueError("QSA query/KV shapes are inconsistent")
@@ -281,10 +295,6 @@ def block_sparse_attention(
     ):
         raise ValueError("QSA query/KV layout is unsupported by the sparse kernel")
     _log_activation()
-    block_starts = block_starts.astype(mx.int32)
-    block_counts = block_counts.astype(mx.int32)
-    tail_indices = tail_indices.astype(mx.int32)
-    tail_counts = tail_counts.astype(mx.int32)
     (output,) = _kernel()(
         inputs=[
             queries,

--- a/vllm_mlx/kernels/qsa_block_sparse.py
+++ b/vllm_mlx/kernels/qsa_block_sparse.py
@@ -53,10 +53,16 @@ _SOURCE = r"""
     }
 
     const int query_offset = batch * query_length + query_index;
-    const int block_count = block_counts[query_offset];
+    const int raw_block_count = block_counts[query_offset];
+    const int block_count = raw_block_count < 0
+        ? 0
+        : (raw_block_count > BLOCK_TOPK ? BLOCK_TOPK : raw_block_count);
     const int block_base = query_offset * BLOCK_TOPK;
     for (int block_index = 0; block_index < block_count; ++block_index) {
         const int physical_start = block_starts[block_base + block_index];
+        if (physical_start < 0 || physical_start > key_length - BLOCK_SIZE) {
+            continue;
+        }
         for (int element = int(tid); element < BLOCK_SIZE * HEAD_DIM;
              element += THREADS) {
             const int token = element / HEAD_DIM;
@@ -96,10 +102,16 @@ _SOURCE = r"""
         threadgroup_barrier(mem_flags::mem_threadgroup);
     }
 
-    const int tail_count = tail_counts[query_offset];
+    const int raw_tail_count = tail_counts[query_offset];
+    const int tail_count = raw_tail_count < 0
+        ? 0
+        : (raw_tail_count > BLOCK_SIZE ? BLOCK_SIZE : raw_tail_count);
     const int tail_base = query_offset * BLOCK_SIZE;
     for (int tail_index = 0; tail_index < tail_count; ++tail_index) {
         const int key_index = tail_indices[tail_base + tail_index];
+        if (key_index < 0 || key_index >= key_length) {
+            continue;
+        }
         for (int dim = int(tid); dim < HEAD_DIM; dim += THREADS) {
             const int offset =
                 ((batch * KV_HEADS + kv_head) * key_length + key_index)

--- a/vllm_mlx/kernels/qsa_block_sparse.py
+++ b/vllm_mlx/kernels/qsa_block_sparse.py
@@ -241,7 +241,6 @@ def block_sparse_attention(
     block_size: int,
 ) -> mx.array:
     """Attend to sorted selected blocks plus the current incomplete tail."""
-    _log_activation()
     if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
         raise ValueError("QSA query/K/V arrays must be rank four")
     if block_size <= 0:
@@ -281,6 +280,7 @@ def block_sparse_attention(
         dtype=queries.dtype,
     ):
         raise ValueError("QSA query/KV layout is unsupported by the sparse kernel")
+    _log_activation()
     block_starts = block_starts.astype(mx.int32)
     block_counts = block_counts.astype(mx.int32)
     tail_indices = tail_indices.astype(mx.int32)

--- a/vllm_mlx/kernels/qsa_block_sparse.py
+++ b/vllm_mlx/kernels/qsa_block_sparse.py
@@ -186,23 +186,6 @@ def block_sparse_decline_reason(
     return None
 
 
-def should_use_block_sparse(
-    query_length: int,
-    physical_kv_length: int,
-    *,
-    training: bool = False,
-) -> bool:
-    """Return whether the route is enabled and past its measured crossover."""
-    return (
-        block_sparse_decline_reason(
-            query_length,
-            physical_kv_length,
-            training=training,
-        )
-        is None
-    )
-
-
 def block_sparse_layout_supported(
     *,
     query_heads: int,

--- a/vllm_mlx/kernels/qsa_block_sparse.py
+++ b/vllm_mlx/kernels/qsa_block_sparse.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in block-sparse QSA prefill attention for Apple Silicon."""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+ENABLE_ENV = "RAPID_MLX_QSA_BLOCK_SPARSE"
+MIN_QUERY_LENGTH = 64
+MIN_PHYSICAL_KV_LENGTH = 16_384
+MAX_GQA_HEADS = 32
+MAX_THREADGROUP_MEMORY_BYTES = 32 * 1024
+
+_SOURCE = r"""
+    constexpr int VALUES_PER_LANE = HEAD_DIM / 32;
+    constexpr int THREADS = GQA_HEADS * 32;
+
+    // Prompt geometry is a runtime uniform so one compiled pipeline serves
+    // every prefill chunk width instead of retaining one library per shape.
+    const int query_length = dims[0];
+    const int key_length = dims[1];
+
+    const uint tid = thread_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const uint simdgroup = simdgroup_index_in_threadgroup;
+    const int query_index = int(threadgroup_position_in_grid.x);
+    const int batch_kv = int(threadgroup_position_in_grid.y);
+    const int batch = batch_kv / KV_HEADS;
+    const int kv_head = batch_kv - batch * KV_HEADS;
+    const int query_head = kv_head * GQA_HEADS + int(simdgroup);
+
+    threadgroup T shared_keys[BLOCK_SIZE * HEAD_DIM];
+    threadgroup T shared_values[BLOCK_SIZE * HEAD_DIM];
+
+    float query_values[VALUES_PER_LANE];
+    float running_max = -INFINITY;
+    float running_sum = 0.0f;
+    float output_values[VALUES_PER_LANE];
+
+    for (int value_index = 0; value_index < VALUES_PER_LANE; ++value_index) {
+        const int dim = int(lane) + value_index * 32;
+        const int offset =
+            ((batch * QUERY_HEADS + query_head) * query_length + query_index)
+            * HEAD_DIM + dim;
+        query_values[value_index] = float(queries[offset]);
+        output_values[value_index] = 0.0f;
+    }
+
+    const int query_offset = batch * query_length + query_index;
+    const int block_count = block_counts[query_offset];
+    const int block_base = query_offset * BLOCK_TOPK;
+    for (int block_index = 0; block_index < block_count; ++block_index) {
+        const int physical_start = block_starts[block_base + block_index];
+        for (int element = int(tid); element < BLOCK_SIZE * HEAD_DIM;
+             element += THREADS) {
+            const int token = element / HEAD_DIM;
+            const int dim = element - token * HEAD_DIM;
+            const int key_index = physical_start + token;
+            const int offset =
+                ((batch * KV_HEADS + kv_head) * key_length + key_index)
+                * HEAD_DIM + dim;
+            shared_keys[element] = keys[offset];
+            shared_values[element] = values[offset];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int token = 0; token < BLOCK_SIZE; ++token) {
+            float partial = 0.0f;
+            for (int value_index = 0; value_index < VALUES_PER_LANE;
+                 ++value_index) {
+                const int dim = int(lane) + value_index * 32;
+                partial += query_values[value_index]
+                    * float(shared_keys[token * HEAD_DIM + dim]);
+            }
+            const float score = simd_sum(partial)
+                * metal::rsqrt(float(HEAD_DIM));
+            const float next_max = metal::max(running_max, score);
+            const float old_weight = metal::exp(running_max - next_max);
+            const float new_weight = metal::exp(score - next_max);
+            running_sum = running_sum * old_weight + new_weight;
+            for (int value_index = 0; value_index < VALUES_PER_LANE;
+                 ++value_index) {
+                const int dim = int(lane) + value_index * 32;
+                output_values[value_index] =
+                    output_values[value_index] * old_weight
+                    + new_weight * float(shared_values[token * HEAD_DIM + dim]);
+            }
+            running_max = next_max;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    const int tail_count = tail_counts[query_offset];
+    const int tail_base = query_offset * BLOCK_SIZE;
+    for (int tail_index = 0; tail_index < tail_count; ++tail_index) {
+        const int key_index = tail_indices[tail_base + tail_index];
+        for (int dim = int(tid); dim < HEAD_DIM; dim += THREADS) {
+            const int offset =
+                ((batch * KV_HEADS + kv_head) * key_length + key_index)
+                * HEAD_DIM + dim;
+            shared_keys[dim] = keys[offset];
+            shared_values[dim] = values[offset];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        float partial = 0.0f;
+        for (int value_index = 0; value_index < VALUES_PER_LANE; ++value_index) {
+            const int dim = int(lane) + value_index * 32;
+            partial += query_values[value_index] * float(shared_keys[dim]);
+        }
+        const float score = simd_sum(partial) * metal::rsqrt(float(HEAD_DIM));
+        const float next_max = metal::max(running_max, score);
+        const float old_weight = metal::exp(running_max - next_max);
+        const float new_weight = metal::exp(score - next_max);
+        running_sum = running_sum * old_weight + new_weight;
+        for (int value_index = 0; value_index < VALUES_PER_LANE; ++value_index) {
+            const int dim = int(lane) + value_index * 32;
+            output_values[value_index] = output_values[value_index] * old_weight
+                + new_weight * float(shared_values[dim]);
+        }
+        running_max = next_max;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    for (int value_index = 0; value_index < VALUES_PER_LANE; ++value_index) {
+        const int dim = int(lane) + value_index * 32;
+        const int output_index =
+            ((batch * QUERY_HEADS + query_head) * query_length + query_index)
+            * HEAD_DIM + dim;
+        output[output_index] = running_sum == 0.0f
+            ? T(0.0f)
+            : T(output_values[value_index] / running_sum);
+    }
+"""
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_qsa_block_sparse",
+        input_names=[
+            "queries",
+            "keys",
+            "values",
+            "block_starts",
+            "block_counts",
+            "tail_indices",
+            "tail_counts",
+            "dims",
+        ],
+        output_names=["output"],
+        source=_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+def block_sparse_decline_reason(
+    query_length: int,
+    physical_kv_length: int,
+    *,
+    training: bool = False,
+) -> str | None:
+    """Return ``None`` when the opt-in route is eligible, else why it declined."""
+    enabled = os.environ.get(ENABLE_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if not enabled:
+        return "disabled"
+    if training:
+        return "training"
+    if query_length < MIN_QUERY_LENGTH:
+        return "query below crossover"
+    if physical_kv_length < MIN_PHYSICAL_KV_LENGTH:
+        return "physical KV below crossover"
+    if not mx.metal.is_available():
+        return "Metal runtime unavailable"
+    return None
+
+
+def should_use_block_sparse(
+    query_length: int,
+    physical_kv_length: int,
+    *,
+    training: bool = False,
+) -> bool:
+    """Return whether the route is enabled and past its measured crossover."""
+    return (
+        block_sparse_decline_reason(
+            query_length,
+            physical_kv_length,
+            training=training,
+        )
+        is None
+    )
+
+
+def block_sparse_layout_supported(
+    *,
+    query_heads: int,
+    kv_heads: int,
+    head_dim: int,
+    block_size: int,
+    dtype: mx.Dtype,
+) -> bool:
+    """Return whether the layout fits the kernel and Metal memory limits."""
+    if kv_heads <= 0 or block_size <= 0 or head_dim <= 0:
+        return False
+    if head_dim % 32 or query_heads % kv_heads:
+        return False
+    gqa_heads = query_heads // kv_heads
+    if not 0 < gqa_heads <= MAX_GQA_HEADS:
+        return False
+    if dtype not in {mx.float16, mx.bfloat16, mx.float32}:
+        return False
+    threadgroup_bytes = 2 * block_size * head_dim * int(dtype.size)
+    return threadgroup_bytes <= MAX_THREADGROUP_MEMORY_BYTES
+
+
+@lru_cache(maxsize=1)
+def _log_activation() -> None:
+    logger.info(
+        "QSA block-sparse prefill enabled (query>=%d, physical_kv>=%d)",
+        MIN_QUERY_LENGTH,
+        MIN_PHYSICAL_KV_LENGTH,
+    )
+
+
+def block_sparse_attention(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    block_starts: mx.array,
+    block_counts: mx.array,
+    tail_indices: mx.array,
+    tail_counts: mx.array,
+    *,
+    block_size: int,
+) -> mx.array:
+    """Attend to sorted selected blocks plus the current incomplete tail."""
+    _log_activation()
+    if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
+        raise ValueError("QSA query/K/V arrays must be rank four")
+    if block_size <= 0:
+        raise ValueError("QSA block size must be positive")
+    batch, query_heads, query_length, head_dim = map(int, queries.shape)
+    key_batch, kv_heads, key_length, key_dim = map(int, keys.shape)
+    expected_rows = (batch, query_length)
+    if block_starts.ndim != 3 or tuple(block_starts.shape[:2]) != expected_rows:
+        raise ValueError("QSA block starts must have shape [batch, query, topk]")
+    if tuple(block_counts.shape) != expected_rows:
+        raise ValueError("QSA block counts must have shape [batch, query]")
+    if tuple(tail_indices.shape) != (*expected_rows, block_size):
+        raise ValueError("QSA tail indices must have shape [batch, query, block_size]")
+    if tuple(tail_counts.shape) != expected_rows:
+        raise ValueError("QSA tail counts must have shape [batch, query]")
+    block_topk = int(block_starts.shape[-1])
+    if key_batch != batch or key_dim != head_dim or values.shape != keys.shape:
+        raise ValueError("QSA query/KV shapes are inconsistent")
+    if queries.dtype != keys.dtype or queries.dtype != values.dtype:
+        raise ValueError("QSA query/K/V arrays must have the same dtype")
+    if head_dim % 32:
+        raise ValueError("QSA head dimension must be divisible by 32")
+    if kv_heads <= 0:
+        raise ValueError("QSA requires at least one KV head")
+    if query_heads % kv_heads:
+        raise ValueError("QSA query heads must be divisible by KV heads")
+    gqa_heads = query_heads // kv_heads
+    if gqa_heads > MAX_GQA_HEADS:
+        raise ValueError(
+            f"QSA supports at most {MAX_GQA_HEADS} query heads per KV head"
+        )
+    if not block_sparse_layout_supported(
+        query_heads=query_heads,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        dtype=queries.dtype,
+    ):
+        raise ValueError("QSA query/KV layout is unsupported by the sparse kernel")
+    block_starts = block_starts.astype(mx.int32)
+    block_counts = block_counts.astype(mx.int32)
+    tail_indices = tail_indices.astype(mx.int32)
+    tail_counts = tail_counts.astype(mx.int32)
+    (output,) = _kernel()(
+        inputs=[
+            queries,
+            keys,
+            values,
+            block_starts,
+            block_counts,
+            tail_indices,
+            tail_counts,
+            mx.array([query_length, key_length], dtype=mx.int32),
+        ],
+        template=[
+            ("T", queries.dtype),
+            ("QUERY_HEADS", query_heads),
+            ("KV_HEADS", kv_heads),
+            ("GQA_HEADS", gqa_heads),
+            ("HEAD_DIM", head_dim),
+            ("BLOCK_SIZE", block_size),
+            ("BLOCK_TOPK", block_topk),
+        ],
+        grid=(gqa_heads * 32 * query_length, batch * kv_heads, 1),
+        threadgroup=(gqa_heads * 32, 1, 1),
+        output_shapes=[queries.shape],
+        output_dtypes=[queries.dtype],
+    )
+    return output

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -821,8 +821,43 @@ class _QSASelection:
     """Compact per-query physical KV indices produced by the QSA indexer."""
 
     token_indices: mx.array
-    valid: mx.array
+    block_valid: mx.array
+    tail_valid: mx.array
     physical_kv_length: int
+
+    def __post_init__(self) -> None:
+        if self.token_indices.ndim != 3:
+            raise ValueError("QSA compact token indices must be rank three")
+        batch, length, width = map(int, self.token_indices.shape)
+        if self.block_valid.ndim != 3 or tuple(self.block_valid.shape[:2]) != (
+            batch,
+            length,
+        ):
+            raise ValueError(
+                "QSA block validity must have shape [batch, query, blocks]"
+            )
+        if self.tail_valid.ndim != 3 or tuple(self.tail_valid.shape[:2]) != (
+            batch,
+            length,
+        ):
+            raise ValueError("QSA tail validity must have shape [batch, query, tail]")
+        block_size = int(self.tail_valid.shape[-1])
+        expected_width = (int(self.block_valid.shape[-1]) + 1) * block_size
+        if block_size <= 0 or width != expected_width:
+            raise ValueError("QSA compact selection does not match its block geometry")
+        if self.block_valid.dtype != mx.bool_ or self.tail_valid.dtype != mx.bool_:
+            raise ValueError("QSA compact validity arrays must be boolean")
+
+    @property
+    def valid(self) -> mx.array:
+        """Expand structurally block-aligned validity for the dense fallback."""
+        batch, length, _ = map(int, self.token_indices.shape)
+        block_size = int(self.tail_valid.shape[-1])
+        block_token_valid = mx.broadcast_to(
+            self.block_valid[..., None],
+            (*self.block_valid.shape, block_size),
+        ).reshape(batch, length, -1)
+        return mx.concatenate([block_token_valid, self.tail_valid], axis=-1)
 
     def dense_mask(self) -> mx.array:
         """Materialize the reference mask for unsupported sparse consumers."""
@@ -931,7 +966,8 @@ class QSAIndexer(nn.Module):
             else [int(value) for value in cache.left_padding.tolist()]
         )
         compact_indices = []
-        compact_valid = []
+        compact_block_valid = []
+        compact_tail_valid = []
         for batch_index in range(batch):
             input_start, valid_length = valid_spans[batch_index]
             available_blocks = cache._compressed_counts[batch_index]
@@ -989,11 +1025,6 @@ class QSAIndexer(nn.Module):
                 blocks[:, :, None] * self.compress_ratio
                 + mx.arange(self.compress_ratio, dtype=mx.int32)[None, None, :]
             ).reshape(length, self.token_budget)
-            block_token_valid = mx.broadcast_to(
-                block_valid[:, :, None],
-                (length, self.block_topk, self.compress_ratio),
-            ).reshape(length, self.token_budget)
-
             tail_start = complete_counts * self.compress_ratio
             tail_counts = logical_positions + 1 - tail_start
             tail_offsets = mx.arange(self.compress_ratio, dtype=mx.int32)[None, :]
@@ -1004,17 +1035,19 @@ class QSAIndexer(nn.Module):
                 query_indices < input_start + valid_length
             )
             indices = mx.concatenate([block_tokens, tail_tokens], axis=-1)
-            valid = mx.concatenate([block_token_valid, tail_valid], axis=-1)
-            valid = valid & query_valid[:, None]
+            block_valid = block_valid & query_valid[:, None]
+            tail_valid = tail_valid & query_valid[:, None]
             indices = mx.clip(
                 indices + left_padding[batch_index], 0, physical_kv_length - 1
             )
             compact_indices.append(indices)
-            compact_valid.append(valid)
+            compact_block_valid.append(block_valid)
+            compact_tail_valid.append(tail_valid)
 
         selection = _QSASelection(
             token_indices=mx.stack(compact_indices),
-            valid=mx.stack(compact_valid),
+            block_valid=mx.stack(compact_block_valid),
+            tail_valid=mx.stack(compact_tail_valid),
             physical_kv_length=physical_kv_length,
         )
         return selection
@@ -1160,7 +1193,7 @@ class QSAAttention(nn.Module):
                 invalid_index = mx.array(
                     physical_length, dtype=selected.token_indices.dtype
                 )
-                block_valid = selected.valid[..., block_slots]
+                block_valid = selected.block_valid
                 block_starts = mx.sort(
                     mx.where(
                         block_valid,
@@ -1169,7 +1202,7 @@ class QSAAttention(nn.Module):
                     ),
                     axis=-1,
                 )
-                tail_valid = selected.valid[..., tail_slots]
+                tail_valid = selected.tail_valid
                 tail_indices = mx.sort(
                     mx.where(
                         tail_valid,

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -1157,12 +1157,27 @@ class QSAAttention(nn.Module):
                     0, self.indexer.token_budget, self.indexer.compress_ratio
                 )
                 tail_slots = slice(self.indexer.token_budget, None)
-                block_starts = mx.sort(
-                    selected.token_indices[..., block_slots], axis=-1
+                invalid_index = mx.array(
+                    physical_length, dtype=selected.token_indices.dtype
                 )
                 block_valid = selected.valid[..., block_slots]
-                tail_indices = selected.token_indices[..., tail_slots]
+                block_starts = mx.sort(
+                    mx.where(
+                        block_valid,
+                        selected.token_indices[..., block_slots],
+                        invalid_index,
+                    ),
+                    axis=-1,
+                )
                 tail_valid = selected.valid[..., tail_slots]
+                tail_indices = mx.sort(
+                    mx.where(
+                        tail_valid,
+                        selected.token_indices[..., tail_slots],
+                        invalid_index,
+                    ),
+                    axis=-1,
+                )
                 output = block_sparse_attention(
                     queries,
                     keys,

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -1163,21 +1163,21 @@ class QSAAttention(nn.Module):
                 block_valid = selected.valid[..., block_slots]
                 tail_indices = selected.token_indices[..., tail_slots]
                 tail_valid = selected.valid[..., tail_slots]
-                try:
-                    output = block_sparse_attention(
-                        queries,
-                        keys,
-                        values,
-                        block_starts,
-                        mx.sum(block_valid, axis=-1).astype(mx.int32),
-                        tail_indices,
-                        mx.sum(tail_valid, axis=-1).astype(mx.int32),
-                        block_size=self.indexer.compress_ratio,
-                    )
-                except Exception as exc:  # noqa: BLE001 - optional path fails closed
-                    decline_reason = f"kernel dispatch failed: {type(exc).__name__}"
-                else:
-                    self.block_sparse_calls += 1
+                output = block_sparse_attention(
+                    queries,
+                    keys,
+                    values,
+                    block_starts,
+                    mx.sum(block_valid, axis=-1).astype(mx.int32),
+                    tail_indices,
+                    mx.sum(tail_valid, axis=-1).astype(mx.int32),
+                    block_size=self.indexer.compress_ratio,
+                )
+                # MLX evaluates lazily. Do not add a per-layer synchronization
+                # in an attempt to catch later Metal failures here: eligibility
+                # declines fall back to dense, while execution failures surface
+                # through the engine's normal generation-error path.
+                self.block_sparse_calls += 1
             if decline_reason is not None:
                 self._record_block_sparse_decline(decline_reason)
 

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -1093,7 +1093,7 @@ class QSAAttention(nn.Module):
             max_position_embeddings=args.max_position_embeddings,
         )
         self.indexer = QSAIndexer(args)
-        self.block_sparse_calls = 0
+        self.block_sparse_route_constructions = 0
         self.block_sparse_declines = 0
         self.block_sparse_decline_reasons: dict[str, int] = {}
 
@@ -1225,7 +1225,7 @@ class QSAAttention(nn.Module):
                 # in an attempt to catch later Metal failures here: eligibility
                 # declines fall back to dense, while execution failures surface
                 # through the engine's normal generation-error path.
-                self.block_sparse_calls += 1
+                self.block_sparse_route_constructions += 1
             if decline_reason is not None:
                 self._record_block_sparse_decline(decline_reason)
 
@@ -1257,16 +1257,16 @@ class QSAAttention(nn.Module):
 
 
 def qwen4_qsa_block_sparse_stats(model: nn.Module) -> dict[str, Any]:
-    """Aggregate QSA sparse-kernel calls and every dense fallback reason."""
+    """Aggregate sparse-route constructions and every dense fallback reason."""
     stats: dict[str, Any] = {
-        "kernel_calls": 0,
+        "route_constructions": 0,
         "declines": 0,
         "decline_reasons": {},
     }
     for _, module in model.named_modules():
         if not isinstance(module, QSAAttention):
             continue
-        stats["kernel_calls"] += module.block_sparse_calls
+        stats["route_constructions"] += module.block_sparse_route_constructions
         stats["declines"] += module.block_sparse_declines
         for reason, count in module.block_sparse_decline_reasons.items():
             stats["decline_reasons"][reason] = (

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -670,9 +670,11 @@ def qwen4_fused_gdn_stats(model: nn.Module) -> dict[str, Any]:
             stats["fallback_reasons"][reason] = (
                 stats["fallback_reasons"].get(reason, 0) + count
             )
-        reason = module.fused_gdn_decode_last_fallback
-        if reason is not None:
-            stats["last_fallbacks"][reason] = stats["last_fallbacks"].get(reason, 0) + 1
+        last_reason = module.fused_gdn_decode_last_fallback
+        if last_reason is not None:
+            stats["last_fallbacks"][last_reason] = (
+                stats["last_fallbacks"].get(last_reason, 0) + 1
+            )
     return stats
 
 

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -36,6 +36,11 @@ from mlx_lm.models.gated_delta import gated_delta_update  # noqa: E402
 from mlx_lm.models.rope_utils import initialize_rope  # noqa: E402
 from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
+from ..kernels.qsa_block_sparse import (  # noqa: E402
+    block_sparse_attention,
+    block_sparse_decline_reason,
+    block_sparse_layout_supported,
+)
 from ..kernels.qwen4_fused_gdn_decode import (  # noqa: E402
     admit_qwen4_fused_gdn_decode,
     fused_gdn_runtime_supported,
@@ -404,6 +409,7 @@ class GatedDeltaNet(nn.Module):
         self.fused_gdn_decode_calls = 0
         self.fused_gdn_decode_fallbacks = 0
         self.fused_gdn_decode_last_fallback: str | None = None
+        self.fused_gdn_decode_fallback_reasons: dict[str, int] = {}
 
     def set_fused_gdn_decode_mode(self, mode: str) -> None:
         """Select the decode path without replacing resident weights."""
@@ -417,6 +423,9 @@ class GatedDeltaNet(nn.Module):
     def _fused_gdn_fallback(self, reason: str):
         self.fused_gdn_decode_fallbacks += 1
         self.fused_gdn_decode_last_fallback = reason
+        self.fused_gdn_decode_fallback_reasons[reason] = (
+            self.fused_gdn_decode_fallback_reasons.get(reason, 0) + 1
+        )
         return None
 
     def _try_fused_decode(
@@ -649,6 +658,7 @@ def qwen4_fused_gdn_stats(model: nn.Module) -> dict[str, Any]:
     stats: dict[str, Any] = {
         "fused_calls": 0,
         "fallbacks": 0,
+        "fallback_reasons": {},
         "last_fallbacks": {},
     }
     for _, module in model.named_modules():
@@ -656,6 +666,10 @@ def qwen4_fused_gdn_stats(model: nn.Module) -> dict[str, Any]:
             continue
         stats["fused_calls"] += module.fused_gdn_decode_calls
         stats["fallbacks"] += module.fused_gdn_decode_fallbacks
+        for reason, count in module.fused_gdn_decode_fallback_reasons.items():
+            stats["fallback_reasons"][reason] = (
+                stats["fallback_reasons"].get(reason, 0) + count
+            )
         reason = module.fused_gdn_decode_last_fallback
         if reason is not None:
             stats["last_fallbacks"][reason] = stats["last_fallbacks"].get(reason, 0) + 1
@@ -850,7 +864,7 @@ class QSAIndexer(nn.Module):
         *,
         physical_kv_length: int,
         record_rollback: bool = False,
-    ) -> mx.array | None:
+    ) -> _QSASelection | None:
         batch, length, _ = hidden_states.shape
         cache._ensure_batch(batch)
         offsets = list(cache._offsets)
@@ -1001,7 +1015,7 @@ class QSAIndexer(nn.Module):
             valid=mx.stack(compact_valid),
             physical_kv_length=physical_kv_length,
         )
-        return selection.dense_mask()
+        return selection
 
 
 class QSAAttention(nn.Module):
@@ -1044,6 +1058,15 @@ class QSAAttention(nn.Module):
             max_position_embeddings=args.max_position_embeddings,
         )
         self.indexer = QSAIndexer(args)
+        self.block_sparse_calls = 0
+        self.block_sparse_declines = 0
+        self.block_sparse_decline_reasons: dict[str, int] = {}
+
+    def _record_block_sparse_decline(self, reason: str) -> None:
+        self.block_sparse_declines += 1
+        self.block_sparse_decline_reasons[reason] = (
+            self.block_sparse_decline_reasons.get(reason, 0) + 1
+        )
 
     def __call__(
         self,
@@ -1112,25 +1135,94 @@ class QSAAttention(nn.Module):
         )
         if kv_cache is not None:
             keys, values = kv_cache.update_and_fetch(keys, values)
-        additive_mask = (
-            mask
-            if selected is None
-            else mx.where(
-                selected,
-                mx.array(0.0, dtype=queries.dtype),
-                mx.array(-1e9, dtype=queries.dtype),
+        output = None
+        if isinstance(selected, _QSASelection):
+            decline_reason = block_sparse_decline_reason(
+                length,
+                physical_length,
+                training=bool(self.training),
             )
-        )
-        output = scaled_dot_product_attention(
-            queries,
-            keys,
-            values,
-            cache=kv_cache,
-            scale=self.scale,
-            mask=additive_mask,
-        )
+            if decline_reason is None and not block_sparse_layout_supported(
+                query_heads=self.num_attention_heads,
+                kv_heads=self.num_key_value_heads,
+                head_dim=self.head_dim,
+                block_size=self.indexer.compress_ratio,
+                dtype=queries.dtype,
+            ):
+                decline_reason = "unsupported layout"
+            if decline_reason is None:
+                block_slots = slice(
+                    0, self.indexer.token_budget, self.indexer.compress_ratio
+                )
+                tail_slots = slice(self.indexer.token_budget, None)
+                block_starts = mx.sort(
+                    selected.token_indices[..., block_slots], axis=-1
+                )
+                block_valid = selected.valid[..., block_slots]
+                tail_indices = selected.token_indices[..., tail_slots]
+                tail_valid = selected.valid[..., tail_slots]
+                try:
+                    output = block_sparse_attention(
+                        queries,
+                        keys,
+                        values,
+                        block_starts,
+                        mx.sum(block_valid, axis=-1).astype(mx.int32),
+                        tail_indices,
+                        mx.sum(tail_valid, axis=-1).astype(mx.int32),
+                        block_size=self.indexer.compress_ratio,
+                    )
+                except Exception as exc:  # noqa: BLE001 - optional path fails closed
+                    decline_reason = f"kernel dispatch failed: {type(exc).__name__}"
+                else:
+                    self.block_sparse_calls += 1
+            if decline_reason is not None:
+                self._record_block_sparse_decline(decline_reason)
+
+        if output is None:
+            dense_selection = (
+                selected.dense_mask()
+                if isinstance(selected, _QSASelection)
+                else selected
+            )
+            additive_mask = (
+                mask
+                if dense_selection is None
+                else mx.where(
+                    dense_selection,
+                    mx.array(0.0, dtype=queries.dtype),
+                    mx.array(-1e9, dtype=queries.dtype),
+                )
+            )
+            output = scaled_dot_product_attention(
+                queries,
+                keys,
+                values,
+                cache=kv_cache,
+                scale=self.scale,
+                mask=additive_mask,
+            )
         output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
         return self.o_proj(output * mx.sigmoid(gate))
+
+
+def qwen4_qsa_block_sparse_stats(model: nn.Module) -> dict[str, Any]:
+    """Aggregate QSA sparse-kernel calls and every dense fallback reason."""
+    stats: dict[str, Any] = {
+        "kernel_calls": 0,
+        "declines": 0,
+        "decline_reasons": {},
+    }
+    for _, module in model.named_modules():
+        if not isinstance(module, QSAAttention):
+            continue
+        stats["kernel_calls"] += module.block_sparse_calls
+        stats["declines"] += module.block_sparse_declines
+        for reason, count in module.block_sparse_decline_reasons.items():
+            stats["decline_reasons"][reason] = (
+                stats["decline_reasons"].get(reason, 0) + count
+            )
+    return stats
 
 
 def _splitmix64(value: int) -> int:


### PR DESCRIPTION
## Goal

Reduce long-context Qwen4/Flash-Next prefill time by consuming QSA's compact selected blocks directly instead of materializing and traversing a dense attention mask.

## Why

At long contexts, QSA selects only a small fixed token budget, but the existing path still builds a full-width mask and asks dense attention to visit the physical cache. Direct indexed reads make work scale with selected tokens and avoid the dense intermediate while preserving a fail-closed stock route.

## Scope

- add a Metal block-sparse QSA prefill kernel behind `RAPID_MLX_QSA_BLOCK_SPARSE=1`
- admit only query width >=64 and physical KV >=16K; retain dense attention everywhere else
- record sparse route constructions and complete eligibility-decline histograms without mislabeling lazy construction as successful execution
- add reproducible latency, dispatch-floor, fp64 numerical, and served-route qualification
- cover the real Metal path on the existing Apple Silicon CI lane

## Non-goals

- no default-on promotion
- no decode, training, public API, model-selection, release, or deployment change
- no claim that isolated kernel speedup equals served end-to-end speedup

## Evidence

On Apple M3 Ultra / MLX 0.32.1, bf16, TF32 disabled, 64 queries over 16,384 keys with 2,048 selected tokens:

- dense masked attention: 2.828 ms median
- direct block-sparse attention: 1.468 ms median (1.93x isolated)
- synchronized dispatch floor: 177.4 us median
- sparse max/RMS error vs fp64: 0.000336 / 0.000118
- dense max/RMS error vs fp64: 0.001031 / 0.000303

Served dogfood on reviewed kernel head `c7371139a` used the immutable 98 GB `rapid-mlx/Qwen3.8-Flash-Next-4bit` snapshot, three cold-cache runs per arm, and identical Metal command-buffer controls:

| Prompt | Baseline TTFT | Sparse TTFT | TTFT change | Prefill change | Decode change | Peak RSS delta |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 16K | 20.125 s | 20.321 s | -0.98% | -0.97% | +0.58% | +0.005 GiB |
| 32K | 45.684 s | 39.159 s | +14.28% | +16.66% | -0.56% | +0.005 GiB |
| 64K | 116.040 s | 79.950 s | +31.10% | +45.14% | +0.86% | -0.002 GiB |

The 98 GB model's parameter materialization intermittently hit the macOS Metal watchdog. The retained pair completed without a new recovery; contaminated attempts are excluded and documented. The buffer controls are qualification controls, not product defaults or a claimed watchdog fix.

Adversarial review then removed a false synchronous-fallback claim: MLX evaluates lazily, so execution failures surface through the engine's normal generation-error path instead of forcing a performance-destroying per-layer synchronization. The receipt is now named `route_constructions`; execution qualification requires both a positive construction delta and successful downstream request completion. The kernel accepts only int32 compact arrays, clamps counts, and guards negative/oversized/`INT_MAX` indices before any K/V read. Invalid entries are replaced by an out-of-range sentinel and sorted behind the valid prefix. Validity is structurally one bit per complete block plus per-token tail validity, so partial complete blocks cannot be represented.

Safety code head `f1ec82bbf` measured 1.487 ms sparse versus 3.348 ms dense (2.25x). Final contract code head `20df4f239` measured 1.577 ms sparse versus 2.755 ms dense (1.75x); both retained unchanged numerical errors.

Verification at exact head `8ef208607`: `pr_validate` is MERGE-SAFE with 433 targeted tests passed/2 skipped, 21,673 full-unit tests passed/122 skipped/22 deselected/6 xfailed/1 xpassed, and 156/156 changed production lines covered. The final intention-scoped review of the production-code head reported no blocker; the exact-head delta only adds the three negative shape-contract assertions required by the strict Apple/Linux coverage union. Coverage includes forced-disable and unsupported-layout dense routing, every kernel shape/layout rejection boundary, construction-error truthfulness, device-side malformed count/index guards, block-aligned validity structure, gapped-validity compaction, multi-batch/multi-KV-head GQA Metal output vs fp64, routing policy, and Apple CI roster coverage. One pre-existing numerical-tolerance test initially exceeded absolute tolerance by 0.0000000368; its isolated rerun and the complete focused suite passed without changing tolerance.

The feature remains opt-in. Automatic promotion still requires a fresh model-scale correctness/path-receipt gate, and the slightly negative 16K result argues for re-measuring a higher default crossover.
