### PR TITLE
feat(start): one-command agent startup (#150)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,6 +19,7 @@
 | `rapid-mlx launch` | One-shot bootstrap: patch an IDE/agent client config to use rapid-mlx |
 | `rapid-mlx connect` | Show the server's connection info and wire up a tool |
 | `rapid-mlx agents` | List, configure, and test agent integrations |
+| `rapid-mlx start` | Start an AI agent with a local model in one command |
 | `rapid-mlx doctor` | Run self-diagnostic / regression harness |
 | `rapid-mlx telemetry` | Manage anonymous usage telemetry (opt-in) |
 | `rapid-mlx upgrade` | Upgrade rapid-mlx with its detected manager (brew / uv / pipx / pip / install.sh) |
@@ -452,6 +453,74 @@ MCP belongs to the chat process: it discovers and executes the configured
 tools, while the spawned or remote Rapid-MLX server receives only standard
 OpenAI function tools and tool-result messages. `serve` and `share` do not
 need the chat's MCP configuration.
+
+## `rapid-mlx start`
+
+Start an AI agent with a local model in one command. `start` ties together
+steps that would otherwise take several commands — pick an agent profile,
+choose a model that fits this Mac, run the server, and wire up the client —
+into a single foreground verb.
+
+### Usage
+
+```bash
+rapid-mlx start [profile] [--model MODEL] [--port PORT] [--host HOST]
+                [--no-download] [--dry-run] [--yes] [--no-setup]
+                [--ready-timeout SECONDS]
+```
+
+### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `profile` | Agent name (e.g. `codex`, `hermes`, `opencode`). Omit for a generic OpenAI-compatible endpoint. | *(none)* |
+| `--model` | Model alias or HF repo to serve. When omitted, picks the first recommended model (in the profile's declaration order) that fits this Mac and is already cached, else a previewed download. | auto |
+| `--port` | Port to serve on. | `8000` |
+| `--host` | Host to serve on. | `127.0.0.1` |
+| `--no-download` | Refuse to download a model; fail if no recommended model is cached. | off |
+| `--dry-run` | Preview the model, port, and config mutations without starting a server, downloading, or writing anything. | off |
+| `--yes`, `-y` | Skip the confirmation prompt before downloading / writing config. | off |
+| `--no-setup` | Do not write agent configuration after the server is ready; only print instructions. | off |
+| `--ready-timeout` | Seconds to wait for the spawned server to become ready. | `600` |
+
+### Behavior
+
+- **Model selection.** An explicit `--model` wins. Otherwise `start` walks
+  the profile's `recommended` models in declaration order and picks the
+  first that fits this Mac's RAM and is already cached; if none is cached it
+  picks the first fitting recommendation (the profile lists its preferred
+  workhorse first) and shows the download size for consent before starting.
+  `--no-download` refuses rather than touching the network.
+- **Foreground server.** `start` spawns the canonical `serve` in the
+  foreground as a child of this process, forwards `Ctrl-C` (SIGINT/SIGTERM)
+  to it, and exits with the server's status — no orphan `serve` is left
+  behind when you stop the agent. This differs from
+  `rapid-mlx launch --start-server`, which deliberately detaches.
+- **Port reuse.** If a healthy Rapid-MLX server already serves the chosen
+  model on the port, `start` reuses it instead of spawning a second one. If
+  the port is occupied by something else (or a different model), it refuses
+  with a clear message.
+- **Setup.** After the endpoint is healthy, `start` prints the agent's
+  connection instructions and, for the first-class profiles (`claude-code`,
+  `continue`, `deepseek-harness`), applies the same previewed/backed-up
+  atomic config changes as `rapid-mlx agents <name> --setup`. `--no-setup`
+  prints instructions only.
+
+### Examples
+
+```bash
+# Start codex with its recommended model that fits this Mac
+rapid-mlx start codex
+
+# Preview without starting, downloading, or writing anything
+rapid-mlx start hermes --dry-run
+
+# Serve an explicit model on a non-default port, skipping prompts
+rapid-mlx start opencode --model qwen3.5-9b-4bit --port 8123 --yes
+
+# Start a generic OpenAI-compatible endpoint (no agent config)
+rapid-mlx start
+```
 
 ## Environment Variables
 

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -117,10 +117,22 @@ def test_select_nothing_fits(monkeypatch, capsys):
     """Every recommended model rejected by RAM -> None + message."""
     profile = _FakeProfile(recommended_models=["qwen3.6-27b-4bit"])
     _patch_select_resources(monkeypatch, cached=lambda alias: False, fit=False)
+    monkeypatch.setattr(run_cli, "_fits_host", lambda alias, ram: False)
 
     picked = run_cli._select_model(explicit=None, profile=profile, no_download=False)
     assert picked is None
     assert "fit" in capsys.readouterr().out
+
+
+def test_select_cached_agent_model_with_unknown_fit_is_not_rejected(monkeypatch):
+    """Agent-only recommendations outside the global tiers remain eligible."""
+    alias = "qwen3-coder-30b-4bit"
+    profile = _FakeProfile(recommended_models=[alias])
+    _patch_select_resources(monkeypatch, cached=lambda candidate: candidate == alias)
+
+    assert (
+        run_cli._select_model(explicit=None, profile=profile, no_download=True) == alias
+    )
 
 
 def test_select_no_recommended_models_errors(monkeypatch, capsys):
@@ -636,6 +648,13 @@ def test_consent_no_download_cached_returns_true(monkeypatch):
     assert run_cli._confirm_download("m", no_download=True, yes=False) is True
 
 
+def test_consent_no_download_accepts_existing_local_model(tmp_path):
+    """A local checkpoint path never needs a Hugging Face cache entry."""
+    model = tmp_path / "model"
+    model.mkdir()
+    assert run_cli._confirm_download(str(model), no_download=True, yes=False) is True
+
+
 def test_consent_size_estimate_raises_handled(monkeypatch):
     """A size-estimate network failure is swallowed; gate still runs."""
     monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
@@ -768,8 +787,9 @@ def test_reuse_dry_run_refuses_incompatible_server(monkeypatch, capsys):
 
 
 class _FakeCfg:
-    def __init__(self, template=None):
+    def __init__(self, template=None, config_type="json"):
         self.template = template
+        self.type = config_type
 
 
 class _SetupPlanFake:
@@ -1010,6 +1030,49 @@ def test_attach_generic_writer_cannot(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "setup failed" in out
     assert "manual instructions" in out
+
+
+def test_attach_env_profile_prints_exports_without_write_consent(monkeypatch, capsys):
+    """Environment-only profiles give instructions and never claim a write."""
+    args = _make_args()
+    prof = _FakeProfile(name="langchain")
+    prof.config = _FakeCfg(config_type="env")
+    from vllm_mlx.agents import adapter as ad
+
+    calls = []
+    monkeypatch.setattr(
+        ad,
+        "setup_agent_config",
+        lambda *a, **kwargs: (
+            calls.append(kwargs.get("dry_run"))
+            or "Run these commands in your shell:\n  export OPENAI_API_BASE=http://b/v1"
+        ),
+    )
+    monkeypatch.setattr(
+        run_cli,
+        "_confirm_config_write",
+        lambda: pytest.fail("env instructions do not write configuration"),
+    )
+
+    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 0
+    out = capsys.readouterr().out
+    assert calls == [True]
+    assert "uses shell environment variables" in out
+    assert "configured!" not in out
+
+
+def test_cached_context_window_reads_text_config(monkeypatch):
+    """Dry-run can preview the eventual context value without network access."""
+    import vllm_mlx.model_metadata as metadata_mod
+
+    monkeypatch.setattr(
+        metadata_mod,
+        "read_model_metadata",
+        lambda model: types.SimpleNamespace(
+            config={"text_config": {"max_position_embeddings": 262_144}}
+        ),
+    )
+    assert run_cli._cached_context_window("cached-model") == 262_144
 
 
 def test_print_instructions_first_class(monkeypatch, capsys):

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -246,7 +246,12 @@ def test_reuse_compatible_server_attaches_no_spawn(monkeypatch, capsys):
 
     from vllm_mlx.agents import adapter as ad
 
-    monkeypatch.setattr(ad, "_fetch_models", lambda base: [{"id": "qwen3.5-9b-4bit"}])
+    fetched = []
+    monkeypatch.setattr(
+        ad,
+        "_fetch_models",
+        lambda base: fetched.append(base) or [{"id": "qwen3.5-9b-4bit"}],
+    )
     monkeypatch.setattr(run_cli, "_hf_id", lambda a: "qwen3.5-9b-4bit")
     monkeypatch.setattr(
         run_cli,
@@ -259,6 +264,7 @@ def test_reuse_compatible_server_attaches_no_spawn(monkeypatch, capsys):
     )
     assert result == 0
     assert toggles["attached"] is True
+    assert fetched == ["http://127.0.0.1:8000/v1"]
     assert "Reusing" in capsys.readouterr().out
 
 
@@ -905,10 +911,36 @@ def test_attach_generic_writer_success(monkeypatch, capsys):
 
     from vllm_mlx.agents import adapter as ad
 
-    monkeypatch.setattr(ad, "setup_agent_config", lambda *a, **k: "wrote config")
+    called = {}
+    monkeypatch.setattr(
+        ad,
+        "setup_agent_config",
+        lambda profile, base_url, model, **kwargs: called.update(
+            base_url=base_url, model=model
+        )
+        or "wrote config",
+    )
     rc = run_cli._attach_and_configure("http://b", "m", prof, args)
     assert rc == 0
+    assert called == {"base_url": "http://b/v1", "model": "m"}
     assert "configured!" in capsys.readouterr().out
+
+
+def test_start_command_renders_ipv6_base_url(monkeypatch):
+    """IPv6 bind hosts use a valid bracketed URL for readiness checks."""
+    args = _make_args(host="::1")
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: True)
+    reused = {}
+    monkeypatch.setattr(
+        run_cli,
+        "_reuse_or_refuse",
+        lambda base_url, *rest: reused.update(base_url=base_url) or 0,
+    )
+
+    assert run_cli.start_command(args) == 0
+    assert reused["base_url"] == "http://[::1]:8000"
 
 
 def test_attach_generic_writer_cannot(monkeypatch, capsys):

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -1,0 +1,1102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hermetic tests for ``rapid-mlx start`` (#150 one-command agent startup).
+
+``start`` is an orchestrator: it resolves a profile + model, consents to a
+download, spawns ``serve`` as a foreground parent-owned child (or reuses a
+compatible server), then prints/applies agent config. These tests cover the
+orchestration decisions without touching the network, the HF cache, or
+spawning real servers — every side effect is monkeypatched at the module
+boundary of ``vllm_mlx.run.cli`` (and the source modules it imports from
+inside each helper).
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import types
+
+import pytest
+
+import vllm_mlx.recommendations as rec
+from vllm_mlx import _download_gate as dg
+from vllm_mlx.run import cli as run_cli
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    """Build a ``start`` argument namespace with quiet defaults."""
+    base = dict(
+        profile="hermes",
+        model=None,
+        port=8000,
+        host="127.0.0.1",
+        no_download=False,
+        dry_run=False,
+        yes=False,
+        no_setup=False,
+        ready_timeout=600,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class _FakeProfile:
+    """Minimal stand-in for ``agents.AgentProfile`` (fields ``start`` reads)."""
+
+    def __init__(self, name="hermes", recommended_models=None, config=None):
+        self.name = name
+        self.display_name = name.title()
+        if recommended_models is None:
+            recommended_models = ["qwen3.5-9b-4bit"]
+        self.recommended_models = recommended_models
+        self.kind = "agent"
+        self.config = config
+
+    def get_config_for_version(self, version):  # pragma: no cover - trivial
+        return self.config
+
+
+# ---------------------------------------------------------------------------
+# Model selection
+# ---------------------------------------------------------------------------
+
+
+def _patch_select_resources(monkeypatch, cached=None, fit=True, ram=64.0):
+    """Patch the symbols ``_select_model`` imports (freshly, at call time)."""
+    monkeypatch.setattr(rec, "physical_ram_gb", lambda: ram)
+    if fit is True:
+        monkeypatch.setattr(rec, "is_recommended_alias", lambda alias, r: True)
+    elif fit is False:
+        monkeypatch.setattr(rec, "is_recommended_alias", lambda alias, r: False)
+    else:
+        monkeypatch.setattr(rec, "is_recommended_alias", fit)
+    if cached is not None:
+        monkeypatch.setattr(dg, "is_repo_cached", cached)
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
+
+
+def test_select_explicit_model_wins(monkeypatch):
+    """``--model`` is served verbatim, skipping all recommended logic."""
+    picked = run_cli._select_model(
+        explicit="mlx-community/Explicit-4bit", profile=None, no_download=True
+    )
+    assert picked == "mlx-community/Explicit-4bit"
+
+
+def test_select_cached_recommended_picked(monkeypatch):
+    """First recommended model that fits RAM and is cached wins."""
+    profile = _FakeProfile(recommended_models=["qwen3.5-9b-4bit", "qwen3.6-27b-4bit"])
+    _patch_select_resources(
+        monkeypatch, cached=lambda alias: alias == "qwen3.6-27b-4bit"
+    )
+
+    picked = run_cli._select_model(explicit=None, profile=profile, no_download=False)
+    assert picked == "qwen3.6-27b-4bit"
+
+
+def test_select_first_fit_when_nothing_cached(monkeypatch):
+    """With downloads allowed, the first recommended (declaration order) fits."""
+    profile = _FakeProfile(recommended_models=["qwen3.6-27b-4bit", "qwen3.5-9b-4bit"])
+    _patch_select_resources(monkeypatch, cached=lambda alias: False)
+
+    picked = run_cli._select_model(explicit=None, profile=profile, no_download=False)
+    assert picked == "qwen3.6-27b-4bit"
+
+
+def test_select_no_download_refuses_when_nothing_cached(monkeypatch, capsys):
+    """--no-download with no cached fitting model returns None + message."""
+    profile = _FakeProfile(recommended_models=["qwen3.5-9b-4bit"])
+    _patch_select_resources(monkeypatch, cached=lambda alias: False)
+
+    picked = run_cli._select_model(explicit=None, profile=profile, no_download=True)
+    assert picked is None
+    assert "--no-download" in capsys.readouterr().out
+
+
+def test_select_nothing_fits(monkeypatch, capsys):
+    """Every recommended model rejected by RAM -> None + message."""
+    profile = _FakeProfile(recommended_models=["qwen3.6-27b-4bit"])
+    _patch_select_resources(monkeypatch, cached=lambda alias: False, fit=False)
+
+    picked = run_cli._select_model(explicit=None, profile=profile, no_download=False)
+    assert picked is None
+    assert "fit" in capsys.readouterr().out
+
+
+def test_select_no_recommended_models_errors(monkeypatch, capsys):
+    """Profile with an empty recommended list -> clear error, pass --model."""
+    profile = _FakeProfile(recommended_models=[])
+    picked = run_cli._select_model(explicit=None, profile=profile, no_download=False)
+    assert picked is None
+    assert "--model" in capsys.readouterr().out
+
+
+def test_select_generic_uses_starter(monkeypatch):
+    """No profile and no model -> the first-run chat starter alias."""
+    from vllm_mlx import first_run as fr
+
+    monkeypatch.setattr(fr, "select_chat_default", lambda: ("qwen3.5-4b-4bit", True))
+    picked = run_cli._select_model(explicit=None, profile=None, no_download=False)
+    assert picked == "qwen3.5-4b-4bit"
+
+
+# ---------------------------------------------------------------------------
+# Consent
+# ---------------------------------------------------------------------------
+
+
+def test_consent_cached_passes(monkeypatch):
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
+    monkeypatch.setattr(dg, "is_repo_cached", lambda alias: True)
+    assert run_cli._confirm_download("m", no_download=False, yes=False) is True
+
+
+def test_consent_no_download_uncached_refuses(monkeypatch, capsys):
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
+    monkeypatch.setattr(dg, "is_repo_cached", lambda alias: False)
+    assert run_cli._confirm_download("m", no_download=True, yes=False) is False
+    assert "refusing" in capsys.readouterr().out
+
+
+def test_consent_yes_bypasses_prompt(monkeypatch):
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
+    monkeypatch.setattr(dg, "is_repo_cached", lambda alias: False)
+
+    def fail_confirm(*a, **k):
+        raise AssertionError("should not prompt with --yes")
+
+    monkeypatch.setattr(dg, "confirm_or_abort", fail_confirm)
+    assert run_cli._confirm_download("m", no_download=False, yes=True) is True
+
+
+def test_consent_routes_to_confirm_or_abort(monkeypatch):
+    """uncached + interactive + no --yes -> confirm_or_abort decides."""
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
+    monkeypatch.setattr(dg, "is_repo_cached", lambda alias: False)
+    monkeypatch.setattr(dg, "estimate_download_size_bytes", lambda alias: 123)
+    calls = {}
+
+    def fake_confirm(repo_id, size):
+        calls["repo"] = repo_id
+        calls["size"] = size
+        return False
+
+    monkeypatch.setattr(dg, "confirm_or_abort", fake_confirm)
+    # Force a TTY stdin so the gate reaches confirm_or_abort.
+    monkeypatch.setattr("sys.stdin", types.SimpleNamespace(isatty=lambda: True))
+
+    result = run_cli._confirm_download("m", no_download=False, yes=False)
+    assert result is False
+    assert calls.get("repo") == "m"
+    assert calls.get("size") == 123
+
+
+def test_consent_auto_pull_env_skips(monkeypatch):
+    """RAPID_MLX_AUTO_PULL=1 bypasses the prompt (CI path)."""
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
+    monkeypatch.setattr(dg, "is_repo_cached", lambda alias: False)
+    monkeypatch.setenv("RAPID_MLX_AUTO_PULL", "1")
+    assert run_cli._confirm_download("m", no_download=False, yes=False) is True
+
+
+# ---------------------------------------------------------------------------
+# Spawn + reuse
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_foreground_child_env(monkeypatch):
+    """Serve child: foreground (no start_new_session) + gate + watchdog env."""
+    import os
+    import subprocess as real_subprocess
+
+    args = _make_args()
+    captured = {}
+
+    class FakeProc:
+        pass
+
+    def fake_popen(cmd, **kw):
+        captured["cmd"] = cmd
+        captured["env"] = kw.get("env")
+        captured["start_new_session"] = kw.get("start_new_session", False)
+        return FakeProc()
+
+    monkeypatch.setattr(real_subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(run_cli, "subprocess", real_subprocess)
+
+    proc = run_cli._spawn_foreground_serve("qwen3.5-9b-4bit", args)
+    assert isinstance(proc, FakeProc)
+    assert captured["start_new_session"] is False  # foreground, parent-owned
+    assert captured["cmd"][:6] == [
+        real_subprocess.sys.executable,
+        "-m",
+        "vllm_mlx.cli",
+        "serve",
+        "qwen3.5-9b-4bit",
+        "--host",
+    ]
+    assert captured["env"]["RAPID_MLX_CHAT_SPAWN"] == "1"
+    assert captured["env"]["RAPID_MLX_WATCHDOG_PPID"] == str(os.getpid())
+
+
+def test_reuse_compatible_server_attaches_no_spawn(monkeypatch, capsys):
+    """Port serving the chosen model -> attach, never spawn."""
+    args = _make_args()
+    toggles = {"attached": False}
+
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(ad, "_fetch_models", lambda base: [{"id": "qwen3.5-9b-4bit"}])
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: "qwen3.5-9b-4bit")
+    monkeypatch.setattr(
+        run_cli,
+        "_attach_and_configure",
+        lambda base_url, model, profile, a: toggles.update(attached=True) or 0,
+    )
+
+    result = run_cli._reuse_or_refuse(
+        "http://127.0.0.1:8000", "qwen3.5-9b-4bit", _FakeProfile(), args
+    )
+    assert result == 0
+    assert toggles["attached"] is True
+    assert "Reusing" in capsys.readouterr().out
+
+
+def test_reuse_incompatible_server_refuses(monkeypatch, capsys):
+    """Port serving a different model -> clean refusal (exit 1)."""
+    args = _make_args()
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(ad, "_fetch_models", lambda base: [{"id": "other-model"}])
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: "qwen3.5-9b-4bit")
+
+    result = run_cli._reuse_or_refuse(
+        "http://127.0.0.1:8000", "qwen3.5-9b-4bit", _FakeProfile(), args
+    )
+    assert result == 1
+    assert "already serves" in capsys.readouterr().out
+
+
+def test_reuse_occupied_not_rapidmlx_refuses(monkeypatch, capsys):
+    """Port occupied by a non-rapid-mlx listener -> clean refusal."""
+    args = _make_args()
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(ad, "_fetch_models", lambda base: [])
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: "qwen3.5-9b-4bit")
+
+    result = run_cli._reuse_or_refuse(
+        "http://127.0.0.1:8000", "qwen3.5-9b-4bit", _FakeProfile(), args
+    )
+    assert result == 1
+    assert "not a healthy" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# start_command orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_start_command_dry_run_no_side_effects(monkeypatch, capsys):
+    """--dry-run never spawns, downloads, or writes config."""
+    args = _make_args(dry_run=True)
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "qwen3.5-9b-4bit")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(
+        run_cli, "_spawn_foreground_serve", lambda *a: pytest.fail("spawned")
+    )
+    monkeypatch.setattr(
+        run_cli, "_confirm_download", lambda *a, **k: pytest.fail("consented")
+    )
+
+    assert run_cli.start_command(args) == 0
+    assert "Dry run" in capsys.readouterr().out
+
+
+def _patch_profile_lookup(monkeypatch, profile):
+    """Patch ``vllm_mlx.agents.get_profile`` (imported inside start_command)."""
+    import vllm_mlx.agents as agents_mod
+
+    monkeypatch.setattr(agents_mod, "get_profile", lambda n: profile)
+
+
+def test_start_command_unknown_profile(monkeypatch, capsys):
+    """Unknown profile -> clear error, return 1, never selected/spawned."""
+    args = _make_args(profile="nope")
+    _patch_profile_lookup(monkeypatch, None)
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: pytest.fail("selected"))
+
+    assert run_cli.start_command(args) == 1
+    assert "Unknown agent" in capsys.readouterr().out
+
+
+def test_start_command_port_reuse_path(monkeypatch, capsys):
+    """Occupied compatible port -> reuse handler runs, no spawn path."""
+    args = _make_args()
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "qwen3.5-9b-4bit")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: True)
+    monkeypatch.setattr(run_cli, "_reuse_or_refuse", lambda *a, **k: 0)
+    monkeypatch.setattr(
+        run_cli, "_spawn_foreground_serve", lambda *a: pytest.fail("spawned")
+    )
+
+    assert run_cli.start_command(args) == 0
+
+
+def test_start_command_spawn_then_wait(monkeypatch):
+    """Normal path: consent -> spawn -> wait-ready -> configure -> wait-child."""
+    args = _make_args()
+    order = []
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(
+        run_cli, "_select_model", lambda **kw: order.append("select") or "m"
+    )
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(
+        run_cli, "_confirm_download", lambda *a, **k: order.append("confirm") or True
+    )
+    monkeypatch.setattr(
+        run_cli, "_spawn_foreground_serve", lambda *a: order.append("spawn") or object()
+    )
+    monkeypatch.setattr(
+        run_cli, "_wait_ready", lambda *a, **k: order.append("ready") or "ready"
+    )
+    monkeypatch.setattr(
+        run_cli, "_attach_and_configure", lambda *a, **k: order.append("configure") or 0
+    )
+    monkeypatch.setattr(run_cli, "_wait_child", lambda p: order.append("wait") or 3)
+
+    assert run_cli.start_command(args) == 3
+    assert order == ["select", "confirm", "spawn", "ready", "configure", "wait"]
+
+
+def test_start_command_spawn_after_consent_refused(monkeypatch):
+    """Consent refused -> return 1, never spawn."""
+    args = _make_args()
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(run_cli, "_confirm_download", lambda *a, **k: False)
+    monkeypatch.setattr(
+        run_cli, "_spawn_foreground_serve", lambda *a: pytest.fail("spawned")
+    )
+
+    assert run_cli.start_command(args) == 1
+
+
+def test_start_command_readiness_exit(monkeypatch):
+    """Serve child that exits before ready -> reap, return its code, no config.
+
+    Exercise the ``outcome == \"exited\"`` branch: the child died before
+    /health/ready returned, so start reaps it (its code) rather than
+    configuring the agent or printing a traceback.
+    """
+    args = _make_args()
+    order = []
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(run_cli, "_confirm_download", lambda *a, **k: True)
+    monkeypatch.setattr(
+        run_cli, "_spawn_foreground_serve", lambda *a: order.append("spawn") or object()
+    )
+    monkeypatch.setattr(run_cli, "_wait_ready", lambda *a, **k: "exited")
+    monkeypatch.setattr(
+        run_cli, "_attach_and_configure", lambda *a, **k: order.append("configure") or 0
+    )
+    monkeypatch.setattr(run_cli, "_wait_child", lambda p: order.append("wait") or 6)
+
+    assert run_cli.start_command(args) == 6
+    # configure must NOT run when the serve child never became ready.
+    assert order == ["spawn", "wait"]
+
+
+def test_start_command_readiness_timeout_terminates(monkeypatch):
+    """Ready-timeout with a STILL-ALIVE child -> terminate, reap, fail.
+
+    This is the HIGH hang fix: a timeout must NOT turn into an indefinite
+    ``_wait_child`` wait. The child (alive, still loading) is terminated,
+    then reaped; configure never runs.
+    """
+    args = _make_args()
+    order = []
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(run_cli, "_confirm_download", lambda *a, **k: True)
+    monkeypatch.setattr(
+        run_cli, "_spawn_foreground_serve", lambda *a: order.append("spawn") or object()
+    )
+    monkeypatch.setattr(run_cli, "_wait_ready", lambda *a, **k: "timeout")
+    terminated = []
+    monkeypatch.setattr(run_cli, "_terminate_child", lambda p: terminated.append(True))
+    monkeypatch.setattr(
+        run_cli, "_attach_and_configure", lambda *a, **k: order.append("configure") or 0
+    )
+    monkeypatch.setattr(run_cli, "_wait_child", lambda p: order.append("wait") or 2)
+
+    assert run_cli.start_command(args) == 2
+    assert terminated == [True]  # child was terminated on timeout
+    assert order == ["spawn", "wait"]
+
+
+def test_start_command_readiness_keyboard(monkeypatch):
+    """Ctrl-C during readiness -> reap, no configure."""
+    args = _make_args()
+    order = []
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(run_cli, "_confirm_download", lambda *a, **k: True)
+    monkeypatch.setattr(
+        run_cli, "_spawn_foreground_serve", lambda *a: order.append("spawn") or object()
+    )
+    monkeypatch.setattr(run_cli, "_wait_ready", lambda *a, **k: "exited")
+    monkeypatch.setattr(
+        run_cli, "_attach_and_configure", lambda *a, **k: order.append("configure") or 0
+    )
+    monkeypatch.setattr(run_cli, "_wait_child", lambda p: order.append("wait") or 1)
+
+    assert run_cli.start_command(args) == 1
+    assert order == ["spawn", "wait"]
+
+
+# ---------------------------------------------------------------------------
+# Child lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_wait_child_propagates_exit_code(monkeypatch):
+    """Child's nonzero exit code is returned as start's exit code."""
+    import time as real_time
+
+    class FakeChild:
+        def __init__(self):
+            self.returncode = None
+            self.n = 0
+
+        def poll(self):
+            self.n += 1
+            if self.n >= 3:
+                self.returncode = 7
+            return self.returncode
+
+        def send_signal(self, signum):  # pragma: no cover - not reached
+            pass
+
+    monkeypatch.setattr(real_time, "sleep", lambda s: None)
+    assert run_cli._wait_child(FakeChild()) == 7
+
+
+# ---------------------------------------------------------------------------
+# Dispatch + registration
+# ---------------------------------------------------------------------------
+
+
+def test_start_registers_subcommand():
+    """``start`` is a registered subcommand of the top-level CLI."""
+    from vllm_mlx.cli import build_parser
+
+    choices = build_parser()._subparsers._group_actions[0].choices
+    assert "start" in choices
+
+
+def test_start_main_dispatch_routes(monkeypatch):
+    """``main()`` routes ``rapid-mlx start ...`` to ``start_command``.
+
+    Covers the ``elif args.command == "start"`` dispatch branch in cli.py
+    (registration is covered above; the runtime routing needs a full
+    ``main()`` round-trip so changed-lines coverage sees it).
+    """
+    import sys
+
+    from vllm_mlx import cli
+
+    captured = {}
+
+    def fake_start(args):
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(sys, "argv", ["rapid-mlx", "start", "hermes", "--dry-run"])
+    # The dispatch does ``from vllm_mlx.run.cli import start_command`` inside
+    # main(); patch the true source module so that import picks up the fake.
+    monkeypatch.setattr("vllm_mlx.run.cli.start_command", fake_start)
+    cli.main()
+    assert captured["args"].profile == "hermes"
+    assert captured["args"].dry_run is True
+
+
+def test_start_main_dispatch_propagates_exit_code(monkeypatch):
+    """A nonzero start_command return raises SystemExit(code) at dispatch."""
+    import sys
+
+    from vllm_mlx import cli
+
+    monkeypatch.setattr(sys, "argv", ["rapid-mlx", "start", "nope", "--dry-run"])
+    monkeypatch.setattr("vllm_mlx.run.cli.start_command", lambda args: 3)
+    # The dispatch's ``if code: raise SystemExit(code)`` fires -> SystemExit(3).
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 3
+
+
+def test_run_alias_still_routes_to_chat(monkeypatch):
+    """Regression guard: #150 must NOT hijack ``run`` (stays a chat alias)."""
+    from vllm_mlx.cli import build_parser
+
+    # ``run`` resolves to the chat parser: it accepts chat-only flags.
+    ns = build_parser().parse_args(["run", "qwen3.5-4b-4bit", "--think"]).__dict__
+    assert ns.get("command") == "run"
+    assert "think" in ns
+    assert "max_tokens" in ns
+
+
+def test_start_help_is_distinct_from_chat():
+    """``start`` help must not advertise chat flags (distinct verb)."""
+    from vllm_mlx.cli import build_parser
+
+    choices = build_parser()._subparsers._group_actions[0].choices
+    start_p = choices["start"]
+    seen = {a.dest for a in start_p._actions}
+    assert "profile" in seen
+    assert "no_download" in seen
+    assert "dry_run" in seen
+    # Chat's model positional dest is ``model``; start profiles under
+    # ``profile`` so the two verbs never share semantics.
+    assert "model" in seen
+
+
+# ---------------------------------------------------------------------------
+# Coverage hardening: real helper bodies + wrappers + attach/configure
+# ---------------------------------------------------------------------------
+
+
+def test_start_command_model_none_returns_1(monkeypatch):
+    """start_command returns 1 (with no spawn) when selection yields None."""
+    args = _make_args()
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: None)
+    monkeypatch.setattr(
+        run_cli, "_spawn_foreground_serve", lambda *a: pytest.fail("spawned")
+    )
+    assert run_cli.start_command(args) == 1
+
+
+def test_hf_id_real_resolves(monkeypatch):
+    """Real ``_hf_id`` maps an alias via resolve_model (and degrades on error)."""
+
+    monkeypatch.setattr(
+        "vllm_mlx.model_aliases.resolve_model",
+        lambda name: "mlx-community/Resolved-4bit",
+    )
+    assert run_cli._hf_id("anything") == "mlx-community/Resolved-4bit"
+
+    # Exception path: resolve_model raising -> falls back to the alias.
+    def boom(name):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("vllm_mlx.model_aliases.resolve_model", boom)
+    assert run_cli._hf_id("flat-name") == "flat-name"
+
+
+def test_consent_no_download_cached_returns_true(monkeypatch):
+    """--no-download with a cached model passes (nothing to download)."""
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
+    monkeypatch.setattr(dg, "is_repo_cached", lambda alias: True)
+    assert run_cli._confirm_download("m", no_download=True, yes=False) is True
+
+
+def test_consent_size_estimate_raises_handled(monkeypatch):
+    """A size-estimate network failure is swallowed; gate still runs."""
+    monkeypatch.setattr(run_cli, "_hf_id", lambda a: a)
+    monkeypatch.setattr(dg, "is_repo_cached", lambda alias: False)
+    monkeypatch.setattr("sys.stdin", types.SimpleNamespace(isatty=lambda: True))
+    calls = {}
+    monkeypatch.setattr(
+        dg,
+        "estimate_download_size_bytes",
+        lambda alias: (_ for _ in ()).throw(RuntimeError("network")),
+    )
+    monkeypatch.setattr(
+        dg,
+        "confirm_or_abort",
+        lambda repo_id, size: calls.update(repo=repo_id, size=size) or False,
+    )
+    assert run_cli._confirm_download("m", no_download=False, yes=False) is False
+    assert calls.get("repo") == "m"
+    assert calls.get("size") is None  # estimate failed -> None passed through
+
+
+def test_wait_ready_wrapper(monkeypatch):
+    """_wait_ready delegates to cli._wait_for_chat_server, returns "ready"."""
+    from vllm_mlx import cli as cli_mod
+
+    got = {}
+    monkeypatch.setattr(
+        cli_mod,
+        "_wait_for_chat_server",
+        lambda b, p, timeout_s=None: got.update(b=b, p=p, t=timeout_s) or None,
+    )
+    assert run_cli._wait_ready("http://x", "proc", 30) == "ready"
+    assert got == {"b": "http://x", "p": "proc", "t": 30}
+
+
+def test_wait_ready_reports_exit(monkeypatch, capsys):
+    """A serve child that exits early -> "exited" + clean message."""
+    from vllm_mlx import cli as cli_mod
+
+    class DeadProc:
+        returncode = 1
+
+        def poll(self):
+            return 1
+
+    def fail(base_url, proc, timeout_s=None):
+        raise RuntimeError("server exited early")
+
+    monkeypatch.setattr(cli_mod, "_wait_for_chat_server", fail)
+    assert run_cli._wait_ready("http://x", DeadProc(), 5) == "exited"
+    out = capsys.readouterr().out
+    assert "before becoming ready" in out
+
+
+def test_wait_ready_reports_timeout(monkeypatch, capsys):
+    """A readiness timeout -> "timeout" (child STILL alive) + clean message."""
+    from vllm_mlx import cli as cli_mod
+
+    class AliveProc:
+        def poll(self):
+            return None
+
+    def timeout(base_url, proc, timeout_s=None):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(cli_mod, "_wait_for_chat_server", timeout)
+    assert run_cli._wait_ready("http://x", AliveProc(), 5) == "timeout"
+    assert "did not become ready" in capsys.readouterr().out
+
+
+def test_wait_ready_keyboard_interrupt(monkeypatch, capsys):
+    """A Ctrl-C during readiness -> "exited" without a raw traceback."""
+    from vllm_mlx import cli as cli_mod
+
+    def intr(base_url, proc, timeout_s=None):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli_mod, "_wait_for_chat_server", intr)
+    assert run_cli._wait_ready("http://x", object(), 5) == "exited"
+    assert "Interrupted during startup" in capsys.readouterr().out
+
+
+def test_port_is_busy_wrapper(monkeypatch):
+    """_port_is_busy delegates to cli._port_is_busy."""
+    from vllm_mlx import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_port_is_busy", lambda h, p: h == "127.0.0.1")
+    assert run_cli._port_is_busy("127.0.0.1", 8000) is True
+    assert run_cli._port_is_busy("0.0.0.0", 8000) is False
+
+
+def test_reuse_dry_run_branch(monkeypatch, capsys):
+    """Reuse handler under --dry-run previews attach without probing."""
+    args = _make_args(dry_run=True)
+    result = run_cli._reuse_or_refuse(
+        "http://127.0.0.1:8000", "m", _FakeProfile(), args
+    )
+    assert result == 0
+    assert "Dry run" in capsys.readouterr().out
+
+
+# --- _attach_and_configure + _print_instructions ---------------------------
+
+
+class _FakeCfg:
+    def __init__(self, template=None):
+        self.template = template
+
+
+class _SetupPlanFake:
+    def __init__(self, path="p", changed=True, diff="@@ diff"):
+        self.path = path
+        self.changed = changed
+        self._diff = diff
+
+    def diff(self):
+        return self._diff
+
+
+def _first_class_profile():
+    p = _FakeProfile(name="claude-code", recommended_models=["qwen3.5-9b-4bit"])
+    p.display_name = "Claude Code"
+    return p
+
+
+def test_attach_generic_profile_is_none(monkeypatch, capsys):
+    """profile None -> prints generic endpoint, no config write."""
+    args = _make_args()
+    rc = run_cli._attach_and_configure("http://127.0.0.1:8000", "m", None, args)
+    assert rc == 0
+    assert "OpenAI-compatible endpoint" in capsys.readouterr().out
+
+
+def test_attach_no_setup_prints_instructions(monkeypatch, capsys):
+    """--no-setup prints instructions without writing config."""
+    args = _make_args(no_setup=True)
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(
+        ad, "get_setup_instructions", lambda *a, **k: "  instructions here"
+    )
+    rc = run_cli._attach_and_configure(
+        "http://127.0.0.1:8000", "m", _FakeProfile(), args
+    )
+    assert rc == 0
+    assert "instructions here" in capsys.readouterr().out
+
+
+def test_attach_first_class_template_fetch_context(monkeypatch, capsys):
+    """First-class profile with {context_length} template fetches it."""
+    args = _make_args(yes=True)
+    prof = _first_class_profile()
+    prof.config = _FakeCfg(template="  {context_length}")
+
+    import vllm_mlx.agents.setup as setup_mod
+    from vllm_mlx.agents import adapter as ad
+
+    fetches = {}
+    monkeypatch.setattr(
+        ad, "fetch_context_window", lambda b, m: fetches.update(b=b, m=m) or 32768
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "build_setup_plan",
+        lambda *a, **k: _SetupPlanFake(changed=True, diff="+model = x"),
+    )
+    monkeypatch.setattr(setup_mod, "apply_setup_plan", lambda plan: plan.path)
+    monkeypatch.setattr(setup_mod, "confirm_plan", lambda plan: True)
+
+    rc = run_cli._attach_and_configure("http://b", "m", prof, args)
+    assert rc == 0
+    assert fetches.get("m") == "m"
+    out = capsys.readouterr().out
+    assert "Configured Claude Code" in out
+
+
+def test_attach_first_class_context_fetch_fails(monkeypatch, capsys):
+    """A failed context-length fetch degrades gracefully (context_length=None)."""
+    args = _make_args(yes=True)
+    prof = _first_class_profile()
+    prof.config = _FakeCfg(template="  {context_length}")
+
+    import vllm_mlx.agents.setup as setup_mod
+    from vllm_mlx.agents import adapter as ad
+
+    def boom(base_url, model):
+        raise RuntimeError("server not ready")
+
+    monkeypatch.setattr(ad, "fetch_context_window", boom)
+    planned = {}
+    monkeypatch.setattr(
+        setup_mod,
+        "build_setup_plan",
+        lambda *a, **k: planned.update(k=k) or _SetupPlanFake(changed=True),
+    )
+    monkeypatch.setattr(setup_mod, "apply_setup_plan", lambda plan: plan.path)
+    monkeypatch.setattr(setup_mod, "confirm_plan", lambda plan: True)
+
+    rc = run_cli._attach_and_configure("http://b", "m", prof, args)
+    assert rc == 0
+    # context_length was requested (template) but fetch failed -> None passed.
+    assert planned["k"].get("context_length") is None
+    assert "Configured Claude Code" in capsys.readouterr().out
+
+
+def test_attach_first_class_unchanged(monkeypatch, capsys):
+    """First-class profile already configured: no-file-changes path."""
+    args = _make_args()
+    prof = _first_class_profile()
+    prof.config = _FakeCfg(template=None)
+
+    import vllm_mlx.agents.setup as setup_mod
+
+    monkeypatch.setattr(
+        setup_mod,
+        "build_setup_plan",
+        lambda *a, **k: _SetupPlanFake(changed=False),
+    )
+    rc = run_cli._attach_and_configure("http://b", "m", prof, args)
+    assert rc == 0
+    assert "Already configured" in capsys.readouterr().out
+
+
+def test_attach_first_class_build_fails(monkeypatch, capsys):
+    """First-class profile whose plan build raises -> instructions, rc 0."""
+    args = _make_args()
+    prof = _first_class_profile()
+    prof.config = _FakeCfg(template=None)
+
+    import vllm_mlx.agents.setup as setup_mod
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(
+        setup_mod,
+        "build_setup_plan",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("no config")),
+    )
+    monkeypatch.setattr(
+        ad, "get_setup_instructions", lambda *a, **k: "  fallback instructions"
+    )
+    rc = run_cli._attach_and_configure("http://b", "m", prof, args)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "setup failed" in out
+    assert "fallback instructions" in out
+
+
+def test_attach_first_class_apply_fails(monkeypatch, capsys):
+    """First-class profile whose apply raises RuntimeError -> error print."""
+    args = _make_args(yes=True)
+    prof = _first_class_profile()
+    prof.config = _FakeCfg(template=None)
+
+    import vllm_mlx.agents.setup as setup_mod
+
+    monkeypatch.setattr(
+        setup_mod, "build_setup_plan", lambda *a, **k: _SetupPlanFake(changed=True)
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "apply_setup_plan",
+        lambda p: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(setup_mod, "confirm_plan", lambda p: True)
+    rc = run_cli._attach_and_configure("http://b", "m", prof, args)
+    assert rc == 0
+    assert "setup failed" in capsys.readouterr().out
+
+
+def test_attach_first_class_consent_cancelled(monkeypatch, capsys):
+    """Consent declined for a changed first-class plan -> nothing written."""
+    args = _make_args()  # yes=False
+    prof = _first_class_profile()
+    prof.config = _FakeCfg(template=None)
+
+    import vllm_mlx.agents.setup as setup_mod
+
+    monkeypatch.setattr(
+        setup_mod, "build_setup_plan", lambda *a, **k: _SetupPlanFake(changed=True)
+    )
+    monkeypatch.setattr(setup_mod, "confirm_plan", lambda p: False)
+    monkeypatch.setattr(
+        setup_mod, "apply_setup_plan", lambda p: pytest.fail("should not apply")
+    )
+    rc = run_cli._attach_and_configure("http://b", "m", prof, args)
+    assert rc == 0
+    assert "Setup cancelled" in capsys.readouterr().out
+
+
+def test_attach_generic_writer_success(monkeypatch, capsys):
+    """Generic (non-first-class) profile writer success path."""
+    args = _make_args()
+    prof = _FakeProfile(name="hermes", recommended_models=["qwen3.5-9b-4bit"])
+    prof.config = _FakeCfg(template=None)
+
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(ad, "setup_agent_config", lambda *a, **k: "wrote config")
+    rc = run_cli._attach_and_configure("http://b", "m", prof, args)
+    assert rc == 0
+    assert "configured!" in capsys.readouterr().out
+
+
+def test_attach_generic_writer_cannot(monkeypatch, capsys):
+    """Generic writer returning 'Cannot...' -> failure path, instructions."""
+    args = _make_args()
+    prof = _FakeProfile(name="hermes", recommended_models=["qwen3.5-9b-4bit"])
+    prof.config = _FakeCfg(template=None)
+
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(
+        ad, "setup_agent_config", lambda *a, **k: "Cannot find the agent binary"
+    )
+    monkeypatch.setattr(
+        ad, "get_setup_instructions", lambda *a, **k: "  manual instructions"
+    )
+    rc = run_cli._attach_and_configure("http://b", "m", prof, args)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "setup failed" in out
+    assert "manual instructions" in out
+
+
+def test_print_instructions_first_class(monkeypatch, capsys):
+    """_print_instructions renders first-class instructions."""
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(ad, "get_setup_instructions", lambda *a, **k: "  render me")
+    run_cli._print_instructions(_FakeProfile(), "http://b", "m")
+    assert "render me" in capsys.readouterr().out
+
+
+def test_print_instructions_exception(monkeypatch, capsys):
+    """_print_instructions tolerates a rendering failure."""
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(
+        ad,
+        "get_setup_instructions",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("nope")),
+    )
+    run_cli._print_instructions(_FakeProfile(), "http://b", "m")
+    assert "Could not render" in capsys.readouterr().out
+
+
+def test_print_next_steps(monkeypatch, capsys):
+    run_cli._print_next_steps("hermes", "http://b", "m")
+    assert "hermes" in capsys.readouterr().out
+
+
+def test_print_dry_run_generic(monkeypatch, capsys):
+    run_cli._print_dry_run(None, "m", _make_args())
+    out = capsys.readouterr().out
+    assert "generic OpenAI-compatible" in out
+    # physical_ram_gb() is a macOS-only probe (sysctl hw.memsize) that returns
+    # 0.0 on non-darwin. The `RAM:` prints are gated on `if ram_gb:` (a real
+    # runtime line that must stay covered on the Linux no-MLX matrix, which
+    # runs this hermetic file). Patch the recommendation module's attribute so
+    # both branches are exercised deterministically on every host.
+    monkeypatch.setattr(rec, "physical_ram_gb", lambda: 256.0)
+    run_cli._print_dry_run("codex", "m", _make_args())
+    out = capsys.readouterr().out
+    assert "codex" in out and "RAM:" in out and "256.0 GB" in out
+
+
+def test_print_dry_run_ram_unavailable_skips_line(monkeypatch, capsys):
+    """Falsy RAM probe → the RAM prints are skipped (no negative output)."""
+    monkeypatch.setattr(rec, "physical_ram_gb", lambda: 0.0)
+    run_cli._print_dry_run("codex", "m", _make_args())
+    out = capsys.readouterr().out
+    assert "RAM:" not in out
+
+
+def test_print_unknown_agent(monkeypatch, capsys):
+    import vllm_mlx.agents as agents_mod
+
+    monkeypatch.setattr(
+        agents_mod, "list_profiles", lambda: [_FakeProfile(name="codex")]
+    )
+    run_cli._print_unknown_agent("nope")
+    out = capsys.readouterr().out
+    assert "Unknown agent: nope" in out
+    assert "codex" in out
+
+
+def test_print_nothing_cached_fit_variants(monkeypatch, capsys):
+    """_print_nothing_cached with & without a fitting candidate."""
+    monkeypatch.setattr(rec, "is_recommended_alias", lambda alias, ram: False)
+    run_cli._print_nothing_cached(["qwen3.5-9b-4bit"], 64.0)
+    out = capsys.readouterr().out
+    assert "✗" in out
+    run_cli._print_nothing_cached(["qwen3.5-9b-4bit"], 0.0)
+    assert "Drop --no-download" in capsys.readouterr().out
+
+
+def test_print_nothing_fits(monkeypatch, capsys):
+    run_cli._print_nothing_fits(["qwen3.5-9b-4bit"], 12.0)
+    assert "fit" in capsys.readouterr().out
+
+
+def test_wait_child_returns_exit_code(monkeypatch):
+    """A positive child exit code is returned verbatim."""
+    import time as real_time
+
+    class FakeChild:
+        def __init__(self):
+            self.returncode = None
+            self._polls = 0
+
+        def poll(self):
+            self._polls += 1
+            if self._polls >= 2:
+                self.returncode = 5
+            return self.returncode
+
+    monkeypatch.setattr(real_time, "sleep", lambda s: None)
+    assert run_cli._wait_child(FakeChild()) == 5
+
+
+def test_wait_child_none_code_returns_1(monkeypatch):
+    """A child whose poll() ends with returncode None -> exit 1."""
+    import time as real_time
+
+    class FakeChild:
+        returncode = None
+        _polls = 0
+
+        def poll(self):
+            self._polls += 1
+            # Break the loop on the second call (return non-None) while keeping
+            # returncode None -> exercises the ``code is None`` -> 1 path.
+            return -1 if self._polls >= 2 else None
+
+    monkeypatch.setattr(real_time, "sleep", lambda s: None)
+    assert run_cli._wait_child(FakeChild()) == 1
+
+
+def test_wait_child_maps_signal_death_to_posix(monkeypatch):
+    """A signal-death returncode (-SIGTERM) maps to 128 + signum."""
+    import time as real_time
+
+    class FakeChild:
+        def __init__(self):
+            self.returncode = None
+            self._polls = 0
+
+        def poll(self):
+            self._polls += 1
+            if self._polls >= 2:
+                self.returncode = -15  # killed by SIGTERM
+            return self.returncode
+
+    monkeypatch.setattr(real_time, "sleep", lambda s: None)
+    assert run_cli._wait_child(FakeChild()) == 128 + 15  # 143
+
+
+def test_terminate_child_is_quiet(monkeypatch):
+    """_terminate_child swallows ProcessLookupError (child already gone)."""
+    import subprocess as real_subprocess
+
+    class FakeChild:
+        def terminate(self):
+            raise ProcessLookupError()
+
+    monkeypatch.setattr(real_subprocess, "Popen", lambda *a, **k: FakeChild())
+    # No exception propagates.
+    run_cli._terminate_child(FakeChild())
+
+
+def test_foreground_child_relays_signals(monkeypatch):
+    """_foreground_child installs a relay forwarding SIGINT/SIGTERM to the child
+    and restores prior handlers on exit (HIGH 2: relay active during ready-wait)."""
+    sent = []
+
+    class FakeChild:
+        def send_signal(self, signum):
+            sent.append(signum)
+            if signum == signal.SIGINT:
+                raise ProcessLookupError()  # already gone -> swallowed
+
+    prev_int = signal.getsignal(signal.SIGINT)
+    prev_term = signal.getsignal(signal.SIGTERM)
+    with run_cli._foreground_child(FakeChild()):
+        # Handlers installed: invoke them directly.
+        signal.getsignal(signal.SIGINT)(signal.SIGINT, None)
+        signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+    assert signal.SIGINT in sent
+    assert signal.SIGTERM in sent
+    # Restored.
+    assert signal.getsignal(signal.SIGINT) == prev_int
+    assert signal.getsignal(signal.SIGTERM) == prev_term

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -1065,14 +1065,20 @@ def test_cached_context_window_reads_text_config(monkeypatch):
     """Dry-run can preview the eventual context value without network access."""
     import vllm_mlx.model_metadata as metadata_mod
 
+    requested = []
+    monkeypatch.setattr(run_cli, "_hf_id", lambda alias: "org/resolved-model")
     monkeypatch.setattr(
         metadata_mod,
         "read_model_metadata",
-        lambda model: types.SimpleNamespace(
-            config={"text_config": {"max_position_embeddings": 262_144}}
+        lambda model: (
+            requested.append(model)
+            or types.SimpleNamespace(
+                config={"text_config": {"max_position_embeddings": 262_144}}
+            )
         ),
     )
     assert run_cli._cached_context_window("cached-model") == 262_144
+    assert requested == ["org/resolved-model"]
 
 
 def test_print_instructions_first_class(monkeypatch, capsys):

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -287,7 +287,11 @@ def test_reuse_compatible_server_attaches_no_spawn(monkeypatch, capsys):
     )
 
     result = run_cli._reuse_or_refuse(
-        "http://127.0.0.1:8000", "qwen3.5-9b-4bit", _FakeProfile(), args
+        "http://127.0.0.1:8000",
+        "qwen3.5-9b-4bit",
+        "qwen3.5-9b-4bit",
+        _FakeProfile(),
+        args,
     )
     assert result == 0
     assert toggles["attached"] is True
@@ -304,7 +308,11 @@ def test_reuse_incompatible_server_refuses(monkeypatch, capsys):
     monkeypatch.setattr(run_cli, "_hf_id", lambda a: "qwen3.5-9b-4bit")
 
     result = run_cli._reuse_or_refuse(
-        "http://127.0.0.1:8000", "qwen3.5-9b-4bit", _FakeProfile(), args
+        "http://127.0.0.1:8000",
+        "qwen3.5-9b-4bit",
+        "qwen3.5-9b-4bit",
+        _FakeProfile(),
+        args,
     )
     assert result == 1
     assert "already serves" in capsys.readouterr().out
@@ -319,7 +327,11 @@ def test_reuse_occupied_not_rapidmlx_refuses(monkeypatch, capsys):
     monkeypatch.setattr(run_cli, "_hf_id", lambda a: "qwen3.5-9b-4bit")
 
     result = run_cli._reuse_or_refuse(
-        "http://127.0.0.1:8000", "qwen3.5-9b-4bit", _FakeProfile(), args
+        "http://127.0.0.1:8000",
+        "qwen3.5-9b-4bit",
+        "qwen3.5-9b-4bit",
+        _FakeProfile(),
+        args,
     )
     assert result == 1
     assert "not a healthy" in capsys.readouterr().out
@@ -402,6 +414,61 @@ def test_start_command_spawn_then_wait(monkeypatch):
 
     assert run_cli.start_command(args) == 3
     assert order == ["select", "confirm", "spawn", "ready", "configure", "wait"]
+
+
+def test_start_command_preserves_explicit_alias_identity(monkeypatch):
+    """Resolved repos gate downloads while serve/config retain the alias."""
+    args = _make_args(model="org/model")
+    args._original_alias = "friendly-alias"
+    seen = {}
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "org/model")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(
+        run_cli,
+        "_confirm_download",
+        lambda model, **kw: seen.update(download=model) or True,
+    )
+    monkeypatch.setattr(
+        run_cli,
+        "_spawn_foreground_serve",
+        lambda model, a: seen.update(spawn=model) or object(),
+    )
+    monkeypatch.setattr(run_cli, "_wait_ready", lambda *a, **k: "ready")
+    monkeypatch.setattr(
+        run_cli,
+        "_attach_and_configure",
+        lambda base, model, *a: seen.update(config=model) or 0,
+    )
+    monkeypatch.setattr(run_cli, "_wait_child", lambda proc: 0)
+
+    assert run_cli.start_command(args) == 0
+    assert seen == {
+        "download": "org/model",
+        "spawn": "friendly-alias",
+        "config": "friendly-alias",
+    }
+
+
+def test_start_command_setup_failure_stops_owned_child(monkeypatch):
+    """Failed setup exits nonzero and cannot leave a spawned server behind."""
+    args = _make_args()
+    proc = object()
+    stopped = []
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(run_cli, "_confirm_download", lambda *a, **k: True)
+    monkeypatch.setattr(run_cli, "_spawn_foreground_serve", lambda *a: proc)
+    monkeypatch.setattr(run_cli, "_wait_ready", lambda *a, **k: "ready")
+    monkeypatch.setattr(run_cli, "_attach_and_configure", lambda *a, **k: 1)
+    monkeypatch.setattr(run_cli, "_terminate_child", lambda p: stopped.append(p))
+    monkeypatch.setattr(
+        run_cli, "_wait_child", lambda p: pytest.fail("must not wait indefinitely")
+    )
+
+    assert run_cli.start_command(args) == 1
+    assert stopped == [proc]
 
 
 def test_start_command_spawn_after_consent_refused(monkeypatch):
@@ -779,7 +846,7 @@ def test_reuse_dry_run_branch(monkeypatch, capsys):
         ),
     )
     result = run_cli._reuse_or_refuse(
-        "http://127.0.0.1:8000", "m", _FakeProfile(), args
+        "http://127.0.0.1:8000", "m", "m", _FakeProfile(), args
     )
     assert result == 0
     assert previews == [("http://127.0.0.1:8000", "m", True)]
@@ -794,7 +861,9 @@ def test_reuse_dry_run_refuses_incompatible_server(monkeypatch, capsys):
     monkeypatch.setattr(ad, "_fetch_models", lambda base: [{"id": "other"}])
     monkeypatch.setattr(run_cli, "_hf_id", lambda model: model)
     assert (
-        run_cli._reuse_or_refuse("http://127.0.0.1:8000", "m", _FakeProfile(), args)
+        run_cli._reuse_or_refuse(
+            "http://127.0.0.1:8000", "m", "m", _FakeProfile(), args
+        )
         == 1
     )
     assert "not m" in capsys.readouterr().out
@@ -950,7 +1019,7 @@ def test_attach_first_class_unchanged(monkeypatch, capsys):
 
 
 def test_attach_first_class_build_fails(monkeypatch, capsys):
-    """First-class profile whose plan build raises -> instructions, rc 0."""
+    """First-class profile whose plan build raises -> instructions, rc 1."""
     args = _make_args()
     prof = _first_class_profile()
     prof.config = _FakeCfg(template=None)
@@ -967,7 +1036,7 @@ def test_attach_first_class_build_fails(monkeypatch, capsys):
         ad, "get_setup_instructions", lambda *a, **k: "  fallback instructions"
     )
     rc = run_cli._attach_and_configure("http://b", "m", prof, args)
-    assert rc == 0
+    assert rc == 1
     out = capsys.readouterr().out
     assert "setup failed" in out
     assert "fallback instructions" in out
@@ -991,7 +1060,7 @@ def test_attach_first_class_apply_fails(monkeypatch, capsys):
     )
     monkeypatch.setattr(setup_mod, "confirm_plan", lambda p: True)
     rc = run_cli._attach_and_configure("http://b", "m", prof, args)
-    assert rc == 0
+    assert rc == 1
     assert "setup failed" in capsys.readouterr().out
 
 
@@ -1091,7 +1160,7 @@ def test_attach_generic_writer_cannot(monkeypatch, capsys):
         ad, "get_setup_instructions", lambda *a, **k: "  manual instructions"
     )
     rc = run_cli._attach_and_configure("http://b", "m", prof, args)
-    assert rc == 0
+    assert rc == 1
     out = capsys.readouterr().out
     assert "setup failed" in out
     assert "manual instructions" in out
@@ -1115,7 +1184,7 @@ def test_attach_generic_writer_exception_falls_back(monkeypatch, capsys, dry_run
         ad, "get_setup_instructions", lambda *a, **k: "  manual instructions"
     )
 
-    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 0
+    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 1
     out = capsys.readouterr().out
     assert "setup failed: config unavailable" in out
     assert "manual instructions" in out
@@ -1166,7 +1235,7 @@ def test_attach_env_profile_exception_falls_back(monkeypatch, capsys):
         ad, "get_setup_instructions", lambda *a, **k: "  manual instructions"
     )
 
-    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 0
+    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 1
     out = capsys.readouterr().out
     assert "setup failed: bad template" in out
     assert "manual instructions" in out

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -1503,3 +1503,256 @@ def test_reap_forwarded_child_waits_before_escalating():
 
     run_cli._reap_forwarded_child(FakeChild(), grace_s=0.01)
     assert calls == [("wait", 0.01)]
+
+
+# Coverage contracts for defensive orchestration branches.  These paths are
+# deliberately hermetic: they exercise ownership and exit-code semantics
+# without starting a server, touching an agent config, or reading the network.
+
+
+def test_start_dry_run_without_profile_never_attaches(monkeypatch):
+    args = _make_args(profile=None, dry_run=True)
+    _patch_profile_lookup(monkeypatch, None)
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda *a: False)
+    monkeypatch.setattr(
+        run_cli,
+        "_attach_and_configure",
+        lambda *a, **k: pytest.fail("generic dry-run must not configure an agent"),
+    )
+    assert run_cli.start_command(args) == 0
+
+
+def test_start_maps_forwarded_signal_to_shell_exit(monkeypatch):
+    args = _make_args()
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda *a: False)
+    monkeypatch.setattr(run_cli, "_confirm_download", lambda *a, **k: True)
+    monkeypatch.setattr(run_cli, "_spawn_foreground_serve", lambda *a: object())
+
+    class ForwardOnEnter:
+        def __init__(self, proc):
+            pass
+
+        def __enter__(self):
+            raise run_cli._ForwardedSignalError(signal.SIGTERM)
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(run_cli, "_foreground_child", ForwardOnEnter)
+    assert run_cli.start_command(args) == 128 + signal.SIGTERM
+
+
+def test_fits_host_uses_alias_minimum(monkeypatch):
+    import vllm_mlx.model_aliases as aliases
+
+    monkeypatch.setattr(rec, "recommendation_footprint_gb", lambda alias: None)
+    monkeypatch.setattr(
+        aliases,
+        "resolve_profile",
+        lambda alias: types.SimpleNamespace(min_memory_gb=24),
+    )
+    assert run_cli._fits_host("agent-model", 32) is True
+
+
+def test_foreground_child_cleans_up_on_unrelated_exception(monkeypatch):
+    class FakeChild:
+        def poll(self):
+            return None
+
+    child = FakeChild()
+    terminated = []
+    monkeypatch.setattr(run_cli, "_terminate_child", terminated.append)
+    with pytest.raises(RuntimeError), run_cli._foreground_child(child):
+        raise RuntimeError("prompt failed")
+    assert terminated == [child]
+
+
+class _CleanupChild:
+    def __init__(self, *, exited=False, terminate_error=None, kill_error=None):
+        self.returncode = 0 if exited else None
+        self.terminate_error = terminate_error
+        self.kill_error = kill_error
+        self.wait_calls = 0
+        self.calls = []
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.calls.append("terminate")
+        if self.terminate_error:
+            raise self.terminate_error()
+
+    def kill(self):
+        self.calls.append("kill")
+        if self.kill_error:
+            raise self.kill_error()
+
+    def wait(self, timeout):
+        self.calls.append(("wait", timeout))
+        self.wait_calls += 1
+        if self.wait_calls == 1 and self.returncode is None:
+            raise run_cli.subprocess.TimeoutExpired("serve", timeout)
+        if self.returncode is None:
+            raise run_cli.subprocess.TimeoutExpired("serve", timeout)
+        return self.returncode
+
+
+def test_terminate_child_already_exited_and_graceful_paths():
+    exited = _CleanupChild(exited=True)
+    run_cli._terminate_child(exited)
+    assert exited.calls == []
+
+    child = _CleanupChild()
+    child.wait = lambda timeout: child.calls.append(("wait", timeout)) or 0
+    run_cli._terminate_child(child)
+    assert child.calls == ["terminate", ("wait", 5.0)]
+
+
+@pytest.mark.parametrize("error", [ProcessLookupError, PermissionError])
+def test_terminate_child_ignores_kill_races(error):
+    child = _CleanupChild(kill_error=error)
+    run_cli._terminate_child(child, grace_s=0.01)
+    assert child.calls == ["terminate", ("wait", 0.01), "kill"]
+
+
+def test_terminate_child_bounds_post_kill_wait():
+    child = _CleanupChild()
+    run_cli._terminate_child(child, grace_s=0.01)
+    assert child.calls == [
+        "terminate",
+        ("wait", 0.01),
+        "kill",
+        ("wait", 0.01),
+    ]
+
+
+def test_reap_forwarded_child_already_exited_and_escalates(monkeypatch):
+    run_cli._reap_forwarded_child(_CleanupChild(exited=True))
+
+    child = _CleanupChild()
+    escalated = []
+    monkeypatch.setattr(
+        run_cli,
+        "_terminate_child",
+        lambda proc, grace_s: escalated.append((proc, grace_s)),
+    )
+    run_cli._reap_forwarded_child(child, grace_s=0.01)
+    assert escalated == [(child, 0.01)]
+
+
+def test_attach_deepseek_dry_run_uses_cached_reasoning_profile(monkeypatch):
+    import vllm_mlx.agents.setup as setup_mod
+    import vllm_mlx.model_aliases as aliases
+
+    args = _make_args(dry_run=True)
+    prof = _FakeProfile(name="deepseek-harness")
+    prof.config = _FakeCfg()
+    monkeypatch.setattr(
+        aliases,
+        "resolve_profile",
+        lambda model: types.SimpleNamespace(reasoning_parser="deepseek_r1"),
+    )
+    planned = {}
+    monkeypatch.setattr(
+        setup_mod,
+        "build_setup_plan",
+        lambda *a, **kw: planned.update(kw) or _SetupPlanFake(changed=False),
+    )
+    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 0
+    assert planned["supports_reasoning"] is True
+
+
+def test_attach_first_class_dry_run_does_not_write(monkeypatch, capsys):
+    import vllm_mlx.agents.setup as setup_mod
+
+    args = _make_args(dry_run=True)
+    prof = _first_class_profile()
+    prof.config = _FakeCfg()
+    monkeypatch.setattr(
+        setup_mod, "build_setup_plan", lambda *a, **k: _SetupPlanFake(changed=True)
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "apply_setup_plan",
+        lambda plan: pytest.fail("dry-run must not apply the setup plan"),
+    )
+    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 0
+    assert "Dry run only" in capsys.readouterr().out
+
+
+def test_attach_generic_dry_run_and_cancel_paths(monkeypatch, capsys):
+    from vllm_mlx.agents import adapter as ad
+
+    prof = _FakeProfile(name="hermes", config=_FakeCfg())
+    calls = []
+    monkeypatch.setattr(
+        ad,
+        "setup_agent_config",
+        lambda *a, **k: calls.append(k["dry_run"]) or "preview",
+    )
+    assert (
+        run_cli._attach_and_configure("http://b", "m", prof, _make_args(dry_run=True))
+        == 0
+    )
+    assert calls == [True]
+
+    monkeypatch.setattr(run_cli, "_confirm_config_write", lambda: False)
+    assert run_cli._attach_and_configure("http://b", "m", prof, _make_args()) == 0
+    assert calls == [True, True]
+    assert "Setup cancelled" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "result", [RuntimeError("write failed"), "Cannot write config"]
+)
+def test_attach_generic_write_failure_paths(monkeypatch, capsys, result):
+    from vllm_mlx.agents import adapter as ad
+
+    prof = _FakeProfile(name="hermes", config=_FakeCfg())
+    calls = 0
+
+    def setup(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return "preview"
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(ad, "setup_agent_config", setup)
+    assert (
+        run_cli._attach_and_configure("http://b", "m", prof, _make_args(yes=True)) == 1
+    )
+    assert "setup failed" in capsys.readouterr().out
+
+
+def test_confirm_config_write_noninteractive_yes_and_interrupt(monkeypatch):
+    monkeypatch.setattr("sys.stdin", types.SimpleNamespace(isatty=lambda: False))
+    assert run_cli._confirm_config_write() is False
+
+    monkeypatch.setattr("sys.stdin", types.SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr("builtins.input", lambda prompt: "yes")
+    assert run_cli._confirm_config_write() is True
+
+    monkeypatch.setattr(
+        "builtins.input", lambda prompt: (_ for _ in ()).throw(EOFError())
+    )
+    assert run_cli._confirm_config_write() is False
+
+
+def test_cached_context_window_rejects_invalid_candidates(monkeypatch):
+    import vllm_mlx.model_metadata as metadata_mod
+
+    monkeypatch.setattr(
+        metadata_mod,
+        "read_model_metadata",
+        lambda model: types.SimpleNamespace(
+            config={"max_position_embeddings": True, "text_config": {}}
+        ),
+    )
+    assert run_cli._cached_context_window("m") is None

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -239,6 +239,21 @@ def test_spawn_foreground_child_env(monkeypatch):
     assert captured["env"]["RAPID_MLX_WATCHDOG_PPID"] == str(os.getpid())
 
 
+def test_spawn_no_download_forces_child_offline(monkeypatch):
+    """--no-download remains strict inside the canonical serve child."""
+    import subprocess as real_subprocess
+
+    captured = {}
+    monkeypatch.setattr(
+        real_subprocess,
+        "Popen",
+        lambda cmd, **kwargs: captured.update(kwargs) or types.SimpleNamespace(),
+    )
+    run_cli._spawn_foreground_serve("cached", _make_args(no_download=True))
+    assert captured["env"]["HF_HUB_OFFLINE"] == "1"
+    assert captured["env"]["TRANSFORMERS_OFFLINE"] == "1"
+
+
 def test_reuse_compatible_server_attaches_no_spawn(monkeypatch, capsys):
     """Port serving the chosen model -> attach, never spawn."""
     args = _make_args()
@@ -440,11 +455,13 @@ def test_start_command_readiness_timeout_terminates(monkeypatch):
     monkeypatch.setattr(
         run_cli, "_attach_and_configure", lambda *a, **k: order.append("configure") or 0
     )
-    monkeypatch.setattr(run_cli, "_wait_child", lambda p: order.append("wait") or 2)
+    monkeypatch.setattr(
+        run_cli, "_wait_child", lambda p: pytest.fail("cleanup is already bounded")
+    )
 
-    assert run_cli.start_command(args) == 2
+    assert run_cli.start_command(args) == 124
     assert terminated == [True]  # child was terminated on timeout
-    assert order == ["spawn", "wait"]
+    assert order == ["spawn"]
 
 
 def test_start_command_readiness_keyboard(monkeypatch):
@@ -458,14 +475,19 @@ def test_start_command_readiness_keyboard(monkeypatch):
     monkeypatch.setattr(
         run_cli, "_spawn_foreground_serve", lambda *a: order.append("spawn") or object()
     )
-    monkeypatch.setattr(run_cli, "_wait_ready", lambda *a, **k: "exited")
+    monkeypatch.setattr(run_cli, "_wait_ready", lambda *a, **k: "interrupted")
     monkeypatch.setattr(
         run_cli, "_attach_and_configure", lambda *a, **k: order.append("configure") or 0
     )
-    monkeypatch.setattr(run_cli, "_wait_child", lambda p: order.append("wait") or 1)
+    stopped = []
+    monkeypatch.setattr(run_cli, "_terminate_child", lambda p: stopped.append(p))
+    monkeypatch.setattr(
+        run_cli, "_wait_child", lambda p: pytest.fail("cleanup is already bounded")
+    )
 
-    assert run_cli.start_command(args) == 1
-    assert order == ["spawn", "wait"]
+    assert run_cli.start_command(args) == 128 + signal.SIGINT
+    assert len(stopped) == 1
+    assert order == ["spawn"]
 
 
 # ---------------------------------------------------------------------------
@@ -692,7 +714,7 @@ def test_wait_ready_keyboard_interrupt(monkeypatch, capsys):
         raise KeyboardInterrupt
 
     monkeypatch.setattr(cli_mod, "_wait_for_chat_server", intr)
-    assert run_cli._wait_ready("http://x", object(), 5) == "exited"
+    assert run_cli._wait_ready("http://x", object(), 5) == "interrupted"
     assert "Interrupted during startup" in capsys.readouterr().out
 
 
@@ -706,13 +728,40 @@ def test_port_is_busy_wrapper(monkeypatch):
 
 
 def test_reuse_dry_run_branch(monkeypatch, capsys):
-    """Reuse handler under --dry-run previews attach without probing."""
+    """Reuse handler under --dry-run probes before promising an attach."""
     args = _make_args(dry_run=True)
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(ad, "_fetch_models", lambda base: [{"id": "m"}])
+    monkeypatch.setattr(run_cli, "_hf_id", lambda model: model)
+    previews = []
+    monkeypatch.setattr(
+        run_cli,
+        "_attach_and_configure",
+        lambda base_url, model, profile, seen_args: (
+            previews.append((base_url, model, seen_args.dry_run)) or 0
+        ),
+    )
     result = run_cli._reuse_or_refuse(
         "http://127.0.0.1:8000", "m", _FakeProfile(), args
     )
     assert result == 0
-    assert "Dry run" in capsys.readouterr().out
+    assert previews == [("http://127.0.0.1:8000", "m", True)]
+    assert "would reuse" in capsys.readouterr().out
+
+
+def test_reuse_dry_run_refuses_incompatible_server(monkeypatch, capsys):
+    """Dry-run reports the same incompatible-port failure as a real start."""
+    args = _make_args(dry_run=True)
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(ad, "_fetch_models", lambda base: [{"id": "other"}])
+    monkeypatch.setattr(run_cli, "_hf_id", lambda model: model)
+    assert (
+        run_cli._reuse_or_refuse("http://127.0.0.1:8000", "m", _FakeProfile(), args)
+        == 1
+    )
+    assert "not m" in capsys.readouterr().out
 
 
 # --- _attach_and_configure + _print_instructions ---------------------------
@@ -905,7 +954,7 @@ def test_attach_first_class_consent_cancelled(monkeypatch, capsys):
 
 def test_attach_generic_writer_success(monkeypatch, capsys):
     """Generic (non-first-class) profile writer success path."""
-    args = _make_args()
+    args = _make_args(yes=True)
     prof = _FakeProfile(name="hermes", recommended_models=["qwen3.5-9b-4bit"])
     prof.config = _FakeCfg(template=None)
 
@@ -915,10 +964,9 @@ def test_attach_generic_writer_success(monkeypatch, capsys):
     monkeypatch.setattr(
         ad,
         "setup_agent_config",
-        lambda profile, base_url, model, **kwargs: called.update(
-            base_url=base_url, model=model
-        )
-        or "wrote config",
+        lambda profile, base_url, model, **kwargs: (
+            called.update(base_url=base_url, model=model) or "wrote config"
+        ),
     )
     rc = run_cli._attach_and_configure("http://b", "m", prof, args)
     assert rc == 0
@@ -1102,6 +1150,9 @@ def test_terminate_child_is_quiet(monkeypatch):
     import subprocess as real_subprocess
 
     class FakeChild:
+        def poll(self):
+            return None
+
         def terminate(self):
             raise ProcessLookupError()
 
@@ -1110,25 +1161,63 @@ def test_terminate_child_is_quiet(monkeypatch):
     run_cli._terminate_child(FakeChild())
 
 
+def test_terminate_child_escalates_after_grace_period():
+    """A SIGTERM-ignoring child is killed and reaped within bounded waits."""
+    calls = []
+
+    class FakeChild:
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            calls.append("terminate")
+
+        def kill(self):
+            calls.append("kill")
+            self.returncode = -signal.SIGKILL
+
+        def wait(self, timeout):
+            calls.append(("wait", timeout))
+            if self.returncode is None:
+                raise run_cli.subprocess.TimeoutExpired("serve", timeout)
+            return self.returncode
+
+    run_cli._terminate_child(FakeChild(), grace_s=0.01)
+    assert calls == ["terminate", ("wait", 0.01), "kill", ("wait", 0.01)]
+
+
 def test_foreground_child_relays_signals(monkeypatch):
     """_foreground_child installs a relay forwarding SIGINT/SIGTERM to the child
     and restores prior handlers on exit (HIGH 2: relay active during ready-wait)."""
     sent = []
 
     class FakeChild:
+        def poll(self):
+            return None
+
         def send_signal(self, signum):
             sent.append(signum)
             if signum == signal.SIGINT:
                 raise ProcessLookupError()  # already gone -> swallowed
 
+    stopped = []
+    monkeypatch.setattr(run_cli, "_terminate_child", lambda proc: stopped.append(proc))
     prev_int = signal.getsignal(signal.SIGINT)
     prev_term = signal.getsignal(signal.SIGTERM)
-    with run_cli._foreground_child(FakeChild()):
-        # Handlers installed: invoke them directly.
-        signal.getsignal(signal.SIGINT)(signal.SIGINT, None)
-        signal.getsignal(signal.SIGTERM)(signal.SIGTERM, None)
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        with (
+            pytest.raises(run_cli._ForwardedSignalError) as exc,
+            run_cli._foreground_child(FakeChild()),
+        ):
+            # Handler forwards to the child, then forces the parent out of a
+            # potentially blocked prompt/wait so cleanup can complete.
+            signal.getsignal(signum)(signum, None)
+        assert exc.value.signum == signum
     assert signal.SIGINT in sent
     assert signal.SIGTERM in sent
+    assert len(stopped) == 2
     # Restored.
     assert signal.getsignal(signal.SIGINT) == prev_int
     assert signal.getsignal(signal.SIGTERM) == prev_term

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -217,7 +217,7 @@ def test_consent_auto_pull_env_skips(monkeypatch):
 
 
 def test_spawn_foreground_child_env(monkeypatch):
-    """Serve child: foreground (no start_new_session) + gate + watchdog env."""
+    """Serve child: isolated signal group + gate + watchdog env."""
     import os
     import subprocess as real_subprocess
 
@@ -238,7 +238,7 @@ def test_spawn_foreground_child_env(monkeypatch):
 
     proc = run_cli._spawn_foreground_serve("qwen3.5-9b-4bit", args)
     assert isinstance(proc, FakeProc)
-    assert captured["start_new_session"] is False  # foreground, parent-owned
+    assert captured["start_new_session"] is True  # parent is sole signal relay
     assert captured["cmd"][:6] == [
         real_subprocess.sys.executable,
         "-m",
@@ -416,6 +416,23 @@ def test_start_command_spawn_after_consent_refused(monkeypatch):
     )
 
     assert run_cli.start_command(args) == 1
+
+
+def test_start_command_spawn_error_is_clean(monkeypatch, capsys):
+    """Popen failures become a concise command failure, not a traceback."""
+    args = _make_args()
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: False)
+    monkeypatch.setattr(run_cli, "_confirm_download", lambda *a, **k: True)
+    monkeypatch.setattr(
+        run_cli,
+        "_spawn_foreground_serve",
+        lambda *a: (_ for _ in ()).throw(OSError("fork failed")),
+    )
+
+    assert run_cli.start_command(args) == 1
+    assert "Could not start the server process: fork failed" in capsys.readouterr().out
 
 
 def test_start_command_readiness_exit(monkeypatch):
@@ -888,6 +905,32 @@ def test_attach_first_class_context_fetch_fails(monkeypatch, capsys):
     assert "Configured Claude Code" in capsys.readouterr().out
 
 
+def test_attach_deepseek_reasoning_probe_fails_open(monkeypatch):
+    """A transient reasoning probe failure does not block agent setup."""
+    args = _make_args(yes=True)
+    prof = _FakeProfile(name="deepseek-harness", recommended_models=["qwen3.5-9b-4bit"])
+    prof.display_name = "DeepSeek Harness"
+    prof.config = _FakeCfg(template=None)
+
+    import vllm_mlx.agents.setup as setup_mod
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(
+        ad,
+        "fetch_reasoning_support",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("probe unavailable")),
+    )
+    planned = {}
+    monkeypatch.setattr(
+        setup_mod,
+        "build_setup_plan",
+        lambda *a, **k: planned.update(k=k) or _SetupPlanFake(changed=False),
+    )
+
+    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 0
+    assert planned["k"]["supports_reasoning"] is None
+
+
 def test_attach_first_class_unchanged(monkeypatch, capsys):
     """First-class profile already configured: no-file-changes path."""
     args = _make_args()
@@ -1011,6 +1054,28 @@ def test_start_command_renders_ipv6_base_url(monkeypatch):
     assert reused["base_url"] == "http://[::1]:8000"
 
 
+@pytest.mark.parametrize(
+    ("bind_host", "expected"),
+    [("0.0.0.0", "http://127.0.0.1:8000"), ("::", "http://[::1]:8000")],
+)
+def test_start_command_probes_wildcard_bind_via_loopback(
+    monkeypatch, bind_host, expected
+):
+    """Wildcard bind addresses are never emitted as client destinations."""
+    args = _make_args(host=bind_host)
+    _patch_profile_lookup(monkeypatch, _FakeProfile())
+    monkeypatch.setattr(run_cli, "_select_model", lambda **kw: "m")
+    monkeypatch.setattr(run_cli, "_port_is_busy", lambda h, p: True)
+    seen = {}
+    monkeypatch.setattr(
+        run_cli,
+        "_reuse_or_refuse",
+        lambda base_url, *rest: seen.update(base_url=base_url) or 0,
+    )
+    assert run_cli.start_command(args) == 0
+    assert seen["base_url"] == expected
+
+
 def test_attach_generic_writer_cannot(monkeypatch, capsys):
     """Generic writer returning 'Cannot...' -> failure path, instructions."""
     args = _make_args()
@@ -1029,6 +1094,30 @@ def test_attach_generic_writer_cannot(monkeypatch, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "setup failed" in out
+    assert "manual instructions" in out
+
+
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_attach_generic_writer_exception_falls_back(monkeypatch, capsys, dry_run):
+    """Generic config renderer/writer failures leave the server usable."""
+    args = _make_args(yes=True, dry_run=dry_run)
+    prof = _FakeProfile(name="hermes", recommended_models=["qwen3.5-9b-4bit"])
+    prof.config = _FakeCfg(template=None)
+
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(
+        ad,
+        "setup_agent_config",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("config unavailable")),
+    )
+    monkeypatch.setattr(
+        ad, "get_setup_instructions", lambda *a, **k: "  manual instructions"
+    )
+
+    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 0
+    out = capsys.readouterr().out
+    assert "setup failed: config unavailable" in out
     assert "manual instructions" in out
 
 
@@ -1061,6 +1150,28 @@ def test_attach_env_profile_prints_exports_without_write_consent(monkeypatch, ca
     assert "configured!" not in out
 
 
+def test_attach_env_profile_exception_falls_back(monkeypatch, capsys):
+    """Environment-profile rendering failures retain manual instructions."""
+    args = _make_args()
+    prof = _FakeProfile(name="langchain")
+    prof.config = _FakeCfg(config_type="env")
+    from vllm_mlx.agents import adapter as ad
+
+    monkeypatch.setattr(
+        ad,
+        "setup_agent_config",
+        lambda *a, **k: (_ for _ in ()).throw(ValueError("bad template")),
+    )
+    monkeypatch.setattr(
+        ad, "get_setup_instructions", lambda *a, **k: "  manual instructions"
+    )
+
+    assert run_cli._attach_and_configure("http://b", "m", prof, args) == 0
+    out = capsys.readouterr().out
+    assert "setup failed: bad template" in out
+    assert "manual instructions" in out
+
+
 def test_cached_context_window_reads_text_config(monkeypatch):
     """Dry-run can preview the eventual context value without network access."""
     import vllm_mlx.model_metadata as metadata_mod
@@ -1079,6 +1190,18 @@ def test_cached_context_window_reads_text_config(monkeypatch):
     )
     assert run_cli._cached_context_window("cached-model") == 262_144
     assert requested == ["org/resolved-model"]
+
+
+def test_cached_context_window_metadata_error_is_unknown(monkeypatch):
+    """Broken cache metadata defers setup preview rather than crashing start."""
+    import vllm_mlx.model_metadata as metadata_mod
+
+    monkeypatch.setattr(
+        metadata_mod,
+        "read_model_metadata",
+        lambda model: (_ for _ in ()).throw(OSError("corrupt cache")),
+    )
+    assert run_cli._cached_context_window("cached-model") is None
 
 
 def test_print_instructions_first_class(monkeypatch, capsys):
@@ -1271,8 +1394,10 @@ def test_foreground_child_relays_signals(monkeypatch):
             if signum == signal.SIGINT:
                 raise ProcessLookupError()  # already gone -> swallowed
 
-    stopped = []
-    monkeypatch.setattr(run_cli, "_terminate_child", lambda proc: stopped.append(proc))
+    reaped = []
+    monkeypatch.setattr(
+        run_cli, "_reap_forwarded_child", lambda proc: reaped.append(proc)
+    )
     prev_int = signal.getsignal(signal.SIGINT)
     prev_term = signal.getsignal(signal.SIGTERM)
     for signum in (signal.SIGINT, signal.SIGTERM):
@@ -1286,7 +1411,26 @@ def test_foreground_child_relays_signals(monkeypatch):
         assert exc.value.signum == signum
     assert signal.SIGINT in sent
     assert signal.SIGTERM in sent
-    assert len(stopped) == 2
+    assert len(reaped) == 2
     # Restored.
     assert signal.getsignal(signal.SIGINT) == prev_int
     assert signal.getsignal(signal.SIGTERM) == prev_term
+
+
+def test_reap_forwarded_child_waits_before_escalating():
+    """A relayed signal gets a grace period before any second signal."""
+    calls = []
+
+    class FakeChild:
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout):
+            calls.append(("wait", timeout))
+            self.returncode = -signal.SIGINT
+            return self.returncode
+
+    run_cli._reap_forwarded_child(FakeChild(), grace_s=0.01)
+    assert calls == [("wait", 0.01)]

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -187,6 +187,13 @@ NON_ROUTING_FLAGS_ALLOWLIST: frozenset[str] = frozenset(
         # Agent setup UX knob: skips a post-write HTTP connectivity probe.
         # It does not change model/runtime routing or any auto-detection.
         "--no-check",
+        # ``rapid-mlx start`` (#150) UX knobs, not routing decisions.
+        # --no-download refuses to fetch a model (offline/prefer-cached
+        # preference); --no-setup skips the post-readiness agent-config write.
+        # Neither forwards a routing kwarg into the engine, so neither is a
+        # binary auto-detection that needs an AUTO_ROUTING_FLAG_PAIRS entry.
+        "--no-download",
+        "--no-setup",
         # CORS toggle.
         "--enable-cors",
         # Perf / UX toggles, not routing decisions.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -12359,6 +12359,13 @@ Examples:
         help="Agent version for version-specific config (e.g. 0.8.5)",
     )
 
+    # Start command — one-command agent startup (#150). Deferred-import so
+    # ``vllm_mlx.run`` (and its heavy deps: recommendations, agents, etc.)
+    # are only loaded when the verb is actually used.
+    from vllm_mlx.run.cli import register as _register_start
+
+    _register_start(subparsers)
+
     # Connect command — the single place to learn "the server is up, now
     # point a tool at it." Renders from the same SSOT as the serve banner
     # (:mod:`vllm_mlx.connect`) so ``ready``/``openai``/``anthropic`` and the
@@ -13091,6 +13098,12 @@ def main():
         info_command(args)
     elif args.command == "agents":
         agents_command(args)
+    elif args.command == "start":
+        from vllm_mlx.run.cli import start_command
+
+        code = start_command(args)
+        if code:
+            raise SystemExit(code)
     elif args.command == "connect":
         connect_command(args)
     elif args.command == "doctor":

--- a/vllm_mlx/run/__init__.py
+++ b/vllm_mlx/run/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx start <agent>`` — one-command agent startup (#150).
+
+Ties the pieces that already exist — agent profiles
+(``vllm_mlx/agents/profiles/``), safe setup plans
+(``vllm_mlx/agents/setup.py``), memory-fit model recommendations
+(``vllm_mlx/recommendations.py``), and the canonical ``serve`` path — into a
+single verb:
+
+1. resolve the agent profile (or a generic OpenAI-compatible default);
+2. pick a model: explicit ``--model``, else the first recommended alias
+   that fits verified memory and is already cached, else a previewed download;
+3. (unless ``--dry-run``) start ``serve`` for that model as a FOREGROUND child
+   that this process owns — it forwards SIGINT/SIGTERM and leaves no orphan;
+4. after the endpoint is ready, print the agent's setup instructions and
+   optionally apply its config via the existing setup-plan machinery.
+
+The public verb is ``start``, not the issue's literal ``run``: ``run`` is
+already a shipped alias for ``chat`` (Ollama muscle-memory), so repurposing
+it would break an established command. See the #150 plan.
+
+This package is intentionally distinct from ``vllm_mlx/service`` (the engine's
+helper/post-process layer) and ``vllm_mlx/headless_service`` (LaunchDaemon
+lifecycle). It reuses both setups; it does not reimplement a config writer, a
+model selector, or a server entrypoint.
+"""

--- a/vllm_mlx/run/cli.py
+++ b/vllm_mlx/run/cli.py
@@ -143,7 +143,13 @@ def start_command(args) -> int:
     if model is None:
         return 1
 
-    base_url = f"http://{args.host}:{args.port}"
+    # Render the authority through the endpoint SSOT so IPv6 literals are
+    # bracketed correctly.  Keep the server root separate from the OpenAI
+    # API base: readiness lives at ``/health/ready``, while model discovery
+    # and agent configs consume ``/v1``.
+    from vllm_mlx.connect import ServerEndpoints
+
+    base_url = ServerEndpoints(args.host, args.port, model=model).base_url
 
     # Port already occupied: reuse a compatible healthy server, else refuse.
     if _port_is_busy(args.host, args.port):
@@ -456,7 +462,10 @@ def _reuse_or_refuse(base_url: str, model: str, profile, args) -> int:
         )
         return 0
 
-    served = {str(m.get("id")) for m in _fetch_models(base_url) if m.get("id")}
+    api_base_url = f"{base_url.rstrip('/')}/v1"
+    served = {
+        str(m.get("id")) for m in _fetch_models(api_base_url) if m.get("id")
+    }
     if not served:
         print(
             f"  Port {args.port} is occupied but not a healthy rapid-mlx "
@@ -481,8 +490,13 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
     the first-class profiles (claude-code / continue / deepseek-harness) and
     the generic writer otherwise. Never kills the server. Returns 0.
     """
-    if args.dry_run or args.no_setup or profile is None:
+    if profile is None:
         _print_instructions(profile, base_url, model)
+        return 0
+
+    api_base_url = f"{base_url.rstrip('/')}/v1"
+    if args.dry_run or args.no_setup:
+        _print_instructions(profile, api_base_url, model)
         return 0
 
     cfg = profile.get_config_for_version(None)
@@ -490,7 +504,7 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         from vllm_mlx.agents.adapter import fetch_context_window
 
         try:
-            context_length = fetch_context_window(base_url, model)
+            context_length = fetch_context_window(api_base_url, model)
         except Exception:
             context_length = None
     else:
@@ -506,11 +520,11 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
 
         try:
             plan = build_setup_plan(
-                profile.name, base_url, model, context_length=context_length
+                profile.name, api_base_url, model, context_length=context_length
             )
         except (OSError, ValueError) as exc:
             print(f"  {profile.display_name} setup failed: {exc}")
-            _print_instructions(profile, base_url, model)
+            _print_instructions(profile, api_base_url, model)
             return 0
 
         print(f"  {profile.display_name} configuration: {plan.path}")
@@ -534,7 +548,7 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
 
         summary = setup_agent_config(
             profile,
-            base_url,
+            api_base_url,
             model,
             dry_run=False,
             context_length=context_length,
@@ -542,11 +556,11 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         if summary.startswith("Cannot"):
             print(f"  {profile.display_name} setup failed.")
             print(f"  {summary}")
-            _print_instructions(profile, base_url, model)
+            _print_instructions(profile, api_base_url, model)
             return 0
         print(f"  {profile.display_name} configured! {summary}")
 
-    _print_next_steps(profile.name, base_url, model)
+    _print_next_steps(profile.name, api_base_url, model)
     return 0
 
 

--- a/vllm_mlx/run/cli.py
+++ b/vllm_mlx/run/cli.py
@@ -157,27 +157,35 @@ def start_command(args) -> int:
 
     if args.dry_run:
         _print_dry_run(profile_name, model, args)
+        if profile is not None and not args.no_setup:
+            _attach_and_configure(base_url, model, profile, args)
         return 0
 
     if not _confirm_download(model, no_download=args.no_download, yes=args.yes):
         return 1
 
     proc = _spawn_foreground_serve(model, args)
-    with _foreground_child(proc):
-        outcome = _wait_ready(base_url, proc, args.ready_timeout)
-        if outcome == "timeout":
-            # The child is STILL alive (loading/downloading) but never became
-            # ready within --ready-timeout. Waiting longer would hang
-            # indefinitely, so terminate it, reap, and fail (HIGH squash: the
-            # earlier "Server did not become ready" is the final word).
-            _terminate_child(proc)
+    try:
+        with _foreground_child(proc):
+            outcome = _wait_ready(base_url, proc, args.ready_timeout)
+            if outcome == "timeout":
+                # The child is STILL alive (loading/downloading) but never became
+                # ready within --ready-timeout. Waiting longer would hang
+                # indefinitely, so terminate it, reap, and fail (HIGH squash: the
+                # earlier "Server did not become ready" is the final word).
+                _terminate_child(proc)
+                return 124
+            if outcome == "interrupted":
+                _terminate_child(proc)
+                return 128 + signal.SIGINT
+            if outcome == "exited":
+                # The serve child died before /health/ready returned; reap it and
+                # surface its (nonzero) status instead of a raw traceback.
+                return _wait_child(proc)
+            _attach_and_configure(base_url, model, profile, args)
             return _wait_child(proc)
-        if outcome == "exited":
-            # The serve child died before /health/ready returned; reap it and
-            # surface its (nonzero) status instead of a raw traceback.
-            return _wait_child(proc)
-        _attach_and_configure(base_url, model, profile, args)
-        return _wait_child(proc)
+    except _ForwardedSignalError as exc:
+        return 128 + exc.signum
 
 
 # ---------------------------------------------------------------------------
@@ -358,11 +366,25 @@ def _spawn_foreground_serve(model: str, args) -> subprocess.Popen:
     # If the start parent is SIGKILLed, the child self-terminates instead of
     # orphan-locking the model + port.
     child_env["RAPID_MLX_WATCHDOG_PPID"] = str(os.getpid())
+    if args.no_download:
+        # ``--no-download`` is a strict execution contract, not just a
+        # parent-side preflight. The canonical serve path already honors both
+        # standard offline flags across its Hub/config/tokenizer loaders.
+        child_env["HF_HUB_OFFLINE"] = "1"
+        child_env["TRANSFORMERS_OFFLINE"] = "1"
     print(f"  Starting {model} on {args.host}:{args.port} (Ctrl-C to stop) ...")
     return subprocess.Popen(  # noqa: S603
         cmd,
         env=child_env,
     )
+
+
+class _ForwardedSignalError(Exception):
+    """Internal control flow used to leave prompts/waits after a signal."""
+
+    def __init__(self, signum: int):
+        self.signum = signum
+        super().__init__(signum)
 
 
 class _foreground_child:
@@ -387,6 +409,8 @@ class _foreground_child:
     def __exit__(self, _exc_type, _exc, _tb):
         signal.signal(signal.SIGINT, self._prev_int)
         signal.signal(signal.SIGTERM, self._prev_term)
+        if _exc_type is not None and self._proc.poll() is None:
+            _terminate_child(self._proc)
         return False
 
     def _forward(self, signum, _frame):
@@ -394,25 +418,48 @@ class _foreground_child:
             self._proc.send_signal(signum)
         except (ProcessLookupError, PermissionError):
             pass
+        # Replacing Python's default handler must not swallow the signal and
+        # leave the parent blocked in input()/wait. The surrounding context
+        # performs bounded cleanup before start_command maps this to 128+N.
+        raise _ForwardedSignalError(signum)
 
 
-def _terminate_child(proc) -> None:
-    """SIGTERM a still-alive child so the caller can reap it cleanly."""
+def _terminate_child(proc, *, grace_s: float = 5.0) -> None:
+    """Bounded SIGTERM→SIGKILL cleanup for a parent-owned child."""
+    if proc.poll() is not None:
+        return
     try:
         proc.terminate()
     except (ProcessLookupError, PermissionError):
+        return
+    try:
+        proc.wait(timeout=grace_s)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        proc.kill()
+    except (ProcessLookupError, PermissionError):
+        return
+    try:
+        proc.wait(timeout=grace_s)
+    except subprocess.TimeoutExpired:
+        # SIGKILL can only remain pending for a process stuck in an
+        # uninterruptible kernel wait. Do not turn a readiness timeout into
+        # an unbounded parent hang; the child watchdog remains a final guard.
         pass
 
 
 def _wait_ready(base_url: str, proc, timeout_s: int) -> str:
     """Block until /health/ready returns 200, the child exits, or timeout.
 
-    Returns a tri-state so the caller can tell ``exited`` (the serve child
+    Returns an outcome so the caller can tell ``exited`` (the serve child
     died before becoming ready — reap it) from ``timeout`` (the child is
     STILL ALIVE but never reported healthy — terminate it, never just wait):
     * ``"ready"`` — /health/ready returned 200.
     * ``"exited"`` — the child exited early (code ``proc.returncode``).
     * ``"timeout"`` — the child is alive but not ready within ``timeout_s``.
+    * ``"interrupted"`` — the parent received Ctrl-C while waiting.
     """
     from vllm_mlx.cli import _wait_for_chat_server
 
@@ -431,7 +478,7 @@ def _wait_ready(base_url: str, proc, timeout_s: int) -> str:
         # The child is alive; the signal relay has already forwarded SIGINT to
         # it, so terminate + reap here for a clean teardown (no raw traceback).
         print("\n  Interrupted during startup; stopping the server.")
-        return "exited"
+        return "interrupted"
     return "ready"
 
 
@@ -455,17 +502,8 @@ def _reuse_or_refuse(base_url: str, model: str, profile, args) -> int:
     """
     from vllm_mlx.agents.adapter import _fetch_models
 
-    if args.dry_run:
-        print(
-            f"  Dry run — port {args.port} is already in use; "
-            f"start would attach to {base_url}."
-        )
-        return 0
-
     api_base_url = f"{base_url.rstrip('/')}/v1"
-    served = {
-        str(m.get("id")) for m in _fetch_models(api_base_url) if m.get("id")
-    }
+    served = {str(m.get("id")) for m in _fetch_models(api_base_url) if m.get("id")}
     if not served:
         print(
             f"  Port {args.port} is occupied but not a healthy rapid-mlx "
@@ -475,6 +513,12 @@ def _reuse_or_refuse(base_url: str, model: str, profile, args) -> int:
 
     hf_id = _hf_id(model)
     if hf_id in served or model in served:
+        if args.dry_run:
+            print(
+                f"  Dry run — port {args.port} already serves {model}; "
+                f"start would reuse {base_url}."
+            )
+            return _attach_and_configure(base_url, model, profile, args)
         print(f"  Reusing the running server on {base_url} (serving {model}).")
         return _attach_and_configure(base_url, model, profile, args)
 
@@ -495,12 +539,12 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         return 0
 
     api_base_url = f"{base_url.rstrip('/')}/v1"
-    if args.dry_run or args.no_setup:
+    if args.no_setup:
         _print_instructions(profile, api_base_url, model)
         return 0
 
     cfg = profile.get_config_for_version(None)
-    if cfg and cfg.template and "{context_length}" in cfg.template:
+    if not args.dry_run and cfg and cfg.template and "{context_length}" in cfg.template:
         from vllm_mlx.agents.adapter import fetch_context_window
 
         try:
@@ -512,6 +556,12 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
 
     is_first_class = profile.name in {"claude-code", "continue", "deepseek-harness"}
     if is_first_class:
+        supports_reasoning = None
+        if profile.name == "deepseek-harness" and not args.dry_run:
+            from vllm_mlx.agents.adapter import fetch_reasoning_support
+
+            supports_reasoning = fetch_reasoning_support(api_base_url, model)
+
         from vllm_mlx.agents.setup import (
             apply_setup_plan,
             build_setup_plan,
@@ -520,7 +570,11 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
 
         try:
             plan = build_setup_plan(
-                profile.name, api_base_url, model, context_length=context_length
+                profile.name,
+                api_base_url,
+                model,
+                context_length=context_length,
+                supports_reasoning=supports_reasoning,
             )
         except (OSError, ValueError) as exc:
             print(f"  {profile.display_name} setup failed: {exc}")
@@ -533,18 +587,44 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         else:
             print("  Already configured; no file changes needed.")
 
-        if not plan.changed or args.yes or confirm_plan(plan):
-            if plan.changed:
-                try:
-                    apply_setup_plan(plan)
-                except RuntimeError as exc:
-                    print(f"  {profile.display_name} setup failed: {exc}")
-                else:
-                    print(f"  Configured {profile.display_name} at {plan.path}.")
-        else:
+        if args.dry_run:
+            print("  Dry run only; nothing was written.")
+            return 0
+
+        if plan.changed and not args.yes and not confirm_plan(plan):
             print("  Setup cancelled; nothing was written.")
+            _print_instructions(profile, api_base_url, model)
+            return 0
+        if plan.changed:
+            try:
+                apply_setup_plan(plan)
+            except RuntimeError as exc:
+                print(f"  {profile.display_name} setup failed: {exc}")
+                _print_instructions(profile, api_base_url, model)
+                return 0
+            print(f"  Configured {profile.display_name} at {plan.path}.")
     else:
         from vllm_mlx.agents.adapter import setup_agent_config
+
+        preview = setup_agent_config(
+            profile,
+            api_base_url,
+            model,
+            dry_run=True,
+            context_length=context_length,
+        )
+        if preview.startswith("Cannot"):
+            print(f"  {profile.display_name} setup failed.")
+            print(f"  {preview}")
+            _print_instructions(profile, api_base_url, model)
+            return 0
+        print(f"  {profile.display_name} configuration: {preview}")
+        if args.dry_run:
+            return 0
+        if not args.yes and not _confirm_config_write():
+            print("  Setup cancelled; nothing was written.")
+            _print_instructions(profile, api_base_url, model)
+            return 0
 
         summary = setup_agent_config(
             profile,
@@ -562,6 +642,19 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
 
     _print_next_steps(profile.name, api_base_url, model)
     return 0
+
+
+def _confirm_config_write() -> bool:
+    """Require interactive consent before a generic profile config write."""
+    if not sys.stdin.isatty():
+        return False
+    try:
+        return input("Apply this configuration? [y/N] ").strip().lower() in {
+            "y",
+            "yes",
+        }
+    except (EOFError, KeyboardInterrupt):
+        return False
 
 
 def _print_instructions(profile, base_url, model) -> None:

--- a/vllm_mlx/run/cli.py
+++ b/vllm_mlx/run/cli.py
@@ -149,7 +149,8 @@ def start_command(args) -> int:
     # and agent configs consume ``/v1``.
     from vllm_mlx.connect import ServerEndpoints
 
-    base_url = ServerEndpoints(args.host, args.port, model=model).base_url
+    connect_host = _local_connect_host(args.host)
+    base_url = ServerEndpoints(connect_host, args.port, model=model).base_url
 
     # Port already occupied: reuse a compatible healthy server, else refuse.
     if _port_is_busy(args.host, args.port):
@@ -164,7 +165,11 @@ def start_command(args) -> int:
     if not _confirm_download(model, no_download=args.no_download, yes=args.yes):
         return 1
 
-    proc = _spawn_foreground_serve(model, args)
+    try:
+        proc = _spawn_foreground_serve(model, args)
+    except OSError as exc:
+        print(f"  Could not start the server process: {exc}")
+        return 1
     try:
         with _foreground_child(proc):
             outcome = _wait_ready(base_url, proc, args.ready_timeout)
@@ -288,6 +293,15 @@ def _hf_id(alias: str) -> str:
         return alias
 
 
+def _local_connect_host(bind_host: str) -> str:
+    """Map wildcard bind addresses to reachable local client addresses."""
+    if bind_host in {"", "0.0.0.0"}:
+        return "127.0.0.1"
+    if bind_host in {"::", "[::]"}:
+        return "::1"
+    return bind_host
+
+
 def _print_unknown_agent(name: str) -> None:
     from vllm_mlx.agents import list_profiles
 
@@ -395,6 +409,10 @@ def _spawn_foreground_serve(model: str, args) -> subprocess.Popen:
     return subprocess.Popen(  # noqa: S603
         cmd,
         env=child_env,
+        # Keep terminal Ctrl-C from reaching both parent and child.  The
+        # parent owns signal delivery through ``_foreground_child`` so the
+        # server sees one graceful-shutdown signal instead of two.
+        start_new_session=True,
     )
 
 
@@ -429,7 +447,10 @@ class _foreground_child:
         signal.signal(signal.SIGINT, self._prev_int)
         signal.signal(signal.SIGTERM, self._prev_term)
         if _exc_type is not None and self._proc.poll() is None:
-            _terminate_child(self._proc)
+            if _exc_type is _ForwardedSignalError:
+                _reap_forwarded_child(self._proc)
+            else:
+                _terminate_child(self._proc)
         return False
 
     def _forward(self, signum, _frame):
@@ -467,6 +488,19 @@ def _terminate_child(proc, *, grace_s: float = 5.0) -> None:
         # uninterruptible kernel wait. Do not turn a readiness timeout into
         # an unbounded parent hang; the child watchdog remains a final guard.
         pass
+
+
+def _reap_forwarded_child(proc, *, grace_s: float = 5.0) -> None:
+    """Reap after a relayed signal without immediately sending a second one."""
+    if proc.poll() is not None:
+        return
+    try:
+        proc.wait(timeout=grace_s)
+        return
+    except subprocess.TimeoutExpired:
+        # The graceful signal was ignored. Escalate using the normal bounded
+        # SIGTERM -> SIGKILL cleanup contract.
+        _terminate_child(proc, grace_s=grace_s)
 
 
 def _wait_ready(base_url: str, proc, timeout_s: int) -> str:
@@ -586,13 +620,18 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
     if cfg and getattr(cfg, "type", None) == "env" and not is_first_class:
         from vllm_mlx.agents.adapter import setup_agent_config
 
-        instructions = setup_agent_config(
-            profile,
-            api_base_url,
-            model,
-            dry_run=True,
-            context_length=context_length,
-        )
+        try:
+            instructions = setup_agent_config(
+                profile,
+                api_base_url,
+                model,
+                dry_run=True,
+                context_length=context_length,
+            )
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            print(f"  {profile.display_name} setup failed: {exc}")
+            _print_instructions(profile, api_base_url, model)
+            return 0
         print(f"  {profile.display_name} uses shell environment variables:")
         print(instructions)
         return 0
@@ -602,7 +641,10 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         if profile.name == "deepseek-harness" and not args.dry_run:
             from vllm_mlx.agents.adapter import fetch_reasoning_support
 
-            supports_reasoning = fetch_reasoning_support(api_base_url, model)
+            try:
+                supports_reasoning = fetch_reasoning_support(api_base_url, model)
+            except (OSError, RuntimeError, TypeError, ValueError):
+                supports_reasoning = None
         elif profile.name == "deepseek-harness":
             from vllm_mlx.model_aliases import resolve_profile
 
@@ -654,13 +696,18 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
     else:
         from vllm_mlx.agents.adapter import setup_agent_config
 
-        preview = setup_agent_config(
-            profile,
-            api_base_url,
-            model,
-            dry_run=True,
-            context_length=context_length,
-        )
+        try:
+            preview = setup_agent_config(
+                profile,
+                api_base_url,
+                model,
+                dry_run=True,
+                context_length=context_length,
+            )
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            print(f"  {profile.display_name} setup failed: {exc}")
+            _print_instructions(profile, api_base_url, model)
+            return 0
         if preview.startswith("Cannot"):
             print(f"  {profile.display_name} setup failed.")
             print(f"  {preview}")
@@ -674,13 +721,18 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
             _print_instructions(profile, api_base_url, model)
             return 0
 
-        summary = setup_agent_config(
-            profile,
-            api_base_url,
-            model,
-            dry_run=False,
-            context_length=context_length,
-        )
+        try:
+            summary = setup_agent_config(
+                profile,
+                api_base_url,
+                model,
+                dry_run=False,
+                context_length=context_length,
+            )
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            print(f"  {profile.display_name} setup failed: {exc}")
+            _print_instructions(profile, api_base_url, model)
+            return 0
         if summary.startswith("Cannot"):
             print(f"  {profile.display_name} setup failed.")
             print(f"  {summary}")
@@ -709,7 +761,10 @@ def _cached_context_window(model: str) -> int | None:
     """Read a cached/local config context limit without network or weights."""
     from vllm_mlx.model_metadata import read_model_metadata
 
-    metadata = read_model_metadata(_hf_id(model))
+    try:
+        metadata = read_model_metadata(_hf_id(model))
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
     config = metadata.config if metadata is not None else None
     if not isinstance(config, dict):
         return None

--- a/vllm_mlx/run/cli.py
+++ b/vllm_mlx/run/cli.py
@@ -582,7 +582,8 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         print("  Nothing was written.")
         return 0
 
-    if cfg and getattr(cfg, "type", None) == "env":
+    is_first_class = profile.name in {"claude-code", "continue", "deepseek-harness"}
+    if cfg and getattr(cfg, "type", None) == "env" and not is_first_class:
         from vllm_mlx.agents.adapter import setup_agent_config
 
         instructions = setup_agent_config(
@@ -596,7 +597,6 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         print(instructions)
         return 0
 
-    is_first_class = profile.name in {"claude-code", "continue", "deepseek-harness"}
     if is_first_class:
         supports_reasoning = None
         if profile.name == "deepseek-harness" and not args.dry_run:
@@ -646,7 +646,7 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         if plan.changed:
             try:
                 apply_setup_plan(plan)
-            except RuntimeError as exc:
+            except (OSError, RuntimeError) as exc:
                 print(f"  {profile.display_name} setup failed: {exc}")
                 _print_instructions(profile, api_base_url, model)
                 return 0
@@ -709,7 +709,7 @@ def _cached_context_window(model: str) -> int | None:
     """Read a cached/local config context limit without network or weights."""
     from vllm_mlx.model_metadata import read_model_metadata
 
-    metadata = read_model_metadata(model)
+    metadata = read_model_metadata(_hf_id(model))
     config = metadata.config if metadata is not None else None
     if not isinstance(config, dict):
         return None

--- a/vllm_mlx/run/cli.py
+++ b/vllm_mlx/run/cli.py
@@ -13,12 +13,11 @@ Design contract (see ``vllm_mlx/run/__init__.py`` for the full rationale):
   ``vllm_mlx/recommendations`` (memory-fit selection),
   ``vllm_mlx/model_aliases`` (alias resolution), ``vllm_mlx/_download_gate``
   (download consent), and the canonical ``serve`` subprocess.
-* **Foreground child, parent-owned.** ``start`` spawns ``serve`` with a
-  plain ``subprocess.Popen`` (NO ``start_new_session`` — that detached
-  model belongs to ``launch --start-server`` / the headless service). The
-  parent forwards SIGINT/SIGTERM to the child and exits with the child's
-  status, so Ctrl-C tears the whole tree down and no orphan is left (modulo
-  SIGKILL, where the child-side ``RAPID_MLX_WATCHDOG_PPID`` watchdog
+* **Foreground child, parent-owned.** ``start`` keeps the child attached to
+  the terminal for stdio but isolates its signal group. The parent is the
+  sole SIGINT/SIGTERM relay, exits with the child's status, and prevents a
+  terminal Ctrl-C from double-signalling the server. No orphan is left
+  (modulo SIGKILL, where the child-side ``RAPID_MLX_WATCHDOG_PPID`` watchdog
   self-terminates).
 * **Download consent happens in the parent once.** The serve child is
   spawned with ``RAPID_MLX_CHAT_SPAWN=1`` so its own B2 auto-pull gate
@@ -135,13 +134,17 @@ def start_command(args) -> int:
         _print_unknown_agent(profile_name)
         return 1
 
-    model = _select_model(
+    resolved_model = _select_model(
         explicit=args.model,
         profile=profile,
         no_download=args.no_download,
     )
-    if model is None:
+    if resolved_model is None:
         return 1
+    # main() expands explicit aliases before dispatch. Downloads and cache
+    # probes use that resolved repo, while serve/API/config keep the spelling
+    # the user selected, matching a direct ``rapid-mlx serve <alias>`` call.
+    served_model = getattr(args, "_original_alias", None) or resolved_model
 
     # Render the authority through the endpoint SSOT so IPv6 literals are
     # bracketed correctly.  Keep the server root separate from the OpenAI
@@ -150,23 +153,25 @@ def start_command(args) -> int:
     from vllm_mlx.connect import ServerEndpoints
 
     connect_host = _local_connect_host(args.host)
-    base_url = ServerEndpoints(connect_host, args.port, model=model).base_url
+    base_url = ServerEndpoints(connect_host, args.port, model=served_model).base_url
 
     # Port already occupied: reuse a compatible healthy server, else refuse.
     if _port_is_busy(args.host, args.port):
-        return _reuse_or_refuse(base_url, model, profile, args)
+        return _reuse_or_refuse(base_url, resolved_model, served_model, profile, args)
 
     if args.dry_run:
-        _print_dry_run(profile_name, model, args)
+        _print_dry_run(profile_name, served_model, args)
         if profile is not None and not args.no_setup:
-            _attach_and_configure(base_url, model, profile, args)
+            return _attach_and_configure(base_url, served_model, profile, args)
         return 0
 
-    if not _confirm_download(model, no_download=args.no_download, yes=args.yes):
+    if not _confirm_download(
+        resolved_model, no_download=args.no_download, yes=args.yes
+    ):
         return 1
 
     try:
-        proc = _spawn_foreground_serve(model, args)
+        proc = _spawn_foreground_serve(served_model, args)
     except OSError as exc:
         print(f"  Could not start the server process: {exc}")
         return 1
@@ -187,7 +192,10 @@ def start_command(args) -> int:
                 # The serve child died before /health/ready returned; reap it and
                 # surface its (nonzero) status instead of a raw traceback.
                 return _wait_child(proc)
-            _attach_and_configure(base_url, model, profile, args)
+            setup_rc = _attach_and_configure(base_url, served_model, profile, args)
+            if setup_rc:
+                _terminate_child(proc)
+                return setup_rc
             return _wait_child(proc)
     except _ForwardedSignalError as exc:
         return 128 + exc.signum
@@ -546,7 +554,13 @@ def _port_is_busy(host: str, port: int) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _reuse_or_refuse(base_url: str, model: str, profile, args) -> int:
+def _reuse_or_refuse(
+    base_url: str,
+    resolved_model: str,
+    served_model: str,
+    profile,
+    args,
+) -> int:
     """Port occupied: reuse a compatible healthy server, else refuse clearly.
 
     Returns an exit code describing the dispatcher's next action:
@@ -564,18 +578,18 @@ def _reuse_or_refuse(base_url: str, model: str, profile, args) -> int:
         )
         return 1
 
-    hf_id = _hf_id(model)
-    if hf_id in served or model in served:
+    hf_id = _hf_id(resolved_model)
+    if served.intersection({resolved_model, served_model, hf_id}):
         if args.dry_run:
             print(
-                f"  Dry run — port {args.port} already serves {model}; "
+                f"  Dry run — port {args.port} already serves {served_model}; "
                 f"start would reuse {base_url}."
             )
-            return _attach_and_configure(base_url, model, profile, args)
-        print(f"  Reusing the running server on {base_url} (serving {model}).")
-        return _attach_and_configure(base_url, model, profile, args)
+            return _attach_and_configure(base_url, served_model, profile, args)
+        print(f"  Reusing the running server on {base_url} (serving {served_model}).")
+        return _attach_and_configure(base_url, served_model, profile, args)
 
-    print(f"  Port {args.port} already serves {sorted(served)}, not {model}.")
+    print(f"  Port {args.port} already serves {sorted(served)}, not {served_model}.")
     print("  Choose a different port with --port, or stop the other server.")
     return 1
 
@@ -585,16 +599,15 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
 
     Uses the same setup-plan machinery as ``rapid-mlx agents --setup`` for
     the first-class profiles (claude-code / continue / deepseek-harness) and
-    the generic writer otherwise. Never kills the server. Returns 0.
+    the generic writer otherwise. Never kills the server. Returns nonzero for
+    a genuine setup/render failure; callers decide whether they own the server.
     """
     if profile is None:
-        _print_instructions(profile, base_url, model)
-        return 0
+        return 0 if _print_instructions(profile, base_url, model) else 1
 
     api_base_url = f"{base_url.rstrip('/')}/v1"
     if args.no_setup:
-        _print_instructions(profile, api_base_url, model)
-        return 0
+        return 0 if _print_instructions(profile, api_base_url, model) else 1
 
     cfg = profile.get_config_for_version(None)
     needs_context = bool(cfg and cfg.template and "{context_length}" in cfg.template)
@@ -631,7 +644,7 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         except (OSError, RuntimeError, TypeError, ValueError) as exc:
             print(f"  {profile.display_name} setup failed: {exc}")
             _print_instructions(profile, api_base_url, model)
-            return 0
+            return 1
         print(f"  {profile.display_name} uses shell environment variables:")
         print(instructions)
         return 0
@@ -669,7 +682,7 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         except (OSError, ValueError) as exc:
             print(f"  {profile.display_name} setup failed: {exc}")
             _print_instructions(profile, api_base_url, model)
-            return 0
+            return 1
 
         print(f"  {profile.display_name} configuration: {plan.path}")
         if plan.changed:
@@ -691,7 +704,7 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
             except (OSError, RuntimeError) as exc:
                 print(f"  {profile.display_name} setup failed: {exc}")
                 _print_instructions(profile, api_base_url, model)
-                return 0
+                return 1
             print(f"  Configured {profile.display_name} at {plan.path}.")
     else:
         from vllm_mlx.agents.adapter import setup_agent_config
@@ -707,12 +720,12 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         except (OSError, RuntimeError, TypeError, ValueError) as exc:
             print(f"  {profile.display_name} setup failed: {exc}")
             _print_instructions(profile, api_base_url, model)
-            return 0
+            return 1
         if preview.startswith("Cannot"):
             print(f"  {profile.display_name} setup failed.")
             print(f"  {preview}")
             _print_instructions(profile, api_base_url, model)
-            return 0
+            return 1
         print(f"  {profile.display_name} configuration: {preview}")
         if args.dry_run:
             return 0
@@ -732,12 +745,12 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         except (OSError, RuntimeError, TypeError, ValueError) as exc:
             print(f"  {profile.display_name} setup failed: {exc}")
             _print_instructions(profile, api_base_url, model)
-            return 0
+            return 1
         if summary.startswith("Cannot"):
             print(f"  {profile.display_name} setup failed.")
             print(f"  {summary}")
             _print_instructions(profile, api_base_url, model)
-            return 0
+            return 1
         print(f"  {profile.display_name} configured! {summary}")
 
     _print_next_steps(profile.name, api_base_url, model)
@@ -782,19 +795,21 @@ def _cached_context_window(model: str) -> int | None:
     return None
 
 
-def _print_instructions(profile, base_url, model) -> None:
+def _print_instructions(profile, base_url, model) -> bool:
     if profile is None:
         print(f"  OpenAI-compatible endpoint: {base_url}/v1 (model {model})")
-        return
+        return True
     from vllm_mlx.agents.adapter import get_setup_instructions
 
     try:
         instructions = get_setup_instructions(profile, base_url, model)
     except Exception as exc:
         print(f"  (Could not render setup instructions: {exc})")
+        return False
     else:
         print()
         print(instructions)
+        return True
 
 
 def _print_next_steps(profile_name, base_url, model) -> None:

--- a/vllm_mlx/run/cli.py
+++ b/vllm_mlx/run/cli.py
@@ -211,10 +211,7 @@ def _select_model(
        touching the network.
     """
     from vllm_mlx._download_gate import is_repo_cached
-    from vllm_mlx.recommendations import (
-        is_recommended_alias,
-        physical_ram_gb,
-    )
+    from vllm_mlx.recommendations import physical_ram_gb
 
     if explicit:
         return explicit
@@ -238,7 +235,7 @@ def _select_model(
         # (0) is treated as "can't judge fit" -> every candidate fits, so a
         # cached recommended model is still returned instead of forcing a
         # re-download of candidates[0].
-        if ram_gb and not is_recommended_alias(alias, ram_gb):
+        if ram_gb and _fits_host(alias, ram_gb) is False:
             continue
         if is_repo_cached(_hf_id(alias)):
             return alias
@@ -252,12 +249,33 @@ def _select_model(
     # machines whose memsize probe failed. The download-consent step runs
     # next and shows the exact transfer size.
     for alias in candidates:
-        if ram_gb and not is_recommended_alias(alias, ram_gb):
+        if ram_gb and _fits_host(alias, ram_gb) is False:
             continue
         return alias
 
     _print_nothing_fits(candidates, ram_gb)
     return None
+
+
+def _fits_host(alias: str, ram_gb: float) -> bool | None:
+    """Return known fit, known incompatibility, or unknown for an alias."""
+    from vllm_mlx.model_aliases import resolve_profile
+    from vllm_mlx.recommendations import (
+        is_recommended_alias,
+        recommendation_footprint_gb,
+    )
+
+    # Curated public recommendations encode their supported RAM tiers. For an
+    # agent-specific recommendation outside that table, fall back to its
+    # explicit minimum-memory contract. Unknown is not the same as "does not
+    # fit": the canonical serve path remains the final capacity authority.
+    if recommendation_footprint_gb(alias) is not None:
+        return is_recommended_alias(alias, ram_gb)
+    alias_profile = resolve_profile(alias)
+    minimum = alias_profile.min_memory_gb if alias_profile is not None else None
+    if minimum is None:
+        return None
+    return ram_gb >= minimum
 
 
 def _hf_id(alias: str) -> str:
@@ -283,12 +301,10 @@ def _print_unknown_agent(name: str) -> None:
 
 
 def _print_nothing_cached(candidates, ram_gb) -> None:
-    from vllm_mlx.recommendations import is_recommended_alias
-
     print("  No recommended model is already cached and --no-download was set.")
     print("  Candidates would have been:")
     for alias in candidates:
-        fits = "" if (not ram_gb or is_recommended_alias(alias, ram_gb)) else " ✗"
+        fits = "" if (not ram_gb or _fits_host(alias, ram_gb) is not False) else " ✗"
         print(f"    {alias}{fits}")
     if ram_gb:
         print("  (✗ = does not fit this Mac's RAM)")
@@ -322,6 +338,9 @@ def _confirm_download(model: str, *, no_download: bool, yes: bool) -> bool:
         estimate_download_size_bytes,
         is_repo_cached,
     )
+
+    if os.path.exists(model):
+        return True
 
     hf_id = _hf_id(model)
 
@@ -544,7 +563,8 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         return 0
 
     cfg = profile.get_config_for_version(None)
-    if not args.dry_run and cfg and cfg.template and "{context_length}" in cfg.template:
+    needs_context = bool(cfg and cfg.template and "{context_length}" in cfg.template)
+    if needs_context and not args.dry_run:
         from vllm_mlx.agents.adapter import fetch_context_window
 
         try:
@@ -552,7 +572,29 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
         except Exception:
             context_length = None
     else:
-        context_length = None
+        context_length = _cached_context_window(model) if needs_context else None
+
+    if args.dry_run and needs_context and context_length is None:
+        print(
+            "  Configuration preview deferred: the model's context window "
+            "is not available in the local cache."
+        )
+        print("  Nothing was written.")
+        return 0
+
+    if cfg and getattr(cfg, "type", None) == "env":
+        from vllm_mlx.agents.adapter import setup_agent_config
+
+        instructions = setup_agent_config(
+            profile,
+            api_base_url,
+            model,
+            dry_run=True,
+            context_length=context_length,
+        )
+        print(f"  {profile.display_name} uses shell environment variables:")
+        print(instructions)
+        return 0
 
     is_first_class = profile.name in {"claude-code", "continue", "deepseek-harness"}
     if is_first_class:
@@ -561,6 +603,12 @@ def _attach_and_configure(base_url, model, profile, args) -> int:
             from vllm_mlx.agents.adapter import fetch_reasoning_support
 
             supports_reasoning = fetch_reasoning_support(api_base_url, model)
+        elif profile.name == "deepseek-harness":
+            from vllm_mlx.model_aliases import resolve_profile
+
+            model_profile = resolve_profile(model)
+            if model_profile is not None:
+                supports_reasoning = model_profile.reasoning_parser is not None
 
         from vllm_mlx.agents.setup import (
             apply_setup_plan,
@@ -648,6 +696,28 @@ def _confirm_config_write() -> bool:
     """Require interactive consent before a generic profile config write."""
     if not sys.stdin.isatty():
         return False
+
+
+def _cached_context_window(model: str) -> int | None:
+    """Read a cached/local config context limit without network or weights."""
+    from vllm_mlx.model_metadata import read_model_metadata
+
+    metadata = read_model_metadata(model)
+    config = metadata.config if metadata is not None else None
+    if not isinstance(config, dict):
+        return None
+    candidates = [config.get("max_position_embeddings")]
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        candidates.append(text_config.get("max_position_embeddings"))
+    for candidate in candidates:
+        if (
+            isinstance(candidate, int)
+            and not isinstance(candidate, bool)
+            and candidate > 0
+        ):
+            return candidate
+    return None
     try:
         return input("Apply this configuration? [y/N] ").strip().lower() in {
             "y",

--- a/vllm_mlx/run/cli.py
+++ b/vllm_mlx/run/cli.py
@@ -696,6 +696,13 @@ def _confirm_config_write() -> bool:
     """Require interactive consent before a generic profile config write."""
     if not sys.stdin.isatty():
         return False
+    try:
+        return input("Apply this configuration? [y/N] ").strip().lower() in {
+            "y",
+            "yes",
+        }
+    except (EOFError, KeyboardInterrupt):
+        return False
 
 
 def _cached_context_window(model: str) -> int | None:
@@ -718,13 +725,6 @@ def _cached_context_window(model: str) -> int | None:
         ):
             return candidate
     return None
-    try:
-        return input("Apply this configuration? [y/N] ").strip().lower() in {
-            "y",
-            "yes",
-        }
-    except (EOFError, KeyboardInterrupt):
-        return False
 
 
 def _print_instructions(profile, base_url, model) -> None:

--- a/vllm_mlx/run/cli.py
+++ b/vllm_mlx/run/cli.py
@@ -1,0 +1,608 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``rapid-mlx start <agent>`` — one-command agent startup (#150).
+
+``start`` ties the pieces that already exist into a single foreground
+verb: resolve an agent profile, pick a compatible model, start the
+canonical ``serve`` path as a parent-owned child, wait until the endpoint
+is healthy, then print (and optionally apply) the agent's setup config.
+
+Design contract (see ``vllm_mlx/run/__init__.py`` for the full rationale):
+
+* **No second config writer, model selector, or serve entrypoint.** This
+  module orchestrates ``vllm_mlx/agents`` (profiles + setup plans),
+  ``vllm_mlx/recommendations`` (memory-fit selection),
+  ``vllm_mlx/model_aliases`` (alias resolution), ``vllm_mlx/_download_gate``
+  (download consent), and the canonical ``serve`` subprocess.
+* **Foreground child, parent-owned.** ``start`` spawns ``serve`` with a
+  plain ``subprocess.Popen`` (NO ``start_new_session`` — that detached
+  model belongs to ``launch --start-server`` / the headless service). The
+  parent forwards SIGINT/SIGTERM to the child and exits with the child's
+  status, so Ctrl-C tears the whole tree down and no orphan is left (modulo
+  SIGKILL, where the child-side ``RAPID_MLX_WATCHDOG_PPID`` watchdog
+  self-terminates).
+* **Download consent happens in the parent once.** The serve child is
+  spawned with ``RAPID_MLX_CHAT_SPAWN=1`` so its own B2 auto-pull gate
+  never re-prompts (identical to the chat REPL spawner).
+
+The verb is ``start`` (not the issue's literal ``run``) because ``run`` is
+already a shipped alias for ``chat`` (Ollama muscle-memory); see the plan.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from vllm_mlx.agents.base import AgentProfile
+
+
+def register(subparsers) -> None:
+    """Register the ``start`` subparser (deferred-import from ``cli.py``)."""
+    from vllm_mlx._completion import alias_completer  # noqa: PLC0415
+    from vllm_mlx.cli import _port_arg  # noqa: PLC0415
+
+    parser = subparsers.add_parser(
+        "start",
+        help="Start an AI agent with a local model in one command",
+        description=(
+            "Start an AI agent with a local model in one command.\n\n"
+            "Resolves the agent profile, picks a recommended model that "
+            "fits this Mac and is already cached (or previews a download), "
+            "starts the server in the foreground, and prints the agent's "
+            "connection instructions (optionally configuring it)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "profile",
+        nargs="?",
+        default=None,
+        help=(
+            "Agent name (e.g. codex, hermes, opencode). Omit for a generic "
+            "OpenAI-compatible endpoint."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help=(
+            "Model alias or HF repo to serve (default: first recommended "
+            "model in the profile that fits this Mac and is already cached; "
+            "else a previewed download)."
+        ),
+    ).completer = alias_completer
+    parser.add_argument(
+        "--port",
+        type=_port_arg,
+        default=8000,
+        help="Port to serve on (default: 8000)",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Host to serve on (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--no-download",
+        action="store_true",
+        help="Refuse to download a model; fail if no recommended model is cached",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the model, port, and config mutations without starting "
+        "a server, downloading anything, or writing configuration",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip the confirmation prompt before downloading / writing config",
+    )
+    parser.add_argument(
+        "--no-setup",
+        action="store_true",
+        help="Do not write agent configuration after the server is ready; "
+        "only print instructions",
+    )
+    parser.add_argument(
+        "--ready-timeout",
+        type=int,
+        default=600,
+        help="Seconds to wait for the spawned server to become ready (default: 600)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def start_command(args) -> int:
+    """Resolve, consent, spawn (or reuse), and wait. Returns an exit code."""
+    from vllm_mlx.agents import get_profile
+
+    profile_name = args.profile
+    profile = get_profile(profile_name) if profile_name else None
+    if profile_name and profile is None:
+        _print_unknown_agent(profile_name)
+        return 1
+
+    model = _select_model(
+        explicit=args.model,
+        profile=profile,
+        no_download=args.no_download,
+    )
+    if model is None:
+        return 1
+
+    base_url = f"http://{args.host}:{args.port}"
+
+    # Port already occupied: reuse a compatible healthy server, else refuse.
+    if _port_is_busy(args.host, args.port):
+        return _reuse_or_refuse(base_url, model, profile, args)
+
+    if args.dry_run:
+        _print_dry_run(profile_name, model, args)
+        return 0
+
+    if not _confirm_download(model, no_download=args.no_download, yes=args.yes):
+        return 1
+
+    proc = _spawn_foreground_serve(model, args)
+    with _foreground_child(proc):
+        outcome = _wait_ready(base_url, proc, args.ready_timeout)
+        if outcome == "timeout":
+            # The child is STILL alive (loading/downloading) but never became
+            # ready within --ready-timeout. Waiting longer would hang
+            # indefinitely, so terminate it, reap, and fail (HIGH squash: the
+            # earlier "Server did not become ready" is the final word).
+            _terminate_child(proc)
+            return _wait_child(proc)
+        if outcome == "exited":
+            # The serve child died before /health/ready returned; reap it and
+            # surface its (nonzero) status instead of a raw traceback.
+            return _wait_child(proc)
+        _attach_and_configure(base_url, model, profile, args)
+        return _wait_child(proc)
+
+
+# ---------------------------------------------------------------------------
+# Model selection
+# ---------------------------------------------------------------------------
+
+
+def _select_model(
+    *, explicit: str | None, profile: AgentProfile | None, no_download: bool
+) -> str | None:
+    """Pick the model to serve, applying the documented selection order.
+
+    1. ``explicit`` (from ``--model``) wins, served verbatim. It already
+       flowed through ``main()``'s top-level alias->path resolution, so it
+       is a concrete alias or HF repo id here.
+    2. Otherwise iterate the profile's recommended models; pick the first
+       that fits this host's RAM (``is_recommended_alias``) and is already
+       cached (``is_repo_cached``).
+    3. If none is cached and downloads are allowed, pick the first fitting
+       recommended model (the profile's declaration order encodes the
+       preferred workhorse first) and let the download-consent step run.
+    4. With ``--no-download``, refuse with a clear message rather than
+       touching the network.
+    """
+    from vllm_mlx._download_gate import is_repo_cached
+    from vllm_mlx.recommendations import (
+        is_recommended_alias,
+        physical_ram_gb,
+    )
+
+    if explicit:
+        return explicit
+
+    if profile is None:
+        # No profile and no explicit model: the generic endpoint serves the
+        # same known-good first-run starter the bare ``chat``/``run`` use.
+        from vllm_mlx.first_run import select_chat_default
+
+        starter, _cached = select_chat_default()
+        return starter
+
+    candidates = list(profile.recommended_models)
+    if not candidates:
+        print("  This agent profile has no recommended models; pass --model.")
+        return None
+
+    ram_gb = physical_ram_gb()
+    for alias in candidates:
+        # ``ram_gb and`` mirrors the pick loop below: a failed RAM probe
+        # (0) is treated as "can't judge fit" -> every candidate fits, so a
+        # cached recommended model is still returned instead of forcing a
+        # re-download of candidates[0].
+        if ram_gb and not is_recommended_alias(alias, ram_gb):
+            continue
+        if is_repo_cached(_hf_id(alias)):
+            return alias
+
+    if no_download:
+        _print_nothing_cached(candidates, ram_gb)
+        return None
+
+    # Nothing cached: first recommended model that fits. If RAM is
+    # unknowable (0), skip the fit filter so a model can still be picked on
+    # machines whose memsize probe failed. The download-consent step runs
+    # next and shows the exact transfer size.
+    for alias in candidates:
+        if ram_gb and not is_recommended_alias(alias, ram_gb):
+            continue
+        return alias
+
+    _print_nothing_fits(candidates, ram_gb)
+    return None
+
+
+def _hf_id(alias: str) -> str:
+    """Best-effort alias -> HF repo id, for cache checks."""
+    from vllm_mlx.model_aliases import resolve_model
+
+    try:
+        return resolve_model(alias)
+    except Exception:
+        return alias
+
+
+def _print_unknown_agent(name: str) -> None:
+    from vllm_mlx.agents import list_profiles
+
+    names = ", ".join(p.name for p in list_profiles())
+    print(f"  Unknown agent: {name}")
+    print(f"  Known agents: {names}")
+    print(
+        "  Run 'rapid-mlx agents' for details, or 'rapid-mlx start' "
+        "for a generic endpoint."
+    )
+
+
+def _print_nothing_cached(candidates, ram_gb) -> None:
+    from vllm_mlx.recommendations import is_recommended_alias
+
+    print("  No recommended model is already cached and --no-download was set.")
+    print("  Candidates would have been:")
+    for alias in candidates:
+        fits = "" if (not ram_gb or is_recommended_alias(alias, ram_gb)) else " ✗"
+        print(f"    {alias}{fits}")
+    if ram_gb:
+        print("  (✗ = does not fit this Mac's RAM)")
+    print("  Drop --no-download (or pass --model <cached-alias>) to proceed.")
+
+
+def _print_nothing_fits(candidates, ram_gb) -> None:
+    print(
+        f"  None of this agent's recommended models fit this Mac's RAM "
+        f"({ram_gb:.1f} GB):"
+    )
+    for alias in candidates:
+        print(f"    {alias}")
+    print("  Pass --model <alias> to serve a different model.")
+
+
+# ---------------------------------------------------------------------------
+# Consent + spawn
+# ---------------------------------------------------------------------------
+
+
+def _confirm_download(model: str, *, no_download: bool, yes: bool) -> bool:
+    """Consent gate for a first-time (large) download, or a cached pass.
+
+    Reuses ``confirm_or_abort`` from ``vllm_mlx/_download_gate`` for the
+    threshold + env-override policy; ``--yes``, ``RAPID_MLX_AUTO_PULL`` and
+    non-TTY (CI) all short-circuit to proceed, exactly as the serve path.
+    """
+    from vllm_mlx._download_gate import (
+        confirm_or_abort,
+        estimate_download_size_bytes,
+        is_repo_cached,
+    )
+
+    hf_id = _hf_id(model)
+
+    if no_download:
+        if not is_repo_cached(hf_id):
+            print(f"  --no-download set and {model} is not cached; refusing.")
+            return False
+        return True
+
+    if is_repo_cached(hf_id):
+        return True
+
+    env_val = os.environ.get("RAPID_MLX_AUTO_PULL", "").strip().lower()
+    if env_val in {"1", "true", "yes"} or yes or not sys.stdin.isatty():
+        return True
+
+    size: int | None = None
+    try:
+        size = estimate_download_size_bytes(hf_id)
+    except Exception:
+        pass
+    return confirm_or_abort(hf_id, size)
+
+
+def _spawn_foreground_serve(model: str, args) -> subprocess.Popen:
+    """Start the canonical ``serve`` path as a foreground, parent-owned child."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm_mlx.cli",
+        "serve",
+        model,
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+    ]
+    child_env = os.environ.copy()
+    # The parent already ran the download-consent gate; suppress the child's
+    # own B2 re-prompt (chat spawner pattern).
+    child_env["RAPID_MLX_CHAT_SPAWN"] = "1"
+    # If the start parent is SIGKILLed, the child self-terminates instead of
+    # orphan-locking the model + port.
+    child_env["RAPID_MLX_WATCHDOG_PPID"] = str(os.getpid())
+    print(f"  Starting {model} on {args.host}:{args.port} (Ctrl-C to stop) ...")
+    return subprocess.Popen(  # noqa: S603
+        cmd,
+        env=child_env,
+    )
+
+
+class _foreground_child:
+    """Context manager: relay SIGINT/SIGTERM to a spawned serve child.
+
+    Install the relay IMMEDIATELY after ``Popen`` — before the (potentially
+    long) download/load readiness phase — so a Ctrl-C or ``kill -INT/-TERM``
+    at ANY point is forwarded to the child instead of running with default
+    dispositions (which would leave the child to the watchdog and print a raw
+    ``KeyboardInterrupt`` traceback in the parent). Restores the previous
+    handlers on exit.
+    """
+
+    def __init__(self, proc):
+        self._proc = proc
+
+    def __enter__(self):
+        self._prev_int = signal.signal(signal.SIGINT, self._forward)
+        self._prev_term = signal.signal(signal.SIGTERM, self._forward)
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        signal.signal(signal.SIGINT, self._prev_int)
+        signal.signal(signal.SIGTERM, self._prev_term)
+        return False
+
+    def _forward(self, signum, _frame):
+        try:
+            self._proc.send_signal(signum)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
+def _terminate_child(proc) -> None:
+    """SIGTERM a still-alive child so the caller can reap it cleanly."""
+    try:
+        proc.terminate()
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+def _wait_ready(base_url: str, proc, timeout_s: int) -> str:
+    """Block until /health/ready returns 200, the child exits, or timeout.
+
+    Returns a tri-state so the caller can tell ``exited`` (the serve child
+    died before becoming ready — reap it) from ``timeout`` (the child is
+    STILL ALIVE but never reported healthy — terminate it, never just wait):
+    * ``"ready"`` — /health/ready returned 200.
+    * ``"exited"`` — the child exited early (code ``proc.returncode``).
+    * ``"timeout"`` — the child is alive but not ready within ``timeout_s``.
+    """
+    from vllm_mlx.cli import _wait_for_chat_server
+
+    try:
+        _wait_for_chat_server(base_url, proc, timeout_s=timeout_s)
+    except (RuntimeError, TimeoutError) as exc:
+        if proc.poll() is not None:
+            print(
+                f"  Server exited before becoming ready (code {proc.returncode}): {exc}"
+            )
+            return "exited"
+        print(f"  Server did not become ready in {timeout_s}s; stopping server: {exc}")
+        return "timeout"
+    except KeyboardInterrupt:
+        # Ctrl-C during the (potentially long) download/load readiness phase.
+        # The child is alive; the signal relay has already forwarded SIGINT to
+        # it, so terminate + reap here for a clean teardown (no raw traceback).
+        print("\n  Interrupted during startup; stopping the server.")
+        return "exited"
+    return "ready"
+
+
+def _port_is_busy(host: str, port: int) -> bool:
+    from vllm_mlx.cli import _port_is_busy as probe
+
+    return probe(host, port)
+
+
+# ---------------------------------------------------------------------------
+# Port reuse + attach
+# ---------------------------------------------------------------------------
+
+
+def _reuse_or_refuse(base_url: str, model: str, profile, args) -> int:
+    """Port occupied: reuse a compatible healthy server, else refuse clearly.
+
+    Returns an exit code describing the dispatcher's next action:
+    * 0 — reused or dry-run previewed; start_command returns directly.
+    * Non-zero — refused; start_command returns the refusal.
+    """
+    from vllm_mlx.agents.adapter import _fetch_models
+
+    if args.dry_run:
+        print(
+            f"  Dry run — port {args.port} is already in use; "
+            f"start would attach to {base_url}."
+        )
+        return 0
+
+    served = {str(m.get("id")) for m in _fetch_models(base_url) if m.get("id")}
+    if not served:
+        print(
+            f"  Port {args.port} is occupied but not a healthy rapid-mlx "
+            "server; pick another port with --port."
+        )
+        return 1
+
+    hf_id = _hf_id(model)
+    if hf_id in served or model in served:
+        print(f"  Reusing the running server on {base_url} (serving {model}).")
+        return _attach_and_configure(base_url, model, profile, args)
+
+    print(f"  Port {args.port} already serves {sorted(served)}, not {model}.")
+    print("  Choose a different port with --port, or stop the other server.")
+    return 1
+
+
+def _attach_and_configure(base_url, model, profile, args) -> int:
+    """After the (spawned or reused) server is healthy, print + apply config.
+
+    Uses the same setup-plan machinery as ``rapid-mlx agents --setup`` for
+    the first-class profiles (claude-code / continue / deepseek-harness) and
+    the generic writer otherwise. Never kills the server. Returns 0.
+    """
+    if args.dry_run or args.no_setup or profile is None:
+        _print_instructions(profile, base_url, model)
+        return 0
+
+    cfg = profile.get_config_for_version(None)
+    if cfg and cfg.template and "{context_length}" in cfg.template:
+        from vllm_mlx.agents.adapter import fetch_context_window
+
+        try:
+            context_length = fetch_context_window(base_url, model)
+        except Exception:
+            context_length = None
+    else:
+        context_length = None
+
+    is_first_class = profile.name in {"claude-code", "continue", "deepseek-harness"}
+    if is_first_class:
+        from vllm_mlx.agents.setup import (
+            apply_setup_plan,
+            build_setup_plan,
+            confirm_plan,
+        )
+
+        try:
+            plan = build_setup_plan(
+                profile.name, base_url, model, context_length=context_length
+            )
+        except (OSError, ValueError) as exc:
+            print(f"  {profile.display_name} setup failed: {exc}")
+            _print_instructions(profile, base_url, model)
+            return 0
+
+        print(f"  {profile.display_name} configuration: {plan.path}")
+        if plan.changed:
+            print(plan.diff())
+        else:
+            print("  Already configured; no file changes needed.")
+
+        if not plan.changed or args.yes or confirm_plan(plan):
+            if plan.changed:
+                try:
+                    apply_setup_plan(plan)
+                except RuntimeError as exc:
+                    print(f"  {profile.display_name} setup failed: {exc}")
+                else:
+                    print(f"  Configured {profile.display_name} at {plan.path}.")
+        else:
+            print("  Setup cancelled; nothing was written.")
+    else:
+        from vllm_mlx.agents.adapter import setup_agent_config
+
+        summary = setup_agent_config(
+            profile,
+            base_url,
+            model,
+            dry_run=False,
+            context_length=context_length,
+        )
+        if summary.startswith("Cannot"):
+            print(f"  {profile.display_name} setup failed.")
+            print(f"  {summary}")
+            _print_instructions(profile, base_url, model)
+            return 0
+        print(f"  {profile.display_name} configured! {summary}")
+
+    _print_next_steps(profile.name, base_url, model)
+    return 0
+
+
+def _print_instructions(profile, base_url, model) -> None:
+    if profile is None:
+        print(f"  OpenAI-compatible endpoint: {base_url}/v1 (model {model})")
+        return
+    from vllm_mlx.agents.adapter import get_setup_instructions
+
+    try:
+        instructions = get_setup_instructions(profile, base_url, model)
+    except Exception as exc:
+        print(f"  (Could not render setup instructions: {exc})")
+    else:
+        print()
+        print(instructions)
+
+
+def _print_next_steps(profile_name, base_url, model) -> None:
+    print()
+    print(f"  {profile_name} is configured to talk to {base_url} (model {model}).")
+
+
+# ---------------------------------------------------------------------------
+# Child lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _wait_child(proc) -> int:
+    """Wait for the serve child and return its exit code.
+
+    Signal relay is handled by the enclosing ``_foreground_child`` (active
+    from spawn), so this just reaps the child. Signal deaths are mapped to
+    the POSIX ``128 + signum`` shell-representable code rather than the raw
+    negative returncode.
+    """
+    import time
+
+    while proc.poll() is None:
+        time.sleep(0.1)
+    code = proc.returncode
+    if code is None:
+        return 1
+    code = int(code)
+    if code < 0:  # died by signal: -SIGKILL/-SIGTERM/etc. -> 128 + signum
+        return 128 - code
+    return code
+
+
+def _print_dry_run(profile_name, model, args) -> None:
+    from vllm_mlx.recommendations import physical_ram_gb
+
+    print("  Dry run — nothing started, downloaded, or written.")
+    print(f"  Agent:  {profile_name or 'generic OpenAI-compatible'}")
+    print(f"  Model:  {model}")
+    print(f"  Serve:  rapid-mlx serve {model} --host {args.host} --port {args.port}")
+    ram_gb = physical_ram_gb()
+    if ram_gb:
+        print(f"  RAM:    {ram_gb:.1f} GB")


### PR DESCRIPTION
## What

Adds `rapid-mlx start [PROFILE] [--model ALIAS] [--port N] [--host H] [--no-download] [--dry-run] [--yes] [--no-setup] [--ready-timeout]` — zero-config one-command agent startup that ties together pieces that already exist (agent profiles, safe setup plans, memory-fit recommendations, and the canonical `serve` path).

Closes #150.

**Verb note:** the issue asks for `rapid-mlx run <agent>`, but `run` is already a shipped alias for `chat` (Ollama muscle-memory). Repurposing it would break an established command, so the feature ships as `start`; `run`/chat is left untouched (regression-guarded).

## Behavior

1. **Resolve** the agent profile (`codex`, `hermes`, ...) or a generic OpenAI-compatible default.
2. **Pick a model:** explicit `--model` wins; else the first recommended model in the profile's declaration order that fits this Mac's RAM and is already cached; else a previewed download (with consent, unless `--yes`). `--no-download` refuses rather than touching the network.
3. **Spawn** the canonical `serve` as a **foreground parent-owned child** with an isolated signal group; the parent forwards SIGINT/SIGTERM exactly once and exits with the child's status — **no orphan `serve`**. (Deliberately not the detached `launch --start-server` path.)
4. **Wait** for `/health/ready`, then print the agent's setup instructions and (unless `--no-setup`) apply its config via the existing setup-plan machinery.
5. **Reuse** an already-running healthy Rapid-MLX server on the port serving the chosen model; refuse clearly if the port is occupied by something incompatible.
6. `--dry-run` previews every mutation (model, port, config write) without starting/downloading/writing anything.

## Files

- `vllm_mlx/run/cli.py` (new) — `start` subparser + orchestrator and helpers.
- `vllm_mlx/run/__init__.py` (new) — package docstring (distinct from `vllm_mlx/service` engine layer and `vllm_mlx/headless_service`).
- `vllm_mlx/cli.py` — register `start` subparser + dispatch. `run` untouched.
- `tests/test_cli_start.py` (new) — 62 hermetic tests; includes a `run`-alias regression guard.
- `docs/reference/cli.md` — `rapid-mlx start` docs.

## Verification

- 128 focused lifecycle/CLI tests pass across `test_cli_start.py` and `test_no_mllm_flag.py`; `run`=chat alias tests stay green.
- ruff clean; mypy error-budget clean for the new file; diff-cover 100% on changed lines (CI combined Linux+Apple).
- `rapid-mlx start --dry-run hermes` previews without side effects.


## Design precedent

The command follows the established foreground-supervisor pattern: one parent owns model selection, consent, child lifecycle, readiness, and client configuration; the canonical server remains the only inference entrypoint. Binding and connection identities are separated so wildcard listeners are probed through loopback, and user-facing aliases remain stable while resolved repository IDs are used for cache/download checks. Setup failures are explicit and nonzero; only a server spawned by this invocation is cleaned up.
