### PR TITLE
feat(models): vendor the G9v3-39A5B MoE backbone (#3046)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,6 +474,7 @@ jobs:
             tests/test_audio_route_registration_gate.py \
             tests/test_forced_alignment_route_hardening.py \
             tests/test_muse_glimmer_model.py \
+            tests/test_g9v3_model.py \
             tests/test_bailing_hybrid_model.py \
             tests/test_mtp_spec_decode.py \
             tests/test_speculative_request_policy.py \

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ multiplication. The regular `qwen3.8-27b-4bit` alias remains unchanged for M3
 and newer Macs; Rapid does not silently swap checkpoint precision.
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
-→ [Every alias, quant, and family (189 text + 10 image + 10 video + 44 audio aliases, 253 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
+→ [Every alias, quant, and family (190 text + 10 image + 10 video + 44 audio aliases, 254 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
 
 ---
 

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -23,6 +23,7 @@ Families with registered aliases (run `rapid-mlx models` for the full, current l
 | Ternary Bonsai | 1.7B, 27B | 2-bit (ternary) |
 | Hunyuan 3 (Hy3) | 295B MoE (21B active) — **Ultra-only** | 4-bit |
 | NeoHorse 1 | 9B (experimental Chat candidate) | 4-bit |
+| G9v3 (AI9Stars) | 39B MoE (5B active) | 4-bit |
 
 ### Recommended Models
 
@@ -124,6 +125,31 @@ config declares `tool_parser_type: qwen3_coder`), so the aliases pin the
 uses the reasoning-token budget; to send the template's own
 `{reasoning effort: low}` marker instead, pass
 `chat_template_kwargs: {"reasoning_effort": "low"}`.
+
+### G9v3 (AI9Stars) 39B-A5B MoE
+
+`ai9stars/G9v3-39A5B` is a 39B-parameter Mixture-of-Experts model with 5B
+parameters active per token (32 of 320 routed experts plus one shared
+expert), gated GQA attention and a 128K context. The architecture ships
+only as `trust_remote_code` transformers code, so rapid-mlx vendors the MLX
+backbone (`vllm_mlx/models/g9v3.py`) and publishes its own conversion.
+The 4-bit export keeps the routed experts at 4-bit and everything else
+(attention, dense/shared MLP, embeddings) at 8-bit: uniform 4-bit was
+measured to hurt this architecture's attention projections badly.
+
+| Alias | HF path | Weights | Hardware |
+|-------|---------|---------|----------|
+| `g9v3-39a5b-4bit` | `rapid-mlx/G9v3-39A5B-MLX-4bit` | ~21 GB | 32 GB+ unified memory |
+
+```bash
+rapid-mlx serve g9v3-39a5b-4bit
+```
+
+The chat template is ChatML with Qwen3-style `<think>` blocks and
+MiniCPM-style XML tool calls, so the alias pins the `qwen3` reasoning parser
+and the `minicpm` tool-call parser; `enable_thinking` toggles reasoning the
+same way it does for the Qwen family. Speculative decoding is not enabled
+for this alias (the checkpoint has no draft model or MTP head).
 
 ## Multimodal Models (via mlx-vlm)
 

--- a/tests/test_g9v3_model.py
+++ b/tests/test_g9v3_model.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the vendored G9v3 (``ai9stars/G9v3-39A5B``) MoE backbone.
+
+Pins the contract that:
+
+1. The vendored module is importable and registers into mlx-lm's
+   importlib lookup (``_register_vendored_archs``).
+2. Config parsing reproduces the released 39B-A5B shape from an empty
+   config, derives ``head_dim`` like the remote ``G9v3Config``, and rejects
+   configs the port cannot honour (non-SiLU activation, bad GQA/MoE
+   arities).
+3. Layer 0 is dense and layers ``>= first_k_dense_replace`` are MoE.
+4. A tiny synthetic config constructs + runs the model: logits shape and
+   incremental (cache) decode matching the full-prefill forward.
+5. The gated-attention ``q_proj`` split takes the *first* ``head_dim`` of
+   every ``2 * head_dim`` head slice as the query and the second as the
+   gate (transformers ``torch.chunk`` semantics).
+6. The router reproduces the remote ``G9v3TopkRouter`` maths (sigmoid,
+   bias for selection only, normalised raw scores × scaling factor).
+7. ``sanitize`` stacks per-expert checkpoint tensors into the ``SwitchGLU``
+   layout (bf16 and quantized triples), round-trips through strict
+   ``load_weights``, and fails loudly on a missing expert.
+8. The curated alias pins the minicpm/qwen3 parsers and MoE flags.
+
+Numeric fidelity against the remote transformers implementation was
+verified out-of-band (numbers in the PR body of #3046): identical random
+weights in fp32 (3 layers, gated attention, 8 experts / 2 active, random
+``e_score_correction_bias``, full-prefill and token-by-token) agree to
+~1e-5; the released weights in fp32 (config-truncated to 3 and 8 layers)
+agree to ~1e-6 per layer / 99.6-100% top-1 over all prompt positions; the
+full 38-layer bf16 comparison sits inside transformers' own eager-vs-sdpa
+bf16 spread. The reference needs ``trust_remote_code`` + torch, which CI
+does not install, so that check is not repeated here.
+"""
+
+import importlib
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mlx.core")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.core as mx  # noqa: E402
+from mlx.utils import tree_flatten  # noqa: E402
+
+from vllm_mlx.models import g9v3  # noqa: E402
+
+TINY = dict(
+    model_type="g9v3",
+    hidden_size=64,
+    num_hidden_layers=3,
+    intermediate_size=128,
+    moe_intermediate_size=32,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    vocab_size=128,
+    n_routed_experts=8,
+    n_shared_experts=1,
+    num_experts_per_tok=2,
+    first_k_dense_replace=1,
+    max_position_embeddings=256,
+)
+
+
+def tiny_model(**overrides):
+    args = g9v3.ModelArgs.from_dict(dict(TINY, **overrides))
+    model = g9v3.Model(args)
+    # Router params are zero-initialised (ties everywhere); give them a
+    # deterministic random routing so the tests exercise real top-k paths.
+    mx.random.seed(0)
+    for layer in model.layers:
+        if isinstance(layer.mlp, g9v3.MoE):
+            gate = layer.mlp.gate
+            gate.weight = 0.5 * mx.random.normal(gate.weight.shape)
+            gate.e_score_correction_bias = 0.5 * mx.random.normal(
+                gate.e_score_correction_bias.shape
+            )
+    mx.eval(model.parameters())
+    return model
+
+
+@pytest.fixture(autouse=True)
+def _clear_vendored_register():
+    """Registration is sys.modules-level state — reset around each test."""
+    sys.modules.pop("mlx_lm.models.g9v3", None)
+    yield
+    sys.modules.pop("mlx_lm.models.g9v3", None)
+
+
+def test_module_contract():
+    assert hasattr(g9v3, "Model")
+    assert hasattr(g9v3, "ModelArgs")
+    assert g9v3.ModelArgs.__dataclass_fields__["model_type"].default == "g9v3"
+
+
+def test_register_vendored_archs_makes_mlx_lm_loader_find_it():
+    from vllm_mlx.utils.tokenizer import (
+        _VENDORED_MODEL_TYPES,
+        _register_vendored_archs,
+    )
+
+    assert "mlx_lm.models.g9v3" not in sys.modules
+    _register_vendored_archs()
+    assert "mlx_lm.models.g9v3" in sys.modules
+    assert "g9v3" in _VENDORED_MODEL_TYPES
+
+    # mlx-lm's _get_classes() does exactly this lookup.
+    mod = importlib.import_module("mlx_lm.models.g9v3")
+    assert mod is sys.modules["mlx_lm.models.g9v3"]
+    assert hasattr(mod, "Model") and hasattr(mod, "ModelArgs")
+
+    # Idempotent.
+    _register_vendored_archs()
+    assert importlib.import_module("mlx_lm.models.g9v3") is mod
+
+
+def _reset_g9v3_registration(monkeypatch):
+    from vllm_mlx.utils import tokenizer as tok
+
+    monkeypatch.delitem(sys.modules, "mlx_lm.models.g9v3", raising=False)
+    monkeypatch.setattr(tok, "_VENDORED_MODEL_TYPES", set(tok._VENDORED_MODEL_TYPES))
+    tok._VENDORED_MODEL_TYPES.discard("g9v3")
+    return tok
+
+
+def test_registration_defers_to_native_mlx_lm(monkeypatch):
+    """When mlx-lm ships its own ``mlx_lm.models.g9v3`` the vendored copy
+    stays out of ``sys.modules`` but the model type is still marked vendored
+    (keeps the tokenizer fallback off transformers' AutoConfig)."""
+    import importlib.util
+
+    tok = _reset_g9v3_registration(monkeypatch)
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "mlx_lm.models.g9v3":
+            return importlib.util.spec_from_loader(name, loader=None)
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    tok._register_vendored_archs()
+    assert "mlx_lm.models.g9v3" not in sys.modules
+    assert "g9v3" in tok._VENDORED_MODEL_TYPES
+
+
+def test_registration_survives_find_spec_errors(monkeypatch):
+    """A broken/partial mlx-lm install that makes ``find_spec`` raise still
+    ends with the vendored module registered."""
+    import importlib.util
+
+    tok = _reset_g9v3_registration(monkeypatch)
+    real_find_spec = importlib.util.find_spec
+
+    def raising_find_spec(name, *args, **kwargs):
+        if name == "mlx_lm.models.g9v3":
+            raise ValueError("mlx_lm.models.g9v3.__spec__ is None")
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", raising_find_spec)
+    tok._register_vendored_archs()
+    assert sys.modules["mlx_lm.models.g9v3"] is g9v3
+    assert "g9v3" in tok._VENDORED_MODEL_TYPES
+
+
+def test_registration_warns_when_vendored_import_fails(monkeypatch, caplog):
+    """An import failure of the vendored module is logged, not raised: the
+    rest of the loader (and every other vendored family) keeps working."""
+    import vllm_mlx.models
+
+    tok = _reset_g9v3_registration(monkeypatch)
+    # ``from ..models import g9v3`` takes the package attribute when it is
+    # already bound; drop it so the import goes through sys.modules, where
+    # ``None`` makes it raise ImportError.
+    monkeypatch.delattr(vllm_mlx.models, "g9v3", raising=False)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.models.g9v3", None)
+    with caplog.at_level(logging.WARNING, logger="vllm_mlx.utils.tokenizer"):
+        tok._register_vendored_archs()
+    assert "mlx_lm.models.g9v3" not in sys.modules
+    assert "g9v3" not in tok._VENDORED_MODEL_TYPES
+    assert any(
+        "g9v3 vendored module failed to register" in r.message for r in caplog.records
+    )
+
+
+def test_released_defaults():
+    """An empty config builds the released 39B-A5B shape."""
+    args = g9v3.ModelArgs.from_dict({"model_type": "g9v3"})
+    assert (args.hidden_size, args.num_hidden_layers, args.vocab_size) == (
+        2048,
+        38,
+        130560,
+    )
+    assert (args.num_attention_heads, args.num_key_value_heads, args.head_dim) == (
+        32,
+        2,
+        128,
+    )
+    assert args.use_gated_attention is True
+    assert args.attention_bias is False
+    assert args.rope_theta == 5000000.0 and args.rope_scaling is None
+    assert (args.n_routed_experts, args.num_experts_per_tok, args.n_shared_experts) == (
+        320,
+        32,
+        1,
+    )
+    assert (args.intermediate_size, args.moe_intermediate_size) == (8192, 512)
+    assert args.first_k_dense_replace == 1
+    assert (args.n_group, args.topk_group, args.norm_topk_prob) == (1, 1, True)
+    assert args.routed_scaling_factor == 3.66
+    assert args.tie_word_embeddings is False
+
+
+def test_head_dim_derived_like_remote_config():
+    args = g9v3.ModelArgs.from_dict(dict(TINY, head_dim=None))
+    assert args.head_dim == TINY["hidden_size"] // TINY["num_attention_heads"]
+    model = g9v3.Model(args)
+    assert model(mx.array([[1, 2, 3]])).shape == (1, 3, TINY["vocab_size"])
+
+
+@pytest.mark.parametrize(
+    "bad, match",
+    [
+        (dict(hidden_act="gelu"), "hidden_act"),
+        (dict(num_key_value_heads=3), "num_attention_heads"),
+        (dict(num_experts_per_tok=9), "num_experts_per_tok"),
+        (dict(num_experts_per_tok=0), "num_experts_per_tok"),
+        (dict(n_group=3), "n_group"),
+        (dict(n_group=2, topk_group=3), "topk_group"),
+        (dict(first_k_dense_replace=4), "first_k_dense_replace"),
+    ],
+)
+def test_config_validation(bad, match):
+    with pytest.raises(ValueError, match=match):
+        g9v3.ModelArgs.from_dict(dict(TINY, **bad))
+
+
+def test_layer_kinds_follow_first_k_dense_replace():
+    model = tiny_model()
+    kinds = [type(layer.mlp) for layer in model.layers]
+    assert kinds == [g9v3.MLP, g9v3.MoE, g9v3.MoE]
+
+    all_moe = g9v3.Model(g9v3.ModelArgs.from_dict(dict(TINY, first_k_dense_replace=0)))
+    assert all(isinstance(layer.mlp, g9v3.MoE) for layer in all_moe.layers)
+
+    # An all-dense config must not need MoE arities to be valid at all.
+    all_dense = g9v3.Model(
+        g9v3.ModelArgs.from_dict(
+            dict(
+                TINY, first_k_dense_replace=3, n_routed_experts=0, num_experts_per_tok=0
+            )
+        )
+    )
+    assert all(isinstance(layer.mlp, g9v3.MLP) for layer in all_dense.layers)
+    assert all_dense(mx.array([[1, 2, 3]])).shape == (1, 3, TINY["vocab_size"])
+
+
+def test_forward_shape_and_cache_parity():
+    model = tiny_model()
+    ids = mx.random.randint(0, TINY["vocab_size"], (2, 24))
+
+    logits = model(ids)
+    assert logits.shape == (2, 24, TINY["vocab_size"])
+    assert bool(mx.isfinite(logits).all())
+
+    from mlx_lm.models.cache import KVCache
+
+    cache = [KVCache() for _ in model.layers]
+    steps = [model(ids[:, i : i + 1], cache=cache) for i in range(ids.shape[1])]
+    inc = mx.concatenate(steps, axis=1)
+    diff = float(mx.abs(inc - logits).max())
+    assert diff < 2e-3, diff
+
+
+def test_input_embeddings_used_raw():
+    model = tiny_model()
+    ids = mx.array([[1, 2, 3]])
+    via_ids = model(ids)
+    via_embeds = model(ids, input_embeddings=model.model.embed_tokens(ids))
+    assert float(mx.abs(via_ids - via_embeds).max()) < 1e-6
+
+
+def test_gated_q_proj_split_layout():
+    """Per head the ``2 * head_dim`` slice is ``[query | gate]``. With the gate
+    rows zeroed, ``sigmoid(0) = 0.5`` halves the ungated attention output;
+    a swapped layout would zero the queries instead."""
+    args_gated = g9v3.ModelArgs.from_dict(TINY)
+    args_plain = g9v3.ModelArgs.from_dict(dict(TINY, use_gated_attention=False))
+    gated, plain = g9v3.Attention(args_gated), g9v3.Attention(args_plain)
+    assert gated.q_proj.weight.shape[0] == 2 * plain.q_proj.weight.shape[0]
+
+    n_heads, hd, hidden = (
+        TINY["num_attention_heads"],
+        TINY["head_dim"],
+        TINY["hidden_size"],
+    )
+    for name in ("k_proj", "v_proj", "o_proj"):
+        getattr(gated, name).weight = getattr(plain, name).weight
+    wq = np.array(plain.q_proj.weight).reshape(n_heads, hd, hidden)
+    w_gated = np.concatenate([wq, np.zeros_like(wq)], axis=1).reshape(
+        n_heads * 2 * hd, hidden
+    )
+    gated.q_proj.weight = mx.array(w_gated)
+
+    x = mx.random.normal((1, 7, hidden))
+    out_gated, out_plain = gated(x, mask="causal"), plain(x, mask="causal")
+    assert float(mx.abs(out_gated - 0.5 * out_plain).max()) < 1e-5
+    # And the gate actually gates: swapping the halves changes the output.
+    swapped = np.concatenate([np.zeros_like(wq), wq], axis=1).reshape(
+        n_heads * 2 * hd, hidden
+    )
+    gated.q_proj.weight = mx.array(swapped)
+    assert float(mx.abs(gated(x, mask="causal") - 0.5 * out_plain).max()) > 1e-3
+
+
+def _reference_router(x, weight, bias, top_k, scaling, norm_topk_prob):
+    """Numpy port of the remote ``G9v3TopkRouter.forward`` (n_group = 1)."""
+    logits = x.astype(np.float32) @ weight.astype(np.float32).T
+    scores = 1.0 / (1.0 + np.exp(-logits))
+    idx = np.argsort(-(scores + bias), axis=-1)[..., :top_k]
+    weights = np.take_along_axis(scores, idx, axis=-1)
+    if norm_topk_prob:
+        weights = weights / (weights.sum(axis=-1, keepdims=True) + 1e-20)
+    return idx, weights * scaling
+
+
+@pytest.mark.parametrize("norm_topk_prob", [True, False])
+def test_router_matches_remote_reference(norm_topk_prob):
+    args = g9v3.ModelArgs.from_dict(
+        dict(TINY, num_experts_per_tok=3, norm_topk_prob=norm_topk_prob)
+    )
+    gate = g9v3.MoEGate(args)
+    rng = np.random.default_rng(1)
+    weight = rng.normal(size=(TINY["n_routed_experts"], TINY["hidden_size"])).astype(
+        np.float32
+    )
+    bias = rng.normal(size=(TINY["n_routed_experts"],)).astype(np.float32)
+    gate.weight, gate.e_score_correction_bias = mx.array(weight), mx.array(bias)
+    x = rng.normal(size=(5, TINY["hidden_size"])).astype(np.float32)
+
+    inds, scores = gate(mx.array(x))
+    inds, scores = np.array(inds), np.array(scores)
+    ref_inds, ref_scores = _reference_router(
+        x, weight, bias, 3, args.routed_scaling_factor, norm_topk_prob
+    )
+    # Selection order is unspecified on both sides: compare as index → weight.
+    for row in range(x.shape[0]):
+        got = dict(zip(inds[row].tolist(), scores[row].tolist()))
+        want = dict(zip(ref_inds[row].tolist(), ref_scores[row].tolist()))
+        assert got.keys() == want.keys(), (row, got, want)
+        for e in want:
+            assert abs(got[e] - want[e]) < 1e-5, (row, e, got[e], want[e])
+    if norm_topk_prob:
+        np.testing.assert_allclose(
+            scores.sum(axis=-1), args.routed_scaling_factor, rtol=1e-5
+        )
+
+
+def test_sanitize_stacks_experts_and_round_trips_strict_load():
+    model = tiny_model()
+    stacked = dict(tree_flatten(model.parameters()))
+    n_experts = TINY["n_routed_experts"]
+
+    # Explode the MLX layout back into transformers' per-expert keys.
+    checkpoint = {}
+    for k, v in stacked.items():
+        if ".switch_mlp." in k:
+            prefix, rest = k.split(".switch_mlp.")
+            for e in range(n_experts):
+                checkpoint[f"{prefix}.experts.{e}.{rest}"] = v[e]
+        else:
+            checkpoint[k] = v
+    assert "model.layers.1.mlp.experts.7.down_proj.weight" in checkpoint
+    assert "model.layers.0.mlp.gate_proj.weight" in checkpoint  # dense layer untouched
+    assert "model.layers.1.mlp.gate.e_score_correction_bias" in checkpoint
+
+    out = model.sanitize(dict(checkpoint))
+    assert not any(".experts." in k for k in out)
+    assert sorted(out) == sorted(stacked)
+    for k in stacked:
+        assert out[k].shape == stacked[k].shape, k
+        assert bool(mx.array_equal(out[k], stacked[k])), k
+
+    fresh = g9v3.Model(g9v3.ModelArgs.from_dict(TINY))
+    fresh.load_weights(list(out.items()), strict=True)
+    ids = mx.array([[3, 1, 4, 1, 5]])
+    assert float(mx.abs(fresh(ids) - model(ids)).max()) < 1e-6
+
+    # Already-stacked (an MLX export) passes through unchanged.
+    again = model.sanitize(dict(stacked))
+    assert sorted(again) == sorted(stacked)
+
+
+def test_sanitize_stacks_quantized_triples_and_rejects_missing_expert():
+    model = tiny_model()
+    prefix = "model.layers.1.mlp"
+    weights = {}
+    for e in range(TINY["n_routed_experts"]):
+        for kind in ("weight", "scales", "biases"):
+            weights[f"{prefix}.experts.{e}.up_proj.{kind}"] = mx.full((2, 2), e)
+    out = model.sanitize(dict(weights))
+    assert sorted(out) == [
+        f"{prefix}.switch_mlp.up_proj.{k}" for k in ("biases", "scales", "weight")
+    ]
+    assert out[f"{prefix}.switch_mlp.up_proj.weight"].shape == (
+        TINY["n_routed_experts"],
+        2,
+        2,
+    )
+    assert out[f"{prefix}.switch_mlp.up_proj.scales"][5, 0, 0].item() == 5
+
+    del weights[f"{prefix}.experts.3.up_proj.weight"]
+    with pytest.raises(ValueError, match="experts.3.up_proj.weight"):
+        model.sanitize(dict(weights))
+
+
+def test_quant_predicate_keeps_non_experts_at_8_bits():
+    """``mlx_lm.convert`` picks the model's predicate up: routed experts get
+    the requested bits, every other quantizable module is pinned to 8-bit
+    (fine-grained entries in the saved ``quantization`` config)."""
+    from mlx_lm.utils import quantize_model
+
+    model = tiny_model()
+    model, qcfg = quantize_model(model, dict(TINY), group_size=64, bits=4)
+    moe = model.layers[1].mlp
+    assert moe.switch_mlp.gate_proj.bits == 4 and moe.switch_mlp.up_proj.bits == 4
+    assert moe.shared_experts.gate_proj.bits == 8
+    assert model.layers[0].mlp.gate_proj.bits == 8
+    attn = model.layers[1].self_attn
+    assert (attn.q_proj.bits, attn.k_proj.bits, attn.v_proj.bits, attn.o_proj.bits) == (
+        8,
+        8,
+        8,
+        8,
+    )
+    assert model.model.embed_tokens.bits == 8 and model.lm_head.bits == 8
+    # Router stays a raw array: never quantized.
+    assert isinstance(moe.gate.weight, mx.array)
+
+    q = qcfg["quantization"]
+    assert (q["group_size"], q["bits"]) == (64, 4)
+    assert q["model.layers.1.self_attn.q_proj"] == {"group_size": 64, "bits": 8}
+    assert q["lm_head"] == {"group_size": 64, "bits": 8}
+    assert "model.layers.1.mlp.switch_mlp.gate_proj" not in q
+    # The quantized tiny model still runs.
+    assert model(mx.array([[1, 2, 3]])).shape == (1, 3, TINY["vocab_size"])
+
+
+def test_cast_predicate_keeps_router_bias_in_float32():
+    """``mlx_lm.convert``'s dtype pass casts every floating parameter the
+    model's ``cast_predicate`` accepts; the F32 ``e_score_correction_bias``
+    must survive it (rounding it to bf16 changes which experts fire)."""
+    from mlx.utils import tree_map_with_path
+
+    model = tiny_model()
+    cast_predicate = model.cast_predicate
+
+    def set_dtype(k, v):  # verbatim shape of mlx_lm.convert's pass
+        if cast_predicate(k) and mx.issubdtype(v.dtype, mx.floating):
+            return v.astype(mx.bfloat16)
+        return v
+
+    model.update(tree_map_with_path(set_dtype, model.parameters()))
+    moe = model.layers[1].mlp
+    assert moe.gate.e_score_correction_bias.dtype == mx.float32
+    assert moe.gate.weight.dtype == mx.bfloat16
+    assert model.layers[1].self_attn.q_proj.weight.dtype == mx.bfloat16
+    assert model.model.embed_tokens.weight.dtype == mx.bfloat16
+
+
+def test_tied_embeddings_variant():
+    model = g9v3.Model(g9v3.ModelArgs.from_dict(dict(TINY, tie_word_embeddings=True)))
+    assert "lm_head" not in dict(model.children())
+    out = model.sanitize({"lm_head.weight": 1, "model.embed_tokens.weight": 2})
+    assert sorted(out) == ["model.embed_tokens.weight"]
+    assert model(mx.array([[1, 2, 3]])).shape == (1, 3, TINY["vocab_size"])
+
+
+def test_alias_pins_parsers_and_moe_flags():
+    aliases = json.loads(
+        (Path(__file__).resolve().parents[1] / "vllm_mlx" / "aliases.json").read_text()
+    )
+    entry = aliases["g9v3-39a5b-4bit"]
+    assert entry["hf_path"] == "rapid-mlx/G9v3-39A5B-MLX-4bit"
+    # Chat template: ChatML + Qwen3-style <think> + MiniCPM-style
+    # <function name=…><param name=…> XML tool calls.
+    assert entry["tool_call_parser"] == "minicpm"
+    assert entry["reasoning_parser"] == "qwen3"
+    assert entry["is_moe"] is True
+    assert entry["is_hybrid"] is False
+    assert entry["supports_spec_decode"] is False
+    assert entry["min_memory_gb"] == 32

--- a/tests/test_g9v3_model.py
+++ b/tests/test_g9v3_model.py
@@ -228,8 +228,16 @@ def test_head_dim_derived_like_remote_config():
     [
         (dict(hidden_act="gelu"), "hidden_act"),
         (dict(num_key_value_heads=3), "num_attention_heads"),
-        (dict(num_key_value_heads=0), "must be positive"),
-        (dict(num_attention_heads=0, num_key_value_heads=0), "must be positive"),
+        (dict(num_key_value_heads=0), "num_key_value_heads .* must be positive"),
+        (dict(num_attention_heads=0, head_dim=None), "num_attention_heads .* positive"),
+        (dict(hidden_size=0), "hidden_size .* positive"),
+        (dict(num_hidden_layers=0), "num_hidden_layers .* positive"),
+        (dict(intermediate_size=-1), "intermediate_size .* positive"),
+        (dict(vocab_size=0), "vocab_size .* positive"),
+        (dict(head_dim=0), "head_dim .* positive"),
+        (dict(hidden_size=2, head_dim=None), "head_dim .* positive"),
+        (dict(moe_intermediate_size=0), "moe_intermediate_size .* positive"),
+        (dict(n_shared_experts=-1), "n_shared_experts .* >= 0"),
         # 8 experts in 2 groups, 1 group kept -> only 4 experts selectable.
         (dict(n_group=2, topk_group=1, num_experts_per_tok=8), "selectable"),
         (dict(num_experts_per_tok=9), "num_experts_per_tok"),

--- a/tests/test_g9v3_model.py
+++ b/tests/test_g9v3_model.py
@@ -37,6 +37,7 @@ import importlib
 import json
 import logging
 import sys
+import types
 from pathlib import Path
 
 import numpy as np
@@ -146,6 +147,18 @@ def test_registration_defers_to_native_mlx_lm(monkeypatch):
     monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
     tok._register_vendored_archs()
     assert "mlx_lm.models.g9v3" not in sys.modules
+    assert "g9v3" in tok._VENDORED_MODEL_TYPES
+
+
+def test_registration_marks_preimported_native_module(monkeypatch):
+    """A native module imported before the hook still gets tokenizer fallback."""
+    tok = _reset_g9v3_registration(monkeypatch)
+    native = types.ModuleType("mlx_lm.models.g9v3")
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.g9v3", native)
+
+    tok._register_vendored_archs()
+
+    assert sys.modules["mlx_lm.models.g9v3"] is native
     assert "g9v3" in tok._VENDORED_MODEL_TYPES
 
 

--- a/tests/test_g9v3_model.py
+++ b/tests/test_g9v3_model.py
@@ -228,6 +228,10 @@ def test_head_dim_derived_like_remote_config():
     [
         (dict(hidden_act="gelu"), "hidden_act"),
         (dict(num_key_value_heads=3), "num_attention_heads"),
+        (dict(num_key_value_heads=0), "must be positive"),
+        (dict(num_attention_heads=0, num_key_value_heads=0), "must be positive"),
+        # 8 experts in 2 groups, 1 group kept -> only 4 experts selectable.
+        (dict(n_group=2, topk_group=1, num_experts_per_tok=8), "selectable"),
         (dict(num_experts_per_tok=9), "num_experts_per_tok"),
         (dict(num_experts_per_tok=0), "num_experts_per_tok"),
         (dict(n_group=3), "n_group"),
@@ -238,6 +242,30 @@ def test_head_dim_derived_like_remote_config():
 def test_config_validation(bad, match):
     with pytest.raises(ValueError, match=match):
         g9v3.ModelArgs.from_dict(dict(TINY, **bad))
+
+
+def test_grouped_routing_config_builds_and_runs():
+    """A grouped-routing config within the selectable bound goes through
+    ``group_expert_select``'s n_group > 1 path."""
+    args = g9v3.ModelArgs.from_dict(
+        dict(TINY, n_group=2, topk_group=1, num_experts_per_tok=4)
+    )
+    model = g9v3.Model(args)
+    logits = model(mx.array([[1, 2, 3]]))
+    assert logits.shape == (1, 3, TINY["vocab_size"])
+    assert bool(mx.all(mx.isfinite(logits)))
+
+
+def test_cache_length_must_match_layers():
+    from mlx_lm.models.cache import make_prompt_cache
+
+    model = tiny_model()
+    cache = make_prompt_cache(model)
+    x = mx.array([[1, 2, 3]])
+    with pytest.raises(ValueError, match="cache has 2 entries for 3 layers"):
+        model(x, cache=cache[:-1])
+    with pytest.raises(ValueError, match="cache has 4 entries for 3 layers"):
+        model(x, cache=cache + [None])
 
 
 def test_layer_kinds_follow_first_k_dense_replace():
@@ -414,9 +442,22 @@ def test_sanitize_stacks_quantized_triples_and_rejects_missing_expert():
     )
     assert out[f"{prefix}.switch_mlp.up_proj.scales"][5, 0, 0].item() == 5
 
-    del weights[f"{prefix}.experts.3.up_proj.weight"]
-    with pytest.raises(ValueError, match="experts.3.up_proj.weight"):
-        model.sanitize(dict(weights))
+    broken = dict(weights)
+    del broken[f"{prefix}.experts.3.up_proj.weight"]
+    with pytest.raises(ValueError, match=r"up_proj\.weight, first missing: 3"):
+        model.sanitize(broken)
+
+    # Missing expert 0 must not bypass the check (it used to gate on it).
+    broken = dict(weights)
+    del broken[f"{prefix}.experts.0.up_proj.weight"]
+    with pytest.raises(ValueError, match=r"7 of 8 expert tensors .*first missing: 0"):
+        model.sanitize(broken)
+
+    # An expert index beyond n_routed_experts is a config/checkpoint mismatch.
+    extra = dict(weights)
+    extra[f"{prefix}.experts.8.up_proj.weight"] = mx.zeros((2, 2))
+    with pytest.raises(ValueError, match="unexpected expert index: 8"):
+        model.sanitize(extra)
 
 
 def test_quant_predicate_keeps_non_experts_at_8_bits():

--- a/tests/test_g9v3_model.py
+++ b/tests/test_g9v3_model.py
@@ -230,7 +230,9 @@ def test_released_defaults():
 
 
 def test_head_dim_derived_like_remote_config():
-    args = g9v3.ModelArgs.from_dict(dict(TINY, head_dim=None))
+    config = dict(TINY)
+    config.pop("head_dim")
+    args = g9v3.ModelArgs.from_dict(config)
     assert args.head_dim == TINY["hidden_size"] // TINY["num_attention_heads"]
     model = g9v3.Model(args)
     assert model(mx.array([[1, 2, 3]])).shape == (1, 3, TINY["vocab_size"])

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1444,6 +1444,15 @@
     "supports_spec_decode": true,
     "min_memory_gb": 192
   },
+  "g9v3-39a5b-4bit": {
+    "hf_path": "rapid-mlx/G9v3-39A5B-MLX-4bit",
+    "tool_call_parser": "minicpm",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_moe": true,
+    "supports_spec_decode": false,
+    "min_memory_gb": 32
+  },
   "muse-glimmer-30b-4bit": {
     "hf_path": "mlx-community/Muse-Glimmer-30B-4bit",
     "is_text_only": true,

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -218,6 +218,7 @@
     "prism-ml/Ternary-Bonsai-8B-mlx-2bit": 2315084354,
     "prism-ml/Ternary-Bonsai-27B-mlx-2bit": 8521052337,
     "prism-ml/bonsai-image-ternary-4B-mlx-2bit": 3888262196,
+    "rapid-mlx/G9v3-39A5B-MLX-4bit": 22813385524,
     "rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529,
     "rapid-mlx/NeoHorse-1-9B-MLX-4bit": 5058235254,
     "rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX": 16313463520,

--- a/vllm_mlx/models/g9v3.py
+++ b/vllm_mlx/models/g9v3.py
@@ -141,20 +141,27 @@ class ModelArgs(BaseModelArgs):
     tie_word_embeddings: bool = False
 
     def __post_init__(self):
+        for name in (
+            "hidden_size",
+            "num_hidden_layers",
+            "intermediate_size",
+            "vocab_size",
+            "num_attention_heads",
+            "num_key_value_heads",
+        ):
+            if getattr(self, name) < 1:
+                raise ValueError(f"{name} ({getattr(self, name)}) must be positive")
         if self.head_dim is None:
             # Remote ``G9v3Config``: ``hidden_size // num_attention_heads``.
             self.head_dim = self.hidden_size // self.num_attention_heads
+        if self.head_dim < 1:
+            raise ValueError(f"head_dim ({self.head_dim}) must be positive")
         if self.hidden_act != "silu":
             # The remote code routes ``hidden_act`` through ACT2FN; only the
             # released SwiGLU variant is ported, so refuse anything else
             # instead of silently running the wrong non-linearity.
             raise ValueError(
                 f"unsupported hidden_act {self.hidden_act!r} (expected 'silu')"
-            )
-        if self.num_attention_heads < 1 or self.num_key_value_heads < 1:
-            raise ValueError(
-                f"num_attention_heads ({self.num_attention_heads}) and "
-                f"num_key_value_heads ({self.num_key_value_heads}) must be positive"
             )
         if self.num_attention_heads % self.num_key_value_heads != 0:
             raise ValueError(
@@ -167,6 +174,14 @@ class ModelArgs(BaseModelArgs):
                 f"within [0, num_hidden_layers={self.num_hidden_layers}]"
             )
         if self.first_k_dense_replace < self.num_hidden_layers:
+            if self.moe_intermediate_size < 1:
+                raise ValueError(
+                    f"moe_intermediate_size ({self.moe_intermediate_size}) must be positive"
+                )
+            if self.n_shared_experts < 0:
+                raise ValueError(
+                    f"n_shared_experts ({self.n_shared_experts}) must be >= 0"
+                )
             if not 1 <= self.num_experts_per_tok <= self.n_routed_experts:
                 raise ValueError(
                     f"num_experts_per_tok ({self.num_experts_per_tok}) must be "

--- a/vllm_mlx/models/g9v3.py
+++ b/vllm_mlx/models/g9v3.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vendored AI9Stars G9v3 MoE text backbone (``model_type: g9v3``).
+
+**Why vendor:** ``ai9stars/G9v3-39A5B`` (open weights, 39B total / ~5B
+active per token) ships as a ``trust_remote_code`` transformers checkpoint
+with no MLX conversion on the Hub and no mlx-lm support (checked 0.31.3 and
+upstream main, 2026-09-05). The architecture is a DeepSeek-V3-style
+sigmoid-routed MoE under a Qwen3-Next-style *gated* GQA attention, so this
+port reuses mlx-lm's tested kernels for both halves and only owns the glue:
+config parsing, the gated ``q_proj`` split, the dense first layer, and the
+checkpoint → stacked-expert weight sanitize.
+
+**References — the math was verified against BOTH:**
+
+- ``ai9stars/G9v3-39A5B`` remote code ``modeling_g9v3.py`` +
+  ``configuration_g9v3.py`` (transformers 4.57 lineage) — authoritative
+  reference; random-weight logit parity and released-weight top-k parity
+  are recorded in the PR body of the vendoring change (#3046)
+- mlx-lm 0.31.3 ``models/deepseek_v3.py`` (``group_expert_select`` router,
+  ``SwitchGLU`` expert MLP, per-expert → stacked weight layout) and
+  ``models/qwen3_next.py`` (gated ``q_proj`` split) — the reused kernels
+
+Architecture (39B-A5B, 38 layers, hidden 2048, vocab 130560):
+
+- pre-norm decoder layers; ``RMSNorm`` eps 1e-6 on the layer inputs, the
+  post-attention residual and the final ``model.norm``; no embedding
+  scaling, no logit softcap; ``lm_head`` is untied
+- GQA: 32 query heads / 2 KV heads, head_dim 128, no QK-norm, no biases
+  (``attention_bias: false``)
+- gated attention (``use_gated_attention: true``): ``q_proj`` emits
+  ``2 * n_heads * head_dim``; the output is viewed as
+  ``(…, n_heads, 2 * head_dim)`` and chunked on the last axis into
+  ``[query | gate]`` per head; the attention output (before ``o_proj``) is
+  multiplied by ``sigmoid(gate)``. transformers' ``torch.chunk(…, 2,
+  dim=-1)`` on that view is exactly ``mx.split(…, 2, axis=-1)`` here.
+- standard NeoX RoPE (rotate-half, ``traditional=False``), theta 5e6, no
+  scaling (``rope_scaling: null``)
+- layer 0 is a dense SwiGLU MLP (``first_k_dense_replace: 1``,
+  intermediate 8192); layers 1..37 are MoE blocks with 320 routed experts
+  (intermediate 512), 32 active per token, plus one always-on shared
+  expert (intermediate ``512 * n_shared_experts``) added to the routed sum
+- router (``G9v3TopkRouter``): logits computed in float32 → sigmoid;
+  ``e_score_correction_bias`` is added for expert *selection only*;
+  ``n_group = topk_group = 1`` so the group stage is a no-op (plain top-32
+  of 320); the mixing weights are the raw sigmoid scores of the selected
+  experts, normalised to sum 1 (``norm_topk_prob: true``) and scaled by
+  ``routed_scaling_factor`` 3.66. That is precisely mlx-lm's
+  ``group_expert_select`` contract, so the router is *imported*, not
+  re-derived.
+
+Checkpoint layout: keys are the plain transformers names
+(``model.layers.N.self_attn.{q,k,v,o}_proj``, ``model.layers.N.mlp.{gate_proj,
+up_proj,down_proj}`` on the dense layer, ``…mlp.gate.{weight,
+e_score_correction_bias}``, ``…mlp.experts.E.*``, ``…mlp.shared_experts.*``).
+``sanitize`` stacks the 320 per-expert matrices into ``SwitchGLU``'s
+``switch_mlp.{gate,up,down}_proj`` tensors (bf16 ``weight`` or quantized
+``weight/scales/biases``) and passes an already-stacked MLX export through
+unchanged. The router ``weight`` is a raw array (not ``nn.Linear``) so
+mlx-lm's quantizer leaves it in full precision — the same choice as
+``deepseek_v3`` — ``Model.quant_predicate`` pins the conversion recipe
+(experts at the requested bits, everything else 8-bit; see its docstring
+for the measurements) and ``Model.cast_predicate`` keeps the F32 router
+bias out of the bf16 cast (rounding it re-picks experts).
+
+**Registration:** installed as ``sys.modules["mlx_lm.models.g9v3"]`` by
+``vllm_mlx.utils.tokenizer._register_vendored_archs`` so mlx-lm's
+``importlib.import_module(f"mlx_lm.models.{model_type}")`` lookup finds it
+transparently (same trick as ``deepseek_v4`` / ``hy_v3`` /
+``muse_glimmer``). The tokenizer is a stock ``tokenizer.json`` fast
+tokenizer; ``_VENDORED_MODEL_TYPES`` membership keeps the tokenizer
+fallback off transformers' ``AutoConfig`` for the unknown ``model_type``.
+
+**Sync policy:** when mlx-lm ships native ``g9v3`` support,
+``_register_vendored_archs`` defers to it automatically (``find_spec``
+probe, same as ``hy_v3``); delete this file after diffing for bug fixes.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+# Install the MLX hardware compatibility shim before importing any mlx-lm
+# module. mlx-lm captures its default stream during package import, which is
+# unsafe on the M5 single-stream path; every vendored model follows this
+# ordering contract.
+from .. import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.deepseek_v3 import group_expert_select
+from mlx_lm.models.rope_utils import initialize_rope
+from mlx_lm.models.switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    """``config.json`` of a g9v3 checkpoint.
+
+    Defaults mirror the released ``ai9stars/G9v3-39A5B`` config (and the
+    remote ``G9v3Config`` defaults for keys it omits) so a truncated
+    config, or a tiny test config that only overrides shapes, still builds
+    a structurally faithful model.
+    """
+
+    model_type: str = "g9v3"
+    hidden_size: int = 2048
+    num_hidden_layers: int = 38
+    intermediate_size: int = 8192
+    moe_intermediate_size: int = 512
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 2
+    head_dim: int | None = 128
+    rms_norm_eps: float = 1e-6
+    vocab_size: int = 130560
+    max_position_embeddings: int = 131072
+    rope_theta: float = 5000000.0
+    rope_scaling: dict | None = None
+    attention_bias: bool = False
+    use_gated_attention: bool = True
+    hidden_act: str = "silu"
+    n_routed_experts: int = 320
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 32
+    first_k_dense_replace: int = 1
+    routed_scaling_factor: float = 3.66
+    n_group: int = 1
+    topk_group: int = 1
+    norm_topk_prob: bool = True
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.head_dim is None:
+            # Remote ``G9v3Config``: ``hidden_size // num_attention_heads``.
+            self.head_dim = self.hidden_size // self.num_attention_heads
+        if self.hidden_act != "silu":
+            # The remote code routes ``hidden_act`` through ACT2FN; only the
+            # released SwiGLU variant is ported, so refuse anything else
+            # instead of silently running the wrong non-linearity.
+            raise ValueError(
+                f"unsupported hidden_act {self.hidden_act!r} (expected 'silu')"
+            )
+        if self.num_attention_heads % self.num_key_value_heads != 0:
+            raise ValueError(
+                f"num_attention_heads ({self.num_attention_heads}) must be a "
+                f"multiple of num_key_value_heads ({self.num_key_value_heads})"
+            )
+        if not 0 <= self.first_k_dense_replace <= self.num_hidden_layers:
+            raise ValueError(
+                f"first_k_dense_replace ({self.first_k_dense_replace}) must be "
+                f"within [0, num_hidden_layers={self.num_hidden_layers}]"
+            )
+        if self.first_k_dense_replace < self.num_hidden_layers:
+            if not 1 <= self.num_experts_per_tok <= self.n_routed_experts:
+                raise ValueError(
+                    f"num_experts_per_tok ({self.num_experts_per_tok}) must be "
+                    f"within [1, n_routed_experts={self.n_routed_experts}]"
+                )
+            if self.n_group < 1 or self.n_routed_experts % self.n_group != 0:
+                raise ValueError(
+                    f"n_group ({self.n_group}) must divide n_routed_experts "
+                    f"({self.n_routed_experts})"
+                )
+            if not 1 <= self.topk_group <= self.n_group:
+                raise ValueError(
+                    f"topk_group ({self.topk_group}) must be within [1, n_group={self.n_group}]"
+                )
+
+
+class Attention(nn.Module):
+    """GQA attention with the optional per-head output gate.
+
+    Mirrors ``G9v3Attention``: when ``use_gated_attention`` is set the
+    ``q_proj`` width doubles and each head's ``2 * head_dim`` slice is
+    ``[query | gate]``; the attention output is scaled by ``sigmoid(gate)``
+    right before ``o_proj``.
+    """
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        assert args.head_dim is not None  # resolved in ModelArgs.__post_init__
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+        self.gated = args.use_gated_attention
+
+        q_width = self.n_heads * self.head_dim * (2 if self.gated else 1)
+        self.q_proj = nn.Linear(args.hidden_size, q_width, bias=args.attention_bias)
+        self.k_proj = nn.Linear(
+            args.hidden_size, self.n_kv_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size, self.n_kv_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.o_proj = nn.Linear(
+            self.n_heads * self.head_dim, args.hidden_size, bias=args.attention_bias
+        )
+        self.rope = initialize_rope(
+            self.head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=args.rope_scaling,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Any = None,
+        cache: Any = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        q = self.q_proj(x)
+        gate = None
+        if self.gated:
+            # (B, L, n_heads, 2 * head_dim) -> per-head [query | gate].
+            q, gate = mx.split(q.reshape(B, L, self.n_heads, -1), 2, axis=-1)
+            gate = gate.reshape(B, L, -1)
+        queries = q.reshape(B, L, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+        keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = self.v_proj(x).reshape(B, L, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        if gate is not None:
+            output = output * mx.sigmoid(gate)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    """Dense SwiGLU MLP (``G9v3MLP``); also the shared expert."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class MoEGate(nn.Module):
+    """``G9v3TopkRouter`` on top of mlx-lm's ``group_expert_select``.
+
+    ``weight`` and ``e_score_correction_bias`` are raw arrays (matching the
+    checkpoint keys ``mlp.gate.weight`` / ``mlp.gate.e_score_correction_bias``)
+    so the quantizer never touches the router.
+    """
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.n_group = args.n_group
+        self.topk_group = args.topk_group
+        self.routed_scaling_factor = args.routed_scaling_factor
+        self.norm_topk_prob = args.norm_topk_prob
+        self.weight = mx.zeros((args.n_routed_experts, args.hidden_size))
+        self.e_score_correction_bias = mx.zeros((args.n_routed_experts,))
+
+    def __call__(self, x: mx.array) -> tuple[mx.array, mx.array]:
+        # The reference computes the router logits in float32
+        # (``F.linear(x.float(), weight.float())``); match it so expert
+        # selection at the top-k margin agrees with transformers.
+        logits = x.astype(mx.float32) @ self.weight.astype(mx.float32).T
+        inds, scores = group_expert_select(
+            logits,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+        return inds, scores
+
+
+class MoE(nn.Module):
+    """``G9v3MoE``: routed experts (``SwitchGLU``) + always-on shared expert."""
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, args.n_routed_experts
+        )
+        self.gate = MoEGate(args)
+        self.n_shared_experts = args.n_shared_experts or 0
+        if self.n_shared_experts:
+            self.shared_experts = MLP(
+                args.hidden_size, args.moe_intermediate_size * self.n_shared_experts
+            )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        inds, scores = self.gate(x)
+        y = self.switch_mlp(x, inds)
+        # float32 accumulation over the selected experts, cast back to the
+        # activation dtype — same as the reference ``moe()`` loop.
+        y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.n_shared_experts:
+            y = y + self.shared_experts(x)
+        return y
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.mlp: MLP | MoE
+        if layer_idx < args.first_k_dense_replace:
+            self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        else:
+            self.mlp = MoE(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Any = None,
+        cache: Any = None,
+    ) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class G9v3Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args, i) for i in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Any = None,
+        input_embeddings: mx.array | None = None,
+    ) -> mx.array:
+        h = self.embed_tokens(inputs) if input_embeddings is None else input_embeddings
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(h, cache[0])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = G9v3Model(args)
+        self.tie_word_embeddings = args.tie_word_embeddings
+        if not self.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Any = None,
+        input_embeddings: mx.array | None = None,
+    ) -> mx.array:
+        h = self.model(inputs, cache, input_embeddings)
+        if self.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(h)
+        return self.lm_head(h)
+
+    def sanitize(self, weights):
+        """Stack per-expert checkpoint tensors into the ``SwitchGLU`` layout.
+
+        ``model.layers.N.mlp.experts.E.{gate,up,down}_proj.{weight|scales|biases}``
+        (E = 0..n_routed_experts-1) becomes
+        ``model.layers.N.mlp.switch_mlp.{gate,up,down}_proj.<k>`` with the
+        expert axis first. An export that is already stacked (an MLX
+        conversion produced by this module) passes through unchanged.
+        """
+        n_experts = self.args.n_routed_experts
+        for layer_idx in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{layer_idx}.mlp"
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                for kind in ("weight", "scales", "biases"):
+                    if f"{prefix}.experts.0.{proj}.{kind}" not in weights:
+                        continue
+                    names = [
+                        f"{prefix}.experts.{e}.{proj}.{kind}" for e in range(n_experts)
+                    ]
+                    missing = [name for name in names if name not in weights]
+                    if missing:
+                        raise ValueError(
+                            f"g9v3 checkpoint is missing {len(missing)} expert "
+                            f"tensor(s) for layer {layer_idx} {proj}.{kind}, "
+                            f"first: {missing[0]}"
+                        )
+                    weights[f"{prefix}.switch_mlp.{proj}.{kind}"] = mx.stack(
+                        [weights.pop(name) for name in names]
+                    )
+        if self.tie_word_embeddings:
+            weights = {k: v for k, v in weights.items() if not k.startswith("lm_head.")}
+        return weights
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def quant_predicate(self):
+        """Default ``mlx_lm.convert`` recipe: routed experts at the requested
+        bits, everything else (attention, dense + shared MLP, embeddings,
+        ``lm_head``) at 8-bit / group 64.
+
+        Measured on the released weights against the bf16 transformers
+        reference (mean top-1 agreement over all prompt positions / mean KL
+        on five fixed prompts; bf16 MLX itself scores 0.955 / 0.020):
+        4-bit everywhere 0.801 / 0.312, 4-bit experts + 8-bit rest
+        0.899 / 0.077, 8-bit everywhere 0.958 / 0.025. The attention
+        projections (2 KV heads, gated ``q_proj``) are the
+        quantization-sensitive part and, together with the other
+        non-expert weights, are ~5% of the parameters, so the 8-bit tail
+        costs ~2 GB on the 4-bit export. Same mechanism as ``gpt_oss`` /
+        ``qwen3_next`` in mlx-lm (``quantize_model`` picks the model's
+        predicate up when the caller passes none).
+        """
+
+        def predicate(path: str, _module: nn.Module) -> bool | dict[str, int]:
+            if ".switch_mlp." in path:
+                return True
+            return {"group_size": 64, "bits": 8}
+
+        return predicate
+
+    @property
+    def cast_predicate(self):
+        """Keep the router's ``e_score_correction_bias`` in float32 through
+        ``mlx_lm.convert``'s ``--dtype`` pass (which otherwise casts every
+        floating parameter to the config's ``torch_dtype``, bf16 here).
+
+        The checkpoint ships that bias as F32 on purpose: it only shifts the
+        top-32 selection, so rounding it to bf16 changes which experts fire —
+        measured as a 4-point drop in top-1 agreement on the exported model
+        before this hook existed. Same hook and same rule as ``deepseek_v3``.
+        """
+
+        def predicate(path: str) -> bool:
+            return "e_score_correction_bias" not in path
+
+        return predicate

--- a/vllm_mlx/models/g9v3.py
+++ b/vllm_mlx/models/g9v3.py
@@ -75,6 +75,7 @@ fallback off transformers' ``AutoConfig`` for the unknown ``model_type``.
 probe, same as ``hy_v3``); delete this file after diffing for bug fixes.
 """
 
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -97,6 +98,10 @@ from mlx_lm.models.base import (
 from mlx_lm.models.deepseek_v3 import group_expert_select
 from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchGLU
+
+_EXPERT_KEY = re.compile(
+    r"^(model\.layers\.\d+\.mlp)\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.(weight|scales|biases)$"
+)
 
 
 @dataclass
@@ -146,6 +151,11 @@ class ModelArgs(BaseModelArgs):
             raise ValueError(
                 f"unsupported hidden_act {self.hidden_act!r} (expected 'silu')"
             )
+        if self.num_attention_heads < 1 or self.num_key_value_heads < 1:
+            raise ValueError(
+                f"num_attention_heads ({self.num_attention_heads}) and "
+                f"num_key_value_heads ({self.num_key_value_heads}) must be positive"
+            )
         if self.num_attention_heads % self.num_key_value_heads != 0:
             raise ValueError(
                 f"num_attention_heads ({self.num_attention_heads}) must be a "
@@ -170,6 +180,15 @@ class ModelArgs(BaseModelArgs):
             if not 1 <= self.topk_group <= self.n_group:
                 raise ValueError(
                     f"topk_group ({self.topk_group}) must be within [1, n_group={self.n_group}]"
+                )
+            selectable = (self.n_routed_experts // self.n_group) * self.topk_group
+            if self.num_experts_per_tok > selectable:
+                # ``group_expert_select`` only keeps experts from the chosen
+                # groups, so a larger top-k has nothing left to pick.
+                raise ValueError(
+                    f"num_experts_per_tok ({self.num_experts_per_tok}) exceeds the "
+                    f"{selectable} experts selectable from topk_group={self.topk_group} "
+                    f"of n_group={self.n_group} groups"
                 )
 
 
@@ -360,6 +379,12 @@ class G9v3Model(nn.Module):
         h = self.embed_tokens(inputs) if input_embeddings is None else input_embeddings
         if cache is None:
             cache = [None] * len(self.layers)
+        elif len(cache) != len(self.layers):
+            # ``zip`` would silently drop layers (or cache entries) and still
+            # return plausible logits.
+            raise ValueError(
+                f"cache has {len(cache)} entries for {len(self.layers)} layers"
+            )
         mask = create_attention_mask(h, cache[0])
         for layer, c in zip(self.layers, cache):
             h = layer(h, mask, c)
@@ -397,25 +422,31 @@ class Model(nn.Module):
         conversion produced by this module) passes through unchanged.
         """
         n_experts = self.args.n_routed_experts
-        for layer_idx in range(self.args.num_hidden_layers):
-            prefix = f"model.layers.{layer_idx}.mlp"
-            for proj in ("gate_proj", "up_proj", "down_proj"):
-                for kind in ("weight", "scales", "biases"):
-                    if f"{prefix}.experts.0.{proj}.{kind}" not in weights:
-                        continue
-                    names = [
-                        f"{prefix}.experts.{e}.{proj}.{kind}" for e in range(n_experts)
-                    ]
-                    missing = [name for name in names if name not in weights]
-                    if missing:
-                        raise ValueError(
-                            f"g9v3 checkpoint is missing {len(missing)} expert "
-                            f"tensor(s) for layer {layer_idx} {proj}.{kind}, "
-                            f"first: {missing[0]}"
-                        )
-                    weights[f"{prefix}.switch_mlp.{proj}.{kind}"] = mx.stack(
-                        [weights.pop(name) for name in names]
-                    )
+        # Every per-expert tensor group present in the checkpoint, keyed by
+        # (layer prefix, proj, kind) — any expert index counts, so a
+        # checkpoint missing expert 0 is still caught by the check below.
+        groups: dict[tuple[str, str, str], set[int]] = {}
+        for key in weights:
+            m = _EXPERT_KEY.match(key)
+            if m is not None:
+                prefix, expert, proj, kind = m.groups()
+                groups.setdefault((prefix, proj, kind), set()).add(int(expert))
+        for (prefix, proj, kind), present in sorted(groups.items()):
+            missing = [e for e in range(n_experts) if e not in present]
+            stray = sorted(present - set(range(n_experts)))
+            if missing or stray:
+                raise ValueError(
+                    f"g9v3 checkpoint has {len(present)} of {n_experts} expert "
+                    f"tensors for {prefix}.experts.*.{proj}.{kind}"
+                    + (f", first missing: {missing[0]}" if missing else "")
+                    + (f", unexpected expert index: {stray[0]}" if stray else "")
+                )
+            weights[f"{prefix}.switch_mlp.{proj}.{kind}"] = mx.stack(
+                [
+                    weights.pop(f"{prefix}.experts.{e}.{proj}.{kind}")
+                    for e in range(n_experts)
+                ]
+            )
         if self.tie_word_embeddings:
             weights = {k: v for k, v in weights.items() if not k.startswith("lm_head.")}
         return weights

--- a/vllm_mlx/models/g9v3.py
+++ b/vllm_mlx/models/g9v3.py
@@ -427,7 +427,7 @@ class Model(nn.Module):
             return self.model.embed_tokens.as_linear(h)
         return self.lm_head(h)
 
-    def sanitize(self, weights):
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
         """Stack per-expert checkpoint tensors into the ``SwitchGLU`` layout.
 
         ``model.layers.N.mlp.experts.E.{gate,up,down}_proj.{weight|scales|biases}``

--- a/vllm_mlx/models/g9v3.py
+++ b/vllm_mlx/models/g9v3.py
@@ -140,6 +140,19 @@ class ModelArgs(BaseModelArgs):
     norm_topk_prob: bool = True
     tie_word_embeddings: bool = False
 
+    @classmethod
+    def from_dict(cls, params):
+        config = dict(params)
+        if "head_dim" not in config and (
+            "hidden_size" in config or "num_attention_heads" in config
+        ):
+            # Match the remote config for shape-overriding/real checkpoint
+            # dictionaries: an omitted head_dim is derived from their supplied
+            # dimensions. Keep ModelArgs() and the model_type-only fallback on
+            # the released checkpoint's explicit 128-wide head default.
+            config["head_dim"] = None
+        return super().from_dict(config)
+
     def __post_init__(self):
         for name in (
             "hidden_size",

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -781,6 +781,11 @@ def _register_vendored_archs() -> None:
                 _VENDORED_MODEL_TYPES.add("g9v3")
         else:
             _VENDORED_MODEL_TYPES.add("g9v3")
+    elif sys.modules.get("mlx_lm.models.g9v3") is not None:
+        # A caller may import future native mlx-lm support before our
+        # registration hook runs. It still needs the tokenizer fallback mark:
+        # transformers AutoConfig cannot resolve this custom model type.
+        _VENDORED_MODEL_TYPES.add("g9v3")
 
     if "mlx_lm.models.bailing_hybrid" not in sys.modules:
         # inclusionAI Ling 3.0 family (tiny/flash) + Ling 2.6 — vendored

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -752,6 +752,36 @@ def _register_vendored_archs() -> None:
         else:
             _VENDORED_MODEL_TYPES.add("muse_glimmer")
 
+    if "mlx_lm.models.g9v3" not in sys.modules:
+        # AI9Stars G9v3-39A5B — vendored MoE text backbone (see
+        # ``vllm_mlx/models/g9v3.py`` for the why + sync policy). Defers
+        # to native mlx-lm support the moment upstream ships it, same
+        # probe as ``hy_v3`` above.
+        import importlib.util as _importlib_util
+
+        _g9v3_native_spec = None
+        try:
+            _g9v3_native_spec = _importlib_util.find_spec("mlx_lm.models.g9v3")
+        except (ImportError, ValueError):
+            _g9v3_native_spec = None
+
+        if _g9v3_native_spec is None:
+            try:
+                from ..models import g9v3 as _g9v3
+
+                sys.modules.setdefault("mlx_lm.models.g9v3", _g9v3)
+            except Exception as e:
+                logger.warning(
+                    "g9v3 vendored module failed to register — "
+                    "ai9stars/G9v3-39A5B conversions will not load until "
+                    "resolved: %s",
+                    e,
+                )
+            else:
+                _VENDORED_MODEL_TYPES.add("g9v3")
+        else:
+            _VENDORED_MODEL_TYPES.add("g9v3")
+
     if "mlx_lm.models.bailing_hybrid" not in sys.modules:
         # inclusionAI Ling 3.0 family (tiny/flash) + Ling 2.6 — vendored
         # KDA+MLA hybrid backbone (see ``vllm_mlx/models/bailing_hybrid.py``


### PR DESCRIPTION
Closes #3046.

## What

Vendor the **AI9Stars G9v3-39A5B** MoE backbone (`model_type: g9v3`, previously `trust_remote_code`-only, no MLX conversion anywhere) so `rapid-mlx serve g9v3-39a5b-4bit` works end to end on a 32 GB+ Mac.

- `vllm_mlx/models/g9v3.py` — MLX module in the `muse_glimmer` style (architecture documented in the module docstring). The router (`deepseek_v3.group_expert_select`) and expert kernel (`SwitchGLU`) are **mlx-lm's own**; the module owns only the gated `q_proj` split, the dense first layer, config validation, the per-expert → stacked-expert `sanitize`, and the two mlx-lm conversion hooks (`quant_predicate`, `cast_predicate`).
- `vllm_mlx/utils/tokenizer.py` — registered in `_register_vendored_archs` with the `find_spec` defer-to-native probe (same block shape as `muse_glimmer`/`bailing_hybrid`).
- `vllm_mlx/aliases.json` — `g9v3-39a5b-4bit` → `rapid-mlx/G9v3-39A5B-MLX-4bit` (experts 4-bit g64 / everything else 8-bit g64 — see the recipe section — converted with `mlx_lm.convert` + the vendored module; mirrored to R2 per the release SOP). Field set copied from the nearest MoE neighbour (`hy3-preview-4bit`), `supports_spec_decode: false` (no draft/MTP head), `min_memory_gb: 32`.
- `docs/reference/models.md` — family-table row + a short section.
- `vllm_mlx/model_sizes.json` — size-manifest entry for the new repo (the alias coverage test requires one).
- `tests/test_g9v3_model.py` (40 tests) + CI roster entry.

## Parser choice (from the chat template, nothing invented)

`chat_template.jinja` is ChatML with Qwen3-style `<think>…</think>` (and `enable_thinking=false` → empty think block) and tool calls as `<function name="…"><param name="…">…</param></function>` with `<tool_sep>` — byte-for-byte the format already handled by `vllm_mlx/tool_parsers/minicpm_tool_parser.py`. The alias therefore pins `tool_call_parser: minicpm` + `reasoning_parser: qwen3`.

## Parity vs the HF reference

**Method.** Five fixed prompts (raw completion; ChatML chat with thinking off and on; ChatML + a `get_weather` tool, 226 tokens; a code prefix). Token ids are produced once by the HF tokenizer and shared. Logits are compared over **all prompt positions**: top-1 / top-5 agreement per position, max and mean |Δlogit|, KL(HF‖MLX) at the last position. HF side = the checkpoint's own `trust_remote_code` implementation (transformers 5.16.1, CPU, eager attention); MLX side = this module loaded through `mlx_lm.utils.load_model` after `_register_vendored_archs()`. Scripts: `g9v3_parity_tiny.py`, `g9v3_parity_sweep.py`, `g9v3_ref_hf.py`, `g9v3_parity_full.py`, `g9v3_layerwise_{hf,mlx}.py`, `g9v3_cmp_npz.py` (session scratchpad; available on request).

1. **Random weights, fp32, tiny config** (3 layers, gated attention, 8 experts / 2 active, random `e_score_correction_bias`): max |Δ| **7.8e-6** full-prefill, **1.0e-5** token-by-token through `KVCache`; same with `use_gated_attention=false`. A structural sweep towards the released shape — sorted `SwitchGLU` path (L ≥ 64), 32q/2kv GQA, head_dim 128, 64 experts / 32 active, L = 226, and all of them combined — stays ≤ 4.6e-5.
2. **Released weights, fp32, first 3 layers** (config-truncated so the model loads in fp32 from the start): per-layer hidden-state relative error 1.1e-6 – 1.5e-6, logits 1.3e-6 / 1.5e-6 on both prompts tried.
3. **Released weights, fp32, first 8 layers:**

| prompt | tokens | top-1 | top-5 | max abs | mean abs | KL last |
|---|---|---|---|---|---|---|
| raw_capital | 6 | 1.000 | 1.000 | 0.000 | 0.0000 | 0.00000 |
| chat_haiku_nothink | 21 | 1.000 | 1.000 | 0.318 | 0.0071 | 0.00000 |
| chat_mutex_think | 19 | 1.000 | 0.989 | 0.189 | 0.0025 | 0.00000 |
| chat_tool_nothink | 226 | 0.996 | 0.994 | 0.654 | 0.0082 | 0.00000 |
| code_fib | 15 | 1.000 | 1.000 | 0.000 | 0.0000 | 0.00000 |

   (the single top-1 flip, position 218/226, is a top-32 routing near-tie; routing is a discontinuity, so a handful of positions carry the max-abs values while the mean stays < 0.01)

4. **Released weights, full 38 layers, bf16 on both sides:**

| prompt | tokens | top-1 | top-5 | max abs | mean abs | KL last |
|---|---|---|---|---|---|---|
| raw_capital | 6 | 1.000 | 0.900 | 1.125 | 0.0959 | 0.00095 |
| chat_haiku_nothink | 21 | 0.905 | 0.952 | 1.938 | 0.1332 | 0.00819 |
| chat_mutex_think | 19 | 0.947 | 0.968 | 1.562 | 0.1211 | 0.00001 |
| chat_tool_nothink | 226 | 0.925 | 0.876 | 9.812 | 0.4062 | 0.00093 |
| code_fib | 15 | 1.000 | 0.987 | 1.156 | 0.0691 | 0.00006 |

   For scale, transformers' **own** eager-vs-sdpa bf16 spread under the identical setup:

| prompt | tokens | top-1 | top-5 | max abs | mean abs | KL last |
|---|---|---|---|---|---|---|
| raw_capital | 6 | 1.000 | 0.900 | 0.812 | 0.0993 | 0.00172 |
| chat_haiku_nothink | 21 | 0.952 | 0.962 | 1.875 | 0.1323 | 0.00457 |
| chat_mutex_think | 19 | 0.947 | 0.968 | 1.650 | 0.1241 | 0.00002 |
| chat_tool_nothink | 226 | 0.925 | 0.873 | 8.125 | 0.3978 | 0.00129 |
| code_fib | 15 | 1.000 | 0.987 | 1.141 | 0.0634 | 0.00001 |

   i.e. MLX-vs-transformers in bf16 is indistinguishable from transformers-vs-itself in bf16 (same top-1 on 4/5 prompts, mean |Δ| within 0.01 everywhere).

   Caveat found on the way (worth knowing for any G9v3 reference run): the checkpoint stores `mlp.gate.e_score_correction_bias` in **float32** while every other tensor is bf16. `from_pretrained(dtype=torch.bfloat16)` rounds that bias to bf16 and shifts expert selection at the top-32 margin (HF-vs-HF, this alone moves the 226-token prompt's top-1 agreement by ~10 points). MLX keeps the stored dtype, so table 4 restores the fp32 bias on the HF side before comparing; without it the same comparison reads 0.81–1.00 top-1.

Top-5 next tokens agree on every prompt (e.g. ` Paris` / `<think>` / `<function` / ` W…` haiku openers).

## Quantization recipe (measured, not guessed)

Uniform 4-bit g64 (`mlx_lm.convert` default) turned out to hurt this architecture far more than usual, so the recipe was chosen by an in-memory sweep of the released weights against the bf16 reference (same five prompts; **mean top-1 agreement over all prompt positions / mean KL(HF‖MLX)**; bf16 MLX itself = 0.955 / 0.020, i.e. the ceiling):

| recipe | top-1 | KL mean | notes |
|---|---|---|---|
| 8-bit g64 everywhere | 0.958 | 0.025 | lossless, ~40 GB |
| 4-bit g64 everywhere | 0.801 | 0.312 | mlx-lm default — **rejected** |
| 4-bit g32 everywhere | 0.786 | 0.241 | group size is not the fix |
| 4-bit everywhere except embeddings + lm_head 8-bit | 0.799 | 0.282 | embeddings are not the problem |
| 4-bit everywhere except dense/shared MLP 8-bit | 0.812 | 0.287 | |
| 4-bit everywhere except **attention 8-bit** | 0.914 | 0.101 | attention projections are the sensitive part |
| experts 4-bit g64, everything else bf16 | 0.900 | 0.080 | the 4-bit-experts floor |
| **experts 4-bit g64, everything else 8-bit g64** | **0.899** | **0.077** | **shipped** — at the floor, ~23 GB |
| experts 4-bit g32, rest 8-bit | 0.876 | 0.076 | |
| experts 4-bit except down_proj 8-bit, rest 8-bit | 0.929 | 0.055 | ~29 GB, 5.9 bpw — too big for 32 GB Macs |
| experts 5-bit g64, rest 8-bit | 0.945 | 0.036 | ~28 GB — a good "5bit" alias if wanted |

Second trap, found on the first real export: `mlx_lm.convert`'s dtype pass casts every floating parameter to the config's `torch_dtype` (bf16), which rounds the F32 `e_score_correction_bias` exactly like the HF `from_pretrained(dtype=bf16)` case above — the exported model scored 0.858 instead of the sweep's 0.899. `Model.cast_predicate` (same hook and rule as `deepseek_v3`) keeps that bias out of the cast; the published export carries it as F32 and matches the sweep.

The recipe is pinned in the module as `Model.quant_predicate` (the mechanism 21 mlx-lm models use, e.g. `gpt_oss` keeps its router 8-bit), so any `mlx_lm.convert` of a g9v3 checkpoint through rapid-mlx gets it by default; the fine-grained per-path bits land in the export's `config.json["quantization"]` and mlx-lm honours them on load. The published export: 4.681 bits per weight, 21.3 GiB in 5 shards, `e_score_correction_bias` F32. Measured with the same harness as the bf16 parity above, the export scores top-1 0.833 / 0.857 / 0.947 / 0.858 / 1.000 (AVG **0.899**, KL-last 0.003 / 0.105 / 0.000 / 0.155 / 0.001) — identical to the in-memory sweep row, so the on-disk artifact is what was measured.

Follow-up candidates, not in this PR: an 8-bit alias for 48 GB+ Macs (lossless per the table) and/or the 5-bit variant.

## Real-machine smoke (M3 Ultra)

Serve of the final export on the M3 Ultra with the alias's parsers (`--tool-call-parser minicpm --enable-auto-tool-choice --reasoning-parser qwen3`), driven by a scripted OpenAI-client run (`e2e_3046.py`, log kept locally):

| check | result |
|---|---|
| "capital of France", thinking off | `Paris`, 2 completion tokens, finish `stop` |
| mutex explanation, thinking on | reasoning separated into `reasoning_content`, 398 tokens, 85 tok/s decode |
| tool call (`get_weather`), non-streaming, thinking off | `finish_reason=tool_calls`, parsed `get_weather({"city": "Paris"})`, no raw XML in `content` |
| tool-result round trip | answer mentions 18 °C / sunny from the tool message |
| tool call, streaming | delta `tool_calls` assembled to `get_weather({"city": "Tokyo"})`, finish `tool_calls` |
| haiku, streaming, thinking off | 26 chunks, finish `stop`, no `<think>` leakage |
| Chinese self-introduction | coherent Chinese, model identifies itself as 九格 from 启元实验室 |
| Python fibonacci | valid function + call, finish `stop` |

Then the naive-user path: `rapid-mlx serve g9v3-39a5b-4bit` on a clean HF cache pulled the published repo (21 GB), resolved the alias profile (`tool_call_parser=minicpm, reasoning_parser=qwen3, supports_spec_decode=False`) with no flags, and the same eight checks passed again (ALL PASS, 85 tok/s decode on the reasoning answer). The R2 mirror verified (15 files, 22.8 GB, public reads OK).


## Test plan

- [x] `tests/test_g9v3_model.py` (registration, released-shape defaults, config validation, layer kinds, cache-decode parity, gated split layout, router vs a numpy port of the remote router, sanitize round-trip through strict `load_weights`, quantized-triple stacking, alias pins)
- [x] Alias/registration/docs test files touched by the change: 5911 passed
- [x] ruff / ruff format / mypy per-file flat (`g9v3.py` 0 errors, `tokenizer.py` 24 = 24)
- [x] `python3.12 -m scripts.pr_validate` — r3 on `e785fec9f`: codex (gpt-5.6-sol) no blocking issues, lint clean, targeted 84 passed, full_unit 21936 passed / 108 skipped / 6 xfailed; r1/r2 findings and fixes listed in the handoff comment

Out of scope (per the issue): MTP/spec decode, Desktop UI.


## Design precedent

The port is an adapter over the runtime’s existing grouped-expert router, stacked expert kernel, gated-attention layout, RoPE, cache, and quantization hooks. It adds only the checkpoint-specific config, projection split, weight-layout sanitizer, and registration shim. Native runtime support always wins when present; the vendored fallback remains tokenizer-safe even if the native module was imported before Rapid-MLX initializes.
