### PR TITLE
fix(release): report disk-constrained fleet families as capacity-skips (#2206)

### DIFF
--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -30,9 +30,18 @@
 #   FLEET_SCOPE=toolchain bash scripts/coherence_sweep.sh
 #
 # Exit codes:
-#   0 — every alias passed its blocking golden gate
+#   0 — every alias passed its blocking golden gate (and any unreached families
+#       were reported as capacity-skipped for insufficient disk, per #2206)
 #   1 — at least one alias failed
-#   2 — pre-flight refusal (port busy) or a server that never came up
+#   2 — pre-flight refusal (port busy), a server that never came up for reasons
+#       other than capacity, or a capacity-skip while
+#       COHERENCE_SWEEP_REQUIRE_ALL=1 is set
+#
+# On a disk-constrained host, a fleet family that `serve` refuses to download
+# because it would exceed free disk is reported as a "capacity-skip" instead of
+# a hard infrastructure failure, and the resident representatives are still
+# validated. Set COHERENCE_SWEEP_REQUIRE_ALL=1 to preserve the strict
+# every-family-required behaviour on fully provisioned release hosts.
 
 set -euo pipefail
 
@@ -105,6 +114,12 @@ line
 
 failed=""
 infra_failed=""
+skipped=""
+# Strict full-fleet mode (issue #2206 part c): when set, an unresident family
+# that is capacity-skipped for lack of disk is treated as an infrastructure
+# failure instead of a reported-but-passing skip. Release hosts provisioned
+# with enough storage keep the old every-family-required behaviour.
+REQUIRE_ALL="${COHERENCE_SWEEP_REQUIRE_ALL:-}"
 for MODEL in $MODELS; do
   line
   echo "  → $MODEL"
@@ -175,9 +190,20 @@ for MODEL in $MODELS; do
     sleep 1
   done
   if [ "$up" != 1 ]; then
-    echo "ERROR: $MODEL server did not come up: $boot_failure. Last log lines:" >&2
-    tail -20 "$LOG" >&2
-    infra_failed="$infra_failed $MODEL(boot)"
+    # #2206: `serve` refuses a download that would exceed free disk with an
+    # exact, greppable line before exiting 1. On a constrained disk that is a
+    # capacity outcome, not a behavioural one — report it as a capacity-skip
+    # and keep validating the resident representatives, rather than dying the
+    # whole release gate for storage rather than correctness.
+    if grep -q "Insufficient disk space for download\." "$LOG"; then
+      echo "  ⚠ $MODEL capacity-skipped: download would exceed free disk." >&2
+      tail -8 "$LOG" >&2
+      skipped="$skipped $MODEL"
+    else
+      echo "ERROR: $MODEL server did not come up: $boot_failure. Last log lines:" >&2
+      tail -20 "$LOG" >&2
+      infra_failed="$infra_failed $MODEL(boot)"
+    fi
   else
     if [ "$DISTILL" = "1" ]; then
       gate_command=("$PY" evals/coherence_gate.py --reasoning-distill)
@@ -208,6 +234,13 @@ for MODEL in $MODELS; do
 done
 
 line
+if [ -n "$skipped" ] && [ -n "$REQUIRE_ALL" ]; then
+  # Strict full-fleet mode: a capacity-skip is a release-blocking gap.
+  echo "  SWEEP INFRASTRUCTURE FAILURE (capacity-skipped under COHERENCE_SWEEP_REQUIRE_ALL) —$skipped" >&2
+  if [ -n "$failed" ]; then echo "  MODEL FAILURES —$failed"; fi
+  line
+  exit 2
+fi
 if [ -n "$infra_failed" ]; then
   echo "  SWEEP INFRASTRUCTURE FAILURE —$infra_failed"
   if [ -n "$failed" ]; then echo "  MODEL FAILURES —$failed"; fi
@@ -216,8 +249,14 @@ if [ -n "$infra_failed" ]; then
 fi
 if [ -n "$failed" ]; then
   echo "  SWEEP FAILED —$failed"
+  if [ -n "$skipped" ]; then echo "  CAPACITY-SKIPPED —$skipped"; fi
   line
   exit 1
+fi
+if [ -n "$skipped" ]; then
+  echo "  SWEEP PASSED — all resident aliases coherent; $skipped capacity-skipped (insufficient disk)"
+  line
+  exit 0
 fi
 echo "  SWEEP PASSED — all aliases coherent"
 line

--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -115,11 +115,19 @@ line
 failed=""
 infra_failed=""
 skipped=""
+passed=""
 # Strict full-fleet mode (issue #2206 part c): when set, an unresident family
 # that is capacity-skipped for lack of disk is treated as an infrastructure
 # failure instead of a reported-but-passing skip. Release hosts provisioned
 # with enough storage keep the old every-family-required behaviour.
-REQUIRE_ALL="${COHERENCE_SWEEP_REQUIRE_ALL:-}"
+case "${COHERENCE_SWEEP_REQUIRE_ALL:-0}" in
+  0) REQUIRE_ALL=0 ;;
+  1) REQUIRE_ALL=1 ;;
+  *)
+    echo "ERROR: COHERENCE_SWEEP_REQUIRE_ALL must be 0 or 1." >&2
+    exit 2
+    ;;
+esac
 for MODEL in $MODELS; do
   line
   echo "  → $MODEL"
@@ -195,7 +203,7 @@ for MODEL in $MODELS; do
     # capacity outcome, not a behavioural one — report it as a capacity-skip
     # and keep validating the resident representatives, rather than dying the
     # whole release gate for storage rather than correctness.
-    if grep -q "Insufficient disk space for download\." "$LOG"; then
+    if grep -Fqx '  Error: Insufficient disk space for download.' "$LOG"; then
       echo "  ⚠ $MODEL capacity-skipped: download would exceed free disk." >&2
       tail -8 "$LOG" >&2
       skipped="$skipped $MODEL"
@@ -215,6 +223,7 @@ for MODEL in $MODELS; do
     fi
     if "${gate_command[@]}"; then
       echo "  ✓ $MODEL coherent"
+      passed="$passed $MODEL"
     else
       gate_status=$?
       if [ "$gate_status" -eq 2 ]; then
@@ -234,15 +243,18 @@ for MODEL in $MODELS; do
 done
 
 line
-if [ -n "$skipped" ] && [ -n "$REQUIRE_ALL" ]; then
-  # Strict full-fleet mode: a capacity-skip is a release-blocking gap.
-  echo "  SWEEP INFRASTRUCTURE FAILURE (capacity-skipped under COHERENCE_SWEEP_REQUIRE_ALL) —$skipped" >&2
-  if [ -n "$failed" ]; then echo "  MODEL FAILURES —$failed"; fi
-  line
-  exit 2
+strict_skipped=""
+if [ -n "$skipped" ] && [ "$REQUIRE_ALL" = 1 ]; then
+  strict_skipped="$skipped"
 fi
-if [ -n "$infra_failed" ]; then
-  echo "  SWEEP INFRASTRUCTURE FAILURE —$infra_failed"
+if [ -n "$infra_failed" ] || [ -n "$strict_skipped" ] || { [ -n "$skipped" ] && [ -z "$passed" ]; }; then
+  echo "  SWEEP INFRASTRUCTURE FAILURE" >&2
+  if [ -n "$infra_failed" ]; then echo "  INFRASTRUCTURE FAILURES —$infra_failed" >&2; fi
+  if [ -n "$strict_skipped" ]; then
+    echo "  CAPACITY-SKIPPED (COHERENCE_SWEEP_REQUIRE_ALL=1) —$strict_skipped" >&2
+  elif [ -n "$skipped" ] && [ -z "$passed" ]; then
+    echo "  NO RESIDENT ALIAS VALIDATED; CAPACITY-SKIPPED —$skipped" >&2
+  fi
   if [ -n "$failed" ]; then echo "  MODEL FAILURES —$failed"; fi
   line
   exit 2

--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -247,7 +247,7 @@ strict_skipped=""
 if [ -n "$skipped" ] && [ "$REQUIRE_ALL" = 1 ]; then
   strict_skipped="$skipped"
 fi
-if [ -n "$infra_failed" ] || [ -n "$strict_skipped" ] || { [ -n "$skipped" ] && [ -z "$passed" ]; }; then
+if [ -n "$infra_failed" ] || [ -n "$strict_skipped" ] || { [ -n "$skipped" ] && [ -z "$passed" ] && [ -z "$failed" ]; }; then
   echo "  SWEEP INFRASTRUCTURE FAILURE" >&2
   if [ -n "$infra_failed" ]; then echo "  INFRASTRUCTURE FAILURES —$infra_failed" >&2; fi
   if [ -n "$strict_skipped" ]; then

--- a/scripts/coherence_sweep.sh
+++ b/scripts/coherence_sweep.sh
@@ -254,6 +254,8 @@ if [ -n "$infra_failed" ] || [ -n "$strict_skipped" ] || { [ -n "$skipped" ] && 
     echo "  CAPACITY-SKIPPED (COHERENCE_SWEEP_REQUIRE_ALL=1) —$strict_skipped" >&2
   elif [ -n "$skipped" ] && [ -z "$passed" ]; then
     echo "  NO RESIDENT ALIAS VALIDATED; CAPACITY-SKIPPED —$skipped" >&2
+  elif [ -n "$skipped" ]; then
+    echo "  CAPACITY-SKIPPED —$skipped" >&2
   fi
   if [ -n "$failed" ]; then echo "  MODEL FAILURES —$failed"; fi
   line

--- a/tests/release/test_coherence_sweep_capacity_skip.sh
+++ b/tests/release/test_coherence_sweep_capacity_skip.sh
@@ -119,8 +119,8 @@ echo "── capacity-skip reports and passes"
 
 # All families capacity-skipped means the gate validated nothing and must fail
 # closed rather than claiming vacuous coherence.
+st=0
 out="$(run_sweep "qwen3.6-27b-4bit qwen3.6-35b" "qwen3.6-27b-4bit:qwen3.6-35b" "")" || st=$?
-st=${st:-0}
 if [ "$st" = 2 ]; then
   ok "an all-capacity-skipped sweep fails because no alias was validated"
 else

--- a/tests/release/test_coherence_sweep_capacity_skip.sh
+++ b/tests/release/test_coherence_sweep_capacity_skip.sh
@@ -74,7 +74,7 @@ if [ "$1" = "-m" ] && [ "$3" = "serve" ]; then
       case ":${PASSING_ALIASES:-}:" in
         *":$model:"*)
           trap 'rm -f "$FAKE_READY"; exit 0' INT TERM EXIT
-          : > "$FAKE_READY"
+          printf '%s' "$model" > "$FAKE_READY"
           while :; do sleep 1; done
           ;;
         *) printf '%s\n' 'RuntimeError: fake engine died before load' ;;
@@ -84,7 +84,13 @@ if [ "$1" = "-m" ] && [ "$3" = "serve" ]; then
   exit 1
 fi
 # release_fleet.py is-reasoning-distill / forces-text-lane -> not that family.
-if [ "$1" = "evals/coherence_gate.py" ]; then exit 0; fi
+if [ "$1" = "evals/coherence_gate.py" ]; then
+  model="$(cat "$FAKE_READY")"
+  case ":${FAILING_ALIASES:-}:" in
+    *":$model:"*) exit 1 ;;
+    *) exit 0 ;;
+  esac
+fi
 exit 1
 EOF
   cat > "$fake_dir/curl" <<'EOF'
@@ -190,14 +196,13 @@ fi
 
 echo "── a real model failure is still a model failure, skips are still noted"
 
-# Not directly runnable hermetically (a booting server + gate are needed), but
-# the summary wiring must still attribute a capacity-skip next to a model
-# failure rather than dropping it. The query of the script text guards that the
-# "CAPACITY-SKIPPED" line sits in the model-failure branch.
-if grep -q 'CAPACITY-SKIPPED —\$skipped' "$SWEEP"; then
-  ok "model-failure summary still attributes any capacity-skips"
+st=0; out="$(run_sweep "bad-answer qwen3.6-27b-4bit" "qwen3.6-27b-4bit" "bad-answer" FAILING_ALIASES=bad-answer)" || st=$?
+if [ "$st" = 1 ] \
+   && printf '%s' "$out" | grep -q 'SWEEP FAILED' \
+   && printf '%s' "$out" | grep -q 'CAPACITY-SKIPPED'; then
+  ok "model failure plus capacity-skip stays a model failure and reports both"
 else
-  bad "model-failure exit path no longer surfaces capacity-skips"
+  bad "mixed model failure/capacity-skip was misclassified:\n$out"
 fi
 
 printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/release/test_coherence_sweep_capacity_skip.sh
+++ b/tests/release/test_coherence_sweep_capacity_skip.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Offline tests for the #2206 capacity-skip behaviour in
+# scripts/coherence_sweep.sh.
+#
+# On a disk-constrained host, a fleet family that `serve` refuses to download
+# because it would exceed free disk is reported as a "capacity-skip" instead of
+# a hard infrastructure failure, and the resident representatives are still
+# validated. `COHERENCE_SWEEP_REQUIRE_ALL=1` restores the strict
+# every-family-required behaviour.
+#
+# The sweep's serve boot is stubbed with a fake `$PY` whose `-m ... serve`
+# immediately writes a chosen boot outcome to the server log and exits, so the
+# readiness loop always reaches the boot-failure (or capacity-skip) branch
+# without a real server, download, GPU, or network.
+#
+#   ./tests/release/test_coherence_sweep_capacity_skip.sh
+#
+# Requires: bash, curl, lsof. No network/git/GPU required.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SWEEP="$REPO_ROOT/scripts/coherence_sweep.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+
+# The sweep must still contain the capacity-skip hook — if the region drifts
+# this test is guarding nothing and should be re-read.
+if ! grep -q 'Insufficient disk space for download\\\.' "$SWEEP"; then
+  printf '  \033[31mFAIL\033[0m capacity-skip detection missing from %s\n' "$SWEEP"
+  exit 1
+fi
+if ! grep -q 'COHERENCE_SWEEP_REQUIRE_ALL' "$SWEEP"; then
+  printf '  \033[31mFAIL\033[0m COHERENCE_SWEEP_REQUIRE_ALL hook missing from %s\n' "$SWEEP"
+  exit 1
+fi
+ok "sweep carries the capacity-skip detection + strict-mode hook"
+
+# A free ephemeral port for every run, so two consecutive sweep runs never
+# collide.
+free_port() {
+  python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+
+# Fake `$PY`: a shell shim standing in for `python3.12`. It dispatches on the
+# command-line shape the sweep issues:
+#   -m vllm_mlx.cli serve <model> ...   -> write a boot outcome to stdout
+#                                         (the sweep redirects it to $LOG) and
+#                                         exit 1
+#   scripts/release_fleet.py is-reasoning-distill / forces-text-lane -> exit 1
+#                                        (neither, matching ordinary families)
+# Capacity models (alias prefixes the $CAPACITY_ALIASES env lists) write the
+# exact `_check_disk_space` refusal; every other model writes a generic crash so
+# the boot-failure (infra) branch is exercised for contrast.
+make_fake_py() {  # $1 = capacity aliases (colon-separated)
+  local fake_dir="$TMP/fakebin"
+  mkdir -p "$fake_dir"
+  cat > "$fake_dir/python3.12" <<EOF
+#!/bin/sh
+if [ "\$1" = "-m" ] && [ "\$3" = "serve" ]; then
+  model="\$4"
+  case ":$1:" in
+    *":\$model:"*) printf '%s\\n' '  Error: Insufficient disk space for download.' ;;
+    *)             printf '%s\\n' 'RuntimeError: fake engine died before load' ;;
+  esac
+  exit 1
+fi
+# release_fleet.py is-reasoning-distill / forces-text-lane -> not that family.
+exit 1
+EOF
+  sed -i.bak "s|:\$1:|:$1:|" "$fake_dir/python3.12" && rm -f "$fake_dir/python3.12.bak"
+  chmod +x "$fake_dir/python3.12"
+  printf '%s' "$fake_dir/python3.12"
+}
+
+run_sweep() {  # $1 = alias list, $2 = capacity aliases, $3.. = extra env
+  local fake_py aliases cap
+  fake_py="$(make_fake_py "$2")"
+  aliases="$1"
+  shift 2
+  env "$@" PY="$fake_py" PORT="$(free_port)" MODELS="$aliases" \
+    bash "$SWEEP" 2>&1; return $?
+}
+
+echo "── capacity-skip reports and passes"
+
+# All families capacity-skipped (no genuine infra failure) -> the sweep
+# validates the empty resident set, reports the skips, and exits 0.
+out="$(run_sweep "qwen3.6-27b-4bit qwen3.6-35b" "qwen3.6-27b-4bit:qwen3.6-35b")" || st=$?
+st=${st:-0}
+if [ "$st" = 0 ]; then
+  ok "capacity-skipped families report but the sweep exits 0"
+else
+  bad "expected exit 0 with only capacity-skips, got $st"
+fi
+if printf '%s' "$out" | grep -q 'capacity-skipped'; then
+  ok "the capacity-skipped families are reported explicitly"
+else
+  bad "capacity-skipped families not reported:\n$out"
+fi
+if printf '%s' "$out" | grep -q 'qwen3.6-27b-4bit' \
+   && printf '%s' "$out" | grep -q 'qwen3.6-35b'; then
+  ok "both capacity-skipped families are named in the output"
+else
+  bad "expected both skipped families present in output:\n$out"
+fi
+
+# A resident representative that boots genuinely passes, while a sibling is
+# capacity-skipped — but a genuine boot failure anywhere still fails the sweep.
+st=0; out="$(run_sweep "qwen3.5-9b-4bit qwen3.6-27b-4bit" "qwen3.6-27b-4bit")" || st=$?
+if [ "$st" = 2 ]; then
+  ok "a generic boot failure among the families still fails the sweep (2)"
+else
+  bad "expected exit 2 when a non-capacity boot failure co-occurs, got $st"
+fi
+
+echo "── a genuine boot failure still fails the sweep"
+
+st=0; out="$(run_sweep "qwen3.5-9b-4bit" "")" || st=$?
+if [ "$st" = 2 ]; then
+  ok "a non-capacity boot failure still exits 2 (infrastructure)"
+else
+  bad "expected exit 2 for a generic boot failure, got $st"
+fi
+if printf '%s' "$out" | grep -q 'INFRASTRUCTURE FAILURE'; then
+  ok "a generic boot failure is reported as infrastructure, not capacity"
+else
+  bad "generic boot failure not flagged as infrastructure:\n$out"
+fi
+
+echo "── strict full-fleet mode is preserved"
+
+st=0; out="$(run_sweep "qwen3.5-9b-4bit qwen3.6-27b-4bit" "qwen3.6-27b-4bit" COHERENCE_SWEEP_REQUIRE_ALL=1)" || st=$?
+if [ "$st" = 2 ]; then
+  ok "COHERENCE_SWEEP_REQUIRE_ALL=1 turns a capacity-skip into a failure"
+else
+  bad "expected exit 2 under REQUIRE_ALL with a capacity-skip, got $st"
+fi
+
+echo "── a real model failure is still a model failure, skips are still noted"
+
+# Not directly runnable hermetically (a booting server + gate are needed), but
+# the summary wiring must still attribute a capacity-skip next to a model
+# failure rather than dropping it. The query of the script text guards that the
+# "CAPACITY-SKIPPED" line sits in the model-failure branch.
+if grep -q 'CAPACITY-SKIPPED —\$skipped' "$SWEEP"; then
+  ok "model-failure summary still attributes any capacity-skips"
+else
+  bad "model-failure exit path no longer surfaces capacity-skips"
+fi
+
+printf '\n  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/release/test_coherence_sweep_capacity_skip.sh
+++ b/tests/release/test_coherence_sweep_capacity_skip.sh
@@ -32,7 +32,7 @@ bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
 
 # The sweep must still contain the capacity-skip hook — if the region drifts
 # this test is guarding nothing and should be re-read.
-if ! grep -q 'Insufficient disk space for download\\\.' "$SWEEP"; then
+if ! grep -Fq "grep -Fqx '  Error: Insufficient disk space for download.'" "$SWEEP"; then
   printf '  \033[31mFAIL\033[0m capacity-skip detection missing from %s\n' "$SWEEP"
   exit 1
 fi
@@ -52,56 +52,73 @@ print(s.getsockname()[1])
 s.close()'
 }
 
-# Fake `$PY`: a shell shim standing in for `python3.12`. It dispatches on the
-# command-line shape the sweep issues:
-#   -m vllm_mlx.cli serve <model> ...   -> write a boot outcome to stdout
-#                                         (the sweep redirects it to $LOG) and
-#                                         exit 1
-#   scripts/release_fleet.py is-reasoning-distill / forces-text-lane -> exit 1
-#                                        (neither, matching ordinary families)
-# Capacity models (alias prefixes the $CAPACITY_ALIASES env lists) write the
-# exact `_check_disk_space` refusal; every other model writes a generic crash so
-# the boot-failure (infra) branch is exercised for contrast.
-make_fake_py() {  # $1 = capacity aliases (colon-separated)
+# Fake `$PY` and curl shims. Capacity models write the exact disk refusal;
+# passing models hold a fake server open and publish a readiness marker;
+# everything else emits a generic boot crash.
+make_fake_bin() {
   local fake_dir="$TMP/fakebin"
   mkdir -p "$fake_dir"
-  cat > "$fake_dir/python3.12" <<EOF
+  cat > "$fake_dir/python3.12" <<'EOF'
 #!/bin/sh
-if [ "\$1" = "-m" ] && [ "\$3" = "serve" ]; then
-  model="\$4"
-  case ":$1:" in
-    *":\$model:"*) printf '%s\\n' '  Error: Insufficient disk space for download.' ;;
-    *)             printf '%s\\n' 'RuntimeError: fake engine died before load' ;;
+if [ "$1" = "-m" ] && [ "$3" = "serve" ]; then
+  model="$4"
+  case ":${CAPACITY_ALIASES:-}:" in
+    *":$model:"*) printf '%s\n' '  Error: Insufficient disk space for download.' ;;
+    *)
+      case ":${LOOKALIKE_ALIASES:-}:" in
+        *":$model:"*)
+          printf '%s\n' 'RuntimeError: Insufficient disk space for download.'
+          exit 1
+          ;;
+      esac
+      case ":${PASSING_ALIASES:-}:" in
+        *":$model:"*)
+          trap 'rm -f "$FAKE_READY"; exit 0' INT TERM EXIT
+          : > "$FAKE_READY"
+          while :; do sleep 1; done
+          ;;
+        *) printf '%s\n' 'RuntimeError: fake engine died before load' ;;
+      esac
+      ;;
   esac
   exit 1
 fi
 # release_fleet.py is-reasoning-distill / forces-text-lane -> not that family.
+if [ "$1" = "evals/coherence_gate.py" ]; then exit 0; fi
 exit 1
 EOF
-  sed -i.bak "s|:\$1:|:$1:|" "$fake_dir/python3.12" && rm -f "$fake_dir/python3.12.bak"
-  chmod +x "$fake_dir/python3.12"
-  printf '%s' "$fake_dir/python3.12"
+  cat > "$fake_dir/curl" <<'EOF'
+#!/bin/sh
+[ -f "${FAKE_READY:?}" ]
+EOF
+  chmod +x "$fake_dir/python3.12" "$fake_dir/curl"
+  printf '%s' "$fake_dir"
 }
 
-run_sweep() {  # $1 = alias list, $2 = capacity aliases, $3.. = extra env
-  local fake_py aliases cap
-  fake_py="$(make_fake_py "$2")"
+run_sweep() {  # $1 aliases, $2 capacity aliases, $3 passing aliases, $4.. env
+  local fake_dir aliases capacity passing
+  fake_dir="$(make_fake_bin)"
   aliases="$1"
-  shift 2
-  env "$@" PY="$fake_py" PORT="$(free_port)" MODELS="$aliases" \
+  capacity="$2"
+  passing="$3"
+  shift 3
+  rm -f "$TMP/server-ready"
+  env "$@" PY="$fake_dir/python3.12" PATH="$fake_dir:$PATH" \
+    FAKE_READY="$TMP/server-ready" CAPACITY_ALIASES="$capacity" \
+    PASSING_ALIASES="$passing" PORT="$(free_port)" MODELS="$aliases" \
     bash "$SWEEP" 2>&1; return $?
 }
 
 echo "── capacity-skip reports and passes"
 
-# All families capacity-skipped (no genuine infra failure) -> the sweep
-# validates the empty resident set, reports the skips, and exits 0.
-out="$(run_sweep "qwen3.6-27b-4bit qwen3.6-35b" "qwen3.6-27b-4bit:qwen3.6-35b")" || st=$?
+# All families capacity-skipped means the gate validated nothing and must fail
+# closed rather than claiming vacuous coherence.
+out="$(run_sweep "qwen3.6-27b-4bit qwen3.6-35b" "qwen3.6-27b-4bit:qwen3.6-35b" "")" || st=$?
 st=${st:-0}
-if [ "$st" = 0 ]; then
-  ok "capacity-skipped families report but the sweep exits 0"
+if [ "$st" = 2 ]; then
+  ok "an all-capacity-skipped sweep fails because no alias was validated"
 else
-  bad "expected exit 0 with only capacity-skips, got $st"
+  bad "expected exit 2 with zero validated aliases, got $st"
 fi
 if printf '%s' "$out" | grep -q 'capacity-skipped'; then
   ok "the capacity-skipped families are reported explicitly"
@@ -115,9 +132,17 @@ else
   bad "expected both skipped families present in output:\n$out"
 fi
 
-# A resident representative that boots genuinely passes, while a sibling is
-# capacity-skipped — but a genuine boot failure anywhere still fails the sweep.
-st=0; out="$(run_sweep "qwen3.5-9b-4bit qwen3.6-27b-4bit" "qwen3.6-27b-4bit")" || st=$?
+# A resident representative genuinely passes while an oversized sibling is
+# capacity-skipped: this is the intended constrained-host success path.
+st=0; out="$(run_sweep "qwen3.5-9b-4bit qwen3.6-27b-4bit" "qwen3.6-27b-4bit" "qwen3.5-9b-4bit")" || st=$?
+if [ "$st" = 0 ] && printf '%s' "$out" | grep -q 'all resident aliases coherent'; then
+  ok "a validated resident family plus a capacity-skip exits 0"
+else
+  bad "expected pass+skip to exit 0 with the resident summary, got $st:\n$out"
+fi
+
+# A capacity-skip must not hide a genuine boot failure elsewhere.
+st=0; out="$(run_sweep "broken qwen3.6-27b-4bit" "qwen3.6-27b-4bit" "")" || st=$?
 if [ "$st" = 2 ]; then
   ok "a generic boot failure among the families still fails the sweep (2)"
 else
@@ -126,7 +151,7 @@ fi
 
 echo "── a genuine boot failure still fails the sweep"
 
-st=0; out="$(run_sweep "qwen3.5-9b-4bit" "")" || st=$?
+st=0; out="$(run_sweep "qwen3.5-9b-4bit" "" "")" || st=$?
 if [ "$st" = 2 ]; then
   ok "a non-capacity boot failure still exits 2 (infrastructure)"
 else
@@ -138,13 +163,29 @@ else
   bad "generic boot failure not flagged as infrastructure:\n$out"
 fi
 
+st=0; out="$(run_sweep "lookalike" "" "" LOOKALIKE_ALIASES=lookalike)" || st=$?
+if [ "$st" = 2 ] && ! printf '%s' "$out" | grep -q 'capacity-skipped:'; then
+  ok "a lookalike error line remains an infrastructure failure"
+else
+  bad "lookalike disk text was misclassified as a capacity-skip:\n$out"
+fi
+
 echo "── strict full-fleet mode is preserved"
 
-st=0; out="$(run_sweep "qwen3.5-9b-4bit qwen3.6-27b-4bit" "qwen3.6-27b-4bit" COHERENCE_SWEEP_REQUIRE_ALL=1)" || st=$?
+st=0; out="$(run_sweep "qwen3.5-9b-4bit qwen3.6-27b-4bit" "qwen3.6-27b-4bit" "qwen3.5-9b-4bit" COHERENCE_SWEEP_REQUIRE_ALL=1)" || st=$?
 if [ "$st" = 2 ]; then
   ok "COHERENCE_SWEEP_REQUIRE_ALL=1 turns a capacity-skip into a failure"
 else
   bad "expected exit 2 under REQUIRE_ALL with a capacity-skip, got $st"
+fi
+
+st=0; out="$(run_sweep "broken qwen3.6-27b-4bit" "qwen3.6-27b-4bit" "" COHERENCE_SWEEP_REQUIRE_ALL=1)" || st=$?
+if [ "$st" = 2 ] \
+   && printf '%s' "$out" | grep -q 'broken(boot)' \
+   && printf '%s' "$out" | grep -q 'CAPACITY-SKIPPED'; then
+  ok "strict mixed failure reports both infrastructure and capacity"
+else
+  bad "strict mixed failure dropped a failure category:\n$out"
 fi
 
 echo "── a real model failure is still a model failure, skips are still noted"

--- a/tests/release/test_coherence_sweep_capacity_skip.sh
+++ b/tests/release/test_coherence_sweep_capacity_skip.sh
@@ -155,6 +155,15 @@ else
   bad "expected exit 2 when a non-capacity boot failure co-occurs, got $st"
 fi
 
+st=0; out="$(run_sweep "passing broken qwen3.6-27b-4bit" "qwen3.6-27b-4bit" "passing")" || st=$?
+if [ "$st" = 2 ] \
+   && printf '%s' "$out" | grep -q 'broken(boot)' \
+   && printf '%s' "$out" | grep -q 'CAPACITY-SKIPPED'; then
+  ok "pass plus infrastructure failure plus skip reports every category"
+else
+  bad "mixed pass/infrastructure/capacity report lost a category:\n$out"
+fi
+
 echo "── a genuine boot failure still fails the sweep"
 
 st=0; out="$(run_sweep "qwen3.5-9b-4bit" "" "")" || st=$?

--- a/tests/release/test_coherence_sweep_capacity_skip.sh
+++ b/tests/release/test_coherence_sweep_capacity_skip.sh
@@ -131,8 +131,9 @@ if printf '%s' "$out" | grep -q 'capacity-skipped'; then
 else
   bad "capacity-skipped families not reported:\n$out"
 fi
-if printf '%s' "$out" | grep -q 'qwen3.6-27b-4bit' \
-   && printf '%s' "$out" | grep -q 'qwen3.6-35b'; then
+skip_summary="$(printf '%s\n' "$out" | grep 'CAPACITY-SKIPPED' | tail -1)"
+if printf '%s' "$skip_summary" | grep -q 'qwen3.6-27b-4bit' \
+   && printf '%s' "$skip_summary" | grep -q 'qwen3.6-35b'; then
   ok "both capacity-skipped families are named in the output"
 else
   bad "expected both skipped families present in output:\n$out"


### PR DESCRIPTION
## Why

`PORT=8018 make release-check-m3` on a disk-constrained host runs the fleet output-coherence sweep (G0a), which requires **every** family to be locally resident. When `hy3-preview-4bit` (or any uncached family) needs a 154.6 GB download but only 39.2 GB is free, `serve` refuses at the downloader disk-safety threshold and the **whole release gate dies as an infrastructure failure** — for capacity, not behavior. The 6 families that DID validate coherently are thrown away with it.

This makes the fleet gate practical on constrained disks: uncached oversized families are reported as **capacity-skipped**, the resident representatives are still validated, and the gate passes with the skips noted when at least one resident representative was validated — instead of failing a complete release validation for storage rather than correctness.

## Scope

- `scripts/coherence_sweep.sh` only: classify a boot failure caused by `serve`'s disk-safety refusal (`Error: Insufficient disk space for download.`) as a capacity-skip instead of a hard infra failure; report skipped families distinctly; gate passes only when at least one resident representative was validated.
- `tests/release/test_coherence_sweep_capacity_skip.sh` (new): hermetic offline tests driving the real sweep against a stubbed `$PY` serve.

## Design precedent

The design distinguishes a *capacity* outcome from a *behavioral* one by keying on the exact, greppable refusal the canonical download gate already emits, then reports but does not fail on the former while preserving hard failure for the latter. It keeps a strict opt-in full-fleet mode for hosts provisioned with enough storage. The adopted operational property is: a resource-constrained skip is reported, never mixed into the behavioral failure class, and never silently hides a real regression (actual infra/model failures still exit 2/1 exactly as before).

## Acceptance contract (issue #2206)

- **Run cached representatives + report uncached oversized families as capacity-skipped** — MET: unresident families that `serve` refuses on disk are reported `⚠ <model> capacity-skipped`; the loop continues, at least one resident representative must pass, and an all-skipped sweep fails closed.
- **Support a configured external HF cache volume** — already MET on current main via the standard `HF_HUB_CACHE`/`HF_HOME` mechanism and the disk-aware recipe path (`_recipe_free_disk_gb`, #2119); no new code needed (noted in scope).
- **Preserve a strict full-fleet mode** — MET: `COHERENCE_SWEEP_REQUIRE_ALL=1` treats any capacity-skip as a release-blocking infrastructure failure (exit 2), preserving the old every-family-required behavior on fully provisioned release hosts.

## Non-goals

- No change to `_check_disk_space` / the downloader safety threshold, to the Python recipe/recommendation disk logic, or to release_host_hygiene.
- No new Python code, no coverage-gate surface (shell script; covered by its own offline shell tests run by CI).

## Failure / rollback behavior

- A capacity-skip is informational only when at least one resident representative passed; an all-skipped sweep exits 2. Real infra/model failures still exit 2/1 (unchanged).
- `COHERENCE_SWEEP_REQUIRE_ALL=1 COHERENCE...` re-arms the old strict behavior for any release host. Revert = drop the commit.

## Test plan

Checked (all local):
1. `bash tests/release/test_coherence_sweep_capacity_skip.sh` — 13 PASS: all-capacity-skips fail closed; resident-pass plus capacity-skip succeeds; exact canonical matching rejects lookalikes; generic and mixed strict failures preserve full attribution.
2. All `tests/release/test_*.sh` (12) pass — no regression in the release-shell suite (CI auto-enrolls the new file via `for t in tests/release/test_*.sh`).
3. Python release tests (`test_release_fleet`, `test_release_baselines`, `test_release_check_m3_port_thread`, `test_release_check_random`) — 99 pass.
4. `bash -n scripts/coherence_sweep.sh` clean; `git diff --check` clean; shellcheck: no new findings (pre-existing SC2269 only).

Fixes #2206
