### PR TITLE
gate(dictation): promote rc2 state-upgrade journey to the PR audio shard (#2365)

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -578,6 +578,12 @@ jobs:
         env:
           RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/dictation
 
+      - name: 'Golden flow: dictation-rc2-upgrade'
+        continue-on-error: true
+        run: ./scripts/gui-golden-flows.sh --flow dictation-rc2-upgrade
+        env:
+          RAPID_GUI_GOLDEN_OUT: ${{ runner.temp }}/golden/dictation-rc2-upgrade
+
       - name: 'Golden flow: settings-mtp'
         continue-on-error: true
         run: ./scripts/gui-golden-flows.sh --flow settings-mtp

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml
@@ -238,7 +238,7 @@ journeys:
     group: audio
     risk: high
     driver: ax
-    ci_tier: local
+    ci_tier: pr
     fixtures: [fake-sidecar, audio-models, isolated-home]
     source_paths: [apps/rapid-mac/Sources/Rapid/Dictation/, apps/rapid-mac/Sources/Rapid/Audio/, apps/rapid-mac/Sources/Rapid/Server/SessionModelRestore.swift, apps/rapid-mac/Sources/Rapid/UI/ContentView.swift]
     owns_baseline: false

--- a/tests/test_gui_golden_ci_coverage.py
+++ b/tests/test_gui_golden_ci_coverage.py
@@ -21,10 +21,10 @@ SWIFT_TESTS = ROOT / "apps/rapid-mac/Tests/RapidTests"
 # `chat-depth` requires all five turns to be simultaneously realised in AX.
 # The hosted runner's 1024x681 app window virtualises the oldest messages, so
 # that assertion is valid on larger local displays but false by construction in
-# CI. The rc2 state-upgrade journey was added during the release window and is
-# verified locally on Studio; hosted dictation-shard gating is tracked in
-# #2365. Keep both exceptions exact: any additional omission is accidental.
-CI_EXCLUSIONS = {"chat-depth", "dictation-rc2-upgrade"}
+# CI. This is the one explicit exception; keep it exact: any additional
+# omission is accidental. The rc2 state-upgrade journey used to be local-only
+# but was gated into the hosted audio shard by #2365.
+CI_EXCLUSIONS = {"chat-depth"}
 
 
 def harness_flows() -> set[str]:


### PR DESCRIPTION
## Why

The `dictation-rc2-upgrade` golden journey — which recreates legacy rc2 persisted chat + Dictation state in an isolated bundle and proves it upgrade-correctly on the current app — was implemented and verified locally on Studio, but left `ci_tier: local`. That means the four rc2 state-upgrade invariants were only checked when a human ran them locally, not continuously on every PR. #2365 asks to gate it into the hosted audio GUI shard so the rc2 upgrade path is continuously validated after the 0.13.0 release window.

## Scope

Promote the existing AX-only `dictation-rc2-upgrade` journey from local to PR tier, into the existing audio GUI shard, without changing its AX-only / Peekaboo-free contract. Three consistent edits:

1. `apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml` — `ci_tier: local` → `pr` for the journey (group `audio`, driver `ax`, fixtures `[fake-sidecar, audio-models, isolated-home]` — unchanged).
2. `.github/workflows/rapid-mac-ci.yml` — add the `Golden flow: dictation-rc2-upgrade` named step alongside its audio siblings (`dictation`, `audio-readiness`).
3. `tests/test_gui_golden_ci_coverage.py` — drop `dictation-rc2-upgrade` from `CI_EXCLUSIONS` (leaving the one real `chat-depth` exception), update the comment that previously parked hosted gating to "#2365".

## Why this is complete (all four original assertions are already implemented)

The AX flow `flow_dictation_rc2_upgrade()` in `gui-golden-flows.sh` already implements every acceptance assertion; this PR only gates it:
1. **catalog/legacy chat alias restored** — writes `rapid.serve.lastAlias fake-alias`, asserts the model-menu value == `fake-alias`.
2. **Send enabled** — `wait_send_idle` after restore.
3. **persisted Dictation intent remains enabled** — writes `dictation.enabled true` + `dictation.model fake-whisper-small`, asserts `Dictation.Enable` reads `1`.
4. **transcription alias never becomes shared process owner** — asserts `server_started` for `fake-alias` but NOT for `fake-whisper-small`.

No harness internals, AX contract, fixtures, or Peekaboo config changed. `owns_baseline: false` is untouched (no new baseline).

## Shard flow counts (acceptance #3, via the existing manifest selector)

`scripts/select_gui_flows.py` derives the audio matrix child from the manifest: the audio shard now enumerates `["dictation", "dictation-rc2-upgrade", "audio-readiness"]` with `flow_count: 3` (was 2). No hand-maintained count edits — the manifest selector updates them, exactly as the issue requires.

## Non-goals

- No re-implementation of the journey or its assertions (all already present).
- No revival of the legacy harness architecture; uses the current declarative source-paths + named-flow framework.
- No change to the `dictation` or `audio-readiness` journeys or baselines.

## Failure / rollback behavior

- If the rc2 journey fails on a PR, its `continue-on-error: true` step records the failure evidence and the job's blocking verdict (`EXPECTED_FLOW_COUNT` guard) fails the merge — the same strict contract every named golden flow uses.
- Revert = drop the commit (tier returns to local).

## Design precedent

The change reuses the existing manifest-as-source-of-truth sharding: a journey declaration (group + ci_tier) is the single lever that both wires a named golden-flow step and derives the per-shard flow count. Auditable, no second list to drift (the coverage-contract test enforces `pr_flows == workflow_flows()`).

## Test plan

Checked (local, all green):
1. `pytest tests/test_gui_golden_ci_coverage.py` — 14/14 (the coverage/gating contract incl. `test_manifest_ci_tiers_match_the_workflow_contract`; now enforces `local_flows == {"chat-depth"}` and `pr_flows == workflow_flows()`).
2. `pytest tests/test_gui_flow_routing.py` — 18/18 (flow-selector derives the audio shard incl. `dictation-rc2-upgrade`).
3. `select_gui_flows.py` on a dictation-affected path → audio shard `["dictation","dictation-rc2-upgrade","audio-readiness"]`, `flow_count:3`; `gui_flow_count:8`.
4. `git diff --check`, `ruff`, YAML parse — clean.

Requires CI (Apple-Silicon hosted shard, can't run locally): the real-app hosted audio GUI shard executes `dictation-rc2-upgrade` on the exact head; `gui-harness-contracts` + `gui-golden-flows` assert the shard counts and diagnostics stay generated.

Fixes #2365
