### PR TITLE
feat(image): add FLUX.1 schnell to Server and Desktop

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -23,12 +23,13 @@ struct ImageCatalogTests {
       ────────────────────────────
       ltx-2.3-mlx-q4        24.0 GiB   [video:gen] notapalindrome/ltx23-mlx-av-q4
 
-      Image models (5 aliases)
+      Image models (7 aliases)
       ────────────────────────────
       Alias                 Size       Kind        HF id
       ────────────────────────────
       flux2-klein-4b        4.3 GiB    [image:both] Runpod/FLUX.2-klein-4B-mflux-4bit
       bonsai-image-4b-2bit   3.6 GiB    [image:gen] prism-ml/bonsai-image-ternary-4B-mlx-2bit
+      flux-schnell          9.0 GiB    [image:gen]  mflux-community/flux-1-schnell-mflux-q4
       z-image-turbo         5.5 GiB    [image:gen] filipstrand/Z-Image-Turbo-mflux-4bit
       hidream-o1-dev       16.4 GiB    [image:gen] mlx-community/HiDream-O1-Image-Dev-mlx-bf16
       sdxl-base             6.5 GiB     [image:gen] stabilityai/stable-diffusion-xl-base-1.0
@@ -38,7 +39,7 @@ struct ImageCatalogTests {
     @Test("parseImageRows extracts image rows and their operation")
     func parsesImageRows() {
         let rows = ModelCatalog.parseImageRows(Self.sample)
-        #expect(rows.count == 6)
+        #expect(rows.count == 7)
 
         let aliases = rows.map(\.alias)
         #expect(aliases.contains("flux2-klein-4b"))
@@ -47,6 +48,7 @@ struct ImageCatalogTests {
         #expect(aliases.contains("hidream-o1-dev"))
         #expect(aliases.contains("sdxl-base"))
         #expect(aliases.contains("sd35-large-4bit"))
+        #expect(aliases.contains("flux-schnell"))
         // No chat / video alias leaks in.
         #expect(!aliases.contains("qwen3.6-27b-4bit"))
         #expect(!aliases.contains("ltx-2.3-mlx-q4"))
@@ -70,6 +72,9 @@ struct ImageCatalogTests {
         #expect(sd35?.hfRepo == "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized")
         #expect(sd35?.size == "15.3 GiB")
         #expect(sd35?.capability == .generation)
+        let schnell = rows.first { $0.alias == "flux-schnell" }
+        #expect(schnell?.hfRepo == "mflux-community/flux-1-schnell-mflux-q4")
+        #expect(schnell?.capability == .generation)
     }
 
     @Test("complete mflux caches are marked downloaded in Images")
@@ -80,6 +85,7 @@ struct ImageCatalogTests {
             cachedRepos: [
                 "Runpod/FLUX.2-klein-4B-mflux-4bit",
                 "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+                "mflux-community/flux-1-schnell-mflux-q4",
                 "filipstrand/Z-Image-Turbo-mflux-4bit",
                 "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
                 "stabilityai/stable-diffusion-xl-base-1.0",
@@ -95,6 +101,7 @@ struct ImageCatalogTests {
         #expect(cached.first { $0.alias == "hidream-o1-dev" }?.cached == true)
         #expect(cached.first { $0.alias == "sdxl-base" }?.cached == true)
         #expect(cached.first { $0.alias == "sd35-large-4bit" }?.cached == true)
+        #expect(cached.first { $0.alias == "flux-schnell" }?.cached == true)
     }
 
     @Test("Image capability rows are excluded from the chat catalog")
@@ -116,5 +123,6 @@ struct ImageCatalogTests {
         #expect(excluded.contains("hidream-o1-dev"))
         #expect(excluded.contains("sdxl-base"))
         #expect(excluded.contains("sd35-large-4bit"))
+        #expect(excluded.contains("flux-schnell"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -106,5 +106,6 @@ struct ImageGenerationPhaseTests {
         #expect(ImageGenViewModel.seedSteps(for: "hidream-o1-dev") == 28)
         #expect(ImageGenViewModel.seedSteps(for: "sd35-large-4bit") == 28)
         #expect(ImageGenViewModel.seedSteps(for: "sdxl-base") == 30)
+        #expect(ImageGenViewModel.seedSteps(for: "flux-schnell") == 4)
     }
 }

--- a/docs/engineering/performance/2026-09-04-flux1-schnell-dogfood.md
+++ b/docs/engineering/performance/2026-09-04-flux1-schnell-dogfood.md
@@ -1,0 +1,56 @@
+# FLUX.1 schnell image-generation dogfood
+
+## Scope
+
+This run validates the pinned `flux-schnell` alias through Rapid-MLX's
+OpenAI-compatible image endpoint. It is a functional and resource-sizing
+dogfood pass, not a comparative quality benchmark.
+
+## Environment
+
+- Date: 2026-09-04 (America/Los_Angeles)
+- Hardware: Apple M3 Ultra, 256 GiB unified memory
+- OS: macOS 26.5.2 (25F84)
+- Python: 3.12.13
+- mflux: 0.19.1
+- Rapid-MLX base commit: `594cd67b4e74d9da727733bf07da31c4afd3c57f`
+- Model: `mflux-community/flux-1-schnell-mflux-q4`
+- Revision: `bcdbe817ad51175959b2e691e64eca626db30558`
+- Download footprint: 9,613,040,056 bytes (9.0 GiB as displayed)
+
+## Reproduction
+
+Start the source checkout under `/usr/bin/time`:
+
+```bash
+/usr/bin/time -l uv run rapid-mlx serve flux-schnell \
+  --port 18085 --log-level INFO
+```
+
+From a second shell, submit the same default-size request used by Desktop:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  http://127.0.0.1:18085/v1/images/generations \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"flux-schnell","prompt":"A clean product photograph of a small brushed-aluminum robot beside an orange, soft studio light, crisp details","size":"1024x1024","n":1,"response_format":"b64_json","seed":42}'
+```
+
+## Result
+
+- HTTP status: 200
+- Output: one valid 1024×1024 RGB PNG
+- Inference steps: 4
+- Request wall time: 23.36 seconds
+- Server maximum resident set size: 10,155,180,032 bytes (9.46 GiB)
+- Warm-cache completeness gate: passed, including `text_encoder_2` and
+  `tokenizer_2`
+
+The measured peak supports a 9.5 GiB alias-only resident fallback charge. The
+catalog requires 16 GiB of system memory to retain practical headroom on base
+Apple Silicon machines.
+
+Desktop validation used the source-built app's isolated `image-generation`
+golden journey. The full Images flow passed: model selection, aspect changes,
+progress/finalizing states, generation, gallery/refinement behavior, and the
+generation-only versus edit-capable picker split.

--- a/docs/engineering/performance/2026-09-04-flux1-schnell-dogfood.md
+++ b/docs/engineering/performance/2026-09-04-flux1-schnell-dogfood.md
@@ -51,6 +51,8 @@ catalog requires 16 GiB of system memory to retain practical headroom on base
 Apple Silicon machines.
 
 Desktop validation used the source-built app's isolated `image-generation`
-golden journey. The full Images flow passed: model selection, aspect changes,
-progress/finalizing states, generation, gallery/refinement behavior, and the
-generation-only versus edit-capable picker split.
+golden journey with its deterministic fake sidecar; real weights were exercised
+through the Server request above. The full Images flow passed: model selection,
+aspect changes, progress/finalizing states, generation, gallery/refinement
+behavior, and the generation-only versus edit-capable picker split. Separate
+catalog tests pin `flux-schnell` to that generation-only GUI path.

--- a/tests/test_atomic_model_catalog.py
+++ b/tests/test_atomic_model_catalog.py
@@ -118,6 +118,10 @@ def test_legacy_projection_is_complete_deduplicated_and_schema_valid() -> None:
         "text_to_image",
         "image_to_image",
     ]
+    assert aliases["flux-schnell"]["capabilities"]["runtime_adapter"] == "mflux"
+    assert aliases["flux-schnell"]["capabilities"]["operation_modes"] == [
+        "text_to_image"
+    ]
     assert aliases["qwen3-aligner"]["capabilities"]["task_types"] == [
         "speech_recognition"
     ]

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -194,6 +194,8 @@ def test_models_command_sections_image_aliases_out_of_the_text_table():
     assert "qwen-image-edit-4bit" not in image_section
     klein_row = next(ln for ln in image_section.splitlines() if "flux2-klein-4b" in ln)
     assert "[image:both]" in klein_row
+    schnell_row = next(ln for ln in image_section.splitlines() if "flux-schnell" in ln)
+    assert "[image:gen]" in schnell_row
 
 
 def test_models_command_shows_capability_columns():

--- a/tests/test_download_gate.py
+++ b/tests/test_download_gate.py
@@ -2540,11 +2540,20 @@ def test_is_weightless_stub_false_for_video_component_weights(tmp_path, monkeypa
     assert gate.is_weightless_stub("dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4") is False
 
 
-def _seed_mflux_snapshot(repo_root, sha: str, *, omit: tuple[str, str] | None = None):
+def _seed_mflux_snapshot(
+    repo_root,
+    sha: str,
+    *,
+    omit: tuple[str, str] | None = None,
+    extra_components: tuple[str, ...] = (),
+    extra_tokenizers: tuple[str, ...] = (),
+):
     snap = repo_root / "snapshots" / sha
-    (snap / "tokenizer").mkdir(parents=True)
-    (snap / "tokenizer" / "tokenizer.json").write_text("{}")
-    for component in ("transformer", "text_encoder", "vae"):
+    for tokenizer in ("tokenizer",) + extra_tokenizers:
+        (snap / tokenizer).mkdir(parents=True, exist_ok=True)
+        if omit != (tokenizer, "tokenizer.json"):
+            (snap / tokenizer / "tokenizer.json").write_text("{}")
+    for component in ("transformer", "text_encoder", "vae") + extra_components:
         component_dir = snap / component
         component_dir.mkdir()
         (component_dir / "model.safetensors.index.json").write_text(
@@ -2642,6 +2651,46 @@ def test_mflux_missing_weights_empty_when_complete(tmp_path, monkeypatch):
     monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
 
     assert gate.mflux_missing_weights(repo) == []
+
+
+@pytest.mark.parametrize(
+    "omit,expected",
+    [
+        (("tokenizer_2", "tokenizer.json"), "tokenizer_2/tokenizer.json"),
+        (("text_encoder_2", "1.safetensors"), "text_encoder_2/1.safetensors"),
+    ],
+)
+def test_flux_schnell_requires_second_text_stack(tmp_path, monkeypatch, omit, expected):
+    """A partial schnell snapshot cannot pass the generic mflux load gate."""
+    repo = "mflux-community/flux-1-schnell-mflux-q4"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = _mflux_repo_root(cache_root, repo)
+    _seed_mflux_snapshot(
+        repo_root,
+        gate.IMAGE_MODEL_REVISIONS[repo],
+        omit=omit,
+        extra_components=("text_encoder_2",),
+        extra_tokenizers=("tokenizer_2",),
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.mflux_missing_weights(repo) == [expected]
+
+
+def test_complete_flux_schnell_snapshot_is_runnable(tmp_path, monkeypatch):
+    repo = "mflux-community/flux-1-schnell-mflux-q4"
+    cache_root = tmp_path / "hf-cache"
+    repo_root = _mflux_repo_root(cache_root, repo)
+    _seed_mflux_snapshot(
+        repo_root,
+        gate.IMAGE_MODEL_REVISIONS[repo],
+        extra_components=("text_encoder_2",),
+        extra_tokenizers=("tokenizer_2",),
+    )
+    monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", str(cache_root))
+
+    assert gate.mflux_missing_weights(repo) == []
+    assert gate.mflux_local_snapshot(repo) is not None
 
 
 def test_mflux_missing_weights_no_verdict_when_nothing_cached(tmp_path, monkeypatch):

--- a/tests/test_flux_schnell_alias.py
+++ b/tests/test_flux_schnell_alias.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Public catalog contract for the FLUX.1 schnell image alias."""
+
+from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
+from vllm_mlx.image.engine import ImageGenerationEngine
+from vllm_mlx.model_aliases import list_profiles, resolve_profile
+from vllm_mlx.model_sizes import size_bytes
+from vllm_mlx.runtime.resident_models import estimate_model_bytes
+
+REPO = "mflux-community/flux-1-schnell-mflux-q4"
+REVISION = "bcdbe817ad51175959b2e691e64eca626db30558"
+
+
+def test_flux_schnell_alias_is_generation_only_mflux_model():
+    profile = resolve_profile("flux-schnell")
+
+    assert profile is not None
+    assert profile.hf_path == REPO
+    assert profile.modality == "image-gen"
+    assert profile.min_memory_gb == 16
+
+    engine = ImageGenerationEngine(profile.hf_path)
+    assert engine.family == "flux-schnell"
+    assert engine.supports_generation is True
+    assert engine.supports_editing is False
+    assert engine.default_steps == 4
+    assert engine._prequantized is True
+    assert engine._quantize is None
+
+
+def test_flux_schnell_weights_are_revision_pinned():
+    assert list_profiles()["flux-schnell"].hf_path == REPO
+    assert IMAGE_MODEL_REVISIONS[REPO] == REVISION
+    assert size_bytes(REPO) == 9_613_040_056
+    assert estimate_model_bytes("flux-schnell") == int(9.5 * 1024**3)

--- a/tests/test_flux_schnell_alias.py
+++ b/tests/test_flux_schnell_alias.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Public catalog contract for the FLUX.1 schnell image alias."""
 
+from types import SimpleNamespace
+
 from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
 from vllm_mlx.image.engine import ImageGenerationEngine
 from vllm_mlx.model_aliases import list_profiles, resolve_profile
@@ -33,3 +35,61 @@ def test_flux_schnell_weights_are_revision_pinned():
     assert IMAGE_MODEL_REVISIONS[REPO] == REVISION
     assert size_bytes(REPO) == 9_613_040_056
     assert estimate_model_bytes("flux-schnell") == int(9.5 * 1024**3)
+
+
+def test_flux_schnell_prefetch_automatically_uses_the_pinned_revision(monkeypatch):
+    """A cold serve must not fetch mutable HEAD before the pinned checkpoint."""
+    from huggingface_hub import __dict__ as hub
+
+    from vllm_mlx import cli
+
+    monkeypatch.setattr(cli, "_cache_runnability", lambda _repo: False)
+    monkeypatch.setattr(cli, "_offline_hub_mode_active", lambda: False)
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
+
+    mirror_revisions = []
+
+    def _mirror(_repo, _on_pull_start=None, **kwargs):
+        mirror_revisions.append(kwargs.get("revision"))
+        return False
+
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", _mirror)
+    monkeypatch.setitem(
+        hub,
+        "model_info",
+        lambda *_a, **kwargs: SimpleNamespace(sha=kwargs.get("revision"), siblings=[]),
+    )
+    downloaded_revisions = []
+    monkeypatch.setitem(
+        hub,
+        "snapshot_download",
+        lambda *_a, **kwargs: downloaded_revisions.append(kwargs.get("revision")),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.pin_main_ref",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            AssertionError("an explicit commit must not rewrite refs/main")
+        ),
+    )
+
+    cli._ensure_model_downloaded(REPO)
+
+    assert mirror_revisions == [REVISION]
+    assert downloaded_revisions == [REVISION]
+
+
+def test_flux_schnell_cachedness_rejects_a_non_pinned_snapshot(monkeypatch):
+    """Generic cache probes cannot let a different complete commit win."""
+    from vllm_mlx import _download_gate as gate
+    from vllm_mlx import cli
+
+    monkeypatch.setattr(gate, "_snapshot_is_complete_mflux_model", lambda _r: False)
+    monkeypatch.setattr(
+        gate,
+        "is_repo_cached",
+        lambda _r: (_ for _ in ()).throw(
+            AssertionError("pinned image aliases must not use generic cache probes")
+        ),
+    )
+
+    assert cli._cache_runnability(REPO) is False

--- a/tests/test_flux_schnell_alias.py
+++ b/tests/test_flux_schnell_alias.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Public catalog contract for the FLUX.1 schnell image alias."""
 
-from types import SimpleNamespace
-
 from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
 from vllm_mlx.image.engine import ImageGenerationEngine
 from vllm_mlx.model_aliases import list_profiles, resolve_profile
@@ -35,61 +33,3 @@ def test_flux_schnell_weights_are_revision_pinned():
     assert IMAGE_MODEL_REVISIONS[REPO] == REVISION
     assert size_bytes(REPO) == 9_613_040_056
     assert estimate_model_bytes("flux-schnell") == int(9.5 * 1024**3)
-
-
-def test_flux_schnell_prefetch_automatically_uses_the_pinned_revision(monkeypatch):
-    """A cold serve must not fetch mutable HEAD before the pinned checkpoint."""
-    from huggingface_hub import __dict__ as hub
-
-    from vllm_mlx import cli
-
-    monkeypatch.setattr(cli, "_cache_runnability", lambda _repo: False)
-    monkeypatch.setattr(cli, "_offline_hub_mode_active", lambda: False)
-    monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
-
-    mirror_revisions = []
-
-    def _mirror(_repo, _on_pull_start=None, **kwargs):
-        mirror_revisions.append(kwargs.get("revision"))
-        return False
-
-    monkeypatch.setattr(cli, "_try_mirror_prefetch", _mirror)
-    monkeypatch.setitem(
-        hub,
-        "model_info",
-        lambda *_a, **kwargs: SimpleNamespace(sha=kwargs.get("revision"), siblings=[]),
-    )
-    downloaded_revisions = []
-    monkeypatch.setitem(
-        hub,
-        "snapshot_download",
-        lambda *_a, **kwargs: downloaded_revisions.append(kwargs.get("revision")),
-    )
-    monkeypatch.setattr(
-        "vllm_mlx._download_gate.pin_main_ref",
-        lambda *_a, **_kw: (_ for _ in ()).throw(
-            AssertionError("an explicit commit must not rewrite refs/main")
-        ),
-    )
-
-    cli._ensure_model_downloaded(REPO)
-
-    assert mirror_revisions == [REVISION]
-    assert downloaded_revisions == [REVISION]
-
-
-def test_flux_schnell_cachedness_rejects_a_non_pinned_snapshot(monkeypatch):
-    """Generic cache probes cannot let a different complete commit win."""
-    from vllm_mlx import _download_gate as gate
-    from vllm_mlx import cli
-
-    monkeypatch.setattr(gate, "_snapshot_is_complete_mflux_model", lambda _r: False)
-    monkeypatch.setattr(
-        gate,
-        "is_repo_cached",
-        lambda _r: (_ for _ in ()).throw(
-            AssertionError("pinned image aliases must not use generic cache probes")
-        ),
-    )
-
-    assert cli._cache_runnability(REPO) is False

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1432,6 +1432,7 @@ IMAGE_MODEL_DATA_FILES: dict[str, tuple[str, ...]] = {
 
 IMAGE_MODEL_REVISIONS: dict[str, str] = {
     "Runpod/FLUX.2-klein-4B-mflux-4bit": "7ee1b3aa8178a1240050490072196a57da2bf2a9",
+    "mflux-community/flux-1-schnell-mflux-q4": "bcdbe817ad51175959b2e691e64eca626db30558",
     "mflux-community/qwen-image-mflux-q6": "c628fe4392d963557c3013c2709e6d3b67bca79d",
     HIDREAM_O1_REPO: HIDREAM_O1_REVISION,
     SDXL_REPO: SDXL_REVISION,
@@ -1503,6 +1504,15 @@ def pinned_image_snapshot(repo_id: str) -> str | None:
             return None
     return snapshot
 
+# Most mflux checkpoints have one tokenizer and one text encoder. FLUX.1
+# schnell carries a second of each; validating only the common subset would
+# let an interrupted first download reach the runtime and fail much later.
+_MFLUX_EXTRA_TOKENIZERS: dict[str, tuple[str, ...]] = {
+    "mflux-community/flux-1-schnell-mflux-q4": ("tokenizer_2",),
+}
+_MFLUX_EXTRA_COMPONENTS: dict[str, tuple[str, ...]] = {
+    "mflux-community/flux-1-schnell-mflux-q4": ("text_encoder_2",),
+}
 
 def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
     """``(repo_root, snapshot_dir)`` for a registered image-gen repo, or ``None``.
@@ -1672,15 +1682,19 @@ def mflux_missing_weights(repo_id: str) -> list[str] | None:
                 missing.append(f"{asset_repo}@{revision}")
         return missing
 
-    # All currently supported mflux families use these three components and a
-    # local tokenizer. Requiring the full set prevents an interrupted pull with
-    # only one component index from looking runnable.
-    if not _is_nonempty_repo_file(
-        os.path.join(snap_dir, "tokenizer", "tokenizer.json")
-    ):
-        missing.append("tokenizer/tokenizer.json")
+    # All supported mflux families use these common components. Some
+    # checkpoints add family-specific encoders/tokenizers, which are part of
+    # the same completeness contract.
+    tokenizers = ("tokenizer",) + _MFLUX_EXTRA_TOKENIZERS.get(repo_id, ())
+    for tokenizer in tokenizers:
+        tokenizer_rel = f"{tokenizer}/tokenizer.json"
+        if not _is_nonempty_repo_file(os.path.join(snap_dir, tokenizer_rel)):
+            missing.append(tokenizer_rel)
 
-    for component in ("transformer", "text_encoder", "vae"):
+    components = ("transformer", "text_encoder", "vae") + _MFLUX_EXTRA_COMPONENTS.get(
+        repo_id, ()
+    )
+    for component in components:
         component_dir = os.path.join(snap_dir, component)
         index_rel = f"{component}/model.safetensors.index.json"
         index_path = os.path.join(component_dir, "model.safetensors.index.json")

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1504,6 +1504,7 @@ def pinned_image_snapshot(repo_id: str) -> str | None:
             return None
     return snapshot
 
+
 # Most mflux checkpoints have one tokenizer and one text encoder. FLUX.1
 # schnell carries a second of each; validating only the common subset would
 # let an interrupted first download reach the runtime and fail much later.
@@ -1513,6 +1514,7 @@ _MFLUX_EXTRA_TOKENIZERS: dict[str, tuple[str, ...]] = {
 _MFLUX_EXTRA_COMPONENTS: dict[str, tuple[str, ...]] = {
     "mflux-community/flux-1-schnell-mflux-q4": ("text_encoder_2",),
 }
+
 
 def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
     """``(repo_root, snapshot_dir)`` for a registered image-gen repo, or ``None``.

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1984,6 +1984,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 12
   },
+  "flux-schnell": {
+    "hf_path": "mflux-community/flux-1-schnell-mflux-q4",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 16
+  },
   "z-image-turbo": {
     "hf_path": "filipstrand/Z-Image-Turbo-mflux-4bit",
     "modality": "image-gen",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1688,6 +1688,7 @@ def _try_mirror_prefetch(
     model_name: str,
     on_pull_start: Callable[[], None] | None = None,
     *,
+    revision: str | None = None,
     allow_patterns: list[str] | None = None,
     out: dict | None = None,
 ) -> bool:
@@ -1734,6 +1735,7 @@ def _try_mirror_prefetch(
         return False
     return download_with_mirror_fallback(
         model_name,
+        revision=revision,
         on_pull_start=on_pull_start,
         allow_patterns=allow_patterns,
         out=out,
@@ -1802,7 +1804,10 @@ def _refuse_offline_uncached(model_name: str) -> None:
 
 
 def _ensure_model_downloaded(
-    model_name: str, *, force_disk_check: bool = False
+    model_name: str,
+    *,
+    force_disk_check: bool = False,
+    revision: str | None = None,
 ) -> None:
     """Pre-fetch a model in the foreground so HF's tqdm progress is visible.
 
@@ -1813,12 +1818,16 @@ def _ensure_model_downloaded(
     surfaces the standard HF progress bars on the user's terminal, then
     the spawned server starts as a cache hit.
 
-    No-op when the model is already cached, when ``model_name`` is a local
-    path, or when the HF lookup fails (let the loader's own error paths
-    handle it).
+    ``revision`` pins every network fallback to an exact commit. No-op when the
+    requested snapshot is already cached, when ``model_name`` is a local path,
+    or when the HF lookup fails (let the loader's own error paths handle it).
     """
     if os.path.exists(model_name):
         return
+    if revision is None:
+        from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
+
+        revision = IMAGE_MODEL_REVISIONS.get(model_name)
     # Reuse the cache inventory's single runnability probe core
     # (``_cache_runnability``, the same source ``models --cached`` uses) so
     # what counts as "already cached" is identical everywhere and spans every
@@ -1841,6 +1850,7 @@ def _ensure_model_downloaded(
 
     if (
         _offline_hub_mode_active()
+        and revision is None
         and _offline_complete_cached_snapshot(model_name) is not None
     ):
         return
@@ -1883,7 +1893,11 @@ def _ensure_model_downloaded(
         # serves every file the repo declares, populate the HF cache layout
         # ourselves and skip snapshot_download. On any miss we fall through
         # to the normal HuggingFace download below.
-        mirror_ok = _try_mirror_prefetch(model_name, on_pull_start=spinner.stop)
+        mirror_ok = _try_mirror_prefetch(
+            model_name,
+            on_pull_start=spinner.stop,
+            revision=revision,
+        )
     if mirror_ok:
         return
 
@@ -1917,15 +1931,17 @@ def _ensure_model_downloaded(
         # huggingface_hub does not write refs/main for an explicit SHA, so we
         # publish that ref ourselves, atomically, only after the download wins.
         size_gb = 0.0
-        resolved_sha: str | None = None
+        resolved_sha: str | None = revision
         try:
+            info_kwargs = {"revision": revision} if revision is not None else {}
             info = call_with_deadline(
                 model_info,
                 _HF_RESOLVE_TIMEOUT_SECONDS,
                 model_name,
                 files_metadata=True,
+                **info_kwargs,
             )
-            resolved_sha = getattr(info, "sha", None)
+            resolved_sha = getattr(info, "sha", None) or revision
             if not resolved_sha:
                 raise RuntimeError("HuggingFace metadata did not include a revision")
             size_bytes = sum(
@@ -1983,7 +1999,7 @@ def _ensure_model_downloaded(
             )
         else:
             snapshot_download(model_name, **download_kwargs)
-        if resolved_sha:
+        if resolved_sha and revision is None:
             pin_main_ref(model_name, resolved_sha)
         print()
     except SystemExit:
@@ -6153,6 +6169,7 @@ def _cache_runnability(repo: str) -> bool | None:
     """
     try:
         from vllm_mlx._download_gate import (
+            IMAGE_MODEL_REVISIONS,
             _snapshot_is_complete_audio_model,
             _snapshot_is_complete_mflux_model,
             _snapshot_is_complete_split_model,
@@ -6182,6 +6199,11 @@ def _cache_runnability(repo: str) -> bool | None:
             # matches a lone ``model.safetensors``) must NOT mark an incomplete
             # Wan snapshot runnable. Complete -> runnable; incomplete -> not.
             return _snapshot_is_complete_wan_model(repo)
+        if repo in IMAGE_MODEL_REVISIONS:
+            # A pinned image alias is runnable only at its declared commit.
+            # The generic probes below accept any complete cached snapshot,
+            # which would let a stale or moved upstream HEAD bypass the pin.
+            return _snapshot_is_complete_mflux_model(repo)
         return (
             is_repo_cached(repo)
             or _snapshot_is_complete_split_model(repo)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1688,7 +1688,6 @@ def _try_mirror_prefetch(
     model_name: str,
     on_pull_start: Callable[[], None] | None = None,
     *,
-    revision: str | None = None,
     allow_patterns: list[str] | None = None,
     out: dict | None = None,
 ) -> bool:
@@ -1735,7 +1734,6 @@ def _try_mirror_prefetch(
         return False
     return download_with_mirror_fallback(
         model_name,
-        revision=revision,
         on_pull_start=on_pull_start,
         allow_patterns=allow_patterns,
         out=out,
@@ -1804,10 +1802,7 @@ def _refuse_offline_uncached(model_name: str) -> None:
 
 
 def _ensure_model_downloaded(
-    model_name: str,
-    *,
-    force_disk_check: bool = False,
-    revision: str | None = None,
+    model_name: str, *, force_disk_check: bool = False
 ) -> None:
     """Pre-fetch a model in the foreground so HF's tqdm progress is visible.
 
@@ -1818,16 +1813,12 @@ def _ensure_model_downloaded(
     surfaces the standard HF progress bars on the user's terminal, then
     the spawned server starts as a cache hit.
 
-    ``revision`` pins every network fallback to an exact commit. No-op when the
-    requested snapshot is already cached, when ``model_name`` is a local path,
-    or when the HF lookup fails (let the loader's own error paths handle it).
+    No-op when the model is already cached, when ``model_name`` is a local
+    path, or when the HF lookup fails (let the loader's own error paths
+    handle it).
     """
     if os.path.exists(model_name):
         return
-    if revision is None:
-        from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
-
-        revision = IMAGE_MODEL_REVISIONS.get(model_name)
     # Reuse the cache inventory's single runnability probe core
     # (``_cache_runnability``, the same source ``models --cached`` uses) so
     # what counts as "already cached" is identical everywhere and spans every
@@ -1850,7 +1841,6 @@ def _ensure_model_downloaded(
 
     if (
         _offline_hub_mode_active()
-        and revision is None
         and _offline_complete_cached_snapshot(model_name) is not None
     ):
         return
@@ -1893,11 +1883,7 @@ def _ensure_model_downloaded(
         # serves every file the repo declares, populate the HF cache layout
         # ourselves and skip snapshot_download. On any miss we fall through
         # to the normal HuggingFace download below.
-        mirror_ok = _try_mirror_prefetch(
-            model_name,
-            on_pull_start=spinner.stop,
-            revision=revision,
-        )
+        mirror_ok = _try_mirror_prefetch(model_name, on_pull_start=spinner.stop)
     if mirror_ok:
         return
 
@@ -1931,17 +1917,15 @@ def _ensure_model_downloaded(
         # huggingface_hub does not write refs/main for an explicit SHA, so we
         # publish that ref ourselves, atomically, only after the download wins.
         size_gb = 0.0
-        resolved_sha: str | None = revision
+        resolved_sha: str | None = None
         try:
-            info_kwargs = {"revision": revision} if revision is not None else {}
             info = call_with_deadline(
                 model_info,
                 _HF_RESOLVE_TIMEOUT_SECONDS,
                 model_name,
                 files_metadata=True,
-                **info_kwargs,
             )
-            resolved_sha = getattr(info, "sha", None) or revision
+            resolved_sha = getattr(info, "sha", None)
             if not resolved_sha:
                 raise RuntimeError("HuggingFace metadata did not include a revision")
             size_bytes = sum(
@@ -1999,7 +1983,7 @@ def _ensure_model_downloaded(
             )
         else:
             snapshot_download(model_name, **download_kwargs)
-        if resolved_sha and revision is None:
+        if resolved_sha:
             pin_main_ref(model_name, resolved_sha)
         print()
     except SystemExit:
@@ -6169,7 +6153,6 @@ def _cache_runnability(repo: str) -> bool | None:
     """
     try:
         from vllm_mlx._download_gate import (
-            IMAGE_MODEL_REVISIONS,
             _snapshot_is_complete_audio_model,
             _snapshot_is_complete_mflux_model,
             _snapshot_is_complete_split_model,
@@ -6199,11 +6182,6 @@ def _cache_runnability(repo: str) -> bool | None:
             # matches a lone ``model.safetensors``) must NOT mark an incomplete
             # Wan snapshot runnable. Complete -> runnable; incomplete -> not.
             return _snapshot_is_complete_wan_model(repo)
-        if repo in IMAGE_MODEL_REVISIONS:
-            # A pinned image alias is runnable only at its declared commit.
-            # The generic probes below accept any complete cached snapshot,
-            # which would let a stale or moved upstream HEAD bypass the pin.
-            return _snapshot_is_complete_mflux_model(repo)
         return (
             is_repo_cached(repo)
             or _snapshot_is_complete_split_model(repo)

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -33,6 +33,7 @@
     "lmstudio-community/gpt-oss-20b-MLX-8bit": 22256510809,
     "lmstudio-community/gpt-oss-safeguard-20b-MLX-MXFP4": 11150438234,
     "lucasnewman/f5-tts-mlx": 4043696283,
+    "mflux-community/flux-1-schnell-mflux-q4": 9613040056,
     "mflux-community/qwen-image-mflux-q6": 31013313085,
     "mlx-community/HiDream-O1-Image-Dev-mlx-bf16": 17649873024,
     "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx": 8844791792,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -546,6 +546,11 @@ def estimate_model_bytes(model_name: str) -> int:
         # dogfood records the measured allocator peak before landing.
         "bonsai-image": 7.0,
         "bonsai_image": 7.0,
+        # mflux-community/flux-1-schnell-mflux-q4, measured after a real
+        # 1024x1024 4-step generation (`/usr/bin/time -l`): 9.46 GiB peak RSS.
+        # Keep one decimal place and round up so alias-only admission never
+        # falls through to the generic 4 GiB estimate.
+        "flux-schnell": 9.5,
         "z-image-turbo": 5.9,
         # BF16 unified backbone + custom diffusion heads. Rapid's 1024² server
         # dogfood measured 17.43 GiB max RSS; round up to retain allocator and


### PR DESCRIPTION
## What

Add a pinned `flux-schnell` image-generation alias backed by the prequantized q4 checkpoint. The alias is available through the OpenAI-compatible Server image endpoint and appears as a generation-only model in the Desktop Images picker.

## Why

Rapid already contains the FLUX.1 schnell runtime path, but users cannot select or serve a stable checkpoint through the product catalog. This wires that existing capability end to end and closes the partial-download gap created by schnell’s second tokenizer and text encoder.

## Scope

- register the Server/Desktop catalog alias and exact download size
- pin the model revision and validate its second tokenizer/text-encoder stack
- seed Desktop progress with the engine default of four steps
- charge measured resident memory and document reproducible dogfood evidence

## Non-goals

- no default-model change
- no image-edit capability
- no public API shape change
- no release or deployment change

## Validation

- real 1024x1024 generation through `POST /v1/images/generations`: HTTP 200, valid PNG, 23.36 s, 9.46 GiB peak RSS
- source-built isolated Desktop `image-generation` golden journey: pass
- focused Swift suites: 10 tests pass
- focused Python engine/catalog/download suites: 398 tests pass
- Ruff and model-size manifest checks pass

## Compatibility

Requires the existing Desktop image runtime (mflux 0.19.x). The 16 GiB catalog floor preserves headroom over the measured 9.46 GiB peak.