### PR TITLE
perf(image): add explicit bf16 path for FLUX.2 Klein

### DIFF
--- a/.agents/handoffs/vector-image-weight-precision.md
+++ b/.agents/handoffs/vector-image-weight-precision.md
@@ -17,20 +17,24 @@
 - The packaged bf16 source loads via `model_path` with `quantize=None`.
 - Relevant alias/image/download/CLI/residency tests pass; exact commands are in
   the eventual PR summary and the performance note.
+- Real M2 Pro dogfood through `rapid-mlx serve` and the image endpoint measured
+  52.703 s q4 versus 41.820 s bf16 median (1.26× throughput), with deterministic
+  repeats and visually coherent output. The exact pinned bf16 package passed
+  the repository completeness guard before loading.
 - A DiffusionGemma-shape M3 Ultra microbenchmark found q4 faster than bf16 at
   both M=256 and M=4096. No Gemma precision policy was changed.
 
 ## Unresolved questions and risks
 
 - The CLI flag is a new public surface and needs Atlas compatibility approval.
-- The 18 GiB residency estimate is conservative rather than a measured peak;
-  the alias independently enforces a 32 GB physical-memory floor.
-- A full q4/bf16 image generation and edit smoke against the new packaged
-  checkpoint still needs the 16 GB weight download. This change verifies the
-  load contract hermetically but does not download that checkpoint on Studio.
+- The 18 GiB residency estimate is conservative; direct-engine dogfood measured
+  about 12.49 GB peak process RSS, and the alias independently enforces a 32 GB
+  physical-memory floor.
+- Text-to-image is qualified end to end. FLUX.2 image editing with the bf16
+  package has not been separately timed in this pass.
 - M1/M2-family automatic selection remains deliberately out of scope.
 
 ## Next action
 
-Atlas should confirm the explicit CLI/alias surface, then run or delegate one
-real 1024×1024 generation and edit smoke on the 32 GB M2 Pro before merge.
+Atlas should confirm the explicit CLI/alias surface and decide whether a
+separate image-edit smoke is required before merge.

--- a/.agents/handoffs/vector-image-weight-precision.md
+++ b/.agents/handoffs/vector-image-weight-precision.md
@@ -1,7 +1,7 @@
 # Vector → Atlas: FLUX.2 Klein explicit bf16 path
 
 - Branch: `perf/3058-image-weight-precision`
-- PR: not opened yet
+- PR: `#3065`
 - Owner/host: Vector / Studio (M3 Ultra)
 - Issue: `raullenchai/Rapid-MLX#3058`
 

--- a/.agents/handoffs/vector-image-weight-precision.md
+++ b/.agents/handoffs/vector-image-weight-precision.md
@@ -18,30 +18,32 @@
 - Cold prefetch carries the registered image revision through the mirror,
   metadata, and Hub download layers, preventing a moving `main` snapshot from
   being downloaded before the pinned 16 GB snapshot.
-- Relevant alias/image/download/CLI/residency tests pass; exact commands are in
-  the eventual PR summary and the performance note.
+- After rebasing on the complete image-stack prerequisites, 670 focused Python
+  tests and 43 Desktop catalog/residency/phase tests pass. The BF16 catalog row
+  exposes its 15.98 GB size, 32 GB floor, four-step default, and image modality
+  through the same server contract consumed by the Desktop picker.
 - Real M2 Pro dogfood through `rapid-mlx serve` and the image endpoint measured
   52.703 s q4 versus 41.820 s bf16 median (1.26× throughput), with deterministic
   repeats and visually coherent output. The exact pinned bf16 package passed
   the repository completeness guard before loading.
 - A DiffusionGemma-shape M3 Ultra microbenchmark found q4 faster than bf16 at
   both M=256 and M=4096. No Gemma precision policy was changed.
-- `pr_validate` additionally exposed a pre-existing DiffusionGemma boot failure:
-  the alias routes to DiffusionEngine while `diffusion_generation_family`
-  returns `diffusion`. The exact failure reproduces on clean `origin/main` and
-  remains a separate follow-up, not part of this image-weight PR.
+- The previously independent DiffusionGemma routing fix is now on `main`; this
+  branch only preserves compatibility with it and does not change its precision
+  policy.
 
 ## Unresolved questions and risks
 
-- The CLI flag is a new public surface and needs Atlas compatibility approval.
 - The 18 GiB residency estimate is conservative; direct-engine dogfood measured
   about 12.49 GB peak process RSS, and the alias independently enforces a 32 GB
-  physical-memory floor.
+  physical-memory floor. Desktop admission intentionally honors that larger
+  hardware floor when it has catalog metadata.
 - Text-to-image is qualified end to end. FLUX.2 image editing with the bf16
   package has not been separately timed in this pass.
 - M1/M2-family automatic selection remains deliberately out of scope.
 
 ## Next action
 
-Atlas should confirm the explicit CLI/alias surface and decide whether a
-separate image-edit smoke is required before merge.
+Monitor exact-head CI and queue the PR once every required check is green.
+Image-edit timing remains a separate qualification rather than a merge blocker
+for this text-to-image performance path.

--- a/.agents/handoffs/vector-image-weight-precision.md
+++ b/.agents/handoffs/vector-image-weight-precision.md
@@ -15,6 +15,9 @@
 - `--image-weight-precision bf16` resolves to that concrete alias before the
   download confirmation and disk checks. No automatic hardware policy exists.
 - The packaged bf16 source loads via `model_path` with `quantize=None`.
+- Cold prefetch carries the registered image revision through the mirror,
+  metadata, and Hub download layers, preventing a moving `main` snapshot from
+  being downloaded before the pinned 16 GB snapshot.
 - Relevant alias/image/download/CLI/residency tests pass; exact commands are in
   the eventual PR summary and the performance note.
 - Real M2 Pro dogfood through `rapid-mlx serve` and the image endpoint measured

--- a/.agents/handoffs/vector-image-weight-precision.md
+++ b/.agents/handoffs/vector-image-weight-precision.md
@@ -26,6 +26,10 @@
   the repository completeness guard before loading.
 - A DiffusionGemma-shape M3 Ultra microbenchmark found q4 faster than bf16 at
   both M=256 and M=4096. No Gemma precision policy was changed.
+- `pr_validate` additionally exposed a pre-existing DiffusionGemma boot failure:
+  the alias routes to DiffusionEngine while `diffusion_generation_family`
+  returns `diffusion`. The exact failure reproduces on clean `origin/main` and
+  remains a separate follow-up, not part of this image-weight PR.
 
 ## Unresolved questions and risks
 

--- a/.agents/handoffs/vector-image-weight-precision.md
+++ b/.agents/handoffs/vector-image-weight-precision.md
@@ -1,0 +1,36 @@
+# Vector → Atlas: FLUX.2 Klein explicit bf16 path
+
+- Branch: `perf/3058-image-weight-precision`
+- PR: not opened yet
+- Owner/host: Vector / Studio (M3 Ultra)
+- Issue: `raullenchai/Rapid-MLX#3058`
+
+## Verified facts
+
+- The existing `flux2-klein-4b` alias remains on its pinned q4 checkpoint.
+- The new `flux2-klein-4b-bf16` alias uses pinned revision
+  `4d8e1bae8eb47c7766705de2cda7dabd6cc4ba67` of the 15.98 GB mflux-layout
+  bf16 checkpoint. Its first transformer shard declares only BF16 tensors and
+  no affine-quantization auxiliaries.
+- `--image-weight-precision bf16` resolves to that concrete alias before the
+  download confirmation and disk checks. No automatic hardware policy exists.
+- The packaged bf16 source loads via `model_path` with `quantize=None`.
+- Relevant alias/image/download/CLI/residency tests pass; exact commands are in
+  the eventual PR summary and the performance note.
+- A DiffusionGemma-shape M3 Ultra microbenchmark found q4 faster than bf16 at
+  both M=256 and M=4096. No Gemma precision policy was changed.
+
+## Unresolved questions and risks
+
+- The CLI flag is a new public surface and needs Atlas compatibility approval.
+- The 18 GiB residency estimate is conservative rather than a measured peak;
+  the alias independently enforces a 32 GB physical-memory floor.
+- A full q4/bf16 image generation and edit smoke against the new packaged
+  checkpoint still needs the 16 GB weight download. This change verifies the
+  load contract hermetically but does not download that checkpoint on Studio.
+- M1/M2-family automatic selection remains deliberately out of scope.
+
+## Next action
+
+Atlas should confirm the explicit CLI/alias surface, then run or delegate one
+real 1024×1024 generation and edit smoke on the 32 GB M2 Pro before merge.

--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -27,10 +27,10 @@ The implementation at commit `4d280191d` was then dogfooded through the real
 - two independent server processes per checkpoint, each with one discarded
   warm-up, followed by five measured requests combined across both processes.
 
-| Weight path | Warm-up | Measured requests | Median |
-|---|---:|---:|---:|
-| Pinned pre-quantized q4 alias | 52.431 / 52.085 s | 54.643 / 60.425 / 51.882 / 52.463 / 52.703 s | 52.703 s |
-| Pinned packaged bf16 alias | 43.287 / 44.036 s | 46.065 / 41.820 / 40.538 / 42.805 / 40.844 s | 41.820 s |
+| Weight path | Warm-up | Measured requests | Median | p95 (nearest rank) |
+|---|---:|---:|---:|---:|
+| Pinned pre-quantized q4 alias | 52.431 / 52.085 s | 54.643 / 60.425 / 51.882 / 52.463 / 52.703 s | 52.703 s | 60.425 s |
+| Pinned packaged bf16 alias | 43.287 / 44.036 s | 46.065 / 41.820 / 40.538 / 42.805 / 40.844 s | 41.820 s | 46.065 s |
 
 The packaged bf16 path reduced median end-to-end wall time by 20.6%, or 1.26×
 throughput. Every repeat within a precision produced the same PNG SHA-256;

--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -17,8 +17,8 @@ measurements from the issue, not a new run performed by this change.
 
 ## Branch dogfood
 
-The implementation at commit `4d280191d` was then dogfooded through the real
-`rapid-mlx serve` and `/v1/images/generations` path on the same class of host:
+The implementation branch was then dogfooded through the real `rapid-mlx serve`
+and `/v1/images/generations` path on the same class of host:
 
 - Mac mini, Apple M2 Pro, 32 GB unified memory, macOS 26.5.2;
 - mflux 0.19.1, MLX 0.32.2, low-power mode off, no recorded thermal warning;

--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -24,7 +24,8 @@ The implementation at commit `4d280191d` was then dogfooded through the real
 - mflux 0.19.1, MLX 0.32.2, low-power mode off, no recorded thermal warning;
 - otherwise-idle host, with its resident QSP service stopped for the A/B;
 - identical prompt, seed 1001, 1024×1024 output, and four inference steps;
-- one warm-up followed by five measured requests per checkpoint.
+- two independent server processes per checkpoint, each with one discarded
+  warm-up, followed by five measured requests combined across both processes.
 
 | Weight path | Warm-up | Measured requests | Median |
 |---|---:|---:|---:|

--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -1,0 +1,101 @@
+# FLUX.2 Klein explicit bf16 execution path
+
+Issue [#3058](https://github.com/raullenchai/Rapid-MLX/issues/3058)
+measured FLUX.2 Klein 4B at 1024×1024, four steps, with the same prompt and
+seed on an otherwise-idle 32 GB M2 Pro Mac mini:
+
+| Weight path | Wall time per image |
+|---|---:|
+| BFL bf16 | 44.0 / 47.4 s |
+| BFL quantized on load to q4 | 52.5 / 52.0 s |
+| Pre-quantized q4 alias | 51.5 / 52.7 s |
+
+The mean q4-to-bf16 throughput gain is about 1.14×. The matching on-load and
+pre-quantized q4 times isolate execution precision, rather than checkpoint
+conversion, as the useful lever for this workload. These figures are supplied
+measurements from the issue, not a new run performed by this change.
+
+Rapid-MLX therefore exposes an opt-in path while preserving existing behavior:
+
+```bash
+rapid-mlx serve flux2-klein-4b --image-weight-precision bf16
+# Equivalent explicit alias:
+rapid-mlx serve flux2-klein-4b-bf16
+```
+
+The bf16 alias uses the pinned, mflux-layout
+`mflux-community/flux2-klein-4b-mflux-bf16` snapshot (15,975,684,703 bytes),
+loads it through `model_path`, and passes `quantize=None`. The q4 alias and all
+other models are unchanged. A range-read of the pinned snapshot's first
+transformer shard found 69 tensors, all declared `BF16`, and no `.scales` or
+`.biases` quantization auxiliaries. Automatic chip selection is deliberately
+deferred until M1/M2 family coverage and peak-working-set measurements exist.
+
+## Reproduction checklist
+
+For a qualification run, record `sw_vers`, `sysctl -n machdep.cpu.brand_string`,
+physical RAM, Rapid-MLX/mflux/MLX versions, power mode, and whether another model
+is resident. Warm each path once, then run at least five timed images with an
+identical prompt, seed, dimensions, and step count; report median and p95 plus
+peak resident memory.
+
+## Other diffusion lanes
+
+DiffusionGemma is **discrete text diffusion**, not an mflux image model. Its
+default canvas is 256 text tokens and each denoising step can likewise present
+multi-row matrix multiplies, so the same q4-kernel crossover is a plausible
+benchmark target. It is not covered by this switch: the curated checkpoint is
+a 26B-total/4B-active MoE, uses mixed 4/8-bit weights, and a full bf16 copy would
+exceed the 32 GB target where Klein bf16 fits.
+
+A shape-level probe on the Studio (`Apple M3 Ultra`, macOS 26.5.2, MLX 0.32.2),
+using DiffusionGemma's real dense projection shape `M×2816 @ 2816×4096`, group
+size 64, five warm-ups and 20 individually synchronized samples, measured:
+
+| Canvas rows | bf16 median | q8 median | q4 median |
+|---:|---:|---:|---:|
+| 256 | 0.676 ms | 0.591 ms | 0.586 ms |
+| 4096 | 6.475 ms | 6.260 ms | 6.183 ms |
+
+On M3 Ultra, dequantizing that projection would therefore be a regression, not
+an optimization. This microbenchmark does not cover the model's grouped MoE
+expert kernels or prove the result on M1/M2. A useful follow-up is an
+end-to-end 4-bit versus 8-bit and selective-dequantization profile on a
+high-memory M1/M2 host; until that exists, changing DiffusionGemma's weight
+precision would be an unmeasured compatibility and memory-policy change.
+
+Reproduce the dense projection probe with:
+
+```python
+import statistics, time
+import mlx.core as mx
+
+def bench(fn, warmup=5, iterations=20):
+    for _ in range(warmup):
+        mx.eval(fn())
+    samples = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        mx.eval(fn())
+        samples.append(time.perf_counter() - started)
+    return statistics.median(samples)
+
+for rows in (256, 4096):
+    x = mx.random.normal((rows, 2816)).astype(mx.bfloat16)
+    weight = mx.random.normal((4096, 2816)).astype(mx.bfloat16)
+    mx.eval(x, weight)
+    print(rows, "bf16", bench(lambda: x @ weight.T))
+    for bits in (8, 4):
+        packed, scales, biases = mx.quantize(weight, group_size=64, bits=bits)
+        mx.eval(packed, scales, biases)
+        print(
+            rows,
+            f"q{bits}",
+            bench(
+                lambda: mx.quantized_matmul(
+                    x, packed, scales, biases, transpose=True,
+                    group_size=64, bits=bits,
+                )
+            ),
+        )
+```

--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -15,6 +15,35 @@ pre-quantized q4 times isolate execution precision, rather than checkpoint
 conversion, as the useful lever for this workload. These figures are supplied
 measurements from the issue, not a new run performed by this change.
 
+## Branch dogfood
+
+The implementation at commit `4d280191d` was then dogfooded through the real
+`rapid-mlx serve` and `/v1/images/generations` path on the same class of host:
+
+- Mac mini, Apple M2 Pro, 32 GB unified memory, macOS 26.5.2;
+- mflux 0.19.1, MLX 0.32.2, low-power mode off, no recorded thermal warning;
+- otherwise-idle host, with its resident QSP service stopped for the A/B;
+- identical prompt, seed 1001, 1024×1024 output, and four inference steps;
+- one warm-up followed by five measured requests per checkpoint.
+
+| Weight path | Warm-up | Measured requests | Median |
+|---|---:|---:|---:|
+| Pinned pre-quantized q4 alias | 52.431 / 52.085 s | 54.643 / 60.425 / 51.882 / 52.463 / 52.703 s | 52.703 s |
+| Pinned packaged bf16 alias | 43.287 / 44.036 s | 46.065 / 41.820 / 40.538 / 42.805 / 40.844 s | 41.820 s |
+
+The packaged bf16 path reduced median end-to-end wall time by 20.6%, or 1.26×
+throughput. Every repeat within a precision produced the same PNG SHA-256;
+q4 and bf16 intentionally produced different bytes because the denoising
+weights differ. Visual inspection found both outputs coherent and faithful to
+the paper-crane prompt. A direct-engine companion run measured peak process RSS
+at approximately 4.57 GB for q4 and 12.49 GB for bf16. Raw timing JSON remains
+on the mini under `~/qsp-node/image_weight_dogfood_{exact_q4,exact_bf16}.json`.
+
+The bf16 run used the exact pinned snapshot below. Before generation,
+`mflux_missing_weights()` returned `[]`, proving all indexed component shards
+were locally present. The QSP LaunchAgent was restored after the run and its
+health endpoint passed.
+
 Rapid-MLX therefore exposes an opt-in path while preserving existing behavior:
 
 ```bash
@@ -29,7 +58,8 @@ loads it through `model_path`, and passes `quantize=None`. The q4 alias and all
 other models are unchanged. A range-read of the pinned snapshot's first
 transformer shard found 69 tensors, all declared `BF16`, and no `.scales` or
 `.biases` quantization auxiliaries. Automatic chip selection is deliberately
-deferred until M1/M2 family coverage and peak-working-set measurements exist.
+deferred until broader M1/M2 family coverage exists; the one measured M2 Pro
+working set is not enough to define a safe hardware policy.
 
 ## Reproduction checklist
 

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -22,6 +22,22 @@ Memory-efficient caching for production / shared system prompts:
 rapid-mlx serve qwen3.5-9b-4bit --port 8000 --use-paged-cache
 ```
 
+### FLUX.2 Klein full-precision weights
+
+On a Mac with at least 32 GB unified memory, explicitly select the bf16 image
+checkpoint with either spelling below. The existing `flux2-klein-4b` alias
+remains q4 and no hardware-based switch happens automatically.
+
+```bash
+rapid-mlx serve flux2-klein-4b --image-weight-precision bf16
+# Equivalent:
+rapid-mlx serve flux2-klein-4b-bf16
+```
+
+Use `--image-weight-precision q4` to force the compact checkpoint. The option
+currently rejects Z-Image, DiffusionGemma, and other diffusion families because
+their q4/bf16 end-to-end paths have not completed the same qualification.
+
 ## Server Options
 
 The most consequential `rapid-mlx serve` flags. The exhaustive list — every
@@ -47,6 +63,7 @@ flag visible in `rapid-mlx serve --help`, grouped by category — lives in the
 | `--completion-batch-size` | Completion batch size | 32 |
 | `--prefill-step-size` | Chunk size for prompt prefill processing | 2048 |
 | `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit (0.0-1.0); advanced override of the automatic per-model budget | auto |
+| `--image-weight-precision` | Explicit FLUX.2 Klein weight source (`q4` or `bf16`); no automatic hardware switch | alias default |
 | `--kv-cache-dtype` | KV cache dtype (`bf16`, `int8`, `int4`); int8/int4 shrink the KV cache 2x/4x at a long-context decode cost. See the [CLI reference](../reference/cli.md#kv-cache-dtype-and-quantization) for the full quantization family (`--kv-cache-quantization*`, `--kv-cache-turboquant*`). | bf16 |
 | `--enable-prefix-cache` / `--disable-prefix-cache` | Toggle prefix caching for repeated prompts | enabled |
 | `--prefix-cache-index` | Prefix-cache lookup index: `radix` (token trie) or `hash` (legacy) | radix |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -141,6 +141,7 @@ are the argparse defaults from `vllm_mlx/cli.py`.
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--force-disk-check` | Proceed even when the pre-flight disk-space check fails — the check still runs and prints its numbers, but a shortfall becomes a warning instead of an abort (the download will likely fail mid-way) | off |
+| `--image-weight-precision` | Explicit FLUX.2 Klein weight source: `q4` selects the compact default checkpoint; `bf16` selects the full-precision checkpoint measured faster on an M2 Pro large-matrix image workload. Other diffusion families are rejected until qualified. | None (alias default) |
 | `--disk-stream` | Stream MoE routed-expert weights from disk instead of holding them resident (opt-in; only architectures registered in `vllm_mlx.registry`) | off |
 | `--disk-stream-cache-gb` | Byte budget (GB) for the disk-stream expert LRU cache; only used with `--disk-stream` | 1.0 |
 | `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB; loading another model evicts the least-recently-used idle unpinned model first. 0 disables. | 0 (disabled) |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -70,6 +70,7 @@ needed by the application; leave it unset for URL/base64-only deployments.
 | `--completion-batch-size` | Completion batch size | `32` |
 | `--prefill-step-size` | Chunk size for prompt prefill processing | `2048` |
 | `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit (0.0-1.0); advanced override of the automatic per-model budget | `auto` |
+| `--image-weight-precision` | Explicit FLUX.2 Klein weight source (`q4` or `bf16`); bf16 requires a 32 GB Mac and is not selected automatically | alias default |
 
 ### Cache Options
 

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -1,10 +1,12 @@
 """Contracts for the explicit FLUX.2 Klein q4/bf16 selector (#3058)."""
 
 import sys
+from types import SimpleNamespace
 
 import pytest
 
 from vllm_mlx import model_sizes
+from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
 from vllm_mlx.cli import build_parser
 from vllm_mlx.image.engine import ImageGenerationEngine
 from vllm_mlx.image.precision import (
@@ -68,9 +70,12 @@ def test_real_cli_selects_bf16_before_download_and_load(monkeypatch):
         captured["model_name"] = model_name
         captured["alias"] = server._model_alias
 
+    def _ensure_model_downloaded(model_name, **_kwargs):
+        captured.setdefault("download_models", []).append(model_name)
+
     monkeypatch.setattr(server, "load_model", _load_model)
     monkeypatch.setattr(cli, "_run_uvicorn", lambda *_a, **_kw: None)
-    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", _ensure_model_downloaded)
     monkeypatch.setattr(cli, "_port_preflight_or_die", lambda *_a, **_kw: None)
     monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
     monkeypatch.setattr(cli, "_check_memory_capacity", lambda *_a, **_kw: None)
@@ -102,6 +107,7 @@ def test_real_cli_selects_bf16_before_download_and_load(monkeypatch):
     assert captured == {
         "model_name": FLUX2_KLEIN_BF16_REPO,
         "alias": FLUX2_KLEIN_BF16_ALIAS,
+        "download_models": [FLUX2_KLEIN_BF16_REPO],
     }
 
 
@@ -133,3 +139,47 @@ def test_bf16_residency_charge_does_not_fall_through_to_q4():
     assert estimate_model_bytes(FLUX2_KLEIN_BF16_ALIAS) == 18 * gib
     assert estimate_model_bytes(FLUX2_KLEIN_BF16_REPO) == 18 * gib
     assert estimate_model_bytes(FLUX2_KLEIN_Q4_ALIAS) < 18 * gib
+
+
+def test_cold_prefetch_keeps_pinned_bf16_revision_through_every_layer(monkeypatch):
+    """Do not download moving main and then the pinned 16 GB snapshot again."""
+
+    from vllm_mlx import cli
+
+    revision = IMAGE_MODEL_REVISIONS[FLUX2_KLEIN_BF16_REPO]
+    observed = {}
+
+    monkeypatch.setattr(cli.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(cli, "_cache_runnability", lambda _model: False)
+    monkeypatch.setattr(cli, "_offline_hub_mode_active", lambda: False)
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
+
+    def _mirror(model_name, **kwargs):
+        observed["mirror"] = (model_name, kwargs.get("revision"))
+        return False
+
+    def _model_info(model_name, **kwargs):
+        observed["metadata"] = (model_name, kwargs.get("revision"))
+        return SimpleNamespace(sha=revision, siblings=[])
+
+    def _snapshot_download(model_name, **kwargs):
+        observed["download"] = (model_name, kwargs.get("revision"))
+        return "/cache/snapshot"
+
+    monkeypatch.setattr(cli, "_try_mirror_prefetch", _mirror)
+    monkeypatch.setattr("huggingface_hub.model_info", _model_info)
+    monkeypatch.setattr("huggingface_hub.snapshot_download", _snapshot_download)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.pin_main_ref",
+        lambda model_name, pinned: observed.setdefault("ref", (model_name, pinned)),
+    )
+
+    cli._ensure_model_downloaded(FLUX2_KLEIN_BF16_REPO)
+
+    expected = (FLUX2_KLEIN_BF16_REPO, revision)
+    assert observed == {
+        "mirror": expected,
+        "metadata": expected,
+        "download": expected,
+        "ref": expected,
+    }

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -1,0 +1,135 @@
+"""Contracts for the explicit FLUX.2 Klein q4/bf16 selector (#3058)."""
+
+import sys
+
+import pytest
+
+from vllm_mlx import model_sizes
+from vllm_mlx.cli import build_parser
+from vllm_mlx.image.engine import ImageGenerationEngine
+from vllm_mlx.image.precision import (
+    FLUX2_KLEIN_BF16_ALIAS,
+    FLUX2_KLEIN_BF16_REPO,
+    FLUX2_KLEIN_Q4_ALIAS,
+    resolve_image_weight_precision,
+)
+from vllm_mlx.model_aliases import resolve_model, resolve_profile
+from vllm_mlx.runtime.resident_models import estimate_model_bytes
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        FLUX2_KLEIN_Q4_ALIAS,
+        "Runpod/FLUX.2-klein-4B-mflux-4bit",
+        FLUX2_KLEIN_BF16_ALIAS,
+        FLUX2_KLEIN_BF16_REPO,
+        "black-forest-labs/FLUX.2-klein-4B",
+    ],
+)
+def test_explicit_precision_selects_curated_klein_alias(source):
+    assert resolve_image_weight_precision(source, "q4") == FLUX2_KLEIN_Q4_ALIAS
+    assert resolve_image_weight_precision(source, "bf16") == FLUX2_KLEIN_BF16_ALIAS
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "z-image-turbo",
+        "filipstrand/Z-Image-Turbo-mflux-4bit",
+        "diffusion-gemma-26b-4bit",
+        "mlx-community/diffusiongemma-26B-A4B-it-4bit",
+    ],
+)
+def test_explicit_precision_rejects_unqualified_diffusion_families(source):
+    with pytest.raises(ValueError, match="FLUX.2 Klein only"):
+        resolve_image_weight_precision(source, "bf16")
+
+
+def test_cli_precision_is_explicit_and_defaults_to_no_override():
+    parser = build_parser()
+    default = parser.parse_args(["serve", FLUX2_KLEIN_Q4_ALIAS])
+    bf16 = parser.parse_args(
+        ["serve", FLUX2_KLEIN_Q4_ALIAS, "--image-weight-precision", "bf16"]
+    )
+
+    assert default.image_weight_precision is None
+    assert bf16.image_weight_precision == "bf16"
+
+
+def test_real_cli_selects_bf16_before_download_and_load(monkeypatch):
+    """Drive main far enough to prove the flag changes the actual source."""
+
+    from vllm_mlx import cli, server
+
+    captured = {}
+
+    def _load_model(model_name, **kwargs):
+        captured["model_name"] = model_name
+        captured["alias"] = server._model_alias
+
+    monkeypatch.setattr(server, "load_model", _load_model)
+    monkeypatch.setattr(cli, "_run_uvicorn", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_port_preflight_or_die", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli, "_resolve_audio_model_for_serve", lambda _n: None)
+    monkeypatch.setattr(
+        "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._version_check.print_staleness_warning_if_any",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rapid-mlx",
+            "serve",
+            FLUX2_KLEIN_Q4_ALIAS,
+            "--image-weight-precision",
+            "bf16",
+            "--port",
+            "0",
+        ],
+    )
+
+    cli.main()
+
+    assert captured == {
+        "model_name": FLUX2_KLEIN_BF16_REPO,
+        "alias": FLUX2_KLEIN_BF16_ALIAS,
+    }
+
+
+def test_bf16_alias_is_image_generation_and_32gb_gated():
+    profile = resolve_profile(FLUX2_KLEIN_BF16_ALIAS)
+    assert profile is not None
+    assert profile.modality == "image-gen"
+    assert profile.min_memory_gb == 32
+    assert resolve_model(FLUX2_KLEIN_BF16_ALIAS) == FLUX2_KLEIN_BF16_REPO
+    assert model_sizes.size_bytes(FLUX2_KLEIN_BF16_REPO) == 15_975_684_703
+
+
+def test_packaged_bf16_uses_model_path_without_onload_quantization(monkeypatch):
+    engine = ImageGenerationEngine(FLUX2_KLEIN_BF16_REPO)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot",
+        lambda repo: "/cache/snapshots/bf16",
+    )
+
+    assert engine.family == "flux2-klein"
+    assert engine._prequantized is False
+    assert engine._packaged_checkpoint is True
+    assert engine._quantize is None
+    assert engine._model_path_for_mflux() == "/cache/snapshots/bf16"
+
+
+def test_bf16_residency_charge_does_not_fall_through_to_q4():
+    gib = 1024**3
+    assert estimate_model_bytes(FLUX2_KLEIN_BF16_ALIAS) == 18 * gib
+    assert estimate_model_bytes(FLUX2_KLEIN_BF16_REPO) == 18 * gib
+    assert estimate_model_bytes(FLUX2_KLEIN_Q4_ALIAS) < 18 * gib

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -131,9 +131,20 @@ def test_bf16_alias_is_image_generation_and_32gb_gated():
 
 def test_packaged_bf16_uses_model_path_without_onload_quantization(monkeypatch):
     engine = ImageGenerationEngine(FLUX2_KLEIN_BF16_REPO)
+    constructor_kwargs = {}
+    built_model = object()
+
+    def _build_flux2_klein(**kwargs):
+        constructor_kwargs.update(kwargs)
+        return built_model
+
     monkeypatch.setattr(
         "vllm_mlx._download_gate.mflux_local_snapshot",
         lambda repo: "/cache/snapshots/bf16",
+    )
+    monkeypatch.setattr(
+        "mflux.models.flux2.variants.txt2img.flux2_klein.Flux2Klein",
+        _build_flux2_klein,
     )
 
     assert engine.family == "flux2-klein"
@@ -141,6 +152,9 @@ def test_packaged_bf16_uses_model_path_without_onload_quantization(monkeypatch):
     assert engine._packaged_checkpoint is True
     assert engine._quantize is None
     assert engine._model_path_for_mflux() == "/cache/snapshots/bf16"
+    assert engine._build_model() is built_model
+    assert constructor_kwargs["model_path"] == "/cache/snapshots/bf16"
+    assert constructor_kwargs["quantize"] is None
 
 
 def test_bf16_residency_charge_does_not_fall_through_to_q4():
@@ -175,7 +189,10 @@ def test_cold_prefetch_keeps_pinned_bf16_revision_through_every_layer(monkeypatc
         observed["download"] = (model_name, kwargs.get("revision"))
         return "/cache/snapshot"
 
-    monkeypatch.setattr(cli, "_try_mirror_prefetch", _mirror)
+    monkeypatch.setattr(
+        "vllm_mlx._mirror.download_with_mirror_fallback",
+        _mirror,
+    )
     monkeypatch.setattr("huggingface_hub.model_info", _model_info)
     monkeypatch.setattr("huggingface_hub.snapshot_download", _snapshot_download)
     monkeypatch.setattr(

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -74,6 +74,15 @@ def test_real_cli_selects_bf16_before_download_and_load(monkeypatch):
         captured.setdefault("download_models", []).append(model_name)
 
     monkeypatch.setattr(server, "load_model", _load_model)
+    # ``serve_command`` normally installs middleware on the process-global
+    # Starlette app. That is outside this ordering contract and makes the test
+    # depend on whether another full-suite test has already started the app.
+    monkeypatch.setattr(server, "configure_cors_from_env", lambda _origins: [])
+    monkeypatch.setattr(server, "configure_trusted_hosts", lambda _hosts: None)
+    monkeypatch.setattr(
+        "vllm_mlx.middleware.request_logging.install_request_logging_middleware",
+        lambda _app: None,
+    )
     monkeypatch.setattr(cli, "_run_uvicorn", lambda *_a, **_kw: None)
     monkeypatch.setattr(cli, "_ensure_model_downloaded", _ensure_model_downloaded)
     monkeypatch.setattr(cli, "_port_preflight_or_die", lambda *_a, **_kw: None)

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -59,6 +59,7 @@ def test_cli_precision_is_explicit_and_defaults_to_no_override():
     assert bf16.image_weight_precision == "bf16"
 
 
+@pytest.mark.requires_mlx
 def test_real_cli_selects_bf16_before_download_and_load(monkeypatch):
     """Drive main far enough to prove the flag changes the actual source."""
 
@@ -148,6 +149,7 @@ def test_bf16_repo_directly_triggers_32gb_admission_warning(monkeypatch, capsys)
     assert "32 GB unified-memory floor" in warning
 
 
+@pytest.mark.requires_mlx
 def test_packaged_bf16_uses_model_path_without_onload_quantization(monkeypatch):
     engine = ImageGenerationEngine(FLUX2_KLEIN_BF16_REPO)
     constructor_kwargs = {}

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -232,18 +232,40 @@ def test_cold_prefetch_keeps_pinned_bf16_revision_through_every_layer(monkeypatc
     }
 
 
-def test_pinned_image_cache_does_not_accept_complete_moving_main(monkeypatch):
+def test_pinned_image_cache_does_not_accept_complete_moving_main(monkeypatch, tmp_path):
     """A cached main snapshot cannot hide a missing pinned image revision."""
 
+    import json
+
+    import huggingface_hub.constants
+
+    from vllm_mlx import _download_gate as download_gate
     from vllm_mlx import cli
 
-    monkeypatch.setattr(
-        "vllm_mlx._download_gate.is_repo_cached",
-        lambda _repo: True,
-    )
-    monkeypatch.setattr(
-        "vllm_mlx._download_gate._snapshot_is_complete_mflux_model",
-        lambda _repo: False,
-    )
+    main_revision = "b" * 40
+    assert main_revision != IMAGE_MODEL_REVISIONS[FLUX2_KLEIN_BF16_REPO]
+    repo_root = tmp_path / f"models--{FLUX2_KLEIN_BF16_REPO.replace('/', '--')}"
+    main_snapshot = repo_root / "snapshots" / main_revision
+    main_snapshot.mkdir(parents=True)
+    (main_snapshot / "model.safetensors").write_bytes(b"complete main weights")
+    tokenizer = main_snapshot / "tokenizer"
+    tokenizer.mkdir()
+    (tokenizer / "tokenizer.json").write_text("{}")
+    for component in ("transformer", "text_encoder", "vae"):
+        component_dir = main_snapshot / component
+        component_dir.mkdir()
+        shard = "model-00001-of-00001.safetensors"
+        (component_dir / shard).write_bytes(b"complete component weights")
+        (component_dir / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {"tensor": shard}})
+        )
+    refs = repo_root / "refs"
+    refs.mkdir()
+    (refs / "main").write_text(main_revision)
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
 
+    assert download_gate.is_repo_cached(FLUX2_KLEIN_BF16_REPO) is True
+    assert (
+        download_gate._snapshot_is_complete_mflux_model(FLUX2_KLEIN_BF16_REPO) is False
+    )
     assert cli._cache_runnability(FLUX2_KLEIN_BF16_REPO) is False

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -209,3 +209,20 @@ def test_cold_prefetch_keeps_pinned_bf16_revision_through_every_layer(monkeypatc
         "download": expected,
         "ref": expected,
     }
+
+
+def test_pinned_image_cache_does_not_accept_complete_moving_main(monkeypatch):
+    """A cached main snapshot cannot hide a missing pinned image revision."""
+
+    from vllm_mlx import cli
+
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.is_repo_cached",
+        lambda _repo: True,
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate._snapshot_is_complete_mflux_model",
+        lambda _repo: False,
+    )
+
+    assert cli._cache_runnability(FLUX2_KLEIN_BF16_REPO) is False

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -48,6 +48,16 @@ def test_explicit_precision_rejects_unqualified_diffusion_families(source):
         resolve_image_weight_precision(source, "bf16")
 
 
+def test_explicit_precision_rejects_unknown_precision():
+    with pytest.raises(ValueError, match="must be one of: q4, bf16"):
+        resolve_image_weight_precision(FLUX2_KLEIN_Q4_ALIAS, "fp8")
+
+
+def test_explicit_precision_rejects_local_checkpoint(tmp_path):
+    with pytest.raises(ValueError, match="not local checkpoints"):
+        resolve_image_weight_precision(str(tmp_path), "bf16")
+
+
 def test_cli_precision_is_explicit_and_defaults_to_no_override():
     parser = build_parser()
     default = parser.parse_args(["serve", FLUX2_KLEIN_Q4_ALIAS])
@@ -59,44 +69,18 @@ def test_cli_precision_is_explicit_and_defaults_to_no_override():
     assert bf16.image_weight_precision == "bf16"
 
 
-@pytest.mark.requires_mlx
-def test_real_cli_selects_bf16_before_download_and_load(monkeypatch):
-    """Drive main far enough to prove the flag changes the actual source."""
+def test_real_cli_selects_bf16_before_serve_dispatch(monkeypatch):
+    """Drive main through selection and alias resolution without MLX imports."""
 
-    from vllm_mlx import cli, server
+    from vllm_mlx import cli
 
     captured = {}
 
-    def _load_model(model_name, **kwargs):
-        captured["model_name"] = model_name
-        captured["alias"] = server._model_alias
+    def _serve_command(args):
+        captured["model_name"] = args.model
+        captured["alias"] = args._original_alias
 
-    def _ensure_model_downloaded(model_name, **_kwargs):
-        captured.setdefault("download_models", []).append(model_name)
-
-    monkeypatch.setattr(server, "load_model", _load_model)
-    # ``serve_command`` normally installs middleware on the process-global
-    # Starlette app. That is outside this ordering contract and makes the test
-    # depend on whether another full-suite test has already started the app.
-    monkeypatch.setattr(server, "configure_cors_from_env", lambda _origins: [])
-    monkeypatch.setattr(server, "configure_trusted_hosts", lambda _hosts: None)
-    monkeypatch.setattr(
-        "vllm_mlx.middleware.request_logging.install_request_logging_middleware",
-        lambda _app: None,
-    )
-    monkeypatch.setattr(cli, "_run_uvicorn", lambda *_a, **_kw: None)
-    monkeypatch.setattr(cli, "_ensure_model_downloaded", _ensure_model_downloaded)
-    monkeypatch.setattr(cli, "_port_preflight_or_die", lambda *_a, **_kw: None)
-    monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
-    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *_a, **_kw: None)
-    monkeypatch.setattr(cli, "_resolve_audio_model_for_serve", lambda _n: None)
-    monkeypatch.setattr(
-        "vllm_mlx._version_check.prompt_upgrade_if_available", lambda: False
-    )
-    monkeypatch.setattr(
-        "vllm_mlx._version_check.print_staleness_warning_if_any",
-        lambda **_kwargs: None,
-    )
+    monkeypatch.setattr(cli, "serve_command", _serve_command)
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
     monkeypatch.setattr(
         sys,
@@ -117,8 +101,29 @@ def test_real_cli_selects_bf16_before_download_and_load(monkeypatch):
     assert captured == {
         "model_name": FLUX2_KLEIN_BF16_REPO,
         "alias": FLUX2_KLEIN_BF16_ALIAS,
-        "download_models": [FLUX2_KLEIN_BF16_REPO],
     }
+
+
+def test_real_cli_reports_unsupported_precision_family(monkeypatch, capsys):
+    from vllm_mlx import cli
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rapid-mlx",
+            "serve",
+            "z-image-turbo",
+            "--image-weight-precision",
+            "bf16",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 2
+    assert "FLUX.2 Klein only" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -120,13 +120,32 @@ def test_real_cli_selects_bf16_before_download_and_load(monkeypatch):
     }
 
 
-def test_bf16_alias_is_image_generation_and_32gb_gated():
-    profile = resolve_profile(FLUX2_KLEIN_BF16_ALIAS)
+@pytest.mark.parametrize(
+    "model_name",
+    [FLUX2_KLEIN_BF16_ALIAS, FLUX2_KLEIN_BF16_REPO],
+)
+def test_bf16_alias_and_repo_are_image_generation_and_32gb_gated(model_name):
+    profile = resolve_profile(model_name)
     assert profile is not None
     assert profile.modality == "image-gen"
     assert profile.min_memory_gb == 32
     assert resolve_model(FLUX2_KLEIN_BF16_ALIAS) == FLUX2_KLEIN_BF16_REPO
     assert model_sizes.size_bytes(FLUX2_KLEIN_BF16_REPO) == 15_975_684_703
+
+
+def test_bf16_repo_directly_triggers_32gb_admission_warning(monkeypatch, capsys):
+    from vllm_mlx import cli
+
+    monkeypatch.setattr(
+        "psutil.virtual_memory",
+        lambda: SimpleNamespace(total=24 * 1024**3),
+    )
+
+    cli._check_alias_min_memory(FLUX2_KLEIN_BF16_REPO)
+
+    warning = capsys.readouterr().out
+    assert FLUX2_KLEIN_BF16_REPO in warning
+    assert "32 GB unified-memory floor" in warning
 
 
 def test_packaged_bf16_uses_model_path_without_onload_quantization(monkeypatch):

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -58,6 +58,14 @@ def test_explicit_precision_rejects_local_checkpoint(tmp_path):
         resolve_image_weight_precision(str(tmp_path), "bf16")
 
 
+def test_explicit_precision_preserves_local_path_precedence(monkeypatch, tmp_path):
+    (tmp_path / FLUX2_KLEIN_Q4_ALIAS).mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="not local checkpoints"):
+        resolve_image_weight_precision(FLUX2_KLEIN_Q4_ALIAS, "bf16")
+
+
 def test_cli_precision_is_explicit_and_defaults_to_no_override():
     parser = build_parser()
     default = parser.parse_args(["serve", FLUX2_KLEIN_Q4_ALIAS])

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1433,6 +1433,7 @@ IMAGE_MODEL_DATA_FILES: dict[str, tuple[str, ...]] = {
 IMAGE_MODEL_REVISIONS: dict[str, str] = {
     "Runpod/FLUX.2-klein-4B-mflux-4bit": "7ee1b3aa8178a1240050490072196a57da2bf2a9",
     "mflux-community/flux-1-schnell-mflux-q4": "bcdbe817ad51175959b2e691e64eca626db30558",
+    "mflux-community/flux2-klein-4b-mflux-bf16": "4d8e1bae8eb47c7766705de2cda7dabd6cc4ba67",
     "mflux-community/qwen-image-mflux-q6": "c628fe4392d963557c3013c2709e6d3b67bca79d",
     HIDREAM_O1_REPO: HIDREAM_O1_REVISION,
     SDXL_REPO: SDXL_REVISION,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1984,6 +1984,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 12
   },
+  "flux2-klein-4b-bf16": {
+    "hf_path": "mflux-community/flux2-klein-4b-mflux-bf16",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 32
+  },
   "flux-schnell": {
     "hf_path": "mflux-community/flux-1-schnell-mflux-q4",
     "modality": "image-gen",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1360,7 +1360,8 @@ def _check_alias_min_memory(user_typed: str) -> None:
     can still opt in. Silent no-op when:
       - The alias has no ``min_memory_gb`` metadata (every model we
         ship under 100 GB weights).
-      - The user typed an HF path directly instead of an alias.
+      - The model has no built-in alias profile (direct HF paths that match a
+        built-in profile inherit its floor through reverse-path resolution).
       - psutil is unavailable / raises.
     """
     try:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1715,6 +1715,7 @@ def _try_mirror_prefetch(
     *,
     allow_patterns: list[str] | None = None,
     out: dict | None = None,
+    revision: str | None = None,
 ) -> bool:
     """Pre-fetch a HuggingFace repo via R2-first / HF-fallback (per file).
 
@@ -1762,6 +1763,7 @@ def _try_mirror_prefetch(
         on_pull_start=on_pull_start,
         allow_patterns=allow_patterns,
         out=out,
+        revision=revision,
     )
 
 
@@ -1884,6 +1886,14 @@ def _ensure_model_downloaded(
     if _offline_hub_mode_active() and cachedness is False:
         _refuse_offline_uncached(model_name)
 
+    # Registered image checkpoints are immutable execution contracts. Carry
+    # their exact revision through every cold-prefetch layer; otherwise the
+    # generic prefetch downloads moving ``main`` and the image engine then
+    # downloads the pinned commit a second time when those revisions differ.
+    from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
+
+    pinned_image_revision = IMAGE_MODEL_REVISIONS.get(model_name)
+
     # Disk-space gate + mirror pull. Both the disk probe (HF ``model_info``)
     # and the mirror's own metadata + ``/api/models`` catalog round-trips run
     # BEFORE the first "Pulling"/"First-time download" line — up to a few
@@ -1908,7 +1918,11 @@ def _ensure_model_downloaded(
         # serves every file the repo declares, populate the HF cache layout
         # ourselves and skip snapshot_download. On any miss we fall through
         # to the normal HuggingFace download below.
-        mirror_ok = _try_mirror_prefetch(model_name, on_pull_start=spinner.stop)
+        mirror_ok = _try_mirror_prefetch(
+            model_name,
+            on_pull_start=spinner.stop,
+            revision=pinned_image_revision,
+        )
     if mirror_ok:
         return
 
@@ -1944,11 +1958,14 @@ def _ensure_model_downloaded(
         size_gb = 0.0
         resolved_sha: str | None = None
         try:
+            metadata_kwargs = {"files_metadata": True}
+            if pinned_image_revision is not None:
+                metadata_kwargs["revision"] = pinned_image_revision
             info = call_with_deadline(
                 model_info,
                 _HF_RESOLVE_TIMEOUT_SECONDS,
                 model_name,
-                files_metadata=True,
+                **metadata_kwargs,
             )
             resolved_sha = getattr(info, "sha", None)
             if not resolved_sha:
@@ -2001,15 +2018,16 @@ def _ensure_model_downloaded(
                 f"fetching {model_name} from HuggingFace ..."
             )
 
-        download_kwargs = {"revision": resolved_sha} if resolved_sha else {}
+        download_revision = pinned_image_revision or resolved_sha
+        download_kwargs = {"revision": download_revision} if download_revision else {}
         if allow_patterns:
             snapshot_download(
                 model_name, allow_patterns=allow_patterns, **download_kwargs
             )
         else:
             snapshot_download(model_name, **download_kwargs)
-        if resolved_sha:
-            pin_main_ref(model_name, resolved_sha)
+        if download_revision:
+            pin_main_ref(model_name, download_revision)
         print()
     except SystemExit:
         # _check_disk_space aborts via sys.exit(1) — let it through.

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1846,6 +1846,13 @@ def _ensure_model_downloaded(
     """
     if os.path.exists(model_name):
         return
+    # Registered image checkpoints are immutable execution contracts. Resolve
+    # the contract before probing cachedness: ``_cache_runnability`` treats a
+    # pinned image repo specially and must not let a complete moving ``main``
+    # snapshot hide a missing pinned snapshot.
+    from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
+
+    pinned_image_revision = IMAGE_MODEL_REVISIONS.get(model_name)
     # Reuse the cache inventory's single runnability probe core
     # (``_cache_runnability``, the same source ``models --cached`` uses) so
     # what counts as "already cached" is identical everywhere and spans every
@@ -1885,14 +1892,6 @@ def _ensure_model_downloaded(
     # TimeoutError / disk-space exits: refuse before server initialization.
     if _offline_hub_mode_active() and cachedness is False:
         _refuse_offline_uncached(model_name)
-
-    # Registered image checkpoints are immutable execution contracts. Carry
-    # their exact revision through every cold-prefetch layer; otherwise the
-    # generic prefetch downloads moving ``main`` and the image engine then
-    # downloads the pinned commit a second time when those revisions differ.
-    from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS
-
-    pinned_image_revision = IMAGE_MODEL_REVISIONS.get(model_name)
 
     # Disk-space gate + mirror pull. Both the disk probe (HF ``model_info``)
     # and the mirror's own metadata + ``/api/models`` catalog round-trips run
@@ -6196,6 +6195,7 @@ def _cache_runnability(repo: str) -> bool | None:
     """
     try:
         from vllm_mlx._download_gate import (
+            IMAGE_MODEL_REVISIONS,
             _snapshot_is_complete_audio_model,
             _snapshot_is_complete_mflux_model,
             _snapshot_is_complete_split_model,
@@ -6225,6 +6225,13 @@ def _cache_runnability(repo: str) -> bool | None:
             # matches a lone ``model.safetensors``) must NOT mark an incomplete
             # Wan snapshot runnable. Complete -> runnable; incomplete -> not.
             return _snapshot_is_complete_wan_model(repo)
+        if repo in IMAGE_MODEL_REVISIONS:
+            # A generic complete ``refs/main`` is not interchangeable with a
+            # registered image checkpoint's pinned commit. The mflux probe
+            # resolves ``snapshots/<pinned revision>`` directly and validates
+            # all component indexes/shards there, so only that exact snapshot
+            # can suppress the foreground download.
+            return _snapshot_is_complete_mflux_model(repo)
         return (
             is_repo_cached(repo)
             or _snapshot_is_complete_split_model(repo)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -10703,6 +10703,17 @@ Examples:
             "on a different filesystem (e.g. external drive via HF_HOME)."
         ),
     )
+    serve_parser.add_argument(
+        "--image-weight-precision",
+        choices=("q4", "bf16"),
+        default=None,
+        help=(
+            "Explicit FLUX.2 Klein weight precision. q4 keeps the compact "
+            "default checkpoint; bf16 selects the full-precision checkpoint "
+            "measured faster on an M2 Pro large-matrix image workload. "
+            "Currently limited to FLUX.2 Klein; no automatic hardware switch."
+        ),
+    )
     # Disk-streaming MoE weight loading (PRD-rapid-mlx-integration.md).
     # Strictly opt-in: default behavior for every existing invocation is
     # unchanged. When set, the model loads lazily (routed-expert weights
@@ -12969,6 +12980,23 @@ def main():
         # (CI / pipe): no notice (it is TTY-only); ``main()`` sets the starter
         # and falls through to the same gate a bare ``rapid-mlx chat`` always
         # used, so scripted callers are unchanged (no new exit-1 path).
+
+    # An explicit image precision selects a concrete curated alias BEFORE the
+    # ordinary alias/download gates run. That ordering makes the 15.98 GB bf16
+    # download visible to the existing confirmation and disk-space checks; a
+    # late engine-only switch would silently gate the 4.6 GB q4 source and then
+    # download a much larger checkpoint on first generation.
+    _image_weight_precision = getattr(args, "image_weight_precision", None)
+    if _image_weight_precision is not None:
+        from vllm_mlx.image.precision import resolve_image_weight_precision
+
+        try:
+            args.model = resolve_image_weight_precision(
+                getattr(args, "model", ""), _image_weight_precision
+            )
+        except ValueError as exc:
+            print(f"\n  Error: {exc}", file=sys.stderr)
+            raise SystemExit(2) from None
 
     # Resolve model aliases before dispatch.
     #

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1958,7 +1958,7 @@ def _ensure_model_downloaded(
         size_gb = 0.0
         resolved_sha: str | None = None
         try:
-            metadata_kwargs = {"files_metadata": True}
+            metadata_kwargs: dict[str, object] = {"files_metadata": True}
             if pinned_image_revision is not None:
                 metadata_kwargs["revision"] = pinned_image_revision
             info = call_with_deadline(

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -195,19 +195,6 @@ def _looks_like_prequantized(model_name: str) -> bool:
     return bool(_QUANT_TAG_RE.search(model_name or ""))
 
 
-def _looks_like_packaged_checkpoint(model_name: str) -> bool:
-    """Whether mflux should load this repository through ``model_path``.
-
-    Quantized community repositories and the curated Klein bf16 repository
-    already use mflux's component layout. The latter is not quantized, but it
-    must follow the same ``model_path`` + ``quantize=None`` load contract;
-    otherwise ModelConfig ignores the requested repository and downloads BFL's
-    canonical source instead.
-    """
-
-    return _looks_like_prequantized(model_name) or is_packaged_bf16_model(model_name)
-
-
 class ImageGenerationEngine:
     """Adapter over a single mflux model family.
 

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -47,6 +47,8 @@ import threading
 import time
 from pathlib import Path
 
+from .precision import is_packaged_bf16_model
+
 # A pre-quantized mflux repo carries a quant tag in its id — either the
 # ``<n>bit`` / ``<n>-bit`` convention (``FLUX.1-schnell-mflux-4bit``) or the
 # ``q<n>`` convention (``Qwen-Image-Edit-mflux-q4``). Anchored to a separator
@@ -193,6 +195,19 @@ def _looks_like_prequantized(model_name: str) -> bool:
     return bool(_QUANT_TAG_RE.search(model_name or ""))
 
 
+def _looks_like_packaged_checkpoint(model_name: str) -> bool:
+    """Whether mflux should load this repository through ``model_path``.
+
+    Quantized community repositories and the curated Klein bf16 repository
+    already use mflux's component layout. The latter is not quantized, but it
+    must follow the same ``model_path`` + ``quantize=None`` load contract;
+    otherwise ModelConfig ignores the requested repository and downloads BFL's
+    canonical source instead.
+    """
+
+    return _looks_like_prequantized(model_name) or is_packaged_bf16_model(model_name)
+
+
 class ImageGenerationEngine:
     """Adapter over a single mflux model family.
 
@@ -221,11 +236,15 @@ class ImageGenerationEngine:
             "bonsai-image",
             "sd35-large",
         } or _looks_like_prequantized(model_name)
-        # ``None`` when a backend owns its local checkpoint conversion, or when
-        # the repo is already quantized. Passing a width for pre-quantized
-        # mflux weights would re-quantize and fail; SDXL quantizes its UNet
-        # inside the vendored loader instead.
-        self._quantize = None if self._prequantized else quantize
+        # Native backends, pre-quantized mflux repos, and the curated Klein BF16
+        # repo all own a packaged local checkpoint that must be handed through
+        # ``model_path``. BF16 remains distinct from ``_prequantized`` so the
+        # runtime state describes the weights truthfully while still disabling
+        # on-load quantization.
+        self._packaged_checkpoint = self._prequantized or is_packaged_bf16_model(
+            model_name
+        )
+        self._quantize = None if self._packaged_checkpoint else quantize
         self._model = None
         self._prompt_tokenizer = None
         # FLUX.2 uses distinct mflux classes for generation and editing. Only
@@ -263,7 +282,7 @@ class ImageGenerationEngine:
     def _model_path_for_mflux(self) -> str | None:
         """``model_path`` to hand mflux: a local directory whenever we have one.
 
-        A pre-quantized repo / local dir is handed to mflux verbatim; a canonical
+        A packaged mflux repo / local dir is handed to mflux verbatim; a canonical
         repo is selected through ``ModelConfig`` instead (``None``) so mflux
         downloads the official weights and quantizes on load.
 
@@ -278,7 +297,7 @@ class ImageGenerationEngine:
         ourselves at the exact verified commit rather than let mflux resolve
         and download whatever ``main`` currently points to.
         """
-        if not self._prequantized:
+        if not self._packaged_checkpoint:
             return None
         from .._download_gate import (
             IMAGE_MODEL_DATA_FILES,

--- a/vllm_mlx/image/precision.py
+++ b/vllm_mlx/image/precision.py
@@ -37,6 +37,9 @@ def resolve_image_weight_precision(model_name: str, precision: str) -> str:
             "image weight precision must be one of: "
             f"{', '.join(IMAGE_WEIGHT_PRECISIONS)}"
         )
+    # Match ``resolve_model``'s repository-wide local-path precedence. A
+    # same-named directory is user-owned checkpoint input, not permission to
+    # discard it and silently select a remote curated checkpoint instead.
     if not model_name or Path(model_name).expanduser().is_dir():
         raise ValueError(
             "--image-weight-precision currently supports the curated "

--- a/vllm_mlx/image/precision.py
+++ b/vllm_mlx/image/precision.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit weight-source selection for the measured FLUX.2 Klein path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+FLUX2_KLEIN_Q4_ALIAS = "flux2-klein-4b"
+FLUX2_KLEIN_BF16_ALIAS = "flux2-klein-4b-bf16"
+FLUX2_KLEIN_Q4_REPO = "Runpod/FLUX.2-klein-4B-mflux-4bit"
+FLUX2_KLEIN_BF16_REPO = "mflux-community/flux2-klein-4b-mflux-bf16"
+
+IMAGE_WEIGHT_PRECISIONS = ("q4", "bf16")
+
+_FLUX2_KLEIN_SOURCES = frozenset(
+    {
+        FLUX2_KLEIN_Q4_ALIAS.casefold(),
+        FLUX2_KLEIN_BF16_ALIAS.casefold(),
+        FLUX2_KLEIN_Q4_REPO.casefold(),
+        FLUX2_KLEIN_BF16_REPO.casefold(),
+        "black-forest-labs/flux.2-klein-4b",
+    }
+)
+
+
+def resolve_image_weight_precision(model_name: str, precision: str) -> str:
+    """Return the curated alias for an explicit image precision request.
+
+    Only FLUX.2 Klein has an end-to-end q4/bf16 qualification today (#3058).
+    Refusing other families prevents a seemingly generic flag from silently
+    selecting an unmeasured checkpoint or changing a user-owned local model.
+    """
+
+    normalized_precision = (precision or "").casefold()
+    if normalized_precision not in IMAGE_WEIGHT_PRECISIONS:
+        raise ValueError(
+            "image weight precision must be one of: "
+            f"{', '.join(IMAGE_WEIGHT_PRECISIONS)}"
+        )
+    if not model_name or Path(model_name).expanduser().is_dir():
+        raise ValueError(
+            "--image-weight-precision currently supports the curated "
+            "FLUX.2 Klein model only, not local checkpoints"
+        )
+    if model_name.casefold() not in _FLUX2_KLEIN_SOURCES:
+        raise ValueError(
+            "--image-weight-precision currently supports FLUX.2 Klein only "
+            "(use flux2-klein-4b); Z-Image and other diffusion families have "
+            "not completed the q4/bf16 qualification"
+        )
+    return (
+        FLUX2_KLEIN_BF16_ALIAS
+        if normalized_precision == "bf16"
+        else FLUX2_KLEIN_Q4_ALIAS
+    )
+
+
+def is_packaged_bf16_model(model_name: str) -> bool:
+    """Whether *model_name* is an mflux-layout bf16 checkpoint."""
+
+    return model_name.casefold() == FLUX2_KLEIN_BF16_REPO.casefold()

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -34,6 +34,7 @@
     "lmstudio-community/gpt-oss-safeguard-20b-MLX-MXFP4": 11150438234,
     "lucasnewman/f5-tts-mlx": 4043696283,
     "mflux-community/flux-1-schnell-mflux-q4": 9613040056,
+    "mflux-community/flux2-klein-4b-mflux-bf16": 15975684703,
     "mflux-community/qwen-image-mflux-q6": 31013313085,
     "mlx-community/HiDream-O1-Image-Dev-mlx-bf16": 17649873024,
     "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx": 8844791792,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -539,6 +539,13 @@ def estimate_model_bytes(model_name: str) -> int:
 
     folded = model_name.casefold()
     known_image_gib = {
+        # Conservative admission charge for the 15.98 GB mflux-layout bf16
+        # payload plus generation activations. The alias itself requires a
+        # 32 GB Mac; this fallback prevents a dynamic load from inheriting the
+        # q4 checkpoint's measured 5.9 GiB charge merely because both names
+        # contain "flux2-klein-4b".
+        "flux2-klein-4b-mflux-bf16": 18.0,
+        "flux2-klein-4b-bf16": 18.0,
         "flux2-klein-4b": 5.9,
         # Published 3.62 GiB fixed payload (2-bit transformer, 4-bit text
         # encoder, FP16 VAE). Keep 7 GiB of admission room for 1024²


### PR DESCRIPTION
## Why

Addresses #3058. On a 32 GB M2 Pro, FLUX.2 Klein's bf16 execution is materially faster than q4 for the 1024×1024 four-step workload, while the existing public alias cannot select that path.

## Scope

- Add an explicit `--image-weight-precision {q4,bf16}` selector for FLUX.2 Klein.
- Add a pinned `flux2-klein-4b-bf16` image-generation alias.
- Load the packaged bf16 checkpoint through `model_path` with `quantize=None`.
- Account for its download size, 32 GB admission floor, cache completeness, resident-memory estimate, and immutable cold-prefetch revision.
- Document reproducible M2 Pro dogfood and the DiffusionGemma precision audit.

## Non-goals

- No automatic chip- or memory-based precision switch.
- No default-alias change: `flux2-klein-4b` remains q4.
- No precision policy change for Z-Image, DiffusionGemma, or other diffusion families.
- No separately qualified FLUX.2 image-edit performance claim.

## Acceptance

- `rapid-mlx serve flux2-klein-4b --image-weight-precision bf16` resolves before download gating to the pinned packaged bf16 checkpoint.
- The default Klein alias and all other model families retain their existing behavior.
- Packaged bf16 loads without on-load quantization and with a verified-complete local snapshot when cached.
- A cold pull uses the registered revision at every prefetch layer and cannot accept or download moving `main` before the pinned snapshot.
- Unsupported/local checkpoint uses fail clearly rather than silently changing weights.

## Verification

- M2 Pro / 32 GB exact-package endpoint dogfood, two process-isolated warm-ups plus five measured requests per precision, 1024×1024, four steps, seed 1001:
  - q4 median 52.703 s; nearest-rank p95 60.425 s
  - bf16 median 41.820 s; nearest-rank p95 46.065 s
  - 1.26× throughput; 20.6% median wall-time reduction
  - byte-identical repeats within each precision; both outputs visually coherent
  - direct-engine peak process RSS: about 4.57 GB q4 / 12.49 GB bf16
- Final rebased-head `python -m scripts.pr_validate 3065 --skip-steps codex_review,stress_e2e_bench,full_unit --fail-fast -v`: **MERGE-SAFE**; Ruff clean; patch coverage 100% (44/44 changed production lines).
- Earlier full stress A/B classified an independent DiffusionGemma routing failure that has since landed on `main`; the rebased cross-family compatibility suites pass without changing DiffusionGemma precision policy.
- Focused suites exercised image routing, real mflux construction, alias admission, cold prefetch, mirror behavior, and Linux no-MLX selection. Multiple negative mutations proved the packaged-bf16 and pinned-cache regressions fail when their production branches are removed.
- GitHub exact-head Apple Silicon, engine contracts, type check, MLX dependency guard, lint, Desktop build/tests, and PR validation checks pass; Linux matrix status is left to the live check rollup.
- Review converged through repeated author-owned, scope-locked adversarial rounds plus local `pr_validate`; one attempted packaged-checkpoint refactor was rejected when native HiDream and SDXL cold-start tests exposed the regression.

## Behaviour delta

Before: Klein always resolves to the q4 checkpoint through the public alias. After: the default remains q4, while an explicit flag or bf16 alias selects the pinned full-precision package.

## AI assistance disclosure

Codex authored and reviewed the implementation, tests, documentation, benchmark harness commands, and DiffusionGemma audit. The result was verified with focused regression suites, exact-checkpoint M2 Pro endpoint dogfood, deterministic output hashes, visual inspection, repeated adversarial review/fix rounds, negative test mutations, exact-head full-unit validation, and A/B classification of unrelated failures.

## Checklist

- [x] Focused and full local suites pass; final exact-head `pr_validate` is MERGE-SAFE
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Critical packaged-checkpoint and pinned-cache production branches were mutation-tested
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API

## Author



