### PR TITLE
feat(image): add HiDream O1 Dev to Server and Desktop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,7 @@ jobs:
             tests/test_glm5_next_forget_gate_quant.py \
             tests/test_glm5_next_runtime_patch.py \
             tests/test_mllm_hybrid_probe.py \
+            tests/test_hidream_o1_alias.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/NOTICE
+++ b/NOTICE
@@ -51,6 +51,13 @@ repository. Each keeps its upstream license text alongside the code.
   MIT License — Copyright (c) 2026 Stability AI.
   See vllm_mlx/audio/sa3/LICENSE and vllm_mlx/audio/sa3/NOTICE.
 
+* vllm_mlx/image/hidream_runtime/
+  HiDream-O1-Image-Dev MLX text-to-image runtime adapted from
+  mlx-community/HiDream-O1-Image-Dev-mlx-bf16 at commit
+  33c7a00bce8e3410304f83ec408a15a1eb6782df.
+  MIT License — Copyright (c) 2026 mrbizarro and contributors.
+  See vllm_mlx/image/hidream_runtime/LICENSE and NOTICE.
+
 * apps/rapid-mac/Vendor/SwiftMath/
   Vendored from https://github.com/mgriebling/SwiftMath at 1.7.3
   (fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7) with a resource-resolution patch.

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -203,6 +203,7 @@ final class ImageGenViewModel {
         // per-family default, so the bar isn't scaled for a 4-step turbo run
         // that is actually a 20-step one.
         if alias.localizedCaseInsensitiveContains("qwen-image") { return 20 }
+        if alias.localizedCaseInsensitiveContains("hidream-o1") { return 28 }
         return alias.localizedCaseInsensitiveContains("z-image") ? 8 : 4
     }
 

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -19,6 +19,11 @@ credits"** link opens.
   design. The required in-product attribution appears in Settings → Privacy.
   https://github.com/youssofal/mtplx
 
+* **HiDream-O1 MLX runtime** — mrbizarro and contributors — MIT License
+  Rapid adapts the pinned text-to-image path for the local Images backend.
+  Its license and provenance notice ship inside the Python sidecar package.
+  https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16
+
 **Scope.** Components this project declares directly: the Swift packages
 in `Package.swift` (plus the transitive ones actually linked into the
 binary), the engine requirements in the monorepo's root `pyproject.toml`,

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -23,22 +23,24 @@ struct ImageCatalogTests {
       ────────────────────────────
       ltx-2.3-mlx-q4        24.0 GiB   [video:gen] notapalindrome/ltx23-mlx-av-q4
 
-      Image models (2 aliases)
+      Image models (3 aliases)
       ────────────────────────────
       Alias                 Size       Kind        HF id
       ────────────────────────────
       flux2-klein-4b        4.3 GiB    [image:both] Runpod/FLUX.2-klein-4B-mflux-4bit
       z-image-turbo         5.5 GiB    [image:gen] filipstrand/Z-Image-Turbo-mflux-4bit
+      hidream-o1-dev       16.4 GiB    [image:gen] mlx-community/HiDream-O1-Image-Dev-mlx-bf16
     """
 
     @Test("parseImageRows extracts image rows and their operation")
     func parsesImageRows() {
         let rows = ModelCatalog.parseImageRows(Self.sample)
-        #expect(rows.count == 2)
+        #expect(rows.count == 3)
 
         let aliases = rows.map(\.alias)
         #expect(aliases.contains("flux2-klein-4b"))
         #expect(aliases.contains("z-image-turbo"))
+        #expect(aliases.contains("hidream-o1-dev"))
         // No chat / video alias leaks in.
         #expect(!aliases.contains("qwen3.6-27b-4bit"))
         #expect(!aliases.contains("ltx-2.3-mlx-q4"))
@@ -47,6 +49,9 @@ struct ImageCatalogTests {
         #expect(klein?.hfRepo == "Runpod/FLUX.2-klein-4B-mflux-4bit")
         #expect(klein?.size == "4.3 GiB")
         #expect(klein?.capability == .generationAndEditing)
+        let hidream = rows.first { $0.alias == "hidream-o1-dev" }
+        #expect(hidream?.hfRepo == "mlx-community/HiDream-O1-Image-Dev-mlx-bf16")
+        #expect(hidream?.capability == .generation)
     }
 
     @Test("complete mflux caches are marked downloaded in Images")
@@ -57,6 +62,7 @@ struct ImageCatalogTests {
             cachedRepos: [
                 "Runpod/FLUX.2-klein-4B-mflux-4bit",
                 "filipstrand/Z-Image-Turbo-mflux-4bit",
+                "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
             ]
         )
 
@@ -64,6 +70,7 @@ struct ImageCatalogTests {
         #expect(klein?.cached == true)
         #expect(klein?.imageCapability == .generationAndEditing)
         #expect(cached.first { $0.alias == "z-image-turbo" }?.cached == true)
+        #expect(cached.first { $0.alias == "hidream-o1-dev" }?.cached == true)
     }
 
     @Test("Image capability rows are excluded from the chat catalog")
@@ -81,5 +88,6 @@ struct ImageCatalogTests {
         let excluded = ModelCatalog.parseExcludedAliases(Self.sample)
         #expect(excluded.contains("flux2-klein-4b"))
         #expect(excluded.contains("z-image-turbo"))
+        #expect(excluded.contains("hidream-o1-dev"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -102,5 +102,6 @@ struct ImageGenerationPhaseTests {
         #expect(ImageGenViewModel.seedSteps(for: "qwen-image-edit") == 20)
         #expect(ImageGenViewModel.seedSteps(for: "z-image-turbo") == 8)
         #expect(ImageGenViewModel.seedSteps(for: "flux2-klein-4b") == 4)
+        #expect(ImageGenViewModel.seedSteps(for: "hidream-o1-dev") == 28)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -80,6 +80,8 @@ struct SidecarBuildScriptTests {
             #expect(script.contains(architecture),
                     "Every Desktop-advertised vision architecture needs a bundled import smoke.")
         }
+        #expect(script.contains("from vllm_mlx.image.hidream_runtime import HiDreamO1"),
+                "The bundled sidecar must include the HiDream image adapter, not only mlx-vlm.")
         #expect(script.contains(#"find_spec("cv2") is None"#))
         #expect(script.contains(#"find_spec("torch") is None"#))
         #expect(script.contains(#"find_spec("torchvision") is None"#),

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -1195,10 +1195,11 @@ from mlx_vlm.models import (
     diffusion_gemma, gemma3, gemma3n, gemma4, gemma4_unified,
     qwen3_5, qwen3_5_moe, qwen3_vl, qwen3_vl_moe,
 )
+from vllm_mlx.image.hidream_runtime import HiDreamO1
 assert importlib.util.find_spec("cv2") is None
 assert importlib.util.find_spec("torch") is None
 assert importlib.util.find_spec("torchvision") is None
-print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma architectures OK")' 2>&1)" || {
+print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma/HiDream architectures OK")' 2>&1)" || {
         echo "ERR: bundled mlx_vlm desktop architecture smoke failed:" >&2
         echo "$VLM_OUT" >&2
         echo "ERR: usually means a new mlx-vlm release added an eager top-level import" >&2

--- a/docs/engineering/performance/2026-09-04-hidream-o1-dev-dogfood.md
+++ b/docs/engineering/performance/2026-09-04-hidream-o1-dev-dogfood.md
@@ -1,0 +1,49 @@
+# HiDream-O1 Dev server dogfood
+
+## Result
+
+The `hidream-o1-dev` alias completed a real OpenAI-compatible image-generation
+request at 1024×1024. The API returned HTTP 200 in 38.73 seconds and produced a
+valid 1,015,295-byte PNG. Visual inspection found a coherent subject, lighting,
+glass material, and composition with no regular grid artifact.
+
+The complete server process peaked at 18,716,459,008 bytes (17.43 GiB) RSS.
+Rapid therefore budgets 18.0 GiB resident memory and keeps the Desktop launch
+warning at 32 GiB total system memory.
+
+A final warm-cache regression run after the pinned-download and prompt-bound
+hardening returned HTTP 200 in 29.46 seconds. It produced a valid 1,063,526-byte
+1024×1024 RGB PNG; visual inspection again found a coherent composition with no
+grid artifact.
+
+## Environment
+
+- Mac Studio (Mac15,14), Apple M3 Ultra, 28 CPU cores, 256 GB unified memory
+- macOS 26.5.2 (25F84)
+- Rapid-MLX source branch `raullenchai/vector-hidream-o1-dev`
+- Model `mlx-community/HiDream-O1-Image-Dev-mlx-bf16`
+- Pinned revision `33c7a00bce8e3410304f83ec408a15a1eb6782df`
+
+## Reproduction
+
+Start the server and capture whole-process resource usage:
+
+```bash
+RAPID_MLX_AUTO_PULL=1 /usr/bin/time -l \
+  uv run rapid-mlx serve hidream-o1-dev --host 127.0.0.1 --port 8019
+```
+
+In another terminal, submit the measured request:
+
+```bash
+curl --fail-with-body --max-time 900 -sS \
+  -o /tmp/hidream-response.json \
+  -w 'http=%{http_code} total=%{time_total}\n' \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"hidream-o1-dev","prompt":"A cinematic product photograph of a translucent glass cheetah sculpture on a black pedestal, warm rim light, crisp reflections, dark studio background","size":"1024x1024","n":1,"steps":28,"seed":42}' \
+  http://127.0.0.1:8019/v1/images/generations
+```
+
+The request timing includes the first lazy model load. The server-process wall
+time (253.07 seconds) additionally includes the initial 17.6 GB snapshot pull
+and time spent waiting before shutdown, so it is not an inference latency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -525,9 +525,12 @@ image = [
     # coexist with the coherence-validated core runtime. Keep a minor cap so
     # image-lane API changes remain deliberate. mflux requires Python >=3.11
     # (Rapid-MLX core still supports 3.10, so the image lane preflight gives
-    # 3.10 users an explicit upgrade diagnostic). Only Apache-2.0 model
-    # families are wired.
+    # 3.10 users an explicit upgrade diagnostic). Only commercially
+    # permissive model families are wired.
     "mflux>=0.19.0,<0.20; platform_system == 'Darwin' and python_version >= '3.11'",
+    # HiDream-O1 reuses the exact Qwen3-VL runtime already validated and
+    # bundled by Desktop. Keep this pin coherent with [vision]/the sidecar.
+    "mlx-vlm==0.6.17; platform_system == 'Darwin' and python_version >= '3.11'",
 ]
 
 [project.urls]
@@ -573,6 +576,10 @@ vllm_mlx = [
     "audio/sa3/LICENSE",
     "audio/sa3/NOTICE",
     "audio/sa3/README.md",
+    # Vendored HiDream-O1 MLX adapter attribution must ship in wheels and the
+    # Desktop sidecar alongside the redistributed MIT source.
+    "image/hidream_runtime/LICENSE",
+    "image/hidream_runtime/NOTICE",
 ]
 videox_fun_mlx = ["LICENSE", "NOTICE"]
 
@@ -652,6 +659,9 @@ ignore = [
 # Keep lint quiet on the copy so upstream sync diffs stay clean. The engine
 # entrypoint (vllm_mlx/audio/music.py) is NOT vendored and is linted normally.
 "vllm_mlx/audio/sa3/**/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
+# Adapted from the pinned upstream HiDream-O1 MLX runtime. Keep source-shape
+# lint exceptions local so the Rapid-owned engine integration stays strict.
+"vllm_mlx/image/hidream_runtime/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
 # Tensor-shape parameter names (B, H, N, D) follow ML literature
 # convention; N803 lowercase rule is incompatible.
 "scripts/bench_attention.py" = ["N803"]

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -151,6 +151,14 @@ def test_qwen4_fused_gdn_coverage_runs_on_apple_silicon() -> None:
     assert "tests/test_qwen4_fused_gdn_decode.py" in apple_run
 
 
+def test_hidream_runtime_coverage_runs_on_apple_silicon() -> None:
+    """The MLX-only image runtime must contribute to the coverage union."""
+    _, workflow = _workflow()
+    apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
+
+    assert "tests/test_hidream_o1_alias.py" in apple_run
+
+
 def test_coverage_data_is_commit_bound_and_fail_closed() -> None:
     text, workflow = _workflow()
     jobs = workflow["jobs"]

--- a/tests/test_hidream_o1_alias.py
+++ b/tests/test_hidream_o1_alias.py
@@ -679,8 +679,10 @@ def test_custom_heads_reject_missing_extra_and_shape_mismatch() -> None:
         )
 
 
+@pytest.mark.parametrize("requested", [REPO, "hidream-o1-dev"])
 def test_pull_uses_exact_revision_and_data_allowlist(
     monkeypatch: pytest.MonkeyPatch,
+    requested: str,
 ) -> None:
     from vllm_mlx import cli
 
@@ -691,7 +693,7 @@ def test_pull_uses_exact_revision_and_data_allowlist(
         lambda args, **kwargs: calls.append((args.model, kwargs)),
     )
     monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
-    args = SimpleNamespace(model=REPO)
+    args = SimpleNamespace(model=requested)
 
     cli.pull_command(args)
 

--- a/tests/test_hidream_o1_alias.py
+++ b/tests/test_hidream_o1_alias.py
@@ -475,6 +475,44 @@ def test_prompt_tokenizer_failures_are_clean_runtime_errors(
         engine._validate_hidream_prompt_tokens("fox")
 
 
+def test_cancel_during_prompt_tokenizer_init_never_reaches_model_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformers import AutoTokenizer
+
+    class Tokenizer:
+        boi_token = "<boi>"
+        tms_token = "<tms>"
+
+        def apply_chat_template(self, *_args, **_kwargs):
+            return "caption"
+
+        def encode(self, *_args, **_kwargs):
+            return [1]
+
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _name: None
+    )
+
+    def load_then_cancel(*_args, **_kwargs):
+        engine.request_cancel()
+        return Tokenizer()
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", load_then_cancel)
+    monkeypatch.setattr(
+        engine,
+        "_ensure_loaded",
+        lambda **_kwargs: pytest.fail("cancelled preflight reached the model loader"),
+    )
+
+    from vllm_mlx.image.engine import ImageGenerationCancelled
+
+    with pytest.raises(ImageGenerationCancelled, match="cancelled"):
+        engine.generate(prompt="fox", width=1024, height=1024, num_inference_steps=28)
+    assert engine._active_seq == 0
+
+
 def test_hidream_cold_snapshot_is_pinned_allowlisted_and_verified(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_hidream_o1_alias.py
+++ b/tests/test_hidream_o1_alias.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the HiDream-O1 Dev MLX image backend and product alias."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vllm_mlx import _download_gate
+from vllm_mlx.catalog import build_catalog_bundle
+from vllm_mlx.image.engine import (
+    ImageGenerationEngine,
+    ImageRuntimeError,
+    _detect_family,
+)
+from vllm_mlx.model_aliases import resolve_profile
+from vllm_mlx.model_sizes import size_bytes
+from vllm_mlx.runtime.resident_models import estimate_model_bytes
+
+REPO = "mlx-community/HiDream-O1-Image-Dev-mlx-bf16"
+REVISION = "33c7a00bce8e3410304f83ec408a15a1eb6782df"
+SIZE = 17_649_873_024
+
+
+def test_alias_routes_to_generation_only_image_backend() -> None:
+    profile = resolve_profile("hidream-o1-dev")
+    assert profile is not None
+    assert profile.hf_path == REPO
+    assert profile.modality == "image-gen"
+    assert profile.min_memory_gb == 32
+    engine = ImageGenerationEngine(REPO)
+    assert engine.family == "hidream-o1-dev"
+    assert engine.supports_generation is True
+    assert engine.supports_editing is False
+    assert engine.default_steps == 28
+    assert engine._prequantized is True  # noqa: SLF001
+
+
+def test_alias_pins_download_size_revision_and_resident_budget() -> None:
+    assert _download_gate.IMAGE_MODEL_REVISIONS[REPO] == REVISION
+    assert size_bytes(REPO) == SIZE
+    for name in ("hidream-o1-dev", REPO):
+        assert estimate_model_bytes(name) == int(18.0 * 1024**3)
+
+
+def test_atomic_catalog_names_the_new_backend() -> None:
+    bundle = build_catalog_bundle()
+    record = next(
+        alias
+        for alias in bundle["snapshot"]["aliases"]
+        if alias["alias"] == "hidream-o1-dev"
+    )
+    capabilities = record["capabilities"]
+    assert capabilities["runtime_adapter"] == "rapid_mlx/hidream_o1"
+    assert capabilities["operation_modes"] == ["text_to_image"]
+
+
+@pytest.mark.parametrize(
+    ("name", "family"),
+    [
+        (REPO, "hidream-o1-dev"),
+        ("/models/hidream_o1_dev", "hidream-o1-dev"),
+    ],
+)
+def test_family_detection(name: str, family: str) -> None:
+    assert _detect_family(name) == family
+
+
+def test_patch_round_trip_and_published_schedule() -> None:
+    pytest.importorskip("mlx")
+    from vllm_mlx.image.hidream_runtime.runtime import (
+        DEFAULT_TIMESTEPS,
+        FlashFlowMatchScheduler,
+        _build_sample,
+        _patchify,
+        _unpatchify,
+    )
+
+    image = np.arange(3 * 64 * 96, dtype=np.float32).reshape(3, 64, 96)
+    patches = _patchify(image)
+    assert patches.shape == (6, 3 * 32 * 32)
+    np.testing.assert_array_equal(_unpatchify(patches, 64, 96), image)
+    scheduler = FlashFlowMatchScheduler()
+    assert tuple(int(value) for value in scheduler.timesteps) == DEFAULT_TIMESTEPS
+    assert len(scheduler.sigmas) == 29
+    assert float(scheduler.sigmas[-1]) == 0.0
+
+    class OversizedProcessor:
+        tokenizer = None
+        boi_token = "<boi>"
+        tms_token = "<tms>"
+
+        def __init__(self) -> None:
+            self.tokenizer = self
+
+        def apply_chat_template(self, *_args, **_kwargs) -> str:
+            return "caption"
+
+        def encode(self, *_args, **_kwargs) -> list[int]:
+            return list(range(1025))
+
+    config = SimpleNamespace(
+        image_token_id=1, video_token_id=2, vision_start_token_id=3
+    )
+    with pytest.raises(ValueError, match="1024 tokens"):
+        _build_sample("prompt", 1024, 1024, OversizedProcessor(), config)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"num_inference_steps": 27}, "28-step"),
+        ({"prompt": "x" * 4097}, "4096 characters"),
+        ({"width": 0}, "between 256 and 2048"),
+        ({"height": 4096}, "between 256 and 2048"),
+        ({"width": 1008}, "multiples of 32"),
+        ({"guidance": 4.0}, "omit the guidance"),
+        ({"negative_prompt": "bad"}, "does not support negative_prompt"),
+        ({"image_paths": ["source.png"]}, "text-to-image only"),
+    ],
+)
+def test_unsupported_requests_fail_before_loading(
+    monkeypatch: pytest.MonkeyPatch, kwargs: dict, message: str
+) -> None:
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(
+        engine,
+        "_ensure_loaded",
+        lambda **_kwargs: pytest.fail("invalid request reached the 17 GB loader"),
+    )
+    request = {
+        "prompt": "test",
+        "width": 1024,
+        "height": 1024,
+        "num_inference_steps": 28,
+        "seed": 1,
+        "guidance": None,
+        "negative_prompt": None,
+        "image_paths": None,
+    }
+    request.update(kwargs)
+    with pytest.raises(ImageRuntimeError, match=message):
+        engine.generate(**request)
+
+
+def _seed_snapshot(root: Path, *, omit: str | None = None) -> None:
+    for relative in _download_gate.HIDREAM_O1_DATA_FILES:
+        if relative == omit:
+            continue
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+
+
+@pytest.mark.parametrize(
+    "missing_file",
+    ["extras/custom_heads.safetensors", "generation_config.json"],
+)
+def test_complete_hidream_snapshot_requires_every_runtime_data_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, missing_file: str
+) -> None:
+    import huggingface_hub.constants
+
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+    snapshot = (
+        tmp_path
+        / "models--mlx-community--HiDream-O1-Image-Dev-mlx-bf16"
+        / "snapshots"
+        / REVISION
+    )
+    _seed_snapshot(snapshot)
+    assert _download_gate.mflux_missing_weights(REPO) == []
+    (snapshot / missing_file).unlink()
+    assert _download_gate.mflux_missing_weights(REPO) == [missing_file]
+
+
+def test_custom_heads_reject_missing_extra_and_shape_mismatch() -> None:
+    pytest.importorskip("mlx")
+    from vllm_mlx.image.hidream_runtime.runtime import (
+        _validate_custom_head_weights,
+    )
+
+    expected = {
+        "t_embedder1.fc1.weight": SimpleNamespace(shape=(4, 2)),
+        "x_embedder.proj1.weight": SimpleNamespace(shape=(8, 4)),
+    }
+    with pytest.raises(ValueError, match="missing=.*x_embedder"):
+        _validate_custom_head_weights(
+            expected,
+            {"t_embedder1.fc1.weight": SimpleNamespace(shape=(4, 2))},
+        )
+    with pytest.raises(ValueError, match="unexpected=.*rogue"):
+        _validate_custom_head_weights(
+            expected,
+            {
+                **expected,
+                "rogue.weight": SimpleNamespace(shape=(1,)),
+            },
+        )
+    with pytest.raises(ValueError, match="shape_mismatch=.*t_embedder1"):
+        _validate_custom_head_weights(
+            expected,
+            {
+                **expected,
+                "t_embedder1.fc1.weight": SimpleNamespace(shape=(4, 3)),
+            },
+        )
+
+
+def test_pull_uses_exact_revision_and_data_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx import cli
+
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "_pull_repository",
+        lambda args, **kwargs: calls.append((args.model, kwargs)),
+    )
+    monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
+    args = SimpleNamespace(model=REPO)
+
+    cli.pull_command(args)
+
+    assert calls == [
+        (
+            REPO,
+            {
+                "allow_patterns_override": list(_download_gate.HIDREAM_O1_DATA_FILES),
+                "revision_override": REVISION,
+            },
+        )
+    ]
+
+
+def test_pinned_pull_bypasses_mirror_and_pins_snapshot_download(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The lower-level pull path must enforce, not merely receive, the pin."""
+    from vllm_mlx import cli
+
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "_try_mirror_prefetch",
+        lambda *_args, **_kwargs: pytest.fail("pinned pulls cannot use mutable main"),
+    )
+    monkeypatch.setattr(cli, "_blob_identifier", lambda _root: ())
+    monkeypatch.setattr(cli, "_print_pull_summary", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        _download_gate, "reap_orphan_incomplete_blobs", lambda _repo: (0, 0)
+    )
+
+    def fake_snapshot_download(repo_id: str, **kwargs) -> str:
+        calls.append((repo_id, kwargs))
+        return str(tmp_path)
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", fake_snapshot_download)
+    cli._pull_repository(
+        SimpleNamespace(model=REPO, bits=None, format=None, json=True),
+        allow_patterns_override=list(_download_gate.HIDREAM_O1_DATA_FILES),
+        revision_override=REVISION,
+    )
+
+    assert calls == [
+        (
+            REPO,
+            {
+                "allow_patterns": list(_download_gate.HIDREAM_O1_DATA_FILES),
+                "revision": REVISION,
+            },
+        )
+    ]

--- a/tests/test_hidream_o1_alias.py
+++ b/tests/test_hidream_o1_alias.py
@@ -397,6 +397,7 @@ def test_unsupported_requests_fail_before_loading(
         engine.generate(**request)
 
 
+@pytest.mark.requires_mlx
 def test_token_dense_prompt_fails_before_the_17gb_loader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -446,6 +447,7 @@ def test_token_dense_prompt_fails_before_the_17gb_loader(
     ]
 
 
+@pytest.mark.requires_mlx
 def test_prompt_tokenizer_failures_are_clean_runtime_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -475,6 +477,7 @@ def test_prompt_tokenizer_failures_are_clean_runtime_errors(
         engine._validate_hidream_prompt_tokens("fox")
 
 
+@pytest.mark.requires_mlx
 def test_cancel_during_prompt_tokenizer_init_never_reaches_model_loader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -546,6 +549,7 @@ def test_hidream_cold_snapshot_is_pinned_allowlisted_and_verified(
     assert verified == [True]
 
 
+@pytest.mark.requires_mlx
 def test_hidream_engine_build_progress_cancel_and_generate_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -600,6 +604,7 @@ def test_hidream_engine_build_progress_cancel_and_generate_dispatch(
         missing._build_model()
 
 
+@pytest.mark.requires_mlx
 def test_hidream_sidecar_requires_mlx_vlm_not_mflux(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_hidream_o1_alias.py
+++ b/tests/test_hidream_o1_alias.py
@@ -397,6 +397,84 @@ def test_unsupported_requests_fail_before_loading(
         engine.generate(**request)
 
 
+def test_token_dense_prompt_fails_before_the_17gb_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformers import AutoTokenizer
+
+    class DenseTokenizer:
+        boi_token = None
+        tms_token = None
+
+        def apply_chat_template(self, *_args, **_kwargs):
+            return "caption"
+
+        def encode(self, *_args, **_kwargs):
+            return list(range(1025))
+
+    tokenizer_calls = []
+    monkeypatch.setattr(
+        AutoTokenizer,
+        "from_pretrained",
+        lambda source, **kwargs: (
+            tokenizer_calls.append((source, kwargs)) or DenseTokenizer()
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _name: None
+    )
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(
+        engine,
+        "_ensure_loaded",
+        lambda **_kwargs: pytest.fail("token-dense prompt reached the 17 GB loader"),
+    )
+
+    with pytest.raises(ImageRuntimeError, match="1024 tokens"):
+        engine.generate(
+            prompt="x",
+            width=1024,
+            height=1024,
+            num_inference_steps=28,
+        )
+
+    assert tokenizer_calls == [
+        (
+            REPO,
+            {"trust_remote_code": False, "revision": REVISION},
+        )
+    ]
+
+
+def test_prompt_tokenizer_failures_are_clean_runtime_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from transformers import AutoTokenizer
+
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _name: None
+    )
+    monkeypatch.setattr(
+        AutoTokenizer,
+        "from_pretrained",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("offline")),
+    )
+    with pytest.raises(ImageRuntimeError, match="load.*tokenizer.*offline"):
+        engine._validate_hidream_prompt_tokens("fox")
+
+    class BrokenTokenizer:
+        boi_token = "<boi>"
+        tms_token = "<tms>"
+
+        def apply_chat_template(self, *_args, **_kwargs):
+            raise ValueError("bad template")
+
+    engine._prompt_tokenizer = BrokenTokenizer()
+    with pytest.raises(ImageRuntimeError, match="tokenize.*bad template"):
+        engine._validate_hidream_prompt_tokens("fox")
+
+
 def test_hidream_cold_snapshot_is_pinned_allowlisted_and_verified(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -463,6 +541,7 @@ def test_hidream_engine_build_progress_cancel_and_generate_dispatch(
 
     monkeypatch.setattr(engine, "_is_cancelled", lambda: False)
     monkeypatch.setattr(engine, "_ensure_loaded", lambda **_kwargs: model)
+    monkeypatch.setattr(engine, "_validate_hidream_prompt_tokens", lambda _prompt: None)
     png = engine.generate(
         prompt="fox", width=256, height=256, num_inference_steps=28, seed=11
     )

--- a/tests/test_hidream_o1_alias.py
+++ b/tests/test_hidream_o1_alias.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from PIL import Image
 
 from vllm_mlx import _download_gate
 from vllm_mlx.catalog import build_catalog_bundle
@@ -109,6 +112,254 @@ def test_patch_round_trip_and_published_schedule() -> None:
         _build_sample("prompt", 1024, 1024, OversizedProcessor(), config)
 
 
+def test_hidream_runtime_numeric_helpers_and_masks() -> None:
+    pytest.importorskip("mlx")
+    import mlx.core as mx
+
+    from vllm_mlx.image.hidream_runtime import HiDreamO1
+    from vllm_mlx.image.hidream_runtime.runtime import (
+        BottleneckPatchEmbed,
+        FinalLayer,
+        FlashFlowMatchScheduler,
+        HiDreamConfig,
+        TimestepEmbedder,
+        _attention_mask,
+        _patchify,
+        _rope_positions,
+        _validate_custom_head_weights,
+    )
+
+    assert HiDreamO1.__name__ == "HiDreamO1"
+    assert HiDreamConfig().hidden_size == 4096
+
+    sample = mx.ones((1, 2), dtype=mx.bfloat16)
+    scheduler = FlashFlowMatchScheduler()
+    stepped = scheduler.step(mx.zeros_like(sample), sample, seed=7)
+    mx.eval(stepped)
+    assert stepped.shape == sample.shape
+    assert scheduler.step_index == 1
+
+    assert TimestepEmbedder.embedding(mx.array([0.5]), 4).shape == (1, 4)
+    assert TimestepEmbedder.embedding(mx.array([0.5]), 5).shape == (1, 5)
+    time_embedder = TimestepEmbedder(hidden_size=4, frequency_embedding_size=4)
+    assert time_embedder(mx.array([0.5])).shape == (1, 4)
+
+    patch_embedder = BottleneckPatchEmbed(hidden_size=4)
+    assert patch_embedder(mx.zeros((1, 1, 3 * 32 * 32))).shape == (1, 1, 4)
+    final = FinalLayer(hidden_size=4)
+    assert final(mx.zeros((1, 1, 4))).shape == (1, 1, 3 * 32 * 32)
+
+    expected = {"weight": SimpleNamespace(shape=(2, 3))}
+    _validate_custom_head_weights(expected, dict(expected))
+    with pytest.raises(ValueError, match="missing=.*weight"):
+        _validate_custom_head_weights(expected, {})
+
+    with pytest.raises(ValueError, match="multiples of 32"):
+        _patchify(np.zeros((3, 33, 32), dtype=np.float32))
+
+    plain = _rope_positions(
+        input_ids=np.asarray([[10, 11]], dtype=np.int64),
+        image_grid=np.empty((0, 3), dtype=np.int64),
+        image_token_id=20,
+        video_token_id=21,
+        vision_start_token_id=22,
+    )
+    np.testing.assert_array_equal(plain[:, 0], [[0, 1], [0, 1], [0, 1]])
+
+    image = _rope_positions(
+        input_ids=np.asarray([[10, 22, 20]], dtype=np.int64),
+        image_grid=np.asarray([[1, 1, 2]], dtype=np.int64),
+        image_token_id=20,
+        video_token_id=21,
+        vision_start_token_id=22,
+    )
+    assert image.shape == (3, 1, 3)
+    with pytest.raises(ValueError, match="video tokens"):
+        _rope_positions(
+            input_ids=np.asarray([[22, 21]], dtype=np.int64),
+            image_grid=np.empty((0, 3), dtype=np.int64),
+            image_token_id=20,
+            video_token_id=21,
+            vision_start_token_id=22,
+        )
+
+    mask = _attention_mask(np.asarray([[0, 1, 0], [0, 0, 0]], dtype=np.int64))
+    assert mask.shape == (2, 1, 3, 3)
+    assert np.all(mask[0, 0, 1] == 0)
+    assert mask[1, 0, 0, 1] < 0
+
+
+def test_build_sample_supports_processor_and_tokenizer_shapes() -> None:
+    pytest.importorskip("mlx")
+    from vllm_mlx.image.hidream_runtime.runtime import _build_sample
+
+    class Tokenizer:
+        def encode(self, _caption, *, add_special_tokens):
+            assert add_special_tokens is False
+            return [7, 8]
+
+    class Processor:
+        tokenizer = Tokenizer()
+
+        def apply_chat_template(self, *_args, **_kwargs):
+            return "caption"
+
+    config = SimpleNamespace(
+        image_token_id=20, video_token_id=21, vision_start_token_id=22
+    )
+    processor = Processor()
+    sample = _build_sample("fox", 64, 32, processor, config)
+    assert processor.tokenizer.boi_token == "<|boi_token|>"
+    assert processor.tokenizer.tms_token == "<|tms_token|>"
+    assert sample["input_ids"].shape == (1, 2)
+    assert sample["position_ids"].shape == (3, 1, 4)
+    assert sample["token_types"].shape == (1, 4)
+    assert int(sample["vinput_mask"].sum()) == 2
+
+    class DirectTokenizer(Tokenizer):
+        boi_token = "<boi>"
+        tms_token = "<tms>"
+
+        def apply_chat_template(self, *_args, **_kwargs):
+            return "caption"
+
+    assert _build_sample("fox", 64, 32, DirectTokenizer(), config)[
+        "input_ids"
+    ].shape == (1, 2)
+
+
+def test_hidream_constructor_loads_only_validated_custom_heads(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pytest.importorskip("mlx")
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    from vllm_mlx.image.hidream_runtime import runtime
+
+    class TinyHead(nn.Module):
+        def __init__(self, *_args, **_kwargs):
+            super().__init__()
+            self.weight = mx.zeros((1,))
+
+    class TinyLanguageModel:
+        model = SimpleNamespace(embed_tokens=lambda value: value)
+
+    backbone = SimpleNamespace(
+        config=SimpleNamespace(),
+        vision_tower=object(),
+        language_model=TinyLanguageModel(),
+    )
+    mlx_vlm = types.ModuleType("mlx_vlm")
+    mlx_vlm.load = lambda model_path: (backbone, f"processor:{model_path}")
+    monkeypatch.setitem(sys.modules, "mlx_vlm", mlx_vlm)
+    monkeypatch.setattr(runtime, "TimestepEmbedder", TinyHead)
+    monkeypatch.setattr(runtime, "BottleneckPatchEmbed", TinyHead)
+    monkeypatch.setattr(runtime, "FinalLayer", TinyHead)
+    monkeypatch.setattr(
+        runtime.mx,
+        "load",
+        lambda _path: {
+            "t_embedder1.weight": mx.zeros((1,)),
+            "x_embedder.weight": mx.zeros((1,)),
+            "final_layer2.weight": mx.zeros((1,)),
+        },
+    )
+    loaded = []
+    monkeypatch.setattr(
+        runtime.HiDreamO1,
+        "load_weights",
+        lambda _self, weights, *, strict: loaded.append((weights, strict)),
+    )
+
+    with pytest.raises(FileNotFoundError, match="custom heads"):
+        runtime.HiDreamO1(str(tmp_path))
+
+    custom = tmp_path / "extras" / "custom_heads.safetensors"
+    custom.parent.mkdir()
+    custom.write_bytes(b"weights")
+    model = runtime.HiDreamO1(str(tmp_path), on_step=lambda *_args: None)
+    assert model.processor == f"processor:{tmp_path}"
+    assert model.visual is backbone.vision_tower
+    assert loaded and loaded[0][1] is False
+
+
+def test_hidream_forward_and_tiny_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("mlx")
+    import mlx.core as mx
+
+    from vllm_mlx.image.hidream_runtime import runtime
+
+    class TinyLanguageCore:
+        def embed_tokens(self, input_ids):
+            return mx.zeros((*input_ids.shape, 4), dtype=mx.float32)
+
+        def __call__(self, _ids, *, inputs_embeds, **_kwargs):
+            return inputs_embeds
+
+    core = TinyLanguageCore()
+    forward_self = SimpleNamespace(
+        config=SimpleNamespace(tms_token_id=9),
+        t_embedder1=lambda _value: mx.ones((1, 4)),
+        x_embedder=lambda value: mx.zeros((*value.shape[:2], 4)),
+        language_model=SimpleNamespace(model=core),
+        final_layer2=lambda value: value,
+    )
+    input_ids = mx.array([[9, 2]])
+    embeddings = runtime.HiDreamO1._text_embeddings(forward_self, input_ids)
+    forwarded = runtime.HiDreamO1._forward(
+        forward_self,
+        embeddings,
+        input_ids,
+        mx.zeros((3, 1, 3), dtype=mx.int32),
+        mx.zeros((1, 1, 3 * 32 * 32)),
+        mx.array([0.5]),
+        mx.zeros((1, 1, 3, 3)),
+    )
+    mx.eval(forwarded)
+    assert forwarded.shape == (1, 3, 4)
+
+    monkeypatch.setattr(
+        runtime,
+        "_build_sample",
+        lambda *_args, **_kwargs: {
+            "input_ids": np.asarray([[9]], dtype=np.int64),
+            "position_ids": np.zeros((3, 1, 1), dtype=np.int64),
+            "token_types": np.asarray([[1]], dtype=np.int64),
+            "vinput_mask": np.asarray([[True]]),
+        },
+    )
+    progress = []
+    generate_self = SimpleNamespace(
+        processor=object(),
+        backbone_config=object(),
+        on_step=lambda step, total: progress.append((step, total)),
+        _text_embeddings=lambda ids: mx.zeros((*ids.shape, 4)),
+        _forward=lambda _emb, _ids, _pos, patches, _time, _mask: patches,
+    )
+    result = runtime.HiDreamO1.generate_image(
+        generate_self, seed=3, prompt="fox", height=32, width=32
+    )
+    assert result.image.size == (32, 32)
+    assert result.image.mode == "RGB"
+    assert progress[0] == (0, 28)
+    assert progress[-1] == (28, 28)
+
+    with pytest.raises(ValueError, match="28-step"):
+        runtime.HiDreamO1.generate_image(
+            generate_self,
+            seed=3,
+            prompt="fox",
+            num_inference_steps=27,
+            height=32,
+            width=32,
+        )
+    with pytest.raises(ValueError, match="multiples of 32"):
+        runtime.HiDreamO1.generate_image(
+            generate_self, seed=3, prompt="fox", height=33, width=32
+        )
+
+
 @pytest.mark.parametrize(
     ("kwargs", "message"),
     [
@@ -144,6 +395,107 @@ def test_unsupported_requests_fail_before_loading(
     request.update(kwargs)
     with pytest.raises(ImageRuntimeError, match=message):
         engine.generate(**request)
+
+
+def test_hidream_cold_snapshot_is_pinned_allowlisted_and_verified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import huggingface_hub
+
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _name: None
+    )
+    verified = []
+    monkeypatch.setattr(
+        engine, "_verify_weights_complete", lambda: verified.append(True)
+    )
+    calls = []
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda model, **kwargs: calls.append((model, kwargs)) or "/pinned/snapshot",
+    )
+
+    assert engine._model_path_for_mflux() == "/pinned/snapshot"
+    assert calls == [
+        (
+            REPO,
+            {
+                "revision": REVISION,
+                "allow_patterns": list(_download_gate.HIDREAM_O1_DATA_FILES),
+            },
+        )
+    ]
+    assert verified == [True]
+
+
+def test_hidream_engine_build_progress_cancel_and_generate_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.image import hidream_runtime
+    from vllm_mlx.image.engine import ImageGenerationCancelled
+
+    built = []
+
+    class TinyHiDream:
+        def __init__(self, path, *, on_step):
+            built.append((path, on_step))
+            self.calls = []
+
+        def generate_image(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(image=Image.new("RGB", (8, 8)))
+
+    monkeypatch.setattr(hidream_runtime, "HiDreamO1", TinyHiDream)
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(engine, "_model_path_for_mflux", lambda: "/snapshot")
+    model = engine._build_model()
+    assert built == [("/snapshot", engine._report_hidream_step)]
+
+    engine._report_hidream_step(4, 28)
+    assert engine._progress["running"] is True
+    assert engine._progress["step"] == 4
+    assert engine._progress["total"] == 28
+    monkeypatch.setattr(engine, "_is_cancelled", lambda: True)
+    with pytest.raises(ImageGenerationCancelled, match="cancelled"):
+        engine._report_hidream_step(5, 28)
+
+    monkeypatch.setattr(engine, "_is_cancelled", lambda: False)
+    monkeypatch.setattr(engine, "_ensure_loaded", lambda **_kwargs: model)
+    png = engine.generate(
+        prompt="fox", width=256, height=256, num_inference_steps=28, seed=11
+    )
+    assert png.startswith(b"\x89PNG")
+    assert model.calls == [
+        {
+            "height": 256,
+            "width": 256,
+            "seed": 11,
+            "prompt": "fox",
+            "num_inference_steps": 28,
+        }
+    ]
+
+    missing = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(missing, "_model_path_for_mflux", lambda: None)
+    with pytest.raises(ImageRuntimeError, match="local model snapshot"):
+        missing._build_model()
+
+
+def test_hidream_sidecar_requires_mlx_vlm_not_mflux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.runtime import image_lane
+
+    probes = []
+    monkeypatch.setattr(
+        image_lane.importlib.util,
+        "find_spec",
+        lambda module: probes.append(module) or object(),
+    )
+    image_lane.require_image_runtime_or_exit(REPO)
+    assert probes == ["mlx_vlm"]
 
 
 def _seed_snapshot(root: Path, *, omit: str | None = None) -> None:
@@ -235,6 +587,26 @@ def test_pull_uses_exact_revision_and_data_allowlist(
             },
         )
     ]
+
+
+def test_non_hidream_pull_keeps_the_generic_download_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx import cli
+    from vllm_mlx.audio import registry
+
+    calls = []
+    monkeypatch.setattr(
+        cli, "_pull_repository", lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
+    monkeypatch.setattr(registry, "runtime_assets_for", lambda _repo: ())
+    monkeypatch.setattr(registry, "runtime_requirements_for", lambda _repo: ())
+    args = SimpleNamespace(model="mlx-community/plain-model")
+
+    cli.pull_command(args)
+
+    assert calls == [((args,), {})]
 
 
 def test_pinned_pull_bypasses_mirror_and_pins_snapshot_download(

--- a/tests/test_hidream_o1_alias.py
+++ b/tests/test_hidream_o1_alias.py
@@ -45,7 +45,7 @@ def test_alias_routes_to_generation_only_image_backend() -> None:
 def test_alias_pins_download_size_revision_and_resident_budget() -> None:
     assert _download_gate.IMAGE_MODEL_REVISIONS[REPO] == REVISION
     assert size_bytes(REPO) == SIZE
-    for name in ("hidream-o1-dev", REPO):
+    for name in ("hidream-o1-dev", REPO, "/models/hidream_o1_dev"):
         assert estimate_model_bytes(name) == int(18.0 * 1024**3)
 
 

--- a/tests/test_pull_audio_runtime_assets.py
+++ b/tests/test_pull_audio_runtime_assets.py
@@ -255,7 +255,7 @@ def test_runtime_asset_uses_normal_filtered_download_pipeline(
     expected = ("prince-canuma/Kokoro-82M", ["voices/*.safetensors"])
     assert seen["mirror"] == expected
     assert seen["snapshot"] == expected
-    assert "runtime assets declared by the audio catalog" in capsys.readouterr().out
+    assert "runtime data files declared by Rapid-MLX" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(

--- a/tests/test_serve_image_gen_completeness.py
+++ b/tests/test_serve_image_gen_completeness.py
@@ -55,7 +55,7 @@ def _seed_cache(tmp_path, monkeypatch, *, omit=None):
     )
 
 
-def _drive_serve(monkeypatch):
+def _drive_serve(monkeypatch, *, alias=_ALIAS, download_hook=None):
     """Run ``rapid-mlx serve flux2-klein-4b`` with the heavy boundaries stubbed.
 
     Only ever driven to the point where the gate refuses. Letting a serve run
@@ -68,7 +68,11 @@ def _drive_serve(monkeypatch):
 
     monkeypatch.setattr(server, "load_model", lambda *_a, **_kw: None)
     monkeypatch.setattr(cli, "_run_uvicorn", lambda *_a, **_kw: None)
-    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        cli,
+        "_ensure_model_downloaded",
+        download_hook or (lambda *_a, **_kw: None),
+    )
     monkeypatch.setattr(cli, "_port_preflight_or_die", lambda *_a, **_kw: None)
     monkeypatch.setattr(cli, "_check_disk_space", lambda *_a, **_kw: None)
     monkeypatch.setattr(cli, "_check_memory_capacity", lambda *_a, **_kw: None)
@@ -83,7 +87,7 @@ def _drive_serve(monkeypatch):
         "vllm_mlx._version_check.print_staleness_warning_if_any",
         lambda **_kwargs: None,
     )
-    monkeypatch.setattr(sys, "argv", ["rapid-mlx", "serve", _ALIAS, "--port", "0"])
+    monkeypatch.setattr(sys, "argv", ["rapid-mlx", "serve", alias, "--port", "0"])
     cli.main()
 
 
@@ -125,3 +129,22 @@ def test_serve_refuses_partially_downloaded_image_model(tmp_path, monkeypatch, c
     err = capsys.readouterr().err
     assert _ALIAS in err, "the operator must see which model to re-pull"
     assert "transformer/0.safetensors" in err
+
+
+def test_hidream_skips_unpinned_generic_prefetch(monkeypatch):
+    """Its ImageEngine owns the exact-revision, data-only cold pull."""
+    calls = []
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_missing_weights",
+        lambda _repo: ["extras/custom_heads.safetensors"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _drive_serve(
+            monkeypatch,
+            alias="hidream-o1-dev",
+            download_hook=lambda *args, **kwargs: calls.append((args, kwargs)),
+        )
+
+    assert excinfo.value.code == 1
+    assert calls == []

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1327,9 +1327,26 @@ def _snapshot_is_complete_wan_model(repo_id: str) -> bool:
 #: A repo absent from this map is unpinned and falls through to today's
 #: behavior; one present here is refused unless the resolved snapshot
 #: matches exactly (see the check in ``_mflux_snapshot_dir``).
+HIDREAM_O1_REPO = "mlx-community/HiDream-O1-Image-Dev-mlx-bf16"
+HIDREAM_O1_REVISION = "33c7a00bce8e3410304f83ec408a15a1eb6782df"
+HIDREAM_O1_DATA_FILES = (
+    "model.safetensors",
+    "extras/custom_heads.safetensors",
+    "config.json",
+    "generation_config.json",
+    "chat_template.json",
+    "preprocessor_config.json",
+    "video_preprocessor_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "merges.txt",
+    "vocab.json",
+)
+
 IMAGE_MODEL_REVISIONS: dict[str, str] = {
     "Runpod/FLUX.2-klein-4B-mflux-4bit": "7ee1b3aa8178a1240050490072196a57da2bf2a9",
     "mflux-community/qwen-image-mflux-q6": "c628fe4392d963557c3013c2709e6d3b67bca79d",
+    HIDREAM_O1_REPO: HIDREAM_O1_REVISION,
 }
 
 
@@ -1485,6 +1502,17 @@ def mflux_missing_weights(repo_id: str) -> list[str] | None:
     import json
 
     missing: list[str] = []
+
+    if repo_id == HIDREAM_O1_REPO:
+        # HiDream is a single root MLX checkpoint plus three custom diffusion
+        # heads, not an mflux component tree. Validate every data file reached
+        # by mlx-vlm/the adapter; lab scripts and samples are deliberately not
+        # downloaded or executed.
+        return [
+            relative
+            for relative in HIDREAM_O1_DATA_FILES
+            if not _is_nonempty_repo_file(os.path.join(snap_dir, *relative.split("/")))
+        ]
 
     # All currently supported mflux families use these three components and a
     # local tokenizer. Requiring the full set prevents an interrupted pull with

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1996,6 +1996,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 64
   },
+  "hidream-o1-dev": {
+    "hf_path": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 32
+  },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",
     "tool_call_parser": null,

--- a/vllm_mlx/catalog/legacy.py
+++ b/vllm_mlx/catalog/legacy.py
@@ -33,10 +33,15 @@ def _image_operations(repo_id: str) -> list[str]:
 def _main_capabilities(profile: Any) -> dict[str, Any]:
     modality = getattr(profile, "modality", "text") or "text"
     if modality == "image-gen":
+        adapter = (
+            "rapid_mlx/hidream_o1"
+            if "hidream-o1" in profile.hf_path.casefold()
+            else "mflux"
+        )
         tasks, operations, adapter = (
             ["image_generation"],
             _image_operations(profile.hf_path),
-            "mflux",
+            adapter,
         )
     elif modality == "video-gen":
         tasks = ["video_generation"]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7695,6 +7695,11 @@ def pull_command(args):
 
     import copy
 
+    from vllm_mlx._download_gate import (
+        HIDREAM_O1_DATA_FILES,
+        HIDREAM_O1_REPO,
+        HIDREAM_O1_REVISION,
+    )
     from vllm_mlx.audio.registry import runtime_assets_for, runtime_requirements_for
     from vllm_mlx.audio.runtime_requirements import (
         AudioRuntimePreparationError,
@@ -7702,20 +7707,28 @@ def pull_command(args):
     )
 
     primary_repo = args.model
-    from vllm_mlx._download_gate import (
-        HIDREAM_O1_DATA_FILES,
-        HIDREAM_O1_REPO,
-        HIDREAM_O1_REVISION,
-    )
+    primary_args = args
+    if primary_repo != HIDREAM_O1_REPO:
+        # ``main()`` normally resolves aliases before dispatch, but keep this
+        # security boundary fail-closed for direct/internal pull_command calls.
+        from vllm_mlx.model_aliases import resolve_model
+
+        if resolve_model(primary_repo) == HIDREAM_O1_REPO:
+            primary_args = copy.copy(args)
+            primary_args._original_alias = (
+                getattr(args, "_original_alias", None) or primary_repo
+            )
+            primary_args.model = HIDREAM_O1_REPO
+            primary_repo = HIDREAM_O1_REPO
 
     if primary_repo == HIDREAM_O1_REPO:
         _pull_repository(
-            args,
+            primary_args,
             allow_patterns_override=list(HIDREAM_O1_DATA_FILES),
             revision_override=HIDREAM_O1_REVISION,
         )
     else:
-        _pull_repository(args)
+        _pull_repository(primary_args)
     for asset in runtime_assets_for(primary_repo):
         if asset.repo_id == primary_repo:
             continue

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3184,6 +3184,10 @@ def serve_command(args):
         getattr(args, "_original_alias", None) or getattr(args, "model", "")
     )
     _is_wan_video = False
+    _is_hidream_o1 = bool(
+        _serve_profile is not None
+        and _serve_profile.hf_path == "mlx-community/HiDream-O1-Image-Dev-mlx-bf16"
+    )
     if _serve_profile is not None and _serve_profile.modality == "video-gen":
         from .runtime.video_lane import require_video_runtime_or_exit
         from .video.wan import is_wan_model
@@ -3404,7 +3408,21 @@ def serve_command(args):
     # revision (or uses RAPID_MLX_WAN_MODEL_DIR). The generic prefetch has no
     # revision parameter and could otherwise download repository HEAD first,
     # duplicating tens of gigabytes before the pinned snapshot is loaded.
-    if not _is_wan_video:
+    # HiDream owns a revision-pinned, data-file-only pull in ImageEngine. The
+    # generic prefetch resolves repository HEAD and downloads every file,
+    # including unreviewed scripts and samples, before that guarded path runs.
+    if _is_hidream_o1:
+        # Preserve the normal first-run disk guard even though the generic
+        # downloader is intentionally bypassed. A complete pinned snapshot is
+        # a warm no-op; cold/partial caches are checked before the 17 GB pull
+        # begins inside ImageEngine.
+        from ._download_gate import mflux_missing_weights as _image_missing
+
+        if _image_missing(args.model) != []:
+            _check_disk_space(
+                args.model, force=getattr(args, "force_disk_check", False)
+            )
+    elif not _is_wan_video:
         if getattr(args, "force_disk_check", False):
             _ensure_model_downloaded(args.model, force_disk_check=True)
         else:
@@ -7416,7 +7434,12 @@ def _sync_pulled_variant_marker(repo_id: str, variant: str | None) -> None:
         pass
 
 
-def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
+def _pull_repository(
+    args,
+    *,
+    allow_patterns_override: list[str] | None = None,
+    revision_override: str | None = None,
+):
     """Download one repository through the normal mirror/HF pipeline."""
     import time
 
@@ -7498,7 +7521,9 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
     # R2-first / HuggingFace-fallback per file. Default mirror is
     # ``https://models.rapidmlx.com``; set ``RAPID_MLX_MODEL_MIRROR=""``
     # to force HF only. The function prints its own progress + summary.
-    if _try_mirror_prefetch(repo_id, allow_patterns=variant_allow, out=_mirror_out):
+    if revision_override is None and _try_mirror_prefetch(
+        repo_id, allow_patterns=variant_allow, out=_mirror_out
+    ):
         from pathlib import Path
 
         try:
@@ -7568,7 +7593,7 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
         # catalog subfolder (one checkpoint per quantization).
         if allow_patterns_override is not None:
             _allow = variant_allow
-            print("  Fetching only the runtime assets declared by the audio catalog.")
+            print("  Fetching only the runtime data files declared by Rapid-MLX.")
         elif variant_allow is not None:
             _allow = variant_allow
             # Literal folder name the user asked for (e.g. "4bit"). Derived
@@ -7618,10 +7643,11 @@ def _pull_repository(args, *, allow_patterns_override: list[str] | None = None):
         _mirror_fetched = _mirror_out.get("network_fetch", False)
         _cache_root = _hf_cache_root(repo_id)
         _before = _blob_identifier(_cache_root)
+        download_kwargs = {"revision": revision_override} if revision_override else {}
         path = (
-            snapshot_download(repo_id, allow_patterns=_allow)
+            snapshot_download(repo_id, allow_patterns=_allow, **download_kwargs)
             if _allow
-            else snapshot_download(repo_id)
+            else snapshot_download(repo_id, **download_kwargs)
         )
         _after = _blob_identifier(_cache_root)
         _was_cached = (_before == _after and _before != ()) and not _mirror_fetched
@@ -7676,7 +7702,20 @@ def pull_command(args):
     )
 
     primary_repo = args.model
-    _pull_repository(args)
+    from vllm_mlx._download_gate import (
+        HIDREAM_O1_DATA_FILES,
+        HIDREAM_O1_REPO,
+        HIDREAM_O1_REVISION,
+    )
+
+    if primary_repo == HIDREAM_O1_REPO:
+        _pull_repository(
+            args,
+            allow_patterns_override=list(HIDREAM_O1_DATA_FILES),
+            revision_override=HIDREAM_O1_REVISION,
+        )
+    else:
+        _pull_repository(args)
     for asset in runtime_assets_for(primary_repo):
         if asset.repo_id == primary_repo:
             continue

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -7,8 +7,8 @@ built-in 4/8-bit quantization. Rapid-MLX owns request validation, the lazy
 load / process-lock lifecycle and the OpenAI-compatible transport; mflux owns
 the diffusion pipeline and weight loading.
 
-Only Apache-2.0-licensed families are wired here so the whole surface stays
-commercially clean:
+Only commercially permissive families are wired here so the whole surface
+stays commercially clean:
 
 * ``flux2-klein``      — text→image + image edit (``FLUX.2-klein-4B``),
   4B/4-step, the fast default: ~3 s @ 512² / ~10 s @ 1024² on an M3 Ultra,
@@ -18,6 +18,8 @@ commercially clean:
 * ``flux-schnell``     — text→image (``black-forest-labs/FLUX.1-schnell``), 12B
 * ``qwen-image``       — text→image (``Qwen/Qwen-Image``), strongest text-in-image
 * ``qwen-image-edit``  — instruction edit (``Qwen/Qwen-Image-Edit-2509``)
+* ``hidream-o1-dev``   — text→image (``HiDream-O1-Image-Dev``), 28-step,
+  VAE-free unified pixel transformer (MIT)
 
 ``flux2-klein`` and ``z-image`` supersede the older/larger families for the
 interactive tab: Klein is ~3× faster than schnell/z-image at the same
@@ -107,6 +109,8 @@ class _ProgressReporter:
 def _detect_family(model_name: str) -> str:
     """Map an alias hf_path (or local dir) to a supported mflux family."""
     name = (model_name or "").casefold()
+    if "hidream-o1" in name or "hidream_o1" in name:
+        return "hidream-o1-dev"
     # Klein first — its repos ("FLUX.2-klein-4B-mflux-4bit") also contain
     # "flux", so the distinctive "klein" / "flux2" token must win before the
     # generic FLUX.1 checks below.
@@ -124,14 +128,15 @@ def _detect_family(model_name: str) -> str:
         return "flux-dev"
     raise ImageRuntimeError(
         f"Unsupported image model '{model_name}'. Supported families: "
-        "flux2-klein, z-image, flux-schnell, qwen-image, qwen-image-edit."
+        "flux2-klein, z-image, flux-schnell, qwen-image, qwen-image-edit, "
+        "hidream-o1-dev."
     )
 
 
 # Families whose ``generate_image`` takes NO ``negative_prompt`` parameter.
 # FLUX.2 Klein omits it (Flux1 / Qwen-Image / Z-Image all accept it), and
 # passing an unknown kwarg raises — so the engine drops it for these.
-_NO_NEGATIVE_PROMPT_FAMILIES = frozenset({"flux2-klein"})
+_NO_NEGATIVE_PROMPT_FAMILIES = frozenset({"flux2-klein", "hidream-o1-dev"})
 
 # Per-family default denoise steps when the request pins none. Distilled/turbo
 # models converge in a handful of steps; a non-distilled model needs many more.
@@ -142,6 +147,7 @@ _DEFAULT_STEPS_BY_FAMILY = {
     "flux-dev": 20,  # non-distilled
     "qwen-image": 20,  # non-distilled 20B
     "qwen-image-edit": 20,
+    "hidream-o1-dev": 28,
 }
 
 
@@ -181,7 +187,9 @@ class ImageGenerationEngine:
         self.default_edit_steps = 4 if self.family == "flux2-klein" else 20
         self.default_edit_guidance = None if self.family == "flux2-klein" else 4.0
         self.supports_negative_prompt = self.family not in _NO_NEGATIVE_PROMPT_FAMILIES
-        self._prequantized = _looks_like_prequantized(model_name)
+        self._prequantized = (
+            self.family == "hidream-o1-dev" or _looks_like_prequantized(model_name)
+        )
         # ``None`` when the repo is already quantized — passing a quantize width
         # for a pre-quantized checkpoint makes mflux re-quantize and error.
         self._quantize = None if self._prequantized else quantize
@@ -238,7 +246,11 @@ class ImageGenerationEngine:
         """
         if not self._prequantized:
             return None
-        from .._download_gate import IMAGE_MODEL_REVISIONS, mflux_local_snapshot
+        from .._download_gate import (
+            HIDREAM_O1_DATA_FILES,
+            IMAGE_MODEL_REVISIONS,
+            mflux_local_snapshot,
+        )
 
         snapshot = mflux_local_snapshot(self.model_name)
         if snapshot is not None:
@@ -248,7 +260,14 @@ class ImageGenerationEngine:
             return self.model_name
         from huggingface_hub import snapshot_download
 
-        downloaded = snapshot_download(self.model_name, revision=pinned_revision)
+        kwargs = {}
+        if self.family == "hidream-o1-dev":
+            # The weights repo also contains executable lab scripts and sample
+            # images. The runtime is vendored+reviewed here; fetch only data.
+            kwargs["allow_patterns"] = list(HIDREAM_O1_DATA_FILES)
+        downloaded = snapshot_download(
+            self.model_name, revision=pinned_revision, **kwargs
+        )
         # A pinned cold pull bypasses ``_verify_weights_complete()``'s
         # normal preflight — at the time it ran (in ``_ensure_loaded``,
         # right before this method), there was nothing cached yet to
@@ -261,6 +280,14 @@ class ImageGenerationEngine:
 
     def _build_model(self):
         """Instantiate the backing mflux model (import-lazy)."""
+        if self.family == "hidream-o1-dev":
+            from .hidream_runtime import HiDreamO1
+
+            model_path = self._model_path_for_mflux()
+            if model_path is None:
+                raise ImageRuntimeError("HiDream-O1 requires a local model snapshot.")
+            return HiDreamO1(model_path, on_step=self._report_hidream_step)
+
         from mflux.models.common.config.model_config import ModelConfig
 
         model_path = self._model_path_for_mflux()
@@ -300,6 +327,14 @@ class ImageGenerationEngine:
         return Flux1(
             quantize=self._quantize, model_path=model_path, model_config=config
         )
+
+    def _report_hidream_step(self, step: int, total: int) -> None:
+        """Bridge HiDream's loop into the shared progress/cancel contract."""
+        self._progress["running"] = True
+        self._progress["step"] = int(step)
+        self._progress["total"] = int(total)
+        if self._is_cancelled():
+            raise ImageGenerationCancelled("Generation cancelled.")
 
     def _build_edit_model(self):
         """Instantiate the edit variant for a model that accepts input images."""
@@ -643,6 +678,37 @@ class ImageGenerationEngine:
                 f"{self.family} is text-to-image only and does not accept input images; "
                 "use an image-edit capable model."
             )
+        if self.family == "hidream-o1-dev":
+            if len(prompt) > 4096:
+                raise ImageRuntimeError(
+                    "HiDream-O1 prompts are limited to 4096 characters."
+                )
+            if num_inference_steps != 28:
+                raise ImageRuntimeError(
+                    "HiDream-O1 Dev supports its published 28-step schedule only."
+                )
+            if (
+                width is None
+                or height is None
+                or not (256 <= width <= 2048)
+                or not (256 <= height <= 2048)
+            ):
+                raise ImageRuntimeError(
+                    "HiDream-O1 dimensions must be between 256 and 2048 pixels."
+                )
+            if width % 32 or height % 32:
+                raise ImageRuntimeError(
+                    "HiDream-O1 dimensions must be multiples of 32."
+                )
+            if guidance is not None:
+                raise ImageRuntimeError(
+                    "HiDream-O1 Dev does not expose classifier-free guidance; "
+                    "omit the guidance field."
+                )
+            if negative_prompt is not None:
+                raise ImageRuntimeError(
+                    "HiDream-O1 Dev does not support negative_prompt."
+                )
 
         with self._lock:
             # Claim a run sequence and arm progress BEFORE loading, so a Cancel
@@ -700,13 +766,26 @@ class ImageGenerationEngine:
                         ),
                     )
                 else:
-                    result = model.generate_image(
-                        height=height,
-                        width=width,
-                        **self._gen_kwargs(
-                            seed, prompt, num_inference_steps, guidance, negative_prompt
-                        ),
-                    )
+                    if self.family == "hidream-o1-dev":
+                        result = model.generate_image(
+                            height=height,
+                            width=width,
+                            seed=seed,
+                            prompt=prompt,
+                            num_inference_steps=num_inference_steps,
+                        )
+                    else:
+                        result = model.generate_image(
+                            height=height,
+                            width=width,
+                            **self._gen_kwargs(
+                                seed,
+                                prompt,
+                                num_inference_steps,
+                                guidance,
+                                negative_prompt,
+                            ),
+                        )
             except ImageRuntimeError:
                 raise  # cancellation + already-clean errors pass straight through
             except Exception as exc:  # noqa: BLE001 — surface a clean API error

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -350,7 +350,7 @@ class ImageGenerationEngine:
 
                 local = mflux_local_snapshot(self.model_name)
                 source = local or self.model_name
-                kwargs = {"trust_remote_code": False}
+                kwargs: dict[str, object] = {"trust_remote_code": False}
                 revision = IMAGE_MODEL_REVISIONS.get(self.model_name)
                 if local is None and revision is not None:
                     kwargs["revision"] = revision

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -194,6 +194,7 @@ class ImageGenerationEngine:
         # for a pre-quantized checkpoint makes mflux re-quantize and error.
         self._quantize = None if self._prequantized else quantize
         self._model = None
+        self._prompt_tokenizer = None
         # FLUX.2 uses distinct mflux classes for generation and editing. Only
         # one stays resident at a time so switching modes does not duplicate
         # the checkpoint in unified memory.
@@ -335,6 +336,43 @@ class ImageGenerationEngine:
         self._progress["total"] = int(total)
         if self._is_cancelled():
             raise ImageGenerationCancelled("Generation cancelled.")
+
+    def _validate_hidream_prompt_tokens(self, prompt: str) -> None:
+        """Reject token-dense prompts before constructing the 17 GB model."""
+
+        from .._download_gate import IMAGE_MODEL_REVISIONS, mflux_local_snapshot
+        from .hidream_runtime.runtime import MAX_PROMPT_TOKENS, _encode_prompt_ids
+
+        processor = getattr(self._model, "processor", None)
+        if processor is None:
+            if self._prompt_tokenizer is None:
+                from transformers import AutoTokenizer
+
+                local = mflux_local_snapshot(self.model_name)
+                source = local or self.model_name
+                kwargs = {"trust_remote_code": False}
+                revision = IMAGE_MODEL_REVISIONS.get(self.model_name)
+                if local is None and revision is not None:
+                    kwargs["revision"] = revision
+                try:
+                    self._prompt_tokenizer = AutoTokenizer.from_pretrained(
+                        source, **kwargs
+                    )
+                except Exception as exc:  # noqa: BLE001 — clean API boundary
+                    raise ImageRuntimeError(
+                        f"Could not load the HiDream prompt tokenizer: {exc}"
+                    ) from exc
+            processor = self._prompt_tokenizer
+        try:
+            token_count = int(_encode_prompt_ids(prompt, processor).shape[-1])
+        except Exception as exc:  # noqa: BLE001 — clean API boundary
+            raise ImageRuntimeError(
+                f"Could not tokenize the HiDream prompt: {exc}"
+            ) from exc
+        if token_count > MAX_PROMPT_TOKENS:
+            raise ImageRuntimeError(
+                f"HiDream-O1 prompts are limited to {MAX_PROMPT_TOKENS} tokens."
+            )
 
     def _build_edit_model(self):
         """Instantiate the edit variant for a model that accepts input images."""
@@ -709,6 +747,7 @@ class ImageGenerationEngine:
                 raise ImageRuntimeError(
                     "HiDream-O1 Dev does not support negative_prompt."
                 )
+            self._validate_hidream_prompt_tokens(prompt)
 
         with self._lock:
             # Claim a run sequence and arm progress BEFORE loading, so a Cancel

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -747,7 +747,6 @@ class ImageGenerationEngine:
                 raise ImageRuntimeError(
                     "HiDream-O1 Dev does not support negative_prompt."
                 )
-            self._validate_hidream_prompt_tokens(prompt)
 
         with self._lock:
             # Claim a run sequence and arm progress BEFORE loading, so a Cancel
@@ -767,6 +766,10 @@ class ImageGenerationEngine:
                 started_at=time.time(),
             )
             try:
+                if self.family == "hidream-o1-dev":
+                    self._validate_hidream_prompt_tokens(prompt)
+                    if self._is_cancelled():
+                        raise ImageGenerationCancelled("Generation cancelled.")
                 model = self._ensure_loaded(for_edit=editing)
                 # Honor a cancel that landed during the warm-up load before we
                 # commit to the denoise loop.

--- a/vllm_mlx/image/hidream_runtime/LICENSE
+++ b/vllm_mlx/image/hidream_runtime/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2026 mrbizarro and contributors
+
+This project (hidream-o1-mlx) is an MLX port of HiDream-O1-Image-Dev for Apple
+Silicon. The upstream HiDream-O1-Image source code (https://github.com/HiDream-ai/HiDream-O1-Image)
+and the model weights (https://huggingface.co/HiDream-ai/HiDream-O1-Image-Dev)
+are released under the MIT License by HiDream-ai. This port preserves that
+license.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vllm_mlx/image/hidream_runtime/NOTICE
+++ b/vllm_mlx/image/hidream_runtime/NOTICE
@@ -1,0 +1,10 @@
+HiDream-O1-Image-Dev MLX runtime
+
+Adapted for Rapid-MLX from the text-to-image runtime published in
+mlx-community/HiDream-O1-Image-Dev-mlx-bf16 at commit
+33c7a00bce8e3410304f83ec408a15a1eb6782df.
+
+The Rapid-MLX adaptation removes the standalone CLI, conversion, editing,
+multi-reference, diagnostic, and file-output paths and integrates generation
+with Rapid's image-engine lifecycle, cancellation, progress, and in-memory PNG
+transport. No model weights are redistributed.

--- a/vllm_mlx/image/hidream_runtime/__init__.py
+++ b/vllm_mlx/image/hidream_runtime/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+"""Pinned MLX runtime for HiDream-O1-Image-Dev text-to-image inference."""
+
+from .runtime import HiDreamO1
+
+__all__ = ["HiDreamO1"]

--- a/vllm_mlx/image/hidream_runtime/runtime.py
+++ b/vllm_mlx/image/hidream_runtime/runtime.py
@@ -262,11 +262,13 @@ def _rope_positions(
     return positions
 
 
-def _build_sample(prompt: str, height: int, width: int, processor, config) -> dict:
+def _encode_prompt_ids(prompt: str, processor) -> np.ndarray:
+    """Apply the published chat wrapper and return bounded-model token ids."""
+
     tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
     for name in ("boi", "tms"):
         attribute = f"{name}_token"
-        if not hasattr(tokenizer, attribute):
+        if not getattr(tokenizer, attribute, None):
             setattr(tokenizer, attribute, f"<|{name}_token|>")
     caption = (
         processor.apply_chat_template(
@@ -277,9 +279,13 @@ def _build_sample(prompt: str, height: int, width: int, processor, config) -> di
         + tokenizer.boi_token
         + tokenizer.tms_token * TIMESTEP_TOKEN_NUM
     )
-    input_ids = np.asarray(
+    return np.asarray(
         tokenizer.encode(caption, add_special_tokens=False), dtype=np.int64
     ).reshape(1, -1)
+
+
+def _build_sample(prompt: str, height: int, width: int, processor, config) -> dict:
+    input_ids = _encode_prompt_ids(prompt, processor)
     if input_ids.shape[-1] > MAX_PROMPT_TOKENS:
         raise ValueError(
             f"HiDream-O1 prompts are limited to {MAX_PROMPT_TOKENS} tokens"

--- a/vllm_mlx/image/hidream_runtime/runtime.py
+++ b/vllm_mlx/image/hidream_runtime/runtime.py
@@ -1,0 +1,455 @@
+# SPDX-License-Identifier: MIT
+"""HiDream-O1-Image-Dev inference adapted from the upstream MLX port.
+
+Vendored from ``mlx-community/HiDream-O1-Image-Dev-mlx-bf16`` commit
+``33c7a00bce8e3410304f83ec408a15a1eb6782df``.  Rapid keeps only the
+text-to-image path and wraps it as an in-process backend; the original CLI,
+edit/multi-reference path, diagnostics, and file-output concerns are omitted.
+See the adjacent LICENSE and NOTICE for provenance and terms.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from PIL import Image
+
+PATCH_SIZE = 32
+TIMESTEP_TOKEN_NUM = 1
+NOISE_SCALE = 7.5
+NOISE_CLIP_STD = 2.5
+T_EPS = 0.001
+MAX_PROMPT_TOKENS = 1024
+
+# Dev's published 28-step schedule, from the upstream pipeline.
+DEFAULT_TIMESTEPS = (
+    999,
+    987,
+    974,
+    960,
+    945,
+    929,
+    913,
+    895,
+    877,
+    857,
+    836,
+    814,
+    790,
+    764,
+    737,
+    707,
+    675,
+    640,
+    602,
+    560,
+    515,
+    464,
+    409,
+    347,
+    278,
+    199,
+    110,
+    8,
+)
+
+
+class FlashFlowMatchScheduler:
+    """The Dev flow-matching Euler scheduler, implemented with MLX arrays."""
+
+    def __init__(self) -> None:
+        self.timesteps = np.asarray(DEFAULT_TIMESTEPS, dtype=np.float32)
+        self.sigmas = np.append(self.timesteps / 1000.0, 0.0).astype(np.float32)
+        self.step_index = 0
+
+    def step(self, model_output: mx.array, sample: mx.array, *, seed: int) -> mx.array:
+        index = self.step_index
+        sigma = float(self.sigmas[index])
+        sigma_next = float(self.sigmas[index + 1])
+        sample_f = sample.astype(mx.float32)
+        output_f = model_output.astype(mx.float32)
+        denoised = sample_f - output_f * sigma
+        key = mx.random.key(seed + index)
+        noise = mx.random.normal(output_f.shape, key=key)
+        std = float(mx.std(noise))
+        noise = mx.clip(noise, -NOISE_CLIP_STD * std, NOISE_CLIP_STD * std)
+        result = sigma_next * noise * NOISE_SCALE + (1.0 - sigma_next) * denoised
+        self.step_index += 1
+        return result.astype(sample.dtype)
+
+
+class TimestepEmbedder(nn.Module):
+    def __init__(self, hidden_size: int, frequency_embedding_size: int = 256):
+        super().__init__()
+        self.frequency_embedding_size = frequency_embedding_size
+        self.fc1 = nn.Linear(frequency_embedding_size, hidden_size, bias=True)
+        self.fc2 = nn.Linear(hidden_size, hidden_size, bias=True)
+
+    @staticmethod
+    def embedding(t: mx.array, dim: int) -> mx.array:
+        half = dim // 2
+        freqs = mx.exp(-math.log(10000.0) * mx.arange(half, dtype=mx.float32) / half)
+        args = t[:, None].astype(mx.float32) * freqs[None]
+        result = mx.concatenate([mx.cos(args), mx.sin(args)], axis=-1)
+        return (
+            mx.concatenate([result, mx.zeros_like(result[:, :1])], axis=-1)
+            if dim % 2
+            else result
+        )
+
+    def __call__(self, t: mx.array) -> mx.array:
+        freq = self.embedding(t * 1000.0, self.frequency_embedding_size)
+        return self.fc2(nn.silu(self.fc1(freq.astype(self.fc1.weight.dtype))))
+
+
+class BottleneckPatchEmbed(nn.Module):
+    def __init__(self, hidden_size: int = 4096):
+        super().__init__()
+        self.proj1 = nn.Linear(PATCH_SIZE * PATCH_SIZE * 3, 1024, bias=False)
+        self.proj2 = nn.Linear(1024, hidden_size, bias=True)
+
+    def __call__(self, value: mx.array) -> mx.array:
+        return self.proj2(self.proj1(value))
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, hidden_size: int = 4096):
+        super().__init__()
+        self.linear = nn.Linear(hidden_size, PATCH_SIZE * PATCH_SIZE * 3, bias=True)
+
+    def __call__(self, value: mx.array) -> mx.array:
+        return self.linear(value)
+
+
+@dataclass(frozen=True)
+class HiDreamConfig:
+    hidden_size: int = 4096
+    tms_token_id: int = 151673
+
+
+def _validate_custom_head_weights(expected: dict, actual: dict) -> None:
+    """Fail closed before installing incompatible diffusion-head tensors."""
+
+    expected_keys = set(expected)
+    actual_keys = set(actual)
+    missing = sorted(expected_keys - actual_keys)
+    extra = sorted(actual_keys - expected_keys)
+    mismatched = sorted(
+        key
+        for key in expected_keys & actual_keys
+        if tuple(actual[key].shape) != tuple(expected[key].shape)
+    )
+    if missing or extra or mismatched:
+        parts = []
+        if missing:
+            parts.append(f"missing={missing}")
+        if extra:
+            parts.append(f"unexpected={extra}")
+        if mismatched:
+            details = {
+                key: (tuple(actual[key].shape), tuple(expected[key].shape))
+                for key in mismatched
+            }
+            parts.append(f"shape_mismatch={details}")
+        raise ValueError("incompatible HiDream custom heads: " + "; ".join(parts))
+
+
+def _patchify(image: np.ndarray) -> np.ndarray:
+    channels, height, width = image.shape
+    if height % PATCH_SIZE or width % PATCH_SIZE:
+        raise ValueError(f"HiDream dimensions must be multiples of {PATCH_SIZE}")
+    value = image.reshape(
+        channels,
+        height // PATCH_SIZE,
+        PATCH_SIZE,
+        width // PATCH_SIZE,
+        PATCH_SIZE,
+    )
+    value = np.transpose(value, (1, 3, 0, 2, 4))
+    return value.reshape(
+        (height // PATCH_SIZE) * (width // PATCH_SIZE),
+        channels * PATCH_SIZE * PATCH_SIZE,
+    )
+
+
+def _unpatchify(patches: np.ndarray, height: int, width: int) -> np.ndarray:
+    value = patches.reshape(
+        height // PATCH_SIZE,
+        width // PATCH_SIZE,
+        3,
+        PATCH_SIZE,
+        PATCH_SIZE,
+    )
+    value = np.transpose(value, (2, 0, 3, 1, 4))
+    return value.reshape(3, height, width)
+
+
+def _rope_positions(
+    *,
+    input_ids: np.ndarray,
+    image_grid: np.ndarray,
+    image_token_id: int,
+    video_token_id: int,
+    vision_start_token_id: int,
+) -> np.ndarray:
+    """Port of HiDream's fixed-point Qwen3-VL mRoPE index builder (T2I)."""
+
+    batch, sequence = input_ids.shape
+    positions = np.ones((3, batch, sequence), dtype=input_ids.dtype)
+    for batch_index in range(batch):
+        ids = input_ids[batch_index]
+        starts = np.argwhere(ids == vision_start_token_id).reshape(-1)
+        following = ids[starts + 1] if len(starts) else np.array([], dtype=ids.dtype)
+        image_count = int((following == image_token_id).sum())
+        video_count = int((following == video_token_id).sum())
+        tokens = ids.tolist()
+        pieces: list[np.ndarray] = []
+        cursor = 0
+        image_index = 0
+        fix_point = 4096
+        remaining_images = image_count
+        remaining_videos = video_count
+        for _ in range(image_count + video_count):
+            image_end = (
+                tokens.index(image_token_id, cursor)
+                if image_token_id in tokens[cursor:] and remaining_images
+                else len(tokens) + 1
+            )
+            video_end = (
+                tokens.index(video_token_id, cursor)
+                if video_token_id in tokens[cursor:] and remaining_videos
+                else len(tokens) + 1
+            )
+            if image_end >= video_end:
+                raise ValueError(
+                    "HiDream text-to-image sample unexpectedly contains video tokens"
+                )
+            grid_t, grid_h, grid_w = (int(v) for v in image_grid[image_index])
+            image_index += 1
+            remaining_images -= 1
+            text_length = max(0, image_end - cursor - 1)
+            start_index = int(pieces[-1].max() + 1) if pieces else 0
+            pieces.append(
+                np.broadcast_to(
+                    np.arange(text_length) + start_index, (3, text_length)
+                ).copy()
+            )
+            t_index = np.repeat(np.arange(grid_t), grid_h * grid_w)
+            h_index = np.tile(np.repeat(np.arange(grid_h), grid_w), grid_t)
+            w_index = np.tile(np.arange(grid_w), grid_t * grid_h)
+            fix_point -= start_index
+            pieces.append(
+                np.stack([t_index, h_index, w_index]) + fix_point + start_index
+            )
+            fix_point = 0
+            cursor = image_end + grid_t * grid_h * grid_w
+        if cursor < len(tokens):
+            start_index = int(pieces[-1].max() + 1) if pieces else 0
+            text_length = len(tokens) - cursor
+            pieces.append(
+                np.broadcast_to(
+                    np.arange(text_length) + start_index, (3, text_length)
+                ).copy()
+            )
+        positions[..., batch_index, :] = np.concatenate(pieces, axis=1).reshape(3, -1)
+    return positions
+
+
+def _build_sample(prompt: str, height: int, width: int, processor, config) -> dict:
+    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    for name in ("boi", "tms"):
+        attribute = f"{name}_token"
+        if not hasattr(tokenizer, attribute):
+            setattr(tokenizer, attribute, f"<|{name}_token|>")
+    caption = (
+        processor.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        + tokenizer.boi_token
+        + tokenizer.tms_token * TIMESTEP_TOKEN_NUM
+    )
+    input_ids = np.asarray(
+        tokenizer.encode(caption, add_special_tokens=False), dtype=np.int64
+    ).reshape(1, -1)
+    if input_ids.shape[-1] > MAX_PROMPT_TOKENS:
+        raise ValueError(
+            f"HiDream-O1 prompts are limited to {MAX_PROMPT_TOKENS} tokens"
+        )
+    image_length = (height // PATCH_SIZE) * (width // PATCH_SIZE)
+    image_grid = np.asarray(
+        [[1, height // PATCH_SIZE, width // PATCH_SIZE]], dtype=np.int64
+    )
+    image_tokens = np.full((1, image_length), config.image_token_id, dtype=np.int64)
+    image_tokens[0, 0] = config.vision_start_token_id
+    padded = np.concatenate([input_ids, image_tokens], axis=-1)
+    position_ids = _rope_positions(
+        input_ids=padded,
+        image_grid=image_grid,
+        image_token_id=config.image_token_id,
+        video_token_id=config.video_token_id,
+        vision_start_token_id=config.vision_start_token_id,
+    )
+    text_length = input_ids.shape[-1]
+    token_types = np.zeros((1, position_ids.shape[-1]), dtype=np.int64)
+    begin = text_length - TIMESTEP_TOKEN_NUM
+    token_types[0, begin : begin + image_length + TIMESTEP_TOKEN_NUM] = 1
+    token_types[0, text_length - TIMESTEP_TOKEN_NUM : text_length] = 3
+    return {
+        "input_ids": input_ids,
+        "position_ids": position_ids,
+        "token_types": (token_types > 0).astype(np.int64),
+        "vinput_mask": token_types == 1,
+    }
+
+
+def _attention_mask(token_types: np.ndarray) -> np.ndarray:
+    batch, sequence = token_types.shape
+    floor = -1e4
+    result = np.full((batch, 1, sequence, sequence), floor, dtype=np.float32)
+    causal = np.triu(np.full((sequence, sequence), floor, dtype=np.float32), k=1)
+    for index in range(batch):
+        mask = causal.copy()
+        mask[token_types[index].astype(bool), :] = 0.0
+        result[index, 0] = mask
+    return result
+
+
+class HiDreamO1(nn.Module):
+    """In-process, text-to-image-only adapter over the published MLX weights."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        on_step: Callable[[int, int], None] | None = None,
+    ) -> None:
+        from mlx_vlm import load as mlx_vlm_load
+
+        super().__init__()
+        backbone, self.processor = mlx_vlm_load(model_path)
+        self.backbone_config = backbone.config
+        self.config = HiDreamConfig()
+        self.visual = backbone.vision_tower
+        self.language_model = backbone.language_model
+        self.t_embedder1 = TimestepEmbedder(self.config.hidden_size)
+        self.x_embedder = BottleneckPatchEmbed(self.config.hidden_size)
+        self.final_layer2 = FinalLayer(self.config.hidden_size)
+        custom_path = Path(model_path) / "extras" / "custom_heads.safetensors"
+        if not custom_path.is_file():
+            raise FileNotFoundError(f"missing HiDream custom heads: {custom_path}")
+        custom_weights = mx.load(str(custom_path))
+        from mlx.utils import tree_flatten
+
+        expected_weights = {}
+        for prefix, module in (
+            ("t_embedder1", self.t_embedder1),
+            ("x_embedder", self.x_embedder),
+            ("final_layer2", self.final_layer2),
+        ):
+            expected_weights.update(
+                {
+                    f"{prefix}.{name}": value
+                    for name, value in tree_flatten(module.parameters())
+                }
+            )
+        _validate_custom_head_weights(expected_weights, custom_weights)
+        # Strict loading on ``self`` would also demand the separately loaded
+        # backbone. Exact key/shape validation above makes this scoped load
+        # fail-closed while intentionally omitting those backbone tensors.
+        self.load_weights(list(custom_weights.items()), strict=False)
+        self.on_step = on_step
+
+    def _text_embeddings(self, input_ids: mx.array) -> mx.array:
+        return self.language_model.model.embed_tokens(input_ids)
+
+    def _forward(
+        self,
+        embeddings: mx.array,
+        input_ids: mx.array,
+        position_ids: mx.array,
+        vinputs: mx.array,
+        timestep: mx.array,
+        mask: mx.array,
+    ) -> mx.array:
+        timestep_embedding = self.t_embedder1(timestep)
+        timestep_mask = mx.broadcast_to(
+            (input_ids == self.config.tms_token_id)[..., None], embeddings.shape
+        )
+        expanded = mx.broadcast_to(timestep_embedding[:, None, :], embeddings.shape)
+        embeddings = mx.where(timestep_mask, expanded, embeddings)
+        image_embeddings = self.x_embedder(vinputs).astype(embeddings.dtype)
+        embeddings = mx.concatenate([embeddings, image_embeddings], axis=1)
+        hidden = self.language_model.model(
+            mx.zeros(embeddings.shape[:2], dtype=mx.int32),
+            inputs_embeds=embeddings,
+            mask=mask,
+            cache=None,
+            position_ids=position_ids,
+        )
+        return self.final_layer2(hidden)
+
+    def generate_image(
+        self,
+        *,
+        seed: int,
+        prompt: str,
+        num_inference_steps: int = 28,
+        height: int = 1024,
+        width: int = 1024,
+    ) -> SimpleNamespace:
+        if num_inference_steps != 28:
+            raise ValueError(
+                "HiDream-O1 Dev supports its published 28-step schedule only"
+            )
+        if height % PATCH_SIZE or width % PATCH_SIZE:
+            raise ValueError(f"HiDream dimensions must be multiples of {PATCH_SIZE}")
+        sample = _build_sample(
+            prompt, height, width, self.processor, self.backbone_config
+        )
+        input_ids = mx.array(sample["input_ids"])
+        position_ids = mx.array(sample["position_ids"])
+        token_types = mx.array(sample["token_types"])
+        mask = mx.array(_attention_mask(sample["token_types"])).astype(mx.bfloat16)
+        image_indices = mx.array(np.where(sample["vinput_mask"][0])[0].astype(np.int32))
+        key = mx.random.key(seed + 1)
+        noise = NOISE_SCALE * mx.random.normal((1, 3, height, width), key=key)
+        patches = mx.array(_patchify(np.asarray(noise)[0])[None]).astype(mx.bfloat16)
+        embeddings = self._text_embeddings(input_ids)
+        mx.eval(embeddings)
+        scheduler = FlashFlowMatchScheduler()
+        total = len(scheduler.timesteps)
+        for index, step in enumerate(scheduler.timesteps):
+            if self.on_step is not None:
+                # Report the number of already-completed steps. This also
+                # checks cancellation before starting the next expensive
+                # forward pass without claiming that pass has finished.
+                self.on_step(index, total)
+            timestep = mx.full([1], 1.0 - float(step) / 1000.0, dtype=mx.float32)
+            sigma = max(float(step) / 1000.0, T_EPS)
+            prediction = self._forward(
+                embeddings,
+                input_ids,
+                position_ids,
+                patches,
+                timestep,
+                mask,
+            )
+            generated = mx.take(prediction, image_indices, axis=1).astype(mx.float32)
+            velocity = (generated - patches.astype(mx.float32)) / sigma
+            patches = scheduler.step(-velocity, patches, seed=seed)
+            mx.eval(patches)
+            if self.on_step is not None:
+                self.on_step(index + 1, total)
+        image = (patches + 1) / 2
+        rgb = _unpatchify(np.asarray(image[0].astype(mx.float32)), height, width)
+        pixels = np.clip(rgb.transpose(1, 2, 0) * 255, 0, 255).astype(np.uint8)
+        return SimpleNamespace(image=Image.fromarray(pixels, mode="RGB"))

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -33,6 +33,7 @@
     "lmstudio-community/gpt-oss-safeguard-20b-MLX-MXFP4": 11150438234,
     "lucasnewman/f5-tts-mlx": 4043696283,
     "mflux-community/qwen-image-mflux-q6": 31013313085,
+    "mlx-community/HiDream-O1-Image-Dev-mlx-bf16": 17649873024,
     "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx": 8844791792,
     "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit": 4619332904,
     "mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit": 18443052369,

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MLX-native text-to-image / image-edit generation lane (mflux backend).
+"""MLX-native text-to-image / image-edit generation lane.
 
 Mirrors the video lane's split: this module is the thin, duck-typed engine
 adapter that ``server.load_model`` dispatches to for ``modality=image-gen``
@@ -16,6 +16,7 @@ from ..image.engine import (
     ImageGenerationCancelled,
     ImageGenerationEngine,
     ImageRuntimeError,
+    _detect_family,
 )
 
 __all__ = [
@@ -37,7 +38,9 @@ def require_image_runtime_or_exit(model_name: str | None = None) -> None:
             file=sys.stderr,
         )
         raise SystemExit(2)
-    if importlib.util.find_spec("mflux") is None:
+    family = _detect_family(model_name) if model_name else ""
+    runtime_module = "mlx_vlm" if family == "hidream-o1-dev" else "mflux"
+    if importlib.util.find_spec(runtime_module) is None:
         print(
             "\n  Error: image generation requires the `rapid-mlx[image]` "
             "Python extra (`pip install 'rapid-mlx[image]'`).\n",

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -545,6 +545,7 @@ def estimate_model_bytes(model_name: str) -> int:
         # dogfood measured 17.43 GiB max RSS; round up to retain allocator and
         # output headroom (docs/engineering/performance/2026-09-04-hidream-o1-dev-dogfood.md).
         "hidream-o1": 18.0,
+        "hidream_o1": 18.0,
         # 6-bit-transformer Qwen-Image (20B) — measured peak RSS during a
         # real generation at 1024x1024 (mflux-community/qwen-image-mflux-q6,
         # the API/GUI default resolution; `/usr/bin/time -l`): ~55.7 GiB.

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -541,6 +541,10 @@ def estimate_model_bytes(model_name: str) -> int:
     known_image_gib = {
         "flux2-klein-4b": 5.9,
         "z-image-turbo": 5.9,
+        # BF16 unified backbone + custom diffusion heads. Rapid's 1024² server
+        # dogfood measured 17.43 GiB max RSS; round up to retain allocator and
+        # output headroom (docs/engineering/performance/2026-09-04-hidream-o1-dev-dogfood.md).
+        "hidream-o1": 18.0,
         # 6-bit-transformer Qwen-Image (20B) — measured peak RSS during a
         # real generation at 1024x1024 (mflux-community/qwen-image-mflux-q6,
         # the API/GUI default resolution; `/usr/bin/time -l`): ~55.7 GiB.


### PR DESCRIPTION
## Why

Rapid-MLX users cannot currently run the MIT-licensed HiDream-O1-Image-Dev checkpoint through the local image API or select it in Desktop, even though a native MLX checkpoint exists. This adds a reviewed in-process text-to-image path without executing repository-side model code.

## Scope

- Add the `hidream-o1-dev` alias and route it through a pinned MLX text-to-image adapter.
- Support OpenAI-compatible `/v1/images/generations`, progress, cancellation, residency accounting, pull/cache completeness, and Desktop catalog/progress behavior.
- Fetch only required data files from the exact checkpoint revision.
- Ship the adapted MIT runtime source and attribution in wheels and the Desktop sidecar.

## Non-goals

- Image editing or multi-reference generation.
- Q6/Q8 checkpoint variants.
- Changes to existing image-model defaults, routes, or mflux behavior.
- A new general-purpose image backend abstraction.

## Acceptance

- `rapid-mlx serve hidream-o1-dev` serves a 1024x1024, 28-step generation request and returns a valid RGB PNG.
- Desktop lists the model as generation-only and seeds progress at 28 steps.
- Cold pulls are revision-pinned and data-only; partial snapshots fail before model loading.
- Unsupported edit, guidance, negative-prompt, schedule, dimension, and oversized-prompt inputs fail cleanly.

## Verification

- Real server dogfood: HTTP 200, 1024x1024 RGB PNG, 29.46 s on a warm checkpoint including first lazy load; visual inspection found no grid artifact.
- Earlier measured full-process peak RSS: 17.43 GiB; reproducible record committed under `docs/engineering/performance/`.
- 511 focused Python tests passed; Ruff format/check passed.
- Final exact-head `pr_validate`: **MERGE-SAFE**; Codex adversarial review found 0 blocking issues and the full suite passed with 22,124 tests.
- 19 focused Swift catalog, progress, and sidecar-contract tests passed.
- Desktop debug build and image-generation GUI golden flow passed.
- Source distribution and wheel built; runtime source plus LICENSE/NOTICE verified inside the wheel.
- Ten scope-locked adversarial review rounds completed; findings fixed around import-safe test collection, pinned data-only prefetch/pull, pre-load prompt bounds, cancellation serialization, and residency accounting.
- Exact-head GitHub CI passed on Python 3.10/3.11/3.12 and Apple Silicon, including 100% changed-lines coverage.

## Behaviour delta

Before: the checkpoint was not a recognized image model and could not be served or selected in Desktop.

After: `hidream-o1-dev` is available as a generation-only model with its fixed 28-step schedule; existing image aliases are unchanged.

## AI assistance disclosure

Codex implemented and adversarially reviewed the Server, Desktop catalog, tests, packaging, and documentation changes. The adapted runtime was checked against the pinned MIT source, exercised with a real model request, visually inspected, and verified through focused Python/Swift tests, Desktop golden flow, lint, and package builds.

## Author



