### PR TITLE
feat(image): add native SDXL Base support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,17 @@
 [run]
 relative_files = True
 source = vllm_mlx
+omit =
+    # Third-party numerical implementation retained close to its pinned source.
+    # Rapid-owned runtime.py stays measured; the adapter, engine, download, and
+    # catalog contracts must still reach 100% changed-line coverage.
+    vllm_mlx/image/sdxl_runtime/caching.py
+    vllm_mlx/image/sdxl_runtime/configuration.py
+    vllm_mlx/image/sdxl_runtime/converters/*
+    vllm_mlx/image/sdxl_runtime/hub.py
+    vllm_mlx/image/sdxl_runtime/modeling.py
+    vllm_mlx/image/sdxl_runtime/models/*
+    vllm_mlx/image/sdxl_runtime/pipelines/sdxl.py
+    vllm_mlx/image/sdxl_runtime/quantization.py
+    vllm_mlx/image/sdxl_runtime/schedulers/*
+    vllm_mlx/image/sdxl_runtime/utils.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,7 @@ jobs:
             tests/test_glm5_next_runtime_patch.py \
             tests/test_mllm_hybrid_probe.py \
             tests/test_hidream_o1_alias.py \
+            tests/test_sdxl_alias.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/NOTICE
+++ b/NOTICE
@@ -58,6 +58,13 @@ repository. Each keeps its upstream license text alongside the code.
   MIT License — Copyright (c) 2026 mrbizarro and contributors.
   See vllm_mlx/image/hidream_runtime/LICENSE and NOTICE.
 
+* vllm_mlx/image/sdxl_runtime/
+  Stable Diffusion XL MLX text-to-image runtime adapted from
+  https://github.com/amirhossein-razlighi/mlx_diffuser at commit
+  a26b42aee4e31999dbb4429226b66d896d49e1d8.
+  CC0 1.0 Universal — original work by Amirhossein Razlighi and contributors.
+  See vllm_mlx/image/sdxl_runtime/LICENSE and NOTICE.
+
 * apps/rapid-mac/Vendor/SwiftMath/
   Vendored from https://github.com/mgriebling/SwiftMath at 1.7.3
   (fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7) with a resource-resolution patch.

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -204,6 +204,7 @@ final class ImageGenViewModel {
         // that is actually a 20-step one.
         if alias.localizedCaseInsensitiveContains("qwen-image") { return 20 }
         if alias.localizedCaseInsensitiveContains("hidream-o1") { return 28 }
+        if alias.localizedCaseInsensitiveContains("sdxl") { return 30 }
         return alias.localizedCaseInsensitiveContains("z-image") ? 8 : 4
     }
 

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -24,6 +24,11 @@ credits"** link opens.
   Its license and provenance notice ship inside the Python sidecar package.
   https://huggingface.co/mlx-community/HiDream-O1-Image-Dev-mlx-bf16
 
+* **SDXL MLX runtime** — Amirhossein Razlighi and contributors — CC0 1.0
+  Rapid adapts the pinned text-to-image path for the local Images backend.
+  Its license and provenance notice ship inside the Python sidecar package.
+  https://github.com/amirhossein-razlighi/mlx_diffuser
+
 **Scope.** Components this project declares directly: the Swift packages
 in `Package.swift` (plus the transitive ones actually linked into the
 binary), the engine requirements in the monorepo's root `pyproject.toml`,

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -23,24 +23,26 @@ struct ImageCatalogTests {
       ────────────────────────────
       ltx-2.3-mlx-q4        24.0 GiB   [video:gen] notapalindrome/ltx23-mlx-av-q4
 
-      Image models (3 aliases)
+      Image models (4 aliases)
       ────────────────────────────
       Alias                 Size       Kind        HF id
       ────────────────────────────
       flux2-klein-4b        4.3 GiB    [image:both] Runpod/FLUX.2-klein-4B-mflux-4bit
       z-image-turbo         5.5 GiB    [image:gen] filipstrand/Z-Image-Turbo-mflux-4bit
       hidream-o1-dev       16.4 GiB    [image:gen] mlx-community/HiDream-O1-Image-Dev-mlx-bf16
+      sdxl-base             6.5 GiB     [image:gen] stabilityai/stable-diffusion-xl-base-1.0
     """
 
     @Test("parseImageRows extracts image rows and their operation")
     func parsesImageRows() {
         let rows = ModelCatalog.parseImageRows(Self.sample)
-        #expect(rows.count == 3)
+        #expect(rows.count == 4)
 
         let aliases = rows.map(\.alias)
         #expect(aliases.contains("flux2-klein-4b"))
         #expect(aliases.contains("z-image-turbo"))
         #expect(aliases.contains("hidream-o1-dev"))
+        #expect(aliases.contains("sdxl-base"))
         // No chat / video alias leaks in.
         #expect(!aliases.contains("qwen3.6-27b-4bit"))
         #expect(!aliases.contains("ltx-2.3-mlx-q4"))
@@ -52,6 +54,10 @@ struct ImageCatalogTests {
         let hidream = rows.first { $0.alias == "hidream-o1-dev" }
         #expect(hidream?.hfRepo == "mlx-community/HiDream-O1-Image-Dev-mlx-bf16")
         #expect(hidream?.capability == .generation)
+        let sdxl = rows.first { $0.alias == "sdxl-base" }
+        #expect(sdxl?.hfRepo == "stabilityai/stable-diffusion-xl-base-1.0")
+        #expect(sdxl?.size == "6.5 GiB")
+        #expect(sdxl?.capability == .generation)
     }
 
     @Test("complete mflux caches are marked downloaded in Images")
@@ -63,6 +69,7 @@ struct ImageCatalogTests {
                 "Runpod/FLUX.2-klein-4B-mflux-4bit",
                 "filipstrand/Z-Image-Turbo-mflux-4bit",
                 "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
+                "stabilityai/stable-diffusion-xl-base-1.0",
             ]
         )
 
@@ -71,6 +78,7 @@ struct ImageCatalogTests {
         #expect(klein?.imageCapability == .generationAndEditing)
         #expect(cached.first { $0.alias == "z-image-turbo" }?.cached == true)
         #expect(cached.first { $0.alias == "hidream-o1-dev" }?.cached == true)
+        #expect(cached.first { $0.alias == "sdxl-base" }?.cached == true)
     }
 
     @Test("Image capability rows are excluded from the chat catalog")
@@ -89,5 +97,6 @@ struct ImageCatalogTests {
         #expect(excluded.contains("flux2-klein-4b"))
         #expect(excluded.contains("z-image-turbo"))
         #expect(excluded.contains("hidream-o1-dev"))
+        #expect(excluded.contains("sdxl-base"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -103,5 +103,6 @@ struct ImageGenerationPhaseTests {
         #expect(ImageGenViewModel.seedSteps(for: "z-image-turbo") == 8)
         #expect(ImageGenViewModel.seedSteps(for: "flux2-klein-4b") == 4)
         #expect(ImageGenViewModel.seedSteps(for: "hidream-o1-dev") == 28)
+        #expect(ImageGenViewModel.seedSteps(for: "sdxl-base") == 30)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -82,6 +82,8 @@ struct SidecarBuildScriptTests {
         }
         #expect(script.contains("from vllm_mlx.image.hidream_runtime import HiDreamO1"),
                 "The bundled sidecar must include the HiDream image adapter, not only mlx-vlm.")
+        #expect(script.contains("from vllm_mlx.image.sdxl_runtime import SDXL"),
+                "The bundled sidecar must include the vendored SDXL image adapter.")
         #expect(script.contains(#"find_spec("cv2") is None"#))
         #expect(script.contains(#"find_spec("torch") is None"#))
         #expect(script.contains(#"find_spec("torchvision") is None"#),

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -1196,10 +1196,11 @@ from mlx_vlm.models import (
     qwen3_5, qwen3_5_moe, qwen3_vl, qwen3_vl_moe,
 )
 from vllm_mlx.image.hidream_runtime import HiDreamO1
+from vllm_mlx.image.sdxl_runtime import SDXL
 assert importlib.util.find_spec("cv2") is None
 assert importlib.util.find_spec("torch") is None
 assert importlib.util.find_spec("torchvision") is None
-print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma/HiDream architectures OK")' 2>&1)" || {
+print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma/HiDream/SDXL architectures OK")' 2>&1)" || {
         echo "ERR: bundled mlx_vlm desktop architecture smoke failed:" >&2
         echo "$VLM_OUT" >&2
         echo "ERR: usually means a new mlx-vlm release added an eager top-level import" >&2

--- a/docs/engineering/performance/2026-09-05-sdxl-base-dogfood.md
+++ b/docs/engineering/performance/2026-09-05-sdxl-base-dogfood.md
@@ -1,0 +1,126 @@
+# SDXL Base Server and Desktop-path dogfood
+
+## Outcome
+
+The `sdxl-base` alias completed real MLX-native text-to-image generations
+through both the engine and the OpenAI-compatible HTTP server. The official
+fp16 checkpoint is revision-pinned, the UNet is quantized to 8-bit at load,
+DeepCache reuses deep UNet features on alternating denoise steps, and no Torch
+runtime is imported or bundled.
+
+## Environment
+
+- Apple M3 Ultra, 256 GiB unified memory
+- macOS 26.5.2 (25F84)
+- Python 3.12.13
+- MLX 0.32.2
+- Transformers 5.15.1
+- Pillow 12.3.0
+- Hugging Face Hub 1.30.0
+- Model `stabilityai/stable-diffusion-xl-base-1.0`
+- Revision `462165984030d82259a11f4367a4eed129e94a7b`
+- Audited download payload: 6,941,201,645 bytes (6.46 GiB)
+
+## Engine quality run
+
+Prompt:
+
+> Editorial photograph of a tiny red panda librarian reading an old book
+> beside a rain-streaked window, warm tungsten light, detailed fur, natural
+> depth of field
+
+Parameters: 1024×1024, 30 steps, guidance 5.0, seed 42, 8-bit UNet, tiled VAE.
+
+Exact-path baseline observed:
+
+- cold construction plus generation: 61.72 seconds
+- MLX peak allocation: 12.42 GiB
+- output: valid 1024×1024 PNG, 1,399,045 bytes
+- progress reached exactly step 30/30 and reset to idle after completion
+- visual inspection: coherent subject, book, window, lighting, and depth;
+  no structural corruption or noise output
+
+DeepCache interval 2, with the same prompt/parameters/seed:
+
+- generation after model construction: 16.46 seconds
+- MLX peak allocation: 12.12 GiB
+- a second clean-process engine run measured 18.43 seconds cold end-to-end
+  and 12.49 GiB peak, versus 61.72 seconds for the exact-path cold run
+  (3.35× lower observed end-to-end latency)
+- the subject, book, window, lighting, fur, and depth remained coherent under
+  side-by-side visual inspection
+- three additional 512² / 30-step prompts (landscape, product, illustration)
+  completed in 4.48, 4.31, and 4.32 seconds with coherent outputs
+
+The exact baseline included a short cold model construction while the
+DeepCache timer began immediately after construction, so the measurements are
+not claimed as a publication-grade paired speedup. They establish a large,
+repeatable latency reduction without the structural failure seen at four steps.
+
+The catalog minimum remains 16 GiB. The resident-model safety charge is 14
+GiB, leaving allocator and PNG headroom above the measured MLX peak.
+
+## HTTP path
+
+Server:
+
+```bash
+RAPID_MLX_NO_UPDATE_CHECK=1 RAPID_MLX_AUTO_PULL=1 \
+  rapid-mlx serve sdxl-base --host 127.0.0.1 --port 8127
+```
+
+Request (steps deliberately omitted to exercise the family default):
+
+```bash
+curl --fail-with-body --max-time 180 \
+  -X POST http://127.0.0.1:8127/v1/images/generations \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"sdxl-base","prompt":"A cobalt blue ceramic teapot on a linen tablecloth, soft daylight, product photography","negative_prompt":"blurry, text, watermark","size":"512x512","seed":17}'
+```
+
+Observed:
+
+- HTTP 200
+- 30 denoise steps selected by the server default
+- valid OpenAI-compatible `data[0].b64_json`
+- decoded PNG: 512×512, 338,013 bytes
+- end-to-end request time with DeepCache: 5.15 seconds
+- visual inspection: coherent blue-and-white teapot and tablecloth composition
+
+## Safety and packaging checks
+
+- A 4-step 512² smoke completed before integration (2.40 seconds, 9.71 GiB
+  MLX peak), but its poor structure confirmed that 4 steps must not be used as
+  the SDXL Base product default.
+- The first server boot exposed a false 71.6 GB warning because the generic
+  preflight sized every artifact in the Hub repository. The final path sizes
+  only the pinned 6.46 GiB allowlist and budgets the measured 14 GiB working
+  set; a repeated clean launch emitted no false pressure warning.
+- Runtime callbacks fire after every evaluated denoise step and enforce the
+  existing cooperative cancel contract.
+- The sidecar smoke imports the vendored runtime while asserting Torch,
+  torchvision, and OpenCV remain absent.
+
+## Reference check (internal)
+
+- The primary serving precedents use a single diffusion model per server, an
+  OpenAI-compatible `/v1/images/generations` surface, explicit size/step
+  validation, and model-recommended defaults. Rapid already had that contract,
+  so this change adds an adapter rather than a second serving mechanism.
+- Current accelerator-server work emphasizes modular pipeline stages, bounded
+  batching, and step-wise execution. On a single Apple GPU, Rapid retains the
+  existing process-wide single-flight lock and true per-step cancellation.
+- The platform-native MLX examples validate direct Hub loading, latent-step
+  evaluation, and quantization on constrained Macs. The selected implementation
+  extends that shape to full SDXL Base, dual CLIP encoders, fp32 VAE decode, and
+  an 8-bit UNet.
+- Desktop references commonly expose image engine/model/size/steps as one
+  dedicated generation workflow. Rapid's existing Images tab already follows
+  the stronger multi-model catalog pattern, so no new interaction model was
+  introduced: SDXL appears as another generation-only row with its own seeded
+  step count.
+
+## Non-goals retained
+
+This work does not add SDXL image-to-image, refiner chaining, LoRA, ControlNet,
+training, arbitrary community checkpoints, release, or deployment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -531,6 +531,9 @@ image = [
     # HiDream-O1 reuses the exact Qwen3-VL runtime already validated and
     # bundled by Desktop. Keep this pin coherent with [vision]/the sidecar.
     "mlx-vlm==0.6.17; platform_system == 'Darwin' and python_version >= '3.11'",
+    # The vendored SDXL backend needs Pillow for PNG encoding. Keep this direct
+    # because SDXL also works on Rapid's Python 3.10 floor without mflux.
+    "pillow>=10.0.0; platform_system == 'Darwin'",
 ]
 
 [project.urls]
@@ -580,6 +583,9 @@ vllm_mlx = [
     # Desktop sidecar alongside the redistributed MIT source.
     "image/hidream_runtime/LICENSE",
     "image/hidream_runtime/NOTICE",
+    # Vendored SDXL MLX runtime attribution must ship beside the CC0 source.
+    "image/sdxl_runtime/LICENSE",
+    "image/sdxl_runtime/NOTICE",
 ]
 videox_fun_mlx = ["LICENSE", "NOTICE"]
 
@@ -662,6 +668,10 @@ ignore = [
 # Adapted from the pinned upstream HiDream-O1 MLX runtime. Keep source-shape
 # lint exceptions local so the Rapid-owned engine integration stays strict.
 "vllm_mlx/image/hidream_runtime/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
+# Vendored SDXL implementation. Rapid-owned adapter/runtime.py remains linted;
+# upstream-shaped model, converter, scheduler, and pipeline files stay syncable.
+"vllm_mlx/image/sdxl_runtime/{caching,configuration,hub,modeling,quantization,utils}.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
+"vllm_mlx/image/sdxl_runtime/{converters,models,pipelines,schedulers}/**/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
 # Tensor-shape parameter names (B, H, N, D) follow ML literature
 # convention; N803 lowercase rule is incompatible.
 "scripts/bench_attention.py" = ["N803"]

--- a/scripts/gen_model_sizes.py
+++ b/scripts/gen_model_sizes.py
@@ -82,7 +82,37 @@ def _collect_hf_paths() -> list[str]:
 
 
 def _size_one(repo_id: str) -> tuple[str, int | None]:
-    from vllm_mlx._download_gate import estimate_repo_size_bytes
+    from vllm_mlx._download_gate import (
+        IMAGE_MODEL_DATA_FILES,
+        IMAGE_MODEL_REVISIONS,
+        estimate_repo_size_bytes,
+    )
+
+    data_files = IMAGE_MODEL_DATA_FILES.get(repo_id)
+    if data_files is not None:
+        # Vendored image runtimes deliberately fetch an audited subset of a
+        # repository. Size that exact pinned payload: SDXL's repository also
+        # contains fp32, refiner, ONNX, and other unused artifacts, so the
+        # generic weight-file estimator overstates the download by >10x.
+        try:
+            from huggingface_hub import model_info
+
+            info = model_info(
+                repo_id,
+                revision=IMAGE_MODEL_REVISIONS[repo_id],
+                files_metadata=True,
+                timeout=5,
+            )
+            sizes = {
+                sibling.rfilename: sibling.size
+                for sibling in (getattr(info, "siblings", None) or [])
+                if hasattr(sibling, "rfilename")
+            }
+            if any(path not in sizes or sizes[path] is None for path in data_files):
+                return repo_id, None
+            return repo_id, sum(int(sizes[path]) for path in data_files)
+        except Exception:
+            return repo_id, None
 
     return repo_id, estimate_repo_size_bytes(repo_id)
 
@@ -101,8 +131,8 @@ def _size_via_subprocess(repo_id: str) -> int | None:
     guarantees a fresh HTTP session.
     """
     code = (
-        "from vllm_mlx._download_gate import estimate_repo_size_bytes;"
-        f"v=estimate_repo_size_bytes({repo_id!r});"
+        "from scripts.gen_model_sizes import _size_one;"
+        f"v=_size_one({repo_id!r})[1];"
         "print(v if v is not None else '')"
     )
     try:

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -159,6 +159,14 @@ def test_hidream_runtime_coverage_runs_on_apple_silicon() -> None:
     assert "tests/test_hidream_o1_alias.py" in apple_run
 
 
+def test_sdxl_runtime_coverage_runs_on_apple_silicon() -> None:
+    """The vendored MLX-only SDXL runtime must contribute to coverage."""
+    _, workflow = _workflow()
+    apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
+
+    assert "tests/test_sdxl_alias.py" in apple_run
+
+
 def test_coverage_data_is_commit_bound_and_fail_closed() -> None:
     text, workflow = _workflow()
     jobs = workflow["jobs"]

--- a/tests/test_sdxl_alias.py
+++ b/tests/test_sdxl_alias.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the pinned, vendored SDXL image backend."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from vllm_mlx import _download_gate
+from vllm_mlx.image.engine import (
+    ImageGenerationCancelled,
+    ImageGenerationEngine,
+    ImageRuntimeError,
+    _detect_family,
+)
+from vllm_mlx.model_aliases import resolve_profile
+
+REPO = "stabilityai/stable-diffusion-xl-base-1.0"
+REVISION = "462165984030d82259a11f4367a4eed129e94a7b"
+
+
+def test_sdxl_alias_is_first_class_image_generation_model() -> None:
+    profile = resolve_profile("sdxl-base")
+    assert profile is not None
+    assert profile.hf_path == REPO
+    assert profile.modality == "image-gen"
+    assert profile.min_memory_gb == 16
+
+    engine = ImageGenerationEngine(REPO)
+    assert engine.family == "sdxl-base"
+    assert engine.default_steps == 30
+    assert engine.supports_generation is True
+    assert engine.supports_editing is False
+    assert engine.supports_negative_prompt is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["sdxl-base", REPO, "/models/my_sdxl_checkpoint"],
+)
+def test_sdxl_family_detection(name: str) -> None:
+    assert _detect_family(name) == "sdxl-base"
+
+
+def test_sdxl_alias_has_size_and_native_catalog_adapter() -> None:
+    sizes = json.loads(
+        (Path(__file__).parents[1] / "vllm_mlx/model_sizes.json").read_text()
+    )["sizes"]
+    assert sizes[REPO] == 6_941_201_645
+
+    from vllm_mlx.catalog.legacy import _main_capabilities
+
+    capabilities = _main_capabilities(resolve_profile("sdxl-base"))
+    assert capabilities["runtime_adapter"] == "rapid_mlx/sdxl"
+    assert capabilities["operation_modes"] == ["text_to_image"]
+
+
+def test_size_generator_counts_only_the_pinned_sdxl_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import huggingface_hub
+
+    from scripts import gen_model_sizes
+
+    siblings = [
+        SimpleNamespace(rfilename=path, size=index + 1)
+        for index, path in enumerate(_download_gate.SDXL_DATA_FILES)
+    ]
+    siblings.append(SimpleNamespace(rfilename="unused-fp32.safetensors", size=10**12))
+    calls = []
+    monkeypatch.setattr(
+        huggingface_hub,
+        "model_info",
+        lambda *args, **kwargs: (
+            calls.append((args, kwargs)) or SimpleNamespace(siblings=siblings)
+        ),
+    )
+
+    assert gen_model_sizes._size_one(REPO) == (
+        REPO,
+        sum(range(1, len(_download_gate.SDXL_DATA_FILES) + 1)),
+    )
+    assert calls == [
+        (
+            (REPO,),
+            {
+                "revision": REVISION,
+                "files_metadata": True,
+                "timeout": 5,
+            },
+        )
+    ]
+
+
+@pytest.mark.requires_mlx
+def test_vendored_runtime_is_torch_free_and_reports_each_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import mlx.core as mx
+
+    from vllm_mlx.image.sdxl_runtime import runtime
+
+    calls = []
+
+    class TinyPipeline:
+        def __call__(self, prompt, **kwargs):
+            calls.append((prompt, kwargs))
+            kwargs["on_step"](1, 2)
+            kwargs["on_step"](2, 2)
+            return mx.zeros((1, 8, 8, 3), dtype=mx.float32)
+
+    monkeypatch.setattr(
+        runtime.StableDiffusionXLPipeline,
+        "from_diffusers",
+        classmethod(lambda _cls, path, **kwargs: TinyPipeline()),
+    )
+    progress = []
+    model = runtime.SDXL("/snapshot", on_step=lambda *args: progress.append(args))
+    result = model.generate_image(
+        prompt="fox",
+        negative_prompt="blurry",
+        height=512,
+        width=768,
+        num_inference_steps=2,
+        seed=7,
+    )
+
+    assert result.image.size == (8, 8)
+    assert progress == [(1, 2), (2, 2)]
+    assert calls[0][1] == {
+        "negative_prompt": "blurry",
+        "height": 512,
+        "width": 768,
+        "num_inference_steps": 2,
+        "guidance_scale": 5.0,
+        "seed": 7,
+        "cache_interval": 2,
+        "tile_vae": True,
+        "progress": False,
+        "on_step": model._on_step,
+    }
+
+    source = Path(runtime.__file__).parent
+    for path in source.rglob("*.py"):
+        assert "import torch" not in path.read_text()
+
+
+@pytest.mark.requires_mlx
+def test_engine_build_dispatch_progress_cancel_and_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.image import sdxl_runtime
+
+    built = []
+
+    class TinySDXL:
+        def __init__(self, path, *, on_step):
+            built.append((path, on_step))
+            self.calls = []
+
+        def generate_image(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(image=Image.new("RGB", (8, 8)))
+
+    monkeypatch.setattr(sdxl_runtime, "SDXL", TinySDXL)
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(engine, "_model_path_for_mflux", lambda: "/snapshot")
+    model = engine._build_model()
+    assert built == [("/snapshot", engine._report_native_step)]
+
+    monkeypatch.setattr(engine, "_model_path_for_mflux", lambda: None)
+    with pytest.raises(ImageRuntimeError, match="requires a local model snapshot"):
+        engine._build_model()
+
+    engine._report_native_step(4, 30)
+    assert engine.progress_snapshot()["step"] == 4
+    monkeypatch.setattr(engine, "_is_cancelled", lambda: True)
+    with pytest.raises(ImageGenerationCancelled, match="cancelled"):
+        engine._report_native_step(5, 30)
+
+    monkeypatch.setattr(engine, "_is_cancelled", lambda: False)
+    monkeypatch.setattr(engine, "_ensure_loaded", lambda **_kwargs: model)
+    png = engine.generate(
+        prompt="fox",
+        negative_prompt="blurry",
+        width=512,
+        height=768,
+        num_inference_steps=30,
+        seed=11,
+    )
+    assert png.startswith(b"\x89PNG")
+    assert model.calls == [
+        {
+            "height": 768,
+            "width": 512,
+            "seed": 11,
+            "prompt": "fox",
+            "num_inference_steps": 30,
+            "negative_prompt": "blurry",
+        }
+    ]
+
+    with pytest.raises(ImageRuntimeError, match="multiples of 8"):
+        engine.generate(prompt="fox", width=513, height=512, num_inference_steps=30)
+    with pytest.raises(ImageRuntimeError, match="between 256 and 2048"):
+        engine.generate(prompt="fox", width=248, height=512, num_inference_steps=30)
+    with pytest.raises(ImageRuntimeError, match="text-to-image only"):
+        engine.generate(
+            prompt="fox",
+            width=512,
+            height=512,
+            num_inference_steps=30,
+            image_paths=["source.png"],
+        )
+
+
+def _seed_snapshot(root: Path, *, omit: str | None = None) -> None:
+    for relative in _download_gate.SDXL_DATA_FILES:
+        if relative == omit:
+            continue
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+
+
+def test_sdxl_snapshot_is_pinned_and_requires_every_runtime_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import huggingface_hub.constants
+
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+    snapshot = (
+        tmp_path
+        / "models--stabilityai--stable-diffusion-xl-base-1.0"
+        / "snapshots"
+        / REVISION
+    )
+    _seed_snapshot(snapshot)
+    assert _download_gate.IMAGE_MODEL_REVISIONS[REPO] == REVISION
+    assert _download_gate.mflux_missing_weights(REPO) == []
+    assert _download_gate.mflux_local_snapshot(REPO) == str(snapshot)
+
+    missing = "unet/diffusion_pytorch_model.fp16.safetensors"
+    (snapshot / missing).unlink()
+    assert _download_gate.mflux_missing_weights(REPO) == [missing]
+    assert _download_gate.mflux_local_snapshot(REPO) is None
+
+
+def test_cold_engine_download_uses_exact_revision_and_data_only_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import huggingface_hub
+
+    calls = []
+    monkeypatch.setattr(_download_gate, "mflux_local_snapshot", lambda _repo: None)
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda repo, **kwargs: calls.append((repo, kwargs)) or "/snapshot",
+    )
+    engine = ImageGenerationEngine(REPO)
+    verified = []
+    monkeypatch.setattr(
+        engine, "_verify_weights_complete", lambda: verified.append(True)
+    )
+
+    assert engine._model_path_for_mflux() == "/snapshot"
+    assert calls == [
+        (
+            REPO,
+            {
+                "revision": REVISION,
+                "allow_patterns": list(_download_gate.SDXL_DATA_FILES),
+            },
+        )
+    ]
+    assert verified == [True]
+
+
+@pytest.mark.parametrize("requested", [REPO, "sdxl-base"])
+def test_pull_uses_exact_revision_and_data_allowlist(
+    monkeypatch: pytest.MonkeyPatch, requested: str
+) -> None:
+    from vllm_mlx import cli
+
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "_pull_repository",
+        lambda args, **kwargs: calls.append((args.model, kwargs)),
+    )
+    monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
+    cli.pull_command(SimpleNamespace(model=requested))
+
+    assert calls == [
+        (
+            REPO,
+            {
+                "allow_patterns_override": list(_download_gate.SDXL_DATA_FILES),
+                "revision_override": REVISION,
+            },
+        )
+    ]
+
+
+def test_sdxl_preflight_uses_vendored_runtime_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.runtime import image_lane
+
+    probes = []
+    monkeypatch.setattr(
+        image_lane.importlib.util,
+        "find_spec",
+        lambda module: probes.append(module) or object(),
+    )
+    image_lane.require_image_runtime_or_exit(REPO)
+    assert probes == ["PIL"]
+
+
+def test_memory_preflight_sizes_only_the_pinned_sdxl_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import huggingface_hub
+    import psutil
+
+    from vllm_mlx import cli
+
+    monkeypatch.setattr(
+        huggingface_hub,
+        "model_info",
+        lambda *_args, **_kwargs: pytest.fail("must not query the 72 GB whole repo"),
+    )
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: SimpleNamespace(total=32 * 1024**3, available=32 * 1024**3),
+    )
+    cli._check_memory_capacity(REPO, alias="sdxl-base")
+
+
+def test_vendored_runtime_provenance_travels_with_source() -> None:
+    root = Path(__file__).parents[1] / "vllm_mlx/image/sdxl_runtime"
+    notice = (root / "NOTICE").read_text()
+    license_text = (root / "LICENSE").read_text()
+    assert "a26b42aee4e31999dbb4429226b66d896d49e1d8" in notice
+    assert "CC0 1.0 Universal" in license_text

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1342,11 +1342,40 @@ HIDREAM_O1_DATA_FILES = (
     "merges.txt",
     "vocab.json",
 )
+SDXL_REPO = "stabilityai/stable-diffusion-xl-base-1.0"
+SDXL_REVISION = "462165984030d82259a11f4367a4eed129e94a7b"
+SDXL_DATA_FILES = (
+    "LICENSE.md",
+    "model_index.json",
+    "scheduler/scheduler_config.json",
+    "tokenizer/merges.txt",
+    "tokenizer/special_tokens_map.json",
+    "tokenizer/tokenizer_config.json",
+    "tokenizer/vocab.json",
+    "tokenizer_2/merges.txt",
+    "tokenizer_2/special_tokens_map.json",
+    "tokenizer_2/tokenizer_config.json",
+    "tokenizer_2/vocab.json",
+    "text_encoder/config.json",
+    "text_encoder/model.fp16.safetensors",
+    "text_encoder_2/config.json",
+    "text_encoder_2/model.fp16.safetensors",
+    "unet/config.json",
+    "unet/diffusion_pytorch_model.fp16.safetensors",
+    "vae/config.json",
+    "vae/diffusion_pytorch_model.fp16.safetensors",
+)
+
+IMAGE_MODEL_DATA_FILES: dict[str, tuple[str, ...]] = {
+    HIDREAM_O1_REPO: HIDREAM_O1_DATA_FILES,
+    SDXL_REPO: SDXL_DATA_FILES,
+}
 
 IMAGE_MODEL_REVISIONS: dict[str, str] = {
     "Runpod/FLUX.2-klein-4B-mflux-4bit": "7ee1b3aa8178a1240050490072196a57da2bf2a9",
     "mflux-community/qwen-image-mflux-q6": "c628fe4392d963557c3013c2709e6d3b67bca79d",
     HIDREAM_O1_REPO: HIDREAM_O1_REVISION,
+    SDXL_REPO: SDXL_REVISION,
 }
 
 
@@ -1503,14 +1532,14 @@ def mflux_missing_weights(repo_id: str) -> list[str] | None:
 
     missing: list[str] = []
 
-    if repo_id == HIDREAM_O1_REPO:
-        # HiDream is a single root MLX checkpoint plus three custom diffusion
-        # heads, not an mflux component tree. Validate every data file reached
-        # by mlx-vlm/the adapter; lab scripts and samples are deliberately not
-        # downloaded or executed.
+    runtime_data_files = IMAGE_MODEL_DATA_FILES.get(repo_id)
+    if runtime_data_files is not None:
+        # Vendored backends have an explicit, revision-pinned data contract
+        # rather than an mflux component index. Validate every consumed file;
+        # repository scripts and samples are deliberately never downloaded.
         return [
             relative
-            for relative in HIDREAM_O1_DATA_FILES
+            for relative in runtime_data_files
             if not _is_nonempty_repo_file(os.path.join(snap_dir, *relative.split("/")))
         ]
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -2008,6 +2008,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 32
   },
+  "sdxl-base": {
+    "hf_path": "stabilityai/stable-diffusion-xl-base-1.0",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 16
+  },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",
     "tool_call_parser": null,

--- a/vllm_mlx/catalog/legacy.py
+++ b/vllm_mlx/catalog/legacy.py
@@ -33,9 +33,12 @@ def _image_operations(repo_id: str) -> list[str]:
 def _main_capabilities(profile: Any) -> dict[str, Any]:
     modality = getattr(profile, "modality", "text") or "text"
     if modality == "image-gen":
+        folded_path = profile.hf_path.casefold()
         adapter = (
             "rapid_mlx/hidream_o1"
-            if "hidream-o1" in profile.hf_path.casefold()
+            if "hidream-o1" in folded_path
+            else "rapid_mlx/sdxl"
+            if "stable-diffusion-xl" in folded_path
             else "mflux"
         )
         tasks, operations, adapter = (

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1428,7 +1428,22 @@ def _check_memory_capacity(model_name: str, *, alias: str | None = None) -> None
     # Resolve model size in bytes — local path, then HF cache, then HF API.
     model_size_bytes = 0
     try:
-        if os.path.isdir(model_name):
+        from vllm_mlx._download_gate import IMAGE_MODEL_DATA_FILES
+
+        if model_name in IMAGE_MODEL_DATA_FILES:
+            # A vendored image backend downloads an audited allowlist, not the
+            # whole Hub repository. SDXL's repository also carries fp32,
+            # refiner, ONNX, and ancillary artifacts (~72 GB total) while the
+            # runtime consumes only the checked-in 6.46 GB fp16 footprint.
+            # Querying repo metadata here therefore creates a false memory
+            # emergency before an otherwise-safe 16 GB launch.
+            from vllm_mlx.model_sizes import size_bytes
+            from vllm_mlx.runtime.resident_models import estimate_model_bytes
+
+            model_size_bytes = size_bytes(model_name) or 0
+            if catalog_working_gb is None:
+                catalog_working_gb = estimate_model_bytes(model_name) / (1024**3)
+        elif os.path.isdir(model_name):
             for root, _dirs, files in os.walk(model_name):
                 for f in files:
                     try:
@@ -3184,9 +3199,10 @@ def serve_command(args):
         getattr(args, "_original_alias", None) or getattr(args, "model", "")
     )
     _is_wan_video = False
-    _is_hidream_o1 = bool(
-        _serve_profile is not None
-        and _serve_profile.hf_path == "mlx-community/HiDream-O1-Image-Dev-mlx-bf16"
+    from ._download_gate import IMAGE_MODEL_DATA_FILES
+
+    _owns_pinned_image_download = bool(
+        _serve_profile is not None and _serve_profile.hf_path in IMAGE_MODEL_DATA_FILES
     )
     if _serve_profile is not None and _serve_profile.modality == "video-gen":
         from .runtime.video_lane import require_video_runtime_or_exit
@@ -3408,14 +3424,15 @@ def serve_command(args):
     # revision (or uses RAPID_MLX_WAN_MODEL_DIR). The generic prefetch has no
     # revision parameter and could otherwise download repository HEAD first,
     # duplicating tens of gigabytes before the pinned snapshot is loaded.
-    # HiDream owns a revision-pinned, data-file-only pull in ImageEngine. The
+    # Vendored image backends own a revision-pinned, data-file-only pull in
+    # ImageEngine. The
     # generic prefetch resolves repository HEAD and downloads every file,
     # including unreviewed scripts and samples, before that guarded path runs.
-    if _is_hidream_o1:
+    if _owns_pinned_image_download:
         # Preserve the normal first-run disk guard even though the generic
         # downloader is intentionally bypassed. A complete pinned snapshot is
-        # a warm no-op; cold/partial caches are checked before the 17 GB pull
-        # begins inside ImageEngine.
+        # a warm no-op; cold/partial caches are checked before the multi-GB
+        # pull begins inside ImageEngine.
         from ._download_gate import mflux_missing_weights as _image_missing
 
         if _image_missing(args.model) != []:
@@ -7696,9 +7713,8 @@ def pull_command(args):
     import copy
 
     from vllm_mlx._download_gate import (
-        HIDREAM_O1_DATA_FILES,
-        HIDREAM_O1_REPO,
-        HIDREAM_O1_REVISION,
+        IMAGE_MODEL_DATA_FILES,
+        IMAGE_MODEL_REVISIONS,
     )
     from vllm_mlx.audio.registry import runtime_assets_for, runtime_requirements_for
     from vllm_mlx.audio.runtime_requirements import (
@@ -7708,24 +7724,24 @@ def pull_command(args):
 
     primary_repo = args.model
     primary_args = args
-    if primary_repo != HIDREAM_O1_REPO:
-        # ``main()`` normally resolves aliases before dispatch, but keep this
-        # security boundary fail-closed for direct/internal pull_command calls.
-        from vllm_mlx.model_aliases import resolve_model
+    # ``main()`` normally resolves aliases before dispatch, but keep this
+    # data-only security boundary fail-closed for direct/internal calls too.
+    from vllm_mlx.model_aliases import resolve_model
 
-        if resolve_model(primary_repo) == HIDREAM_O1_REPO:
-            primary_args = copy.copy(args)
-            primary_args._original_alias = (
-                getattr(args, "_original_alias", None) or primary_repo
-            )
-            primary_args.model = HIDREAM_O1_REPO
-            primary_repo = HIDREAM_O1_REPO
+    resolved_primary = resolve_model(primary_repo)
+    if resolved_primary in IMAGE_MODEL_DATA_FILES and resolved_primary != primary_repo:
+        primary_args = copy.copy(args)
+        primary_args._original_alias = (
+            getattr(args, "_original_alias", None) or primary_repo
+        )
+        primary_args.model = resolved_primary
+        primary_repo = resolved_primary
 
-    if primary_repo == HIDREAM_O1_REPO:
+    if primary_repo in IMAGE_MODEL_DATA_FILES:
         _pull_repository(
             primary_args,
-            allow_patterns_override=list(HIDREAM_O1_DATA_FILES),
-            revision_override=HIDREAM_O1_REVISION,
+            allow_patterns_override=list(IMAGE_MODEL_DATA_FILES[primary_repo]),
+            revision_override=IMAGE_MODEL_REVISIONS[primary_repo],
         )
     else:
         _pull_repository(primary_args)

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""mflux-backed image generation engine.
+"""MLX-native image generation engine.
 
 Thin wrapper over `mflux <https://github.com/filipstrand/mflux>`_ — an
 MLX-native, line-by-line port of the FLUX / Qwen-Image model families with
@@ -20,6 +20,8 @@ stays commercially clean:
 * ``qwen-image-edit``  — instruction edit (``Qwen/Qwen-Image-Edit-2509``)
 * ``hidream-o1-dev``   — text→image (``HiDream-O1-Image-Dev``), 28-step,
   VAE-free unified pixel transformer (MIT)
+* ``sdxl-base``        — text→image (``Stable Diffusion XL Base 1.0``),
+  30-step, dual-CLIP + UNet + VAE pipeline (OpenRAIL++)
 
 ``flux2-klein`` and ``z-image`` supersede the older/larger families for the
 interactive tab: Klein is ~3× faster than schnell/z-image at the same
@@ -111,6 +113,8 @@ def _detect_family(model_name: str) -> str:
     name = (model_name or "").casefold()
     if "hidream-o1" in name or "hidream_o1" in name:
         return "hidream-o1-dev"
+    if "stable-diffusion-xl" in name or "sdxl" in name:
+        return "sdxl-base"
     # Klein first — its repos ("FLUX.2-klein-4B-mflux-4bit") also contain
     # "flux", so the distinctive "klein" / "flux2" token must win before the
     # generic FLUX.1 checks below.
@@ -129,7 +133,7 @@ def _detect_family(model_name: str) -> str:
     raise ImageRuntimeError(
         f"Unsupported image model '{model_name}'. Supported families: "
         "flux2-klein, z-image, flux-schnell, qwen-image, qwen-image-edit, "
-        "hidream-o1-dev."
+        "hidream-o1-dev, sdxl-base."
     )
 
 
@@ -148,6 +152,7 @@ _DEFAULT_STEPS_BY_FAMILY = {
     "qwen-image": 20,  # non-distilled 20B
     "qwen-image-edit": 20,
     "hidream-o1-dev": 28,
+    "sdxl-base": 30,
 }
 
 
@@ -187,11 +192,14 @@ class ImageGenerationEngine:
         self.default_edit_steps = 4 if self.family == "flux2-klein" else 20
         self.default_edit_guidance = None if self.family == "flux2-klein" else 4.0
         self.supports_negative_prompt = self.family not in _NO_NEGATIVE_PROMPT_FAMILIES
-        self._prequantized = (
-            self.family == "hidream-o1-dev" or _looks_like_prequantized(model_name)
-        )
-        # ``None`` when the repo is already quantized — passing a quantize width
-        # for a pre-quantized checkpoint makes mflux re-quantize and error.
+        self._prequantized = self.family in {
+            "hidream-o1-dev",
+            "sdxl-base",
+        } or _looks_like_prequantized(model_name)
+        # ``None`` when a backend owns its local checkpoint conversion, or when
+        # the repo is already quantized. Passing a width for pre-quantized
+        # mflux weights would re-quantize and fail; SDXL quantizes its UNet
+        # inside the vendored loader instead.
         self._quantize = None if self._prequantized else quantize
         self._model = None
         self._prompt_tokenizer = None
@@ -248,7 +256,7 @@ class ImageGenerationEngine:
         if not self._prequantized:
             return None
         from .._download_gate import (
-            HIDREAM_O1_DATA_FILES,
+            IMAGE_MODEL_DATA_FILES,
             IMAGE_MODEL_REVISIONS,
             mflux_local_snapshot,
         )
@@ -262,10 +270,11 @@ class ImageGenerationEngine:
         from huggingface_hub import snapshot_download
 
         kwargs = {}
-        if self.family == "hidream-o1-dev":
-            # The weights repo also contains executable lab scripts and sample
-            # images. The runtime is vendored+reviewed here; fetch only data.
-            kwargs["allow_patterns"] = list(HIDREAM_O1_DATA_FILES)
+        allow_patterns = IMAGE_MODEL_DATA_FILES.get(self.model_name)
+        if allow_patterns is not None:
+            # Vendored runtimes execute only reviewed local code. Fetch the
+            # pinned model data they consume, never repository scripts.
+            kwargs["allow_patterns"] = list(allow_patterns)
         downloaded = snapshot_download(
             self.model_name, revision=pinned_revision, **kwargs
         )
@@ -288,6 +297,14 @@ class ImageGenerationEngine:
             if model_path is None:
                 raise ImageRuntimeError("HiDream-O1 requires a local model snapshot.")
             return HiDreamO1(model_path, on_step=self._report_hidream_step)
+
+        if self.family == "sdxl-base":
+            from .sdxl_runtime import SDXL
+
+            model_path = self._model_path_for_mflux()
+            if model_path is None:
+                raise ImageRuntimeError("SDXL requires a local model snapshot.")
+            return SDXL(model_path, on_step=self._report_native_step)
 
         from mflux.models.common.config.model_config import ModelConfig
 
@@ -329,13 +346,17 @@ class ImageGenerationEngine:
             quantize=self._quantize, model_path=model_path, model_config=config
         )
 
-    def _report_hidream_step(self, step: int, total: int) -> None:
-        """Bridge HiDream's loop into the shared progress/cancel contract."""
+    def _report_native_step(self, step: int, total: int) -> None:
+        """Bridge a vendored runtime into the shared progress/cancel contract."""
         self._progress["running"] = True
         self._progress["step"] = int(step)
         self._progress["total"] = int(total)
         if self._is_cancelled():
             raise ImageGenerationCancelled("Generation cancelled.")
+
+    def _report_hidream_step(self, step: int, total: int) -> None:
+        """Backward-compatible HiDream callback name used by existing tests."""
+        self._report_native_step(step, total)
 
     def _validate_hidream_prompt_tokens(self, prompt: str) -> None:
         """Reject token-dense prompts before constructing the 17 GB model."""
@@ -747,6 +768,18 @@ class ImageGenerationEngine:
                 raise ImageRuntimeError(
                     "HiDream-O1 Dev does not support negative_prompt."
                 )
+        elif self.family == "sdxl-base":
+            if (
+                width is None
+                or height is None
+                or not (256 <= width <= 2048)
+                or not (256 <= height <= 2048)
+            ):
+                raise ImageRuntimeError(
+                    "SDXL dimensions must be between 256 and 2048 pixels."
+                )
+            if width % 8 or height % 8:
+                raise ImageRuntimeError("SDXL dimensions must be multiples of 8.")
 
         with self._lock:
             # Claim a run sequence and arm progress BEFORE loading, so a Cancel

--- a/vllm_mlx/image/sdxl_runtime/LICENSE
+++ b/vllm_mlx/image/sdxl_runtime/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/vllm_mlx/image/sdxl_runtime/NOTICE
+++ b/vllm_mlx/image/sdxl_runtime/NOTICE
@@ -1,0 +1,7 @@
+SDXL runtime source derived from mlx_diffuser at commit
+a26b42aee4e31999dbb4429226b66d896d49e1d8:
+https://github.com/amirhossein-razlighi/mlx_diffuser
+
+Original work by Amirhossein Razlighi and contributors, released under CC0 1.0.
+Rapid-MLX modifications narrow the runtime to SDXL, add an in-loop progress and
+cancellation hook, and adapt image results to Rapid-MLX's image engine contract.

--- a/vllm_mlx/image/sdxl_runtime/__init__.py
+++ b/vllm_mlx/image/sdxl_runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Vendored, MLX-native Stable Diffusion XL runtime."""
+
+from .runtime import SDXL
+
+__all__ = ["SDXL"]

--- a/vllm_mlx/image/sdxl_runtime/caching.py
+++ b/vllm_mlx/image/sdxl_runtime/caching.py
@@ -1,0 +1,111 @@
+"""First-Block Cache (FBCache): skip redundant transformer compute across steps.
+
+Adjacent denoising steps feed the diffusion transformer almost-identical inputs,
+so its output changes slowly. FBCache exploits this: each step it computes only the
+*first* transformer block (cheap), and if that block's output barely moved since the
+last full step, it reuses the cached residual of all the remaining blocks instead of
+recomputing them — turning a full forward into ~1/N of the work on cacheable steps.
+
+This is lossy in principle but near-lossless at small thresholds, and it is opt-in
+(``threshold = 0`` disables it). It's the same idea as TeaCache / ParaAttention's
+first-block cache, kept model-agnostic: the only signal is the relative change of the
+first block's hidden state.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+class DeepCache:
+    """DeepCache for U-Net diffusion: skip the deep blocks on most steps.
+
+    A U-Net's deep (bottleneck) features change slowly across denoising steps, while
+    the shallow blocks carry the high-frequency detail. DeepCache recomputes the full
+    network only every ``interval`` steps; in between it runs just the shallowest
+    down/up blocks and reuses the cached deep feature — skipping the most expensive
+    levels (for SDXL, the 1280-channel / 10-transformer-layer blocks).
+
+    ``interval = 1`` disables caching (every step full). ``interval = 2`` caches every
+    other step (~1.5-1.8x). The first step is always full (no cache yet).
+    """
+
+    def __init__(self, interval: int = 1):
+        self.interval = interval
+        self.deep: mx.array | None = None
+        self.steps = 0
+        self.skipped = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.interval > 1
+
+    def reset(self) -> None:
+        self.deep = None
+        self.steps = 0
+        self.skipped = 0
+
+    def should_reuse(self) -> bool:
+        """Return whether this step should reuse the cached deep feature."""
+        reuse = (
+            self.enabled and self.deep is not None and (self.steps % self.interval != 0)
+        )
+        self.steps += 1
+        if reuse:
+            self.skipped += 1
+        return reuse
+
+
+class FirstBlockCache:
+    """Decide, per step, whether to reuse the cached transformer residual.
+
+    Args:
+        threshold: accumulated relative first-block change that triggers a full
+            recompute. ``0`` disables caching (always full / exact). On WAN 2.1 1.3B
+            (256px, 25 steps) ``0.1`` ≈ 1.5x and ``0.2`` ≈ 2.2x with no visible quality
+            change (the sample differs but stays sharp and coherent); ``>= 0.3``
+            starts to degrade. Higher = faster, lower fidelity.
+    """
+
+    def __init__(self, threshold: float = 0.0):
+        self.threshold = threshold
+        self.prev_first: mx.array | None = None
+        self.residual: mx.array | None = None
+        self._accum = 0.0
+        self.steps = 0
+        self.skipped = 0
+
+    def reset(self) -> None:
+        """Clear state before a new generation."""
+        self.prev_first = None
+        self.residual = None
+        self._accum = 0.0
+        self.steps = 0
+        self.skipped = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.threshold > 0.0
+
+    def should_reuse(self, first_residual: mx.array) -> bool:
+        """Given this step's first-block *contribution*, return whether to reuse.
+
+        Accumulates the relative L1 change of the first block's residual (its output
+        minus its input); while the running total stays under ``threshold`` we reuse,
+        and we force a recompute (resetting the accumulator) once it crosses. The
+        first step, and any step before a residual exists, always recomputes.
+        """
+        self.steps += 1
+        if not self.enabled or self.prev_first is None or self.residual is None:
+            self.prev_first = first_residual
+            return False
+        rel = mx.mean(mx.abs(first_residual - self.prev_first)) / (
+            mx.mean(mx.abs(self.prev_first)) + 1e-8
+        )
+        self.prev_first = first_residual
+        self._accum += float(rel)  # one tiny scalar sync per step (~nothing vs a block)
+        if self._accum < self.threshold:
+            self.skipped += 1
+            return True
+        self._accum = 0.0
+        return False

--- a/vllm_mlx/image/sdxl_runtime/configuration.py
+++ b/vllm_mlx/image/sdxl_runtime/configuration.py
@@ -1,0 +1,69 @@
+"""Configuration base class.
+
+A ``Config`` is a plain ``@dataclass`` that round-trips to ``config.json``. It is
+deliberately tiny: no validation framework, no schema registry — just dataclass
+fields plus JSON (de)serialization. Subclasses look like::
+
+    @dataclass
+    class UNet2DConfig(Config):
+        in_channels: int = 4
+        hidden_size: int = 320
+        ...
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+from typing import Any, TypeVar
+
+CONFIG_NAME = "config.json"
+
+T = TypeVar("T", bound="Config")
+
+
+@dataclasses.dataclass
+class Config:
+    """Base for all model / scheduler configs."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict, tagged with the concrete class name."""
+        data = dataclasses.asdict(self)
+        data["_class_name"] = type(self).__name__
+        return data
+
+    @classmethod
+    def from_dict(cls: type[T], data: dict[str, Any]) -> T:
+        """Build a config, ignoring unknown keys (forward compatibility)."""
+        field_names = {f.name for f in dataclasses.fields(cls)}
+        known = {k: v for k, v in data.items() if k in field_names}
+        unknown = set(data) - field_names - {"_class_name"}
+        if unknown:
+            from .utils import get_logger
+
+            get_logger().debug(
+                "%s: ignoring unknown config keys %s", cls.__name__, sorted(unknown)
+            )
+        return cls(**known)
+
+    def save(self, save_directory: str | Path) -> Path:
+        """Write ``config.json`` into ``save_directory`` and return its path."""
+        save_directory = Path(save_directory)
+        save_directory.mkdir(parents=True, exist_ok=True)
+        path = save_directory / CONFIG_NAME
+        path.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True))
+        return path
+
+    @classmethod
+    def load(cls: type[T], path: str | Path) -> T:
+        """Load from a ``config.json`` file or a directory containing one."""
+        path = Path(path)
+        if path.is_dir():
+            path = path / CONFIG_NAME
+        data = json.loads(path.read_text())
+        return cls.from_dict(data)
+
+    def replace(self: T, **changes: Any) -> T:
+        """Return a copy with ``changes`` applied (like ``dataclasses.replace``)."""
+        return dataclasses.replace(self, **changes)

--- a/vllm_mlx/image/sdxl_runtime/converters/__init__.py
+++ b/vllm_mlx/image/sdxl_runtime/converters/__init__.py
@@ -1,0 +1,6 @@
+"""Converters for official diffusers-format SDXL components."""
+
+from . import sdxl as _sdxl  # noqa: F401 -- registers SDXL converters
+from .base import get_converter
+
+__all__ = ["get_converter"]

--- a/vllm_mlx/image/sdxl_runtime/converters/base.py
+++ b/vllm_mlx/image/sdxl_runtime/converters/base.py
@@ -1,0 +1,206 @@
+"""Converter registry and shared tensor helpers.
+
+A :class:`Converter` knows how to turn one external component (a diffusers
+subfolder such as ``vae/`` or ``transformer/``) into one of our models: it
+translates the ``config.json`` into our :class:`~mlx_diffuser.configuration.Config`
+and remaps the weight tensors onto the model's channels-last parameter tree.
+
+The heavy lifting is a *build-and-fill* strategy: we instantiate the target model,
+read its expected ``(key -> shape)`` tree, and assert every key is filled with a
+matching shape. A converter that drifts from the architecture fails loudly here
+rather than silently producing noise.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+if TYPE_CHECKING:
+    from ..modeling import ModelMixin
+
+__all__ = [
+    "Converter",
+    "convert_conv_weight",
+    "get_converter",
+    "load_safetensors_folder",
+    "register_converter",
+]
+
+
+def convert_conv_weight(w: mx.array) -> mx.array:
+    """Reorder a PyTorch conv kernel to MLX channels-last layout.
+
+    Conv2d ``(O, I, kH, kW) -> (O, kH, kW, I)``; Conv3d ``(O, I, kT, kH, kW) ->
+    (O, kT, kH, kW, I)``. Other ranks are returned unchanged.
+    """
+    if w.ndim == 4:
+        return w.transpose(0, 2, 3, 1)
+    if w.ndim == 5:
+        return w.transpose(0, 2, 3, 4, 1)
+    return w
+
+
+def load_safetensors_folder(folder: str | Path) -> dict[str, mx.array]:
+    """Load and merge every ``*.safetensors`` shard in ``folder`` into one dict.
+
+    MLX reads safetensors natively, so no PyTorch dependency is needed to convert
+    weights. Sharded checkpoints (``*-00001-of-000NN.safetensors``) are merged.
+    """
+    folder = Path(folder)
+    shards = sorted(folder.glob("*.safetensors"))
+    if not shards:
+        raise FileNotFoundError(f"No .safetensors files in {folder}")
+    merged: dict[str, mx.array] = {}
+    for shard in shards:
+        merged.update(mx.load(str(shard)))  # type: ignore[arg-type]  # safetensors -> dict
+    return merged
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with open(path) as f:
+        value = json.load(f)
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected a JSON object in {path}")
+    return value
+
+
+class Converter:
+    """Base class for one component converter (one diffusers subfolder).
+
+    Subclasses set :attr:`source_class` (the diffusers ``_class_name`` they accept)
+    and implement :meth:`build_config` and :meth:`convert_weights`.
+    """
+
+    #: diffusers ``_class_name`` this converter consumes.
+    source_class: str
+
+    def build_config(self, hf_config: dict):
+        """Translate a diffusers ``config.json`` dict into our ``Config``."""
+        raise NotImplementedError
+
+    def build_model(self, hf_config: dict) -> ModelMixin:
+        """Instantiate the (empty) target model from a diffusers config."""
+        raise NotImplementedError
+
+    def convert_weights(
+        self, weights: dict[str, mx.array], hf_config: dict
+    ) -> dict[str, mx.array]:
+        """Map a diffusers state dict onto our model's parameter keys."""
+        raise NotImplementedError
+
+    def convert(
+        self,
+        source: str | Path,
+        *,
+        dtype: mx.Dtype | None = None,
+        quantize: int | None = None,
+        quant_group_size: int = 64,
+    ) -> ModelMixin:
+        """Load a diffusers component and return a populated model.
+
+        ``source`` is either a diffusers subfolder (``config.json`` + safetensors
+        shards) or a single ``.safetensors`` file (config falls back to the
+        converter's defaults). Weights are loaded strictly so any missing / extra /
+        mis-shaped tensor raises immediately. ``dtype`` casts the floating-point
+        weights; ``quantize`` (2/3/4/6/8) weight-quantizes the model.
+
+        Conversion is memory-safe for very large encoders: safetensors are loaded
+        lazily (memory-mapped) and only materialized at the final ``mx.eval``, so
+        quantizing a multi-GB model never holds it all in RAM at once.
+        """
+        from ..quantization import quantize_module  # local import avoids a cycle
+
+        source = Path(source)
+        if source.is_dir():
+            cfg = source / "config.json"
+            hf_config = _load_json(cfg) if cfg.exists() else {}
+            weights = load_safetensors_folder(source)
+        else:
+            # Standalone research checkpoints commonly use ``component.json`` next
+            # to ``component.safetensors`` (TRELLIS does this), while diffusers uses
+            # a generic ``config.json`` inside each component directory.
+            named_sibling = source.with_suffix(".json")
+            generic_sibling = source.parent / "config.json"
+            sibling = named_sibling if named_sibling.exists() else generic_sibling
+            hf_config = _load_json(sibling) if sibling.exists() else {}
+            weights = mx.load(str(source))  # type: ignore[assignment]
+
+        model = self.build_model(hf_config)
+        converted = self.convert_weights(weights, hf_config)
+        _assert_matches(model, converted)
+        model.load_weights(list(converted.items()), strict=True)
+        if dtype is not None:
+            model.set_dtype(dtype)
+        if quantize is not None:
+            quantize_module(model, bits=quantize, group_size=quant_group_size)
+        # Materialize the parameter tree in chunks rather than one `mx.eval`. The weights
+        # are lazy (mmap'd); a single eval would force every source tensor resident at
+        # once, spiking to the *unquantized* size (~24 GB for FLUX). We first drop our own
+        # references to the source dicts so that, as each chunk is quantized, its bf16
+        # source can be freed — then peak stays near the quantized footprint instead of
+        # swapping. (For unquantized loads this is just a chunked eval, equally correct.)
+        del converted, weights
+        _eval_in_chunks(model.parameters())
+        model.eval()
+        return model
+
+
+def _eval_in_chunks(params, chunk: int = 24) -> None:
+    """Evaluate a parameter tree ``chunk`` leaves at a time to bound peak memory.
+
+    Quantizing a multi-GB model in one ``mx.eval`` holds every source tensor resident at
+    once; evaluating small groups (and releasing MLX's buffer cache between them) keeps
+    only a handful of transient full-precision tensors live, so peak tracks the quantized
+    result rather than the original. The caller must drop its references to the source
+    (unquantized) weights first, or they stay resident regardless.
+    """
+    leaves = [v for _, v in tree_flatten(params)]  # type: ignore[union-attr, str-unpack]
+    for i in range(0, len(leaves), chunk):
+        mx.eval(leaves[i : i + chunk])
+        mx.clear_cache()  # return the just-freed source buffers to the OS, not MLX's pool
+
+
+def _assert_matches(model: ModelMixin, converted: dict[str, mx.array]) -> None:
+    """Check the converted dict exactly covers the model's parameter tree."""
+    expected = {k: tuple(v.shape) for k, v in tree_flatten(model.parameters())}  # type: ignore[union-attr, str-unpack]
+    got = {k: tuple(v.shape) for k, v in converted.items()}
+    missing = sorted(set(expected) - set(got))
+    extra = sorted(set(got) - set(expected))
+    mismatched = sorted(
+        k for k in expected.keys() & got.keys() if expected[k] != got[k]
+    )
+    if missing or extra or mismatched:
+        lines = []
+        if missing:
+            lines.append(f"missing {len(missing)} keys, e.g. {missing[:5]}")
+        if extra:
+            lines.append(f"extra {len(extra)} keys, e.g. {extra[:5]}")
+        if mismatched:
+            ex = [(k, expected[k], got[k]) for k in mismatched[:5]]
+            lines.append(f"shape mismatch on {len(mismatched)}, e.g. {ex}")
+        raise ValueError(
+            "Converted weights do not match the model:\n  " + "\n  ".join(lines)
+        )
+
+
+_REGISTRY: dict[str, Converter] = {}
+
+
+def register_converter(converter_cls: type[Converter]) -> type[Converter]:
+    """Class decorator: register a converter under its ``source_class``."""
+    _REGISTRY[converter_cls.source_class] = converter_cls()
+    return converter_cls
+
+
+def get_converter(source_class: str) -> Converter:
+    """Look up a registered converter by diffusers ``_class_name``."""
+    if source_class not in _REGISTRY:
+        raise KeyError(
+            f"No converter for '{source_class}'. Registered: {sorted(_REGISTRY)}"
+        )
+    return _REGISTRY[source_class]

--- a/vllm_mlx/image/sdxl_runtime/converters/sdxl.py
+++ b/vllm_mlx/image/sdxl_runtime/converters/sdxl.py
@@ -1,0 +1,134 @@
+"""Converters for the Stable Diffusion XL components (diffusers/transformers format).
+
+Each converter turns one component folder of an ``stable-diffusion-xl-base`` checkpoint
+into the matching MLX model. The CLIP text encoders convert nearly identity (module
+names mirror transformers); the VAE and UNet need conv kernels reordered to
+channels-last.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from ..models.autoencoder_kl_sd import AutoencoderKLSD, AutoencoderKLSDConfig
+from ..models.clip_text import CLIPTextConfig, CLIPTextModel
+from ..models.unet_sdxl import SDXLUNet, SDXLUNetConfig
+from .base import Converter, convert_conv_weight, register_converter
+
+
+class _CLIPConverter(Converter):
+    with_projection = False
+
+    def build_config(self, hf_config: dict) -> CLIPTextConfig:
+        return CLIPTextConfig(
+            vocab_size=hf_config["vocab_size"],
+            hidden_size=hf_config["hidden_size"],
+            intermediate_size=hf_config["intermediate_size"],
+            num_hidden_layers=hf_config["num_hidden_layers"],
+            num_attention_heads=hf_config["num_attention_heads"],
+            max_position_embeddings=hf_config["max_position_embeddings"],
+            hidden_act=hf_config["hidden_act"],
+            projection_dim=hf_config.get("projection_dim", hf_config["hidden_size"]),
+            layer_norm_eps=hf_config.get("layer_norm_eps", 1e-5),
+            with_projection=self.with_projection,
+        )
+
+    def build_model(self, hf_config: dict) -> CLIPTextModel:
+        return CLIPTextModel(self.build_config(hf_config))
+
+    def convert_weights(
+        self, weights: dict[str, mx.array], hf_config: dict
+    ) -> dict[str, mx.array]:
+        # Identity, minus registered buffers (position_ids) that aren't parameters.
+        return {k: v for k, v in weights.items() if not k.endswith("position_ids")}
+
+
+@register_converter
+class CLIPTextModelConverter(_CLIPConverter):
+    source_class = "CLIPTextModel"
+    with_projection = False
+
+
+@register_converter
+class CLIPTextModelWithProjectionConverter(_CLIPConverter):
+    source_class = "CLIPTextModelWithProjection"
+    with_projection = True
+
+
+@register_converter
+class SDVAEConverter(Converter):
+    source_class = "AutoencoderKL"
+
+    def build_config(self, hf_config: dict) -> AutoencoderKLSDConfig:
+        return AutoencoderKLSDConfig(
+            in_channels=hf_config["in_channels"],
+            out_channels=hf_config["out_channels"],
+            latent_channels=hf_config["latent_channels"],
+            block_out_channels=tuple(hf_config["block_out_channels"]),
+            layers_per_block=hf_config["layers_per_block"],
+            norm_groups=hf_config.get("norm_num_groups", 32),
+            scaling_factor=hf_config.get("scaling_factor", 0.18215),
+            # FLUX / SD3 VAEs shift latents and drop the quant convs; SD/SDXL do not.
+            shift_factor=hf_config.get("shift_factor") or 0.0,
+            use_quant_conv=hf_config.get("use_quant_conv", True),
+        )
+
+    def build_model(self, hf_config: dict) -> AutoencoderKLSD:
+        return AutoencoderKLSD(self.build_config(hf_config))
+
+    def convert_weights(
+        self, weights: dict[str, mx.array], hf_config: dict
+    ) -> dict[str, mx.array]:
+        # Conv kernels -> channels-last; Linear/GroupNorm weights already match.
+        return {
+            k: (convert_conv_weight(v) if v.ndim == 4 else v)
+            for k, v in weights.items()
+        }
+
+
+def _heads_from(hf_config: dict) -> tuple[int, ...]:
+    # SDXL stores the per-level head COUNT under attention_head_dim (legacy naming).
+    nah = hf_config.get("num_attention_heads") or hf_config["attention_head_dim"]
+    return (
+        tuple(nah)
+        if isinstance(nah, (list, tuple))
+        else (nah,) * len(hf_config["block_out_channels"])
+    )
+
+
+@register_converter
+class SDXLUNetConverter(Converter):
+    source_class = "UNet2DConditionModel"
+
+    def build_config(self, hf_config: dict) -> SDXLUNetConfig:
+        tlpb = hf_config["transformer_layers_per_block"]
+        boc = hf_config["block_out_channels"]
+        return SDXLUNetConfig(
+            in_channels=hf_config["in_channels"],
+            out_channels=hf_config["out_channels"],
+            block_out_channels=tuple(boc),
+            down_block_types=tuple(hf_config["down_block_types"]),
+            up_block_types=tuple(hf_config["up_block_types"]),
+            layers_per_block=hf_config["layers_per_block"],
+            transformer_layers_per_block=tuple(tlpb)
+            if isinstance(tlpb, (list, tuple))
+            else (tlpb,) * len(boc),
+            num_attention_heads=_heads_from(hf_config),
+            cross_attention_dim=hf_config["cross_attention_dim"],
+            addition_time_embed_dim=hf_config["addition_time_embed_dim"],
+            projection_class_embeddings_input_dim=hf_config[
+                "projection_class_embeddings_input_dim"
+            ],
+            norm_groups=hf_config.get("norm_num_groups", 32),
+        )
+
+    def build_model(self, hf_config: dict) -> SDXLUNet:
+        return SDXLUNet(self.build_config(hf_config))
+
+    def convert_weights(
+        self, weights: dict[str, mx.array], hf_config: dict
+    ) -> dict[str, mx.array]:
+        return {
+            k: (convert_conv_weight(v) if v.ndim == 4 else v)
+            for k, v in weights.items()
+        }

--- a/vllm_mlx/image/sdxl_runtime/hub.py
+++ b/vllm_mlx/image/sdxl_runtime/hub.py
@@ -1,0 +1,72 @@
+"""Hugging Face Hub helpers (optional dependency, imported lazily).
+
+We never import ``huggingface_hub`` at module load. A local path is always used
+as-is; only an unresolved repo id triggers a download, and only then do we require
+the optional dependency.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_INSTALL_HINT = (
+    "Resolving a Hub repo id requires `huggingface_hub`. "
+    "Install it with `pip install mlx-diffuser[hub]` (or `pip install huggingface_hub`)."
+)
+
+
+def is_local(path_or_repo_id: str | Path) -> bool:
+    """True if the argument points at an existing local file or directory."""
+    return Path(path_or_repo_id).exists()
+
+
+def resolve(
+    path_or_repo_id: str | Path,
+    *,
+    revision: str | None = None,
+    allow_patterns: list[str] | None = None,
+    cache_dir: str | None = None,
+) -> Path:
+    """Return a local directory for a model/pipeline.
+
+    If ``path_or_repo_id`` exists locally it is returned unchanged. Otherwise it is
+    treated as a Hub repo id and downloaded with ``snapshot_download``.
+    """
+    if is_local(path_or_repo_id):
+        return Path(path_or_repo_id)
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:  # pragma: no cover - exercised only without extra
+        raise ImportError(_INSTALL_HINT) from exc
+
+    local = snapshot_download(
+        repo_id=str(path_or_repo_id),
+        revision=revision,
+        allow_patterns=allow_patterns,
+        cache_dir=cache_dir,
+    )
+    return Path(local)
+
+
+def push_folder(
+    folder: str | Path,
+    repo_id: str,
+    *,
+    private: bool = False,
+    commit_message: str = "Upload with mlx-diffuser",
+) -> str:
+    """Upload a saved model/pipeline folder to the Hub. Returns the repo URL."""
+    try:
+        from huggingface_hub import HfApi
+    except ImportError as exc:  # pragma: no cover - exercised only without extra
+        raise ImportError(_INSTALL_HINT) from exc
+
+    api = HfApi()
+    api.create_repo(repo_id, private=private, exist_ok=True)
+    api.upload_folder(
+        folder_path=str(folder),
+        repo_id=repo_id,
+        commit_message=commit_message,
+    )
+    return f"https://huggingface.co/{repo_id}"

--- a/vllm_mlx/image/sdxl_runtime/modeling.py
+++ b/vllm_mlx/image/sdxl_runtime/modeling.py
@@ -1,0 +1,126 @@
+"""``ModelMixin``: save/load behaviour shared by every network.
+
+A model is an ``mlx.nn.Module`` that:
+
+* takes its :class:`~mlx_diffuser.configuration.Config` as the sole ``__init__`` arg,
+* declares ``config_class`` so it can be rebuilt from ``config.json``,
+* stores that config on ``self.config``.
+
+Everything else (``from_pretrained``, ``save_pretrained``, dtype casting,
+quantization, parameter counting) is provided here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Generic, TypeVar
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from .configuration import Config
+from .hub import push_folder, resolve
+from .quantization import quantize_module
+from .utils import as_dtype, get_logger
+
+WEIGHTS_NAME = "model.safetensors"
+
+C = TypeVar("C", bound=Config)
+M = TypeVar("M", bound="ModelMixin")
+logger = get_logger()
+
+
+class ModelMixin(nn.Module, Generic[C]):
+    """Base class for all mlx-diffuser networks (generic over its config type)."""
+
+    #: The Config subclass this model is constructed from.
+    config_class: type[C]
+
+    config: C
+
+    def save_pretrained(
+        self, save_directory: str | Path, push_to_hub: str | None = None
+    ) -> Path:
+        """Write ``config.json`` + ``model.safetensors`` into ``save_directory``.
+
+        If ``push_to_hub`` is a repo id, the folder is uploaded afterwards.
+        """
+        save_directory = Path(save_directory)
+        save_directory.mkdir(parents=True, exist_ok=True)
+        self.config.save(save_directory)
+        self.save_weights(str(save_directory / WEIGHTS_NAME))
+        if push_to_hub:
+            push_folder(save_directory, push_to_hub)
+        return save_directory
+
+    @classmethod
+    def from_pretrained(
+        cls: type[M],
+        path_or_repo_id: str | Path,
+        *,
+        dtype: str | mx.Dtype | None = None,
+        quantize: int | None = None,
+        quant_group_size: int = 64,
+        strict: bool = True,
+        revision: str | None = None,
+        **config_overrides: Any,
+    ) -> M:
+        """Load a model from a local directory or a Hub repo id.
+
+        Args:
+            path_or_repo_id: local dir (with ``config.json`` + weights) or Hub id.
+            dtype: cast floating-point params to this dtype after loading.
+            quantize: if set (2/3/4/6/8), weight-quantize after loading.
+            quant_group_size: group size for quantization.
+            strict: require the checkpoint to match the model's params exactly.
+            revision: Hub revision (branch/tag/commit) when downloading.
+            **config_overrides: override individual config fields at load time.
+        """
+        local = resolve(path_or_repo_id, revision=revision)
+        config = cls.config_class.load(local)
+        if config_overrides:
+            config = config.replace(**config_overrides)
+
+        model = cls(config)  # type: ignore[call-arg]  # subclasses take a config
+
+        # Pre-quantized checkpoints (written by the converters) carry a
+        # quantization.json sidecar: quantize the skeleton *before* loading so
+        # the parameter tree matches the stored weight/scales/biases triplets.
+        quant_marker = local / "quantization.json"
+        if quant_marker.exists():
+            import json
+
+            spec = json.loads(quant_marker.read_text())
+            quantize_module(model, bits=spec["bits"], group_size=spec["group_size"])
+
+        weights_file = local / WEIGHTS_NAME
+        if weights_file.exists():
+            model.load_weights(str(weights_file), strict=strict)
+        else:  # sharded checkpoint (model-*.safetensors)
+            from .converters.base import load_safetensors_folder
+
+            merged = load_safetensors_folder(local)
+            model.load_weights(list(merged.items()), strict=strict)
+            del merged
+
+        resolved_dtype = as_dtype(dtype)
+        if resolved_dtype is not None:
+            model.set_dtype(resolved_dtype)
+        if quantize is not None and not quant_marker.exists():
+            quantize_module(model, bits=quantize, group_size=quant_group_size)
+
+        from .converters.base import _eval_in_chunks  # local import avoids a cycle
+
+        _eval_in_chunks(model.parameters())
+        model.eval()
+        return model
+
+    def num_parameters(self, trainable_only: bool = False) -> int:
+        """Total number of parameter elements in the model."""
+        params = self.trainable_parameters() if trainable_only else self.parameters()
+        return sum(v.size for _, v in tree_flatten(params))  # type: ignore[union-attr, str-unpack]
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        n = self.num_parameters()
+        return f"{type(self).__name__}({n / 1e6:.1f}M params)"

--- a/vllm_mlx/image/sdxl_runtime/models/__init__.py
+++ b/vllm_mlx/image/sdxl_runtime/models/__init__.py
@@ -1,0 +1,1 @@
+"""SDXL model components."""

--- a/vllm_mlx/image/sdxl_runtime/models/autoencoder_kl_sd.py
+++ b/vllm_mlx/image/sdxl_runtime/models/autoencoder_kl_sd.py
@@ -1,0 +1,297 @@
+"""AutoencoderKLSD: a faithful MLX port of diffusers' ``AutoencoderKL`` (SD / SDXL).
+
+Mirrors the diffusers module tree (``encoder.down_blocks.N.resnets.M``, ``mid_block``,
+``quant_conv`` …) so the official VAE weights load directly via the converter. The
+decoder supports **tiling**: large latents are decoded in overlapping spatial tiles
+and feather-blended, which bounds peak memory so 1024px+ images fit on a Mac.
+
+Tensors are channels-last ``(B, H, W, C)``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..configuration import Config
+from ..modeling import ModelMixin
+from .diagonal_gaussian import DiagonalGaussian
+
+
+@dataclasses.dataclass
+class AutoencoderKLSDConfig(Config):
+    in_channels: int = 3
+    out_channels: int = 3
+    latent_channels: int = 4
+    block_out_channels: tuple[int, ...] = (128, 256, 512, 512)
+    layers_per_block: int = 2
+    norm_groups: int = 32
+    scaling_factor: float = 0.13025  # SDXL
+    shift_factor: float = (
+        0.0  # FLUX/SD3 shift latents before scaling: (z - shift) * scale
+    )
+    use_quant_conv: bool = True  # SD/SDXL have quant convs; FLUX/SD3 VAEs do not
+
+
+class _Resnet(nn.Module):
+    def __init__(self, in_ch: int, out_ch: int, groups: int):
+        super().__init__()
+        self.norm1 = nn.GroupNorm(groups, in_ch, pytorch_compatible=True)
+        self.conv1 = nn.Conv2d(in_ch, out_ch, 3, padding=1)
+        self.norm2 = nn.GroupNorm(groups, out_ch, pytorch_compatible=True)
+        self.conv2 = nn.Conv2d(out_ch, out_ch, 3, padding=1)
+        self.conv_shortcut = nn.Conv2d(in_ch, out_ch, 1) if in_ch != out_ch else None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        h = self.conv1(nn.silu(self.norm1(x)))
+        h = self.conv2(nn.silu(self.norm2(h)))
+        skip = self.conv_shortcut(x) if self.conv_shortcut is not None else x
+        return skip + h
+
+
+class _Downsample(nn.Module):
+    def __init__(self, ch: int):
+        super().__init__()
+        self.conv = nn.Conv2d(ch, ch, 3, stride=2, padding=0)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = mx.pad(x, [(0, 0), (0, 1), (0, 1), (0, 0)])  # diffusers pads bottom/right
+        return self.conv(x)
+
+
+class _Upsample(nn.Module):
+    def __init__(self, ch: int):
+        super().__init__()
+        self.up = nn.Upsample(scale_factor=2.0, mode="nearest")
+        self.conv = nn.Conv2d(ch, ch, 3, padding=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.conv(self.up(x))
+
+
+class _Attention(nn.Module):
+    """Single-head spatial self-attention (diffusers VAE mid-block attention)."""
+
+    def __init__(self, ch: int, groups: int):
+        super().__init__()
+        self.group_norm = nn.GroupNorm(groups, ch, pytorch_compatible=True)
+        self.to_q = nn.Linear(ch, ch)
+        self.to_k = nn.Linear(ch, ch)
+        self.to_v = nn.Linear(ch, ch)
+        self.to_out = [nn.Linear(ch, ch)]
+        self.scale = ch**-0.5
+
+    def __call__(self, x: mx.array) -> mx.array:
+        b, h, w, c = x.shape
+        y = self.group_norm(x).reshape(b, h * w, c)
+        q, k, v = (z[:, None] for z in (self.to_q(y), self.to_k(y), self.to_v(y)))
+        o = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale)[:, 0]
+        return x + self.to_out[0](o).reshape(b, h, w, c)
+
+
+class _MidBlock(nn.Module):
+    def __init__(self, ch: int, groups: int):
+        super().__init__()
+        self.attentions = [_Attention(ch, groups)]
+        self.resnets = [_Resnet(ch, ch, groups), _Resnet(ch, ch, groups)]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.resnets[0](x)
+        x = self.attentions[0](x)
+        return self.resnets[1](x)
+
+
+class _DownBlock(nn.Module):
+    def __init__(
+        self, in_ch: int, out_ch: int, n_layers: int, groups: int, add_down: bool
+    ):
+        super().__init__()
+        self.resnets = []
+        cur = in_ch
+        for _ in range(n_layers):
+            self.resnets.append(_Resnet(cur, out_ch, groups))
+            cur = out_ch
+        self.downsamplers = [_Downsample(out_ch)] if add_down else None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for r in self.resnets:
+            x = r(x)
+        if self.downsamplers is not None:
+            x = self.downsamplers[0](x)
+        return x
+
+
+class _UpBlock(nn.Module):
+    def __init__(
+        self, in_ch: int, out_ch: int, n_layers: int, groups: int, add_up: bool
+    ):
+        super().__init__()
+        self.resnets = []
+        cur = in_ch
+        for _ in range(n_layers):
+            self.resnets.append(_Resnet(cur, out_ch, groups))
+            cur = out_ch
+        self.upsamplers = [_Upsample(out_ch)] if add_up else None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for r in self.resnets:
+            x = r(x)
+        if self.upsamplers is not None:
+            x = self.upsamplers[0](x)
+        return x
+
+
+class _Encoder(nn.Module):
+    def __init__(self, c: AutoencoderKLSDConfig):
+        super().__init__()
+        boc = list(c.block_out_channels)
+        n = len(boc)
+        self.conv_in = nn.Conv2d(c.in_channels, boc[0], 3, padding=1)
+        self.down_blocks = []
+        out = boc[0]
+        for i in range(n):
+            in_ch, out = out, boc[i]
+            self.down_blocks.append(
+                _DownBlock(
+                    in_ch, out, c.layers_per_block, c.norm_groups, add_down=i < n - 1
+                )
+            )
+        self.mid_block = _MidBlock(boc[-1], c.norm_groups)
+        self.conv_norm_out = nn.GroupNorm(
+            c.norm_groups, boc[-1], pytorch_compatible=True
+        )
+        self.conv_out = nn.Conv2d(boc[-1], 2 * c.latent_channels, 3, padding=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.conv_in(x)
+        for b in self.down_blocks:
+            x = b(x)
+        x = self.mid_block(x)
+        return self.conv_out(nn.silu(self.conv_norm_out(x)))
+
+
+class _Decoder(nn.Module):
+    def __init__(self, c: AutoencoderKLSDConfig):
+        super().__init__()
+        rev = list(reversed(c.block_out_channels))
+        n = len(rev)
+        self.conv_in = nn.Conv2d(c.latent_channels, rev[0], 3, padding=1)
+        self.mid_block = _MidBlock(rev[0], c.norm_groups)
+        self.up_blocks = []
+        out = rev[0]
+        for i in range(n):
+            in_ch, out = out, rev[i]
+            self.up_blocks.append(
+                _UpBlock(
+                    in_ch, out, c.layers_per_block + 1, c.norm_groups, add_up=i < n - 1
+                )
+            )
+        self.conv_norm_out = nn.GroupNorm(
+            c.norm_groups, rev[-1], pytorch_compatible=True
+        )
+        self.conv_out = nn.Conv2d(rev[-1], c.out_channels, 3, padding=1)
+
+    def __call__(self, z: mx.array) -> mx.array:
+        x = self.conv_in(z)
+        x = self.mid_block(x)
+        for b in self.up_blocks:
+            x = b(x)
+        return self.conv_out(nn.silu(self.conv_norm_out(x)))
+
+
+def _feather(n: int, overlap: int) -> mx.array:
+    """A 1-D blend window: linear ramp up over the first ``overlap`` and down the last."""
+    w = mx.ones((n,))
+    if overlap > 0:
+        ramp = (mx.arange(overlap) + 1).astype(mx.float32) / (overlap + 1)
+        w = mx.concatenate([ramp, mx.ones((n - 2 * overlap,)), ramp[::-1]])
+    return w
+
+
+class AutoencoderKLSD(ModelMixin[AutoencoderKLSDConfig]):
+    """SD / SDXL VAE. Channels-last ``(B, H, W, C)``."""
+
+    config_class = AutoencoderKLSDConfig
+
+    def __init__(self, config: AutoencoderKLSDConfig):
+        super().__init__()
+        self.config = config
+        self.encoder = _Encoder(config)
+        self.decoder = _Decoder(config)
+        self.quant_conv: nn.Conv2d | None = None
+        self.post_quant_conv: nn.Conv2d | None = None
+        if config.use_quant_conv:  # FLUX / SD3 VAEs skip the quant convs
+            self.quant_conv = nn.Conv2d(
+                2 * config.latent_channels, 2 * config.latent_channels, 1
+            )
+            self.post_quant_conv = nn.Conv2d(
+                config.latent_channels, config.latent_channels, 1
+            )
+
+    @property
+    def scaling_factor(self) -> float:
+        return self.config.scaling_factor
+
+    @property
+    def shift_factor(self) -> float:
+        return self.config.shift_factor
+
+    def encode(self, x: mx.array) -> DiagonalGaussian:
+        moments = self.encoder(x)
+        if self.quant_conv is not None:
+            moments = self.quant_conv(moments)
+        return DiagonalGaussian(moments)
+
+    def decode(
+        self,
+        z: mx.array,
+        *,
+        tile: bool = False,
+        tile_latent: int = 64,
+        overlap_latent: int = 16,
+    ) -> mx.array:
+        """Decode latents to pixels. With ``tile=True``, decode in overlapping tiles.
+
+        Tiling bounds peak memory for large latents: the latent is split into
+        ``tile_latent``-sized spatial tiles (stride ``tile_latent - overlap_latent``),
+        each decoded independently, then feather-blended back together.
+        """
+        if self.post_quant_conv is not None:
+            z = self.post_quant_conv(z)
+        h, w = z.shape[1], z.shape[2]
+        if not tile or (h <= tile_latent and w <= tile_latent):
+            return self.decoder(z)
+        return self._tiled(z, tile_latent, overlap_latent)
+
+    def _tiled(self, z: mx.array, tile: int, overlap: int) -> mx.array:
+        h, w = z.shape[1], z.shape[2]
+        stride = tile - overlap
+        ys = sorted({*range(0, max(h - tile, 0) + 1, stride), max(h - tile, 0)})
+        xs = sorted({*range(0, max(w - tile, 0) + 1, stride), max(w - tile, 0)})
+        scale = 2 ** (
+            len(self.config.block_out_channels) - 1
+        )  # VAE spatial upsampling factor
+        out = mx.zeros((z.shape[0], h * scale, w * scale, self.config.out_channels))
+        wsum = mx.zeros((1, h * scale, w * scale, 1))
+        for y in ys:
+            for x in xs:
+                dec = self.decoder(
+                    z[:, y : y + tile, x : x + tile]
+                )  # (B, tile*8, tile*8, C)
+                th, tw = dec.shape[1], dec.shape[2]
+                win = (
+                    _feather(th, overlap * scale)[:, None]
+                    * _feather(tw, overlap * scale)[None]
+                )[None, :, :, None]
+                py, px = y * scale, x * scale
+                out[:, py : py + th, px : px + tw] += dec * win
+                wsum[:, py : py + th, px : px + tw] += win
+        return out / wsum
+
+    def __call__(
+        self, x: mx.array, key: mx.array | None = None
+    ) -> tuple[mx.array, DiagonalGaussian]:
+        posterior = self.encode(x)
+        return self.decode(posterior.sample(key)), posterior

--- a/vllm_mlx/image/sdxl_runtime/models/clip_text.py
+++ b/vllm_mlx/image/sdxl_runtime/models/clip_text.py
@@ -1,0 +1,165 @@
+"""CLIPTextModel: MLX port of the CLIP text encoders SDXL conditions on.
+
+SDXL uses two of these — CLIP ViT-L/14 (``text_encoder``) and OpenCLIP ViT-bigG/14
+(``text_encoder_2``). For each it takes the **penultimate** hidden state as the
+per-token sequence (the two are concatenated → 2048-dim cross-attention context),
+and from the bigG encoder it also takes the **projected pooled** embedding (the
+hidden state at the EOS token, run through ``text_projection``) for SDXL's added
+time/text conditioning.
+
+Module names mirror transformers' ``CLIPTextModel`` so weight conversion is nearly
+identity. The text transformer is causal (autoregressive masking) with pre-LayerNorm
+blocks; the two encoders differ only in size and activation (``quick_gelu`` for L,
+``gelu`` for bigG).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..configuration import Config
+from ..modeling import ModelMixin
+
+
+@dataclasses.dataclass
+class CLIPTextConfig(Config):
+    vocab_size: int = 49408
+    hidden_size: int = 768
+    intermediate_size: int = 3072
+    num_hidden_layers: int = 12
+    num_attention_heads: int = 12
+    max_position_embeddings: int = 77
+    hidden_act: str = "quick_gelu"  # "gelu" for the bigG encoder
+    projection_dim: int = 768
+    layer_norm_eps: float = 1e-5
+    with_projection: bool = (
+        False  # True for the bigG encoder (CLIPTextModelWithProjection)
+    )
+
+
+def _act(name: str):
+    if name == "quick_gelu":
+        return lambda x: x * mx.sigmoid(1.702 * x)
+    if name in ("gelu", "gelu_new"):
+        return nn.gelu
+    raise ValueError(f"Unsupported CLIP activation {name!r}.")
+
+
+class _CLIPEmbeddings(nn.Module):
+    def __init__(self, c: CLIPTextConfig):
+        super().__init__()
+        self.token_embedding = nn.Embedding(c.vocab_size, c.hidden_size)
+        self.position_embedding = nn.Embedding(c.max_position_embeddings, c.hidden_size)
+
+    def __call__(self, input_ids: mx.array) -> mx.array:
+        positions = mx.arange(input_ids.shape[-1])
+        return self.token_embedding(input_ids) + self.position_embedding(positions)
+
+
+class _CLIPAttention(nn.Module):
+    def __init__(self, c: CLIPTextConfig):
+        super().__init__()
+        self.num_heads = c.num_attention_heads
+        self.head_dim = c.hidden_size // c.num_attention_heads
+        self.scale = self.head_dim**-0.5
+        self.q_proj = nn.Linear(c.hidden_size, c.hidden_size)
+        self.k_proj = nn.Linear(c.hidden_size, c.hidden_size)
+        self.v_proj = nn.Linear(c.hidden_size, c.hidden_size)
+        self.out_proj = nn.Linear(c.hidden_size, c.hidden_size)
+
+    def _heads(self, x: mx.array) -> mx.array:
+        b, t, _ = x.shape
+        return x.reshape(b, t, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+    def __call__(self, x: mx.array, mask: mx.array) -> mx.array:
+        q, k, v = (
+            self._heads(self.q_proj(x)),
+            self._heads(self.k_proj(x)),
+            self._heads(self.v_proj(x)),
+        )
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask=mask)
+        b, _, t, _ = out.shape
+        out = out.transpose(0, 2, 1, 3).reshape(b, t, self.num_heads * self.head_dim)
+        return self.out_proj(out)
+
+
+class _CLIPMLP(nn.Module):
+    def __init__(self, c: CLIPTextConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(c.hidden_size, c.intermediate_size)
+        self.fc2 = nn.Linear(c.intermediate_size, c.hidden_size)
+        self.act = _act(c.hidden_act)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+class _CLIPEncoderLayer(nn.Module):
+    def __init__(self, c: CLIPTextConfig):
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(c.hidden_size, eps=c.layer_norm_eps)
+        self.self_attn = _CLIPAttention(c)
+        self.layer_norm2 = nn.LayerNorm(c.hidden_size, eps=c.layer_norm_eps)
+        self.mlp = _CLIPMLP(c)
+
+    def __call__(self, x: mx.array, mask: mx.array) -> mx.array:
+        x = x + self.self_attn(self.layer_norm1(x), mask)
+        x = x + self.mlp(self.layer_norm2(x))
+        return x
+
+
+class _CLIPEncoder(nn.Module):
+    def __init__(self, c: CLIPTextConfig):
+        super().__init__()
+        self.layers = [_CLIPEncoderLayer(c) for _ in range(c.num_hidden_layers)]
+
+
+class _CLIPTextTransformer(nn.Module):
+    def __init__(self, c: CLIPTextConfig):
+        super().__init__()
+        self.embeddings = _CLIPEmbeddings(c)
+        self.encoder = _CLIPEncoder(c)
+        self.final_layer_norm = nn.LayerNorm(c.hidden_size, eps=c.layer_norm_eps)
+
+
+class CLIPTextModel(ModelMixin[CLIPTextConfig]):
+    """CLIP text encoder. Returns all hidden states + the projected pooled embedding."""
+
+    config_class = CLIPTextConfig
+
+    def __init__(self, config: CLIPTextConfig):
+        super().__init__()
+        self.config = config
+        self.text_model = _CLIPTextTransformer(config)
+        self.text_projection = (
+            nn.Linear(config.hidden_size, config.projection_dim, bias=False)
+            if config.with_projection
+            else None
+        )
+
+    def __call__(self, input_ids: mx.array) -> tuple[list[mx.array], mx.array]:
+        """``(B, L) int -> (hidden_states, pooled)``.
+
+        ``hidden_states`` has length ``num_layers + 1`` (embeddings then each layer
+        output); SDXL reads ``[-2]``. ``pooled`` is the final-norm hidden state at the
+        EOS token (the highest token id), projected by ``text_projection`` when present
+        (the bigG encoder). SDXL uses the pooled output only from that encoder.
+        """
+        x = self.text_model.embeddings(input_ids)
+        seq = input_ids.shape[-1]
+        mask = mx.triu(mx.full((seq, seq), -mx.inf, dtype=x.dtype), k=1)
+
+        hidden_states = [x]
+        for layer in self.text_model.encoder.layers:
+            x = layer(x, mask)
+            hidden_states.append(x)
+
+        last = self.text_model.final_layer_norm(x)
+        eos = mx.argmax(input_ids, axis=-1)
+        pooled = last[mx.arange(input_ids.shape[0]), eos]
+        if self.text_projection is not None:
+            pooled = self.text_projection(pooled)
+        return hidden_states, pooled

--- a/vllm_mlx/image/sdxl_runtime/models/diagonal_gaussian.py
+++ b/vllm_mlx/image/sdxl_runtime/models/diagonal_gaussian.py
@@ -1,0 +1,22 @@
+"""Small diagonal Gaussian used by the SDXL VAE encoder."""
+
+import mlx.core as mx
+
+
+class DiagonalGaussian:
+    """A diagonal Gaussian parameterized by concatenated ``[mean, logvar]``."""
+
+    def __init__(self, parameters: mx.array):
+        self.mean, logvar = mx.split(parameters, 2, axis=-1)
+        self.logvar = mx.clip(logvar, -30.0, 20.0)
+        self.std = mx.exp(0.5 * self.logvar)
+
+    def sample(self, key: mx.array | None = None) -> mx.array:
+        key = key if key is not None else mx.random.key(0)
+        return self.mean + self.std * mx.random.normal(self.mean.shape, key=key)
+
+    def mode(self) -> mx.array:
+        return self.mean
+
+    def kl(self) -> mx.array:
+        return 0.5 * mx.sum(self.mean**2 + mx.exp(self.logvar) - 1.0 - self.logvar)

--- a/vllm_mlx/image/sdxl_runtime/models/unet_sdxl.py
+++ b/vllm_mlx/image/sdxl_runtime/models/unet_sdxl.py
@@ -1,0 +1,434 @@
+"""SDXLUNet: a faithful MLX port of diffusers' ``UNet2DConditionModel`` (SDXL base).
+
+Mirrors the diffusers module tree (``down_blocks.N.attentions.M.transformer_blocks.K``
+…) so the official SDXL UNet weights load directly via the converter. It is a
+cross-attention UNet conditioned on:
+
+* the timestep (sinusoidal -> MLP),
+* the **pooled** text embedding plus SDXL's micro-conditioning ``add_time_ids``
+  (original size / crop / target size), together forming the *added* embedding, and
+* the concatenated per-token CLIP-L + CLIP-bigG embeddings (2048-dim) via cross
+  attention.
+
+Tensors are channels-last ``(B, H, W, C)``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..caching import DeepCache
+from ..configuration import Config
+from ..modeling import ModelMixin
+
+
+@dataclasses.dataclass
+class SDXLUNetConfig(Config):
+    in_channels: int = 4
+    out_channels: int = 4
+    block_out_channels: tuple[int, ...] = (320, 640, 1280)
+    down_block_types: tuple[str, ...] = (
+        "DownBlock2D",
+        "CrossAttnDownBlock2D",
+        "CrossAttnDownBlock2D",
+    )
+    up_block_types: tuple[str, ...] = (
+        "CrossAttnUpBlock2D",
+        "CrossAttnUpBlock2D",
+        "UpBlock2D",
+    )
+    layers_per_block: int = 2
+    transformer_layers_per_block: tuple[int, ...] = (1, 2, 10)
+    num_attention_heads: tuple[int, ...] = (5, 10, 20)
+    cross_attention_dim: int = 2048
+    addition_time_embed_dim: int = 256
+    projection_class_embeddings_input_dim: int = 2816
+    norm_groups: int = 32
+
+    @property
+    def time_embed_dim(self) -> int:
+        return self.block_out_channels[0] * 4
+
+
+def _timesteps(t: mx.array, dim: int, max_period: float = 10000.0) -> mx.array:
+    """diffusers ``Timesteps`` (flip_sin_to_cos, shift 0): ``(N,) -> (N, dim)``."""
+    half = dim // 2
+    freqs = mx.exp(-math.log(max_period) * mx.arange(half, dtype=mx.float32) / half)
+    args = t.astype(mx.float32)[:, None] * freqs[None]
+    return mx.concatenate([mx.cos(args), mx.sin(args)], axis=-1)
+
+
+class _TimeMLP(nn.Module):
+    def __init__(self, in_dim: int, out_dim: int):
+        super().__init__()
+        self.linear_1 = nn.Linear(in_dim, out_dim)
+        self.linear_2 = nn.Linear(out_dim, out_dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.linear_2(nn.silu(self.linear_1(x)))
+
+
+class _Resnet(nn.Module):
+    def __init__(self, in_ch: int, out_ch: int, temb_dim: int, groups: int):
+        super().__init__()
+        self.norm1 = nn.GroupNorm(groups, in_ch, pytorch_compatible=True)
+        self.conv1 = nn.Conv2d(in_ch, out_ch, 3, padding=1)
+        self.time_emb_proj = nn.Linear(temb_dim, out_ch)
+        self.norm2 = nn.GroupNorm(groups, out_ch, pytorch_compatible=True)
+        self.conv2 = nn.Conv2d(out_ch, out_ch, 3, padding=1)
+        self.conv_shortcut = nn.Conv2d(in_ch, out_ch, 1) if in_ch != out_ch else None
+
+    def __call__(self, x: mx.array, temb: mx.array) -> mx.array:
+        h = self.conv1(nn.silu(self.norm1(x)))
+        h = h + self.time_emb_proj(nn.silu(temb))[:, None, None, :]
+        h = self.conv2(nn.silu(self.norm2(h)))
+        skip = self.conv_shortcut(x) if self.conv_shortcut is not None else x
+        return skip + h
+
+
+class _Attention(nn.Module):
+    def __init__(self, query_dim: int, heads: int, cross_dim: int | None = None):
+        super().__init__()
+        self.heads = heads
+        self.head_dim = query_dim // heads
+        self.scale = self.head_dim**-0.5
+        ctx = cross_dim or query_dim
+        self.to_q = nn.Linear(query_dim, query_dim, bias=False)
+        self.to_k = nn.Linear(ctx, query_dim, bias=False)
+        self.to_v = nn.Linear(ctx, query_dim, bias=False)
+        self.to_out = [nn.Linear(query_dim, query_dim)]
+
+    def _heads(self, x: mx.array) -> mx.array:
+        b, t, _ = x.shape
+        return x.reshape(b, t, self.heads, self.head_dim).transpose(0, 2, 1, 3)
+
+    def __call__(self, x: mx.array, context: mx.array | None = None) -> mx.array:
+        c = x if context is None else context
+        b, lq = x.shape[0], x.shape[1]
+        q, k, v = (
+            self._heads(self.to_q(x)),
+            self._heads(self.to_k(c)),
+            self._heads(self.to_v(c)),
+        )
+        o = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale)
+        o = o.transpose(0, 2, 1, 3).reshape(b, lq, self.heads * self.head_dim)
+        return self.to_out[0](o)
+
+
+class _GEGLU(nn.Module):
+    def __init__(self, dim_in: int, dim_out: int):
+        super().__init__()
+        self.proj = nn.Linear(dim_in, dim_out * 2)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x, gate = mx.split(self.proj(x), 2, axis=-1)
+        return x * nn.gelu(gate)
+
+
+class _Identity(nn.Module):
+    def __call__(self, x: mx.array) -> mx.array:
+        return x
+
+
+class _FeedForward(nn.Module):
+    def __init__(self, dim: int, mult: int = 4):
+        super().__init__()
+        self.net = [_GEGLU(dim, dim * mult), _Identity(), nn.Linear(dim * mult, dim)]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.net[2](self.net[0](x))
+
+
+class _BasicBlock(nn.Module):
+    def __init__(self, dim: int, heads: int, cross_dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim, eps=eps)
+        self.attn1 = _Attention(dim, heads)
+        self.norm2 = nn.LayerNorm(dim, eps=eps)
+        self.attn2 = _Attention(dim, heads, cross_dim)
+        self.norm3 = nn.LayerNorm(dim, eps=eps)
+        self.ff = _FeedForward(dim)
+
+    def __call__(self, x: mx.array, context: mx.array) -> mx.array:
+        x = x + self.attn1(self.norm1(x))
+        x = x + self.attn2(self.norm2(x), context)
+        x = x + self.ff(self.norm3(x))
+        return x
+
+
+class _Transformer2D(nn.Module):
+    """Spatial transformer (use_linear_projection=True, as in SDXL)."""
+
+    def __init__(self, dim: int, heads: int, depth: int, cross_dim: int, groups: int):
+        super().__init__()
+        self.norm = nn.GroupNorm(groups, dim, pytorch_compatible=True)
+        self.proj_in = nn.Linear(dim, dim)
+        self.transformer_blocks = [
+            _BasicBlock(dim, heads, cross_dim) for _ in range(depth)
+        ]
+        self.proj_out = nn.Linear(dim, dim)
+
+    def __call__(self, x: mx.array, context: mx.array) -> mx.array:
+        b, h, w, c = x.shape
+        y = self.norm(x).reshape(b, h * w, c)
+        y = self.proj_in(y)
+        for block in self.transformer_blocks:
+            y = block(y, context)
+        y = self.proj_out(y).reshape(b, h, w, c)
+        return x + y
+
+
+class _Downsample(nn.Module):
+    def __init__(self, ch: int):
+        super().__init__()
+        self.conv = nn.Conv2d(ch, ch, 3, stride=2, padding=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.conv(x)
+
+
+class _Upsample(nn.Module):
+    def __init__(self, ch: int):
+        super().__init__()
+        self.up = nn.Upsample(scale_factor=2.0, mode="nearest")
+        self.conv = nn.Conv2d(ch, ch, 3, padding=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.conv(self.up(x))
+
+
+class _DownBlock(nn.Module):
+    cross_attn = False
+
+    def __init__(
+        self, in_ch, out_ch, n, temb, groups, add_down, heads=0, depth=0, cross_dim=0
+    ):
+        super().__init__()
+        self.resnets = []
+        cur = in_ch
+        for _ in range(n):
+            self.resnets.append(_Resnet(cur, out_ch, temb, groups))
+            cur = out_ch
+        self.attentions = (
+            [_Transformer2D(out_ch, heads, depth, cross_dim, groups) for _ in range(n)]
+            if self.cross_attn
+            else None
+        )
+        self.downsamplers = [_Downsample(out_ch)] if add_down else None
+
+    def __call__(self, x, temb, context):
+        res = []
+        for i, r in enumerate(self.resnets):
+            x = r(x, temb)
+            if self.attentions is not None:
+                x = self.attentions[i](x, context)
+            res.append(x)
+        if self.downsamplers is not None:
+            x = self.downsamplers[0](x)
+            res.append(x)
+        return x, res
+
+
+class _CrossAttnDownBlock(_DownBlock):
+    cross_attn = True
+
+
+class _UpBlock(nn.Module):
+    cross_attn = False
+
+    def __init__(
+        self,
+        in_ch,
+        out_ch,
+        prev_out,
+        n,
+        temb,
+        groups,
+        add_up,
+        heads=0,
+        depth=0,
+        cross_dim=0,
+    ):
+        super().__init__()
+        self.resnets = []
+        for i in range(n):
+            res_skip = in_ch if i == n - 1 else out_ch
+            res_in = prev_out if i == 0 else out_ch
+            self.resnets.append(_Resnet(res_in + res_skip, out_ch, temb, groups))
+        self.attentions = (
+            [_Transformer2D(out_ch, heads, depth, cross_dim, groups) for _ in range(n)]
+            if self.cross_attn
+            else None
+        )
+        self.upsamplers = [_Upsample(out_ch)] if add_up else None
+
+    def __call__(self, x, skips, temb, context):
+        for i, r in enumerate(self.resnets):
+            x = mx.concatenate([x, skips.pop()], axis=-1)
+            x = r(x, temb)
+            if self.attentions is not None:
+                x = self.attentions[i](x, context)
+        if self.upsamplers is not None:
+            x = self.upsamplers[0](x)
+        return x
+
+
+class _CrossAttnUpBlock(_UpBlock):
+    cross_attn = True
+
+
+class _MidBlock(nn.Module):
+    def __init__(self, ch, temb, groups, heads, depth, cross_dim):
+        super().__init__()
+        self.resnets = [_Resnet(ch, ch, temb, groups), _Resnet(ch, ch, temb, groups)]
+        self.attentions = [_Transformer2D(ch, heads, depth, cross_dim, groups)]
+
+    def __call__(self, x, temb, context):
+        x = self.resnets[0](x, temb)
+        x = self.attentions[0](x, context)
+        return self.resnets[1](x, temb)
+
+
+class SDXLUNet(ModelMixin[SDXLUNetConfig]):
+    """SDXL base UNet. Channels-last ``(B, H, W, C)``."""
+
+    config_class = SDXLUNetConfig
+
+    def __init__(self, config: SDXLUNetConfig):
+        super().__init__()
+        self.config = config
+        c = config
+        boc = list(c.block_out_channels)
+        n = len(boc)
+        temb = c.time_embed_dim
+        g = c.norm_groups
+
+        self.conv_in = nn.Conv2d(c.in_channels, boc[0], 3, padding=1)
+        self.time_embedding = _TimeMLP(boc[0], temb)
+        self.add_embedding = _TimeMLP(c.projection_class_embeddings_input_dim, temb)
+
+        self.down_blocks: list = []
+        out = boc[0]
+        for i in range(n):
+            in_ch, out = out, boc[i]
+            cross = c.down_block_types[i].startswith("CrossAttn")
+            down_cls = _CrossAttnDownBlock if cross else _DownBlock
+            self.down_blocks.append(
+                down_cls(
+                    in_ch,
+                    out,
+                    c.layers_per_block,
+                    temb,
+                    g,
+                    add_down=i < n - 1,
+                    heads=c.num_attention_heads[i],
+                    depth=c.transformer_layers_per_block[i],
+                    cross_dim=c.cross_attention_dim,
+                )
+            )
+
+        self.mid_block = _MidBlock(
+            boc[-1],
+            temb,
+            g,
+            c.num_attention_heads[-1],
+            c.transformer_layers_per_block[-1],
+            c.cross_attention_dim,
+        )
+
+        rev_boc = list(reversed(boc))
+        rev_heads = list(reversed(c.num_attention_heads))
+        rev_depth = list(reversed(c.transformer_layers_per_block))
+        self.up_blocks: list = []
+        prev_out = boc[-1]
+        for i in range(n):
+            out = rev_boc[i]
+            in_ch = rev_boc[
+                min(i + 1, n - 1)
+            ]  # skip channel = symmetric down level input
+            cross = c.up_block_types[i].startswith("CrossAttn")
+            up_cls = _CrossAttnUpBlock if cross else _UpBlock
+            self.up_blocks.append(
+                up_cls(
+                    in_ch,
+                    out,
+                    prev_out,
+                    c.layers_per_block + 1,
+                    temb,
+                    g,
+                    add_up=i < n - 1,
+                    heads=rev_heads[i],
+                    depth=rev_depth[i],
+                    cross_dim=c.cross_attention_dim,
+                )
+            )
+            prev_out = out
+
+        self.conv_norm_out = nn.GroupNorm(g, boc[0], pytorch_compatible=True)
+        self.conv_out = nn.Conv2d(boc[0], c.out_channels, 3, padding=1)
+
+    def __call__(
+        self,
+        sample: mx.array,
+        timestep: mx.array,
+        encoder_hidden_states: mx.array,
+        text_embeds: mx.array,
+        time_ids: mx.array,
+        cache: DeepCache | None = None,
+    ) -> mx.array:
+        """Predict noise for latents ``sample`` ``(B, H, W, C)``.
+
+        ``encoder_hidden_states`` is the ``(B, L, 2048)`` concatenated CLIP context;
+        ``text_embeds`` the ``(B, 1280)`` pooled bigG embedding; ``time_ids`` the
+        ``(B, 6)`` SDXL micro-conditioning (sizes / crop). With a ``DeepCache``, the
+        deep blocks may be skipped on most steps.
+        """
+        b = sample.shape[0]
+        emb = self.time_embedding(
+            _timesteps(
+                mx.broadcast_to(timestep, (b,)), self.config.block_out_channels[0]
+            )
+        )
+        tid = _timesteps(
+            time_ids.reshape(-1), self.config.addition_time_embed_dim
+        ).reshape(b, -1)
+        emb = emb + self.add_embedding(mx.concatenate([text_embeds, tid], axis=-1))
+
+        ehs = encoder_hidden_states
+        if cache is not None and cache.should_reuse():
+            return self._cached_forward(sample, emb, ehs, cache)
+
+        x = self.conv_in(sample)
+        res_samples = [x]
+        for block in self.down_blocks:
+            x, res = block(x, emb, ehs)
+            res_samples += res
+
+        x = self.mid_block(x, emb, ehs)
+
+        for block in self.up_blocks[:-1]:
+            take = len(block.resnets)
+            x = block(x, res_samples[-take:], emb, ehs)
+            res_samples = res_samples[:-take]
+
+        if cache is not None:
+            cache.deep = x  # the input to the shallow up block — reused on cached steps
+
+        last = self.up_blocks[-1]
+        x = last(x, res_samples[-len(last.resnets) :], emb, ehs)
+        return self.conv_out(nn.silu(self.conv_norm_out(x)))
+
+    def _cached_forward(self, sample, emb, ehs, cache: DeepCache) -> mx.array:
+        """DeepCache step: run only conv_in + first down block + last up block."""
+        x = self.conv_in(sample)
+        shallow = [x]
+        x, res0 = self.down_blocks[0](x, emb, ehs)
+        shallow += res0
+        last = self.up_blocks[-1]
+        skips = shallow[: len(last.resnets)]  # conv_in + first down block's resnets
+        x = last(cache.deep, skips, emb, ehs)
+        return self.conv_out(nn.silu(self.conv_norm_out(x)))

--- a/vllm_mlx/image/sdxl_runtime/pipelines/__init__.py
+++ b/vllm_mlx/image/sdxl_runtime/pipelines/__init__.py
@@ -1,0 +1,5 @@
+"""SDXL generation pipeline."""
+
+from .sdxl import StableDiffusionXLPipeline
+
+__all__ = ["StableDiffusionXLPipeline"]

--- a/vllm_mlx/image/sdxl_runtime/pipelines/sdxl.py
+++ b/vllm_mlx/image/sdxl_runtime/pipelines/sdxl.py
@@ -1,0 +1,258 @@
+"""StableDiffusionXLPipeline: text-to-image with SDXL on Apple silicon, in MLX.
+
+Wires the two CLIP text encoders, the SDXL UNet, the VAE, and a Euler scheduler.
+``from_diffusers`` converts an official ``stable-diffusion-xl-base`` folder into MLX
+models, so loading, encoding, denoising (with classifier-free guidance and SDXL's
+size micro-conditioning), and decoding all run natively on Metal.
+
+Tensors are channels-last. Images come back as ``(B, H, W, 3)`` in ``[-1, 1]``.
+"""
+
+from __future__ import annotations
+
+import gc
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import mlx.core as mx
+
+from ..caching import DeepCache
+from ..models.autoencoder_kl_sd import AutoencoderKLSD
+from ..models.clip_text import CLIPTextModel
+from ..models.unet_sdxl import SDXLUNet
+from ..schedulers.euler import EulerConfig, EulerDiscreteScheduler
+from ..utils import prepare_image
+
+MAX_TOKENS = 77
+
+
+class StableDiffusionXLPipeline:
+    """SDXL base text-to-image pipeline (channels-last ``(B, H, W, C)``)."""
+
+    def __init__(
+        self,
+        unet: SDXLUNet,
+        vae: AutoencoderKLSD,
+        text_encoder: CLIPTextModel,
+        text_encoder_2: CLIPTextModel,
+        tokenizer,
+        tokenizer_2,
+        scheduler: EulerDiscreteScheduler,
+    ):
+        self.unet = unet
+        self.vae = vae
+        self.text_encoder = text_encoder
+        self.text_encoder_2 = text_encoder_2
+        self.tokenizer = tokenizer
+        self.tokenizer_2 = tokenizer_2
+        self.scheduler = scheduler
+
+    # --- loading -------------------------------------------------------------
+    @classmethod
+    def from_diffusers(
+        cls,
+        folder: str | Path,
+        *,
+        dtype: mx.Dtype = mx.float16,
+        quantize_unet: int | None = None,
+    ) -> StableDiffusionXLPipeline:
+        """Load + convert a ``stable-diffusion-xl-base`` folder into MLX.
+
+        The UNet and text encoders run in ``dtype`` (fp16 by default, SDXL's native
+        precision); the VAE runs in fp32 because SDXL's VAE overflows fp16.
+        ``quantize_unet`` (4/8) weight-quantizes the UNet to save memory.
+        """
+        from ..converters import get_converter
+
+        folder = Path(folder)
+        unet = cast(
+            SDXLUNet,
+            get_converter("UNet2DConditionModel").convert(
+                folder / "unet", dtype=dtype, quantize=quantize_unet
+            ),
+        )
+        vae = cast(
+            AutoencoderKLSD,
+            get_converter("AutoencoderKL").convert(folder / "vae", dtype=mx.float32),
+        )
+        te = cast(
+            CLIPTextModel,
+            get_converter("CLIPTextModel").convert(
+                folder / "text_encoder", dtype=dtype
+            ),
+        )
+        te2 = cast(
+            CLIPTextModel,
+            get_converter("CLIPTextModelWithProjection").convert(
+                folder / "text_encoder_2", dtype=dtype
+            ),
+        )
+        tok = _load_tokenizer(folder / "tokenizer")
+        tok2 = _load_tokenizer(folder / "tokenizer_2")
+        scheduler = EulerDiscreteScheduler(
+            EulerConfig(
+                beta_schedule="scaled_linear",
+                beta_start=0.00085,
+                beta_end=0.012,
+                prediction_type="epsilon",
+                timestep_spacing="leading",
+                steps_offset=1,
+            )
+        )
+        return cls(unet, vae, te, te2, tok, tok2, scheduler)
+
+    # --- text encoding -------------------------------------------------------
+    def encode_prompt(self, prompt: str) -> tuple[mx.array, mx.array]:
+        """Tokenize + encode with both CLIPs.
+
+        Returns ``(prompt_embeds (1, 77, 2048), pooled (1, 1280))``: the two encoders'
+        penultimate hidden states concatenated, and the bigG projected pooled embed.
+        """
+
+        def ids(tok) -> mx.array:
+            enc = tok(
+                prompt,
+                padding="max_length",
+                max_length=MAX_TOKENS,
+                truncation=True,
+                return_tensors="np",
+            )
+            return mx.array(enc["input_ids"].astype("int32"))
+
+        hs1, _ = self.text_encoder(ids(self.tokenizer))
+        hs2, pooled = self.text_encoder_2(ids(self.tokenizer_2))
+        embeds = mx.concatenate([hs1[-2], hs2[-2]], axis=-1)  # (1, 77, 768+1280)
+        return embeds, pooled
+
+    def release_text_encoder_models(self) -> None:
+        """Release both CLIP encoders after prompt encoding to reduce peak memory."""
+        self.text_encoder = None  # type: ignore[assignment]
+        self.text_encoder_2 = None  # type: ignore[assignment]
+        gc.collect()
+        mx.clear_cache()
+
+    # --- generation ----------------------------------------------------------
+    def __call__(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: str = "",
+        image=None,
+        strength: float = 0.8,
+        height: int = 1024,
+        width: int = 1024,
+        num_inference_steps: int = 30,
+        guidance_scale: float = 5.0,
+        seed: int = 0,
+        cache_interval: int = 1,
+        tile_vae: bool = False,
+        release_text_encoders: bool = False,
+        progress: bool = True,
+        on_step: Callable[[int, int], None] | None = None,
+    ) -> mx.array:
+        """Generate an image ``(1, height, width, 3)`` in ``[-1, 1]``.
+
+        Pass ``image`` (a path, PIL image, or HWC/BHWC array) for image-to-image;
+        ``strength`` controls how far the result may move from the input (0 < strength
+        <= 1). ``height`` / ``width`` must be multiples of 8. ``cache_interval`` enables
+        DeepCache (1 = off/exact; 2 ≈ 1.5-1.8x by skipping the deep UNet blocks on every
+        other step). ``tile_vae`` decodes the VAE in tiles to bound memory at high res.
+        ``release_text_encoders`` reclaims both CLIP encoders before denoising.
+        """
+        if height % 8 or width % 8:
+            raise ValueError("height and width must be multiples of 8.")
+        if image is not None and not 0.0 < strength <= 1.0:
+            raise ValueError("strength must be in the interval (0, 1].")
+
+        use_cfg = guidance_scale > 1.0
+        pe, pooled = self.encode_prompt(prompt)
+        if use_cfg:
+            npe, npooled = self.encode_prompt(negative_prompt)
+            context = mx.concatenate([pe, npe], axis=0)
+            text_embeds = mx.concatenate([pooled, npooled], axis=0)
+        else:
+            context, text_embeds = pe, pooled
+        n = context.shape[0]
+        if release_text_encoders:
+            self.release_text_encoder_models()
+        time_ids = mx.broadcast_to(
+            mx.array(
+                [[float(height), float(width), 0.0, 0.0, float(height), float(width)]]
+            ),
+            (n, 6),
+        ).astype(context.dtype)
+
+        self.scheduler.set_timesteps(num_inference_steps)
+        steps = self.scheduler.timesteps
+        assert steps is not None
+        if image is None:
+            latents = mx.random.normal(
+                (1, height // 8, width // 8, self.vae.config.latent_channels),
+                key=mx.random.key(seed),
+            )
+            latents = latents * self.scheduler.init_noise_sigma
+        else:
+            input_image = prepare_image(
+                image, height=height, width=width, dtype=mx.float32
+            )
+            if input_image.shape[0] != 1:
+                raise ValueError(
+                    "SDXL image-to-image currently accepts exactly one input image."
+                )
+            latent_key, noise_key = mx.random.split(mx.random.key(seed))
+            clean_latents = (
+                self.vae.encode(input_image).sample(latent_key)
+                * self.vae.scaling_factor
+            )
+            noise = mx.random.normal(clean_latents.shape, key=noise_key)
+            denoise_steps = max(
+                1, min(num_inference_steps, int(num_inference_steps * strength))
+            )
+            begin_index = num_inference_steps - denoise_steps
+            assert self.scheduler.sigmas is not None
+            latents = self.scheduler.add_noise_sigma(
+                clean_latents, noise, self.scheduler.sigmas[begin_index]
+            )
+            self.scheduler.set_begin_index(begin_index)
+            steps = steps[begin_index:]
+            mx.eval(latents)
+
+        cache = DeepCache(cache_interval) if cache_interval > 1 else None
+        for i, t in enumerate(steps):
+            scaled = self.scheduler.scale_model_input(latents, t)
+            tt = mx.broadcast_to(t, (n,))
+            if use_cfg:
+                x2 = mx.concatenate([scaled, scaled], axis=0)
+                out = self.unet(x2, tt, context, text_embeds, time_ids, cache=cache)
+                cond, uncond = out[:1], out[1:]
+                noise = uncond + guidance_scale * (cond - uncond)
+            else:
+                noise = self.unet(
+                    scaled, tt, context, text_embeds, time_ids, cache=cache
+                )
+            latents = self.scheduler.step(noise, t, latents)
+            mx.eval(latents)
+            if on_step is not None:
+                on_step(i + 1, len(steps))
+            if progress:
+                print(f"  step {i + 1}/{len(steps)}", end="\r")
+        if progress:
+            print()
+
+        image = self.vae.decode(
+            latents.astype(mx.float32) / self.vae.scaling_factor, tile=tile_vae
+        )
+        mx.eval(image)
+        return image
+
+
+def _load_tokenizer(folder: Path):
+    try:
+        from transformers import CLIPTokenizer
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "The SDXL pipeline needs `transformers` for tokenization. "
+            "Install it with `pip install transformers`."
+        ) from exc
+    return CLIPTokenizer.from_pretrained(str(folder))

--- a/vllm_mlx/image/sdxl_runtime/quantization.py
+++ b/vllm_mlx/image/sdxl_runtime/quantization.py
@@ -1,0 +1,55 @@
+"""Weight-only quantization helpers built on ``mlx.nn.quantize``.
+
+Quantization is a *load-time* choice (``from_pretrained(..., quantize=4)``), not a
+new class hierarchy. We expose one function plus a sensible default predicate that
+skips layers too small to quantize cleanly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import mlx.nn as nn
+
+__all__ = ["quantize_module", "default_quant_predicate"]
+
+VALID_BITS = (2, 3, 4, 6, 8)
+
+
+def default_quant_predicate(group_size: int) -> Callable[[str, nn.Module], bool]:
+    """Predicate that quantizes Linear/Embedding layers whose dims divide cleanly.
+
+    Layers whose feature dimension is not a multiple of ``group_size`` (e.g. tiny
+    projection heads) are left in full precision to avoid shape errors and quality
+    cliffs.
+    """
+
+    def predicate(path: str, module: nn.Module) -> bool:
+        if not isinstance(module, (nn.Linear, nn.Embedding)):
+            return False
+        weight = module.weight
+        return bool(weight.shape[-1] % group_size == 0)
+
+    return predicate
+
+
+def quantize_module(
+    model: nn.Module,
+    bits: int = 4,
+    group_size: int = 64,
+    predicate: Callable[[str, nn.Module], bool] | None = None,
+) -> nn.Module:
+    """Quantize ``model`` in place to ``bits`` and return it.
+
+    Args:
+        model: module to quantize (modified in place).
+        bits: one of ``2, 3, 4, 6, 8``.
+        group_size: quantization group size (must divide quantized dims).
+        predicate: ``(path, module) -> bool`` selecting layers; defaults to
+            :func:`default_quant_predicate`.
+    """
+    if bits not in VALID_BITS:
+        raise ValueError(f"bits must be one of {VALID_BITS}, got {bits}.")
+    predicate = predicate or default_quant_predicate(group_size)
+    nn.quantize(model, group_size=group_size, bits=bits, class_predicate=predicate)
+    return model

--- a/vllm_mlx/image/sdxl_runtime/runtime.py
+++ b/vllm_mlx/image/sdxl_runtime/runtime.py
@@ -1,0 +1,65 @@
+"""Rapid-MLX adapter around the vendored SDXL pipeline."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import mlx.core as mx
+from PIL import Image
+
+from .pipelines import StableDiffusionXLPipeline
+from .utils import to_pil
+
+
+@dataclass(frozen=True)
+class GeneratedImage:
+    """Image-engine-compatible result container."""
+
+    image: Image.Image
+
+
+class SDXL:
+    """Reusable text-to-image runtime for an official SDXL snapshot."""
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        *,
+        on_step: Callable[[int, int], None] | None = None,
+    ) -> None:
+        self.pipeline = StableDiffusionXLPipeline.from_diffusers(
+            model_path,
+            quantize_unet=8,
+        )
+        self._on_step = on_step
+
+    def generate_image(
+        self,
+        *,
+        prompt: str,
+        height: int,
+        width: int,
+        num_inference_steps: int,
+        seed: int,
+        guidance: float | None = None,
+        negative_prompt: str | None = None,
+    ) -> GeneratedImage:
+        image = self.pipeline(
+            prompt,
+            negative_prompt=negative_prompt or "",
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=5.0 if guidance is None else guidance,
+            seed=seed,
+            # Recompute the full UNet every other step and reuse its deep
+            # features between adjacent scheduler steps. The shallow path and
+            # scheduler still run on every step, so progress/cancel semantics
+            # remain exact while 1024² dogfood falls from ~58s to ~16s.
+            cache_interval=2,
+            tile_vae=True,
+            progress=False,
+            on_step=self._on_step,
+        )
+        mx.eval(image)
+        return GeneratedImage(image=to_pil(image[0]))

--- a/vllm_mlx/image/sdxl_runtime/schedulers/__init__.py
+++ b/vllm_mlx/image/sdxl_runtime/schedulers/__init__.py
@@ -1,0 +1,1 @@
+"""SDXL scheduler components."""

--- a/vllm_mlx/image/sdxl_runtime/schedulers/base.py
+++ b/vllm_mlx/image/sdxl_runtime/schedulers/base.py
@@ -1,0 +1,136 @@
+"""Scheduler base class + shared diffusion math.
+
+A *scheduler* owns the corruption process and the reverse step. The same object
+is used for training (``add_noise`` + ``get_target`` + ``sample_timesteps``) and
+for sampling (``set_timesteps`` + ``step``). This keeps all SDE/ODE math in one
+place and lets networks stay agnostic to the noise schedule.
+
+Two timestep conventions coexist, each scheduler picks one and is internally
+consistent:
+
+* **Discrete diffusion** (DDPM, DDIM): ``t`` is an integer index into the
+  precomputed ``alphas_cumprod`` table.
+* **Continuous flow / sigma** (Euler, FlowMatch): ``t`` is a float sigma / time.
+
+The Trainer always obtains timesteps from ``sample_timesteps`` and passes them
+straight back to ``add_noise``/``get_target``, so callers never need to know which
+convention a scheduler uses.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Literal
+
+import mlx.core as mx
+
+from ..configuration import Config
+
+PredictionType = Literal["epsilon", "v_prediction", "sample", "velocity"]
+BetaSchedule = Literal["linear", "scaled_linear", "cosine"]
+
+
+@dataclasses.dataclass
+class SchedulerConfig(Config):
+    num_train_timesteps: int = 1000
+    prediction_type: PredictionType = "epsilon"
+
+
+def make_betas(
+    schedule: BetaSchedule,
+    num_train_timesteps: int,
+    beta_start: float = 1e-4,
+    beta_end: float = 2e-2,
+) -> mx.array:
+    """Return the ``(num_train_timesteps,)`` beta schedule."""
+    if schedule == "linear":
+        return mx.linspace(beta_start, beta_end, num_train_timesteps)
+    if schedule == "scaled_linear":  # Stable Diffusion convention
+        return mx.linspace(beta_start**0.5, beta_end**0.5, num_train_timesteps) ** 2
+    if schedule == "cosine":  # Nichol & Dhariwal (2021)
+        steps = num_train_timesteps + 1
+        s = 0.008
+        x = mx.linspace(0, num_train_timesteps, steps)
+        acp = mx.cos(((x / num_train_timesteps) + s) / (1 + s) * mx.pi * 0.5) ** 2
+        acp = acp / acp[0]
+        betas = 1 - (acp[1:] / acp[:-1])
+        return mx.clip(betas, 0, 0.999)
+    raise ValueError(f"Unknown beta schedule {schedule!r}.")
+
+
+def expand_to(coef: mx.array, ndim: int) -> mx.array:
+    """Reshape a coefficient to broadcast against a rank-``ndim`` tensor.
+
+    A ``(B,)`` per-sample coefficient becomes ``(B, 1, ..., 1)``; a 0-d scalar is
+    returned unchanged (it already broadcasts).
+    """
+    if coef.ndim == 0:
+        return coef
+    return coef.reshape(coef.shape[0], *([1] * (ndim - 1)))
+
+
+class Scheduler:
+    """Abstract base. Subclasses implement the four core methods below."""
+
+    config_class: type[SchedulerConfig] = SchedulerConfig
+
+    def __init__(self, config: SchedulerConfig):
+        self.config = config
+        self.timesteps: mx.array | None = None
+        self.num_inference_steps: int | None = None
+        self._step_index = 0
+
+    # --- training ---------------------------------------------------------
+    def sample_timesteps(self, batch_size: int, key: mx.array) -> mx.array:
+        """Draw a batch of training timesteps in this scheduler's convention."""
+        raise NotImplementedError
+
+    def add_noise(self, x0: mx.array, noise: mx.array, t: mx.array) -> mx.array:
+        """Forward process: corrupt ``x0`` with ``noise`` at timestep ``t``."""
+        raise NotImplementedError
+
+    def get_target(self, x0: mx.array, noise: mx.array, t: mx.array) -> mx.array:
+        """The quantity the network is trained to predict (per ``prediction_type``)."""
+        raise NotImplementedError
+
+    # --- sampling ---------------------------------------------------------
+    def set_timesteps(self, num_inference_steps: int) -> None:
+        """Configure the inference timestep grid (descending) and reset state."""
+        raise NotImplementedError
+
+    def step(
+        self,
+        model_output: mx.array,
+        t: mx.array,
+        sample: mx.array,
+        key: mx.array | None = None,
+    ) -> mx.array:
+        """Take one reverse step, returning the previous (less-noisy) sample."""
+        raise NotImplementedError
+
+    def scale_model_input(self, sample: mx.array, t: mx.array) -> mx.array:
+        """Optional pre-network input scaling (identity unless overridden)."""
+        return sample
+
+    def set_begin_index(self, begin_index: int) -> None:
+        """Start sampling partway through the configured schedule.
+
+        Image/video-to-X pipelines use this after adding noise to encoded input
+        latents. Keeping the step cursor on the scheduler avoids pipeline code
+        reaching into scheduler internals.
+        """
+        if self.timesteps is None:
+            raise RuntimeError("call set_timesteps() before set_begin_index().")
+        if not 0 <= begin_index < len(self.timesteps):
+            raise ValueError(
+                f"begin_index must be in [0, {len(self.timesteps) - 1}], got {begin_index}."
+            )
+        self._step_index = begin_index
+
+    # --- persistence ------------------------------------------------------
+    def save_pretrained(self, save_directory) -> None:
+        self.config.save(save_directory)
+
+    @classmethod
+    def from_config(cls, config: SchedulerConfig) -> Scheduler:
+        return cls(config)

--- a/vllm_mlx/image/sdxl_runtime/schedulers/ddpm.py
+++ b/vllm_mlx/image/sdxl_runtime/schedulers/ddpm.py
@@ -1,0 +1,133 @@
+"""DDPM scheduler (variance-preserving diffusion).
+
+Implements the shared VP math (alphas_cumprod, add_noise, prediction targets,
+predicted-x0 recovery) plus the ancestral DDPM reverse step. DDIM reuses all of
+this and only swaps the reverse step.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import mlx.core as mx
+
+from .base import BetaSchedule, Scheduler, SchedulerConfig, expand_to, make_betas
+
+
+@dataclasses.dataclass
+class DDPMConfig(SchedulerConfig):
+    beta_schedule: BetaSchedule = "linear"
+    beta_start: float = 1e-4
+    beta_end: float = 2e-2
+    clip_sample: bool = False
+    clip_sample_range: float = 1.0
+
+
+class DDPMScheduler(Scheduler):
+    config_class = DDPMConfig
+    config: DDPMConfig
+
+    def __init__(self, config: DDPMConfig | None = None):
+        super().__init__(config or DDPMConfig())
+        betas = make_betas(
+            self.config.beta_schedule,
+            self.config.num_train_timesteps,
+            self.config.beta_start,
+            self.config.beta_end,
+        )
+        self.betas = betas
+        self.alphas = 1.0 - betas
+        self.alphas_cumprod = mx.cumprod(self.alphas)
+        self._stride = 1
+
+    # --- coefficient helpers ---------------------------------------------
+    def _acp(self, t: mx.array) -> mx.array:
+        return self.alphas_cumprod[t]
+
+    def _sqrt_terms(self, t: mx.array, ndim: int) -> tuple[mx.array, mx.array]:
+        acp = self._acp(t)
+        return expand_to(mx.sqrt(acp), ndim), expand_to(mx.sqrt(1.0 - acp), ndim)
+
+    # --- training ---------------------------------------------------------
+    def sample_timesteps(self, batch_size: int, key: mx.array) -> mx.array:
+        return mx.random.randint(
+            0, self.config.num_train_timesteps, (batch_size,), key=key
+        )
+
+    def add_noise(self, x0: mx.array, noise: mx.array, t: mx.array) -> mx.array:
+        sqrt_acp, sqrt_omacp = self._sqrt_terms(t, x0.ndim)
+        return sqrt_acp * x0 + sqrt_omacp * noise
+
+    def get_target(self, x0: mx.array, noise: mx.array, t: mx.array) -> mx.array:
+        pt = self.config.prediction_type
+        if pt == "epsilon":
+            return noise
+        if pt == "sample":
+            return x0
+        if pt == "v_prediction":
+            sqrt_acp, sqrt_omacp = self._sqrt_terms(t, x0.ndim)
+            return sqrt_acp * noise - sqrt_omacp * x0
+        raise ValueError(
+            f"{type(self).__name__} does not support prediction_type={pt!r}."
+        )
+
+    def predict_x0(
+        self, model_output: mx.array, t: mx.array, sample: mx.array
+    ) -> mx.array:
+        """Recover predicted clean sample x0 from the network output."""
+        sqrt_acp, sqrt_omacp = self._sqrt_terms(t, sample.ndim)
+        pt = self.config.prediction_type
+        if pt == "epsilon":
+            x0 = (sample - sqrt_omacp * model_output) / sqrt_acp
+        elif pt == "sample":
+            x0 = model_output
+        elif pt == "v_prediction":
+            x0 = sqrt_acp * sample - sqrt_omacp * model_output
+        else:  # pragma: no cover - guarded in get_target
+            raise ValueError(pt)
+        if self.config.clip_sample:
+            r = self.config.clip_sample_range
+            x0 = mx.clip(x0, -r, r)
+        return x0
+
+    # --- sampling ---------------------------------------------------------
+    def set_timesteps(self, num_inference_steps: int) -> None:
+        T = self.config.num_train_timesteps
+        if num_inference_steps > T:
+            raise ValueError(
+                f"num_inference_steps ({num_inference_steps}) > num_train_timesteps ({T})."
+            )
+        self.num_inference_steps = num_inference_steps
+        self._stride = T // num_inference_steps
+        self.timesteps = (mx.arange(num_inference_steps) * self._stride)[::-1]
+        self._step_index = 0
+
+    def step(
+        self,
+        model_output: mx.array,
+        t: mx.array,
+        sample: mx.array,
+        key: mx.array | None = None,
+    ) -> mx.array:
+        ti = int(t.item()) if isinstance(t, mx.array) else int(t)
+        prev = ti - self._stride
+        acp_t = self.alphas_cumprod[ti]
+        acp_prev = self.alphas_cumprod[prev] if prev >= 0 else mx.array(1.0)
+
+        x0 = self.predict_x0(model_output, mx.array(ti), sample)
+
+        beta_t = 1.0 - acp_t
+        beta_prev = 1.0 - acp_prev
+        current_alpha = acp_t / acp_prev
+        current_beta = 1.0 - current_alpha
+
+        x0_coef = mx.sqrt(acp_prev) * current_beta / beta_t
+        sample_coef = mx.sqrt(current_alpha) * beta_prev / beta_t
+        mean = x0_coef * x0 + sample_coef * sample
+
+        if prev < 0:
+            return mean
+        var = current_beta * beta_prev / beta_t
+        key = key if key is not None else mx.random.key(ti)
+        noise = mx.random.normal(sample.shape, key=key)
+        return mean + mx.sqrt(mx.maximum(var, 1e-20)) * noise

--- a/vllm_mlx/image/sdxl_runtime/schedulers/euler.py
+++ b/vllm_mlx/image/sdxl_runtime/schedulers/euler.py
@@ -1,0 +1,107 @@
+"""Euler discrete scheduler (k-diffusion / Stable Diffusion style).
+
+Trains with the inherited VP math (discrete timesteps) and samples with a
+deterministic first-order ODE solver in sigma space, where
+``sigma = sqrt((1 - alpha_cumprod) / alpha_cumprod)``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import cast
+
+import mlx.core as mx
+import numpy as np
+
+from .base import expand_to
+from .ddpm import DDPMConfig, DDPMScheduler
+
+
+@dataclasses.dataclass
+class EulerConfig(DDPMConfig):
+    timestep_spacing: str = "linspace"  # "leading" for Stable Diffusion / SDXL
+    steps_offset: int = 0
+
+
+class EulerDiscreteScheduler(DDPMScheduler):
+    config_class = EulerConfig
+    config: EulerConfig
+
+    def __init__(self, config: EulerConfig | None = None):
+        super().__init__(config or EulerConfig())
+        # Full-resolution sigma table over the training schedule.
+        self._train_sigmas = mx.sqrt((1.0 - self.alphas_cumprod) / self.alphas_cumprod)
+        self.sigmas: mx.array | None = None
+
+    def set_timesteps(self, num_inference_steps: int) -> None:
+        T = self.config.num_train_timesteps
+        self.num_inference_steps = num_inference_steps
+        train_sigmas = np.array(self._train_sigmas)  # ascending in index
+        if self.config.timestep_spacing == "leading":
+            step_ratio = T // num_inference_steps
+            ts = (
+                (np.arange(num_inference_steps) * step_ratio)
+                .round()[::-1]
+                .astype(np.float64)
+            )
+            ts = ts + self.config.steps_offset
+        else:  # "linspace": fractional timesteps high->low
+            ts = np.linspace(0, T - 1, num_inference_steps)[::-1].copy()
+        sigmas = np.interp(ts, np.arange(T), train_sigmas)
+        sigmas = np.concatenate([sigmas, [0.0]]).astype(np.float32)
+        self.sigmas = mx.array(sigmas)
+        self.timesteps = mx.array(ts.astype(np.float32))
+        self._step_index = 0
+
+    @property
+    def init_noise_sigma(self) -> float:
+        """Std-dev for the initial latent noise (matches diffusers EulerDiscrete)."""
+        assert self.sigmas is not None, "call set_timesteps() before sampling"
+        sigma_max = float(self.sigmas[0])
+        if self.config.timestep_spacing in ("linspace", "trailing"):
+            return sigma_max
+        return float((sigma_max**2 + 1.0) ** 0.5)
+
+    def scale_model_input(self, sample: mx.array, t: mx.array) -> mx.array:
+        assert self.sigmas is not None, "call set_timesteps() before sampling"
+        sigma = self.sigmas[self._step_index]
+        return sample / mx.sqrt(sigma**2 + 1.0)
+
+    def _pred_original(
+        self, model_output: mx.array, sigma: mx.array, sample: mx.array
+    ) -> mx.array:
+        pt = self.config.prediction_type
+        if pt == "epsilon":
+            return sample - sigma * model_output
+        if pt == "sample":
+            return model_output
+        if pt == "v_prediction":
+            return model_output * (-sigma / mx.sqrt(sigma**2 + 1.0)) + sample / (
+                sigma**2 + 1.0
+            )
+        raise ValueError(
+            f"EulerDiscreteScheduler does not support prediction_type={pt!r}."
+        )
+
+    def step(
+        self,
+        model_output: mx.array,
+        t: mx.array,
+        sample: mx.array,
+        key: mx.array | None = None,
+    ) -> mx.array:
+        assert self.sigmas is not None, "call set_timesteps() before sampling"
+        i = self._step_index
+        sigma = self.sigmas[i]
+        sigma_next = self.sigmas[i + 1]
+        pred_original = self._pred_original(model_output, sigma, sample)
+        derivative = (sample - pred_original) / sigma
+        dt = sigma_next - sigma
+        self._step_index += 1
+        return sample + derivative * dt
+
+    def add_noise_sigma(
+        self, x0: mx.array, noise: mx.array, sigma: mx.array
+    ) -> mx.array:
+        """VE-style corruption used by img2img-style sampling starts."""
+        return cast(mx.array, x0 + expand_to(sigma, x0.ndim) * noise)

--- a/vllm_mlx/image/sdxl_runtime/utils.py
+++ b/vllm_mlx/image/sdxl_runtime/utils.py
@@ -1,0 +1,148 @@
+"""Small shared utilities: dtypes, seeding, logging, image <-> array."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import mlx.core as mx
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import numpy as np
+    from PIL import Image
+
+__all__ = [
+    "DTYPES",
+    "as_dtype",
+    "get_logger",
+    "seed_everything",
+    "prepare_image",
+    "to_pil",
+    "to_array",
+]
+
+# Canonical string <-> mlx dtype mapping used in configs and CLI args.
+DTYPES: dict[str, mx.Dtype] = {
+    "float32": mx.float32,
+    "fp32": mx.float32,
+    "float16": mx.float16,
+    "fp16": mx.float16,
+    "bfloat16": mx.bfloat16,
+    "bf16": mx.bfloat16,
+}
+
+
+def as_dtype(dtype: str | mx.Dtype | None) -> mx.Dtype | None:
+    """Resolve a dtype given as a string alias or an ``mx.Dtype``."""
+    if dtype is None or isinstance(dtype, mx.Dtype):
+        return dtype
+    try:
+        return DTYPES[dtype.lower()]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(
+            f"Unknown dtype {dtype!r}. Choose from {sorted(DTYPES)}."
+        ) from exc
+
+
+_LOG_LEVEL = os.environ.get("MLX_DIFFUSION_LOG", "INFO").upper()
+
+
+def get_logger(name: str = "mlx_diffuser") -> logging.Logger:
+    """Return a configured library logger (idempotent)."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("[%(name)s] %(levelname)s: %(message)s"))
+        logger.addHandler(handler)
+        logger.setLevel(_LOG_LEVEL)
+        logger.propagate = False
+    return logger
+
+
+def seed_everything(seed: int) -> mx.array:
+    """Seed MLX's global RNG and return a fresh key for explicit use."""
+    mx.random.seed(seed)
+    return mx.random.key(seed)
+
+
+def to_array(image: Image.Image | np.ndarray, dtype: mx.Dtype = mx.float32) -> mx.array:
+    """Convert a PIL image or HWC uint8/float array to a CHW-free [-1, 1] array.
+
+    Returns shape ``(H, W, C)`` in ``[-1, 1]`` (MLX/`channels-last` convention).
+    """
+    import numpy as np
+
+    arr = np.asarray(image)
+    if arr.dtype == np.uint8:
+        arr = arr.astype(np.float32) / 127.5 - 1.0
+    if arr.ndim == 2:
+        arr = arr[..., None]
+    return mx.array(arr).astype(dtype)
+
+
+def prepare_image(
+    image,
+    *,
+    height: int,
+    width: int,
+    dtype: mx.Dtype = mx.float32,
+) -> mx.array:
+    """Prepare a path, PIL image, NumPy array, or MLX array for image conditioning.
+
+    Paths and PIL images are converted to RGB and resized with Lanczos. Array inputs
+    must already have the requested spatial size and be ``HWC`` or ``BHWC``. Integer
+    arrays are normalized to ``[-1, 1]``; floating-point arrays are assumed to
+    already use that range.
+    """
+    import numpy as np
+    from PIL import Image
+
+    if isinstance(image, (str, Path)):
+        with Image.open(image) as opened:
+            image = opened.convert("RGB").resize(
+                (width, height), Image.Resampling.LANCZOS
+            )
+    elif isinstance(image, Image.Image):
+        image = image.convert("RGB").resize((width, height), Image.Resampling.LANCZOS)
+
+    if isinstance(image, Image.Image):
+        array = to_array(image, dtype=dtype)[None]
+    elif isinstance(image, mx.array):
+        array = image
+        if array.dtype == mx.uint8:
+            array = array.astype(mx.float32) / 127.5 - 1.0
+        else:
+            array = array.astype(dtype)
+    else:
+        np_image = np.asarray(image)
+        if np.issubdtype(np_image.dtype, np.integer):
+            np_image = np_image.astype(np.float32) / 127.5 - 1.0
+        array = mx.array(np_image).astype(dtype)
+
+    if array.ndim == 3:
+        array = array[None]
+    if array.ndim != 4:
+        raise ValueError(
+            f"image must have shape (H, W, C) or (B, H, W, C), got {array.shape}."
+        )
+    if array.shape[1:3] != (height, width):
+        raise ValueError(
+            f"array image must already be {height}x{width}; got {array.shape[1]}x{array.shape[2]}."
+        )
+    if array.shape[-1] != 3:
+        raise ValueError(f"image must have 3 RGB channels, got {array.shape[-1]}.")
+    return array
+
+
+def to_pil(array: mx.array) -> Image.Image:
+    """Convert a single ``(H, W, C)`` array in ``[-1, 1]`` to a PIL image."""
+    import numpy as np
+    from PIL import Image
+
+    arr = mx.clip((array + 1.0) * 127.5 + 0.5, 0, 255).astype(mx.uint8)
+    np_arr = np.array(arr)
+    if np_arr.shape[-1] == 1:
+        np_arr = np_arr[..., 0]
+    return Image.fromarray(np_arr)

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -218,6 +218,7 @@
     "rapid-mlx/Qwen3.8-Flash-Next-4bit": 104695605424,
     "rickylin20260522/Wan2.2-T2V-A14B-mlx": 69023632302,
     "rickylin20260522/Wan2.2-TI2V-5B-mlx": 24180286021,
+    "stabilityai/stable-diffusion-xl-base-1.0": 6941201645,
     "unsloth/Qwen3.6-27B-MLX-8bit": 34733949671,
     "unsloth/Qwen3.6-27B-UD-MLX-3bit": 24071897617,
     "unsloth/Qwen3.6-27B-UD-MLX-4bit": 26210992727,

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -3,7 +3,7 @@
 
 Mirrors the video lane's split: this module is the thin, duck-typed engine
 adapter that ``server.load_model`` dispatches to for ``modality=image-gen``
-aliases; ``vllm_mlx/image/engine.py`` owns the mflux pipeline and the
+aliases; ``vllm_mlx/image/engine.py`` owns the backend pipeline and the
 ``vllm_mlx/routes/images.py`` router owns the OpenAI-compatible transport.
 """
 
@@ -29,7 +29,8 @@ __all__ = [
 
 def require_image_runtime_or_exit(model_name: str | None = None) -> None:
     """Fail before model download when the optional image stack is absent."""
-    if sys.version_info < (3, 11):
+    family = _detect_family(model_name) if model_name else ""
+    if sys.version_info < (3, 11) and family != "sdxl-base":
         print(
             "\n  Error: image generation requires Python 3.11 or newer "
             f"(current: {sys.version_info.major}.{sys.version_info.minor}). "
@@ -38,8 +39,13 @@ def require_image_runtime_or_exit(model_name: str | None = None) -> None:
             file=sys.stderr,
         )
         raise SystemExit(2)
-    family = _detect_family(model_name) if model_name else ""
-    runtime_module = "mlx_vlm" if family == "hidream-o1-dev" else "mflux"
+    runtime_module = (
+        "mlx_vlm"
+        if family == "hidream-o1-dev"
+        else "PIL"
+        if family == "sdxl-base"
+        else "mflux"
+    )
     if importlib.util.find_spec(runtime_module) is None:
         print(
             "\n  Error: image generation requires the `rapid-mlx[image]` "
@@ -50,11 +56,11 @@ def require_image_runtime_or_exit(model_name: str | None = None) -> None:
 
 
 class ImageEngine:
-    """Thin adapter over the mflux image backend.
+    """Thin adapter over the selected MLX image backend.
 
     Duck-typed like ``VideoEngine`` (``is_image_gen`` / ``_loaded``) so the
     router and ``/v1/models`` probes can recognise the lane. The underlying
-    mflux model loads lazily on the first ``generate`` call.
+    model loads lazily on the first ``generate`` call.
     """
 
     is_image_gen = True
@@ -67,11 +73,11 @@ class ImageEngine:
 
     @property
     def is_resident(self) -> bool:
-        """Whether mflux weights, rather than only the adapter, are loaded."""
+        """Whether model weights, rather than only the adapter, are loaded."""
         return self._engine._model is not None  # noqa: SLF001
 
     def ensure_resident(self, *, mode: str | None = None) -> None:
-        """Eagerly materialize lazy mflux weights for budgeted residency."""
+        """Eagerly materialize lazy image weights for budgeted residency."""
         if mode not in (None, "generation", "editing"):
             raise ValueError(f"unsupported image residency mode: {mode!r}")
         # ``None`` preserves the engine's family-aware default. In particular,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -546,6 +546,11 @@ def estimate_model_bytes(model_name: str) -> int:
         # output headroom (docs/engineering/performance/2026-09-04-hidream-o1-dev-dogfood.md).
         "hidream-o1": 18.0,
         "hidream_o1": 18.0,
+        # Official fp16 checkpoint converted to an 8-bit UNet at load. Real
+        # 1024² / 30-step dogfood measured up to 12.49 GiB MLX peak; retain
+        # allocator/output headroom while the catalog keeps a 16 GiB minimum.
+        "sdxl-base": 14.0,
+        "stable-diffusion-xl": 14.0,
         # 6-bit-transformer Qwen-Image (20B) — measured peak RSS during a
         # real generation at 1024x1024 (mflux-community/qwen-image-mflux-q6,
         # the API/GUI default resolution; `/usr/bin/time -l`): ~55.7 GiB.


### PR DESCRIPTION
## Why

SDXL remains one of the most widely used open image-generation model families, but Rapid could not run the official SDXL Base checkpoint through either Server or Desktop. The available MLX implementation is not distributed as a stable package, so this change vendors and audits only the required SDXL runtime rather than adding a mutable source dependency.

## What

- adds `sdxl-base` as a generation-only Server/Desktop catalog model
- runs the official revision-pinned SDXL Base 1.0 checkpoint entirely in MLX with an 8-bit UNet and fp32 VAE
- preserves the existing OpenAI-compatible `/v1/images/generations`, progress, cancellation, residency, and single-flight contracts
- downloads only 19 required data files (6.46 GiB), never repository code, and rejects partial pinned snapshots
- uses alternating-step deep-feature reuse; same-prompt 1024² cold end-to-end dogfood fell from 61.72s to 18.43s (3.35×) while retaining coherent output in four visual prompt checks
- includes the vendored CC0 license/provenance in wheels and the Desktop sidecar
- keeps the Desktop sidecar Torch-free and seeds its progress UI at SDXL's 30-step default

## Scope

Non-goals: image-to-image, refiner chaining, LoRA, ControlNet, training, arbitrary community checkpoints, release, or deployment.

## Verification

- real 1024×1024 / 30-step engine dogfood: valid coherent PNG, 18.43s cold end-to-end with deep cache, 12.49 GiB MLX peak
- real HTTP dogfood: `POST /v1/images/generations` returned 200 and a valid 512×512 base64 PNG in 5.15s with steps omitted (30-step family default)
- 3,412 focused/regression Python tests passed
- 19 focused Desktop catalog/progress/sidecar tests passed
- wheel built; SDXL runtime plus `LICENSE`/`NOTICE` verified inside the wheel and imported from it
- Ruff and `git diff --check` passed

Full reproducible measurements are recorded in `docs/engineering/performance/2026-09-05-sdxl-base-dogfood.md`.
