### PR TITLE
feat(image): add Bonsai Image 4B 2-bit support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,5 @@ omit =
     vllm_mlx/image/sdxl_runtime/quantization.py
     vllm_mlx/image/sdxl_runtime/schedulers/*
     vllm_mlx/image/sdxl_runtime/utils.py
+    # Exact third-party numerical core; Rapid-owned adapter remains covered.
+    vllm_mlx/image/bonsai_runtime/_vendor/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
       - name: Install project and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[vision]"
+          pip install -e ".[vision,image]"
           # Test infra comes from the declared `ci-apple` extra (issue #2489).
           pip install -e ".[ci-apple]"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,6 +487,7 @@ jobs:
             tests/test_mllm_hybrid_probe.py \
             tests/test_hidream_o1_alias.py \
             tests/test_sdxl_alias.py \
+            tests/test_bonsai_image_alias.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -232,6 +232,7 @@ The largest and most self-contained components:
 | Component | Upstream | Upstream license | In-tree |
 | --- | --- | --- | --- |
 | MLX Stable Audio 3 | https://github.com/Stability-AI/stable-audio-3 | MIT | `vllm_mlx/audio/sa3/` (`LICENSE`, `NOTICE`) |
+| Bonsai Image low-bit FLUX.2 core | https://github.com/PrismML-Eng/mflux-prism (`bcd13e8`) | MIT | `vllm_mlx/image/bonsai_runtime/_vendor/` (`LICENSE`, `NOTICE`) |
 | CogVideoX-Fun MLX | https://github.com/dgrauet/VideoX-Fun-mlx | Apache-2.0 | `videox_fun_mlx/` (`LICENSE`, `NOTICE`) |
 | TurboQuant Metal kernels | https://github.com/arozanov/turboquant-mlx | Apache-2.0 | `vllm_mlx/kernels/turboquant_fused.metal` |
 | GLM-5 Next image processor | https://github.com/jundot/omlx (`c520d7e`) | Apache-2.0 | `vllm_mlx/patches/glm5_next_processor.py` |

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -23,11 +23,12 @@ struct ImageCatalogTests {
       ────────────────────────────
       ltx-2.3-mlx-q4        24.0 GiB   [video:gen] notapalindrome/ltx23-mlx-av-q4
 
-      Image models (4 aliases)
+      Image models (5 aliases)
       ────────────────────────────
       Alias                 Size       Kind        HF id
       ────────────────────────────
       flux2-klein-4b        4.3 GiB    [image:both] Runpod/FLUX.2-klein-4B-mflux-4bit
+      bonsai-image-4b-2bit   3.6 GiB    [image:gen] prism-ml/bonsai-image-ternary-4B-mlx-2bit
       z-image-turbo         5.5 GiB    [image:gen] filipstrand/Z-Image-Turbo-mflux-4bit
       hidream-o1-dev       16.4 GiB    [image:gen] mlx-community/HiDream-O1-Image-Dev-mlx-bf16
       sdxl-base             6.5 GiB     [image:gen] stabilityai/stable-diffusion-xl-base-1.0
@@ -36,10 +37,11 @@ struct ImageCatalogTests {
     @Test("parseImageRows extracts image rows and their operation")
     func parsesImageRows() {
         let rows = ModelCatalog.parseImageRows(Self.sample)
-        #expect(rows.count == 4)
+        #expect(rows.count == 5)
 
         let aliases = rows.map(\.alias)
         #expect(aliases.contains("flux2-klein-4b"))
+        #expect(aliases.contains("bonsai-image-4b-2bit"))
         #expect(aliases.contains("z-image-turbo"))
         #expect(aliases.contains("hidream-o1-dev"))
         #expect(aliases.contains("sdxl-base"))
@@ -58,6 +60,10 @@ struct ImageCatalogTests {
         #expect(sdxl?.hfRepo == "stabilityai/stable-diffusion-xl-base-1.0")
         #expect(sdxl?.size == "6.5 GiB")
         #expect(sdxl?.capability == .generation)
+        let bonsai = rows.first { $0.alias == "bonsai-image-4b-2bit" }
+        #expect(bonsai?.hfRepo == "prism-ml/bonsai-image-ternary-4B-mlx-2bit")
+        #expect(bonsai?.size == "3.6 GiB")
+        #expect(bonsai?.capability == .generation)
     }
 
     @Test("complete mflux caches are marked downloaded in Images")
@@ -67,6 +73,7 @@ struct ImageCatalogTests {
             rows,
             cachedRepos: [
                 "Runpod/FLUX.2-klein-4B-mflux-4bit",
+                "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
                 "filipstrand/Z-Image-Turbo-mflux-4bit",
                 "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
                 "stabilityai/stable-diffusion-xl-base-1.0",
@@ -76,6 +83,7 @@ struct ImageCatalogTests {
         let klein = cached.first { $0.alias == "flux2-klein-4b" }
         #expect(klein?.cached == true)
         #expect(klein?.imageCapability == .generationAndEditing)
+        #expect(cached.first { $0.alias == "bonsai-image-4b-2bit" }?.cached == true)
         #expect(cached.first { $0.alias == "z-image-turbo" }?.cached == true)
         #expect(cached.first { $0.alias == "hidream-o1-dev" }?.cached == true)
         #expect(cached.first { $0.alias == "sdxl-base" }?.cached == true)
@@ -95,6 +103,7 @@ struct ImageCatalogTests {
         // The chat parser drops the image alias entirely.
         let excluded = ModelCatalog.parseExcludedAliases(Self.sample)
         #expect(excluded.contains("flux2-klein-4b"))
+        #expect(excluded.contains("bonsai-image-4b-2bit"))
         #expect(excluded.contains("z-image-turbo"))
         #expect(excluded.contains("hidream-o1-dev"))
         #expect(excluded.contains("sdxl-base"))

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -102,6 +102,7 @@ struct ImageGenerationPhaseTests {
         #expect(ImageGenViewModel.seedSteps(for: "qwen-image-edit") == 20)
         #expect(ImageGenViewModel.seedSteps(for: "z-image-turbo") == 8)
         #expect(ImageGenViewModel.seedSteps(for: "flux2-klein-4b") == 4)
+        #expect(ImageGenViewModel.seedSteps(for: "bonsai-image-4b-2bit") == 4)
         #expect(ImageGenViewModel.seedSteps(for: "hidream-o1-dev") == 28)
         #expect(ImageGenViewModel.seedSteps(for: "sdxl-base") == 30)
     }

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -127,6 +127,8 @@ struct SidecarBuildScriptTests {
                 "The Qwen Image import path must defer PiD's optional torch checkpoint converter.")
         #expect(script.contains(#"importlib.import_module("mflux.models.qwen.variants.txt2img.qwen_image")"#),
                 "The bundle build must prove qwen-image itself imports without torch.")
+        #expect(script.contains(#"importlib.import_module("vllm_mlx.image.bonsai_runtime")"#),
+                "The bundle build must prove the Desktop-advertised Bonsai adapter imports without torch.")
         #expect(script.contains("SIDECAR_IMAGE_SMOKE_MODEL"),
                 "Release-candidate builds must opt into a real image-generation model.")
         #expect(script.contains("$REPO_ROOT/scripts/smoke-sidecar-image.py"),

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -570,16 +570,19 @@ PY
 
 # Fail closed: with no torch in the stage, importing mflux's weight loader
 # is itself the proof that the image lane no longer needs a 363 MB
-# dependency. A regression here means every Images-tab generation 500s.
+# dependency. Import the Rapid-owned Bonsai adapter too: it is separately
+# advertised in Desktop and reaches additional FLUX.2 modules. A regression
+# here means the corresponding Images-tab generation fails at startup.
 PYTHONPATH="$STAGE/site-packages" PYTHONNOUSERSITE=1 "$STAGE/python/bin/python3.12" -s - <<'PY'
 import importlib
 import sys
 
 importlib.import_module("mflux.models.common.weights.loading.weight_loader")
 importlib.import_module("mflux.models.qwen.variants.txt2img.qwen_image")
+importlib.import_module("vllm_mlx.image.bonsai_runtime")
 if "torch" in sys.modules:
     raise SystemExit("ERR: mflux still pulls torch at import time")
-print("==> mflux image lane imports without torch: OK")
+print("==> mflux and Bonsai image lanes import without torch: OK")
 PY
 
 # ----- step 2.7: bundle minimal video runtime --no-deps ---------------

--- a/docs/engineering/performance/2026-09-05-bonsai-image-4b-2bit-dogfood.md
+++ b/docs/engineering/performance/2026-09-05-bonsai-image-4b-2bit-dogfood.md
@@ -1,0 +1,74 @@
+# Bonsai Image 4B 2-bit dogfood
+
+Date: 2026-09-05
+
+Owner/host: Vector, Local Mac
+
+Model: `prism-ml/bonsai-image-ternary-4B-mlx-2bit`
+
+Revision: `2c24c81b934a658ba5590cf39088ba929985b4a8`
+
+## Result
+
+Rapid-MLX generated coherent PNGs through both the direct engine and the real
+OpenAI-compatible Server route. The fixed selective download contained exactly
+25 reviewed data files totaling 3,888,262,196 bytes (3.62 GiB). No upstream
+Python files were downloaded or executed.
+
+| Path | Resolution | Steps | End-to-end | MLX peak | Process peak footprint |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Direct, cold process | 512×512 | 4 | 5.392 s | 5.637 GiB | 6.475 GiB |
+| Direct, cold process | 1024×1024 | 4 | 13.949 s | 5.758 GiB | 6.522 GiB |
+| Server, warm model | 512×512 | 4 | 3.922 s HTTP | — | — |
+
+The 1024² process peak supports a conservative 7.0 GiB resident admission
+charge. The published alias remains at a 12 GB minimum-memory tier to retain OS,
+Desktop, and request headroom on entry Apple Silicon machines.
+
+A same-process 256² lifecycle probe also passed three consecutive generations:
+first prompt 3.467 s, same-prompt cache hit 1.325 s, and different-prompt
+text-encoder reload 1.627 s. Active MLX memory after each generation was
+approximately 1.408 GiB, confirming that the one-entry embedding cache and
+text-encoder eviction work across both hit and miss paths.
+
+## Reproduction
+
+Environment: Apple Silicon macOS, Python 3.12.14, MLX 0.32.2, mlx-lm 0.31.3,
+mflux 0.19.1.
+
+The Desktop sidecar's exact `mflux==0.19.0` pin was then installed in place of
+0.19.1; a fresh 256² four-step generation also completed successfully (3.892 s,
+110,243-byte PNG).
+
+```bash
+RAPID_MLX_AUTO_PULL=1 .venv/bin/rapid-mlx pull bonsai-image-4b-2bit
+
+/usr/bin/time -l .venv/bin/python - <<'PY'
+import time
+import mlx.core as mx
+from vllm_mlx.image.engine import ImageGenerationEngine
+
+mx.reset_peak_memory()
+engine = ImageGenerationEngine(
+    "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
+)
+started = time.perf_counter()
+png = engine.generate(
+    prompt="A red fox curled beside an alpine lake at sunrise",
+    width=1024,
+    height=1024,
+    num_inference_steps=4,
+    seed=73,
+)
+print(len(png), time.perf_counter() - started, mx.get_peak_memory())
+PY
+```
+
+Server route:
+
+```bash
+.venv/bin/rapid-mlx serve bonsai-image-4b-2bit --port 18090
+curl http://127.0.0.1:18090/v1/images/generations \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"bonsai-image-4b-2bit","prompt":"A glass greenhouse in rain","size":"512x512","n":1,"response_format":"b64_json","seed":101}'
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -586,6 +586,10 @@ vllm_mlx = [
     # Vendored SDXL MLX runtime attribution must ship beside the CC0 source.
     "image/sdxl_runtime/LICENSE",
     "image/sdxl_runtime/NOTICE",
+    # Vendored Bonsai low-bit numerical core attribution must ship with every
+    # wheel and Desktop sidecar that contains the adapted MIT source.
+    "image/bonsai_runtime/LICENSE",
+    "image/bonsai_runtime/NOTICE",
 ]
 videox_fun_mlx = ["LICENSE", "NOTICE"]
 
@@ -614,6 +618,9 @@ exclude = [
     # Vendored Stability AI MLX Stable Audio 3 (models + scripts). Keep
     # formatting identical to the upstream source so future syncs stay clean.
     "vllm_mlx/audio/sa3/**/*.py",
+    # Vendored Bonsai low-bit FLUX.2 numerical core. The Rapid-owned adapter
+    # in runtime.py remains under the normal formatter.
+    "vllm_mlx/image/bonsai_runtime/_vendor/**/*.py",
     # Vendored CogVideoX-Fun MLX runtime. Keep iso-upstream.
     "videox_fun_mlx/**/*.py",
 ]
@@ -672,6 +679,9 @@ ignore = [
 # upstream-shaped model, converter, scheduler, and pipeline files stay syncable.
 "vllm_mlx/image/sdxl_runtime/{caching,configuration,hub,modeling,quantization,utils}.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
 "vllm_mlx/image/sdxl_runtime/{converters,models,pipelines,schedulers}/**/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
+# Adapted verbatim from the pinned low-bit runtime. Keep exceptions confined
+# to _vendor; the checkpoint validation and product adapter stay strict.
+"vllm_mlx/image/bonsai_runtime/_vendor/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
 # Tensor-shape parameter names (B, H, N, D) follow ML literature
 # convention; N803 lowercase rule is incompatible.
 "scripts/bench_attention.py" = ["N803"]
@@ -690,6 +700,12 @@ python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Exact third-party numerical core; Rapid-owned runtime.py remains under the
+# repository-wide shrink-only error budget.
+module = "vllm_mlx.image.bonsai_runtime._vendor.*"
+ignore_errors = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_bonsai_image_alias.py
+++ b/tests/test_bonsai_image_alias.py
@@ -1,0 +1,570 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the pinned Bonsai Image MLX backend and product alias."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from vllm_mlx import _download_gate
+from vllm_mlx.catalog import build_catalog_bundle
+from vllm_mlx.image.engine import (
+    ImageGenerationEngine,
+    ImageRuntimeError,
+    _detect_family,
+)
+from vllm_mlx.model_aliases import resolve_profile
+from vllm_mlx.model_sizes import size_bytes
+from vllm_mlx.runtime.resident_models import estimate_model_bytes
+
+REPO = "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
+REVISION = "2c24c81b934a658ba5590cf39088ba929985b4a8"
+SIZE = 3_888_262_196
+
+
+def test_alias_routes_to_generation_only_image_backend() -> None:
+    profile = resolve_profile("bonsai-image-4b-2bit")
+    assert profile is not None
+    assert profile.hf_path == REPO
+    assert profile.modality == "image-gen"
+    assert profile.min_memory_gb == 12
+
+    engine = ImageGenerationEngine(REPO)
+    assert engine.family == "bonsai-image"
+    assert engine.supports_generation is True
+    assert engine.supports_editing is False
+    assert engine.supports_negative_prompt is False
+    assert engine.default_steps == 4
+    assert engine._prequantized is True  # noqa: SLF001
+
+
+def test_alias_pins_size_revision_and_resident_budget() -> None:
+    assert _download_gate.IMAGE_MODEL_REVISIONS[REPO] == REVISION
+    assert size_bytes(REPO) == SIZE
+    for name in ("bonsai-image-4b-2bit", REPO, "/models/bonsai_image"):
+        assert estimate_model_bytes(name) == int(7.0 * 1024**3)
+
+
+def test_atomic_catalog_names_the_bonsai_adapter() -> None:
+    bundle = build_catalog_bundle()
+    record = next(
+        alias
+        for alias in bundle["snapshot"]["aliases"]
+        if alias["alias"] == "bonsai-image-4b-2bit"
+    )
+    assert record["capabilities"]["runtime_adapter"] == "rapid_mlx/bonsai_image"
+    assert record["capabilities"]["operation_modes"] == ["text_to_image"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [REPO, "bonsai-image-4b-2bit", "/models/bonsai_image"],
+)
+def test_family_detection(name: str) -> None:
+    assert _detect_family(name) == "bonsai-image"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"num_inference_steps": 5}, "4-step"),
+        ({"width": 257}, "multiples of 32"),
+        ({"height": 224}, "between 256 and 2048"),
+        ({"guidance": 1.1}, "guidance 1.0"),
+        ({"negative_prompt": "blur"}, "negative_prompt"),
+        ({"image_paths": ["input.png"]}, "text-to-image only"),
+        ({"prompt": "x" * 4097}, "4096 characters"),
+    ],
+)
+def test_request_contract_rejects_before_model_load(kwargs: dict, message: str) -> None:
+    engine = ImageGenerationEngine(REPO)
+    request = {
+        "prompt": "a bonsai tree",
+        "width": 512,
+        "height": 512,
+        "num_inference_steps": 4,
+        **kwargs,
+    }
+    engine._ensure_loaded = lambda **_kwargs: pytest.fail(  # type: ignore[method-assign]  # noqa: SLF001
+        "invalid request reached the model loader"
+    )
+    with pytest.raises(ImageRuntimeError, match=message):
+        engine.generate(**request)
+
+
+def test_generation_dispatch_uses_fixed_published_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    class TinyModel:
+        def generate_image(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(image=Image.new("RGB", (8, 8)))
+
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(engine, "_ensure_loaded", lambda **_kwargs: TinyModel())
+    png = engine.generate(
+        prompt="a bonsai tree", width=512, height=512, seed=17, guidance=1.0
+    )
+    assert png.startswith(b"\x89PNG")
+    assert calls == [
+        {
+            "height": 512,
+            "width": 512,
+            "seed": 17,
+            "prompt": "a bonsai tree",
+            "num_inference_steps": 4,
+            "guidance": 1.0,
+        }
+    ]
+
+
+def _seed_snapshot(root: Path, *, omit: str | None = None) -> None:
+    for relative in _download_gate.BONSAI_IMAGE_DATA_FILES:
+        if relative == omit:
+            continue
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+
+
+@pytest.mark.parametrize(
+    "missing_file",
+    [
+        "transformer-packed-mflux/diffusion_pytorch_model.safetensors",
+        "text_encoder-mlx-4bit/model.safetensors.index.json",
+        "tokenizer/chat_template.jinja",
+    ],
+)
+def test_complete_snapshot_requires_every_reviewed_data_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, missing_file: str
+) -> None:
+    import huggingface_hub.constants
+
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+    snapshot = (
+        tmp_path
+        / "models--prism-ml--bonsai-image-ternary-4B-mlx-2bit"
+        / "snapshots"
+        / REVISION
+    )
+    _seed_snapshot(snapshot)
+    assert _download_gate.mflux_missing_weights(REPO) == []
+    (snapshot / missing_file).unlink()
+    assert _download_gate.mflux_missing_weights(REPO) == [missing_file]
+
+
+def test_cold_snapshot_is_pinned_allowlisted_and_verified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import huggingface_hub
+
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _name: None
+    )
+    verified = []
+    monkeypatch.setattr(
+        engine, "_verify_weights_complete", lambda: verified.append(True)
+    )
+    calls = []
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda model, **kwargs: calls.append((model, kwargs)) or "/pinned/snapshot",
+    )
+
+    assert engine._model_path_for_mflux() == "/pinned/snapshot"
+    assert calls == [
+        (
+            REPO,
+            {
+                "revision": REVISION,
+                "allow_patterns": list(_download_gate.BONSAI_IMAGE_DATA_FILES),
+            },
+        )
+    ]
+    assert verified == [True]
+
+
+@pytest.mark.parametrize("requested", [REPO, "bonsai-image-4b-2bit"])
+def test_pull_uses_exact_revision_and_data_allowlist(
+    monkeypatch: pytest.MonkeyPatch, requested: str
+) -> None:
+    from vllm_mlx import cli
+    from vllm_mlx.audio import registry
+
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "_pull_repository",
+        lambda args, **kwargs: calls.append((args.model, kwargs)),
+    )
+    monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
+    monkeypatch.setattr(registry, "runtime_assets_for", lambda _repo: ())
+    monkeypatch.setattr(registry, "runtime_requirements_for", lambda _repo: ())
+
+    cli.pull_command(SimpleNamespace(model=requested))
+
+    assert calls == [
+        (
+            REPO,
+            {
+                "allow_patterns_override": list(_download_gate.BONSAI_IMAGE_DATA_FILES),
+                "revision_override": REVISION,
+            },
+        )
+    ]
+
+
+@pytest.mark.requires_mlx
+def test_runtime_checkpoint_validation_is_fail_closed(tmp_path: Path) -> None:
+    pytest.importorskip("mflux")
+    from vllm_mlx.image.bonsai_runtime.runtime import (
+        BONSAI_IMAGE_REPO,
+        BONSAI_IMAGE_REVISION,
+        BonsaiCheckpointError,
+        _validate_checkpoint,
+    )
+
+    assert BONSAI_IMAGE_REPO == REPO
+    assert BONSAI_IMAGE_REVISION == REVISION
+    with pytest.raises(BonsaiCheckpointError, match="incomplete"):
+        _validate_checkpoint(tmp_path)
+
+    files = {
+        "model_index.json": '{"_class_name":"Flux2KleinPipeline"}',
+        "scheduler/scheduler_config.json": "{}",
+        "tokenizer/tokenizer.json": "{}",
+        "text_encoder-mlx-4bit/config.json": (
+            '{"quantization":{"bits":4,"group_size":64}}'
+        ),
+        "text_encoder-mlx-4bit/model.safetensors": "weights",
+        "transformer-packed-mflux/config.json": "{}",
+        "transformer-packed-mflux/quantization_config.json": (
+            '{"bits":2,"group_size":128}'
+        ),
+        "transformer-packed-mflux/diffusion_pytorch_model.safetensors": "weights",
+        "vae/config.json": "{}",
+        "vae/diffusion_pytorch_model.safetensors": "weights",
+    }
+    for relative, body in files.items():
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    _validate_checkpoint(tmp_path)
+
+    (tmp_path / "transformer-packed-mflux/quantization_config.json").write_text(
+        '{"bits":4,"group_size":128}'
+    )
+    with pytest.raises(BonsaiCheckpointError, match="2-bit/group-128"):
+        _validate_checkpoint(tmp_path)
+
+
+@pytest.mark.requires_mlx
+def test_engine_builds_only_the_fixed_bonsai_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("mflux")
+    from vllm_mlx.image import bonsai_runtime
+
+    built = []
+
+    class TinyBonsai:
+        def __init__(self, path):
+            built.append(path)
+
+    monkeypatch.setattr(bonsai_runtime, "BonsaiImage", TinyBonsai)
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(engine, "_model_path_for_mflux", lambda: "/snapshot")
+    assert isinstance(engine._build_model(), TinyBonsai)
+    assert built == ["/snapshot"]
+
+    unsupported = ImageGenerationEngine("/models/bonsai_image")
+    with pytest.raises(ImageRuntimeError, match="pinned official checkpoint"):
+        unsupported._build_model()
+
+    missing = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(missing, "_model_path_for_mflux", lambda: None)
+    with pytest.raises(ImageRuntimeError, match="local model snapshot"):
+        missing._build_model()
+
+
+@pytest.mark.requires_mlx
+def test_runtime_definitions_and_json_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("mflux")
+    from vllm_mlx.image.bonsai_runtime import runtime
+
+    components = runtime._VAEWeightDefinition.get_components()
+    assert [component.name for component in components] == ["vae"]
+    assert runtime._VAEWeightDefinition.get_download_patterns() == [
+        "vae/*.safetensors",
+        "vae/*.json",
+    ]
+    assert runtime._VAEWeightDefinition.quantization_predicate(
+        "linear", SimpleNamespace(to_quantized=True)
+    )
+    assert not runtime._VAEWeightDefinition.quantization_predicate("norm", object())
+    tokenizer = runtime._tokenizer_definition()
+    assert tokenizer.hf_subdir == "tokenizer"
+    assert tokenizer.max_length == 512
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{")
+    with pytest.raises(runtime.BonsaiCheckpointError, match="Could not read"):
+        runtime._read_json_object(malformed)
+    malformed.write_text("[]")
+    with pytest.raises(runtime.BonsaiCheckpointError, match="JSON object"):
+        runtime._read_json_object(malformed)
+
+    monkeypatch.setattr(runtime.mx, "load", lambda _path: "not named tensors")
+    with pytest.raises(runtime.BonsaiCheckpointError, match="named tensors"):
+        runtime._load_safetensors(tmp_path / "weights.safetensors")
+
+
+@pytest.mark.requires_mlx
+def test_checkpoint_rejects_wrong_pipeline_and_text_quantization(
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("mflux")
+    from vllm_mlx.image.bonsai_runtime import runtime
+
+    files = {
+        "model_index.json": '{"_class_name":"WrongPipeline"}',
+        "scheduler/scheduler_config.json": "{}",
+        "tokenizer/tokenizer.json": "{}",
+        "text_encoder-mlx-4bit/config.json": "{}",
+        "text_encoder-mlx-4bit/model.safetensors": "weights",
+        "transformer-packed-mflux/config.json": "{}",
+        "transformer-packed-mflux/quantization_config.json": (
+            '{"bits":2,"group_size":128}'
+        ),
+        "transformer-packed-mflux/diffusion_pytorch_model.safetensors": "weights",
+        "vae/config.json": "{}",
+        "vae/diffusion_pytorch_model.safetensors": "weights",
+    }
+    for relative, body in files.items():
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+
+    with pytest.raises(runtime.BonsaiCheckpointError, match="not a FLUX.2"):
+        runtime._validate_checkpoint(tmp_path)
+    (tmp_path / "model_index.json").write_text('{"_class_name":"Flux2KleinPipeline"}')
+    with pytest.raises(runtime.BonsaiCheckpointError, match="no quantization"):
+        runtime._validate_checkpoint(tmp_path)
+    (tmp_path / "text_encoder-mlx-4bit/config.json").write_text(
+        '{"quantization":{"bits":8,"group_size":64}}'
+    )
+    with pytest.raises(runtime.BonsaiCheckpointError, match="4-bit/group-64"):
+        runtime._validate_checkpoint(tmp_path)
+
+
+@pytest.mark.requires_mlx
+def test_runtime_load_helpers_apply_the_fixed_quantization(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pytest.importorskip("mflux")
+    from vllm_mlx.image.bonsai_runtime import runtime
+
+    class Weight:
+        def __init__(self, name: str):
+            self.name = name
+
+        def astype(self, dtype):
+            return (self.name, dtype)
+
+    class Encoder:
+        def __init__(self, **overrides):
+            self.overrides = overrides
+            self.updated = None
+
+        def update(self, weights):
+            self.updated = weights
+
+    quantized = []
+    monkeypatch.setattr(
+        runtime.mx,
+        "load",
+        lambda path: {"model.layers.0.weight": Weight(path)},
+    )
+    monkeypatch.setattr(runtime, "tree_unflatten", lambda items: {"nested": items})
+    monkeypatch.setattr(runtime, "Qwen3TextEncoder", Encoder)
+    monkeypatch.setattr(
+        runtime.nn,
+        "quantize",
+        lambda model, **kwargs: quantized.append((model, kwargs)),
+    )
+    encoder = runtime._load_text_encoder(tmp_path, {"hidden_size": 4})
+    assert encoder.overrides == {"hidden_size": 4}
+    assert encoder.updated["nested"][0][0] == "layers.0.weight"
+    assert quantized[0][1]["bits"] == 4
+    assert quantized[0][1]["group_size"] == 64
+    assert quantized[0][1]["class_predicate"](
+        "linear", SimpleNamespace(to_quantized=True)
+    )
+
+    monkeypatch.setattr(runtime.mx, "load", lambda _path: {"metadata": Weight("x")})
+    with pytest.raises(runtime.BonsaiCheckpointError, match="no model weights"):
+        runtime._load_text_encoder(tmp_path, {})
+
+    spec = SimpleNamespace(
+        in_channels=3,
+        num_double_blocks=1,
+        num_single_blocks=2,
+        head_dim=4,
+        num_heads=5,
+        context_dim=6,
+        mlp_ratio=7,
+        axes_dims_rope=(1, 1, 2),
+        rope_theta=10_000,
+        layer_norm_eps=1e-6,
+        rms_norm_eps=1e-6,
+    )
+    transformer = SimpleNamespace(
+        time_guidance_embed=SimpleNamespace(
+            linear_1=SimpleNamespace(weight=None),
+            linear_2=SimpleNamespace(weight=None),
+        )
+    )
+    calls = []
+    monkeypatch.setattr(runtime, "Flux2KleinMegakernelSpec", lambda: spec)
+    monkeypatch.setattr(
+        runtime,
+        "load_klein_fast_packed_weights_from_disk",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or "packed",
+    )
+    monkeypatch.setattr(
+        runtime,
+        "Flux2KleinFastTransformer",
+        lambda **kwargs: calls.append(kwargs) or transformer,
+    )
+    monkeypatch.setattr(
+        runtime.mx,
+        "load",
+        lambda _path: {
+            "time_guidance_embed.timestep_embedder.linear_1.weight": Weight("one"),
+            "time_guidance_embed.timestep_embedder.linear_2.weight": Weight("two"),
+        },
+    )
+    assert runtime._load_transformer(tmp_path) is transformer
+    assert calls[0][0][1] is spec
+    assert calls[1]["precision"] == "2bit"
+    assert transformer.time_guidance_embed.linear_1.weight[0] == "one"
+
+    monkeypatch.setattr(runtime.mx, "load", lambda _path: {})
+    with pytest.raises(runtime.BonsaiCheckpointError, match="timestep weights"):
+        runtime._load_transformer(tmp_path)
+
+
+@pytest.mark.requires_mlx
+def test_runtime_constructor_and_prompt_cache_lifecycle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pytest.importorskip("mflux")
+    from vllm_mlx.image.bonsai_runtime import runtime
+
+    model_config = SimpleNamespace(text_encoder_overrides={"hidden_size": 4})
+    callbacks = object()
+    encoder = object()
+    vae_weights = object()
+    transformer = object()
+    applied = []
+    monkeypatch.setattr(
+        runtime, "_validate_checkpoint", lambda root: applied.append(root)
+    )
+    monkeypatch.setattr(runtime.ModelConfig, "flux2_klein_4b", lambda: model_config)
+    monkeypatch.setattr(runtime, "CallbackRegistry", lambda: callbacks)
+    monkeypatch.setattr(
+        runtime.TokenizerLoader,
+        "load_all",
+        lambda **kwargs: applied.append(kwargs) or {"qwen3": object()},
+    )
+    monkeypatch.setattr(runtime, "_load_text_encoder", lambda *_args: encoder)
+
+    class FakeVAE:
+        _bonsai_tiling = "tiling"
+
+        def __new__(cls):
+            return "vae"
+
+    monkeypatch.setattr(runtime, "_TiledFlux2VAE", FakeVAE)
+    monkeypatch.setattr(runtime.WeightLoader, "load", lambda **_kwargs: vae_weights)
+    monkeypatch.setattr(
+        runtime.WeightApplier,
+        "apply_and_quantize",
+        lambda **kwargs: applied.append(kwargs),
+    )
+    monkeypatch.setattr(runtime, "_load_transformer", lambda _root: transformer)
+
+    model = runtime.BonsaiImage(tmp_path)
+    assert model.callbacks is callbacks
+    assert model.text_encoder is encoder
+    assert model.vae == "vae"
+    assert model.transformer is transformer
+    assert model.bits == 2
+    assert applied[0] == tmp_path.resolve()
+
+    model.prompt_cache = {}
+    model.text_encoder = None
+    reloaded = object()
+    monkeypatch.setattr(runtime, "_load_text_encoder", lambda *_args: reloaded)
+    encoded = []
+    monkeypatch.setattr(
+        runtime.Flux2Klein,
+        "_encode_prompt_pair",
+        lambda self, **kwargs: (
+            encoded.append((self.text_encoder, kwargs))
+            or ("embeds", "ids", "negative", "negative_ids")
+        ),
+    )
+    monkeypatch.setattr(runtime.mx, "eval", lambda *args: applied.append(args))
+    monkeypatch.setattr(runtime.mx, "clear_cache", lambda: applied.append("clear"))
+    monkeypatch.setattr(runtime.gc, "collect", lambda: applied.append("gc") or 0)
+
+    assert model._encode_prompt_pair(
+        prompt="tree", negative_prompt="ignored", guidance=99
+    ) == ("embeds", "ids", None, None)
+    assert encoded == [
+        (
+            reloaded,
+            {"prompt": "tree", "negative_prompt": None, "guidance": 1.0},
+        )
+    ]
+    assert model.text_encoder is None
+    assert model._encode_prompt_pair(
+        prompt="tree", negative_prompt=None, guidance=1
+    ) == ("embeds", "ids", None, None)
+    assert len(encoded) == 1
+
+
+@pytest.mark.requires_mlx
+def test_tiled_vae_uses_bonsai_default_and_honors_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("mflux")
+    from vllm_mlx.image.bonsai_runtime import runtime
+
+    calls = []
+    monkeypatch.setattr(
+        runtime.Flux2VAE,
+        "decode_packed_latents",
+        lambda self, packed, *, tiling_config: (
+            calls.append((packed, tiling_config)) or "decoded"
+        ),
+    )
+    vae = runtime._TiledFlux2VAE()
+    assert vae.decode_packed_latents("latents") == "decoded"
+    custom = object()
+    assert vae.decode_packed_latents("other", custom) == "decoded"
+    assert calls == [
+        ("latents", runtime._TiledFlux2VAE._bonsai_tiling),
+        ("other", custom),
+    ]

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -167,6 +167,14 @@ def test_sdxl_runtime_coverage_runs_on_apple_silicon() -> None:
     assert "tests/test_sdxl_alias.py" in apple_run
 
 
+def test_bonsai_runtime_coverage_runs_on_apple_silicon() -> None:
+    """The MLX-only product adapter must contribute to the coverage union."""
+    _, workflow = _workflow()
+    apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
+
+    assert "tests/test_bonsai_image_alias.py" in apple_run
+
+
 def test_coverage_data_is_commit_bound_and_fail_closed() -> None:
     text, workflow = _workflow()
     jobs = workflow["jobs"]

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -168,11 +168,18 @@ def test_sdxl_runtime_coverage_runs_on_apple_silicon() -> None:
 
 
 def test_bonsai_runtime_coverage_runs_on_apple_silicon() -> None:
-    """The MLX-only product adapter must contribute to the coverage union."""
+    """The MLX-only product adapter and dependency must reach the Apple lane."""
     _, workflow = _workflow()
-    apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
+    steps = workflow["jobs"]["test-apple-silicon"]["steps"]
+    apple_run = steps[-2]["run"]
+    install = next(
+        step["run"]
+        for step in steps
+        if step.get("name") == "Install project and dependencies"
+    )
 
     assert "tests/test_bonsai_image_alias.py" in apple_run
+    assert 'pip install -e ".[vision,image]"' in install
 
 
 def test_coverage_data_is_commit_bound_and_fail_closed() -> None:

--- a/tests/test_serve_image_gen_completeness.py
+++ b/tests/test_serve_image_gen_completeness.py
@@ -148,3 +148,22 @@ def test_hidream_skips_unpinned_generic_prefetch(monkeypatch):
 
     assert excinfo.value.code == 1
     assert calls == []
+
+
+def test_bonsai_skips_unpinned_generic_prefetch(monkeypatch):
+    """Bonsai's ImageEngine owns the exact-revision, data-only cold pull."""
+    calls = []
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_missing_weights",
+        lambda _repo: ["transformer-packed-mflux/diffusion_pytorch_model.safetensors"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _drive_serve(
+            monkeypatch,
+            alias="bonsai-image-4b-2bit",
+            download_hook=lambda *args, **kwargs: calls.append((args, kwargs)),
+        )
+
+    assert excinfo.value.code == 1
+    assert calls == []

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1366,9 +1366,40 @@ SDXL_DATA_FILES = (
     "vae/diffusion_pytorch_model.fp16.safetensors",
 )
 
+BONSAI_IMAGE_REPO = "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
+BONSAI_IMAGE_REVISION = "2c24c81b934a658ba5590cf39088ba929985b4a8"
+BONSAI_IMAGE_DATA_FILES = (
+    "LICENSE",
+    "NOTICE.md",
+    "model_index.json",
+    "scheduler/scheduler_config.json",
+    "text_encoder-mlx-4bit/added_tokens.json",
+    "text_encoder-mlx-4bit/config.json",
+    "text_encoder-mlx-4bit/merges.txt",
+    "text_encoder-mlx-4bit/model.safetensors",
+    "text_encoder-mlx-4bit/model.safetensors.index.json",
+    "text_encoder-mlx-4bit/special_tokens_map.json",
+    "text_encoder-mlx-4bit/tokenizer.json",
+    "text_encoder-mlx-4bit/tokenizer_config.json",
+    "text_encoder-mlx-4bit/vocab.json",
+    "tokenizer/added_tokens.json",
+    "tokenizer/chat_template.jinja",
+    "tokenizer/merges.txt",
+    "tokenizer/special_tokens_map.json",
+    "tokenizer/tokenizer.json",
+    "tokenizer/tokenizer_config.json",
+    "tokenizer/vocab.json",
+    "transformer-packed-mflux/config.json",
+    "transformer-packed-mflux/diffusion_pytorch_model.safetensors",
+    "transformer-packed-mflux/quantization_config.json",
+    "vae/config.json",
+    "vae/diffusion_pytorch_model.safetensors",
+)
+
 IMAGE_MODEL_DATA_FILES: dict[str, tuple[str, ...]] = {
     HIDREAM_O1_REPO: HIDREAM_O1_DATA_FILES,
     SDXL_REPO: SDXL_DATA_FILES,
+    BONSAI_IMAGE_REPO: BONSAI_IMAGE_DATA_FILES,
 }
 
 IMAGE_MODEL_REVISIONS: dict[str, str] = {
@@ -1376,6 +1407,7 @@ IMAGE_MODEL_REVISIONS: dict[str, str] = {
     "mflux-community/qwen-image-mflux-q6": "c628fe4392d963557c3013c2709e6d3b67bca79d",
     HIDREAM_O1_REPO: HIDREAM_O1_REVISION,
     SDXL_REPO: SDXL_REVISION,
+    BONSAI_IMAGE_REPO: BONSAI_IMAGE_REVISION,
 }
 
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1972,6 +1972,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 12
   },
+  "bonsai-image-4b-2bit": {
+    "hf_path": "prism-ml/bonsai-image-ternary-4B-mlx-2bit",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 12
+  },
   "z-image-turbo": {
     "hf_path": "filipstrand/Z-Image-Turbo-mflux-4bit",
     "modality": "image-gen",

--- a/vllm_mlx/catalog/legacy.py
+++ b/vllm_mlx/catalog/legacy.py
@@ -33,14 +33,15 @@ def _image_operations(repo_id: str) -> list[str]:
 def _main_capabilities(profile: Any) -> dict[str, Any]:
     modality = getattr(profile, "modality", "text") or "text"
     if modality == "image-gen":
-        folded_path = profile.hf_path.casefold()
-        adapter = (
-            "rapid_mlx/hidream_o1"
-            if "hidream-o1" in folded_path
-            else "rapid_mlx/sdxl"
-            if "stable-diffusion-xl" in folded_path
-            else "mflux"
-        )
+        folded_hf_path = profile.hf_path.casefold()
+        if "hidream-o1" in folded_hf_path:
+            adapter = "rapid_mlx/hidream_o1"
+        elif "stable-diffusion-xl" in folded_hf_path:
+            adapter = "rapid_mlx/sdxl"
+        elif "bonsai-image" in folded_hf_path:
+            adapter = "rapid_mlx/bonsai_image"
+        else:
+            adapter = "mflux"
         tasks, operations, adapter = (
             ["image_generation"],
             _image_operations(profile.hf_path),

--- a/vllm_mlx/image/bonsai_runtime/LICENSE
+++ b/vllm_mlx/image/bonsai_runtime/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Filip Strand
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vllm_mlx/image/bonsai_runtime/NOTICE
+++ b/vllm_mlx/image/bonsai_runtime/NOTICE
@@ -1,0 +1,8 @@
+The low-bit FLUX.2 Klein runtime in _vendor/ is adapted from
+PrismML-Eng/mflux-prism commit bcd13e83b7fcfd76186c98ef322dd9cf28e996c1,
+which is derived from mflux and distributed under the accompanying MIT license.
+
+Rapid-MLX modifications place the code under its own package namespace and add
+a fail-closed adapter for the fixed Bonsai Image checkpoint. Model weights are
+not redistributed; their upstream Apache-2.0 LICENSE and NOTICE remain in the
+downloaded Hugging Face snapshot.

--- a/vllm_mlx/image/bonsai_runtime/__init__.py
+++ b/vllm_mlx/image/bonsai_runtime/__init__.py
@@ -1,0 +1,21 @@
+"""Native MLX runtime for Bonsai Image."""
+
+from .runtime import (
+    BONSAI_IMAGE_GUIDANCE,
+    BONSAI_IMAGE_MAX_PROMPT_TOKENS,
+    BONSAI_IMAGE_REPO,
+    BONSAI_IMAGE_REVISION,
+    BONSAI_IMAGE_STEPS,
+    BonsaiCheckpointError,
+    BonsaiImage,
+)
+
+__all__ = [
+    "BONSAI_IMAGE_GUIDANCE",
+    "BONSAI_IMAGE_MAX_PROMPT_TOKENS",
+    "BONSAI_IMAGE_REPO",
+    "BONSAI_IMAGE_REVISION",
+    "BONSAI_IMAGE_STEPS",
+    "BonsaiCheckpointError",
+    "BonsaiImage",
+]

--- a/vllm_mlx/image/bonsai_runtime/_vendor/__init__.py
+++ b/vllm_mlx/image/bonsai_runtime/_vendor/__init__.py
@@ -1,0 +1,11 @@
+"""Vendored low-bit FLUX.2 Klein numerical core."""
+
+from .loader import load_klein_fast_packed_weights_from_disk
+from .megakernel import Flux2KleinMegakernelSpec
+from .transformer import Flux2KleinFastTransformer
+
+__all__ = [
+    "Flux2KleinFastTransformer",
+    "Flux2KleinMegakernelSpec",
+    "load_klein_fast_packed_weights_from_disk",
+]

--- a/vllm_mlx/image/bonsai_runtime/_vendor/blocks.py
+++ b/vllm_mlx/image/bonsai_runtime/_vendor/blocks.py
@@ -1,0 +1,881 @@
+"""Flux2 Klein transformer block building blocks for MLX.
+
+RoPE uses mflux's compact (S, D/2) cos/sin representation and matches
+AttentionUtils.apply_rope_bshd so outputs are bit-identical to the reference
+blocks at matched dtypes/eps.
+
+Spec exposes layer_norm_eps and rms_norm_eps separately. Defaults (1e-6 for
+both) match the canonical FLUX.2 Klein reference: diffusers' Flux2Attention
+and Flux2TransformerBlock both consume the single `eps` field from
+transformer/config.json (1e-06 in black-forest-labs/FLUX.2-klein-4B). mflux's
+Flux2Attention hardcodes RMSNorm(eps=1e-5), which disagrees with that config;
+callers using real Klein weights should stick to 1e-6 for both.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Literal
+
+import mlx.core as mx
+import mlx.nn
+import numpy as np
+
+PrecisionName = Literal["bf16", "1bit", "2bit"]
+
+_SUPPORTED_BITS = (1, 2)
+_SUPPORTED_SCALE_DTYPES = {"bfloat16": mx.bfloat16}
+_SUPPORTED_GROUP_SIZES = (128,)
+_DEFAULT_AXES_DIMS_ROPE = (32, 32, 32, 32)
+DEFAULT_QUANT_GROUP_SIZE = 128
+
+
+@dataclass(frozen=True)
+class Flux2KleinBlockSpec:
+    dim: int = 3072
+    num_heads: int = 24
+    head_dim: int = 128
+    mlp_ratio: float = 3.0
+    layer_norm_eps: float = 1e-6
+    rms_norm_eps: float = 1e-6
+    rope_theta: int = 2000
+    axes_dims_rope: tuple[int, ...] = _DEFAULT_AXES_DIMS_ROPE
+
+    @property
+    def mlp_hidden_dim(self) -> int:
+        return int(self.dim * self.mlp_ratio)
+
+    @property
+    def qkv_mlp_out_dim(self) -> int:
+        return (3 * self.dim) + (2 * self.mlp_hidden_dim)
+
+    @property
+    def out_proj_in_dim(self) -> int:
+        return self.dim + self.mlp_hidden_dim
+
+    @property
+    def modulation_single_out_dim(self) -> int:
+        return 3 * self.dim
+
+    @property
+    def modulation_double_out_dim(self) -> int:
+        return 6 * self.dim
+
+    @classmethod
+    def from_transformer_config(cls, config_path: Path) -> "Flux2KleinBlockSpec":
+        config = json.loads(config_path.read_text())
+        dim = int(config["num_attention_heads"]) * int(config["attention_head_dim"])
+        eps = float(config["eps"])
+        return cls(
+            dim=dim,
+            num_heads=int(config["num_attention_heads"]),
+            head_dim=int(config["attention_head_dim"]),
+            mlp_ratio=float(config["mlp_ratio"]),
+            layer_norm_eps=eps,
+            rms_norm_eps=eps,
+            rope_theta=int(config.get("rope_theta", 2000)),
+            axes_dims_rope=tuple(config.get("axes_dims_rope", _DEFAULT_AXES_DIMS_ROPE)),
+        )
+
+
+@dataclass
+class PackedWeight:
+    """Pre-quantized weight triple consumed by `_make_linear` as a fast path
+    that skips `quantize_affine_nbit`. Shapes match `quantize_affine_nbit`'s
+    outputs: packed (rows, cols // (32 // bits)), scales (rows, cols // group_size),
+    biases (rows, cols // group_size).
+    """
+
+    packed: mx.array
+    scales: mx.array
+    biases: mx.array
+    bits: int
+    group_size: int
+
+
+WeightOrPacked = mx.array | PackedWeight
+
+
+@dataclass
+class SingleBlockWeights:
+    modulation: mx.array
+    qkv_mlp_proj: WeightOrPacked
+    out_proj: WeightOrPacked
+    norm_q: mx.array
+    norm_k: mx.array
+
+
+@dataclass
+class DoubleBlockWeights:
+    modulation_img: mx.array
+    modulation_txt: mx.array
+    to_q: WeightOrPacked
+    to_k: WeightOrPacked
+    to_v: WeightOrPacked
+    add_q_proj: WeightOrPacked
+    add_k_proj: WeightOrPacked
+    add_v_proj: WeightOrPacked
+    to_out: WeightOrPacked
+    to_add_out: WeightOrPacked
+    ff_linear_in: WeightOrPacked
+    ff_linear_out: WeightOrPacked
+    ff_context_linear_in: WeightOrPacked
+    ff_context_linear_out: WeightOrPacked
+    norm_q: mx.array
+    norm_k: mx.array
+    norm_added_q: mx.array
+    norm_added_k: mx.array
+
+
+def single_block_weight_keys(block_index: int) -> dict[str, str]:
+    prefix = f"single_transformer_blocks.{block_index}.attn"
+    return {
+        "modulation": "single_stream_modulation.linear.weight",
+        "qkv_mlp_proj": f"{prefix}.to_qkv_mlp_proj.weight",
+        "out_proj": f"{prefix}.to_out.weight",
+        "norm_q": f"{prefix}.norm_q.weight",
+        "norm_k": f"{prefix}.norm_k.weight",
+    }
+
+
+def double_block_weight_keys(block_index: int) -> dict[str, str]:
+    prefix = f"transformer_blocks.{block_index}"
+    attn = f"{prefix}.attn"
+    return {
+        "modulation_img": "double_stream_modulation_img.linear.weight",
+        "modulation_txt": "double_stream_modulation_txt.linear.weight",
+        "to_q": f"{attn}.to_q.weight",
+        "to_k": f"{attn}.to_k.weight",
+        "to_v": f"{attn}.to_v.weight",
+        "add_q_proj": f"{attn}.add_q_proj.weight",
+        "add_k_proj": f"{attn}.add_k_proj.weight",
+        "add_v_proj": f"{attn}.add_v_proj.weight",
+        "to_out": f"{attn}.to_out.0.weight",
+        "to_add_out": f"{attn}.to_add_out.weight",
+        "ff_linear_in": f"{prefix}.ff.linear_in.weight",
+        "ff_linear_out": f"{prefix}.ff.linear_out.weight",
+        "ff_context_linear_in": f"{prefix}.ff_context.linear_in.weight",
+        "ff_context_linear_out": f"{prefix}.ff_context.linear_out.weight",
+        "norm_q": f"{attn}.norm_q.weight",
+        "norm_k": f"{attn}.norm_k.weight",
+        "norm_added_q": f"{attn}.norm_added_q.weight",
+        "norm_added_k": f"{attn}.norm_added_k.weight",
+    }
+
+
+def _require_supported_bits(bits: int) -> None:
+    if bits not in _SUPPORTED_BITS:
+        raise ValueError(f"bits must be one of {_SUPPORTED_BITS}, got {bits}")
+
+
+def _require_divisible(value: int, divisor: int, label: str) -> None:
+    if value % divisor != 0:
+        raise ValueError(f"{label}={value} must be divisible by {divisor}")
+
+
+def _silu(x: mx.array) -> mx.array:
+    return mlx.nn.silu(x)
+
+
+def _layer_norm_affine(x: mx.array, weight: mx.array, bias: mx.array, eps: float) -> mx.array:
+    return mx.fast.layer_norm(x, weight, bias, eps)
+
+
+def _rms_norm_with_weight(x: mx.array, weight: mx.array, eps: float) -> mx.array:
+    return mx.fast.rms_norm(x, weight, eps)
+
+
+def _scale_dtype_from_name(name: str) -> mx.Dtype:
+    if name not in _SUPPORTED_SCALE_DTYPES:
+        supported = ", ".join(sorted(_SUPPORTED_SCALE_DTYPES))
+        raise ValueError(f"Unsupported scale dtype '{name}'. Supported: {supported}")
+    return _SUPPORTED_SCALE_DTYPES[name]
+
+
+def _ensure_batched_hidden_states(x: mx.array) -> tuple[mx.array, bool]:
+    if x.ndim == 2:
+        return x[None, :, :], True
+    if x.ndim != 3:
+        raise ValueError(f"Expected hidden states with ndim=2 or 3, got ndim={x.ndim}")
+    return x, False
+
+
+def _restore_hidden_states(x: mx.array, squeezed: bool) -> mx.array:
+    return x[0] if squeezed else x
+
+
+def _apply_rope_bshd(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    """Apply Flux-style RoPE to an [B, H, S, D] tensor using compact (S, D/2) cos/sin.
+
+    Matches mflux.models.flux.model.flux_transformer.common.attention_utils.AttentionUtils.apply_rope_bshd.
+    """
+    out_dtype = x.dtype
+    x_f = x.astype(mx.float32)
+    cos_b = cos.reshape(1, 1, cos.shape[0], cos.shape[1])
+    sin_b = sin.reshape(1, 1, sin.shape[0], sin.shape[1])
+    x2 = x_f.reshape(*x_f.shape[:-1], -1, 2)
+    real = x2[..., 0]
+    imag = x2[..., 1]
+    out0 = real * cos_b + (-imag) * sin_b
+    out1 = imag * cos_b + real * sin_b
+    out = mx.stack([out0, out1], axis=-1).reshape(*x_f.shape)
+    return out.astype(out_dtype)
+
+
+_FUSED_SINGLE_NORM_ROPE_SOURCE = """
+    uint global_tid = thread_position_in_grid.x;
+    uint pos = global_tid / 32;
+    uint tid = global_tid % 32;
+
+    const int S_DIM = {S_DIM};
+    const int H_DIM = {H_DIM};
+    const int D_DIM = {D_DIM};
+    const int D_HALF = D_DIM / 2;
+    const int FUSED_DIM = {FUSED_DIM};
+    const int DIM = {DIM};
+    const float eps = {EPS}f;
+    const int ELEMS = D_DIM / 32;
+
+    uint b = pos / (S_DIM * H_DIM);
+    uint s = (pos / H_DIM) % S_DIM;
+    uint h = pos % H_DIM;
+
+    uint fused_base = b * S_DIM * FUSED_DIM + s * FUSED_DIM;
+    uint q_col = h * D_DIM;
+    uint k_col = DIM + h * D_DIM;
+    uint v_col = 2 * DIM + h * D_DIM;
+
+    float qv[{ELEMS}], kv[{ELEMS}], vv[{ELEMS}];
+    float sq_q = 0.0f, sq_k = 0.0f;
+
+    for (int i = 0; i < ELEMS; i++) {{
+        uint d = tid * ELEMS + i;
+        qv[i] = float(fused[fused_base + q_col + d]);
+        kv[i] = float(fused[fused_base + k_col + d]);
+        vv[i] = float(fused[fused_base + v_col + d]);
+        sq_q += qv[i] * qv[i];
+        sq_k += kv[i] * kv[i];
+    }}
+
+    float total_sq_q = simd_sum(sq_q);
+    float total_sq_k = simd_sum(sq_k);
+    float inv_rms_q = metal::rsqrt(total_sq_q / float(D_DIM) + eps);
+    float inv_rms_k = metal::rsqrt(total_sq_k / float(D_DIM) + eps);
+
+    for (int i = 0; i < ELEMS; i++) {{
+        uint d = tid * ELEMS + i;
+        qv[i] = qv[i] * inv_rms_q * float(norm_q[d]);
+        kv[i] = kv[i] * inv_rms_k * float(norm_k[d]);
+    }}
+
+    uint cos_base = s * D_HALF;
+    for (int p = 0; p < ELEMS; p += 2) {{
+        uint d = tid * ELEMS + p;
+        uint d_half = d >> 1;
+        float c = float(cos_vals[cos_base + d_half]);
+        float sn = float(sin_vals[cos_base + d_half]);
+        float q0 = qv[p], q1 = qv[p + 1];
+        float k0 = kv[p], k1 = kv[p + 1];
+        qv[p]     = q0 * c - q1 * sn;
+        qv[p + 1] = q1 * c + q0 * sn;
+        kv[p]     = k0 * c - k1 * sn;
+        kv[p + 1] = k1 * c + k0 * sn;
+    }}
+
+    uint out_base = b * H_DIM * S_DIM * D_DIM + h * S_DIM * D_DIM + s * D_DIM;
+    for (int i = 0; i < ELEMS; i++) {{
+        uint d = tid * ELEMS + i;
+        q_out[out_base + d] = T(qv[i]);
+        k_out[out_base + d] = T(kv[i]);
+        v_out[out_base + d] = T(vv[i]);
+    }}
+"""
+
+
+_FUSED_DOUBLE_NORM_ROPE_SOURCE = """
+    uint global_tid = thread_position_in_grid.x;
+    uint pos = global_tid / 32;
+    uint tid = global_tid % 32;
+
+    const int S_IMG = {S_IMG};
+    const int S_TXT = {S_TXT};
+    const int S_TOTAL = S_IMG + S_TXT;
+    const int H_DIM = {H_DIM};
+    const int D_DIM = {D_DIM};
+    const int D_HALF = D_DIM / 2;
+    const int DIM = {DIM};
+    const float eps = {EPS}f;
+    const int ELEMS = D_DIM / 32;
+
+    uint b = pos / (S_TOTAL * H_DIM);
+    uint s = (pos / H_DIM) % S_TOTAL;
+    uint h = pos % H_DIM;
+
+    bool is_txt = (s < S_TXT);
+    uint src_s = is_txt ? s : (s - S_TXT);
+    uint q_col = h * D_DIM;
+    uint k_col = DIM + h * D_DIM;
+    uint v_col = 2 * DIM + h * D_DIM;
+
+    float qv[{ELEMS}], kv[{ELEMS}], vv[{ELEMS}];
+    float sq_q = 0.0f, sq_k = 0.0f;
+
+    int src_stride = is_txt ? (S_TXT * 3 * DIM) : (S_IMG * 3 * DIM);
+    uint base = b * src_stride + src_s * 3 * DIM;
+
+    for (int i = 0; i < ELEMS; i++) {{
+        uint d = tid * ELEMS + i;
+        if (is_txt) {{
+            qv[i] = float(txt_qkv[base + q_col + d]);
+            kv[i] = float(txt_qkv[base + k_col + d]);
+            vv[i] = float(txt_qkv[base + v_col + d]);
+        }} else {{
+            qv[i] = float(img_qkv[base + q_col + d]);
+            kv[i] = float(img_qkv[base + k_col + d]);
+            vv[i] = float(img_qkv[base + v_col + d]);
+        }}
+        sq_q += qv[i] * qv[i];
+        sq_k += kv[i] * kv[i];
+    }}
+
+    float total_sq_q = simd_sum(sq_q);
+    float total_sq_k = simd_sum(sq_k);
+    float inv_rms_q = metal::rsqrt(total_sq_q / float(D_DIM) + eps);
+    float inv_rms_k = metal::rsqrt(total_sq_k / float(D_DIM) + eps);
+
+    for (int i = 0; i < ELEMS; i++) {{
+        uint d = tid * ELEMS + i;
+        if (is_txt) {{
+            qv[i] = qv[i] * inv_rms_q * float(norm_added_q[d]);
+            kv[i] = kv[i] * inv_rms_k * float(norm_added_k[d]);
+        }} else {{
+            qv[i] = qv[i] * inv_rms_q * float(norm_q[d]);
+            kv[i] = kv[i] * inv_rms_k * float(norm_k[d]);
+        }}
+    }}
+
+    uint cos_base = s * D_HALF;
+    for (int p = 0; p < ELEMS; p += 2) {{
+        uint d = tid * ELEMS + p;
+        uint d_half = d >> 1;
+        float c = float(cos_vals[cos_base + d_half]);
+        float sn = float(sin_vals[cos_base + d_half]);
+        float q0 = qv[p], q1 = qv[p + 1];
+        float k0 = kv[p], k1 = kv[p + 1];
+        qv[p]     = q0 * c - q1 * sn;
+        qv[p + 1] = q1 * c + q0 * sn;
+        kv[p]     = k0 * c - k1 * sn;
+        kv[p + 1] = k1 * c + k0 * sn;
+    }}
+
+    uint out_base = b * H_DIM * S_TOTAL * D_DIM + h * S_TOTAL * D_DIM + s * D_DIM;
+    for (int i = 0; i < ELEMS; i++) {{
+        uint d = tid * ELEMS + i;
+        q_out[out_base + d] = T(qv[i]);
+        k_out[out_base + d] = T(kv[i]);
+        v_out[out_base + d] = T(vv[i]);
+    }}
+"""
+
+
+_fused_single_kernel_cache: dict[str, Any] = {}
+_fused_double_kernel_cache: dict[str, Any] = {}
+
+
+def _get_fused_double_norm_rope_kernel(
+    spec: "Flux2KleinBlockSpec", img_seq: int, txt_seq: int
+) -> Any:
+    key = f"{img_seq}_{txt_seq}_{spec.dim}_{spec.num_heads}_{spec.head_dim}_{spec.rms_norm_eps}"
+    if key not in _fused_double_kernel_cache:
+        elems = spec.head_dim // 32
+        if elems < 2 or (elems % 2) != 0:
+            raise ValueError(
+                f"head_dim={spec.head_dim} incompatible with 32-wide SIMD group; "
+                "kernel requires head_dim to be a multiple of 64."
+            )
+        source = _FUSED_DOUBLE_NORM_ROPE_SOURCE.format(
+            S_IMG=img_seq,
+            S_TXT=txt_seq,
+            H_DIM=spec.num_heads,
+            D_DIM=spec.head_dim,
+            DIM=spec.dim,
+            EPS=spec.rms_norm_eps,
+            ELEMS=elems,
+        )
+        safe_key = key.replace(".", "_").replace("-", "n").replace("+", "p")
+        _fused_double_kernel_cache[key] = mx.fast.metal_kernel(
+            name=f"flux2_fused_double_norm_rope_{safe_key}",
+            input_names=[
+                "img_qkv", "txt_qkv",
+                "norm_q", "norm_k", "norm_added_q", "norm_added_k",
+                "cos_vals", "sin_vals",
+            ],
+            output_names=["q_out", "k_out", "v_out"],
+            source=source,
+        )
+    return _fused_double_kernel_cache[key]
+
+
+def _get_fused_single_norm_rope_kernel(spec: "Flux2KleinBlockSpec", seq_len: int) -> Any:
+    fused_dim = spec.qkv_mlp_out_dim
+    key = f"{seq_len}_{spec.dim}_{spec.num_heads}_{spec.head_dim}_{fused_dim}_{spec.rms_norm_eps}"
+    if key not in _fused_single_kernel_cache:
+        elems = spec.head_dim // 32
+        if elems < 2 or (elems % 2) != 0:
+            raise ValueError(
+                f"head_dim={spec.head_dim} incompatible with 32-wide SIMD group; "
+                "kernel requires head_dim to be a multiple of 64."
+            )
+        source = _FUSED_SINGLE_NORM_ROPE_SOURCE.format(
+            S_DIM=seq_len,
+            H_DIM=spec.num_heads,
+            D_DIM=spec.head_dim,
+            FUSED_DIM=fused_dim,
+            DIM=spec.dim,
+            EPS=spec.rms_norm_eps,
+            ELEMS=elems,
+        )
+        safe_key = key.replace(".", "_").replace("-", "n").replace("+", "p")
+        _fused_single_kernel_cache[key] = mx.fast.metal_kernel(
+            name=f"flux2_fused_single_norm_rope_{safe_key}",
+            input_names=["fused", "norm_q", "norm_k", "cos_vals", "sin_vals"],
+            output_names=["q_out", "k_out", "v_out"],
+            source=source,
+        )
+    return _fused_single_kernel_cache[key]
+
+
+def _require_supported_group_size(group_size: int) -> None:
+    if group_size not in _SUPPORTED_GROUP_SIZES:
+        raise ValueError(
+            f"group_size must be one of {_SUPPORTED_GROUP_SIZES}, got {group_size}"
+        )
+
+
+def quantize_affine_nbit(
+    weight: mx.array,
+    *,
+    bits: int,
+    group_size: int = DEFAULT_QUANT_GROUP_SIZE,
+    scale_dtype: str = "bfloat16",
+) -> tuple[mx.array, mx.array, mx.array]:
+    _require_supported_bits(bits)
+    _require_supported_group_size(group_size)
+    mx_scale_dtype = _scale_dtype_from_name(scale_dtype)
+
+    weight_np = np.asarray(weight.astype(mx.float32))
+    if weight_np.ndim != 2:
+        raise ValueError(f"Expected a 2D weight matrix, got ndim={weight_np.ndim}")
+
+    rows, cols = weight_np.shape
+    _require_divisible(cols, group_size, "in_features")
+
+    max_q = (1 << bits) - 1
+    vals_per_u32 = 32 // bits
+    _require_divisible(cols, vals_per_u32, "in_features")
+
+    grouped = weight_np.reshape(rows, cols // group_size, group_size)
+    g_min = np.min(grouped, axis=2)
+    g_max = np.max(grouped, axis=2)
+    scales = np.maximum((g_max - g_min) / max_q, 1e-7)
+    biases = g_min
+
+    q = np.round((grouped - biases[:, :, None]) / scales[:, :, None])
+    q = np.clip(q, 0, max_q).astype(np.uint32)
+    q_flat = q.reshape(rows, -1)
+    q_grouped = q_flat.reshape(rows, -1, vals_per_u32)
+    shifts = (np.arange(vals_per_u32, dtype=np.uint32) * bits).reshape(1, 1, vals_per_u32)
+    packed = np.sum(np.left_shift(q_grouped, shifts), axis=2, dtype=np.uint32)
+
+    return (
+        mx.array(packed),
+        mx.array(scales).astype(mx_scale_dtype),
+        mx.array(biases).astype(mx_scale_dtype),
+    )
+
+
+@lru_cache(maxsize=None)
+def _require_native_quantized_matmul(bits: int, group_size: int) -> None:
+    """Verify that the active MLX runtime supports native quantized matmul at
+    the requested (bits, group_size). Raises at first call if the kernel is
+    not available; result is cached so subsequent calls are free.
+    """
+    _require_supported_bits(bits)
+    _require_supported_group_size(group_size)
+    probe_weight = mx.arange(group_size, dtype=mx.float32).reshape(1, group_size) - (group_size // 2)
+    packed_weight, scales, biases = quantize_affine_nbit(
+        probe_weight,
+        bits=bits,
+        group_size=group_size,
+    )
+    probe_x = mx.ones((1, group_size), dtype=mx.bfloat16)
+    probe_out = mx.quantized_matmul(
+        probe_x,
+        packed_weight,
+        scales,
+        biases,
+        group_size=group_size,
+        bits=bits,
+    )
+    mx.eval(probe_out)
+
+
+class DenseLinearKernel:
+    def __init__(self, weight: mx.array):
+        self.weight = weight.astype(mx.bfloat16)
+
+    @property
+    def out_features(self) -> int:
+        return int(self.weight.shape[0])
+
+    def __call__(self, x: mx.array) -> mx.array:
+        original_shape = x.shape
+        if x.ndim == 1:
+            x = x[None, :]
+        flat_x = x.reshape((-1, x.shape[-1])).astype(mx.bfloat16)
+        output = flat_x @ self.weight.transpose()
+        return output.reshape((*original_shape[:-1], self.out_features))
+
+
+@dataclass
+class QuantizedLinearKernel:
+    packed_weight: mx.array
+    scales: mx.array
+    biases: mx.array
+    bits: int
+    group_size: int
+
+    @classmethod
+    def from_weight(
+        cls,
+        weight: mx.array,
+        *,
+        bits: int,
+        group_size: int,
+        scale_dtype: str = "bfloat16",
+    ) -> "QuantizedLinearKernel":
+        _require_native_quantized_matmul(bits, group_size)
+        packed_weight, scales, biases = quantize_affine_nbit(
+            weight,
+            bits=bits,
+            group_size=group_size,
+            scale_dtype=scale_dtype,
+        )
+        return cls(packed_weight=packed_weight, scales=scales, biases=biases, bits=bits, group_size=group_size)
+
+    @property
+    def out_features(self) -> int:
+        return int(self.scales.shape[0])
+
+    def __call__(self, x: mx.array) -> mx.array:
+        original_shape = x.shape
+        if x.ndim == 1:
+            x = x[None, :]
+        flat_x = x.reshape((-1, x.shape[-1])).astype(mx.bfloat16)
+        output = mx.quantized_matmul(
+            flat_x,
+            self.packed_weight,
+            self.scales,
+            self.biases,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        return output.reshape((*original_shape[:-1], self.out_features))
+
+
+LinearKernel = DenseLinearKernel | QuantizedLinearKernel
+
+
+def _fuse_quantized_linears(linears: list[QuantizedLinearKernel]) -> QuantizedLinearKernel:
+    return QuantizedLinearKernel(
+        packed_weight=mx.concatenate([l.packed_weight for l in linears], axis=0),
+        scales=mx.concatenate([l.scales for l in linears], axis=0),
+        biases=mx.concatenate([l.biases for l in linears], axis=0),
+        bits=linears[0].bits,
+        group_size=linears[0].group_size,
+    )
+
+
+def _fuse_dense_linears(linears: list[DenseLinearKernel]) -> DenseLinearKernel:
+    return DenseLinearKernel(mx.concatenate([l.weight for l in linears], axis=0))
+
+
+def _fuse_linears(linears: list[LinearKernel]) -> LinearKernel:
+    if all(isinstance(l, QuantizedLinearKernel) for l in linears):
+        return _fuse_quantized_linears(linears)
+    if all(isinstance(l, DenseLinearKernel) for l in linears):
+        return _fuse_dense_linears(linears)
+    raise TypeError("Cannot fuse mixed linear kernel types")
+
+
+def _make_linear(weight: WeightOrPacked, precision: PrecisionName, group_size: int) -> LinearKernel:
+    if isinstance(weight, PackedWeight):
+        _require_native_quantized_matmul(weight.bits, weight.group_size)
+        return QuantizedLinearKernel(
+            packed_weight=weight.packed,
+            scales=weight.scales,
+            biases=weight.biases,
+            bits=weight.bits,
+            group_size=weight.group_size,
+        )
+    if precision == "bf16":
+        return DenseLinearKernel(weight)
+    bits = 1 if precision == "1bit" else 2
+    return QuantizedLinearKernel.from_weight(weight, bits=bits, group_size=group_size)
+
+
+def _swiglu_projected(x: mx.array) -> mx.array:
+    gate, value = mx.split(x, 2, axis=-1)
+    return _silu(gate) * value
+
+
+class SingleFlux2Block:
+    def __init__(
+        self,
+        *,
+        spec: Flux2KleinBlockSpec,
+        weights: SingleBlockWeights,
+        precision: PrecisionName,
+        group_size: int,
+    ):
+        self.spec = spec
+        # Modulation linear stays Dense regardless of `precision`.
+        self.modulation = DenseLinearKernel(weights.modulation)
+        self.qkv_mlp_proj = _make_linear(weights.qkv_mlp_proj, precision, group_size)
+        self.out_proj = _make_linear(weights.out_proj, precision, group_size)
+        self.norm_q = weights.norm_q.astype(mx.bfloat16)
+        self.norm_k = weights.norm_k.astype(mx.bfloat16)
+
+    def prepare_modulation(self, temb: mx.array) -> tuple[mx.array, mx.array, mx.array]:
+        if temb.ndim == 1:
+            temb = temb[None, :]
+        mod = self.modulation(_silu(temb)).reshape((temb.shape[0], 1, 3, self.spec.dim))
+        shift = mod[:, :, 0, :]
+        scale = mod[:, :, 1, :]
+        gate = mod[:, :, 2, :]
+        norm_w = (1.0 + scale).reshape(-1)
+        norm_b = shift.reshape(-1)
+        return norm_w, norm_b, gate.reshape(-1)
+
+    def forward_from_modulation(
+        self,
+        hidden_states: mx.array,
+        modulation: tuple[mx.array, mx.array, mx.array],
+        rotary_cos: mx.array,
+        rotary_sin: mx.array,
+    ) -> mx.array:
+        norm_w, norm_b, gate = modulation
+        norm_hidden_states = _layer_norm_affine(hidden_states, norm_w, norm_b, self.spec.layer_norm_eps)
+
+        fused = self.qkv_mlp_proj(norm_hidden_states)
+        mlp_hidden = fused[:, :, 3 * self.spec.dim :]
+
+        batch_size = int(hidden_states.shape[0])
+        seq_len = int(hidden_states.shape[1])
+        H = self.spec.num_heads
+        D = self.spec.head_dim
+
+        kernel = _get_fused_single_norm_rope_kernel(self.spec, seq_len)
+        query, key, value = kernel(
+            inputs=[fused, self.norm_q, self.norm_k, rotary_cos, rotary_sin],
+            template=[("T", mx.bfloat16)],
+            grid=(batch_size * seq_len * H * 32, 1, 1),
+            threadgroup=(32, 1, 1),
+            output_shapes=[
+                (batch_size, H, seq_len, D),
+                (batch_size, H, seq_len, D),
+                (batch_size, H, seq_len, D),
+            ],
+            output_dtypes=[mx.bfloat16, mx.bfloat16, mx.bfloat16],
+        )
+
+        attn_output = mx.fast.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            scale=1.0 / math.sqrt(D),
+        )
+        attn_output = attn_output.transpose(0, 2, 1, 3).reshape((batch_size, seq_len, self.spec.dim))
+        mlp_output = _swiglu_projected(mlp_hidden)
+        fused_out = mx.concatenate([attn_output, mlp_output], axis=-1)
+        block_output = self.out_proj(fused_out)
+        return hidden_states + gate * block_output
+
+    def forward(
+        self,
+        hidden_states: mx.array,
+        temb: mx.array,
+        rotary_cos: mx.array,
+        rotary_sin: mx.array,
+    ) -> mx.array:
+        hidden_states, squeezed = _ensure_batched_hidden_states(hidden_states)
+        output = self.forward_from_modulation(
+            hidden_states,
+            self.prepare_modulation(temb),
+            rotary_cos,
+            rotary_sin,
+        )
+        return _restore_hidden_states(output, squeezed)
+
+
+class DoubleFlux2Block:
+    def __init__(
+        self,
+        *,
+        spec: Flux2KleinBlockSpec,
+        weights: DoubleBlockWeights,
+        precision: PrecisionName,
+        group_size: int,
+    ):
+        self.spec = spec
+        # Modulation linears stay Dense regardless of `precision`.
+        self.modulation_img = DenseLinearKernel(weights.modulation_img)
+        self.modulation_txt = DenseLinearKernel(weights.modulation_txt)
+        img_qkv_parts = [
+            _make_linear(weights.to_q, precision, group_size),
+            _make_linear(weights.to_k, precision, group_size),
+            _make_linear(weights.to_v, precision, group_size),
+        ]
+        txt_qkv_parts = [
+            _make_linear(weights.add_q_proj, precision, group_size),
+            _make_linear(weights.add_k_proj, precision, group_size),
+            _make_linear(weights.add_v_proj, precision, group_size),
+        ]
+        self.img_qkv = _fuse_linears(img_qkv_parts)
+        self.txt_qkv = _fuse_linears(txt_qkv_parts)
+        self.to_out = _make_linear(weights.to_out, precision, group_size)
+        self.to_add_out = _make_linear(weights.to_add_out, precision, group_size)
+        self.ff_linear_in = _make_linear(weights.ff_linear_in, precision, group_size)
+        self.ff_linear_out = _make_linear(weights.ff_linear_out, precision, group_size)
+        self.ff_context_linear_in = _make_linear(weights.ff_context_linear_in, precision, group_size)
+        self.ff_context_linear_out = _make_linear(weights.ff_context_linear_out, precision, group_size)
+        self.norm_q = weights.norm_q.astype(mx.bfloat16)
+        self.norm_k = weights.norm_k.astype(mx.bfloat16)
+        self.norm_added_q = weights.norm_added_q.astype(mx.bfloat16)
+        self.norm_added_k = weights.norm_added_k.astype(mx.bfloat16)
+
+    def prepare_modulation(
+        self,
+        linear: LinearKernel,
+        temb: mx.array,
+    ) -> tuple[tuple[mx.array, mx.array, mx.array], ...]:
+        if temb.ndim == 1:
+            temb = temb[None, :]
+        mod = linear(_silu(temb)).reshape((temb.shape[0], 1, 2, 3, self.spec.dim))
+        shift_msa = mod[:, :, 0, 0, :]
+        scale_msa = mod[:, :, 0, 1, :]
+        gate_msa = mod[:, :, 0, 2, :]
+        shift_mlp = mod[:, :, 1, 0, :]
+        scale_mlp = mod[:, :, 1, 1, :]
+        gate_mlp = mod[:, :, 1, 2, :]
+        return (
+            ((1.0 + scale_msa).reshape(-1), shift_msa.reshape(-1), gate_msa.reshape(-1)),
+            ((1.0 + scale_mlp).reshape(-1), shift_mlp.reshape(-1), gate_mlp.reshape(-1)),
+        )
+
+    def _feedforward(self, x: mx.array, linear_in: LinearKernel, linear_out: LinearKernel) -> mx.array:
+        return linear_out(_swiglu_projected(linear_in(x)))
+
+    def forward_from_modulation(
+        self,
+        hidden_states: mx.array,
+        encoder_hidden_states: mx.array,
+        img_modulation: tuple[tuple[mx.array, mx.array, mx.array], ...],
+        txt_modulation: tuple[tuple[mx.array, mx.array, mx.array], ...],
+        rotary_cos: mx.array,
+        rotary_sin: mx.array,
+    ) -> tuple[mx.array, mx.array]:
+        (w_msa, b_msa, gate_msa), (w_mlp, b_mlp, gate_mlp) = img_modulation
+        (c_w_msa, c_b_msa, c_gate_msa), (c_w_mlp, c_b_mlp, c_gate_mlp) = txt_modulation
+
+        norm_hidden_states = _layer_norm_affine(hidden_states, w_msa, b_msa, self.spec.layer_norm_eps)
+        norm_encoder_hidden_states = _layer_norm_affine(
+            encoder_hidden_states, c_w_msa, c_b_msa, self.spec.layer_norm_eps
+        )
+
+        batch_size = int(hidden_states.shape[0])
+        img_seq = int(hidden_states.shape[1])
+        txt_seq = int(encoder_hidden_states.shape[1])
+        H = self.spec.num_heads
+        D = self.spec.head_dim
+
+        img_qkv = self.img_qkv(norm_hidden_states)
+        txt_qkv = self.txt_qkv(norm_encoder_hidden_states)
+
+        kernel = _get_fused_double_norm_rope_kernel(self.spec, img_seq, txt_seq)
+        full_query, full_key, full_value = kernel(
+            inputs=[
+                img_qkv, txt_qkv,
+                self.norm_q, self.norm_k,
+                self.norm_added_q, self.norm_added_k,
+                rotary_cos, rotary_sin,
+            ],
+            template=[("T", mx.bfloat16)],
+            grid=(batch_size * (img_seq + txt_seq) * H * 32, 1, 1),
+            threadgroup=(32, 1, 1),
+            output_shapes=[
+                (batch_size, H, txt_seq + img_seq, D),
+                (batch_size, H, txt_seq + img_seq, D),
+                (batch_size, H, txt_seq + img_seq, D),
+            ],
+            output_dtypes=[mx.bfloat16, mx.bfloat16, mx.bfloat16],
+        )
+
+        attn = mx.fast.scaled_dot_product_attention(
+            full_query,
+            full_key,
+            full_value,
+            scale=1.0 / math.sqrt(D),
+        )
+        attn = attn.transpose(0, 2, 1, 3).reshape((batch_size, txt_seq + img_seq, self.spec.dim))
+        context_attn_output = self.to_add_out(attn[:, :txt_seq])
+        attn_output = self.to_out(attn[:, txt_seq:])
+
+        hidden_states = hidden_states + gate_msa * attn_output
+        norm_hidden_states = _layer_norm_affine(hidden_states, w_mlp, b_mlp, self.spec.layer_norm_eps)
+        hidden_states = hidden_states + gate_mlp * self._feedforward(
+            norm_hidden_states,
+            self.ff_linear_in,
+            self.ff_linear_out,
+        )
+
+        encoder_hidden_states = encoder_hidden_states + c_gate_msa * context_attn_output
+        norm_encoder_hidden_states = _layer_norm_affine(
+            encoder_hidden_states, c_w_mlp, c_b_mlp, self.spec.layer_norm_eps
+        )
+        encoder_hidden_states = encoder_hidden_states + c_gate_mlp * self._feedforward(
+            norm_encoder_hidden_states,
+            self.ff_context_linear_in,
+            self.ff_context_linear_out,
+        )
+
+        return encoder_hidden_states, hidden_states
+
+    def forward(
+        self,
+        hidden_states: mx.array,
+        encoder_hidden_states: mx.array,
+        temb: mx.array,
+        rotary_cos: mx.array,
+        rotary_sin: mx.array,
+    ) -> tuple[mx.array, mx.array]:
+        hidden_states, squeezed_hidden = _ensure_batched_hidden_states(hidden_states)
+        encoder_hidden_states, squeezed_encoder = _ensure_batched_hidden_states(encoder_hidden_states)
+        if squeezed_hidden != squeezed_encoder:
+            raise ValueError("hidden_states and encoder_hidden_states must have matching batch structure")
+        enc_out, hid_out = self.forward_from_modulation(
+            hidden_states,
+            encoder_hidden_states,
+            self.prepare_modulation(self.modulation_img, temb),
+            self.prepare_modulation(self.modulation_txt, temb),
+            rotary_cos,
+            rotary_sin,
+        )
+        return (
+            _restore_hidden_states(enc_out, squeezed_hidden),
+            _restore_hidden_states(hid_out, squeezed_hidden),
+        )

--- a/vllm_mlx/image/bonsai_runtime/_vendor/loader.py
+++ b/vllm_mlx/image/bonsai_runtime/_vendor/loader.py
@@ -1,0 +1,189 @@
+"""Load FLUX.2 Klein 4B packed weights into MegakernelWeights.
+
+`load_klein_fast_packed_weights_from_disk` consumes the pre-packed MLX
+  artifact `transformer-packed-mflux/` (packed uint32 weights + bf16
+  scales/biases + bf16 for the skip-list layers). Returns a MegakernelWeights
+  where each block linear is already a PackedWeight triple, bypassing runtime
+  quantization.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import mlx.core as mx
+
+from vllm_mlx.image.bonsai_runtime._vendor.blocks import (
+    DoubleBlockWeights,
+    PackedWeight,
+    SingleBlockWeights,
+    WeightOrPacked,
+    double_block_weight_keys,
+    single_block_weight_keys,
+)
+from vllm_mlx.image.bonsai_runtime._vendor.megakernel import (
+    Flux2KleinMegakernelSpec,
+    MegakernelWeights,
+)
+
+_GLOBAL_KEYS: dict[str, str] = {
+    "x_embedder": "x_embedder.weight",
+    "context_embedder": "context_embedder.weight",
+    "norm_out_linear": "norm_out.linear.weight",
+    "proj_out": "proj_out.weight",
+}
+
+_SHARED_MODULATION_KEYS: dict[str, str] = {
+    "double_mod_img": "double_stream_modulation_img.linear.weight",
+    "double_mod_txt": "double_stream_modulation_txt.linear.weight",
+    "single_mod": "single_stream_modulation.linear.weight",
+}
+
+_QUANT_CONFIG_NAME = "quantization_config.json"
+
+
+def _get_and_cast(raw: dict[str, mx.array], key: str, dtype: mx.Dtype) -> mx.array:
+    if key not in raw:
+        raise KeyError(f"Missing tensor '{key}' in transformer checkpoint")
+    tensor = raw[key]
+    return tensor if tensor.dtype == dtype else tensor.astype(dtype)
+
+
+def _load_raw_safetensors(transformer_dir: Path) -> dict[str, mx.array]:
+    shards = sorted(p for p in transformer_dir.glob("*.safetensors") if not p.name.startswith("._"))
+    if not shards:
+        raise FileNotFoundError(f"No safetensors files found in {transformer_dir}")
+    merged: dict[str, mx.array] = {}
+    for shard in shards:
+        merged.update(mx.load(str(shard)))
+    return merged
+
+
+def _load_packed_or_dense_linear(
+    raw: dict[str, mx.array],
+    hf_weight_key: str,
+    *,
+    bits: int,
+    group_size: int,
+    dtype: mx.Dtype,
+) -> WeightOrPacked:
+    """Return PackedWeight if the layer has sibling `.scales`/`.biases`; else bf16."""
+    if not hf_weight_key.endswith(".weight"):
+        raise ValueError(f"Expected key to end in '.weight': {hf_weight_key}")
+    layer_prefix = hf_weight_key[: -len(".weight")]
+    scales_key = f"{layer_prefix}.scales"
+    if scales_key not in raw:
+        return _get_and_cast(raw, hf_weight_key, dtype)
+    biases_key = f"{layer_prefix}.biases"
+    if biases_key not in raw:
+        raise KeyError(f"Found '{scales_key}' but missing '{biases_key}' in packed artifact")
+    if hf_weight_key not in raw:
+        raise KeyError(f"Missing packed weight '{hf_weight_key}' in packed artifact")
+    packed = raw[hf_weight_key]
+    if packed.dtype != mx.uint32:
+        raise ValueError(
+            f"Packed weight '{hf_weight_key}' must be uint32, got {packed.dtype}"
+        )
+    return PackedWeight(
+        packed=packed,
+        scales=raw[scales_key].astype(dtype),
+        biases=raw[biases_key].astype(dtype),
+        bits=bits,
+        group_size=group_size,
+    )
+
+
+def _read_packed_quant_config(packed_dir: Path) -> tuple[int, int]:
+    config_path = packed_dir / _QUANT_CONFIG_NAME
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"Packed artifact missing {_QUANT_CONFIG_NAME}: {config_path}"
+        )
+    cfg = json.loads(config_path.read_text())
+    bits = int(cfg["bits"])
+    group_size = int(cfg["group_size"])
+    return bits, group_size
+
+
+def load_klein_fast_packed_weights_from_disk(
+    packed_dir: Path,
+    spec: Flux2KleinMegakernelSpec,
+    dtype: mx.Dtype = mx.bfloat16,
+) -> MegakernelWeights:
+    """Load a pre-packed quantized artifact directly into MegakernelWeights.
+
+    Expected layout:
+
+        packed_dir/
+          diffusion_pytorch_model.safetensors   # uint32 packed + bf16 scales/biases/skips
+          quantization_config.json              # bits, group_size, skip_patterns
+          config.json, checkpoint_manifest.json # (passthrough; not consumed here)
+
+    Block linears outside the skip list are returned as PackedWeight triples.
+    Skip-pattern layers and the 4 outer linears remain plain bf16 mx.array.
+    """
+    packed_dir = Path(packed_dir)
+    bits, group_size = _read_packed_quant_config(packed_dir)
+    raw = _load_raw_safetensors(packed_dir)
+    return _build_megakernel_weights_from_packed(
+        raw, spec, dtype=dtype, bits=bits, group_size=group_size
+    )
+
+
+def _build_megakernel_weights_from_packed(
+    raw: dict[str, mx.array],
+    spec: Flux2KleinMegakernelSpec,
+    *,
+    dtype: mx.Dtype,
+    bits: int,
+    group_size: int,
+) -> MegakernelWeights:
+    shared_double_mod_img = _get_and_cast(raw, _SHARED_MODULATION_KEYS["double_mod_img"], dtype)
+    shared_double_mod_txt = _get_and_cast(raw, _SHARED_MODULATION_KEYS["double_mod_txt"], dtype)
+    shared_single_mod = _get_and_cast(raw, _SHARED_MODULATION_KEYS["single_mod"], dtype)
+
+    def load_block_linear(hf_key: str) -> WeightOrPacked:
+        return _load_packed_or_dense_linear(
+            raw, hf_key, bits=bits, group_size=group_size, dtype=dtype
+        )
+
+    double_block_weights: list[DoubleBlockWeights] = []
+    for i in range(spec.num_double_blocks):
+        keys = double_block_weight_keys(i)
+        fields: dict = {}
+        for field_name, hf_key in keys.items():
+            if field_name == "modulation_img":
+                fields[field_name] = shared_double_mod_img
+            elif field_name == "modulation_txt":
+                fields[field_name] = shared_double_mod_txt
+            elif field_name.startswith("norm_"):
+                fields[field_name] = _get_and_cast(raw, hf_key, dtype)
+            else:
+                fields[field_name] = load_block_linear(hf_key)
+        double_block_weights.append(DoubleBlockWeights(**fields))
+
+    single_block_weights: list[SingleBlockWeights] = []
+    for i in range(spec.num_single_blocks):
+        keys = single_block_weight_keys(i)
+        fields = {}
+        for field_name, hf_key in keys.items():
+            if field_name == "modulation":
+                fields[field_name] = shared_single_mod
+            elif field_name.startswith("norm_"):
+                fields[field_name] = _get_and_cast(raw, hf_key, dtype)
+            else:
+                fields[field_name] = load_block_linear(hf_key)
+        single_block_weights.append(SingleBlockWeights(**fields))
+
+    return MegakernelWeights(
+        x_embedder=_get_and_cast(raw, _GLOBAL_KEYS["x_embedder"], dtype),
+        context_embedder=_get_and_cast(raw, _GLOBAL_KEYS["context_embedder"], dtype),
+        norm_out_linear=_get_and_cast(raw, _GLOBAL_KEYS["norm_out_linear"], dtype),
+        proj_out=_get_and_cast(raw, _GLOBAL_KEYS["proj_out"], dtype),
+        double_block_weights=double_block_weights,
+        single_block_weights=single_block_weights,
+    )
+
+
+__all__ = ["load_klein_fast_packed_weights_from_disk"]

--- a/vllm_mlx/image/bonsai_runtime/_vendor/megakernel.py
+++ b/vllm_mlx/image/bonsai_runtime/_vendor/megakernel.py
@@ -1,0 +1,244 @@
+"""FLUX.2 Klein 25-block megakernel for MLX.
+
+forward() accepts rotary_cos / rotary_sin as arguments so the enclosing
+transformer can supply per-call RoPE for variable image sizes. Callers pass
+a pre-computed `temb` (shape (B, dim), bf16) produced by mflux's
+Flux2TimestepGuidanceEmbeddings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import mlx.core as mx
+import mlx.nn
+
+from vllm_mlx.image.bonsai_runtime._vendor.blocks import (
+    DenseLinearKernel,
+    DoubleBlockWeights,
+    DoubleFlux2Block,
+    Flux2KleinBlockSpec,
+    QuantizedLinearKernel,
+    SingleBlockWeights,
+    SingleFlux2Block,
+    _layer_norm_affine,
+    _silu,
+)
+
+PrecisionName = Literal["bf16", "1bit", "2bit"]
+
+
+@dataclass(frozen=True)
+class Flux2KleinMegakernelSpec:
+    num_double_blocks: int = 5
+    num_single_blocks: int = 20
+    dim: int = 3072
+    num_heads: int = 24
+    head_dim: int = 128
+    mlp_ratio: float = 3.0
+    layer_norm_eps: float = 1e-6
+    rms_norm_eps: float = 1e-6
+    rope_theta: int = 2000
+    axes_dims_rope: tuple[int, ...] = (32, 32, 32, 32)
+    in_channels: int = 128
+    context_dim: int = 7680
+
+    @property
+    def block_spec(self) -> Flux2KleinBlockSpec:
+        return Flux2KleinBlockSpec(
+            dim=self.dim,
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+            mlp_ratio=self.mlp_ratio,
+            layer_norm_eps=self.layer_norm_eps,
+            rms_norm_eps=self.rms_norm_eps,
+            rope_theta=self.rope_theta,
+            axes_dims_rope=self.axes_dims_rope,
+        )
+
+
+@dataclass
+class MegakernelWeights:
+    x_embedder: mx.array
+    context_embedder: mx.array
+    norm_out_linear: mx.array
+    proj_out: mx.array
+    double_block_weights: list[DoubleBlockWeights]
+    single_block_weights: list[SingleBlockWeights]
+
+
+class Flux2KleinMegakernel:
+    def __init__(
+        self,
+        *,
+        spec: Flux2KleinMegakernelSpec,
+        weights: MegakernelWeights,
+        precision: PrecisionName,
+        group_size: int,
+    ):
+        if len(weights.double_block_weights) != spec.num_double_blocks:
+            raise ValueError(
+                f"Expected {spec.num_double_blocks} double block weight sets, got {len(weights.double_block_weights)}"
+            )
+        if len(weights.single_block_weights) != spec.num_single_blocks:
+            raise ValueError(
+                f"Expected {spec.num_single_blocks} single block weight sets, got {len(weights.single_block_weights)}"
+            )
+
+        self.spec = spec
+        block_spec = spec.block_spec
+
+        self.x_embedder = DenseLinearKernel(weights.x_embedder)
+        self.context_embedder = DenseLinearKernel(weights.context_embedder)
+        self.norm_out_linear = DenseLinearKernel(weights.norm_out_linear)
+        self.proj_out = DenseLinearKernel(weights.proj_out)
+
+        self.double_blocks = [
+            DoubleFlux2Block(
+                spec=block_spec,
+                weights=w,
+                precision=precision,
+                group_size=group_size,
+            )
+            for w in weights.double_block_weights
+        ]
+        self.single_blocks = [
+            SingleFlux2Block(
+                spec=block_spec,
+                weights=w,
+                precision=precision,
+                group_size=group_size,
+            )
+            for w in weights.single_block_weights
+        ]
+
+    def prepare_all_modulations(self, temb: mx.array) -> dict:
+        """Pre-compute all 25 block modulations + norm_out affine params.
+
+        Returns a dict of flattened modulation tuples suitable for use as
+        closure constants in a compiled forward pass.
+        """
+        if temb.ndim == 1:
+            temb = temb[None, :]
+        dim = self.spec.dim
+
+        double_mods = []
+        for block in self.double_blocks:
+            img_mod = block.prepare_modulation(block.modulation_img, temb)
+            txt_mod = block.prepare_modulation(block.modulation_txt, temb)
+            double_mods.append((img_mod, txt_mod))
+
+        single_mods = [block.prepare_modulation(temb) for block in self.single_blocks]
+
+        norm_mod = self.norm_out_linear(_silu(temb))
+        norm_scale, norm_shift = mx.split(norm_mod, 2, axis=-1)
+        norm_w = (1.0 + norm_scale).reshape(-1)
+        norm_b = norm_shift.reshape(-1)
+
+        return {
+            "double_mods": double_mods,
+            "single_mods": single_mods,
+            "norm_w": norm_w,
+            "norm_b": norm_b,
+        }
+
+    def forward(
+        self,
+        latents: mx.array,
+        text_embeddings: mx.array,
+        temb: mx.array,
+        rotary_cos: mx.array,
+        rotary_sin: mx.array,
+    ) -> mx.array:
+        img = self.x_embedder(latents)
+        txt = self.context_embedder(text_embeddings)
+        text_seq_len = int(txt.shape[1])
+
+        for block in self.double_blocks:
+            txt, img = block.forward(img, txt, temb, rotary_cos, rotary_sin)
+
+        hidden = mx.concatenate([txt, img], axis=1)
+
+        for block in self.single_blocks:
+            hidden = block.forward(hidden, temb, rotary_cos, rotary_sin)
+
+        img_out = hidden[:, text_seq_len:, :]
+
+        mod = self.norm_out_linear(_silu(temb))
+        scale, shift = mx.split(mod, 2, axis=-1)
+        img_out = mx.fast.layer_norm(
+            img_out,
+            (1.0 + scale).reshape(-1),
+            shift.reshape(-1),
+            self.spec.layer_norm_eps,
+        )
+
+        return self.proj_out(img_out)
+
+    def forward_from_modulations(
+        self,
+        latents: mx.array,
+        text_embeddings: mx.array,
+        precomputed: dict,
+        rotary_cos: mx.array,
+        rotary_sin: mx.array,
+    ) -> mx.array:
+        double_mods = precomputed["double_mods"]
+        single_mods = precomputed["single_mods"]
+        norm_w = precomputed["norm_w"]
+        norm_b = precomputed["norm_b"]
+
+        img = self.x_embedder(latents)
+        txt = self.context_embedder(text_embeddings)
+        text_seq_len = int(txt.shape[1])
+
+        for i, block in enumerate(self.double_blocks):
+            img_mod, txt_mod = double_mods[i]
+            txt, img = block.forward_from_modulation(
+                img, txt, img_mod, txt_mod, rotary_cos, rotary_sin
+            )
+
+        hidden = mx.concatenate([txt, img], axis=1)
+
+        for i, block in enumerate(self.single_blocks):
+            hidden = block.forward_from_modulation(
+                hidden, single_mods[i], rotary_cos, rotary_sin
+            )
+
+        img_out = hidden[:, text_seq_len:, :]
+        img_out = _layer_norm_affine(img_out, norm_w, norm_b, self.spec.layer_norm_eps)
+        return self.proj_out(img_out)
+
+
+def eval_megakernel_constants(model: Flux2KleinMegakernel) -> None:
+    """Materialize all lazy weight arrays so they are not rebuilt per call.
+
+    Useful before benchmarking or serving: ensures quantized packed weights,
+    scales, biases, and RMSNorm gains are realized on-device.
+    """
+    arrays: list[mx.array] = []
+
+    def _collect_linear(linear):
+        if isinstance(linear, QuantizedLinearKernel):
+            arrays.extend([linear.packed_weight, linear.scales, linear.biases])
+        elif isinstance(linear, DenseLinearKernel):
+            arrays.append(linear.weight)
+
+    _collect_linear(model.x_embedder)
+    _collect_linear(model.context_embedder)
+    _collect_linear(model.norm_out_linear)
+    _collect_linear(model.proj_out)
+
+    for block in [*model.double_blocks, *model.single_blocks]:
+        for attr_name in dir(block):
+            if attr_name.startswith("_"):
+                continue
+            attr = getattr(block, attr_name)
+            if isinstance(attr, mx.array):
+                arrays.append(attr)
+            elif isinstance(attr, (QuantizedLinearKernel, DenseLinearKernel)):
+                _collect_linear(attr)
+
+    if arrays:
+        mx.eval(*arrays)

--- a/vllm_mlx/image/bonsai_runtime/_vendor/transformer.py
+++ b/vllm_mlx/image/bonsai_runtime/_vendor/transformer.py
@@ -1,0 +1,150 @@
+"""Drop-in replacement for Flux2Transformer backed by the fused 25-block megakernel.
+
+Wraps the 25-block Flux2KleinMegakernel with mflux's standard embedding /
+positional-encoding modules so it slots into the existing pipeline without
+changes to the caller. The `__call__` signature matches
+Flux2Transformer.__call__ exactly:
+    (hidden_states, encoder_hidden_states, timestep, img_ids, txt_ids, guidance)
+
+`temb` is used only to build prepare_all_modulations outside the compiled
+graph, then a single mx.compile'd forward_from_modulations runs the full
+25-block stack. The compiled function is cached on the transformer instance
+and reused across diffusion steps; shape-identical calls hit the compile cache.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+from mlx import nn
+
+from mflux.models.common.config.model_config import ModelConfig
+from vllm_mlx.image.bonsai_runtime._vendor.blocks import DEFAULT_QUANT_GROUP_SIZE
+from vllm_mlx.image.bonsai_runtime._vendor.megakernel import (
+    Flux2KleinMegakernel,
+    Flux2KleinMegakernelSpec,
+    MegakernelWeights,
+    PrecisionName,
+    eval_megakernel_constants,
+)
+from mflux.models.flux2.model.flux2_transformer.pos_embed import Flux2PosEmbed
+from mflux.models.flux2.model.flux2_transformer.timestep_guidance_embeddings import Flux2TimestepGuidanceEmbeddings
+
+
+class Flux2KleinFastTransformer(nn.Module):
+    def __init__(
+        self,
+        *,
+        weights: MegakernelWeights,
+        precision: PrecisionName,
+        group_size: int = DEFAULT_QUANT_GROUP_SIZE,
+        patch_size: int = 1,
+        in_channels: int = 128,
+        out_channels: int | None = None,
+        num_layers: int = 5,
+        num_single_layers: int = 20,
+        attention_head_dim: int = 128,
+        num_attention_heads: int = 24,
+        joint_attention_dim: int = 7680,
+        timestep_guidance_channels: int = 256,
+        mlp_ratio: float = 3.0,
+        axes_dims_rope: tuple[int, ...] = (32, 32, 32, 32),
+        rope_theta: int = 2000,
+        guidance_embeds: bool = False,
+        layer_norm_eps: float = 1e-6,
+        rms_norm_eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.out_channels = out_channels or in_channels
+        self.patch_size = patch_size
+        self.inner_dim = num_attention_heads * attention_head_dim
+
+        self.pos_embed = Flux2PosEmbed(theta=rope_theta, axes_dim=axes_dims_rope)
+        self.time_guidance_embed = Flux2TimestepGuidanceEmbeddings(
+            in_channels=timestep_guidance_channels,
+            embedding_dim=self.inner_dim,
+            guidance_embeds=guidance_embeds,
+        )
+
+        spec = Flux2KleinMegakernelSpec(
+            num_double_blocks=num_layers,
+            num_single_blocks=num_single_layers,
+            dim=self.inner_dim,
+            num_heads=num_attention_heads,
+            head_dim=attention_head_dim,
+            mlp_ratio=mlp_ratio,
+            layer_norm_eps=layer_norm_eps,
+            rms_norm_eps=rms_norm_eps,
+            rope_theta=rope_theta,
+            axes_dims_rope=axes_dims_rope,
+            in_channels=in_channels,
+            context_dim=joint_attention_dim,
+        )
+        self.megakernel = Flux2KleinMegakernel(
+            spec=spec,
+            weights=weights,
+            precision=precision,
+            group_size=group_size,
+        )
+        # Materialize all quantized/dense weight arrays so they live as on-device
+        # constants rather than lazy subgraphs rebuilt each call.
+        eval_megakernel_constants(self.megakernel)
+
+        # Compile the per-step forward once; shape-identical calls hit the cache.
+        def _forward_with_modulations(
+            hidden_states: mx.array,
+            encoder_hidden_states: mx.array,
+            temb: mx.array,
+            rotary_cos: mx.array,
+            rotary_sin: mx.array,
+        ) -> mx.array:
+            precomputed = self.megakernel.prepare_all_modulations(temb)
+            return self.megakernel.forward_from_modulations(
+                hidden_states, encoder_hidden_states, precomputed, rotary_cos, rotary_sin
+            )
+
+        self._compiled_forward = mx.compile(_forward_with_modulations)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        encoder_hidden_states: mx.array,
+        timestep: mx.array | float | int,
+        img_ids: mx.array,
+        txt_ids: mx.array,
+        guidance: mx.array | float | int | None = None,
+    ) -> mx.array:
+        if not isinstance(timestep, mx.array):
+            timestep = mx.array(timestep, dtype=hidden_states.dtype)
+        if timestep.ndim == 0:
+            timestep = mx.full((hidden_states.shape[0],), timestep, dtype=hidden_states.dtype)
+        timestep = timestep.astype(hidden_states.dtype)
+        timestep_scale = mx.where(mx.max(timestep) <= 1.0, 1000.0, 1.0).astype(hidden_states.dtype)
+        timestep = timestep * timestep_scale
+        if guidance is not None:
+            if not isinstance(guidance, mx.array):
+                guidance = mx.array(guidance, dtype=hidden_states.dtype)
+            if guidance.ndim == 0:
+                guidance = mx.full((hidden_states.shape[0],), guidance, dtype=hidden_states.dtype)
+            guidance = guidance.astype(hidden_states.dtype)
+            guidance_scale = mx.where(mx.max(guidance) <= 1.0, 1000.0, 1.0).astype(hidden_states.dtype)
+            guidance = guidance * guidance_scale
+        temb = self.time_guidance_embed(timestep, guidance)
+        temb = temb.astype(ModelConfig.precision)
+
+        if img_ids.ndim == 3:
+            img_ids = img_ids[0]
+        if txt_ids.ndim == 3:
+            txt_ids = txt_ids[0]
+
+        image_rotary_emb = self.pos_embed(img_ids)
+        text_rotary_emb = self.pos_embed(txt_ids)
+        concat_cos = mx.concatenate([text_rotary_emb[0], image_rotary_emb[0]], axis=0)
+        concat_sin = mx.concatenate([text_rotary_emb[1], image_rotary_emb[1]], axis=0)
+
+        return self._compiled_forward(
+            hidden_states,
+            encoder_hidden_states,
+            temb,
+            concat_cos,
+            concat_sin,
+        )

--- a/vllm_mlx/image/bonsai_runtime/runtime.py
+++ b/vllm_mlx/image/bonsai_runtime/runtime.py
@@ -1,0 +1,315 @@
+"""Rapid-owned adapter for the fixed Bonsai Image MLX checkpoint."""
+
+from __future__ import annotations
+
+import gc
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import mlx.core as mx
+import mlx.nn as nn
+from mflux.callbacks.callback_registry import CallbackRegistry
+from mflux.models.common.config.model_config import ModelConfig
+from mflux.models.common.tokenizer import LanguageTokenizer, TokenizerLoader
+from mflux.models.common.vae.tiling_config import TilingConfig
+from mflux.models.common.weights.loading.weight_applier import WeightApplier
+from mflux.models.common.weights.loading.weight_definition import (
+    ComponentDefinition,
+    TokenizerDefinition,
+)
+from mflux.models.common.weights.loading.weight_loader import WeightLoader
+from mflux.models.flux2.model.flux2_text_encoder.qwen3_text_encoder import (
+    Qwen3TextEncoder,
+)
+from mflux.models.flux2.model.flux2_vae.vae import Flux2VAE
+from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
+from mflux.models.flux2.weights.flux2_weight_mapping import Flux2WeightMapping
+from mlx.utils import tree_unflatten
+
+from ._vendor import (
+    Flux2KleinFastTransformer,
+    Flux2KleinMegakernelSpec,
+    load_klein_fast_packed_weights_from_disk,
+)
+
+BONSAI_IMAGE_REPO = "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
+BONSAI_IMAGE_REVISION = "2c24c81b934a658ba5590cf39088ba929985b4a8"
+BONSAI_IMAGE_STEPS = 4
+BONSAI_IMAGE_GUIDANCE = 1.0
+BONSAI_IMAGE_MAX_PROMPT_TOKENS = 512
+
+_PACKED_TRANSFORMER = "transformer-packed-mflux"
+_TEXT_ENCODER = "text_encoder-mlx-4bit"
+_TEXT_ENCODER_BITS = 4
+_TEXT_ENCODER_GROUP_SIZE = 64
+
+
+class BonsaiCheckpointError(RuntimeError):
+    """The pinned snapshot is absent, incomplete, or structurally invalid."""
+
+
+class _VAEWeightDefinition:
+    @staticmethod
+    def get_components() -> list[ComponentDefinition]:
+        return [
+            ComponentDefinition(
+                name="vae",
+                hf_subdir="vae",
+                precision=ModelConfig.precision,
+                mapping_getter=Flux2WeightMapping.get_vae_mapping,
+            )
+        ]
+
+    @staticmethod
+    def get_download_patterns() -> list[str]:
+        return ["vae/*.safetensors", "vae/*.json"]
+
+    @staticmethod
+    def quantization_predicate(path: str, module: object) -> bool:
+        return hasattr(module, "to_quantized")
+
+
+def _tokenizer_definition() -> TokenizerDefinition:
+    return TokenizerDefinition(
+        name="qwen3",
+        hf_subdir="tokenizer",
+        tokenizer_class="Qwen2TokenizerFast",
+        encoder_class=LanguageTokenizer,
+        max_length=BONSAI_IMAGE_MAX_PROMPT_TOKENS,
+        use_chat_template=True,
+        chat_template_kwargs={"enable_thinking": False},
+        download_patterns=["tokenizer/**"],
+    )
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise BonsaiCheckpointError(f"Could not read {path.name}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise BonsaiCheckpointError(f"{path.name} must contain a JSON object.")
+    return value
+
+
+def _load_safetensors(path: Path) -> dict[str, mx.array]:
+    loaded = mx.load(str(path))
+    if not isinstance(loaded, dict):
+        raise BonsaiCheckpointError(f"{path.name} did not contain named tensors.")
+    return cast(dict[str, mx.array], loaded)
+
+
+def _validate_checkpoint(root: Path) -> None:
+    required = (
+        "model_index.json",
+        "scheduler/scheduler_config.json",
+        "tokenizer/tokenizer.json",
+        f"{_TEXT_ENCODER}/config.json",
+        f"{_TEXT_ENCODER}/model.safetensors",
+        f"{_PACKED_TRANSFORMER}/config.json",
+        f"{_PACKED_TRANSFORMER}/quantization_config.json",
+        f"{_PACKED_TRANSFORMER}/diffusion_pytorch_model.safetensors",
+        "vae/config.json",
+        "vae/diffusion_pytorch_model.safetensors",
+    )
+    missing = [
+        name
+        for name in required
+        if not (root / name).is_file() or (root / name).stat().st_size <= 0
+    ]
+    if missing:
+        raise BonsaiCheckpointError(
+            "Bonsai Image snapshot is incomplete; missing or empty: "
+            + ", ".join(missing)
+        )
+
+    model_index = _read_json_object(root / "model_index.json")
+    if model_index.get("_class_name") != "Flux2KleinPipeline":
+        raise BonsaiCheckpointError(
+            "Bonsai Image model_index.json is not a FLUX.2 Klein pipeline."
+        )
+
+    quant = _read_json_object(root / _PACKED_TRANSFORMER / "quantization_config.json")
+    bits = quant.get("bits")
+    group_size = quant.get("group_size")
+    if (
+        isinstance(bits, bool)
+        or bits != 2
+        or isinstance(group_size, bool)
+        or group_size != 128
+    ):
+        raise BonsaiCheckpointError(
+            "Bonsai Image requires the published MLX 2-bit/group-128 transformer."
+        )
+
+    text_config = _read_json_object(root / _TEXT_ENCODER / "config.json")
+    quantization = text_config.get("quantization")
+    if not isinstance(quantization, dict):
+        raise BonsaiCheckpointError(
+            "Bonsai Image text encoder has no quantization contract."
+        )
+    if quantization.get("bits") != 4 or quantization.get("group_size") != 64:
+        raise BonsaiCheckpointError(
+            "Bonsai Image requires the published MLX 4-bit/group-64 text encoder."
+        )
+
+
+def _load_text_encoder(root: Path, overrides: dict[str, Any]) -> Qwen3TextEncoder:
+    weights_path = root / _TEXT_ENCODER / "model.safetensors"
+    raw = _load_safetensors(weights_path)
+    stripped = {
+        key.removeprefix("model."): value
+        for key, value in raw.items()
+        if key.startswith("model.")
+    }
+    if not stripped:
+        raise BonsaiCheckpointError(
+            "Bonsai Image text encoder contains no model weights."
+        )
+    nested = tree_unflatten(list(stripped.items()))
+    encoder = Qwen3TextEncoder(**overrides)
+    nn.quantize(
+        encoder,
+        class_predicate=lambda _path, module: hasattr(module, "to_quantized"),
+        bits=_TEXT_ENCODER_BITS,
+        group_size=_TEXT_ENCODER_GROUP_SIZE,
+    )
+    encoder.update(nested)
+    return encoder
+
+
+def _load_transformer(root: Path) -> Flux2KleinFastTransformer:
+    spec = Flux2KleinMegakernelSpec()
+    packed_dir = root / _PACKED_TRANSFORMER
+    weights = load_klein_fast_packed_weights_from_disk(
+        packed_dir,
+        spec,
+        dtype=mx.bfloat16,
+    )
+    transformer = Flux2KleinFastTransformer(
+        weights=weights,
+        precision="2bit",
+        patch_size=1,
+        in_channels=spec.in_channels,
+        out_channels=spec.in_channels,
+        num_layers=spec.num_double_blocks,
+        num_single_layers=spec.num_single_blocks,
+        attention_head_dim=spec.head_dim,
+        num_attention_heads=spec.num_heads,
+        joint_attention_dim=spec.context_dim,
+        timestep_guidance_channels=256,
+        mlp_ratio=spec.mlp_ratio,
+        axes_dims_rope=spec.axes_dims_rope,
+        rope_theta=spec.rope_theta,
+        guidance_embeds=False,
+        layer_norm_eps=spec.layer_norm_eps,
+        rms_norm_eps=spec.rms_norm_eps,
+    )
+    raw = _load_safetensors(packed_dir / "diffusion_pytorch_model.safetensors")
+    try:
+        transformer.time_guidance_embed.linear_1.weight = raw[
+            "time_guidance_embed.timestep_embedder.linear_1.weight"
+        ].astype(mx.bfloat16)
+        transformer.time_guidance_embed.linear_2.weight = raw[
+            "time_guidance_embed.timestep_embedder.linear_2.weight"
+        ].astype(mx.bfloat16)
+    except KeyError as exc:
+        raise BonsaiCheckpointError(
+            f"Bonsai Image transformer is missing required timestep weights: {exc}"
+        ) from exc
+    return transformer
+
+
+class _TiledFlux2VAE(Flux2VAE):
+    """Use the upstream Bonsai 128px tiled decode without changing mflux globally."""
+
+    _bonsai_tiling = TilingConfig(vae_decode_tile_size=128, vae_decode_overlap=8)
+
+    def decode_packed_latents(
+        self,
+        packed_latents: mx.array,
+        tiling_config: TilingConfig | None = None,
+    ) -> mx.array:
+        return cast(
+            mx.array,
+            super().decode_packed_latents(
+                packed_latents,
+                tiling_config=tiling_config or self._bonsai_tiling,
+            ),
+        )
+
+
+class BonsaiImage(Flux2Klein):
+    """FLUX.2 Klein pipeline backed by Bonsai's fixed prepacked MLX weights."""
+
+    def __init__(self, model_path: str | Path):
+        nn.Module.__init__(self)
+        self._root = Path(model_path).expanduser().resolve()
+        _validate_checkpoint(self._root)
+        self.model_config = ModelConfig.flux2_klein_4b()
+        self.callbacks = CallbackRegistry()
+        self.prompt_cache: dict[str, tuple[mx.array, mx.array]] = {}
+        self.tiling_config = _TiledFlux2VAE._bonsai_tiling
+        self.tokenizers = TokenizerLoader.load_all(
+            definitions=[_tokenizer_definition()],
+            model_path=str(self._root),
+        )
+        self.text_encoder = _load_text_encoder(
+            self._root,
+            self.model_config.text_encoder_overrides,
+        )
+        self.vae = _TiledFlux2VAE()
+        vae_weights = WeightLoader.load(
+            weight_definition=_VAEWeightDefinition,
+            model_path=str(self._root),
+        )
+        WeightApplier.apply_and_quantize(
+            weights=vae_weights,
+            quantize_arg=None,
+            weight_definition=_VAEWeightDefinition,
+            models={"vae": self.vae},
+        )
+        self.transformer = _load_transformer(self._root)
+        self.bits = 2
+        self.lora_paths = None
+        self.lora_scales = None
+
+    def _encode_prompt_pair(
+        self,
+        *,
+        prompt: str,
+        negative_prompt: str | None,
+        guidance: float,
+    ) -> tuple[mx.array, mx.array, mx.array | None, mx.array | None]:
+        cached = self.prompt_cache.get(prompt)
+        if cached is None:
+            if self.text_encoder is None:
+                self.text_encoder = _load_text_encoder(
+                    self._root,
+                    self.model_config.text_encoder_overrides,
+                )
+            prompt_embeds, text_ids, _, _ = super()._encode_prompt_pair(
+                prompt=prompt,
+                negative_prompt=None,
+                guidance=BONSAI_IMAGE_GUIDANCE,
+            )
+            mx.eval(prompt_embeds, text_ids)
+            self.prompt_cache.clear()
+            self.prompt_cache[prompt] = (prompt_embeds, text_ids)
+            cached = (prompt_embeds, text_ids)
+            self.text_encoder = None
+            gc.collect()
+            mx.clear_cache()
+        return cached[0], cached[1], None, None
+
+
+__all__ = [
+    "BONSAI_IMAGE_GUIDANCE",
+    "BONSAI_IMAGE_MAX_PROMPT_TOKENS",
+    "BONSAI_IMAGE_REPO",
+    "BONSAI_IMAGE_REVISION",
+    "BONSAI_IMAGE_STEPS",
+    "BonsaiCheckpointError",
+    "BonsaiImage",
+]

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -22,6 +22,8 @@ stays commercially clean:
   VAE-free unified pixel transformer (MIT)
 * ``sdxl-base``        — text→image (``Stable Diffusion XL Base 1.0``),
   30-step, dual-CLIP + UNet + VAE pipeline (OpenRAIL++)
+* ``bonsai-image``     — text→image (ternary ``FLUX.2-klein-4B``), 4-step,
+  prepacked MLX 2-bit transformer with a 4-bit Qwen3 encoder (Apache-2.0)
 
 ``flux2-klein`` and ``z-image`` supersede the older/larger families for the
 interactive tab: Klein is ~3× faster than schnell/z-image at the same
@@ -111,6 +113,8 @@ class _ProgressReporter:
 def _detect_family(model_name: str) -> str:
     """Map an alias hf_path (or local dir) to a supported mflux family."""
     name = (model_name or "").casefold()
+    if "bonsai-image" in name or "bonsai_image" in name:
+        return "bonsai-image"
     if "hidream-o1" in name or "hidream_o1" in name:
         return "hidream-o1-dev"
     if "stable-diffusion-xl" in name or "sdxl" in name:
@@ -133,14 +137,16 @@ def _detect_family(model_name: str) -> str:
     raise ImageRuntimeError(
         f"Unsupported image model '{model_name}'. Supported families: "
         "flux2-klein, z-image, flux-schnell, qwen-image, qwen-image-edit, "
-        "hidream-o1-dev, sdxl-base."
+        "hidream-o1-dev, sdxl-base, bonsai-image."
     )
 
 
 # Families whose ``generate_image`` takes NO ``negative_prompt`` parameter.
 # FLUX.2 Klein omits it (Flux1 / Qwen-Image / Z-Image all accept it), and
 # passing an unknown kwarg raises — so the engine drops it for these.
-_NO_NEGATIVE_PROMPT_FAMILIES = frozenset({"flux2-klein", "hidream-o1-dev"})
+_NO_NEGATIVE_PROMPT_FAMILIES = frozenset(
+    {"flux2-klein", "hidream-o1-dev", "bonsai-image"}
+)
 
 # Per-family default denoise steps when the request pins none. Distilled/turbo
 # models converge in a handful of steps; a non-distilled model needs many more.
@@ -153,6 +159,7 @@ _DEFAULT_STEPS_BY_FAMILY = {
     "qwen-image-edit": 20,
     "hidream-o1-dev": 28,
     "sdxl-base": 30,
+    "bonsai-image": 4,
 }
 
 
@@ -195,6 +202,7 @@ class ImageGenerationEngine:
         self._prequantized = self.family in {
             "hidream-o1-dev",
             "sdxl-base",
+            "bonsai-image",
         } or _looks_like_prequantized(model_name)
         # ``None`` when a backend owns its local checkpoint conversion, or when
         # the repo is already quantized. Passing a width for pre-quantized
@@ -290,6 +298,18 @@ class ImageGenerationEngine:
 
     def _build_model(self):
         """Instantiate the backing mflux model (import-lazy)."""
+        if self.family == "bonsai-image":
+            from .bonsai_runtime import BONSAI_IMAGE_REPO, BonsaiImage
+
+            if self.model_name != BONSAI_IMAGE_REPO:
+                raise ImageRuntimeError(
+                    "Bonsai Image currently supports only the pinned official "
+                    f"checkpoint '{BONSAI_IMAGE_REPO}'."
+                )
+            model_path = self._model_path_for_mflux()
+            if model_path is None:
+                raise ImageRuntimeError("Bonsai Image requires a local model snapshot.")
+            return BonsaiImage(model_path)
         if self.family == "hidream-o1-dev":
             from .hidream_runtime import HiDreamO1
 
@@ -780,6 +800,36 @@ class ImageGenerationEngine:
                 )
             if width % 8 or height % 8:
                 raise ImageRuntimeError("SDXL dimensions must be multiples of 8.")
+        elif self.family == "bonsai-image":
+            if len(prompt) > 4096:
+                raise ImageRuntimeError(
+                    "Bonsai Image prompts are limited to 4096 characters."
+                )
+            if num_inference_steps != 4:
+                raise ImageRuntimeError(
+                    "Bonsai Image supports its published 4-step schedule only."
+                )
+            if (
+                width is None
+                or height is None
+                or not (256 <= width <= 2048)
+                or not (256 <= height <= 2048)
+            ):
+                raise ImageRuntimeError(
+                    "Bonsai Image dimensions must be between 256 and 2048 pixels."
+                )
+            if width % 32 or height % 32:
+                raise ImageRuntimeError(
+                    "Bonsai Image dimensions must be multiples of 32."
+                )
+            if guidance not in (None, 1.0):
+                raise ImageRuntimeError(
+                    "Bonsai Image uses guidance 1.0; omit guidance or set it to 1.0."
+                )
+            if negative_prompt is not None:
+                raise ImageRuntimeError(
+                    "Bonsai Image does not support negative_prompt."
+                )
 
         with self._lock:
             # Claim a run sequence and arm progress BEFORE loading, so a Cancel

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -212,6 +212,7 @@
     "prism-ml/Ternary-Bonsai-1.7B-mlx-2bit": 495525300,
     "prism-ml/Ternary-Bonsai-8B-mlx-2bit": 2315084354,
     "prism-ml/Ternary-Bonsai-27B-mlx-2bit": 8521052337,
+    "prism-ml/bonsai-image-ternary-4B-mlx-2bit": 3888262196,
     "rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529,
     "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX": 16320413916,
     "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX": 14788605437,

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -540,6 +540,12 @@ def estimate_model_bytes(model_name: str) -> int:
     folded = model_name.casefold()
     known_image_gib = {
         "flux2-klein-4b": 5.9,
+        # Published 3.62 GiB fixed payload (2-bit transformer, 4-bit text
+        # encoder, FP16 VAE). Keep 7 GiB of admission room for 1024²
+        # activations, Metal compilation, tiled decode, and output encoding;
+        # dogfood records the measured allocator peak before landing.
+        "bonsai-image": 7.0,
+        "bonsai_image": 7.0,
         "z-image-turbo": 5.9,
         # BF16 unified backbone + custom diffusion heads. Rapid's 1024² server
         # dogfood measured 17.43 GiB max RSS; round up to retain allocator and


### PR DESCRIPTION
## Why

Rapid-MLX users currently cannot run the compact Bonsai Image 4B 2-bit checkpoint through either the OpenAI-compatible image API or the Desktop Images workflow, even though a native MLX artifact is available. This adds a small, fast generation option that fits the 12 GB tier.

## Scope

Add the `bonsai-image-4b-2bit` generation-only alias, a revision-pinned and data-only download contract, the packed 2-bit FLUX.2 runtime adapter, strict request validation, residency sizing, Desktop catalog/progress support, redistribution notices, tests, and reproducible dogfood evidence.

## Non-goals

This does not add image editing, arbitrary Bonsai-derived or local checkpoints, configurable schedules/guidance, runtime quantization, or support for any other image model.

## Acceptance

- `rapid-mlx pull bonsai-image-4b-2bit` fetches only the reviewed 25-file closure at the pinned commit.
- `rapid-mlx serve bonsai-image-4b-2bit` serves valid PNGs through `/v1/images/generations`.
- Desktop lists the model as generation-only, excludes it from chat, and seeds the published four-step progress contract.
- Invalid steps, dimensions, guidance, negative prompts, edits, and unsupported checkpoint paths fail before inference.
- The signed-sidecar build contract proves the adapter imports with the reduced Torch-free image dependency set.

## Verification

- 615 focused Python regression tests passed after rebasing onto current `main`, including the existing SDXL contracts.
- 19 focused Swift catalog, progress, and sidecar-build tests passed after the rebase; the full 3,433-test Swift suite also passed during implementation.
- Changed Rapid-owned Python lines: 100% covered (171/171).
- Ruff format/check, targeted mypy, compileall, shell syntax, wheel contents, and license/notice packaging passed.
- Real weights: direct 512² and 1024² generations, a real HTTP 512² generation, prompt-cache lifecycle, and the exact Desktop `mflux==0.19.0` pin passed.
- Post-rebase real 256² generation produced a coherent 119,315-byte PNG in 4.027 seconds.
- Desktop app build and the image-generation golden flow passed.

## Behaviour delta

Before: the checkpoint is unknown to Rapid-MLX and cannot be selected or served. After: the alias is discoverable in Server and Desktop, downloads an immutable 3.62 GiB data closure, and generates with the fixed four-step contract.

## AI assistance disclosure

Codex authored and adversarially self-reviewed the implementation across engine, download, catalog, Desktop contracts, tests, and documentation. Every changed path was validated with focused regressions; the runtime was additionally exercised with real model weights through both direct and HTTP paths.
