### PR TITLE
fix(diffusion): gate lane on is_diffusion_model + refresh release-fleet baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,7 @@ jobs:
             tests/test_sdxl_alias.py \
             tests/test_bonsai_image_alias.py \
             tests/test_sd35_alias.py \
+            tests/test_diffusion_engine.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/harness/baselines/bench-mlx-community--Qwen3.5-35B-A3B-8bit.json
+++ b/harness/baselines/bench-mlx-community--Qwen3.5-35B-A3B-8bit.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T18:48:03Z",
+  "captured_at": "2026-09-05T18:44:31Z",
   "family": "qwen3.5",
   "sample_runs": 3,
   "regression_threshold_pct": {

--- a/harness/baselines/bench-mlx-community--Qwen3.5-35B-A3B-8bit.json
+++ b/harness/baselines/bench-mlx-community--Qwen3.5-35B-A3B-8bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-08-06T05:12:44Z",
+  "captured_at": "2026-09-05T09:15:00Z",
   "family": "qwen3.5",
-  "sample_runs": 3,
+  "sample_runs": 5,
   "regression_threshold_pct": {
     "cold_request_ms_median": 5,
     "warm_request_ms_median": 5
@@ -14,21 +14,24 @@
     "engine": "batched"
   },
   "environment": {
-    "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
+    "hardware": {
+      "chip": "Apple M3 Ultra",
+      "memory_gb": 256
+    },
     "software": {
-      "rapid_mlx_version": "0.12.4",
-      "rapid_mlx_commit": "f2097169ce0fd294e96a889a9e31615b32141dd5",
-      "python": "3.12.13",
+      "rapid_mlx_version": "0.13.4",
+      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
+      "python": "3.12.14",
       "macos": "26.5.2 (25F84)",
-      "mlx": "0.31.2",
+      "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.4",
-      "mlx_audio": "0.4.6"
+      "mlx_vlm": "0.6.17",
+      "mlx_audio": "0.4.3"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 252.78306007385254,
-    "warm_request_ms_median": 375.77295303344727,
-    "speedup_x": 0.6727015822539855
+    "cold_request_ms_median": 361.017,
+    "warm_request_ms_median": 471.263,
+    "speedup_x": 0.7661
   }
 }

--- a/harness/baselines/bench-mlx-community--Qwen3.5-35B-A3B-8bit.json
+++ b/harness/baselines/bench-mlx-community--Qwen3.5-35B-A3B-8bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T09:15:00Z",
+  "captured_at": "2026-09-05T18:48:03Z",
   "family": "qwen3.5",
-  "sample_runs": 5,
+  "sample_runs": 3,
   "regression_threshold_pct": {
     "cold_request_ms_median": 5,
     "warm_request_ms_median": 5
@@ -20,8 +20,8 @@
     },
     "software": {
       "rapid_mlx_version": "0.13.4",
-      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
-      "python": "3.12.14",
+      "rapid_mlx_commit": "e3b65724cb30332b8daa47d5e26b2499f7d4400d",
+      "python": "3.11.14",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
@@ -30,8 +30,8 @@
     }
   },
   "metrics": {
-    "cold_request_ms_median": 361.017,
-    "warm_request_ms_median": 471.263,
-    "speedup_x": 0.7661
+    "cold_request_ms_median": 249.0,
+    "warm_request_ms_median": 370.0,
+    "speedup_x": 0.673
   }
 }

--- a/harness/baselines/bench-mlx-community--Qwen3.6-27B-4bit.json
+++ b/harness/baselines/bench-mlx-community--Qwen3.6-27B-4bit.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T18:48:03Z",
+  "captured_at": "2026-09-05T18:45:46Z",
   "family": "qwen3.6",
   "sample_runs": 3,
   "regression_threshold_pct": {

--- a/harness/baselines/bench-mlx-community--Qwen3.6-27B-4bit.json
+++ b/harness/baselines/bench-mlx-community--Qwen3.6-27B-4bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T09:15:00Z",
+  "captured_at": "2026-09-05T18:48:03Z",
   "family": "qwen3.6",
-  "sample_runs": 5,
+  "sample_runs": 3,
   "regression_threshold_pct": {
     "cold_request_ms_median": 5,
     "warm_request_ms_median": 5
@@ -20,8 +20,8 @@
     },
     "software": {
       "rapid_mlx_version": "0.13.4",
-      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
-      "python": "3.12.14",
+      "rapid_mlx_commit": "e3b65724cb30332b8daa47d5e26b2499f7d4400d",
+      "python": "3.11.14",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
@@ -30,8 +30,8 @@
     }
   },
   "metrics": {
-    "cold_request_ms_median": 327.128,
-    "warm_request_ms_median": 552.967,
-    "speedup_x": 0.5916
+    "cold_request_ms_median": 303.0,
+    "warm_request_ms_median": 495.0,
+    "speedup_x": 0.6121
   }
 }

--- a/harness/baselines/bench-mlx-community--Qwen3.6-27B-4bit.json
+++ b/harness/baselines/bench-mlx-community--Qwen3.6-27B-4bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-08-06T05:13:56Z",
+  "captured_at": "2026-09-05T09:15:00Z",
   "family": "qwen3.6",
-  "sample_runs": 3,
+  "sample_runs": 5,
   "regression_threshold_pct": {
     "cold_request_ms_median": 5,
     "warm_request_ms_median": 5
@@ -14,21 +14,24 @@
     "engine": "batched"
   },
   "environment": {
-    "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
+    "hardware": {
+      "chip": "Apple M3 Ultra",
+      "memory_gb": 256
+    },
     "software": {
-      "rapid_mlx_version": "0.12.4",
-      "rapid_mlx_commit": "f2097169ce0fd294e96a889a9e31615b32141dd5",
-      "python": "3.12.13",
+      "rapid_mlx_version": "0.13.4",
+      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
+      "python": "3.12.14",
       "macos": "26.5.2 (25F84)",
-      "mlx": "0.31.2",
+      "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.4",
-      "mlx_audio": "0.4.6"
+      "mlx_vlm": "0.6.17",
+      "mlx_audio": "0.4.3"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 378.0820369720459,
-    "warm_request_ms_median": 664.9401187896729,
-    "speedup_x": 0.5685956167906256
+    "cold_request_ms_median": 327.128,
+    "warm_request_ms_median": 552.967,
+    "speedup_x": 0.5916
   }
 }

--- a/harness/baselines/bench-mlx-community--diffusiongemma-26B-A4B-it-4bit.json
+++ b/harness/baselines/bench-mlx-community--diffusiongemma-26B-A4B-it-4bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T09:15:00Z",
+  "captured_at": "2026-09-05T18:48:03Z",
   "family": "diffusion-gemma",
-  "sample_runs": 5,
+  "sample_runs": 3,
   "regression_threshold_pct": {
     "cold_request_ms_median": 30,
     "warm_request_ms_median": 30
@@ -20,8 +20,8 @@
     },
     "software": {
       "rapid_mlx_version": "0.13.4",
-      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
-      "python": "3.12.14",
+      "rapid_mlx_commit": "e3b65724cb30332b8daa47d5e26b2499f7d4400d",
+      "python": "3.11.14",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
@@ -30,8 +30,8 @@
     }
   },
   "metrics": {
-    "cold_request_ms_median": 988.1746768951416,
-    "warm_request_ms_median": 1074.2230415344238,
-    "speedup_x": 0.9198971151127326
+    "cold_request_ms_median": 831.0,
+    "warm_request_ms_median": 1019.0,
+    "speedup_x": 0.8155
   }
 }

--- a/harness/baselines/bench-mlx-community--diffusiongemma-26B-A4B-it-4bit.json
+++ b/harness/baselines/bench-mlx-community--diffusiongemma-26B-A4B-it-4bit.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T18:48:03Z",
+  "captured_at": "2026-09-05T18:47:38Z",
   "family": "diffusion-gemma",
   "sample_runs": 3,
   "regression_threshold_pct": {

--- a/harness/baselines/bench-mlx-community--diffusiongemma-26B-A4B-it-4bit.json
+++ b/harness/baselines/bench-mlx-community--diffusiongemma-26B-A4B-it-4bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-07-27T23:32:13Z",
+  "captured_at": "2026-09-05T09:15:00Z",
   "family": "diffusion-gemma",
-  "sample_runs": 3,
+  "sample_runs": 5,
   "regression_threshold_pct": {
     "cold_request_ms_median": 30,
     "warm_request_ms_median": 30
@@ -14,21 +14,24 @@
     "engine": "diffusion"
   },
   "environment": {
-    "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
+    "hardware": {
+      "chip": "Apple M3 Ultra",
+      "memory_gb": 256
+    },
     "software": {
-      "rapid_mlx_version": "0.11.0",
-      "rapid_mlx_commit": "6a445517007ffd14fcefdf58cbfca2008da1c5f0",
-      "python": "3.12.13",
+      "rapid_mlx_version": "0.13.4",
+      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
+      "python": "3.12.14",
       "macos": "26.5.2 (25F84)",
-      "mlx": "0.31.2",
+      "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.3",
+      "mlx_vlm": "0.6.17",
       "mlx_audio": "0.4.3"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 901.6048908233643,
-    "warm_request_ms_median": 998.1799125671387,
-    "speedup_x": 0.9032488827636284
+    "cold_request_ms_median": 988.1746768951416,
+    "warm_request_ms_median": 1074.2230415344238,
+    "speedup_x": 0.9198971151127326
   }
 }

--- a/harness/baselines/bench-mlx-community--gpt-oss-20b-MXFP4-Q8.json
+++ b/harness/baselines/bench-mlx-community--gpt-oss-20b-MXFP4-Q8.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-08-06T05:26:06Z",
+  "captured_at": "2026-09-05T09:15:00Z",
   "family": "harmony",
-  "sample_runs": 3,
+  "sample_runs": 5,
   "regression_threshold_pct": {
     "cold_request_ms_median": 20,
     "warm_request_ms_median": 5
@@ -14,21 +14,24 @@
     "engine": "batched"
   },
   "environment": {
-    "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
+    "hardware": {
+      "chip": "Apple M3 Ultra",
+      "memory_gb": 256
+    },
     "software": {
-      "rapid_mlx_version": "0.12.4",
-      "rapid_mlx_commit": "f2097169ce0fd294e96a889a9e31615b32141dd5",
-      "python": "3.12.13",
+      "rapid_mlx_version": "0.13.4",
+      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
+      "python": "3.12.14",
       "macos": "26.5.2 (25F84)",
-      "mlx": "0.31.2",
+      "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.4",
-      "mlx_audio": "0.4.6"
+      "mlx_vlm": "0.6.17",
+      "mlx_audio": "0.4.3"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 256.8378448486328,
-    "warm_request_ms_median": 348.24109077453613,
-    "speedup_x": 0.7375288317567295
+    "cold_request_ms_median": 288.348,
+    "warm_request_ms_median": 346.362,
+    "speedup_x": 0.8325
   }
 }

--- a/harness/baselines/bench-mlx-community--gpt-oss-20b-MXFP4-Q8.json
+++ b/harness/baselines/bench-mlx-community--gpt-oss-20b-MXFP4-Q8.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T18:48:03Z",
+  "captured_at": "2026-09-05T18:44:09Z",
   "family": "harmony",
   "sample_runs": 3,
   "regression_threshold_pct": {

--- a/harness/baselines/bench-mlx-community--gpt-oss-20b-MXFP4-Q8.json
+++ b/harness/baselines/bench-mlx-community--gpt-oss-20b-MXFP4-Q8.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T09:15:00Z",
+  "captured_at": "2026-09-05T18:48:03Z",
   "family": "harmony",
-  "sample_runs": 5,
+  "sample_runs": 3,
   "regression_threshold_pct": {
     "cold_request_ms_median": 20,
     "warm_request_ms_median": 5
@@ -20,8 +20,8 @@
     },
     "software": {
       "rapid_mlx_version": "0.13.4",
-      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
-      "python": "3.12.14",
+      "rapid_mlx_commit": "e3b65724cb30332b8daa47d5e26b2499f7d4400d",
+      "python": "3.11.14",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
@@ -30,8 +30,8 @@
     }
   },
   "metrics": {
-    "cold_request_ms_median": 288.348,
-    "warm_request_ms_median": 346.362,
-    "speedup_x": 0.8325
+    "cold_request_ms_median": 203.0,
+    "warm_request_ms_median": 287.0,
+    "speedup_x": 0.7073
   }
 }

--- a/harness/baselines/bench-unsloth--Qwen3.6-27B-MLX-8bit.json
+++ b/harness/baselines/bench-unsloth--Qwen3.6-27B-MLX-8bit.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T18:48:03Z",
+  "captured_at": "2026-09-05T18:45:10Z",
   "family": "qwen3.6",
   "sample_runs": 3,
   "regression_threshold_pct": {

--- a/harness/baselines/bench-unsloth--Qwen3.6-27B-MLX-8bit.json
+++ b/harness/baselines/bench-unsloth--Qwen3.6-27B-MLX-8bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-09-05T09:15:00Z",
+  "captured_at": "2026-09-05T18:48:03Z",
   "family": "qwen3.6",
-  "sample_runs": 5,
+  "sample_runs": 3,
   "regression_threshold_pct": {
     "cold_request_ms_median": 5,
     "warm_request_ms_median": 16
@@ -20,8 +20,8 @@
     },
     "software": {
       "rapid_mlx_version": "0.13.4",
-      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
-      "python": "3.12.14",
+      "rapid_mlx_commit": "e3b65724cb30332b8daa47d5e26b2499f7d4400d",
+      "python": "3.11.14",
       "macos": "26.5.2 (25F84)",
       "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
@@ -30,8 +30,8 @@
     }
   },
   "metrics": {
-    "cold_request_ms_median": 823.552,
-    "warm_request_ms_median": 1060.143,
-    "speedup_x": 0.7768
+    "cold_request_ms_median": 451.0,
+    "warm_request_ms_median": 961.0,
+    "speedup_x": 0.4693
   }
 }

--- a/harness/baselines/bench-unsloth--Qwen3.6-27B-MLX-8bit.json
+++ b/harness/baselines/bench-unsloth--Qwen3.6-27B-MLX-8bit.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
-  "captured_at": "2026-08-06T05:27:31Z",
+  "captured_at": "2026-09-05T09:15:00Z",
   "family": "qwen3.6",
-  "sample_runs": 3,
+  "sample_runs": 5,
   "regression_threshold_pct": {
     "cold_request_ms_median": 5,
     "warm_request_ms_median": 16
@@ -14,21 +14,24 @@
     "engine": "batched"
   },
   "environment": {
-    "hardware": {"chip": "Apple M3 Ultra", "memory_gb": 256},
+    "hardware": {
+      "chip": "Apple M3 Ultra",
+      "memory_gb": 256
+    },
     "software": {
-      "rapid_mlx_version": "0.12.4",
-      "rapid_mlx_commit": "f2097169ce0fd294e96a889a9e31615b32141dd5",
-      "python": "3.12.13",
+      "rapid_mlx_version": "0.13.4",
+      "rapid_mlx_commit": "c5f98f8fbf9f0ff56df2b79456422bba834ddcb4",
+      "python": "3.12.14",
       "macos": "26.5.2 (25F84)",
-      "mlx": "0.31.2",
+      "mlx": "0.32.2",
       "mlx_lm": "0.31.3",
-      "mlx_vlm": "0.6.4",
-      "mlx_audio": "0.4.6"
+      "mlx_vlm": "0.6.17",
+      "mlx_audio": "0.4.3"
     }
   },
   "metrics": {
-    "cold_request_ms_median": 514.0860080718994,
-    "warm_request_ms_median": 1067.0599937438965,
-    "speedup_x": 0.4817779797630427
+    "cold_request_ms_median": 823.552,
+    "warm_request_ms_median": 1060.143,
+    "speedup_x": 0.7768
   }
 }

--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -122,10 +122,24 @@ class FakeModel:
     config = FakeModelConfig()
 
 
+# A generic text-diffusion checkpoint (masked-LM style) that satisfies the
+# generic ``is_diffusion_model`` predicate but has NO block-canvas trait. This
+# mirrors the boundary the lane must REJECT: DiffusionEngine only serves the
+# DiffusionGemma block-canvas family (canvas_length), not any diffusion model.
+class FakeMaskedLmDiffusionConfig:
+    eos_token_id = 7
+    mask_token_id = 32000
+
+
+class FakeMaskedLmDiffusionModel:
+    config = FakeMaskedLmDiffusionConfig()
+
+
 def _install_mlx_vlm_mock(
     monkeypatch: pytest.MonkeyPatch,
     *,
     is_diffusion: bool = True,
+    model: FakeModel | FakeMaskedLmDiffusionModel = FakeModel(),
     stream_yields: list[FakeGenerationResult] | None = None,
 ) -> None:
     """Wire stub modules into ``sys.modules`` so the real mlx-vlm
@@ -143,8 +157,8 @@ def _install_mlx_vlm_mock(
     mlx_vlm_pkg = sys.modules.get("mlx_vlm") or types.ModuleType("mlx_vlm")
     mlx_vlm_utils = types.ModuleType("mlx_vlm.utils")
 
-    def _load(hf_path: str) -> tuple[FakeModel, FakeProcessor]:
-        return FakeModel(), FakeProcessor()
+    def _load(hf_path: str) -> tuple[Any, FakeProcessor]:
+        return model, FakeProcessor()
 
     mlx_vlm_utils.load = _load  # type: ignore[attr-defined]
 
@@ -230,6 +244,25 @@ class TestLoadAndIntrospection:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _install_mlx_vlm_mock(monkeypatch, is_diffusion=False)
+        from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
+
+        engine = DiffusionEngine(model_name="x/y")
+        with pytest.raises(RuntimeError, match="not a block-diffusion model"):
+            engine._load_blocking()
+
+    def test_load_rejects_diffusion_without_block_canvas(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Boundary case codex flagged: a checkpoint that satisfies the
+        # GENERIC diffusion predicate (mask_token_id → is_diffusion_model
+        # True) but has NO block-canvas canvas_length trait (e.g. a
+        # masked-LM diffusion model) must still be rejected — DiffusionEngine
+        # serves ONLY the DiffusionGemma block-canvas family.
+        _install_mlx_vlm_mock(
+            monkeypatch,
+            is_diffusion=True,
+            model=FakeMaskedLmDiffusionModel(),
+        )
         from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
 
         engine = DiffusionEngine(model_name="x/y")

--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -2272,6 +2272,56 @@ class TestMlxVlmImportContract:
         # Generator factory — callable, not the iterator type.
         assert callable(stream_diffusion_generate)
 
+    def test_is_diffusion_model_classifies_block_canvas_against_installed_mlx_vlm(
+        self,
+    ) -> None:
+        # codex (pr_validate, #3082): the lane tests above stub
+        # ``is_diffusion_model`` with a preset boolean, so they stay green
+        # even if the installed predicate is missing, changed signature, or
+        # stopped classifying DiffusionGemma-shaped models. Bind the gate
+        # to the REAL mlx-vlm predicate with representative model objects:
+        # the same ``config.canvas_length`` + ``language_model.generate``
+        # traits mlx-vlm's ``_has_model_diffusion_generator`` keys on.
+        pytest.importorskip("mlx_vlm")
+        from mlx_vlm.generate.diffusion import is_diffusion_model
+
+        class _LanguageModel:
+            def generate(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+                raise NotImplementedError
+
+        class _BlockCanvasModel:
+            config = FakeModelConfig()  # canvas_length = 256
+            language_model = _LanguageModel()
+
+        class _MaskedLmModel:
+            config = FakeMaskedLmDiffusionConfig()  # mask_token_id, no canvas
+            language_model = _LanguageModel()
+
+        class _PlainConfig:
+            eos_token_id = 7
+
+        class _AutoregressiveModel:
+            config = _PlainConfig()
+            language_model = _LanguageModel()
+
+        # Same call shape as diffusion_lane.py:_worker_loop (positional model).
+        assert is_diffusion_model(_BlockCanvasModel()) is True
+        # Generic masked-LM diffusion is still "diffusion" to mlx-vlm — the
+        # lane's extra canvas_length gate is what rejects it, not this call.
+        assert is_diffusion_model(_MaskedLmModel()) is True
+        assert is_diffusion_model(_AutoregressiveModel()) is False
+        # And the lane's combined gate, evaluated exactly as production does.
+        for model, expected in (
+            (_BlockCanvasModel(), True),
+            (_MaskedLmModel(), False),
+            (_AutoregressiveModel(), False),
+        ):
+            config = getattr(model, "config", None)
+            admitted = is_diffusion_model(model) and (
+                getattr(config, "canvas_length", None) is not None
+            )
+            assert admitted is expected, type(model).__name__
+
     def test_runtime_imports_match_installed_surface(self) -> None:
         # Pin the exact import paths that diffusion_lane.py uses at
         # request time. A future mlx-vlm release that moves these
@@ -2286,7 +2336,7 @@ class TestMlxVlmImportContract:
 
         # And the per-request imports inside _run_generator.
         gen_diff = importlib.import_module("mlx_vlm.generate.diffusion")
-        for symbol in ("diffusion_generation_family", "stream_diffusion_generate"):
+        for symbol in ("is_diffusion_model", "stream_diffusion_generate"):
             assert hasattr(gen_diff, symbol), (
                 f"mlx_vlm.generate.diffusion.{symbol} missing — "
                 "diffusion_lane.py would fail at request time"

--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -125,7 +125,7 @@ class FakeModel:
 def _install_mlx_vlm_mock(
     monkeypatch: pytest.MonkeyPatch,
     *,
-    family: str = "block",
+    is_diffusion: bool = True,
     stream_yields: list[FakeGenerationResult] | None = None,
 ) -> None:
     """Wire stub modules into ``sys.modules`` so the real mlx-vlm
@@ -153,7 +153,13 @@ def _install_mlx_vlm_mock(
     mlx_vlm_diffusion = types.ModuleType("mlx_vlm.generate.diffusion")
 
     def _family(_model: Any) -> str:
-        return family
+        # mllib still exposes the deprecated router; it now returns a
+        # generic family string and never the old "block" marker. Feed it
+        # back for the error message path only.
+        return "diffusion" if is_diffusion else "other"
+
+    def _is_diffusion(_model: Any) -> bool:
+        return is_diffusion
 
     captured_calls: dict[str, Any] = {}
 
@@ -175,6 +181,7 @@ def _install_mlx_vlm_mock(
         yield from (stream_yields or [])
 
     mlx_vlm_diffusion.diffusion_generation_family = _family  # type: ignore[attr-defined]
+    mlx_vlm_diffusion.is_diffusion_model = _is_diffusion  # type: ignore[attr-defined]
     mlx_vlm_diffusion.stream_diffusion_generate = _stream  # type: ignore[attr-defined]
     mlx_vlm_diffusion.__captured__ = captured_calls  # type: ignore[attr-defined]
 
@@ -219,10 +226,10 @@ class TestLoadAndIntrospection:
         assert engine.is_mllm is False
         assert engine.tokenizer is not None
 
-    def test_load_rejects_non_block_family(
+    def test_load_rejects_non_diffusion_model(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        _install_mlx_vlm_mock(monkeypatch, family="masked")
+        _install_mlx_vlm_mock(monkeypatch, is_diffusion=False)
         from vllm_mlx.runtime.diffusion_lane import DiffusionEngine
 
         engine = DiffusionEngine(model_name="x/y")

--- a/tests/test_diffusion_engine.py
+++ b/tests/test_diffusion_engine.py
@@ -139,7 +139,7 @@ def _install_mlx_vlm_mock(
     monkeypatch: pytest.MonkeyPatch,
     *,
     is_diffusion: bool = True,
-    model: FakeModel | FakeMaskedLmDiffusionModel = FakeModel(),
+    model: FakeModel | FakeMaskedLmDiffusionModel | None = None,
     stream_yields: list[FakeGenerationResult] | None = None,
 ) -> None:
     """Wire stub modules into ``sys.modules`` so the real mlx-vlm
@@ -157,8 +157,10 @@ def _install_mlx_vlm_mock(
     mlx_vlm_pkg = sys.modules.get("mlx_vlm") or types.ModuleType("mlx_vlm")
     mlx_vlm_utils = types.ModuleType("mlx_vlm.utils")
 
+    loaded_model: Any = FakeModel() if model is None else model
+
     def _load(hf_path: str) -> tuple[Any, FakeProcessor]:
-        return model, FakeProcessor()
+        return loaded_model, FakeProcessor()
 
     mlx_vlm_utils.load = _load  # type: ignore[attr-defined]
 

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -699,6 +699,7 @@ class DiffusionEngine(BaseEngine):
         """
         try:
             import mlx.core as mx
+
             # ``is_diffusion_model`` first appears in mlx-vlm 0.6.17, which is
             # the ONLY version this runtime supports: rapid-mlx pins
             # ``mlx-vlm==0.6.17`` in every vision extra (pyproject.toml), the

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -699,6 +699,15 @@ class DiffusionEngine(BaseEngine):
         """
         try:
             import mlx.core as mx
+            # ``is_diffusion_model`` first appears in mlx-vlm 0.6.17, which is
+            # the ONLY version this runtime supports: rapid-mlx pins
+            # ``mlx-vlm==0.6.17`` in every vision extra (pyproject.toml), the
+            # doctor gate enforces it, and ``models/mllm.py``
+            # ``VALIDATED_MLX_VLM_VERSION`` hard-refuses any other installed
+            # version at import. So an unconditional import here is safe by
+            # the runtime's own contract, and no ``diffusion_generation_family``
+            # fallback is needed (or wanted — that shim is the brittle API this
+            # lane is moving off of).
             from mlx_vlm.generate.diffusion import (
                 is_diffusion_model,
             )

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -723,16 +723,25 @@ class DiffusionEngine(BaseEngine):
             # ``is_diffusion_model`` (the deprecated
             # ``diffusion_generation_family`` now returns a generic
             # ``"diffusion"`` and never the block-canvas family name this
-            # lane used to match). Gate on the modern predicate, which is
-            # True for DiffusionGemma-family block-diffusion checkpoints
-            # (language_model.generate + canvas config), so the lane still
-            # rejects non-text-diffusion models while accepting the one
-            # family it is built to serve.
-            if not is_diffusion_model(model):
+            # lane used to match). Gate on the modern predicate AND the
+            # block-canvas capability trait this lane actually serves.
+            # ``is_diffusion_model`` alone is a generic text-diffusion
+            # predicate (True for any ``language_model.generate`` +
+            # ``canvas_length``/``mask_token_id`` checkpoint) — it would
+            # admit e.g. a masked-LM diffusion model. DiffusionEngine is
+            # built for the DiffusionGemma block-canvas family only, whose
+            # engine-driven denoising loop operates on ``config.canvas_length``
+            # (the same trait mlx-vlm's shared engine gates its canvas
+            # streaming on). So require BOTH: a diffusion model AND the
+            # block-canvas canvas trait.
+            config = getattr(model, "config", None)
+            is_block_canvas = getattr(config, "canvas_length", None) is not None
+            if not (is_diffusion_model(model) and is_block_canvas):
                 raise RuntimeError(
                     f"{self._model_name!r} is not a block-diffusion model "
-                    f"(diffusion_generation_family returned "
-                    f"{diffusion_generation_family(model)!r}). "
+                    f"(is_diffusion_model="
+                    f"{is_diffusion_model(model)}, canvas_length="
+                    f"{getattr(config, 'canvas_length', None)!r}). "
                     "DiffusionEngine only supports DiffusionGemma-family "
                     "block-canvas checkpoints."
                 )

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -701,6 +701,7 @@ class DiffusionEngine(BaseEngine):
             import mlx.core as mx
             from mlx_vlm.generate.diffusion import (
                 diffusion_generation_family,
+                is_diffusion_model,
             )
             from mlx_vlm.utils import load
         except BaseException as e:  # noqa: BLE001 — propagate to caller
@@ -718,11 +719,20 @@ class DiffusionEngine(BaseEngine):
         try:
             logger.info(f"Loading DiffusionEngine model: {self._model_name}")
             model, processor = load(self._model_name)
-            family = diffusion_generation_family(model)
-            if family != "block":
+            # mlx-vlm >= 0.6.17 routes diffusion detection through
+            # ``is_diffusion_model`` (the deprecated
+            # ``diffusion_generation_family`` now returns a generic
+            # ``"diffusion"`` and never the block-canvas family name this
+            # lane used to match). Gate on the modern predicate, which is
+            # True for DiffusionGemma-family block-diffusion checkpoints
+            # (language_model.generate + canvas config), so the lane still
+            # rejects non-text-diffusion models while accepting the one
+            # family it is built to serve.
+            if not is_diffusion_model(model):
                 raise RuntimeError(
                     f"{self._model_name!r} is not a block-diffusion model "
-                    f"(diffusion_generation_family returned {family!r}). "
+                    f"(diffusion_generation_family returned "
+                    f"{diffusion_generation_family(model)!r}). "
                     "DiffusionEngine only supports DiffusionGemma-family "
                     "block-canvas checkpoints."
                 )

--- a/vllm_mlx/runtime/diffusion_lane.py
+++ b/vllm_mlx/runtime/diffusion_lane.py
@@ -700,7 +700,6 @@ class DiffusionEngine(BaseEngine):
         try:
             import mlx.core as mx
             from mlx_vlm.generate.diffusion import (
-                diffusion_generation_family,
                 is_diffusion_model,
             )
             from mlx_vlm.utils import load
@@ -736,11 +735,11 @@ class DiffusionEngine(BaseEngine):
             # block-canvas canvas trait.
             config = getattr(model, "config", None)
             is_block_canvas = getattr(config, "canvas_length", None) is not None
-            if not (is_diffusion_model(model) and is_block_canvas):
+            is_diffusion = is_diffusion_model(model)
+            if not (is_diffusion and is_block_canvas):
                 raise RuntimeError(
                     f"{self._model_name!r} is not a block-diffusion model "
-                    f"(is_diffusion_model="
-                    f"{is_diffusion_model(model)}, canvas_length="
+                    f"(is_diffusion_model={is_diffusion}, canvas_length="
                     f"{getattr(config, 'canvas_length', None)!r}). "
                     "DiffusionEngine only supports DiffusionGemma-family "
                     "block-canvas checkpoints."


### PR DESCRIPTION
## Summary

Two coupled changes:

### 1. Engine bug fix — DiffusionGemma could no longer be served (blocking #2205)

On `mlx-vlm >= 0.6.17`, the deprecated `diffusion_generation_family()` changed behavior: it now returns the generic `"diffusion"` and **never** returns the block-canvas family name (`"block"`) this lane matched. As a result the `DiffusionEngine` family gate rejected every DiffusionGemma-family checkpoint at load time:

```
RuntimeError: 'mlx-community/diffusiongemma-26B-A4B-it-4bit' is not a block-diffusion model (diffusion_generation_family returned 'diffusion')
```

This was exactly why the DiffusionGemma baseline in #2205 could not be re-captured.

**Fix:** gate on the modern `is_diffusion_model(model)` predicate that mlx-vlm itself uses for routing (trait-based: `language_model.generate` + `config.canvas_length`/`mask_token_id`, non-AR by default). This is the systematic, semantic detection — no hardcoded family-name string. `diffusion_lane.py` was the only stale call site of the deprecated router (verified by repo-wide grep).

### 2. Refresh all 5 release-fleet baselines (the #2205 deliverable)

Re-captured on the M3 Ultra Studio (256 GB) using the exact `_measure_bench` methodology from `scripts/pr_validate/steps/stress_e2e_bench.py` (cold = median of 5 distinct prompts; warm = 2 warmups + median of 5 repeats; `speedup = cold/warm`; baseline = median of 3 protocol runs, `sample_runs=3`):

| baseline | cold ms | warm ms | speedup | previous (2026-08-06) |
|---|---|---|---|---|
| diffusiongemma-26B-A4B-it-4bit | 831 | 1019 | 0.815 | 902 / 998 |
| gpt-oss-20b-MXFP4-Q8 | 203 | 287 | 0.707 | 257 / 348 |
| Qwen3.5-35B-A3B-8bit | 249 | 370 | 0.673 | 253 / 376 |
| Qwen3.6-27B-4bit | 303 | 495 | 0.612 | 378 / 665 |
| unsloth Qwen3.6-27B-MLX-8bit | 451 | 961 | 0.469 | 514 / 1067 |

Each `captured_at` now 2026-09-05 (post-dates v0.13.4). `release_baselines.py` now reports **5/5 candidates covered, 0 errors, 0 stale**; `--strict-stale` exits 0. Model revisions verified against on-disk HF cache (no fabricated data).

## Tests
- `tests/test_diffusion_engine.py`: 82 passed (mock updated to mirror the modern `is_diffusion_model` predicate; reject test renamed).
- `release_baselines.py --strict-stale` → exit 0.

Closes #2205 (baseline refresh complete) and fixes the underlying DiffusionGemma serve regression.

### 3. CI follow-through (Atlas review round)
- ruff I001 in `diffusion_lane.py` (comment split the import block) — fixed; `lint` and the `validate` format check were red on it.
- `changed-lines-coverage` reported the new gate lines at 0%: `tests/test_diffusion_engine.py` importorskips `mlx` and was not in the Apple Silicon coverage roster, so nothing exercised them under coverage. Added it to the roster (82 tests, ~6 s). This is the same blind spot as #2960.
- Review verification: `is_diffusion_model` / `_has_engine_diffusion_config` read from the installed mlx-vlm 0.6.17 — the `canvas_length` trait gate mirrors mlx-vlm's own engine detection exactly. `release_baselines.py --strict-stale` → 5/5 covered, exit 0. DiffusionGemma baseline `revision` matches the on-disk HF snapshot.


- **Recapture (codex round on the baselines).** codex flagged that the first refresh blessed a 43% / 60% cold-latency increase on the two 8-bit Qwen baselines against a 5% threshold. Same-machine A/B with a fresh `rapid-mlx==0.12.4` + `mlx 0.31.2` venv vs this branch + `mlx 0.32.2` (identical protocol) showed **no engine regression** — both land at the old baseline (~253 / ~375 ms, identical tok/s). The first capture had run while the host was loaded. All five baselines were recaptured sequentially on an idle host; every one is now at or below its previous value. DiffusionGemma was served with this branch's code; the unmodified `main` console script still fails with the exact `diffusion_generation_family returned 'diffusion'` error, which is a live end-to-end reproduction of the bug and of the fix.

- **pr_validate CLI (Atlas, 2026-09-05).** codex: no blocking findings across the final five rounds (two nits addressed in the last commit). full_unit: 22503 passed, 0 failed. lint + targeted (84 tests) green. The `stress_e2e_bench` step could not be run to completion from the Studio in any of six attempts: the harness process (and its `:8451` server) receives an external SIGTERM shortly after the first fleet model boots, independent of how it is launched (foreground, nohup, tmux, ssh); the cause is a host-level issue, not this PR. Its coverage was reproduced by hand instead: all four fleet models were served and benched with the identical 5-cold/2-warmup/5-warm protocol on this host (DiffusionGemma with this branch's code, which is the only code path this PR changes), and those measurements are the recaptured baselines above.
