### PR TITLE
feat(image): support Stable Diffusion 3.5 Large

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,3 +17,4 @@ omit =
     vllm_mlx/image/sdxl_runtime/utils.py
     # Exact third-party numerical core; Rapid-owned adapter remains covered.
     vllm_mlx/image/bonsai_runtime/_vendor/*
+    vllm_mlx/image/sd35_runtime/_vendor/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,7 @@ jobs:
             tests/test_hidream_o1_alias.py \
             tests/test_sdxl_alias.py \
             tests/test_bonsai_image_alias.py \
+            tests/test_sd35_alias.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/NOTICE
+++ b/NOTICE
@@ -65,6 +65,12 @@ repository. Each keeps its upstream license text alongside the code.
   CC0 1.0 Universal — original work by Amirhossein Razlighi and contributors.
   See vllm_mlx/image/sdxl_runtime/LICENSE and NOTICE.
 
+* vllm_mlx/image/sd35_runtime/
+  Stable Diffusion 3.5 Large MLX runtime adapted from DiffusionKit at commit
+  498e5dba5fb48b0f01cb6b5c2292a6dbea67a317.
+  MIT License — Copyright (c) 2024 Argmax, Inc.
+  See vllm_mlx/image/sd35_runtime/LICENSE and NOTICE.
+
 * apps/rapid-mac/Vendor/SwiftMath/
   Vendored from https://github.com/mgriebling/SwiftMath at 1.7.3
   (fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7) with a resource-resolution patch.

--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -204,6 +204,8 @@ final class ImageGenViewModel {
         // that is actually a 20-step one.
         if alias.localizedCaseInsensitiveContains("qwen-image") { return 20 }
         if alias.localizedCaseInsensitiveContains("hidream-o1") { return 28 }
+        if alias.localizedCaseInsensitiveContains("sd35")
+            || alias.localizedCaseInsensitiveContains("stable-diffusion-3.5") { return 28 }
         if alias.localizedCaseInsensitiveContains("sdxl") { return 30 }
         return alias.localizedCaseInsensitiveContains("z-image") ? 8 : 4
     }

--- a/apps/rapid-mac/THIRD_PARTY.md
+++ b/apps/rapid-mac/THIRD_PARTY.md
@@ -240,6 +240,7 @@ The largest and most self-contained components:
 | Gemma 4 model classes | https://github.com/Blaizzy/mlx-vlm (v0.6.3) | MIT | `vllm_mlx/models/gemma4_vendored/` |
 | Hunyuan 3 model class | https://github.com/ml-explore/mlx-lm (PR #1211) | MIT | `vllm_mlx/models/hy_v3.py` |
 | DeepSeek V4 model classes | https://github.com/ml-explore/mlx-lm (`_ds4` branch, © Apple Inc.) | MIT | `vllm_mlx/models/deepseek_v4.py`, `deepseek_v4_cache.py`, `deepseek_v4_hyper_connection.py`, `deepseek_v4_switch.py` |
+| Stable Diffusion 3.5 Large MLX runtime | https://github.com/argmaxinc/DiffusionKit (`498e5db`) | MIT | `vllm_mlx/image/sd35_runtime/` (`LICENSE`, `NOTICE`) |
 | MTP speculative-decoding head + generator | https://github.com/ml-explore/mlx-lm (PR #990) | MIT | `vllm_mlx/spec_decode/mtp/head.py`, `generator.py` |
 | Request/status model, adapted | https://github.com/vllm-project/vllm | Apache-2.0 | `vllm_mlx/request.py` |
 | Several tool parsers, ported | https://github.com/vllm-project/vllm, https://github.com/sgl-project/sglang | Apache-2.0 | `vllm_mlx/tool_parsers/` |

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -32,12 +32,13 @@ struct ImageCatalogTests {
       z-image-turbo         5.5 GiB    [image:gen] filipstrand/Z-Image-Turbo-mflux-4bit
       hidream-o1-dev       16.4 GiB    [image:gen] mlx-community/HiDream-O1-Image-Dev-mlx-bf16
       sdxl-base             6.5 GiB     [image:gen] stabilityai/stable-diffusion-xl-base-1.0
+      sd35-large-4bit       15.3 GiB    [image:gen] argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized
     """
 
     @Test("parseImageRows extracts image rows and their operation")
     func parsesImageRows() {
         let rows = ModelCatalog.parseImageRows(Self.sample)
-        #expect(rows.count == 5)
+        #expect(rows.count == 6)
 
         let aliases = rows.map(\.alias)
         #expect(aliases.contains("flux2-klein-4b"))
@@ -45,6 +46,7 @@ struct ImageCatalogTests {
         #expect(aliases.contains("z-image-turbo"))
         #expect(aliases.contains("hidream-o1-dev"))
         #expect(aliases.contains("sdxl-base"))
+        #expect(aliases.contains("sd35-large-4bit"))
         // No chat / video alias leaks in.
         #expect(!aliases.contains("qwen3.6-27b-4bit"))
         #expect(!aliases.contains("ltx-2.3-mlx-q4"))
@@ -64,6 +66,10 @@ struct ImageCatalogTests {
         #expect(bonsai?.hfRepo == "prism-ml/bonsai-image-ternary-4B-mlx-2bit")
         #expect(bonsai?.size == "3.6 GiB")
         #expect(bonsai?.capability == .generation)
+        let sd35 = rows.first { $0.alias == "sd35-large-4bit" }
+        #expect(sd35?.hfRepo == "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized")
+        #expect(sd35?.size == "15.3 GiB")
+        #expect(sd35?.capability == .generation)
     }
 
     @Test("complete mflux caches are marked downloaded in Images")
@@ -77,6 +83,7 @@ struct ImageCatalogTests {
                 "filipstrand/Z-Image-Turbo-mflux-4bit",
                 "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
                 "stabilityai/stable-diffusion-xl-base-1.0",
+                "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized",
             ]
         )
 
@@ -87,6 +94,7 @@ struct ImageCatalogTests {
         #expect(cached.first { $0.alias == "z-image-turbo" }?.cached == true)
         #expect(cached.first { $0.alias == "hidream-o1-dev" }?.cached == true)
         #expect(cached.first { $0.alias == "sdxl-base" }?.cached == true)
+        #expect(cached.first { $0.alias == "sd35-large-4bit" }?.cached == true)
     }
 
     @Test("Image capability rows are excluded from the chat catalog")
@@ -107,5 +115,6 @@ struct ImageCatalogTests {
         #expect(excluded.contains("z-image-turbo"))
         #expect(excluded.contains("hidream-o1-dev"))
         #expect(excluded.contains("sdxl-base"))
+        #expect(excluded.contains("sd35-large-4bit"))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageGenerationPhaseTests.swift
@@ -104,6 +104,7 @@ struct ImageGenerationPhaseTests {
         #expect(ImageGenViewModel.seedSteps(for: "flux2-klein-4b") == 4)
         #expect(ImageGenViewModel.seedSteps(for: "bonsai-image-4b-2bit") == 4)
         #expect(ImageGenViewModel.seedSteps(for: "hidream-o1-dev") == 28)
+        #expect(ImageGenViewModel.seedSteps(for: "sd35-large-4bit") == 28)
         #expect(ImageGenViewModel.seedSteps(for: "sdxl-base") == 30)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -62,6 +62,8 @@ struct SidecarBuildScriptTests {
         let constraints = try String(contentsOf: Self.constraintsURL, encoding: .utf8)
 
         #expect(constraints.contains("mlx-vlm==0.6.17"))
+        #expect(constraints.contains("sentencepiece==0.2.2"),
+                "SD3.5's T5 tokenizer dependency must not float in signed builds.")
         #expect(!script.contains("'mlx-vlm>=0.6.3,!=0.6.4,<0.7'"),
                 "The no-deps sidecar install must never float within a range.")
         #expect(script.contains(#"--constraint "$SIDECAR_CONSTRAINTS""#),
@@ -82,6 +84,10 @@ struct SidecarBuildScriptTests {
         }
         #expect(script.contains("from vllm_mlx.image.hidream_runtime import HiDreamO1"),
                 "The bundled sidecar must include the HiDream image adapter, not only mlx-vlm.")
+        #expect(script.contains("from vllm_mlx.image.sd35_runtime import SD35Large"),
+                "The bundled sidecar must include the vendored SD3.5 image adapter.")
+        #expect(script.contains("import sentencepiece"),
+                "The bundled sidecar must prove SD3.5's tokenizer dependency imports.")
         #expect(script.contains("from vllm_mlx.image.sdxl_runtime import SDXL"),
                 "The bundled sidecar must include the vendored SDXL image adapter.")
         #expect(script.contains(#"find_spec("cv2") is None"#))

--- a/apps/rapid-mac/scripts/build-sidecar.sh
+++ b/apps/rapid-mac/scripts/build-sidecar.sh
@@ -489,7 +489,7 @@ echo "==> bundling mlx-vlm --no-deps + Pillow (gemma-4 + DiffusionGemma loader p
 # Pin exactly, for the same reason as mlx-vlm above: with --no-deps a range
 # would let the desktop float onto an mflux release whose loader wants a
 # dependency this bundle does not carry.
-echo "==> bundling mflux --no-deps + platformdirs/piexif/toml (Images tab image-gen lane)"
+echo "==> bundling mflux --no-deps + image runtime dependencies (Images tab image-gen lane)"
 "$STAGE/python/bin/python3.12" -m pip install \
     --target "$STAGE/site-packages" \
     --no-warn-script-location \
@@ -499,7 +499,8 @@ echo "==> bundling mflux --no-deps + platformdirs/piexif/toml (Images tab image-
     'mflux' \
     'platformdirs>=4.0,<5.0' \
     'piexif>=1.1.3,<2.0' \
-    'toml>=0.10.2,<1.0'
+    'toml>=0.10.2,<1.0' \
+    'sentencepiece>=0.2.0,<1.0'
 
 # Defer mflux's module-level torch imports into the three functions that
 # use them. Fails the build when the expected lines are gone: an mflux bump
@@ -1194,16 +1195,18 @@ else
         'import importlib.metadata
 import importlib.util
 import mlx_vlm
+import sentencepiece
 from mlx_vlm.models import (
     diffusion_gemma, gemma3, gemma3n, gemma4, gemma4_unified,
     qwen3_5, qwen3_5_moe, qwen3_vl, qwen3_vl_moe,
 )
 from vllm_mlx.image.hidream_runtime import HiDreamO1
+from vllm_mlx.image.sd35_runtime import SD35Large
 from vllm_mlx.image.sdxl_runtime import SDXL
 assert importlib.util.find_spec("cv2") is None
 assert importlib.util.find_spec("torch") is None
 assert importlib.util.find_spec("torchvision") is None
-print("mlx_vlm", mlx_vlm.__version__, "desktop Qwen/Gemma/HiDream/SDXL architectures OK")' 2>&1)" || {
+print("mlx_vlm", mlx_vlm.__version__, "sentencepiece", sentencepiece.__version__, "desktop Qwen/Gemma/HiDream/SDXL/SD3.5 architectures OK")' 2>&1)" || {
         echo "ERR: bundled mlx_vlm desktop architecture smoke failed:" >&2
         echo "$VLM_OUT" >&2
         echo "ERR: usually means a new mlx-vlm release added an eager top-level import" >&2

--- a/apps/rapid-mac/scripts/sidecar-constraints.txt
+++ b/apps/rapid-mac/scripts/sidecar-constraints.txt
@@ -3,5 +3,6 @@ mlx==0.32.2
 transformers==5.15.1
 mlx-vlm==0.6.17
 mflux==0.19.0
+sentencepiece==0.2.2
 mlx-video-with-audio==0.1.36
 mlx-arsenal==0.12.1

--- a/docs/engineering/performance/2026-09-05-sd35-large-dogfood.md
+++ b/docs/engineering/performance/2026-09-05-sd35-large-dogfood.md
@@ -1,0 +1,113 @@
+# Stable Diffusion 3.5 Large Server and Desktop-path dogfood
+
+## Outcome
+
+The `sd35-large-4bit` alias completed real MLX-native text-to-image generation
+through the OpenAI-compatible HTTP server. The runtime uses all three published
+text encoders (CLIP-L, CLIP-G, and T5-XXL), emits true denoise progress, and
+does not execute model-repository Python code.
+
+## Environment
+
+- Apple M3 Ultra, 256 GiB unified memory
+- macOS 26.5.2 (25F84)
+- Python 3.12.13
+- MLX 0.32.1
+- Transformers 5.15.1
+- SentencePiece 0.2.2
+- Pillow 12.3.0
+- Hugging Face Hub 1.30.0
+- Primary checkpoint revision: `0f92f6c2a9f9e1abc6738209e87ac22b049a7d26`
+- Shared text-assets revision: `7b7a9946015fe6ae602464dfc026c19f6b6306f9`
+- T5 tokenizer revision: `3db67ab1af984cf10548a73467f0e5bca2aaaeb2`
+- Exact audited payload: 16,378,940,179 bytes (15.25 GiB)
+
+## HTTP path
+
+Server:
+
+```bash
+RAPID_MLX_NO_UPDATE_CHECK=1 RAPID_MLX_AUTO_PULL=1 \
+  rapid-mlx serve sd35-large-4bit --host 127.0.0.1 --port 8135
+```
+
+Request (steps deliberately omitted to exercise the family default):
+
+```bash
+curl --fail-with-body --max-time 240 \
+  -X POST http://127.0.0.1:8135/v1/images/generations \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"sd35-large-4bit","prompt":"Editorial photograph of a tiny red panda astronaut standing on the moon, reflective helmet visor, Earth in the background, detailed fur, cinematic natural light","negative_prompt":"blurry, deformed, text, watermark","size":"512x512","seed":42}'
+```
+
+Observed:
+
+- HTTP 200 with a valid OpenAI-compatible `data[0].b64_json`
+- 28 denoise steps selected by the server default
+- decoded RGB PNG: 512×512, 457,015 bytes
+- end-to-end request time: 62.17 seconds
+- progress reached exactly 28/28 and reset to idle
+- visual inspection: coherent red panda, space suit, moon surface, and Earth;
+  no structural corruption or noise output
+
+A second clean-process 512×512 / 28-step run completed in 57.29 seconds and
+returned a 501,432-byte PNG. `/usr/bin/time -l` reported:
+
+- maximum resident set size: 7,389,003,776 bytes (6.88 GiB)
+- peak memory footprint: 16,667,122,480 bytes (15.52 GiB)
+- swaps: 0
+
+The catalog minimum is 32 GiB. Resident admission uses a conservative 20 GiB
+charge: the measured 15.52 GiB peak plus allocator/output headroom. The 32 GiB
+minimum also leaves room for the app, display compositor, and normal desktop
+workloads on unified memory.
+
+## Quality decision: keep T5 enabled
+
+Before integration, the same 512×512 / 28-step prompt was tested without T5.
+It produced a coherent astronaut but missed the requested red-panda subject.
+The full three-encoder path produced the requested composition in 66.25 seconds
+with a 4.76 GiB MLX allocator peak during the staged run. Rapid therefore keeps
+T5 enabled by default and does not expose a lower-quality no-T5 mode in this PR.
+
+After the allocator/cache cleanup fixes, a same-process 256×256 / 2-step
+runtime smoke completed twice in 2.86 and 3.00 seconds with callbacks 1/2 and
+2/2 on both runs. A fault-injection run then cancelled at the first denoise
+callback; the same runtime instance recovered and completed the next render.
+These short runs validate repeatability and cancellation recovery, not visual
+quality or the product's fixed 28-step schedule.
+
+## Safety, reproducibility, and packaging
+
+- Every consumed file is revision-pinned and allowlisted. An incomplete
+  primary or auxiliary snapshot fails before model construction.
+- The runtime receives only verified local directories; `from_pretrained` is
+  local-only and no remote model code is trusted or executed.
+- The Desktop sidecar imports the SD3.5 adapter and SentencePiece during its
+  build smoke, while continuing to assert that Torch, torchvision, and OpenCV
+  are absent.
+- The vendored numerical source retains its MIT license and exact provenance.
+  No model weights are redistributed by Rapid-MLX.
+- The model weights remain subject to the
+  [Stability AI Community License](https://stability.ai/license), including its
+  revenue threshold and Acceptable Use Policy. Users must confirm that those
+  terms cover their deployment.
+
+## Reference check (internal)
+
+- The primary inference-server precedents were checked for Stable Diffusion 3
+  pipeline structure, explicit stages, recommended sampling defaults, and
+  gated-model handling. Rapid retained its existing single-flight image lane
+  and OpenAI-compatible transport, adding only a family adapter.
+- MLX-native implementations were checked next for tensor mapping, quantized
+  checkpoint loading, staged encoder/model/VAE residency, and platform API
+  compatibility. The selected runtime was validated on MLX 0.32.1 and adapted
+  to current allocator and attention APIs.
+- The Desktop already has the appropriate dedicated Images workflow and generic
+  image-model catalog. The GUI change is intentionally limited to the model row
+  and its 28-step progress seed; no new interaction model was introduced.
+
+## Non-goals retained
+
+This work does not add image-to-image, ControlNet, LoRA, arbitrary SD3-family
+checkpoints, a no-T5 quality toggle, training, release, or deployment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -525,15 +525,18 @@ image = [
     # coexist with the coherence-validated core runtime. Keep a minor cap so
     # image-lane API changes remain deliberate. mflux requires Python >=3.11
     # (Rapid-MLX core still supports 3.10, so the image lane preflight gives
-    # 3.10 users an explicit upgrade diagnostic). Only commercially
-    # permissive model families are wired.
+    # 3.10 users an explicit upgrade diagnostic). Model-weight licenses are
+    # independent of this runtime and documented per family.
     "mflux>=0.19.0,<0.20; platform_system == 'Darwin' and python_version >= '3.11'",
     # HiDream-O1 reuses the exact Qwen3-VL runtime already validated and
     # bundled by Desktop. Keep this pin coherent with [vision]/the sidecar.
     "mlx-vlm==0.6.17; platform_system == 'Darwin' and python_version >= '3.11'",
     # The vendored SDXL backend needs Pillow for PNG encoding. Keep this direct
-    # because SDXL also works on Rapid's Python 3.10 floor without mflux.
+    # because SDXL and SD3.5 also work on Rapid's Python 3.10 floor without
+    # mflux. SD3.5's reviewed local T5 tokenizer additionally needs
+    # sentencepiece on that same floor.
     "pillow>=10.0.0; platform_system == 'Darwin'",
+    "sentencepiece>=0.2.0; platform_system == 'Darwin'",
 ]
 
 [project.urls]
@@ -590,6 +593,9 @@ vllm_mlx = [
     # wheel and Desktop sidecar that contains the adapted MIT source.
     "image/bonsai_runtime/LICENSE",
     "image/bonsai_runtime/NOTICE",
+    # Vendored SD3.5 MLX runtime attribution must ship beside the MIT source.
+    "image/sd35_runtime/LICENSE",
+    "image/sd35_runtime/NOTICE",
 ]
 videox_fun_mlx = ["LICENSE", "NOTICE"]
 
@@ -682,6 +688,9 @@ ignore = [
 # Adapted verbatim from the pinned low-bit runtime. Keep exceptions confined
 # to _vendor; the checkpoint validation and product adapter stay strict.
 "vllm_mlx/image/bonsai_runtime/_vendor/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
+# Pinned DiffusionKit numerical core. Rapid-owned adapter/runtime.py stays
+# linted; only the source-shaped vendor directory receives exceptions.
+"vllm_mlx/image/sd35_runtime/_vendor/**/*.py" = ["UP", "B", "SIM", "N", "F", "I", "E", "W"]
 # Tensor-shape parameter names (B, H, N, D) follow ML literature
 # convention; N803 lowercase rule is incompatible.
 "scripts/bench_attention.py" = ["N803"]
@@ -705,6 +714,12 @@ ignore_missing_imports = true
 # Exact third-party numerical core; Rapid-owned runtime.py remains under the
 # repository-wide shrink-only error budget.
 module = "vllm_mlx.image.bonsai_runtime._vendor.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+# Pinned third-party numerical core; keep the Rapid-owned SD3.5 adapter under
+# the repository-wide shrink-only error budget.
+module = "vllm_mlx.image.sd35_runtime._vendor.*"
 ignore_errors = true
 
 [tool.pytest.ini_options]

--- a/scripts/gen_model_sizes.py
+++ b/scripts/gen_model_sizes.py
@@ -86,6 +86,7 @@ def _size_one(repo_id: str) -> tuple[str, int | None]:
         IMAGE_MODEL_DATA_FILES,
         IMAGE_MODEL_REVISIONS,
         estimate_repo_size_bytes,
+        image_runtime_assets_for,
     )
 
     data_files = IMAGE_MODEL_DATA_FILES.get(repo_id)
@@ -97,20 +98,27 @@ def _size_one(repo_id: str) -> tuple[str, int | None]:
         try:
             from huggingface_hub import model_info
 
-            info = model_info(
-                repo_id,
-                revision=IMAGE_MODEL_REVISIONS[repo_id],
-                files_metadata=True,
-                timeout=5,
+            payloads = (
+                (repo_id, IMAGE_MODEL_REVISIONS[repo_id], data_files),
+                *image_runtime_assets_for(repo_id),
             )
-            sizes = {
-                sibling.rfilename: sibling.size
-                for sibling in (getattr(info, "siblings", None) or [])
-                if hasattr(sibling, "rfilename")
-            }
-            if any(path not in sizes or sizes[path] is None for path in data_files):
-                return repo_id, None
-            return repo_id, sum(int(sizes[path]) for path in data_files)
+            total = 0
+            for payload_repo, revision, allowlist in payloads:
+                info = model_info(
+                    payload_repo,
+                    revision=revision,
+                    files_metadata=True,
+                    timeout=5,
+                )
+                sizes = {
+                    sibling.rfilename: sibling.size
+                    for sibling in (getattr(info, "siblings", None) or [])
+                    if hasattr(sibling, "rfilename")
+                }
+                if any(path not in sizes or sizes[path] is None for path in allowlist):
+                    return repo_id, None
+                total += sum(int(sizes[path]) for path in allowlist)
+            return repo_id, total
         except Exception:
             return repo_id, None
 

--- a/tests/test_sd35_alias.py
+++ b/tests/test_sd35_alias.py
@@ -1,0 +1,605 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for the pinned, vendored SD3.5 Large image backend."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from vllm_mlx import _download_gate
+from vllm_mlx.image.engine import (
+    ImageGenerationCancelled,
+    ImageGenerationEngine,
+    ImageRuntimeError,
+    _detect_family,
+)
+from vllm_mlx.model_aliases import resolve_profile
+
+REPO = _download_gate.SD35_REPO
+REVISION = _download_gate.SD35_REVISION
+
+
+def test_sd35_alias_is_first_class_image_generation_model() -> None:
+    profile = resolve_profile("sd35-large-4bit")
+    assert profile is not None
+    assert profile.hf_path == REPO
+    assert profile.modality == "image-gen"
+    assert profile.min_memory_gb == 32
+
+    engine = ImageGenerationEngine(REPO)
+    assert engine.family == "sd35-large"
+    assert engine.default_steps == 28
+    assert engine._prequantized is True  # noqa: SLF001
+    assert engine.supports_generation is True
+    assert engine.supports_editing is False
+    assert engine.supports_negative_prompt is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["sd35-large-4bit", REPO, "/models/my_sd3.5_checkpoint"],
+)
+def test_sd35_family_detection(name: str) -> None:
+    assert _detect_family(name) == "sd35-large"
+
+
+def test_sd35_alias_has_composite_size_and_native_catalog_adapter() -> None:
+    sizes = json.loads(
+        (Path(__file__).parents[1] / "vllm_mlx/model_sizes.json").read_text()
+    )["sizes"]
+    assert sizes[REPO] == 16_378_940_179
+
+    from vllm_mlx.catalog.legacy import _main_capabilities
+
+    capabilities = _main_capabilities(resolve_profile("sd35-large-4bit"))
+    assert capabilities["runtime_adapter"] == "rapid_mlx/sd35"
+    assert capabilities["operation_modes"] == ["text_to_image"]
+
+
+def test_size_generator_sums_primary_and_pinned_runtime_assets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import huggingface_hub
+
+    from scripts import gen_model_sizes
+
+    payloads = (
+        (REPO, REVISION, _download_gate.SD35_DATA_FILES),
+        (
+            _download_gate.SD35_SHARED_REPO,
+            _download_gate.SD35_SHARED_REVISION,
+            _download_gate.SD35_SHARED_DATA_FILES,
+        ),
+        (
+            _download_gate.SD35_T5_TOKENIZER_REPO,
+            _download_gate.SD35_T5_TOKENIZER_REVISION,
+            _download_gate.SD35_T5_TOKENIZER_DATA_FILES,
+        ),
+    )
+    metadata = {
+        repo: SimpleNamespace(
+            siblings=[
+                SimpleNamespace(rfilename=path, size=index + 1)
+                for index, path in enumerate(files)
+            ]
+        )
+        for repo, _revision, files in payloads
+    }
+    calls = []
+
+    def model_info(repo, **kwargs):
+        calls.append((repo, kwargs))
+        return metadata[repo]
+
+    monkeypatch.setattr(huggingface_hub, "model_info", model_info)
+    expected = sum(sum(range(1, len(files) + 1)) for _, _, files in payloads)
+    assert gen_model_sizes._size_one(REPO) == (REPO, expected)
+    assert calls == [
+        (
+            repo,
+            {"revision": revision, "files_metadata": True, "timeout": 5},
+        )
+        for repo, revision, _files in payloads
+    ]
+
+
+def _seed_snapshot(root: Path, files: tuple[str, ...], *, omit: str | None = None):
+    for relative in files:
+        if relative == omit:
+            continue
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+
+
+def _snapshot_root(cache: Path, repo: str, revision: str) -> Path:
+    return cache / f"models--{repo.replace('/', '--')}" / "snapshots" / revision
+
+
+def test_sd35_snapshot_requires_primary_and_every_auxiliary_asset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import huggingface_hub.constants
+
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+    payloads = (
+        (REPO, REVISION, _download_gate.SD35_DATA_FILES),
+        (
+            _download_gate.SD35_SHARED_REPO,
+            _download_gate.SD35_SHARED_REVISION,
+            _download_gate.SD35_SHARED_DATA_FILES,
+        ),
+        (
+            _download_gate.SD35_T5_TOKENIZER_REPO,
+            _download_gate.SD35_T5_TOKENIZER_REVISION,
+            _download_gate.SD35_T5_TOKENIZER_DATA_FILES,
+        ),
+    )
+    roots = []
+    for repo, revision, files in payloads:
+        root = _snapshot_root(tmp_path, repo, revision)
+        roots.append(root)
+        _seed_snapshot(root, files)
+
+    assert _download_gate.mflux_missing_weights(REPO) == []
+    assert _download_gate.mflux_local_snapshot(REPO) == str(roots[0])
+
+    (roots[1] / _download_gate.SD35_SHARED_DATA_FILES[-1]).unlink()
+    assert _download_gate.mflux_missing_weights(REPO) == [
+        f"{_download_gate.SD35_SHARED_REPO}@{_download_gate.SD35_SHARED_REVISION}"
+    ]
+    assert _download_gate.mflux_local_snapshot(REPO) is None
+
+
+def test_pinned_snapshot_fails_closed_for_unavailable_or_unsafe_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import builtins
+    import os
+
+    import huggingface_hub.constants
+
+    assert _download_gate.pinned_image_snapshot("publisher/not-registered") is None
+
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "huggingface_hub.constants":
+            raise ImportError("hub constants unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    assert _download_gate.pinned_image_snapshot(REPO) is None
+    monkeypatch.setattr(builtins, "__import__", real_import)
+
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+    assert _download_gate.pinned_image_snapshot(REPO) is None
+
+    snapshot = _snapshot_root(tmp_path, REPO, REVISION)
+    _seed_snapshot(snapshot, _download_gate.SD35_DATA_FILES)
+    outside = tmp_path / "outside.safetensors"
+    outside.write_bytes(b"x")
+    first = snapshot / _download_gate.SD35_DATA_FILES[0]
+    first.unlink()
+    first.symlink_to(outside)
+    assert _download_gate.pinned_image_snapshot(REPO) is None
+
+    first.unlink()
+    first.write_bytes(b"x")
+    monkeypatch.setattr(
+        os.path, "getsize", lambda _path: (_ for _ in ()).throw(OSError())
+    )
+    assert _download_gate.pinned_image_snapshot(REPO) is None
+
+
+@pytest.mark.parametrize("requested", [REPO, "sd35-large-4bit"])
+def test_pull_fetches_all_three_exact_allowlisted_snapshots(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], requested: str
+) -> None:
+    from vllm_mlx import cli
+
+    calls = []
+    monkeypatch.setattr(
+        cli,
+        "_pull_repository",
+        lambda args, **kwargs: calls.append((args.model, kwargs)),
+    )
+    monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
+    cli.pull_command(SimpleNamespace(model=requested))
+
+    assert "Stability AI Community License" in capsys.readouterr().out
+
+    assert calls == [
+        (
+            REPO,
+            {
+                "allow_patterns_override": list(_download_gate.SD35_DATA_FILES),
+                "revision_override": REVISION,
+            },
+        ),
+        (
+            _download_gate.SD35_SHARED_REPO,
+            {
+                "allow_patterns_override": list(_download_gate.SD35_SHARED_DATA_FILES),
+                "revision_override": _download_gate.SD35_SHARED_REVISION,
+            },
+        ),
+        (
+            _download_gate.SD35_T5_TOKENIZER_REPO,
+            {
+                "allow_patterns_override": list(
+                    _download_gate.SD35_T5_TOKENIZER_DATA_FILES
+                ),
+                "revision_override": _download_gate.SD35_T5_TOKENIZER_REVISION,
+            },
+        ),
+    ]
+
+
+def test_engine_ensures_only_missing_pinned_runtime_assets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import huggingface_hub
+
+    engine = ImageGenerationEngine(REPO)
+    calls = []
+    monkeypatch.setattr(
+        _download_gate,
+        "pinned_image_snapshot",
+        lambda repo: "/cached" if repo == _download_gate.SD35_SHARED_REPO else None,
+    )
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda repo, **kwargs: calls.append((repo, kwargs)) or "/downloaded",
+    )
+    engine._ensure_runtime_assets()  # noqa: SLF001
+    assert calls == [
+        (
+            _download_gate.SD35_T5_TOKENIZER_REPO,
+            {
+                "revision": _download_gate.SD35_T5_TOKENIZER_REVISION,
+                "allow_patterns": list(_download_gate.SD35_T5_TOKENIZER_DATA_FILES),
+            },
+        )
+    ]
+
+
+def test_engine_runtime_asset_download_is_local_noop_and_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    local_model = tmp_path / "sd3.5-local"
+    local_model.mkdir()
+    ImageGenerationEngine(str(local_model))._ensure_runtime_assets()  # noqa: SLF001
+
+    import huggingface_hub
+
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(_download_gate, "pinned_image_snapshot", lambda _repo: None)
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+    with pytest.raises(ImageRuntimeError, match="Could not download.*offline"):
+        engine._ensure_runtime_assets()  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [_download_gate.SD35_SHARED_REPO, _download_gate.SD35_T5_TOKENIZER_REPO],
+)
+def test_direct_pull_of_an_auxiliary_repo_keeps_generic_semantics(
+    monkeypatch: pytest.MonkeyPatch, repo: str
+) -> None:
+    from vllm_mlx import cli
+
+    calls = []
+    monkeypatch.setattr(
+        cli, "_pull_repository", lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(cli, "_emit_pull_activation", lambda: None)
+    args = SimpleNamespace(model=repo)
+    cli.pull_command(args)
+
+    assert calls == [((args,), {})]
+
+
+@pytest.mark.requires_mlx
+def test_runtime_accepts_only_complete_local_assets_and_forwards_generation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from vllm_mlx.image.sd35_runtime import runtime
+
+    model = tmp_path / "model"
+    shared = tmp_path / "shared"
+    t5 = tmp_path / "t5"
+    _seed_snapshot(model, runtime.MODEL_FILES)
+    _seed_snapshot(shared, runtime.SHARED_FILES)
+    _seed_snapshot(t5, runtime.T5_TOKENIZER_FILES)
+    (model / "config.json").write_text(
+        json.dumps({"name": "stable-diffusion-3.5-large-4bit-quantized"})
+    )
+    constructed = []
+    generated = []
+
+    class TinyPipeline:
+        def __init__(self, **kwargs):
+            constructed.append(kwargs)
+
+        def generate_image(self, **kwargs):
+            generated.append(kwargs)
+            return Image.new("RGB", (8, 8)), {"peak_memory": 1.0}
+
+    monkeypatch.setattr(runtime, "DiffusionPipeline", TinyPipeline)
+    progress = lambda *_args: None
+    adapter = runtime.SD35Large(model, shared, t5, on_step=progress)
+    result = adapter.generate_image(
+        prompt="fox",
+        height=512,
+        width=768,
+        num_inference_steps=28,
+        seed=7,
+        guidance=None,
+        negative_prompt="blurry",
+    )
+    assert result.image.size == (8, 8)
+    assert constructed == [
+        {
+            "w16": True,
+            "a16": True,
+            "shift": 3.0,
+            "use_t5": True,
+            "model_version": runtime.MODEL_REPO,
+            "low_memory_mode": True,
+            "local_ckpt": model / runtime.MODEL_FILENAME,
+            "on_step": progress,
+        }
+    ]
+    assert generated == [
+        {
+            "text": "fox",
+            "num_steps": 28,
+            "cfg_weight": 3.5,
+            "negative_text": "blurry",
+            "latent_size": (64, 96),
+            "seed": 7,
+            "verbose": False,
+        }
+    ]
+
+    with pytest.raises(ValueError, match="directory is missing"):
+        runtime._require_files(tmp_path / "absent", ("weight.safetensors",))
+
+    (model / "config.json").write_text(json.dumps({"name": "wrong-checkpoint"}))
+    with pytest.raises(ValueError, match="Unsupported SD3.5 checkpoint"):
+        runtime.SD35Large(model, shared, t5)
+    (model / "config.json").write_text(
+        json.dumps({"name": "stable-diffusion-3.5-large-4bit-quantized"})
+    )
+
+    (shared / runtime.SHARED_FILES[0]).unlink()
+    with pytest.raises(ValueError, match="missing"):
+        runtime.SD35Large(model, shared, t5)
+
+
+@pytest.mark.requires_mlx
+def test_runtime_accepts_hf_blob_symlinks_but_rejects_external_ones(
+    tmp_path: Path,
+) -> None:
+    from vllm_mlx.image.sd35_runtime import runtime
+    from vllm_mlx.image.sd35_runtime._vendor import model_io
+
+    repo_root = tmp_path / "models--publisher--model"
+    snapshot = repo_root / "snapshots" / "revision"
+    blob = repo_root / "blobs" / "abc"
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(b"x")
+    snapshot.mkdir(parents=True)
+    (snapshot / "weight.safetensors").symlink_to(blob)
+    runtime._require_files(snapshot, ("weight.safetensors",))
+    model_io.configure_asset_roots({"repo/model": snapshot}, t5_tokenizer_root=snapshot)
+    assert model_io._asset_path("repo/model", "weight.safetensors") == str(blob)
+
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"x")
+    (snapshot / "external.safetensors").symlink_to(outside)
+    with pytest.raises(ValueError, match="missing"):
+        runtime._require_files(snapshot, ("external.safetensors",))
+    with pytest.raises(FileNotFoundError, match="missing"):
+        model_io._asset_path("repo/model", "external.safetensors")
+
+
+@pytest.mark.requires_mlx
+@pytest.mark.parametrize("fail", [False, True])
+def test_t5_low_memory_scope_restores_the_callers_allocator_limit(
+    monkeypatch: pytest.MonkeyPatch, fail: bool
+) -> None:
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    from vllm_mlx.image.sd35_runtime._vendor.t5 import TransformerEncoder
+
+    class Layer:
+        def __call__(self, value, *, mask):
+            if fail:
+                raise RuntimeError("encoder failed")
+            return value
+
+    class Identity:
+        def __call__(self, value, *args):
+            return value if not args else None
+
+    encoder = TransformerEncoder.__new__(TransformerEncoder)
+    nn.Module.__init__(encoder)
+    encoder.low_memory_mode = True
+    encoder.layers = [Layer()]
+    encoder.ln = Identity()
+    encoder.relative_attention_bias = Identity()
+    calls = []
+
+    def set_memory_limit(limit):
+        calls.append(limit)
+        return 9 * 1024**3
+
+    monkeypatch.setattr(mx, "set_memory_limit", set_memory_limit)
+    if fail:
+        with pytest.raises(RuntimeError, match="encoder failed"):
+            encoder(mx.ones((1, 2, 3)))
+    else:
+        assert encoder(mx.ones((1, 2, 3))).shape == (1, 2, 3)
+    assert calls == [4 * 1024**3, 9 * 1024**3]
+
+
+@pytest.mark.requires_mlx
+def test_sd35_cancellation_restores_cached_modulation_weights() -> None:
+    import mlx.core as mx
+
+    from vllm_mlx.image.sd35_runtime._vendor.pipeline import sample_euler
+
+    class Sampler:
+        @staticmethod
+        def timestep(sigmas):
+            return sigmas
+
+    class Denoiser:
+        def __init__(self):
+            self.model = SimpleNamespace(sampler=Sampler(), activation_dtype=mx.float32)
+            self.cleared = 0
+
+        def cache_modulation_params(self, pooled, timesteps):
+            assert pooled == "pooled"
+
+        def clear_cache(self):
+            self.cleared += 1
+
+        def __call__(self, value, *_args, **_kwargs):
+            return mx.zeros_like(value)
+
+    denoiser = Denoiser()
+
+    def cancel(*_args):
+        raise ImageGenerationCancelled("cancelled")
+
+    with pytest.raises(ImageGenerationCancelled, match="cancelled"):
+        sample_euler(
+            denoiser,
+            mx.ones((1, 2)),
+            mx.array([1.0, 0.0]),
+            extra_args={"pooled_conditioning": "pooled"},
+            on_step=cancel,
+        )
+    assert denoiser.cleared == 1
+
+
+@pytest.mark.requires_mlx
+def test_engine_build_dispatch_progress_cancel_and_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.image import sd35_runtime
+
+    built = []
+
+    class TinySD35:
+        def __init__(self, model, shared, t5, *, on_step):
+            built.append((model, shared, t5, on_step))
+            self.calls = []
+
+        def generate_image(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(image=Image.new("RGB", (8, 8)))
+
+    monkeypatch.setattr(sd35_runtime, "SD35Large", TinySD35)
+    monkeypatch.setattr(
+        _download_gate,
+        "pinned_image_snapshot",
+        lambda repo: {
+            _download_gate.SD35_SHARED_REPO: "/shared",
+            _download_gate.SD35_T5_TOKENIZER_REPO: "/t5",
+        }.get(repo),
+    )
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(engine, "_model_path_for_mflux", lambda: "/model")
+    model = engine._build_model()  # noqa: SLF001
+    assert built == [
+        ("/model", "/shared", "/t5", engine._report_native_step)  # noqa: SLF001
+    ]
+
+    monkeypatch.setattr(_download_gate, "pinned_image_snapshot", lambda _repo: None)
+    with pytest.raises(ImageRuntimeError, match="requires its pinned model"):
+        engine._build_model()  # noqa: SLF001
+
+    engine._report_native_step(4, 28)  # noqa: SLF001
+    assert engine.progress_snapshot()["step"] == 4
+    monkeypatch.setattr(engine, "_is_cancelled", lambda: True)
+    with pytest.raises(ImageGenerationCancelled, match="cancelled"):
+        engine._report_native_step(5, 28)  # noqa: SLF001
+
+    monkeypatch.setattr(engine, "_is_cancelled", lambda: False)
+    monkeypatch.setattr(engine, "_ensure_loaded", lambda **_kwargs: model)
+    png = engine.generate(
+        prompt="red panda astronaut",
+        negative_prompt="blurry",
+        width=512,
+        height=768,
+        num_inference_steps=28,
+        seed=11,
+        guidance=3.5,
+    )
+    assert png.startswith(b"\x89PNG")
+    assert model.calls == [
+        {
+            "height": 768,
+            "width": 512,
+            "seed": 11,
+            "prompt": "red panda astronaut",
+            "num_inference_steps": 28,
+            "guidance": 3.5,
+            "negative_prompt": "blurry",
+        }
+    ]
+
+    with pytest.raises(ImageRuntimeError, match="28-step"):
+        engine.generate(prompt="fox", width=512, height=512, num_inference_steps=4)
+    with pytest.raises(ImageRuntimeError, match="4096 characters"):
+        engine.generate(
+            prompt="x" * 4097, width=512, height=512, num_inference_steps=28
+        )
+    with pytest.raises(ImageRuntimeError, match="multiples of 16"):
+        engine.generate(prompt="fox", width=520, height=512, num_inference_steps=28)
+    with pytest.raises(ImageRuntimeError, match="between 256 and 1536"):
+        engine.generate(prompt="fox", width=2048, height=512, num_inference_steps=28)
+    with pytest.raises(ImageRuntimeError, match="guidance"):
+        engine.generate(
+            prompt="fox", width=512, height=512, num_inference_steps=28, guidance=21
+        )
+
+
+def test_sd35_preflight_uses_bundled_runtime_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.runtime import image_lane
+
+    probes = []
+    monkeypatch.setattr(
+        image_lane.importlib.util,
+        "find_spec",
+        lambda module: probes.append(module) or object(),
+    )
+    image_lane.require_image_runtime_or_exit(REPO)
+    assert probes == ["PIL"]
+
+
+def test_vendored_runtime_provenance_and_model_license_boundary() -> None:
+    root = Path(__file__).parents[1] / "vllm_mlx/image/sd35_runtime"
+    assert "498e5dba5fb48b0f01cb6b5c2292a6dbea67a317" in (root / "NOTICE").read_text()
+    assert "MIT License" in (root / "LICENSE").read_text()
+    assert not list(root.rglob("*.safetensors"))
+    assert (
+        "no model weights are distributed"
+        in (Path(__file__).parents[1] / "NOTICE").read_text().casefold()
+    )

--- a/tests/test_sidecar_distribution_constraints.py
+++ b/tests/test_sidecar_distribution_constraints.py
@@ -37,6 +37,7 @@ def test_emitted_constraints_are_stable_and_complete(constraints) -> None:
         "transformers==5.15.1",
         "mlx-vlm==0.6.17",
         "mflux==0.19.0",
+        "sentencepiece==0.2.2",
         "mlx-video-with-audio==0.1.36",
         "mlx-arsenal==0.12.1",
     ]

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1365,6 +1365,33 @@ SDXL_DATA_FILES = (
     "vae/config.json",
     "vae/diffusion_pytorch_model.fp16.safetensors",
 )
+SD35_REPO = "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized"
+SD35_REVISION = "0f92f6c2a9f9e1abc6738209e87ac22b049a7d26"
+SD35_DATA_FILES = (
+    "config.json",
+    "sd3.5_large_4bit_quantized.safetensors",
+)
+SD35_SHARED_REPO = "argmaxinc/stable-diffusion"
+SD35_SHARED_REVISION = "7b7a9946015fe6ae602464dfc026c19f6b6306f9"
+SD35_SHARED_DATA_FILES = (
+    "clip_l/config.json",
+    "clip_l/model.fp16.safetensors",
+    "clip_g/config.json",
+    "clip_g/model.fp16.safetensors",
+    "tokenizer_l/vocab.json",
+    "tokenizer_l/merges.txt",
+    "tokenizer_g/vocab.json",
+    "tokenizer_g/merges.txt",
+    "t5/t5xxl.safetensors",
+)
+SD35_T5_TOKENIZER_REPO = "google/t5-v1_1-xxl"
+SD35_T5_TOKENIZER_REVISION = "3db67ab1af984cf10548a73467f0e5bca2aaaeb2"
+SD35_T5_TOKENIZER_DATA_FILES = (
+    "config.json",
+    "special_tokens_map.json",
+    "spiece.model",
+    "tokenizer_config.json",
+)
 
 BONSAI_IMAGE_REPO = "prism-ml/bonsai-image-ternary-4B-mlx-2bit"
 BONSAI_IMAGE_REVISION = "2c24c81b934a658ba5590cf39088ba929985b4a8"
@@ -1400,6 +1427,7 @@ IMAGE_MODEL_DATA_FILES: dict[str, tuple[str, ...]] = {
     HIDREAM_O1_REPO: HIDREAM_O1_DATA_FILES,
     SDXL_REPO: SDXL_DATA_FILES,
     BONSAI_IMAGE_REPO: BONSAI_IMAGE_DATA_FILES,
+    SD35_REPO: SD35_DATA_FILES,
 }
 
 IMAGE_MODEL_REVISIONS: dict[str, str] = {
@@ -1408,7 +1436,72 @@ IMAGE_MODEL_REVISIONS: dict[str, str] = {
     HIDREAM_O1_REPO: HIDREAM_O1_REVISION,
     SDXL_REPO: SDXL_REVISION,
     BONSAI_IMAGE_REPO: BONSAI_IMAGE_REVISION,
+    SD35_REPO: SD35_REVISION,
 }
+
+# Some native image checkpoints intentionally reuse separately published text
+# assets. Each dependency is pinned and allowlisted exactly like the primary;
+# runtime code receives only verified local snapshot directories.
+IMAGE_MODEL_RUNTIME_ASSETS: dict[str, tuple[tuple[str, str, tuple[str, ...]], ...]] = {
+    SD35_REPO: (
+        (SD35_SHARED_REPO, SD35_SHARED_REVISION, SD35_SHARED_DATA_FILES),
+        (
+            SD35_T5_TOKENIZER_REPO,
+            SD35_T5_TOKENIZER_REVISION,
+            SD35_T5_TOKENIZER_DATA_FILES,
+        ),
+    )
+}
+
+
+def image_runtime_assets_for(
+    repo_id: str,
+) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
+    """Pinned auxiliary data repositories required by an image checkpoint."""
+
+    return IMAGE_MODEL_RUNTIME_ASSETS.get(repo_id, ())
+
+
+def pinned_image_snapshot(repo_id: str) -> str | None:
+    """Return a complete exact-revision image-data snapshot, else ``None``."""
+
+    revision = IMAGE_MODEL_REVISIONS.get(repo_id)
+    files = IMAGE_MODEL_DATA_FILES.get(repo_id)
+    if revision is None or files is None:
+        # Auxiliary repos intentionally stay OUT of IMAGE_MODEL_DATA_FILES:
+        # registering them as primary models would make a direct
+        # ``rapid-mlx pull <aux-repo>`` silently fetch only this backend's
+        # subset instead of preserving the generic whole-repository behavior.
+        for assets in IMAGE_MODEL_RUNTIME_ASSETS.values():
+            for asset_repo, asset_revision, asset_files in assets:
+                if asset_repo == repo_id:
+                    revision, files = asset_revision, asset_files
+                    break
+            if revision is not None and files is not None:
+                break
+    if revision is None or files is None:
+        return None
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+    except ImportError:
+        return None
+    repo_root = os.path.realpath(
+        os.path.join(HF_HUB_CACHE, f"models--{repo_id.replace('/', '--')}")
+    )
+    snapshot = os.path.join(repo_root, "snapshots", revision)
+    if not os.path.isdir(snapshot):
+        return None
+    for relative in files:
+        candidate = os.path.join(snapshot, *relative.split("/"))
+        real = os.path.realpath(candidate)
+        if real != repo_root and not real.startswith(repo_root + os.sep):
+            return None
+        try:
+            if not os.path.isfile(candidate) or os.path.getsize(candidate) <= 0:
+                return None
+        except OSError:
+            return None
+    return snapshot
 
 
 def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
@@ -1569,11 +1662,15 @@ def mflux_missing_weights(repo_id: str) -> list[str] | None:
         # Vendored backends have an explicit, revision-pinned data contract
         # rather than an mflux component index. Validate every consumed file;
         # repository scripts and samples are deliberately never downloaded.
-        return [
+        missing = [
             relative
             for relative in runtime_data_files
             if not _is_nonempty_repo_file(os.path.join(snap_dir, *relative.split("/")))
         ]
+        for asset_repo, revision, _files in image_runtime_assets_for(repo_id):
+            if pinned_image_snapshot(asset_repo) is None:
+                missing.append(f"{asset_repo}@{revision}")
+        return missing
 
     # All currently supported mflux families use these three components and a
     # local tokenizer. Requiring the full set prevents an interrupted pull with

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -2032,6 +2032,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 16
   },
+  "sd35-large-4bit": {
+    "hf_path": "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 32
+  },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",
     "tool_call_parser": null,

--- a/vllm_mlx/catalog/legacy.py
+++ b/vllm_mlx/catalog/legacy.py
@@ -36,6 +36,8 @@ def _main_capabilities(profile: Any) -> dict[str, Any]:
         folded_hf_path = profile.hf_path.casefold()
         if "hidream-o1" in folded_hf_path:
             adapter = "rapid_mlx/hidream_o1"
+        elif "stable-diffusion-3.5" in folded_hf_path:
+            adapter = "rapid_mlx/sd35"
         elif "stable-diffusion-xl" in folded_hf_path:
             adapter = "rapid_mlx/sdxl"
         elif "bonsai-image" in folded_hf_path:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -7715,6 +7715,8 @@ def pull_command(args):
     from vllm_mlx._download_gate import (
         IMAGE_MODEL_DATA_FILES,
         IMAGE_MODEL_REVISIONS,
+        SD35_REPO,
+        image_runtime_assets_for,
     )
     from vllm_mlx.audio.registry import runtime_assets_for, runtime_requirements_for
     from vllm_mlx.audio.runtime_requirements import (
@@ -7737,6 +7739,13 @@ def pull_command(args):
         primary_args.model = resolved_primary
         primary_repo = resolved_primary
 
+    if primary_repo == SD35_REPO:
+        print(
+            "\n  Model terms: Stable Diffusion 3.5 weights are subject to the "
+            "Stability AI Community License and Acceptable Use Policy. Review "
+            "https://stability.ai/license before commercial or hosted use."
+        )
+
     if primary_repo in IMAGE_MODEL_DATA_FILES:
         _pull_repository(
             primary_args,
@@ -7745,6 +7754,18 @@ def pull_command(args):
         )
     else:
         _pull_repository(primary_args)
+    for asset_repo, revision, allow_patterns in image_runtime_assets_for(primary_repo):
+        print(f"\n  Runtime assets: {asset_repo}")
+        dependency_args = copy.copy(args)
+        dependency_args.model = asset_repo
+        dependency_args._original_alias = asset_repo
+        dependency_args.bits = None
+        dependency_args.format = None
+        _pull_repository(
+            dependency_args,
+            allow_patterns_override=list(allow_patterns),
+            revision_override=revision,
+        )
     for asset in runtime_assets_for(primary_repo):
         if asset.repo_id == primary_repo:
             continue

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """MLX-native image generation engine.
 
-Thin wrapper over `mflux <https://github.com/filipstrand/mflux>`_ — an
-MLX-native, line-by-line port of the FLUX / Qwen-Image model families with
-built-in 4/8-bit quantization. Rapid-MLX owns request validation, the lazy
-load / process-lock lifecycle and the OpenAI-compatible transport; mflux owns
-the diffusion pipeline and weight loading.
+Unified adapter over mflux and the pinned native MLX runtimes used by image
+families outside mflux. Rapid-MLX owns request validation, the lazy-load /
+process-lock lifecycle, checkpoint boundaries, and the OpenAI-compatible
+transport; each family backend owns its diffusion pipeline and weight loading.
 
-Only commercially permissive families are wired here so the whole surface
-stays commercially clean:
+Each wired family has an explicit runtime and model-license contract. Some
+checkpoints are permissive; others require the user to accept model-specific
+terms before commercial use:
 
 * ``flux2-klein``      — text→image + image edit (``FLUX.2-klein-4B``),
   4B/4-step, the fast default: ~3 s @ 512² / ~10 s @ 1024² on an M3 Ultra,
@@ -24,6 +24,8 @@ stays commercially clean:
   30-step, dual-CLIP + UNet + VAE pipeline (OpenRAIL++)
 * ``bonsai-image``     — text→image (ternary ``FLUX.2-klein-4B``), 4-step,
   prepacked MLX 2-bit transformer with a 4-bit Qwen3 encoder (Apache-2.0)
+* ``sd35-large``       — text→image (``Stable Diffusion 3.5 Large``), 28-step,
+  triple-encoder MMDiT pipeline (Stability AI Community License)
 
 ``flux2-klein`` and ``z-image`` supersede the older/larger families for the
 interactive tab: Klein is ~3× faster than schnell/z-image at the same
@@ -38,6 +40,7 @@ from __future__ import annotations
 
 import gc
 import io
+import math
 import os
 import re
 import threading
@@ -117,6 +120,13 @@ def _detect_family(model_name: str) -> str:
         return "bonsai-image"
     if "hidream-o1" in name or "hidream_o1" in name:
         return "hidream-o1-dev"
+    if (
+        "stable-diffusion-3.5" in name
+        or "stable_diffusion_3.5" in name
+        or "sd3.5" in name
+        or "sd35" in name
+    ):
+        return "sd35-large"
     if "stable-diffusion-xl" in name or "sdxl" in name:
         return "sdxl-base"
     # Klein first — its repos ("FLUX.2-klein-4B-mflux-4bit") also contain
@@ -137,7 +147,7 @@ def _detect_family(model_name: str) -> str:
     raise ImageRuntimeError(
         f"Unsupported image model '{model_name}'. Supported families: "
         "flux2-klein, z-image, flux-schnell, qwen-image, qwen-image-edit, "
-        "hidream-o1-dev, sdxl-base, bonsai-image."
+        "hidream-o1-dev, sdxl-base, bonsai-image, sd35-large."
     )
 
 
@@ -160,6 +170,7 @@ _DEFAULT_STEPS_BY_FAMILY = {
     "hidream-o1-dev": 28,
     "sdxl-base": 30,
     "bonsai-image": 4,
+    "sd35-large": 28,
 }
 
 
@@ -203,6 +214,7 @@ class ImageGenerationEngine:
             "hidream-o1-dev",
             "sdxl-base",
             "bonsai-image",
+            "sd35-large",
         } or _looks_like_prequantized(model_name)
         # ``None`` when a backend owns its local checkpoint conversion, or when
         # the repo is already quantized. Passing a width for pre-quantized
@@ -325,6 +337,29 @@ class ImageGenerationEngine:
             if model_path is None:
                 raise ImageRuntimeError("SDXL requires a local model snapshot.")
             return SDXL(model_path, on_step=self._report_native_step)
+
+        if self.family == "sd35-large":
+            from .._download_gate import (
+                SD35_SHARED_REPO,
+                SD35_T5_TOKENIZER_REPO,
+                pinned_image_snapshot,
+            )
+            from .sd35_runtime import SD35Large
+
+            model_path = self._model_path_for_mflux()
+            shared_path = pinned_image_snapshot(SD35_SHARED_REPO)
+            t5_tokenizer_path = pinned_image_snapshot(SD35_T5_TOKENIZER_REPO)
+            if not model_path or not shared_path or not t5_tokenizer_path:
+                raise ImageRuntimeError(
+                    "SD3.5 Large requires its pinned model and text-encoder assets. "
+                    "Re-run the model download to finish them."
+                )
+            return SD35Large(
+                model_path,
+                shared_path,
+                t5_tokenizer_path,
+                on_step=self._report_native_step,
+            )
 
         from mflux.models.common.config.model_config import ModelConfig
 
@@ -474,6 +509,32 @@ class ImageGenerationEngine:
             "generating with it would produce noise rather than an image. "
             f"Missing: {', '.join(missing)}. Re-run the download to finish it."
         )
+
+    def _ensure_runtime_assets(self) -> None:
+        """Fetch pinned auxiliary image data needed by a vendored runtime."""
+        if Path(self.model_name).expanduser().is_dir():
+            return
+        from .._download_gate import image_runtime_assets_for, pinned_image_snapshot
+
+        assets = image_runtime_assets_for(self.model_name)
+        if not assets:
+            return
+        from huggingface_hub import snapshot_download
+
+        for repo_id, revision, allow_patterns in assets:
+            if pinned_image_snapshot(repo_id) is not None:
+                continue
+            try:
+                snapshot_download(
+                    repo_id,
+                    revision=revision,
+                    allow_patterns=list(allow_patterns),
+                )
+            except Exception as exc:  # noqa: BLE001 — clean runtime boundary
+                raise ImageRuntimeError(
+                    f"Could not download required image runtime assets "
+                    f"'{repo_id}' at pinned revision {revision}: {exc}"
+                ) from exc
 
     # Hidden size mflux hardcodes for the Qwen2 text encoder backing both
     # qwen-image and qwen-image-edit (``QwenEncoderLayer.__init__``'s
@@ -687,6 +748,7 @@ class ImageGenerationEngine:
             self._loaded_mode = None
             _release_allocator_cache()
         if self._model is None:
+            self._ensure_runtime_assets()
             self._verify_weights_complete()
             try:
                 self._model = (
@@ -829,6 +891,34 @@ class ImageGenerationEngine:
             if negative_prompt is not None:
                 raise ImageRuntimeError(
                     "Bonsai Image does not support negative_prompt."
+                )
+        elif self.family == "sd35-large":
+            if len(prompt) > 4096:
+                raise ImageRuntimeError(
+                    "SD3.5 Large prompts are limited to 4096 characters."
+                )
+            if num_inference_steps != 28:
+                raise ImageRuntimeError(
+                    "SD3.5 Large supports its validated 28-step schedule only."
+                )
+            if (
+                width is None
+                or height is None
+                or not (256 <= width <= 1536)
+                or not (256 <= height <= 1536)
+            ):
+                raise ImageRuntimeError(
+                    "SD3.5 Large dimensions must be between 256 and 1536 pixels."
+                )
+            if width % 16 or height % 16:
+                raise ImageRuntimeError(
+                    "SD3.5 Large dimensions must be multiples of 16."
+                )
+            if guidance is not None and (
+                not math.isfinite(guidance) or not (0.0 <= guidance <= 20.0)
+            ):
+                raise ImageRuntimeError(
+                    "SD3.5 Large guidance must be a finite value between 0 and 20."
                 )
 
         with self._lock:

--- a/vllm_mlx/image/sd35_runtime/LICENSE
+++ b/vllm_mlx/image/sd35_runtime/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Argmax, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vllm_mlx/image/sd35_runtime/NOTICE
+++ b/vllm_mlx/image/sd35_runtime/NOTICE
@@ -1,0 +1,8 @@
+SD3.5 MLX runtime source derived from DiffusionKit at commit
+498e5dba5fb48b0f01cb6b5c2292a6dbea67a317:
+https://github.com/argmaxinc/DiffusionKit
+
+Original work by Argmax, Inc. and contributors, released under the MIT License.
+Rapid-MLX modifications remove Torch/CoreML-only dependencies, require reviewed
+local asset roots, update the MLX attention API, expose progress/cancellation,
+and narrow the adapter to SD3.5 Large text-to-image generation.

--- a/vllm_mlx/image/sd35_runtime/__init__.py
+++ b/vllm_mlx/image/sd35_runtime/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MLX Stable Diffusion 3.5 Large runtime."""
+
+from .runtime import SD35Large
+
+__all__ = ["SD35Large"]

--- a/vllm_mlx/image/sd35_runtime/_vendor/__init__.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned third-party numerical core for the SD3.5 runtime."""

--- a/vllm_mlx/image/sd35_runtime/_vendor/clip.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/clip.py
@@ -1,0 +1,120 @@
+# reference: https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import CLIPTextModelConfig
+
+_ACTIVATIONS = {"quick_gelu": nn.gelu_fast_approx, "gelu": nn.gelu}
+
+
+@dataclass
+class CLIPOutput:
+    # The last_hidden_state indexed at the EOS token and possibly projected if
+    # the model has a projection layer
+    pooled_output: Optional[mx.array] = None
+
+    # The full sequence output of the transformer after the final layernorm
+    last_hidden_state: Optional[mx.array] = None
+
+    # A list of hidden states corresponding to the outputs of the transformer layers
+    hidden_states: Optional[List[mx.array]] = None
+
+
+class CLIPEncoderLayer(nn.Module):
+    """The transformer encoder layer from CLIP."""
+
+    def __init__(self, model_dims: int, num_heads: int, activation: str):
+        super().__init__()
+
+        self.layer_norm1 = nn.LayerNorm(model_dims)
+        self.layer_norm2 = nn.LayerNorm(model_dims)
+
+        self.attention = nn.MultiHeadAttention(model_dims, num_heads)
+        # Add biases to the attention projections to match CLIP
+        self.attention.query_proj.bias = mx.zeros(model_dims)
+        self.attention.key_proj.bias = mx.zeros(model_dims)
+        self.attention.value_proj.bias = mx.zeros(model_dims)
+        self.attention.out_proj.bias = mx.zeros(model_dims)
+
+        self.linear1 = nn.Linear(model_dims, 4 * model_dims)
+        self.linear2 = nn.Linear(4 * model_dims, model_dims)
+
+        self.act = _ACTIVATIONS[activation]
+
+    def __call__(self, x, attn_mask=None):
+        y = self.layer_norm1(x)
+        y = self.attention(y, y, y, attn_mask)
+        x = y + x
+
+        y = self.layer_norm2(x)
+        y = self.linear1(y)
+        y = self.act(y)
+        y = self.linear2(y)
+        x = y + x
+
+        return x
+
+
+class CLIPTextModel(nn.Module):
+    """Implements the text encoder transformer from CLIP."""
+
+    def __init__(self, config: CLIPTextModelConfig):
+        super().__init__()
+
+        self.max_length = config.max_length
+
+        self.token_embedding = nn.Embedding(config.vocab_size, config.model_dims)
+        self.position_embedding = nn.Embedding(config.max_length, config.model_dims)
+        self.layers = [
+            CLIPEncoderLayer(config.model_dims, config.num_heads, config.hidden_act)
+            for i in range(config.num_layers)
+        ]
+        self.final_layer_norm = nn.LayerNorm(config.model_dims)
+
+        if config.projection_dim is not None:
+            self.text_projection = nn.Linear(
+                config.model_dims, config.projection_dim, bias=False
+            )
+
+    def _get_mask(self, N, dtype):
+        indices = mx.arange(N)
+        mask = indices[:, None] < indices[None]
+        mask = mask.astype(dtype) * (
+            -6e4 if (dtype == mx.bfloat16 or dtype == mx.float16) else -1e9
+        )
+        return mask
+
+    def __call__(self, x):
+        # Extract some shapes
+        B, N = x.shape
+        eos_tokens = x.argmax(-1)
+
+        # Compute the embeddings
+        x = self.token_embedding(x)
+        x = x + self.position_embedding.weight[:N]
+
+        # Compute the features from the transformer
+        mask = self._get_mask(N, x.dtype)
+        hidden_states = []
+        for l in self.layers:
+            x = l(x, mask)
+            hidden_states.append(x)
+
+        # Apply the final layernorm and return
+        x = self.final_layer_norm(x)
+        last_hidden_state = x
+
+        # Select the EOS token
+        pooled_output = x[mx.arange(len(x)), eos_tokens]
+        if "text_projection" in self:
+            pooled_output = self.text_projection(pooled_output)
+
+        return CLIPOutput(
+            pooled_output=pooled_output,
+            last_hidden_state=last_hidden_state,
+            hidden_states=hidden_states,
+        )

--- a/vllm_mlx/image/sd35_runtime/_vendor/config.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/config.py
@@ -1,0 +1,152 @@
+# reference: https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion
+
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
+#
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional, Tuple
+
+import mlx.core as mx
+
+
+class PositionalEncoding(Enum):
+    LearnedInputEmbedding = 1
+    PreSDPARope = 2
+
+
+@dataclass
+class MMDiTConfig:
+    """Multi-modal Diffusion Transformer Configuration"""
+
+    # Transformer spec
+    num_heads: int = 24
+    depth_multimodal: int = 24  # e.g. SD3: 24 (2b) or 38 (8b), FLUX.1: 19
+    depth_unified: int = 0  # e.g. SD3: 0 (2b and 8b),      FLUX.1: 38
+    parallel_mlp_for_unified_blocks: bool = (
+        True  # e.g. FLUX.1 unified blocks, https://arxiv.org/pdf/2302.05442
+    )
+    mlp_ratio: int = 4
+    vae_latent_dim: int = 16  # = in_channels = out_channels
+    layer_norm_eps: float = 1e-6
+    pos_embed_type: PositionalEncoding = PositionalEncoding.LearnedInputEmbedding
+    rope_axes_dim: Optional[Tuple[int]] = None
+    # FLUX uses RMSNorm post-QK projection
+    use_qk_norm: bool = False
+    upcast_multimodal_blocks: Optional[List[int]] = None
+    upcast_unified_blocks: Optional[List[int]] = None
+
+    # 64 * self.depth_multimodal is the SD3 convention, but can be overridden
+    hidden_size_override: Optional[int] = None
+
+    @property
+    def hidden_size(self) -> int:
+        return self.hidden_size_override or (64 * self.depth_multimodal)
+
+    # x: Latent image input spec
+    max_latent_resolution: int = 192
+    patch_size: int = 2
+    # If true, reshapes input to enact (patch_size, patch_size) space-to-depth operation
+    # If false, uses 2D convolution with kernel_size=patch_size and stride=patch_size
+    patchify_via_reshape: bool = False
+
+    # y: Text input spec
+    # e.g. SD3:    768 (CLIP-L/14) + 1280 (CLIP-G/14) = 2048
+    #      FLUX.1: 768 (CLIP-L/14)                    = 768
+    pooled_text_embed_dim: int = 2048
+    # e.g. SD3:  4096 (T5-XXL) = 768 (CLIP-L/14) + 1280 (CLIP-G/14) + 2048 (zero padding)
+    #      FLUX: 4096 (T5-XXL)
+    token_level_text_embed_dim: int = 4096
+
+    # t: Timestep input spec
+    frequency_embed_dim: int = 256
+    max_period: int = 10000
+
+    dtype: mx.Dtype = mx.bfloat16
+    float16_dtype: mx.Dtype = mx.bfloat16
+
+    low_memory_mode: bool = True
+
+    guidance_embed: bool = False
+
+
+SD3_8b = MMDiTConfig(
+    depth_multimodal=38, num_heads=38, upcast_multimodal_blocks=[35], use_qk_norm=True
+)
+
+SD3_2b = MMDiTConfig(
+    depth_multimodal=24, num_heads=24, float16_dtype=mx.float16, dtype=mx.float16
+)
+
+FLUX_SCHNELL = MMDiTConfig(
+    num_heads=24,
+    depth_multimodal=19,
+    depth_unified=38,
+    parallel_mlp_for_unified_blocks=True,
+    hidden_size_override=3072,
+    patchify_via_reshape=True,
+    pos_embed_type=PositionalEncoding.PreSDPARope,
+    rope_axes_dim=(16, 56, 56),
+    pooled_text_embed_dim=768,  # CLIP-L/14 only
+    use_qk_norm=True,
+    float16_dtype=mx.bfloat16,
+    dtype=mx.bfloat16,
+)
+
+FLUX_DEV = MMDiTConfig(
+    num_heads=24,
+    depth_multimodal=19,
+    depth_unified=38,
+    parallel_mlp_for_unified_blocks=True,
+    hidden_size_override=3072,
+    patchify_via_reshape=True,
+    pos_embed_type=PositionalEncoding.PreSDPARope,
+    rope_axes_dim=(16, 56, 56),
+    pooled_text_embed_dim=768,  # CLIP-L/14 only
+    use_qk_norm=True,
+    float16_dtype=mx.bfloat16,
+    guidance_embed=True,
+    dtype=mx.bfloat16,
+)
+
+
+@dataclass
+class AutoencoderConfig:
+    in_channels: int = 3
+    out_channels: int = 3
+    latent_channels_out: int = 8
+    latent_channels_in: int = 4
+    block_out_channels: Tuple[int] = (128, 256, 512, 512)
+    layers_per_block: int = 2
+    norm_num_groups: int = 32
+    scaling_factor: float = 0.18215
+
+
+@dataclass
+class VAEDecoderConfig:
+    in_channels: int = 16
+    out_channels: int = 3
+    block_out_channels: Tuple[int] = (128, 256, 512, 512)
+    layers_per_block: int = 3
+    resnet_groups: int = 32
+
+
+@dataclass
+class VAEEncoderConfig:
+    in_channels: int = 3
+    out_channels: int = 32
+    block_out_channels: Tuple[int] = (128, 256, 512, 512)
+    layers_per_block: int = 2
+    resnet_groups: int = 32
+
+
+@dataclass
+class CLIPTextModelConfig:
+    num_layers: int = 23
+    model_dims: int = 1024
+    num_heads: int = 16
+    max_length: int = 77
+    vocab_size: int = 49408
+    projection_dim: Optional[int] = None
+    hidden_act: str = "quick_gelu"

--- a/vllm_mlx/image/sd35_runtime/_vendor/mmdit.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/mmdit.py
@@ -1,0 +1,982 @@
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
+#
+
+# fmt: off
+
+from functools import partial
+import logging
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from typing import Dict, List, Optional, Tuple
+from mlx.utils import tree_map
+
+from .config import MMDiTConfig, PositionalEncoding
+
+logger = logging.getLogger(__name__)
+
+SDPA_FLASH_ATTN_THRESHOLD = 1024
+
+
+class MMDiT(nn.Module):
+    """Multi-modal Diffusion Transformer Architecture
+    as described in https://arxiv.org/abs/2403.03206
+    """
+
+    def __init__(self, config: MMDiTConfig):
+        super().__init__()
+        self.config = config
+
+        if config.guidance_embed:
+            self.guidance_in = MLPEmbedder(
+                in_dim=config.frequency_embed_dim, hidden_dim=config.hidden_size
+            )
+        else:
+            self.guidance_in = nn.Identity()
+
+        # Input adapters and embeddings
+        self.x_embedder = LatentImageAdapter(config)
+
+        if config.pos_embed_type == PositionalEncoding.LearnedInputEmbedding:
+            self.x_pos_embedder = LatentImagePositionalEmbedding(config)
+            self.pre_sdpa_rope = nn.Identity()
+        elif config.pos_embed_type == PositionalEncoding.PreSDPARope:
+            self.pre_sdpa_rope = RoPE(
+                theta=10000,
+                axes_dim=config.rope_axes_dim,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported positional encoding type: {config.pos_embed_type}"
+            )
+
+        self.y_embedder = PooledTextEmbeddingAdapter(config)
+        self.t_embedder = TimestepAdapter(config)
+        self.context_embedder = nn.Linear(
+            config.token_level_text_embed_dim,
+            config.hidden_size,
+        )
+
+        self.multimodal_transformer_blocks = [
+            MultiModalTransformerBlock(
+                config,
+                skip_text_post_sdpa=(i == config.depth_multimodal - 1)
+                and (config.depth_unified < 1),
+            )
+            for i in range(config.depth_multimodal)
+        ]
+
+        if config.depth_unified > 0:
+            self.unified_transformer_blocks = [
+                UnifiedTransformerBlock(config) for _ in range(config.depth_unified)
+            ]
+
+        self.final_layer = FinalLayer(config)
+
+    def cache_modulation_params(
+        self,
+        pooled_text_embeddings: mx.array,
+        timesteps: mx.array,
+    ):
+        """Compute modulation parameters ahead of time to reduce peak memory load during MMDiT inference
+        by offloading all adaLN_modulation parameters
+        """
+        y_embed = self.y_embedder(pooled_text_embeddings)
+        batch_size = pooled_text_embeddings.shape[0]
+
+        offload_size = 0
+        to_offload = []
+
+        for timestep in timesteps:
+            final_timestep = timestep.item() == timesteps[-1].item()
+            timestep_key = timestep.item()
+            modulation_inputs = y_embed[:, None, None, :] + self.t_embedder(
+                mx.repeat(timestep[None], batch_size, axis=0)
+            )
+
+            for block in self.multimodal_transformer_blocks:
+                if not hasattr(block.image_transformer_block, "_modulation_params"):
+                    block.image_transformer_block._modulation_params = dict()
+                    block.text_transformer_block._modulation_params = dict()
+
+                block.image_transformer_block._modulation_params[
+                    timestep_key
+                ] = block.image_transformer_block.adaLN_modulation(modulation_inputs)
+                block.text_transformer_block._modulation_params[
+                    timestep_key
+                ] = block.text_transformer_block.adaLN_modulation(modulation_inputs)
+                mx.eval(block.image_transformer_block._modulation_params[timestep_key])
+                mx.eval(block.text_transformer_block._modulation_params[timestep_key])
+
+                if final_timestep:
+                    offload_size += (
+                        block.image_transformer_block.adaLN_modulation.layers[
+                            1
+                        ].weight.size
+                        * block.image_transformer_block.adaLN_modulation.layers[
+                            1
+                        ].weight.dtype.size
+                    )
+                    offload_size += (
+                        block.text_transformer_block.adaLN_modulation.layers[
+                            1
+                        ].weight.size
+                        * block.text_transformer_block.adaLN_modulation.layers[
+                            1
+                        ].weight.dtype.size
+                    )
+                    to_offload.extend(
+                        [
+                            block.image_transformer_block.adaLN_modulation.layers[1],
+                            block.text_transformer_block.adaLN_modulation.layers[1],
+                        ]
+                    )
+
+            if self.config.depth_unified > 0:
+                for block in self.unified_transformer_blocks:
+                    if not hasattr(block.transformer_block, "_modulation_params"):
+                        block.transformer_block._modulation_params = dict()
+                    block.transformer_block._modulation_params[
+                        timestep_key
+                    ] = block.transformer_block.adaLN_modulation(modulation_inputs)
+                    mx.eval(block.transformer_block._modulation_params[timestep_key])
+
+                    if final_timestep:
+                        offload_size += (
+                            block.transformer_block.adaLN_modulation.layers[
+                                1
+                            ].weight.size
+                            * block.transformer_block.adaLN_modulation.layers[
+                                1
+                            ].weight.dtype.size
+                        )
+                        to_offload.extend(
+                            [block.transformer_block.adaLN_modulation.layers[1]]
+                        )
+
+            if not hasattr(self.final_layer, "_modulation_params"):
+                self.final_layer._modulation_params = dict()
+            self.final_layer._modulation_params[
+                timestep_key
+            ] = self.final_layer.adaLN_modulation(modulation_inputs)
+            mx.eval(self.final_layer._modulation_params[timestep_key])
+
+            if final_timestep:
+                offload_size += (
+                    self.final_layer.adaLN_modulation.layers[1].weight.size
+                    * self.final_layer.adaLN_modulation.layers[1].weight.dtype.size
+                )
+                to_offload.extend([self.final_layer.adaLN_modulation.layers[1]])
+
+        self.to_offload = to_offload
+        for x in self.to_offload:
+            x.update(tree_map(lambda _: mx.array([]), x.parameters()))
+            # x.clear()
+
+        logger.info(f"Cached modulation_params for timesteps={timesteps}")
+        logger.info(
+            f"Cached modulation_params will reduce peak memory by {(offload_size) / 1e9:.1f} GB"
+        )
+
+    def clear_modulation_params_cache(self):
+        for name, module in self.named_modules():
+            if hasattr(module, "_modulation_params"):
+                delattr(module, "_modulation_params")
+        logger.info("Cleared modulation_params cache")
+
+    def __call__(
+        self,
+        latent_image_embeddings: mx.array,
+        token_level_text_embeddings: mx.array,
+        timestep: mx.array,
+    ) -> mx.array:
+        batch, latent_height, latent_width, _ = latent_image_embeddings.shape
+        token_level_text_embeddings = self.context_embedder(token_level_text_embeddings)
+
+        if hasattr(self, "x_pos_embedder"):
+            latent_image_embeddings = self.x_embedder(
+                latent_image_embeddings
+            ) + self.x_pos_embedder(latent_image_embeddings)
+        else:
+            latent_image_embeddings = self.x_embedder(latent_image_embeddings)
+
+        latent_image_embeddings = latent_image_embeddings.reshape(
+            batch, -1, 1, self.config.hidden_size
+        )
+
+        if self.config.pos_embed_type == PositionalEncoding.PreSDPARope:
+            positional_encodings = self.pre_sdpa_rope(
+                text_sequence_length=token_level_text_embeddings.shape[1],
+                latent_image_resolution=(
+                    latent_height // self.config.patch_size,
+                    latent_width // self.config.patch_size,
+                ),
+            )
+        else:
+            positional_encodings = None
+
+        if self.config.guidance_embed:
+            timestep = self.guidance_in(self.t_embedder(timestep))
+
+        # MultiModalTransformer layers
+        if self.config.depth_multimodal > 0:
+            for bidx, block in enumerate(self.multimodal_transformer_blocks):
+                latent_image_embeddings, token_level_text_embeddings = block(
+                    latent_image_embeddings,
+                    token_level_text_embeddings,
+                    timestep,
+                    positional_encodings=positional_encodings,
+                )
+
+        # UnifiedTransformerBlock layers
+        if self.config.depth_unified > 0:
+            latent_unified_embeddings = mx.concatenate(
+                (token_level_text_embeddings, latent_image_embeddings), axis=1
+            )
+
+            for bidx, block in enumerate(self.unified_transformer_blocks):
+                latent_unified_embeddings = block(
+                    latent_unified_embeddings,
+                    timestep,
+                    positional_encodings=positional_encodings,
+                )
+
+            latent_image_embeddings = latent_unified_embeddings[
+                :, token_level_text_embeddings.shape[1] :, ...
+            ]
+
+        latent_image_embeddings = self.final_layer(
+            latent_image_embeddings,
+            timestep,
+        )
+
+        if self.config.patchify_via_reshape:
+            latent_image_embeddings = self.x_embedder.unpack(
+                latent_image_embeddings, (latent_height, latent_width)
+            )
+        else:
+            latent_image_embeddings = unpatchify(
+                latent_image_embeddings,
+                patch_size=self.config.patch_size,
+                target_height=latent_height,
+                target_width=latent_width,
+                vae_latent_dim=self.config.vae_latent_dim,
+            )
+        return latent_image_embeddings
+
+
+class LatentImageAdapter(nn.Module):
+    """Adapts the latent image input by:
+    - Patchifying to reduce sequence length by `config.patch_size ** 2`
+    - Projecting to `hidden_size`
+    """
+
+    def __init__(self, config: MMDiTConfig):
+        super().__init__()
+        self.config = config
+        in_dim = config.vae_latent_dim
+        kernel_size = stride = config.patch_size
+
+        if config.patchify_via_reshape:
+            in_dim *= config.patch_size**2
+            kernel_size = stride = 1
+
+        self.proj = nn.Conv2d(
+            in_dim,
+            config.hidden_size,
+            kernel_size,
+            stride,
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if self.config.patchify_via_reshape:
+            b, h_latent, w_latent, c = x.shape
+            p = self.config.patch_size
+            x = (
+                x.reshape(b, h_latent // p, p, w_latent // p, p, c)
+                .transpose(0, 1, 3, 5, 2, 4)
+                .reshape(b, h_latent // p, w_latent // p, -1)
+            )
+
+        return self.proj(x)
+
+    def unpack(self, x: mx.array, latent_image_resolution: Tuple[int]) -> mx.array:
+        """Unpacks the latent image embeddings to the original resolution
+        for `config.patchify_via_reshape` models
+        """
+        assert self.config.patchify_via_reshape
+
+        b = x.shape[0]
+        p = self.config.patch_size
+        h = latent_image_resolution[0] // p
+        w = latent_image_resolution[1] // p
+        x = (
+            x.reshape(
+                b, h, w, -1, p, p
+            )  # (b, hw, 1, (c*ph*pw)) -> (b, h, w, c, ph, pw)
+            .transpose(0, 1, 4, 2, 5, 3)  # (b, h, w, c, ph, pw) -> (b, h, ph, w, pw, c)
+            .reshape(b, h * p, w * p, -1)  # (b, h, ph, w, pw, c) -> (b, h*ph, w*pw, c)
+        )
+        return x
+
+
+class LatentImagePositionalEmbedding(nn.Module):
+    def __init__(self, config: MMDiTConfig):
+        super().__init__()
+        self.pos_embed = nn.Embedding(
+            num_embeddings=config.max_latent_resolution**2, dims=config.hidden_size
+        )
+        self.max_hw = config.max_latent_resolution
+        self.patch_size = config.patch_size
+        self.weight_shape = (1, self.max_hw, self.max_hw, config.hidden_size)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        b, h, w, _ = x.shape
+        assert h <= self.max_hw and w <= self.max_hw
+
+        h = h // self.patch_size
+        w = w // self.patch_size
+
+        # Center crop the positional embedding to match the input resolution
+        y0 = (self.max_hw - h) // 2
+        y1 = y0 + h
+        x0 = (self.max_hw - w) // 2
+        x1 = x0 + w
+
+        w = self.pos_embed.weight.reshape(*self.weight_shape)
+        w = w[:, y0:y1, x0:x1, :]
+        return mx.repeat(w, repeats=b, axis=0)
+
+
+class PooledTextEmbeddingAdapter(nn.Module):
+    def __init__(self, config: MMDiTConfig):
+        super().__init__()
+
+        d1, d2 = config.pooled_text_embed_dim, config.hidden_size
+        self.mlp = nn.Sequential(
+            nn.Linear(d1, d2),
+            nn.SiLU(),
+            nn.Linear(d2, d2),
+        )
+
+    def __call__(self, y: mx.array) -> mx.array:
+        return self.mlp(y)
+
+
+class TimestepAdapter(nn.Module):
+    def __init__(self, config: MMDiTConfig):
+        super().__init__()
+
+        d1, d2 = config.frequency_embed_dim, config.hidden_size
+        self.mlp = nn.Sequential(
+            nn.Linear(d1, d2),
+            nn.SiLU(),
+            nn.Linear(d2, d2),
+        )
+        self.config = config
+
+    def timestep_embedding(self, t: mx.array) -> mx.array:
+        half = self.config.frequency_embed_dim // 2
+
+        frequencies = mx.exp(
+            -mx.log(mx.array(self.config.max_period))
+            * mx.arange(start=0, stop=half, dtype=self.config.dtype)
+            / half
+        ).astype(self.config.dtype)
+
+        args = t[:, None].astype(self.config.dtype) * frequencies[None]
+        return mx.concatenate([mx.cos(args), mx.sin(args)], axis=-1)
+
+    def __call__(self, t: mx.array) -> mx.array:
+        return self.mlp(self.timestep_embedding(t)[:, None, None, :])
+
+
+class TransformerBlock(nn.Module):
+    def __init__(
+        self,
+        config: MMDiTConfig,
+        skip_post_sdpa: bool = False,
+        parallel_mlp: bool = False,
+        num_modulation_params: Optional[int] = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.parallel_mlp = parallel_mlp
+        self.skip_post_sdpa = skip_post_sdpa
+        self.per_head_dim = config.hidden_size // config.num_heads
+
+        self.norm1 = LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.attn = Attention(config.hidden_size, config.num_heads)
+        if not self.parallel_mlp:
+            # If parallel, reuse norm1 across attention and mlp
+            self.norm2 = LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+        if skip_post_sdpa:
+            self.attn.o_proj = nn.Identity()
+        else:
+            self.mlp = FFN(
+                embed_dim=config.hidden_size,
+                expansion_factor=config.mlp_ratio,
+                activation_fn=nn.GELU(),
+            )
+
+        if num_modulation_params is None:
+            num_modulation_params = 6
+            if skip_post_sdpa:
+                num_modulation_params = 2
+
+        self.num_modulation_params = num_modulation_params
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(
+                config.hidden_size, self.num_modulation_params * config.hidden_size
+            ),
+        )
+
+        if config.use_qk_norm:
+            self.qk_norm = QKNorm(config.hidden_size // config.num_heads)
+
+    def pre_sdpa(
+        self,
+        tensor: mx.array,
+        timestep: mx.array,
+    ) -> Dict[str, mx.array]:
+        if timestep.size > 1:
+            timestep = timestep[0]
+        modulation_params = self._modulation_params[timestep.item()]
+
+        modulation_params = mx.split(
+            modulation_params, self.num_modulation_params, axis=-1
+        )
+
+        post_norm1_shift = modulation_params[0]
+        post_norm1_residual_scale = modulation_params[1]
+
+        # LayerNorm and modulate before SDPA
+        try:
+            modulated_pre_attention = affine_transform(
+                tensor,
+                shift=post_norm1_shift,
+                residual_scale=post_norm1_residual_scale,
+                norm_module=self.norm1,
+            )
+        except Exception as e:
+            logger.error(
+                f"Error in pre_sdpa: {e}",
+                exc_info=True,
+            )
+            raise e
+
+        q = self.attn.q_proj(modulated_pre_attention)
+        k = self.attn.k_proj(modulated_pre_attention)
+        v = self.attn.v_proj(modulated_pre_attention)
+
+        batch = tensor.shape[0]
+
+        def rearrange_for_norm(t):
+            # Target data layout: (batch, head, seq_len, channel)
+            return t.reshape(
+                batch, -1, self.config.num_heads, self.per_head_dim
+            ).transpose(0, 2, 1, 3)
+
+        q = rearrange_for_norm(q)
+        k = rearrange_for_norm(k)
+        v = rearrange_for_norm(v)
+
+        if self.config.use_qk_norm:
+            q, k = self.qk_norm(q, k)
+
+        if self.config.depth_unified == 0:
+            q = q.transpose(0, 2, 1, 3).reshape(batch, -1, 1, self.config.hidden_size)
+            k = k.transpose(0, 2, 1, 3).reshape(batch, -1, 1, self.config.hidden_size)
+            v = v.transpose(0, 2, 1, 3).reshape(batch, -1, 1, self.config.hidden_size)
+
+        results = {"q": q, "k": k, "v": v}
+
+        results["modulated_pre_attention"] = modulated_pre_attention
+
+        assert len(modulation_params) in [2, 3, 6]
+        results.update(
+            {
+                "post_norm1_shift": post_norm1_shift,
+                "post_norm1_residual_scale": post_norm1_residual_scale,
+            }
+        )
+
+        if len(modulation_params) > 2:
+            results.update({"post_attn_scale": modulation_params[2]})
+
+        if len(modulation_params) > 3:
+            results.update(
+                {
+                    "post_norm2_shift": modulation_params[3],
+                    "post_norm2_residual_scale": modulation_params[4],
+                    "post_mlp_scale": modulation_params[5],
+                }
+            )
+
+        return results
+
+    def post_sdpa(
+        self,
+        residual: mx.array,
+        sdpa_output: mx.array,
+        modulated_pre_attention: mx.array,
+        post_attn_scale: Optional[mx.array] = None,
+        post_norm2_shift: Optional[mx.array] = None,
+        post_norm2_residual_scale: Optional[mx.array] = None,
+        post_mlp_scale: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        attention_out = self.attn.o_proj(sdpa_output)
+        if self.parallel_mlp:
+            # Reuse the modulation parameters and self.norm1 across attn and mlp
+            mlp_out = self.mlp(modulated_pre_attention)
+            return residual + post_attn_scale * (attention_out + mlp_out)
+        else:
+            residual = residual + attention_out * post_attn_scale
+            # Apply separate modulation parameters and LayerNorm across attn and mlp
+            mlp_out = self.mlp(
+                affine_transform(
+                    residual,
+                    shift=post_norm2_shift,
+                    residual_scale=post_norm2_residual_scale,
+                    norm_module=self.norm2,
+                )
+            )
+            return residual + post_mlp_scale * mlp_out
+
+    def __call__(self):
+        raise NotImplementedError("This module is not intended to be used directly")
+
+
+class MultiModalTransformerBlock(nn.Module):
+    def __init__(self, config: MMDiTConfig, skip_text_post_sdpa: bool = False):
+        super().__init__()
+        self.image_transformer_block = TransformerBlock(config)
+        self.text_transformer_block = TransformerBlock(
+            config, skip_post_sdpa=skip_text_post_sdpa
+        )
+
+        sdpa_impl = mx.fast.scaled_dot_product_attention
+        self.sdpa = partial(sdpa_impl)
+
+        self.config = config
+        self.per_head_dim = config.hidden_size // config.num_heads
+
+    def __call__(
+        self,
+        latent_image_embeddings: mx.array,  # latent image embeddings
+        token_level_text_embeddings: mx.array,  # token-level text embeddings
+        timestep: mx.array,  # pooled text embeddings + timestep embeddings
+        positional_encodings: mx.array = None,  # positional encodings for rope
+    ):
+        # Prepare multi-modal SDPA inputs
+        image_intermediates = self.image_transformer_block.pre_sdpa(
+            latent_image_embeddings,
+            timestep=timestep,
+        )
+
+        text_intermediates = self.text_transformer_block.pre_sdpa(
+            token_level_text_embeddings,
+            timestep=timestep,
+        )
+
+        batch = latent_image_embeddings.shape[0]
+
+        def rearrange_for_sdpa(t):
+            # Target data layout: (batch, head, seq_len, channel)
+            return t.reshape(
+                batch, -1, self.config.num_heads, self.per_head_dim
+            ).transpose(0, 2, 1, 3)
+
+        if self.config.depth_unified > 0:
+            multimodal_sdpa_inputs = {
+                "q": mx.concatenate(
+                    [text_intermediates["q"], image_intermediates["q"]], axis=2
+                ),
+                "k": mx.concatenate(
+                    [text_intermediates["k"], image_intermediates["k"]], axis=2
+                ),
+                "v": mx.concatenate(
+                    [text_intermediates["v"], image_intermediates["v"]], axis=2
+                ),
+                "scale": 1.0 / np.sqrt(self.per_head_dim),
+            }
+        else:
+            multimodal_sdpa_inputs = {
+                "q": rearrange_for_sdpa(
+                    mx.concatenate(
+                        [image_intermediates["q"], text_intermediates["q"]], axis=1
+                    )
+                ),
+                "k": rearrange_for_sdpa(
+                    mx.concatenate(
+                        [image_intermediates["k"], text_intermediates["k"]], axis=1
+                    )
+                ),
+                "v": rearrange_for_sdpa(
+                    mx.concatenate(
+                        [image_intermediates["v"], text_intermediates["v"]], axis=1
+                    )
+                ),
+                "scale": 1.0 / np.sqrt(self.per_head_dim),
+            }
+
+        if self.config.pos_embed_type == PositionalEncoding.PreSDPARope:
+            assert positional_encodings is not None
+            multimodal_sdpa_inputs["q"] = RoPE.apply(
+                multimodal_sdpa_inputs["q"], positional_encodings
+            )
+            multimodal_sdpa_inputs["k"] = RoPE.apply(
+                multimodal_sdpa_inputs["k"], positional_encodings
+            )
+
+        # Compute multi-modal SDPA
+        sdpa_outputs = (
+            self.sdpa(**multimodal_sdpa_inputs)
+            .transpose(0, 2, 1, 3)
+            .reshape(batch, -1, 1, self.config.hidden_size)
+        )
+
+        # Split into image-text sequences for post-SDPA layers
+        img_seq_len = latent_image_embeddings.shape[1]
+        txt_seq_len = token_level_text_embeddings.shape[1]
+
+        if self.config.depth_unified > 0:
+            text_sdpa_output = sdpa_outputs[:, :txt_seq_len, :, :]
+            image_sdpa_output = sdpa_outputs[:, txt_seq_len:, :, :]
+        else:
+            image_sdpa_output = sdpa_outputs[:, :img_seq_len, :, :]
+            text_sdpa_output = sdpa_outputs[:, -txt_seq_len:, :, :]
+
+        # Post-SDPA layers
+        latent_image_embeddings = self.image_transformer_block.post_sdpa(
+            residual=latent_image_embeddings,
+            sdpa_output=image_sdpa_output,
+            **image_intermediates,
+        )
+        if self.text_transformer_block.skip_post_sdpa:
+            # Text token related outputs from the final layer do not impact the model output
+            token_level_text_embeddings = None
+        else:
+            token_level_text_embeddings = self.text_transformer_block.post_sdpa(
+                residual=token_level_text_embeddings,
+                sdpa_output=text_sdpa_output,
+                **text_intermediates,
+            )
+
+        return latent_image_embeddings, token_level_text_embeddings
+
+
+class UnifiedTransformerBlock(nn.Module):
+    def __init__(self, config: MMDiTConfig):
+        super().__init__()
+        self.transformer_block = TransformerBlock(
+            config,
+            num_modulation_params=3 if config.parallel_mlp_for_unified_blocks else 6,
+            parallel_mlp=config.parallel_mlp_for_unified_blocks,
+        )
+
+        sdpa_impl = mx.fast.scaled_dot_product_attention
+        self.sdpa = partial(sdpa_impl)
+
+        self.config = config
+        self.per_head_dim = config.hidden_size // config.num_heads
+
+    def __call__(
+        self,
+        latent_unified_embeddings: mx.array,  # latent image embeddings
+        timestep: mx.array,  # pooled text embeddings + timestep embeddings
+        positional_encodings: mx.array = None,  # positional encodings for rope
+    ):
+        # Prepare multi-modal SDPA inputs
+        intermediates = self.transformer_block.pre_sdpa(
+            latent_unified_embeddings,
+            timestep=timestep,
+        )
+
+        batch = latent_unified_embeddings.shape[0]
+
+        def rearrange_for_sdpa(t):
+            # Target data layout: (batch, head, seq_len, channel)
+            return t.reshape(
+                batch, -1, self.config.num_heads, self.per_head_dim
+            ).transpose(0, 2, 1, 3)
+
+        multimodal_sdpa_inputs = {
+            "q": intermediates["q"],
+            "k": intermediates["k"],
+            "v": intermediates["v"],
+            "scale": 1.0 / np.sqrt(self.per_head_dim),
+        }
+
+        if self.config.pos_embed_type == PositionalEncoding.PreSDPARope:
+            assert positional_encodings is not None
+            multimodal_sdpa_inputs["q"] = RoPE.apply(
+                multimodal_sdpa_inputs["q"], positional_encodings
+            )
+            multimodal_sdpa_inputs["k"] = RoPE.apply(
+                multimodal_sdpa_inputs["k"], positional_encodings
+            )
+
+        # Compute multi-modal SDPA
+        sdpa_outputs = (
+            self.sdpa(**multimodal_sdpa_inputs)
+            .transpose(0, 2, 1, 3)
+            .reshape(batch, -1, 1, self.config.hidden_size)
+        )
+
+        # o_proj and mlp.fc2 uses the same bias, remove mlp.fc2 bias
+        self.transformer_block.mlp.fc2.bias = self.transformer_block.mlp.fc2.bias * 0.0
+
+        # Post-SDPA layers
+        latent_unified_embeddings = self.transformer_block.post_sdpa(
+            residual=latent_unified_embeddings,
+            sdpa_output=sdpa_outputs,
+            **intermediates,
+        )
+
+        return latent_unified_embeddings
+
+
+class QKNorm(nn.Module):
+    def __init__(self, head_dim):
+        super().__init__()
+        self.q_norm = nn.RMSNorm(head_dim, eps=1e-6)
+        self.k_norm = nn.RMSNorm(head_dim, eps=1e-6)
+
+    def __call__(self, q: mx.array, k: mx.array) -> Tuple[mx.array, mx.array]:
+        # Note: mlx.nn.RMSNorm has high precision accumulation (does not require upcasting)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        return q, k
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, config: MMDiTConfig):
+        super().__init__()
+        self.norm_final = LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.linear = nn.Linear(
+            config.hidden_size,
+            (config.patch_size**2) * config.vae_latent_dim,
+        )
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(config.hidden_size, 2 * config.hidden_size),
+        )
+
+    def __call__(
+        self,
+        latent_image_embeddings: mx.array,
+        timestep: mx.array,
+    ) -> mx.array:
+        if timestep.size > 1:
+            timestep = timestep[0]
+        modulation_params = self._modulation_params[timestep.item()]
+
+        shift, residual_scale = mx.split(modulation_params, 2, axis=-1)
+        latent_image_embeddings = affine_transform(
+            latent_image_embeddings,
+            shift=shift,
+            residual_scale=residual_scale,
+            norm_module=self.norm_final,
+        )
+        return self.linear(latent_image_embeddings)
+
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        n_heads: int,
+    ):
+        super().__init__()
+
+        # Configure dimensions for SDPA
+        self.embed_dim = embed_dim
+        self.n_heads = n_heads
+        assert (
+            self.embed_dim % self.n_heads == 0
+        ), "Embedding dimension must be divisible by number of heads"
+
+        self._sdpa_implementation = mx.fast.scaled_dot_product_attention
+
+        # Initialize layers
+        self.per_head_dim = self.embed_dim // self.n_heads
+        self.kv_proj_embed_dim = self.per_head_dim * n_heads
+
+        # Note: key bias is redundant due to softmax invariance
+        self.k_proj = nn.Linear(embed_dim, self.kv_proj_embed_dim, bias=False)
+        self.q_proj = nn.Linear(embed_dim, embed_dim)
+        self.v_proj = nn.Linear(embed_dim, self.kv_proj_embed_dim)
+        self.o_proj = nn.Linear(embed_dim, embed_dim)
+
+
+class FFN(nn.Module):
+    def __init__(self, embed_dim, expansion_factor, activation_fn):
+        super().__init__()
+        self.fc1 = nn.Linear(embed_dim, embed_dim * expansion_factor)
+        self.act_fn = activation_fn
+        self.fc2 = nn.Linear(embed_dim * expansion_factor, embed_dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.fc2(self.act_fn(self.fc1(x)))
+
+
+class LayerNorm(nn.Module):
+    def __init__(self, num_channels, eps=1e-5):
+        super().__init__()
+        self.num_channels = num_channels
+        self.eps = eps
+
+    def __call__(self, inputs: mx.array) -> mx.array:
+        input_rank = len(inputs.shape)
+        if input_rank != 4:
+            raise ValueError(f"Input tensor must have rank 4, got {input_rank}")
+
+        return mx.fast.layer_norm(inputs, weight=None, bias=None, eps=self.eps)
+
+
+class RoPE(nn.Module):
+    """Custom RoPE implementation for FLUX"""
+
+    def __init__(self, theta: int, axes_dim: List[int]) -> None:
+        super().__init__()
+        self.theta = theta
+        self.axes_dim = axes_dim
+
+        # Cache for consecutive identical calls
+        self.rope_embeddings = None
+        self.last_image_resolution = None
+        self.last_text_sequence_length = None
+
+    def _get_positions(
+        self, latent_image_resolution: Tuple[int], text_sequence_length: int
+    ) -> mx.array:
+        h, w = latent_image_resolution
+        image_positions = mx.stack(
+            [
+                mx.zeros((h, w)),
+                mx.repeat(mx.arange(h)[:, None], w, axis=1),
+                mx.repeat(mx.arange(w)[None, :], h, axis=0),
+            ],
+            axis=-1,
+        ).flatten(
+            0, 1
+        )  # (h * w, 3)
+
+        text_and_image_positions = mx.concatenate(
+            [
+                mx.zeros((text_sequence_length, 3)),
+                image_positions,
+            ],
+            axis=0,
+        )[
+            None
+        ]  # (text_sequence_length + h * w, 3)
+
+        return text_and_image_positions
+
+    def rope(self, positions: mx.array, dim: int, theta: int = 10_000) -> mx.array:
+        def _rope_per_dim(positions, dim, theta):
+            scale = mx.arange(0, dim, 2, dtype=mx.float32) / dim
+            omega = 1.0 / (theta**scale)
+            out = (
+                positions[..., None] * omega[None, None, :]
+            )  # mx.einsum("bn,d->bnd", positions, omega)
+            return mx.stack(
+                [mx.cos(out), -mx.sin(out), mx.sin(out), mx.cos(out)], axis=-1
+            ).reshape(*positions.shape, dim // 2, 2, 2)
+
+        return mx.concatenate(
+            [
+                _rope_per_dim(
+                    positions=positions[..., i], dim=self.axes_dim[i], theta=self.theta
+                )
+                for i in range(len(self.axes_dim))
+            ],
+            axis=-3,
+        ).astype(positions.dtype)
+
+    def __call__(
+        self, latent_image_resolution: Tuple[int], text_sequence_length: int
+    ) -> mx.array:
+        identical_to_last_call = (
+            latent_image_resolution == self.last_image_resolution
+            and text_sequence_length == self.last_text_sequence_length
+        )
+
+        if self.rope_embeddings is None or not identical_to_last_call:
+            self.last_image_resolution = latent_image_resolution
+            self.last_text_sequence_length = text_sequence_length
+            positions = self._get_positions(
+                latent_image_resolution, text_sequence_length
+            )
+            self.rope_embeddings = self.rope(positions, self.theta)
+            self.rope_embeddings = mx.expand_dims(self.rope_embeddings, axis=1)
+        else:
+            logger.debug("Returning cached RoPE embeddings")
+
+        return self.rope_embeddings
+
+    @staticmethod
+    def apply(q_or_k: mx.array, rope: mx.array) -> mx.array:
+        in_dtype = q_or_k.dtype
+        q_or_k = q_or_k.astype(mx.float32).reshape(*q_or_k.shape[:-1], -1, 1, 2)
+        return (
+            (rope[..., 0] * q_or_k[..., 0] + rope[..., 1] * q_or_k[..., 1])
+            .astype(in_dtype)
+            .flatten(-2)
+        )
+
+
+class MLPEmbedder(nn.Module):
+    def __init__(self, in_dim: int, hidden_dim: int):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(in_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+        )
+
+    def __call__(self, x):
+        return self.mlp(x)
+
+
+def affine_transform(
+    x: mx.array,
+    shift: mx.array,
+    residual_scale: mx.array,
+    norm_module: nn.Module = None,
+) -> mx.array:
+    """Affine transformation (Used for Adaptive LayerNorm Modulation)"""
+    if x.shape[0] == 1 and norm_module is not None:
+        return mx.fast.layer_norm(
+            x, 1.0 + residual_scale.squeeze(), shift.squeeze(), norm_module.eps
+        )
+    elif norm_module is not None:
+        return norm_module(x) * (1.0 + residual_scale) + shift
+    else:
+        return x * (1.0 + residual_scale) + shift
+
+
+def unpatchify(
+    x: mx.array,
+    patch_size: int,
+    target_height: int,
+    target_width: int,
+    vae_latent_dim: int,
+) -> mx.array:
+    """Unpatchify to restore VAE latent space compatible data format"""
+    h, w = target_height // patch_size, target_width // patch_size
+    x = x.reshape(x.shape[0], h, w, patch_size, patch_size, vae_latent_dim)
+    x = x.transpose(0, 5, 1, 3, 2, 4)  # x = mx.einsum("bhwpqc->bchpwq", x)
+    return x.reshape(x.shape[0], vae_latent_dim, target_height, target_width).transpose(
+        0, 2, 3, 1
+    )
+
+# fmt: on

--- a/vllm_mlx/image/sd35_runtime/_vendor/model_io.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/model_io.py
@@ -1,0 +1,1003 @@
+# reference: https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion
+
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
+#
+
+# fmt: off
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import mlx.core as mx
+from mlx import nn
+from mlx.utils import tree_flatten, tree_unflatten
+from transformers import T5Config
+
+from .clip import CLIPTextModel
+from .config import (
+    FLUX_SCHNELL,
+    AutoencoderConfig,
+    CLIPTextModelConfig,
+    SD3_2b,
+    SD3_8b,
+    VAEDecoderConfig,
+    VAEEncoderConfig,
+)
+from .mmdit import MMDiT
+from .t5 import SD3T5Encoder
+from .tokenizer import T5Tokenizer, Tokenizer
+from .vae import Autoencoder, VAEDecoder, VAEEncoder
+
+# import argmaxtools.mlx.utils as axu
+
+
+RANK = 32
+_DEFAULT_MMDIT = "argmaxinc/mlx-stable-diffusion-3-medium"
+_MMDIT = {
+    "argmaxinc/mlx-stable-diffusion-3-medium": {
+        "argmaxinc/mlx-stable-diffusion-3-medium": "sd3_medium.safetensors",
+        "vae": "sd3_medium.safetensors",
+    },
+    "argmaxinc/mlx-FLUX.1-schnell": {
+        "argmaxinc/mlx-FLUX.1-schnell": "flux-schnell.safetensors",
+        "vae": "ae.safetensors",
+    },
+    "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": {
+        "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": "flux-schnell-4bit-quantized.safetensors",
+        "vae": "ae.safetensors",
+    },
+    "argmaxinc/mlx-FLUX.1-dev": {
+        "argmaxinc/mlx-FLUX.1-dev": "flux1-dev.safetensors",
+        "vae": "ae.safetensors",
+    },
+    "argmaxinc/mlx-stable-diffusion-3.5-large": {
+        "argmaxinc/mlx-stable-diffusion-3.5-large": "sd3.5_large.safetensors",
+        "vae": "sd3.5_large.safetensors",
+    },
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": {
+        "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": "sd3.5_large_4bit_quantized.safetensors",
+        "vae": "sd3.5_large_4bit_quantized.safetensors",
+    },
+}
+_DEFAULT_MODEL = "argmaxinc/stable-diffusion"
+_MODELS = {
+    "argmaxinc/stable-diffusion": {
+        "clip_l_config": "clip_l/config.json",
+        "clip_l": "clip_l/model.fp16.safetensors",
+        "clip_g_config": "clip_g/config.json",
+        "clip_g": "clip_g/model.fp16.safetensors",
+        "tokenizer_l_vocab": "tokenizer_l/vocab.json",
+        "tokenizer_l_merges": "tokenizer_l/merges.txt",
+        "tokenizer_g_vocab": "tokenizer_g/vocab.json",
+        "tokenizer_g_merges": "tokenizer_g/merges.txt",
+        "t5": "t5/t5xxl.safetensors",
+    },
+}
+
+_PREFIX = {
+    "argmaxinc/mlx-stable-diffusion-3-medium": {
+        "vae_encoder": "first_stage_model.encoder.",
+        "vae_decoder": "first_stage_model.decoder.",
+    },
+    "argmaxinc/mlx-FLUX.1-schnell": {
+        "vae_encoder": "encoder.",
+        "vae_decoder": "decoder.",
+    },
+    "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": {
+        "vae_encoder": "encoder.",
+        "vae_decoder": "decoder.",
+    },
+    "argmaxinc/mlx-FLUX.1-dev": {
+        "vae_encoder": "encoder.",
+        "vae_decoder": "decoder.",
+    },
+    "argmaxinc/mlx-stable-diffusion-3.5-large": {
+        "vae_encoder": "first_stage_model.encoder.",
+        "vae_decoder": "first_stage_model.decoder.",
+    },
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": {
+        "vae_encoder": "first_stage_model.encoder.",
+        "vae_decoder": "first_stage_model.decoder.",
+    },
+}
+
+_CONFIG = {
+    "argmaxinc/mlx-stable-diffusion-3-medium": SD3_2b,
+    "argmaxinc/mlx-FLUX.1-schnell": FLUX_SCHNELL,
+    "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": FLUX_SCHNELL,
+    "argmaxinc/mlx-FLUX.1-dev": FLUX_SCHNELL,
+    "argmaxinc/mlx-stable-diffusion-3.5-large": SD3_8b,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": SD3_8b,
+}
+
+_FLOAT16 = mx.bfloat16
+
+DEPTH = {
+    "argmaxinc/mlx-stable-diffusion-3-medium": 24,
+    "argmaxinc/mlx-stable-diffusion-3.5-large": 38,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": 38,
+}
+MAX_LATENT_RESOLUTION = {
+    "argmaxinc/mlx-stable-diffusion-3-medium": 96,
+    "argmaxinc/mlx-stable-diffusion-3.5-large": 192,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": 192,
+}
+
+LOCAl_SD3_CKPT = None
+_ASSET_ROOTS: dict[str, Path] = {}
+_T5_TOKENIZER_ROOT: Path | None = None
+
+
+def configure_asset_roots(
+    roots: dict[str, str | Path], *, t5_tokenizer_root: str | Path
+) -> None:
+    global _ASSET_ROOTS, _T5_TOKENIZER_ROOT
+    _ASSET_ROOTS = {repo_id: Path(root).resolve() for repo_id, root in roots.items()}
+    _T5_TOKENIZER_ROOT = Path(t5_tokenizer_root).resolve()
+
+
+def _asset_path(repo_id: str, filename: str) -> str:
+    root = _ASSET_ROOTS.get(repo_id)
+    if root is None:
+        raise ValueError(f"No reviewed local asset root configured for {repo_id!r}.")
+    candidate = root.joinpath(*filename.split("/"))
+    allowed_root = root.parents[1].resolve() if root.parent.name == "snapshots" else root
+    try:
+        path = candidate.resolve(strict=True)
+    except OSError:
+        raise FileNotFoundError(
+            f"Required SD3.5 asset is missing: {filename}"
+        ) from None
+    if (
+        not candidate.is_relative_to(root)
+        or not path.is_relative_to(allowed_root)
+        or not path.is_file()
+    ):
+        raise FileNotFoundError(f"Required SD3.5 asset is missing: {filename}")
+    return str(path)
+
+
+def flux_state_dict_adjustments(state_dict, prefix="", hidden_size=3072, mlp_ratio=4):
+    state_dict = {
+        k.replace("double_blocks", "multimodal_transformer_blocks"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("single_blocks", "unified_transformer_blocks"): v
+        for k, v in state_dict.items()
+    }
+
+    # Split qkv proj and rename:
+    # *transformer_block.attn.qkv.{weigth/bias}  -> transformer_block.attn.{q/k/v}_proj.{weigth/bias}
+    # *transformer_block.attn.proj.{weigth/bias} -> transformer_block.attn.o_proj.{weight/bias}
+    keys_to_pop = []
+    state_dict_update = {}
+    for k in state_dict:
+        if "attn.qkv" in k:
+            keys_to_pop.append(k)
+            for name, weight in zip(["q", "k", "v"], mx.split(state_dict[k], 3)):
+                state_dict_update[k.replace("attn.qkv", f"attn.{name}_proj")] = (
+                    weight if "weight" in k else weight
+                )
+
+    [state_dict.pop(k) for k in keys_to_pop]
+    state_dict.update(state_dict_update)
+
+    state_dict = {
+        k.replace("txt_attn", "text_transformer_block.attn"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("img_attn", "image_transformer_block.attn"): v
+        for k, v in state_dict.items()
+    }
+
+    state_dict = {
+        k.replace("txt_mlp.0", "text_transformer_block.mlp.fc1"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("txt_mlp.2", "text_transformer_block.mlp.fc2"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("img_mlp.0", "image_transformer_block.mlp.fc1"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("img_mlp.2", "image_transformer_block.mlp.fc2"): v
+        for k, v in state_dict.items()
+    }
+
+    state_dict = {
+        k.replace("img_mod.lin", "image_transformer_block.adaLN_modulation.layers.1"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("txt_mod.lin", "text_transformer_block.adaLN_modulation.layers.1"): v
+        for k, v in state_dict.items()
+    }
+
+    state_dict = {k.replace(".proj", ".o_proj"): v for k, v in state_dict.items()}
+
+    state_dict = {
+        k.replace(".attn.norm.key_norm.scale", ".qk_norm.k_norm.weight"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace(".attn.norm.query_norm.scale", ".qk_norm.q_norm.weight"): v
+        for k, v in state_dict.items()
+    }
+
+    state_dict = {
+        k.replace(".modulation.lin", ".transformer_block.adaLN_modulation.layers.1"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace(".norm.key_norm.scale", ".transformer_block.qk_norm.k_norm.weight"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace(
+            ".norm.query_norm.scale", ".transformer_block.qk_norm.q_norm.weight"
+        ): v
+        for k, v in state_dict.items()
+    }
+
+    # Split qkv proj and mlp in unified transformer block and rename:
+    keys_to_pop = []
+    state_dict_update = {}
+    for k in state_dict:
+        if ".linear1" in k:
+            keys_to_pop.append(k)
+            for name, weight in zip(
+                ["attn.q", "attn.k", "attn.v", "mlp.fc1"],
+                mx.split(
+                    state_dict[k],
+                    [
+                        hidden_size,
+                        2 * hidden_size,
+                        3 * hidden_size,
+                        (3 + mlp_ratio) * hidden_size,
+                    ],
+                ),
+            ):
+                if name == "mlp.fc1":
+                    state_dict_update[
+                        k.replace(".linear1", f".transformer_block.{name}")
+                    ] = (weight if "weight" in k else weight)
+                else:
+                    state_dict_update[
+                        k.replace(".linear1", f".transformer_block.{name}_proj")
+                    ] = (weight if "weight" in k else weight)
+
+    [state_dict.pop(k) for k in keys_to_pop]
+    state_dict.update(state_dict_update)
+
+    # Split o_proj and mlp in unified transformer block and rename:
+    keys_to_pop = []
+    state_dict_update = {}
+    for k in state_dict:
+        if ".linear2" in k:
+            keys_to_pop.append(k)
+            if "bias" in k:
+                state_dict_update[
+                    k.replace(".linear2", ".transformer_block.attn.o_proj")
+                ] = state_dict[k]
+                state_dict_update[
+                    k.replace(".linear2", ".transformer_block.mlp.fc2")
+                ] = state_dict[k]
+            else:
+                for name, weight in zip(
+                    ["attn.o", "mlp.fc2"],
+                    mx.split(
+                        state_dict[k],
+                        [hidden_size, (1 + mlp_ratio) * hidden_size],
+                        axis=1,
+                    ),
+                ):
+                    if name == "mlp.fc2":
+                        state_dict_update[
+                            k.replace(".linear2", f".transformer_block.{name}")
+                        ] = (weight if "weight" in k else weight)
+                    else:
+                        state_dict_update[
+                            k.replace(".linear2", f".transformer_block.{name}_proj")
+                        ] = (weight if "weight" in k else weight)
+
+    [state_dict.pop(k) for k in keys_to_pop]
+    state_dict.update(state_dict_update)
+
+    state_dict = {
+        k.replace("img_in.", "x_embedder.proj."): v for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("txt_in.", "context_embedder."): v for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("time_in.", "t_embedder."): v for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("vector_in.", "y_embedder."): v for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace(".in_layer.", ".mlp.layers.0."): v for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace(".out_layer.", ".mlp.layers.2."): v for k, v in state_dict.items()
+    }
+
+    state_dict = {
+        k.replace(
+            "final_layer.adaLN_modulation.1", "final_layer.adaLN_modulation.layers.1"
+        ): v
+        for k, v in state_dict.items()
+    }
+
+    state_dict["x_embedder.proj.weight"] = mx.expand_dims(
+        mx.expand_dims(state_dict["x_embedder.proj.weight"], axis=1), axis=1
+    )
+
+    return state_dict
+
+
+def mmdit_state_dict_adjustments(state_dict, prefix=""):
+    # Remove prefix
+    state_dict = {k.lstrip(prefix): v for k, v in state_dict.items()}
+
+    state_dict = {
+        k.replace("y_embedder.mlp", "y_embedder.mlp.layers"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("t_embedder.mlp", "t_embedder.mlp.layers"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("adaLN_modulation", "adaLN_modulation.layers"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("al_layer", "final_layer"): v for k, v in state_dict.items()
+    }
+
+    # Rename joint_blocks -> multimodal_transformer_blocks
+    state_dict = {
+        k.replace("joint_blocks", "multimodal_transformer_blocks"): v
+        for k, v in state_dict.items()
+    }
+
+    # Remap context_block -> text_block
+    state_dict = {
+        k.replace("context_block", "text_transformer_block"): v
+        for k, v in state_dict.items()
+    }
+
+    # Remap x_block -> image_block
+    state_dict = {
+        k.replace("x_block", "image_transformer_block"): v
+        for k, v in state_dict.items()
+    }
+
+    # Remap qk_norm
+    state_dict = {
+        k.replace(".attn.ln_q.", ".qk_norm.q_norm."): v for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace(".attn.ln_k.", ".qk_norm.k_norm."): v for k, v in state_dict.items()
+    }
+
+    # Split qkv proj and rename:
+    # *transformer_block.attn.qkv.{weigth/bias}  -> transformer_block.attn.{q/k/v}_proj.{weigth/bias}
+    # *transformer_block.attn.proj.{weigth/bias} -> transformer_block.attn.o_proj.{weight/bias}
+    keys_to_pop = []
+    state_dict_update = {}
+    for k in state_dict:
+        if "attn.qkv" in k:
+            keys_to_pop.append(k)
+            for name, weight in zip(["q", "k", "v"], mx.split(state_dict[k], 3)):
+                state_dict_update[k.replace("attn.qkv", f"attn.{name}_proj")] = (
+                    weight if "weight" in k else weight
+                )
+
+    [state_dict.pop(k) for k in keys_to_pop]
+    state_dict.update(state_dict_update)
+
+    state_dict = {
+        k.replace("attn.proj", "attn.o_proj"): (
+            v if "attn.proj" in k and "weight" in k else v
+        )
+        for k, v in state_dict.items()
+    }
+
+    # Filter out VAE Decoder related tensors
+    state_dict = {k: v for k, v in state_dict.items() if "decoder." not in k}
+
+    # Filter out VAE Encoder related tensors
+    state_dict = {k: v for k, v in state_dict.items() if "encoder." not in k}
+
+    # Filter out k_proj.bias related tensors
+    state_dict = {k: v for k, v in state_dict.items() if "k_proj.bias" not in k}
+
+    # Filter out teacher_model related tensors
+    state_dict = {k: v for k, v in state_dict.items() if "teacher_model." not in k}
+
+    # Remap pos_embed buffer -> nn.Embedding
+    state_dict = {
+        k.replace("pos_embed", "x_pos_embedder.pos_embed.weight"): (
+            v[0] if "pos_embed" in k else v
+        )
+        for k, v in state_dict.items()
+    }
+
+    # Transpose x_embedder.proj.weight
+    state_dict["x_embedder.proj.weight"] = state_dict[
+        "x_embedder.proj.weight"
+    ].transpose(0, 2, 3, 1)
+
+    return state_dict
+
+
+def vae_decoder_state_dict_adjustments(state_dict, prefix="decoder."):
+    # Keep only the keys that have the prefix
+    state_dict = {k: v for k, v in state_dict.items() if prefix in k}
+    state_dict = {k.replace(prefix, ""): v for k, v in state_dict.items()}
+
+    # Filter out MMDIT related tensors
+    state_dict = {k: v for k, v in state_dict.items() if "diffusion_model." not in k}
+
+    state_dict = {k.replace("up", "up_blocks"): v for k, v in state_dict.items()}
+    state_dict = {k.replace("mid", "mid_blocks"): v for k, v in state_dict.items()}
+
+    state_dict = {
+        k.replace("mid_blocks.block_1", "mid_blocks.0"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("mid_blocks.block_2", "mid_blocks.2"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("mid_blocks.attn_1", "mid_blocks.1"): v for k, v in state_dict.items()
+    }
+
+    state_dict = {k.replace(".norm.", ".group_norm."): v for k, v in state_dict.items()}
+
+    state_dict = {k.replace(".q", ".query_proj"): v for k, v in state_dict.items()}
+    state_dict = {k.replace(".k", ".key_proj"): v for k, v in state_dict.items()}
+    state_dict = {k.replace(".v", ".value_proj"): v for k, v in state_dict.items()}
+    state_dict = {k.replace(".proj_out", ".out_proj"): v for k, v in state_dict.items()}
+
+    state_dict = {k.replace(".block.", ".resnets."): v for k, v in state_dict.items()}
+    state_dict = {
+        k.replace(".nin_shortcut.", ".conv_shortcut."): v for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace(".up_blockssample.conv.", ".upsample."): v
+        for k, v in state_dict.items()
+    }
+
+    state_dict = {
+        k.replace("norm_out", "conv_norm_out"): v for k, v in state_dict.items()
+    }
+
+    # reshape weights
+
+    state_dict = {
+        k: v.transpose(0, 2, 3, 1) if "upsample" in k and "weight" in k else v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k: (
+            v.transpose(0, 2, 3, 1)
+            if "resnets" in k and "conv" in k and "weight" in k
+            else v
+        )
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k: (
+            v.transpose(0, 2, 3, 1)
+            if "mid_blocks" in k and "conv" in k and "weight" in k
+            else v
+        )
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k: v[:, 0, 0, :] if "conv_shortcut.weight" in k else v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k: v[:, :, 0, 0] if "proj.weight" in k else v for k, v in state_dict.items()
+    }
+    state_dict["conv_in.weight"] = state_dict["conv_in.weight"].transpose(0, 2, 3, 1)
+    state_dict["conv_out.weight"] = state_dict["conv_out.weight"].transpose(0, 2, 3, 1)
+
+    return state_dict
+
+
+def vae_encoder_state_dict_adjustments(state_dict, prefix="encoder."):
+    # Keep only the keys that have the prefix
+    state_dict = {k: v for k, v in state_dict.items() if prefix in k}
+    state_dict = {k.replace(prefix, ""): v for k, v in state_dict.items()}
+
+    # Filter out MMDIT related tensors
+    state_dict = {k: v for k, v in state_dict.items() if "diffusion_model." not in k}
+
+    state_dict = {k.replace("down.", "down_blocks."): v for k, v in state_dict.items()}
+    state_dict = {
+        k.replace(".downsample.conv.", ".downsample."): v for k, v in state_dict.items()
+    }
+    state_dict = {k.replace(".block.", ".resnets."): v for k, v in state_dict.items()}
+    state_dict = {
+        k.replace(".nin_shortcut.", ".conv_shortcut."): v for k, v in state_dict.items()
+    }
+
+    state_dict = {k.replace(".q", ".query_proj"): v for k, v in state_dict.items()}
+    state_dict = {k.replace(".k", ".key_proj"): v for k, v in state_dict.items()}
+    state_dict = {k.replace(".v", ".value_proj"): v for k, v in state_dict.items()}
+    state_dict = {k.replace(".proj_out", ".out_proj"): v for k, v in state_dict.items()}
+
+    state_dict = {k.replace("mid", "mid_blocks"): v for k, v in state_dict.items()}
+
+    state_dict = {
+        k.replace("mid_blocks.block_1", "mid_blocks.0"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("mid_blocks.block_2", "mid_blocks.2"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("mid_blocks.attn_1", "mid_blocks.1"): v for k, v in state_dict.items()
+    }
+
+    state_dict = {k.replace(".norm.", ".group_norm."): v for k, v in state_dict.items()}
+    state_dict = {
+        k.replace("norm_out", "conv_norm_out"): v for k, v in state_dict.items()
+    }
+
+    # reshape weights
+
+    state_dict = {
+        k: v.transpose(0, 2, 3, 1) if "downsample" in k and "weight" in k else v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k: (
+            v.transpose(0, 2, 3, 1)
+            if "resnets" in k and "conv" in k and "weight" in k
+            else v
+        )
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k: (
+            v.transpose(0, 2, 3, 1)
+            if "mid_blocks" in k and "conv" in k and "weight" in k
+            else v
+        )
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k: v[:, 0, 0, :] if "conv_shortcut.weight" in k else v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k: v[:, :, 0, 0] if "proj.weight" in k else v for k, v in state_dict.items()
+    }
+    state_dict["conv_in.weight"] = state_dict["conv_in.weight"].transpose(0, 2, 3, 1)
+    state_dict["conv_out.weight"] = state_dict["conv_out.weight"].transpose(0, 2, 3, 1)
+
+    return state_dict
+
+
+def t5_encoder_state_dict_adjustments(state_dict, prefix=""):
+    state_dict = {k.replace(prefix, ""): v for k, v in state_dict.items()}
+
+    for i in range(2):
+        state_dict = {
+            k.replace(f"layer.{i}.layer_norm", f"ln{i+1}"): v
+            for k, v in state_dict.items()
+        }
+    for i in range(2):
+        state_dict = {k.replace(f"layer.{i}.", ""): v for k, v in state_dict.items()}
+    state_dict = {k.replace("block", "layers"): v for k, v in state_dict.items()}
+    state_dict = {
+        k.replace("SelfAttention.q", "attention.query_proj"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("SelfAttention.k", "attention.key_proj"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("SelfAttention.v", "attention.value_proj"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("SelfAttention.o", "attention.out_proj"): v
+        for k, v in state_dict.items()
+    }
+    state_dict = {
+        k.replace("DenseReluDense", "dense"): v for k, v in state_dict.items()
+    }
+
+    state_dict["encoder.relative_attention_bias.embeddings.weight"] = state_dict[
+        "encoder.layers.0.SelfAttention.relative_attention_bias.weight"
+    ]
+    del state_dict["encoder.layers.0.SelfAttention.relative_attention_bias.weight"]
+
+    state_dict["wte.weight"] = state_dict["encoder.embed_tokens.weight"]
+    del state_dict["encoder.embed_tokens.weight"]
+    del state_dict["shared.weight"]
+
+    state_dict["encoder.ln.weight"] = state_dict["encoder.final_layer_norm.weight"]
+    del state_dict["encoder.final_layer_norm.weight"]
+
+    return state_dict
+
+
+def map_clip_text_encoder_weights(key, value):
+    # Remove prefixes
+    if key.startswith("text_model."):
+        key = key[11:]
+    if key.startswith("embeddings."):
+        key = key[11:]
+    if key.startswith("encoder."):
+        key = key[8:]
+
+    # Map attention layers
+    if "self_attn." in key:
+        key = key.replace("self_attn.", "attention.")
+    if "q_proj." in key:
+        key = key.replace("q_proj.", "query_proj.")
+    if "k_proj." in key:
+        key = key.replace("k_proj.", "key_proj.")
+    if "v_proj." in key:
+        key = key.replace("v_proj.", "value_proj.")
+
+    # Map ffn layers
+    if "mlp.fc1" in key:
+        key = key.replace("mlp.fc1", "linear1")
+    if "mlp.fc2" in key:
+        key = key.replace("mlp.fc2", "linear2")
+
+    return [(key, value)]
+
+
+def map_vae_weights(key, value):
+    # Map up/downsampling
+    if "downsamplers" in key:
+        key = key.replace("downsamplers.0.conv", "downsample")
+    if "upsamplers" in key:
+        key = key.replace("upsamplers.0.conv", "upsample")
+
+    # Map attention layers
+    if "to_k" in key:
+        key = key.replace("to_k", "key_proj")
+    if "to_out.0" in key:
+        key = key.replace("to_out.0", "out_proj")
+    if "to_q" in key:
+        key = key.replace("to_q", "query_proj")
+    if "to_v" in key:
+        key = key.replace("to_v", "value_proj")
+
+    # Map the mid block
+    if "mid_block.resnets.0" in key:
+        key = key.replace("mid_block.resnets.0", "mid_blocks.0")
+    if "mid_block.attentions.0" in key:
+        key = key.replace("mid_block.attentions.0", "mid_blocks.1")
+    if "mid_block.resnets.1" in key:
+        key = key.replace("mid_block.resnets.1", "mid_blocks.2")
+
+    # Map the quant/post_quant layers
+    if "quant_conv" in key:
+        key = key.replace("quant_conv", "quant_proj")
+        value = value.squeeze()
+
+    # Map the conv_shortcut to linear
+    if "conv_shortcut.weight" in key:
+        value = value.squeeze()
+
+    if len(value.shape) == 4:
+        value = value.transpose(0, 2, 3, 1)
+        value = value.reshape(-1).reshape(value.shape)
+
+    return [(key, value)]
+
+
+""" Code obtained from
+https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/model_io.py
+"""
+
+
+def _flatten(params):
+    return [(k, v) for p in params for (k, v) in p]
+
+
+""" Code obtained from
+https://github.com/ml-explore/mlx-examples/blob/main/stable_diffusion/stable_diffusion/model_io.py
+"""
+
+
+def _load_safetensor_weights(mapper, model, weight_file, float16: bool = False):
+    dtype = _FLOAT16 if float16 else mx.float32
+    weights = mx.load(weight_file)
+    weights = _flatten([mapper(k, v.astype(dtype)) for k, v in weights.items()])
+    model.update(tree_unflatten(weights))
+
+
+def _check_key(key: str, part: str):
+    if key not in _MODELS:
+        raise ValueError(
+            f"[{part}] '{key}' model not found, choose one of {{{','.join(_MODELS.keys())}}}"
+        )
+
+
+def load_mmdit(
+    key: str = _DEFAULT_MMDIT,
+    float16: bool = False,
+    model_key: str = "mmdit_2b",
+    low_memory_mode: bool = True,
+    only_modulation_dict: bool = False,
+):
+    """Load the MM-DiT model from the checkpoint file."""
+    """only_modulation_dict: Only returns the modulation dictionary"""
+    dtype = _FLOAT16 if float16 else mx.float32
+    config = _CONFIG[key]
+    config.low_memory_mode = low_memory_mode
+    model = MMDiT(config)
+
+    mmdit_weights = _MMDIT[key][model_key]
+    mmdit_weights_ckpt = LOCAl_SD3_CKPT or _asset_path(key, mmdit_weights)
+    _asset_path(key, "config.json")
+    weights = mx.load(mmdit_weights_ckpt)
+    prefix = "model.diffusion_model."
+
+    if key != "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized":
+        weights = mmdit_state_dict_adjustments(weights, prefix=prefix)
+    else:
+        nn.quantize(
+            model, class_predicate=lambda _, module: isinstance(module, nn.Linear)
+        )
+        weights = {k.replace(prefix, ""): v for k, v in weights.items() if prefix in k}
+
+    weights = {
+        k: v.astype(dtype) if v.dtype != mx.uint32 else v for k, v in weights.items()
+    }
+    if only_modulation_dict:
+        weights = {k: v for k, v in weights.items() if "adaLN" in k}
+        return tree_flatten(weights)
+    model.load_weights(list(weights.items()))
+
+    return model
+
+
+def load_flux(
+    key: str = "argmaxinc/mlx-FLUX.1-schnell",
+    float16: bool = False,
+    model_key: str = "argmaxinc/mlx-FLUX.1-schnell",
+    low_memory_mode: bool = True,
+    only_modulation_dict: bool = False,
+):
+    """Load the MM-DiT Flux model from the checkpoint file."""
+    dtype = _FLOAT16 if float16 else mx.float32
+    config = FLUX_SCHNELL
+    config.low_memory_mode = low_memory_mode
+    model = MMDiT(config)
+
+    flux_weights = _MMDIT[key][model_key]
+    flux_weights_ckpt = LOCAl_SD3_CKPT or _asset_path(key, flux_weights)
+    _asset_path(key, "config.json")
+    weights = mx.load(flux_weights_ckpt)
+
+    if model_key in ["argmaxinc/mlx-FLUX.1-schnell", "argmaxinc/mlx-FLUX.1-dev"]:
+        weights = flux_state_dict_adjustments(
+            weights,
+            prefix="",
+            hidden_size=config.hidden_size,
+            mlp_ratio=config.mlp_ratio,
+        )
+    elif (
+        model_key == "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized"
+    ):  # 4-bit ckpt already adjusted
+        nn.quantize(model)
+
+    weights = {
+        k: v.astype(dtype) if v.dtype != mx.uint32 else v for k, v in weights.items()
+    }
+    if only_modulation_dict:
+        weights = {k: v for k, v in weights.items() if "adaLN" in k}
+        return tree_flatten(weights)
+    model.update(tree_unflatten(tree_flatten(weights)))
+
+    return model
+
+
+def load_text_encoder(
+    key: str = _DEFAULT_MODEL,
+    float16: bool = False,
+    model_key: str = "text_encoder",
+    config_key: Optional[str] = None,
+):
+    """Load the stable diffusion text encoder from Hugging Face Hub."""
+    _check_key(key, "load_text_encoder")
+
+    config_key = config_key or (model_key + "_config")
+
+    # Download the config and create the model
+    text_encoder_config = _MODELS[key][config_key]
+    with open(_asset_path(key, text_encoder_config)) as f:
+        config = json.load(f)
+
+    with_projection = "WithProjection" in config["architectures"][0]
+
+    model = CLIPTextModel(
+        CLIPTextModelConfig(
+            num_layers=config["num_hidden_layers"],
+            model_dims=config["hidden_size"],
+            num_heads=config["num_attention_heads"],
+            max_length=config["max_position_embeddings"],
+            vocab_size=config["vocab_size"],
+            projection_dim=config["projection_dim"] if with_projection else None,
+            hidden_act=config.get("hidden_act", "quick_gelu"),
+        )
+    )
+
+    # Download the weights and map them into the model
+    text_encoder_weights = _MODELS[key][model_key]
+    weight_file = _asset_path(key, text_encoder_weights)
+    _load_safetensor_weights(map_clip_text_encoder_weights, model, weight_file, float16)
+
+    return model
+
+
+def load_autoencoder(key: str = _DEFAULT_MODEL, float16: bool = False):
+    """Load the stable diffusion autoencoder from Hugging Face Hub."""
+    _check_key(key, "load_autoencoder")
+
+    # Download the config and create the model
+    vae_config = _MODELS[key]["vae_config"]
+    with open(_asset_path(key, vae_config)) as f:
+        config = json.load(f)
+
+    config["latent_channels"] = 16
+
+    model = Autoencoder(
+        AutoencoderConfig(
+            in_channels=config["in_channels"],
+            out_channels=config["out_channels"],
+            latent_channels_out=2 * config["latent_channels"],
+            latent_channels_in=config["latent_channels"],
+            block_out_channels=config["block_out_channels"],
+            layers_per_block=config["layers_per_block"],
+            norm_num_groups=config["norm_num_groups"],
+            scaling_factor=config.get("scaling_factor", 0.18215),
+        )
+    )
+
+    # Download the weights and map them into the model
+    vae_weights = _MODELS[key]["vae"]
+    weight_file = _asset_path(key, vae_weights)
+    _load_safetensor_weights(map_vae_weights, model, weight_file, float16)
+
+    return model
+
+
+def load_vae_decoder(
+    key: str = _DEFAULT_MMDIT,
+    float16: bool = False,
+    model_key: str = "vae",
+):
+    """Load the SD3 VAE Decoder model from the checkpoint file."""
+    config = VAEDecoderConfig()
+    model = VAEDecoder(
+        in_channels=config.in_channels,
+        out_channels=config.out_channels,
+        block_out_channels=config.block_out_channels,
+        layers_per_block=config.layers_per_block,
+        resnet_groups=config.resnet_groups,
+    )
+
+    dtype = _FLOAT16 if float16 else mx.float32
+    vae_weights = _MMDIT[key][model_key]
+    vae_weights_ckpt = LOCAl_SD3_CKPT or _asset_path(key, vae_weights)
+    weights = mx.load(vae_weights_ckpt)
+    prefix = _PREFIX[key]["vae_decoder"]
+
+    if key != "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized":
+        weights = vae_decoder_state_dict_adjustments(weights, prefix=prefix)
+    else:
+        weights = {k.replace(prefix, ""): v for k, v in weights.items() if prefix in k}
+
+    weights = {k: v.astype(dtype) for k, v in weights.items()}
+    model.load_weights(list(weights.items()))
+
+    return model
+
+
+def load_vae_encoder(
+    key: str = _DEFAULT_MMDIT,
+    float16: bool = False,
+    model_key: str = "vae",
+):
+    """Load the SD3 VAE Encoder model from the checkpoint file."""
+    config = VAEEncoderConfig()
+    model = VAEEncoder(
+        in_channels=config.in_channels,
+        out_channels=config.out_channels,
+        block_out_channels=config.block_out_channels,
+        layers_per_block=config.layers_per_block,
+        resnet_groups=config.resnet_groups,
+    )
+
+    dtype = _FLOAT16 if float16 else mx.float32
+    vae_weights = _MMDIT[key][model_key]
+    vae_weights_ckpt = LOCAl_SD3_CKPT or _asset_path(key, vae_weights)
+    weights = mx.load(vae_weights_ckpt)
+    prefix = _PREFIX[key]["vae_encoder"]
+
+    if key != "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized":
+        weights = vae_encoder_state_dict_adjustments(weights, prefix=prefix)
+    else:
+        weights = {k.replace(prefix, ""): v for k, v in weights.items() if prefix in k}
+
+    weights = {k: v.astype(dtype) for k, v in weights.items()}
+    model.load_weights(list(weights.items()))
+
+    return model
+
+
+def load_t5_encoder(
+    key: str = _DEFAULT_MODEL,
+    float16: bool = False,
+    model_key: str = "t5",
+    low_memory_mode: bool = True,
+):
+    if _T5_TOKENIZER_ROOT is None:
+        raise ValueError("No reviewed local T5 tokenizer root configured.")
+    config = T5Config.from_pretrained(_T5_TOKENIZER_ROOT, local_files_only=True)
+    model = SD3T5Encoder(config, low_memory_mode=low_memory_mode)
+
+    dtype = _FLOAT16 if float16 else mx.float32
+    t5_weights = _MODELS[key][model_key]
+    weights = mx.load(_asset_path(key, t5_weights))
+    weights = t5_encoder_state_dict_adjustments(weights, prefix="")
+    weights = {k: v.astype(dtype) for k, v in weights.items()}
+    model.update(tree_unflatten(tree_flatten(weights)))
+
+    return model
+
+
+def load_tokenizer(
+    key: str = _DEFAULT_MODEL,
+    vocab_key: str = "tokenizer_vocab",
+    merges_key: str = "tokenizer_merges",
+    pad_with_eos: bool = False,
+):
+    _check_key(key, "load_tokenizer")
+
+    vocab_file = _asset_path(key, _MODELS[key][vocab_key])
+    with open(vocab_file, encoding="utf-8") as f:
+        vocab = json.load(f)
+
+    merges_file = _asset_path(key, _MODELS[key][merges_key])
+    with open(merges_file, encoding="utf-8") as f:
+        bpe_merges = f.read().strip().split("\n")[1 : 49152 - 256 - 2 + 1]
+    bpe_merges = [tuple(m.split()) for m in bpe_merges]
+    bpe_ranks = dict(map(reversed, enumerate(bpe_merges)))
+
+    return Tokenizer(bpe_ranks, vocab, pad_with_eos)
+
+
+def load_t5_tokenizer(max_context_length: int = 256):
+    if _T5_TOKENIZER_ROOT is None:
+        raise ValueError("No reviewed local T5 tokenizer root configured.")
+    config = T5Config.from_pretrained(_T5_TOKENIZER_ROOT, local_files_only=True)
+    return T5Tokenizer(config, max_context_length, _T5_TOKENIZER_ROOT)
+
+# fmt: on

--- a/vllm_mlx/image/sd35_runtime/_vendor/pipeline.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/pipeline.py
@@ -1,0 +1,792 @@
+# reference: https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion
+
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
+#
+
+# fmt: off
+
+import gc
+import logging
+import math
+import time
+from collections.abc import Callable
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from PIL import Image
+
+from . import model_io
+from .model_io import (
+    _DEFAULT_MODEL,
+    load_flux,
+    load_mmdit,
+    load_t5_encoder,
+    load_t5_tokenizer,
+    load_text_encoder,
+    load_tokenizer,
+    load_vae_decoder,
+    load_vae_encoder,
+)
+from .sampler import FluxSampler, ModelSamplingDiscreteFlow
+
+logger = logging.getLogger(__name__)
+
+
+def bytes2gigabytes(n: int) -> float:
+    return n / 1024**3
+
+MMDIT_CKPT = {
+    "argmaxinc/mlx-stable-diffusion-3-medium": "argmaxinc/mlx-stable-diffusion-3-medium",
+    "argmaxinc/mlx-stable-diffusion-3.5-large": "argmaxinc/mlx-stable-diffusion-3.5-large",
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized",
+    "argmaxinc/mlx-FLUX.1-schnell": "argmaxinc/mlx-FLUX.1-schnell",
+    "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized",
+    "argmaxinc/mlx-FLUX.1-dev": "argmaxinc/mlx-FLUX.1-dev",
+}
+
+T5_MAX_LENGTH = {
+    "argmaxinc/mlx-stable-diffusion-3-medium": 512,
+    "argmaxinc/mlx-stable-diffusion-3.5-large": 512,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": 512,
+    "argmaxinc/mlx-FLUX.1-schnell": 256,
+    "argmaxinc/mlx-FLUX.1-schnell-4bit-quantized": 256,
+    "argmaxinc/mlx-FLUX.1-dev": 512,
+}
+
+
+class DiffusionPipeline:
+    def __init__(
+        self,
+        w16: bool = False,
+        shift: float = 1.0,
+        use_t5: bool = True,
+        model_version: str = "argmaxinc/mlx-stable-diffusion-3-medium",
+        low_memory_mode: bool = True,
+        a16: bool = False,
+        local_ckpt=None,
+        on_step: Callable[[int, int], None] | None = None,
+    ):
+        model_io.LOCAl_SD3_CKPT = local_ckpt
+        self.float16_dtype = mx.float16
+        model_io._FLOAT16 = self.float16_dtype
+        self.dtype = self.float16_dtype if w16 else mx.float32
+        self.activation_dtype = self.float16_dtype if a16 else mx.float32
+        self.use_t5 = use_t5
+        self.mmdit_ckpt = MMDIT_CKPT[model_version]
+        self.low_memory_mode = low_memory_mode
+        self.model = _DEFAULT_MODEL
+        self.model_version = model_version
+        self.sampler = ModelSamplingDiscreteFlow(shift=shift)
+        self.latent_format = SD3LatentFormat()
+        self.use_clip_g = True
+        self.on_step = on_step
+        self.check_and_load_models()
+
+    def load_mmdit(self, only_modulation_dict=False):
+        if only_modulation_dict:
+            return load_mmdit(
+                float16=True if self.dtype == self.float16_dtype else False,
+                key=self.mmdit_ckpt,
+                model_key=self.model_version,
+                low_memory_mode=self.low_memory_mode,
+                only_modulation_dict=only_modulation_dict,
+            )
+        self.mmdit = load_mmdit(
+            float16=True if self.dtype == self.float16_dtype else False,
+            key=self.mmdit_ckpt,
+            model_key=self.model_version,
+            low_memory_mode=self.low_memory_mode,
+            only_modulation_dict=only_modulation_dict,
+        )
+
+    def check_and_load_models(self):
+        if not hasattr(self, "mmdit"):
+            self.load_mmdit()
+        if not hasattr(self, "decoder"):
+            self.decoder = load_vae_decoder(
+                float16=True if self.dtype == self.float16_dtype else False,
+                key=self.mmdit_ckpt,
+            )
+        if not hasattr(self, "clip_l"):
+            self.clip_l = load_text_encoder(
+                self.model,
+                float16=True if self.dtype == self.float16_dtype else False,
+                model_key="clip_l",
+            )
+            self.tokenizer_l = load_tokenizer(
+                self.model,
+                merges_key="tokenizer_l_merges",
+                vocab_key="tokenizer_l_vocab",
+                pad_with_eos=True,
+            )
+        if self.use_clip_g and not hasattr(self, "clip_g"):
+            self.clip_g = load_text_encoder(
+                self.model,
+                float16=True if self.dtype == self.float16_dtype else False,
+                model_key="clip_g",
+            )
+            self.tokenizer_g = load_tokenizer(
+                self.model,
+                merges_key="tokenizer_g_merges",
+                vocab_key="tokenizer_g_vocab",
+                pad_with_eos=False,
+            )
+        if self.use_t5 and not hasattr(self, "t5_encoder"):
+            self.set_up_t5()
+
+    def set_up_t5(self):
+        if not hasattr(self, "t5_encoder") or self.t5_encoder is None:
+            self.t5_encoder = load_t5_encoder(
+                float16=True if self.dtype == self.float16_dtype else False,
+                low_memory_mode=self.low_memory_mode,
+            )
+        if not hasattr(self, "t5_tokenizer") or self.t5_tokenizer is None:
+            self.t5_tokenizer = load_t5_tokenizer(
+                max_context_length=T5_MAX_LENGTH[self.model_version]
+            )
+        self.use_t5 = True
+
+    def unload_t5(self):
+        if self.t5_encoder is not None:
+            del self.t5_encoder
+            self.t5_encoder = None
+        if self.t5_tokenizer is not None:
+            del self.t5_tokenizer
+            self.t5_tokenizer = None
+        gc.collect()
+        self.use_t5 = False
+
+    def ensure_models_are_loaded(self):
+        mx.eval(self.mmdit.parameters())
+        mx.eval(self.clip_l.parameters())
+        mx.eval(self.decoder.parameters())
+        if hasattr(self, "clip_g"):
+            mx.eval(self.clip_g.parameters())
+        if hasattr(self, "t5_encoder") and self.use_t5:
+            mx.eval(self.t5_encoder.parameters())
+
+    def _tokenize(self, tokenizer, text: str, negative_text: Optional[str] = None):
+        if negative_text is None:
+            negative_text = ""
+        if tokenizer.pad_with_eos:
+            pad_token = tokenizer.eos_token
+        else:
+            pad_token = 0
+
+        # Tokenize the text
+        tokens = [tokenizer.tokenize(text)]
+        if tokenizer.pad_to_max_length:
+            tokens[0].extend([pad_token] * (tokenizer.max_length - len(tokens[0])))
+        if negative_text is not None:
+            tokens += [tokenizer.tokenize(negative_text)]
+        lengths = [len(t) for t in tokens]
+        N = max(lengths)
+        tokens = [t + [pad_token] * (N - len(t)) for t in tokens]
+        tokens = mx.array(tokens)
+
+        return tokens
+
+    def encode_text(
+        self,
+        text: str,
+        cfg_weight: float = 7.5,
+        negative_text: str = "",
+    ):
+        tokens_l = self._tokenize(
+            self.tokenizer_l,
+            text,
+            (negative_text if cfg_weight > 1 else None),
+        )
+        tokens_g = self._tokenize(
+            self.tokenizer_g,
+            text,
+            (negative_text if cfg_weight > 1 else None),
+        )
+
+        conditioning_l = self.clip_l(tokens_l)
+        conditioning_g = self.clip_g(tokens_g)
+        conditioning = mx.concatenate(
+            [conditioning_l.hidden_states[-2], conditioning_g.hidden_states[-2]],
+            axis=-1,
+        )
+        pooled_conditioning = mx.concatenate(
+            [conditioning_l.pooled_output, conditioning_g.pooled_output],
+            axis=-1,
+        )
+
+        conditioning = mx.concatenate(
+            [
+                conditioning,
+                mx.zeros(
+                    (
+                        conditioning.shape[0],
+                        conditioning.shape[1],
+                        4096 - conditioning.shape[2],
+                    )
+                ),
+            ],
+            axis=-1,
+        )
+
+        if self.use_t5:
+            tokens_t5 = self._tokenize(
+                self.t5_tokenizer,
+                text,
+                (negative_text if cfg_weight > 1 else None),
+            )
+            t5_conditioning = self.t5_encoder(tokens_t5)
+            mx.eval(t5_conditioning)
+        else:
+            t5_conditioning = mx.zeros_like(conditioning)
+        conditioning = mx.concatenate([conditioning, t5_conditioning], axis=1)
+
+        return conditioning, pooled_conditioning
+
+    def denoise_latents(
+        self,
+        conditioning,
+        pooled_conditioning,
+        num_steps: int = 2,
+        cfg_weight: float = 0.0,
+        latent_size: Tuple[int, int] = (64, 64),
+        seed=None,
+        image_path: Optional[str] = None,
+        denoise: float = 1.0,
+    ):
+        # Set the PRNG state
+        seed = int(time.time()) if seed is None else seed
+        logger.info(f"Seed: {seed}")
+        mx.random.seed(seed)
+
+        x_T = self.get_empty_latent(*latent_size)
+        if image_path is None:
+            denoise = 1.0
+        else:
+            x_T = self.encode_image_to_latents(image_path, seed=seed)
+            x_T = self.latent_format.process_in(x_T)
+        noise = self.get_noise(seed, x_T)
+        sigmas = self.get_sigmas(self.sampler, num_steps)
+        sigmas = sigmas[int(num_steps * (1 - denoise)) :]
+        extra_args = {
+            "conditioning": conditioning,
+            "cfg_weight": cfg_weight,
+            "pooled_conditioning": pooled_conditioning,
+        }
+        noise_scaled = self.sampler.noise_scaling(
+            sigmas[0], noise, x_T, self.max_denoise(sigmas)
+        )
+        latent, iter_time = sample_euler(
+            CFGDenoiser(self),
+            noise_scaled,
+            sigmas,
+            extra_args=extra_args,
+            on_step=self.on_step,
+        )
+
+        latent = self.latent_format.process_out(latent)
+
+        return latent, iter_time
+
+    def generate_image(
+        self,
+        text: str,
+        num_steps: int = 2,
+        cfg_weight: float = 0.0,
+        negative_text: str = "",
+        latent_size: Tuple[int, int] = (64, 64),
+        seed=None,
+        verbose: bool = True,
+        image_path: Optional[str] = None,
+        denoise: float = 1.0,
+    ):
+        # Check latent size is divisible by 2
+        assert (
+            latent_size[0] % 2 == 0
+        ), f"Height must be divisible by 16 ({latent_size[0]*8}/16={latent_size[0]/2})"
+        assert (
+            latent_size[1] % 2 == 0
+        ), f"Width must be divisible by 16 ({latent_size[1]*8}/16={latent_size[1]/2})"
+        self.check_and_load_models()
+        # Start timing
+        start_time = time.time()
+
+        # Initialize the memory log
+        log = {
+            "text_encoding": {
+                "pre": {
+                    "peak_memory": round(
+                        bytes2gigabytes(mx.get_peak_memory()), 3
+                    ),
+                    "active_memory": round(
+                        bytes2gigabytes(mx.get_active_memory()), 3
+                    ),
+                },
+                "post": {"peak_memory": None, "active_memory": None},
+            },
+            "denoising": {
+                "pre": {"peak_memory": None, "active_memory": None},
+                "post": {"peak_memory": None, "active_memory": None},
+            },
+            "decoding": {
+                "pre": {"peak_memory": None, "active_memory": None},
+                "post": {"peak_memory": None, "active_memory": None},
+            },
+            "peak_memory": 0.0,
+        }
+
+        # Get the text conditioning
+        text_encoding_start_time = time.time()
+        if verbose:
+            logger.info(
+                f"Pre text encoding peak memory: {log['text_encoding']['pre']['peak_memory']}GB"
+            )
+            logger.info(
+                f"Pre text encoding active memory: {log['text_encoding']['pre']['active_memory']}GB"
+            )
+
+        # FIXME(arda): Need the same for CLIP models (low memory mode will not succeed a second time otherwise)
+        if self.use_t5 and not hasattr(self, "t5_encoder"):
+            self.set_up_t5()
+
+        conditioning, pooled_conditioning = self.encode_text(
+            text, cfg_weight, negative_text
+        )
+        mx.eval(conditioning)
+        mx.eval(pooled_conditioning)
+        log["text_encoding"]["post"]["peak_memory"] = round(
+            bytes2gigabytes(mx.get_peak_memory()), 3
+        )
+        log["text_encoding"]["post"]["active_memory"] = round(
+            bytes2gigabytes(mx.get_active_memory()), 3
+        )
+        log["peak_memory"] = max(
+            log["peak_memory"], log["text_encoding"]["post"]["peak_memory"]
+        )
+        log["text_encoding"]["time"] = round(time.time() - text_encoding_start_time, 3)
+        if verbose:
+            logger.info(
+                f"Post text encoding peak memory: {log['text_encoding']['post']['peak_memory']}GB"
+            )
+            logger.info(
+                f"Post text encoding active memory: {log['text_encoding']['post']['active_memory']}GB"
+            )
+            logger.info(f"Text encoding time: {log['text_encoding']['time']}s")
+
+        # unload T5 and CLIP models after obtaining conditioning in low memory mode
+        if self.low_memory_mode:
+            if hasattr(self, "t5_encoder"):
+                del self.t5_encoder
+            if hasattr(self, "clip_g"):
+                del self.clip_g
+            del self.clip_l
+            gc.collect()
+
+        logger.debug(f"Conditioning dtype before casting: {conditioning.dtype}")
+        logger.debug(
+            f"Pooled Conditioning dtype before casting: {pooled_conditioning.dtype}"
+        )
+        conditioning = conditioning.astype(self.activation_dtype)
+        pooled_conditioning = pooled_conditioning.astype(self.activation_dtype)
+        logger.debug(f"Conditioning dtype after casting: {conditioning.dtype}")
+        logger.debug(
+            f"Pooled Conditioning dtype after casting: {pooled_conditioning.dtype}"
+        )
+
+        # Reset peak memory info
+        mx.reset_peak_memory()
+
+        # Generate the latents
+        denoising_start_time = time.time()
+        log["denoising"]["pre"]["peak_memory"] = round(
+            bytes2gigabytes(mx.get_peak_memory()), 3
+        )
+        log["denoising"]["pre"]["active_memory"] = round(
+            bytes2gigabytes(mx.get_active_memory()), 3
+        )
+        log["peak_memory"] = max(
+            log["peak_memory"], log["denoising"]["pre"]["peak_memory"]
+        )
+        if verbose:
+            logger.info(
+                f"Pre denoise peak memory: {log['denoising']['pre']['peak_memory']}GB"
+            )
+            logger.info(
+                f"Pre denoise active memory: {log['denoising']['pre']['active_memory']}GB"
+            )
+
+        latents, iter_time = self.denoise_latents(
+            conditioning,
+            pooled_conditioning,
+            num_steps=num_steps,
+            cfg_weight=cfg_weight,
+            latent_size=latent_size,
+            seed=seed,
+            image_path=image_path,
+            denoise=denoise,
+        )
+        mx.eval(latents)
+
+        log["denoising"]["post"]["peak_memory"] = round(
+            bytes2gigabytes(mx.get_peak_memory()), 3
+        )
+        log["denoising"]["post"]["active_memory"] = round(
+            bytes2gigabytes(mx.get_active_memory()), 3
+        )
+        log["peak_memory"] = max(
+            log["peak_memory"], log["denoising"]["post"]["peak_memory"]
+        )
+        log["denoising"]["time"] = round(time.time() - denoising_start_time, 3)
+        log["denoising"]["iter_time"] = iter_time
+        if verbose:
+            logger.info(
+                f"Post denoise peak memory: {log['denoising']['post']['peak_memory']}GB"
+            )
+            logger.info(
+                f"Post denoise active memory: {log['denoising']['post']['active_memory']}GB"
+            )
+            logger.info(f"Denoising time: {log['denoising']['time']}s")
+
+        # unload MMDIT model after obtaining latents in low memory mode
+        if self.low_memory_mode:
+            del self.mmdit
+            gc.collect()
+
+        logger.debug(f"Latents dtype before casting: {latents.dtype}")
+        latents = latents.astype(self.activation_dtype)
+        logger.debug(f"Latents dtype after casting: {latents.dtype}")
+
+        # Reset peak memory info
+        mx.reset_peak_memory()
+
+        # Decode the latents
+        decoding_start_time = time.time()
+        log["decoding"]["pre"]["peak_memory"] = round(
+            bytes2gigabytes(mx.get_peak_memory()), 3
+        )
+        log["decoding"]["pre"]["active_memory"] = round(
+            bytes2gigabytes(mx.get_active_memory()), 3
+        )
+        log["peak_memory"] = max(
+            log["peak_memory"], log["decoding"]["pre"]["peak_memory"]
+        )
+        if verbose:
+            logger.info(
+                f"Pre decode peak memory: {log['decoding']['pre']['peak_memory']}GB"
+            )
+            logger.info(
+                f"Pre decode active memory: {log['decoding']['pre']['active_memory']}GB"
+            )
+        latents = latents.astype(self.activation_dtype)
+        decoded = self.decode_latents_to_image(latents)
+        mx.eval(decoded)
+
+        log["decoding"]["post"]["peak_memory"] = round(
+            bytes2gigabytes(mx.get_peak_memory()), 3
+        )
+        log["decoding"]["post"]["active_memory"] = round(
+            bytes2gigabytes(mx.get_active_memory()), 3
+        )
+        log["peak_memory"] = max(
+            log["peak_memory"], log["decoding"]["post"]["peak_memory"]
+        )
+        log["decoding"]["time"] = round(time.time() - decoding_start_time, 3)
+        if verbose:
+            logger.info(
+                f"Post decode peak memory: {log['decoding']['post']['peak_memory']}GB"
+            )
+            logger.info(
+                f"Post decode active memory: {log['decoding']['post']['active_memory']}GB"
+            )
+
+        if verbose:
+            logger.info("============= Summary =============")
+            logger.info(f"Text encoder: {log['text_encoding']['time']:.1f}s")
+            logger.info(f"Denoising: {log['denoising']['time']:.1f}s")
+            logger.info(f"Image decoder: {log['decoding']['time']:.1f}s")
+            logger.info(f"Peak memory: {log['peak_memory']:.1f}GB")
+
+        # unload VAE Decoder model after decoding in low memory mode
+        if self.low_memory_mode:
+            del self.decoder
+            gc.collect()
+
+        # Convert the decoded images to uint8
+        x = mx.concatenate(decoded, axis=0)
+        x = (x * 255).astype(mx.uint8)
+
+        # End timing
+        end_time = time.time()
+        log["total_time"] = round(end_time - start_time, 3)
+        if verbose:
+            logger.info(f"Total time: {log['total_time']}s")
+
+        return Image.fromarray(np.array(x)), log
+
+    def read_image(self, image_path: str):
+        # Read the image
+        img = Image.open(image_path)
+
+        # Make sure image shape is divisible by 64
+        W, H = (dim - dim % 64 for dim in (img.width, img.height))
+        if W != img.width or H != img.height:
+            logger.warning(
+                f"Warning: image shape is not divisible by 64, downsampling to {W}x{H}"
+            )
+            img = img.resize((W, H), Image.LANCZOS)  # use desired downsampling filter
+
+        img = mx.array(np.array(img))
+        img = (img[:, :, :3].astype(mx.float32) / 255) * 2 - 1.0
+
+        return mx.expand_dims(img, axis=0)
+
+    def get_noise(self, seed, x_T):
+        np.random.seed(seed)
+        noise = np.random.randn(*x_T.transpose(0, 3, 1, 2).shape)
+        noise = mx.array(noise).transpose(0, 2, 3, 1)
+        return noise
+
+    def get_sigmas(self, sampler, num_steps: int):
+        start = sampler.timestep(sampler.sigma_max).item()
+        end = sampler.timestep(sampler.sigma_min).item()
+        if isinstance(sampler, FluxSampler):
+            num_steps += 1
+        timesteps = mx.linspace(start, end, num_steps)
+        sigs = []
+        for x in range(len(timesteps)):
+            ts = timesteps[x]
+            sigs.append(sampler.sigma(ts))
+        if not isinstance(sampler, FluxSampler):
+            sigs += [0.0]
+        return mx.array(sigs)
+
+    def get_empty_latent(self, *shape):
+        return mx.ones([1, *shape, 16]) * 0.0609
+
+    def max_denoise(self, sigmas):
+        max_sigma = float(self.sampler.sigma_max.item())
+        sigma = float(sigmas[0].item())
+        return math.isclose(max_sigma, sigma, rel_tol=1e-05) or sigma > max_sigma
+
+    def decode_latents_to_image(self, x_t):
+        x = self.decoder(x_t)
+        x = mx.clip(x / 2 + 0.5, 0, 1)
+        return x
+
+    def encode_image_to_latents(self, image_path: str, seed):
+        image = self.read_image(image_path)
+        hidden = self.encoder(image)
+        mean, logvar = hidden.split(2, axis=-1)
+        logvar = mx.clip(logvar, -30.0, 20.0)
+        std = mx.exp(0.5 * logvar)
+        noise = self.get_noise(seed, mean)
+
+        return mean + std * noise
+
+
+class FluxPipeline(DiffusionPipeline):
+    def __init__(
+        self,
+        w16: bool = False,
+        shift: float = 1.0,
+        use_t5: bool = True,
+        model_version: str = "argmaxinc/mlx-FLUX.1-schnell",
+        low_memory_mode: bool = True,
+        a16: bool = False,
+        local_ckpt=None,
+        quantize_mmdit: bool = False,
+    ):
+        model_io.LOCAl_SD3_CKPT = local_ckpt
+        self.float16_dtype = mx.bfloat16
+        model_io._FLOAT16 = self.float16_dtype
+        self.dtype = self.float16_dtype if w16 else mx.float32
+        self.activation_dtype = self.float16_dtype if a16 else mx.float32
+        self.mmdit_ckpt = MMDIT_CKPT[model_version]
+        self.low_memory_mode = low_memory_mode
+        self.model = _DEFAULT_MODEL
+        self.model_version = model_version
+        self.sampler = FluxSampler(shift=shift)
+        self.latent_format = FluxLatentFormat()
+        self.use_t5 = True
+        self.use_clip_g = False
+        self.quantize_mmdit = quantize_mmdit
+        self.check_and_load_models()
+
+    def load_mmdit(self, only_modulation_dict=False):
+        if only_modulation_dict:
+            return load_flux(
+                key=self.mmdit_ckpt,
+                model_key=self.model_version,
+                float16=True if self.dtype == self.float16_dtype else False,
+                low_memory_mode=self.low_memory_mode,
+                only_modulation_dict=only_modulation_dict,
+            )
+        self.mmdit = load_flux(
+            key=self.mmdit_ckpt,
+            model_key=self.model_version,
+            float16=True if self.dtype == self.float16_dtype else False,
+            low_memory_mode=self.low_memory_mode,
+            only_modulation_dict=only_modulation_dict,
+        )
+
+    def encode_text(
+        self,
+        text: str,
+        cfg_weight: float = 7.5,
+        negative_text: str = "",
+    ):
+        tokens_l = self._tokenize(
+            self.tokenizer_l,
+            text,
+            (negative_text if cfg_weight > 1 else None),
+        )
+        conditioning_l = self.clip_l(tokens_l[[0], :])  # Ignore negative text
+        pooled_conditioning = conditioning_l.pooled_output
+
+        tokens_t5 = self._tokenize(
+            self.t5_tokenizer,
+            text,
+            (negative_text if cfg_weight > 1 else None),
+        )
+        padded_tokens_t5 = mx.zeros((1, T5_MAX_LENGTH[self.model_version])).astype(
+            tokens_t5.dtype
+        )
+        padded_tokens_t5[:, : tokens_t5.shape[1]] = tokens_t5[
+            [0], :
+        ]  # Ignore negative text
+        t5_conditioning = self.t5_encoder(padded_tokens_t5)
+        mx.eval(t5_conditioning)
+        conditioning = t5_conditioning
+
+        return conditioning, pooled_conditioning
+
+
+class CFGDenoiser(nn.Module):
+    """Helper for applying CFG Scaling to diffusion outputs"""
+
+    def __init__(self, model: DiffusionPipeline):
+        super().__init__()
+        self.model = model
+
+    def cache_modulation_params(self, pooled_text_embeddings, sigmas):
+        self.model.mmdit.cache_modulation_params(
+            pooled_text_embeddings, sigmas.astype(self.model.activation_dtype)
+        )
+
+    def clear_cache(self):
+        self.model.mmdit.load_weights(
+            self.model.load_mmdit(only_modulation_dict=True), strict=False
+        )
+
+    def __call__(
+        self,
+        x_t,
+        timestep,
+        sigma,
+        conditioning,
+        cfg_weight: float = 7.5,
+        pooled_conditioning=None,
+    ):
+        if cfg_weight <= 0:
+            logger.debug("CFG Weight disabled")
+            x_t_mmdit = x_t.astype(self.model.activation_dtype)
+        else:
+            x_t_mmdit = mx.concatenate([x_t] * 2, axis=0).astype(
+                self.model.activation_dtype
+            )
+        mmdit_input = {
+            "latent_image_embeddings": x_t_mmdit,
+            "token_level_text_embeddings": mx.expand_dims(conditioning, 2),
+            "timestep": mx.broadcast_to(timestep, [len(x_t_mmdit)]),
+        }
+
+        mmdit_output = self.model.mmdit(**mmdit_input)
+        eps_pred = self.model.sampler.calculate_denoised(sigma, mmdit_output, x_t_mmdit)
+        if cfg_weight <= 0:
+            return eps_pred
+        else:
+            eps_text, eps_neg = eps_pred.split(2)
+            return eps_neg + cfg_weight * (eps_text - eps_neg)
+
+
+class LatentFormat:
+    """Base class for latent format conversion"""
+
+    def __init__(self):
+        self.scale_factor = 1.0
+        self.shift_factor = 0.0
+
+    def process_in(self, latent):
+        return (latent - self.shift_factor) * self.scale_factor
+
+    def process_out(self, latent):
+        return (latent / self.scale_factor) + self.shift_factor
+
+
+class SD3LatentFormat(LatentFormat):
+    def __init__(self):
+        super().__init__()
+        self.scale_factor = 1.5305
+        self.shift_factor = 0.0609
+
+
+class FluxLatentFormat(LatentFormat):
+    def __init__(self):
+        super().__init__()
+        self.scale_factor = 0.3611
+        self.shift_factor = 0.1159
+
+
+def append_dims(x, target_dims):
+    """Appends dimensions to the end of a tensor until it has target_dims dimensions."""
+    dims_to_append = target_dims - x.ndim
+    return x[(...,) + (None,) * dims_to_append]
+
+
+def to_d(x, sigma, denoised):
+    """Converts a denoiser output to a Karras ODE derivative."""
+    return (x - denoised) / append_dims(sigma, x.ndim)
+
+
+def sample_euler(
+    model: CFGDenoiser,
+    x,
+    sigmas,
+    extra_args=None,
+    on_step: Callable[[int, int], None] | None = None,
+):
+    """Implements Algorithm 2 (Euler steps) from Karras et al. (2022)."""
+    extra_args = {} if extra_args is None else extra_args
+
+    timesteps = model.model.sampler.timestep(sigmas).astype(
+        model.model.activation_dtype
+    )
+    model.cache_modulation_params(extra_args.pop("pooled_conditioning"), timesteps)
+
+    iter_time = []
+    total = len(sigmas) - 1
+    try:
+        for i in range(total):
+            start_time = time.perf_counter()
+            denoised = model(x, timesteps[i], sigmas[i], **extra_args)
+            d = to_d(x, sigmas[i], denoised)
+            dt = sigmas[i + 1] - sigmas[i]
+            # Euler method
+            x = x + d * dt
+            mx.eval(x)
+            end_time = time.perf_counter()
+            iter_time.append(round((end_time - start_time), 3))
+            if on_step is not None:
+                on_step(i + 1, total)
+    finally:
+        # ``cache_modulation_params`` replaces live modulation weights with
+        # timestep-specific values. Cancellation and model errors must restore
+        # them too or the retained model poisons the next request.
+        model.clear_cache()
+
+    return x, iter_time
+
+# fmt: on

--- a/vllm_mlx/image/sd35_runtime/_vendor/sampler.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/sampler.py
@@ -1,0 +1,77 @@
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
+#
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class ModelSamplingDiscreteFlow(nn.Module):
+    """Helper for sampler scheduling (ie timestep/sigma calculations) for Discrete Flow models"""
+
+    def __init__(self, shift=1.0):
+        super().__init__()
+        self.shift = shift
+        timesteps = 1000
+        ts = self.sigma(mx.arange(1, timesteps + 1, 1))
+        self.sigmas = ts
+
+    @property
+    def sigma_min(self):
+        return self.sigmas[0]
+
+    @property
+    def sigma_max(self):
+        return self.sigmas[-1]
+
+    def timestep(self, sigma):
+        return sigma * 1000
+
+    def sigma(self, timestep: mx.array):
+        timestep = timestep / 1000.0
+        if self.shift == 1.0:
+            return timestep
+        return self.shift * timestep / (1 + (self.shift - 1) * timestep)
+
+    def calculate_denoised(self, sigma, model_output, model_input):
+        sigma = sigma.reshape(sigma.shape[:1] + (1,) * (model_output.ndim - 1))
+        return model_input - model_output * sigma
+
+    def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
+        return sigma * noise + (1.0 - sigma) * latent_image
+
+
+class FluxSampler(nn.Module):
+    """Helper for sampler scheduling (ie timestep/sigma calculations) for Flux models"""
+
+    def __init__(self, shift=1.0):
+        super().__init__()
+        self.shift = shift
+        timesteps = 1000
+        ts = self.sigma(mx.arange(0, timesteps + 1, 1))
+        self.sigmas = ts
+
+    @property
+    def sigma_min(self):
+        return self.sigmas[0]
+
+    @property
+    def sigma_max(self):
+        return self.sigmas[-1]
+
+    def timestep(self, sigma):
+        return sigma * 1000
+
+    def sigma(self, timestep: mx.array):
+        timestep = timestep / 1000.0
+        if self.shift == 1.0:
+            return timestep
+        return self.shift * timestep / (1 + (self.shift - 1) * timestep)
+
+    def calculate_denoised(self, sigma, model_output, model_input):
+        sigma = sigma.reshape(sigma.shape[:1] + (1,) * (model_output.ndim - 1))
+        return model_input - model_output * sigma
+
+    def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
+        return sigma * noise + (1.0 - sigma) * latent_image

--- a/vllm_mlx/image/sd35_runtime/_vendor/t5.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/t5.py
@@ -1,0 +1,334 @@
+# reference: https://github.com/ml-explore/mlx-examples/tree/main/t5
+
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
+#
+
+import logging
+from typing import List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from transformers import T5Config
+
+logger = logging.getLogger(__name__)
+
+
+def _relative_position_bucket(
+    relative_position, bidirectional=True, num_buckets=32, max_distance=128
+):
+    """
+    Adapted from HF Tensorflow:
+    https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py
+
+    Translate relative position to a bucket number for relative attention. The relative position is defined as
+    memory_position - query_position, i.e. the distance in tokens from the attending position to the attended-to
+    position. If bidirectional=False, then positive relative positions are invalid. We use smaller buckets for
+    small absolute relative_position and larger buckets for larger absolute relative_positions. All relative
+    positions >=max_distance map to the same bucket. All relative positions <=-max_distance map to the same bucket.
+    This should allow for more graceful generalization to longer sequences than the model has been trained on
+
+    Args:
+        relative_position: an int32 Tensor
+        bidirectional: a boolean - whether the attention is bidirectional
+        num_buckets: an integer
+        max_distance: an integer
+
+    Returns:
+        a Tensor with the same shape as relative_position, containing int32 values in the range [0, num_buckets)
+    """
+    relative_buckets = 0
+    if bidirectional:
+        num_buckets //= 2
+        relative_buckets += (relative_position > 0).astype(mx.int16) * num_buckets
+        relative_position = mx.abs(relative_position)
+    else:
+        relative_position = -mx.minimum(
+            relative_position, mx.zeros_like(relative_position)
+        )
+    # now relative_position is in the range [0, inf)
+
+    # half of the buckets are for exact increments in positions
+    max_exact = num_buckets // 2
+    is_small = relative_position < max_exact
+
+    # The other half of the buckets are for logarithmically bigger bins in positions up to max_distance
+    scale = (num_buckets - max_exact) / np.log(max_distance / max_exact)
+    relative_position_if_large = max_exact + (
+        mx.log(relative_position.astype(mx.float32) / max_exact) * scale
+    ).astype(mx.int16)
+    relative_position_if_large = mx.minimum(relative_position_if_large, num_buckets - 1)
+    relative_buckets += mx.where(
+        is_small, relative_position, relative_position_if_large
+    )
+    return relative_buckets
+
+
+class RelativePositionBias(nn.Module):
+    def __init__(self, config: T5Config, bidirectional: bool):
+        self.bidirectional = bidirectional
+        self.num_buckets = config.relative_attention_num_buckets
+        self.max_distance = config.relative_attention_max_distance
+        self.n_heads = config.num_heads
+        self.embeddings = nn.Embedding(
+            config.relative_attention_num_buckets, config.num_heads
+        )
+
+    def __call__(self, query_length: int, key_length: int, offset: int = 0):
+        """Compute binned relative position bias"""
+        context_position = mx.arange(offset, query_length)[:, None]
+        memory_position = mx.arange(key_length)[None, :]
+
+        # shape (query_length, key_length)
+        relative_position = memory_position - context_position
+        relative_position_bucket = _relative_position_bucket(
+            relative_position,
+            bidirectional=self.bidirectional,
+            num_buckets=self.num_buckets,
+            max_distance=self.max_distance,
+        )
+
+        # shape (query_length, key_length, num_heads)
+        values = self.embeddings(relative_position_bucket)
+
+        # shape (num_heads, query_length, key_length)
+        return values.transpose(2, 0, 1)
+
+
+class MultiHeadAttention(nn.Module):
+    def __init__(self, config: T5Config):
+        super().__init__()
+        inner_dim = config.d_kv * config.num_heads
+        self.num_heads = config.num_heads
+        self.query_proj = nn.Linear(config.d_model, inner_dim, bias=False)
+        self.key_proj = nn.Linear(config.d_model, inner_dim, bias=False)
+        self.value_proj = nn.Linear(config.d_model, inner_dim, bias=False)
+        self.out_proj = nn.Linear(inner_dim, config.d_model, bias=False)
+
+    def __call__(
+        self,
+        queries: mx.array,
+        keys: mx.array,
+        values: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Tuple[mx.array, mx.array]] = None,
+    ) -> [mx.array, Tuple[mx.array, mx.array]]:
+        queries = self.query_proj(queries)
+        keys = self.key_proj(keys)
+        values = self.value_proj(values)
+
+        num_heads = self.num_heads
+        B, L, _ = queries.shape
+        _, S, _ = keys.shape
+        queries = queries.reshape(B, L, num_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, S, num_heads, -1).transpose(0, 2, 3, 1)
+        values = values.reshape(B, S, num_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            key_cache, value_cache = cache
+            keys = mx.concatenate([key_cache, keys], axis=3)
+            values = mx.concatenate([value_cache, values], axis=2)
+
+        # Dimensions are [batch x num heads x sequence x hidden dim]
+        scores = queries @ keys
+        if mask is not None:
+            scores = scores + mask.astype(scores.dtype)
+
+        scores = mx.softmax(scores.astype(mx.float32), axis=-1).astype(scores.dtype)
+        values_hat = (scores @ values).transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.out_proj(values_hat), (keys, values)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dims: int, eps: float = 1e-5):
+        super().__init__()
+        self.weight = mx.ones((dims,))
+        self.eps = eps
+
+    def _norm(self, x):
+        import math
+
+        # return x * mx.rsqrt(x.square().mean(-1, keepdims=True) + self.eps)
+        return x * mx.rsqrt(
+            (x * (1.0 / math.sqrt(self.weight.shape[0])))
+            .square()
+            .sum(-1, keepdims=True)
+            + self.eps
+        )
+
+    def __call__(self, x):
+        t = x.dtype
+        output = self._norm(x).astype(t)
+        return self.weight * output
+
+
+class DenseActivation(nn.Module):
+    def __init__(self, config: T5Config):
+        super().__init__()
+        mlp_dims = config.d_ff or config.d_model * 4
+        self.gated = config.feed_forward_proj.startswith("gated")
+        if self.gated:
+            self.wi_0 = nn.Linear(config.d_model, mlp_dims, bias=False)
+            self.wi_1 = nn.Linear(config.d_model, mlp_dims, bias=False)
+        else:
+            self.wi = nn.Linear(config.d_model, mlp_dims, bias=False)
+        self.wo = nn.Linear(mlp_dims, config.d_model, bias=False)
+        activation = config.feed_forward_proj.removeprefix("gated-")
+        if activation == "relu":
+            self.act = nn.relu
+        elif activation == "gelu":
+            self.act = nn.gelu
+        elif activation == "silu":
+            self.act = nn.silu
+        else:
+            raise ValueError(f"Unknown activation: {activation}")
+
+    def __call__(self, x):
+        if self.gated:
+            hidden_act = self.act(self.wi_0(x))
+            hidden_linear = self.wi_1(x)
+            x = hidden_act * hidden_linear
+        else:
+            x = self.act(self.wi(x))
+        return self.wo(x)
+
+
+class TransformerEncoderLayer(nn.Module):
+    def __init__(self, config: T5Config):
+        super().__init__()
+        self.attention = MultiHeadAttention(config)
+        self.ln1 = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.ln2 = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.dense = DenseActivation(config)
+
+    def __call__(self, x, mask):
+        y = self.ln1(x)
+        y = y.astype(self.ln1.weight.dtype)
+        y, _ = self.attention(y, y, y, mask=mask)
+        y = y.astype(mx.float32)
+        x = x + y
+
+        y = self.ln2(x)
+        y = self.dense(y)
+        return x + y
+
+
+class TransformerEncoder(nn.Module):
+    def __init__(self, config: T5Config, low_memory_mode=True):
+        super().__init__()
+        self.low_memory_mode = low_memory_mode
+        self.layers = [
+            TransformerEncoderLayer(config) for i in range(config.num_layers)
+        ]
+        self.ln = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.relative_attention_bias = RelativePositionBias(config, bidirectional=True)
+
+    def __call__(self, x: mx.array):
+        t = x.dtype
+        pos_bias = self.relative_attention_bias(x.shape[1], x.shape[1])
+
+        previous_memory_limit = None
+        if self.low_memory_mode:
+            previous_memory_limit = mx.set_memory_limit(4 * 1024**3)
+
+        try:
+            for layer in self.layers:
+                x = layer(x, mask=pos_bias)
+
+            if self.low_memory_mode:
+                self.layers.clear()
+
+            output = self.ln(x).astype(t)
+            mx.eval(output)
+            return output
+        finally:
+            # Restore the caller's actual allocator policy. Resetting to total
+            # physical memory silently overwrote Rapid/MLX safety limits and an
+            # encoder exception previously left the whole process capped at
+            # 4 GiB for all subsequent work.
+            if previous_memory_limit is not None:
+                mx.set_memory_limit(previous_memory_limit)
+
+
+class TransformerDecoderLayer(nn.Module):
+    def __init__(self, config: T5Config):
+        super().__init__()
+        self.self_attention = MultiHeadAttention(config)
+        self.cross_attention = MultiHeadAttention(config)
+        self.ln1 = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.ln2 = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.ln3 = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.dense = DenseActivation(config)
+
+    def __call__(
+        self,
+        x: mx.array,
+        memory: mx.array,
+        mask: mx.array,
+        memory_mask: mx.array,
+        cache: Optional[List[Tuple[mx.array, mx.array]]] = None,
+    ):
+        y = self.ln1(x)
+        y, cache = self.self_attention(y, y, y, mask, cache)
+        x = x + y
+
+        y = self.ln2(x)
+        y, _ = self.cross_attention(y, memory, memory, memory_mask)
+        x = x + y
+
+        y = self.ln3(x)
+        y = self.dense(y)
+        x = x + y
+
+        return x, cache
+
+
+class TransformerDecoder(nn.Module):
+    def __init__(self, config: T5Config):
+        super().__init__()
+        n_layers = getattr(config, "num_decoder_layers", config.num_layers)
+        self.layers = [TransformerDecoderLayer(config) for i in range(n_layers)]
+        self.ln = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
+        self.relative_attention_bias = RelativePositionBias(config, bidirectional=False)
+
+    def __call__(self, x, memory, mask, memory_mask, cache=None):
+        if cache is not None:
+            offset = cache[0][0].shape[3]
+        else:
+            offset = 0
+            cache = [None] * len(self.layers)
+
+        T = offset + x.shape[1]
+        pos_bias = self.relative_attention_bias(T, T, offset=offset)
+        if mask is not None:
+            mask += pos_bias
+        else:
+            mask = pos_bias
+
+        for e, layer in enumerate(self.layers):
+            x, cache[e] = layer(x, memory, mask, memory_mask, cache=cache[e])
+        x = self.ln(x)
+
+        return x, cache
+
+
+class OutputHead(nn.Module):
+    def __init__(self, config: T5Config):
+        self.linear = nn.Linear(config.d_model, config.vocab_size, bias=False)
+
+    def __call__(self, inputs):
+        return self.linear(inputs)
+
+
+class SD3T5Encoder(nn.Module):
+    def __init__(self, config: T5Config, low_memory_mode=True):
+        self.wte = nn.Embedding(config.vocab_size, config.d_model)
+        self.encoder = TransformerEncoder(config, low_memory_mode=low_memory_mode)
+        self.model_dim = config.d_model
+
+    def __call__(self, inputs: mx.array):
+        out = self.wte(inputs)
+        out = self.encoder(out)
+        return out

--- a/vllm_mlx/image/sd35_runtime/_vendor/tokenizer.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/tokenizer.py
@@ -1,0 +1,167 @@
+# reference: https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion
+
+import logging
+from pathlib import Path
+from typing import List
+
+import mlx.core as mx
+import numpy as np
+import regex
+from transformers import AutoTokenizer, T5Config
+
+logger = logging.getLogger(__name__)
+
+
+class Tokenizer:
+    """A simple port of CLIPTokenizer from https://github.com/huggingface/transformers/ ."""
+
+    def __init__(self, bpe_ranks, vocab, pad_with_eos=False):
+        self.bpe_ranks = bpe_ranks
+        self.vocab = vocab
+        self.pat = regex.compile(
+            r"""<\|startoftext\|>|<\|endoftext\|>|'s|'t|'re|'ve|'m|'ll|'d|[\p{L}]+|[\p{N}]|[^\s\p{L}\p{N}]+""",
+            regex.IGNORECASE,
+        )
+
+        self.pad_to_max_length = True
+        self.max_length = 77
+
+        self._cache = {self.bos: self.bos, self.eos: self.eos}
+        self.pad_with_eos = pad_with_eos
+
+    @property
+    def bos(self):
+        return "<|startoftext|>"
+
+    @property
+    def bos_token(self):
+        return self.vocab[self.bos]
+
+    @property
+    def eos(self):
+        return "<|endoftext|>"
+
+    @property
+    def eos_token(self):
+        return self.vocab[self.eos]
+
+    def bpe(self, text):
+        if text in self._cache:
+            return self._cache[text]
+
+        unigrams = list(text[:-1]) + [text[-1] + "</w>"]
+        unique_bigrams = set(zip(unigrams, unigrams[1:]))
+
+        if not unique_bigrams:
+            return unigrams
+
+        # In every iteration try to merge the two most likely bigrams. If none
+        # was merged we are done.
+        #
+        # Ported from https://github.com/huggingface/transformers/blob/main/src/transformers/models/clip/tokenization_clip.py
+        while unique_bigrams:
+            bigram = min(
+                unique_bigrams, key=lambda pair: self.bpe_ranks.get(pair, float("inf"))
+            )
+            if bigram not in self.bpe_ranks:
+                break
+
+            new_unigrams = []
+            skip = False
+            for a, b in zip(unigrams, unigrams[1:]):
+                if skip:
+                    skip = False
+                    continue
+
+                if (a, b) == bigram:
+                    new_unigrams.append(a + b)
+                    skip = True
+
+                else:
+                    new_unigrams.append(a)
+
+            if not skip:
+                new_unigrams.append(b)
+
+            unigrams = new_unigrams
+            unique_bigrams = set(zip(unigrams, unigrams[1:]))
+
+        self._cache[text] = unigrams
+
+        return unigrams
+
+    def tokenize(self, text, prepend_bos=True, append_eos=True):
+        if isinstance(text, list):
+            return [self.tokenize(t, prepend_bos, append_eos) for t in text]
+
+        # Lower case cleanup and split according to self.pat. Hugging Face does
+        # a much more thorough job here but this should suffice for 95% of
+        # cases.
+        clean_text = regex.sub(r"\s+", " ", text.lower())
+        tokens = regex.findall(self.pat, clean_text)
+
+        # Split the tokens according to the byte-pair merge file
+        bpe_tokens = [ti for t in tokens for ti in self.bpe(t)]
+
+        # Map to token ids and return
+        tokens = [self.vocab[t] for t in bpe_tokens]
+
+        # Truncate
+        max_length = self.max_length - int(prepend_bos) - int(append_eos)
+        if len(tokens) > max_length:
+            tokens = tokens[:max_length]
+            logger.warning(
+                f"Length of tokens exceeds {self.max_length}. Truncating to {self.max_length}."
+            )
+        if prepend_bos:
+            tokens = [self.bos_token] + tokens
+        if append_eos:
+            tokens.append(self.eos_token)
+
+        return tokens
+
+
+class T5Tokenizer:
+    def __init__(
+        self,
+        config: T5Config,
+        max_context_length: int,
+        tokenizer_path: str | Path,
+    ):
+        self.max_length = max_context_length
+        self._decoder_start_id = config.decoder_start_token_id
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_path,
+            legacy=False,
+            model_max_length=self.max_length,
+            local_files_only=True,
+        )
+
+        self.pad_to_max_length = True
+        self.pad_with_eos = False
+
+    @property
+    def eos_id(self) -> int:
+        return self._tokenizer.eos_token_id
+
+    @property
+    def decoder_start_id(self) -> int:
+        return self._decoder_start_id
+
+    def encode(self, s: str) -> mx.array:
+        return mx.array(
+            self._tokenizer(
+                s,
+                return_tensors="np",
+                return_attention_mask=False,
+                max_length=self.max_length,
+                truncation=True,
+            )["input_ids"]
+        )
+
+    def decode(self, t: List[int], with_sep: bool = True) -> str:
+        tokens = self._tokenizer.convert_ids_to_tokens(t)
+        return "".join(t.replace("▁", " " if with_sep else "") for t in tokens)
+
+    def tokenize(self, s: str) -> np.array:
+        return [t.item() for t in self.encode(s)[0]]

--- a/vllm_mlx/image/sd35_runtime/_vendor/vae.py
+++ b/vllm_mlx/image/sd35_runtime/_vendor/vae.py
@@ -1,0 +1,467 @@
+# reference: https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion
+
+#
+# For licensing see accompanying LICENSE.md file.
+# Copyright (C) 2024 Argmax, Inc. All Rights Reserved.
+#
+
+import math
+import logging
+from typing import List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import AutoencoderConfig
+
+logger = logging.getLogger(__name__)
+
+
+def upsample_nearest(x, scale: int = 2):
+    B, H, W, C = x.shape
+    x = mx.broadcast_to(x[:, :, None, :, None, :], (B, H, scale, W, scale, C))
+    x = x.reshape(B, H * scale, W * scale, C)
+
+    return x
+
+
+class Attention(nn.Module):
+    """A single head unmasked attention for use with the VAE."""
+
+    def __init__(self, dims: int, norm_groups: int = 32):
+        super().__init__()
+
+        self.group_norm = nn.GroupNorm(norm_groups, dims, pytorch_compatible=True)
+        self.query_proj = nn.Linear(dims, dims)
+        self.key_proj = nn.Linear(dims, dims)
+        self.value_proj = nn.Linear(dims, dims)
+        self.out_proj = nn.Linear(dims, dims)
+
+    def __call__(self, x):
+        B, H, W, C = x.shape
+
+        y = self.group_norm(x)
+
+        queries = self.query_proj(y).reshape(B, H * W, C)
+        keys = self.key_proj(y).reshape(B, H * W, C)
+        values = self.value_proj(y).reshape(B, H * W, C)
+
+        scale = 1 / math.sqrt(queries.shape[-1])
+        scores = (queries * scale) @ keys.transpose(0, 2, 1)
+        attn = mx.softmax(scores, axis=-1)
+        y = (attn @ values).reshape(B, H, W, C)
+
+        y = self.out_proj(y)
+        x = x + y
+
+        return x
+
+
+class ResnetBlock2D(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: Optional[int] = None,
+        groups: int = 32,
+        temb_channels: Optional[int] = None,
+    ):
+        super().__init__()
+
+        out_channels = out_channels or in_channels
+
+        self.norm1 = nn.GroupNorm(groups, in_channels, pytorch_compatible=True)
+        self.conv1 = nn.Conv2d(
+            in_channels, out_channels, kernel_size=3, stride=1, padding=1
+        )
+        if temb_channels is not None:
+            self.time_emb_proj = nn.Linear(temb_channels, out_channels)
+        self.norm2 = nn.GroupNorm(groups, out_channels, pytorch_compatible=True)
+        self.conv2 = nn.Conv2d(
+            out_channels, out_channels, kernel_size=3, stride=1, padding=1
+        )
+
+        if in_channels != out_channels:
+            self.conv_shortcut = nn.Linear(in_channels, out_channels)
+
+    def __call__(self, x, temb=None):
+        if temb is not None:
+            temb = self.time_emb_proj(nn.silu(temb))
+
+        y = self.norm1(x)
+        y = nn.silu(y)
+        y = self.conv1(y)
+        if temb is not None:
+            y = y + temb[:, None, None, :]
+        y = self.norm2(y)
+        y = nn.silu(y)
+        y = self.conv2(y)
+
+        x = y + (x if "conv_shortcut" not in self else self.conv_shortcut(x))
+
+        return x
+
+
+class EncoderDecoderBlock2D(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        num_layers: int = 1,
+        resnet_groups: int = 32,
+        add_downsample=True,
+        add_upsample=True,
+    ):
+        super().__init__()
+
+        # Add the resnet blocks
+        self.resnets = [
+            ResnetBlock2D(
+                in_channels=in_channels if i == 0 else out_channels,
+                out_channels=out_channels,
+                groups=resnet_groups,
+            )
+            for i in range(num_layers)
+        ]
+
+        # Add an optional downsampling layer
+        if add_downsample:
+            self.downsample = nn.Conv2d(
+                out_channels, out_channels, kernel_size=3, stride=2, padding=0
+            )
+
+        # or upsampling layer
+        if add_upsample:
+            self.upsample = nn.Conv2d(
+                out_channels, out_channels, kernel_size=3, stride=1, padding=1
+            )
+
+    def __call__(self, x):
+        for resnet in self.resnets:
+            x = resnet(x)
+
+        if "downsample" in self:
+            x = mx.pad(x, [(0, 0), (0, 1), (0, 1), (0, 0)])
+            x = self.downsample(x)
+
+        if "upsample" in self:
+            x = self.upsample(upsample_nearest(x))
+
+        return x
+
+
+class Encoder(nn.Module):
+    """Implements the encoder side of the Autoencoder."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        block_out_channels: List[int] = [64],
+        layers_per_block: int = 2,
+        resnet_groups: int = 32,
+    ):
+        super().__init__()
+
+        self.conv_in = nn.Conv2d(
+            in_channels, block_out_channels[0], kernel_size=3, stride=1, padding=1
+        )
+
+        channels = [block_out_channels[0]] + list(block_out_channels)
+        self.down_blocks = [
+            EncoderDecoderBlock2D(
+                in_channels,
+                out_channels,
+                num_layers=layers_per_block,
+                resnet_groups=resnet_groups,
+                add_downsample=i < len(block_out_channels) - 1,
+                add_upsample=False,
+            )
+            for i, (in_channels, out_channels) in enumerate(zip(channels, channels[1:]))
+        ]
+
+        self.mid_blocks = [
+            ResnetBlock2D(
+                in_channels=block_out_channels[-1],
+                out_channels=block_out_channels[-1],
+                groups=resnet_groups,
+            ),
+            Attention(block_out_channels[-1], resnet_groups),
+            ResnetBlock2D(
+                in_channels=block_out_channels[-1],
+                out_channels=block_out_channels[-1],
+                groups=resnet_groups,
+            ),
+        ]
+
+        self.conv_norm_out = nn.GroupNorm(
+            resnet_groups, block_out_channels[-1], pytorch_compatible=True
+        )
+        self.conv_out = nn.Conv2d(block_out_channels[-1], out_channels, 3, padding=1)
+
+    def __call__(self, x):
+        x = self.conv_in(x)
+
+        for l in self.down_blocks:
+            x = l(x)
+
+        x = self.mid_blocks[0](x)
+        x = self.mid_blocks[1](x)
+        x = self.mid_blocks[2](x)
+
+        x = self.conv_norm_out(x)
+        x = nn.silu(x)
+        x = self.conv_out(x)
+
+        return x
+
+
+class Decoder(nn.Module):
+    """Implements the decoder side of the Autoencoder."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        block_out_channels: List[int] = [64],
+        layers_per_block: int = 2,
+        resnet_groups: int = 32,
+    ):
+        super().__init__()
+
+        self.conv_in = nn.Conv2d(
+            in_channels, block_out_channels[-1], kernel_size=3, stride=1, padding=1
+        )
+
+        self.mid_blocks = [
+            ResnetBlock2D(
+                in_channels=block_out_channels[-1],
+                out_channels=block_out_channels[-1],
+                groups=resnet_groups,
+            ),
+            Attention(block_out_channels[-1], resnet_groups),
+            ResnetBlock2D(
+                in_channels=block_out_channels[-1],
+                out_channels=block_out_channels[-1],
+                groups=resnet_groups,
+            ),
+        ]
+
+        channels = list(reversed(block_out_channels))
+        channels = [channels[0]] + channels
+        self.up_blocks = [
+            EncoderDecoderBlock2D(
+                in_channels,
+                out_channels,
+                num_layers=layers_per_block,
+                resnet_groups=resnet_groups,
+                add_downsample=False,
+                add_upsample=i < len(block_out_channels) - 1,
+            )
+            for i, (in_channels, out_channels) in enumerate(zip(channels, channels[1:]))
+        ]
+
+        self.conv_norm_out = nn.GroupNorm(
+            resnet_groups, block_out_channels[0], pytorch_compatible=True
+        )
+        self.conv_out = nn.Conv2d(block_out_channels[0], out_channels, 3, padding=1)
+
+    def __call__(self, x):
+        x = self.conv_in(x)
+
+        x = self.mid_blocks[0](x)
+        x = self.mid_blocks[1](x)
+        x = self.mid_blocks[2](x)
+
+        for l in self.up_blocks:
+            x = l(x)
+
+        x = self.conv_norm_out(x)
+        x = nn.silu(x)
+        x = self.conv_out(x)
+
+        return x
+
+
+class Autoencoder(nn.Module):
+    """The autoencoder that allows us to perform diffusion in the latent space."""
+
+    def __init__(self, config: AutoencoderConfig):
+        super().__init__()
+
+        self.latent_channels = config.latent_channels_in
+        self.scaling_factor = config.scaling_factor
+        self.encoder = Encoder(
+            config.in_channels,
+            config.latent_channels_out,
+            config.block_out_channels,
+            config.layers_per_block,
+            resnet_groups=config.norm_num_groups,
+        )
+        self.decoder = Decoder(
+            config.latent_channels_in,
+            config.out_channels,
+            config.block_out_channels,
+            config.layers_per_block + 1,
+            resnet_groups=config.norm_num_groups,
+        )
+
+        self.quant_proj = nn.Linear(
+            config.latent_channels_out, config.latent_channels_out
+        )
+        self.post_quant_proj = nn.Linear(
+            config.latent_channels_in, config.latent_channels_in
+        )
+
+    def decode(self, z):
+        z = z / self.scaling_factor
+        return self.decoder(self.post_quant_proj(z))
+
+    def encode(self, x):
+        x = self.encoder(x)
+        x = self.quant_proj(x)
+        mean, logvar = x.split(2, axis=-1)
+        mean = mean * self.scaling_factor
+        logvar = logvar + 2 * math.log(self.scaling_factor)
+
+        return mean, logvar
+
+    def __call__(self, x, key=None):
+        mean, logvar = self.encode(x)
+        z = mx.random.normal(mean.shape, key=key) * mx.exp(0.5 * logvar) + mean
+        x_hat = self.decode(z)
+
+        return dict(x_hat=x_hat, z=z, mean=mean, logvar=logvar)
+
+
+class VAEDecoder(nn.Module):
+    """Implements the decoder side of the Autoencoder for SD3"""
+
+    def __init__(
+        self,
+        in_channels: int = 16,
+        out_channels: int = 3,
+        block_out_channels: List[int] = [128, 256, 512, 512],
+        layers_per_block: int = 3,
+        resnet_groups: int = 32,
+    ):
+        super().__init__()
+
+        self.conv_in = nn.Conv2d(
+            in_channels, block_out_channels[-1], kernel_size=3, stride=1, padding=1
+        )
+
+        self.mid_blocks = [
+            ResnetBlock2D(
+                in_channels=block_out_channels[-1],
+                out_channels=block_out_channels[-1],
+                groups=resnet_groups,
+            ),
+            Attention(block_out_channels[-1], resnet_groups),
+            ResnetBlock2D(
+                in_channels=block_out_channels[-1],
+                out_channels=block_out_channels[-1],
+                groups=resnet_groups,
+            ),
+        ]
+
+        channels = list(reversed(block_out_channels))
+        channels = [channels[0]] + channels
+        self.up_blocks = []
+        for i, (in_c, out_c) in enumerate(zip(channels, channels[1:])):
+            up = EncoderDecoderBlock2D(
+                in_c,
+                out_c,
+                num_layers=layers_per_block,
+                resnet_groups=resnet_groups,
+                add_downsample=False,
+                add_upsample=i < len(block_out_channels) - 1,
+            )
+            self.up_blocks.insert(0, up)
+
+        self.conv_norm_out = nn.GroupNorm(
+            resnet_groups, block_out_channels[0], pytorch_compatible=True
+        )
+        self.conv_out = nn.Conv2d(block_out_channels[0], out_channels, 3, padding=1)
+
+    def __call__(self, x):
+        x = self.conv_in(x)
+
+        x = self.mid_blocks[0](x)
+        x = self.mid_blocks[1](x)
+        x = self.mid_blocks[2](x)
+
+        for l in reversed(self.up_blocks):
+            x = l(x)
+            mx.eval(x)
+
+        x = self.conv_norm_out(x)
+        x = nn.silu(x)
+        x = self.conv_out(x)
+
+        return x
+
+
+class VAEEncoder(nn.Module):
+    """Implements the encoder side of the Autoencoder."""
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        out_channels: int = 32,
+        block_out_channels: List[int] = [128, 256, 512, 512],
+        layers_per_block: int = 2,
+        resnet_groups: int = 32,
+    ):
+        super().__init__()
+
+        self.conv_in = nn.Conv2d(
+            in_channels, block_out_channels[0], kernel_size=3, stride=1, padding=1
+        )
+
+        channels = [block_out_channels[0]] + list(block_out_channels)
+        self.down_blocks = [
+            EncoderDecoderBlock2D(
+                in_channels,
+                out_channels,
+                num_layers=layers_per_block,
+                resnet_groups=resnet_groups,
+                add_downsample=i < len(block_out_channels) - 1,
+                add_upsample=False,
+            )
+            for i, (in_channels, out_channels) in enumerate(zip(channels, channels[1:]))
+        ]
+
+        self.mid_blocks = [
+            ResnetBlock2D(
+                in_channels=block_out_channels[-1],
+                out_channels=block_out_channels[-1],
+                groups=resnet_groups,
+            ),
+            Attention(block_out_channels[-1], resnet_groups),
+            ResnetBlock2D(
+                in_channels=block_out_channels[-1],
+                out_channels=block_out_channels[-1],
+                groups=resnet_groups,
+            ),
+        ]
+
+        self.conv_norm_out = nn.GroupNorm(
+            resnet_groups, block_out_channels[-1], pytorch_compatible=True
+        )
+        self.conv_out = nn.Conv2d(block_out_channels[-1], out_channels, 3, padding=1)
+
+    def __call__(self, x):
+        x = self.conv_in(x)
+
+        for l in self.down_blocks:
+            x = l(x)
+
+        x = self.mid_blocks[0](x)
+        x = self.mid_blocks[1](x)
+        x = self.mid_blocks[2](x)
+
+        x = self.conv_norm_out(x)
+        x = nn.silu(x)
+        x = self.conv_out(x)
+
+        return x

--- a/vllm_mlx/image/sd35_runtime/runtime.py
+++ b/vllm_mlx/image/sd35_runtime/runtime.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rapid-MLX adapter for the pinned SD3.5 Large 4-bit MLX checkpoint."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from PIL import Image
+
+from ._vendor import model_io
+from ._vendor.pipeline import DiffusionPipeline
+
+MODEL_REPO = "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized"
+SHARED_REPO = "argmaxinc/stable-diffusion"
+T5_TOKENIZER_REPO = "google/t5-v1_1-xxl"
+MODEL_FILENAME = "sd3.5_large_4bit_quantized.safetensors"
+
+MODEL_FILES = ("config.json", MODEL_FILENAME)
+SHARED_FILES = (
+    "clip_l/config.json",
+    "clip_l/model.fp16.safetensors",
+    "clip_g/config.json",
+    "clip_g/model.fp16.safetensors",
+    "tokenizer_l/vocab.json",
+    "tokenizer_l/merges.txt",
+    "tokenizer_g/vocab.json",
+    "tokenizer_g/merges.txt",
+    "t5/t5xxl.safetensors",
+)
+T5_TOKENIZER_FILES = (
+    "config.json",
+    "special_tokens_map.json",
+    "spiece.model",
+    "tokenizer_config.json",
+)
+
+
+@dataclass(frozen=True)
+class GeneratedImage:
+    """Image-engine-compatible result container."""
+
+    image: Image.Image
+
+
+def _require_files(root: Path, names: tuple[str, ...]) -> None:
+    resolved = root.resolve()
+    if not resolved.is_dir():
+        raise ValueError(f"Required SD3.5 asset directory is missing: {root}")
+    # Hugging Face snapshots are symlink farms into the same repository's
+    # sibling ``blobs/`` directory. Permit that standard layout while still
+    # refusing traversal or a symlink into another repo/arbitrary filesystem.
+    allowed_root = (
+        resolved.parents[1].resolve()
+        if resolved.parent.name == "snapshots"
+        else resolved
+    )
+    for name in names:
+        candidate = resolved.joinpath(*name.split("/"))
+        try:
+            real = candidate.resolve(strict=True)
+        except OSError:
+            raise ValueError(f"Required SD3.5 asset is missing: {name}") from None
+        if (
+            not candidate.is_relative_to(resolved)
+            or not real.is_relative_to(allowed_root)
+            or not real.is_file()
+        ):
+            raise ValueError(f"Required SD3.5 asset is missing: {name}")
+
+
+class SD35Large:
+    """Full three-encoder SD3.5 Large text-to-image runtime."""
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        shared_path: str | Path,
+        t5_tokenizer_path: str | Path,
+        *,
+        on_step: Callable[[int, int], None] | None = None,
+    ) -> None:
+        model_root = Path(model_path).resolve()
+        shared_root = Path(shared_path).resolve()
+        t5_root = Path(t5_tokenizer_path).resolve()
+        _require_files(model_root, MODEL_FILES)
+        _require_files(shared_root, SHARED_FILES)
+        _require_files(t5_root, T5_TOKENIZER_FILES)
+
+        with (model_root / "config.json").open(encoding="utf-8") as handle:
+            config = json.load(handle)
+        if config != {"name": "stable-diffusion-3.5-large-4bit-quantized"}:
+            raise ValueError("Unsupported SD3.5 checkpoint configuration.")
+
+        model_io.configure_asset_roots(
+            {MODEL_REPO: model_root, SHARED_REPO: shared_root},
+            t5_tokenizer_root=t5_root,
+        )
+        self.pipeline = DiffusionPipeline(
+            w16=True,
+            a16=True,
+            shift=3.0,
+            use_t5=True,
+            model_version=MODEL_REPO,
+            low_memory_mode=True,
+            local_ckpt=model_root / MODEL_FILENAME,
+            on_step=on_step,
+        )
+
+    def generate_image(
+        self,
+        *,
+        prompt: str,
+        height: int,
+        width: int,
+        num_inference_steps: int,
+        seed: int,
+        guidance: float | None = None,
+        negative_prompt: str | None = None,
+    ) -> GeneratedImage:
+        image, _log = self.pipeline.generate_image(
+            text=prompt,
+            num_steps=num_inference_steps,
+            cfg_weight=3.5 if guidance is None else guidance,
+            negative_text=negative_prompt or "",
+            latent_size=(height // 8, width // 8),
+            seed=seed,
+            verbose=False,
+        )
+        return GeneratedImage(image=image)

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -10,6 +10,7 @@
     "Runpod/FLUX.2-klein-4B-mflux-4bit": 4619695783,
     "Vontra/DeepSeek-V4-Flash-0731-MXFP4-MLX": 167094577743,
     "Vontra/GLM-5.3-Flash-MLX-4bit-MTP": 181741731388,
+    "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized": 16378940179,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx": 21098225260,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q4": 14261049583,
     "dgrauet/CogVideoX-Fun-V1.5-5b-InP-mlx-q8": 16640011867,

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -30,7 +30,7 @@ __all__ = [
 def require_image_runtime_or_exit(model_name: str | None = None) -> None:
     """Fail before model download when the optional image stack is absent."""
     family = _detect_family(model_name) if model_name else ""
-    if sys.version_info < (3, 11) and family != "sdxl-base":
+    if sys.version_info < (3, 11) and family not in {"sdxl-base", "sd35-large"}:
         print(
             "\n  Error: image generation requires Python 3.11 or newer "
             f"(current: {sys.version_info.major}.{sys.version_info.minor}). "
@@ -43,7 +43,7 @@ def require_image_runtime_or_exit(model_name: str | None = None) -> None:
         "mlx_vlm"
         if family == "hidream-o1-dev"
         else "PIL"
-        if family == "sdxl-base"
+        if family in {"sdxl-base", "sd35-large"}
         else "mflux"
     )
     if importlib.util.find_spec(runtime_module) is None:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -557,6 +557,12 @@ def estimate_model_bytes(model_name: str) -> int:
         # allocator/output headroom while the catalog keeps a 16 GiB minimum.
         "sdxl-base": 14.0,
         "stable-diffusion-xl": 14.0,
+        # 15.25 GiB of revision-pinned MMDiT + CLIP/T5/tokenizer payloads.
+        # The low-memory runtime stages text encoding, denoising and decoding;
+        # keep a conservative 20 GiB admission charge pending broader hardware
+        # measurements, while the public alias requires a 32 GiB Mac.
+        "sd35-large": 20.0,
+        "stable-diffusion-3.5": 20.0,
         # 6-bit-transformer Qwen-Image (20B) — measured peak RSS during a
         # real generation at 1024x1024 (mflux-community/qwen-image-mflux-q6,
         # the API/GUI default resolution; `/usr/bin/time -l`): ~55.7 GiB.


### PR DESCRIPTION
## Why

Add a high-quality non-mflux image model that users can pull once and run locally through the same Rapid-MLX Server and macOS Images workflow.

## Scope

- Add `sd35-large-4bit` for the pinned `argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized` checkpoint.
- Add a local-only MLX SD3.5 runtime, adapted from pinned MIT-licensed DiffusionKit numerical code, with full T5 conditioning.
- Pin and exact-allowlist the primary checkpoint plus its shared CLIP/T5 assets; include all three payloads in cache completeness and displayed size.
- Wire Server generation/progress/cancellation and macOS image catalog/default-step behavior.
- Bundle the runtime, attribution, and `sentencepiece` dependency in wheels and the Desktop sidecar.

## Non-goals

- No image editing, ControlNet, LoRA, arbitrary SD3.5 checkpoints, or additional model families.
- No change to generic direct-pull semantics for the auxiliary asset repositories.
- No release or deployment changes.

## Acceptance

- `rapid-mlx pull sd35-large-4bit` downloads only exact pinned files for the primary model and two auxiliary repositories.
- `rapid-mlx serve sd35-large-4bit` generates a PNG through the OpenAI-compatible image endpoint, reports 28-step progress, and recovers after cancellation.
- The macOS Images catalog exposes the model as generation-only and seeds 28 steps.
- Wheels and Desktop sidecars contain runtime code/licenses but no model weights.
- Existing Bonsai Image support remains intact after rebasing onto main.

## Verification

- Real HTTP dogfood on Apple Silicon: two independent 512x512, 28-step generations returned HTTP 200 in 62.17s and 57.29s; measured peak memory footprint 15.52 GiB with zero swaps.
- Same-runtime repeated generation passed; cancel-then-generate recovery passed; allocator limit restored on both success and error.
- `263 passed, 7 skipped` across SD3.5, Bonsai, pull-summary, auxiliary-runtime-assets, and download-gate tests after rebasing onto current main.
- `19 passed` across macOS image catalog, generation phase, and sidecar build contract suites.
- Broader pre-rebase alias/catalog/download regression: `3,758 passed`.
- Targeted Ruff lint and format checks passed; `git diff --check` passed.
- Wheel build passed; runtime source plus LICENSE/NOTICE present, no `.safetensors`, and image metadata includes `sentencepiece`.
- Five author-owned adversarial review rounds converged after fixes for cache-symlink confinement, allocator restoration, cancellation cache cleanup, auxiliary pull isolation, and post-rebase catalog count.

## Behaviour delta

Before: SD3.5 Large checkpoints are not recognized by Rapid-MLX. After: `sd35-large-4bit` is a first-class Server and macOS Images model with pinned 15.3 GiB download accounting and a validated 28-step generation contract.

The model is governed by the Stability AI Community License. The CLI shows a license notice before download; commercial use at or above the licensor revenue threshold requires an enterprise license under the current terms.

## AI assistance disclosure

Codex implemented and author-reviewed the Python runtime/integration, tests, Swift catalog wiring, packaging, attribution, and performance record. Every changed path was reviewed against the stated scope and verified with unit/Swift tests, wheel inspection, and real local generation. The numerical core is adapted from the pinned MIT-licensed upstream source identified in the shipped NOTICE.

## Checklist

- [x] Relevant tests pass locally; full suite: 22,584 passed, with 7 Bonsai failures reproduced unchanged on current main
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated: local `pr_validate` returned MERGE-SAFE (22,537 passed); exact-head GitHub PR validation passed
- [x] New critical-path tests were mutation/negative-path spot-checked
- [x] Updated docs where applicable
- [x] No breaking changes to existing API

## Author
