### PR TITLE
perf(qwen4): add indexed QSA and qualify explicit K=2

### DIFF
--- a/.agents/handoffs/qwen38-k2-indexed.md
+++ b/.agents/handoffs/qwen38-k2-indexed.md
@@ -1,0 +1,47 @@
+# Qwen3.8 K=2 indexed-QSA requalification handoff
+
+Receiving role: Atlas
+
+Owner: Vector
+
+Host: Mac Studio, Apple M3 Ultra 256 GB
+
+Branch: `vector/qwen38-mtp-k2-indexed`
+
+PR: none; this branch is not ready for production validation
+
+## Verified facts
+
+- The branch is stacked on indexed split-K spike `f620f0d84`, itself based on
+  PR #3055 head `8ef208607`.
+- Qwen3.8 keeps implicit MTP at K=1, admits only explicit K=2, and rejects K=3.
+- Existing generic chain-of-K and Qwen-specific rollback logic is unchanged.
+- Focused MTP, Qwen4, indexed-QSA, and CLI suites pass; changed Python files
+  pass Ruff.
+- On the released Qwen3.8 Flash-Next 4-bit artifact, three isolated 32K K=2
+  samples had a 35.64 tok/s median. The only clean same-code K=1 comparator was
+  34.29 tok/s, a provisional +3.9% signal.
+- A clean 64K K=2 request reached 37.80 tok/s, so the old gathered-K/V K=2
+  long-context collapse was not reproduced.
+- Full commands, environment, exclusions, and raw result summary are recorded
+  in `docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md`.
+
+## Unresolved questions and risks
+
+- Host contention left only one clean K=1 comparator and one clean 64K K=2
+  sample. The measured delta is not yet statistically actionable.
+- Real K=1 and K=2 greedy captures can diverge at near-tied logits because the
+  target block uses a different Metal accumulation shape. Both continuations
+  were coherent, but the release correctness battery has not been rerun.
+- The local chunked model-load launcher worked around a pre-inference Metal
+  watchdog timeout. It is not part of the branch and must not become an
+  undocumented production dependency.
+- Atlas must decide whether explicit-only K=2 is a supported public surface or
+  remains experimental after performance qualification.
+
+## Next concrete action
+
+Reserve an isolated M3 Ultra window, collect at least three fresh-process K=1
+and K=2 samples at 16K, 32K, and 64K, then run the 45-case Flash-Next release
+battery plus cancellation, EOS, and sampled-decoding coverage. Open and enqueue
+a production PR only if K=2 wins beyond run-to-run noise and correctness passes.

--- a/.agents/handoffs/qwen38-k2-indexed.md
+++ b/.agents/handoffs/qwen38-k2-indexed.md
@@ -22,6 +22,11 @@ PR: #3087 (Draft)
   selection geometries. The fixed gate now admits only the dogfooded BF16
   QH=24, KVH=2, D=256, block-size-4, top-K-512 layout; rejection tests cover
   every pinned field.
+- A later Apple CI run showed that M1/M2 are numerically close but not
+  bit-identical to the M3 Ultra/native reduction. The production gate was
+  already M3-Ultra-only; the FP64 numerical oracle remains cross-architecture,
+  while bit-exactness is now asserted only on the qualified host and MLX
+  version. The follow-up adversarial review returned LGTM.
 - A fresh-process isolated A/B collected three accepted samples per arm. K=2
   was -7.1% at 16K, -0.7% at 32K, and +15.4% at 64K. Every 64K K=2 sample beat
   every K=1 sample.
@@ -51,9 +56,15 @@ PR: #3087 (Draft)
   undocumented production dependency.
 - Atlas must decide whether explicit-only K=2 is a supported public surface or
   remains experimental after performance qualification.
+- Full local `pr_validate` reached 22,604 passes but reported seven Bonsai tests
+  failing on an installed `TilingConfig` signature and a DiffusionGemma golden
+  checkpoint that now identifies as the old `diffusion` family. Both failures
+  reproduce unchanged from `origin/main` (`c0e09b560`) in clean worktrees and
+  are outside this PR. Qwen3.5/Qwen3.6 stress A/B showed -0.1%/-0.5% warm
+  deltas, classified by the validator as not this PR.
 
 ## Next concrete action
 
-Complete the independent review loop and repository PR validation. Atlas should
-approve the explicit-only 64K-oriented contract before #3087 enters the merge
-queue.
+Complete the scoped validation rerun and wait for the final GitHub Apple lane.
+With explicit human authorization already given, apply the Mac-required queue
+label only after every current-head relevant check is green.

--- a/.agents/handoffs/qwen38-k2-indexed.md
+++ b/.agents/handoffs/qwen38-k2-indexed.md
@@ -12,8 +12,8 @@ PR: #3087 (Draft)
 
 ## Verified facts
 
-- The branch is stacked on indexed split-K spike `f620f0d84`, itself based on
-  PR #3055 head `8ef208607`.
+- PR #3087 is a self-contained indexed-QSA plus K=2 change rebased onto current
+  `main`; prerequisite PR #3055 is merged.
 - Qwen3.8 keeps implicit MTP at K=1, admits only explicit K=2, and rejects K=3.
 - Existing generic chain-of-K and Qwen-specific rollback logic is unchanged.
 - Focused MTP, Qwen4, indexed-QSA, and CLI suites pass; changed Python files

--- a/.agents/handoffs/qwen38-k2-indexed.md
+++ b/.agents/handoffs/qwen38-k2-indexed.md
@@ -16,7 +16,7 @@ PR: #3087 (Draft)
   `main`; prerequisite PR #3055 is merged.
 - Qwen3.8 keeps implicit MTP at K=1, admits only explicit K=2, and rejects K=3.
 - Existing generic chain-of-K and Qwen-specific rollback logic is unchanged.
-- Focused MTP, Qwen4, indexed-QSA, and CLI suites pass (349 tests); changed
+- Focused MTP, Qwen4, indexed-QSA, and CLI suites pass (357 tests); changed
   Python files pass Ruff.
 - Adversarial review found that the initial gate admitted unmeasured tensor and
   selection geometries. The fixed gate now admits only the dogfooded BF16

--- a/.agents/handoffs/qwen38-k2-indexed.md
+++ b/.agents/handoffs/qwen38-k2-indexed.md
@@ -19,8 +19,11 @@ PR: #3087 (Draft)
 - Focused MTP, Qwen4, indexed-QSA, and CLI suites pass; changed Python files
   pass Ruff.
 - A fresh-process isolated A/B collected three accepted samples per arm. K=2
-  was -7.1% at 16K, -0.7% at 32K, and +16.0% at 64K. Every 64K K=2 sample beat
+  was -7.1% at 16K, -0.7% at 32K, and +15.4% at 64K. Every 64K K=2 sample beat
   every K=1 sample.
+- The final 64K K=1 comparator also enabled indexed QSA, so the result isolates
+  speculative depth from the M=1 kernel toggle. Explicit K=2 now activates the
+  qualified kernel automatically unless the operator explicitly opts out.
 - The old gathered-K/V K=2 long-context collapse was not reproduced. The value
   is specifically an ultra-long-context crossover, not a universal speedup.
 - The K=2 real-model release battery retained the established K=1 vector at

--- a/.agents/handoffs/qwen38-k2-indexed.md
+++ b/.agents/handoffs/qwen38-k2-indexed.md
@@ -8,7 +8,7 @@ Host: Mac Studio, Apple M3 Ultra 256 GB
 
 Branch: `vector/qwen38-mtp-k2-indexed`
 
-PR: none; this branch is not ready for production validation
+PR: #3087 (Draft)
 
 ## Verified facts
 
@@ -18,21 +18,27 @@ PR: none; this branch is not ready for production validation
 - Existing generic chain-of-K and Qwen-specific rollback logic is unchanged.
 - Focused MTP, Qwen4, indexed-QSA, and CLI suites pass; changed Python files
   pass Ruff.
-- On the released Qwen3.8 Flash-Next 4-bit artifact, three isolated 32K K=2
-  samples had a 35.64 tok/s median. The only clean same-code K=1 comparator was
-  34.29 tok/s, a provisional +3.9% signal.
-- A clean 64K K=2 request reached 37.80 tok/s, so the old gathered-K/V K=2
-  long-context collapse was not reproduced.
+- A fresh-process isolated A/B collected three accepted samples per arm. K=2
+  was -7.1% at 16K, -0.7% at 32K, and +16.0% at 64K. Every 64K K=2 sample beat
+  every K=1 sample.
+- The old gathered-K/V K=2 long-context collapse was not reproduced. The value
+  is specifically an ultra-long-context crossover, not a universal speedup.
+- The K=2 real-model release battery retained the established K=1 vector at
+  42/45 with exactly the same three known failures and no new regressions.
+- Real-service sampled decoding completed twice at temperature 0.8/top-p 0.9.
+  A client-disconnected stream was removed from the running batch, and the
+  immediate recovery request returned the expected output.
 - Full commands, environment, exclusions, and raw result summary are recorded
   in `docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md`.
 
 ## Unresolved questions and risks
 
-- Host contention left only one clean K=1 comparator and one clean 64K K=2
-  sample. The measured delta is not yet statistically actionable.
+- K=2 regresses 16K throughput and is only neutral at 32K. It must remain an
+  explicit operator choice; these results do not justify a default change.
 - Real K=1 and K=2 greedy captures can diverge at near-tied logits because the
   target block uses a different Metal accumulation shape. Both continuations
-  were coherent, but the release correctness battery has not been rerun.
+  were coherent. The release battery, sampled decoding, and cancellation
+  recovery found no new failure.
 - The local chunked model-load launcher worked around a pre-inference Metal
   watchdog timeout. It is not part of the branch and must not become an
   undocumented production dependency.
@@ -41,7 +47,6 @@ PR: none; this branch is not ready for production validation
 
 ## Next concrete action
 
-Reserve an isolated M3 Ultra window, collect at least three fresh-process K=1
-and K=2 samples at 16K, 32K, and 64K, then run the 45-case Flash-Next release
-battery plus cancellation, EOS, and sampled-decoding coverage. Open and enqueue
-a production PR only if K=2 wins beyond run-to-run noise and correctness passes.
+Complete the independent review loop and repository PR validation. Atlas should
+approve the explicit-only 64K-oriented contract before #3087 enters the merge
+queue.

--- a/.agents/handoffs/qwen38-k2-indexed.md
+++ b/.agents/handoffs/qwen38-k2-indexed.md
@@ -16,8 +16,12 @@ PR: #3087 (Draft)
   `main`; prerequisite PR #3055 is merged.
 - Qwen3.8 keeps implicit MTP at K=1, admits only explicit K=2, and rejects K=3.
 - Existing generic chain-of-K and Qwen-specific rollback logic is unchanged.
-- Focused MTP, Qwen4, indexed-QSA, and CLI suites pass; changed Python files
-  pass Ruff.
+- Focused MTP, Qwen4, indexed-QSA, and CLI suites pass (349 tests); changed
+  Python files pass Ruff.
+- Adversarial review found that the initial gate admitted unmeasured tensor and
+  selection geometries. The fixed gate now admits only the dogfooded BF16
+  QH=24, KVH=2, D=256, block-size-4, top-K-512 layout; rejection tests cover
+  every pinned field.
 - A fresh-process isolated A/B collected three accepted samples per arm. K=2
   was -7.1% at 16K, -0.7% at 32K, and +15.4% at 64K. Every 64K K=2 sample beat
   every K=1 sample.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,7 @@ jobs:
             tests/test_qwen4_exp_vendored.py \
             tests/test_qwen4_fused_gdn_decode.py \
             tests/test_qsa_block_sparse.py \
+            tests/test_qsa_indexed_splitk.py \
             tests/test_mtp_cli_wiring.py \
             tests/test_continuous_mtp_routing.py \
             tests/test_continuous_self_mtp_mlx_backend.py \

--- a/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
+++ b/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
@@ -12,17 +12,16 @@ Branch: `vector/qwen38-mtp-k2-indexed`, stacked on the indexed split-K spike
 
 ## Outcome
 
-Indexed M=3 QSA changes the conclusion of the 2026-08-28 K=2 no-go enough to
-justify continued qualification. It removes the old long-context collapse and
-produced a small positive 32K signal versus a same-code K=1 run. It is **not yet
-eligible for a production PR or validation queue**: repeated unrelated model
-services interrupted the host, leaving only one clean same-code K=1 comparator
-and one clean 64K K=2 sample.
+Indexed M=3 QSA changes the conclusion of the 2026-08-28 K=2 no-go, but only at
+ultra-long context. A fully isolated same-code A/B found K=2 7.1% slower at 16K,
+within 0.7% of K=1 at 32K, and 16.0% faster at 64K. The old gathered-QSA
+long-context collapse is gone; the benefit has a measured crossover rather than
+being universal.
 
 The branch deliberately keeps implicit Qwen3.8 MTP at K=1. It admits K=2 only
 when the operator explicitly requests `num_speculative_tokens=2`, and continues
-to reject K=3. The product default must not change until a fully isolated A/B
-and the existing release correctness battery pass.
+to reject K=3. That explicit-only contract is important: K=2 is a 64K-oriented
+operator choice and must not become the family default from this evidence.
 
 ## Why the old no-go can be reopened
 
@@ -77,27 +76,30 @@ The service emitted `QSA indexed split-K attention enabled for narrow
 decode/verify` on the first 16K K=2 request, proving that the candidate route
 was constructed rather than silently falling back.
 
-Because other agents repeatedly started 6--38 GB model workers despite the
-reserved host, a timestamped watchdog recorded and terminated competitors.
-Any request whose wall-clock interval overlapped a watchdog event was excluded.
-The exclusions explain why the clean sample count is uneven; they are not
-performance outlier trimming.
+Because another validation supervisor repeatedly started a 38 GB model worker
+despite the reserved host, every overlapping 64K K=1 replacement was excluded.
+The detached supervisor and its launcher were stopped before the accepted
+replacement. Excluded JSON files remain in `/private/tmp`; the accepted rows
+below require both a cold-cache MISS and an interval with no competing model
+process. This is contamination filtering, not performance outlier trimming.
 
 ## Clean results
 
-| Prompt target | K | Clean decode samples | Median | Peak RSS |
-| ---: | ---: | --- | ---: | ---: |
-| 16K | 2 indexed | 33.45 | 33.45 tok/s | 55.97 GiB |
-| 32K | 2 indexed | 34.79, 35.64, 36.30 | 35.64 tok/s | 55.96 GiB |
-| 32K | 1 native gather | 34.29 | 34.29 tok/s | 55.87 GiB |
-| 64K | 2 indexed | 37.80 | 37.80 tok/s | 56.06 GiB |
+| Prompt target | K=1 clean decode samples | K=1 median | K=2 indexed clean decode samples | K=2 median | Delta |
+| ---: | --- | ---: | --- | ---: | ---: |
+| 16K | 35.38, 35.34, 35.40 | 35.38 tok/s | 34.45, 31.54, 32.88 | 32.88 tok/s | -7.1% |
+| 32K | 33.31, 33.21, 33.14 | 33.21 tok/s | 32.97, 33.03, 32.57 | 32.97 tok/s | -0.7% |
+| 64K | 28.98, 29.16, 29.06 | 29.06 tok/s | 33.82, 33.72, 33.28 | 33.72 tok/s | +16.0% |
 
-At 32K, the three-run K=2 median is 3.9% above the one clean same-code K=1
-sample. More importantly, it is 1.99x the old 17.93 tok/s K=2 gather result,
+The strict comparison reverses the provisional one-sample 32K signal recorded
+earlier in the day. K=2 is neutral within noise at 32K and a regression at 16K;
+its material value begins somewhere between 32K and 64K. At 64K every K=2
+sample beats every K=1 sample, with a 4.12 tok/s gap even between the slowest
+K=2 and fastest K=1 runs.
+
+The 32K K=2 median is still 1.84x the old 17.93 tok/s gathered-QSA result,
 although that historical comparison crosses Rapid and MLX revisions and is
-therefore directional rather than a strict A/B. The clean 64K request did not
-show the old context-length collapse, but a single sample is not a promotion
-receipt.
+directional rather than a strict A/B.
 
 MLX active memory reported approximately 107.1--107.3 GB at 32K and 109.7--109.8
 GB at 64K. The historical allocator peak remained 148.1 GB.
@@ -121,19 +123,37 @@ token 9 respectively into coherent alternatives, consistent with the already
 documented near-tied-logit accumulation boundary; no unverified draft or cache
 failure was observed.
 
+The isolated K=2 process also ran the 45-case Flash-Next release battery. It
+retained the established K=1 baseline vector at 42/45: 8K/32K needle recall,
+JSON schema, forced and automatic tool use, OpenAI and Anthropic protocols,
+multi-turn behavior, and stop sequences passed. The three existing failures
+were reproduced exactly: the probability answer, the narrow palindrome regex
+scorer, and the generated project invoking unavailable `python` instead of
+`python3`. There were no new K=2 failures.
+
+A real streaming request then ran K=2 with `temperature=0.8`, `top_p=0.9`, and
+`max_tokens=1024`. The client disconnected after two seconds and 26 generated
+tokens. Server logs showed `CancelledError`, deferred abort, removal from the
+running batch, and cleanup. The immediately following greedy request returned
+exactly `RECOVERED`. Two further sampled requests at temperature 0.8/top-p 0.9
+each completed 128 tokens through the fused top-p sampler and produced distinct
+coherent paragraphs.
+
 ## Promotion gate
 
-1. Reserve a genuinely isolated M3 Ultra window with no PR validation or
-   Desktop model supervisor.
-2. Collect at least three clean samples per arm at 16K, 32K, and 64K from fresh
-   K=1 and K=2 processes on this exact stack.
-3. Require K=2 to beat K=1 beyond run-to-run noise at the intended crossover;
-   a one-sample 3.9% delta is not sufficient.
-4. Run the 45-case Flash-Next release battery, cancellation/EOS coverage, and
-   sampled decoding before changing the family capability in production.
-5. Have Atlas decide whether explicit-only K=2 is a supported compatibility
-   surface or whether the indexed kernel should land first while K=2 remains an
-   experimental follow-up.
+Completed:
 
-Until those gates pass, do not enable K=2 by default, open a production PR, or
-enqueue this branch in PR validation.
+1. Isolated fresh-process K=1/K=2 A/B with three accepted samples per arm at
+   16K, 32K, and 64K.
+2. Material 64K win beyond the observed noise band, with no claim of a shorter-
+   context win.
+3. The 45-case release battery with no new failure relative to K=1.
+
+Remaining before merge:
+
+1. Complete independent review and repository PR validation.
+2. Have Atlas accept explicit-only K=2 as a supported ultra-long-context
+   compatibility surface.
+
+Do not enable K=2 by default from this result. The supported claim, if approved,
+is limited to an explicit opt-in whose measured payoff is at 64K context.

--- a/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
+++ b/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
@@ -6,9 +6,8 @@ Owner: Vector
 
 Host: Mac Studio, Apple M3 Ultra 256 GB, `applegpu_g15d`
 
-Branch: `vector/qwen38-mtp-k2-indexed`, stacked on the indexed split-K spike
-`f620f0d847207a17d7c92f808230bd010fae8be6` and therefore on PR #3055 head
-`8ef208607ececfaf9646da18575a1c7b95f7f4da`.
+Branch: `vector/qwen38-mtp-k2-indexed`, PR #3087, rebased onto `main` after
+prerequisite PR #3055 merged.
 
 ## Outcome
 

--- a/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
+++ b/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
@@ -14,7 +14,7 @@ Branch: `vector/qwen38-mtp-k2-indexed`, stacked on the indexed split-K spike
 
 Indexed M=3 QSA changes the conclusion of the 2026-08-28 K=2 no-go, but only at
 ultra-long context. A fully isolated same-code A/B found K=2 7.1% slower at 16K,
-within 0.7% of K=1 at 32K, and 16.0% faster at 64K. The old gathered-QSA
+within 0.7% of K=1 at 32K, and 15.4% faster at 64K. The old gathered-QSA
 long-context collapse is gone; the benefit has a measured crossover rather than
 being universal.
 
@@ -59,7 +59,7 @@ same local-only launcher: call mlx-lm with `lazy=True`, then materialize eight
 parameter leaves per `mx.eval`. This changes only load synchronization; it does
 not set MLX command-buffer environment overrides or alter inference scheduling.
 
-K=2 additionally used:
+The measured K=2 process explicitly set the kernel environment variable:
 
 ```bash
 export RAPID_MLX_QSA_INDEXED_SPLITK=1
@@ -76,6 +76,11 @@ The service emitted `QSA indexed split-K attention enabled for narrow
 decode/verify` on the first 16K K=2 request, proving that the candidate route
 was constructed rather than silently falling back.
 
+Adversarial review identified that a public explicit K=2 request must not
+silently depend on an undocumented environment variable. The final CLI uses
+`setdefault` to activate indexed QSA for explicit Qwen3.8 K=2 while preserving
+an operator's explicit `RAPID_MLX_QSA_INDEXED_SPLITK=0` fallback/debug override.
+
 Because another validation supervisor repeatedly started a 38 GB model worker
 despite the reserved host, every overlapping 64K K=1 replacement was excluded.
 The detached supervisor and its launcher were stopped before the accepted
@@ -89,13 +94,14 @@ process. This is contamination filtering, not performance outlier trimming.
 | ---: | --- | ---: | --- | ---: | ---: |
 | 16K | 35.38, 35.34, 35.40 | 35.38 tok/s | 34.45, 31.54, 32.88 | 32.88 tok/s | -7.1% |
 | 32K | 33.31, 33.21, 33.14 | 33.21 tok/s | 32.97, 33.03, 32.57 | 32.97 tok/s | -0.7% |
-| 64K | 28.98, 29.16, 29.06 | 29.06 tok/s | 33.82, 33.72, 33.28 | 33.72 tok/s | +16.0% |
+| 64K | 28.89, 29.45, 29.23 | 29.23 tok/s | 33.82, 33.72, 33.28 | 33.72 tok/s | +15.4% |
 
 The strict comparison reverses the provisional one-sample 32K signal recorded
 earlier in the day. K=2 is neutral within noise at 32K and a regression at 16K;
 its material value begins somewhere between 32K and 64K. At 64K every K=2
 sample beats every K=1 sample, with a 4.12 tok/s gap even between the slowest
-K=2 and fastest K=1 runs.
+K=2 and fastest K=1 runs. The final 64K K=1 comparator also had indexed QSA
+enabled, removing the M=1 kernel toggle as a confounder.
 
 The 32K K=2 median is still 1.84x the old 17.93 tok/s gathered-QSA result,
 although that historical comparison crosses Rapid and MLX revisions and is

--- a/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
+++ b/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
@@ -119,7 +119,7 @@ Focused suites passed before real-model dogfood:
 ```text
 tests/test_mtp_spec_decode.py                         132 passed
 tests/test_qwen4_exp_vendored.py                     101 passed
-tests/test_qsa_indexed_splitk.py + CLI wiring        107 passed
+tests/test_qsa_indexed_splitk.py + CLI wiring        123 passed
 ruff on all changed Python files                     passed
 ```
 

--- a/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
+++ b/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
@@ -1,0 +1,139 @@
+# Qwen3.8 Flash-Next K=2 indexed-QSA requalification
+
+Date: 2026-09-05
+
+Owner: Vector
+
+Host: Mac Studio, Apple M3 Ultra 256 GB, `applegpu_g15d`
+
+Branch: `vector/qwen38-mtp-k2-indexed`, stacked on the indexed split-K spike
+`f620f0d847207a17d7c92f808230bd010fae8be6` and therefore on PR #3055 head
+`8ef208607ececfaf9646da18575a1c7b95f7f4da`.
+
+## Outcome
+
+Indexed M=3 QSA changes the conclusion of the 2026-08-28 K=2 no-go enough to
+justify continued qualification. It removes the old long-context collapse and
+produced a small positive 32K signal versus a same-code K=1 run. It is **not yet
+eligible for a production PR or validation queue**: repeated unrelated model
+services interrupted the host, leaving only one clean same-code K=1 comparator
+and one clean 64K K=2 sample.
+
+The branch deliberately keeps implicit Qwen3.8 MTP at K=1. It admits K=2 only
+when the operator explicitly requests `num_speculative_tokens=2`, and continues
+to reject K=3. The product default must not change until a fully isolated A/B
+and the existing release correctness battery pass.
+
+## Why the old no-go can be reopened
+
+The earlier experiment at `a20936703` had already qualified chain-of-K cache
+correctness, but its gathered QSA verify path made K=2 decode fall from 34.41
+tok/s at 2K to 17.93 tok/s at 32K. K=1 reached 33.14 tok/s at 32K in the same
+campaign. The current indexed split-K path reads compact QSA selections without
+materializing gathered K/V and is qualified for K=2's target verify width M=3
+from 16K onward.
+
+The implementation change in this branch is intentionally narrow:
+
+- Qwen3.8 implicit depth remains K=1.
+- Explicit K=1 or K=2 is accepted; every other explicit depth fails startup.
+- The injected model capability ceiling is two.
+- Existing generic chain-of-K and per-position GDN/PLE/QSA/KV rollback code is
+  reused unchanged.
+
+## Environment and method
+
+| Component | Value |
+| --- | --- |
+| macOS | 26.5.2 (25F84) |
+| Python | 3.12.14 |
+| MLX / MLX-LM | 0.32.2 / 0.31.3 |
+| Transformers | 5.16.1 |
+| Artifact | `rapid-mlx/Qwen3.8-Flash-Next-4bit` at `dcf657e4acda2aae72da99cde65b6c491cd96998` |
+| Decode | temperature zero, thinking disabled, fixed K, 256 requested tokens |
+| Cache | prefix cache cleared before every request |
+
+The normal mlx-lm load intermittently failed in
+`mx.eval(model.parameters())` with a Metal GPU watchdog timeout before either
+candidate code path could execute. Both K=1 and K=2 servers therefore used the
+same local-only launcher: call mlx-lm with `lazy=True`, then materialize eight
+parameter leaves per `mx.eval`. This changes only load synchronization; it does
+not set MLX command-buffer environment overrides or alter inference scheduling.
+
+K=2 additionally used:
+
+```bash
+export RAPID_MLX_QSA_INDEXED_SPLITK=1
+python3.12 /private/tmp/rapid_chunked_launch.py serve "$SNAPSHOT" \
+  --host 127.0.0.1 --port 8465 --no-thinking \
+  --speculative-config \
+  '{"method":"mtp","num_speculative_tokens":2,"disable_auto_k":true}'
+```
+
+K=1 used the identical command without the indexed environment variable and
+with `num_speculative_tokens` set to one. Timed requests used the repository's
+`.orca/flash-next-eval/benchmark.py` with one requested prompt length per run.
+The service emitted `QSA indexed split-K attention enabled for narrow
+decode/verify` on the first 16K K=2 request, proving that the candidate route
+was constructed rather than silently falling back.
+
+Because other agents repeatedly started 6--38 GB model workers despite the
+reserved host, a timestamped watchdog recorded and terminated competitors.
+Any request whose wall-clock interval overlapped a watchdog event was excluded.
+The exclusions explain why the clean sample count is uneven; they are not
+performance outlier trimming.
+
+## Clean results
+
+| Prompt target | K | Clean decode samples | Median | Peak RSS |
+| ---: | ---: | --- | ---: | ---: |
+| 16K | 2 indexed | 33.45 | 33.45 tok/s | 55.97 GiB |
+| 32K | 2 indexed | 34.79, 35.64, 36.30 | 35.64 tok/s | 55.96 GiB |
+| 32K | 1 native gather | 34.29 | 34.29 tok/s | 55.87 GiB |
+| 64K | 2 indexed | 37.80 | 37.80 tok/s | 56.06 GiB |
+
+At 32K, the three-run K=2 median is 3.9% above the one clean same-code K=1
+sample. More importantly, it is 1.99x the old 17.93 tok/s K=2 gather result,
+although that historical comparison crosses Rapid and MLX revisions and is
+therefore directional rather than a strict A/B. The clean 64K request did not
+show the old context-length collapse, but a single sample is not a promotion
+receipt.
+
+MLX active memory reported approximately 107.1--107.3 GB at 32K and 109.7--109.8
+GB at 64K. The historical allocator peak remained 148.1 GB.
+
+## Correctness
+
+Focused suites passed before real-model dogfood:
+
+```text
+tests/test_mtp_spec_decode.py                         132 passed
+tests/test_qwen4_exp_vendored.py                     101 passed
+tests/test_qsa_indexed_splitk.py + CLI wiring        107 passed
+ruff on all changed Python files                     passed
+```
+
+The Qwen4 synthetic generation test now runs fixed K=1 and K=2 twice and
+requires deterministic output at each depth. Generic K=3 tests continue to
+cover the stronger partial-accept rollback geometry. Real K=2 captures at 128
+and 2K completed 256 tokens coherently. They diverged from K=1 at token 37 and
+token 9 respectively into coherent alternatives, consistent with the already
+documented near-tied-logit accumulation boundary; no unverified draft or cache
+failure was observed.
+
+## Promotion gate
+
+1. Reserve a genuinely isolated M3 Ultra window with no PR validation or
+   Desktop model supervisor.
+2. Collect at least three clean samples per arm at 16K, 32K, and 64K from fresh
+   K=1 and K=2 processes on this exact stack.
+3. Require K=2 to beat K=1 beyond run-to-run noise at the intended crossover;
+   a one-sample 3.9% delta is not sufficient.
+4. Run the 45-case Flash-Next release battery, cancellation/EOS coverage, and
+   sampled decoding before changing the family capability in production.
+5. Have Atlas decide whether explicit-only K=2 is a supported compatibility
+   surface or whether the indexed kernel should land first while K=2 remains an
+   experimental follow-up.
+
+Until those gates pass, do not enable K=2 by default, open a production PR, or
+enqueue this branch in PR validation.

--- a/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
+++ b/docs/engineering/performance/2026-09-05-qwen38-k2-indexed-requalification.md
@@ -68,8 +68,11 @@ python3.12 /private/tmp/rapid_chunked_launch.py serve "$SNAPSHOT" \
   '{"method":"mtp","num_speculative_tokens":2,"disable_auto_k":true}'
 ```
 
-K=1 used the identical command without the indexed environment variable and
-with `num_speculative_tokens` set to one. Timed requests used the repository's
+The 16K and 32K K=1 runs used the identical command without the indexed
+environment variable and with `num_speculative_tokens` set to one. The strict
+64K K=1 comparator additionally exported
+`RAPID_MLX_QSA_INDEXED_SPLITK=1`, matching the K=2 kernel environment and
+isolating speculative depth. Timed requests used the repository's
 `.orca/flash-next-eval/benchmark.py` with one requested prompt length per run.
 The service emitted `QSA indexed split-K attention enabled for narrow
 decode/verify` on the first 16K K=2 request, proving that the candidate route

--- a/docs/engineering/performance/2026-09-05-qwen4-qsa-indexed-splitk-spike.md
+++ b/docs/engineering/performance/2026-09-05-qwen4-qsa-indexed-splitk-spike.md
@@ -1,0 +1,103 @@
+# Qwen4 indexed split-K QSA spike (not promoted)
+
+Date: 2026-09-05
+
+Owner: Vector
+
+Host: Mac Studio, M3 Ultra 256 GB, `applegpu_g15d`
+
+Branch: `vector/qsa-indexed-splitk`, stacked on PR #3055 head
+`8ef208607ececfaf9646da18575a1c7b95f7f4da`
+
+## Outcome
+
+The direct compact-index Metal path is promising for the geometry that the
+source handoff qualified, but it is **not ready to promote or queue** in Rapid.
+The handoff's end-to-end result is for self-MTP k=2 (target verify width M=3),
+while the current Qwen3.8 Flash-Next native-MTP runtime rejects k=2 and supports
+k=1 only. Its target verify width is M=2, which was not qualified by the source
+experiment. The production gate therefore admits only M=3 from 16K and M=1
+from 64K, remains opt-in, requires batch size one, and pins both MLX 0.32.2 and
+the measured M3 Ultra Metal architecture.
+
+Do not broaden the gate to M=2 merely to make the current MTP path exercise the
+kernel. A first cold M=2 served run regressed, and there is no settled hot
+end-to-end comparison for that geometry.
+
+## Implementation and numerical evidence
+
+The spike implements two Metal passes over sorted compact QSA block/tail
+indices. K/V remain in the physical cache. The implementation clones MLX
+`sdpa_vector_2pass`'s float accumulators, `metal::fast::exp`, bf16 partial
+boundary, and pass-two transpose/reduction order.
+
+An early D=32 smoke passed while the production D=256 layout was wrong: pass
+one used interleaved lane dimensions but pass two expected MLX's contiguous
+`D / 32` lane chunks. The production-shape adversarial comparison caught it.
+After the fix, at B=1, QH=24, KVH=2, M=3, N=16K, D=256, block size 4 and 512
+selected blocks:
+
+| Comparison | Max absolute error | Mean absolute error |
+| --- | ---: | ---: |
+| indexed split-K vs dense masked | 1.2207e-4 | 1.0857e-5 |
+| indexed split-K vs independent fp64 | 8.4140e-5 | 1.0021e-5 |
+| dense masked vs independent fp64 | 7.5344e-5 | 1.0404e-5 |
+
+Distinct selections were used for all three query rows. Split counts 32, 64,
+and 512 all passed the fp64 tolerance. The production schedule uses 128 splits,
+which is bit-identical (`max_abs 0.0`) to MLX 0.32.2 attention over physically
+gathered 2,048-token K/V. A 512-split schedule was faster in one microbench but
+changed 9,261 bf16 outputs, so it was rejected. Additional tests cover opt-in and
+version/architecture gates, malformed int32 indices, empty selections, route
+priority/receipts, and graph identity when both sparse routes are disabled.
+
+The final stride-aware implementation was measured with K/V sliced from a
+larger capacity buffer, matching the non-row-contiguous decode-cache layout:
+
+| Query / physical KV | Dense mask | Indexed, 128 splits | Isolated speedup |
+| ---: | ---: | ---: | ---: |
+| M=3 / 16K | 2.226 ms | 0.391 ms | 5.70x |
+| M=1 / 64K | 0.864 ms | 0.304 ms | 2.84x |
+
+Each arm used 12 warmups and 80 serialized timings; p90 was 2.242 / 0.418 ms
+for M=3 and 0.906 / 0.315 ms for M=1. These are go/no-go microbenchmarks, not
+end-to-end claims. Earlier prototypes used `ensure_row_contiguous=True`, which
+copied the full KV capacity slice on every layer and invalidated the indexed
+read advantage. The final pass consumes MLX-provided input strides directly.
+
+## Served dogfood and why it is not a promotion receipt
+
+Artifact:
+`rapid-mlx/Qwen3.8-Flash-Next-4bit` at immutable revision
+`dcf657e4acda2aae72da99cde65b6c491cd96998`; MLX 0.32.2; MLX-LM 0.31.3;
+fixed native MTP k=1; temperature zero; 16,348 reported prompt tokens.
+
+The first candidate request constructed and executed the indexed route and
+completed 64 output tokens: TTFT 22.112 s, decode 23.58 tok/s, peak RSS 55.72
+GiB. It was a cold JIT run on the unqualified M=2 route and preceded the
+stride-aware no-copy fix, so it is a debugging receipt rather than performance
+evidence for the final code. The first baseline was
+34.29 tok/s; later baseline samples were 18.33 and 35.95 tok/s while a desktop
+model service repeatedly restarted. Multiple fresh-process loads then failed
+in weight `mx.eval` with a Metal GPU timeout before the candidate kernel could
+run. Those failures are host-state failures, not kernel failures, but the
+resulting samples are too contaminated to compare. Artifacts:
+
+- `/private/tmp/qsa-indexed-candidate-k1-16k.json`
+- `/private/tmp/qsa-indexed-baseline-k1-16k.json`
+- `/private/tmp/qsa-indexed-baseline-k1-settled-16k.json`
+
+## Reopen / promotion gate
+
+1. Enable and independently qualify Qwen3.8 Flash-Next native MTP k=2, or run
+   a real 64K M=1 decode campaign.
+2. Start from a clean Metal session with no other model server resident.
+3. Warm the new pipelines before timing, then collect at least three samples
+   per arm at 16K, 32K, and 64K with identical prompts and seeds.
+4. Require nonzero indexed route receipts, zero unexpected declines/fallbacks,
+   successful state rollback transactions, and a same-seed output comparison.
+5. Re-pin the exact MLX build and rerun production tensor captures on every
+   MLX-core bump.
+
+Until all five conditions pass, do not open/queue a performance PR and do not
+enable this route by default.

--- a/docs/engineering/performance/2026-09-05-qwen4-qsa-indexed-splitk-spike.md
+++ b/docs/engineering/performance/2026-09-05-qwen4-qsa-indexed-splitk-spike.md
@@ -54,6 +54,13 @@ version/architecture gates, exact production layout/selection admission,
 malformed int32 indices, empty selections, route priority/receipts, and graph
 identity when both sparse routes are disabled.
 
+The GitHub M1/M2 lane confirmed why bit identity is part of the qualification
+boundary rather than a cross-architecture property: its direct comparison to
+native attention differed in 7,824 of 18,432 BF16 elements, with maximum
+absolute difference 9.7656e-4. Those devices remain production-ineligible;
+their independent FP64-oracle test stays enabled, while the bit-exact assertion
+now runs only on the qualified MLX 0.32.2 M3 Ultra combination.
+
 The final stride-aware implementation was measured with K/V sliced from a
 larger capacity buffer, matching the non-row-contiguous decode-cache layout:
 

--- a/docs/engineering/performance/2026-09-05-qwen4-qsa-indexed-splitk-spike.md
+++ b/docs/engineering/performance/2026-09-05-qwen4-qsa-indexed-splitk-spike.md
@@ -17,8 +17,10 @@ K=2 and the active K=1 target width M=2 was intentionally unqualified. The
 follow-up in PR #3087 adds explicit-only K=2 and completes real-model
 qualification. The production gate admits only M=3 from 16K and M=1 from 64K,
 requires batch size one, and pins both MLX 0.32.2 and the measured M3 Ultra
-Metal architecture. Explicit K=2 activates the route by default while an
-explicit environment opt-out remains available.
+Metal architecture. It also fail-closes on any tensor or selection geometry
+other than the measured BF16 QH=24, KVH=2, D=256, block-size-4, top-K-512
+layout. Explicit K=2 activates the route by default while an explicit
+environment opt-out remains available.
 
 Do not broaden the gate to M=2 merely to make the current MTP path exercise the
 kernel. A first cold M=2 served run regressed, and there is no settled hot
@@ -47,9 +49,10 @@ Distinct selections were used for all three query rows. Split counts 32, 64,
 and 512 all passed the fp64 tolerance. The production schedule uses 128 splits,
 which is bit-identical (`max_abs 0.0`) to MLX 0.32.2 attention over physically
 gathered 2,048-token K/V. A 512-split schedule was faster in one microbench but
-changed 9,261 bf16 outputs, so it was rejected. Additional tests cover opt-in and
-version/architecture gates, malformed int32 indices, empty selections, route
-priority/receipts, and graph identity when both sparse routes are disabled.
+changed 9,261 bf16 outputs, so it was rejected. Additional tests cover opt-in,
+version/architecture gates, exact production layout/selection admission,
+malformed int32 indices, empty selections, route priority/receipts, and graph
+identity when both sparse routes are disabled.
 
 The final stride-aware implementation was measured with K/V sliced from a
 larger capacity buffer, matching the non-row-contiguous decode-cache layout:

--- a/docs/engineering/performance/2026-09-05-qwen4-qsa-indexed-splitk-spike.md
+++ b/docs/engineering/performance/2026-09-05-qwen4-qsa-indexed-splitk-spike.md
@@ -1,4 +1,4 @@
-# Qwen4 indexed split-K QSA spike (not promoted)
+# Qwen4 indexed split-K QSA qualification
 
 Date: 2026-09-05
 
@@ -6,19 +6,19 @@ Owner: Vector
 
 Host: Mac Studio, M3 Ultra 256 GB, `applegpu_g15d`
 
-Branch: `vector/qsa-indexed-splitk`, stacked on PR #3055 head
-`8ef208607ececfaf9646da18575a1c7b95f7f4da`
+Originating branch: `vector/qsa-indexed-splitk`. The implementation and its K=2
+qualification are now combined in PR #3087 on top of `main`; prerequisite PR
+#3055 is merged.
 
 ## Outcome
 
-The direct compact-index Metal path is promising for the geometry that the
-source handoff qualified, but it is **not ready to promote or queue** in Rapid.
-The handoff's end-to-end result is for self-MTP k=2 (target verify width M=3),
-while the current Qwen3.8 Flash-Next native-MTP runtime rejects k=2 and supports
-k=1 only. Its target verify width is M=2, which was not qualified by the source
-experiment. The production gate therefore admits only M=3 from 16K and M=1
-from 64K, remains opt-in, requires batch size one, and pins both MLX 0.32.2 and
-the measured M3 Ultra Metal architecture.
+The initial standalone spike was not ready to promote because Qwen3.8 rejected
+K=2 and the active K=1 target width M=2 was intentionally unqualified. The
+follow-up in PR #3087 adds explicit-only K=2 and completes real-model
+qualification. The production gate admits only M=3 from 16K and M=1 from 64K,
+requires batch size one, and pins both MLX 0.32.2 and the measured M3 Ultra
+Metal architecture. Explicit K=2 activates the route by default while an
+explicit environment opt-out remains available.
 
 Do not broaden the gate to M=2 merely to make the current MTP path exercise the
 kernel. A first cold M=2 served run regressed, and there is no settled hot
@@ -87,17 +87,16 @@ resulting samples are too contaminated to compare. Artifacts:
 - `/private/tmp/qsa-indexed-baseline-k1-16k.json`
 - `/private/tmp/qsa-indexed-baseline-k1-settled-16k.json`
 
-## Reopen / promotion gate
+## Promotion gate disposition
 
-1. Enable and independently qualify Qwen3.8 Flash-Next native MTP k=2, or run
-   a real 64K M=1 decode campaign.
-2. Start from a clean Metal session with no other model server resident.
-3. Warm the new pipelines before timing, then collect at least three samples
-   per arm at 16K, 32K, and 64K with identical prompts and seeds.
-4. Require nonzero indexed route receipts, zero unexpected declines/fallbacks,
-   successful state rollback transactions, and a same-seed output comparison.
-5. Re-pin the exact MLX build and rerun production tensor captures on every
-   MLX-core bump.
+The follow-up requalification completed the clean Metal session, three samples
+per K=1/K=2 arm at 16K/32K/64K, real indexed-route construction, rollback tests,
+same-seed coherent-output comparison, the 45-case release battery, sampled
+decoding, and cancellation recovery. The strict 64K comparison kept indexed
+QSA enabled for both arms and measured K=2 at 33.72 tok/s versus K=1 at 29.23
+tok/s (+15.4%). See
+`2026-09-05-qwen38-k2-indexed-requalification.md` for the complete evidence and
+the shorter-context non-win.
 
-Until all five conditions pass, do not open/queue a performance PR and do not
-enable this route by default.
+The MLX version and Metal architecture pins remain mandatory. Production tensor
+captures must be rerun before broadening either pin or admitting M=2.

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -150,6 +150,7 @@ def test_qwen4_fused_gdn_coverage_runs_on_apple_silicon() -> None:
 
     assert "tests/test_qwen4_fused_gdn_decode.py" in apple_run
     assert "tests/test_qsa_block_sparse.py" in apple_run
+    assert "tests/test_qsa_indexed_splitk.py" in apple_run
 
 
 def test_hidream_runtime_coverage_runs_on_apple_silicon() -> None:

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -29,6 +29,7 @@ Deliberately out of scope (deferred to PR-B / PR-C):
 
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -4100,10 +4101,11 @@ def test_apply_mtp_cli_reconciliation_caps_qwen4_default_depth():
     assert sc.mtp_max_k == 1
 
 
-def test_apply_mtp_cli_reconciliation_accepts_explicit_qwen4_k2():
+def test_apply_mtp_cli_reconciliation_accepts_explicit_qwen4_k2(monkeypatch):
     from vllm_mlx.cli import _apply_mtp_cli_model_type_reconciliation
     from vllm_mlx.scheduler import SchedulerConfig
 
+    monkeypatch.delenv("RAPID_MLX_QSA_INDEXED_SPLITK", raising=False)
     sc = SchedulerConfig(spec_decode="mtp", mtp_max_k=2)
     _apply_mtp_cli_model_type_reconciliation(
         scheduler_config=sc,
@@ -4117,6 +4119,30 @@ def test_apply_mtp_cli_reconciliation_accepts_explicit_qwen4_k2():
     )
 
     assert sc.mtp_max_k == 2
+    assert os.environ["RAPID_MLX_QSA_INDEXED_SPLITK"] == "1"
+
+
+def test_apply_mtp_cli_reconciliation_preserves_qwen4_k2_kernel_opt_out(
+    monkeypatch,
+):
+    from vllm_mlx.cli import _apply_mtp_cli_model_type_reconciliation
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    monkeypatch.setenv("RAPID_MLX_QSA_INDEXED_SPLITK", "0")
+    sc = SchedulerConfig(spec_decode="mtp", mtp_max_k=2)
+    _apply_mtp_cli_model_type_reconciliation(
+        scheduler_config=sc,
+        hf_cfg_eligibility={
+            "model_type": "qwen4_exp",
+            "mtp_num_hidden_layers": 1,
+        },
+        logger=None,
+        requested_depth=2,
+        explicit_depth=True,
+    )
+
+    assert sc.mtp_max_k == 2
+    assert os.environ["RAPID_MLX_QSA_INDEXED_SPLITK"] == "0"
 
 
 def test_apply_mtp_cli_reconciliation_rejects_explicit_qwen4_k3(capsys):

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -292,13 +292,14 @@ def test_config_vetted_mtp_support_allowlist_is_qwen_only():
     assert _config_vetted_mtp_supports_spec_decode(None) is False
 
 
-def test_qwen4_native_mtp_depth_is_one_and_rejects_explicit_deeper_chain():
+def test_qwen4_native_mtp_defaults_to_one_and_bounds_explicit_chain():
     from vllm_mlx.cli import _resolve_mtp_depth_for_model
 
     assert _resolve_mtp_depth_for_model("qwen4_exp", 3, explicit=False) == 1
     assert _resolve_mtp_depth_for_model("qwen3_5", 3, explicit=True) == 3
-    with pytest.raises(ValueError, match="num_speculative_tokens=1 only"):
-        _resolve_mtp_depth_for_model("qwen4_exp", 2, explicit=True)
+    assert _resolve_mtp_depth_for_model("qwen4_exp", 2, explicit=True) == 2
+    with pytest.raises(ValueError, match=r"num_speculative_tokens in \[1, 2\]"):
+        _resolve_mtp_depth_for_model("qwen4_exp", 3, explicit=True)
 
 
 # ---------------------------------------------------------------------------
@@ -4099,7 +4100,26 @@ def test_apply_mtp_cli_reconciliation_caps_qwen4_default_depth():
     assert sc.mtp_max_k == 1
 
 
-def test_apply_mtp_cli_reconciliation_rejects_explicit_qwen4_depth(capsys):
+def test_apply_mtp_cli_reconciliation_accepts_explicit_qwen4_k2():
+    from vllm_mlx.cli import _apply_mtp_cli_model_type_reconciliation
+    from vllm_mlx.scheduler import SchedulerConfig
+
+    sc = SchedulerConfig(spec_decode="mtp", mtp_max_k=2)
+    _apply_mtp_cli_model_type_reconciliation(
+        scheduler_config=sc,
+        hf_cfg_eligibility={
+            "model_type": "qwen4_exp",
+            "mtp_num_hidden_layers": 1,
+        },
+        logger=None,
+        requested_depth=2,
+        explicit_depth=True,
+    )
+
+    assert sc.mtp_max_k == 2
+
+
+def test_apply_mtp_cli_reconciliation_rejects_explicit_qwen4_k3(capsys):
     from vllm_mlx.cli import _apply_mtp_cli_model_type_reconciliation
     from vllm_mlx.scheduler import SchedulerConfig
 
@@ -4112,11 +4132,11 @@ def test_apply_mtp_cli_reconciliation_rejects_explicit_qwen4_depth(capsys):
                 "mtp_num_hidden_layers": 1,
             },
             logger=None,
-            requested_depth=2,
+            requested_depth=3,
             explicit_depth=True,
         )
 
-    assert "num_speculative_tokens=1 only" in capsys.readouterr().err
+    assert "num_speculative_tokens in [1, 2]" in capsys.readouterr().err
 
 
 def test_install_mtp_vendored_uid_reuse_clears_stale_state(monkeypatch):

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -162,6 +162,11 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # context crossover; model, parser, tier, and engine routing are
         # unchanged. Unsupported layouts and the default path remain dense.
         "RAPID_MLX_QSA_BLOCK_SPARSE",
+        # Opt-in indexed split-K kernel for the compact QSA selection of an
+        # already-selected Qwen4-Exp model. The model/parser/lane are unchanged;
+        # unqualified query shapes, MLX builds, and Metal architectures remain
+        # on the existing dense attention implementation.
+        "RAPID_MLX_QSA_INDEXED_SPLITK",
         # Opt-out of the blocked-seq GDN prefill Metal kernel
         # (vllm_mlx/gdn_prefill.py). Same shape as DISABLE_FUSED_SAMPLER —
         # a kernel-selection perf toggle computing the exact same

--- a/tests/test_qsa_indexed_splitk.py
+++ b/tests/test_qsa_indexed_splitk.py
@@ -208,6 +208,13 @@ def test_indexed_splitk_production_layout_matches_fp64_with_distinct_rows():
     not mx.metal.is_available(), reason="QSA indexed split-K kernel requires Metal"
 )
 def test_indexed_splitk_is_bit_exact_with_native_gather_path():
+    if (
+        qsa_indexed_splitk._mlx_version()
+        not in qsa_indexed_splitk.QUALIFIED_MLX_VERSIONS
+        or qsa_indexed_splitk._metal_architecture()
+        not in qsa_indexed_splitk.QUALIFIED_METAL_ARCHITECTURES
+    ):
+        pytest.skip("bit-exact production schedule is qualified only on M3 Ultra")
     mx.random.seed(3058)
     rng = np.random.default_rng(8)
     batch, query_heads, kv_heads = 1, 24, 2

--- a/tests/test_qsa_indexed_splitk.py
+++ b/tests/test_qsa_indexed_splitk.py
@@ -35,8 +35,8 @@ def _args(**overrides) -> TextModelArgs:
         "indexer_n_heads": 2,
         "indexer_kv_heads": 1,
         "indexer_head_dim": 64,
-        "indexer_budget": 8,
-        "indexer_compress_ratio": 2,
+        "indexer_budget": 2048,
+        "indexer_compress_ratio": 4,
         "ple_layer_ids": [],
         "eos_token_id": 31,
     }
@@ -106,19 +106,30 @@ def test_indexed_splitk_gate_is_opt_in_version_and_shape_qualified(monkeypatch):
     )
 
 
-def test_indexed_splitk_layout_gate_bounds_threads_and_dtype():
-    assert qsa_indexed_splitk.indexed_splitk_layout_supported(
-        query_heads=24, kv_heads=2, head_dim=256, dtype=mx.bfloat16
-    )
-    assert not qsa_indexed_splitk.indexed_splitk_layout_supported(
-        query_heads=33, kv_heads=1, head_dim=256, dtype=mx.bfloat16
-    )
-    assert not qsa_indexed_splitk.indexed_splitk_layout_supported(
-        query_heads=24, kv_heads=2, head_dim=255, dtype=mx.bfloat16
-    )
-    assert not qsa_indexed_splitk.indexed_splitk_layout_supported(
-        query_heads=24, kv_heads=2, head_dim=256, dtype=mx.int32
-    )
+@pytest.mark.parametrize(
+    ("override", "expected"),
+    [
+        ({}, True),
+        ({"query_heads": 32}, False),
+        ({"kv_heads": 3}, False),
+        ({"head_dim": 128}, False),
+        ({"block_size": 8}, False),
+        ({"block_topk": 256}, False),
+        ({"dtype": mx.float16}, False),
+        ({"dtype": mx.float32}, False),
+    ],
+)
+def test_indexed_splitk_layout_gate_is_exactly_production_qualified(override, expected):
+    layout = {
+        "query_heads": 24,
+        "kv_heads": 2,
+        "head_dim": 256,
+        "block_size": 4,
+        "block_topk": 512,
+        "dtype": mx.bfloat16,
+    }
+    layout.update(override)
+    assert qsa_indexed_splitk.indexed_splitk_layout_supported(**layout) is expected
 
 
 @pytest.mark.skipif(
@@ -317,6 +328,7 @@ class _FakeKVCache:
 def test_qsa_attention_routes_narrow_selection_and_records_receipt(monkeypatch):
     args = _args()
     attention = QSAAttention(args)
+    attention.set_dtype(mx.bfloat16)
     attention.eval()
     attention.indexer = _FakeIndexer(args)
     monkeypatch.setattr(
@@ -358,15 +370,15 @@ def test_qsa_attention_routes_narrow_selection_and_records_receipt(monkeypatch):
         ),
     )
     output = attention(
-        mx.zeros((1, 3, args.hidden_size)),
+        mx.zeros((1, 3, args.hidden_size), dtype=mx.bfloat16),
         [_FakeKVCache(), object()],
         mask="causal",
     )
     mx.eval(output)
     assert output.shape == (1, 3, args.hidden_size)
     assert len(observed) == 1
-    assert observed[0][:4] == ((1, 3, 4), (1, 3), (1, 3, 2), (1, 3))
-    assert observed[0][4:] == (2, 256**-0.5)
+    assert observed[0][:4] == ((1, 3, 512), (1, 3), (1, 3, 4), (1, 3))
+    assert observed[0][4:] == (4, 256**-0.5)
     assert qwen4_exp.qwen4_qsa_indexed_splitk_stats(attention) == {
         "route_constructions": 1,
         "declines": 0,

--- a/tests/test_qsa_indexed_splitk.py
+++ b/tests/test_qsa_indexed_splitk.py
@@ -169,7 +169,10 @@ def test_indexed_splitk_production_layout_matches_fp64_with_distinct_rows():
     for query_index in range(query_length):
         selected = np.concatenate(
             [
-                *(np.arange(start, start + block_size) for start in starts_np[0, query_index]),
+                *(
+                    np.arange(start, start + block_size)
+                    for start in starts_np[0, query_index]
+                ),
                 tails_np[0, query_index, : tail_counts_np[0, query_index]],
             ]
         )
@@ -182,8 +185,7 @@ def test_indexed_splitk_production_layout_matches_fp64_with_distinct_rows():
             weights = np.exp(scores - scores.max())
             weights /= weights.sum()
             reference[0, head, query_index] = (
-                weights[:, None]
-                * values_fp[0, kv_head, selected].astype(np.float64)
+                weights[:, None] * values_fp[0, kv_head, selected].astype(np.float64)
             ).sum(axis=0)
 
     np.testing.assert_allclose(
@@ -203,23 +205,21 @@ def test_indexed_splitk_is_bit_exact_with_native_gather_path():
     scale = head_dim**-0.5
     # Deliberately slice padded capacity so pass 1 must honor input strides
     # instead of copying the physical KV cache on every decode layer.
-    queries = mx.random.normal(
-        (batch, query_heads, query_length + 1, head_dim)
-    ).astype(mx.bfloat16)[:, :, :query_length, :]
-    keys = mx.random.normal(
-        (batch, kv_heads, key_length + 7, head_dim)
-    ).astype(mx.bfloat16)[:, :, :key_length, :]
-    values = mx.random.normal(
-        (batch, kv_heads, key_length + 7, head_dim)
-    ).astype(mx.bfloat16)[:, :, :key_length, :]
+    queries = mx.random.normal((batch, query_heads, query_length + 1, head_dim)).astype(
+        mx.bfloat16
+    )[:, :, :query_length, :]
+    keys = mx.random.normal((batch, kv_heads, key_length + 7, head_dim)).astype(
+        mx.bfloat16
+    )[:, :, :key_length, :]
+    values = mx.random.normal((batch, kv_heads, key_length + 7, head_dim)).astype(
+        mx.bfloat16
+    )[:, :, :key_length, :]
     starts = []
     gathered_outputs = []
     for query_index in range(query_length):
         row_starts = (
             np.sort(
-                rng.choice(
-                    key_length // block_size, size=block_topk, replace=False
-                )
+                rng.choice(key_length // block_size, size=block_topk, replace=False)
             ).astype(np.int32)
             * block_size
         )
@@ -236,21 +236,11 @@ def test_indexed_splitk_is_bit_exact_with_native_gather_path():
             )
         )
     gathered = mx.concatenate(gathered_outputs, axis=2)
-    padded_starts = mx.full(
-        (batch, query_length, block_topk + 1), -1, dtype=mx.int32
-    )
-    padded_starts[:, :, :block_topk] = mx.array(
-        np.array(starts, dtype=np.int32)[None]
-    )
-    padded_counts = mx.full(
-        (batch, query_length + 1), block_topk, dtype=mx.int32
-    )
-    padded_tails = mx.zeros(
-        (batch, query_length, block_size + 1), dtype=mx.int32
-    )
-    padded_tail_counts = mx.zeros(
-        (batch, query_length + 1), dtype=mx.int32
-    )
+    padded_starts = mx.full((batch, query_length, block_topk + 1), -1, dtype=mx.int32)
+    padded_starts[:, :, :block_topk] = mx.array(np.array(starts, dtype=np.int32)[None])
+    padded_counts = mx.full((batch, query_length + 1), block_topk, dtype=mx.int32)
+    padded_tails = mx.zeros((batch, query_length, block_size + 1), dtype=mx.int32)
+    padded_tail_counts = mx.zeros((batch, query_length + 1), dtype=mx.int32)
     indexed = qsa_indexed_splitk.indexed_splitk_attention(
         queries,
         keys,
@@ -329,7 +319,9 @@ def test_qsa_attention_routes_narrow_selection_and_records_receipt(monkeypatch):
     attention = QSAAttention(args)
     attention.eval()
     attention.indexer = _FakeIndexer(args)
-    monkeypatch.setattr(qwen4_exp, "indexed_splitk_decline_reason", lambda *a, **k: None)
+    monkeypatch.setattr(
+        qwen4_exp, "indexed_splitk_decline_reason", lambda *a, **k: None
+    )
     observed = []
 
     def fake_indexed(
@@ -346,7 +338,14 @@ def test_qsa_attention_routes_narrow_selection_and_records_receipt(monkeypatch):
     ):
         del keys, values
         observed.append(
-            (block_starts.shape, block_counts.shape, tail_indices.shape, tail_counts.shape, block_size, scale)
+            (
+                block_starts.shape,
+                block_counts.shape,
+                tail_indices.shape,
+                tail_counts.shape,
+                block_size,
+                scale,
+            )
         )
         return mx.zeros_like(queries)
 

--- a/tests/test_qsa_indexed_splitk.py
+++ b/tests/test_qsa_indexed_splitk.py
@@ -55,6 +55,12 @@ def test_indexed_splitk_gate_is_opt_in_version_and_shape_qualified(monkeypatch):
     monkeypatch.setenv(qsa_indexed_splitk.ENABLE_ENV, "1")
     assert (
         qsa_indexed_splitk.indexed_splitk_decline_reason(
+            3, 16_384, batch_size=1, training=True, mlx_version="0.32.2"
+        )
+        == "training"
+    )
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
             3, 16_384, batch_size=2, mlx_version="0.32.2"
         )
         == "batch size is not qualified"
@@ -83,6 +89,13 @@ def test_indexed_splitk_gate_is_opt_in_version_and_shape_qualified(monkeypatch):
         )
         == "unqualified MLX version 0.32.1"
     )
+    monkeypatch.setattr(qsa_indexed_splitk.mx.metal, "is_available", lambda: False)
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            3, 16_384, batch_size=1, mlx_version="0.32.2"
+        )
+        == "Metal runtime unavailable"
+    )
     monkeypatch.setattr(qsa_indexed_splitk.mx.metal, "is_available", lambda: True)
     assert (
         qsa_indexed_splitk.indexed_splitk_decline_reason(
@@ -104,6 +117,22 @@ def test_indexed_splitk_gate_is_opt_in_version_and_shape_qualified(monkeypatch):
         )
         == "unqualified Metal architecture applegpu_g16s"
     )
+
+
+def test_indexed_splitk_runtime_metadata_fails_closed(monkeypatch):
+    qsa_indexed_splitk._mlx_version.cache_clear()
+    monkeypatch.setattr(
+        qsa_indexed_splitk,
+        "version",
+        lambda _package: (_ for _ in ()).throw(qsa_indexed_splitk.PackageNotFoundError),
+    )
+    assert qsa_indexed_splitk._mlx_version() == "unknown"
+    qsa_indexed_splitk._mlx_version.cache_clear()
+
+    qsa_indexed_splitk._metal_architecture.cache_clear()
+    monkeypatch.setattr(qsa_indexed_splitk.mx, "device_info", lambda: {})
+    assert qsa_indexed_splitk._metal_architecture() == "unknown"
+    qsa_indexed_splitk._metal_architecture.cache_clear()
 
 
 @pytest.mark.parametrize(
@@ -130,6 +159,67 @@ def test_indexed_splitk_layout_gate_is_exactly_production_qualified(override, ex
     }
     layout.update(override)
     assert qsa_indexed_splitk.indexed_splitk_layout_supported(**layout) is expected
+
+
+@pytest.mark.parametrize(
+    "layout",
+    [
+        {"query_heads": 2, "kv_heads": 0, "head_dim": 32, "dtype": mx.float16},
+        {"query_heads": 0, "kv_heads": 1, "head_dim": 32, "dtype": mx.float16},
+        {"query_heads": 33, "kv_heads": 1, "head_dim": 32, "dtype": mx.float16},
+        {"query_heads": 2, "kv_heads": 1, "head_dim": 33, "dtype": mx.float16},
+    ],
+)
+def test_indexed_splitk_kernel_layout_rejects_unrepresentable_shapes(layout):
+    assert not qsa_indexed_splitk._kernel_layout_supported(**layout)
+
+
+def test_indexed_splitk_production_split_schedule():
+    assert qsa_indexed_splitk._split_count(65_536, 1) == 128
+
+
+def test_indexed_splitk_input_validation_fails_before_kernel_dispatch():
+    defaults = {
+        "queries": mx.zeros((1, 2, 1, 32), dtype=mx.float16),
+        "keys": mx.zeros((1, 1, 8, 32), dtype=mx.float16),
+        "values": mx.zeros((1, 1, 8, 32), dtype=mx.float16),
+        "block_starts": mx.zeros((1, 1, 1), dtype=mx.int32),
+        "block_counts": mx.ones((1, 1), dtype=mx.int32),
+        "tail_indices": mx.zeros((1, 1, 2), dtype=mx.int32),
+        "tail_counts": mx.ones((1, 1), dtype=mx.int32),
+        "block_size": 2,
+        "scale": 32**-0.5,
+        "splits": 32,
+    }
+
+    def invoke(**overrides):
+        arguments = defaults | overrides
+        return qsa_indexed_splitk.indexed_splitk_attention(**arguments)
+
+    with pytest.raises(ValueError, match="rank four"):
+        invoke(queries=defaults["queries"].squeeze(0))
+    with pytest.raises(ValueError, match="batch size one"):
+        invoke(queries=mx.zeros((2, 2, 1, 32), dtype=mx.float16))
+    with pytest.raises(ValueError, match="one to three query tokens"):
+        invoke(queries=mx.zeros((1, 2, 4, 32), dtype=mx.float16))
+    with pytest.raises(ValueError, match="shapes are inconsistent"):
+        invoke(values=mx.zeros((1, 1, 7, 32), dtype=mx.float16))
+    with pytest.raises(ValueError, match="same dtype"):
+        invoke(values=defaults["values"].astype(mx.float32))
+    with pytest.raises(ValueError, match="block geometry"):
+        invoke(block_counts=mx.ones((1, 2), dtype=mx.int32))
+    with pytest.raises(ValueError, match="block starts"):
+        invoke(block_starts=mx.zeros((1, 1), dtype=mx.int32))
+    with pytest.raises(ValueError, match="tail indices"):
+        invoke(tail_indices=mx.zeros((1, 1, 3), dtype=mx.int32))
+    with pytest.raises(ValueError, match="tail counts"):
+        invoke(tail_counts=mx.ones((1, 2), dtype=mx.int32))
+    with pytest.raises(ValueError, match="must use int32"):
+        invoke(block_starts=defaults["block_starts"].astype(mx.float32))
+    with pytest.raises(ValueError, match="layout is unsupported"):
+        invoke(queries=mx.zeros((1, 33, 1, 32), dtype=mx.float16))
+    with pytest.raises(ValueError, match="positive multiple of 32"):
+        invoke(splits=1)
 
 
 @pytest.mark.skipif(
@@ -390,6 +480,33 @@ def test_qsa_attention_routes_narrow_selection_and_records_receipt(monkeypatch):
         "route_constructions": 1,
         "declines": 0,
         "decline_reasons": {},
+    }
+
+
+def test_qsa_attention_unqualified_layout_falls_back_and_records_reason(monkeypatch):
+    args = _args()
+    attention = QSAAttention(args)
+    attention.eval()
+    attention.indexer = _FakeIndexer(args)
+    monkeypatch.setattr(
+        qwen4_exp, "indexed_splitk_decline_reason", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        qwen4_exp,
+        "scaled_dot_product_attention",
+        lambda queries, *a, **k: mx.zeros_like(queries),
+    )
+    output = attention(
+        mx.zeros((1, 3, args.hidden_size)),
+        [_FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+    assert output.shape == (1, 3, args.hidden_size)
+    assert qwen4_exp.qwen4_qsa_indexed_splitk_stats(attention) == {
+        "route_constructions": 0,
+        "declines": 1,
+        "decline_reasons": {"unsupported layout": 1},
     }
 
 

--- a/tests/test_qsa_indexed_splitk.py
+++ b/tests/test_qsa_indexed_splitk.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytest.importorskip("mlx_lm")
+pytestmark = pytest.mark.requires_mlx
+
+import vllm_mlx.models.qwen4_exp as qwen4_exp
+from vllm_mlx.kernels import qsa_indexed_splitk
+from vllm_mlx.models.qwen4_exp import QSAAttention, TextModelArgs
+
+
+def _args(**overrides) -> TextModelArgs:
+    values = {
+        "hidden_size": 8,
+        "num_hidden_layers": 1,
+        "vocab_size": 32,
+        "num_attention_heads": 24,
+        "num_key_value_heads": 2,
+        "head_dim": 256,
+        "linear_num_key_heads": 1,
+        "linear_num_value_heads": 3,
+        "linear_key_head_dim": 4,
+        "linear_value_head_dim": 4,
+        "linear_conv_kernel_dim": 3,
+        "num_experts": 4,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": 4,
+        "shared_expert_intermediate_size": 4,
+        "hc_count": 4,
+        "hc_lowrank": 3,
+        "layer_types": ["full_attention"],
+        "indexer_n_heads": 2,
+        "indexer_kv_heads": 1,
+        "indexer_head_dim": 64,
+        "indexer_budget": 8,
+        "indexer_compress_ratio": 2,
+        "ple_layer_ids": [],
+        "eos_token_id": 31,
+    }
+    values.update(overrides)
+    return TextModelArgs(**values)
+
+
+def test_indexed_splitk_gate_is_opt_in_version_and_shape_qualified(monkeypatch):
+    monkeypatch.delenv(qsa_indexed_splitk.ENABLE_ENV, raising=False)
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            3, 16_384, batch_size=1, mlx_version="0.32.2"
+        )
+        == "disabled"
+    )
+    monkeypatch.setenv(qsa_indexed_splitk.ENABLE_ENV, "1")
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            3, 16_384, batch_size=2, mlx_version="0.32.2"
+        )
+        == "batch size is not qualified"
+    )
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            4, 65_536, batch_size=1, mlx_version="0.32.2"
+        )
+        == "query length is not qualified"
+    )
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            2, 65_536, batch_size=1, mlx_version="0.32.2"
+        )
+        == "query length is not qualified"
+    )
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            1, 65_535, batch_size=1, mlx_version="0.32.2"
+        )
+        == "physical KV below crossover"
+    )
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            3, 16_384, batch_size=1, mlx_version="0.32.1"
+        )
+        == "unqualified MLX version 0.32.1"
+    )
+    monkeypatch.setattr(qsa_indexed_splitk.mx.metal, "is_available", lambda: True)
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            3,
+            16_384,
+            batch_size=1,
+            mlx_version="0.32.2",
+            metal_architecture="applegpu_g15d",
+        )
+        is None
+    )
+    assert (
+        qsa_indexed_splitk.indexed_splitk_decline_reason(
+            3,
+            16_384,
+            batch_size=1,
+            mlx_version="0.32.2",
+            metal_architecture="applegpu_g16s",
+        )
+        == "unqualified Metal architecture applegpu_g16s"
+    )
+
+
+def test_indexed_splitk_layout_gate_bounds_threads_and_dtype():
+    assert qsa_indexed_splitk.indexed_splitk_layout_supported(
+        query_heads=24, kv_heads=2, head_dim=256, dtype=mx.bfloat16
+    )
+    assert not qsa_indexed_splitk.indexed_splitk_layout_supported(
+        query_heads=33, kv_heads=1, head_dim=256, dtype=mx.bfloat16
+    )
+    assert not qsa_indexed_splitk.indexed_splitk_layout_supported(
+        query_heads=24, kv_heads=2, head_dim=255, dtype=mx.bfloat16
+    )
+    assert not qsa_indexed_splitk.indexed_splitk_layout_supported(
+        query_heads=24, kv_heads=2, head_dim=256, dtype=mx.int32
+    )
+
+
+@pytest.mark.skipif(
+    not mx.metal.is_available(), reason="QSA indexed split-K kernel requires Metal"
+)
+def test_indexed_splitk_production_layout_matches_fp64_with_distinct_rows():
+    rng = np.random.default_rng(3058)
+    batch, query_heads, kv_heads = 1, 24, 2
+    query_length, key_length, head_dim = 3, 128, 256
+    block_size, block_topk = 4, 12
+    queries_np = rng.normal(0, 0.25, (batch, query_heads, query_length, head_dim))
+    keys_np = rng.normal(0, 0.25, (batch, kv_heads, key_length, head_dim))
+    values_np = rng.normal(0, 0.25, (batch, kv_heads, key_length, head_dim))
+    starts_np = np.empty((batch, query_length, block_topk), dtype=np.int32)
+    tails_np = np.empty((batch, query_length, block_size), dtype=np.int32)
+    tail_counts_np = np.array([[1, 3, 4]], dtype=np.int32)
+    for query_index in range(query_length):
+        blocks = np.sort(
+            rng.choice(key_length // block_size, size=block_topk, replace=False)
+        )
+        starts_np[0, query_index] = blocks * block_size
+        tails_np[0, query_index] = rng.choice(
+            key_length, size=block_size, replace=False
+        )
+
+    queries = mx.array(queries_np).astype(mx.bfloat16)
+    keys = mx.array(keys_np).astype(mx.bfloat16)
+    values = mx.array(values_np).astype(mx.bfloat16)
+    output = qsa_indexed_splitk.indexed_splitk_attention(
+        queries,
+        keys,
+        values,
+        mx.array(starts_np),
+        mx.full((batch, query_length), block_topk, dtype=mx.int32),
+        mx.array(tails_np),
+        mx.array(tail_counts_np),
+        block_size=block_size,
+        scale=head_dim**-0.5,
+        splits=32,
+    )
+    mx.eval(output)
+
+    queries_fp = np.array(queries.astype(mx.float32))
+    keys_fp = np.array(keys.astype(mx.float32))
+    values_fp = np.array(values.astype(mx.float32))
+    reference = np.zeros(output.shape, dtype=np.float64)
+    heads_per_kv = query_heads // kv_heads
+    for query_index in range(query_length):
+        selected = np.concatenate(
+            [
+                *(np.arange(start, start + block_size) for start in starts_np[0, query_index]),
+                tails_np[0, query_index, : tail_counts_np[0, query_index]],
+            ]
+        )
+        for head in range(query_heads):
+            kv_head = head // heads_per_kv
+            scores = (
+                keys_fp[0, kv_head, selected].astype(np.float64)
+                @ queries_fp[0, head, query_index].astype(np.float64)
+            ) * (head_dim**-0.5)
+            weights = np.exp(scores - scores.max())
+            weights /= weights.sum()
+            reference[0, head, query_index] = (
+                weights[:, None]
+                * values_fp[0, kv_head, selected].astype(np.float64)
+            ).sum(axis=0)
+
+    np.testing.assert_allclose(
+        np.array(output.astype(mx.float32)), reference, rtol=8e-2, atol=7e-4
+    )
+
+
+@pytest.mark.skipif(
+    not mx.metal.is_available(), reason="QSA indexed split-K kernel requires Metal"
+)
+def test_indexed_splitk_is_bit_exact_with_native_gather_path():
+    mx.random.seed(3058)
+    rng = np.random.default_rng(8)
+    batch, query_heads, kv_heads = 1, 24, 2
+    query_length, key_length, head_dim = 3, 4096, 256
+    block_size, block_topk = 4, 512
+    scale = head_dim**-0.5
+    # Deliberately slice padded capacity so pass 1 must honor input strides
+    # instead of copying the physical KV cache on every decode layer.
+    queries = mx.random.normal(
+        (batch, query_heads, query_length + 1, head_dim)
+    ).astype(mx.bfloat16)[:, :, :query_length, :]
+    keys = mx.random.normal(
+        (batch, kv_heads, key_length + 7, head_dim)
+    ).astype(mx.bfloat16)[:, :, :key_length, :]
+    values = mx.random.normal(
+        (batch, kv_heads, key_length + 7, head_dim)
+    ).astype(mx.bfloat16)[:, :, :key_length, :]
+    starts = []
+    gathered_outputs = []
+    for query_index in range(query_length):
+        row_starts = (
+            np.sort(
+                rng.choice(
+                    key_length // block_size, size=block_topk, replace=False
+                )
+            ).astype(np.int32)
+            * block_size
+        )
+        starts.append(row_starts)
+        indices = np.concatenate(
+            [np.arange(start, start + block_size) for start in row_starts]
+        )
+        gathered_outputs.append(
+            mx.fast.scaled_dot_product_attention(
+                queries[:, :, query_index : query_index + 1],
+                mx.take(keys, mx.array(indices), axis=2),
+                mx.take(values, mx.array(indices), axis=2),
+                scale=scale,
+            )
+        )
+    gathered = mx.concatenate(gathered_outputs, axis=2)
+    padded_starts = mx.full(
+        (batch, query_length, block_topk + 1), -1, dtype=mx.int32
+    )
+    padded_starts[:, :, :block_topk] = mx.array(
+        np.array(starts, dtype=np.int32)[None]
+    )
+    padded_counts = mx.full(
+        (batch, query_length + 1), block_topk, dtype=mx.int32
+    )
+    padded_tails = mx.zeros(
+        (batch, query_length, block_size + 1), dtype=mx.int32
+    )
+    padded_tail_counts = mx.zeros(
+        (batch, query_length + 1), dtype=mx.int32
+    )
+    indexed = qsa_indexed_splitk.indexed_splitk_attention(
+        queries,
+        keys,
+        values,
+        padded_starts[:, :, :block_topk],
+        padded_counts[:, :query_length],
+        padded_tails[:, :, :block_size],
+        padded_tail_counts[:, :query_length],
+        block_size=block_size,
+        scale=scale,
+    )
+    mx.eval(indexed, gathered)
+    np.testing.assert_array_equal(
+        np.array(indexed.astype(mx.float32)),
+        np.array(gathered.astype(mx.float32)),
+    )
+
+
+@pytest.mark.skipif(
+    not mx.metal.is_available(), reason="QSA indexed split-K kernel requires Metal"
+)
+def test_indexed_splitk_empty_or_malformed_selection_returns_zero():
+    output = qsa_indexed_splitk.indexed_splitk_attention(
+        mx.zeros((1, 2, 1, 32), dtype=mx.float16),
+        mx.zeros((1, 1, 8, 32), dtype=mx.float16),
+        mx.ones((1, 1, 8, 32), dtype=mx.float16),
+        mx.array([[[2**31 - 1]]], dtype=mx.int32),
+        mx.ones((1, 1), dtype=mx.int32),
+        mx.array([[[-1, 99]]], dtype=mx.int32),
+        mx.full((1, 1), 2, dtype=mx.int32),
+        block_size=2,
+        scale=32**-0.5,
+        splits=32,
+    )
+    mx.eval(output)
+    np.testing.assert_array_equal(
+        np.array(output.astype(mx.float32)), np.zeros(output.shape)
+    )
+
+
+class _FakeIndexer(qwen4_exp.QSAIndexer):
+    def __call__(
+        self,
+        hidden_states,
+        cache=None,
+        *,
+        physical_kv_length=None,
+        record_rollback=False,
+    ):
+        del cache, record_rollback
+        length = int(hidden_states.shape[1])
+        block_size = self.compress_ratio
+        block_count = self.token_budget // block_size
+        indices = mx.arange(self.token_budget + block_size, dtype=mx.int32)
+        return qwen4_exp._QSASelection(
+            token_indices=mx.broadcast_to(indices, (1, length, indices.size)),
+            block_valid=mx.ones((1, length, block_count), dtype=mx.bool_),
+            tail_valid=mx.ones((1, length, block_size), dtype=mx.bool_),
+            physical_kv_length=int(physical_kv_length),
+        )
+
+
+class _FakeKVCache:
+    offset = 16_381
+    _idx = 16_381
+
+    def size(self):
+        return self._idx
+
+    def update_and_fetch(self, keys, values):
+        return keys, values
+
+
+def test_qsa_attention_routes_narrow_selection_and_records_receipt(monkeypatch):
+    args = _args()
+    attention = QSAAttention(args)
+    attention.eval()
+    attention.indexer = _FakeIndexer(args)
+    monkeypatch.setattr(qwen4_exp, "indexed_splitk_decline_reason", lambda *a, **k: None)
+    observed = []
+
+    def fake_indexed(
+        queries,
+        keys,
+        values,
+        block_starts,
+        block_counts,
+        tail_indices,
+        tail_counts,
+        *,
+        block_size,
+        scale,
+    ):
+        del keys, values
+        observed.append(
+            (block_starts.shape, block_counts.shape, tail_indices.shape, tail_counts.shape, block_size, scale)
+        )
+        return mx.zeros_like(queries)
+
+    monkeypatch.setattr(qwen4_exp, "indexed_splitk_attention", fake_indexed)
+    monkeypatch.setattr(
+        qwen4_exp,
+        "block_sparse_attention",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("indexed split-K must win the narrow-route priority")
+        ),
+    )
+    output = attention(
+        mx.zeros((1, 3, args.hidden_size)),
+        [_FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+    assert output.shape == (1, 3, args.hidden_size)
+    assert len(observed) == 1
+    assert observed[0][:4] == ((1, 3, 4), (1, 3), (1, 3, 2), (1, 3))
+    assert observed[0][4:] == (2, 256**-0.5)
+    assert qwen4_exp.qwen4_qsa_indexed_splitk_stats(attention) == {
+        "route_constructions": 1,
+        "declines": 0,
+        "decline_reasons": {},
+    }
+
+
+def test_disabled_sparse_routes_do_not_add_compaction_to_dense_graph(monkeypatch):
+    args = _args()
+    attention = QSAAttention(args)
+    attention.eval()
+    attention.indexer = _FakeIndexer(args)
+    monkeypatch.delenv(qsa_indexed_splitk.ENABLE_ENV, raising=False)
+    monkeypatch.delenv("RAPID_MLX_QSA_BLOCK_SPARSE", raising=False)
+    monkeypatch.setattr(
+        qwen4_exp.mx,
+        "sort",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("disabled routes must not sort compact indices")
+        ),
+    )
+    monkeypatch.setattr(
+        qwen4_exp,
+        "scaled_dot_product_attention",
+        lambda queries, *a, **k: mx.zeros_like(queries),
+    )
+    output = attention(
+        mx.zeros((1, 3, args.hidden_size)),
+        [_FakeKVCache(), object()],
+        mask="causal",
+    )
+    mx.eval(output)
+    assert output.shape == (1, 3, args.hidden_size)

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1415,7 +1415,8 @@ def test_qwen4_verify_block_matches_tokenwise_forward():
     )
 
 
-def test_qwen4_mtp_target_verify_matches_synthetic_greedy(monkeypatch):
+@pytest.mark.parametrize("max_k", [1, 2])
+def test_qwen4_mtp_target_verify_matches_synthetic_greedy(monkeypatch, max_k):
     import importlib
 
     import mlx.nn as nn
@@ -1438,21 +1439,32 @@ def test_qwen4_mtp_target_verify_matches_synthetic_greedy(monkeypatch):
 
     monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
     assert dispatch_mtp_inject(model, "qwen4_exp", allow_random_init=True) is True
-    counter = MTPAcceptCounter()
-    speculative = [
-        int(token)
-        for token, _logprobs, _draft in mtp_generate_step(
-            prompt,
-            model.language_model,
-            max_tokens=12,
-            max_k=1,
-            disable_auto_k=True,
-            accept_counter=counter,
+    runs = []
+    for _ in range(2):
+        counter = MTPAcceptCounter()
+        runs.append(
+            [
+                int(token)
+                for token, _logprobs, _draft in mtp_generate_step(
+                    prompt,
+                    model.language_model,
+                    max_tokens=12,
+                    max_k=max_k,
+                    disable_auto_k=True,
+                    accept_counter=counter,
+                )
+            ]
         )
-    ]
+        assert counter.snapshot().attempts > 0
 
-    assert speculative == baseline
-    assert counter.snapshot().attempts > 0
+    # K=1 retains the fixture's serial-token identity contract. Wider block
+    # verification is deterministic, but can select a different near-tied
+    # argmax because Metal uses a different accumulation shape; independent
+    # block-vs-token and rollback tests cover the state-transition contract.
+    assert runs[0] == runs[1]
+    assert len(runs[0]) == 12
+    if max_k == 1:
+        assert runs[0] == baseline
 
 
 def test_qwen4_native_mtp_dispatch_attaches_synthetic_head(monkeypatch):
@@ -1482,7 +1494,7 @@ def test_qwen4_native_mtp_dispatch_attaches_synthetic_head(monkeypatch):
     )
     assert dispatch_mtp_inject(model, "qwen4_exp", allow_random_init=True) is True
     assert dispatch_mtp_validate(model, "qwen4_exp") is True
-    assert model.mtp_max_speculative_tokens == 1
+    assert model.mtp_max_speculative_tokens == 2
 
     inner = model.language_model
     cache = inner.make_mtp_cache()

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1416,7 +1416,7 @@ def test_qwen4_verify_block_matches_tokenwise_forward():
 
 
 @pytest.mark.parametrize("max_k", [1, 2])
-def test_qwen4_mtp_target_verify_matches_synthetic_greedy(monkeypatch, max_k):
+def test_qwen4_mtp_target_verify_matches_forced_greedy_oracle(monkeypatch, max_k):
     import importlib
 
     import mlx.nn as nn
@@ -1435,7 +1435,23 @@ def test_qwen4_mtp_target_verify_matches_synthetic_greedy(monkeypatch, max_k):
     args.mtp_num_hidden_layers = 1
     model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
     prompt = mx.array([1, 2, 3], dtype=mx.uint32)
-    baseline = [int(token) for token, _ in generate_step(prompt, model, max_tokens=12)]
+
+    def force_successor(tokens, logits):
+        """Give every position a unique, architecture-independent argmax."""
+        successor = (tokens[-1] + 1) % logits.shape[-1]
+        vocabulary = mx.arange(logits.shape[-1], dtype=successor.dtype)
+        return mx.where(vocabulary == successor, mx.zeros_like(logits), -mx.inf)
+
+    baseline = [
+        int(token)
+        for token, _ in generate_step(
+            prompt,
+            model,
+            max_tokens=12,
+            logits_processors=[force_successor],
+        )
+    ]
+    assert baseline == list(range(4, 16))
 
     monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
     assert dispatch_mtp_inject(model, "qwen4_exp", allow_random_init=True) is True
@@ -1452,19 +1468,18 @@ def test_qwen4_mtp_target_verify_matches_synthetic_greedy(monkeypatch, max_k):
                     max_k=max_k,
                     disable_auto_k=True,
                     accept_counter=counter,
+                    logits_processors=[force_successor],
                 )
             ]
         )
         assert counter.snapshot().attempts > 0
 
-    # K=1 retains the fixture's serial-token identity contract. Wider block
-    # verification is deterministic, but can select a different near-tied
-    # argmax because Metal uses a different accumulation shape; independent
-    # block-vs-token and rollback tests cover the state-transition contract.
+    # The successor oracle removes architecture-dependent near-tied logits, so
+    # both speculative depths must retain tokenwise greedy identity as well as
+    # repeatability. Independent block-vs-token and rollback tests cover the
+    # underlying state transitions with unmodified model logits.
     assert runs[0] == runs[1]
-    assert len(runs[0]) == 12
-    if max_k == 1:
-        assert runs[0] == baseline
+    assert runs[0] == baseline
 
 
 def test_qwen4_native_mtp_dispatch_attaches_synthetic_head(monkeypatch):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1310,12 +1310,17 @@ def _resolve_mtp_depth_for_model(
 
     if model_type != "qwen4_exp":
         return requested
-    if explicit and requested != 1:
+    if not explicit:
+        # Keep the production default at the previously qualified K=1.
+        # K=2 is an explicit-only capability while its end-to-end indexed-QSA
+        # performance is being qualified on the released checkpoint.
+        return 1
+    if requested not in {1, 2}:
         raise ValueError(
             "Qwen3.8 Flash-Next native MTP currently supports "
-            "num_speculative_tokens=1 only"
+            "num_speculative_tokens in [1, 2]"
         )
-    return 1
+    return requested
 
 
 def _check_alias_min_memory(user_typed: str) -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1298,6 +1298,15 @@ def _apply_mtp_cli_model_type_reconciliation(
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         sys.exit(2)
+    if (
+        _eligibility_model_type == "qwen4_exp"
+        and explicit_depth
+        and scheduler_config.mtp_max_k == 2
+    ):
+        # K=2 is qualified with compact indexed-QSA verification. Make the
+        # public opt-in self-contained while preserving an explicit operator
+        # override for fallback/debug comparisons.
+        os.environ.setdefault("RAPID_MLX_QSA_INDEXED_SPLITK", "1")
 
 
 def _resolve_mtp_depth_for_model(
@@ -1312,8 +1321,8 @@ def _resolve_mtp_depth_for_model(
         return requested
     if not explicit:
         # Keep the production default at the previously qualified K=1.
-        # K=2 is an explicit-only capability while its end-to-end indexed-QSA
-        # performance is being qualified on the released checkpoint.
+        # K=2 is an explicit-only capability because its indexed-QSA speedup
+        # is qualified at ultra-long context, not across shorter prompts.
         return 1
     if requested not in {1, 2}:
         raise ValueError(

--- a/vllm_mlx/kernels/qsa_indexed_splitk.py
+++ b/vllm_mlx/kernels/qsa_indexed_splitk.py
@@ -25,6 +25,12 @@ MAX_QUERY_LENGTH = 3
 QUALIFIED_QUERY_LENGTHS = frozenset({1, 3})
 MIN_KV_LENGTH_VERIFY = 16_384
 MIN_KV_LENGTH_DECODE = 65_536
+QUALIFIED_QUERY_HEADS = 24
+QUALIFIED_KV_HEADS = 2
+QUALIFIED_HEAD_DIM = 256
+QUALIFIED_DTYPE = mx.bfloat16
+QUALIFIED_BLOCK_SIZE = 4
+QUALIFIED_BLOCK_TOPK = 512
 MAX_GQA_HEADS = 32
 SIMD_WIDTH = 32
 
@@ -86,8 +92,29 @@ def indexed_splitk_decline_reason(
 
 
 def indexed_splitk_layout_supported(
+    *,
+    query_heads: int,
+    kv_heads: int,
+    head_dim: int,
+    block_size: int,
+    block_topk: int,
+    dtype: mx.Dtype,
+) -> bool:
+    """Return whether this is the exact production-qualified Qwen3.8 layout."""
+    return (
+        query_heads == QUALIFIED_QUERY_HEADS
+        and kv_heads == QUALIFIED_KV_HEADS
+        and head_dim == QUALIFIED_HEAD_DIM
+        and block_size == QUALIFIED_BLOCK_SIZE
+        and block_topk == QUALIFIED_BLOCK_TOPK
+        and dtype == QUALIFIED_DTYPE
+    )
+
+
+def _kernel_layout_supported(
     *, query_heads: int, kv_heads: int, head_dim: int, dtype: mx.Dtype
 ) -> bool:
+    """Validate the broader set of layouts that the Metal kernel can represent."""
     if kv_heads <= 0 or head_dim <= 0 or query_heads % kv_heads:
         return False
     gqa_heads = query_heads // kv_heads
@@ -364,7 +391,7 @@ def indexed_splitk_attention(
     compact = (block_starts, block_counts, tail_indices, tail_counts)
     if any(array.dtype != mx.int32 for array in compact):
         raise ValueError("QSA compact indices and counts must use int32")
-    if not indexed_splitk_layout_supported(
+    if not _kernel_layout_supported(
         query_heads=query_heads,
         kv_heads=kv_heads,
         head_dim=head_dim,

--- a/vllm_mlx/kernels/qsa_indexed_splitk.py
+++ b/vllm_mlx/kernels/qsa_indexed_splitk.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in indexed split-K attention for narrow QSA decode/verify calls.
+
+The compact QSA selection is consumed directly: K/V stay in their physical
+cache and each split walks logical selected-token ordinals.  The two-pass
+reduction deliberately mirrors MLX's ``sdpa_vector_2pass`` accumulator types,
+``metal::fast::exp`` calls, bf16/fp16 partials, and second-pass reduction order.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+ENABLE_ENV = "RAPID_MLX_QSA_INDEXED_SPLITK"
+QUALIFIED_MLX_VERSIONS = frozenset({"0.32.2"})
+QUALIFIED_METAL_ARCHITECTURES = frozenset({"applegpu_g15d"})
+MAX_QUERY_LENGTH = 3
+QUALIFIED_QUERY_LENGTHS = frozenset({1, 3})
+MIN_KV_LENGTH_VERIFY = 16_384
+MIN_KV_LENGTH_DECODE = 65_536
+MAX_GQA_HEADS = 32
+SIMD_WIDTH = 32
+
+
+@lru_cache(maxsize=1)
+def _mlx_version() -> str:
+    try:
+        return version("mlx")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+@lru_cache(maxsize=1)
+def _metal_architecture() -> str:
+    return str(mx.device_info().get("architecture", "unknown"))
+
+
+def _enabled() -> bool:
+    return os.environ.get(ENABLE_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def indexed_splitk_decline_reason(
+    query_length: int,
+    physical_kv_length: int,
+    *,
+    batch_size: int,
+    training: bool = False,
+    mlx_version: str | None = None,
+    metal_architecture: str | None = None,
+) -> str | None:
+    """Return ``None`` only for the narrow, qualified opt-in route."""
+    if not _enabled():
+        return "disabled"
+    if training:
+        return "training"
+    if batch_size != 1:
+        return "batch size is not qualified"
+    if query_length not in QUALIFIED_QUERY_LENGTHS:
+        return "query length is not qualified"
+    crossover = (
+        MIN_KV_LENGTH_DECODE if query_length == 1 else MIN_KV_LENGTH_VERIFY
+    )
+    if physical_kv_length < crossover:
+        return "physical KV below crossover"
+    installed_version = _mlx_version() if mlx_version is None else mlx_version
+    if installed_version not in QUALIFIED_MLX_VERSIONS:
+        return f"unqualified MLX version {installed_version}"
+    if not mx.metal.is_available():
+        return "Metal runtime unavailable"
+    architecture = (
+        _metal_architecture() if metal_architecture is None else metal_architecture
+    )
+    if architecture not in QUALIFIED_METAL_ARCHITECTURES:
+        return f"unqualified Metal architecture {architecture}"
+    return None
+
+
+def indexed_splitk_layout_supported(
+    *, query_heads: int, kv_heads: int, head_dim: int, dtype: mx.Dtype
+) -> bool:
+    if kv_heads <= 0 or head_dim <= 0 or query_heads % kv_heads:
+        return False
+    gqa_heads = query_heads // kv_heads
+    if not 0 < gqa_heads <= MAX_GQA_HEADS:
+        return False
+    if gqa_heads * SIMD_WIDTH > 1024 or head_dim % SIMD_WIDTH:
+        return False
+    return dtype in {mx.float16, mx.bfloat16, mx.float32}
+
+
+def _split_count(physical_kv_length: int, query_length: int) -> int:
+    """Match MLX's M3-Ultra schedule for the gathered 2K QSA reference."""
+    del physical_kv_length, query_length
+    return 128
+
+
+_PASS1_SOURCE = r"""
+    constexpr int VALUES_PER_LANE = HEAD_DIM / 32;
+    constexpr int THREADS = GQA_HEADS * 32;
+
+    const uint tid = thread_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const uint simdgroup = simdgroup_index_in_threadgroup;
+    const int query_index = int(threadgroup_position_in_grid.x);
+    const int batch_kv = int(threadgroup_position_in_grid.y);
+    const int split = int(threadgroup_position_in_grid.z);
+    const int batch = batch_kv / KV_HEADS;
+    const int kv_head = batch_kv - batch * KV_HEADS;
+    const int query_head = kv_head * GQA_HEADS + int(simdgroup);
+    const int query_length = dims[0];
+    const int key_length = dims[1];
+    threadgroup T shared_keys[HEAD_DIM];
+    threadgroup T shared_values[HEAD_DIM];
+    float q[VALUES_PER_LANE];
+    float o[VALUES_PER_LANE];
+    for (int i = 0; i < VALUES_PER_LANE; ++i) {
+        // Match MLX sdpa_vector_2pass: a lane owns one contiguous D / 32
+        // chunk.  Pass 2 relies on this exact partials layout when it
+        // transposes dimensions and split blocks through threadgroup memory.
+        const int dim = int(lane) * VALUES_PER_LANE + i;
+        const size_t q_offset = batch * queries_strides[0]
+            + query_head * queries_strides[1]
+            + query_index * queries_strides[2]
+            + dim * queries_strides[3];
+        q[i] = scale[0] * float(queries[q_offset]);
+        o[i] = 0.0f;
+    }
+
+    const size_t count_offset = batch * block_counts_strides[0]
+        + query_index * block_counts_strides[1];
+    const int raw_blocks = block_counts[count_offset];
+    const int block_count = metal::max(0, metal::min(raw_blocks, BLOCK_TOPK));
+    const size_t tail_count_offset = batch * tail_counts_strides[0]
+        + query_index * tail_counts_strides[1];
+    const int raw_tail = tail_counts[tail_count_offset];
+    const int tail_count = metal::max(0, metal::min(raw_tail, BLOCK_SIZE));
+    const int block_tokens = block_count * BLOCK_SIZE;
+    const int selected_tokens = block_tokens + tail_count;
+    float max_score = -INFINITY;
+    float sum_exp_score = 0.0f;
+
+    for (int ordinal = split; ordinal < selected_tokens; ordinal += SPLITS) {
+        int key_index;
+        bool valid_key;
+        if (ordinal < block_tokens) {
+            const int selected_block = ordinal / BLOCK_SIZE;
+            const int within_block = ordinal - selected_block * BLOCK_SIZE;
+            const size_t block_offset = batch * block_starts_strides[0]
+                + query_index * block_starts_strides[1]
+                + selected_block * block_starts_strides[2];
+            const int block_start = block_starts[block_offset];
+            valid_key = block_start >= 0
+                && block_start <= key_length - BLOCK_SIZE;
+            key_index = valid_key ? block_start + within_block : 0;
+        } else {
+            const size_t tail_offset = batch * tail_indices_strides[0]
+                + query_index * tail_indices_strides[1]
+                + (ordinal - block_tokens) * tail_indices_strides[2];
+            key_index = tail_indices[tail_offset];
+            valid_key = key_index >= 0 && key_index < key_length;
+        }
+        for (int dim = int(tid); dim < HEAD_DIM; dim += THREADS) {
+            if (valid_key) {
+                const size_t k_offset = batch * keys_strides[0]
+                    + kv_head * keys_strides[1]
+                    + key_index * keys_strides[2]
+                    + dim * keys_strides[3];
+                const size_t v_offset = batch * values_strides[0]
+                    + kv_head * values_strides[1]
+                    + key_index * values_strides[2]
+                    + dim * values_strides[3];
+                shared_keys[dim] = keys[k_offset];
+                shared_values[dim] = values[v_offset];
+            } else {
+                shared_keys[dim] = T(0.0f);
+                shared_values[dim] = T(0.0f);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (valid_key) {
+            float score = 0.0f;
+            for (int i = 0; i < VALUES_PER_LANE; ++i) {
+                const int dim = int(lane) * VALUES_PER_LANE + i;
+                score += q[i] * float(shared_keys[dim]);
+            }
+            score = simd_sum(score);
+            const float new_max = metal::max(max_score, score);
+            const float old_factor = metal::fast::exp(max_score - new_max);
+            const float exp_score = metal::fast::exp(score - new_max);
+            max_score = new_max;
+            sum_exp_score = sum_exp_score * old_factor + exp_score;
+            for (int i = 0; i < VALUES_PER_LANE; ++i) {
+                const int dim = int(lane) * VALUES_PER_LANE + i;
+                o[i] = o[i] * old_factor
+                    + exp_score * float(shared_values[dim]);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    const int partial_base =
+        (((batch * QUERY_HEADS + query_head) * query_length + query_index)
+        * SPLITS + split) * HEAD_DIM;
+    for (int i = 0; i < VALUES_PER_LANE; ++i) {
+        partials[partial_base + int(lane) * VALUES_PER_LANE + i] = T(o[i]);
+    }
+    if (lane == 0) {
+        const int stat_offset =
+            ((batch * QUERY_HEADS + query_head) * query_length + query_index)
+            * SPLITS + split;
+        sums[stat_offset] = sum_exp_score;
+        maxs[stat_offset] = max_score;
+    }
+"""
+
+
+_PASS2_SOURCE = r"""
+    constexpr int BN = 32;
+    constexpr int VALUES_PER_LANE = HEAD_DIM / 32;
+    const uint lane = thread_index_in_simdgroup;
+    const uint simdgroup = simdgroup_index_in_threadgroup;
+    const int batch_head = int(threadgroup_position_in_grid.x);
+    const int query_index = int(threadgroup_position_in_grid.y);
+    const int query_length = dims[0];
+    const int q_offset = batch_head * query_length + query_index;
+    const int stats_base = q_offset * SPLITS;
+    const int partial_base = stats_base * HEAD_DIM;
+
+    float max_score = -INFINITY;
+    for (int b = 0; b < SPLITS / BN; ++b) {
+        max_score = metal::max(max_score, maxs[stats_base + int(lane) + BN * b]);
+    }
+    max_score = simd_max(max_score);
+
+    float sum_exp_score = 0.0f;
+    for (int b = 0; b < SPLITS / BN; ++b) {
+        const int split = int(lane) + BN * b;
+        const float factor = sums[stats_base + split] > 0.0f
+            ? metal::fast::exp(maxs[stats_base + split] - max_score)
+            : 0.0f;
+        sum_exp_score += factor * sums[stats_base + split];
+    }
+    sum_exp_score = simd_sum(sum_exp_score);
+
+    float o[VALUES_PER_LANE];
+    for (int i = 0; i < VALUES_PER_LANE; ++i) {
+        o[i] = 0.0f;
+    }
+    for (int b = 0; b < SPLITS / BN; ++b) {
+        const int split = int(simdgroup) + BN * b;
+        const float factor = sums[stats_base + split] > 0.0f
+            ? metal::fast::exp(maxs[stats_base + split] - max_score)
+            : 0.0f;
+        const int offset = partial_base + split * HEAD_DIM
+            + int(lane) * VALUES_PER_LANE;
+        for (int i = 0; i < VALUES_PER_LANE; ++i) {
+            o[i] += factor * float(partials[offset + i]);
+        }
+    }
+
+    threadgroup float transpose[BN * BN];
+    for (int i = 0; i < VALUES_PER_LANE; ++i) {
+        transpose[int(lane) * BN + int(simdgroup)] = o[i];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        o[i] = simd_sum(transpose[int(simdgroup) * BN + int(lane)]);
+        o[i] = sum_exp_score == 0.0f ? o[i] : o[i] / sum_exp_score;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (lane == 0) {
+        const int output_base = q_offset * HEAD_DIM
+            + int(simdgroup) * VALUES_PER_LANE;
+        for (int i = 0; i < VALUES_PER_LANE; ++i) {
+            output[output_base + i] = T(o[i]);
+        }
+    }
+"""
+
+
+@lru_cache(maxsize=1)
+def _pass1_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_qsa_indexed_splitk_pass1",
+        input_names=[
+            "queries",
+            "keys",
+            "values",
+            "block_starts",
+            "block_counts",
+            "tail_indices",
+            "tail_counts",
+            "dims",
+            "scale",
+        ],
+        output_names=["partials", "sums", "maxs"],
+        source=_PASS1_SOURCE,
+        # KVCache returns a view over capacity. Copying it on every decode
+        # layer defeats indexed reads, so pass 1 consumes MLX-provided strides.
+        ensure_row_contiguous=False,
+    )
+
+
+@lru_cache(maxsize=1)
+def _pass2_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_qsa_indexed_splitk_pass2",
+        input_names=["partials", "sums", "maxs", "dims"],
+        output_names=["output"],
+        source=_PASS2_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _log_activation() -> None:
+    logger.info("QSA indexed split-K attention enabled for narrow decode/verify")
+
+
+def indexed_splitk_attention(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    block_starts: mx.array,
+    block_counts: mx.array,
+    tail_indices: mx.array,
+    tail_counts: mx.array,
+    *,
+    block_size: int,
+    scale: float,
+    splits: int | None = None,
+) -> mx.array:
+    """Attend directly through compact, sorted QSA block/tail indices."""
+    if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
+        raise ValueError("QSA query/K/V arrays must be rank four")
+    batch, query_heads, query_length, head_dim = map(int, queries.shape)
+    key_batch, kv_heads, key_length, key_dim = map(int, keys.shape)
+    expected_rows = (batch, query_length)
+    if batch != 1:
+        raise ValueError("indexed split-K QSA currently requires batch size one")
+    if not 1 <= query_length <= MAX_QUERY_LENGTH:
+        raise ValueError("indexed split-K QSA requires one to three query tokens")
+    if key_batch != batch or key_dim != head_dim or values.shape != keys.shape:
+        raise ValueError("QSA query/KV shapes are inconsistent")
+    if queries.dtype != keys.dtype or queries.dtype != values.dtype:
+        raise ValueError("QSA query/K/V arrays must have the same dtype")
+    if block_size <= 0 or tuple(block_counts.shape) != expected_rows:
+        raise ValueError("QSA block geometry is inconsistent")
+    if block_starts.ndim != 3 or tuple(block_starts.shape[:2]) != expected_rows:
+        raise ValueError("QSA block starts must have shape [batch, query, topk]")
+    if tuple(tail_indices.shape) != (*expected_rows, block_size):
+        raise ValueError("QSA tail indices must have shape [batch, query, block_size]")
+    if tuple(tail_counts.shape) != expected_rows:
+        raise ValueError("QSA tail counts must have shape [batch, query]")
+    compact = (block_starts, block_counts, tail_indices, tail_counts)
+    if any(array.dtype != mx.int32 for array in compact):
+        raise ValueError("QSA compact indices and counts must use int32")
+    if not indexed_splitk_layout_supported(
+        query_heads=query_heads,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        dtype=queries.dtype,
+    ):
+        raise ValueError("QSA query/K/V layout is unsupported by indexed split-K")
+    split_count = _split_count(key_length, query_length) if splits is None else splits
+    if split_count <= 0 or split_count % SIMD_WIDTH:
+        raise ValueError("indexed split-K split count must be a positive multiple of 32")
+
+    block_topk = int(block_starts.shape[-1])
+    gqa_heads = query_heads // kv_heads
+    dims = mx.array([query_length, key_length], dtype=mx.int32)
+    scale_array = mx.array([scale], dtype=mx.float32)
+    partial_shape = (batch, query_heads, query_length, split_count, head_dim)
+    stat_shape = partial_shape[:-1]
+    _log_activation()
+    partials, sums, maxs = _pass1_kernel()(
+        inputs=[
+            queries,
+            keys,
+            values,
+            block_starts,
+            block_counts,
+            tail_indices,
+            tail_counts,
+            dims,
+            scale_array,
+        ],
+        template=[
+            ("T", queries.dtype),
+            ("QUERY_HEADS", query_heads),
+            ("KV_HEADS", kv_heads),
+            ("GQA_HEADS", gqa_heads),
+            ("HEAD_DIM", head_dim),
+            ("BLOCK_SIZE", block_size),
+            ("BLOCK_TOPK", block_topk),
+            ("SPLITS", split_count),
+        ],
+        grid=(gqa_heads * SIMD_WIDTH * query_length, batch * kv_heads, split_count),
+        threadgroup=(gqa_heads * SIMD_WIDTH, 1, 1),
+        output_shapes=[partial_shape, stat_shape, stat_shape],
+        output_dtypes=[queries.dtype, mx.float32, mx.float32],
+    )
+    (output,) = _pass2_kernel()(
+        inputs=[partials, sums, maxs, dims],
+        template=[
+            ("T", queries.dtype),
+            ("HEAD_DIM", head_dim),
+            ("SPLITS", split_count),
+        ],
+        grid=(1024 * batch * query_heads, query_length, 1),
+        threadgroup=(1024, 1, 1),
+        output_shapes=[queries.shape],
+        output_dtypes=[queries.dtype],
+    )
+    return output

--- a/vllm_mlx/kernels/qsa_indexed_splitk.py
+++ b/vllm_mlx/kernels/qsa_indexed_splitk.py
@@ -69,9 +69,7 @@ def indexed_splitk_decline_reason(
         return "batch size is not qualified"
     if query_length not in QUALIFIED_QUERY_LENGTHS:
         return "query length is not qualified"
-    crossover = (
-        MIN_KV_LENGTH_DECODE if query_length == 1 else MIN_KV_LENGTH_VERIFY
-    )
+    crossover = MIN_KV_LENGTH_DECODE if query_length == 1 else MIN_KV_LENGTH_VERIFY
     if physical_kv_length < crossover:
         return "physical KV below crossover"
     installed_version = _mlx_version() if mlx_version is None else mlx_version
@@ -375,7 +373,9 @@ def indexed_splitk_attention(
         raise ValueError("QSA query/K/V layout is unsupported by indexed split-K")
     split_count = _split_count(key_length, query_length) if splits is None else splits
     if split_count <= 0 or split_count % SIMD_WIDTH:
-        raise ValueError("indexed split-K split count must be a positive multiple of 32")
+        raise ValueError(
+            "indexed split-K split count must be a positive multiple of 32"
+        )
 
     block_topk = int(block_starts.shape[-1])
     gqa_heads = query_heads // kv_heads

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -41,6 +41,11 @@ from ..kernels.qsa_block_sparse import (  # noqa: E402
     block_sparse_decline_reason,
     block_sparse_layout_supported,
 )
+from ..kernels.qsa_indexed_splitk import (  # noqa: E402
+    indexed_splitk_attention,
+    indexed_splitk_decline_reason,
+    indexed_splitk_layout_supported,
+)
 from ..kernels.qwen4_fused_gdn_decode import (  # noqa: E402
     admit_qwen4_fused_gdn_decode,
     fused_gdn_runtime_supported,
@@ -1096,11 +1101,20 @@ class QSAAttention(nn.Module):
         self.block_sparse_route_constructions = 0
         self.block_sparse_declines = 0
         self.block_sparse_decline_reasons: dict[str, int] = {}
+        self.indexed_splitk_route_constructions = 0
+        self.indexed_splitk_declines = 0
+        self.indexed_splitk_decline_reasons: dict[str, int] = {}
 
     def _record_block_sparse_decline(self, reason: str) -> None:
         self.block_sparse_declines += 1
         self.block_sparse_decline_reasons[reason] = (
             self.block_sparse_decline_reasons.get(reason, 0) + 1
+        )
+
+    def _record_indexed_splitk_decline(self, reason: str) -> None:
+        self.indexed_splitk_declines += 1
+        self.indexed_splitk_decline_reasons[reason] = (
+            self.indexed_splitk_decline_reasons.get(reason, 0) + 1
         )
 
     def __call__(
@@ -1172,6 +1186,19 @@ class QSAAttention(nn.Module):
             keys, values = kv_cache.update_and_fetch(keys, values)
         output = None
         if isinstance(selected, _QSASelection):
+            indexed_decline = indexed_splitk_decline_reason(
+                length,
+                physical_length,
+                batch_size=batch,
+                training=bool(self.training),
+            )
+            if indexed_decline is None and not indexed_splitk_layout_supported(
+                query_heads=self.num_attention_heads,
+                kv_heads=self.num_key_value_heads,
+                head_dim=self.head_dim,
+                dtype=queries.dtype,
+            ):
+                indexed_decline = "unsupported layout"
             decline_reason = block_sparse_decline_reason(
                 length,
                 physical_length,
@@ -1185,7 +1212,11 @@ class QSAAttention(nn.Module):
                 dtype=queries.dtype,
             ):
                 decline_reason = "unsupported layout"
-            if decline_reason is None:
+
+            # Keep the default dense path graph-identical: sorting and
+            # compact-count construction happen only when a sparse consumer
+            # is actually eligible.
+            if indexed_decline is None or decline_reason is None:
                 block_slots = slice(
                     0, self.indexer.token_budget, self.indexer.compress_ratio
                 )
@@ -1202,6 +1233,7 @@ class QSAAttention(nn.Module):
                     ),
                     axis=-1,
                 )
+                block_counts = mx.sum(block_valid, axis=-1).astype(mx.int32)
                 tail_valid = selected.tail_valid
                 tail_indices = mx.sort(
                     mx.where(
@@ -1211,22 +1243,38 @@ class QSAAttention(nn.Module):
                     ),
                     axis=-1,
                 )
-                output = block_sparse_attention(
-                    queries,
-                    keys,
-                    values,
-                    block_starts,
-                    mx.sum(block_valid, axis=-1).astype(mx.int32),
-                    tail_indices,
-                    mx.sum(tail_valid, axis=-1).astype(mx.int32),
-                    block_size=self.indexer.compress_ratio,
-                )
-                # MLX evaluates lazily. Do not add a per-layer synchronization
-                # in an attempt to catch later Metal failures here: eligibility
-                # declines fall back to dense, while execution failures surface
-                # through the engine's normal generation-error path.
-                self.block_sparse_route_constructions += 1
-            if decline_reason is not None:
+                tail_counts = mx.sum(tail_valid, axis=-1).astype(mx.int32)
+
+                if indexed_decline is None:
+                    output = indexed_splitk_attention(
+                        queries,
+                        keys,
+                        values,
+                        block_starts,
+                        block_counts,
+                        tail_indices,
+                        tail_counts,
+                        block_size=self.indexer.compress_ratio,
+                        scale=self.scale,
+                    )
+                    self.indexed_splitk_route_constructions += 1
+                elif decline_reason is None:
+                    output = block_sparse_attention(
+                        queries,
+                        keys,
+                        values,
+                        block_starts,
+                        block_counts,
+                        tail_indices,
+                        tail_counts,
+                        block_size=self.indexer.compress_ratio,
+                    )
+                    # MLX evaluates lazily. Do not add a per-layer sync here.
+                    self.block_sparse_route_constructions += 1
+
+            if indexed_decline is not None:
+                self._record_indexed_splitk_decline(indexed_decline)
+            if output is None and decline_reason is not None:
                 self._record_block_sparse_decline(decline_reason)
 
         if output is None:
@@ -1269,6 +1317,25 @@ def qwen4_qsa_block_sparse_stats(model: nn.Module) -> dict[str, Any]:
         stats["route_constructions"] += module.block_sparse_route_constructions
         stats["declines"] += module.block_sparse_declines
         for reason, count in module.block_sparse_decline_reasons.items():
+            stats["decline_reasons"][reason] = (
+                stats["decline_reasons"].get(reason, 0) + count
+            )
+    return stats
+
+
+def qwen4_qsa_indexed_splitk_stats(model: nn.Module) -> dict[str, Any]:
+    """Aggregate indexed split-K constructions and fail-closed reasons."""
+    stats: dict[str, Any] = {
+        "route_constructions": 0,
+        "declines": 0,
+        "decline_reasons": {},
+    }
+    for _, module in model.named_modules():
+        if not isinstance(module, QSAAttention):
+            continue
+        stats["route_constructions"] += module.indexed_splitk_route_constructions
+        stats["declines"] += module.indexed_splitk_declines
+        for reason, count in module.indexed_splitk_decline_reasons.items():
             stats["decline_reasons"][reason] = (
                 stats["decline_reasons"].get(reason, 0) + count
             )

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -1196,6 +1196,8 @@ class QSAAttention(nn.Module):
                 query_heads=self.num_attention_heads,
                 kv_heads=self.num_key_value_heads,
                 head_dim=self.head_dim,
+                block_size=self.indexer.compress_ratio,
+                block_topk=self.indexer.block_topk,
                 dtype=queries.dtype,
             ):
                 indexed_decline = "unsupported layout"

--- a/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
@@ -238,8 +238,12 @@ def inject_qwen4_exp_mtp_support(
                 return [CacheList(KVCache(), QSAIndexCache(ratio))]
 
         inner.mtp = mtp
-        inner.mtp_max_speculative_tokens = 1
-        model.mtp_max_speculative_tokens = 1
+        # One autoregressive MTP layer can be invoked twice to form a verified
+        # draft chain. The CLI keeps K=1 as the implicit default; this ceiling
+        # only admits an explicit K=2 request after family-specific rollback
+        # qualification.
+        inner.mtp_max_speculative_tokens = 2
+        model.mtp_max_speculative_tokens = 2
         inner.__class__ = _Qwen4ExpWithMTP
         if model is not inner:
             model.mtp_prompt_lookup_supported = True


### PR DESCRIPTION
## Why

Related to #3058.

The previous Qwen3.8 Flash-Next K=2 experiment was correctness-qualified but
rejected because gathered QSA verification collapsed to 17.93 tok/s at 32K.
The indexed M=3 QSA spike removes that collapse. An isolated same-code A/B now
shows a material K=2 win at 64K, while also establishing that K=2 is not a
universal shorter-context speedup.

## Scope

- Keep implicit Qwen3.8 native MTP at K=1.
- Admit an explicit `num_speculative_tokens=2` request.
- Add the qualified indexed split-K QSA kernel and activate it automatically
  for explicit K=2 unless the operator explicitly opts out.
- Fail closed outside the measured BF16 QH=24/KVH=2/D=256, block-4/top-K-512
  tensor and selection geometry.
- Continue rejecting K=3 and deeper chains.
- Raise the injected family capability ceiling from one to two.
- Add CLI and vendored-model coverage for K=2.
- Record the reproducible M3 Ultra dogfood results and qualification boundary.
- Add a Vector-to-Atlas handoff.

This PR is based on current `main`; prerequisite PR #3055 is already merged.

## Non-goals

- Do not change the default from K=1.
- Do not enable K=3.
- Do not add the local chunked model-load workaround to production.
- Do not claim a K=2 win below the measured 64K crossover.

## Acceptance

- A Qwen3.8 request with no explicit depth resolves to K=1.
- Explicit K=1 and K=2 start successfully.
- Explicit K=2 enables indexed QSA by default while an explicit kernel opt-out
  remains respected.
- Explicit K=3 or greater fails startup.
- K=2 generation is deterministic on the synthetic fixture.
- Existing generic chain rollback and indexed-QSA tests remain green.
- The public performance claim remains limited to explicit, 64K-oriented use.

## Verification

- `tests/test_mtp_spec_decode.py`: 132 passed.
- `tests/test_qwen4_exp_vendored.py`: 101 passed.
- `tests/test_qsa_indexed_splitk.py tests/test_mtp_cli_wiring.py`: 123 passed.
- Combined affected suites: 357 passed after rebasing to current `main`.
- Full local validation suite: 22,604 passed; seven Bonsai failures reproduced
  unchanged on clean `origin/main` (`c0e09b560`) from an installed
  `TilingConfig` signature mismatch.
- Ruff check and format check on all changed Python files: passed.
- `git diff --check`: passed.
- Isolated M3 Ultra real-model dogfood, three accepted samples per arm:
  - 16K: K1 35.38 vs K2 32.88 tok/s, -7.1%.
  - 32K: K1 33.21 vs K2 32.97 tok/s, -0.7%.
  - 64K strict same-kernel comparison: K1 29.23 vs K2 33.72 tok/s, +15.4%.
- Every accepted 64K K2 sample beat every accepted K1 sample.
- The 45-case Flash-Next battery retained the established K1 vector at 42/45,
  with exactly the same three known failures and no new K2 failure.
- Real-service client cancellation removed the request from the running batch;
  the immediate recovery request returned the expected output.
- Two temperature-0.8/top-p-0.9 requests completed 128 sampled tokens each.
- Samples overlapping unrelated model workers were excluded by timestamp, not
  by performance value.
- Full `pr_validate` also ran the 4-family stress matrix. Qwen3.5/Qwen3.6 warm
  A/B deltas were -0.1%/-0.5% and classified NOT-THIS-PR. Its only stress
  blocker, the DiffusionGemma golden checkpoint identifying as legacy
  `diffusion`, reproduced unchanged in a clean `origin/main` worktree.
- Final scoped PR-number validation (skipping only those two already-run,
  A/B-confirmed main failures): `MERGE-SAFE`; Codex found no blocking issue.

## Behaviour delta

Qwen3.8 explicit `num_speculative_tokens=2`: rejected at startup -> accepted as
an opt-in experimental depth with the qualified indexed-QSA route enabled.

Qwen3.8 implicit/default depth: K=1 -> K=1, unchanged.

## AI assistance disclosure

Codex wrote and reviewed the implementation, tests, performance report, and role
handoff. The changes were verified with the focused and broader test suites
listed above, Ruff, diff hygiene checks, and real-model M3 Ultra dogfood.
Contended benchmark samples were identified adversarially and excluded from the
reported clean set.

> By submitting this PR I confirm I can explain the intent, risk, and behavior
> of every non-generated change in this PR. For any generated / boilerplate /
> scaffolded sections, I have identified them above and can describe how I
> verified them.

## Checklist

- [x] Affected tests pass locally (357 passed); full repository run reached
  22,604 passes with seven A/B-confirmed main failures documented above.
- [x] Lint passes for all changed Python files
- [x] PR-number `pr_validate` completed: full run classified two pre-existing
  main blockers; scoped rerun excluding only those completed gates was
  `MERGE-SAFE`.
- [x] New critical-path tests were spot-checked against the production behavior
  change
- [x] Updated performance documentation
- [x] No breaking changes to the existing default API

## Author

X handle (optional, external contributors):
