### PR TITLE
fix(image): allow complete cached snapshots to start offline

### DIFF
--- a/tests/test_disk_space_check.py
+++ b/tests/test_disk_space_check.py
@@ -158,6 +158,31 @@ class TestDiskSpaceCheck:
             _check_disk_space("filipstrand/Z-Image-Turbo-mflux-4bit")
         statvfs.assert_not_called()
 
+    def test_complete_image_snapshot_skips_remote_revision_pricing(self):
+        """A runnable warm image snapshot must not be repriced from the Hub.
+
+        The remote repo may have advanced since the local snapshot was pulled.
+        Image loading deliberately uses the verified local snapshot in that
+        case, so querying the newer revision can falsely demand tens of GB and
+        block startup even though no download will occur.
+        """
+        model_info = MagicMock()
+        cache_lookup = MagicMock()
+        statvfs = MagicMock()
+        with (
+            patch(
+                "vllm_mlx._download_gate.mflux_missing_weights", return_value=[]
+            ),
+            patch("huggingface_hub.model_info", model_info),
+            patch("huggingface_hub.try_to_load_from_cache", cache_lookup),
+            patch("os.statvfs", statvfs),
+        ):
+            _check_disk_space("stabilityai/stable-diffusion-xl-base-1.0")
+
+        model_info.assert_not_called()
+        cache_lookup.assert_not_called()
+        statvfs.assert_not_called()
+
     def test_partial_mflux_cache_counts_only_missing_files(self, tmp_path):
         """A partial component cache requires space only for missing weights."""
         cached_transformer = tmp_path / "transformer.safetensors"

--- a/tests/test_disk_space_check.py
+++ b/tests/test_disk_space_check.py
@@ -170,9 +170,7 @@ class TestDiskSpaceCheck:
         cache_lookup = MagicMock()
         statvfs = MagicMock()
         with (
-            patch(
-                "vllm_mlx._download_gate.mflux_missing_weights", return_value=[]
-            ),
+            patch("vllm_mlx._download_gate.mflux_missing_weights", return_value=[]),
             patch("huggingface_hub.model_info", model_info),
             patch("huggingface_hub.try_to_load_from_cache", cache_lookup),
             patch("os.statvfs", statvfs),

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -1008,6 +1008,17 @@ def _check_disk_space(model_name: str, force: bool = False) -> None:
     if os.path.exists(model_name):
         return
 
+    # Image loaders consume their verified local snapshot directly once every
+    # runtime-required file is present.  Check that contract before comparing
+    # against the Hub's *current* revision: a repo can advance after the local
+    # snapshot was downloaded, and pricing the newer remote revision here
+    # would reject a perfectly runnable warm start as a huge new download.
+    # Text checkpoints retain the selective-loader fast path below.
+    from vllm_mlx._download_gate import mflux_missing_weights
+
+    if mflux_missing_weights(model_name) == []:
+        return
+
     # Which directory inside the repo this alias actually needs. Resolved
     # OUTSIDE the cache probe below: that probe is best-effort and swallows
     # its own failures, and folding the prefix into it meant one flaky


### PR DESCRIPTION
## Summary

- skip remote disk pricing when the registered image checkpoint is already verified complete locally
- preserve conservative behavior for partial, absent, and inconclusive caches
- add a regression for remote revisions advancing after a warm snapshot was downloaded

## User impact

Switching to an already-downloaded image model no longer fails with a misleading large download-space error when the upstream repository has advanced. The existing verified local snapshot starts directly.

## Scope

This changes only the image warm-start disk preflight and its focused regression coverage. It does not alter downloads for incomplete models, image generation behavior, the model catalog, or release configuration.

## Validation

- `pytest tests/test_disk_space_check.py tests/test_serve_image_gen_completeness.py tests/test_download_gate.py -q` — 195 passed
- `ruff check vllm_mlx/cli.py tests/test_disk_space_check.py`
- real Desktop dogfood: cached SDXL previously failed by pricing a 65.2 GB remote revision against 44.8 GB free; patched build loaded the same cached snapshot, generated HTTP 200, rendered a coherent 512×512 image, then switched back to Bonsai successfully

No release or deployment is included.