### PR TITLE
feat(cache): lossless hybrid verify transaction — Qwen4ExpStateCache cache_rollback contract

### DIFF
--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -940,6 +940,48 @@ def test_qwen4_state_cache_rollback_via_composite_cache_list():
     np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(rb0[1]))
 
 
+def test_qwen4_state_cache_transactional_restore_on_later_leaf_failure():
+    """A failure mid-``trim_all`` atomically restores an already-trimmed leaf.
+
+    ``trim_all`` checkpoints every leaf before trimming, then restores all of
+    them if ANY leaf fails after an earlier trim already committed. Without
+    this the earlier leaf would be left half-trimmed — breaking the lossless
+    rollback contract. Force the failure in a later leaf and assert the
+    recurrent cache returns to its exact pre-trim (verify) state, undo record
+    intact.
+    """
+    from vllm_mlx.cache_rollback import trim_all
+
+    class _FailingLeaf:
+        def can_trim(self, n):
+            return True
+
+        def trim(self, n):
+            raise RuntimeError("boom")
+
+    recurrent = Qwen4ExpStateCache(size=2)
+    rb0 = [
+        mx.array([[1.0, 2.0]], dtype=mx.float32),
+        mx.array([[3.0, 4.0]], dtype=mx.float32),
+    ]
+    rb1 = [
+        mx.array([[5.0, 6.0]], dtype=mx.float32),
+        mx.array([[7.0, 8.0]], dtype=mx.float32),
+    ]
+    # The verify advanced to boundary 1 and captured a 2-entry undo record.
+    recurrent.cache = [rb1[0], rb1[1]]
+    recurrent.record_slot_snapshots(0, [rb0[0], rb1[0]])
+    recurrent.record_slot_snapshots(1, [rb0[1], rb1[1]], finalize=True)
+
+    composite = CacheList(recurrent, _FailingLeaf())
+    assert not trim_all([composite], 1)
+    # Atomic: the earlier successful trim was rolled back, not left half-applied.
+    assert recurrent.rollback_state is not None
+    assert len(recurrent.rollback_state) == 2
+    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(rb1[0]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(rb1[1]))
+
+
 def test_suffix_scheduler_falls_through_before_qsa_multitoken_verify():
     from vllm_mlx.scheduler import _install_suffix_decoding
 

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -891,8 +891,10 @@ def test_qwen4_state_cache_trim_matches_mtp_generator_restore():
             np.array(via_trim.cache[0]), np.array(expected[0])
         )
 
-    # Dropping more than the K drafts is refused rather than aliased.
+    # Dropping more than the K drafts is refused rather than aliased, and a
+    # cache with no undo record (outside a verify window) refuses any trim.
     assert fresh().trim(k_len + 1) == 0
+    assert Qwen4ExpStateCache(size=2).trim(1) == 0
 
 
 def test_qwen4_state_cache_zero_trim_is_side_effect_free():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -791,6 +791,111 @@ def test_qsa_speculative_snapshot_fails_closed_on_invalid_boundary():
         qsa.restore_rollback(3, 3)
 
 
+def test_qwen4_state_cache_implements_cache_rollback_contract():
+    """``Qwen4ExpStateCache`` participates in the composite verify transaction.
+
+    Layer B' of #2561: the draftless n-gram suffix path (and the composite
+    ``cache_rollback`` transaction) rejected hybrid recurring layers because
+    ``Qwen4ExpStateCache`` did not satisfy ``cache_rollback.can_trim``. It now
+    exposes the same ``is_trimmable``/``can_trim``/``trim``/
+    ``trim_checkpoint``/``restore_trim_checkpoint`` contract QSA already has,
+    backed by the existing ``record_slot_snapshots``/``rollback_state``
+    undo record. Only the spec-verify window is trimmable; the preflight and
+    transactional restore must behave correctly.
+    """
+    from vllm_mlx.cache_rollback import can_advance, can_trim, trim_all
+
+    recurrent = Qwen4ExpStateCache(size=2)
+
+    # Not in a spec-verify window → nothing to roll back.
+    assert not recurrent.is_trimmable()
+    assert not can_trim(recurrent, 1)
+    assert not can_advance(recurrent, 1)
+
+    # A 2-draft verify captures 3 boundaries: the base (committed prefix)
+    # plus one per accepted position — so the undo record has 3 entries and
+    # can drop up to 2 (full rejection → keep base only), mirroring the QSA
+    # ``rollback_state``/``restore_rollback`` convention.
+    recurrent.record_slot_snapshots(
+        0,
+        [
+            mx.ones((1, 1, 2), dtype=mx.float32),
+            mx.ones((1, 1, 2), dtype=mx.float32),
+            mx.ones((1, 1, 2), dtype=mx.float32),
+        ],
+    )
+    recurrent.record_slot_snapshots(
+        1,
+        [
+            mx.ones((1, 1, 2), dtype=mx.float32),
+            mx.ones((1, 1, 2), dtype=mx.float32),
+            mx.ones((1, 1, 2), dtype=mx.float32),
+        ],
+        finalize=True,
+    )
+    assert recurrent.is_trimmable()
+    assert can_trim(recurrent, 1)
+    assert can_trim(recurrent, 2)
+    assert can_advance(recurrent, 2)
+
+    # Transactional trim drops the rejected tail and clears the undo record.
+    assert trim_all([recurrent], 1)
+    assert recurrent.rollback_state is None
+
+
+def test_qwen4_state_cache_rollback_via_composite_cache_list():
+    """A QSA + recurrent composite now admits multi-token rollback losslessly.
+
+    The suffix verify path preflights the WHOLE composite cache with
+    ``cache_rollback.can_advance``/``trim_all``. Both leaves (QSA compressed
+    keys and Qwen4 recurrent state) must roll back to the same committed
+    boundary. This is the Layer B' precondition for opening the hybrid n-gram
+    allowlist.
+    """
+    from vllm_mlx.cache_rollback import can_advance, trim_all
+
+    def transform(group, start):
+        return group + start
+
+    initial = mx.arange(9, dtype=mx.float32).reshape(1, 9, 1)
+    verify = mx.array([[[90.0], [91.0]]])
+
+    qsa = QSAIndexCache(compress_ratio=4)
+    qsa.update(initial, transform)
+    # Verify forward of [base, d_0, d_1] with rollback captured.
+    qsa.update(verify, transform, record_rollback=True)
+
+    recurrent = Qwen4ExpStateCache(size=2)
+    # The QSA verify above published 2 boundaries (from a 2-token verify that
+    # completed one extra compressed group), which supports dropping 1. The
+    # recurrent cache publishes a matching undo record so BOTH leaves roll back
+    # to the same committed boundary.
+    recurrent.record_slot_snapshots(
+        0,
+        [
+            mx.ones((1, 1, 2), dtype=mx.float32),
+            mx.ones((1, 1, 2), dtype=mx.float32),
+        ],
+    )
+    recurrent.record_slot_snapshots(
+        1,
+        [
+            mx.ones((1, 1, 2), dtype=mx.float32),
+            mx.ones((1, 1, 2), dtype=mx.float32),
+        ],
+        finalize=True,
+    )
+
+    composite = CacheList(qsa, recurrent)
+
+    # Multi-token verify admissible now that BOTH leaves are trimmable.
+    assert can_advance(composite, 1)
+    # Reject the last draft → roll back both leaves by one.
+    assert trim_all([composite], 1)
+    assert qsa.rollback_state is None
+    assert recurrent.rollback_state is None
+
+
 def test_suffix_scheduler_falls_through_before_qsa_multitoken_verify():
     from vllm_mlx.scheduler import _install_suffix_decoding
 

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -812,42 +812,87 @@ def test_qwen4_state_cache_implements_cache_rollback_contract():
     assert not can_trim(recurrent, 1)
     assert not can_advance(recurrent, 1)
 
-    # A 2-draft verify captures 3 boundaries: the base (committed prefix)
-    # plus one per accepted position — so the undo record has 3 entries and
-    # can drop up to 2 (full rejection → keep base only), mirroring the QSA
-    # ``rollback_state``/``restore_rollback`` convention. Each boundary carries
-    # DISTINCT slot values so a wrong boundary or a lost slot is caught.
-    # ``rollback_state[position] = [slot0, slot1]``; ``cache`` is the flattened
-    # slot list, so restoring boundary ``keep-1`` must restore exactly
-    # ``[slot0(keep-1), slot1(keep-1)]``.
-    b0 = [
+    # Producer convention (``qwen4_exp.py`` ``record_slot_snapshots`` over
+    # ``range(1, length)`` and the MTP generator's ``verify_size = k_len + 1``):
+    # a 2-draft verify forward ``[committed, d_0, d_1]`` (L = 3) records L-1 = 2
+    # boundaries — the state after position 1 and after position 2 — while the
+    # live ``cache`` holds the state after all 3 tokens. Dropping ``n`` rejected
+    # drafts keeps ``L - n`` tokens and must restore ``snapshots[L - n - 1]``.
+    # Each boundary carries DISTINCT slot values so an off-by-one is caught.
+    after1 = [
         mx.array([[1.0, 2.0]], dtype=mx.float32),
         mx.array([[3.0, 4.0]], dtype=mx.float32),
     ]
-    b1 = [
+    after2 = [
         mx.array([[5.0, 6.0]], dtype=mx.float32),
         mx.array([[7.0, 8.0]], dtype=mx.float32),
     ]
-    b2 = [
+    after3 = [
         mx.array([[9.0, 10.0]], dtype=mx.float32),
         mx.array([[11.0, 12.0]], dtype=mx.float32),
     ]
-    recurrent.record_slot_snapshots(0, [b0[0], b1[0], b2[0]])
-    recurrent.record_slot_snapshots(1, [b0[1], b1[1], b2[1]], finalize=True)
+    recurrent.cache = list(after3)
+    recurrent.record_slot_snapshots(0, [after1[0], after2[0]])
+    recurrent.record_slot_snapshots(1, [after1[1], after2[1]], finalize=True)
 
     assert recurrent.is_trimmable()
     assert can_trim(recurrent, 1)
     assert can_trim(recurrent, 2)
+    # Only the K = 2 drafts are droppable; the committed first token never is.
+    assert not can_trim(recurrent, 3)
     assert can_advance(recurrent, 2)
 
-    # Transactional trim drops ONE rejected tail → keep boundary b1 (keep = 3-1
-    # = 2 → snapshots[1]), and clears the undo record. The restored cache must
-    # MATCH b1's slots exactly, proving lossless rollback (not just a cleared
-    # record).
+    # Reject ONE draft → keep 2 tokens → the state after position 2, and the
+    # undo record is consumed. The restored cache must MATCH that boundary
+    # exactly, proving lossless rollback (not just a cleared record).
     assert trim_all([recurrent], 1)
     assert recurrent.rollback_state is None
-    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(b1[0]))
-    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(b1[1]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(after2[0]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(after2[1]))
+
+
+def test_qwen4_state_cache_trim_matches_mtp_generator_restore():
+    """``trim(n)`` must land on the same boundary as the MTP generator's call.
+
+    ``spec_decode/mtp/generator.py`` rolls a Qwen4 cache back with
+    ``restore_rollback(n_to_drop, verify_size=k_len + 1)``. The composite
+    ``cache_rollback`` contract has no ``verify_size`` argument, so ``trim``
+    must derive it from the undo record (``len(rollback_state) + 1``); passing
+    ``len(rollback_state)`` (the QSA convention) lands one token too early and
+    silently desynchronises the recurrent state from the trimmed KV cache.
+    """
+    k_len = 3
+    boundaries = [
+        [
+            mx.array([[float(10 * position + 1)]], dtype=mx.float32),
+            mx.array([[float(10 * position + 2)]], dtype=mx.float32),
+        ]
+        for position in range(1, k_len + 1)
+    ]
+
+    def fresh() -> Qwen4ExpStateCache:
+        cache = Qwen4ExpStateCache(size=2)
+        cache.record_slot_snapshots(0, [b[0] for b in boundaries])
+        cache.record_slot_snapshots(1, [b[1] for b in boundaries], finalize=True)
+        return cache
+
+    for n_to_drop in range(1, k_len + 1):
+        via_generator = fresh()
+        via_generator.restore_rollback(n_to_drop, verify_size=k_len + 1)
+        via_trim = fresh()
+        assert via_trim.trim(n_to_drop) == n_to_drop
+        for slot in range(2):
+            np.testing.assert_array_equal(
+                np.array(via_trim.cache[slot]), np.array(via_generator.cache[slot])
+            )
+        # Explicitly: keep = (k_len + 1) - n_to_drop tokens → boundary index keep-1.
+        expected = boundaries[k_len - n_to_drop]
+        np.testing.assert_array_equal(
+            np.array(via_trim.cache[0]), np.array(expected[0])
+        )
+
+    # Dropping more than the K drafts is refused rather than aliased.
+    assert fresh().trim(k_len + 1) == 0
 
 
 def test_qwen4_state_cache_zero_trim_is_side_effect_free():
@@ -885,30 +930,31 @@ def test_qwen4_state_cache_zero_trim_is_side_effect_free():
 
 
 def test_qwen4_state_cache_rollback_full_rejection():
-    """Full rejection restores the base (committed-prefix) boundary losslessly."""
+    """Rejecting every draft restores the state after the committed token."""
     from vllm_mlx.cache_rollback import trim_all
 
     recurrent = Qwen4ExpStateCache(size=2)
-    b0 = [
+    after1 = [
         mx.array([[1.0, 2.0]], dtype=mx.float32),
         mx.array([[3.0, 4.0]], dtype=mx.float32),
     ]
-    b1 = [
+    after2 = [
         mx.array([[5.0, 6.0]], dtype=mx.float32),
         mx.array([[7.0, 8.0]], dtype=mx.float32),
     ]
-    b2 = [
+    after3 = [
         mx.array([[9.0, 10.0]], dtype=mx.float32),
         mx.array([[11.0, 12.0]], dtype=mx.float32),
     ]
-    recurrent.record_slot_snapshots(0, [b0[0], b1[0], b2[0]])
-    recurrent.record_slot_snapshots(1, [b0[1], b1[1], b2[1]], finalize=True)
+    recurrent.cache = list(after3)
+    recurrent.record_slot_snapshots(0, [after1[0], after2[0]])
+    recurrent.record_slot_snapshots(1, [after1[1], after2[1]], finalize=True)
 
-    # Reject both drafts → keep base (keep = 3-2 = 1 → snapshots[0]).
+    # Reject both drafts → keep only the committed token → state after position 1.
     assert trim_all([recurrent], 2)
     assert recurrent.rollback_state is None
-    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(b0[0]))
-    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(b0[1]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(after1[0]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(after1[1]))
 
 
 def test_qwen4_state_cache_rollback_via_composite_cache_list():
@@ -940,19 +986,24 @@ def test_qwen4_state_cache_rollback_via_composite_cache_list():
     recurrent = Qwen4ExpStateCache(size=2)
     # The QSA verify above published 2 boundaries (from a 2-token verify that
     # completed one extra compressed group), which supports dropping 1. The
-    # recurrent cache publishes a matching undo record with DISTINCT per-boundary
-    # values so BOTH leaves roll back to the same committed base boundary and a
-    # wrong restore cannot slip through.
-    rb0 = [
+    # recurrent cache saw the same [committed, d_0, d_1] forward, so its undo
+    # record holds the state after position 1 and after position 2 (its live
+    # ``cache`` is the state after position 3). Dropping one token must land on
+    # ``after2``; DISTINCT per-boundary values catch a wrong restore.
+    after1 = [
         mx.array([[1.0, 2.0]], dtype=mx.float32),
         mx.array([[3.0, 4.0]], dtype=mx.float32),
     ]
-    rb1 = [
+    after2 = [
         mx.array([[5.0, 6.0]], dtype=mx.float32),
         mx.array([[7.0, 8.0]], dtype=mx.float32),
     ]
-    recurrent.record_slot_snapshots(0, [rb0[0], rb1[0]])
-    recurrent.record_slot_snapshots(1, [rb0[1], rb1[1]], finalize=True)
+    recurrent.cache = [
+        mx.array([[9.0, 10.0]], dtype=mx.float32),
+        mx.array([[11.0, 12.0]], dtype=mx.float32),
+    ]
+    recurrent.record_slot_snapshots(0, [after1[0], after2[0]])
+    recurrent.record_slot_snapshots(1, [after1[1], after2[1]], finalize=True)
 
     composite = CacheList(qsa, recurrent)
 
@@ -969,9 +1020,9 @@ def test_qwen4_state_cache_rollback_via_composite_cache_list():
     assert qsa._compressed_counts == list(q_counts)
     assert qsa._pending_left_padding == list(q_pending)
     np.testing.assert_array_equal(np.array(qsa.raw_ring), np.array(q_raw))
-    # …and the recurrent cache restored the base boundary's slot values.
-    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(rb0[0]))
-    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(rb0[1]))
+    # …and the recurrent cache restored the state after the two kept tokens.
+    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(after2[0]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(after2[1]))
 
 
 def test_qwen4_state_cache_transactional_restore_on_later_leaf_failure():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -815,32 +815,48 @@ def test_qwen4_state_cache_implements_cache_rollback_contract():
     # A 2-draft verify captures 3 boundaries: the base (committed prefix)
     # plus one per accepted position — so the undo record has 3 entries and
     # can drop up to 2 (full rejection → keep base only), mirroring the QSA
-    # ``rollback_state``/``restore_rollback`` convention.
-    recurrent.record_slot_snapshots(
-        0,
-        [
-            mx.ones((1, 1, 2), dtype=mx.float32),
-            mx.ones((1, 1, 2), dtype=mx.float32),
-            mx.ones((1, 1, 2), dtype=mx.float32),
-        ],
-    )
-    recurrent.record_slot_snapshots(
-        1,
-        [
-            mx.ones((1, 1, 2), dtype=mx.float32),
-            mx.ones((1, 1, 2), dtype=mx.float32),
-            mx.ones((1, 1, 2), dtype=mx.float32),
-        ],
-        finalize=True,
-    )
+    # ``rollback_state``/``restore_rollback`` convention. Each boundary carries
+    # DISTINCT slot values so a wrong boundary or a lost slot is caught.
+    # ``rollback_state[position] = [slot0, slot1]``; ``cache`` is the flattened
+    # slot list, so restoring boundary ``keep-1`` must restore exactly
+    # ``[slot0(keep-1), slot1(keep-1)]``.
+    b0 = [mx.array([[1.0, 2.0]], dtype=mx.float32), mx.array([[3.0, 4.0]], dtype=mx.float32)]
+    b1 = [mx.array([[5.0, 6.0]], dtype=mx.float32), mx.array([[7.0, 8.0]], dtype=mx.float32)]
+    b2 = [mx.array([[9.0, 10.0]], dtype=mx.float32), mx.array([[11.0, 12.0]], dtype=mx.float32)]
+    recurrent.record_slot_snapshots(0, [b0[0], b1[0], b2[0]])
+    recurrent.record_slot_snapshots(1, [b0[1], b1[1], b2[1]], finalize=True)
+
     assert recurrent.is_trimmable()
     assert can_trim(recurrent, 1)
     assert can_trim(recurrent, 2)
     assert can_advance(recurrent, 2)
 
-    # Transactional trim drops the rejected tail and clears the undo record.
+    # Transactional trim drops ONE rejected tail → keep boundary b1 (keep = 3-1
+    # = 2 → snapshots[1]), and clears the undo record. The restored cache must
+    # MATCH b1's slots exactly, proving lossless rollback (not just a cleared
+    # record).
     assert trim_all([recurrent], 1)
     assert recurrent.rollback_state is None
+    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(b1[0]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(b1[1]))
+
+
+def test_qwen4_state_cache_rollback_full_rejection():
+    """Full rejection restores the base (committed-prefix) boundary losslessly."""
+    from vllm_mlx.cache_rollback import trim_all
+
+    recurrent = Qwen4ExpStateCache(size=2)
+    b0 = [mx.array([[1.0, 2.0]], dtype=mx.float32), mx.array([[3.0, 4.0]], dtype=mx.float32)]
+    b1 = [mx.array([[5.0, 6.0]], dtype=mx.float32), mx.array([[7.0, 8.0]], dtype=mx.float32)]
+    b2 = [mx.array([[9.0, 10.0]], dtype=mx.float32), mx.array([[11.0, 12.0]], dtype=mx.float32)]
+    recurrent.record_slot_snapshots(0, [b0[0], b1[0], b2[0]])
+    recurrent.record_slot_snapshots(1, [b0[1], b1[1], b2[1]], finalize=True)
+
+    # Reject both drafts → keep base (keep = 3-2 = 1 → snapshots[0]).
+    assert trim_all([recurrent], 2)
+    assert recurrent.rollback_state is None
+    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(b0[0]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(b0[1]))
 
 
 def test_qwen4_state_cache_rollback_via_composite_cache_list():

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -850,6 +850,40 @@ def test_qwen4_state_cache_implements_cache_rollback_contract():
     np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(b1[1]))
 
 
+def test_qwen4_state_cache_zero_trim_is_side_effect_free():
+    """``trim(0)`` must not discard the verify undo record.
+
+    A degenerate ``n=0`` trim previously passed ``can_trim`` and invoked
+    ``restore_rollback``, rewriting ``cache`` to the last snapshot boundary and
+    clearing ``rollback_state`` (throwing away the verify window) even though
+    zero tokens were trimmed. ``can_trim(0)`` must be ``False`` so ``trim(0)``
+    is a no-op that leaves cache and undo record untouched.
+    """
+    from vllm_mlx.cache_rollback import can_trim, trim_all
+
+    recurrent = Qwen4ExpStateCache(size=2)
+    b0 = [
+        mx.array([[1.0, 2.0]], dtype=mx.float32),
+        mx.array([[3.0, 4.0]], dtype=mx.float32),
+    ]
+    b1 = [
+        mx.array([[5.0, 6.0]], dtype=mx.float32),
+        mx.array([[7.0, 8.0]], dtype=mx.float32),
+    ]
+    recurrent.cache = [b1[0], b1[1]]
+    recurrent.record_slot_snapshots(0, [b0[0], b1[0]])
+    recurrent.record_slot_snapshots(1, [b0[1], b1[1]], finalize=True)
+
+    assert not can_trim(recurrent, 0)
+    # trim_all short-circuits n<=0 (returns True) without invoking any trim;
+    # state must be left completely intact.
+    assert trim_all([recurrent], 0)
+    assert recurrent.rollback_state is not None
+    assert len(recurrent.rollback_state) == 2
+    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(b1[0]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(b1[1]))
+
+
 def test_qwen4_state_cache_rollback_full_rejection():
     """Full rejection restores the base (committed-prefix) boundary losslessly."""
     from vllm_mlx.cache_rollback import trim_all

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -820,9 +820,18 @@ def test_qwen4_state_cache_implements_cache_rollback_contract():
     # ``rollback_state[position] = [slot0, slot1]``; ``cache`` is the flattened
     # slot list, so restoring boundary ``keep-1`` must restore exactly
     # ``[slot0(keep-1), slot1(keep-1)]``.
-    b0 = [mx.array([[1.0, 2.0]], dtype=mx.float32), mx.array([[3.0, 4.0]], dtype=mx.float32)]
-    b1 = [mx.array([[5.0, 6.0]], dtype=mx.float32), mx.array([[7.0, 8.0]], dtype=mx.float32)]
-    b2 = [mx.array([[9.0, 10.0]], dtype=mx.float32), mx.array([[11.0, 12.0]], dtype=mx.float32)]
+    b0 = [
+        mx.array([[1.0, 2.0]], dtype=mx.float32),
+        mx.array([[3.0, 4.0]], dtype=mx.float32),
+    ]
+    b1 = [
+        mx.array([[5.0, 6.0]], dtype=mx.float32),
+        mx.array([[7.0, 8.0]], dtype=mx.float32),
+    ]
+    b2 = [
+        mx.array([[9.0, 10.0]], dtype=mx.float32),
+        mx.array([[11.0, 12.0]], dtype=mx.float32),
+    ]
     recurrent.record_slot_snapshots(0, [b0[0], b1[0], b2[0]])
     recurrent.record_slot_snapshots(1, [b0[1], b1[1], b2[1]], finalize=True)
 
@@ -846,9 +855,18 @@ def test_qwen4_state_cache_rollback_full_rejection():
     from vllm_mlx.cache_rollback import trim_all
 
     recurrent = Qwen4ExpStateCache(size=2)
-    b0 = [mx.array([[1.0, 2.0]], dtype=mx.float32), mx.array([[3.0, 4.0]], dtype=mx.float32)]
-    b1 = [mx.array([[5.0, 6.0]], dtype=mx.float32), mx.array([[7.0, 8.0]], dtype=mx.float32)]
-    b2 = [mx.array([[9.0, 10.0]], dtype=mx.float32), mx.array([[11.0, 12.0]], dtype=mx.float32)]
+    b0 = [
+        mx.array([[1.0, 2.0]], dtype=mx.float32),
+        mx.array([[3.0, 4.0]], dtype=mx.float32),
+    ]
+    b1 = [
+        mx.array([[5.0, 6.0]], dtype=mx.float32),
+        mx.array([[7.0, 8.0]], dtype=mx.float32),
+    ]
+    b2 = [
+        mx.array([[9.0, 10.0]], dtype=mx.float32),
+        mx.array([[11.0, 12.0]], dtype=mx.float32),
+    ]
     recurrent.record_slot_snapshots(0, [b0[0], b1[0], b2[0]])
     recurrent.record_slot_snapshots(1, [b0[1], b1[1], b2[1]], finalize=True)
 
@@ -880,36 +898,46 @@ def test_qwen4_state_cache_rollback_via_composite_cache_list():
     qsa.update(initial, transform)
     # Verify forward of [base, d_0, d_1] with rollback captured.
     qsa.update(verify, transform, record_rollback=True)
+    # The first rollback boundary is the committed prefix a rejected verify must
+    # return to; capture it (as its own (offsets, counts, pending, raw_ring)
+    # tuple) so the post-trim state can be compared against it exactly.
+    qbase = qsa.rollback_state[0]
 
     recurrent = Qwen4ExpStateCache(size=2)
     # The QSA verify above published 2 boundaries (from a 2-token verify that
     # completed one extra compressed group), which supports dropping 1. The
-    # recurrent cache publishes a matching undo record so BOTH leaves roll back
-    # to the same committed boundary.
-    recurrent.record_slot_snapshots(
-        0,
-        [
-            mx.ones((1, 1, 2), dtype=mx.float32),
-            mx.ones((1, 1, 2), dtype=mx.float32),
-        ],
-    )
-    recurrent.record_slot_snapshots(
-        1,
-        [
-            mx.ones((1, 1, 2), dtype=mx.float32),
-            mx.ones((1, 1, 2), dtype=mx.float32),
-        ],
-        finalize=True,
-    )
+    # recurrent cache publishes a matching undo record with DISTINCT per-boundary
+    # values so BOTH leaves roll back to the same committed base boundary and a
+    # wrong restore cannot slip through.
+    rb0 = [
+        mx.array([[1.0, 2.0]], dtype=mx.float32),
+        mx.array([[3.0, 4.0]], dtype=mx.float32),
+    ]
+    rb1 = [
+        mx.array([[5.0, 6.0]], dtype=mx.float32),
+        mx.array([[7.0, 8.0]], dtype=mx.float32),
+    ]
+    recurrent.record_slot_snapshots(0, [rb0[0], rb1[0]])
+    recurrent.record_slot_snapshots(1, [rb0[1], rb1[1]], finalize=True)
 
     composite = CacheList(qsa, recurrent)
 
     # Multi-token verify admissible now that BOTH leaves are trimmable.
     assert can_advance(composite, 1)
-    # Reject the last draft → roll back both leaves by one.
+    # Reject the last draft → roll back both leaves by one to the base boundary.
     assert trim_all([composite], 1)
     assert qsa.rollback_state is None
     assert recurrent.rollback_state is None
+    # QSA restored its committed-prefix (offsets, counts, pending, raw_ring)
+    # boundary exactly, matching the rollback snapshot it was recorded from.
+    (q_offsets, q_counts, q_pending, q_raw) = qbase
+    assert qsa._offsets == list(q_offsets)
+    assert qsa._compressed_counts == list(q_counts)
+    assert qsa._pending_left_padding == list(q_pending)
+    np.testing.assert_array_equal(np.array(qsa.raw_ring), np.array(q_raw))
+    # …and the recurrent cache restored the base boundary's slot values.
+    np.testing.assert_array_equal(np.array(recurrent.cache[0]), np.array(rb0[0]))
+    np.testing.assert_array_equal(np.array(recurrent.cache[1]), np.array(rb0[1]))
 
 
 def test_suffix_scheduler_falls_through_before_qsa_multitoken_verify():

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -112,19 +112,35 @@ class Qwen4ExpStateCache(ArraysCache):
     # non-trimmable. Only the spec-verify window is trimmable (matches DSpark's
     # ``is_trimmable == has undo record``), and only rollback as far as the
     # captured boundary.
+    # Boundary convention — MUST match the ``restore_rollback`` callers in
+    # ``spec_decode/mtp/generator.py`` and the producers in ``qwen4_exp.py``:
+    # a verify forward of ``L = K + 1`` tokens ``[committed, d_0..d_{K-1}]``
+    # records ``L - 1`` boundaries, the recurrent state after positions
+    # ``1..L-1`` (``range(1, length)``); the state after all ``L`` tokens is
+    # the live ``cache`` itself and the pre-verify state is never needed
+    # because the first token is already committed. Hence
+    # ``verify_size == len(rollback_state) + 1``, dropping ``n`` rejected
+    # tokens keeps ``L - n`` and restores ``snapshots[L - n - 1]``, and ``n``
+    # ranges over ``1..K == len(rollback_state)``. (QSA differs: its record
+    # holds exactly ``verify_size`` entries, so it may pass ``len(...)``
+    # straight through — do not copy that here.)
+    def _verify_size(self) -> int | None:
+        snapshots = self.rollback_state
+        if snapshots is None:
+            return None
+        return len(snapshots) + 1
+
     def is_trimmable(self) -> bool:
         return self.rollback_state is not None
 
     def can_trim(self, n: int) -> bool:
         # ``n <= 0`` is degenerate: ``trim(0)`` would invoke ``restore_rollback``
         # and discard the undo record without dropping any tokens, breaking the
-        # verify window. Mirror QSA's leaf contract: only a positive trim may
-        # roll back.
-        if n <= 0:
+        # verify window. Only a positive trim may roll back.
+        snapshots = self.rollback_state
+        if n <= 0 or snapshots is None:
             return False
-        if self.rollback_state is None:
-            return False
-        return 1 <= len(self.rollback_state) - n <= len(self.rollback_state)
+        return n <= len(snapshots)
 
     def trim_checkpoint(self):
         return (
@@ -145,9 +161,10 @@ class Qwen4ExpStateCache(ArraysCache):
         ) = state
 
     def trim(self, n: int) -> int:
-        if not self.can_trim(n):
+        verify_size = self._verify_size()
+        if verify_size is None or not self.can_trim(n):
             return 0
-        self.restore_rollback(n, len(self.rollback_state))
+        self.restore_rollback(n, verify_size)
         return n
 
 

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -116,7 +116,11 @@ class Qwen4ExpStateCache(ArraysCache):
         return self.rollback_state is not None
 
     def can_trim(self, n: int) -> bool:
-        if n < 0:
+        # ``n <= 0`` is degenerate: ``trim(0)`` would invoke ``restore_rollback``
+        # and discard the undo record without dropping any tokens, breaking the
+        # verify window. Mirror QSA's leaf contract: only a positive trim may
+        # roll back.
+        if n <= 0:
             return False
         if self.rollback_state is None:
             return False

--- a/vllm_mlx/models/qwen4_exp_cache.py
+++ b/vllm_mlx/models/qwen4_exp_cache.py
@@ -94,6 +94,58 @@ class Qwen4ExpStateCache(ArraysCache):
         self.rollback_state = None
         self._rollback_slots = None
 
+    # ------------------------------------------------------------------
+    # cache_rollback contract.
+    #
+    # During a speculative-verify forward the recurrent state is advanced by
+    # the whole draft in one call, and a rejected suffix must be rolled back
+    # to the last committed boundary losslessly. The per-position recurrent
+    # boundaries captured by ``record_slot_snapshots(..., finalize=True)``
+    # (``rollback_state``) are exactly the undo record this cache needs, the
+    # same way DeepSeek V4's rotating/pooling caches carry an undo log
+    # (``deepseek_v4_rollback``). Exposing them through the ``cache_rollback``
+    # contract (``is_trimmable``/``can_trim``/``trim``/``trim_checkpoint``/
+    # ``restore_trim_checkpoint``) lets ``cache_rollback.can_advance``/``trim_all``
+    # build an atomic multi-token verify transaction over a composite HYBRID
+    # cache — without which the draftless n-gram suffix path rejected hybrid
+    # recurring (Qwen3.5/3.6 GatedDeltaNet, Granite4 Mamba2) layers as
+    # non-trimmable. Only the spec-verify window is trimmable (matches DSpark's
+    # ``is_trimmable == has undo record``), and only rollback as far as the
+    # captured boundary.
+    def is_trimmable(self) -> bool:
+        return self.rollback_state is not None
+
+    def can_trim(self, n: int) -> bool:
+        if n < 0:
+            return False
+        if self.rollback_state is None:
+            return False
+        return 1 <= len(self.rollback_state) - n <= len(self.rollback_state)
+
+    def trim_checkpoint(self):
+        return (
+            list(self.cache),
+            self.rollback_state,
+            self._rollback_slots,
+            self.left_padding,
+            self.lengths,
+        )
+
+    def restore_trim_checkpoint(self, state) -> None:
+        (
+            self.cache,
+            self.rollback_state,
+            self._rollback_slots,
+            self.left_padding,
+            self.lengths,
+        ) = state
+
+    def trim(self, n: int) -> int:
+        if not self.can_trim(n):
+            return 0
+        self.restore_rollback(n, len(self.rollback_state))
+        return n
+
 
 class QSAIndexCache(ArraysCache):
     """Raw circular index keys plus persistent compressed-key state."""


### PR DESCRIPTION
## Why (Part of #2561 — lossless draftless n-gram on hybrid Flash-Next)

#2561 asks for draftless n-gram speculative decoding that is *lossless* (greedy-token-identical) on hybrid Flash-Next. The hybrid barrier: the suffix decoding path (and the composite `cache_rollback` transaction) rejects hybrid recurring layers because `Qwen4ExpStateCache` did not satisfy `can_trim()`, so `cache_rollback.can_advance()` on a composite QSA+recurrent cache returned False and suffix decoding **fell through on hybrid Qwen3.5/3.6 GatedDeltaNet / Granite4 Mamba2** (scheduler: "chunked-batched verify isn't numerically equivalent to step-update on recurrent layers").

`Qwen4ExpStateCache` already captured per-position recurrent boundaries for its own verify paths (`rollback_state` via `record_slot_snapshots`, `restore_rollback`), but did **not** expose them through the `cache_rollback` contract — so the engine-owned verify transaction couldn't roll a hybrid cache back losslessly.

## Change

Expose the `cache_rollback` contract on `Qwen4ExpStateCache`:
- `is_trimmable()` → True when the spec-verify undo record (`rollback_state`) is present
- `can_trim(n)` → rollback as far as the captured boundary
- `trim(n)` → `restore_rollback(n, len(rollback_state) + 1)` — the producers record L-1 boundaries for an L-token verify and the MTP generator restores with `verify_size = k_len + 1`, so `verify_size` is derived as `len(rollback_state) + 1` (passing the record length, as QSA does, lands one token early — fixed in review)
- `trim_checkpoint()` / `restore_trim_checkpoint()` → transactional snapshot/restore

This matches the existing `QSAIndexCache` and DeepSeek-V4 undo-log precedent, so `cache_rollback.can_advance`/`trim_all` now build an atomic multi-token verify transaction over a composite **hybrid** cache.

## Why this is the right Layer B' slice

Correctness-preserving and additive: hybrid remains default-off (`--suffix-decoding` opt-in + `supports_spec_decode` profile gate untouched). This PR makes the cache trimmable (the mechanical precondition); a follow-on layer flips the allowlist *only behind a bit-exactness guard* (the quantized-drift caveat documented in `dspark-feasibility-note.md`).

## Design precedent

Reuses the in-tree DeepSeek-V4 / QSA verify-rollback transaction (checkpoint → trim/snapshot+replay → committed-prefix; only committed inputs seed the next proposal — the `#2886` transaction discipline).

## Test plan
- New: `Qwen4ExpStateCache` participates in `cache_rollback` — `can_advance` passes and `trim_all` rolls a QSA+recurrent composite back to the same boundary losslessly.
- `tests/test_qwen4_exp_vendored.py` + `tests/test_suffix_decoding.py`: **136 passed** (incl. new `test_qwen4_state_cache_trim_matches_mtp_generator_restore` parity test), ruff clean, mypy budget flat.

## Follow-on required before the allowlist flip
The suffix verify forward (`scheduler.py`, `gb.model(verify_input, cache=gb.prompt_cache)`) does not pass `record_rollback=True`, so on that path `rollback_state` stays `None` and `can_advance` still falls through on hybrids. The flip must thread `record_rollback` through the suffix verify forward.

## Non-goals (this slice)
- No allowlist flip, no `--suffix-decoding` default change, no version bump, no hybrid enablement yet.