### PR TITLE
feat(image): show readiness details before model load

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Images/ImageGenViewModel.swift
@@ -197,7 +197,7 @@ final class ImageGenViewModel {
         progress?.total ?? Self.seedSteps(for: inFlightAlias ?? selectedAlias)
     }
 
-    static func seedSteps(for alias: String) -> Int {
+    nonisolated static func seedSteps(for alias: String) -> Int {
         // Non-distilled Qwen-Image denoises for ~20 steps (both the base
         // text-to-image model and the edit variant) — matching the engine's
         // per-family default, so the bar isn't scaled for a 4-step turbo run
@@ -517,9 +517,10 @@ final class ImageGenViewModel {
         return RequestTarget(
             alias: selected.alias,
             hfPath: selected.hfRepo,
-            estimatedMemoryGB: ModelSizing.residentEstimateGB(
+            estimatedMemoryGB: ModelSizing.imageResidentEstimateGB(
                 alias: selected.alias,
-                sizeText: selected.sizeOnDisk
+                sizeText: selected.sizeOnDisk,
+                minimumMemoryGB: selected.minimumMemoryGB
             )
         )
     }

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -254,9 +254,10 @@ struct ModelEntry: Identifiable, Hashable, Sendable {
 
     /// Image-only operation metadata. `nil` for chat/audio/video rows.
     var imageCapability: ImageModelCapability? = nil
+    var imageDefaultSteps: Int? = nil
 
-    /// Video-only operation and hardware metadata. Empty/`nil` for every
-    /// other modality and for older sidecars that do not advertise it.
+    /// Video-only operation metadata plus the whole-machine memory floor used
+    /// by video and image rows. `nil` for older sidecars that omit it.
     var videoCapabilities: Set<VideoModelCapability> = []
     var minimumMemoryGB: Double? = nil
 
@@ -1446,9 +1447,15 @@ enum ModelCatalog {
         let cached = await cachedTask
         let json = await modelsJSON
         if json.succeeded, let atomic = parseAtomicModelEntriesJSON(json.stdout) {
+            let readinessByAlias = parseImageReadinessJSON(json.stdout)
             return mergeAtomicAndCached(
                 atomic: atomic, cached: cached, excluded: []
-            ).filter { $0.supports(.image) }
+            ).filter { $0.supports(.image) }.map { entry in
+                var enriched = entry
+                enriched.minimumMemoryGB = readinessByAlias[entry.alias]?.minimumMemoryGB
+                enriched.imageDefaultSteps = readinessByAlias[entry.alias]?.defaultSteps
+                return enriched
+            }
         }
         let modelsOut = await runRapidMlx(binary: binary, args: ["models"])
         let rows = parseImageRows(modelsOut)
@@ -1479,6 +1486,37 @@ enum ModelCatalog {
                 imageCapability: row.capability
             )
         }
+    }
+
+    /// Read image hardware floors from the versioned legacy projection that
+    /// accompanies the atomic catalog. The atomic envelope owns capability and
+    /// runtime identity; this projection supplies checked-in sizing metadata
+    /// without teaching Desktop model-name heuristics.
+    struct ImageReadiness: Equatable {
+        let minimumMemoryGB: Double
+        let defaultSteps: Int
+    }
+
+    static func parseImageReadinessJSON(_ output: String) -> [String: ImageReadiness] {
+        guard let data = output.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rows = root["image"] as? [[String: Any]] else { return [:] }
+        var result: [String: ImageReadiness] = [:]
+        for row in rows {
+            guard let alias = row["alias"] as? String, isSafeAlias(alias),
+                  row["min_memory_gb"] as? Bool == nil,
+                  let number = row["min_memory_gb"] as? NSNumber,
+                  number.doubleValue.isFinite,
+                  number.doubleValue > 0,
+                  row["default_steps"] as? Bool == nil,
+                  let defaultSteps = row["default_steps"] as? Int,
+                  (1...200).contains(defaultSteps) else { continue }
+            result[alias] = ImageReadiness(
+                minimumMemoryGB: number.doubleValue,
+                defaultSteps: defaultSteps
+            )
+        }
+        return result
     }
 
     /// Audio aliases for Settings and the dedicated Audio surface. Cached

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -146,6 +146,24 @@ enum ModelSizing {
         return max(heuristic, diskGiB * 1.25 + 0.5)
     }
 
+    /// Image catalog memory is a whole-machine support floor. Convert it to
+    /// the same 80%-usable process budget used by the existing live-pressure
+    /// admission guard, while retaining artifact sizing as the lower bound.
+    static func imageResidentEstimateGB(
+        alias: String,
+        sizeText: String? = nil,
+        minimumMemoryGB: Double? = nil
+    ) -> Double {
+        let artifactEstimate = residentEstimateGB(alias: alias, sizeText: sizeText)
+        guard let minimumMemoryGB,
+              minimumMemoryGB.isFinite,
+              minimumMemoryGB > 0 else { return artifactEstimate }
+        return max(
+            artifactEstimate,
+            minimumMemoryGB * MacHardware.modelUsableMemoryFraction
+        )
+    }
+
     /// Pick a KV-reserve target proportional to model size — bigger
     /// models have bigger per-token cache cost. The picker is mostly
     /// concerned with order-of-magnitude, not precision.

--- a/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ImagesView.swift
@@ -7,6 +7,27 @@ struct ImageCatalogRefreshKey: Hashable {
     let cacheGeneration: UInt
 }
 
+enum ImageReadinessPresentation {
+    static func runtimeName(_ adapter: String?) -> String? {
+        guard let adapter else { return nil }
+        if adapter == "mflux" { return "mflux" }
+        if adapter.hasPrefix("rapid_mlx/") { return "Rapid MLX" }
+        return nil
+    }
+
+    static func rowTitle(_ entry: ModelEntry) -> String {
+        var details: [String] = []
+        if let size = entry.sizeOnDisk, !size.isEmpty { details.append(size) }
+        if let memory = entry.minimumMemoryGB, memory.isFinite, memory > 0 {
+            details.append(String(format: "≥%.0f GB RAM", memory))
+        }
+        details.append("512² default")
+        details.append("\(entry.imageDefaultSteps ?? ImageGenViewModel.seedSteps(for: entry.alias)) steps")
+        if let runtime = runtimeName(entry.runtimeAdapter) { details.append(runtime) }
+        return ([entry.alias] + details).joined(separator: " · ")
+    }
+}
+
 /// The Images tab. Deliberately mirrors ``ChatView``: a scrollable results
 /// area on top and, at the bottom, the *same* compose box — a `surfaceRaised`
 /// rounded field with the model picker + submit button clustered at its
@@ -325,9 +346,10 @@ struct ImagesView: View {
         _ = await server.ensureServing(
             alias: alias,
             hfPath: hfPath,
-            estimatedMemoryGB: ModelSizing.residentEstimateGB(
+            estimatedMemoryGB: ModelSizing.imageResidentEstimateGB(
                 alias: alias,
-                sizeText: entry?.sizeOnDisk
+                sizeText: entry?.sizeOnDisk,
+                minimumMemoryGB: entry?.minimumMemoryGB
             ),
             imageMode: viewModel.isEditing ? .editing : .generation,
             // mflux is a modal engine, like TTS: it cannot be admitted through
@@ -840,7 +862,7 @@ struct ImagesView: View {
                         viewModel.selectedAlias = entry.alias
                     } label: {
                         Label(
-                            modelRowTitle(entry),
+                            ImageReadinessPresentation.rowTitle(entry),
                             systemImage: ModelPickerBar.cacheGlyph(cached: entry.cached)
                         )
                     }
@@ -883,20 +905,21 @@ struct ImagesView: View {
         .fixedSize()
         .disabled(viewModel.isGenerating)
         .onHover { pickerHovering = $0 }
-        .help(viewModel.selectedAlias.isEmpty ? "Choose a model" : "Model: \(viewModel.selectedAlias)")
+        .help(selectedModelHelp)
         // Mirror the tooltip into an accessibility hint: SwiftUI's `.help(_)`
         // reaches AXHelp on macOS 15 but not on macOS 26 for a `Menu` styled as
         // a button, so without this the model the picker resolved to is
         // invisible to VoiceOver and to the golden-flow harness on 26.
-        .accessibilityHint(viewModel.selectedAlias.isEmpty ? "Choose a model" : "Model: \(viewModel.selectedAlias)")
+        .accessibilityHint(selectedModelHelp)
         .accessibilityIdentifier("Images.ModelPicker")
     }
 
-    private func modelRowTitle(_ entry: ModelEntry) -> String {
-        if let size = entry.sizeOnDisk, !size.isEmpty {
-            return "\(entry.alias) · \(size)"
-        }
-        return entry.alias
+    private var selectedModelHelp: String {
+        guard !viewModel.selectedAlias.isEmpty else { return "Choose a model" }
+        guard let entry = viewModel.imageModels.first(where: {
+            $0.alias == viewModel.selectedAlias
+        }) else { return "Model: \(viewModel.selectedAlias)" }
+        return "Model: \(ImageReadinessPresentation.rowTitle(entry))"
     }
 
     /// Submit / stop, styled exactly like ChatView's send button: an amber

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
@@ -31,7 +31,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect.landscape" desc="4:3" enabled=true
           AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 512 × 512" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=true
-          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=true
+          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model> · <size> · 512² default · 4 steps" enabled=true
           AXButton id="Images.Generate" desc="Up" help="Load the model first" enabled=false
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -29,7 +29,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect.landscape" desc="4:3" enabled=true
           AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 512 × 512" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
-          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=false
+          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model> · <size> · 512² default · 4 steps" enabled=false
           AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -39,7 +39,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect.landscape" desc="4:3" enabled=true
           AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 512 × 512" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=true
-          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=true
+          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model> · <size> · 512² default · 4 steps" enabled=true
           AXButton id="Images.Generate" desc="Up" help="Generate" enabled=false
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -30,7 +30,7 @@ AXApplication title="Rapid-MLX"
           AXButton id="Images.Aspect.landscape" desc="4:3" enabled=true
           AXPopUpButton id="Images.Resolution" desc="Output resolution" help="Output resolution: 512 × 512" value=text enabled=true
           AXButton id="Images.Edit.Import" desc="Import image to edit" help="Import image to edit" enabled=false
-          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model>" enabled=false
+          AXPopUpButton id="Images.ModelPicker" desc="<model>" help="Model: <model> · <size> · 512² default · 4 steps" enabled=false
           AXButton id="Images.Generate" desc="Stop" help="Cancel" enabled=true
       AXButton id="ContentView.Settings" desc="Settings" help="Settings — ⌘," enabled=true
       AXButton id="ContentView.ToggleLogs" desc="Show logs" help="Show logs" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -89,6 +89,36 @@ struct ImageCatalogTests {
         #expect(cached.first { $0.alias == "sdxl-base" }?.cached == true)
     }
 
+    @Test("image JSON exposes validated minimum-memory floors")
+    func parsesImageMemoryFloors() {
+        let payload = #"{"image":[{"alias":"sdxl-base","min_memory_gb":16,"default_steps":30},{"alias":"bad","min_memory_gb":true,"default_steps":4},{"alias":"missing","min_memory_gb":12,"default_steps":null}]}"#
+        let readiness = ModelCatalog.parseImageReadinessJSON(payload)
+        #expect(readiness == [
+            "sdxl-base": ModelCatalog.ImageReadiness(
+                minimumMemoryGB: 16, defaultSteps: 30
+            )
+        ])
+    }
+
+    @Test("image picker summarizes load readiness before selection")
+    func imageReadinessSummary() {
+        let entry = ModelEntry(
+            alias: "sdxl-base",
+            hfRepo: "stabilityai/stable-diffusion-xl-base-1.0",
+            sizeOnDisk: "6.5 GiB",
+            cached: true,
+            kind: .image,
+            imageCapability: .generation,
+            imageDefaultSteps: 30,
+            minimumMemoryGB: 16,
+            runtimeAdapter: "rapid_mlx/sdxl"
+        )
+        #expect(
+            ImageReadinessPresentation.rowTitle(entry)
+                == "sdxl-base · 6.5 GiB · ≥16 GB RAM · 512² default · 30 steps · Rapid MLX"
+        )
+    }
+
     @Test("Image capability rows are excluded from the chat catalog")
     func imageRowsExcludedFromChat() {
         // hasNonChatKindTag now drops image alongside audio/video.

--- a/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ModelResidencyTests.swift
@@ -893,6 +893,16 @@ struct ModelResidencyTests {
         #expect(estimate > ModelSizing.residentEstimateGB(alias: "z-image-turbo"))
     }
 
+    @Test("Image residency estimate honors the catalog hardware floor")
+    func imageEstimateHonorsCatalogFloor() {
+        let estimate = ModelSizing.imageResidentEstimateGB(
+            alias: "sdxl-base",
+            sizeText: "6.5 GiB",
+            minimumMemoryGB: 16
+        )
+        #expect(abs(estimate - 12.8) < 0.001)
+    }
+
     @Test("Selecting a chat model does not retain the legacy server restart flow")
     func selectionDoesNotRestartServer() throws {
         let rapidMacRoot = URL(fileURLWithPath: #filePath)

--- a/tests/test_cli_models_json.py
+++ b/tests/test_cli_models_json.py
@@ -49,6 +49,7 @@ def test_available_payload_shape() -> None:
         "modality",
         "video_modes",
         "min_memory_gb",
+        "default_steps",
         "is_builtin",
         "is_text_only",
     ):
@@ -89,6 +90,16 @@ def test_available_sections_are_split_by_modality() -> None:
     assert all(e["modality"] == "video-gen" for e in payload["video"])
     assert all(e["modality"] == "image-gen" for e in payload["image"])
     assert all(e["modality"] == "audio" for e in payload["audio"])
+
+
+def test_image_entries_expose_runtime_default_steps() -> None:
+    payload = _available_models_json_payload()
+    by_alias = {entry["alias"]: entry for entry in payload["image"]}
+
+    assert by_alias["bonsai-image-4b-2bit"]["default_steps"] == 4
+    assert by_alias["hidream-o1-dev"]["default_steps"] == 28
+    assert by_alias["sdxl-base"]["default_steps"] == 30
+    assert all(entry["default_steps"] is None for entry in payload["text"])
 
 
 def test_video_entries_expose_pre_serve_modes_and_memory_floor() -> None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6631,6 +6631,12 @@ def _available_models_json_payload() -> dict:
             raw = size_bytes(p.hf_path)
         except Exception:
             raw = None
+        modality = _modality(p)
+        default_steps = None
+        if modality == "image-gen":
+            from vllm_mlx.image.engine import default_steps_for_model
+
+            default_steps = default_steps_for_model(p.hf_path)
         return {
             "alias": alias,
             "hf_path": p.hf_path,
@@ -6646,9 +6652,10 @@ def _available_models_json_payload() -> dict:
             "mtp_continuous_batching_tier": getattr(
                 p, "mtp_continuous_batching_tier", "unknown"
             ),
-            "modality": _modality(p),
+            "modality": modality,
             "video_modes": list(p.video_modes or ()),
             "min_memory_gb": p.min_memory_gb,
+            "default_steps": default_steps,
             # Desktop consumes these as a launch-safety contract. Only
             # curated aliases may opt into eager MLLM loading, and an
             # explicit text-only pin always wins over name inference.

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -163,6 +163,11 @@ _DEFAULT_STEPS_BY_FAMILY = {
 }
 
 
+def default_steps_for_model(model_name: str) -> int:
+    """Public catalog view of the same family default used at generation."""
+    return _DEFAULT_STEPS_BY_FAMILY.get(_detect_family(model_name), 4)
+
+
 def _looks_like_prequantized(model_name: str) -> bool:
     """A pre-quantized mflux repo / local dir is loaded via ``model_path``.
 


### PR DESCRIPTION
## Summary

- show each image model's disk size, minimum unified memory, 512² Desktop default, runtime-owned default steps, and runtime type in the Images picker
- publish default image steps from the same engine family table used at generation, avoiding alias-name guesses
- include the catalog memory floor in the existing pre-load live-memory admission estimate
- preserve compatibility with older sidecars by treating the new readiness fields as optional

## User impact

Users can judge download cost, hardware fit, expected generation work, and backend type before choosing or starting an image model. A model's published memory floor now strengthens the existing pre-load warning instead of being display-only.

## Scope

This is a bounded image-readiness change. It does not add models, change generation defaults, add another memory policy, redesign the Images workflow, or perform a release/deployment.

## Validation

- Python image/catalog suites: 174 passed
- Desktop image catalog/residency/phase suites: 43 passed
- Ruff and diff checks passed
- isolated Desktop build and AX/visual dogfood confirmed the complete readiness line for all six current image models and the selected-model accessibility hint

## Compatibility

The additional JSON field is additive. Desktop falls back to its existing step estimate and omits unavailable RAM/runtime details when paired with an older sidecar.