### PR TITLE
feat(desktop): add local workflow execution kernel

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -35,6 +35,9 @@ protocol LocalWorkflowFallbackResolving: Sendable {
 }
 
 protocol LocalWorkflowApproving: Sendable {
+    /// Implementations must return promptly when their task is cancelled so
+    /// the executor's structured timeout can drain without retaining approval
+    /// requests or their dependencies.
     func requestApproval(_ request: WorkflowApprovalRequest) async -> WorkflowApprovalDecision
 }
 
@@ -615,29 +618,24 @@ actor LocalWorkflowExecutor {
     }
 
     private func requestApproval(_ request: WorkflowApprovalRequest) async -> WorkflowApprovalDecision {
-        let race = WorkflowApprovalRace()
         let approver = approver
         let timeoutNanoseconds = approvalTimeoutNanoseconds
-        let approvalTask = Task {
-            let decision = await approver.requestApproval(request)
-            await race.resolve(decision)
-        }
-        let timeoutTask = Task {
-            do {
-                try await Task.sleep(nanoseconds: timeoutNanoseconds)
-                await race.resolve(.unavailable)
-            } catch {
-                // The winning approval path cancels this timeout task.
+        return await withTaskGroup(of: WorkflowApprovalDecision.self) { group in
+            group.addTask {
+                await approver.requestApproval(request)
             }
+            group.addTask {
+                do {
+                    try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                } catch {
+                    return .unavailable
+                }
+                return .unavailable
+            }
+            let decision = await group.next() ?? .unavailable
+            group.cancelAll()
+            return decision
         }
-        let decision = await withTaskCancellationHandler {
-            await race.wait()
-        } onCancel: {
-            Task { await race.resolve(.unavailable) }
-        }
-        approvalTask.cancel()
-        timeoutTask.cancel()
-        return decision
     }
 
     /// Model text shown in an approval prompt is untrusted display data. Make
@@ -737,28 +735,5 @@ actor LocalWorkflowExecutor {
                 actionMayHaveOccurred: actionMayHaveOccurredOnFailure
             )
         }
-    }
-}
-
-private actor WorkflowApprovalRace {
-    private var decision: WorkflowApprovalDecision?
-    private var continuation: CheckedContinuation<WorkflowApprovalDecision, Never>?
-
-    func wait() async -> WorkflowApprovalDecision {
-        if let decision { return decision }
-        return await withCheckedContinuation { continuation in
-            if let decision {
-                continuation.resume(returning: decision)
-            } else {
-                self.continuation = continuation
-            }
-        }
-    }
-
-    func resolve(_ decision: WorkflowApprovalDecision) {
-        guard self.decision == nil else { return }
-        self.decision = decision
-        continuation?.resume(returning: decision)
-        continuation = nil
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -160,7 +160,11 @@ actor LocalWorkflowExecutor {
 
         while run.nextStepIndex < workflow.steps.count {
             if Task.isCancelled {
-                return await cancel(run, stepID: nil, actionMayHaveOccurred: false)
+                return await cancel(
+                    run,
+                    stepID: nil,
+                    actionMayHaveOccurred: run.nextStepIndex > 0
+                )
             }
             let step = workflow.steps[run.nextStepIndex]
             let result = await executeStep(step, workflow: workflow, run: run)

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -35,10 +35,13 @@ protocol LocalWorkflowFallbackResolving: Sendable {
 }
 
 protocol LocalWorkflowApproving: Sendable {
-    /// Implementations must return promptly when their task is cancelled so
-    /// the executor's structured timeout can drain without retaining approval
-    /// requests or their dependencies.
-    func requestApproval(_ request: WorkflowApprovalRequest) async -> WorkflowApprovalDecision
+    /// The adapter owns its UI continuation and must enforce this deadline
+    /// without leaving an orphan waiter. It must also return promptly when its
+    /// task is cancelled.
+    func requestApproval(
+        _ request: WorkflowApprovalRequest,
+        timeoutNanoseconds: UInt64
+    ) async -> WorkflowApprovalDecision
 }
 
 protocol LocalWorkflowLedgerWriting: Sendable {
@@ -174,6 +177,13 @@ actor LocalWorkflowExecutor {
             switch result {
             case .completed:
                 run.nextStepIndex += 1
+                if Task.isCancelled {
+                    return await cancel(
+                        run,
+                        stepID: step.id,
+                        actionMayHaveOccurred: true
+                    )
+                }
                 run.status = .running
             case .paused(let reason, let code, let actionMayHaveOccurred):
                 return await pause(
@@ -192,6 +202,13 @@ actor LocalWorkflowExecutor {
             }
         }
 
+        if Task.isCancelled {
+            return await cancel(
+                run,
+                stepID: nil,
+                actionMayHaveOccurred: run.nextStepIndex > 0
+            )
+        }
         run.status = .completed
         do {
             try await record(
@@ -618,24 +635,10 @@ actor LocalWorkflowExecutor {
     }
 
     private func requestApproval(_ request: WorkflowApprovalRequest) async -> WorkflowApprovalDecision {
-        let approver = approver
-        let timeoutNanoseconds = approvalTimeoutNanoseconds
-        return await withTaskGroup(of: WorkflowApprovalDecision.self) { group in
-            group.addTask {
-                await approver.requestApproval(request)
-            }
-            group.addTask {
-                do {
-                    try await Task.sleep(nanoseconds: timeoutNanoseconds)
-                } catch {
-                    return .unavailable
-                }
-                return .unavailable
-            }
-            let decision = await group.next() ?? .unavailable
-            group.cancelAll()
-            return decision
-        }
+        await approver.requestApproval(
+            request,
+            timeoutNanoseconds: approvalTimeoutNanoseconds
+        )
     }
 
     /// Model text shown in an approval prompt is untrusted display data. Make

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -215,7 +215,7 @@ actor LocalWorkflowExecutor {
         workflow: LocalWorkflow,
         run: LocalWorkflowRun
     ) async -> StepResult {
-        var priorActionMayHaveOccurred = false
+        var priorActionMayHaveOccurred = run.nextStepIndex > 0
         do {
             // Decode is allowed to bypass ``LocalWorkflowStep``'s initializer,
             // so clamp again at the trust boundary before constructing a range.

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -56,6 +56,7 @@ actor LocalWorkflowExecutor {
     private let fallbackResolver: any LocalWorkflowFallbackResolving
     private let approver: any LocalWorkflowApproving
     private let ledger: any LocalWorkflowLedgerWriting
+    private var activeRunID: UUID?
 
     init(
         observer: any LocalWorkflowObserving,
@@ -77,18 +78,42 @@ actor LocalWorkflowExecutor {
 
     func execute(_ workflow: LocalWorkflow, resuming run: LocalWorkflowRun? = nil) async -> LocalWorkflowRun {
         var run = run ?? LocalWorkflowRun(workflowID: workflow.id)
+        guard activeRunID == nil else {
+            return await pause(
+                run,
+                stepID: "executor-busy",
+                reason: .unsafeState,
+                code: .executorBusy,
+                actionMayHaveOccurred: true
+            )
+        }
+        activeRunID = run.id
+        defer { activeRunID = nil }
+
         guard run.workflowID == workflow.id,
               run.nextStepIndex >= 0,
               run.nextStepIndex <= workflow.steps.count,
               Set(workflow.steps.map(\.id)).count == workflow.steps.count,
               workflow.steps.allSatisfy({ !$0.id.isEmpty })
         else {
-            return await pause(run, stepID: "invalid-run", reason: .unsafeState, code: .invalidResumeState)
+            return await pause(
+                run,
+                stepID: "invalid-run",
+                reason: .unsafeState,
+                code: .invalidResumeState,
+                actionMayHaveOccurred: run.status.actionMayHaveOccurred
+            )
         }
 
         if run.nextStepIndex == workflow.steps.count {
             guard run.status.permitsExecution || run.status == .completed else {
-                return await pause(run, stepID: "invalid-run", reason: .unsafeState, code: .invalidResumeState)
+                return await pause(
+                    run,
+                    stepID: "invalid-run",
+                    reason: .unsafeState,
+                    code: .invalidResumeState,
+                    actionMayHaveOccurred: run.status.actionMayHaveOccurred
+                )
             }
             run.status = .completed
             await record(run, stepID: nil, kind: .runCompleted)
@@ -96,24 +121,42 @@ actor LocalWorkflowExecutor {
         }
 
         guard run.status.permitsExecution else {
-            return await pause(run, stepID: "invalid-run", reason: .unsafeState, code: .invalidResumeState)
+            return await pause(
+                run,
+                stepID: "invalid-run",
+                reason: .unsafeState,
+                code: .invalidResumeState,
+                actionMayHaveOccurred: run.status.actionMayHaveOccurred
+            )
         }
 
         run.status = .running
         await record(run, stepID: nil, kind: .runStarted)
 
         while run.nextStepIndex < workflow.steps.count {
-            if Task.isCancelled { return await cancel(run) }
+            if Task.isCancelled {
+                return await cancel(run, stepID: nil, actionMayHaveOccurred: false)
+            }
             let step = workflow.steps[run.nextStepIndex]
             let result = await executeStep(step, workflow: workflow, run: run)
             switch result {
             case .completed:
                 run.nextStepIndex += 1
                 run.status = .running
-            case .paused(let reason, let code):
-                return await pause(run, stepID: step.id, reason: reason, code: code)
-            case .cancelled:
-                return await cancel(run)
+            case .paused(let reason, let code, let actionMayHaveOccurred):
+                return await pause(
+                    run,
+                    stepID: step.id,
+                    reason: reason,
+                    code: code,
+                    actionMayHaveOccurred: actionMayHaveOccurred
+                )
+            case .cancelled(let actionMayHaveOccurred):
+                return await cancel(
+                    run,
+                    stepID: step.id,
+                    actionMayHaveOccurred: actionMayHaveOccurred
+                )
             }
         }
 
@@ -124,8 +167,8 @@ actor LocalWorkflowExecutor {
 
     private enum StepResult {
         case completed
-        case paused(WorkflowPauseReason, code: WorkflowLedgerCode)
-        case cancelled
+        case paused(WorkflowPauseReason, code: WorkflowLedgerCode, actionMayHaveOccurred: Bool)
+        case cancelled(actionMayHaveOccurred: Bool)
     }
 
     private func executeStep(
@@ -133,12 +176,15 @@ actor LocalWorkflowExecutor {
         workflow: LocalWorkflow,
         run: LocalWorkflowRun
     ) async -> StepResult {
+        var priorActionMayHaveOccurred = false
         do {
             // Decode is allowed to bypass ``LocalWorkflowStep``'s initializer,
             // so clamp again at the trust boundary before constructing a range.
             let attemptLimit = min(max(1, step.maxGroundingAttempts), 3)
             for attempt in 1 ... attemptLimit {
-                if Task.isCancelled { return .cancelled }
+                if Task.isCancelled {
+                    return .cancelled(actionMayHaveOccurred: priorActionMayHaveOccurred)
+                }
                 let observed = try await validObservation(for: step)
                 let proposed = try await grounder.ground(step: step, observation: observed)
                 let action = GroundedWorkflowAction(
@@ -167,20 +213,37 @@ actor LocalWorkflowExecutor {
                 case .verified:
                     return .completed
                 case .retry(let actionWasPerformed):
+                    priorActionMayHaveOccurred = priorActionMayHaveOccurred || actionWasPerformed
                     if actionWasPerformed && !step.isIdempotent {
-                        return .paused(.recoveryExhausted, code: .visualRetriesExhausted)
+                        return .paused(
+                            .recoveryExhausted,
+                            code: .visualRetriesExhausted,
+                            actionMayHaveOccurred: true
+                        )
                     }
                     continue
-                case .paused(let reason, let code):
-                    return .paused(reason, code: code)
+                case .paused(let reason, let code, let actionMayHaveOccurred):
+                    return .paused(
+                        reason,
+                        code: code,
+                        actionMayHaveOccurred: priorActionMayHaveOccurred || actionMayHaveOccurred
+                    )
                 }
             }
 
             guard let fallbackIdentifier = step.semanticFallbackIdentifier else {
-                return .paused(.recoveryExhausted, code: .visualRetriesExhausted)
+                return .paused(
+                    .recoveryExhausted,
+                    code: .visualRetriesExhausted,
+                    actionMayHaveOccurred: priorActionMayHaveOccurred
+                )
             }
             guard step.isIdempotent else {
-                return .paused(.recoveryExhausted, code: .visualRetriesExhausted)
+                return .paused(
+                    .recoveryExhausted,
+                    code: .visualRetriesExhausted,
+                    actionMayHaveOccurred: priorActionMayHaveOccurred
+                )
             }
             let observed = try await validObservation(for: step)
             guard var fallback = try await fallbackResolver.fallbackAction(
@@ -188,7 +251,11 @@ actor LocalWorkflowExecutor {
                 step: step,
                 observation: observed
             ) else {
-                return .paused(.recoveryExhausted, code: .fallbackUnavailable)
+                return .paused(
+                    .recoveryExhausted,
+                    code: .fallbackUnavailable,
+                    actionMayHaveOccurred: priorActionMayHaveOccurred
+                )
             }
             fallback = GroundedWorkflowAction(
                 observationID: fallback.observationID,
@@ -216,23 +283,49 @@ actor LocalWorkflowExecutor {
             case .verified:
                 return .completed
             case .retry:
-                return .paused(.recoveryExhausted, code: .fallbackNotVerified)
-            case .paused(let reason, let code):
-                return .paused(reason, code: code)
+                return .paused(
+                    .recoveryExhausted,
+                    code: .fallbackNotVerified,
+                    actionMayHaveOccurred: true
+                )
+            case .paused(let reason, let code, let actionMayHaveOccurred):
+                return .paused(
+                    reason,
+                    code: code,
+                    actionMayHaveOccurred: priorActionMayHaveOccurred || actionMayHaveOccurred
+                )
             }
+        } catch WorkflowKernelError.cancelled(let actionMayHaveOccurred) {
+            return .cancelled(
+                actionMayHaveOccurred: priorActionMayHaveOccurred || actionMayHaveOccurred
+            )
         } catch is CancellationError {
-            return .cancelled
-        } catch WorkflowKernelError.invalidObservation {
-            return .paused(.unsafeState, code: .invalidObservation)
+            return .cancelled(actionMayHaveOccurred: priorActionMayHaveOccurred)
+        } catch WorkflowKernelError.invalidObservation(let actionMayHaveOccurred) {
+            return .paused(
+                .unsafeState,
+                code: .invalidObservation,
+                actionMayHaveOccurred: priorActionMayHaveOccurred || actionMayHaveOccurred
+            )
+        } catch WorkflowKernelError.dependencyFailure(let actionMayHaveOccurred) {
+            return .paused(
+                .dependencyFailure,
+                code: .dependencyFailure,
+                actionMayHaveOccurred: priorActionMayHaveOccurred || actionMayHaveOccurred
+            )
         } catch {
-            return .paused(.dependencyFailure, code: .dependencyFailure)
+            return .paused(
+                .dependencyFailure,
+                code: .dependencyFailure,
+                actionMayHaveOccurred: priorActionMayHaveOccurred
+            )
         }
     }
 
     private enum AttemptResult {
         case verified
         case retry(actionWasPerformed: Bool)
-        case paused(WorkflowPauseReason, code: WorkflowLedgerCode)
+        case paused(WorkflowPauseReason, code: WorkflowLedgerCode, actionMayHaveOccurred: Bool)
     }
 
     private func performIfCurrent(
@@ -252,7 +345,11 @@ actor LocalWorkflowExecutor {
                 source: action.source,
                 code: .invalidAction
             )
-            return .paused(.unsafeState, code: .invalidAction)
+            return .paused(
+                .unsafeState,
+                code: .invalidAction,
+                actionMayHaveOccurred: false
+            )
         }
         guard action.observationID == observed.id else {
             await record(
@@ -287,7 +384,7 @@ actor LocalWorkflowExecutor {
                     workflowID: workflow.id,
                     runID: run.id,
                     stepID: step.id,
-                    stepTitle: step.title,
+                    stepTitle: Self.displaySafeSummary(step.title),
                     actionSummary: Self.displaySafeSummary(action.safeSummary),
                     risk: effectiveRisk
                 )
@@ -295,9 +392,17 @@ actor LocalWorkflowExecutor {
             switch decision {
             case .denied:
                 await record(run, stepID: step.id, kind: .approvalDenied, attempt: attempt, source: action.source)
-                return .paused(.approvalDenied, code: .userDenied)
+                return .paused(
+                    .approvalDenied,
+                    code: .userDenied,
+                    actionMayHaveOccurred: false
+                )
             case .unavailable:
-                return .paused(.approvalUnavailable, code: .approvalUnavailable)
+                return .paused(
+                    .approvalUnavailable,
+                    code: .approvalUnavailable,
+                    actionMayHaveOccurred: false
+                )
             case .approved:
                 await record(run, stepID: step.id, kind: .approvalGranted, attempt: attempt, source: action.source)
             }
@@ -319,10 +424,33 @@ actor LocalWorkflowExecutor {
         }
 
         if Task.isCancelled { throw CancellationError() }
-        try await actuator.perform(action, against: current)
+        do {
+            try await actuator.perform(action, against: current)
+        } catch is CancellationError {
+            throw WorkflowKernelError.cancelled(actionMayHaveOccurred: true)
+        } catch {
+            throw WorkflowKernelError.dependencyFailure(actionMayHaveOccurred: true)
+        }
+        if Task.isCancelled {
+            throw WorkflowKernelError.cancelled(actionMayHaveOccurred: true)
+        }
         await record(run, stepID: step.id, kind: .actionPerformed, attempt: attempt, source: action.source)
-        let after = try await validObservation(for: step)
-        switch try await verifier.verify(step: step, before: current, after: after) {
+        if Task.isCancelled {
+            throw WorkflowKernelError.cancelled(actionMayHaveOccurred: true)
+        }
+        let after = try await validObservation(for: step, actionMayHaveOccurred: true)
+        let verification: WorkflowVerification
+        do {
+            verification = try await verifier.verify(step: step, before: current, after: after)
+        } catch is CancellationError {
+            throw WorkflowKernelError.cancelled(actionMayHaveOccurred: true)
+        } catch {
+            throw WorkflowKernelError.dependencyFailure(actionMayHaveOccurred: true)
+        }
+        if Task.isCancelled {
+            throw WorkflowKernelError.cancelled(actionMayHaveOccurred: true)
+        }
+        switch verification {
         case .satisfied:
             await record(run, stepID: step.id, kind: .verificationPassed, attempt: attempt, source: action.source)
             return .verified
@@ -345,7 +473,11 @@ actor LocalWorkflowExecutor {
                 source: action.source,
                 code: WorkflowLedgerCode(code)
             )
-            return .paused(.unsafeState, code: WorkflowLedgerCode(code))
+            return .paused(
+                .unsafeState,
+                code: WorkflowLedgerCode(code),
+                actionMayHaveOccurred: true
+            )
         }
     }
 
@@ -353,22 +485,41 @@ actor LocalWorkflowExecutor {
         _ original: LocalWorkflowRun,
         stepID: String,
         reason: WorkflowPauseReason,
-        code: WorkflowLedgerCode
+        code: WorkflowLedgerCode,
+        actionMayHaveOccurred: Bool
     ) async -> LocalWorkflowRun {
         var run = original
-        run.status = .paused(stepID: stepID, reason: reason)
+        run.status = .paused(
+            stepID: stepID,
+            reason: reason,
+            actionMayHaveOccurred: actionMayHaveOccurred
+        )
         await record(run, stepID: stepID, kind: .runPaused, code: code)
         return run
     }
 
     private enum WorkflowKernelError: Error {
-        case invalidObservation
+        case invalidObservation(actionMayHaveOccurred: Bool)
+        case dependencyFailure(actionMayHaveOccurred: Bool)
+        case cancelled(actionMayHaveOccurred: Bool)
     }
 
-    private func validObservation(for step: LocalWorkflowStep) async throws -> WorkflowObservation {
-        let observation = try await observer.observe(for: step)
+    private func validObservation(
+        for step: LocalWorkflowStep,
+        actionMayHaveOccurred: Bool = false
+    ) async throws -> WorkflowObservation {
+        let observation: WorkflowObservation
+        do {
+            observation = try await observer.observe(for: step)
+        } catch is CancellationError {
+            throw WorkflowKernelError.cancelled(actionMayHaveOccurred: actionMayHaveOccurred)
+        } catch {
+            throw WorkflowKernelError.dependencyFailure(actionMayHaveOccurred: actionMayHaveOccurred)
+        }
         guard observation.isStructurallyValid else {
-            throw WorkflowKernelError.invalidObservation
+            throw WorkflowKernelError.invalidObservation(
+                actionMayHaveOccurred: actionMayHaveOccurred
+            )
         }
         return observation
     }
@@ -376,33 +527,56 @@ actor LocalWorkflowExecutor {
     /// Model text shown in an approval prompt is untrusted display data. Make
     /// controls and Unicode formatting characters visible, flatten whitespace,
     /// and cap it so a misleading suffix cannot be pushed off-screen.
-    private static func displaySafeSummary(_ raw: String, cap: Int = 240) -> String {
+    private static func displaySafeSummary(_ raw: String, capBytes: Int = 240) -> String {
+        let ellipsis = "…"
+        let contentLimit = max(0, capBytes - ellipsis.utf8.count)
         var result = ""
-        result.reserveCapacity(min(raw.count, cap))
+        result.reserveCapacity(min(raw.utf8.count, contentLimit))
+        var byteCount = 0
         var previousWasWhitespace = false
+        var truncated = false
         for scalar in raw.unicodeScalars {
-            if result.count >= cap { break }
+            let token: String
             if scalar.properties.isWhitespace {
-                if !result.isEmpty && !previousWasWhitespace { result.append(" ") }
+                if result.isEmpty || previousWasWhitespace {
+                    previousWasWhitespace = true
+                    continue
+                }
+                token = " "
                 previousWasWhitespace = true
-                continue
+            } else {
+                previousWasWhitespace = false
+                switch scalar.properties.generalCategory {
+                case .control, .format, .lineSeparator, .paragraphSeparator,
+                     .privateUse, .surrogate, .unassigned:
+                    token = String(format: "\\u{%04X}", scalar.value)
+                default:
+                    token = String(scalar)
+                }
             }
-            previousWasWhitespace = false
-            switch scalar.properties.generalCategory {
-            case .control, .format, .lineSeparator, .paragraphSeparator,
-                 .privateUse, .surrogate, .unassigned:
-                result += String(format: "\\u{%04X}", scalar.value)
-            default:
-                result.unicodeScalars.append(scalar)
+            let tokenBytes = token.utf8.count
+            guard byteCount + tokenBytes <= contentLimit else {
+                truncated = true
+                break
             }
+            result += token
+            byteCount += tokenBytes
         }
         while result.last == " " { result.removeLast() }
-        return raw.count > cap ? result + "…" : result
+        if result.isEmpty && !raw.isEmpty { return "Protected action" }
+        return truncated ? result + ellipsis : result
     }
 
-    private func cancel(_ original: LocalWorkflowRun) async -> LocalWorkflowRun {
+    private func cancel(
+        _ original: LocalWorkflowRun,
+        stepID: String?,
+        actionMayHaveOccurred: Bool
+    ) async -> LocalWorkflowRun {
         var run = original
-        run.status = .cancelled
+        run.status = .cancelled(
+            stepID: stepID,
+            actionMayHaveOccurred: actionMayHaveOccurred
+        )
         await record(run, stepID: nil, kind: .runCancelled)
         return run
     }

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -93,6 +93,7 @@ actor LocalWorkflowExecutor {
         guard run.workflowID == workflow.id,
               run.nextStepIndex >= 0,
               run.nextStepIndex <= workflow.steps.count,
+              run.status != .ready || run.nextStepIndex == 0,
               Set(workflow.steps.map(\.id)).count == workflow.steps.count,
               workflow.steps.allSatisfy({ !$0.id.isEmpty })
         else {

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -1,0 +1,430 @@
+import Foundation
+
+protocol LocalWorkflowObserving: Sendable {
+    func observe(for step: LocalWorkflowStep) async throws -> WorkflowObservation
+}
+
+protocol LocalWorkflowGrounding: Sendable {
+    func ground(
+        step: LocalWorkflowStep,
+        observation: WorkflowObservation
+    ) async throws -> GroundedWorkflowAction
+}
+
+protocol LocalWorkflowActuating: Sendable {
+    func perform(
+        _ action: GroundedWorkflowAction,
+        against currentObservation: WorkflowObservation
+    ) async throws
+}
+
+protocol LocalWorkflowVerifying: Sendable {
+    func verify(
+        step: LocalWorkflowStep,
+        before: WorkflowObservation,
+        after: WorkflowObservation
+    ) async throws -> WorkflowVerification
+}
+
+protocol LocalWorkflowFallbackResolving: Sendable {
+    func fallbackAction(
+        identifier: String,
+        step: LocalWorkflowStep,
+        observation: WorkflowObservation
+    ) async throws -> GroundedWorkflowAction?
+}
+
+protocol LocalWorkflowApproving: Sendable {
+    func requestApproval(_ request: WorkflowApprovalRequest) async -> WorkflowApprovalDecision
+}
+
+protocol LocalWorkflowLedgerWriting: Sendable {
+    func append(_ event: WorkflowLedgerEvent) async
+}
+
+/// Deterministic orchestration for a learned local workflow.
+///
+/// The grounder proposes one action; it never owns progress, retries, approval,
+/// or completion. Every action is rebound to a fresh observation immediately
+/// before execution, and protected actions are rebound once more after the user
+/// answers so a slow approval cannot authorize a click against changed UI.
+actor LocalWorkflowExecutor {
+    private let observer: any LocalWorkflowObserving
+    private let grounder: any LocalWorkflowGrounding
+    private let actuator: any LocalWorkflowActuating
+    private let verifier: any LocalWorkflowVerifying
+    private let fallbackResolver: any LocalWorkflowFallbackResolving
+    private let approver: any LocalWorkflowApproving
+    private let ledger: any LocalWorkflowLedgerWriting
+
+    init(
+        observer: any LocalWorkflowObserving,
+        grounder: any LocalWorkflowGrounding,
+        actuator: any LocalWorkflowActuating,
+        verifier: any LocalWorkflowVerifying,
+        fallbackResolver: any LocalWorkflowFallbackResolving,
+        approver: any LocalWorkflowApproving,
+        ledger: any LocalWorkflowLedgerWriting
+    ) {
+        self.observer = observer
+        self.grounder = grounder
+        self.actuator = actuator
+        self.verifier = verifier
+        self.fallbackResolver = fallbackResolver
+        self.approver = approver
+        self.ledger = ledger
+    }
+
+    func execute(_ workflow: LocalWorkflow, resuming run: LocalWorkflowRun? = nil) async -> LocalWorkflowRun {
+        var run = run ?? LocalWorkflowRun(workflowID: workflow.id)
+        guard run.workflowID == workflow.id,
+              run.nextStepIndex >= 0,
+              run.nextStepIndex <= workflow.steps.count,
+              Set(workflow.steps.map(\.id)).count == workflow.steps.count,
+              workflow.steps.allSatisfy({ !$0.id.isEmpty })
+        else {
+            return await pause(run, stepID: "invalid-run", reason: .unsafeState, code: .invalidResumeState)
+        }
+
+        if run.nextStepIndex == workflow.steps.count {
+            guard run.status.permitsExecution || run.status == .completed else {
+                return await pause(run, stepID: "invalid-run", reason: .unsafeState, code: .invalidResumeState)
+            }
+            run.status = .completed
+            await record(run, stepID: nil, kind: .runCompleted)
+            return run
+        }
+
+        guard run.status.permitsExecution else {
+            return await pause(run, stepID: "invalid-run", reason: .unsafeState, code: .invalidResumeState)
+        }
+
+        run.status = .running
+        await record(run, stepID: nil, kind: .runStarted)
+
+        while run.nextStepIndex < workflow.steps.count {
+            if Task.isCancelled { return await cancel(run) }
+            let step = workflow.steps[run.nextStepIndex]
+            let result = await executeStep(step, workflow: workflow, run: run)
+            switch result {
+            case .completed:
+                run.nextStepIndex += 1
+                run.status = .running
+            case .paused(let reason, let code):
+                return await pause(run, stepID: step.id, reason: reason, code: code)
+            case .cancelled:
+                return await cancel(run)
+            }
+        }
+
+        run.status = .completed
+        await record(run, stepID: nil, kind: .runCompleted)
+        return run
+    }
+
+    private enum StepResult {
+        case completed
+        case paused(WorkflowPauseReason, code: WorkflowLedgerCode)
+        case cancelled
+    }
+
+    private func executeStep(
+        _ step: LocalWorkflowStep,
+        workflow: LocalWorkflow,
+        run: LocalWorkflowRun
+    ) async -> StepResult {
+        do {
+            // Decode is allowed to bypass ``LocalWorkflowStep``'s initializer,
+            // so clamp again at the trust boundary before constructing a range.
+            let attemptLimit = min(max(1, step.maxGroundingAttempts), 3)
+            for attempt in 1 ... attemptLimit {
+                if Task.isCancelled { return .cancelled }
+                let observed = try await validObservation(for: step)
+                let proposed = try await grounder.ground(step: step, observation: observed)
+                let action = GroundedWorkflowAction(
+                    observationID: proposed.observationID,
+                    payload: proposed.payload,
+                    source: .visualGrounding,
+                    safeSummary: proposed.safeSummary,
+                    risk: proposed.risk
+                )
+                await record(
+                    run,
+                    stepID: step.id,
+                    kind: .actionGrounded,
+                    attempt: attempt,
+                    source: action.source
+                )
+                let outcome = try await performIfCurrent(
+                    action,
+                    step: step,
+                    workflow: workflow,
+                    run: run,
+                    observed: observed,
+                    attempt: attempt
+                )
+                switch outcome {
+                case .verified:
+                    return .completed
+                case .retry(let actionWasPerformed):
+                    if actionWasPerformed && !step.isIdempotent {
+                        return .paused(.recoveryExhausted, code: .visualRetriesExhausted)
+                    }
+                    continue
+                case .paused(let reason, let code):
+                    return .paused(reason, code: code)
+                }
+            }
+
+            guard let fallbackIdentifier = step.semanticFallbackIdentifier else {
+                return .paused(.recoveryExhausted, code: .visualRetriesExhausted)
+            }
+            guard step.isIdempotent else {
+                return .paused(.recoveryExhausted, code: .visualRetriesExhausted)
+            }
+            let observed = try await validObservation(for: step)
+            guard var fallback = try await fallbackResolver.fallbackAction(
+                identifier: fallbackIdentifier,
+                step: step,
+                observation: observed
+            ) else {
+                return .paused(.recoveryExhausted, code: .fallbackUnavailable)
+            }
+            fallback = GroundedWorkflowAction(
+                observationID: fallback.observationID,
+                payload: fallback.payload,
+                source: .semanticFallback,
+                safeSummary: fallback.safeSummary,
+                risk: fallback.risk
+            )
+            await record(
+                run,
+                stepID: step.id,
+                kind: .semanticFallbackUsed,
+                attempt: attemptLimit + 1,
+                source: .semanticFallback
+            )
+            let outcome = try await performIfCurrent(
+                fallback,
+                step: step,
+                workflow: workflow,
+                run: run,
+                observed: observed,
+                attempt: attemptLimit + 1
+            )
+            switch outcome {
+            case .verified:
+                return .completed
+            case .retry:
+                return .paused(.recoveryExhausted, code: .fallbackNotVerified)
+            case .paused(let reason, let code):
+                return .paused(reason, code: code)
+            }
+        } catch is CancellationError {
+            return .cancelled
+        } catch WorkflowKernelError.invalidObservation {
+            return .paused(.unsafeState, code: .invalidObservation)
+        } catch {
+            return .paused(.dependencyFailure, code: .dependencyFailure)
+        }
+    }
+
+    private enum AttemptResult {
+        case verified
+        case retry(actionWasPerformed: Bool)
+        case paused(WorkflowPauseReason, code: WorkflowLedgerCode)
+    }
+
+    private func performIfCurrent(
+        _ action: GroundedWorkflowAction,
+        step: LocalWorkflowStep,
+        workflow: LocalWorkflow,
+        run: LocalWorkflowRun,
+        observed: WorkflowObservation,
+        attempt: Int
+    ) async throws -> AttemptResult {
+        guard action.payload.isStructurallyValid else {
+            await record(
+                run,
+                stepID: step.id,
+                kind: .staleActionRejected,
+                attempt: attempt,
+                source: action.source,
+                code: .invalidAction
+            )
+            return .paused(.unsafeState, code: .invalidAction)
+        }
+        guard action.observationID == observed.id else {
+            await record(
+                run,
+                stepID: step.id,
+                kind: .staleActionRejected,
+                attempt: attempt,
+                source: action.source,
+                code: .observationIDMismatch
+            )
+            return .retry(actionWasPerformed: false)
+        }
+
+        var current = try await validObservation(for: step)
+        guard observed.representsSameInteractionState(as: current) else {
+            await record(
+                run,
+                stepID: step.id,
+                kind: .staleActionRejected,
+                attempt: attempt,
+                source: action.source,
+                code: .interactionStateChanged
+            )
+            return .retry(actionWasPerformed: false)
+        }
+
+        let effectiveRisk = max(step.risk, action.risk)
+        if effectiveRisk.requiresApproval {
+            await record(run, stepID: step.id, kind: .approvalRequested, attempt: attempt, source: action.source)
+            let decision = await approver.requestApproval(
+                WorkflowApprovalRequest(
+                    workflowID: workflow.id,
+                    runID: run.id,
+                    stepID: step.id,
+                    stepTitle: step.title,
+                    actionSummary: Self.displaySafeSummary(action.safeSummary),
+                    risk: effectiveRisk
+                )
+            )
+            switch decision {
+            case .denied:
+                await record(run, stepID: step.id, kind: .approvalDenied, attempt: attempt, source: action.source)
+                return .paused(.approvalDenied, code: .userDenied)
+            case .unavailable:
+                return .paused(.approvalUnavailable, code: .approvalUnavailable)
+            case .approved:
+                await record(run, stepID: step.id, kind: .approvalGranted, attempt: attempt, source: action.source)
+            }
+
+            if Task.isCancelled { throw CancellationError() }
+            let afterApproval = try await validObservation(for: step)
+            guard current.representsSameInteractionState(as: afterApproval) else {
+                await record(
+                    run,
+                    stepID: step.id,
+                    kind: .staleActionRejected,
+                    attempt: attempt,
+                    source: action.source,
+                    code: .stateChangedDuringApproval
+                )
+                return .retry(actionWasPerformed: false)
+            }
+            current = afterApproval
+        }
+
+        if Task.isCancelled { throw CancellationError() }
+        try await actuator.perform(action, against: current)
+        await record(run, stepID: step.id, kind: .actionPerformed, attempt: attempt, source: action.source)
+        let after = try await validObservation(for: step)
+        switch try await verifier.verify(step: step, before: current, after: after) {
+        case .satisfied:
+            await record(run, stepID: step.id, kind: .verificationPassed, attempt: attempt, source: action.source)
+            return .verified
+        case .notSatisfied(let code):
+            await record(
+                run,
+                stepID: step.id,
+                kind: .verificationFailed,
+                attempt: attempt,
+                source: action.source,
+                code: WorkflowLedgerCode(code)
+            )
+            return .retry(actionWasPerformed: true)
+        case .unsafe(let code):
+            await record(
+                run,
+                stepID: step.id,
+                kind: .verificationFailed,
+                attempt: attempt,
+                source: action.source,
+                code: WorkflowLedgerCode(code)
+            )
+            return .paused(.unsafeState, code: WorkflowLedgerCode(code))
+        }
+    }
+
+    private func pause(
+        _ original: LocalWorkflowRun,
+        stepID: String,
+        reason: WorkflowPauseReason,
+        code: WorkflowLedgerCode
+    ) async -> LocalWorkflowRun {
+        var run = original
+        run.status = .paused(stepID: stepID, reason: reason)
+        await record(run, stepID: stepID, kind: .runPaused, code: code)
+        return run
+    }
+
+    private enum WorkflowKernelError: Error {
+        case invalidObservation
+    }
+
+    private func validObservation(for step: LocalWorkflowStep) async throws -> WorkflowObservation {
+        let observation = try await observer.observe(for: step)
+        guard observation.isStructurallyValid else {
+            throw WorkflowKernelError.invalidObservation
+        }
+        return observation
+    }
+
+    /// Model text shown in an approval prompt is untrusted display data. Make
+    /// controls and Unicode formatting characters visible, flatten whitespace,
+    /// and cap it so a misleading suffix cannot be pushed off-screen.
+    private static func displaySafeSummary(_ raw: String, cap: Int = 240) -> String {
+        var result = ""
+        result.reserveCapacity(min(raw.count, cap))
+        var previousWasWhitespace = false
+        for scalar in raw.unicodeScalars {
+            if result.count >= cap { break }
+            if scalar.properties.isWhitespace {
+                if !result.isEmpty && !previousWasWhitespace { result.append(" ") }
+                previousWasWhitespace = true
+                continue
+            }
+            previousWasWhitespace = false
+            switch scalar.properties.generalCategory {
+            case .control, .format, .lineSeparator, .paragraphSeparator,
+                 .privateUse, .surrogate, .unassigned:
+                result += String(format: "\\u{%04X}", scalar.value)
+            default:
+                result.unicodeScalars.append(scalar)
+            }
+        }
+        while result.last == " " { result.removeLast() }
+        return raw.count > cap ? result + "…" : result
+    }
+
+    private func cancel(_ original: LocalWorkflowRun) async -> LocalWorkflowRun {
+        var run = original
+        run.status = .cancelled
+        await record(run, stepID: nil, kind: .runCancelled)
+        return run
+    }
+
+    private func record(
+        _ run: LocalWorkflowRun,
+        stepID: String?,
+        kind: WorkflowLedgerEventKind,
+        attempt: Int? = nil,
+        source: WorkflowActionSource? = nil,
+        code: WorkflowLedgerCode? = nil
+    ) async {
+        await ledger.append(
+            WorkflowLedgerEvent(
+                runID: run.id,
+                workflowID: run.workflowID,
+                stepID: stepID,
+                kind: kind,
+                attempt: attempt,
+                actionSource: source,
+                code: code
+            )
+        )
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -39,7 +39,7 @@ protocol LocalWorkflowApproving: Sendable {
 }
 
 protocol LocalWorkflowLedgerWriting: Sendable {
-    func append(_ event: WorkflowLedgerEvent) async
+    func append(_ event: WorkflowLedgerEvent) async throws
 }
 
 /// Deterministic orchestration for a learned local workflow.
@@ -56,6 +56,7 @@ actor LocalWorkflowExecutor {
     private let fallbackResolver: any LocalWorkflowFallbackResolving
     private let approver: any LocalWorkflowApproving
     private let ledger: any LocalWorkflowLedgerWriting
+    private let approvalTimeoutNanoseconds: UInt64
     private var activeRunID: UUID?
 
     init(
@@ -65,7 +66,8 @@ actor LocalWorkflowExecutor {
         verifier: any LocalWorkflowVerifying,
         fallbackResolver: any LocalWorkflowFallbackResolving,
         approver: any LocalWorkflowApproving,
-        ledger: any LocalWorkflowLedgerWriting
+        ledger: any LocalWorkflowLedgerWriting,
+        approvalTimeoutNanoseconds: UInt64 = 300_000_000_000
     ) {
         self.observer = observer
         self.grounder = grounder
@@ -74,16 +76,16 @@ actor LocalWorkflowExecutor {
         self.fallbackResolver = fallbackResolver
         self.approver = approver
         self.ledger = ledger
+        self.approvalTimeoutNanoseconds = approvalTimeoutNanoseconds
     }
 
     func execute(_ workflow: LocalWorkflow, resuming run: LocalWorkflowRun? = nil) async -> LocalWorkflowRun {
         var run = run ?? LocalWorkflowRun(workflowID: workflow.id)
         guard activeRunID == nil else {
-            return await pause(
+            return pausedWithoutRecording(
                 run,
                 stepID: "executor-busy",
                 reason: .unsafeState,
-                code: .executorBusy,
                 actionMayHaveOccurred: true
             )
         }
@@ -106,8 +108,12 @@ actor LocalWorkflowExecutor {
             )
         }
 
+        if run.status == .completed, run.nextStepIndex == workflow.steps.count {
+            return run
+        }
+
         if run.nextStepIndex == workflow.steps.count {
-            guard run.status.permitsExecution || run.status == .completed else {
+            guard run.status.permitsExecution else {
                 return await pause(
                     run,
                     stepID: "invalid-run",
@@ -117,7 +123,16 @@ actor LocalWorkflowExecutor {
                 )
             }
             run.status = .completed
-            await record(run, stepID: nil, kind: .runCompleted)
+            do {
+                try await record(run, stepID: nil, kind: .runCompleted)
+            } catch {
+                return pausedWithoutRecording(
+                    run,
+                    stepID: "ledger",
+                    reason: .dependencyFailure,
+                    actionMayHaveOccurred: false
+                )
+            }
             return run
         }
 
@@ -132,7 +147,16 @@ actor LocalWorkflowExecutor {
         }
 
         run.status = .running
-        await record(run, stepID: nil, kind: .runStarted)
+        do {
+            try await record(run, stepID: nil, kind: .runStarted)
+        } catch {
+            return pausedWithoutRecording(
+                run,
+                stepID: "ledger",
+                reason: .dependencyFailure,
+                actionMayHaveOccurred: false
+            )
+        }
 
         while run.nextStepIndex < workflow.steps.count {
             if Task.isCancelled {
@@ -162,7 +186,21 @@ actor LocalWorkflowExecutor {
         }
 
         run.status = .completed
-        await record(run, stepID: nil, kind: .runCompleted)
+        do {
+            try await record(
+                run,
+                stepID: nil,
+                kind: .runCompleted,
+                actionMayHaveOccurredOnFailure: run.nextStepIndex > 0
+            )
+        } catch {
+            return pausedWithoutRecording(
+                run,
+                stepID: "ledger",
+                reason: .dependencyFailure,
+                actionMayHaveOccurred: run.nextStepIndex > 0
+            )
+        }
         return run
     }
 
@@ -195,7 +233,7 @@ actor LocalWorkflowExecutor {
                     safeSummary: proposed.safeSummary,
                     risk: proposed.risk
                 )
-                await record(
+                try await record(
                     run,
                     stepID: step.id,
                     kind: .actionGrounded,
@@ -265,7 +303,7 @@ actor LocalWorkflowExecutor {
                 safeSummary: fallback.safeSummary,
                 risk: fallback.risk
             )
-            await record(
+            try await record(
                 run,
                 stepID: step.id,
                 kind: .semanticFallbackUsed,
@@ -283,11 +321,11 @@ actor LocalWorkflowExecutor {
             switch outcome {
             case .verified:
                 return .completed
-            case .retry:
+            case .retry(let actionWasPerformed):
                 return .paused(
                     .recoveryExhausted,
                     code: .fallbackNotVerified,
-                    actionMayHaveOccurred: true
+                    actionMayHaveOccurred: priorActionMayHaveOccurred || actionWasPerformed
                 )
             case .paused(let reason, let code, let actionMayHaveOccurred):
                 return .paused(
@@ -338,7 +376,7 @@ actor LocalWorkflowExecutor {
         attempt: Int
     ) async throws -> AttemptResult {
         guard action.payload.isStructurallyValid else {
-            await record(
+            try await record(
                 run,
                 stepID: step.id,
                 kind: .staleActionRejected,
@@ -353,7 +391,7 @@ actor LocalWorkflowExecutor {
             )
         }
         guard action.observationID == observed.id else {
-            await record(
+            try await record(
                 run,
                 stepID: step.id,
                 kind: .staleActionRejected,
@@ -366,7 +404,7 @@ actor LocalWorkflowExecutor {
 
         var current = try await validObservation(for: step)
         guard observed.representsSameInteractionState(as: current) else {
-            await record(
+            try await record(
                 run,
                 stepID: step.id,
                 kind: .staleActionRejected,
@@ -379,8 +417,8 @@ actor LocalWorkflowExecutor {
 
         let effectiveRisk = max(step.risk, action.risk)
         if effectiveRisk.requiresApproval {
-            await record(run, stepID: step.id, kind: .approvalRequested, attempt: attempt, source: action.source)
-            let decision = await approver.requestApproval(
+            try await record(run, stepID: step.id, kind: .approvalRequested, attempt: attempt, source: action.source)
+            let decision = await requestApproval(
                 WorkflowApprovalRequest(
                     workflowID: workflow.id,
                     runID: run.id,
@@ -390,9 +428,10 @@ actor LocalWorkflowExecutor {
                     risk: effectiveRisk
                 )
             )
+            if Task.isCancelled { throw CancellationError() }
             switch decision {
             case .denied:
-                await record(run, stepID: step.id, kind: .approvalDenied, attempt: attempt, source: action.source)
+                try await record(run, stepID: step.id, kind: .approvalDenied, attempt: attempt, source: action.source)
                 return .paused(
                     .approvalDenied,
                     code: .userDenied,
@@ -405,13 +444,13 @@ actor LocalWorkflowExecutor {
                     actionMayHaveOccurred: false
                 )
             case .approved:
-                await record(run, stepID: step.id, kind: .approvalGranted, attempt: attempt, source: action.source)
+                try await record(run, stepID: step.id, kind: .approvalGranted, attempt: attempt, source: action.source)
             }
 
             if Task.isCancelled { throw CancellationError() }
             let afterApproval = try await validObservation(for: step)
             guard current.representsSameInteractionState(as: afterApproval) else {
-                await record(
+                try await record(
                     run,
                     stepID: step.id,
                     kind: .staleActionRejected,
@@ -435,7 +474,14 @@ actor LocalWorkflowExecutor {
         if Task.isCancelled {
             throw WorkflowKernelError.cancelled(actionMayHaveOccurred: true)
         }
-        await record(run, stepID: step.id, kind: .actionPerformed, attempt: attempt, source: action.source)
+        try await record(
+            run,
+            stepID: step.id,
+            kind: .actionPerformed,
+            attempt: attempt,
+            source: action.source,
+            actionMayHaveOccurredOnFailure: true
+        )
         if Task.isCancelled {
             throw WorkflowKernelError.cancelled(actionMayHaveOccurred: true)
         }
@@ -453,26 +499,35 @@ actor LocalWorkflowExecutor {
         }
         switch verification {
         case .satisfied:
-            await record(run, stepID: step.id, kind: .verificationPassed, attempt: attempt, source: action.source)
+            try await record(
+                run,
+                stepID: step.id,
+                kind: .verificationPassed,
+                attempt: attempt,
+                source: action.source,
+                actionMayHaveOccurredOnFailure: true
+            )
             return .verified
         case .notSatisfied(let code):
-            await record(
+            try await record(
                 run,
                 stepID: step.id,
                 kind: .verificationFailed,
                 attempt: attempt,
                 source: action.source,
-                code: WorkflowLedgerCode(code)
+                code: WorkflowLedgerCode(code),
+                actionMayHaveOccurredOnFailure: true
             )
             return .retry(actionWasPerformed: true)
         case .unsafe(let code):
-            await record(
+            try await record(
                 run,
                 stepID: step.id,
                 kind: .verificationFailed,
                 attempt: attempt,
                 source: action.source,
-                code: WorkflowLedgerCode(code)
+                code: WorkflowLedgerCode(code),
+                actionMayHaveOccurredOnFailure: true
             )
             return .paused(
                 .unsafeState,
@@ -495,7 +550,37 @@ actor LocalWorkflowExecutor {
             reason: reason,
             actionMayHaveOccurred: actionMayHaveOccurred
         )
-        await record(run, stepID: stepID, kind: .runPaused, code: code)
+        do {
+            try await record(
+                run,
+                stepID: stepID,
+                kind: .runPaused,
+                code: code,
+                actionMayHaveOccurredOnFailure: actionMayHaveOccurred
+            )
+        } catch {
+            return pausedWithoutRecording(
+                run,
+                stepID: stepID,
+                reason: .dependencyFailure,
+                actionMayHaveOccurred: actionMayHaveOccurred
+            )
+        }
+        return run
+    }
+
+    private func pausedWithoutRecording(
+        _ original: LocalWorkflowRun,
+        stepID: String,
+        reason: WorkflowPauseReason,
+        actionMayHaveOccurred: Bool
+    ) -> LocalWorkflowRun {
+        var run = original
+        run.status = .paused(
+            stepID: stepID,
+            reason: reason,
+            actionMayHaveOccurred: actionMayHaveOccurred
+        )
         return run
     }
 
@@ -523,6 +608,32 @@ actor LocalWorkflowExecutor {
             )
         }
         return observation
+    }
+
+    private func requestApproval(_ request: WorkflowApprovalRequest) async -> WorkflowApprovalDecision {
+        let race = WorkflowApprovalRace()
+        let approver = approver
+        let timeoutNanoseconds = approvalTimeoutNanoseconds
+        let approvalTask = Task {
+            let decision = await approver.requestApproval(request)
+            await race.resolve(decision)
+        }
+        let timeoutTask = Task {
+            do {
+                try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                await race.resolve(.unavailable)
+            } catch {
+                // The winning approval path cancels this timeout task.
+            }
+        }
+        let decision = await withTaskCancellationHandler {
+            await race.wait()
+        } onCancel: {
+            Task { await race.resolve(.unavailable) }
+        }
+        approvalTask.cancel()
+        timeoutTask.cancel()
+        return decision
     }
 
     /// Model text shown in an approval prompt is untrusted display data. Make
@@ -578,7 +689,21 @@ actor LocalWorkflowExecutor {
             stepID: stepID,
             actionMayHaveOccurred: actionMayHaveOccurred
         )
-        await record(run, stepID: nil, kind: .runCancelled)
+        do {
+            try await record(
+                run,
+                stepID: nil,
+                kind: .runCancelled,
+                actionMayHaveOccurredOnFailure: actionMayHaveOccurred
+            )
+        } catch {
+            return pausedWithoutRecording(
+                run,
+                stepID: stepID ?? "ledger",
+                reason: .dependencyFailure,
+                actionMayHaveOccurred: actionMayHaveOccurred
+            )
+        }
         return run
     }
 
@@ -588,18 +713,48 @@ actor LocalWorkflowExecutor {
         kind: WorkflowLedgerEventKind,
         attempt: Int? = nil,
         source: WorkflowActionSource? = nil,
-        code: WorkflowLedgerCode? = nil
-    ) async {
-        await ledger.append(
-            WorkflowLedgerEvent(
-                runID: run.id,
-                workflowID: run.workflowID,
-                stepID: stepID,
-                kind: kind,
-                attempt: attempt,
-                actionSource: source,
-                code: code
+        code: WorkflowLedgerCode? = nil,
+        actionMayHaveOccurredOnFailure: Bool = false
+    ) async throws {
+        do {
+            try await ledger.append(
+                WorkflowLedgerEvent(
+                    runID: run.id,
+                    workflowID: run.workflowID,
+                    stepID: stepID,
+                    kind: kind,
+                    attempt: attempt,
+                    actionSource: source,
+                    code: code
+                )
             )
-        )
+        } catch {
+            throw WorkflowKernelError.dependencyFailure(
+                actionMayHaveOccurred: actionMayHaveOccurredOnFailure
+            )
+        }
+    }
+}
+
+private actor WorkflowApprovalRace {
+    private var decision: WorkflowApprovalDecision?
+    private var continuation: CheckedContinuation<WorkflowApprovalDecision, Never>?
+
+    func wait() async -> WorkflowApprovalDecision {
+        if let decision { return decision }
+        return await withCheckedContinuation { continuation in
+            if let decision {
+                continuation.resume(returning: decision)
+            } else {
+                self.continuation = continuation
+            }
+        }
+    }
+
+    func resolve(_ decision: WorkflowApprovalDecision) {
+        guard self.decision == nil else { return }
+        self.decision = decision
+        continuation?.resume(returning: decision)
+        continuation = nil
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowModels.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowModels.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+/// A learned desktop procedure expressed as semantic, verifiable steps.
+///
+/// The workflow intentionally stores intent rather than screen coordinates.
+/// Coordinates belong to a short-lived grounded action and are valid only for
+/// the exact observation from which they were produced.
+struct LocalWorkflow: Codable, Equatable, Identifiable, Sendable {
+    let id: UUID
+    let title: String
+    let steps: [LocalWorkflowStep]
+
+    init(id: UUID = UUID(), title: String, steps: [LocalWorkflowStep]) {
+        self.id = id
+        self.title = title
+        self.steps = steps
+    }
+}
+
+struct LocalWorkflowStep: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let instruction: String
+    let successCriteria: String
+    let risk: WorkflowActionRisk
+    let isIdempotent: Bool
+    let maxGroundingAttempts: Int
+    let semanticFallbackIdentifier: String?
+
+    init(
+        id: String,
+        title: String,
+        instruction: String,
+        successCriteria: String,
+        risk: WorkflowActionRisk = .localChange,
+        isIdempotent: Bool = false,
+        maxGroundingAttempts: Int = 1,
+        semanticFallbackIdentifier: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.instruction = instruction
+        self.successCriteria = successCriteria
+        self.risk = risk
+        self.isIdempotent = isIdempotent
+        self.maxGroundingAttempts = min(max(1, maxGroundingAttempts), 3)
+        self.semanticFallbackIdentifier = semanticFallbackIdentifier
+    }
+}
+
+/// The consequence class is authored by the compiled workflow, not trusted to
+/// the visual model. The executor uses the stricter of the step and action.
+enum WorkflowActionRisk: Int, Codable, Comparable, Sendable {
+    case readOnly = 0
+    case localChange = 1
+    case externalCommunication = 2
+    case financial = 3
+    case destructive = 4
+
+    static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+
+    var requiresApproval: Bool { self >= .externalCommunication }
+}
+
+struct WorkflowWindowFrame: Codable, Equatable, Sendable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    var isStructurallyValid: Bool {
+        x.isFinite && y.isFinite && width.isFinite && height.isFinite
+            && width > 0 && height > 0
+    }
+}
+
+struct WorkflowInteractionTarget: Codable, Equatable, Sendable {
+    let bundleIdentifier: String
+    let processIdentifier: Int32
+    let windowIdentifier: String
+    let windowFrame: WorkflowWindowFrame
+}
+
+/// Metadata for one screen observation. Pixel data and accessibility contents
+/// remain ephemeral in the observer implementation and are never part of the
+/// persistent run state or audit ledger.
+struct WorkflowObservation: Equatable, Sendable {
+    let id: UUID
+    let target: WorkflowInteractionTarget
+    let contentRevision: String
+
+    init(
+        id: UUID = UUID(),
+        target: WorkflowInteractionTarget,
+        contentRevision: String
+    ) {
+        self.id = id
+        self.target = target
+        self.contentRevision = contentRevision
+    }
+
+    func representsSameInteractionState(as other: Self) -> Bool {
+        target == other.target && contentRevision == other.contentRevision
+    }
+
+    var isStructurallyValid: Bool {
+        !target.bundleIdentifier.isEmpty
+            && target.processIdentifier > 0
+            && !target.windowIdentifier.isEmpty
+            && target.windowFrame.isStructurallyValid
+            && !contentRevision.isEmpty
+    }
+}
+
+enum WorkflowActionPayload: Equatable, Sendable {
+    case click(normalizedX: Double, normalizedY: Double)
+    case typeText(String)
+    case keyPress(key: String, modifiers: [String])
+
+    var isStructurallyValid: Bool {
+        switch self {
+        case .click(let x, let y):
+            x.isFinite && y.isFinite && (0 ... 1).contains(x) && (0 ... 1).contains(y)
+        case .typeText:
+            true
+        case .keyPress(let key, let modifiers):
+            !key.isEmpty && key.count <= 40 && modifiers.count <= 4
+                && modifiers.allSatisfy { !$0.isEmpty && $0.count <= 20 }
+        }
+    }
+}
+
+enum WorkflowActionSource: String, Codable, Equatable, Sendable {
+    case visualGrounding
+    case semanticFallback
+}
+
+/// A runtime-only action. Payloads may contain typed text, so this type is
+/// deliberately not Codable and must never be copied into the audit ledger.
+struct GroundedWorkflowAction: Equatable, Sendable {
+    let observationID: UUID
+    let payload: WorkflowActionPayload
+    let source: WorkflowActionSource
+    let safeSummary: String
+    let risk: WorkflowActionRisk
+}
+
+enum WorkflowVerificationCode: String, Codable, Equatable, Sendable {
+    case targetUnchanged
+    case unexpectedAccount
+    case unexpectedDestination
+    case focusChanged
+    case windowChanged
+    case contentChanged
+    case unknown
+}
+
+enum WorkflowVerification: Equatable, Sendable {
+    case satisfied
+    case notSatisfied(code: WorkflowVerificationCode)
+    case unsafe(code: WorkflowVerificationCode)
+}
+
+struct WorkflowApprovalRequest: Equatable, Sendable {
+    let workflowID: UUID
+    let runID: UUID
+    let stepID: String
+    let stepTitle: String
+    let actionSummary: String
+    let risk: WorkflowActionRisk
+}
+
+enum WorkflowApprovalDecision: Equatable, Sendable {
+    case approved
+    case denied
+    case unavailable
+}
+
+enum WorkflowPauseReason: String, Codable, Equatable, Sendable {
+    case approvalDenied
+    case approvalUnavailable
+    case recoveryExhausted
+    case unsafeState
+    case dependencyFailure
+}
+
+enum LocalWorkflowRunStatus: Codable, Equatable, Sendable {
+    case ready
+    case running
+    case awaitingApproval(stepID: String)
+    case paused(stepID: String, reason: WorkflowPauseReason)
+    case completed
+    case cancelled
+
+    var permitsExecution: Bool {
+        switch self {
+        case .ready, .paused:
+            true
+        case .running, .awaitingApproval, .completed, .cancelled:
+            false
+        }
+    }
+}
+
+struct LocalWorkflowRun: Codable, Equatable, Identifiable, Sendable {
+    let id: UUID
+    let workflowID: UUID
+    var nextStepIndex: Int
+    var status: LocalWorkflowRunStatus
+
+    init(
+        id: UUID = UUID(),
+        workflowID: UUID,
+        nextStepIndex: Int = 0,
+        status: LocalWorkflowRunStatus = .ready
+    ) {
+        self.id = id
+        self.workflowID = workflowID
+        self.nextStepIndex = nextStepIndex
+        self.status = status
+    }
+}
+
+enum WorkflowLedgerEventKind: String, Codable, Equatable, Sendable {
+    case runStarted
+    case actionGrounded
+    case staleActionRejected
+    case approvalRequested
+    case approvalGranted
+    case approvalDenied
+    case actionPerformed
+    case verificationPassed
+    case verificationFailed
+    case semanticFallbackUsed
+    case runPaused
+    case runCompleted
+    case runCancelled
+}
+
+/// Deliberately metadata-only. Instructions, screenshots, typed values, model
+/// reasoning, errors, and clipboard contents do not have fields to leak into.
+struct WorkflowLedgerEvent: Codable, Equatable, Sendable {
+    let runID: UUID
+    let workflowID: UUID
+    let stepID: String?
+    let kind: WorkflowLedgerEventKind
+    let attempt: Int?
+    let actionSource: WorkflowActionSource?
+    let code: WorkflowLedgerCode?
+}
+
+enum WorkflowLedgerCode: String, Codable, Equatable, Sendable {
+    case invalidResumeState
+    case observationIDMismatch
+    case interactionStateChanged
+    case invalidAction
+    case invalidObservation
+    case stateChangedDuringApproval
+    case userDenied
+    case approvalUnavailable
+    case visualRetriesExhausted
+    case fallbackUnavailable
+    case fallbackNotVerified
+    case dependencyFailure
+    case targetUnchanged
+    case unexpectedAccount
+    case unexpectedDestination
+    case focusChanged
+    case windowChanged
+    case contentChanged
+    case unknown
+
+    init(_ verification: WorkflowVerificationCode) {
+        self = WorkflowLedgerCode(rawValue: verification.rawValue) ?? .unknown
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowModels.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowModels.swift
@@ -187,16 +187,29 @@ enum WorkflowPauseReason: String, Codable, Equatable, Sendable {
 enum LocalWorkflowRunStatus: Codable, Equatable, Sendable {
     case ready
     case running
-    case awaitingApproval(stepID: String)
-    case paused(stepID: String, reason: WorkflowPauseReason)
+    case paused(stepID: String, reason: WorkflowPauseReason, actionMayHaveOccurred: Bool)
     case completed
-    case cancelled
+    case cancelled(stepID: String?, actionMayHaveOccurred: Bool)
 
     var permitsExecution: Bool {
         switch self {
-        case .ready, .paused:
+        case .ready:
             true
-        case .running, .awaitingApproval, .completed, .cancelled:
+        case .running, .paused, .completed, .cancelled:
+            false
+        }
+    }
+
+    /// Conservative persisted uncertainty used when an invalid resume is
+    /// rejected. A run interrupted while executing may already have crossed
+    /// the external side-effect boundary even if no result was recorded.
+    var actionMayHaveOccurred: Bool {
+        switch self {
+        case .running, .completed:
+            true
+        case .paused(_, _, let value), .cancelled(_, let value):
+            value
+        case .ready:
             false
         }
     }
@@ -251,6 +264,7 @@ struct WorkflowLedgerEvent: Codable, Equatable, Sendable {
 
 enum WorkflowLedgerCode: String, Codable, Equatable, Sendable {
     case invalidResumeState
+    case executorBusy
     case observationIDMismatch
     case interactionStateChanged
     case invalidAction

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowModels.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowModels.swift
@@ -113,6 +113,11 @@ struct WorkflowObservation: Equatable, Sendable {
 }
 
 enum WorkflowActionPayload: Equatable, Sendable {
+    /// Keeps a compromised or confused grounder from handing the input layer
+    /// an unbounded allocation. This is bytes, not graphemes, so the bound is
+    /// stable for every Unicode payload.
+    static let maximumTypedTextBytes = 65_536
+
     case click(normalizedX: Double, normalizedY: Double)
     case typeText(String)
     case keyPress(key: String, modifiers: [String])
@@ -121,8 +126,8 @@ enum WorkflowActionPayload: Equatable, Sendable {
         switch self {
         case .click(let x, let y):
             x.isFinite && y.isFinite && (0 ... 1).contains(x) && (0 ... 1).contains(y)
-        case .typeText:
-            true
+        case .typeText(let text):
+            !text.isEmpty && text.utf8.count <= Self.maximumTypedTextBytes
         case .keyPress(let key, let modifiers):
             !key.isEmpty && key.count <= 40 && modifiers.count <= 4
                 && modifiers.allSatisfy { !$0.isEmpty && $0.count <= 20 }

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -154,6 +154,44 @@ struct LocalWorkflowExecutorTests {
         #expect(await dependencies.actuator.count == 0)
     }
 
+    @Test("an approval provider that misses its deadline fails closed")
+    func approvalTimeoutFailsClosed() async throws {
+        let workflow = LocalWorkflow(
+            title: "Lunch",
+            steps: [step(risk: .financial, maxAttempts: 1)]
+        )
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "checkout"),
+            observation(revision: "checkout"),
+        ])
+        let grounder = ScriptedWorkflowGrounder(
+            payload: .click(normalizedX: 0.2, normalizedY: 0.3),
+            actionSummary: "Place order"
+        )
+        let actuator = RecordingWorkflowActuator()
+        let approver = SlowWorkflowApprover()
+        let executor = LocalWorkflowExecutor(
+            observer: observer,
+            grounder: grounder,
+            actuator: actuator,
+            verifier: ScriptedWorkflowVerifier([]),
+            fallbackResolver: ScriptedWorkflowFallback(),
+            approver: approver,
+            ledger: RecordingWorkflowLedger(),
+            approvalTimeoutNanoseconds: 1_000_000
+        )
+
+        let run = await executor.execute(workflow)
+
+        #expect(run.status == .paused(
+            stepID: "choose",
+            reason: .approvalUnavailable,
+            actionMayHaveOccurred: false
+        ))
+        #expect(await approver.count == 1)
+        #expect(await actuator.count == 0)
+    }
+
     @Test("approval text flattens whitespace, exposes invisible controls, and is bounded")
     func approvalSummaryIsDisplaySafe() async throws {
         let unsafeTitle = "Publish \u{202E}now"
@@ -348,6 +386,90 @@ struct LocalWorkflowExecutorTests {
         #expect(await dependencies.approver.count == 0)
     }
 
+    @Test("an already completed run is returned without duplicate ledger events")
+    func completedResumeIsIdempotent() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
+        let completed = LocalWorkflowRun(
+            workflowID: workflow.id,
+            nextStepIndex: workflow.steps.count,
+            status: .completed
+        )
+        let dependencies = Dependencies(
+            observer: ScriptedWorkflowObserver([]),
+            verifications: []
+        )
+
+        let returned = await dependencies.executor.execute(workflow, resuming: completed)
+
+        #expect(returned == completed)
+        #expect(await dependencies.ledger.events.isEmpty)
+        #expect(await dependencies.actuator.count == 0)
+    }
+
+    @Test("ledger failure before execution prevents observation and input")
+    func initialLedgerFailureFailsClosed() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
+        let observer = ScriptedWorkflowObserver([observation(revision: "menu")])
+        let grounder = ScriptedWorkflowGrounder(
+            payload: .click(normalizedX: 0.2, normalizedY: 0.3),
+            actionSummary: "Choose meal"
+        )
+        let actuator = RecordingWorkflowActuator()
+        let ledger = FailingWorkflowLedger(failAtAppend: 1)
+        let executor = LocalWorkflowExecutor(
+            observer: observer,
+            grounder: grounder,
+            actuator: actuator,
+            verifier: ScriptedWorkflowVerifier([]),
+            fallbackResolver: ScriptedWorkflowFallback(),
+            approver: ScriptedWorkflowApprover([]),
+            ledger: ledger
+        )
+
+        let run = await executor.execute(workflow)
+
+        #expect(run.status == .paused(
+            stepID: "ledger",
+            reason: .dependencyFailure,
+            actionMayHaveOccurred: false
+        ))
+        #expect(await grounder.count == 0)
+        #expect(await actuator.count == 0)
+    }
+
+    @Test("ledger failure after input preserves side-effect uncertainty")
+    func postActionLedgerFailureFailsClosed() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step(maxAttempts: 1)])
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "menu"),
+            observation(revision: "menu"),
+        ])
+        let grounder = ScriptedWorkflowGrounder(
+            payload: .click(normalizedX: 0.2, normalizedY: 0.3),
+            actionSummary: "Choose meal"
+        )
+        let actuator = RecordingWorkflowActuator()
+        let ledger = FailingWorkflowLedger(failAtAppend: 3)
+        let executor = LocalWorkflowExecutor(
+            observer: observer,
+            grounder: grounder,
+            actuator: actuator,
+            verifier: ScriptedWorkflowVerifier([]),
+            fallbackResolver: ScriptedWorkflowFallback(),
+            approver: ScriptedWorkflowApprover([]),
+            ledger: ledger
+        )
+
+        let run = await executor.execute(workflow)
+
+        #expect(run.status == .paused(
+            stepID: "choose",
+            reason: .dependencyFailure,
+            actionMayHaveOccurred: true
+        ))
+        #expect(await actuator.count == 1)
+    }
+
     @Test("the executor rejects an overlapping claim before duplicate actuation")
     func overlappingRunIsRejected() async throws {
         let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
@@ -374,6 +496,9 @@ struct LocalWorkflowExecutorTests {
         ))
         #expect(completed.status == .completed)
         #expect(await dependencies.actuator.count == 1)
+        let eventKinds = await dependencies.ledger.events.map(\.kind)
+        #expect(!eventKinds.contains(.runPaused))
+        #expect(eventKinds.filter { $0 == .runCompleted }.count == 1)
     }
 
     @Test("cancellation becomes durable run state")
@@ -649,10 +774,36 @@ private actor ScriptedWorkflowApprover: LocalWorkflowApproving {
     }
 }
 
+private actor SlowWorkflowApprover: LocalWorkflowApproving {
+    private(set) var count = 0
+
+    func requestApproval(_: WorkflowApprovalRequest) async -> WorkflowApprovalDecision {
+        count += 1
+        do {
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        } catch {
+            return .unavailable
+        }
+        return .approved
+    }
+}
+
 private actor RecordingWorkflowLedger: LocalWorkflowLedgerWriting {
     private(set) var events: [WorkflowLedgerEvent] = []
 
     func append(_ event: WorkflowLedgerEvent) async { events.append(event) }
+}
+
+private actor FailingWorkflowLedger: LocalWorkflowLedgerWriting {
+    private let failAtAppend: Int
+    private var appendCount = 0
+
+    init(failAtAppend: Int) { self.failAtAppend = failAtAppend }
+
+    func append(_: WorkflowLedgerEvent) async throws {
+        appendCount += 1
+        if appendCount == failAtAppend { throw TestDependencyError.exhausted }
+    }
 }
 
 private struct Dependencies {

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -74,6 +74,30 @@ struct LocalWorkflowExecutorTests {
         #expect(events.last?.kind == .runCompleted)
     }
 
+    @Test("exhausted idempotent retries preserve that an action occurred")
+    func exhaustedRetriesPreserveActionUncertainty() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step(maxAttempts: 2)])
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "a"), observation(revision: "a"), observation(revision: "b"),
+            observation(revision: "b"), observation(revision: "b"), observation(revision: "c"),
+        ])
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [
+                .notSatisfied(code: .targetUnchanged),
+                .notSatisfied(code: .targetUnchanged),
+            ]
+        )
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .paused(
+            stepID: "choose",
+            reason: .recoveryExhausted,
+            actionMayHaveOccurred: true
+        ))
+    }
+
     @Test("approval is action-scoped and changed UI after approval forces a fresh proposal")
     func approvalRebindsBeforeActing() async throws {
         let workflow = LocalWorkflow(
@@ -121,21 +145,34 @@ struct LocalWorkflowExecutorTests {
 
         let run = await dependencies.executor.execute(workflow)
 
-        #expect(run.status == .paused(stepID: "choose", reason: .approvalDenied))
+        #expect(run.status == .paused(
+            stepID: "choose",
+            reason: .approvalDenied,
+            actionMayHaveOccurred: false
+        ))
         #expect(run.nextStepIndex == 0)
         #expect(await dependencies.actuator.count == 0)
     }
 
     @Test("approval text flattens whitespace, exposes invisible controls, and is bounded")
     func approvalSummaryIsDisplaySafe() async throws {
+        let unsafeTitle = "Publish \u{202E}now"
         let workflow = LocalWorkflow(
             title: "Publish",
-            steps: [step(risk: .externalCommunication)]
+            steps: [
+                LocalWorkflowStep(
+                    id: "choose",
+                    title: unsafeTitle,
+                    instruction: "Publish the draft",
+                    successCriteria: "The draft is published",
+                    risk: .externalCommunication
+                ),
+            ]
         )
         let observer = ScriptedWorkflowObserver([
             observation(revision: "draft"), observation(revision: "draft"),
         ])
-        let rawSummary = "Publish\nnow \u{202E}" + String(repeating: "x", count: 300)
+        let rawSummary = "Publish\nnow \u{202E}e" + String(repeating: "\u{0301}", count: 300)
         let dependencies = Dependencies(
             observer: observer,
             verifications: [],
@@ -148,7 +185,8 @@ struct LocalWorkflowExecutorTests {
 
         #expect(!request.actionSummary.contains("\n"))
         #expect(request.actionSummary.contains("\\u{202E}"))
-        #expect(request.actionSummary.count <= 250)
+        #expect(request.actionSummary.utf8.count <= 240)
+        #expect(request.stepTitle.contains("\\u{202E}"))
     }
 
     @Test("an unsafe verifier result pauses without trying a different click")
@@ -164,7 +202,11 @@ struct LocalWorkflowExecutorTests {
 
         let run = await dependencies.executor.execute(workflow)
 
-        #expect(run.status == .paused(stepID: "choose", reason: .unsafeState))
+        #expect(run.status == .paused(
+            stepID: "choose",
+            reason: .unsafeState,
+            actionMayHaveOccurred: true
+        ))
         #expect(await dependencies.grounder.count == 1)
         #expect(await dependencies.actuator.count == 1)
     }
@@ -189,8 +231,20 @@ struct LocalWorkflowExecutorTests {
 
         let run = await dependencies.executor.execute(workflow)
 
-        #expect(run.status == .paused(stepID: "choose", reason: .recoveryExhausted))
+        #expect(run.status == .paused(
+            stepID: "choose",
+            reason: .recoveryExhausted,
+            actionMayHaveOccurred: true
+        ))
         #expect(await dependencies.grounder.count == 1)
+        #expect(await dependencies.actuator.count == 1)
+
+        let resumed = await dependencies.executor.execute(workflow, resuming: run)
+        #expect(resumed.status == .paused(
+            stepID: "invalid-run",
+            reason: .unsafeState,
+            actionMayHaveOccurred: true
+        ))
         #expect(await dependencies.actuator.count == 1)
     }
 
@@ -206,7 +260,11 @@ struct LocalWorkflowExecutorTests {
 
         let run = await dependencies.executor.execute(workflow)
 
-        #expect(run.status == .paused(stepID: "choose", reason: .unsafeState))
+        #expect(run.status == .paused(
+            stepID: "choose",
+            reason: .unsafeState,
+            actionMayHaveOccurred: false
+        ))
         #expect(await dependencies.actuator.count == 0)
         #expect((await dependencies.ledger.events).contains { $0.code == .invalidAction })
     }
@@ -230,7 +288,11 @@ struct LocalWorkflowExecutorTests {
 
         let run = await dependencies.executor.execute(workflow)
 
-        #expect(run.status == .paused(stepID: "choose", reason: .unsafeState))
+        #expect(run.status == .paused(
+            stepID: "choose",
+            reason: .unsafeState,
+            actionMayHaveOccurred: false
+        ))
         #expect(await dependencies.grounder.count == 0)
         #expect((await dependencies.ledger.events).contains { $0.code == .invalidObservation })
     }
@@ -249,8 +311,40 @@ struct LocalWorkflowExecutorTests {
 
         let run = await dependencies.executor.execute(workflow, resuming: interrupted)
 
-        #expect(run.status == .paused(stepID: "invalid-run", reason: .unsafeState))
+        #expect(run.status == .paused(
+            stepID: "invalid-run",
+            reason: .unsafeState,
+            actionMayHaveOccurred: true
+        ))
         #expect(await dependencies.actuator.count == 0)
+    }
+
+    @Test("the executor rejects an overlapping claim before duplicate actuation")
+    func overlappingRunIsRejected() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
+        let initial = LocalWorkflowRun(workflowID: workflow.id)
+        let observer = BlockingFirstWorkflowObserver([
+            observation(revision: "menu"),
+            observation(revision: "menu"),
+            observation(revision: "selected"),
+        ])
+        let dependencies = Dependencies(observer: observer, verifications: [.satisfied])
+
+        let first = Task {
+            await dependencies.executor.execute(workflow, resuming: initial)
+        }
+        await observer.waitUntilBlocked()
+        let overlapping = await dependencies.executor.execute(workflow, resuming: initial)
+        await observer.release()
+        let completed = await first.value
+
+        #expect(overlapping.status == .paused(
+            stepID: "executor-busy",
+            reason: .unsafeState,
+            actionMayHaveOccurred: true
+        ))
+        #expect(completed.status == .completed)
+        #expect(await dependencies.actuator.count == 1)
     }
 
     @Test("cancellation becomes durable run state")
@@ -261,9 +355,45 @@ struct LocalWorkflowExecutorTests {
 
         let run = await dependencies.executor.execute(workflow)
 
-        #expect(run.status == .cancelled)
+        #expect(run.status == .cancelled(stepID: "choose", actionMayHaveOccurred: false))
         #expect(run.nextStepIndex == 0)
         #expect((await dependencies.ledger.events).last?.kind == .runCancelled)
+    }
+
+    @Test("cancellation while input is suspended cannot become completed")
+    func cancellationDuringActuationIsConservative() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "menu"),
+            observation(revision: "menu"),
+        ])
+        let grounder = ScriptedWorkflowGrounder(
+            payload: .click(normalizedX: 0.2, normalizedY: 0.3),
+            actionSummary: "Choose meal"
+        )
+        let actuator = BlockingWorkflowActuator()
+        let ledger = RecordingWorkflowLedger()
+        let executor = LocalWorkflowExecutor(
+            observer: observer,
+            grounder: grounder,
+            actuator: actuator,
+            verifier: ScriptedWorkflowVerifier([.satisfied]),
+            fallbackResolver: ScriptedWorkflowFallback(),
+            approver: ScriptedWorkflowApprover([]),
+            ledger: ledger
+        )
+
+        let task = Task { await executor.execute(workflow) }
+        await actuator.waitUntilBlocked()
+        task.cancel()
+        await actuator.release()
+        let run = await task.value
+
+        #expect(run.status == .cancelled(
+            stepID: "choose",
+            actionMayHaveOccurred: true
+        ))
+        #expect((await ledger.events).last?.kind == .runCancelled)
     }
 
     @Test("audit events have no field capable of persisting action text or workflow instructions")
@@ -341,6 +471,48 @@ private actor ScriptedWorkflowObserver: LocalWorkflowObserving {
     }
 }
 
+private actor OneShotWorkflowGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let current = waiters
+        waiters.removeAll()
+        current.forEach { $0.resume() }
+    }
+}
+
+private actor BlockingFirstWorkflowObserver: LocalWorkflowObserving {
+    private var observations: [WorkflowObservation]
+    private var callCount = 0
+    private let blocked = OneShotWorkflowGate()
+    private let released = OneShotWorkflowGate()
+
+    init(_ observations: [WorkflowObservation]) { self.observations = observations }
+
+    func observe(for _: LocalWorkflowStep) async throws -> WorkflowObservation {
+        callCount += 1
+        if callCount == 1 {
+            await blocked.open()
+            await released.wait()
+        }
+        guard !observations.isEmpty else { throw TestDependencyError.exhausted }
+        return observations.removeFirst()
+    }
+
+    func waitUntilBlocked() async { await blocked.wait() }
+    func release() async { await released.open() }
+}
+
 private actor CancellingWorkflowObserver: LocalWorkflowObserving {
     func observe(for _: LocalWorkflowStep) async throws -> WorkflowObservation {
         throw CancellationError()
@@ -382,6 +554,22 @@ private actor RecordingWorkflowActuator: LocalWorkflowActuating {
     ) async throws {
         actions.append(action)
     }
+}
+
+private actor BlockingWorkflowActuator: LocalWorkflowActuating {
+    private let blocked = OneShotWorkflowGate()
+    private let released = OneShotWorkflowGate()
+
+    func perform(
+        _: GroundedWorkflowAction,
+        against _: WorkflowObservation
+    ) async throws {
+        await blocked.open()
+        await released.wait()
+    }
+
+    func waitUntilBlocked() async { await blocked.wait() }
+    func release() async { await released.open() }
 }
 
 private actor ScriptedWorkflowVerifier: LocalWorkflowVerifying {

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -1,0 +1,480 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Local workflow execution kernel")
+struct LocalWorkflowExecutorTests {
+    @Test("verified steps advance deterministically without asking for harmless actions")
+    func verifiedStepsComplete() async throws {
+        let stepA = step(id: "open", risk: .readOnly)
+        let stepB = step(id: "select")
+        let workflow = LocalWorkflow(title: "Lunch", steps: [stepA, stepB])
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "a"), observation(revision: "a"), observation(revision: "b"),
+            observation(revision: "b"), observation(revision: "b"), observation(revision: "c"),
+        ])
+        let dependencies = Dependencies(observer: observer, verifications: [.satisfied, .satisfied])
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .completed)
+        #expect(run.nextStepIndex == 2)
+        #expect(await dependencies.actuator.count == 2)
+        #expect(await dependencies.approver.count == 0)
+    }
+
+    @Test("a changed window snapshot rejects the stale action and re-observes")
+    func staleObservationRetriesWithoutActing() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step(maxAttempts: 2)])
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "old"),
+            observation(revision: "changed"),
+            observation(revision: "changed"),
+            observation(revision: "changed"),
+            observation(revision: "done"),
+        ])
+        let dependencies = Dependencies(observer: observer, verifications: [.satisfied])
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .completed)
+        #expect(await dependencies.grounder.count == 2)
+        #expect(await dependencies.actuator.count == 1)
+        let events = await dependencies.ledger.events
+        #expect(events.contains { $0.kind == .staleActionRejected && $0.code == .interactionStateChanged })
+    }
+
+    @Test("failed visual retries use one semantic fallback before pausing")
+    func semanticFallbackRecovers() async throws {
+        let workflow = LocalWorkflow(
+            title: "Lunch",
+            steps: [step(maxAttempts: 2, fallback: "student-profile")]
+        )
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "a"), observation(revision: "a"), observation(revision: "b"),
+            observation(revision: "b"), observation(revision: "b"), observation(revision: "c"),
+            observation(revision: "c"), observation(revision: "c"), observation(revision: "done"),
+        ])
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [
+                .notSatisfied(code: .targetUnchanged),
+                .notSatisfied(code: .targetUnchanged),
+                .satisfied,
+            ]
+        )
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .completed)
+        #expect(await dependencies.actuator.count == 3)
+        #expect(await dependencies.fallback.count == 1)
+        let events = await dependencies.ledger.events
+        #expect(events.contains { $0.kind == .semanticFallbackUsed })
+        #expect(events.last?.kind == .runCompleted)
+    }
+
+    @Test("approval is action-scoped and changed UI after approval forces a fresh proposal")
+    func approvalRebindsBeforeActing() async throws {
+        let workflow = LocalWorkflow(
+            title: "Publish",
+            steps: [step(risk: .externalCommunication, maxAttempts: 2)]
+        )
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "draft"),
+            observation(revision: "draft"),
+            observation(revision: "edited-during-approval"),
+            observation(revision: "edited-during-approval"),
+            observation(revision: "edited-during-approval"),
+            observation(revision: "edited-during-approval"),
+            observation(revision: "published"),
+        ])
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [.satisfied],
+            approvals: [.approved, .approved]
+        )
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .completed)
+        #expect(await dependencies.approver.count == 2)
+        #expect(await dependencies.actuator.count == 1)
+        let events = await dependencies.ledger.events
+        #expect(events.contains { $0.code == .stateChangedDuringApproval })
+    }
+
+    @Test("a protected action denied by the user never reaches the actuator")
+    func approvalDenialFailsClosed() async throws {
+        let workflow = LocalWorkflow(
+            title: "Checkout",
+            steps: [step(risk: .financial)]
+        )
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "review"), observation(revision: "review"),
+        ])
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [],
+            approvals: [.denied]
+        )
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .paused(stepID: "choose", reason: .approvalDenied))
+        #expect(run.nextStepIndex == 0)
+        #expect(await dependencies.actuator.count == 0)
+    }
+
+    @Test("approval text flattens whitespace, exposes invisible controls, and is bounded")
+    func approvalSummaryIsDisplaySafe() async throws {
+        let workflow = LocalWorkflow(
+            title: "Publish",
+            steps: [step(risk: .externalCommunication)]
+        )
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "draft"), observation(revision: "draft"),
+        ])
+        let rawSummary = "Publish\nnow \u{202E}" + String(repeating: "x", count: 300)
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [],
+            approvals: [.denied],
+            actionSummary: rawSummary
+        )
+
+        _ = await dependencies.executor.execute(workflow)
+        let request = try #require(await dependencies.approver.requests.first)
+
+        #expect(!request.actionSummary.contains("\n"))
+        #expect(request.actionSummary.contains("\\u{202E}"))
+        #expect(request.actionSummary.count <= 250)
+    }
+
+    @Test("an unsafe verifier result pauses without trying a different click")
+    func unsafeVerificationStopsRecovery() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step(maxAttempts: 3)])
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "a"), observation(revision: "a"), observation(revision: "unexpected"),
+        ])
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [.unsafe(code: .unexpectedAccount)]
+        )
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .paused(stepID: "choose", reason: .unsafeState))
+        #expect(await dependencies.grounder.count == 1)
+        #expect(await dependencies.actuator.count == 1)
+    }
+
+    @Test("a non-idempotent step never repeats an action that could have taken effect")
+    func nonIdempotentActionDoesNotRetry() async throws {
+        let workflow = LocalWorkflow(
+            title: "Submit",
+            steps: [step(risk: .externalCommunication, maxAttempts: 1)]
+        )
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "draft"),
+            observation(revision: "draft"),
+            observation(revision: "draft"),
+            observation(revision: "unknown"),
+        ])
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [.notSatisfied(code: .targetUnchanged)],
+            approvals: [.approved]
+        )
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .paused(stepID: "choose", reason: .recoveryExhausted))
+        #expect(await dependencies.grounder.count == 1)
+        #expect(await dependencies.actuator.count == 1)
+    }
+
+    @Test("invalid normalized coordinates fail closed before input injection")
+    func invalidActionFailsClosed() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
+        let observer = ScriptedWorkflowObserver([observation(revision: "menu")])
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [],
+            payload: .click(normalizedX: 1.5, normalizedY: 0.5)
+        )
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .paused(stepID: "choose", reason: .unsafeState))
+        #expect(await dependencies.actuator.count == 0)
+        #expect((await dependencies.ledger.events).contains { $0.code == .invalidAction })
+    }
+
+    @Test("an invalid observation fails closed before grounding")
+    func invalidObservationFailsClosed() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
+        let invalid = WorkflowObservation(
+            target: WorkflowInteractionTarget(
+                bundleIdentifier: "com.example.portal",
+                processIdentifier: 42,
+                windowIdentifier: "main",
+                windowFrame: WorkflowWindowFrame(x: 0, y: 0, width: 0, height: 800)
+            ),
+            contentRevision: "menu"
+        )
+        let dependencies = Dependencies(
+            observer: ScriptedWorkflowObserver([invalid]),
+            verifications: []
+        )
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .paused(stepID: "choose", reason: .unsafeState))
+        #expect(await dependencies.grounder.count == 0)
+        #expect((await dependencies.ledger.events).contains { $0.code == .invalidObservation })
+    }
+
+    @Test("an interrupted in-flight run cannot replay a possibly completed action")
+    func runningResumeFailsClosed() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
+        let interrupted = LocalWorkflowRun(
+            workflowID: workflow.id,
+            status: .running
+        )
+        let dependencies = Dependencies(
+            observer: ScriptedWorkflowObserver([]),
+            verifications: []
+        )
+
+        let run = await dependencies.executor.execute(workflow, resuming: interrupted)
+
+        #expect(run.status == .paused(stepID: "invalid-run", reason: .unsafeState))
+        #expect(await dependencies.actuator.count == 0)
+    }
+
+    @Test("cancellation becomes durable run state")
+    func cancellationIsRecorded() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step()])
+        let observer = CancellingWorkflowObserver()
+        let dependencies = Dependencies(observer: observer, verifications: [])
+
+        let run = await dependencies.executor.execute(workflow)
+
+        #expect(run.status == .cancelled)
+        #expect(run.nextStepIndex == 0)
+        #expect((await dependencies.ledger.events).last?.kind == .runCancelled)
+    }
+
+    @Test("audit events have no field capable of persisting action text or workflow instructions")
+    func auditLedgerRedactsPayloads() async throws {
+        let secret = "4111-1111-1111-1111"
+        let workflow = LocalWorkflow(
+            title: "Private task",
+            steps: [
+                LocalWorkflowStep(
+                    id: "choose",
+                    title: "Enter saved value",
+                    instruction: "Type \(secret)",
+                    successCriteria: "The secret appears",
+                    risk: .localChange
+                ),
+            ]
+        )
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "a"), observation(revision: "a"), observation(revision: "b"),
+        ])
+        let dependencies = Dependencies(
+            observer: observer,
+            verifications: [.satisfied],
+            payload: .typeText(secret)
+        )
+
+        _ = await dependencies.executor.execute(workflow)
+        let encoded = try JSONEncoder().encode(await dependencies.ledger.events)
+        let json = String(decoding: encoded, as: UTF8.self)
+
+        #expect(!json.contains(secret))
+        #expect(!json.contains("Type"))
+        #expect(!json.contains("secret appears"))
+    }
+
+    private func step(
+        id: String = "choose",
+        risk: WorkflowActionRisk = .localChange,
+        maxAttempts: Int = 2,
+        fallback: String? = nil
+    ) -> LocalWorkflowStep {
+        LocalWorkflowStep(
+            id: id,
+            title: "Choose meal",
+            instruction: "Choose the preferred meal",
+            successCriteria: "The meal is selected",
+            risk: risk,
+            isIdempotent: maxAttempts > 1 || fallback != nil,
+            maxGroundingAttempts: maxAttempts,
+            semanticFallbackIdentifier: fallback
+        )
+    }
+
+    private func observation(revision: String) -> WorkflowObservation {
+        WorkflowObservation(
+            target: WorkflowInteractionTarget(
+                bundleIdentifier: "com.example.portal",
+                processIdentifier: 42,
+                windowIdentifier: "main",
+                windowFrame: WorkflowWindowFrame(x: 0, y: 0, width: 1200, height: 800)
+            ),
+            contentRevision: revision
+        )
+    }
+}
+
+private actor ScriptedWorkflowObserver: LocalWorkflowObserving {
+    private var observations: [WorkflowObservation]
+
+    init(_ observations: [WorkflowObservation]) { self.observations = observations }
+
+    func observe(for _: LocalWorkflowStep) async throws -> WorkflowObservation {
+        guard !observations.isEmpty else { throw TestDependencyError.exhausted }
+        return observations.removeFirst()
+    }
+}
+
+private actor CancellingWorkflowObserver: LocalWorkflowObserving {
+    func observe(for _: LocalWorkflowStep) async throws -> WorkflowObservation {
+        throw CancellationError()
+    }
+}
+
+private actor ScriptedWorkflowGrounder: LocalWorkflowGrounding {
+    private(set) var count = 0
+    private let payload: WorkflowActionPayload
+    private let actionSummary: String
+
+    init(payload: WorkflowActionPayload, actionSummary: String) {
+        self.payload = payload
+        self.actionSummary = actionSummary
+    }
+
+    func ground(
+        step _: LocalWorkflowStep,
+        observation: WorkflowObservation
+    ) async throws -> GroundedWorkflowAction {
+        count += 1
+        return GroundedWorkflowAction(
+            observationID: observation.id,
+            payload: payload,
+            source: .visualGrounding,
+            safeSummary: actionSummary,
+            risk: .readOnly
+        )
+    }
+}
+
+private actor RecordingWorkflowActuator: LocalWorkflowActuating {
+    private(set) var actions: [GroundedWorkflowAction] = []
+    var count: Int { actions.count }
+
+    func perform(
+        _ action: GroundedWorkflowAction,
+        against _: WorkflowObservation
+    ) async throws {
+        actions.append(action)
+    }
+}
+
+private actor ScriptedWorkflowVerifier: LocalWorkflowVerifying {
+    private var results: [WorkflowVerification]
+
+    init(_ results: [WorkflowVerification]) { self.results = results }
+
+    func verify(
+        step _: LocalWorkflowStep,
+        before _: WorkflowObservation,
+        after _: WorkflowObservation
+    ) async throws -> WorkflowVerification {
+        guard !results.isEmpty else { throw TestDependencyError.exhausted }
+        return results.removeFirst()
+    }
+}
+
+private actor ScriptedWorkflowFallback: LocalWorkflowFallbackResolving {
+    private(set) var count = 0
+
+    func fallbackAction(
+        identifier _: String,
+        step _: LocalWorkflowStep,
+        observation: WorkflowObservation
+    ) async throws -> GroundedWorkflowAction? {
+        count += 1
+        return GroundedWorkflowAction(
+            observationID: observation.id,
+            payload: .click(normalizedX: 0.5, normalizedY: 0.5),
+            source: .semanticFallback,
+            safeSummary: "Activate the named control",
+            risk: .readOnly
+        )
+    }
+}
+
+private actor ScriptedWorkflowApprover: LocalWorkflowApproving {
+    private var decisions: [WorkflowApprovalDecision]
+    private(set) var requests: [WorkflowApprovalRequest] = []
+    var count: Int { requests.count }
+
+    init(_ decisions: [WorkflowApprovalDecision]) { self.decisions = decisions }
+
+    func requestApproval(_ request: WorkflowApprovalRequest) async -> WorkflowApprovalDecision {
+        requests.append(request)
+        guard !decisions.isEmpty else { return .unavailable }
+        return decisions.removeFirst()
+    }
+}
+
+private actor RecordingWorkflowLedger: LocalWorkflowLedgerWriting {
+    private(set) var events: [WorkflowLedgerEvent] = []
+
+    func append(_ event: WorkflowLedgerEvent) async { events.append(event) }
+}
+
+private struct Dependencies {
+    let grounder: ScriptedWorkflowGrounder
+    let actuator: RecordingWorkflowActuator
+    let fallback: ScriptedWorkflowFallback
+    let approver: ScriptedWorkflowApprover
+    let ledger: RecordingWorkflowLedger
+    let executor: LocalWorkflowExecutor
+
+    init(
+        observer: any LocalWorkflowObserving,
+        verifications: [WorkflowVerification],
+        approvals: [WorkflowApprovalDecision] = [],
+        payload: WorkflowActionPayload = .click(normalizedX: 0.2, normalizedY: 0.3),
+        actionSummary: String = "Activate the selected control"
+    ) {
+        let grounder = ScriptedWorkflowGrounder(payload: payload, actionSummary: actionSummary)
+        let actuator = RecordingWorkflowActuator()
+        let fallback = ScriptedWorkflowFallback()
+        let approver = ScriptedWorkflowApprover(approvals)
+        let ledger = RecordingWorkflowLedger()
+        self.grounder = grounder
+        self.actuator = actuator
+        self.fallback = fallback
+        self.approver = approver
+        self.ledger = ledger
+        self.executor = LocalWorkflowExecutor(
+            observer: observer,
+            grounder: grounder,
+            actuator: actuator,
+            verifier: ScriptedWorkflowVerifier(verifications),
+            fallbackResolver: fallback,
+            approver: approver,
+            ledger: ledger
+        )
+    }
+}
+
+private enum TestDependencyError: Error {
+    case exhausted
+}

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -319,6 +319,35 @@ struct LocalWorkflowExecutorTests {
         #expect(await dependencies.actuator.count == 0)
     }
 
+    @Test("a forged ready checkpoint cannot skip workflow steps")
+    func advancedReadyResumeFailsClosed() async throws {
+        let workflow = LocalWorkflow(
+            title: "Lunch",
+            steps: [step(id: "choose"), step(id: "checkout", risk: .financial)]
+        )
+        let dependencies = Dependencies(
+            observer: ScriptedWorkflowObserver([]),
+            verifications: []
+        )
+
+        for nextStepIndex in [1, workflow.steps.count] {
+            let forged = LocalWorkflowRun(
+                workflowID: workflow.id,
+                nextStepIndex: nextStepIndex,
+                status: .ready
+            )
+            let run = await dependencies.executor.execute(workflow, resuming: forged)
+
+            #expect(run.status == .paused(
+                stepID: "invalid-run",
+                reason: .unsafeState,
+                actionMayHaveOccurred: false
+            ))
+        }
+        #expect(await dependencies.actuator.count == 0)
+        #expect(await dependencies.approver.count == 0)
+    }
+
     @Test("the executor rejects an overlapping claim before duplicate actuation")
     func overlappingRunIsRejected() async throws {
         let workflow = LocalWorkflow(title: "Lunch", steps: [step()])

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -470,6 +470,45 @@ struct LocalWorkflowExecutorTests {
         #expect(await actuator.count == 1)
     }
 
+    @Test("a later-step ledger failure preserves earlier side-effect uncertainty")
+    func laterStepLedgerFailurePreservesPriorAction() async throws {
+        let workflow = LocalWorkflow(
+            title: "Lunch",
+            steps: [step(id: "choose", maxAttempts: 1), step(id: "review", maxAttempts: 1)]
+        )
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "menu"),
+            observation(revision: "menu"),
+            observation(revision: "selected"),
+            observation(revision: "review"),
+        ])
+        let grounder = ScriptedWorkflowGrounder(
+            payload: .click(normalizedX: 0.2, normalizedY: 0.3),
+            actionSummary: "Choose meal"
+        )
+        let actuator = RecordingWorkflowActuator()
+        let ledger = FailingWorkflowLedger(failAtAppend: 5)
+        let executor = LocalWorkflowExecutor(
+            observer: observer,
+            grounder: grounder,
+            actuator: actuator,
+            verifier: ScriptedWorkflowVerifier([.satisfied]),
+            fallbackResolver: ScriptedWorkflowFallback(),
+            approver: ScriptedWorkflowApprover([]),
+            ledger: ledger
+        )
+
+        let run = await executor.execute(workflow)
+
+        #expect(run.status == .paused(
+            stepID: "review",
+            reason: .dependencyFailure,
+            actionMayHaveOccurred: true
+        ))
+        #expect(run.nextStepIndex == 1)
+        #expect(await actuator.count == 1)
+    }
+
     @Test("the executor rejects an overlapping claim before duplicate actuation")
     func overlappingRunIsRejected() async throws {
         let workflow = LocalWorkflow(title: "Lunch", steps: [step()])

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -307,6 +307,33 @@ struct LocalWorkflowExecutorTests {
         #expect((await dependencies.ledger.events).contains { $0.code == .invalidAction })
     }
 
+    @Test("typed text must be nonempty and bounded by UTF-8 bytes")
+    func typedTextIsBoundedBeforeInputInjection() async throws {
+        let workflow = LocalWorkflow(title: "Compose", steps: [step(maxAttempts: 1)])
+        let limit = WorkflowActionPayload.maximumTypedTextBytes
+        #expect(WorkflowActionPayload.typeText(String(repeating: "a", count: limit)).isStructurallyValid)
+
+        for payload in [
+            WorkflowActionPayload.typeText(""),
+            WorkflowActionPayload.typeText(String(repeating: "é", count: limit / 2 + 1)),
+        ] {
+            let dependencies = Dependencies(
+                observer: ScriptedWorkflowObserver([observation(revision: "editor")]),
+                verifications: [],
+                payload: payload
+            )
+
+            let run = await dependencies.executor.execute(workflow)
+
+            #expect(run.status == .paused(
+                stepID: "choose",
+                reason: .unsafeState,
+                actionMayHaveOccurred: false
+            ))
+            #expect(await dependencies.actuator.count == 0)
+        }
+    }
+
     @Test("an invalid observation fails closed before grounding")
     func invalidObservationFailsClosed() async throws {
         let workflow = LocalWorkflow(title: "Lunch", steps: [step()])

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -589,6 +589,38 @@ struct LocalWorkflowExecutorTests {
         #expect((await ledger.events).last?.kind == .runCancelled)
     }
 
+    @Test("cancellation during final verification audit cannot become completed")
+    func cancellationDuringFinalVerificationAuditIsObserved() async throws {
+        let workflow = LocalWorkflow(title: "Lunch", steps: [step(maxAttempts: 1)])
+        let observer = ScriptedWorkflowObserver([
+            observation(revision: "menu"),
+            observation(revision: "menu"),
+            observation(revision: "selected"),
+        ])
+        let grounder = ScriptedWorkflowGrounder(
+            payload: .click(normalizedX: 0.2, normalizedY: 0.3),
+            actionSummary: "Choose meal"
+        )
+        let ledger = CancellingOnEventWorkflowLedger(kind: .verificationPassed)
+        let executor = LocalWorkflowExecutor(
+            observer: observer,
+            grounder: grounder,
+            actuator: RecordingWorkflowActuator(),
+            verifier: ScriptedWorkflowVerifier([.satisfied]),
+            fallbackResolver: ScriptedWorkflowFallback(),
+            approver: ScriptedWorkflowApprover([]),
+            ledger: ledger
+        )
+
+        let execution = Task { await executor.execute(workflow) }
+        let run = await execution.value
+        let eventKinds = await ledger.events.map(\.kind)
+
+        #expect(run.status == .cancelled(stepID: "choose", actionMayHaveOccurred: true))
+        #expect(!eventKinds.contains(.runCompleted))
+        #expect(eventKinds.last == .runCancelled)
+    }
+
     @Test("audit events have no field capable of persisting action text or workflow instructions")
     func auditLedgerRedactsPayloads() async throws {
         let secret = "4111-1111-1111-1111"
@@ -806,7 +838,10 @@ private actor ScriptedWorkflowApprover: LocalWorkflowApproving {
 
     init(_ decisions: [WorkflowApprovalDecision]) { self.decisions = decisions }
 
-    func requestApproval(_ request: WorkflowApprovalRequest) async -> WorkflowApprovalDecision {
+    func requestApproval(
+        _ request: WorkflowApprovalRequest,
+        timeoutNanoseconds _: UInt64
+    ) async -> WorkflowApprovalDecision {
         requests.append(request)
         guard !decisions.isEmpty else { return .unavailable }
         return decisions.removeFirst()
@@ -816,14 +851,17 @@ private actor ScriptedWorkflowApprover: LocalWorkflowApproving {
 private actor SlowWorkflowApprover: LocalWorkflowApproving {
     private(set) var count = 0
 
-    func requestApproval(_: WorkflowApprovalRequest) async -> WorkflowApprovalDecision {
+    func requestApproval(
+        _: WorkflowApprovalRequest,
+        timeoutNanoseconds: UInt64
+    ) async -> WorkflowApprovalDecision {
         count += 1
         do {
-            try await Task.sleep(nanoseconds: 1_000_000_000)
+            try await Task.sleep(nanoseconds: timeoutNanoseconds)
         } catch {
             return .unavailable
         }
-        return .approved
+        return .unavailable
     }
 }
 
@@ -842,6 +880,20 @@ private actor FailingWorkflowLedger: LocalWorkflowLedgerWriting {
     func append(_: WorkflowLedgerEvent) async throws {
         appendCount += 1
         if appendCount == failAtAppend { throw TestDependencyError.exhausted }
+    }
+}
+
+private actor CancellingOnEventWorkflowLedger: LocalWorkflowLedgerWriting {
+    private let kind: WorkflowLedgerEventKind
+    private(set) var events: [WorkflowLedgerEvent] = []
+
+    init(kind: WorkflowLedgerEventKind) { self.kind = kind }
+
+    func append(_ event: WorkflowLedgerEvent) async throws {
+        events.append(event)
+        if event.kind == kind {
+            withUnsafeCurrentTask { task in task?.cancel() }
+        }
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -311,7 +311,20 @@ struct LocalWorkflowExecutorTests {
     func typedTextIsBoundedBeforeInputInjection() async throws {
         let workflow = LocalWorkflow(title: "Compose", steps: [step(maxAttempts: 1)])
         let limit = WorkflowActionPayload.maximumTypedTextBytes
-        #expect(WorkflowActionPayload.typeText(String(repeating: "a", count: limit)).isStructurallyValid)
+        let validBoundary = Dependencies(
+            observer: ScriptedWorkflowObserver([
+                observation(revision: "editor"),
+                observation(revision: "editor"),
+                observation(revision: "typed"),
+            ]),
+            verifications: [.satisfied],
+            payload: .typeText(String(repeating: "a", count: limit))
+        )
+
+        let completed = await validBoundary.executor.execute(workflow)
+
+        #expect(completed.status == .completed)
+        #expect(await validBoundary.actuator.count == 1)
 
         for payload in [
             WorkflowActionPayload.typeText(""),


### PR DESCRIPTION
## Why

Local visual models can identify controls, but a free-running model loop is not
safe enough to own user progress or consequential desktop actions. Rapid needs a
deterministic layer that turns one-step visual grounding into a verified,
bounded, inspectable workflow before recording and live macOS input are exposed.

This is the first implementation slice of #3094.

## What

- Add semantic workflow, step, action-risk, observation, run-state, and
  metadata-only audit-event models.
- Add an actor-isolated execution kernel with injected observation, grounding,
  actuation, verification, fallback, approval, and ledger seams.
- Re-observe immediately before every action and again after protected-action
  approval; reject the proposal if app/window/frame/content identity changed.
- Keep automatic retries finite (maximum three) and allow action-after-failure
  retry or semantic fallback only for steps explicitly marked idempotent.
- Require approval for external communication, financial, and destructive
  actions, using the stricter of workflow-authored and model-proposed risk.
- Keep action payloads, screenshots, instructions, errors, and model reasoning
  out of the audit schema; sanitize untrusted approval summaries.
- Fail closed on invalid observations/actions, unsafe verification, unavailable
  approval, cancellation, dependency failure, and interrupted in-flight runs.

## Scope and non-goals

Allowed scope is the pure Swift workflow kernel and focused tests. This PR does
not add a UI, recorder, scheduler, screen capture, input injection, model
download, cloud fallback, or telemetry. Those adapters remain separate phases
behind the experimental product contract in #3094.

## Design precedent

Mature desktop automation systems converge on a recorded demonstration being
compiled into semantic steps, with live re-grounding rather than coordinate
replay. Reliable agent systems similarly keep orchestration, verification,
bounded recovery, and approval outside the model loop. This PR adopts that
separation: the model proposes one ephemeral action, while a deterministic
controller owns state transitions and safety policy.

## Acceptance evidence

- `swift test --no-parallel --filter LocalWorkflowExecutorTests` — 24/24 pass.
- `git diff --check` — pass.
- Tests cover verified multi-step completion, stale-observation rejection,
  bounded semantic fallback, approval-time UI drift, denial, display-safe
  approval text, unsafe verification, non-idempotent no-replay, malformed
  action/observation rejection, interrupted-run handling, cancellation, and
  audit redaction, plus overlapping-run and mid-actuation cancellation races.

## Risk

No production caller is wired in this slice, so behavior is inert until a later
experimental adapter opts into the kernel. The main compatibility risk is the
shape of the new internal contracts; focused tests pin their safety semantics.

Part of #3094
