### PR TITLE
fix(cli): report cache flags not applied under --no-memory-aware-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,7 @@ jobs:
             tests/test_bonsai_image_alias.py \
             tests/test_sd35_alias.py \
             tests/test_diffusion_engine.py \
+            tests/test_legacy_prefix_cache_flag_warnings.py \
             -v --tb=short \
             -m "not slow" \
             -k "not Integration" \

--- a/tests/test_legacy_prefix_cache_flag_warnings.py
+++ b/tests/test_legacy_prefix_cache_flag_warnings.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -140,3 +141,95 @@ def test_serve_command_consults_the_helper_with_sys_argv():
     assert isinstance(argv_arg, ast.Attribute)
     assert isinstance(argv_arg.value, ast.Name) and argv_arg.value.id == "sys"
     assert argv_arg.attr == "argv"
+
+
+def _stub_heavy_serve_deps(monkeypatch) -> dict:
+    """Stub ``serve_command``'s heavyweight prologue (download, memory and
+    disk probes, model load, middleware wiring, ``uvicorn.run``) so the real
+    control flow runs from ``cli.main()`` through the warning loop to the
+    uvicorn dispatch. Mirrors ``tests/test_serve_listen_fd.py``; a new heavy
+    step in ``serve_command`` should be stubbed here rather than worked
+    around so the test keeps following the production path.
+    """
+    import uvicorn
+
+    from vllm_mlx import _version_check
+    from vllm_mlx import server as server_mod
+    from vllm_mlx.middleware import auth as auth_mod
+    from vllm_mlx.middleware import request_logging as reqlog_mod
+
+    captured: dict = {}
+
+    def fake_run(app, **kwargs):
+        captured["app"] = app
+        captured.update(kwargs)
+
+    monkeypatch.setattr(_version_check, "prompt_upgrade_if_available", lambda: False)
+    monkeypatch.setattr(
+        _version_check, "print_staleness_warning_if_any", lambda **_kwargs: None
+    )
+    monkeypatch.setattr(cli, "_ensure_model_downloaded", lambda model: None)
+    monkeypatch.setattr(cli, "_check_memory_capacity", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_check_disk_space", lambda *a, **kw: None)
+    monkeypatch.setattr(server_mod, "configure_logging", lambda level: "info")
+    monkeypatch.setattr(server_mod, "load_model", lambda *a, **kw: None)
+    monkeypatch.setattr(server_mod, "configure_cors", lambda *a, **kw: None)
+    monkeypatch.setattr(auth_mod, "configure_rate_limiter", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        reqlog_mod, "install_request_logging_middleware", lambda *a: None
+    )
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+    return captured
+
+
+def _run_serve(monkeypatch, capsys, *extra_argv: str) -> tuple[str, dict]:
+    captured = _stub_heavy_serve_deps(monkeypatch)
+    monkeypatch.setattr(
+        sys, "argv", ["rapid-mlx", "serve", "qwen3.5-4b-8bit", *extra_argv]
+    )
+    cli.main()
+    assert "app" in captured, "serve_command never reached uvicorn.run"
+    return capsys.readouterr().out, captured
+
+
+@pytest.mark.requires_mlx
+def test_serve_command_prints_dropped_flag_warnings_end_to_end(monkeypatch, capsys):
+    """Behavioral pin: a real ``serve`` invocation that types both flags under
+    ``--no-memory-aware-cache`` must print one warning per dropped flag and
+    still boot (reach ``uvicorn.run``). Guards against the loop being deleted
+    or its result discarded, which the structural AST test cannot catch."""
+    out, _ = _run_serve(
+        monkeypatch,
+        capsys,
+        "--no-memory-aware-cache",
+        "--hybrid-cache-entries",
+        "8",
+        "--prefix-cache-index",
+        "hash",
+    )
+    assert (
+        "  Warning: with --no-memory-aware-cache, --hybrid-cache-entries=8 is a "
+        "memory-aware cache quota" in out
+    ), out
+    assert (
+        "  Warning: with --no-memory-aware-cache, --prefix-cache-index=hash is not "
+        "read by the legacy entry-count cache" in out
+    ), out
+    assert out.count("Warning: with --no-memory-aware-cache") == 2, out
+
+
+@pytest.mark.requires_mlx
+def test_serve_command_stays_silent_when_memory_aware_cache_enabled(
+    monkeypatch, capsys
+):
+    """Same flags under the default memory-aware cache: no warning, since the
+    flags are honoured there."""
+    out, _ = _run_serve(
+        monkeypatch,
+        capsys,
+        "--hybrid-cache-entries",
+        "8",
+        "--prefix-cache-index",
+        "hash",
+    )
+    assert "Warning: with --no-memory-aware-cache" not in out, out

--- a/tests/test_legacy_prefix_cache_flag_warnings.py
+++ b/tests/test_legacy_prefix_cache_flag_warnings.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cache settings the legacy prefix cache does not apply are reported.
+
+``--hybrid-cache-entries`` and ``--prefix-cache-index`` configure the
+prefix-cache backend through ``MemoryAwarePrefixCache``. The legacy branch of
+``Scheduler.__init__`` builds a bare ``PrefixCacheManager(model, max_entries)``
+that applies neither, so a serve that typed them under
+``--no-memory-aware-cache`` came up healthy with the hybrid quota replaced by
+the global entry limit and no radix index built, and nothing said so.
+
+Only explicitly typed values are reported: ``--prefix-cache-index`` defaults
+to ``radix`` and ``--hybrid-cache-entries`` is auto-derived for hybrid models,
+and the auto-derived value still gates message-boundary snapshots in the
+batched engine, so neither default is a dropped expectation.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx import cli
+from vllm_mlx.cli import _legacy_prefix_cache_dropped_flags
+
+
+def _args(**overrides):
+    base = {
+        "no_memory_aware_cache": True,
+        "use_paged_cache": False,
+        "enable_prefix_cache": True,
+        "disable_prefix_cache": False,
+        "prefix_cache_index": "radix",
+        "prefix_cache_size": 100,
+        "hybrid_cache_entries": 0,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+BASE_ARGV = ["rapid-mlx", "serve", "m", "--no-memory-aware-cache"]
+
+
+def test_reports_explicit_hybrid_entries():
+    argv = BASE_ARGV + ["--hybrid-cache-entries", "8"]
+    lines = _legacy_prefix_cache_dropped_flags(_args(hybrid_cache_entries=8), argv)
+    assert len(lines) == 1
+    assert lines[0].startswith("--hybrid-cache-entries=8")
+    assert "--prefix-cache-size=100" in lines[0]
+
+
+def test_reports_explicit_hybrid_entries_equals_form():
+    argv = BASE_ARGV + ["--hybrid-cache-entries=4"]
+    lines = _legacy_prefix_cache_dropped_flags(_args(hybrid_cache_entries=4), argv)
+    assert len(lines) == 1
+    assert lines[0].startswith("--hybrid-cache-entries=4")
+
+
+def test_silent_for_auto_derived_hybrid_entries():
+    """The CLI auto-derives 8 for hybrid models; that value still gates
+    message-boundary snapshots and was never typed, so it is not reported."""
+    assert (
+        _legacy_prefix_cache_dropped_flags(_args(hybrid_cache_entries=8), BASE_ARGV)
+        == []
+    )
+
+
+def test_silent_for_explicit_zero_hybrid_entries():
+    argv = BASE_ARGV + ["--hybrid-cache-entries", "0"]
+    assert _legacy_prefix_cache_dropped_flags(_args(hybrid_cache_entries=0), argv) == []
+
+
+@pytest.mark.parametrize("value", ["radix", "hash"])
+def test_reports_explicit_index(value):
+    argv = BASE_ARGV + ["--prefix-cache-index", value]
+    lines = _legacy_prefix_cache_dropped_flags(_args(prefix_cache_index=value), argv)
+    assert len(lines) == 1
+    assert lines[0].startswith(f"--prefix-cache-index={value}")
+    assert "RadixPrefixIndex" in lines[0]
+
+
+def test_reports_explicit_index_equals_form():
+    argv = BASE_ARGV + ["--prefix-cache-index=hash"]
+    lines = _legacy_prefix_cache_dropped_flags(_args(prefix_cache_index="hash"), argv)
+    assert len(lines) == 1
+
+
+def test_reports_both_flags_in_order():
+    argv = BASE_ARGV + ["--prefix-cache-index=hash", "--hybrid-cache-entries=8"]
+    lines = _legacy_prefix_cache_dropped_flags(
+        _args(prefix_cache_index="hash", hybrid_cache_entries=8), argv
+    )
+    assert [line.split("=")[0] for line in lines] == [
+        "--hybrid-cache-entries",
+        "--prefix-cache-index",
+    ]
+
+
+def test_silent_for_defaulted_index():
+    assert _legacy_prefix_cache_dropped_flags(_args(), BASE_ARGV) == []
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"no_memory_aware_cache": False},
+        {"use_paged_cache": True},
+        {"disable_prefix_cache": True},
+    ],
+)
+def test_silent_when_legacy_branch_not_taken(overrides):
+    argv = [
+        "rapid-mlx",
+        "serve",
+        "m",
+        "--prefix-cache-index",
+        "hash",
+        "--hybrid-cache-entries",
+        "8",
+    ]
+    args = _args(prefix_cache_index="hash", hybrid_cache_entries=8, **overrides)
+    assert _legacy_prefix_cache_dropped_flags(args, argv) == []
+
+
+def test_serve_command_consults_the_helper_with_sys_argv():
+    """The helper is only useful if ``serve_command`` calls it against the
+    real command line; pin the call site so deleting the loop fails here."""
+    tree = ast.parse(inspect.getsource(cli.serve_command))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_legacy_prefix_cache_dropped_flags"
+    ]
+    assert len(calls) == 1
+    argv_arg = calls[0].args[1]
+    assert isinstance(argv_arg, ast.Attribute)
+    assert isinstance(argv_arg.value, ast.Name) and argv_arg.value.id == "sys"
+    assert argv_arg.attr == "argv"

--- a/tests/test_legacy_prefix_cache_flag_warnings.py
+++ b/tests/test_legacy_prefix_cache_flag_warnings.py
@@ -68,9 +68,14 @@ def test_silent_for_auto_derived_hybrid_entries():
     )
 
 
-def test_silent_for_explicit_zero_hybrid_entries():
+def test_reports_explicit_zero_hybrid_entries():
+    """Typed 0 means "retain no hybrid entries"; the memory-aware cache honours
+    that, the legacy cache keeps them under --prefix-cache-size, so it is
+    reported like any other typed value."""
     argv = BASE_ARGV + ["--hybrid-cache-entries", "0"]
-    assert _legacy_prefix_cache_dropped_flags(_args(hybrid_cache_entries=0), argv) == []
+    lines = _legacy_prefix_cache_dropped_flags(_args(hybrid_cache_entries=0), argv)
+    assert len(lines) == 1
+    assert lines[0].startswith("--hybrid-cache-entries=0 is a memory-aware cache")
 
 
 @pytest.mark.parametrize("value", ["radix", "hash"])

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2877,7 +2877,10 @@ def _legacy_prefix_cache_dropped_flags(args, argv: list[str]) -> list[str]:
 
     dropped: list[str] = []
     hybrid_entries = int(getattr(args, "hybrid_cache_entries", 0) or 0)
-    if hybrid_entries > 0 and _explicit("--hybrid-cache-entries"):
+    # An explicit 0 is a dropped expectation too: the memory-aware cache
+    # honours 0 by not retaining hybrid entries at all, the legacy cache keeps
+    # them under --prefix-cache-size regardless.
+    if _explicit("--hybrid-cache-entries"):
         dropped.append(
             f"--hybrid-cache-entries={hybrid_entries} is a memory-aware cache "
             "quota; the legacy entry-count cache keeps hybrid entries under "

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2838,6 +2838,60 @@ def _resolve_hybrid_cache_entries(
     return explicit_value
 
 
+def _legacy_prefix_cache_dropped_flags(args, argv: list[str]) -> list[str]:
+    """Return warnings for cache settings the legacy prefix cache does not apply.
+
+    Two serve flags configure the prefix-cache backend through
+    ``MemoryAwarePrefixCache``. The legacy branch of ``Scheduler.__init__``
+    builds a bare ``PrefixCacheManager(model, max_entries)`` that applies
+    neither:
+
+    * ``--hybrid-cache-entries`` bounds the live-stored, evictable
+      non-trimmable (recurrent-state) entries the memory-aware cache keeps.
+      The entry-count cache keeps such entries under the global
+      ``--prefix-cache-size`` instead, so a typed quota is silently replaced
+      by that limit. The value is not dead: the batched engine still reads it
+      as the message-boundary snapshot signal, which is why only an
+      explicitly typed request is reported and the auto-derived hybrid
+      default is left alone.
+    * ``--prefix-cache-index`` selects the memory-aware cache's lookup index
+      (``RadixPrefixIndex`` for ``radix``). The entry-count cache always uses
+      its own token trie and never constructs that index. The flag defaults
+      to ``radix``, so only a typed value is a dropped expectation.
+
+    Returns one human-readable line per dropped flag; empty when the legacy
+    branch is not taken (memory-aware or paged cache, or prefix cache off).
+    """
+    if not getattr(args, "no_memory_aware_cache", False):
+        return []
+    if getattr(args, "use_paged_cache", False):
+        return []
+    enable_prefix_cache = getattr(args, "enable_prefix_cache", False) and not getattr(
+        args, "disable_prefix_cache", False
+    )
+    if not enable_prefix_cache:
+        return []
+
+    def _explicit(flag: str) -> bool:
+        return flag in argv or any(a.startswith(f"{flag}=") for a in argv)
+
+    dropped: list[str] = []
+    hybrid_entries = int(getattr(args, "hybrid_cache_entries", 0) or 0)
+    if hybrid_entries > 0 and _explicit("--hybrid-cache-entries"):
+        dropped.append(
+            f"--hybrid-cache-entries={hybrid_entries} is a memory-aware cache "
+            "quota; the legacy entry-count cache keeps hybrid entries under "
+            f"--prefix-cache-size={getattr(args, 'prefix_cache_size', None)} instead"
+        )
+    if _explicit("--prefix-cache-index"):
+        dropped.append(
+            f"--prefix-cache-index={getattr(args, 'prefix_cache_index', None)} is not "
+            "read by the legacy entry-count cache, which always uses its own token "
+            "trie (RadixPrefixIndex is built only for the memory-aware cache)"
+        )
+    return dropped
+
+
 def _config_declares_sliding_window(config: dict | None) -> bool:
     """True if the checkpoint config declares sliding-window (local) attention.
 
@@ -4418,6 +4472,8 @@ def serve_command(args):
         model_name=getattr(args, "_original_alias", None) or args.model,
         model_config=auto_config,
     )
+    for _dropped_flag in _legacy_prefix_cache_dropped_flags(args, sys.argv):
+        print(f"  Warning: with --no-memory-aware-cache, {_dropped_flag}")
     _prefill_user_set_explicit = "--prefill-step-size" in sys.argv or any(
         a.startswith("--prefill-step-size=") for a in sys.argv
     )


### PR DESCRIPTION
> Maintainer re-submission of #3086 by @pierre427 (external contribution). Fork pull requests are ineligible for the Mergify batch queue (`-from-fork`, see docs/engineering/operations/path-aware-merge-queue.md); after Atlas review the accepted commits are brought onto this same-repository branch unchanged (contributor authorship preserved on the commits). Closes #3086.

## Why

`--hybrid-cache-entries` and `--prefix-cache-index` configure the prefix-cache backend through `MemoryAwarePrefixCache`. They are parsed, resolved and threaded into `SchedulerConfig`, and then the legacy branch of `Scheduler.__init__` (`--no-memory-aware-cache`) builds a bare `PrefixCacheManager(model, max_entries=prefix_cache_size)` that applies neither (the hybrid count is not dead elsewhere: the batched engine still reads it as the message-boundary snapshot signal). A serve that typed them under `--no-memory-aware-cache` comes up healthy, logs `Prefix cache enabled with max_entries=...`, and silently gets something else than it asked for:

- a typed hybrid quota (the bound on live-stored, evictable non-trimmable entries in the memory-aware cache) is replaced by the global `--prefix-cache-size` limit; the entry-count cache does keep recurrent-state entries and reuses shorter prefixes without trimming, it just has no separate bound for them;
- an explicit `--prefix-cache-index` never builds `RadixPrefixIndex`; the entry-count cache always uses its own token trie.

This is the silent-option class #2955 closed for the paged cache ("fail loudly rather than come up healthy" with a different configuration than requested). Confirmed on the lab's own serve script, where `--no-memory-aware-cache` had been quietly overriding a typed `--hybrid-cache-entries`.

## Scope

- `vllm_mlx/cli.py`: `_legacy_prefix_cache_dropped_flags(args, argv)` returns one line per explicitly typed flag the legacy branch will not apply (either `--flag value` or `--flag=value` spelling, the same `sys.argv` check `serve` already uses for `--hybrid-cache-entries` and `--prefill-step-size`). `serve_command` prints each as `Warning: with --no-memory-aware-cache, ...` right after the hybrid-entry resolution, before the scheduler config is built.
- `tests/test_legacy_prefix_cache_flag_warnings.py`: explicit (including a typed `0`, which the memory-aware cache honours by retaining no hybrid entries while the legacy cache keeps them under `--prefix-cache-size`), `=`-form, auto-derived, defaulted, both-flags, and not-legacy configurations; an AST test pinning that `serve_command` calls the helper with `sys.argv`; and two behavioral tests that drive the real `rapid-mlx serve` path (heavy prologue stubbed as in `tests/test_serve_listen_fd.py`) through to `uvicorn.run` and assert the warning lines are printed under `--no-memory-aware-cache` and absent under the default cache. The file is registered in the Apple CI roster so the changed-lines-coverage gate sees the print site.

## Non-goals

- Making the entry-count cache honour either flag. That would be a feature; this PR makes the substitution visible.
- Warning on defaults. `--prefix-cache-index` defaults to `radix`, and the auto-derived hybrid count (#1122) still gates message-boundary snapshots in `BatchedEngine._needs_prefix_boundary_snapshot`, so neither is a dropped expectation and neither is reported.
- The paged-cache branch (`--use-paged-cache`), which has its own capability gate (#2955), and the scheduler itself; no cache construction or default changes.

## Acceptance

- `rapid-mlx serve <model> --no-memory-aware-cache --hybrid-cache-entries 8` prints `Warning: with --no-memory-aware-cache, --hybrid-cache-entries=8 is a memory-aware cache quota; the legacy entry-count cache keeps hybrid entries under --prefix-cache-size=... instead`.
- `rapid-mlx serve <model> --no-memory-aware-cache --prefix-cache-index hash` prints `Warning: with --no-memory-aware-cache, --prefix-cache-index=hash is not read by the legacy entry-count cache, which always uses its own token trie (RadixPrefixIndex is built only for the memory-aware cache)`.
- A default serve, a `--no-memory-aware-cache` serve with no typed cache-index and no typed hybrid count (including a hybrid model whose count is auto-derived), and any paged or prefix-cache-disabled serve print nothing new. A typed `--hybrid-cache-entries 0` under `--no-memory-aware-cache` is reported: the memory-aware cache honours 0 by not retaining hybrid entries, the legacy cache retains them regardless (maintainer review follow-up).
- Deleting the call site in `serve_command` fails the AST test.

## Verification

- `ruff check` and `ruff format --check` clean on both touched files.
- `python -m pytest tests/test_legacy_prefix_cache_flag_warnings.py`: 13 passed. With the `serve_command` loop deleted, the call-site test fails (1 failed), as intended.
- Neighbouring suites over the same CLI helpers and an existing `serve_command` entry test: `tests/test_hybrid_prefix_cache_auto_default.py`, `tests/test_audio_boot_check.py`: 48 passed.
- Not run for this PR: the full suite and the model-loading steps of `pr_validate` (no Metal execution was permitted on the submitting machine during this work); `pr_validate --body-only` was run on the description.

## Behaviour delta

One or two new `Warning:` lines on the startup banner in the explicit cases above; no change to cache construction, defaults, or admission.

## AI assistance disclosure

AI-assisted throughout. The CLI helper and the tests were written by an AI coding agent (Claude) and adversarially reviewed by a second agent (Codex) in two passes before submission (the first pass corrected an over-claim about the entry-count cache's hybrid handling, which is why the warnings describe a substitution rather than a dead flag); verification is the targeted runs listed above. The diagnosis of where each flag is consumed was checked against the source by the submitter, who can explain the intent, risk and behaviour of each change.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Targeted tests pass locally (see Verification; the full suite was not run for this PR)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#> --body-only` (heavy steps left to the maintainer lane)
- [x] New tests spot-checked to fail when the corresponding production line is broken (see Verification)
- [x] No docs change needed beyond the warning text
- [x] No breaking changes to existing API



## Provenance

Commits: 
- 6f8600bcf fix(cli): report an explicitly typed --hybrid-cache-entries 0 under the legacy cache too

- 27c5bfdbd test(cli): drive serve_command end-to-end to assert dropped-flag warnings

- 421a4ce5d fix(cli): report cache flags not honoured under --no-memory-aware-cache

Co-authored-by: Pierre Lamy <pierre@userid.org>
Co-authored-by: Raullen <raullenstudio@Raullens-Mac-Studio.local>
