### PR TITLE
fix(benchmark): show host memory, model, and result summary in benchmark CLI

### DIFF
--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -2779,9 +2779,39 @@ def test_cli_results_prints_empty_hint_then_rows(
         }
     )
     assert community_cli.benchmark_command(args) == 0
-    assert "00000000-0000-4000-8000-000000000002  image_generation" in (
-        capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert (
+        "00000000-0000-4000-8000-000000000002  image_generation   failed"
+        "     2026-09-01T00:00:01Z  -\n"
+    ) in out
+
+    # The primary component wins even when an auxiliary component (e.g. a
+    # draft model) is listed first.
+    rows.append(
+        {
+            "run_id": "00000000-0000-4000-8000-000000000003",
+            "workload": {"task_type": "text_generation"},
+            "outcome": {"status": "completed"},
+            "completed_at": "2026-09-01T00:00:02Z",
+            "model": {
+                "components": [
+                    {
+                        "role": "draft",
+                        "source": {"kind": "huggingface", "repo_id": "org/draft"},
+                    },
+                    {
+                        "role": "primary",
+                        "artifact": {"path": "/models/primary"},
+                    },
+                ]
+            },
+        }
     )
+    assert community_cli.benchmark_command(args) == 0
+    out = capsys.readouterr().out
+    assert "00000000-0000-4000-8000-000000000003" in out
+    assert "  /models/primary" in out
+    assert "org/draft" not in out
 
 
 def test_cli_inspect_prints_full_json_without_flag(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -2644,9 +2644,56 @@ def test_cli_catalog_prints_focus_marker_and_run_hint(
     assert community_cli.benchmark_command(args) == 0
     out = capsys.readouterr().out
     assert "Community Benchmark models (local by default)" in out
+    assert "This Mac: 8 GB unified memory" in out
     assert "★ focus-model" in out
     assert "does not fit" in out
     assert "Run: rapid-mlx benchmark run <model>" in out
+
+
+def test_cli_catalog_defaults_memory_to_this_mac(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Without --memory-gib the fit column must come from the host probe, not
+    print "unknown" for every model (0.13.5 dogfood F1)."""
+    _cli_archive(monkeypatch, SimpleNamespace())
+    seen: dict[str, object] = {}
+
+    def fake_catalog(**kwargs):
+        seen.update(kwargs)
+        return {"models": []}
+
+    monkeypatch.setattr(community_cli, "benchmark_catalog", fake_catalog)
+    monkeypatch.setattr(community_cli, "host_memory_gib", lambda: 48)
+    args = SimpleNamespace(benchmark_action="catalog", memory_gib=None, json=False)
+
+    assert community_cli.benchmark_command(args) == 0
+    assert seen == {"memory_gib": 48}
+    assert "This Mac: 48 GB unified memory" in capsys.readouterr().out
+
+    monkeypatch.setattr(community_cli, "host_memory_gib", lambda: None)
+    assert community_cli.benchmark_command(args) == 0
+    assert seen == {"memory_gib": None}
+    assert "memory unknown; pass --memory-gib" in capsys.readouterr().out
+
+    args_json = SimpleNamespace(benchmark_action="catalog", memory_gib=None, json=True)
+    monkeypatch.setattr(community_cli, "host_memory_gib", lambda: 48)
+    assert community_cli.benchmark_command(args_json) == 0
+    assert json.loads(capsys.readouterr().out)["host_memory_gib"] == 48
+
+
+def test_host_memory_gib_degrades_to_none_when_probe_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.community_bench import hardware
+
+    monkeypatch.setattr(hardware, "_ram_gb", lambda: 256)
+    assert hardware.host_memory_gib() == 256
+
+    def boom() -> int:
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(hardware, "_ram_gb", boom)
+    assert hardware.host_memory_gib() is None
 
 
 def test_cli_plan_prints_protocol_and_local_storage(
@@ -2702,6 +2749,17 @@ def test_cli_results_prints_empty_hint_then_rows(
             "workload": {"task_type": "text_generation"},
             "outcome": {"status": "completed"},
             "completed_at": "2026-09-01T00:00:00Z",
+            "model": {
+                "components": [
+                    {
+                        "role": "primary",
+                        "source": {
+                            "kind": "huggingface",
+                            "repo_id": "mlx-community/Qwen3.5-9B-4bit",
+                        },
+                    }
+                ]
+            },
         }
     )
     assert community_cli.benchmark_command(args) == 0
@@ -2709,6 +2767,21 @@ def test_cli_results_prints_empty_hint_then_rows(
     assert "00000000-0000-4000-8000-000000000001" in out
     assert "text_generation" in out
     assert "completed" in out
+    # A run list without the model is unusable (0.13.5 dogfood F2).
+    assert "mlx-community/Qwen3.5-9B-4bit" in out
+
+    rows.append(
+        {
+            "run_id": "00000000-0000-4000-8000-000000000002",
+            "workload": {"task_type": "image_generation"},
+            "outcome": {"status": "failed"},
+            "completed_at": "2026-09-01T00:00:01Z",
+        }
+    )
+    assert community_cli.benchmark_command(args) == 0
+    assert "00000000-0000-4000-8000-000000000002  image_generation" in (
+        capsys.readouterr().out
+    )
 
 
 def test_cli_inspect_prints_full_json_without_flag(
@@ -2736,9 +2809,33 @@ def test_cli_run_prints_local_only_confirmation(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _cli_archive(monkeypatch, SimpleNamespace())
-    monkeypatch.setattr(
-        community_cli, "run_local", lambda alias, **kwargs: {"run_id": "abc-123"}
-    )
+    text_run = {
+        "run_id": "abc-123",
+        "measurements": [
+            {
+                "case_id": "pp512-tg128",
+                "completed": True,
+                "round_index": index,
+                "prompt_tokens": 512,
+                "output_tokens": 128,
+                "decode_duration_ms": decode_ms,
+                "ttft_ms": ttft_ms,
+                "total_duration_ms": decode_ms + ttft_ms,
+            }
+            for index, (decode_ms, ttft_ms) in enumerate(
+                [(1000.0, 450.0), (1280.0, 460.0), (1000.0, 470.0)], start=1
+            )
+        ]
+        + [
+            {
+                "case_id": "pp2048-tg512",
+                "completed": False,
+                "round_index": 1,
+                "failure": "timeout",
+            }
+        ],
+    }
+    monkeypatch.setattr(community_cli, "run_local", lambda alias, **kwargs: text_run)
     args = SimpleNamespace(
         benchmark_action="run",
         benchmark_model="example-text",
@@ -2749,7 +2846,36 @@ def test_cli_run_prints_local_only_confirmation(
     assert community_cli.benchmark_command(args) == 0
     out = capsys.readouterr().out
     assert "Saved local result abc-123" in out
+    # The user must see their numbers without opening the JSON (0.13.5 dogfood
+    # F3): median decode throughput and TTFT per case, completed rounds only.
+    assert "pp512-tg128" in out
+    assert "128.0 tok/s decode" in out  # median of 128, 100, 128 tok/s
+    assert "TTFT    460 ms" in out
+    assert "(3 rounds)" in out
+    assert "pp2048-tg512" not in out
     assert "Nothing was uploaded." in out
+    assert "Share it: rapid-mlx benchmark share abc-123" in out
+
+
+def test_summarize_measurements_reports_wall_time_for_image_and_video() -> None:
+    run = {
+        "measurements": [
+            {
+                "case_id": "t2i-1024-square",
+                "completed": True,
+                "round_index": 1,
+                "width": 1024,
+                "height": 1024,
+                "image_count": 1,
+                "total_duration_ms": 83653.1,
+            }
+        ]
+    }
+    assert community_cli.summarize_measurements(run) == [
+        "  t2i-1024-square    83.65 s per run   (1 rounds)"
+    ]
+    assert community_cli.summarize_measurements({"run_id": "x"}) == []
+    assert community_cli.summarize_measurements({"measurements": [{"x": 1}]}) == []
 
 
 def test_cli_failure_json_includes_saved_run_payload(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -2937,6 +2937,14 @@ def test_summarize_measurements_reports_wall_time_for_image_and_video() -> None:
     ]
     assert community_cli.summarize_measurements({"run_id": "x"}) == []
     assert community_cli.summarize_measurements({"measurements": [{"x": 1}]}) == []
+    # A completed sample that carries neither decode nor wall-time fields has
+    # nothing to summarise and is skipped rather than rendered as a blank row.
+    assert (
+        community_cli.summarize_measurements(
+            {"measurements": [{"case_id": "odd", "completed": True, "round_index": 1}]}
+        )
+        == []
+    )
 
 
 def test_cli_failure_json_includes_saved_run_payload(

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -2644,7 +2644,8 @@ def test_cli_catalog_prints_focus_marker_and_run_hint(
     assert community_cli.benchmark_command(args) == 0
     out = capsys.readouterr().out
     assert "Community Benchmark models (local by default)" in out
-    assert "This Mac: 8 GB unified memory" in out
+    assert "Fit column assumes 8 GB (--memory-gib), not this Mac's memory" in out
+    assert "This Mac:" not in out
     assert "★ focus-model" in out
     assert "does not fit" in out
     assert "Run: rapid-mlx benchmark run <model>" in out
@@ -2678,7 +2679,13 @@ def test_cli_catalog_defaults_memory_to_this_mac(
     args_json = SimpleNamespace(benchmark_action="catalog", memory_gib=None, json=True)
     monkeypatch.setattr(community_cli, "host_memory_gib", lambda: 48)
     assert community_cli.benchmark_command(args_json) == 0
-    assert json.loads(capsys.readouterr().out)["host_memory_gib"] == 48
+    payload = json.loads(capsys.readouterr().out)
+    assert (payload["memory_gib"], payload["memory_source"]) == (48, "host")
+
+    args_json.memory_gib = 8
+    assert community_cli.benchmark_command(args_json) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert (payload["memory_gib"], payload["memory_source"]) == (8, "override")
 
 
 def test_host_memory_gib_degrades_to_none_when_probe_fails(
@@ -2811,6 +2818,30 @@ def test_cli_results_prints_empty_hint_then_rows(
     out = capsys.readouterr().out
     assert "00000000-0000-4000-8000-000000000003" in out
     assert "  /models/primary" in out
+    assert "org/draft" not in out
+
+    # A primary without a usable label must not fall through to the draft.
+    rows.append(
+        {
+            "run_id": "00000000-0000-4000-8000-000000000004",
+            "workload": {"task_type": "text_generation"},
+            "outcome": {"status": "completed"},
+            "completed_at": "2026-09-01T00:00:03Z",
+            "model": {
+                "components": [
+                    {
+                        "role": "draft",
+                        "source": {"kind": "huggingface", "repo_id": "org/draft"},
+                    },
+                    {"role": "primary", "source": {"kind": "local"}},
+                ]
+            },
+        }
+    )
+    assert community_cli.benchmark_command(args) == 0
+    out = capsys.readouterr().out
+    assert "00000000-0000-4000-8000-000000000004" in out
+    assert "2026-09-01T00:00:03Z  -\n" in out
     assert "org/draft" not in out
 
 

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -36,20 +36,32 @@ def _print_json(value: Any) -> None:
 
 
 def _run_model_label(run: dict[str, Any]) -> str:
-    """Human label for an archived run: the primary component's repo id."""
+    """Human label for an archived run: the primary component's repo id.
+
+    Prefers the component whose ``role`` is ``primary`` regardless of its
+    position; falls back to the first component with a source only when no
+    component is marked primary.
+    """
 
     model = run.get("model")
     components = model.get("components") if isinstance(model, dict) else None
-    if isinstance(components, list):
-        for component in components:
-            if not isinstance(component, dict):
-                continue
-            source = component.get("source")
-            if isinstance(source, dict) and isinstance(source.get("repo_id"), str):
-                return source["repo_id"]
-            manifest = component.get("artifact")
-            if isinstance(manifest, dict) and isinstance(manifest.get("path"), str):
-                return manifest["path"]
+    if not isinstance(components, list):
+        return "-"
+    typed = [component for component in components if isinstance(component, dict)]
+    ordered = [c for c in typed if c.get("role") == "primary"] + [
+        c for c in typed if c.get("role") != "primary"
+    ]
+    for component in ordered:
+        source = component.get("source")
+        if isinstance(source, dict):
+            repo_id = source.get("repo_id")
+            if isinstance(repo_id, str):
+                return repo_id
+        manifest = component.get("artifact")
+        if isinstance(manifest, dict):
+            path = manifest.get("path")
+            if isinstance(path, str):
+                return path
     return "-"
 
 

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import json
+import statistics
 import sys
 from typing import Any
 from urllib.parse import quote
 
 from .atomic_upload import preview_run, upload_run
+from .hardware import host_memory_gib
 from .local_runner import LocalBenchmarkError, run_local
 from .workspace import LocalRunArchive, benchmark_catalog, plan_for_alias
 
@@ -31,6 +33,72 @@ def _contributor_profile(receipt: dict[str, Any]) -> tuple[str, str] | None:
 
 def _print_json(value: Any) -> None:
     print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _run_model_label(run: dict[str, Any]) -> str:
+    """Human label for an archived run: the primary component's repo id."""
+
+    model = run.get("model")
+    components = model.get("components") if isinstance(model, dict) else None
+    if isinstance(components, list):
+        for component in components:
+            if not isinstance(component, dict):
+                continue
+            source = component.get("source")
+            if isinstance(source, dict) and isinstance(source.get("repo_id"), str):
+                return source["repo_id"]
+            manifest = component.get("artifact")
+            if isinstance(manifest, dict) and isinstance(manifest.get("path"), str):
+                return manifest["path"]
+    return "-"
+
+
+def summarize_measurements(run: dict[str, Any]) -> list[str]:
+    """One line per case with the numbers a user actually wants to see.
+
+    Text cases report median decode throughput and time-to-first-token; image
+    and video cases report the median wall time. Medians over completed rounds
+    only, matching how the board aggregates. Returns ``[]`` when the run has
+    no completed measurements so callers can fall back to the raw record.
+    """
+
+    measurements = run.get("measurements")
+    if not isinstance(measurements, list):
+        return []
+    by_case: dict[str, list[dict[str, Any]]] = {}
+    for sample in measurements:
+        if not isinstance(sample, dict) or not sample.get("completed"):
+            continue
+        case_id = sample.get("case_id")
+        if isinstance(case_id, str):
+            by_case.setdefault(case_id, []).append(sample)
+    lines: list[str] = []
+    for case_id, samples in by_case.items():
+        decode = [
+            s["output_tokens"] / (s["decode_duration_ms"] / 1000.0)
+            for s in samples
+            if isinstance(s.get("output_tokens"), int | float)
+            and isinstance(s.get("decode_duration_ms"), int | float)
+            and s["decode_duration_ms"] > 0
+        ]
+        ttft = [
+            s["ttft_ms"] for s in samples if isinstance(s.get("ttft_ms"), int | float)
+        ]
+        total = [
+            s["total_duration_ms"]
+            for s in samples
+            if isinstance(s.get("total_duration_ms"), int | float)
+        ]
+        if decode:
+            line = f"  {case_id:<16} {statistics.median(decode):7.1f} tok/s decode"
+            if ttft:
+                line += f"   TTFT {statistics.median(ttft):6.0f} ms"
+        elif total:
+            line = f"  {case_id:<16} {statistics.median(total) / 1000.0:7.2f} s per run"
+        else:
+            continue
+        lines.append(f"{line}   ({len(samples)} rounds)")
+    return lines
 
 
 def _print_failure(args, exc: Exception) -> int:
@@ -64,7 +132,11 @@ def benchmark_command(args) -> int:
     archive = LocalRunArchive.default()
     try:
         if action == "catalog":
-            value = benchmark_catalog(memory_gib=args.memory_gib)
+            memory_gib = args.memory_gib
+            if memory_gib is None:
+                memory_gib = host_memory_gib()
+            value = benchmark_catalog(memory_gib=memory_gib)
+            value["host_memory_gib"] = memory_gib
         elif action == "plan":
             value = plan_for_alias(args.benchmark_model)
         elif action == "run":
@@ -126,7 +198,14 @@ def benchmark_command(args) -> int:
     if args.json:
         _print_json(value)
     elif action == "catalog":
-        print("Community Benchmark models (local by default)\n")
+        print("Community Benchmark models (local by default)")
+        memory_gib = value.get("host_memory_gib")
+        if isinstance(memory_gib, int):
+            print(f"This Mac: {memory_gib} GB unified memory (fit column below)\n")
+        else:
+            print(
+                "This Mac: memory unknown; pass --memory-gib to fill the fit column\n"
+            )
         for model in value["models"]:
             marker = "★" if model["focus"] else " "
             fit = model["memory_fit"].replace("_", " ")
@@ -147,7 +226,8 @@ def benchmark_command(args) -> int:
         for run in runs:
             print(
                 f"{run['run_id']}  {run['workload']['task_type']:<18} "
-                f"{run['outcome']['status']:<10} {run['completed_at']}"
+                f"{run['outcome']['status']:<10} {run['completed_at']}  "
+                f"{_run_model_label(run)}"
             )
     elif action == "inspect":
         _print_json(value)
@@ -172,7 +252,10 @@ def benchmark_command(args) -> int:
             print("Upload cancelled. Nothing was sent.")
     else:  # run
         print(f"Saved local result {value['run_id']}")
+        for line in summarize_measurements(value):
+            print(line)
         print("Nothing was uploaded.")
+        print(f"Share it: rapid-mlx benchmark share {value['run_id']}")
     return 0
 
 

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -38,9 +38,9 @@ def _print_json(value: Any) -> None:
 def _run_model_label(run: dict[str, Any]) -> str:
     """Human label for an archived run: the primary component's repo id.
 
-    Prefers the component whose ``role`` is ``primary`` regardless of its
-    position; falls back to the first component with a source only when no
-    component is marked primary.
+    Only primary components are considered when any is present, regardless
+    of position; other components are consulted only when no component is
+    marked primary.
     """
 
     model = run.get("model")
@@ -48,10 +48,10 @@ def _run_model_label(run: dict[str, Any]) -> str:
     if not isinstance(components, list):
         return "-"
     typed = [component for component in components if isinstance(component, dict)]
-    ordered = [c for c in typed if c.get("role") == "primary"] + [
-        c for c in typed if c.get("role") != "primary"
-    ]
-    for component in ordered:
+    primary = [c for c in typed if c.get("role") == "primary"]
+    # A primary component is authoritative: if one exists but carries no
+    # usable label, never attribute the run to an auxiliary (draft) model.
+    for component in primary or typed:
         source = component.get("source")
         if isinstance(source, dict):
             repo_id = source.get("repo_id")
@@ -145,10 +145,16 @@ def benchmark_command(args) -> int:
     try:
         if action == "catalog":
             memory_gib = args.memory_gib
+            memory_source = "override"
             if memory_gib is None:
                 memory_gib = host_memory_gib()
+                memory_source = "host"
             value = benchmark_catalog(memory_gib=memory_gib)
-            value["host_memory_gib"] = memory_gib
+            # ``memory_gib`` is what the fit column was computed against;
+            # ``memory_source`` says whether that is this Mac's probed
+            # unified memory or a planning value the user typed.
+            value["memory_gib"] = memory_gib
+            value["memory_source"] = memory_source
         elif action == "plan":
             value = plan_for_alias(args.benchmark_model)
         elif action == "run":
@@ -211,8 +217,13 @@ def benchmark_command(args) -> int:
         _print_json(value)
     elif action == "catalog":
         print("Community Benchmark models (local by default)")
-        memory_gib = value.get("host_memory_gib")
-        if isinstance(memory_gib, int):
+        memory_gib = value.get("memory_gib")
+        if isinstance(memory_gib, int) and value.get("memory_source") == "override":
+            print(
+                f"Fit column assumes {memory_gib} GB (--memory-gib), "
+                "not this Mac's memory\n"
+            )
+        elif isinstance(memory_gib, int):
             print(f"This Mac: {memory_gib} GB unified memory (fit column below)\n")
         else:
             print(

--- a/vllm_mlx/community_bench/hardware.py
+++ b/vllm_mlx/community_bench/hardware.py
@@ -126,6 +126,18 @@ def _ram_gb() -> int:
     return round(bytes_ / (1 << 30))
 
 
+def host_memory_gib() -> int | None:
+    """Best-effort unified-memory size of this Mac for planning output.
+
+    Returns ``None`` when the sysctl probe is unavailable (non-macOS, sandbox)
+    so callers can degrade to "unknown" instead of failing a read-only command.
+    """
+    try:
+        return _ram_gb()
+    except (RuntimeError, ValueError, OSError):
+        return None
+
+
 def _cpu_cores() -> int:
     """`sysctl -n hw.ncpu` → integer count."""
     return int(_run(["/usr/sbin/sysctl", "-n", "hw.ncpu"], _SYSCTL_TIMEOUT_S))


### PR DESCRIPTION
## Summary

Dogfood of the 0.13.5 candidate (Community Benchmark is the release focus) surfaced three CLI UX gaps in `rapid-mlx benchmark`. All three are output-only; no protocol, receipt, or upload behaviour changes.

- `benchmark catalog` printed `unknown` in the fit column unless the user passed `--memory-gib`. It now defaults to the host's unified memory via the existing hardware probe (degrades to `None` if the probe fails) and prints a `This Mac: N GB unified memory` header. `--json` gains `memory_gib` plus `memory_source` (`host` or `override`); an explicit `--memory-gib` prints `Fit column assumes N GB (--memory-gib)` instead of `This Mac`.
- `benchmark results` listed run ids without the model, so a user with two runs could not tell which was which. Rows now end with the primary component's `repo_id` (or artifact path, or `-`); when a primary component exists only primary components are consulted, so a draft model is never shown.
- `benchmark run` saved the run and printed only the run id; the numbers were only visible via `inspect` or the JSON. It now prints a per-case summary (median decode tok/s + median TTFT for text; wall time per run for image/video; completed rounds only) plus the exact `rapid-mlx benchmark share <run_id>` command.

## Test plan

- `pytest tests/test_community_benchmark_workspace.py tests/test_community_bench.py tests/test_cli_bench.py` (296 passed) including new tests: catalog default host memory + header + JSON field, hardware probe failure → `None`, results model column with and without a model, run summary lines (median tok/s, TTFT, rounds, skipped failed case), image wall-time summary.
- Live on M3 Ultra with the built 0.13.4 sidecar CLI: `benchmark catalog` shows `This Mac: 256 GB` and `fits`; `benchmark results` shows repo ids; `benchmark run qwen3.5-9b-4bit` prints `pp512-tg128 114.8 tok/s decode TTFT 457 ms (5 rounds)` then `Share it: ...`.