### PR TITLE
feat(suffix): opt-in hybrid scratch-verify transaction (#2561 B2.1)

### DIFF
--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -178,6 +178,9 @@ NON_ROUTING_FLAGS_ALLOWLIST: frozenset[str] = frozenset(
         "--enable-kv-cache-turboquant",
         "--enable-prefix-cache",
         "--disable-prefix-cache",
+        # Evaluation-only numerical guard override for the explicitly selected
+        # hybrid suffix feature; it does not auto-detect or select a route.
+        "--no-suffix-hybrid-bit-exact",
         # Chat-template toggle, not engine routing.
         "--no-thinking",
         # `--no-think` is a hidden back-compat alias of `--no-thinking` on

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -395,18 +395,38 @@ def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
     assert args.suffix_min_draft_len == 2
 
 
-def test_hybrid_cli_keeps_default_cap_for_pure_attention() -> None:
-    """The CLI must NOT raise ``suffix_max_draft`` when ``--suffix-hybrid`` is
-    set: the hybrid width raise is gated on an actual hybrid model in the
-    installer, so a pure-attention model (where the flag is a no-op) keeps the
-    normal 8-token default instead of silently tripling its verify width."""
+def test_hybrid_below_floor_cap_fails_fast(capsys) -> None:
+    """``--suffix-hybrid`` with a below-floor ``--suffix-max-draft`` is a
+    contradictory config: either the hybrid feature is a silent no-op or the
+    max-width limit is silently violated. Fail fast with an actionable error
+    naming the flag to raise (no silent override, no pure-attention leak)."""
+    import pytest
+
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
         suffix_decoding=True, suffix_hybrid=True, suffix_min_match_len=24
     )
+    with pytest.raises(SystemExit) as excinfo:
+        _normalize_speculative_config_or_exit(args)
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "--suffix-hybrid requires --suffix-max-draft" in err
+    assert "suffix_max_draft=8" in err
+
+
+def test_hybrid_at_floor_cap_ok() -> None:
+    """``--suffix-hybrid`` with ``--suffix-max-draft >= floor`` validates."""
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        suffix_decoding=True,
+        suffix_hybrid=True,
+        suffix_min_match_len=24,
+        suffix_max_draft=24,
+    )
     _normalize_speculative_config_or_exit(args)
-    assert args.suffix_max_draft == 8
+    assert args.suffix_max_draft == 24
 
 
 def test_no_speculative_config_preserves_programmatic_runtime_fields() -> None:

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -395,38 +395,89 @@ def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
     assert args.suffix_min_draft_len == 2
 
 
-def test_hybrid_below_floor_cap_fails_fast(capsys) -> None:
-    """``--suffix-hybrid`` with a below-floor ``--suffix-max-draft`` is a
-    contradictory config: either the hybrid feature is a silent no-op or the
-    max-width limit is silently violated. Fail fast with an actionable error
-    naming the flag to raise (no silent override, no pure-attention leak)."""
-    import pytest
+def test_hybrid_default_cap_raises_to_floor_only_for_confirmed_hybrid() -> None:
+    """The hybrid cap-raise is DEFERRED to model resolution (the CLI cannot
+    know the model is hybrid until the ``serve`` profile resolves). A
+    CONFIRMED hybrid model + ``--suffix-hybrid`` + no explicit cap gets its
+    effective width raised to the 24-token match floor so the opt-in works out
+    of the box; an explicit below-floor cap (the operator's bound), a
+    pure-attention model (where ``--suffix-hybrid`` is a no-op flag), and the
+    non-hybrid flag are all unchanged."""
+    from types import SimpleNamespace
 
+    from vllm_mlx.cli import _hybrid_suffix_cap
+    from vllm_mlx.model_profile import ModelProfile
+
+    def _args(**overrides):
+        base = _spec_config_args(
+            suffix_decoding=True,
+            suffix_hybrid=True,
+            suffix_min_match_len=24,
+            suffix_max_draft=8,
+            _suffix_max_draft_was_explicit=False,
+        )
+        for k, v in overrides.items():
+            setattr(base, k, v)
+        return base
+
+    hybrid = SimpleNamespace(is_hybrid=True)
+    pure = SimpleNamespace(is_hybrid=False)
+    # (a) Default cap (8), confirmed hybrid, no explicit cap → raised to floor.
+    assert _hybrid_suffix_cap(_args(), hybrid) == 24
+    # (b) Cap already at the floor → unchanged.
+    assert (
+        _hybrid_suffix_cap(
+            _args(suffix_max_draft=24, _suffix_max_draft_was_explicit=True), hybrid
+        )
+        == 24
+    )
+    # (c) EXPLICIT below-floor cap (operator's bound) → honored as-is.
+    assert (
+        _hybrid_suffix_cap(
+            _args(suffix_max_draft=8, _suffix_max_draft_was_explicit=True), hybrid
+        )
+        == 8
+    )
+    # (d) Confirmed hybrid but flag OFF → unchanged (default 8).
+    assert _hybrid_suffix_cap(_args(suffix_hybrid=False), hybrid) == 8
+    # (e) Pure-attention model + --suffix-hybrid (a no-op flag there) → kept.
+    assert _hybrid_suffix_cap(_args(), pure) == 8
+    # (f) AliasProfile parity: the attribute the serve path reads is
+    # ``is_hybrid`` on the resolved profile — verify the helper reads it via
+    # getattr so a real ModelProfile object behaves identically.
+    assert (
+        _hybrid_suffix_cap(
+            _args(), ModelProfile(is_hybrid=True, hf_path="x/y")
+        )
+        == 24
+    )
+
+
+def test_hybrid_does_not_fail_fast_on_defaults() -> None:
+    """``--suffix-hybrid`` with only default knobs must NOT fail fast — the
+    below-floor cap is deferred to model resolution, and the normalizer merely
+    records whether ``--suffix-max-draft`` was explicit (the default 8 is the
+    pure-attention width, valid on its own)."""
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
         suffix_decoding=True, suffix_hybrid=True, suffix_min_match_len=24
     )
-    with pytest.raises(SystemExit) as excinfo:
-        _normalize_speculative_config_or_exit(args)
-    assert excinfo.value.code == 2
-    err = capsys.readouterr().err
-    assert "--suffix-hybrid requires --suffix-max-draft" in err
-    assert "suffix_max_draft=8" in err
+    _normalize_speculative_config_or_exit(args)
+    # Default cap filled, flagged as NOT explicit.
+    assert args.suffix_max_draft == 8
+    assert args._suffix_max_draft_was_explicit is False
 
-
-def test_hybrid_at_floor_cap_ok() -> None:
-    """``--suffix-hybrid`` with ``--suffix-max-draft >= floor`` validates."""
-    from vllm_mlx.cli import _normalize_speculative_config_or_exit
-
-    args = _spec_config_args(
+    # An explicit cap keeps the sentinel set so the hybrid raise applies.
+    explicit = _spec_config_args(
         suffix_decoding=True,
         suffix_hybrid=True,
         suffix_min_match_len=24,
         suffix_max_draft=24,
     )
-    _normalize_speculative_config_or_exit(args)
-    assert args.suffix_max_draft == 24
+    _normalize_speculative_config_or_exit(explicit)
+    assert explicit.suffix_max_draft == 24
+    assert explicit._suffix_max_draft_was_explicit is True
 
 
 def test_no_speculative_config_preserves_programmatic_runtime_fields() -> None:

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -446,10 +446,7 @@ def test_hybrid_default_cap_raises_to_floor_only_for_confirmed_hybrid() -> None:
     # ``is_hybrid`` on the resolved profile — verify the helper reads it via
     # getattr so a real ModelProfile object behaves identically.
     assert (
-        _hybrid_suffix_cap(
-            _args(), ModelProfile(is_hybrid=True, hf_path="x/y")
-        )
-        == 24
+        _hybrid_suffix_cap(_args(), ModelProfile(is_hybrid=True, hf_path="x/y")) == 24
     )
 
 

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -453,22 +453,43 @@ def test_hybrid_default_cap_raises_to_floor_only_for_confirmed_hybrid() -> None:
     )
 
 
-def test_hybrid_does_not_fail_fast_on_defaults() -> None:
+def test_hybrid_normalizer_fills_cap_and_sentinel() -> None:
     """``--suffix-hybrid`` with only default knobs must NOT fail fast — the
     below-floor cap is deferred to model resolution, and the normalizer merely
     records whether ``--suffix-max-draft`` was explicit (the default 8 is the
-    pure-attention width, valid on its own)."""
+    pure-attention width, valid on its own).
+
+    The sentinel is initialized ONLY when absent (``hasattr`` guard) so it
+    survives repeated normalization: a defaulted cap must stay "implicit" (so
+    ``_hybrid_suffix_cap`` can still raise it to the floor), not flip to
+    "explicit" merely because a later call sees the filled-in 8."""
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
         suffix_decoding=True, suffix_hybrid=True, suffix_min_match_len=24
     )
     _normalize_speculative_config_or_exit(args)
-    # Default cap filled, flagged as NOT explicit.
+    # Default cap filled, flagged as NOT explicit (so the hybrid path can
+    # still raise it to the floor at model resolution).
     assert args.suffix_max_draft == 8
     assert args._suffix_max_draft_was_explicit is False
 
     # An explicit cap keeps the sentinel set so the hybrid raise applies.
+    # Pre-setting the sentinel exercises the ``hasattr`` guard branch: a
+    # pre-existing sentinel is preserved, never recomputed from the cap field
+    # (which has been filled to 8 by the default-fill). This is what allows a
+    # programmatic/pre-normalized args to stay "implicit" across reuse.
+    pre_set = _spec_config_args(
+        suffix_decoding=True,
+        suffix_hybrid=True,
+        suffix_min_match_len=24,
+        suffix_max_draft=8,
+    )
+    pre_set._suffix_max_draft_was_explicit = False
+    _normalize_speculative_config_or_exit(pre_set)
+    assert pre_set.suffix_max_draft == 8
+    assert pre_set._suffix_max_draft_was_explicit is False
+
     explicit = _spec_config_args(
         suffix_decoding=True,
         suffix_hybrid=True,

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -395,29 +395,15 @@ def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
     assert args.suffix_min_draft_len == 2
 
 
-def test_hybrid_default_raises_draft_cap_to_floor() -> None:
-    """``--suffix-hybrid`` alone must default the draft cap to the 24-token
-    match floor (the pure-attention default 8 would make the hybrid opt-in a
-    no-op, since no draft could clear the floor)."""
+def test_hybrid_cli_keeps_default_cap_for_pure_attention() -> None:
+    """The CLI must NOT raise ``suffix_max_draft`` when ``--suffix-hybrid`` is
+    set: the hybrid width raise is gated on an actual hybrid model in the
+    installer, so a pure-attention model (where the flag is a no-op) keeps the
+    normal 8-token default instead of silently tripling its verify width."""
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 
     args = _spec_config_args(
         suffix_decoding=True, suffix_hybrid=True, suffix_min_match_len=24
-    )
-    _normalize_speculative_config_or_exit(args)
-    assert args.suffix_max_draft == 24
-
-
-def test_hybrid_explicit_below_floor_cap_is_preserved() -> None:
-    """An EXPLICIT below-floor ``--suffix-max-draft`` is the operator's bound
-    and wins over the hybrid default raise."""
-    from vllm_mlx.cli import _normalize_speculative_config_or_exit
-
-    args = _spec_config_args(
-        suffix_decoding=True,
-        suffix_hybrid=True,
-        suffix_min_match_len=24,
-        suffix_max_draft=8,
     )
     _normalize_speculative_config_or_exit(args)
     assert args.suffix_max_draft == 8

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -497,6 +497,24 @@ def test_hybrid_normalizer_fills_cap_and_sentinel() -> None:
     assert explicit.suffix_max_draft == 24
     assert explicit._suffix_max_draft_was_explicit is True
 
+    # Codex round-9l NIT: the sentinel records EXPLICIT intent independently of
+    # the current cap value, and the default-fill must only ever apply to a
+    # still-None cap. A programmatic caller that pre-set the sentinel to False
+    # (i.e. a prior normalize recorded the RUN-TIME default as implicit) and
+    # then set a NON-default cap of 16 must keep 16 — the pre-fix code re-set
+    # it to 8 on every normalize because it keyed the fill on the (False)
+    # sentinel rather than on ``suffix_max_draft is None``.
+    prog = _spec_config_args(
+        suffix_decoding=True,
+        suffix_hybrid=True,
+        suffix_min_match_len=24,
+        suffix_max_draft=16,  # programmatic override, set after prior normalize
+    )
+    prog._suffix_max_draft_was_explicit = False  # intent: run-time default
+    _normalize_speculative_config_or_exit(prog)
+    assert prog.suffix_max_draft == 16  # NOT clobbered back to 8
+    assert prog._suffix_max_draft_was_explicit is False  # intent unchanged
+
 
 def test_no_speculative_config_preserves_programmatic_runtime_fields() -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit

--- a/tests/test_speculative_config.py
+++ b/tests/test_speculative_config.py
@@ -395,6 +395,34 @@ def test_no_speculative_config_fills_suffix_runtime_defaults() -> None:
     assert args.suffix_min_draft_len == 2
 
 
+def test_hybrid_default_raises_draft_cap_to_floor() -> None:
+    """``--suffix-hybrid`` alone must default the draft cap to the 24-token
+    match floor (the pure-attention default 8 would make the hybrid opt-in a
+    no-op, since no draft could clear the floor)."""
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        suffix_decoding=True, suffix_hybrid=True, suffix_min_match_len=24
+    )
+    _normalize_speculative_config_or_exit(args)
+    assert args.suffix_max_draft == 24
+
+
+def test_hybrid_explicit_below_floor_cap_is_preserved() -> None:
+    """An EXPLICIT below-floor ``--suffix-max-draft`` is the operator's bound
+    and wins over the hybrid default raise."""
+    from vllm_mlx.cli import _normalize_speculative_config_or_exit
+
+    args = _spec_config_args(
+        suffix_decoding=True,
+        suffix_hybrid=True,
+        suffix_min_match_len=24,
+        suffix_max_draft=8,
+    )
+    _normalize_speculative_config_or_exit(args)
+    assert args.suffix_max_draft == 8
+
+
 def test_no_speculative_config_preserves_programmatic_runtime_fields() -> None:
     from vllm_mlx.cli import _normalize_speculative_config_or_exit
 

--- a/tests/test_suffix_decoding.py
+++ b/tests/test_suffix_decoding.py
@@ -86,31 +86,44 @@ class TestDrafterBasics:
         # ourselves is forbidden, so no draft.
         assert drafter.get_draft() == []
 
-    def test_rewind_to_restores_history_and_drafts(self):
+    def test_snapshot_restore_restores_history_and_drafts(self):
         # The scheduler's post-commit rollback undoes accepted-draft
-        # add_generated_token calls via rewind_to(len_before). Rewinding must
-        # restore the exact pre-add history so the proposed draft is unchanged.
+        # add_generated_token calls via snapshot_state/restore_state. Restoring
+        # must reproduce the exact pre-add history so the proposed draft is
+        # unchanged.
         drafter = SuffixDecodingDrafter(max_draft_tokens=4, max_suffix_len=4)
         drafter.add_prompt_tokens([1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2])
-        lens_before = len(drafter._tokens)
+        snap = drafter.snapshot_state()
         draft_before = drafter.get_draft()
         drafter.add_generated_token(3)
         drafter.add_generated_token(4)
         drafter.add_generated_token(5)
-        assert len(drafter._tokens) == lens_before + 3
-        drafter.rewind_to(lens_before)
-        assert len(drafter._tokens) == lens_before
+        drafter.restore_state(snap)
         # History identical -> identical draft (the rollback must be lossless).
         assert drafter.get_draft() == draft_before
 
-    def test_rewind_to_noop_at_boundary(self):
-        drafter = SuffixDecodingDrafter(max_draft_tokens=4, max_suffix_len=2)
-        drafter.add_prompt_tokens([1, 2, 3])
-        n = len(drafter._tokens)
-        drafter.rewind_to(n)  # no-op
-        assert len(drafter._tokens) == n
-        drafter.rewind_to(n + 99)  # clamp to existing length, still no-op
-        assert len(drafter._tokens) == n
+    def test_snapshot_restore_survives_max_history_head_trim(self):
+        # Codex round-9k finding #1: appending can cross max_history and trim the
+        # HEAD (evicting tokens + advancing _shift) while keeping the length
+        # unchanged. A length-based rewind can't recover that; snapshot/restore
+        # must reproduce the exact pre-add history (incl. _shift) even after a
+        # trim crossed the boundary.
+        drafter = SuffixDecodingDrafter(
+            max_draft_tokens=4, max_suffix_len=2, max_history=6
+        )
+        drafter.add_prompt_tokens([1, 2, 3, 4, 5])  # 5 tokens, shift 0
+        snap = drafter.snapshot_state()
+        draft_before = drafter.get_draft()
+        # Add several tokens so the head trims (len stays <= max_history, but
+        # _shift advances and old history is evicted).
+        for t in [8, 9, 8, 9]:
+            drafter.add_generated_token(t)
+        # Sanity: a trim actually happened (shift advanced past 0).
+        assert drafter._shift > 0, "test must actually cross the trim boundary"
+        drafter.restore_state(snap)
+        # Restored _shift + tokens -> the index is exactly the pre-add state.
+        assert drafter._shift == 0
+        assert drafter.get_draft() == draft_before
 
 
 class TestHistoryTrimming:

--- a/tests/test_suffix_decoding.py
+++ b/tests/test_suffix_decoding.py
@@ -86,6 +86,32 @@ class TestDrafterBasics:
         # ourselves is forbidden, so no draft.
         assert drafter.get_draft() == []
 
+    def test_rewind_to_restores_history_and_drafts(self):
+        # The scheduler's post-commit rollback undoes accepted-draft
+        # add_generated_token calls via rewind_to(len_before). Rewinding must
+        # restore the exact pre-add history so the proposed draft is unchanged.
+        drafter = SuffixDecodingDrafter(max_draft_tokens=4, max_suffix_len=4)
+        drafter.add_prompt_tokens([1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2])
+        lens_before = len(drafter._tokens)
+        draft_before = drafter.get_draft()
+        drafter.add_generated_token(3)
+        drafter.add_generated_token(4)
+        drafter.add_generated_token(5)
+        assert len(drafter._tokens) == lens_before + 3
+        drafter.rewind_to(lens_before)
+        assert len(drafter._tokens) == lens_before
+        # History identical -> identical draft (the rollback must be lossless).
+        assert drafter.get_draft() == draft_before
+
+    def test_rewind_to_noop_at_boundary(self):
+        drafter = SuffixDecodingDrafter(max_draft_tokens=4, max_suffix_len=2)
+        drafter.add_prompt_tokens([1, 2, 3])
+        n = len(drafter._tokens)
+        drafter.rewind_to(n)  # no-op
+        assert len(drafter._tokens) == n
+        drafter.rewind_to(n + 99)  # clamp to existing length, still no-op
+        assert len(drafter._tokens) == n
+
 
 class TestHistoryTrimming:
     def test_trim_preserves_recent_lookups(self):

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -140,7 +140,10 @@ class TestScratchVerifyCore:
         x = 4
         d0 = _next_step(x)  # greedy next after [1,2,3,4] -> accepted at pos 0
         g1 = _next_step(d0)  # greedy next after [1,2,3,4,d0]
-        d1 = g1 + 1  # guaranteed rejected at position 1
+        # A guarantee-rejected token: the model's greedy choice plus one,
+        # wrapped within the vocabulary so ``g1 == last_vocab_id`` cannot
+        # produce an out-of-range token that breaks the embedding lookup.
+        d1 = (g1 + 1) % 32  # guaranteed rejected at position 1
 
         live = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=live))
@@ -165,7 +168,7 @@ class TestScratchVerifyCore:
         vlog = model(mx.array([[4, 5, 6]]), cache=probe)
         mx.eval(vlog)
         preds = mx.argmax(vlog, axis=-1).tolist()[0]
-        d0 = preds[0] + 1  # guaranteed rejected at position 0
+        d0 = (preds[0] + 1) % 32  # guaranteed rejected at position 0
         d1 = preds[1]
 
         before = model.make_cache()
@@ -248,6 +251,49 @@ class TestHybridInstallGate:
         assert bg._suffix_stats["suffix_hybrid"] is True
         assert bg._suffix_stats["suffix_min_match_len"] == 24
 
+    def test_hybrid_drafter_cap_raised_to_floor(self, monkeypatch):
+        """Finding: the hybrid path must construct the drafter with
+        ``_effective_max_draft`` (>= the 24-token floor), or drafts stay capped
+        below the floor and every repeat falls through ``ft_short_match`` —
+        making the opt-in hybrid path dead on a default install."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+
+        # A real drafter (not a stub) so we check the actual constructed cap.
+        bg, gb = self._make_fake_bg()
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        assert scheduler._install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=profile,
+            max_draft=8,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+        )
+        # Force first-_step by feeding a synthetic uid + token via gb.
+        gb._next_tokens = mx.array([1], dtype=mx.int32)
+        gb._num_tokens = [0]
+        gb.max_tokens = [100]
+        gb.uids = [1]
+        gb.tokens = [[]]
+        gb.state_machines = [SimpleNamespace(match=lambda s, _t: (s, None, None))]
+        gb._matcher_states = [None]
+        gb.logits_processors = []
+        gb.model = MagicMock()
+        gb._orig_step = lambda: ([1], [])
+        # uid 1 has no drafter yet -> lazy-init constructs one this step.
+        gb._step()
+        drafter = gb._suffix_drafters[1]
+        # Effective max draft must be at least the 24-token floor (raised from
+        # the configured default 8 on the hybrid path).
+        assert drafter.max_draft_tokens >= 24
+
     def test_installed_reject_first_commits_primary(self, monkeypatch):
         """Installed-path reject-first verify: the live cache must equal
         prompt + X after ``gb._step()``.
@@ -274,8 +320,8 @@ class TestHybridInstallGate:
         mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
         l0 = model(mx.array([[7]]), cache=probe)
         mx.eval(l0)
-        d0 = int(mx.argmax(l0[:, -1], axis=-1).item()) + 1  # rejected
-        d1 = d0 + 1
+        d0 = (int(mx.argmax(l0[:, -1], axis=-1).item()) + 1) % 32  # rejected
+        d1 = (d0 + 1) % 32
         draft = [d0, d1]
 
         class Drafter:
@@ -540,9 +586,9 @@ class TestTokenIdentityAndStateEquality:
         # A draft whose token 0 is guaranteed rejected (probe on a copy).
         probe = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
-        d0 = self._stepwise_next(model, probe, 7) + 1
-        verify_input = mx.array([[7, d0, d0 + 1]])
-        draft = [d0, d0 + 1]
+        d0 = (self._stepwise_next(model, probe, 7) + 1) % 32
+        verify_input = mx.array([[7, d0, (d0 + 1) % 32]])
+        draft = [d0, (d0 + 1) % 32]
         commit_head = copy.deepcopy(cache)
         res = _verify_scratch(model, cache, verify_input, draft, commit_head)
         assert res["n_accepted"] == 0
@@ -564,8 +610,8 @@ class TestTokenIdentityAndStateEquality:
         probe = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
         d0 = self._stepwise_next(model, probe, 7)
-        verify_input = mx.array([[7, d0, d0 + 1]])
-        draft = [d0, d0 + 1]
+        verify_input = mx.array([[7, d0, (d0 + 1) % 32]])
+        draft = [d0, (d0 + 1) % 32]
         commit_head = copy.deepcopy(cache)
         res = _verify_scratch(model, cache, verify_input, draft, commit_head)
         na = res["n_accepted"]
@@ -1232,3 +1278,118 @@ class TestSingleSnapshotCommit:
         calls, bg = self._install_and_step(monkeypatch, guard_on=False)
         # Guard off -> no probe -> stepwise commit helper replays once.
         assert calls["commit"] == 1
+
+
+class TestHybridTerminalRepair:
+    """Finding #1: a hybrid finish part-way through the accepted drafts must
+    drop the un-surfaced accepted tail from the delivered response cache.
+
+    On the pure-attention path the terminal branch trims un-surfaced accepted
+    drafts via ``trim_all``. The Qwen4 recurrent cache cannot trim a rejected
+    tail (the whole reason B2.1 uses scratch+replay instead of trim_all), so a
+    hybrid terminal must instead rebuild the response cache from the retained
+    pristine pre-verify snapshot plus ONLY the surfaced tokens — dropping the
+    tail by never replaying it. This mirrors the DSpark ``_pending_replay``
+    terminal-repair pattern and prevents a poisoned (cache-ahead-of-tokens)
+    saved prefix from poisoning prefix-cache reuse for the next request.
+    """
+
+    def test_hybrid_terminal_drops_unsurfaced_accepted_tail(self, monkeypatch):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        # Greedy accept-all draft of 2 tokens (step-exact -> no drift).
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
+
+        drafter = [[d0, d1]]
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return list(drafter[0])
+
+        cache = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+        # max_tokens=1 forces a length-finish after the FIRST synthetic draft
+        # (X), leaving the second accepted draft (d1) un-surfaced.
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=cache,
+            _num_tokens=[0],
+            max_tokens=[1],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: gb.prompt_cache,
+            filter=lambda keep: setattr(gb, "uids", list(keep)),
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        # Baseline ``_step``/``next`` placeholders (install wraps them).
+        gb._step = lambda: ([7], [])
+        # ``_orig_next`` returns the primary response (X, not yet finished);
+        # the terminal fires later while draining the synthetic emits.
+        gb.next = lambda: [SimpleNamespace(uid=1, finish_reason=None)]
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+
+        gb._step()  # hybrid verify: X + d0 accepted, d1 accepted too
+        # The verify committed prompt+[7,d0,d1]; pending emits = [d0, d1].
+        # A length-terminal fires when emitting d0 (emit_idx 0 -> unused 1).
+        outs = gb.next()
+        # The finishing response's cache must equal prompt + [7, d0] only —
+        # d1 was never surfaced and must be dropped.
+        finish = [o for o in outs if o.finish_reason is not None]
+        assert len(finish) == 1
+        delivered = finish[0].prompt_cache
+        # ``delivered`` is the repaired cache list (per-layer cells) built by
+        # the terminal-repair branch. Build the step-replayed gold cache list.
+        gold = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
+        mx.eval(model(mx.array([[7]]), cache=gold))
+        mx.eval(model(mx.array([[d0]]), cache=gold))
+        _assert_state_equal(delivered, gold)

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -213,6 +213,7 @@ class TestHybridInstallGate:
         from vllm_mlx.scheduler import _install_suffix_decoding
 
         bg, gb = self._make_fake_bg()
+        orig_step = gb._step
         profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
         assert not _install_suffix_decoding(
             bg,
@@ -224,7 +225,7 @@ class TestHybridInstallGate:
             requests={},
             uid_to_request_id={},
         )
-        assert gb._step is not None  # old step preserved
+        assert gb._step is orig_step  # skipped install leaves the step untouched
 
     def test_hybrid_profile_with_optin_installs(self):
         from unittest.mock import MagicMock
@@ -380,11 +381,14 @@ class TestHybridInstallGate:
         )
         result = gb._step()
         assert result[0] == [7]
-        # Live cache must equal prompt + [7] (X committed despite reject).
+        # Live cache (now ``gb.prompt_cache`` — the guard-on commit path SWAPS
+        # in the probe head by rebinding, leaving the original pristine list as
+        # the retained replay snapshot) must equal prompt + [7] (X committed
+        # despite reject).
         gold = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
         mx.eval(model(mx.array([[7]]), cache=gold))
-        _assert_state_equal(cache, gold)
+        _assert_state_equal(gb.prompt_cache, gold)
 
     def test_pure_attention_optin_ignored(self):
         """suffix_hybrid on a pure-attention model is a no-op (not a raised error)."""

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -34,6 +34,7 @@ from vllm_mlx.models.qwen4_exp_cache import (  # noqa: E402
     Qwen4ExpStateCache,
 )
 from vllm_mlx.scheduler import (  # noqa: E402
+    SchedulerConfig,
     _commit_scratch_accepted,
     _verify_scratch,
 )
@@ -87,32 +88,36 @@ class TestScratchVerifyCore:
         import copy
 
         model, cache = _model_and_prompt()
-        # gold: commit [4,5] stepwise
-        gold = model.make_cache()
-        mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
-        for t in ([4], [5]):
-            mx.eval(model(mx.array([t]), cache=gold))
-
-        draft = [5, 6]
-        commit_head = copy.deepcopy(cache)
-        result = _verify_scratch(
-            model, cache, mx.array([[4, 5, 6]]), draft, commit_head
-        )
-        # Accept-all only if both draft tokens match greedy. Probe first.
+        # Build the draft FROM the model's actual stepwise greedy predictions,
+        # so both draft tokens are guaranteed to match the verify and accept
+        # UNCONDITIONALLY (no ``if``-gated assertion). Probe on a THROWAWAY
+        # copy so the live ``cache`` is not advanced by the probe.
         probe = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
-        vlog = model(mx.array([[4, 5, 6]]), cache=probe)
-        mx.eval(vlog)
-        preds = mx.argmax(vlog, axis=-1).tolist()[0]
-        if preds[0] == 5 and preds[1] == 6:
-            assert result["n_accepted"] == 2
+
+        def _next_step(tok):
+            logits = model(mx.array([[tok]]), cache=probe)
+            mx.eval(logits)
+            return int(mx.argmax(logits[:, -1], axis=-1).item())
+
+        x = 4
+        d0 = _next_step(x)  # greedy next after [1,2,3,4]
+        d1 = _next_step(d0)  # greedy next after [1,2,3,4,d0]
+
+        draft = [d0, d1]
+        verify_input = mx.array([[x, d0, d1]])
+        commit_head = copy.deepcopy(cache)
+        result = _verify_scratch(model, cache, verify_input, draft, commit_head)
+        # Both draft tokens are the model's greedy stepwise predictions, so
+        # the chunked verify MUST accept both — assert it unconditionally.
+        assert result["n_accepted"] == 2
         # Commit accepted (whatever it is) and compare to the stepwise gold
-        # of THAT same accepted prefix: gold = prompt + committed [4,5,..].
+        # of THAT same accepted prefix: gold = prompt + committed [x, d0].
         na = result["n_accepted"]
-        _commit_scratch_accepted(model, cache, mx.array([[4, 5, 6]]), na)
+        _commit_scratch_accepted(model, cache, verify_input, na)
         g2 = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=g2))
-        for t in ([4], [5], [6])[: na + 1]:
+        for t in ([x], [d0], [d1])[: na + 1]:
             mx.eval(model(mx.array([t]), cache=g2))
         _assert_state_equal(cache, g2)
 
@@ -120,20 +125,27 @@ class TestScratchVerifyCore:
         import copy
 
         model, _cache = _model_and_prompt()
-        # Probe the verify predictions to choose a draft whose token 0 is
-        # accepted and token 1 is rejected.
+        # Build a draft with token 0 accepted and token 1 rejected
+        # UNCONDITIONALLY, from the model's ACTUAL greedy predictions (not a
+        # guess): d0 = greedy next after X; d1 = (greedy next after d0) + 1,
+        # which is guaranteed to mismatch the position-1 pred.
         probe = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
-        vlog = model(mx.array([[4, 5, 6]]), cache=probe)
-        mx.eval(vlog)
-        preds = mx.argmax(vlog, axis=-1).tolist()[0]
-        d0 = preds[0]  # accepted at position 0
-        d1 = (preds[1] + 1) % 100  # rejected at position 1
+
+        def _next_step(tok):
+            logits = model(mx.array([[tok]]), cache=probe)
+            mx.eval(logits)
+            return int(mx.argmax(logits[:, -1], axis=-1).item())
+
+        x = 4
+        d0 = _next_step(x)  # greedy next after [1,2,3,4] -> accepted at pos 0
+        g1 = _next_step(d0)  # greedy next after [1,2,3,4,d0]
+        d1 = g1 + 1  # guaranteed rejected at position 1
 
         live = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=live))
         commit_head = copy.deepcopy(live)
-        verify_input = mx.array([[4, d0, d1]])
+        verify_input = mx.array([[x, d0, d1]])
         result = _verify_scratch(model, live, verify_input, [d0, d1], commit_head)
         assert result["n_accepted"] == 1
         _commit_scratch_accepted(model, live, verify_input, 1)
@@ -853,3 +865,370 @@ class TestBitExactnessGuard:
         assert bg._suffix_stats["hybrid_drifts"] == 1
         assert bg._suffix_stats["ft_hybrid_drift"] == 1
         assert result[0] == [7]
+
+
+class TestBitExactDefault:
+    """The bit-exactness guard is DEFAULT ON (finding #1: hybrid is only
+    lossless when the drift guard is on). Disabling is a non-lossless/unsafe
+    mode for eval only."""
+
+    def test_scheduler_config_defaults_guard_on(self):
+        assert SchedulerConfig().suffix_hybrid_bit_exact is True
+
+    def test_install_default_arg_guard_on(self, monkeypatch):
+        """A hybrid install WITHOUT passing ``suffix_hybrid_bit_exact`` must
+        default the bit-exactness guard ON — the drift path is armed by
+        default, not the lossless-bypassing fast path.
+
+        Behaviorally: a model whose chunked verify drifts from stepwise must
+        be refused (hybrid_drifts == 1) even though the caller never passed
+        ``suffix_hybrid_bit_exact=True``. This is exactly
+        ``TestBitExactnessGuard.test_guard_refuses_on_drift`` minus the
+        explicit True flag."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        import mlx.core as mx
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        class DriftingModel:
+            def __call__(self, tokens, cache=None, **kw):
+                L = tokens.shape[1]
+                if L > 1:  # chunked verify forward
+                    logits = mx.full((1, L, 8), -10.0)
+                    for i in range(L):
+                        logits[0, i, 5] = 10.0
+                    return logits
+                logits = mx.full((1, 1, 8), -10.0)
+                logits[0, 0, 6] = 10.0  # stepwise differs -> drift
+                return logits
+
+        cache = [SimpleNamespace(offset=0, max_size=100, size=lambda: 0)]
+
+        class Drafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [5, 5]
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((8,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=cache,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=DriftingModel(),
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", Drafter)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=gb.model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            # NOTE: suffix_hybrid_bit_exact intentionally omitted -> must be True.
+        )
+        result = gb._step()
+        # Guard armed by default: drift is refused even without the flag.
+        assert bg._suffix_stats["hybrid_drifts"] == 1
+        assert bg._suffix_stats["ft_hybrid_drift"] == 1
+        assert result[0] == [7]
+
+    def test_default_guard_misfire_free_on_step_exact_model(self, monkeypatch):
+        """With the guard now default-on, the real step-exact tiny hybrid must
+        still accept fully (no spurious drift) — mirrors
+        ``TestBitExactnessGuard.test_guard_does_not_misfire_on_step_exact_model``
+        but WITHOUT passing ``suffix_hybrid_bit_exact=True``."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
+        greedy_draft = [d0, d1]
+
+        drafter = [greedy_draft]
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return list(drafter[0])
+
+        cache = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=cache,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+        )
+        result = gb._step()
+        assert result[0] == [7]
+        assert bg._suffix_stats["hybrid_drifts"] == 0
+        assert bg._suffix_stats["verify_steps"] == 1
+
+
+class TestHybridCLI:
+    """CLI-level wiring: bit-exact default ON + positive integer validation."""
+
+    @staticmethod
+    def _parse(argv):
+        import sys
+        from unittest import mock
+
+        from vllm_mlx import cli
+
+        captured = {}
+
+        def _capture(args):
+            captured["args"] = args
+
+        with (
+            mock.patch.object(cli, "serve_command", _capture),
+            mock.patch.object(sys, "argv", ["rapid-mlx", *argv]),
+        ):
+            cli.main()
+        assert "args" in captured
+        args = captured["args"]
+        cli._normalize_speculative_config_or_exit(args)
+        return args
+
+    def test_cli_default_guard_on(self):
+        args = self._parse(["serve", "qwen3-1.7b", "--suffix-hybrid"])
+        assert args.suffix_hybrid_bit_exact is True
+        assert args.suffix_min_match_len == 24
+
+    def test_cli_guard_off_via_no_flag(self):
+        args = self._parse(
+            ["serve", "qwen3-1.7b", "--suffix-hybrid", "--no-suffix-hybrid-bit-exact"]
+        )
+        assert args.suffix_hybrid_bit_exact is False
+
+    def test_cli_min_match_len_rejects_non_positive_at_parse_time(self):
+        import sys
+        from unittest import mock
+
+        from vllm_mlx import cli
+
+        # argparse ``type=positive_int`` rejects <=0 BEFORE any engine boot.
+        for bad in ("0", "-1", "-5"):
+            with (
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "rapid-mlx",
+                        "serve",
+                        "qwen3-1.7b",
+                        "--suffix-min-match-len",
+                        bad,
+                    ],
+                ),
+                mock.patch.object(cli, "serve_command", lambda args: None),
+                pytest.raises(SystemExit) as excinfo,
+            ):
+                cli.main()
+            assert excinfo.value.code == 2
+
+    def test_cli_min_match_len_accepts_positive(self):
+        args = self._parse(["serve", "qwen3-1.7b", "--suffix-min-match-len", "16"])
+        assert args.suffix_min_match_len == 16
+
+
+class TestSingleSnapshotCommit:
+    """Finding #4: the successful hybrid verify must use ONE pre-verify
+    snapshot for probe AND commit (no double deepcopy / redundant replay).
+
+    With the bit-exactness guard ON (the default) and no drift, the commit
+    reuses the guard's already-replayed `probe_head` by installing it directly
+    onto the live cache — so ``_commit_scratch_accepted`` (which would deep-copy
+    the cache AGAIN and re-step every accepted token) must NOT run on that path.
+    When the guard is explicitly OFF (non-lossless/debug mode) no probe ran, so
+    the stepwise commit helper IS still used.
+    """
+
+    @staticmethod
+    def _install_and_step(monkeypatch, *, guard_on):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        # Greedy accept-all draft (step-exact model -> no drift).
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
+
+        drafter = [[d0, d1]]
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return list(drafter[0])
+
+        cache = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=cache,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+
+        calls = {"commit": 0}
+
+        def spy_commit(*a, **k):
+            calls["commit"] += 1
+            # Keep real behavior so state equality stays meaningful.
+            return _commit_scratch_accepted(*a, **k)
+
+        monkeypatch.setattr(scheduler, "_commit_scratch_accepted", spy_commit)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=guard_on,
+        )
+        result = gb._step()
+        assert result[0] == [7]
+        return calls, bg
+
+    def test_commit_reuses_probe_head_on_default_guard(self, monkeypatch):
+        calls, bg = self._install_and_step(monkeypatch, guard_on=True)
+        # Guard passed (accept-all, no drift): the commit must reuse the
+        # guard's probe head NOT call _commit_scratch_accepted again.
+        assert bg._suffix_stats["hybrid_drifts"] == 0
+        assert calls["commit"] == 0
+
+    def test_commit_uses_step_replay_when_guard_off(self, monkeypatch):
+        calls, bg = self._install_and_step(monkeypatch, guard_on=False)
+        # Guard off -> no probe -> stepwise commit helper replays once.
+        assert calls["commit"] == 1

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1776,9 +1776,42 @@ class TestSingleSnapshotCommit:
         from types import SimpleNamespace
         from unittest.mock import MagicMock
 
-        from vllm_mlx import scheduler
+        import vllm_mlx.scheduler as scheduler
         from vllm_mlx.model_auto_config import ModelConfig
-        from vllm_mlx.speculative import suffix_decoding
+        from vllm_mlx.speculative import suffix_counter, suffix_decoding
+
+        # Spy on the shared counter: the deferred-publication fix (round-9k
+        # finding #2) means a failure in the mutation tail must leave the
+        # global counter COMPLETELY untouched — no record_verify, no
+        # record_cooldown_trip, no set_state. Guard-proofed below.
+        class SpyCounter(suffix_counter.SuffixAcceptCounter):
+            def __init__(self):
+                super().__init__()
+                self.success_publish_calls = 0  # record_verify with n_accepted>0
+
+            def record_verify(self, *a, **k):
+                # The success-path publish passes the accepted count; the
+                # handler's error-parity publish always passes 0. The deferred
+                # publication (round-9k finding #2) must keep the n_accepted>0
+                # call OUT of a tail that then fails.
+                accepted = a[1] if len(a) > 1 else 0
+                if accepted > 0:
+                    self.success_publish_calls += 1
+                return super().record_verify(*a, **k)
+
+            def record_cooldown_trip(self, *a, **k):
+                # Only called from the final commit block — an error-parity call
+                # never fires it. Any call here before the tail succeeds is
+                # premature publication.
+                self.success_publish_calls += 1
+                return super().record_cooldown_trip(*a, **k)
+
+            def set_state(self, *a, **k):
+                self.success_publish_calls += 1
+                return super().set_state(*a, **k)
+
+        spy = SpyCounter()
+        monkeypatch.setattr(suffix_counter, "get_global_counter", lambda: spy)
 
         model, _ = _model_and_prompt()
         probe = model.make_cache()
@@ -1790,24 +1823,38 @@ class TestSingleSnapshotCommit:
         mx.eval(l1)
         d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
 
+        # Capture the REAL class BEFORE the patch below, so the wrapper's
+        # __init__ (which runs after install, i.e. after the patch) still
+        # constructs a genuine SuffixDecodingDrafter rather than recursing.
+        real_drafter_cls = suffix_decoding.SuffixDecodingDrafter
+
         class MockDrafter:
             max_draft_tokens = 2
 
             def __init__(self, **_kw):
-                self._tokens = []
-                self.rewind_to = lambda _n: None
+                # A REAL drafter: the scheduler's transactional rollback calls
+                # snapshot_state/restore_state on it, so the assertion below
+                # genuinely checks the drafter history was restored (codex
+                # round-9k NIT — a no-op stub could not detect corruption).
+                self._real = real_drafter_cls(max_draft_tokens=2, max_suffix_len=2)
 
-            def add_prompt_tokens(self, _t):
-                pass
+            def add_prompt_tokens(self, toks):
+                self._real.add_prompt_tokens(toks)
 
-            def add_generated_token(self, _t):
-                self._tokens.append(_t)
+            def add_generated_token(self, t):
+                self._real.add_generated_token(t)
 
-            def record_acceptance(self, _c):
-                pass
+            def record_acceptance(self, c):
+                self._real.record_acceptance(c)
 
             def get_draft(self):
                 return [d0, d1]
+
+            def snapshot_state(self):
+                return self._real.snapshot_state()
+
+            def restore_state(self, snap):
+                self._real.restore_state(snap)
 
         pristine = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
@@ -1850,6 +1897,10 @@ class TestSingleSnapshotCommit:
         # Warm-up: seed _uid_state and let the commit path run once.
         gb._step()
         pre_fail = _copy.deepcopy(gb.prompt_cache)
+        # The warm-up step legitimately published the counter; reset the spy so
+        # it only observes the FAILING step. Any deferred-counter call from here
+        # on is corruption.
+        spy.success_publish_calls = 0
         # Record the observable pre-state of the mutated surfaces.
         pre_tokens_len = len(gb.tokens[0])
         pre_next_tokens = gb._next_tokens
@@ -1874,6 +1925,9 @@ class TestSingleSnapshotCommit:
         assert len(gb.tokens[0]) == pre_tokens_len
         # _next_tokens restored (the commit didn't stash the bonus).
         assert gb._next_tokens is pre_next_tokens
+        # Deferred counter publication (round-9k finding #2): a failure in the
+        # mutation tail must leave the shared counter completely untouched.
+        assert spy.success_publish_calls == 0
 
     def test_post_commit_exception_drops_retained_replay_entry(self, monkeypatch):
         """Codex round-9h finding #1: a post-commit exception must pop the

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1766,6 +1766,116 @@ class TestSingleSnapshotCommit:
         assert spy.set_state_calls == 0
         _assert_state_equal(gb.prompt_cache, pre_fail)
 
+    def test_post_commit_exception_drops_retained_replay_entry(self, monkeypatch):
+        """Codex round-9h finding #1: a post-commit exception must pop the
+        uid's retained ``_pending_hybrid_replay`` entry. If it leaked, a later
+        terminal response for that uid would rebuild its delivered cache from a
+        NOW-STALE pristine snapshot (the cache was restored to that snapshot and
+        re-advanced by the fall-through re-run) and the full duplicate snapshot
+        would leak until UID cleanup.
+
+        We prove the entry is dropped by reaching the terminal branch of the
+        wrapped ``_suffix_next`` after a post-commit exception: if the entry
+        were still present, the terminal would be repaired (delivered cache =
+        pristine + X); because the fix pops it, the terminal passes through
+        with the live (restored) cache untouched."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import vllm_mlx.scheduler as scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        # Accepted draft ([d0] matches greedy), so the hybrid commit retains a
+        # replay entry — the leak codex round-9h finding #1 guards against.
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [d0, d1]
+
+        pristine = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=pristine,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: [SimpleNamespace(uid=1, finish_reason="length")]
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+        # Force a post-commit exception on the hybrid commit. The handler must
+        # (a) restore the pristine cache AND (b) drop the retained replay entry
+        # so the subsequent terminal response is NOT rebuilt from a stale
+        # snapshot.
+        with (
+            patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            gb._step()
+        _assert_state_equal(gb.prompt_cache, pristine)
+        # A terminal (length) primary now flows through _suffix_next. With the
+        # replay entry correctly dropped, the passed-through response is left
+        # UNTOUCHED by the terminal repair — i.e. no ``prompt_cache`` attr was
+        # set on it (the repair is what would set it). Had the stale entry
+        # leaked, the repair would have assigned pristine + X here, rebuilding
+        # from a now-obsolete snapshot.
+        outs = gb.next()
+        terminals = [o for o in outs if o.finish_reason is not None]
+        assert len(terminals) == 1
+        assert not hasattr(terminals[0], "prompt_cache")
+        _assert_state_equal(gb.prompt_cache, pristine)
+
 
 class TestHybridTerminalRepair:
     """Finding #1: a hybrid finish part-way through the accepted drafts must

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -252,48 +252,56 @@ class TestHybridInstallGate:
         assert bg._suffix_stats["suffix_hybrid"] is True
         assert bg._suffix_stats["suffix_min_match_len"] == 24
 
-    def test_hybrid_drafter_cap_raised_to_floor(self, monkeypatch):
-        """Finding: the hybrid path must construct the drafter with
-        ``_effective_max_draft`` (>= the 24-token floor), or drafts stay capped
-        below the floor and every repeat falls through ``ft_short_match`` —
-        making the opt-in hybrid path dead on a default install."""
+    def test_hybrid_drafter_cap_never_exceeds_config_and_reaches_floor(
+        self, monkeypatch
+    ):
+        """Finding: the hybrid drafter cap must never exceed the operator's
+        explicit ``suffix_max_draft`` (``_effective_max_draft = min(max_draft,
+        floor)``), while reaching the 24-token floor when the cap allows it."""
         from types import SimpleNamespace
         from unittest.mock import MagicMock
 
         from vllm_mlx import scheduler
         from vllm_mlx.model_auto_config import ModelConfig
 
-        # A real drafter (not a stub) so we check the actual constructed cap.
-        bg, gb = self._make_fake_bg()
-        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
-        assert scheduler._install_suffix_decoding(
-            bg,
-            model=MagicMock(),
-            profile=profile,
-            max_draft=8,
-            max_suffix_len=4,
-            min_confidence=0.3,
-            requests={},
-            uid_to_request_id={},
-            suffix_hybrid=True,
-        )
-        # Force first-_step by feeding a synthetic uid + token via gb.
-        gb._next_tokens = mx.array([1], dtype=mx.int32)
-        gb._num_tokens = [0]
-        gb.max_tokens = [100]
-        gb.uids = [1]
-        gb.tokens = [[]]
-        gb.state_machines = [SimpleNamespace(match=lambda s, _t: (s, None, None))]
-        gb._matcher_states = [None]
-        gb.logits_processors = []
-        gb.model = MagicMock()
-        gb._orig_step = lambda: ([1], [])
-        # uid 1 has no drafter yet -> lazy-init constructs one this step.
-        gb._step()
-        drafter = gb._suffix_drafters[1]
-        # Effective max draft must be at least the 24-token floor (raised from
-        # the configured default 8 on the hybrid path).
-        assert drafter.max_draft_tokens >= 24
+        def _install_opts(max_draft):
+            bg, gb = self._make_fake_bg()
+            profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+            assert scheduler._install_suffix_decoding(
+                bg,
+                model=MagicMock(),
+                profile=profile,
+                max_draft=max_draft,
+                max_suffix_len=4,
+                min_confidence=0.3,
+                requests={},
+                uid_to_request_id={},
+                suffix_hybrid=True,
+                suffix_min_match_len=24,
+            )
+            gb._next_tokens = mx.array([1], dtype=mx.int32)
+            gb._num_tokens = [0]
+            gb.max_tokens = [100]
+            gb.uids = [1]
+            gb.tokens = [[]]
+            gb.state_machines = [SimpleNamespace(match=lambda s, _t: (s, None, None))]
+            gb._matcher_states = [None]
+            gb.logits_processors = []
+            gb.model = MagicMock()
+            gb._orig_step = lambda: ([1], [])
+            gb._step()  # lazy-init constructs the drafter this step
+            return bg, gb, gb._suffix_drafters[1]
+
+        # (a) Below-floor cap (default 8): drafter is clamped AT 8, never above.
+        _bg, _gb, drafter8 = _install_opts(8)
+        assert drafter8.max_draft_tokens == 8
+        assert drafter8.max_draft_tokens < 24
+        # (b) Cap at/above the floor: drafter reaches the 24-token floor.
+        _bg, _gb, drafter32 = _install_opts(32)
+        assert drafter32.max_draft_tokens == 24
+        # (c) Cap above the floor is not lowered below it.
+        _bg, _gb, drafter24 = _install_opts(24)
+        assert drafter24.max_draft_tokens == 24
 
     def test_installed_reject_first_commits_primary(self, monkeypatch):
         """Installed-path reject-first verify: the live cache must equal
@@ -1353,7 +1361,14 @@ class TestHybridTerminalRepair:
             state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
             _matcher_states=[None],
             extract_cache=lambda _r: gb.prompt_cache,
-            filter=lambda keep: setattr(gb, "uids", list(keep)),
+            # Faithful-ish filter: production ``GenerationBatch.filter`` compacts
+            # the live cache list in place and drops finished rows. We clear
+            # the cache list to simulate the finishing row being compacted away,
+            # then assert the delivered response cache is still intact+decodable.
+            filter=lambda keep: (
+                setattr(gb, "uids", list(keep)),
+                gb.prompt_cache.clear() if not keep else None,
+            ),
             model=model,
         )
         gb.Response = SimpleNamespace
@@ -1391,9 +1406,20 @@ class TestHybridTerminalRepair:
         assert len(finish) == 1
         delivered = finish[0].prompt_cache
         # ``delivered`` is the repaired cache list (per-layer cells) built by
-        # the terminal-repair branch. Build the step-replayed gold cache list.
+        # the terminal-repair branch. Even after the faithful filter CLEARED
+        # the shared live cache list (simulating the finishing row being
+        # compacted away), the delivered response cache must remain intact,
+        # independent, and decodable. Build the step-replayed gold cache list.
         gold = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
         mx.eval(model(mx.array([[7]]), cache=gold))
         mx.eval(model(mx.array([[d0]]), cache=gold))
         _assert_state_equal(delivered, gold)
+        # Independent/decodable: continuing from the delivered cache produces
+        # the same next token as continuing from the gold cache.
+        nxt_raw = model(mx.array([[8]]), cache=delivered)
+        nxt_gold = model(mx.array([[8]]), cache=gold)
+        mx.eval(nxt_raw, nxt_gold)
+        assert int(mx.argmax(nxt_raw[:, -1], axis=-1).item()) == int(
+            mx.argmax(nxt_gold[:, -1], axis=-1).item()
+        )

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -236,6 +236,98 @@ class TestHybridInstallGate:
         assert bg._suffix_stats["suffix_hybrid"] is True
         assert bg._suffix_stats["suffix_min_match_len"] == 24
 
+    def test_installed_reject_first_commits_primary(self, monkeypatch):
+        """Installed-path reject-first verify: the live cache must equal
+        prompt + X after ``gb._step()``.
+
+        A reject-first draft (n_accepted == 0) still emits X (the greedy
+        primary). The hybrid commit-only path must therefore commit the
+        [X] prefix even when no draft token is accepted — otherwise the live
+        cache is left BEFORE X and the next decode step reads stale state.
+        This exercises ``_hybrid_scratch_verify`` + ``_suffix_step`` (not the
+        helper directly), so it guards the production zero-accept path.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _c = _model_and_prompt()
+        # Probe the greedy next token on a throwaway copy (X = 7, the token
+        # we're about to feed as the primary). Build a draft whose token 0 is
+        # guaranteed rejected.
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item()) + 1  # rejected
+        d1 = d0 + 1
+        draft = [d0, d1]
+
+        class Drafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return list(draft)
+
+        cache = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=cache,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", Drafter)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+        )
+        result = gb._step()
+        assert result[0] == [7]
+        # Live cache must equal prompt + [7] (X committed despite reject).
+        gold = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
+        mx.eval(model(mx.array([[7]]), cache=gold))
+        _assert_state_equal(cache, gold)
+
     def test_pure_attention_optin_ignored(self):
         """suffix_hybrid on a pure-attention model is a no-op (not a raised error)."""
         from unittest.mock import MagicMock
@@ -655,6 +747,109 @@ class TestBitExactnessGuard:
         )
         result = gb._step()
         # Drift detected: refuse, fall through (no wrong tokens committed).
+        assert bg._suffix_stats["hybrid_drifts"] == 1
+        assert bg._suffix_stats["ft_hybrid_drift"] == 1
+        assert result[0] == [7]
+
+    def test_guard_catches_drift_beyond_position_four(self, monkeypatch):
+        """The bit-exactness guard must probe EVERY committed position.
+
+        The old guard replayed only ``suffix_hybrid_probe_len`` (default 4)
+        positions, so a quantized-hybrid drift that only appears AFTER the
+        fourth accepted token committed silently under the "bit-exact"
+        contract. Here the drift first shows up at position 5: the chunked
+        verify accepts a 6-token draft (n_accepted == 6), and stepwise greedy
+        matches for positions 0..3 but diverges at position 4. The guard must
+        still refuse, proving it probes the full accepted prefix.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        import mlx.core as mx
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        class LateDriftModel:
+            def __init__(self):
+                self._stepwise_calls = 0
+
+            def __call__(self, tokens, cache=None, **kw):
+                L = tokens.shape[1]
+                logits = mx.full((1, L, 16), -10.0)
+                if L > 1:  # chunked verify forward: predict draft token 10
+                    for i in range(L):
+                        logits[0, i, 10] = 10.0
+                    return logits
+                # stepwise probe: agree with the chunked pred for the first
+                # four committed positions (j = 0..3), then diverge at j = 4
+                # (the 5th stepwise call) — exactly the position the OLD
+                # probe window (suffix_hybrid_probe_len=4) never inspected.
+                self._stepwise_calls += 1
+                if self._stepwise_calls >= 5:
+                    logits[0, 0, 11] = 10.0  # drift beyond old window
+                else:
+                    logits[0, 0, 10] = 10.0  # matches chunked
+                return logits
+
+        cache = [SimpleNamespace(offset=0, max_size=100, size=lambda: 0)]
+
+        class Drafter:
+            max_draft_tokens = 6
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [10, 10, 10, 10, 10, 10]
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((8,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=cache,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=LateDriftModel(),
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", Drafter)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=gb.model,
+            profile=profile,
+            max_draft=6,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=6,
+            suffix_hybrid_bit_exact=True,
+        )
+        result = gb._step()
+        # Drift at position 4 (beyond the old fixed window) is caught.
         assert bg._suffix_stats["hybrid_drifts"] == 1
         assert bg._suffix_stats["ft_hybrid_drift"] == 1
         assert result[0] == [7]

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -184,6 +184,32 @@ class TestScratchVerifyCore:
         mx.eval(model(mx.array([[1, 2, 3]]), cache=fresh))
         _assert_state_equal(before, fresh)
 
+    def test_restore_pending_emits_preserves_other_uids(self):
+        """Codex round-9l finding #2: the post-commit rollback must restore the
+        pending-emit map PER-UID — dropping entries the failed transaction
+        added and restoring entries it mutated, but never ``clear()``-ing the
+        whole map (which would silently drop ANOTHER request's queued accepted
+        tokens). ``_restore_pending_emits`` is the module-level rollback helper;
+        ``clear()`` was the buggy pre-fix behavior."""
+        from vllm_mlx.scheduler import _restore_pending_emits
+
+        # Two requests already have queued accepted tokens (a different uid and
+        # the failing uid), plus the failing step adds a brand-new uid.
+        snapshot = {1: [(100, mx.array([0.1]))], 2: [(200, mx.array([0.2]))]}
+        current = {
+            1: [(100, mx.array([0.1]))],  # unchanged by failed step
+            2: [(200, mx.array([0.2])), (201, mx.array([0.3]))],  # step appended
+            3: [(300, mx.array([0.4]))],  # added by the failed step
+        }
+        _restore_pending_emits(current, snapshot)
+        # uid 1 untouched; uid 2's extra appended entry rolled back; uid 3
+        # (added by the failed transaction) dropped.
+        assert set(current.keys()) == {1, 2}
+        assert [t for t, _ in current[1]] == [100]
+        assert [t for t, _ in current[2]] == [200]
+        # A naive clear() would have left uid 1/2 empty — this preserves them.
+        assert len(current) == 2
+
 
 class TestHybridInstallGate:
     """suffix_hybrid must open the hybrid install gate, default stays closed."""
@@ -1904,6 +1930,10 @@ class TestSingleSnapshotCommit:
         # Record the observable pre-state of the mutated surfaces.
         pre_tokens_len = len(gb.tokens[0])
         pre_next_tokens = gb._next_tokens
+        stats0 = bg._suffix_stats
+        pre_error_total = stats0["errors"]
+        pre_fallthrough_total = stats0["fallthrough_steps"]
+        pre_ft_error_total = stats0["ft_error"]
 
         # Inject a LATE failure: the publish ``gb.tokens[0].append(last_token)``
         # raises (runs after cooldown + drafter + stat mutations). The handler
@@ -1928,6 +1958,18 @@ class TestSingleSnapshotCommit:
         # Deferred counter publication (round-9k finding #2): a failure in the
         # mutation tail must leave the shared counter completely untouched.
         assert spy.success_publish_calls == 0
+        # Codex round-9l finding #1: the transactional rollback must NOT erase
+        # the error/fallthrough metrics this failure records. Because the
+        # handler rolls the snapshot back FIRST and then bumps the error counts,
+        # ``_suffix_stats`` (the exported ``_stats`` surface) must carry the
+        # failure exactly once — if the rollback ran after the bumps, the
+        # restored snapshot would have zeroed them while the shared counter
+        # still recorded, diverging the two surfaces. Guard-proofed: reverting
+        # the reorder makes this fail.
+        stats = bg._suffix_stats
+        assert stats["errors"] == pre_error_total + 1
+        assert stats["fallthrough_steps"] == pre_fallthrough_total + 1
+        assert stats["ft_error"] == pre_ft_error_total + 1
 
     def test_post_commit_exception_drops_retained_replay_entry(self, monkeypatch):
         """Codex round-9h finding #1: a post-commit exception must pop the

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -299,19 +299,27 @@ class TestHybridInstallGate:
             gb._step()  # lazy-init constructs the drafter this step
             return gb._suffix_drafters[1]
 
-        # (a) Hybrid, below-floor configured cap (default 8): width is raised
-        # to the 24-token floor so the feature engages.
-        drafter8 = _install_opts(8, is_hybrid=True)
-        assert drafter8.max_draft_tokens == 24
-        # (b) Hybrid, cap above the floor: width reaches the floor, not higher.
+        # The installer HONORS ``max_draft`` on every path (CLI reject-projects
+        # a below-floor hybrid combo before it reaches here). The hybrid width
+        # is seeded at min(floor, max_draft); the drafter's per-step width
+        # equals that seed.
+        #
+        # (a) Hybrid, configured cap AT the floor: width = the 24-token floor.
+        drafter24 = _install_opts(24, is_hybrid=True)
+        assert drafter24.max_draft_tokens == 24
+        # (b) Hybrid, cap ABOVE the floor: width still seeds at the floor
+        # (adaptively grows toward the cap only on full-acceptance).
         drafter32 = _install_opts(32, is_hybrid=True)
         assert drafter32.max_draft_tokens == 24
-        # (c) PURE-ATTENTION, same flag: the width stays at the normal adaptive
-        # start (2), NOT raised to the 24-token floor — the hybrid raise must
-        # not leak into a no-op-flag pure-attention model.
+        # (c) Hybrid, BELOW-floor cap (programmatic; CLI rejects this): width
+        # degrades to the cap — no silent raise above the documented limit.
+        drafter8 = _install_opts(8, is_hybrid=True)
+        assert drafter8.max_draft_tokens == 8
+        # (d) PURE-ATTENTION, same flag: width stays at the normal adaptive
+        # start (2) — the hybrid floor must NOT leak into a no-op-flag model.
         drafter_pa8 = _install_opts(8, is_hybrid=False)
         assert drafter_pa8.max_draft_tokens == 2
-        # (d) Pure-attention, explicit higher cap: also not raised to the floor.
+        # (e) Pure-attention, explicit higher cap: also not pushed to the floor.
         drafter_pa32 = _install_opts(32, is_hybrid=False)
         assert drafter_pa32.max_draft_tokens == 2
 

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -409,6 +409,10 @@ class TestHybridInstallGate:
         mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
         mx.eval(model(mx.array([[7]]), cache=gold))
         _assert_state_equal(gb.prompt_cache, gold)
+        # Finding (round-8 #2): reject-first (n_accepted == 0) has NO synthetic
+        # emits, so no pristine replay head should be retained — the live cache
+        # already holds exactly what will be surfaced.
+        assert 1 not in gb._suffix_hybrid_replay
 
     def test_pure_attention_optin_ignored(self):
         """suffix_hybrid on a pure-attention model is a no-op (not a raised error)."""

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1,0 +1,660 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hybrid scratch-verify battery for the opt-in suffix_hybrid path (#2561 B2.1).
+
+The B1 slice (#3090) gave Qwen4ExpStateCache / QSAIndexCache a ``cache_rollback``
+contract. Empirically that contract cannot support a multi-token rejection on the
+real hybrid capture: ``record_slot_snapshots(finalize=True)`` publishes *K*
+boundaries for a K-token verify (not K+1), so ``can_trim(1)`` is ``False`` once a
+K-token verify has run, and ``Qwen4ExpStateCache.trim``/``trim_all`` cannot roll a
+rejected tail back. The hybrid path therefore mirrors SGLang NGRAMWorker + the
+scheduler's DSpark path: verify against a copy of the committed cache (scratch),
+then on accept replay ONLY the accepted prefix onto the live cache (commit-only),
+dropping the rejected tail by never advancing the live cache past it. This is
+step-equivalent and lossless.
+
+These tests exercise the real tiny Qwen4-exp hybrid model (GDN recurrent + PLE +
+QSA attention) so the state-equality claims are non-tautological.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytest.importorskip("mlx_lm")
+
+from dataclasses import asdict  # noqa: E402
+
+import numpy as np  # noqa: E402
+from mlx_lm.models.cache import CacheList  # noqa: E402
+
+from tests.test_qwen4_exp_vendored import _ple_args  # noqa: E402
+from vllm_mlx.models.qwen4_exp import Model, ModelArgs  # noqa: E402
+from vllm_mlx.models.qwen4_exp_cache import (  # noqa: E402
+    Qwen4ExpStateCache,
+)
+from vllm_mlx.scheduler import (  # noqa: E402
+    _commit_scratch_accepted,
+    _verify_scratch,
+)
+
+
+def _offsets(cache):
+    return [
+        None
+        if not isinstance(lc, CacheList)
+        else (int(lc[0].offset), int(lc[1].offset))
+        for lc in cache
+    ]
+
+
+def _assert_state_equal(a, b):
+    """Recurrent tensors + attention/QSA offsets + raw ring exact equality."""
+    assert len(a) == len(b)
+    for la, lb in zip(a, b):
+        if isinstance(la, Qwen4ExpStateCache):
+            assert isinstance(lb, Qwen4ExpStateCache)
+            assert len(la.cache) == len(lb.cache)
+            for x, y in zip(la.cache, lb.cache):
+                if x is None and y is None:
+                    continue
+                np.testing.assert_array_equal(np.asarray(x), np.asarray(y))
+        elif isinstance(la, CacheList):
+            assert isinstance(lb, CacheList)
+            assert la[0].offset == lb[0].offset
+            assert la[1].offset == lb[1].offset
+            qa, qb = la[1], lb[1]
+            assert qa._offsets == qb._offsets
+            assert qa._compressed_counts == qb._compressed_counts
+            ra, rb = qa.raw_ring, qb.raw_ring
+            np.testing.assert_array_equal(np.asarray(ra), np.asarray(rb))
+        else:  # pragma: no cover - unexpected layer type
+            pytest.fail(f"unexpected cache layer: {type(la)!r}")
+
+
+def _model_and_prompt():
+    args = _ple_args()
+    model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    cache = model.make_cache()
+    mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+    return model, cache
+
+
+class TestScratchVerifyCore:
+    """Direct (unit-level) tests of the scratch verify helper."""
+
+    def test_accept_all_commits_all(self):
+        import copy
+
+        model, cache = _model_and_prompt()
+        # gold: commit [4,5] stepwise
+        gold = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
+        for t in ([4], [5]):
+            mx.eval(model(mx.array([t]), cache=gold))
+
+        draft = [5, 6]
+        commit_head = copy.deepcopy(cache)
+        result = _verify_scratch(
+            model, cache, mx.array([[4, 5, 6]]), draft, commit_head
+        )
+        # Accept-all only if both draft tokens match greedy. Probe first.
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        vlog = model(mx.array([[4, 5, 6]]), cache=probe)
+        mx.eval(vlog)
+        preds = mx.argmax(vlog, axis=-1).tolist()[0]
+        if preds[0] == 5 and preds[1] == 6:
+            assert result["n_accepted"] == 2
+        # Commit accepted (whatever it is) and compare to the stepwise gold
+        # of THAT same accepted prefix: gold = prompt + committed [4,5,..].
+        na = result["n_accepted"]
+        _commit_scratch_accepted(model, cache, mx.array([[4, 5, 6]]), na)
+        g2 = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=g2))
+        for t in ([4], [5], [6])[: na + 1]:
+            mx.eval(model(mx.array([t]), cache=g2))
+        _assert_state_equal(cache, g2)
+
+    def test_partial_reject_commits_only_accepted(self):
+        import copy
+
+        model, _cache = _model_and_prompt()
+        # Probe the verify predictions to choose a draft whose token 0 is
+        # accepted and token 1 is rejected.
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        vlog = model(mx.array([[4, 5, 6]]), cache=probe)
+        mx.eval(vlog)
+        preds = mx.argmax(vlog, axis=-1).tolist()[0]
+        d0 = preds[0]  # accepted at position 0
+        d1 = (preds[1] + 1) % 100  # rejected at position 1
+
+        live = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=live))
+        commit_head = copy.deepcopy(live)
+        verify_input = mx.array([[4, d0, d1]])
+        result = _verify_scratch(model, live, verify_input, [d0, d1], commit_head)
+        assert result["n_accepted"] == 1
+        _commit_scratch_accepted(model, live, verify_input, 1)
+        # gold: prompt + committed [4, d0]
+        g2 = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=g2))
+        mx.eval(model(mx.array([[4]]), cache=g2))
+        mx.eval(model(mx.array([[d0]]), cache=g2))
+        _assert_state_equal(live, g2)
+
+    def test_reject_first_commits_nothing(self):
+        import copy
+
+        model, _cache = _model_and_prompt()
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        vlog = model(mx.array([[4, 5, 6]]), cache=probe)
+        mx.eval(vlog)
+        preds = mx.argmax(vlog, axis=-1).tolist()[0]
+        d0 = preds[0] + 1  # guaranteed rejected at position 0
+        d1 = preds[1]
+
+        before = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=before))
+        commit_head = copy.deepcopy(before)
+        verify_input = mx.array([[4, d0, d1]])
+        result = _verify_scratch(model, before, verify_input, [d0, d1], commit_head)
+        assert result["n_accepted"] == 0
+        # No commit → cache bit-identical to a fresh unadvanced prompt cache.
+        fresh = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=fresh))
+        _assert_state_equal(before, fresh)
+
+
+class TestHybridInstallGate:
+    """suffix_hybrid must open the hybrid install gate, default stays closed."""
+
+    def _make_fake_bg(self):
+        class _GB:
+            pass
+
+        gb = _GB()
+        gb._step = lambda: ([], [])
+        gb.next = lambda: []
+
+        class _BG:
+            def __init__(self):
+                self.removed = []
+
+            def remove(self, uids, return_prompt_caches=False):
+                self.removed.append(list(uids))
+                return {}
+
+        bg = _BG()
+        bg._generation_batch = gb
+        return bg, gb
+
+    def test_hybrid_profile_without_optin_still_skips(self):
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.scheduler import _install_suffix_decoding
+
+        bg, gb = self._make_fake_bg()
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        assert not _install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=profile,
+            max_draft=8,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+        )
+        assert gb._step is not None  # old step preserved
+
+    def test_hybrid_profile_with_optin_installs(self):
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.scheduler import _install_suffix_decoding
+
+        bg, gb = self._make_fake_bg()
+        orig_step = gb._step
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        assert _install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=profile,
+            max_draft=8,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+        )
+        assert gb._step is not orig_step
+        assert hasattr(bg, "_suffix_stats")
+        assert bg._suffix_stats["suffix_hybrid"] is True
+        assert bg._suffix_stats["suffix_min_match_len"] == 24
+
+    def test_pure_attention_optin_ignored(self):
+        """suffix_hybrid on a pure-attention model is a no-op (not a raised error)."""
+        from unittest.mock import MagicMock
+
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.scheduler import _install_suffix_decoding
+
+        bg, gb = self._make_fake_bg()
+        profile = ModelConfig()  # supports_spec_decode=True, not hybrid
+        assert _install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=profile,
+            max_draft=8,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+        )
+        assert bg._suffix_stats["suffix_hybrid"] is False
+
+
+class TestMinMatchFloor:
+    """Drafts shorter than suffix_min_match_len fall through, no verify."""
+
+    def _install(self, suffix_min_match_len=24, monkeypatch=None, **kw):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        import mlx.core as mx
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        class Drafter:
+            def __init__(self, **_kw):
+                self.max_draft_tokens = 8
+                self.draft = kw.get("draft", [5, 6])
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def get_draft(self):
+                return list(self.draft)
+
+            def record_acceptance(self, _c):
+                pass
+
+        class Cache:
+            def can_advance(self, _n):
+                return True
+
+        if monkeypatch:
+            monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", Drafter)
+        bg = MagicMock()
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([1], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((5,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=[Cache()],
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+        )
+        gbResponse = SimpleNamespace
+        gb.Response = gbResponse
+        gb._step = lambda: ([1], [])
+        gb.next = lambda: []
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=MagicMock(),
+            profile=profile,
+            max_draft=8,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=suffix_min_match_len,
+        )
+        return bg, gb
+
+    def test_short_draft_falls_through_without_verify(self, monkeypatch):
+        _bg, gb = self._install(suffix_min_match_len=24, monkeypatch=monkeypatch)
+        # nb: drafter returns [5,6] (len 2 < 24) -> falls through, no verify.
+        gb._suffix_uid_state = {
+            1: {"cooldown": 0, "level": 0, "zeros": 0, "k": 2, "pending": []}
+        }
+        # Patch a model that would fail if called (verify must NOT run).
+        calls = {"n": 0}
+
+        def boom(*a, **k):
+            calls["n"] += 1
+            raise AssertionError("verify should not run")
+
+        gb.model = boom
+        gb._orig_step = lambda: ([1], [])
+        # reset the stats/uid state wiring by reaching into installed closure
+        result = gb._step()
+        assert result[0] == [1]
+        assert calls["n"] == 0
+        assert _bg._suffix_stats["ft_short_match"] == 1
+
+    def test_long_enough_draft_runs_verify(self, monkeypatch):
+        _bg, gb = self._install(suffix_min_match_len=2, monkeypatch=monkeypatch)
+        gb._suffix_uid_state = {
+            1: {"cooldown": 0, "level": 0, "zeros": 0, "k": 2, "pending": []}
+        }
+
+        class Cache2:
+            def can_advance(self, _n):
+                return True
+
+        # A real-ish model returning greedy-matching logits.
+        import mlx.core as mx
+
+        calls = {"n": 0}
+
+        def fake_model(tokens, cache=None, **kw):
+            calls["n"] += 1
+            L = tokens.shape[1]
+            logits = mx.full((1, L, 5), -10.0)
+            # pred at each position = the draft token at that position (so
+            # everything accepted)
+            for i in range(L):
+                tok = int(tokens[0, i].item())
+                logits[0, i, (tok + 1) % 4] = 10.0
+            return logits
+
+        gb.model = fake_model
+        gb._orig_step = lambda: ([1], [])
+        result = gb._step()
+        assert result[0] == [1]  # primary returned
+        assert calls["n"] >= 1
+        assert _bg._suffix_stats["verify_steps"] >= 1
+
+
+class TestTokenIdentityAndStateEquality:
+    """Real-model, multi-step: token-identity vs baseline + state equality.
+
+    The tiny Qwen4-exp hybrid is step-exact (chunked == stepwise for argmax),
+    so a scratch-verify decode that commits exactly the greedy-accepted prefix
+    must be token-identical to baseline greedy decode, and the cache state
+    must match at every step.
+    """
+
+    def _stepwise_next(self, model, cache, inp_tok):
+        logits = model(mx.array([[inp_tok]]), cache=cache)
+        mx.eval(logits)
+        return int(mx.argmax(logits[:, -1], axis=-1).item())
+
+    def test_identity_over_repeated_drafts(self):
+        import copy
+
+        model, _ = _model_and_prompt()
+        # Prompt-only live cache (X=7 NOT committed yet).
+        cache = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+        # Probe the greedy next tokens on a THROWAWAY copy so the live cache
+        # is not advanced by the probe (production feeds X during verify).
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        d0 = self._stepwise_next(model, probe, 7)
+        d1 = self._stepwise_next(model, probe, d0)
+        verify_input = mx.array([[7, d0, d1]])
+        draft = [d0, d1]
+        commit_head = copy.deepcopy(cache)
+        res = _verify_scratch(model, cache, verify_input, draft, commit_head)
+        na = res["n_accepted"]
+        # d0,d1 ARE the greedy stepwise next tokens, so accept-all (2).
+        _commit_scratch_accepted(model, cache, verify_input, na)
+        assert na == 2
+        # Committed state == baseline greedy commit of [7, d0, d1].
+        gold = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
+        for t in ([7], [d0], [d1]):
+            mx.eval(model(mx.array([t]), cache=gold))
+        _assert_state_equal(cache, gold)
+
+    def test_full_reject_leaves_committed_state_intact(self):
+        import copy
+
+        model, _ = _model_and_prompt()
+        cache = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+        # A draft whose token 0 is guaranteed rejected (probe on a copy).
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        d0 = self._stepwise_next(model, probe, 7) + 1
+        verify_input = mx.array([[7, d0, d0 + 1]])
+        draft = [d0, d0 + 1]
+        commit_head = copy.deepcopy(cache)
+        res = _verify_scratch(model, cache, verify_input, draft, commit_head)
+        assert res["n_accepted"] == 0
+        _commit_scratch_accepted(model, cache, verify_input, 0)
+        # reject-first still advances X=7 (the primary is always emitted):
+        # committed prefix = [7]. State must equal prompt + [7].
+        gold = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
+        mx.eval(model(mx.array([[7]]), cache=gold))
+        _assert_state_equal(cache, gold)
+
+    def test_prefix_cache_reuse_after_commit(self):
+        """A committed scratch prefix is reusable as a prefix-cache source."""
+        import copy
+
+        model, _ = _model_and_prompt()
+        cache = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        d0 = self._stepwise_next(model, probe, 7)
+        verify_input = mx.array([[7, d0, d0 + 1]])
+        draft = [d0, d0 + 1]
+        commit_head = copy.deepcopy(cache)
+        res = _verify_scratch(model, cache, verify_input, draft, commit_head)
+        na = res["n_accepted"]
+        _commit_scratch_accepted(model, cache, verify_input, na)
+        # The committed prefix cache must remain directly decodable (i.e. it
+        # is a valid prefix-cache source that the next step can continue from).
+        next_tok = model(mx.array([[8]]), cache=cache)
+        mx.eval(next_tok, [c.state for c in cache])
+        assert next_tok.shape[-1] > 0
+
+
+class TestBitExactnessGuard:
+    """The opt-in hybrid drift guard refuses (falls through) on any chunked
+    verify that disagrees with stepwise greedy, without committing."""
+
+    def test_guard_does_not_misfire_on_step_exact_model(self, monkeypatch):
+        # On the tiny (step-exact) model, enabling the guard must not change
+        # the accepted commit — the drift probe matches the chunked preds.
+
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        # greedy next two tokens (accept-all draft)
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
+        greedy_draft = [d0, d1]
+
+        drafter = [greedy_draft]
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return list(drafter[0])
+
+        cache = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=cache))
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=cache,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+        # The step-exact model's chunked verify == stepwise, so the guard
+        # passes and the verify runs (no drift refusal, accept-all commit).
+        result = gb._step()
+        assert result[0] == [7]
+        assert bg._suffix_stats["hybrid_drifts"] == 0
+        assert bg._suffix_stats["verify_steps"] == 1
+
+    def test_guard_refuses_on_drift(self, monkeypatch):
+        # Force drift: a fake model whose chunked (multi-token) forward
+        # disagrees with its own stepwise single-token forward.
+
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        import mlx.core as mx
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        calls = {"verify": 0, "step": 0}
+
+        class DriftingModel:
+            def __call__(self, tokens, cache=None, **kw):
+                L = tokens.shape[1]
+                if L > 1:  # chunked verify forward
+                    calls["verify"] += 1
+                    logits = mx.full((1, L, 8), -10.0)
+                    # chunked predicts draft[0]==draft[1] at each position
+                    for i in range(L):
+                        logits[0, i, 5] = 10.0  # always predicts token 5
+                    return logits
+                # single token stepwise
+                calls["step"] += 1
+                logits = mx.full((1, 1, 8), -10.0)
+                logits[0, 0, 6] = 10.0  # stepwise predicts token 6
+                return logits
+
+        cache = [SimpleNamespace(offset=0, max_size=100, size=lambda: 0)]
+
+        class Drafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [5, 5]
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((8,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=cache,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=DriftingModel(),
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        # Seed the closure's drafter via monkeypatch BEFORE install, because
+        # ``_install_suffix_decoding`` binds SuffixDecodingDrafter into the
+        # closure at install time.
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", Drafter)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=gb.model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+        result = gb._step()
+        # Drift detected: refuse, fall through (no wrong tokens committed).
+        assert bg._suffix_stats["hybrid_drifts"] == 1
+        assert bg._suffix_stats["ft_hybrid_drift"] == 1
+        assert result[0] == [7]

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import pytest
 
+pytestmark = pytest.mark.requires_mlx
+
 mx = pytest.importorskip("mlx.core")
 pytest.importorskip("mlx_lm")
 

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1647,6 +1647,125 @@ class TestSingleSnapshotCommit:
             gb._step()
         _assert_state_equal(gb.prompt_cache, pristine)
 
+    def test_post_commit_failure_deferres_mutation_tail(self, monkeypatch):
+        """Codex round-9g finding: the post-commit phase must not leave ANY
+        bookkeeping half-mutated when a fallible MLX op raises. The fix does
+        this by reordering so all fallible compute (logprob construction) runs
+        BEFORE the mutation tail (cooldown/adaptive width set_state, drafter,
+        counter, gb fields, emit stash). We prove the deferral by spying on the
+        counter's ``set_state`` — it is only invoked in the mutation tail, so
+        if a ``logsumexp`` raise happens first, ``set_state`` must never run."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import vllm_mlx.scheduler as scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_counter, suffix_decoding
+
+        class SpyCounter(suffix_counter.SuffixAcceptCounter):
+            def __init__(self):
+                super().__init__()
+                self.set_state_calls = 0
+
+            def set_state(self, current_k, backoff_level):
+                self.set_state_calls += 1
+                return super().set_state(current_k, backoff_level)
+
+        spy = SpyCounter()
+        monkeypatch.setattr(suffix_counter, "get_global_counter", lambda: spy)
+
+        model, _ = _model_and_prompt()
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        d1 = d0  # accept-all draft so the step commits
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [d0, d1]
+
+        pristine = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=pristine,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+        # Seed the per-uid state so a later step does not trigger ``_state_for``
+        # lazy-init (which publishes the at-rest gauge via ``set_state`` — that
+        # is pre-verify and not part of the post-commit tail). Run one full
+        # successful hybrid step to populate ``_uid_state`` for uid 1. It also
+        # ratifies the wiring (verify commits + emits are stashed).
+        gb._step()
+        # After the warm-up step the live cache has advanced past the primary;
+        # capture a FRESH pristine snapshot that the failing step must restore.
+        import copy as _copy
+
+        pre_fail = _copy.deepcopy(gb.prompt_cache)
+        # Now the uid state exists, so ``_state_for`` returns without calling
+        # ``set_state``. Any ``set_state`` from here on can only come from the
+        # post-commit mutation tail.
+        spy.set_state_calls = 0
+        # Fail in the fallible logprob compute (which now runs FIRST, before
+        # the mutation tail). Because the mutation tail never runs, the counter
+        # ``set_state`` is never called: no cooldown/width state was mutated on
+        # the way to the exception, and the pristine cache is restored. The step
+        # falls through and the caller re-derives state on the re-run.
+        with (
+            patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            gb._step()
+        assert spy.set_state_calls == 0
+        _assert_state_equal(gb.prompt_cache, pre_fail)
+
 
 class TestHybridTerminalRepair:
     """Finding #1: a hybrid finish part-way through the accepted drafts must

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1548,6 +1548,105 @@ class TestSingleSnapshotCommit:
             gb._step()
         _assert_state_equal(gb.prompt_cache, pristine)
 
+    def test_zero_accept_hybrid_commit_still_restores_pristine_on_post_commit_error(
+        self, monkeypatch
+    ):
+        """Codex round-9f finding: ``_hybrid_pc_snapshot`` used to be captured
+        only when ``n_accepted > 0``. But even a ZERO-accept hybrid commit swaps
+        the commit head in (advancing the live cache through the primary X),
+        so a post-commit exception with no accepted drafts left ``gb.prompt_cache``
+        advanced with no snapshot to restore. Fix captures the pristine snapshot
+        unconditionally after every hybrid commit; the replay HEAD stays gated on
+        ``n_accepted > 0`` (no synthetic emits to drain when nothing was accepted).
+
+        We force a mismatch draft (draft[0] != pred for X) so ``n_accepted == 0``,
+        then fail inside the shared post-commit logprob construction and assert
+        the re-raised exception restores the pristine cache.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import vllm_mlx.scheduler as scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        # Probe what X predicts so we can build a DELIBERATELY WRONG draft that
+        # guarantees zero acceptance.
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        x_pred = int(mx.argmax(l0[:, -1], axis=-1).item())
+        vocab_size = _ple_args().vocab_size or 4**6
+        wrong_draft = [(x_pred + 1) % vocab_size, x_pred + 2]
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return list(wrong_draft)
+
+        pristine = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=pristine,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+        # Fail after the zero-accept commit head is swapped in (logprob
+        # construction). Must re-raise AND restore the pristine cache — the
+        # regression this guards is the live cache staying advanced through X.
+        with (
+            patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            gb._step()
+        _assert_state_equal(gb.prompt_cache, pristine)
+
 
 class TestHybridTerminalRepair:
     """Finding #1: a hybrid finish part-way through the accepted drafts must

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1539,12 +1539,11 @@ class TestSingleSnapshotCommit:
             suffix_hybrid_bit_exact=True,
         )
         # Fail inside the post-commit logprob construction (runs after the
-        # commit head swap). The wrapped _step must re-raise AND restore the
-        # pristine cache.
-        with (
-            patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")),
-            pytest.raises(RuntimeError, match="boom"),
-        ):
+        # commit head swap). Per codex round-9i finding #1, the wrapped _step
+        # must advertise the vanilla fallthrough — it absorbs the exception and
+        # runs ``_orig_step()`` on the restored (PRISTINE) cache, rather than
+        # re-raising (which would abort generation).
+        with patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")):
             gb._step()
         _assert_state_equal(gb.prompt_cache, pristine)
 
@@ -1579,7 +1578,9 @@ class TestSingleSnapshotCommit:
         mx.eval(l0)
         x_pred = int(mx.argmax(l0[:, -1], axis=-1).item())
         vocab_size = _ple_args().vocab_size or 4**6
-        wrong_draft = [(x_pred + 1) % vocab_size, x_pred + 2]
+        # Wrap BOTH tokens mod vocab_size so neither can exceed vocab-1 and
+        # break the embedding lookup before the zero-accept path is exercised.
+        wrong_draft = [(x_pred + 1) % vocab_size, (x_pred + 2) % vocab_size]
 
         class MockDrafter:
             max_draft_tokens = 2
@@ -1638,12 +1639,11 @@ class TestSingleSnapshotCommit:
             suffix_hybrid_bit_exact=True,
         )
         # Fail after the zero-accept commit head is swapped in (logprob
-        # construction). Must re-raise AND restore the pristine cache — the
-        # regression this guards is the live cache staying advanced through X.
-        with (
-            patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")),
-            pytest.raises(RuntimeError, match="boom"),
-        ):
+        # construction). Per round-9i finding #1 the exception is absorbed and
+        # the step falls through to ``_orig_step`` on the restored pristine
+        # cache — the regression this guards is the live cache staying advanced
+        # through X.
+        with patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")):
             gb._step()
         _assert_state_equal(gb.prompt_cache, pristine)
 
@@ -1756,12 +1756,10 @@ class TestSingleSnapshotCommit:
         # Fail in the fallible logprob compute (which now runs FIRST, before
         # the mutation tail). Because the mutation tail never runs, the counter
         # ``set_state`` is never called: no cooldown/width state was mutated on
-        # the way to the exception, and the pristine cache is restored. The step
-        # falls through and the caller re-derives state on the re-run.
-        with (
-            patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")),
-            pytest.raises(RuntimeError, match="boom"),
-        ):
+        # the way to the exception, and the pristine cache is restored. Per
+        # round-9i finding #1 the step absorbs the exception and falls through
+        # to ``_orig_step``; the caller re-derives state on that re-run.
+        with patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")):
             gb._step()
         assert spy.set_state_calls == 0
         _assert_state_equal(gb.prompt_cache, pre_fail)
@@ -1857,11 +1855,9 @@ class TestSingleSnapshotCommit:
         # Force a post-commit exception on the hybrid commit. The handler must
         # (a) restore the pristine cache AND (b) drop the retained replay entry
         # so the subsequent terminal response is NOT rebuilt from a stale
-        # snapshot.
-        with (
-            patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")),
-            pytest.raises(RuntimeError, match="boom"),
-        ):
+        # snapshot. (Per round-9i finding #1 the exception is absorbed and the
+        # step falls through to ``_orig_step``.)
+        with patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")):
             gb._step()
         _assert_state_equal(gb.prompt_cache, pristine)
         # A terminal (length) primary now flows through _suffix_next. With the

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1764,6 +1764,117 @@ class TestSingleSnapshotCommit:
         assert spy.set_state_calls == 0
         _assert_state_equal(gb.prompt_cache, pre_fail)
 
+    def test_post_commit_late_publish_failure_rolls_back_everything(self, monkeypatch):
+        """Codex round-9j finding #3: previous tests only injected the failure in
+        the (pre-mutation) compute section, so they could not catch corruption
+        from a failure late in the mutation tail. Here we inject a failure at
+        ``gb.tokens[0].append`` — a LATE publish that runs AFTER the cooldown/
+        drafter/stat mutations — and assert the transactional snapshot restores
+        the cache, ``_stats``, drafter history, and next-token state so the
+        step is exactly as before it ran (the advertised vanilla fallthrough)."""
+        import copy as _copy
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                self._tokens = []
+                self.rewind_to = lambda _n: None
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                self._tokens.append(_t)
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [d0, d1]
+
+        pristine = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=pristine,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+        # Warm-up: seed _uid_state and let the commit path run once.
+        gb._step()
+        pre_fail = _copy.deepcopy(gb.prompt_cache)
+        # Record the observable pre-state of the mutated surfaces.
+        pre_tokens_len = len(gb.tokens[0])
+        pre_next_tokens = gb._next_tokens
+
+        # Inject a LATE failure: the publish ``gb.tokens[0].append(last_token)``
+        # raises (runs after cooldown + drafter + stat mutations). The handler
+        # must roll back everything. Replace the tokens[0] list with a proxy
+        # whose append raises.
+        class BoomList(list):
+            def append(self, x):
+                raise RuntimeError("boom")
+
+        real_tokens0 = gb.tokens[0]
+        gb.tokens[0] = BoomList(real_tokens0)
+        try:
+            gb._step()  # absorbed: falls through to _orig_step, no raise
+        finally:
+            gb.tokens[0] = real_tokens0
+        # Cache restored to pre-fail pristine.
+        _assert_state_equal(gb.prompt_cache, pre_fail)
+        # tokens[0] not extended (failed append rolled back): length unchanged.
+        assert len(gb.tokens[0]) == pre_tokens_len
+        # _next_tokens restored (the commit didn't stash the bonus).
+        assert gb._next_tokens is pre_next_tokens
+
     def test_post_commit_exception_drops_retained_replay_entry(self, monkeypatch):
         """Codex round-9h finding #1: a post-commit exception must pop the
         uid's retained ``_pending_hybrid_replay`` entry. If it leaked, a later

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1454,6 +1454,100 @@ class TestSingleSnapshotCommit:
         )
         assert gb3.prompt_cache == "live2"
 
+    def test_post_commit_phase_exception_restores_cache(self, monkeypatch):
+        """Codex round-9e finding #3: a failure AFTER the hybrid commit but in
+        the shared post-commit preparation phase (cooldown bookkeeping / logprob
+        construction / pending-emission creation) must restore the pristine
+        pre-verify cache, never leaving ``gb.prompt_cache`` advanced beyond the
+        surfaced tokens.
+
+        We inject the failure in the logprob construction (``mx.logsumexp``),
+        which runs inside the post-commit envelope AFTER the commit head was
+        swapped in, and assert the re-raised exception propagates to the wrapper
+        while the live cache has been restored to the pristine snapshot."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import vllm_mlx.scheduler as scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [d0, d1]
+
+        pristine = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=pristine,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+        # Fail inside the post-commit logprob construction (runs after the
+        # commit head swap). The wrapped _step must re-raise AND restore the
+        # pristine cache.
+        with (
+            patch.object(scheduler.mx, "logsumexp", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            gb._step()
+        _assert_state_equal(gb.prompt_cache, pristine)
+
 
 class TestHybridTerminalRepair:
     """Finding #1: a hybrid finish part-way through the accepted drafts must
@@ -1586,3 +1680,107 @@ class TestHybridTerminalRepair:
         assert int(mx.argmax(nxt_raw[:, -1], axis=-1).item()) == int(
             mx.argmax(nxt_gold[:, -1], axis=-1).item()
         )
+
+    def test_primary_terminal_drops_every_queued_accepted_draft(self, monkeypatch):
+        """Codex round-9e finding #2: the PRIMARY can be terminal (a length
+        finish on the primary token X itself), leaving every queued accepted
+        draft un-surfaced. The delivered response cache must then hold ONLY
+        pristine + X (the Finding-1 repair), dropping all accepted drafts.
+
+        Model the real generation path: the primary _step advances
+        ``_num_tokens`` to 1, so the synthetic emits are never reached (the
+        primary's length limit stops the request). The returning primary
+        response is terminal, and ``_suffix_next`` must repair its cache to
+        pristine + X via the primary-terminal repair (not the synthetic-drain
+        loop, which never runs)."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from vllm_mlx import scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [d0, d1]
+
+        pristine = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=pristine,
+            _num_tokens=[0],
+            max_tokens=[1],  # length-limit: the PRIMARY X saturates it
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        # The PRIMARY _step commits X (increments _num_tokens to 1) and
+        # stashes [d0, d1] as pending emits. The primary is terminal (length).
+        gb._step = lambda: ([7], [])
+        # The returned primary is the terminal length response.
+        gb.next = lambda: [SimpleNamespace(uid=1, finish_reason="length")]
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+
+        # Commit the hybrid verify: X + d0 + d1 all accepted, [d0, d1] queued.
+        gb._step()
+        # The next() wrapper returns the terminal primary; Finding-1 repair
+        # must rebuild its cache to pristine + X ONLY (d0, d1 dropped because
+        # they were never surfaced).
+        outs = gb.next()
+        terminals = [o for o in outs if o.finish_reason is not None]
+        assert len(terminals) == 1
+        delivered = terminals[0].prompt_cache
+        # Gold = pristine + X (no accepted drafts surfaced).
+        gold = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=gold))
+        mx.eval(model(mx.array([[7]]), cache=gold))
+        _assert_state_equal(delivered, gold)

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -42,9 +42,11 @@ from vllm_mlx.scheduler import (  # noqa: E402
 
 def _offsets(cache):
     return [
-        None
-        if not isinstance(lc, CacheList)
-        else (int(lc[0].offset), int(lc[1].offset))
+        (
+            None
+            if not isinstance(lc, CacheList)
+            else (int(lc[0].offset), int(lc[1].offset))
+        )
         for lc in cache
     ]
 
@@ -1314,6 +1316,128 @@ class TestSingleSnapshotCommit:
         calls, bg = self._install_and_step(monkeypatch, guard_on=False)
         # Guard off -> no probe -> stepwise commit helper replays once.
         assert calls["commit"] == 1
+
+    def test_post_commit_exception_restores_pristine_cache_then_falls_through(
+        self, monkeypatch
+    ):
+        """Codex BLOCKING (round-9c): an exception raised AFTER the hybrid
+        commit head is swapped in must NOT run ``_orig_step`` against the
+        already-advanced cache. The hybrid ``except`` in ``_suffix_step``
+        restores ``gb.prompt_cache`` to the pristine pre-verify snapshot before
+        falling through.
+
+        The restore logic lives in the module-level
+        ``_restore_hybrid_cache_after_exception`` (unit-tested directly below);
+        both invocations of it (pre-commit no-op + post-commit restore) are
+        covered there. The pre-commit exception path through the real
+        ``_suffix_step`` is covered here: when the verify forward raises before
+        commit, ``result`` is the empty init dict and the fall-through must
+        leave the pristine cache untouched."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        import vllm_mlx.scheduler as scheduler
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.speculative import suffix_decoding
+
+        model, _ = _model_and_prompt()
+
+        class MockDrafter:
+            max_draft_tokens = 2
+
+            def __init__(self, **_kw):
+                pass
+
+            def add_prompt_tokens(self, _t):
+                pass
+
+            def add_generated_token(self, _t):
+                pass
+
+            def record_acceptance(self, _c):
+                pass
+
+            def get_draft(self):
+                return [5, 6]
+
+        pristine = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
+
+        gb = SimpleNamespace(
+            _next_tokens=mx.array([7], dtype=mx.int32),
+            _next_logprobs=[mx.zeros((64,))],
+            uids=[1],
+            tokens=[[]],
+            logits_processors=[],
+            prompt_cache=pristine,
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[SimpleNamespace(match=lambda s, _t: (s, None, None))],
+            _matcher_states=[None],
+            extract_cache=lambda _r: [],
+            model=model,
+        )
+        gb.Response = SimpleNamespace
+        gb._step = lambda: ([7], [])
+        gb.next = lambda: []
+        bg = MagicMock()
+        bg._generation_batch = gb
+        bg.remove = lambda *a, **k: {}
+        # Force the guard probe to raise during the stepwise replay: a cache
+        # whose layer can't forward cleanly. We make the probe replay blow up
+        # by swapping in a model that raises on the SECOND decode (the probe
+        # step), i.e. BEFORE commit. This exercises the `result={}` init +
+        # exception path (no restore needed, pristine cache untouched).
+        real_call = {"n": 0}
+
+        def _flaky_model(inp, cache=None, **kw):
+            real_call["n"] += 1
+            raise RuntimeError("flaky decode before commit")
+
+        gb.model = _flaky_model
+        monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+        scheduler._install_suffix_decoding(
+            bg,
+            model=_flaky_model,
+            profile=profile,
+            max_draft=2,
+            max_suffix_len=4,
+            min_confidence=0.3,
+            requests={},
+            uid_to_request_id={},
+            suffix_hybrid=True,
+            suffix_min_match_len=2,
+            suffix_hybrid_bit_exact=True,
+        )
+        # The pre-commit exception is absorbed by the hybrid except -> clean
+        # fall-through (no raise to caller), and the pristine cache is intact.
+        gb._step()
+        _assert_state_equal(gb.prompt_cache, pristine)
+
+    def test_restore_hybrid_cache_helper(self):
+        """Direct unit test of ``_restore_hybrid_cache_after_exception``: a
+        committed result (``committed`` + ``replay_snapshot``) restores the
+        cache; an empty / pre-commit result is a no-op."""
+        from types import SimpleNamespace
+
+        import vllm_mlx.scheduler as scheduler
+
+        gb = SimpleNamespace(prompt_cache="committed_head")
+        # (a) post-commit exception -> restore to pristine snapshot.
+        result = {"committed": True, "replay_snapshot": "pristine_snapshot"}
+        scheduler._restore_hybrid_cache_after_exception(gb, result)
+        assert gb.prompt_cache == "pristine_snapshot"
+        # (b) pre-commit exception (empty result) -> no restore.
+        gb2 = SimpleNamespace(prompt_cache="live")
+        scheduler._restore_hybrid_cache_after_exception(gb2, {})
+        assert gb2.prompt_cache == "live"
+        # (c) committed but no snapshot (shouldn't happen) -> no restore.
+        gb3 = SimpleNamespace(prompt_cache="live2")
+        scheduler._restore_hybrid_cache_after_exception(
+            gb3, {"committed": True, "replay_snapshot": None}
+        )
+        assert gb3.prompt_cache == "live2"
 
 
 class TestHybridTerminalRepair:

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -252,21 +252,28 @@ class TestHybridInstallGate:
         assert bg._suffix_stats["suffix_hybrid"] is True
         assert bg._suffix_stats["suffix_min_match_len"] == 24
 
-    def test_hybrid_drafter_cap_never_exceeds_config_and_reaches_floor(
+    def test_hybrid_drafter_reaches_floor_but_pure_attention_keeps_cap(
         self, monkeypatch
     ):
-        """Finding: the hybrid drafter cap must never exceed the operator's
-        explicit ``suffix_max_draft`` (``_effective_max_draft = min(max_draft,
-        floor)``), while reaching the 24-token floor when the cap allows it."""
+        """Final design (rounds 5-7): on the HYBRID path the drafter cap is
+        raised to at least the 24-token match floor so the opt-in feature is
+        not a silent no-op; on PURE-ATTENTION (where --suffix-hybrid is a
+        no-op flag) the configured ``max_draft`` is preserved untouched —
+        the hybrid cap raise must NOT leak into pure-attention models."""
         from types import SimpleNamespace
         from unittest.mock import MagicMock
 
         from vllm_mlx import scheduler
         from vllm_mlx.model_auto_config import ModelConfig
 
-        def _install_opts(max_draft):
+        def _install_opts(max_draft, is_hybrid):
             bg, gb = self._make_fake_bg()
-            profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
+            # Pure-attention installs need supports_spec_decode=True (the
+            # hybrid opt-in path bypasses that gate); hybrid is gated only on
+            # is_hybrid + suffix_hybrid.
+            profile = ModelConfig(
+                is_hybrid=is_hybrid, supports_spec_decode=not is_hybrid
+            )
             assert scheduler._install_suffix_decoding(
                 bg,
                 model=MagicMock(),
@@ -290,18 +297,23 @@ class TestHybridInstallGate:
             gb.model = MagicMock()
             gb._orig_step = lambda: ([1], [])
             gb._step()  # lazy-init constructs the drafter this step
-            return bg, gb, gb._suffix_drafters[1]
+            return gb._suffix_drafters[1]
 
-        # (a) Below-floor cap (default 8): drafter is clamped AT 8, never above.
-        _bg, _gb, drafter8 = _install_opts(8)
-        assert drafter8.max_draft_tokens == 8
-        assert drafter8.max_draft_tokens < 24
-        # (b) Cap at/above the floor: drafter reaches the 24-token floor.
-        _bg, _gb, drafter32 = _install_opts(32)
+        # (a) Hybrid, below-floor configured cap (default 8): width is raised
+        # to the 24-token floor so the feature engages.
+        drafter8 = _install_opts(8, is_hybrid=True)
+        assert drafter8.max_draft_tokens == 24
+        # (b) Hybrid, cap above the floor: width reaches the floor, not higher.
+        drafter32 = _install_opts(32, is_hybrid=True)
         assert drafter32.max_draft_tokens == 24
-        # (c) Cap above the floor is not lowered below it.
-        _bg, _gb, drafter24 = _install_opts(24)
-        assert drafter24.max_draft_tokens == 24
+        # (c) PURE-ATTENTION, same flag: the width stays at the normal adaptive
+        # start (2), NOT raised to the 24-token floor — the hybrid raise must
+        # not leak into a no-op-flag pure-attention model.
+        drafter_pa8 = _install_opts(8, is_hybrid=False)
+        assert drafter_pa8.max_draft_tokens == 2
+        # (d) Pure-attention, explicit higher cap: also not raised to the floor.
+        drafter_pa32 = _install_opts(32, is_hybrid=False)
+        assert drafter_pa32.max_draft_tokens == 2
 
     def test_installed_reject_first_commits_primary(self, monkeypatch):
         """Installed-path reject-first verify: the live cache must equal

--- a/tests/test_suffix_hybrid_scratch_verify.py
+++ b/tests/test_suffix_hybrid_scratch_verify.py
@@ -1326,13 +1326,12 @@ class TestSingleSnapshotCommit:
         restores ``gb.prompt_cache`` to the pristine pre-verify snapshot before
         falling through.
 
-        The restore logic lives in the module-level
-        ``_restore_hybrid_cache_after_exception`` (unit-tested directly below);
-        both invocations of it (pre-commit no-op + post-commit restore) are
-        covered there. The pre-commit exception path through the real
-        ``_suffix_step`` is covered here: when the verify forward raises before
-        commit, ``result`` is the empty init dict and the fall-through must
-        leave the pristine cache untouched."""
+        We inject a POST-commit exception by patching the module-level
+        ``_retain_hybrid_replay`` (the in-try step that runs after
+        ``result[\"committed\"] = True``) to raise. The commit already swapped
+        the probe head onto the live cache, so the except MUST restore the
+        pristine snapshot before ``_orig_step`` — and the wrapped ``_orig_step``
+        observer records that it saw the pristine cache."""
         from types import SimpleNamespace
         from unittest.mock import MagicMock
 
@@ -1341,6 +1340,15 @@ class TestSingleSnapshotCommit:
         from vllm_mlx.speculative import suffix_decoding
 
         model, _ = _model_and_prompt()
+        # Greedy accept-all draft (step-exact model -> no drift, n_accepted>0).
+        probe = model.make_cache()
+        mx.eval(model(mx.array([[1, 2, 3]]), cache=probe))
+        l0 = model(mx.array([[7]]), cache=probe)
+        mx.eval(l0)
+        d0 = int(mx.argmax(l0[:, -1], axis=-1).item())
+        l1 = model(mx.array([[d0]]), cache=probe)
+        mx.eval(l1)
+        d1 = int(mx.argmax(l1[:, -1], axis=-1).item())
 
         class MockDrafter:
             max_draft_tokens = 2
@@ -1358,7 +1366,7 @@ class TestSingleSnapshotCommit:
                 pass
 
             def get_draft(self):
-                return [5, 6]
+                return [d0, d1]
 
         pristine = model.make_cache()
         mx.eval(model(mx.array([[1, 2, 3]]), cache=pristine))
@@ -1383,23 +1391,30 @@ class TestSingleSnapshotCommit:
         bg = MagicMock()
         bg._generation_batch = gb
         bg.remove = lambda *a, **k: {}
-        # Force the guard probe to raise during the stepwise replay: a cache
-        # whose layer can't forward cleanly. We make the probe replay blow up
-        # by swapping in a model that raises on the SECOND decode (the probe
-        # step), i.e. BEFORE commit. This exercises the `result={}` init +
-        # exception path (no restore needed, pristine cache untouched).
-        real_call = {"n": 0}
 
-        def _flaky_model(inp, cache=None, **kw):
-            real_call["n"] += 1
-            raise RuntimeError("flaky decode before commit")
+        # Wrap the vanilla step to record which cache it observes. Install
+        # captures ``gb._step`` as its ``_orig_step``, so we put the observer
+        # IN ``gb._step`` (pre-install). This is the crux of the codex finding:
+        # after a post-commit exception + restore, the fall-through _orig_step
+        # must run against the PRISTINE pre-verify cache, not the advanced
+        # (committed probe) head.
+        observed = {"cache": None}
 
-        gb.model = _flaky_model
+        def _orig_step():
+            observed["cache"] = list(gb.prompt_cache)
+            return ([7], [])
+
+        gb._step = _orig_step
+
+        def _boom_retain(*a, **k):
+            raise MemoryError("simulated post-commit OOM in replay retain")
+
         monkeypatch.setattr(suffix_decoding, "SuffixDecodingDrafter", MockDrafter)
+        monkeypatch.setattr(scheduler, "_retain_hybrid_replay", _boom_retain)
         profile = ModelConfig(is_hybrid=True, supports_spec_decode=False)
         scheduler._install_suffix_decoding(
             bg,
-            model=_flaky_model,
+            model=model,
             profile=profile,
             max_draft=2,
             max_suffix_len=4,
@@ -1410,10 +1425,10 @@ class TestSingleSnapshotCommit:
             suffix_min_match_len=2,
             suffix_hybrid_bit_exact=True,
         )
-        # The pre-commit exception is absorbed by the hybrid except -> clean
-        # fall-through (no raise to caller), and the pristine cache is intact.
+        # The post-commit exception is absorbed by the hybrid except -> clean
+        # fall-through, and the wrapped _orig_step observed the PRISTINE cache.
         gb._step()
-        _assert_state_equal(gb.prompt_cache, pristine)
+        _assert_state_equal(observed["cache"], pristine)
 
     def test_restore_hybrid_cache_helper(self):
         """Direct unit test of ``_restore_hybrid_cache_after_exception``: a

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2331,18 +2331,25 @@ def _normalize_speculative_config_or_exit(args):
         return fields
 
     def _fill_suffix_defaults() -> None:
+        if getattr(args, "suffix_hybrid", None) is None:
+            args.suffix_hybrid = False
+        if getattr(args, "suffix_min_match_len", None) is None:
+            args.suffix_min_match_len = 24
         if getattr(args, "suffix_max_draft", None) is None:
-            args.suffix_max_draft = 8
+            # Default the draft cap to at least the hybrid match floor when
+            # hybrid is ON. The 24-token floor only makes sense with a verify
+            # width that can reach it; the pure-attention default of 8 would
+            # silently make --suffix-hybrid a no-op. An EXPLICIT below-floor
+            # cap is still honored (the operator's bound wins).
+            args.suffix_max_draft = (
+                args.suffix_min_match_len if args.suffix_hybrid else 8
+            )
         if getattr(args, "suffix_max_suffix_len", None) is None:
             args.suffix_max_suffix_len = 4
         if getattr(args, "suffix_min_confidence", None) is None:
             args.suffix_min_confidence = 0.3
         if getattr(args, "suffix_min_draft_len", None) is None:
             args.suffix_min_draft_len = 2
-        if getattr(args, "suffix_hybrid", None) is None:
-            args.suffix_hybrid = False
-        if getattr(args, "suffix_min_match_len", None) is None:
-            args.suffix_min_match_len = 24
         # Bit-exactness guard is DEFAULT ON (the hybrid path is only lossless
         # when bit-exact). --no-suffix-hybrid-bit-exact explicitly turns it
         # off — a NON-LOSSLESS / unsafe mode for eval/measurement — and wins

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2335,12 +2335,18 @@ def _normalize_speculative_config_or_exit(args):
             args.suffix_hybrid = False
         if getattr(args, "suffix_min_match_len", None) is None:
             args.suffix_min_match_len = 24
-        if getattr(args, "suffix_max_draft", None) is None:
-            # Keep the pure-attention default (8). The hybrid path raises the
-            # effective width to the match floor ONLY for an actual hybrid
-            # model in the installer (profile.is_hybrid-gated), so a pure-
-            # attention model with --suffix-hybrid (a no-op flag there) keeps
-            # its normal verify width instead of silently tripling it.
+        # Record whether the operator explicitly set --suffix-max-draft (vs the
+        # 8 default). The hybrid path raises the effective width to the match
+        # floor for a CONFIRMED HYBRID model when the cap was NOT explicitly set
+        # — an explicit below-floor cap is the operator's bound and gets an
+        # install-time warning instead. This lets --suffix-hybrid work out of
+        # the box on a real hybrid while never tripling a pure-attention model's
+        # verify width (pure-attention is not hybrid-gated, so it keeps 8/its
+        # normal adaptive width).
+        args._suffix_max_draft_was_explicit = getattr(
+            args, "suffix_max_draft", None
+        ) is not None
+        if not args._suffix_max_draft_was_explicit:
             args.suffix_max_draft = 8
         if getattr(args, "suffix_max_suffix_len", None) is None:
             args.suffix_max_suffix_len = 4
@@ -2624,24 +2630,6 @@ def _normalize_speculative_config_or_exit(args):
             args.suffix_min_draft_len = config.min_draft_len
 
     _fill_suffix_defaults()
-
-    # Fail fast instead of silently contradicting the operator. suffix_hybrid
-    # needs a verify width that can reach the 24-token match floor; honoring an
-    # explicitly-set suffix_max_draft below the floor would make the opt-in a
-    # silent no-op, and silently raising the cap would violate the documented
-    # max width (memory) contract. Reject the contradictory combination with an
-    # actionable message naming the flag to raise.
-    if getattr(args, "suffix_hybrid", False) and (
-        getattr(args, "suffix_max_draft", 0) < getattr(args, "suffix_min_match_len", 24)
-    ):
-        print(
-            "error: --suffix-hybrid requires --suffix-max-draft >= "
-            f"suffix_min_match_len ({args.suffix_min_match_len}); "
-            f"got suffix_max_draft={args.suffix_max_draft}. Raise "
-            "--suffix-max-draft to enable the hybrid path.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
 
 
 def _resolve_dflash_drafter_repo(args, profile) -> str | None:
@@ -3447,6 +3435,29 @@ def _auto_config_lookup_key(config_identity: str) -> str:
     from .utils.tokenizer import _resolve_subfolder_checkpoint
 
     return _resolve_subfolder_checkpoint(config_identity)
+
+
+def _hybrid_suffix_cap(args, profile) -> int:
+    """Effective ``--suffix-max-draft`` for the SuffixDecoding config.
+
+    Deferred to model resolution because the CLI cannot know the model is
+    hybrid until the ``serve`` profile is resolved. For a CONFIRMED hybrid
+    model with ``--suffix-hybrid`` and NO explicit ``--suffix-max-draft``,
+    raise the cap to the match floor so the opt-in works out of the box (the
+    pure-attention default 8 cannot clear the 24-token match floor). An
+    EXPLICIT below-floor cap is the operator's bound and is honored as-is
+    (the scheduler install issues a no-op warning). A pure-attention model
+    with ``--suffix-hybrid`` (a documented no-op flag there) keeps its cap.
+    """
+    effective = args.suffix_max_draft
+    if (
+        args.suffix_hybrid
+        and profile is not None
+        and getattr(profile, "is_hybrid", False)
+        and not getattr(args, "_suffix_max_draft_was_explicit", False)
+    ):
+        effective = max(args.suffix_max_draft, args.suffix_min_match_len)
+    return effective
 
 
 def serve_command(args):
@@ -4721,6 +4732,11 @@ def serve_command(args):
         except Exception:  # pragma: no cover — best-effort
             _cli_mtp_model_type = None
 
+    # SuffixDecoding hybrid cap: DEFERRED to model resolution (see
+    # ``_hybrid_suffix_cap``) — the CLI cannot know the model is hybrid until
+    # the resolved ``_serve_profile`` is available here.
+    _effective_suffix_max_draft = _hybrid_suffix_cap(args, _serve_profile)
+
     scheduler_config = SchedulerConfig(
         max_num_seqs=args.max_num_seqs,
         max_concurrent_requests=args.max_concurrent_requests,
@@ -4786,9 +4802,15 @@ def serve_command(args):
         mtp_allow_dynamic_membership=getattr(
             args, "mtp_allow_dynamic_membership", False
         ),
-        # SuffixDecoding
+        # SuffixDecoding. For a CONFIRMED hybrid model with --suffix-hybrid and
+        # no explicit --suffix-max-draft, raise the cap to the match floor so
+        # the opt-in works out of the box (the pure-attention default 8 cannot
+        # clear the 24-token floor). An EXPLICIT below-floor cap is the
+        # operator's bound and is honored as-is (WARNING at install). A pure-
+        # attention model with --suffix-hybrid (a no-op flag) keeps its cap, so
+        # its verify width is never tripled.
         enable_suffix_decoding=args.suffix_decoding,
-        suffix_max_draft=args.suffix_max_draft,
+        suffix_max_draft=_effective_suffix_max_draft,
         suffix_max_suffix_len=args.suffix_max_suffix_len,
         suffix_min_confidence=args.suffix_min_confidence,
         suffix_min_draft_len=args.suffix_min_draft_len,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2345,8 +2345,6 @@ def _normalize_speculative_config_or_exit(args):
             args.suffix_min_match_len = 24
         if getattr(args, "suffix_hybrid_bit_exact", None) is None:
             args.suffix_hybrid_bit_exact = False
-        if getattr(args, "suffix_hybrid_probe_len", None) is None:
-            args.suffix_hybrid_probe_len = 4
 
     def _legacy_speculative_config_payload() -> dict | None:
         methods: list[tuple[str, dict]] = []
@@ -4766,7 +4764,6 @@ def serve_command(args):
         suffix_hybrid=args.suffix_hybrid,
         suffix_min_match_len=args.suffix_min_match_len,
         suffix_hybrid_bit_exact=args.suffix_hybrid_bit_exact,
-        suffix_hybrid_probe_len=args.suffix_hybrid_probe_len,
         # KV cache quantization (R15 #300: dtype string is the canonical
         # observability surface; ``_quantization`` / ``_bits`` are the
         # wire-level toggles that drive ``mlx_lm.QuantizedKVCache``).
@@ -11513,12 +11510,6 @@ Examples:
     serve_parser.add_argument(
         "--suffix-hybrid-bit-exact",
         action="store_true",
-        default=None,
-        help=argparse.SUPPRESS,
-    )
-    serve_parser.add_argument(
-        "--suffix-hybrid-probe-len",
-        type=int,
         default=None,
         help=argparse.SUPPRESS,
     )

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2625,6 +2625,24 @@ def _normalize_speculative_config_or_exit(args):
 
     _fill_suffix_defaults()
 
+    # Fail fast instead of silently contradicting the operator. suffix_hybrid
+    # needs a verify width that can reach the 24-token match floor; honoring an
+    # explicitly-set suffix_max_draft below the floor would make the opt-in a
+    # silent no-op, and silently raising the cap would violate the documented
+    # max width (memory) contract. Reject the contradictory combination with an
+    # actionable message naming the flag to raise.
+    if getattr(args, "suffix_hybrid", False) and (
+        getattr(args, "suffix_max_draft", 0) < getattr(args, "suffix_min_match_len", 24)
+    ):
+        print(
+            "error: --suffix-hybrid requires --suffix-max-draft >= "
+            f"suffix_min_match_len ({args.suffix_min_match_len}); "
+            f"got suffix_max_draft={args.suffix_max_draft}. Raise "
+            "--suffix-max-draft to enable the hybrid path.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
 
 def _resolve_dflash_drafter_repo(args, profile) -> str | None:
     """Return the effective DFlash drafter repo for normalized CLI args."""

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2343,9 +2343,14 @@ def _normalize_speculative_config_or_exit(args):
         # the box on a real hybrid while never tripling a pure-attention model's
         # verify width (pure-attention is not hybrid-gated, so it keeps 8/its
         # normal adaptive width).
-        args._suffix_max_draft_was_explicit = getattr(
-            args, "suffix_max_draft", None
-        ) is not None
+        # The sentinel is initialized ONLY when absent so it survives repeated
+        # normalization: a defaulted cap must stay "implicit" (so the hybrid
+        # path can still raise it to the floor), not flip to "explicit" merely
+        # because a second call now sees the filled-in 8.
+        if not hasattr(args, "_suffix_max_draft_was_explicit"):
+            args._suffix_max_draft_was_explicit = getattr(
+                args, "suffix_max_draft", None
+            ) is not None
         if not args._suffix_max_draft_was_explicit:
             args.suffix_max_draft = 8
         if getattr(args, "suffix_max_suffix_len", None) is None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2351,7 +2351,12 @@ def _normalize_speculative_config_or_exit(args):
             args._suffix_max_draft_was_explicit = (
                 getattr(args, "suffix_max_draft", None) is not None
             )
-        if not args._suffix_max_draft_was_explicit:
+        # Fill the default ONLY when the value is actually unset. The sentinel
+        # is tracked independently (above) so a repeated normalization does not
+        # re-default a value a programmatic caller changed between calls (codex
+        # round-9l NIT): the explicit/implicit intent is recorded once, and the
+        # default fill only ever applies to a genuinely-None cap.
+        if getattr(args, "suffix_max_draft", None) is None:
             args.suffix_max_draft = 8
         if getattr(args, "suffix_max_suffix_len", None) is None:
             args.suffix_max_suffix_len = 4

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2336,14 +2336,12 @@ def _normalize_speculative_config_or_exit(args):
         if getattr(args, "suffix_min_match_len", None) is None:
             args.suffix_min_match_len = 24
         if getattr(args, "suffix_max_draft", None) is None:
-            # Default the draft cap to at least the hybrid match floor when
-            # hybrid is ON. The 24-token floor only makes sense with a verify
-            # width that can reach it; the pure-attention default of 8 would
-            # silently make --suffix-hybrid a no-op. An EXPLICIT below-floor
-            # cap is still honored (the operator's bound wins).
-            args.suffix_max_draft = (
-                args.suffix_min_match_len if args.suffix_hybrid else 8
-            )
+            # Keep the pure-attention default (8). The hybrid path raises the
+            # effective width to the match floor ONLY for an actual hybrid
+            # model in the installer (profile.is_hybrid-gated), so a pure-
+            # attention model with --suffix-hybrid (a no-op flag there) keeps
+            # its normal verify width instead of silently tripling it.
+            args.suffix_max_draft = 8
         if getattr(args, "suffix_max_suffix_len", None) is None:
             args.suffix_max_suffix_len = 4
         if getattr(args, "suffix_min_confidence", None) is None:

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2348,9 +2348,9 @@ def _normalize_speculative_config_or_exit(args):
         # path can still raise it to the floor), not flip to "explicit" merely
         # because a second call now sees the filled-in 8.
         if not hasattr(args, "_suffix_max_draft_was_explicit"):
-            args._suffix_max_draft_was_explicit = getattr(
-                args, "suffix_max_draft", None
-            ) is not None
+            args._suffix_max_draft_was_explicit = (
+                getattr(args, "suffix_max_draft", None) is not None
+            )
         if not args._suffix_max_draft_was_explicit:
             args.suffix_max_draft = 8
         if getattr(args, "suffix_max_suffix_len", None) is None:
@@ -6949,9 +6949,9 @@ def _cached_models_json_payload() -> dict:
                     "subfolder": subfolder,
                     "size_bytes": int(artifact_size),
                     "modified_epoch": int(mtime) if mtime and mtime > 0 else None,
-                    "age_seconds": int(max(0, now - mtime))
-                    if mtime and mtime > 0
-                    else None,
+                    "age_seconds": (
+                        int(max(0, now - mtime)) if mtime and mtime > 0 else None
+                    ),
                     "state": state,
                     "external": is_external,
                 }

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3467,7 +3467,7 @@ def _hybrid_suffix_cap(args, profile) -> int:
         and not getattr(args, "_suffix_max_draft_was_explicit", False)
     ):
         effective = max(args.suffix_max_draft, args.suffix_min_match_len)
-    return effective
+    return int(effective)
 
 
 def serve_command(args):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2339,6 +2339,14 @@ def _normalize_speculative_config_or_exit(args):
             args.suffix_min_confidence = 0.3
         if getattr(args, "suffix_min_draft_len", None) is None:
             args.suffix_min_draft_len = 2
+        if getattr(args, "suffix_hybrid", None) is None:
+            args.suffix_hybrid = False
+        if getattr(args, "suffix_min_match_len", None) is None:
+            args.suffix_min_match_len = 24
+        if getattr(args, "suffix_hybrid_bit_exact", None) is None:
+            args.suffix_hybrid_bit_exact = False
+        if getattr(args, "suffix_hybrid_probe_len", None) is None:
+            args.suffix_hybrid_probe_len = 4
 
     def _legacy_speculative_config_payload() -> dict | None:
         methods: list[tuple[str, dict]] = []
@@ -4755,6 +4763,10 @@ def serve_command(args):
         suffix_max_suffix_len=args.suffix_max_suffix_len,
         suffix_min_confidence=args.suffix_min_confidence,
         suffix_min_draft_len=args.suffix_min_draft_len,
+        suffix_hybrid=args.suffix_hybrid,
+        suffix_min_match_len=args.suffix_min_match_len,
+        suffix_hybrid_bit_exact=args.suffix_hybrid_bit_exact,
+        suffix_hybrid_probe_len=args.suffix_hybrid_probe_len,
         # KV cache quantization (R15 #300: dtype string is the canonical
         # observability surface; ``_quantization`` / ``_bits`` are the
         # wire-level toggles that drive ``mlx_lm.QuantizedKVCache``).
@@ -11482,6 +11494,30 @@ Examples:
     )
     serve_parser.add_argument(
         "--suffix-min-draft-len",
+        type=int,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    serve_parser.add_argument(
+        "--suffix-hybrid",
+        action="store_true",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    serve_parser.add_argument(
+        "--suffix-min-match-len",
+        type=int,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    serve_parser.add_argument(
+        "--suffix-hybrid-bit-exact",
+        action="store_true",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    serve_parser.add_argument(
+        "--suffix-hybrid-probe-len",
         type=int,
         default=None,
         help=argparse.SUPPRESS,

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2343,8 +2343,16 @@ def _normalize_speculative_config_or_exit(args):
             args.suffix_hybrid = False
         if getattr(args, "suffix_min_match_len", None) is None:
             args.suffix_min_match_len = 24
-        if getattr(args, "suffix_hybrid_bit_exact", None) is None:
+        # Bit-exactness guard is DEFAULT ON (the hybrid path is only lossless
+        # when bit-exact). --no-suffix-hybrid-bit-exact explicitly turns it
+        # off — a NON-LOSSLESS / unsafe mode for eval/measurement — and wins
+        # over the default. ``--suffix-hybrid-bit-exact`` (store_true) needs
+        # an explicit False sentinel so the flag is distinguishable from the
+        # default-fill path.
+        if bool(getattr(args, "no_suffix_hybrid_bit_exact", False)):
             args.suffix_hybrid_bit_exact = False
+        elif getattr(args, "suffix_hybrid_bit_exact", None) is None:
+            args.suffix_hybrid_bit_exact = True
 
     def _legacy_speculative_config_payload() -> dict | None:
         methods: list[tuple[str, dict]] = []
@@ -11503,7 +11511,7 @@ Examples:
     )
     serve_parser.add_argument(
         "--suffix-min-match-len",
-        type=int,
+        type=positive_int,
         default=None,
         help=argparse.SUPPRESS,
     )
@@ -11511,6 +11519,13 @@ Examples:
         "--suffix-hybrid-bit-exact",
         action="store_true",
         default=None,
+        help=argparse.SUPPRESS,
+    )
+    serve_parser.add_argument(
+        "--no-suffix-hybrid-bit-exact",
+        dest="no_suffix_hybrid_bit_exact",
+        action="store_true",
+        default=False,
         help=argparse.SUPPRESS,
     )
     # Deprecated no-op flags — accepted-but-ignored for backward compat.

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2952,6 +2952,25 @@ def _retain_hybrid_replay(replay_dict, uid, snapshot, verify_input) -> None:
     replay_dict[uid] = (snapshot, verify_input)
 
 
+def _restore_pending_emits(current: dict, snapshot: dict) -> None:
+    """Roll the pending-emit map back to a pre-transaction snapshot per-uid.
+
+    Codex round-9l finding #2: the post-commit rollback must remove ONLY the
+    entries the failed transaction added/changed and restore the pre-existing
+    ones — never ``clear()`` the whole map, which would silently drop ANOTHER
+    request's queued accepted tokens. ``snapshot`` is the pre-transaction map
+    (deep-copied list values); every current uid present in the snapshot is
+    restored to its snapshot value, any current uid absent from the snapshot
+    (added by the failed step) is popped. Module-level so the rollback is
+    unit-testable (``_pending_emits`` is a closure dict).
+    """
+    for u in list(current):
+        if u in snapshot:
+            current[u] = snapshot[u]
+        else:
+            current.pop(u, None)
+
+
 def _restore_hybrid_cache_after_exception(gb, result: dict) -> None:
     """Restore the live cache to the pristine pre-verify snapshot after a
     hybrid-verify exception, when the commit head was already swapped in.
@@ -3880,8 +3899,12 @@ def _install_suffix_decoding(
                 "next_tokens": gb._next_tokens,
                 "next_logprobs": gb._next_logprobs,
                 "n_tokens_in_tokens": len(gb.tokens[0]) if gb.tokens else 0,
-                "n_pending_emits": len(_pending_emits),
-                "n_pending_replay": len(_pending_hybrid_replay),
+                # Snapshot the pending-emits map itself (list value copied per
+                # uid), NOT just a count: the rollback must remove ONLY entries
+                # created/changed by THIS failed transaction, restoring the
+                # pre-existing ones (codex round-9l finding #2). ``clear()``
+                # would silently drop another request's queued accepted tokens.
+                "pending_emits": {u: list(v) for u, v in _pending_emits.items()},
             }
             # Drafter history += newly-committed tokens. We add ONLY the
             # accepted drafts here; ``bonus`` will be added on the next
@@ -4019,16 +4042,17 @@ def _install_suffix_decoding(
 
         except Exception as e:  # noqa: BLE001
             logger.debug(f"[SuffixDecoding] post-commit phase failed: {e!r}")
-            _stats["errors"] += 1
-            # fallthrough buckets must reconcile with the aggregate (round-9i #3).
-            _stats["fallthrough_steps"] += 1
-            _stats["ft_error"] += 1
-            # Counter consistency: every other error fallthrough records the
-            # attempt + error on the shared counter, so the exported counter
-            # does not diverge from ``_stats`` for exactly this failure class.
-            _counter.record_error()
-            _counter.record_verify(K, 0)
             if _hybrid_active:
+                # Reorder matters (codex round-9l finding #1): the FULL
+                # transactional rollback must run BEFORE recording the
+                # error/fallthrough metrics, because the rollback restores
+                # ``_stats`` from the pre-error snapshot. If the counters were
+                # bumped first, the restore would erase them — yet the shared
+                # counter (recorded below, NOT rolled back) would still carry
+                # the failure, so the exported ``_stats`` and the global counter
+                # would diverge. Roll back, THEN bump both surfaces together so
+                # they stay in agreement.
+                #
                 # HYBRID post-commit exception -> advertise the VANILLA
                 # fallthrough (codex round-9i finding #1): restore the pristine
                 # pre-verify cache so the live cache never stays advanced beyond
@@ -4062,9 +4086,18 @@ def _install_suffix_decoding(
                     gb._next_logprobs = _tx["next_logprobs"]
                     if gb.tokens:
                         del gb.tokens[0][_tx["n_tokens_in_tokens"] :]
-                    # Drop any pending emits/replay added during this (failed)
-                    # step (see below for why the replay drop is unconditional).
-                    _pending_emits.clear()
+                    _restore_pending_emits(_pending_emits, _tx["pending_emits"])
+                # Record the error/fallthrough after the rollback so the
+                # restored ``_stats`` is not erased retroactively (round-9l #1).
+                _stats["errors"] += 1
+                # fallthrough buckets must reconcile with the aggregate (round-9i #3).
+                _stats["fallthrough_steps"] += 1
+                _stats["ft_error"] += 1
+                # Counter consistency: every other error fallthrough records the
+                # attempt + error on the shared counter, so the exported counter
+                # does not diverge from ``_stats`` for exactly this failure class.
+                _counter.record_error()
+                _counter.record_verify(K, 0)
                 # Restore the retained replay head for this uid UNCONDITIONALLY
                 # (findings #1/#2): it was retained BEFORE the compute section
                 # (in the hybrid branch), so even a compute-section exception
@@ -4081,6 +4114,11 @@ def _install_suffix_decoding(
             # silently fall through to a re-generated primary that would leave
             # the untrimmable cache inconsistent. Re-raise (pre-existing
             # behavior, unchanged by this diff).
+            _stats["errors"] += 1
+            _stats["fallthrough_steps"] += 1
+            _stats["ft_error"] += 1
+            _counter.record_error()
+            _counter.record_verify(K, 0)
             raise
 
     def _suffix_next():

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -360,8 +360,8 @@ class SchedulerConfig:
     # SuffixDecoding — drafter-free speculative decoding using a suffix
     # tree over prompt + generated tokens. Predicts repeated patterns
     # (tool boilerplate, JSON schemas, ReAct loops) at zero drafter
-    # cost. Pure-attention only; the architecture allowlist is enforced
-    # via ``ModelConfig.supports_spec_decode`` at install time.
+    # cost. Pure-attention only by default; the hybrid (recurrent)
+    # path is additionally gated behind ``suffix_hybrid`` (see below).
     enable_suffix_decoding: bool = False
     suffix_max_draft: int = 8  # Max draft tokens per step (verify cost ∝ this)
     suffix_max_suffix_len: int = 4  # Longest k-gram indexed for matching
@@ -372,6 +372,37 @@ class SchedulerConfig:
     # win. Default 2 keeps chat near regression-floor while still
     # accepting most useful drafts on tool/JSON workloads.
     suffix_min_draft_len: int = 2
+    # Opt-in hybrid (recurrent / GatedDeltaNet / PLE / QSA) suffix
+    # decoding. Off by default: SUFFIX_POC_REPORT.md shows multi-token
+    # verify can drift from step-update on recurrent layers. When enabled,
+    # the scheduler runs the verify in cache-scratch (the Qwen4 recurrent /
+    # conv / PLE state is snapshotted by the model forward) and commits
+    # only the accepted positions, so a rejected tail is dropped without
+    # corrupting persistent state. A bit-exactness guard refuses to draft
+    # if the quantized hybrid verify drifts from greedy (see
+    # ``_hybrid_scratch_verify_drift_free``).
+    suffix_hybrid: bool = False
+    # Tunnel-verify probe length for the hybrid bit-exactness guard (how
+    # many committed positions the guard replays to detect drift from
+    # greedy). A small pod value is enough to catch a quantized-hybrid
+    # drift signature without paying a long replay on every fallthrough.
+    suffix_hybrid_probe_len: int = 4
+    # Bit-exactness guard for the hybrid path (issue #2561). A quantized
+    # hybrid can DRIFT from greedy because the chunked-batched verify
+    # forward is not step-update-equivalent on recurrent layers; even with
+    # commit-only-accepted scratch replay, accepted tokens can be wrong.
+    # When enabled, the guard replays the committed path stepwise and
+    # compares greedy predictions to the chunked verify; on any mismatch it
+    # refuses to draft (falls through) rather than silently corrupting.
+    # Default OFF (it costs a replay per verify — it is a correctness net /
+    # eval tool, not a free lunch).
+    suffix_hybrid_bit_exact: bool = False
+    # Hybrid minimum-match floor. A draft shorter than this falls through
+    # without paying the (multi-token) hybrid verify cost at all, so novel
+    # text never touches the tentative-verify path. Mirrors the issue's
+    # 24-token figure; see design note gap-1. Pure-attention path keeps its
+    # own ``suffix_min_draft_len`` (default 2) for chat-economy.
+    suffix_min_match_len: int = 24
 
     # Admission control: hard cap on concurrent in-flight requests
     # (queued + running). A buggy client (or simple fork bomb) used to
@@ -2274,6 +2305,72 @@ def _config_vetted_mtp_supports_spec_decode(model_type: str | None) -> bool:
     return model_type in {"qwen3_5", "qwen3_5_moe", "hy_v3", "qwen4_exp"}
 
 
+def _verify_scratch(
+    model: Any,
+    live_cache: list[Any],
+    verify_input: mx.array,
+    draft: list[int],
+    commit_head: list[Any],
+) -> dict:
+    """Scratch-verify a hybrid draft WITHOUT touching persistent state.
+
+    Mirrors SGLang NGRAMWorker: the persistent recurrent/conv/PLE/QSA state
+    (``live_cache``) stays untouched during the tentative multi-token verify.
+    ``commit_head`` is a deepcopy of ``live_cache`` taken by the caller and
+    used ONLY as the scratch buffer for the verify forward. Returns
+    ``{"n_accepted", "verify_logits", "preds_list"}``; the caller decides
+    whether to commit (replay the accepted prefix) and how, so a bit-exactness
+    guard can gate the commit.
+
+    ``verify_input`` is the ``(1, K+1)`` [X, d_0..d_{K-1}] batch whose
+    greedy predictions gate acceptance.
+    """
+    verify_logits = model(verify_input, cache=commit_head)
+    preds = mx.argmax(verify_logits, axis=-1)
+    mx.eval(preds)
+    preds_list = preds.tolist()[0]
+    n_accepted = 0
+    for i, tok in enumerate(draft):
+        if preds_list[i] == tok:
+            n_accepted += 1
+        else:
+            break
+    return {
+        "n_accepted": n_accepted,
+        "verify_logits": verify_logits,
+        "preds_list": preds_list,
+    }
+
+
+def _commit_scratch_accepted(
+    model: Any,
+    live_cache: list[Any],
+    committed_input: mx.array,
+    n_accepted: int,
+) -> None:
+    """Commit only the accepted prefix of a scratch verify onto live cache.
+
+    ``committed_input = [X, d_0..d_{K-1}]``; the accepted prefix
+    ``[X, d_0..d_{n_accepted-1}]`` is replayed one step at a time onto a
+    FRESH copy of the pre-verify state, which then replaces ``live_cache``.
+    The rejected tail is dropped (never replayed), so the persistent
+    recurrent/conv/PLE/QSA state holds exactly the greedy-committed prefix.
+    """
+    import copy
+
+    commit_head = copy.deepcopy(live_cache)
+    # The committed prefix is [X, d_0..d_{n_accepted-1}] = the first
+    # ``n_accepted + 1`` tokens of ``committed_input``. ``live_cache`` is the
+    # PRE-verify state and does NOT contain X yet (X is fed during the verify
+    # forward in production), so ALL ``n_accepted + 1`` tokens are replayed —
+    # X plus the accepted drafts. The rejected tail (tokens past
+    # ``n_accepted``) is dropped by never being replayed, which is what makes
+    # the commit-only-accepted scratch verify lossless.
+    for token in committed_input[0, 0 : n_accepted + 1].tolist():
+        mx.eval(model(mx.array([[token]]), cache=commit_head))
+    live_cache[:] = commit_head
+
+
 def _replay_dspark_committed(
     model: Any,
     cache_snapshot: list[Any],
@@ -2841,6 +2938,10 @@ def _install_suffix_decoding(
     requests: dict[str, Any],
     uid_to_request_id: dict[int, str],
     min_draft_len: int = 2,
+    suffix_hybrid: bool = False,
+    suffix_min_match_len: int = 24,
+    suffix_hybrid_bit_exact: bool = False,
+    suffix_hybrid_probe_len: int = 4,
 ) -> bool:
     """Monkey-patch BatchGenerator's GenerationBatch to add SuffixDecoding.
 
@@ -2873,18 +2974,24 @@ def _install_suffix_decoding(
     The architecture allowlist is enforced upstream via
     ``ModelConfig.supports_spec_decode``: hybrid linear-attention models
     (Qwen3.5/3.6 GatedDeltaNet, Granite 4 Mamba2) skip install entirely
-    because chunked-batched verify isn't numerically equivalent to
-    step-update on recurrent layers — see SUFFIX_POC_REPORT.md.
+    by default because chunked-batched verify isn't numerically equivalent
+    to step-update on recurrent layers — see SUFFIX_POC_REPORT.md. When the
+    operator explicitly opts into the hybrid path (``suffix_hybrid=True``),
+    the verify runs against cache scratch (the Qwen4 recurrent/conv/PLE/QSA
+    state is snapshotted in the tentative forward) and only accepted
+    positions are committed, mirroring SGLang's NGRAMWorker.
     """
     from .speculative.suffix_counter import get_global_counter as _suffix_counter
     from .speculative.suffix_decoding import SuffixDecodingDrafter
 
-    if profile is not None and not profile.supports_spec_decode:
+    hybrid = bool(suffix_hybrid) and profile is not None and profile.is_hybrid
+    if profile is not None and not profile.supports_spec_decode and not hybrid:
         logger.warning(
             "[SuffixDecoding] disabled: model is hybrid (linear-attention/"
             "Mamba). Multi-token verify path is not numerically equivalent "
             "to step-update on recurrent layers. See "
-            "evals/results/SUFFIX_POC_REPORT.md."
+            "evals/results/SUFFIX_POC_REPORT.md. Pass suffix_hybrid=True to "
+            "opt into the scratch-verify hybrid path."
         )
         return False
 
@@ -2932,6 +3039,8 @@ def _install_suffix_decoding(
         "ft_no_draft": 0,
         "ft_cooldown": 0,
         "ft_non_trimmable_cache": 0,
+        "ft_short_match": 0,
+        "ft_hybrid_drift": 0,
         # Error fallbacks are fallthroughs too. Without this key the
         # breakdown stops summing to ``fallthrough_steps`` exactly when
         # something is going wrong — which is when the breakdown is being
@@ -2946,6 +3055,15 @@ def _install_suffix_decoding(
         "cooldown_level": 0,
         # Current adaptive draft width (see _current_k).
         "k_current": 0,
+        # Hybrid-path bookkeeping (only populated when suffix_hybrid installs).
+        "suffix_hybrid": hybrid,
+        "suffix_min_match_len": suffix_min_match_len,
+        # Evidence: how many drift refusals the bit-exactness guard recorded.
+        # Kept as an additive locally-scoped counter (new key), NOT a new
+        # exported metric name — the shared counter surface (verify_steps /
+        # fallthrough_steps / draft_tokens_proposed / tokens_accepted) is
+        # unchanged. Short-match fallthroughs surface via ``ft_short_match``.
+        "hybrid_drifts": 0,
     }
 
     # Per-UID drafting state. MUST be keyed by request: the drafter itself
@@ -2963,6 +3081,72 @@ def _install_suffix_decoding(
     #
     # Cleared alongside ``_drafters`` when the request finishes.
     _uid_state: dict[int, dict] = {}
+
+    # Hybrid scratch-verify is opt-in and only meaningful for hybrid models.
+    # ``_hybrid_active`` is False on the pure-attention path so the existing
+    # (attention-tuned) verify flow is untouched.
+    _hybrid_active = bool(hybrid)
+    _hybrid_bit_exact = bool(suffix_hybrid_bit_exact)
+
+    def _hybrid_scratch_verify(
+        verify_input: mx.array, committed_input: mx.array, draft: list[int]
+    ) -> dict:
+        """Scratch-verify a hybrid draft against the live cache.
+
+        Runs the tentative forward on a *copied* commit head so the persistent
+        recurrent/conv/PLE/QSA state stays untouched, and (when the optional
+        bit-exactness guard is disabled) replays only the accepted prefix back
+        onto the live cache — the SGLang NGRAMWorker commit-only-accepted,
+        drop-the-tail pattern, which is step-equivalent. When the guard IS
+        enabled the commit is deferred to the caller via the ``commit_head``
+        it shares, so a drift refusal never mutates the live cache.
+        """
+        import copy
+
+        committed_head = copy.deepcopy(gb.prompt_cache)
+        result = _verify_scratch(
+            gb.model,
+            gb.prompt_cache,
+            verify_input,
+            draft,
+            committed_head,
+        )
+        n_accepted = result["n_accepted"]
+        if n_accepted > 0:
+            if _hybrid_bit_exact:
+                # Bit-exactness guard: replay the committed prefix stepwise on
+                # a fresh pre-verify copy and compare each step's greedy pred
+                # to the chunked verify's pred at that position. Any mismatch
+                # means the chunked-batched forward DRIFTED from step-update
+                # on the recurrent layers (quantized-hybrid signature) — refuse
+                # to commit rather than surface silently-wrong accepted tokens.
+                # Nothing has been committed yet, so a refusal is a clean
+                # fall-through.
+                probe_head = copy.deepcopy(gb.prompt_cache)
+                probe_len = min(len(verify_input[0]), suffix_hybrid_probe_len)
+                drift = False
+                # The chunked verify predict at ``preds_list[j]`` is the model's
+                # greedy prediction AFTER consuming ``verify_input[:, :j+1]``.
+                # The stepwise probe feeds token ``j`` at iteration ``j`` (so X
+                # at j=0, then d_0, ...) and compares each stepwise pred to the
+                # corresponding chunk row.
+                for j in range(probe_len):
+                    step_logits = gb.model(verify_input[:, j : j + 1], cache=probe_head)
+                    step_pred = mx.argmax(step_logits, axis=-1)
+                    mx.eval(step_pred)
+                    if int(step_pred[0, 0].item()) != result["preds_list"][j]:
+                        drift = True
+                        break
+                if drift:
+                    result["drift"] = True
+                    return result
+            _commit_scratch_accepted(
+                gb.model,
+                gb.prompt_cache,
+                committed_input,
+                n_accepted,
+            )
+        return result
 
     def _reset_state_gauges_if_idle() -> None:
         """Return the state gauges to their at-rest values when no request
@@ -3202,56 +3386,118 @@ def _install_suffix_decoding(
 
         K = len(draft)
 
-        # Defense-in-depth: even though ``profile.supports_spec_decode``
-        # already gates installation on hybrid arches, verify that EVERY
-        # cache layer is trimmable before paying the verify-forward cost.
-        # If any layer can't trim and we end up needing to roll back, the
-        # cache state would silently diverge — better to fall through.
-        # Preflight the maximum possible rollback amount before the verify
-        # forward mutates anything. Composite caches are checked recursively,
-        # so one side-cache cannot refuse after its sibling already trimmed.
-        from .cache_rollback import can_advance
+        n_rejected_to_trim = 0
+        if _hybrid_active:
+            # Hybrid path. The 24-token minimum-match floor (issue #2561)
+            # means a draft shorter than the floor falls through WITHOUT
+            # paying the multi-token verify cost at all — novel text (which
+            # the suffix drafter proposes short drafts for) is the common
+            # case and must never touch the tentative-verify path.
+            if suffix_min_match_len > K:
+                _stats["fallthrough_steps"] += 1
+                _stats["ft_short_match"] += 1
+                _counter.record_fallthrough("short_match")
+                return _orig_step()
 
-        if not all(can_advance(c, K) for c in gb.prompt_cache):
-            _stats["fallthrough_steps"] += 1
-            _stats["ft_non_trimmable_cache"] += 1
-            _counter.record_fallthrough("non_trimmable_cache")
-            return _orig_step()
+            _stats["verify_steps"] += 1
+            _stats["draft_tokens_proposed"] += K
 
-        _stats["verify_steps"] += 1
-        _stats["draft_tokens_proposed"] += K
+            # Scratch-verify: run the tentative forward on a COPY of the
+            # committed cache so the persistent recurrent/conv/PLE/QSA state
+            # stays untouched, then commit ONLY accepted positions. This
+            # sidesteps the attention-only ``can_advance`` preflight below
+            # (which the Qwen4 recurrent budget cannot satisfy anyway —
+            # trim_all on Qwen4ExpStateCache cannot roll a rejection back).
+            try:
+                draft_arr = mx.array([draft], dtype=inputs.dtype)
+                verify_input = mx.concatenate([inputs[:, None], draft_arr], axis=1)
+                # ``committed_input`` == ``verify_input`` here: the accepted
+                # prefix is a prefix of the verify batch, so the same tensor
+                # is replayed on the commit head (the helper slices it by
+                # ``n_accepted``).
+                committed_input = verify_input
+                result = _hybrid_scratch_verify(verify_input, committed_input, draft)
+                n_accepted = result["n_accepted"]
+                verify_logits = result["verify_logits"]
+                preds_list = result["preds_list"]
+                n_rejected_to_trim = 0
+                if result.get("drift"):
+                    # Bit-exactness guard fired: the chunked-batched verify
+                    # drifted from greedy on the recurrent layers. Refuse to
+                    # draft this step (nothing was committed) rather than
+                    # surface silently-wrong accepted tokens.
+                    _stats["hybrid_drifts"] += 1
+                    _stats["fallthrough_steps"] += 1
+                    _stats["ft_hybrid_drift"] += 1
+                    _counter.record_verify(K, 0)
+                    _counter.record_fallthrough("hybrid_drift")
+                    return _orig_step()
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"[SuffixDecoding] hybrid verify failed: {e!r}")
+                _stats["errors"] += 1
+                _stats["fallthrough_steps"] += 1
+                _stats["ft_error"] += 1
+                _counter.record_verify(K, 0)
+                _counter.record_error()
+                # On failure the scratch head was not installed (the raised
+                # forward predates the ``live_cache[:] = committed_head`` in
+                # ``_verify_accept_and_commit_scratch``), so the live cache
+                # is still the pre-verify state — safe to fall through.
+                return _orig_step()
 
-        # Verify forward: [last_token, d_0..d_{K-1}] of shape (1, K+1).
-        try:
-            draft_arr = mx.array([draft], dtype=inputs.dtype)
-            verify_input = mx.concatenate([inputs[:, None], draft_arr], axis=1)
-            verify_logits = gb.model(verify_input, cache=gb.prompt_cache)
-            # logits shape (1, K+1, V); greedy verify.
-            preds = mx.argmax(verify_logits, axis=-1)
-            mx.eval(preds)
-            preds_list = preds.tolist()[0]
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"[SuffixDecoding] verify forward failed: {e!r}")
-            _stats["errors"] += 1
-            _stats["fallthrough_steps"] += 1
-            _stats["ft_error"] += 1
-            # The attempt happened — ``_stats`` counted it above the forward
-            # and the exported totals must agree, or a model that fails
-            # verification repeatedly shows an attempt rate that quietly
-            # understates the work being done.
-            _counter.record_verify(K, 0)
-            _counter.record_error()
-            # Cache was not advanced because the forward raised; safe to
-            # retry via vanilla path below.
-            return _orig_step()
+        else:
+            # Pure-attention path (unchanged).
+            # Defense-in-depth: even though ``profile.supports_spec_decode``
+            # already gates installation on hybrid arches, verify that EVERY
+            # cache layer is trimmable before paying the verify-forward cost.
+            # If any layer can't trim and we end up needing to roll back, the
+            # cache state would silently diverge — better to fall through.
+            # Preflight the maximum possible rollback amount before the verify
+            # forward mutates anything. Composite caches are checked
+            # recursively, so one side-cache cannot refuse after its sibling
+            # already trimmed.
+            from .cache_rollback import can_advance
 
-        # Accept up to first mismatch (greedy).
-        n_accepted = 0
-        for i in range(K):
-            if preds_list[i] == draft[i]:
-                n_accepted += 1
-            else:
-                break
+            if not all(can_advance(c, K) for c in gb.prompt_cache):
+                _stats["fallthrough_steps"] += 1
+                _stats["ft_non_trimmable_cache"] += 1
+                _counter.record_fallthrough("non_trimmable_cache")
+                return _orig_step()
+
+            _stats["verify_steps"] += 1
+            _stats["draft_tokens_proposed"] += K
+
+            # Verify forward: [last_token, d_0..d_{K-1}] of shape (1, K+1).
+            try:
+                draft_arr = mx.array([draft], dtype=inputs.dtype)
+                verify_input = mx.concatenate([inputs[:, None], draft_arr], axis=1)
+                verify_logits = gb.model(verify_input, cache=gb.prompt_cache)
+                # logits shape (1, K+1, V); greedy verify.
+                preds = mx.argmax(verify_logits, axis=-1)
+                mx.eval(preds)
+                preds_list = preds.tolist()[0]
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"[SuffixDecoding] verify forward failed: {e!r}")
+                _stats["errors"] += 1
+                _stats["fallthrough_steps"] += 1
+                _stats["ft_error"] += 1
+                # The attempt happened — ``_stats`` counted it above the
+                # forward and the exported totals must agree, or a model that
+                # fails verification repeatedly shows an attempt rate that
+                # quietly understates the work being done.
+                _counter.record_verify(K, 0)
+                _counter.record_error()
+                # Cache was not advanced because the forward raised; safe to
+                # retry via vanilla path below.
+                return _orig_step()
+
+            # Accept up to first mismatch (greedy).
+            n_accepted = 0
+            for i in range(K):
+                if preds_list[i] == draft[i]:
+                    n_accepted += 1
+                else:
+                    break
 
         # Cooldown bookkeeping: track consecutive zero-accept verifies
         # so workloads with weak drafter signal (e.g., free-form chat)
@@ -3332,10 +3578,17 @@ def _install_suffix_decoding(
         _counter.set_state(st["k"], st["level"])
 
         n_rejected = K - n_accepted
-        if n_rejected > 0:
+        if _hybrid_active:
+            # Hybrid commit-only path: the rejected tail was never advanced
+            # onto the live cache (scratch verify), so there is nothing to
+            # roll back. ``n_rejected_to_trim`` stays 0.
+            n_rejected_for_rollback = n_rejected_to_trim
+        else:
+            n_rejected_for_rollback = n_rejected
+        if n_rejected_for_rollback > 0:
             from .cache_rollback import trim_all
 
-            if not trim_all(gb.prompt_cache, n_rejected):
+            if not trim_all(gb.prompt_cache, n_rejected_for_rollback):
                 raise RuntimeError(
                     "suffix verification cache rollback violated its preflight"
                 )
@@ -4785,6 +5038,14 @@ class Scheduler:
                 max_suffix_len=self.config.suffix_max_suffix_len,
                 min_confidence=self.config.suffix_min_confidence,
                 min_draft_len=self.config.suffix_min_draft_len,
+                suffix_hybrid=getattr(self.config, "suffix_hybrid", False),
+                suffix_min_match_len=getattr(self.config, "suffix_min_match_len", 24),
+                suffix_hybrid_bit_exact=getattr(
+                    self.config, "suffix_hybrid_bit_exact", False
+                ),
+                suffix_hybrid_probe_len=getattr(
+                    self.config, "suffix_hybrid_probe_len", 4
+                ),
                 requests=self.requests,
                 uid_to_request_id=self.uid_to_request_id,
             ):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3109,19 +3109,16 @@ def _install_suffix_decoding(
     _hybrid_bit_exact = bool(suffix_hybrid_bit_exact)
 
     # The hybrid path has a 24-token minimum-match floor (a draft shorter
-    # falls through without paying the multi-token verify cost). Opting into
-    # the hybrid path (``suffix_hybrid=True`` + ``profile.is_hybrid``)
-    # establishes a floor-compatible verify width: ``_effective_max_draft`` is
-    # raised to at least the floor so the advertised feature is not a silent
-    # no-op. This is gated on ``_hybrid_active`` — a pure-attention model with
-    # ``--suffix-hybrid`` (a no-op flag there) keeps its configured
-    # ``max_draft`` unchanged. A below-floor ``suffix_max_draft`` is overridden
-    # for the hybrid path and the install WARNING below says so explicitly.
-    # The bit-exactness guard probes EVERY committed position (the full
-    # accepted prefix), so there is no probe-length knob to tune.
-    _effective_max_draft = (
-        max(max_draft, suffix_min_match_len) if _hybrid_active else max_draft
-    )
+    # falls through without paying the multi-token verify cost). ``max_draft``
+    # is the operator's hard cap on verify width and is honored as-is on every
+    # path — the CLI rejects a hybrid config whose cap is below the floor, so a
+    # below-floor cap here (programmatic call only) makes the hybrid path a
+    # no-op rather than silently overriding the documented width limit. A
+    # pure-attention model with ``--suffix-hybrid`` (a no-op flag there) keeps
+    # its configured ``max_draft`` unchanged. The bit-exactness guard probes
+    # EVERY committed position (the full accepted prefix), so there is no
+    # probe-length knob to tune.
+    _effective_max_draft = max_draft
 
     def _hybrid_scratch_verify(
         verify_input: mx.array, committed_input: mx.array, draft: list[int]
@@ -3171,6 +3168,13 @@ def _install_suffix_decoding(
             # the full committed prefix through ``n_accepted``.
             probe_len = n_accepted + 1
             drift = False
+            # Capture the STEPWISE logits for each committed position. The chunked
+            # ``verify_logits`` can drift from true single-token decode on
+            # quantized hybrids even when argmax agrees; deriving the returned
+            # logprobs from those would violate the lossless contract. The guard
+            # replay below produces the numerically step-equivalent logits, so
+            # they are used for logprobs when the guard is ON.
+            probe_logits: list[mx.array] = []
             # The chunked verify predict at ``preds_list[j]`` is the model's
             # greedy prediction AFTER consuming ``verify_input[:, :j+1]``. The
             # stepwise probe feeds token ``j`` at iteration ``j`` (so X at j=0,
@@ -3178,10 +3182,11 @@ def _install_suffix_decoding(
             for j in range(probe_len):
                 step_logits = gb.model(verify_input[:, j : j + 1], cache=probe_head)
                 step_pred = mx.argmax(step_logits, axis=-1)
-                mx.eval(step_pred)
+                mx.eval(step_logits, step_pred)
                 if int(step_pred[0, 0].item()) != result["preds_list"][j]:
                     drift = True
                     break
+                probe_logits.append(step_logits)
             if drift:
                 result["drift"] = True
                 return result
@@ -3193,6 +3198,9 @@ def _install_suffix_decoding(
             # now referenced only there, so we stay at 2x (pristine + committed).
             gb.prompt_cache = probe_head
             result["replay_snapshot"] = pristine
+            # Stepwise logits per committed position (X + accepted drafts),
+            # used for lossless logprobs instead of the chunked verify logits.
+            result["stepwise_logits"] = probe_logits
             return result
         # Guard OFF (non-lossless/debug mode, ``--no-suffix-hybrid-bit-exact``):
         # no drift check and the stepwise commit helper deep-copies its base. We
@@ -3316,9 +3324,11 @@ def _install_suffix_decoding(
     # below then climbs to ``_effective_max_draft`` once acceptance is proven.
     if _hybrid_active:
         # Seed the hybrid width AT the match floor so a floor-length repeat is
-        # issued on the first step and the verify path is reachable (the
-        # effective cap is raised to the floor above, so this never deadlocks).
-        _K_MIN = suffix_min_match_len
+        # issued on the first step and the verify path is reachable — but never
+        # above ``max_draft`` (CLI validation guarantees cap >= floor, so this
+        # equals the floor in a normal install; a programmatic below-floor cap
+        # degrades cleanly instead of deadlocking).
+        _K_MIN = min(suffix_min_match_len, max_draft)
     else:
         _K_MIN = min(max(2, min_draft_len), max_draft)
 
@@ -3352,6 +3362,10 @@ def _install_suffix_decoding(
         logprobs. Additional emitted tokens (accepted drafts + bonus)
         are stashed in ``_pending_emits`` for ``_suffix_next`` to drain.
         """
+        # Set on the hybrid guard-on path (stepwise logprobs); always None on
+        # the pure-attention path so the shared logprobs code falls back cleanly.
+        stepwise_logits: list[mx.array] | None = None
+
         # Single-request guard. _next_tokens has shape (B,).
         if gb._next_tokens is None or gb._next_tokens.shape[0] != 1:
             _stats["fallthrough_steps"] += 1
@@ -3510,6 +3524,13 @@ def _install_suffix_decoding(
                 result = _hybrid_scratch_verify(verify_input, committed_input, draft)
                 n_accepted = result["n_accepted"]
                 verify_logits = result["verify_logits"]
+                # When the bit-exactness guard ran and passed it produced the
+                # stepwise (numerically step-equivalent) logits for the committed
+                # prefix; prefer those for logprobs so the "lossless" contract
+                # extends to the returned distributions, not just argmax (a
+                # chunked verify_logits can drift from true single-token decode
+                # on quantized hybrids even when argmax agrees).
+                stepwise_logits = result.get("stepwise_logits")
                 preds_list = result["preds_list"]
                 n_rejected_to_trim = 0
                 if result.get("drift"):
@@ -3724,6 +3745,14 @@ def _install_suffix_decoding(
         # (see early bug: every-other-token doubling).
         bonus = preds_list[n_accepted]
 
+        if stepwise_logits is not None:
+            # Lossless logprobs from the stepwise guard replay. Each committed
+            # position's logits are the stepwise ``(1,1,V)`` row; stack them
+            # into a ``(1, probe_len, V)`` tensor. Accepted positions and the
+            # bonus (position n_accepted) are all within probe_len, so the same
+            # downstream slicing applies. Row 0 (the primary's own pred is not
+            # surfaced; ``primary_logprobs`` comes from the previous step).
+            verify_logits = mx.concatenate(stepwise_logits, axis=1)
         full_logprobs = verify_logits - mx.logsumexp(
             verify_logits, axis=-1, keepdims=True
         )
@@ -4059,20 +4088,6 @@ def _install_suffix_decoding(
         max_suffix_len,
         min_confidence,
     )
-    if _hybrid_active and _effective_max_draft > max_draft:
-        # The hybrid opt-in established a floor-compatible width that exceeds
-        # the configured (pure-attention-oriented) suffix_max_draft. Do not
-        # let that happen silently — say so and name the knob to raise if the
-        # operator wants to bound it.
-        logger.warning(
-            "[SuffixDecoding] hybrid path raises effective max draft from "
-            "suffix_max_draft=%d to suffix_min_match_len=%d so drafts can clear "
-            "the %d-token match floor (set --suffix-max-draft to at least that "
-            "to make it explicit)",
-            max_draft,
-            _effective_max_draft,
-            suffix_min_match_len,
-        )
     return True
 
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3293,6 +3293,15 @@ def _install_suffix_decoding(
         )
         n_accepted = result["n_accepted"]
         del committed_head
+        # Build the FULL result (with ``committed`` + ``replay_snapshot``) BEFORE
+        # the in-place commit (codex round-9j finding #1): ``_commit_scratch_accepted``
+        # mutates ``gb.prompt_cache`` in place, so if anything between the commit
+        # and the result-population previously raised, the outer handler saw an
+        # incomplete result and skipped restoration — running ``_orig_step()``
+        # against an already-advanced cache. Stamping the restore info first
+        # guarantees every post-commit exception unconditionally restores it.
+        result["replay_snapshot"] = snapshot
+        result["committed"] = True
         _commit_scratch_accepted(
             gb.model,
             gb.prompt_cache,
@@ -3300,11 +3309,6 @@ def _install_suffix_decoding(
             n_accepted,
             snapshot=snapshot,
         )
-        result["replay_snapshot"] = snapshot
-        # The live cache was committed in place by ``_commit_scratch_accepted``
-        # — same post-commit semantics as the guard-on path, so a later
-        # ``_suffix_step`` exception restores it before falling through.
-        result["committed"] = True
         return result
 
     def _reset_state_gauges_if_idle() -> None:
@@ -3596,6 +3600,11 @@ def _install_suffix_decoding(
         # on the pure-attention path too (reachable via --force-spec-decode),
         # where it is legitimately absent.
         stepwise_logits = None
+        # Transactional snapshot of the mutation tail (set AFTER the fallible
+        # compute section completes, before any bookkeeping write). ``None`` until
+        # the snapshot is taken, so a pre-snapshot (compute) exception must not
+        # attempt a rollback that would reference unbound state.
+        _tx: dict | None = None
 
         n_rejected_to_trim = 0
         if _hybrid_active:
@@ -3843,6 +3852,31 @@ def _install_suffix_decoding(
             # already-scheduled arrays — no fallible op remains past that point.
             bonus_arr = mx.array([bonus], dtype=inputs.dtype)
             mx.async_eval(bonus_arr, bonus_logprobs)
+            # TRANSACTIONAL SNAPSHOT (codex round-9j finding #2): capture the
+            # small mutable state the mutation tail writes, so a post-commit
+            # failure can roll it ALL back before ``_orig_step()`` re-runs the
+            # token. Everything still-mutable downstream (drafter history,
+            # cooldown ``st``, ``_stats``, counter, ``gb._next_*``, ``gb.tokens``,
+            # ``_pending_emits``, ``_pending_hybrid_replay``) is captured here —
+            # the compute section above is pure (no public state written yet).
+            _tx = {
+                "st": dict(st),
+                "stats": dict(_stats),
+                # Drafter rollback is only meaningful/safe on the real drafter
+                # (a test stub need not expose ``_tokens``/``stats``); fall back
+                # to a no-op rewind by capturing ``None`` (rewind_to(0) on the
+                # real drafter would already be handled, but we never call it
+                # when absent).
+                "drafter_len": len(getattr(drafter, "_tokens", [])),
+                "drafter_acc": getattr(
+                    getattr(drafter, "stats", None), "total_draft_tokens_accepted", 0
+                ),
+                "next_tokens": gb._next_tokens,
+                "next_logprobs": gb._next_logprobs,
+                "n_tokens_in_tokens": len(gb.tokens[0]) if gb.tokens else 0,
+                "n_pending_emits": len(_pending_emits),
+                "n_pending_replay": len(_pending_hybrid_replay),
+            }
             # Drafter history += newly-committed tokens. We add ONLY the
             # accepted drafts here; ``bonus`` will be added on the next
             # ``_suffix_step`` call (line ~1235 ``drafter.add_generated_token
@@ -3987,17 +4021,38 @@ def _install_suffix_decoding(
                 # narrow hybrid-verify except path uses) — NOT re-raise, which
                 # would abort generation instead.
                 #
-                # State discarded here:
-                #  * cooldown/width ``st`` + ``_stats`` counters — re-derived on
-                #    the re-run (the fallthrough epoch is a fresh single-token
-                #    step).
-                #  * the retained replay head for this uid (findings #1/#2): it
-                #    referenced a snapshot that will be re-advanced by the
-                #    re-run, so a later terminal must not rebuild from the
-                #    now-stale cache (and the full duplicate snapshot would leak
-                #    until UID cleanup).
+                # FULL TRANSACTIONAL ROLLBACK (codex round-9j finding #2): the
+                # pre-tail snapshot captured every field the mutation tail
+                # touches. Restore them all so the fallthrough ``_orig_step()``
+                # runs from an identical pre-commit state — NOT just the cache
+                # and replay/emit entries. ``_tx`` is None when the exception
+                # fired during the (pre-snapshot) compute section, in which case
+                # no public state was mutated yet.
+                if _tx is not None:
+                    st.clear()
+                    st.update(_tx["st"])
+                    _stats.clear()
+                    _stats.update(_tx["stats"])
+                    if hasattr(drafter, "rewind_to"):
+                        drafter.rewind_to(_tx["drafter_len"])
+                    if hasattr(
+                        getattr(drafter, "stats", None), "total_draft_tokens_accepted"
+                    ):
+                        drafter.stats.total_draft_tokens_accepted = _tx["drafter_acc"]
+                    gb._next_tokens = _tx["next_tokens"]
+                    gb._next_logprobs = _tx["next_logprobs"]
+                    if gb.tokens:
+                        del gb.tokens[0][_tx["n_tokens_in_tokens"] :]
+                    # Drop any pending emits/replay added during this (failed)
+                    # step (see below for why the replay drop is unconditional).
+                    _pending_emits.clear()
+                # Restore the retained replay head for this uid UNCONDITIONALLY
+                # (findings #1/#2): it was retained BEFORE the compute section
+                # (in the hybrid branch), so even a compute-section exception
+                # (where ``_tx`` is None) must drop it — a later terminal must
+                # not rebuild from the now-stale cache, and the full duplicate
+                # snapshot would leak until UID cleanup.
                 _pending_hybrid_replay.pop(uid, None)
-                _pending_emits.pop(uid, None)
                 if _hybrid_pc_snapshot is not None:
                     gb.prompt_cache = _hybrid_pc_snapshot
                 return _orig_step()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3669,6 +3669,17 @@ def _install_suffix_decoding(
                 # post-commit exception site. The ``except`` below restores the
                 # pristine snapshot so a post-commit raise never runs
                 # ``_orig_step`` against the already-advanced cache.
+                # Capture the pristine pre-verify snapshot for the post-commit
+                # exception envelope REGARDLESS of acceptance (codex round-9f
+                # finding): even a zero-accept hybrid commit advances the live
+                # cache through the primary X (the commit head is swapped in),
+                # so if the shared post-commit phase below raises, the ``except``
+                # must restore pristine to let the caller fall through and
+                # re-generate X. The replay HEAD (used only for draining accepted
+                # synthetic emits) is retained separately, gated on
+                # ``n_accepted > 0``.
+                _hybrid_pc_snapshot = result["replay_snapshot"]
+
                 if n_accepted > 0:
                     # Retain the replay snapshot via the module-level helper so
                     # a post-commit exception here is testable (see
@@ -3679,11 +3690,6 @@ def _install_suffix_decoding(
                         result["replay_snapshot"],
                         verify_input,
                     )
-                    # Capture the pristine snapshot for the post-commit
-                    # exception envelope. The shared post-commit phase below
-                    # must NEVER leave the live cache advanced beyond the
-                    # surfaced tokens: if it raises, we restore this.
-                    _hybrid_pc_snapshot = result["replay_snapshot"]
             except Exception as e:  # noqa: BLE001
                 logger.debug(f"[SuffixDecoding] hybrid verify failed: {e!r}")
                 _stats["errors"] += 1

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3194,15 +3194,20 @@ def _install_suffix_decoding(
                 return result
             # Guard passed: ``probe_head`` has replayed exactly the committed
             # prefix ``[X, d_0..d_{n_accepted-1}]`` one step at a time, so it IS
-            # the commit state. SWAP it in by rebinding ``gb.prompt_cache`` to
-            # ``probe_head`` — the original live list (still pristine) is
-            # retained as ``pristine`` for terminal replay, and its tensors are
-            # now referenced only there, so we stay at 2x (pristine + committed).
-            gb.prompt_cache = probe_head
+            # the commit state. Build the COMPLETE result (including the replay
+            # bookkeeping) BEFORE swapping the live cache: if constructing it
+            # raises (e.g. MemoryError), the live cache is still pristine and
+            # ``_suffix_step``'s exception path falls through to ``_orig_step``
+            # on the un-advanced cache. Only after the result is fully built do
+            # we SWAP the commit head in by rebinding ``gb.prompt_cache`` — the
+            # original live list (still pristine) is retained as ``pristine``
+            # for terminal replay, and its tensors are now referenced only
+            # there, so we stay at 2x (pristine + committed).
             result["replay_snapshot"] = pristine
             # Stepwise logits per committed position (X + accepted drafts),
             # used for lossless logprobs instead of the chunked verify logits.
             result["stepwise_logits"] = probe_logits
+            gb.prompt_cache = probe_head
             return result
         # Guard OFF (non-lossless/debug mode, ``--no-suffix-hybrid-bit-exact``):
         # no drift check and the stepwise commit helper deep-copies its base. We

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3836,6 +3836,13 @@ def _install_suffix_decoding(
             # logprobs row at position n_accepted is the one that produced
             # the bonus — used for the bonus surfacing in the next step.
             bonus_logprobs = full_logprobs[0, n_accepted, :]
+            # Schedule the bonus for the next step's primary EARLY. ``async_eval``
+            # is a fallible MLX op (device work), so per codex round-9h finding #2
+            # it must complete while still in the compute section, BEFORE any
+            # bookkeeping mutation. The mutation tail only points ``gb`` at these
+            # already-scheduled arrays — no fallible op remains past that point.
+            bonus_arr = mx.array([bonus], dtype=inputs.dtype)
+            mx.async_eval(bonus_arr, bonus_logprobs)
             # Cooldown bookkeeping: track consecutive zero-accept verifies
             # so workloads with weak drafter signal (e.g., free-form chat)
             # automatically stop paying verify overhead.
@@ -3943,12 +3950,11 @@ def _install_suffix_decoding(
             _counter.record_verify(K, n_accepted)
 
             # Update gb state for the next _step call. Bonus becomes the
-            # next step's primary input. async_eval overlaps device work
-            # with engine bookkeeping (matches _orig_step's pattern).
-            bonus_arr = mx.array([bonus], dtype=inputs.dtype)
+            # next step's primary input. ``bonus_arr``/``bonus_logprobs`` were
+            # scheduled (async_eval'd) back in the compute section; the tail
+            # just rebinds gb to those arrays — pure Python, cannot raise here.
             gb._next_tokens = bonus_arr
             gb._next_logprobs = [bonus_logprobs]
-            mx.async_eval(bonus_arr, bonus_logprobs)
 
             # _step normally appends inputs.tolist()[i] to gb.tokens[i].
             # We do the same for last_token (the primary that we return).
@@ -3965,6 +3971,12 @@ def _install_suffix_decoding(
             logger.debug(f"[SuffixDecoding] post-commit phase failed: {e!r}")
             _stats["errors"] += 1
             _stats["ft_error"] += 1
+            # Counter consistency (codex round-9h finding #3): every other
+            # error fallthrough records the attempt + error on the shared
+            # counter; this path must too, so the exported counter does not
+            # diverge from ``_stats`` for exactly this failure class.
+            _counter.record_error()
+            _counter.record_verify(K, 0)
             # Post-commit exception: restore the pristine pre-verify cache so the
             # live cache never stays advanced beyond the surfaced tokens, then
             # re-raise so the caller handles this step as a normal fall-through.
@@ -3976,7 +3988,13 @@ def _install_suffix_decoding(
             # primary from scratch (cooldown/width are re-derived on that run).
             # By reordering we already ran all fallible MLX ops BEFORE mutating
             # any bookkeeping, so there is no half-mutated drafter/counter/gb
-            # state to unwind.
+            # state to unwind. The retained replay head for this uid (codex
+            # round-9h finding #1) is dropped too: it referenced the pristine
+            # pre-verify snapshot, which is now restored and will be re-advanced
+            # by the fall-through re-run, so a later terminal must NOT rebuild
+            # the delivered cache from the now-stale snapshot (and the full
+            # duplicate cache would otherwise leak until UID cleanup).
+            _pending_hybrid_replay.pop(uid, None)
             if _hybrid_pc_snapshot is not None:
                 gb.prompt_cache = _hybrid_pc_snapshot
             raise

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -382,11 +382,6 @@ class SchedulerConfig:
     # if the quantized hybrid verify drifts from greedy (see
     # ``_hybrid_scratch_verify_drift_free``).
     suffix_hybrid: bool = False
-    # Tunnel-verify probe length for the hybrid bit-exactness guard (how
-    # many committed positions the guard replays to detect drift from
-    # greedy). A small pod value is enough to catch a quantized-hybrid
-    # drift signature without paying a long replay on every fallthrough.
-    suffix_hybrid_probe_len: int = 4
     # Bit-exactness guard for the hybrid path (issue #2561). A quantized
     # hybrid can DRIFT from greedy because the chunked-batched verify
     # forward is not step-update-equivalent on recurrent layers; even with
@@ -2941,7 +2936,6 @@ def _install_suffix_decoding(
     suffix_hybrid: bool = False,
     suffix_min_match_len: int = 24,
     suffix_hybrid_bit_exact: bool = False,
-    suffix_hybrid_probe_len: int = 4,
 ) -> bool:
     """Monkey-patch BatchGenerator's GenerationBatch to add SuffixDecoding.
 
@@ -3088,6 +3082,22 @@ def _install_suffix_decoding(
     _hybrid_active = bool(hybrid)
     _hybrid_bit_exact = bool(suffix_hybrid_bit_exact)
 
+    # The hybrid path has a 24-token minimum-match floor (a draft shorter
+    # falls through without paying the multi-token verify cost), but the
+    # configured ``suffix_max_draft`` cap defaults to 8. With the stock
+    # drafter the verify width can never reach the floor, so the opt-in
+    # hybrid path would be dead on every default install. When hybrid is
+    # active we therefore RAISE the effective draft cap to at least the
+    # match floor so a repeat pattern can actually clear it (a draft can be
+    # at most as long as the suffix-match of the prompt/prefix, so a plain
+    # prompt needs only 24+ generated tokens to build one — reachable).
+    #
+    # The bit-exactness guard below probes EVERY committed position (the
+    # full accepted prefix), so there is no probe-length knob to tune.
+    _effective_max_draft = (
+        max(max_draft, suffix_min_match_len) if _hybrid_active else max_draft
+    )
+
     def _hybrid_scratch_verify(
         verify_input: mx.array, committed_input: mx.array, draft: list[int]
     ) -> dict:
@@ -3112,40 +3122,47 @@ def _install_suffix_decoding(
             committed_head,
         )
         n_accepted = result["n_accepted"]
-        if n_accepted > 0:
-            if _hybrid_bit_exact:
-                # Bit-exactness guard: replay the committed prefix stepwise on
-                # a fresh pre-verify copy and compare each step's greedy pred
-                # to the chunked verify's pred at that position. Any mismatch
-                # means the chunked-batched forward DRIFTED from step-update
-                # on the recurrent layers (quantized-hybrid signature) — refuse
-                # to commit rather than surface silently-wrong accepted tokens.
-                # Nothing has been committed yet, so a refusal is a clean
-                # fall-through.
-                probe_head = copy.deepcopy(gb.prompt_cache)
-                probe_len = min(len(verify_input[0]), suffix_hybrid_probe_len)
-                drift = False
-                # The chunked verify predict at ``preds_list[j]`` is the model's
-                # greedy prediction AFTER consuming ``verify_input[:, :j+1]``.
-                # The stepwise probe feeds token ``j`` at iteration ``j`` (so X
-                # at j=0, then d_0, ...) and compares each stepwise pred to the
-                # corresponding chunk row.
-                for j in range(probe_len):
-                    step_logits = gb.model(verify_input[:, j : j + 1], cache=probe_head)
-                    step_pred = mx.argmax(step_logits, axis=-1)
-                    mx.eval(step_pred)
-                    if int(step_pred[0, 0].item()) != result["preds_list"][j]:
-                        drift = True
-                        break
-                if drift:
-                    result["drift"] = True
-                    return result
-            _commit_scratch_accepted(
-                gb.model,
-                gb.prompt_cache,
-                committed_input,
-                n_accepted,
-            )
+        if _hybrid_bit_exact:
+            # Bit-exactness guard: replay the committed prefix stepwise on
+            # a fresh pre-verify copy and compare each step's greedy pred
+            # to the chunked verify's pred at that position. Any mismatch
+            # means the chunked-batched forward DRIFTED from step-update
+            # on the recurrent layers (quantized-hybrid signature) — refuse
+            # to commit rather than surface silently-wrong accepted tokens.
+            # Nothing has been committed yet, so a refusal is a clean
+            # fall-through.
+            probe_head = copy.deepcopy(gb.prompt_cache)
+            # Probe EVERY committed position (X plus each accepted draft).
+            # A fixed probe window could let drift after the Nth position
+            # commit silently under a "bit-exact" contract, so the replay
+            # must cover the full committed prefix through ``n_accepted``.
+            probe_len = n_accepted + 1
+            drift = False
+            # The chunked verify predict at ``preds_list[j]`` is the model's
+            # greedy prediction AFTER consuming ``verify_input[:, :j+1]``.
+            # The stepwise probe feeds token ``j`` at iteration ``j`` (so X
+            # at j=0, then d_0, ...) and compares each stepwise pred to the
+            # corresponding chunk row.
+            for j in range(probe_len):
+                step_logits = gb.model(verify_input[:, j : j + 1], cache=probe_head)
+                step_pred = mx.argmax(step_logits, axis=-1)
+                mx.eval(step_pred)
+                if int(step_pred[0, 0].item()) != result["preds_list"][j]:
+                    drift = True
+                    break
+            if drift:
+                result["drift"] = True
+                return result
+        # Commit the FULL committed prefix [X, d_0..d_{n_accepted-1}] — always,
+        # including the reject-first (``n_accepted == 0``) case where only X is
+        # committed. X is emitted as the primary by the caller, so leaving the
+        # live cache before X would corrupt the next decode step.
+        _commit_scratch_accepted(
+            gb.model,
+            gb.prompt_cache,
+            committed_input,
+            n_accepted,
+        )
         return result
 
     def _reset_state_gauges_if_idle() -> None:
@@ -3235,7 +3252,19 @@ def _install_suffix_decoding(
     # ``max_draft`` on the other side, since ``num_speculative_tokens``
     # accepts 1 and a floor of 2 would issue two-token drafts against a
     # configured cap of one.
-    _K_MIN = min(max(2, min_draft_len), max_draft)
+    #
+    # On the hybrid path this floor deadlock is exactly the trap that would
+    # silently disable the feature: width only grows AFTER a full-accept
+    # VERIFY, but a below-floor draft falls back BEFORE the width-update code
+    # runs — so starting at the default 2 deadlocks there even though the
+    # effective cap was raised above the match floor. Seed the hybrid width
+    # AT the match floor so a floor-length repeat is issued on the first step
+    # and the verify path is actually reachable; the adaptive ``*2`` growth
+    # below then climbs to ``_effective_max_draft`` once acceptance is proven.
+    if _hybrid_active:
+        _K_MIN = suffix_min_match_len
+    else:
+        _K_MIN = min(max(2, min_draft_len), max_draft)
 
     def _is_greedy_for_uid(uid: int) -> bool:
         """Detect whether the request's sampler is effectively greedy.
@@ -3514,9 +3543,9 @@ def _install_suffix_decoding(
         # SHORT — we left tokens on the table — so double. A partial accept
         # means we paid for K but only n landed; retarget just above n.
         if n_accepted >= K:
-            st["k"] = min(st["k"] * 2, max_draft)
+            st["k"] = min(st["k"] * 2, _effective_max_draft)
         else:
-            st["k"] = max(_K_MIN, min(n_accepted + 1, max_draft))
+            st["k"] = max(_K_MIN, min(n_accepted + 1, _effective_max_draft))
         _stats["k_current"] = st["k"]
 
         if n_accepted == 0:
@@ -5042,9 +5071,6 @@ class Scheduler:
                 suffix_min_match_len=getattr(self.config, "suffix_min_match_len", 24),
                 suffix_hybrid_bit_exact=getattr(
                     self.config, "suffix_hybrid_bit_exact", False
-                ),
-                suffix_hybrid_probe_len=getattr(
-                    self.config, "suffix_hybrid_probe_len", 4
                 ),
                 requests=self.requests,
                 uid_to_request_id=self.uid_to_request_id,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -389,9 +389,14 @@ class SchedulerConfig:
     # When enabled, the guard replays the committed path stepwise and
     # compares greedy predictions to the chunked verify; on any mismatch it
     # refuses to draft (falls through) rather than silently corrupting.
-    # Default OFF (it costs a replay per verify — it is a correctness net /
-    # eval tool, not a free lunch).
-    suffix_hybrid_bit_exact: bool = False
+    # DEFAULT ON: the hybrid path is only genuinely lossless when bit-exact,
+    # so the guard is the safe default. Disabling it (--no-suffix-hybrid-
+    # bit-exact) turns the hybrid path into a NON-LOSSLESS / unsafe mode —
+    # it can surface silently-wrong accepted tokens on a drifted quantized
+    # hybrid — and is only meant for eval/measurement, not production.
+    # (Each replay costs a stepwise forward per commit; the pure-attention
+    # path is unaffected.)
+    suffix_hybrid_bit_exact: bool = True
     # Hybrid minimum-match floor. A draft shorter than this falls through
     # without paying the (multi-token) hybrid verify cost at all, so novel
     # text never touches the tentative-verify path. Mirrors the issue's
@@ -2935,7 +2940,7 @@ def _install_suffix_decoding(
     min_draft_len: int = 2,
     suffix_hybrid: bool = False,
     suffix_min_match_len: int = 24,
-    suffix_hybrid_bit_exact: bool = False,
+    suffix_hybrid_bit_exact: bool = True,
 ) -> bool:
     """Monkey-patch BatchGenerator's GenerationBatch to add SuffixDecoding.
 
@@ -3104,16 +3109,28 @@ def _install_suffix_decoding(
         """Scratch-verify a hybrid draft against the live cache.
 
         Runs the tentative forward on a *copied* commit head so the persistent
-        recurrent/conv/PLE/QSA state stays untouched, and (when the optional
-        bit-exactness guard is disabled) replays only the accepted prefix back
-        onto the live cache — the SGLang NGRAMWorker commit-only-accepted,
-        drop-the-tail pattern, which is step-equivalent. When the guard IS
-        enabled the commit is deferred to the caller via the ``commit_head``
-        it shares, so a drift refusal never mutates the live cache.
+        recurrent/conv/PLE/QSA state stays untouched, and replays only the
+        accepted prefix back onto the live cache — the SGLang NGRAMWorker
+        commit-only-accepted, drop-the-tail pattern, which is step-equivalent.
+        The bit-exactness guard (default ON) replays the committed prefix
+        stepwise on the SAME pre-verify snapshot before committing; a drift
+        refusal never mutates the live cache.
         """
         import copy
 
-        committed_head = copy.deepcopy(gb.prompt_cache)
+        # ONE pre-verify snapshot of the live cache, reused by every path
+        # that needs a scratch state: the tentative verify, the bit-exactness
+        # probe, and the commit replay each derive their scratch head from
+        # this single pristine copy. Deep-copying the prompt cache is
+        # context-sized, so the previous code hitting it twice on a successful
+        # verify (once here, once in ``_commit_scratch_accepted``, plus the
+        # guard's own copy) drove transient peak memory to ~2-3x the live
+        # cache in the decode hot path. One snapshot keeps it at 1x.
+        snapshot = copy.deepcopy(gb.prompt_cache)
+        # Fresh head for the tentative verify. ``_verify_scratch`` writes into
+        # ``committed_head``, so it must not alias the pristine ``snapshot``
+        # that the probe/commit re-derive from.
+        committed_head = copy.deepcopy(snapshot)
         result = _verify_scratch(
             gb.model,
             gb.prompt_cache,
@@ -3123,15 +3140,15 @@ def _install_suffix_decoding(
         )
         n_accepted = result["n_accepted"]
         if _hybrid_bit_exact:
-            # Bit-exactness guard: replay the committed prefix stepwise on
-            # a fresh pre-verify copy and compare each step's greedy pred
-            # to the chunked verify's pred at that position. Any mismatch
-            # means the chunked-batched forward DRIFTED from step-update
-            # on the recurrent layers (quantized-hybrid signature) — refuse
-            # to commit rather than surface silently-wrong accepted tokens.
-            # Nothing has been committed yet, so a refusal is a clean
+            # Bit-exactness guard: replay the committed prefix stepwise on a
+            # head derived from the SHARED pristine snapshot and compare each
+            # step's greedy pred to the chunked verify's pred at that position.
+            # Any mismatch means the chunked-batched forward DRIFTED from
+            # step-update on the recurrent layers (quantized-hybrid signature)
+            # — refuse to commit rather than surface silently-wrong accepted
+            # tokens. Nothing has been committed yet, so a refusal is a clean
             # fall-through.
-            probe_head = copy.deepcopy(gb.prompt_cache)
+            probe_head = copy.deepcopy(snapshot)
             # Probe EVERY committed position (X plus each accepted draft).
             # A fixed probe window could let drift after the Nth position
             # commit silently under a "bit-exact" contract, so the replay
@@ -3157,12 +3174,25 @@ def _install_suffix_decoding(
         # including the reject-first (``n_accepted == 0``) case where only X is
         # committed. X is emitted as the primary by the caller, so leaving the
         # live cache before X would corrupt the next decode step.
-        _commit_scratch_accepted(
-            gb.model,
-            gb.prompt_cache,
-            committed_input,
-            n_accepted,
-        )
+        if _hybrid_bit_exact and not result.get("drift"):
+            # The guard already replayed the committed prefix stepwise onto
+            # ``probe_head`` (one token per step, ending at exactly the
+            # committed state ``[X, d_0..d_{n_accepted-1}]``) — that IS the
+            # commit. Install it directly so the commit path reuses the single
+            # pre-verify snapshot instead of deep-copying the prompt cache
+            # again (context-sized) and redundantly re-stepping every accepted
+            # token. ``probe_head`` is defined whenever ``_hybrid_bit_exact``
+            # and we reach here on the no-drift path.
+            gb.prompt_cache[:] = probe_head
+        else:
+            # Guard off (non-lossless/debug mode): no probe ran, so fall back
+            # to the stepwise commit replay (deep-copies once and re-steps).
+            _commit_scratch_accepted(
+                gb.model,
+                gb.prompt_cache,
+                committed_input,
+                n_accepted,
+            )
         return result
 
     def _reset_state_gauges_if_idle() -> None:
@@ -5070,7 +5100,7 @@ class Scheduler:
                 suffix_hybrid=getattr(self.config, "suffix_hybrid", False),
                 suffix_min_match_len=getattr(self.config, "suffix_min_match_len", 24),
                 suffix_hybrid_bit_exact=getattr(
-                    self.config, "suffix_hybrid_bit_exact", False
+                    self.config, "suffix_hybrid_bit_exact", True
                 ),
                 requests=self.requests,
                 uid_to_request_id=self.uid_to_request_id,

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2940,6 +2940,18 @@ def _install_dspark(
     return True
 
 
+def _retain_hybrid_replay(replay_dict, uid, snapshot, verify_input) -> None:
+    """Retain the pristine pre-verify snapshot + verify batch for a uid.
+
+    Module-level so the post-commit replay-retain step is patchable in tests
+    (``_pending_hybrid_replay`` is a closure dict and cannot be monkeypatched
+    directly). Raising from here simulates a post-commit exception and lets a
+    test assert ``_suffix_step`` restores the pristine cache before falling
+    through.
+    """
+    replay_dict[uid] = (snapshot, verify_input)
+
+
 def _restore_hybrid_cache_after_exception(gb, result: dict) -> None:
     """Restore the live cache to the pristine pre-verify snapshot after a
     hybrid-verify exception, when the commit head was already swapped in.
@@ -3620,7 +3632,12 @@ def _install_suffix_decoding(
                 # pristine snapshot so a post-commit raise never runs
                 # ``_orig_step`` against the already-advanced cache.
                 if n_accepted > 0:
-                    _pending_hybrid_replay[uid] = (
+                    # Retain the replay snapshot via the module-level helper so
+                    # a post-commit exception here is testable (see
+                    # ``_retain_hybrid_replay``).
+                    _retain_hybrid_replay(
+                        _pending_hybrid_replay,
+                        uid,
                         result["replay_snapshot"],
                         verify_input,
                     )

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3111,13 +3111,15 @@ def _install_suffix_decoding(
     # The hybrid path has a 24-token minimum-match floor (a draft shorter
     # falls through without paying the multi-token verify cost). ``max_draft``
     # is the operator's hard cap on verify width and is honored as-is on every
-    # path — the CLI rejects a hybrid config whose cap is below the floor, so a
-    # below-floor cap here (programmatic call only) makes the hybrid path a
-    # no-op rather than silently overriding the documented width limit. A
-    # pure-attention model with ``--suffix-hybrid`` (a no-op flag there) keeps
-    # its configured ``max_draft`` unchanged. The bit-exactness guard probes
-    # EVERY committed position (the full accepted prefix), so there is no
-    # probe-length knob to tune.
+    # path. The CLI raises the DEFAULT cap to the floor for a CONFIRMED hybrid
+    # model (model-resolution time), so a below-floor cap here is either an
+    # explicit operator override (documented) or a programmatic call — in
+    # either case it makes the hybrid path a no-op rather than silently
+    # overriding the documented width limit. A pure-attention model with
+    # ``--suffix-hybrid`` (a no-op flag there) keeps its configured
+    # ``max_draft`` unchanged. The bit-exactness guard probes EVERY committed
+    # position (the full accepted prefix), so there is no probe-length knob to
+    # tune.
     _effective_max_draft = max_draft
 
     def _hybrid_scratch_verify(

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -372,38 +372,6 @@ class SchedulerConfig:
     # win. Default 2 keeps chat near regression-floor while still
     # accepting most useful drafts on tool/JSON workloads.
     suffix_min_draft_len: int = 2
-    # Opt-in hybrid (recurrent / GatedDeltaNet / PLE / QSA) suffix
-    # decoding. Off by default: SUFFIX_POC_REPORT.md shows multi-token
-    # verify can drift from step-update on recurrent layers. When enabled,
-    # the scheduler runs the verify in cache-scratch (the Qwen4 recurrent /
-    # conv / PLE state is snapshotted by the model forward) and commits
-    # only the accepted positions, so a rejected tail is dropped without
-    # corrupting persistent state. A bit-exactness guard refuses to draft
-    # if the quantized hybrid verify drifts from greedy (see
-    # ``_hybrid_scratch_verify_drift_free``).
-    suffix_hybrid: bool = False
-    # Bit-exactness guard for the hybrid path (issue #2561). A quantized
-    # hybrid can DRIFT from greedy because the chunked-batched verify
-    # forward is not step-update-equivalent on recurrent layers; even with
-    # commit-only-accepted scratch replay, accepted tokens can be wrong.
-    # When enabled, the guard replays the committed path stepwise and
-    # compares greedy predictions to the chunked verify; on any mismatch it
-    # refuses to draft (falls through) rather than silently corrupting.
-    # DEFAULT ON: the hybrid path is only genuinely lossless when bit-exact,
-    # so the guard is the safe default. Disabling it (--no-suffix-hybrid-
-    # bit-exact) turns the hybrid path into a NON-LOSSLESS / unsafe mode —
-    # it can surface silently-wrong accepted tokens on a drifted quantized
-    # hybrid — and is only meant for eval/measurement, not production.
-    # (Each replay costs a stepwise forward per commit; the pure-attention
-    # path is unaffected.)
-    suffix_hybrid_bit_exact: bool = True
-    # Hybrid minimum-match floor. A draft shorter than this falls through
-    # without paying the (multi-token) hybrid verify cost at all, so novel
-    # text never touches the tentative-verify path. Mirrors the issue's
-    # 24-token figure; see design note gap-1. Pure-attention path keeps its
-    # own ``suffix_min_draft_len`` (default 2) for chat-economy.
-    suffix_min_match_len: int = 24
-
     # Admission control: hard cap on concurrent in-flight requests
     # (queued + running). A buggy client (or simple fork bomb) used to
     # be able to OOM the Metal allocator and crash the server for all
@@ -591,6 +559,18 @@ class SchedulerConfig:
     # not shifted — see ``test_scheduler_config_preserves_the_historical_
     # positional_prefix``.
     kv_cache_dtype_explicit: bool = False
+
+    # APPEND-ONLY: opt-in hybrid (recurrent / GatedDeltaNet / PLE / QSA)
+    # suffix decoding. These fields must remain after the entire historical
+    # SchedulerConfig surface so positional external callers cannot silently
+    # rebind existing arguments.
+    suffix_hybrid: bool = False
+    # The bit-exactness guard is the safe default. Disabling it with
+    # --no-suffix-hybrid-bit-exact is an unsafe evaluation-only knob because
+    # chunked recurrent verification can drift from stepwise greedy decode.
+    suffix_hybrid_bit_exact: bool = True
+    # Drafts below this floor fall through without paying hybrid verify cost.
+    suffix_min_match_len: int = 24
 
     def __post_init__(self) -> None:
         if not isinstance(self.mtp_continuous_batching, bool):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2327,7 +2327,13 @@ def _verify_scratch(
     """
     verify_logits = model(verify_input, cache=commit_head)
     preds = mx.argmax(verify_logits, axis=-1)
-    mx.eval(preds)
+    # Materialize BOTH outputs together. Leaving ``verify_logits`` as an
+    # unevaluated lazy graph keeps the scratch forward - and therefore the
+    # scratch cache tensors - referenced even after the caller drops
+    # ``commit_head``, quietly defeating the ~2x-cache envelope once the
+    # bit-exactness probe allocates its own head. Realizing it here releases
+    # the scratch graph as soon as this helper returns.
+    mx.eval(verify_logits, preds)
     preds_list = preds.tolist()[0]
     n_accepted = 0
     for i, tok in enumerate(draft):
@@ -3520,14 +3526,20 @@ def _install_suffix_decoding(
                 # The committed prefix is now on the live cache ([X, d_0..
                 # d_{n_accepted-1}]) and the extra accepted drafts are queued
                 # for emission. Retain the pristine pre-verify snapshot (plus
-                # the verify batch) so a terminal stop part-way through the
-                # synthetic emits can rebuild the delivered response cache
-                # from only the surfaced tokens — the Qwen4 recurrent cache
-                # cannot roll an un-surfaced accepted tail back any other way.
-                _pending_hybrid_replay[uid] = (
-                    result["replay_snapshot"],
-                    verify_input,
-                )
+                # the verify batch) ONLY while there are accepted drafts to
+                # drain, so a terminal stop part-way through the synthetic
+                # emits can rebuild the delivered response cache from only the
+                # surfaced tokens — the Qwen4 recurrent cache cannot roll an
+                # un-surfaced accepted tail back any other way. With
+                # ``n_accepted == 0`` there are no synthetic emits, so the
+                # live cache already holds exactly what will be surfaced and
+                # no replay head is retained (avoids a sustained 2x hold for
+                # the common reject/vanilla fast path).
+                if n_accepted > 0:
+                    _pending_hybrid_replay[uid] = (
+                        result["replay_snapshot"],
+                        verify_input,
+                    )
             except Exception as e:  # noqa: BLE001
                 logger.debug(f"[SuffixDecoding] hybrid verify failed: {e!r}")
                 _stats["errors"] += 1
@@ -3951,6 +3963,12 @@ def _install_suffix_decoding(
                         all_tokens=None,
                     )
                 )
+            # All pending synthetic emits for this uid were drained WITHOUT a
+            # terminal firing, so there is no un-surfaced accepted tail to
+            # repair — release the retained pristine replay head now (it would
+            # otherwise hold a full 2nd cache for the rest of the request).
+            # A terminal path already reaped it via ``_reap_uid`` above.
+            _pending_hybrid_replay.pop(uid, None)
 
         return augmented
 
@@ -4029,6 +4047,10 @@ def _install_suffix_decoding(
     # cleanup. Production code should not mutate this directly.
     gb._suffix_drafters = _drafters
     gb._suffix_uid_state = _uid_state
+    # Expose the per-uid hybrid replay slot (retained pristine snapshot + verify
+    # batch) for tests to assert its lifecycle (stored only when accepted drafts
+    # are pending, released when they drain). Test-only.
+    gb._suffix_hybrid_replay = _pending_hybrid_replay
 
     logger.info(
         "[SuffixDecoding] installed: max_draft=%d, max_suffix_len=%d, "

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3103,16 +3103,18 @@ def _install_suffix_decoding(
     _hybrid_bit_exact = bool(suffix_hybrid_bit_exact)
 
     # The hybrid path has a 24-token minimum-match floor (a draft shorter
-    # falls through without paying the multi-token verify cost). ``max_draft``
-    # is the operator's HARD cap on verify width (memory-bound); we never
-    # exceed it — a below-floor cap (the default 8) simply means the hybrid
-    # feature cannot reach the floor and degrades to a no-op, which the
-    # install WARNING below says explicitly. When ``max_draft`` IS >= the
-    # floor the effective ceiling is the floor. The bit-exactness guard
-    # probes EVERY committed position (the full accepted prefix), so there
-    # is no probe-length knob to tune.
+    # falls through without paying the multi-token verify cost). Opting into
+    # the hybrid path (``suffix_hybrid=True`` + ``profile.is_hybrid``)
+    # establishes a floor-compatible verify width: ``_effective_max_draft`` is
+    # raised to at least the floor so the advertised feature is not a silent
+    # no-op. This is gated on ``_hybrid_active`` — a pure-attention model with
+    # ``--suffix-hybrid`` (a no-op flag there) keeps its configured
+    # ``max_draft`` unchanged. A below-floor ``suffix_max_draft`` is overridden
+    # for the hybrid path and the install WARNING below says so explicitly.
+    # The bit-exactness guard probes EVERY committed position (the full
+    # accepted prefix), so there is no probe-length knob to tune.
     _effective_max_draft = (
-        min(max_draft, suffix_min_match_len) if _hybrid_active else max_draft
+        max(max_draft, suffix_min_match_len) if _hybrid_active else max_draft
     )
 
     def _hybrid_scratch_verify(
@@ -3308,10 +3310,9 @@ def _install_suffix_decoding(
     # below then climbs to ``_effective_max_draft`` once acceptance is proven.
     if _hybrid_active:
         # Seed the hybrid width AT the match floor so a floor-length repeat is
-        # issued on the first step and the verify path is reachable — but never
-        # above the operator's hard cap (a below-floor cap degrades the hybrid
-        # feature to a no-op rather than deadlocking or exceeding the bound).
-        _K_MIN = min(suffix_min_match_len, max_draft)
+        # issued on the first step and the verify path is reachable (the
+        # effective cap is raised to the floor above, so this never deadlocks).
+        _K_MIN = suffix_min_match_len
     else:
         _K_MIN = min(max(2, min_draft_len), max_draft)
 
@@ -4036,17 +4037,18 @@ def _install_suffix_decoding(
         max_suffix_len,
         min_confidence,
     )
-    if _hybrid_active and _effective_max_draft < suffix_min_match_len:
-        # Do not silently leave the hybrid feature a no-op. ``max_draft`` is the
-        # operator's HARD cap and we respect it, so a below-floor cap (the
-        # default 8) means drafts can never clear the 24-token match floor and
-        # the hybrid path never engages. Say so and name the flag to raise.
+    if _hybrid_active and _effective_max_draft > max_draft:
+        # The hybrid opt-in established a floor-compatible width that exceeds
+        # the configured (pure-attention-oriented) suffix_max_draft. Do not
+        # let that happen silently — say so and name the knob to raise if the
+        # operator wants to bound it.
         logger.warning(
-            "[SuffixDecoding] hybrid suffix decoding DEGRADED to a no-op: "
-            "suffix_max_draft=%d is below the %d-token match floor, so no draft "
-            "can clear the floor and the hybrid verify path never runs. Raise "
-            "--suffix-max-draft to >= suffix_min_match_len to enable it.",
+            "[SuffixDecoding] hybrid path raises effective max draft from "
+            "suffix_max_draft=%d to suffix_min_match_len=%d so drafts can clear "
+            "the %d-token match floor (set --suffix-max-draft to at least that "
+            "to make it explicit)",
             max_draft,
+            _effective_max_draft,
             suffix_min_match_len,
         )
     return True

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2940,6 +2940,27 @@ def _install_dspark(
     return True
 
 
+def _restore_hybrid_cache_after_exception(gb, result: dict) -> None:
+    """Restore the live cache to the pristine pre-verify snapshot after a
+    hybrid-verify exception, when the commit head was already swapped in.
+
+    The hybrid scratch-verify runs in TWO phases inside the ``_suffix_step``
+    try block: (1) the verify/commit (which swaps ``gb.prompt_cache`` to the
+    committed head — guard-on rebinds it to the probe head, guard-off mutates
+    it in place) and (2) retaining the replay head bookkeeping. If an exception
+    lands in the try AFTER the commit but before that bookkeeping (e.g.
+    MemoryError), running ``_orig_step`` against the already-advanced cache
+    would corrupt cache/token alignment. This restores the pristine snapshot
+    retained as ``result["replay_snapshot"]`` first.
+
+    When ``result`` is empty (the helper raised pre-commit) or the commit never
+    happened (``committed`` unset), the live cache is still the pre-verify state
+    and no restore is needed.
+    """
+    if result.get("committed") and result.get("replay_snapshot") is not None:
+        gb.prompt_cache = result["replay_snapshot"]
+
+
 def _install_suffix_decoding(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -3113,13 +3134,14 @@ def _install_suffix_decoding(
     # is the operator's hard cap on verify width and is honored as-is on every
     # path. The CLI raises the DEFAULT cap to the floor for a CONFIRMED hybrid
     # model (model-resolution time), so a below-floor cap here is either an
-    # explicit operator override (documented) or a programmatic call — in
-    # either case it makes the hybrid path a no-op rather than silently
-    # overriding the documented width limit. A pure-attention model with
-    # ``--suffix-hybrid`` (a no-op flag there) keeps its configured
-    # ``max_draft`` unchanged. The bit-exactness guard probes EVERY committed
-    # position (the full accepted prefix), so there is no probe-length knob to
-    # tune.
+    # explicit operator override or a programmatic call — in either case the
+    # hybrid path becomes a no-op, and the install block below WARNs loudly
+    # naming ``--suffix-max-draft`` to raise (rather than silently overriding
+    # the documented width limit or silently disabling the feature). A pure-
+    # attention model with ``--suffix-hybrid`` (a no-op flag there) keeps its
+    # configured ``max_draft`` unchanged. The bit-exactness guard probes EVERY
+    # committed position (the full accepted prefix), so there is no probe-length
+    # knob to tune.
     _effective_max_draft = max_draft
 
     def _hybrid_scratch_verify(
@@ -3207,6 +3229,13 @@ def _install_suffix_decoding(
             # Stepwise logits per committed position (X + accepted drafts),
             # used for lossless logprobs instead of the chunked verify logits.
             result["stepwise_logits"] = probe_logits
+            # Mark that the commit head has been swapped in (the live cache is
+            # now NOT the pre-verify state). ``_suffix_step``'s exception path
+            # uses this to restore ``gb.prompt_cache`` to the pristine snapshot
+            # before falling through to ``_orig_step`` — a post-swap exception
+            # (e.g. MemoryError while retaining the replay head) must not run
+            # the vanilla step against the already-advanced cache.
+            result["committed"] = True
             gb.prompt_cache = probe_head
             return result
         # Guard OFF (non-lossless/debug mode, ``--no-suffix-hybrid-bit-exact``):
@@ -3230,6 +3259,10 @@ def _install_suffix_decoding(
             snapshot=snapshot,
         )
         result["replay_snapshot"] = snapshot
+        # The live cache was committed in place by ``_commit_scratch_accepted``
+        # — same post-commit semantics as the guard-on path, so a later
+        # ``_suffix_step`` exception restores it before falling through.
+        result["committed"] = True
         return result
 
     def _reset_state_gauges_if_idle() -> None:
@@ -3332,9 +3365,20 @@ def _install_suffix_decoding(
     if _hybrid_active:
         # Seed the hybrid width AT the match floor so a floor-length repeat is
         # issued on the first step and the verify path is reachable — but never
-        # above ``max_draft`` (CLI validation guarantees cap >= floor, so this
-        # equals the floor in a normal install; a programmatic below-floor cap
-        # degrades cleanly instead of deadlocking).
+        # above ``max_draft``. In a normal install the CLI raises the DEFAULT
+        # cap to the floor for a confirmed hybrid (so this equals the floor).
+        # An EXPLICIT below-floor cap (operator override) degrades the hybrid
+        # path to an unreachable no-op: every draft is shorter than the floor,
+        # hits ``ft_short_match`` before the width-update code runs, and the
+        # verify path is never reached. Warn loudly, naming the flag to raise,
+        # so the operator knows the opt-in is inert rather than silently so.
+        if max_draft < suffix_min_match_len:
+            logger.warning(
+                "[SuffixDecoding] hybrid path is UNREACHABLE: --suffix-max-draft "
+                f"{max_draft} < match floor {suffix_min_match_len}. Every draft "
+                "falls through before verify. Raise --suffix-max-draft to at "
+                f"least {suffix_min_match_len} to enable the hybrid scratch-verify."
+            )
         _K_MIN = min(suffix_min_match_len, max_draft)
     else:
         _K_MIN = min(max(2, min_draft_len), max_draft)
@@ -3520,6 +3564,11 @@ def _install_suffix_decoding(
             # sidesteps the attention-only ``can_advance`` preflight below
             # (which the Qwen4 recurrent budget cannot satisfy anyway —
             # trim_all on Qwen4ExpStateCache cannot roll a rejection back).
+            # ``result`` is initialized BEFORE the helper so the ``except``
+            # below can safely test ``result.get("committed")`` even when the
+            # helper raises pre-commit (then ``result`` stays {} and no restore
+            # runs — the live cache is still pristine).
+            result: dict = {}
             try:
                 draft_arr = mx.array([draft], dtype=inputs.dtype)
                 verify_input = mx.concatenate([inputs[:, None], draft_arr], axis=1)
@@ -3563,6 +3612,13 @@ def _install_suffix_decoding(
                 # live cache already holds exactly what will be surfaced and
                 # no replay head is retained (avoids a sustained 2x hold for
                 # the common reject/vanilla fast path).
+                # NOTE: this is the LAST statement inside the hybrid ``try``.
+                # Anything after the commit head is swapped in (guard path
+                # rebinds ``gb.prompt_cache`` to the probe head; guard-off
+                # mutates it in place) and before this point is a potential
+                # post-commit exception site. The ``except`` below restores the
+                # pristine snapshot so a post-commit raise never runs
+                # ``_orig_step`` against the already-advanced cache.
                 if n_accepted > 0:
                     _pending_hybrid_replay[uid] = (
                         result["replay_snapshot"],
@@ -3575,10 +3631,16 @@ def _install_suffix_decoding(
                 _stats["ft_error"] += 1
                 _counter.record_verify(K, 0)
                 _counter.record_error()
-                # On failure the scratch head was not installed (the raised
-                # forward predates the ``live_cache[:] = committed_head`` in
-                # ``_verify_accept_and_commit_scratch``), so the live cache
-                # is still the pre-verify state — safe to fall through.
+                # If the commit head was already swapped in before the raise
+                # (guard path rebinds ``gb.prompt_cache`` to the probe head;
+                # guard-off mutates it in place), restore the pristine pre-
+                # verify snapshot before falling through — running
+                # ``_orig_step`` against the already-advanced cache would
+                # corrupt cache/token alignment. When no commit happened (or
+                # ``result`` is empty because the helper raised pre-commit),
+                # the live cache is still the pre-verify state and no restore
+                # is needed.
+                _restore_hybrid_cache_after_exception(gb, result)
                 return _orig_step()
 
         else:
@@ -8652,8 +8714,9 @@ class Scheduler:
                         "_cache_snapshot_boundary",
                         getattr(request, "prefix_boundary", 0),
                     )
-                    if self.memory_aware_cache is not None and 0 < retry_boundary < len(
-                        tokens_to_process
+                    if (
+                        self.memory_aware_cache is not None
+                        and 0 < retry_boundary < len(tokens_to_process)
                     ):
                         uids = self.batch_generator.insert_segments(
                             [

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3103,19 +3103,16 @@ def _install_suffix_decoding(
     _hybrid_bit_exact = bool(suffix_hybrid_bit_exact)
 
     # The hybrid path has a 24-token minimum-match floor (a draft shorter
-    # falls through without paying the multi-token verify cost), but the
-    # configured ``suffix_max_draft`` cap defaults to 8. With the stock
-    # drafter the verify width can never reach the floor, so the opt-in
-    # hybrid path would be dead on every default install. When hybrid is
-    # active we therefore RAISE the effective draft cap to at least the
-    # match floor so a repeat pattern can actually clear it (a draft can be
-    # at most as long as the suffix-match of the prompt/prefix, so a plain
-    # prompt needs only 24+ generated tokens to build one — reachable).
-    #
-    # The bit-exactness guard below probes EVERY committed position (the
-    # full accepted prefix), so there is no probe-length knob to tune.
+    # falls through without paying the multi-token verify cost). ``max_draft``
+    # is the operator's HARD cap on verify width (memory-bound); we never
+    # exceed it — a below-floor cap (the default 8) simply means the hybrid
+    # feature cannot reach the floor and degrades to a no-op, which the
+    # install WARNING below says explicitly. When ``max_draft`` IS >= the
+    # floor the effective ceiling is the floor. The bit-exactness guard
+    # probes EVERY committed position (the full accepted prefix), so there
+    # is no probe-length knob to tune.
     _effective_max_draft = (
-        max(max_draft, suffix_min_match_len) if _hybrid_active else max_draft
+        min(max_draft, suffix_min_match_len) if _hybrid_active else max_draft
     )
 
     def _hybrid_scratch_verify(
@@ -3310,7 +3307,11 @@ def _install_suffix_decoding(
     # and the verify path is actually reachable; the adaptive ``*2`` growth
     # below then climbs to ``_effective_max_draft`` once acceptance is proven.
     if _hybrid_active:
-        _K_MIN = suffix_min_match_len
+        # Seed the hybrid width AT the match floor so a floor-length repeat is
+        # issued on the first step and the verify path is reachable — but never
+        # above the operator's hard cap (a below-floor cap degrades the hybrid
+        # feature to a no-op rather than deadlocking or exceeding the bound).
+        _K_MIN = min(suffix_min_match_len, max_draft)
     else:
         _K_MIN = min(max(2, min_draft_len), max_draft)
 
@@ -3713,6 +3714,12 @@ def _install_suffix_decoding(
         full_logprobs = verify_logits - mx.logsumexp(
             verify_logits, axis=-1, keepdims=True
         )
+        # Materialize the verify logprobs promptly. ``verify_logits`` is a lazy
+        # MLX graph over the scratch cache; leaving it unevaluated keeps the
+        # scratch tensors referenced into the NEXT step's verify deepcopy,
+        # quietly defeating the 2x-cache envelope. Realizing it here frees the
+        # scratch arrays as soon as the logprobs row slices are taken below.
+        mx.eval(full_logprobs)
         # The primary's logprobs come from the PREVIOUS step (saved in
         # gb._next_logprobs). Passing them through preserves the same
         # contract as _orig_step.
@@ -3883,13 +3890,14 @@ def _install_suffix_decoding(
                             # Suffix decode is a single-request fast path, so
                             # the rebuilt head IS the per-request cache; no
                             # per-cell ``extract`` (whose inner KVCache cells
-                            # can lack ``extract``). The shared live cache held
-                            # un-surfaced accepted tails for this finishing
-                            # uid and is filtered out below, so point it at the
-                            # repaired head to keep the batch consistent with
-                            # the delivered output.
+                            # can lack ``extract``). The finishing uid is about
+                            # to be filtered out of the live batch, so we do
+                            # NOT alias ``gb.prompt_cache`` to ``repaired`` —
+                            # the delivered response cache must stay an
+                            # independent head, and the live cache (which still
+                            # holds the un-surfaced accepted tails) is
+                            # discarded along with the removed uid.
                             prompt_cache = repaired
-                            gb.prompt_cache = repaired
                         else:
                             from .cache_rollback import trim_all
 
@@ -4028,18 +4036,17 @@ def _install_suffix_decoding(
         max_suffix_len,
         min_confidence,
     )
-    if _hybrid_active and _effective_max_draft > max_draft:
-        # Do not silently exceed the operator's explicit draft cap. The hybrid
-        # path requires a >=24-token match before paying verify cost, so a
-        # below-floor ``--suffix-max-draft`` would otherwise dead-disable the
-        # feature; we raise the effective width to the floor and say so rather
-        # than override the operator's bound invisibly.
+    if _hybrid_active and _effective_max_draft < suffix_min_match_len:
+        # Do not silently leave the hybrid feature a no-op. ``max_draft`` is the
+        # operator's HARD cap and we respect it, so a below-floor cap (the
+        # default 8) means drafts can never clear the 24-token match floor and
+        # the hybrid path never engages. Say so and name the flag to raise.
         logger.warning(
-            "[SuffixDecoding] hybrid path raises effective max draft from "
-            "suffix_max_draft=%d to suffix_min_match_len=%d so drafts can clear "
-            "the %d-token match floor (set --suffix-max-draft to silence)",
+            "[SuffixDecoding] hybrid suffix decoding DEGRADED to a no-op: "
+            "suffix_max_draft=%d is below the %d-token match floor, so no draft "
+            "can clear the floor and the hybrid verify path never runs. Raise "
+            "--suffix-max-draft to >= suffix_min_match_len to enable it.",
             max_draft,
-            _effective_max_draft,
             suffix_min_match_len,
         )
     return True

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2973,6 +2973,36 @@ def _restore_hybrid_cache_after_exception(gb, result: dict) -> None:
         gb.prompt_cache = result["replay_snapshot"]
 
 
+def _repair_hybrid_terminal(model, snapshot, verify_input_batch, surfaced_len):
+    """Rebuild a delivered cache from the pristine snapshot + surfaced prefix.
+
+    The Qwen4 recurrent cache cannot ``trim_all`` an un-surfaced accepted tail
+    (the B2.1 scratch path sidesteps attention-only rollback for exactly this
+    reason). When a finish stops part-way through the accepted drafts — whether
+    on the primary token or on a synthetic emit — we rebuild the DELIVERED
+    response cache from the retained pristine pre-verify snapshot plus ONLY
+    the surfaced prefix, dropping the tail by never replaying it (the DSpark
+    ``_pending_replay`` terminal-repair pattern).
+
+    ``surfaced_len`` is the number of surfaced tokens: 1 for a primary-terminal
+    (only X), ``emit_idx + 2`` for a synthetic-drain terminal (X + drained
+    drafts). We step the surfaced prefix one token at a time on a scratch copy
+    so recurrent state advances exactly as an equivalent single-token decode
+    would (chunked != step-update is the known recurrent caveat).
+
+    Suffix decode is a single-request fast path, so the rebuilt head IS the
+    per-request cache; no per-cell ``extract``. The result is an INDEPENDENT
+    head (deep-copied from the snapshot) — the caller must NOT alias the live
+    cache to it.
+    """
+    import copy
+
+    repaired = copy.deepcopy(snapshot)
+    for s in range(surfaced_len):
+        mx.eval(model(verify_input_batch[:, s : s + 1], cache=repaired))
+    return repaired
+
+
 def _install_suffix_decoding(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -3554,6 +3584,14 @@ def _install_suffix_decoding(
 
         K = len(draft)
 
+        # Retained pristine pre-verify snapshot for the POST-COMMIT exception
+        # envelope (codex round-9e finding #3). Set on a successful hybrid
+        # commit; ``None`` on the pure-attention path (which uses trimmable
+        # rollback, not snapshot-restore) and when nothing was committed. The
+        # post-commit ``except`` restores this before re-raising when a step
+        # after the commit head fails.
+        _hybrid_pc_snapshot = None
+
         n_rejected_to_trim = 0
         if _hybrid_active:
             # Hybrid path. The 24-token minimum-match floor (issue #2561)
@@ -3641,6 +3679,11 @@ def _install_suffix_decoding(
                         result["replay_snapshot"],
                         verify_input,
                     )
+                    # Capture the pristine snapshot for the post-commit
+                    # exception envelope. The shared post-commit phase below
+                    # must NEVER leave the live cache advanced beyond the
+                    # surfaced tokens: if it raises, we restore this.
+                    _hybrid_pc_snapshot = result["replay_snapshot"]
             except Exception as e:  # noqa: BLE001
                 logger.debug(f"[SuffixDecoding] hybrid verify failed: {e!r}")
                 _stats["errors"] += 1
@@ -3714,188 +3757,209 @@ def _install_suffix_decoding(
                 else:
                     break
 
-        # Cooldown bookkeeping: track consecutive zero-accept verifies
-        # so workloads with weak drafter signal (e.g., free-form chat)
-        # automatically stop paying verify overhead.
-        #
-        # First trip needs ``_COOLDOWN_TRIGGER`` misses so a brief stumble in
-        # otherwise-accepting traffic doesn't cost a skip window. Once we
-        # HAVE backed off, a single miss re-arms: the previous window already
-        # established this traffic has no drafter signal, so waiting for two
-        # more misses just buys two more wasted verifies. Each re-trip
-        # doubles the window (10, 20, 40 … capped), so a low-overlap request
-        # converges to ~no drafting after a handful of probes.
-        # Adaptive width update. Full acceptance means the draft was too
-        # SHORT — we left tokens on the table — so double. A partial accept
-        # means we paid for K but only n landed; retarget just above n.
-        if n_accepted >= K:
-            st["k"] = min(st["k"] * 2, _effective_max_draft)
-        else:
-            st["k"] = max(_K_MIN, min(n_accepted + 1, _effective_max_draft))
-        _stats["k_current"] = st["k"]
+        # POST-COMMIT phase (codex round-9e finding #3): from here through the
+        # emit stash, ``gb.prompt_cache`` on the hybrid path holds the commit head
+        # advanced through all ``n_accepted`` drafts. Cooldown bookkeeping, rollback,
+        # logprob construction, state-machine processing, and pending-emission
+        # creation must ALL complete before any of it is trustworthy. If any of them
+        # raises after the commit, restore the pristine snapshot (retained as
+        # ``_hybrid_pc_snapshot``) so the live cache never stays advanced beyond the
+        # surfaced tokens, then re-raise so the caller falls through as a normal
+        # step failure.
+        try:
+            # Cooldown bookkeeping: track consecutive zero-accept verifies
+            # so workloads with weak drafter signal (e.g., free-form chat)
+            # automatically stop paying verify overhead.
+            #
+            # First trip needs ``_COOLDOWN_TRIGGER`` misses so a brief stumble in
+            # otherwise-accepting traffic doesn't cost a skip window. Once we
+            # HAVE backed off, a single miss re-arms: the previous window already
+            # established this traffic has no drafter signal, so waiting for two
+            # more misses just buys two more wasted verifies. Each re-trip
+            # doubles the window (10, 20, 40 … capped), so a low-overlap request
+            # converges to ~no drafting after a handful of probes.
+            # Adaptive width update. Full acceptance means the draft was too
+            # SHORT — we left tokens on the table — so double. A partial accept
+            # means we paid for K but only n landed; retarget just above n.
+            if n_accepted >= K:
+                st["k"] = min(st["k"] * 2, _effective_max_draft)
+            else:
+                st["k"] = max(_K_MIN, min(n_accepted + 1, _effective_max_draft))
+            _stats["k_current"] = st["k"]
 
-        if n_accepted == 0:
-            st["zeros"] += 1
-            trigger = _COOLDOWN_TRIGGER if st["level"] == 0 else 1
-            if st["zeros"] >= trigger:
-                st["level"] += 1
-                st["cooldown"] = min(
-                    _COOLDOWN_BASE * (2 ** (st["level"] - 1)),
-                    _COOLDOWN_MAX,
-                )
+            if n_accepted == 0:
+                st["zeros"] += 1
+                trigger = _COOLDOWN_TRIGGER if st["level"] == 0 else 1
+                if st["zeros"] >= trigger:
+                    st["level"] += 1
+                    st["cooldown"] = min(
+                        _COOLDOWN_BASE * (2 ** (st["level"] - 1)),
+                        _COOLDOWN_MAX,
+                    )
+                    st["zeros"] = 0
+                    _stats["cooldown_trips"] += 1
+                    _stats["cooldown_level"] = st["level"]
+                    _counter.record_cooldown_trip(st["level"])
+            else:
                 st["zeros"] = 0
-                _stats["cooldown_trips"] += 1
-                _stats["cooldown_level"] = st["level"]
-                _counter.record_cooldown_trip(st["level"])
-        else:
-            st["zeros"] = 0
-            # DECAY one level, don't reset to eager. A single lucky accept in
-            # otherwise-signalless traffic must not undo several levels of
-            # backoff — with a full reset, low-overlap traffic kept
-            # re-arming (measured: 8 trips, level back to 0, still -24%).
-            # Sustained acceptance walks the level back down within a few
-            # verifies, so a chat that starts emitting a repeated code block
-            # still reaches full speed quickly.
+                # DECAY one level, don't reset to eager. A single lucky accept in
+                # otherwise-signalless traffic must not undo several levels of
+                # backoff — with a full reset, low-overlap traffic kept
+                # re-arming (measured: 8 trips, level back to 0, still -24%).
+                # Sustained acceptance walks the level back down within a few
+                # verifies, so a chat that starts emitting a repeated code block
+                # still reaches full speed quickly.
+                #
+                # A 1-of-K accept is noise, not signal: require at least
+                # ``_BACKOFF_DECAY_MIN_ACCEPT`` accepted draft tokens before
+                # crediting the traffic with having drafter signal.
+                #
+                # The noise floor has to be checked BEFORE the strong-signal
+                # branch, not alongside it. After a back-off the adaptive width
+                # is ``_K_MIN`` (2), where a single accepted token satisfies
+                # ``n_accepted * 2 >= K`` — so without this guard the one
+                # outcome the policy calls noise would reset the whole level,
+                # and low-overlap traffic with the occasional 1-of-2 accept
+                # would bounce back to eager drafting instead of converging.
+                # That is precisely the regression the back-off exists to stop.
+                # Clamped to the configured width, not absolute: with
+                # ``max_draft=1`` a 1-of-1 accept IS full acceptance, and an
+                # absolute floor of 2 would make that configuration unable to
+                # ever leave a back-off — every later isolated miss would arm a
+                # longer cooldown however well the drafts in between landed.
+                _decay_floor = min(_BACKOFF_DECAY_MIN_ACCEPT, K)
+                if st["level"] and n_accepted >= _decay_floor:
+                    if n_accepted * 2 >= K:
+                        # STRONG signal — at least half the draft landed. This is
+                        # unambiguously high-overlap traffic; go straight back to
+                        # eager rather than walking down one level per verify,
+                        # which a deep window gives too few chances to do.
+                        st["level"] = 0
+                    else:
+                        # Real but weak signal — walk down one level.
+                        st["level"] -= 1
+                    _stats["cooldown_level"] = st["level"]
+
+            # Publish AFTER the backoff transition. Publishing before it left the
+            # gauge showing the pre-reset level, permanently so if the request
+            # finished on that burst.
+            _counter.set_state(st["k"], st["level"])
+
+            n_rejected = K - n_accepted
+            if _hybrid_active:
+                # Hybrid commit-only path: the rejected tail was never advanced
+                # onto the live cache (scratch verify), so there is nothing to
+                # roll back. ``n_rejected_to_trim`` stays 0.
+                n_rejected_for_rollback = n_rejected_to_trim
+            else:
+                n_rejected_for_rollback = n_rejected
+            if n_rejected_for_rollback > 0:
+                from .cache_rollback import trim_all
+
+                if not trim_all(gb.prompt_cache, n_rejected_for_rollback):
+                    raise RuntimeError(
+                        "suffix verification cache rollback violated its preflight"
+                    )
+
+            # Token emission accounting.
             #
-            # A 1-of-K accept is noise, not signal: require at least
-            # ``_BACKOFF_DECAY_MIN_ACCEPT`` accepted draft tokens before
-            # crediting the traffic with having drafter signal.
+            # _orig_step emits one token per call: the ``inputs`` it just
+            # fed through the model (= what was previously in
+            # ``_next_tokens``). The newly-sampled token is stashed in
+            # ``_next_tokens`` for the next step.
             #
-            # The noise floor has to be checked BEFORE the strong-signal
-            # branch, not alongside it. After a back-off the adaptive width
-            # is ``_K_MIN`` (2), where a single accepted token satisfies
-            # ``n_accepted * 2 >= K`` — so without this guard the one
-            # outcome the policy calls noise would reset the whole level,
-            # and low-overlap traffic with the occasional 1-of-2 accept
-            # would bounce back to eager drafting instead of converging.
-            # That is precisely the regression the back-off exists to stop.
-            # Clamped to the configured width, not absolute: with
-            # ``max_draft=1`` a 1-of-1 accept IS full acceptance, and an
-            # absolute floor of 2 would make that configuration unable to
-            # ever leave a back-off — every later isolated miss would arm a
-            # longer cooldown however well the drafts in between landed.
-            _decay_floor = min(_BACKOFF_DECAY_MIN_ACCEPT, K)
-            if st["level"] and n_accepted >= _decay_floor:
-                if n_accepted * 2 >= K:
-                    # STRONG signal — at least half the draft landed. This is
-                    # unambiguously high-overlap traffic; go straight back to
-                    # eager rather than walking down one level per verify,
-                    # which a deep window gives too few chances to do.
-                    st["level"] = 0
-                else:
-                    # Real but weak signal — walk down one level.
-                    st["level"] -= 1
-                _stats["cooldown_level"] = st["level"]
+            # For spec-decode the verify forward consumed K+1 tokens
+            # (last_token + K drafts), so we have committed to the cache
+            # ``[..., last_token, d_0..d_{n_accepted-1}]`` after trim.
+            # Tokens that NEED to surface on the response stream:
+            #
+            #   - last_token   ← primary, returned by this _step (1 token)
+            #   - d_0..d_{n-1} ← accepted drafts (n tokens, drained by
+            #                    _suffix_next as synthetic responses)
+            #
+            # The bonus (= preds[n_accepted], the correction at the
+            # rejection point or the post-K bonus) is **NOT** emitted this
+            # step — it gets stashed in _next_tokens and surfaces as the
+            # primary of the NEXT _step call. Otherwise it would duplicate
+            # (see early bug: every-other-token doubling).
+            bonus = preds_list[n_accepted]
 
-        # Publish AFTER the backoff transition. Publishing before it left the
-        # gauge showing the pre-reset level, permanently so if the request
-        # finished on that burst.
-        _counter.set_state(st["k"], st["level"])
+            if stepwise_logits is not None:
+                # Lossless logprobs from the stepwise guard replay. Each committed
+                # position's logits are the stepwise ``(1,1,V)`` row; stack them
+                # into a ``(1, probe_len, V)`` tensor. Accepted positions and the
+                # bonus (position n_accepted) are all within probe_len, so the same
+                # downstream slicing applies. Row 0 (the primary's own pred is not
+                # surfaced; ``primary_logprobs`` comes from the previous step).
+                verify_logits = mx.concatenate(stepwise_logits, axis=1)
+            full_logprobs = verify_logits - mx.logsumexp(
+                verify_logits, axis=-1, keepdims=True
+            )
+            # Materialize the verify logprobs promptly. ``verify_logits`` is a lazy
+            # MLX graph over the scratch cache; leaving it unevaluated keeps the
+            # scratch tensors referenced into the NEXT step's verify deepcopy,
+            # quietly defeating the 2x-cache envelope. Realizing it here frees the
+            # scratch arrays as soon as the logprobs row slices are taken below.
+            mx.eval(full_logprobs)
+            # The primary's logprobs come from the PREVIOUS step (saved in
+            # gb._next_logprobs). Passing them through preserves the same
+            # contract as _orig_step.
+            primary_logprobs = (
+                gb._next_logprobs[0]
+                if gb._next_logprobs is not None and len(gb._next_logprobs) > 0
+                else full_logprobs[0, 0, :]
+            )
+            extra_tokens = list(draft[:n_accepted])
+            extra_logprobs: list[mx.array] = []
+            for i in range(n_accepted):
+                # full_logprobs[0, i, :] is the logprobs row that PRODUCED
+                # the token at sequence position N+i+1, i.e. d_i.
+                extra_logprobs.append(full_logprobs[0, i, :])
+            # logprobs row at position n_accepted is the one that produced
+            # the bonus — used for the bonus surfacing in the next step.
+            bonus_logprobs = full_logprobs[0, n_accepted, :]
 
-        n_rejected = K - n_accepted
-        if _hybrid_active:
-            # Hybrid commit-only path: the rejected tail was never advanced
-            # onto the live cache (scratch verify), so there is nothing to
-            # roll back. ``n_rejected_to_trim`` stays 0.
-            n_rejected_for_rollback = n_rejected_to_trim
-        else:
-            n_rejected_for_rollback = n_rejected
-        if n_rejected_for_rollback > 0:
-            from .cache_rollback import trim_all
+            # Drafter history += newly-committed tokens. We add ONLY the
+            # accepted drafts here; ``bonus`` will be added on the next
+            # ``_suffix_step`` call (line ~1235 ``drafter.add_generated_token
+            # (last_token)`` where ``last_token = bonus`` since we just
+            # stashed it in ``_next_tokens``). Adding it here too would
+            # double-index it in the suffix tree and skew future drafts.
+            for tok in extra_tokens:
+                drafter.add_generated_token(tok)
+            drafter.record_acceptance(n_accepted)
+            _stats["tokens_accepted"] += n_accepted
+            _counter.record_verify(K, n_accepted)
 
-            if not trim_all(gb.prompt_cache, n_rejected_for_rollback):
-                raise RuntimeError(
-                    "suffix verification cache rollback violated its preflight"
-                )
+            # Update gb state for the next _step call. Bonus becomes the
+            # next step's primary input. async_eval overlaps device work
+            # with engine bookkeeping (matches _orig_step's pattern).
+            bonus_arr = mx.array([bonus], dtype=inputs.dtype)
+            gb._next_tokens = bonus_arr
+            gb._next_logprobs = [bonus_logprobs]
+            mx.async_eval(bonus_arr, bonus_logprobs)
 
-        # Token emission accounting.
-        #
-        # _orig_step emits one token per call: the ``inputs`` it just
-        # fed through the model (= what was previously in
-        # ``_next_tokens``). The newly-sampled token is stashed in
-        # ``_next_tokens`` for the next step.
-        #
-        # For spec-decode the verify forward consumed K+1 tokens
-        # (last_token + K drafts), so we have committed to the cache
-        # ``[..., last_token, d_0..d_{n_accepted-1}]`` after trim.
-        # Tokens that NEED to surface on the response stream:
-        #
-        #   - last_token   ← primary, returned by this _step (1 token)
-        #   - d_0..d_{n-1} ← accepted drafts (n tokens, drained by
-        #                    _suffix_next as synthetic responses)
-        #
-        # The bonus (= preds[n_accepted], the correction at the
-        # rejection point or the post-K bonus) is **NOT** emitted this
-        # step — it gets stashed in _next_tokens and surfaces as the
-        # primary of the NEXT _step call. Otherwise it would duplicate
-        # (see early bug: every-other-token doubling).
-        bonus = preds_list[n_accepted]
+            # _step normally appends inputs.tolist()[i] to gb.tokens[i].
+            # We do the same for last_token (the primary that we return).
+            # The extra tokens get appended in the next() wrapper as each
+            # synthetic Response is built, mirroring _orig_step's flow.
+            gb.tokens[0].append(last_token)
 
-        if stepwise_logits is not None:
-            # Lossless logprobs from the stepwise guard replay. Each committed
-            # position's logits are the stepwise ``(1,1,V)`` row; stack them
-            # into a ``(1, probe_len, V)`` tensor. Accepted positions and the
-            # bonus (position n_accepted) are all within probe_len, so the same
-            # downstream slicing applies. Row 0 (the primary's own pred is not
-            # surfaced; ``primary_logprobs`` comes from the previous step).
-            verify_logits = mx.concatenate(stepwise_logits, axis=1)
-        full_logprobs = verify_logits - mx.logsumexp(
-            verify_logits, axis=-1, keepdims=True
-        )
-        # Materialize the verify logprobs promptly. ``verify_logits`` is a lazy
-        # MLX graph over the scratch cache; leaving it unevaluated keeps the
-        # scratch tensors referenced into the NEXT step's verify deepcopy,
-        # quietly defeating the 2x-cache envelope. Realizing it here frees the
-        # scratch arrays as soon as the logprobs row slices are taken below.
-        mx.eval(full_logprobs)
-        # The primary's logprobs come from the PREVIOUS step (saved in
-        # gb._next_logprobs). Passing them through preserves the same
-        # contract as _orig_step.
-        primary_logprobs = (
-            gb._next_logprobs[0]
-            if gb._next_logprobs is not None and len(gb._next_logprobs) > 0
-            else full_logprobs[0, 0, :]
-        )
-        extra_tokens = list(draft[:n_accepted])
-        extra_logprobs: list[mx.array] = []
-        for i in range(n_accepted):
-            # full_logprobs[0, i, :] is the logprobs row that PRODUCED
-            # the token at sequence position N+i+1, i.e. d_i.
-            extra_logprobs.append(full_logprobs[0, i, :])
-        # logprobs row at position n_accepted is the one that produced
-        # the bonus — used for the bonus surfacing in the next step.
-        bonus_logprobs = full_logprobs[0, n_accepted, :]
+            # Stash extras for next() to drain.
+            _pending_emits[uid] = list(zip(extra_tokens, extra_logprobs))
 
-        # Drafter history += newly-committed tokens. We add ONLY the
-        # accepted drafts here; ``bonus`` will be added on the next
-        # ``_suffix_step`` call (line ~1235 ``drafter.add_generated_token
-        # (last_token)`` where ``last_token = bonus`` since we just
-        # stashed it in ``_next_tokens``). Adding it here too would
-        # double-index it in the suffix tree and skew future drafts.
-        for tok in extra_tokens:
-            drafter.add_generated_token(tok)
-        drafter.record_acceptance(n_accepted)
-        _stats["tokens_accepted"] += n_accepted
-        _counter.record_verify(K, n_accepted)
+            return [last_token], [primary_logprobs]
 
-        # Update gb state for the next _step call. Bonus becomes the
-        # next step's primary input. async_eval overlaps device work
-        # with engine bookkeeping (matches _orig_step's pattern).
-        bonus_arr = mx.array([bonus], dtype=inputs.dtype)
-        gb._next_tokens = bonus_arr
-        gb._next_logprobs = [bonus_logprobs]
-        mx.async_eval(bonus_arr, bonus_logprobs)
-
-        # _step normally appends inputs.tolist()[i] to gb.tokens[i].
-        # We do the same for last_token (the primary that we return).
-        # The extra tokens get appended in the next() wrapper as each
-        # synthetic Response is built, mirroring _orig_step's flow.
-        gb.tokens[0].append(last_token)
-
-        # Stash extras for next() to drain.
-        _pending_emits[uid] = list(zip(extra_tokens, extra_logprobs))
-
-        return [last_token], [primary_logprobs]
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"[SuffixDecoding] post-commit phase failed: {e!r}")
+            _stats["errors"] += 1
+            _stats["ft_error"] += 1
+            # Post-commit exception: restore the pristine pre-verify cache so the
+            # live cache never stays advanced beyond the surfaced tokens, then
+            # re-raise so the caller handles this step as a normal fall-through.
+            if _hybrid_pc_snapshot is not None:
+                gb.prompt_cache = _hybrid_pc_snapshot
+            raise
 
     def _suffix_next():
         """Wrapped GenerationBatch.next.
@@ -3912,9 +3976,29 @@ def _install_suffix_decoding(
         # up over a long-running server even on workloads that never hit
         # the synthetic-emit path. Run this before the early-return so
         # plain (non-spec-decode) finishes are also reaped.
+        #
+        # PRIMARY-TERMINAL repair (codex round-9e finding #1): when the
+        # PRIMARY response is terminal (finish_reason set by _orig_next),
+        # the cache was advanced through ALL accepted drafts but ONLY the
+        # primary token (X) was surfaced — the synthetic-emit loop below
+        # never runs for this uid. If we delivered this response as-is, its
+        # returned prefix cache would still hold the un-surfaced accepted
+        # tail and poison prefix-cache reuse for the next request. Repair it
+        # from the retained pristine snapshot + the surfaced primary (X
+        # only), exactly like the synthetic-drain terminal repair but with
+        # ``surfaced_len == 1``.
         if responses:
             for r in responses:
                 if r.finish_reason is not None:
+                    replay_state = _pending_hybrid_replay.pop(r.uid, None)
+                    if replay_state is not None:
+                        snapshot, verify_input_batch = replay_state
+                        # The primary token (X) was surfaced; rebuild the
+                        # delivered cache as pristine + X, dropping any
+                        # accepted drafts that were never surfaced.
+                        r.prompt_cache = _repair_hybrid_terminal(
+                            model, snapshot, verify_input_batch, surfaced_len=1
+                        )
                     _reap_uid(r.uid)
             _reset_state_gauges_if_idle()
 
@@ -3988,33 +4072,12 @@ def _install_suffix_decoding(
                             # rollback for exactly this reason). Instead
                             # rebuild the delivered response cache from the
                             # retained pristine pre-verify snapshot plus only
-                            # the surfaced prefix, dropping the tail by never
-                            # replaying it — the same terminal-repair pattern
-                            # as the DSpark ``_pending_replay`` slot. Compute
-                            # the surfaced prefix: X (1) + the ``emit_idx + 1``
-                            # drafts already drained by this loop.
+                            # the surfaced prefix (X + the ``emit_idx + 1``
+                            # drafts already drained by this loop), dropping
+                            # the tail by never replaying it — the DSpark
+                            # ``_pending_replay`` terminal-repair pattern.
                             snapshot, verify_input_batch = replay_state
-                            # Replay onto the pristine snapshot chunks of
-                            # the surfaced prefix? No — the B2.1 scratch
-                            # machinery is lossless on chunked forward for
-                            # the ACCEPTED prefix (the probe proved it),
-                            # but to be strictly safe across the whole slice
-                            # we step the surfaced prefix one token at a
-                            # time on a scratch copy so recurrent state is
-                            # advanced exactly as an equivalent single-token
-                            # decode would have (chunked != step-update is
-                            # the known recurrent caveat).
-                            import copy
-
-                            repaired = copy.deepcopy(snapshot)
                             surfaced_len = emit_idx + 2  # X + drained drafts
-                            for s in range(surfaced_len):
-                                mx.eval(
-                                    model(
-                                        verify_input_batch[:, s : s + 1],
-                                        cache=repaired,
-                                    )
-                                )
                             # Suffix decode is a single-request fast path, so
                             # the rebuilt head IS the per-request cache; no
                             # per-cell ``extract`` (whose inner KVCache cells
@@ -4025,7 +4088,9 @@ def _install_suffix_decoding(
                             # independent head, and the live cache (which still
                             # holds the un-surfaced accepted tails) is
                             # discarded along with the removed uid.
-                            prompt_cache = repaired
+                            prompt_cache = _repair_hybrid_terminal(
+                                model, snapshot, verify_input_batch, surfaced_len
+                            )
                         else:
                             from .cache_rollback import trim_all
 
@@ -8731,9 +8796,8 @@ class Scheduler:
                         "_cache_snapshot_boundary",
                         getattr(request, "prefix_boundary", 0),
                     )
-                    if (
-                        self.memory_aware_cache is not None
-                        and 0 < retry_boundary < len(tokens_to_process)
+                    if self.memory_aware_cache is not None and 0 < retry_boundary < len(
+                        tokens_to_process
                     ):
                         uids = self.batch_generator.insert_segments(
                             [

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3843,6 +3843,17 @@ def _install_suffix_decoding(
             # already-scheduled arrays — no fallible op remains past that point.
             bonus_arr = mx.array([bonus], dtype=inputs.dtype)
             mx.async_eval(bonus_arr, bonus_logprobs)
+            # Drafter history += newly-committed tokens. We add ONLY the
+            # accepted drafts here; ``bonus`` will be added on the next
+            # ``_suffix_step`` call (line ~1235 ``drafter.add_generated_token
+            # (last_token)`` where ``last_token = bonus`` since we just
+            # stashed it in ``_next_tokens``). Adding it here too would
+            # double-index it in the suffix tree and skew future drafts.
+            for tok in extra_tokens:
+                drafter.add_generated_token(tok)
+            drafter.record_acceptance(n_accepted)
+            _stats["tokens_accepted"] += n_accepted
+            _counter.record_verify(K, n_accepted)
             # Cooldown bookkeeping: track consecutive zero-accept verifies
             # so workloads with weak drafter signal (e.g., free-form chat)
             # automatically stop paying verify overhead.
@@ -3937,18 +3948,6 @@ def _install_suffix_decoding(
                         "suffix verification cache rollback violated its preflight"
                     )
 
-            # Drafter history += newly-committed tokens. We add ONLY the
-            # accepted drafts here; ``bonus`` will be added on the next
-            # ``_suffix_step`` call (line ~1235 ``drafter.add_generated_token
-            # (last_token)`` where ``last_token = bonus`` since we just
-            # stashed it in ``_next_tokens``). Adding it here too would
-            # double-index it in the suffix tree and skew future drafts.
-            for tok in extra_tokens:
-                drafter.add_generated_token(tok)
-            drafter.record_acceptance(n_accepted)
-            _stats["tokens_accepted"] += n_accepted
-            _counter.record_verify(K, n_accepted)
-
             # Update gb state for the next _step call. Bonus becomes the
             # next step's primary input. ``bonus_arr``/``bonus_logprobs`` were
             # scheduled (async_eval'd) back in the compute section; the tail
@@ -3970,33 +3969,44 @@ def _install_suffix_decoding(
         except Exception as e:  # noqa: BLE001
             logger.debug(f"[SuffixDecoding] post-commit phase failed: {e!r}")
             _stats["errors"] += 1
+            # fallthrough buckets must reconcile with the aggregate (round-9i #3).
+            _stats["fallthrough_steps"] += 1
             _stats["ft_error"] += 1
-            # Counter consistency (codex round-9h finding #3): every other
-            # error fallthrough records the attempt + error on the shared
-            # counter; this path must too, so the exported counter does not
-            # diverge from ``_stats`` for exactly this failure class.
+            # Counter consistency: every other error fallthrough records the
+            # attempt + error on the shared counter, so the exported counter
+            # does not diverge from ``_stats`` for exactly this failure class.
             _counter.record_error()
             _counter.record_verify(K, 0)
-            # Post-commit exception: restore the pristine pre-verify cache so the
-            # live cache never stays advanced beyond the surfaced tokens, then
-            # re-raise so the caller handles this step as a normal fall-through.
-            #
-            # Any partial mutation tail (cooldown/width set_state, a stashed
-            # ``_pending_emits`` entry) or the retained hybrid replay head is
-            # discarded too — the step is treated as if it never committed, so
-            # ``_orig_step`` re-runs from the pristine cache and re-samples the
-            # primary from scratch (cooldown/width are re-derived on that run).
-            # By reordering we already ran all fallible MLX ops BEFORE mutating
-            # any bookkeeping, so there is no half-mutated drafter/counter/gb
-            # state to unwind. The retained replay head for this uid (codex
-            # round-9h finding #1) is dropped too: it referenced the pristine
-            # pre-verify snapshot, which is now restored and will be re-advanced
-            # by the fall-through re-run, so a later terminal must NOT rebuild
-            # the delivered cache from the now-stale snapshot (and the full
-            # duplicate cache would otherwise leak until UID cleanup).
-            _pending_hybrid_replay.pop(uid, None)
-            if _hybrid_pc_snapshot is not None:
-                gb.prompt_cache = _hybrid_pc_snapshot
+            if _hybrid_active:
+                # HYBRID post-commit exception -> advertise the VANILLA
+                # fallthrough (codex round-9i finding #1): restore the pristine
+                # pre-verify cache so the live cache never stays advanced beyond
+                # the surfaced tokens, drop any partially-mutated state, then
+                # run ``_orig_step()`` directly (the same "treat as never-
+                # committed, re-generate the primary from scratch" contract the
+                # narrow hybrid-verify except path uses) — NOT re-raise, which
+                # would abort generation instead.
+                #
+                # State discarded here:
+                #  * cooldown/width ``st`` + ``_stats`` counters — re-derived on
+                #    the re-run (the fallthrough epoch is a fresh single-token
+                #    step).
+                #  * the retained replay head for this uid (findings #1/#2): it
+                #    referenced a snapshot that will be re-advanced by the
+                #    re-run, so a later terminal must not rebuild from the
+                #    now-stale cache (and the full duplicate snapshot would leak
+                #    until UID cleanup).
+                _pending_hybrid_replay.pop(uid, None)
+                _pending_emits.pop(uid, None)
+                if _hybrid_pc_snapshot is not None:
+                    gb.prompt_cache = _hybrid_pc_snapshot
+                return _orig_step()
+            # PURE-ATTENTION post-commit exception: FAIL CLOSED. On this path a
+            # rollback ``trim_all`` preflight violation is a genuine invariant
+            # breach (the cache can't be rolled back), so it must propagate, not
+            # silently fall through to a re-generated primary that would leave
+            # the untrimmable cache inconsistent. Re-raise (pre-existing
+            # behavior, unchanged by this diff).
             raise
 
     def _suffix_next():

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -2347,6 +2347,7 @@ def _commit_scratch_accepted(
     live_cache: list[Any],
     committed_input: mx.array,
     n_accepted: int,
+    snapshot: list[Any] | None = None,
 ) -> None:
     """Commit only the accepted prefix of a scratch verify onto live cache.
 
@@ -2355,10 +2356,15 @@ def _commit_scratch_accepted(
     FRESH copy of the pre-verify state, which then replaces ``live_cache``.
     The rejected tail is dropped (never replayed), so the persistent
     recurrent/conv/PLE/QSA state holds exactly the greedy-committed prefix.
+
+    ``snapshot`` is an optional pre-verify deepcopy of ``live_cache`` already
+    held by the caller (the decode hot path retains one for terminal replay).
+    When provided it is copied instead of deep-copying the live cache again,
+    so the commit adds only ONE extra context-sized head rather than two.
     """
     import copy
 
-    commit_head = copy.deepcopy(live_cache)
+    commit_head = copy.deepcopy(snapshot if snapshot is not None else live_cache)
     # The committed prefix is [X, d_0..d_{n_accepted-1}] = the first
     # ``n_accepted + 1`` tokens of ``committed_input``. ``live_cache`` is the
     # PRE-verify state and does NOT contain X yet (X is fed during the verify
@@ -3018,6 +3024,15 @@ def _install_suffix_decoding(
     # ``next()`` then drains the queue, producing one synthetic Response
     # per token so the engine surface stays consistent.
     _pending_emits: dict[int, list[tuple[int, mx.array]]] = {}
+    # For the hybrid path only: retain the pre-verify pristine snapshot plus
+    # the verify batch so a terminal (stop/length) finish part-way through the
+    # accepted drafts can rebuild the delivered response cache from ONLY the
+    # surfaced tokens, dropping the un-surfaced accepted tail. The Qwen4
+    # recurrent cache cannot ``trim_all`` a rejected tail (B2.1 sidesteps the
+    # attention-only rollback on purpose), so exact replay from the pristine
+    # snapshot is the only safe way to keep the saved prefix consistent —
+    # mirroring the DSpark ``_pending_replay`` terminal-repair pattern.
+    _pending_hybrid_replay: dict[int, tuple[list[Any], mx.array]] = {}
 
     _stats = {
         "verify_steps": 0,
@@ -3118,18 +3133,17 @@ def _install_suffix_decoding(
         """
         import copy
 
-        # ONE pre-verify snapshot of the live cache, reused by every path
-        # that needs a scratch state: the tentative verify, the bit-exactness
-        # probe, and the commit replay each derive their scratch head from
-        # this single pristine copy. Deep-copying the prompt cache is
-        # context-sized, so the previous code hitting it twice on a successful
-        # verify (once here, once in ``_commit_scratch_accepted``, plus the
-        # guard's own copy) drove transient peak memory to ~2-3x the live
-        # cache in the decode hot path. One snapshot keeps it at 1x.
+        # ONE pre-verify snapshot of the live cache. Two live roles split
+        # from it: the tentative verify and the bit-exactness probe each get
+        # their own scratch copy, and the pristine snapshot itself is retained
+        # until the request finishes so a terminal stop can rebuild the
+        # response cache from only the surfaced tokens (see the terminal
+        # replay slot). At most ONE scratch head exists alongside the pristine
+        # snapshot at a time — the verify scratch is dropped (`del`) before
+        # the probe copy is allocated — so peak memory is ~2x the live cache
+        # in the decode hot path, not 3x (this is the SGLang/DSpark scratch-
+        # verify envelope: one retained pristine state + one working head).
         snapshot = copy.deepcopy(gb.prompt_cache)
-        # Fresh head for the tentative verify. ``_verify_scratch`` writes into
-        # ``committed_head``, so it must not alias the pristine ``snapshot``
-        # that the probe/commit re-derive from.
         committed_head = copy.deepcopy(snapshot)
         result = _verify_scratch(
             gb.model,
@@ -3139,6 +3153,9 @@ def _install_suffix_decoding(
             committed_head,
         )
         n_accepted = result["n_accepted"]
+        # The verify scratch is spent — drop it so the probe below does not
+        # hold two working heads simultaneously (context-sized deepcopies).
+        del committed_head
         if _hybrid_bit_exact:
             # Bit-exactness guard: replay the committed prefix stepwise on a
             # head derived from the SHARED pristine snapshot and compare each
@@ -3169,30 +3186,29 @@ def _install_suffix_decoding(
                     break
             if drift:
                 result["drift"] = True
+                result["replay_snapshot"] = snapshot
                 return result
-        # Commit the FULL committed prefix [X, d_0..d_{n_accepted-1}] — always,
-        # including the reject-first (``n_accepted == 0``) case where only X is
-        # committed. X is emitted as the primary by the caller, so leaving the
-        # live cache before X would corrupt the next decode step.
-        if _hybrid_bit_exact and not result.get("drift"):
-            # The guard already replayed the committed prefix stepwise onto
-            # ``probe_head`` (one token per step, ending at exactly the
-            # committed state ``[X, d_0..d_{n_accepted-1}]``) — that IS the
-            # commit. Install it directly so the commit path reuses the single
-            # pre-verify snapshot instead of deep-copying the prompt cache
-            # again (context-sized) and redundantly re-stepping every accepted
-            # token. ``probe_head`` is defined whenever ``_hybrid_bit_exact``
-            # and we reach here on the no-drift path.
+            # Guard passed: ``probe_head`` has replayed exactly the committed
+            # prefix ``[X, d_0..d_{n_accepted-1}]`` one step at a time, so it
+            # IS the commit state. Install it by shared reference — the probe
+            # already paid for the replay, no redundant deepcopy/re-step.
             gb.prompt_cache[:] = probe_head
-        else:
-            # Guard off (non-lossless/debug mode): no probe ran, so fall back
-            # to the stepwise commit replay (deep-copies once and re-steps).
-            _commit_scratch_accepted(
-                gb.model,
-                gb.prompt_cache,
-                committed_input,
-                n_accepted,
-            )
+            # Retain the pristine snapshot for terminal replay (a stop/length
+            # finish mid-synthetic-emit must drop un-surfaced accepted tails
+            # from the delivered cache — the recurrent cache can't trim).
+            result["replay_snapshot"] = snapshot
+            return result
+        # Guard off (non-lossless/debug mode): no probe ran, so replay the
+        # accepted prefix through the stepwise commit helper, which now takes
+        # the retained snapshot as its base (sparing a fresh deepcopy).
+        _commit_scratch_accepted(
+            gb.model,
+            gb.prompt_cache,
+            committed_input,
+            n_accepted,
+            snapshot=snapshot,
+        )
+        result["replay_snapshot"] = snapshot
         return result
 
     def _reset_state_gauges_if_idle() -> None:
@@ -3219,6 +3235,7 @@ def _install_suffix_decoding(
         _pending_emits.pop(uid, None)
         _drafters.pop(uid, None)
         _uid_state.pop(uid, None)
+        _pending_hybrid_replay.pop(uid, None)
 
     def _state_for(uid: int) -> dict:
         st = _uid_state.get(uid)
@@ -3370,7 +3387,13 @@ def _install_suffix_decoding(
                 else []
             )
             drafter = SuffixDecodingDrafter(
-                max_draft_tokens=max_draft,
+                # On the hybrid path the adaptive width is raised to at least
+                # ``suffix_min_match_len`` by ``_effective_max_draft``; the
+                # drafter's OWN cap must match, or its drafts stay below the
+                # 24-token floor and the opt-in hybrid path is dead (every
+                # draft lands on ``ft_short_match``). Pure-attention is
+                # unaffected — ``_effective_max_draft == max_draft`` there.
+                max_draft_tokens=_effective_max_draft,
                 max_suffix_len=max_suffix_len,
                 min_confidence=min_confidence,
             )
@@ -3491,6 +3514,17 @@ def _install_suffix_decoding(
                     _counter.record_verify(K, 0)
                     _counter.record_fallthrough("hybrid_drift")
                     return _orig_step()
+                # The committed prefix is now on the live cache ([X, d_0..
+                # d_{n_accepted-1}]) and the extra accepted drafts are queued
+                # for emission. Retain the pristine pre-verify snapshot (plus
+                # the verify batch) so a terminal stop part-way through the
+                # synthetic emits can rebuild the delivered response cache
+                # from only the surfaced tokens — the Qwen4 recurrent cache
+                # cannot roll an un-surfaced accepted tail back any other way.
+                _pending_hybrid_replay[uid] = (
+                    result["replay_snapshot"],
+                    verify_input,
+                )
             except Exception as e:  # noqa: BLE001
                 logger.debug(f"[SuffixDecoding] hybrid verify failed: {e!r}")
                 _stats["errors"] += 1
@@ -3810,12 +3844,64 @@ def _install_suffix_decoding(
                     # reuse for the next request that hits this prefix.
                     unused = len(pending) - emit_idx - 1
                     if unused > 0:
-                        from .cache_rollback import trim_all
+                        replay_state = _pending_hybrid_replay.get(uid)
+                        if replay_state is not None:
+                            # Hybrid terminal: the Qwen4 recurrent cache
+                            # cannot ``trim_all`` an un-surfaced accepted tail
+                            # (the B2.1 scratch path sidesteps attention-only
+                            # rollback for exactly this reason). Instead
+                            # rebuild the delivered response cache from the
+                            # retained pristine pre-verify snapshot plus only
+                            # the surfaced prefix, dropping the tail by never
+                            # replaying it — the same terminal-repair pattern
+                            # as the DSpark ``_pending_replay`` slot. Compute
+                            # the surfaced prefix: X (1) + the ``emit_idx + 1``
+                            # drafts already drained by this loop.
+                            snapshot, verify_input_batch = replay_state
+                            # Replay onto the pristine snapshot chunks of
+                            # the surfaced prefix? No — the B2.1 scratch
+                            # machinery is lossless on chunked forward for
+                            # the ACCEPTED prefix (the probe proved it),
+                            # but to be strictly safe across the whole slice
+                            # we step the surfaced prefix one token at a
+                            # time on a scratch copy so recurrent state is
+                            # advanced exactly as an equivalent single-token
+                            # decode would have (chunked != step-update is
+                            # the known recurrent caveat).
+                            import copy
 
-                        if not trim_all(gb.prompt_cache, unused):
-                            raise RuntimeError(
-                                "suffix terminal cache rollback violated its preflight"
-                            )
+                            repaired = copy.deepcopy(snapshot)
+                            surfaced_len = emit_idx + 2  # X + drained drafts
+                            for s in range(surfaced_len):
+                                mx.eval(
+                                    model(
+                                        verify_input_batch[:, s : s + 1],
+                                        cache=repaired,
+                                    )
+                                )
+                            # Suffix decode is a single-request fast path, so
+                            # the rebuilt head IS the per-request cache; no
+                            # per-cell ``extract`` (whose inner KVCache cells
+                            # can lack ``extract``). The shared live cache held
+                            # un-surfaced accepted tails for this finishing
+                            # uid and is filtered out below, so point it at the
+                            # repaired head to keep the batch consistent with
+                            # the delivered output.
+                            prompt_cache = repaired
+                            gb.prompt_cache = repaired
+                        else:
+                            from .cache_rollback import trim_all
+
+                            # Real missing snapshot on a pure-attention finish
+                            # is impossible (slot only set on hybrid), but the
+                            # pure-attention path still trims as before.
+                            if not trim_all(gb.prompt_cache, unused):
+                                raise RuntimeError(
+                                    "suffix terminal cache rollback violated its preflight"
+                                )
+                            prompt_cache = gb.extract_cache(row)
+                    else:
+                        prompt_cache = gb.extract_cache(row)
                     augmented.append(
                         gb.Response(
                             uid=uid,
@@ -3824,7 +3910,7 @@ def _install_suffix_decoding(
                             finish_reason=finish_reason,
                             current_state=current_state,
                             match_sequence=match_sequence,
-                            prompt_cache=gb.extract_cache(row),
+                            prompt_cache=prompt_cache,
                             all_tokens=gb.tokens[row],
                         )
                     )

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3133,50 +3133,43 @@ def _install_suffix_decoding(
         """
         import copy
 
-        # ONE pre-verify snapshot of the live cache. Two live roles split
-        # from it: the tentative verify and the bit-exactness probe each get
-        # their own scratch copy, and the pristine snapshot itself is retained
-        # until the request finishes so a terminal stop can rebuild the
-        # response cache from only the surfaced tokens (see the terminal
-        # replay slot). At most ONE scratch head exists alongside the pristine
-        # snapshot at a time — the verify scratch is dropped (`del`) before
-        # the probe copy is allocated — so peak memory is ~2x the live cache
-        # in the decode hot path, not 3x (this is the SGLang/DSpark scratch-
-        # verify envelope: one retained pristine state + one working head).
-        snapshot = copy.deepcopy(gb.prompt_cache)
-        committed_head = copy.deepcopy(snapshot)
-        result = _verify_scratch(
-            gb.model,
-            gb.prompt_cache,
-            verify_input,
-            draft,
-            committed_head,
-        )
-        n_accepted = result["n_accepted"]
-        # The verify scratch is spent — drop it so the probe below does not
-        # hold two working heads simultaneously (context-sized deepcopies).
-        del committed_head
         if _hybrid_bit_exact:
+            # Bit-exactness guard ON (the default / lossless path): the ORIGINAL
+            # live cache doubles as the retained pristine state — we never copy
+            # it, we SWAP it out at commit time. So at any instant there are at
+            # most TWO full caches: the pristine live cache plus one working
+            # head (the verify scratch, then the probe/commit head, never both —
+            # the scratch is dropped before the probe allocates). That is the
+            # SGLang/DSpark scratch-verify envelope (~2x the live cache), not
+            # the 3x a naive "snapshot + verify head + probe head" would hold.
+            pristine = gb.prompt_cache
+            committed_head = copy.deepcopy(pristine)
+            result = _verify_scratch(
+                gb.model, pristine, verify_input, draft, committed_head
+            )
+            n_accepted = result["n_accepted"]
+            # The verify scratch is spent — drop it so the probe below does not
+            # hold two working heads simultaneously (context-sized deepcopies).
+            del committed_head
             # Bit-exactness guard: replay the committed prefix stepwise on a
-            # head derived from the SHARED pristine snapshot and compare each
-            # step's greedy pred to the chunked verify's pred at that position.
-            # Any mismatch means the chunked-batched forward DRIFTED from
-            # step-update on the recurrent layers (quantized-hybrid signature)
-            # — refuse to commit rather than surface silently-wrong accepted
+            # head derived from the pristine live cache and compare each step's
+            # greedy pred to the chunked verify's pred at that position. Any
+            # mismatch means the chunked-batched forward DRIFTED from step-
+            # update on the recurrent layers (quantized-hybrid signature) —
+            # refuse to commit rather than surface silently-wrong accepted
             # tokens. Nothing has been committed yet, so a refusal is a clean
             # fall-through.
-            probe_head = copy.deepcopy(snapshot)
-            # Probe EVERY committed position (X plus each accepted draft).
-            # A fixed probe window could let drift after the Nth position
-            # commit silently under a "bit-exact" contract, so the replay
-            # must cover the full committed prefix through ``n_accepted``.
+            probe_head = copy.deepcopy(pristine)
+            # Probe EVERY committed position (X plus each accepted draft). A
+            # fixed probe window could let drift after the Nth position commit
+            # silently under a "bit-exact" contract, so the replay must cover
+            # the full committed prefix through ``n_accepted``.
             probe_len = n_accepted + 1
             drift = False
             # The chunked verify predict at ``preds_list[j]`` is the model's
-            # greedy prediction AFTER consuming ``verify_input[:, :j+1]``.
-            # The stepwise probe feeds token ``j`` at iteration ``j`` (so X
-            # at j=0, then d_0, ...) and compares each stepwise pred to the
-            # corresponding chunk row.
+            # greedy prediction AFTER consuming ``verify_input[:, :j+1]``. The
+            # stepwise probe feeds token ``j`` at iteration ``j`` (so X at j=0,
+            # then d_0, ...) and compares each stepwise pred to the chunk row.
             for j in range(probe_len):
                 step_logits = gb.model(verify_input[:, j : j + 1], cache=probe_head)
                 step_pred = mx.argmax(step_logits, axis=-1)
@@ -3186,21 +3179,29 @@ def _install_suffix_decoding(
                     break
             if drift:
                 result["drift"] = True
-                result["replay_snapshot"] = snapshot
                 return result
             # Guard passed: ``probe_head`` has replayed exactly the committed
-            # prefix ``[X, d_0..d_{n_accepted-1}]`` one step at a time, so it
-            # IS the commit state. Install it by shared reference — the probe
-            # already paid for the replay, no redundant deepcopy/re-step.
-            gb.prompt_cache[:] = probe_head
-            # Retain the pristine snapshot for terminal replay (a stop/length
-            # finish mid-synthetic-emit must drop un-surfaced accepted tails
-            # from the delivered cache — the recurrent cache can't trim).
-            result["replay_snapshot"] = snapshot
+            # prefix ``[X, d_0..d_{n_accepted-1}]`` one step at a time, so it IS
+            # the commit state. SWAP it in by rebinding ``gb.prompt_cache`` to
+            # ``probe_head`` — the original live list (still pristine) is
+            # retained as ``pristine`` for terminal replay, and its tensors are
+            # now referenced only there, so we stay at 2x (pristine + committed).
+            gb.prompt_cache = probe_head
+            result["replay_snapshot"] = pristine
             return result
-        # Guard off (non-lossless/debug mode): no probe ran, so replay the
-        # accepted prefix through the stepwise commit helper, which now takes
-        # the retained snapshot as its base (sparing a fresh deepcopy).
+        # Guard OFF (non-lossless/debug mode, ``--no-suffix-hybrid-bit-exact``):
+        # no drift check and the stepwise commit helper deep-copies its base. We
+        # therefore keep a dedicated pre-verify copy as the replay base, and the
+        # commit helper copies that once more — this debug path may hold up to
+        # 3 full caches transiently, which is acceptable off-default (it is an
+        # explicit escape hatch, not the production path).
+        snapshot = copy.deepcopy(gb.prompt_cache)
+        committed_head = copy.deepcopy(snapshot)
+        result = _verify_scratch(
+            gb.model, gb.prompt_cache, verify_input, draft, committed_head
+        )
+        n_accepted = result["n_accepted"]
+        del committed_head
         _commit_scratch_accepted(
             gb.model,
             gb.prompt_cache,
@@ -4027,6 +4028,20 @@ def _install_suffix_decoding(
         max_suffix_len,
         min_confidence,
     )
+    if _hybrid_active and _effective_max_draft > max_draft:
+        # Do not silently exceed the operator's explicit draft cap. The hybrid
+        # path requires a >=24-token match before paying verify cost, so a
+        # below-floor ``--suffix-max-draft`` would otherwise dead-disable the
+        # feature; we raise the effective width to the floor and say so rather
+        # than override the operator's bound invisibly.
+        logger.warning(
+            "[SuffixDecoding] hybrid path raises effective max draft from "
+            "suffix_max_draft=%d to suffix_min_match_len=%d so drafts can clear "
+            "the %d-token match floor (set --suffix-max-draft to silence)",
+            max_draft,
+            _effective_max_draft,
+            suffix_min_match_len,
+        )
     return True
 
 

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3591,6 +3591,11 @@ def _install_suffix_decoding(
         # post-commit ``except`` restores this before re-raising when a step
         # after the commit head fails.
         _hybrid_pc_snapshot = None
+        # Stepwise (bit-exactness guard) logits; only the hybrid path sets it.
+        # Defaulted here so the shared post-commit compute step can reference it
+        # on the pure-attention path too (reachable via --force-spec-decode),
+        # where it is legitimately absent.
+        stepwise_logits = None
 
         n_rejected_to_trim = 0
         if _hybrid_active:
@@ -3763,16 +3768,74 @@ def _install_suffix_decoding(
                 else:
                     break
 
-        # POST-COMMIT phase (codex round-9e finding #3): from here through the
-        # emit stash, ``gb.prompt_cache`` on the hybrid path holds the commit head
-        # advanced through all ``n_accepted`` drafts. Cooldown bookkeeping, rollback,
-        # logprob construction, state-machine processing, and pending-emission
-        # creation must ALL complete before any of it is trustworthy. If any of them
+        # POST-COMMIT phase (codex round-9e finding #3, reordered per round-9g):
+        # from here through the emit stash, ``gb.prompt_cache`` on the hybrid path
+        # holds the commit head advanced through all ``n_accepted`` drafts. All
+        # FALLIBLE MLX ops run FIRST (logprob compute) with zero prior mutation,
+        # then the pure-Python mutation tail (cooldown/rollback/drafter/counter/
+        # state/emits) which cannot raise. If any fallible op
         # raises after the commit, restore the pristine snapshot (retained as
         # ``_hybrid_pc_snapshot``) so the live cache never stays advanced beyond the
         # surfaced tokens, then re-raise so the caller falls through as a normal
         # step failure.
         try:
+            # Token emission accounting.
+            #
+            # _orig_step emits one token per call: the ``inputs`` it just
+            # fed through the model (= what was previously in
+            # ``_next_tokens``). The newly-sampled token is stashed in
+            # ``_next_tokens`` for the next step.
+            #
+            # For spec-decode the verify forward consumed K+1 tokens
+            # (last_token + K drafts), so we have committed to the cache
+            # ``[..., last_token, d_0..d_{n_accepted-1}]`` after trim.
+            # Tokens that NEED to surface on the response stream:
+            #
+            #   - last_token   ← primary, returned by this _step (1 token)
+            #   - d_0..d_{n-1} ← accepted drafts (n tokens, drained by
+            #                    _suffix_next as synthetic responses)
+            #
+            # The bonus (= preds[n_accepted], the correction at the
+            # rejection point or the post-K bonus) is **NOT** emitted this
+            # step — it gets stashed in _next_tokens and surfaces as the
+            # primary of the NEXT _step call. Otherwise it would duplicate
+            # (see early bug: every-other-token doubling).
+            bonus = preds_list[n_accepted]
+
+            if stepwise_logits is not None:
+                # Lossless logprobs from the stepwise guard replay. Each committed
+                # position's logits are the stepwise ``(1,1,V)`` row; stack them
+                # into a ``(1, probe_len, V)`` tensor. Accepted positions and the
+                # bonus (position n_accepted) are all within probe_len, so the same
+                # downstream slicing applies. Row 0 (the primary's own pred is not
+                # surfaced; ``primary_logprobs`` comes from the previous step).
+                verify_logits = mx.concatenate(stepwise_logits, axis=1)
+            full_logprobs = verify_logits - mx.logsumexp(
+                verify_logits, axis=-1, keepdims=True
+            )
+            # Materialize the verify logprobs promptly. ``verify_logits`` is a lazy
+            # MLX graph over the scratch cache; leaving it unevaluated keeps the
+            # scratch tensors referenced into the NEXT step's verify deepcopy,
+            # quietly defeating the 2x-cache envelope. Realizing it here frees the
+            # scratch arrays as soon as the logprobs row slices are taken below.
+            mx.eval(full_logprobs)
+            # The primary's logprobs come from the PREVIOUS step (saved in
+            # gb._next_logprobs). Passing them through preserves the same
+            # contract as _orig_step.
+            primary_logprobs = (
+                gb._next_logprobs[0]
+                if gb._next_logprobs is not None and len(gb._next_logprobs) > 0
+                else full_logprobs[0, 0, :]
+            )
+            extra_tokens = list(draft[:n_accepted])
+            extra_logprobs: list[mx.array] = []
+            for i in range(n_accepted):
+                # full_logprobs[0, i, :] is the logprobs row that PRODUCED
+                # the token at sequence position N+i+1, i.e. d_i.
+                extra_logprobs.append(full_logprobs[0, i, :])
+            # logprobs row at position n_accepted is the one that produced
+            # the bonus — used for the bonus surfacing in the next step.
+            bonus_logprobs = full_logprobs[0, n_accepted, :]
             # Cooldown bookkeeping: track consecutive zero-accept verifies
             # so workloads with weak drafter signal (e.g., free-form chat)
             # automatically stop paying verify overhead.
@@ -3867,64 +3930,6 @@ def _install_suffix_decoding(
                         "suffix verification cache rollback violated its preflight"
                     )
 
-            # Token emission accounting.
-            #
-            # _orig_step emits one token per call: the ``inputs`` it just
-            # fed through the model (= what was previously in
-            # ``_next_tokens``). The newly-sampled token is stashed in
-            # ``_next_tokens`` for the next step.
-            #
-            # For spec-decode the verify forward consumed K+1 tokens
-            # (last_token + K drafts), so we have committed to the cache
-            # ``[..., last_token, d_0..d_{n_accepted-1}]`` after trim.
-            # Tokens that NEED to surface on the response stream:
-            #
-            #   - last_token   ← primary, returned by this _step (1 token)
-            #   - d_0..d_{n-1} ← accepted drafts (n tokens, drained by
-            #                    _suffix_next as synthetic responses)
-            #
-            # The bonus (= preds[n_accepted], the correction at the
-            # rejection point or the post-K bonus) is **NOT** emitted this
-            # step — it gets stashed in _next_tokens and surfaces as the
-            # primary of the NEXT _step call. Otherwise it would duplicate
-            # (see early bug: every-other-token doubling).
-            bonus = preds_list[n_accepted]
-
-            if stepwise_logits is not None:
-                # Lossless logprobs from the stepwise guard replay. Each committed
-                # position's logits are the stepwise ``(1,1,V)`` row; stack them
-                # into a ``(1, probe_len, V)`` tensor. Accepted positions and the
-                # bonus (position n_accepted) are all within probe_len, so the same
-                # downstream slicing applies. Row 0 (the primary's own pred is not
-                # surfaced; ``primary_logprobs`` comes from the previous step).
-                verify_logits = mx.concatenate(stepwise_logits, axis=1)
-            full_logprobs = verify_logits - mx.logsumexp(
-                verify_logits, axis=-1, keepdims=True
-            )
-            # Materialize the verify logprobs promptly. ``verify_logits`` is a lazy
-            # MLX graph over the scratch cache; leaving it unevaluated keeps the
-            # scratch tensors referenced into the NEXT step's verify deepcopy,
-            # quietly defeating the 2x-cache envelope. Realizing it here frees the
-            # scratch arrays as soon as the logprobs row slices are taken below.
-            mx.eval(full_logprobs)
-            # The primary's logprobs come from the PREVIOUS step (saved in
-            # gb._next_logprobs). Passing them through preserves the same
-            # contract as _orig_step.
-            primary_logprobs = (
-                gb._next_logprobs[0]
-                if gb._next_logprobs is not None and len(gb._next_logprobs) > 0
-                else full_logprobs[0, 0, :]
-            )
-            extra_tokens = list(draft[:n_accepted])
-            extra_logprobs: list[mx.array] = []
-            for i in range(n_accepted):
-                # full_logprobs[0, i, :] is the logprobs row that PRODUCED
-                # the token at sequence position N+i+1, i.e. d_i.
-                extra_logprobs.append(full_logprobs[0, i, :])
-            # logprobs row at position n_accepted is the one that produced
-            # the bonus — used for the bonus surfacing in the next step.
-            bonus_logprobs = full_logprobs[0, n_accepted, :]
-
             # Drafter history += newly-committed tokens. We add ONLY the
             # accepted drafts here; ``bonus`` will be added on the next
             # ``_suffix_step`` call (line ~1235 ``drafter.add_generated_token
@@ -3963,6 +3968,15 @@ def _install_suffix_decoding(
             # Post-commit exception: restore the pristine pre-verify cache so the
             # live cache never stays advanced beyond the surfaced tokens, then
             # re-raise so the caller handles this step as a normal fall-through.
+            #
+            # Any partial mutation tail (cooldown/width set_state, a stashed
+            # ``_pending_emits`` entry) or the retained hybrid replay head is
+            # discarded too — the step is treated as if it never committed, so
+            # ``_orig_step`` re-runs from the pristine cache and re-samples the
+            # primary from scratch (cooldown/width are re-derived on that run).
+            # By reordering we already ran all fallible MLX ops BEFORE mutating
+            # any bookkeeping, so there is no half-mutated drafter/counter/gb
+            # state to unwind.
             if _hybrid_pc_snapshot is not None:
                 gb.prompt_cache = _hybrid_pc_snapshot
             raise

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3605,6 +3605,9 @@ def _install_suffix_decoding(
         # the snapshot is taken, so a pre-snapshot (compute) exception must not
         # attempt a rollback that would reference unbound state.
         _tx: dict | None = None
+        # Cooldown-trip level to publish to the counter in the FINAL commit
+        # (deferred so a mid-tail failure doesn't half-publish). None = no trip.
+        _cooldown_tripped: int | None = None
 
         n_rejected_to_trim = 0
         if _hybrid_active:
@@ -3862,12 +3865,15 @@ def _install_suffix_decoding(
             _tx = {
                 "st": dict(st),
                 "stats": dict(_stats),
-                # Drafter rollback is only meaningful/safe on the real drafter
-                # (a test stub need not expose ``_tokens``/``stats``); fall back
-                # to a no-op rewind by capturing ``None`` (rewind_to(0) on the
-                # real drafter would already be handled, but we never call it
-                # when absent).
-                "drafter_len": len(getattr(drafter, "_tokens", [])),
+                # Drafter rollback via snapshot/restore (codex round-9k finding #1):
+                # captures _shift + full history so restore is correct even when the
+                # accepted-token add crossed the max_history head-trim boundary. Test
+                # stubs need not expose snapshot_state; None => no drafter rollback.
+                "drafter_state": (
+                    drafter.snapshot_state()
+                    if hasattr(drafter, "snapshot_state")
+                    else None
+                ),
                 "drafter_acc": getattr(
                     getattr(drafter, "stats", None), "total_draft_tokens_accepted", 0
                 ),
@@ -3887,7 +3893,9 @@ def _install_suffix_decoding(
                 drafter.add_generated_token(tok)
             drafter.record_acceptance(n_accepted)
             _stats["tokens_accepted"] += n_accepted
-            _counter.record_verify(K, n_accepted)
+            # Counter publication for THIS step is DEFERRED to the final commit
+            # block (see below), so a failure anywhere before it leaves the
+            # shared global counter untouched — no partial/double counting.
             # Cooldown bookkeeping: track consecutive zero-accept verifies
             # so workloads with weak drafter signal (e.g., free-form chat)
             # automatically stop paying verify overhead.
@@ -3920,7 +3928,7 @@ def _install_suffix_decoding(
                     st["zeros"] = 0
                     _stats["cooldown_trips"] += 1
                     _stats["cooldown_level"] = st["level"]
-                    _counter.record_cooldown_trip(st["level"])
+                    _cooldown_tripped = st["level"]
             else:
                 st["zeros"] = 0
                 # DECAY one level, don't reset to eager. A single lucky accept in
@@ -3961,10 +3969,8 @@ def _install_suffix_decoding(
                         st["level"] -= 1
                     _stats["cooldown_level"] = st["level"]
 
-            # Publish AFTER the backoff transition. Publishing before it left the
-            # gauge showing the pre-reset level, permanently so if the request
-            # finished on that burst.
-            _counter.set_state(st["k"], st["level"])
+            # Backoff transition complete; gauge publication is DEFERRED to the
+            # final commit block (so a late failure does not half-publish).
 
             n_rejected = K - n_accepted
             if _hybrid_active:
@@ -3997,6 +4003,17 @@ def _install_suffix_decoding(
 
             # Stash extras for next() to drain.
             _pending_emits[uid] = list(zip(extra_tokens, extra_logprobs))
+
+            # FINAL COMMIT: publish the shared counter ONLY after every fallible
+            # mutation above succeeded (codex round-9k finding #2). Deferring
+            # here means a failure anywhere in the tail leaves the global counter
+            # untouched — no partial ``record_verify``/``record_cooldown_trip``
+            # and no gauge set_state half-way. These are monotonic/pointed
+            # in-place updates: they cannot raise.
+            _counter.record_verify(K, n_accepted)
+            if _cooldown_tripped is not None:
+                _counter.record_cooldown_trip(_cooldown_tripped)
+            _counter.set_state(st["k"], st["level"])
 
             return [last_token], [primary_logprobs]
 
@@ -4033,8 +4050,10 @@ def _install_suffix_decoding(
                     st.update(_tx["st"])
                     _stats.clear()
                     _stats.update(_tx["stats"])
-                    if hasattr(drafter, "rewind_to"):
-                        drafter.rewind_to(_tx["drafter_len"])
+                    if _tx["drafter_state"] is not None and hasattr(
+                        drafter, "restore_state"
+                    ):
+                        drafter.restore_state(_tx["drafter_state"])
                     if hasattr(
                         getattr(drafter, "stats", None), "total_draft_tokens_accepted"
                     ):

--- a/vllm_mlx/speculative/suffix_counter.py
+++ b/vllm_mlx/speculative/suffix_counter.py
@@ -57,6 +57,11 @@ class SuffixAcceptCounter:
         "no_draft",
         "cooldown",
         "non_trimmable_cache",
+        # Hybrid path (#2561): a draft shorter than the hybrid minimum-match
+        # floor, or a bit-exactness-guard drift refusal, both take a plain
+        # forward. Additive buckets (no existing metric renamed).
+        "short_match",
+        "hybrid_drift",
         # Drafter or verify-forward raised; the step still took a plain
         # forward, so it must appear in the breakdown or verify +
         # fallthrough stops reconciling with actual decode steps exactly

--- a/vllm_mlx/speculative/suffix_decoding.py
+++ b/vllm_mlx/speculative/suffix_decoding.py
@@ -188,39 +188,35 @@ class SuffixDecodingDrafter:
                 for key in stale_keys:
                     del bucket[key]
 
-    def rewind_to(self, n_tokens: int) -> None:
-        """Roll the index back to the first ``n_tokens`` of ``_tokens``.
+    def snapshot_state(self):
+        """Capture a restorable snapshot of the mutable index state.
 
-        Used by the scheduler's post-commit exception path to undo the accepted-
-        draft ``add_generated_token`` calls when the committed step falls through
-        to a vanilla re-generate. Undoes exactly the tokens appended after
-        position ``n_tokens``: truncates ``_tokens`` and removes the k-groups
-        that end in the dropped range (guaranteed absent from any pre-existing
-        bucket because ``_add_one`` appends positions monotonically). Cheap --
-        O(dropped tokens * max_suffix_len). ``_shift`` is untouched because a
-        rewind never crosses the max_history head-trim boundary (it only removes
-        the most-recent additions).
+        Used by the scheduler's post-commit exception path to roll the drafter
+        back before a vanilla re-generate. Captures ``_shift`` and a copy of
+        ``_tokens`` so ``restore_state`` can recover the EXACT pre-add history
+        even when appending crossed the ``max_history`` head-trim boundary
+        (which evicts the head and advances ``_shift`` — a length-only rewind
+        cannot restore that).
         """
-        n = len(self._tokens)
-        if n_tokens >= n:
-            return
-        dropped = n - n_tokens
-        for k in range(1, self.max_suffix_len + 1):
-            bucket = self._suffix_index[k]
-            # End-positions we appended for the dropped tokens are the last
-            # ``dropped`` entries that land in this bucket; drop any list tail
-            # whose end >= the end of the first kept token (n_tokens + shift).
-            kept_end = self._shift + n_tokens  # first end-pos kept (exclusive)
-            stale_keys = []
-            for kgram, ends in bucket.items():
-                fresh = [e for e in ends if e < kept_end]
-                if fresh:
-                    bucket[kgram] = fresh
-                else:
-                    stale_keys.append(kgram)
-            for key in stale_keys:
-                del bucket[key]
-        self._tokens = self._tokens[:n_tokens]
+        return (list(self._tokens), self._shift)
+
+    def restore_state(self, state) -> None:
+        """Restore ``_tokens``/``_shift`` to a captured snapshot and rebuild the
+        k-gram index from them. Correct after a head-trim: re-indexing from the
+        restored tokens reproduces exactly the pre-add index. O(len *
+        max_suffix_len) — only run on the exceptional rollback path."""
+        tokens, shift = state
+        self._tokens = list(tokens)
+        self._shift = shift
+        self._suffix_index = [defaultdict(list) for _ in range(self.max_suffix_len + 1)]
+        for i, tok in enumerate(self._tokens):
+            abs_pos = shift + i
+            for k in range(1, self.max_suffix_len + 1):
+                local = i + 1 - k
+                if local < 0:
+                    continue
+                kgram = tuple(self._tokens[local : local + k])
+                self._suffix_index[k][kgram].append(abs_pos)
 
     # --- Drafting ------------------------------------------------------
 

--- a/vllm_mlx/speculative/suffix_decoding.py
+++ b/vllm_mlx/speculative/suffix_decoding.py
@@ -188,6 +188,40 @@ class SuffixDecodingDrafter:
                 for key in stale_keys:
                     del bucket[key]
 
+    def rewind_to(self, n_tokens: int) -> None:
+        """Roll the index back to the first ``n_tokens`` of ``_tokens``.
+
+        Used by the scheduler's post-commit exception path to undo the accepted-
+        draft ``add_generated_token`` calls when the committed step falls through
+        to a vanilla re-generate. Undoes exactly the tokens appended after
+        position ``n_tokens``: truncates ``_tokens`` and removes the k-groups
+        that end in the dropped range (guaranteed absent from any pre-existing
+        bucket because ``_add_one`` appends positions monotonically). Cheap --
+        O(dropped tokens * max_suffix_len). ``_shift`` is untouched because a
+        rewind never crosses the max_history head-trim boundary (it only removes
+        the most-recent additions).
+        """
+        n = len(self._tokens)
+        if n_tokens >= n:
+            return
+        dropped = n - n_tokens
+        for k in range(1, self.max_suffix_len + 1):
+            bucket = self._suffix_index[k]
+            # End-positions we appended for the dropped tokens are the last
+            # ``dropped`` entries that land in this bucket; drop any list tail
+            # whose end >= the end of the first kept token (n_tokens + shift).
+            kept_end = self._shift + n_tokens  # first end-pos kept (exclusive)
+            stale_keys = []
+            for kgram, ends in bucket.items():
+                fresh = [e for e in ends if e < kept_end]
+                if fresh:
+                    bucket[kgram] = fresh
+                else:
+                    stale_keys.append(kgram)
+            for key in stale_keys:
+                del bucket[key]
+        self._tokens = self._tokens[:n_tokens]
+
     # --- Drafting ------------------------------------------------------
 
     def get_draft(self) -> list[int]:


### PR DESCRIPTION
## Why (Part of #2561 B2 — lossless hybrid n-gram)

The portfolio B2 contract + issue #2561 want draftless n-gram speculative decoding to work losslessly on **hybrid Flash-Next** (recurrent/GatedDeltaNet/PLE/QSA). The pure-attention suffix path rejects hybrid because chunked-batched verify isn't step-equivalent on recurrent layers. This PR implements the **engine verify transaction** for hybrid, default-off and opt-in, mirroring vLLM/SGLang's n-gram worker.

## Change (suffix_hybrid, default-off)

Adds an opt-in `--suffix-hybrid` path to the existing suffix decoder (`_install_suffix_decoding` / `_suffix_step`):
- **Scratch-verify** (`_verify_scratch`): run the tentative multi-token `model([X, d_0..d_{K-1}])` forward on a **deepcopy'd scratch cache** so the persistent recurrent/conv/PLE/QSA state stays untouched (SGLang NGRAMWorker isolation).
- **Commit-only-accepted** (`_commit_scratch_accepted`): replay ONLY the accepted prefix `[X, d_0..d_{n-1}]` stepwise onto a fresh pre-verify copy, then swap it into the live cache — the rejected tail is never advanced (drop-the-tail), so it's lossless.
- **24-token min-match floor** (`suffix_min_match_len=24`): a draft shorter than the floor falls through (`ft_short_match`) without paying the multi-token verify cost — novel text never touches the tentative-verify path.
- **Bit-exactness guard** (`--suffix-hybrid-bit-exact`, default ON; `--no-suffix-hybrid-bit-exact` is an explicit unsafe evaluation opt-out): replays the committed path stepwise and compares greedy preds to the chunked verify; on any mismatch (quantized-hybrid drift signature) it refuses to commit and falls through (`ft_hybrid_drift`) rather than silently corrupting.
- Hybrid gate opens only when `suffix_hybrid=True` AND `profile.is_hybrid`. Pure-attention path untouched. Additive `ft_short_match`/`ft_hybrid_drift` fallthrough buckets + `hybrid_drifts` counter; **no existing metric renamed**.

## Key finding (independently verified)
The #3090 `Qwen4ExpStateCache.can_trim`/`trim_all` contract, while a correct standalone invariant, does NOT by itself unlock the hybrid flip: on the real hybrid capture, `record_slot_snapshots(finalize=True)` publishes **K** boundaries for a K-token verify (not K+1), so `can_trim(K)`=False → `can_advance(c,K)`=False → the attention verify preflight fails on hybrid. This design therefore **sidesteps `trim_all`/`can_advance` entirely** using the scratch+replay (drop-the-tail) pattern — #3090 + B2.1 together deliver the lossless hybrid enablement.

## Reference (raullen rule)
SGLang `python/sglang/srt/speculative/ngram_worker.py` + `spec_utils.py`: hybrid Mamba/linear-attention n-gram spec-decode via scratch verify + commit-only-accepted of the last correct step. This PR mirrors that (isolation + selective commit) rather than reinventing.

## Test plan
- Expanded `tests/test_suffix_hybrid_scratch_verify.py` transaction/regression battery: scratch-verify core (accept-all/partial/reject-first state-equality on the **real tiny Qwen4-exp hybrid** via exact recurrent/QSA/conv equality vs stepwise gold), install-gate opt-in, 24-floor short-match fallthrough, bit-exactness guard (step-exact no-misfire + forced-drift refuses cleanly), token-identity + lifecycle, prefix-cache decodability after commit.
- Current post-main-rebase gate: 171 focused suffix/config tests pass; ruff, format, and diff checks are clean. Real served dogfood and the release hold are recorded in the latest PR comment.

## Non-goals (this slice)
- No default enablement (hybrid stays opt-in). No version bump, no CI changes, no metric renames. Full real Flash-Next serve bakeoff = B2.2 follow-on.
