### PR TITLE
perf(mla): add opt-in absorbed verify path

### DIFF
--- a/.agents/handoffs/mla-absorbed-verify.md
+++ b/.agents/handoffs/mla-absorbed-verify.md
@@ -8,7 +8,7 @@ Host: Mac Studio, Apple M3 Ultra 256 GB
 
 Branch: `vector/mla-absorbed-verify`
 
-PR: #3110 (Draft)
+PR: #3110
 
 ## Verified facts
 
@@ -36,6 +36,8 @@ PR: #3110 (Draft)
 
 ## Next concrete action
 
-Atlas should decide whether this experimental compatibility lever is useful
-enough to merge before upstream mlx-lm PR #1817 lands. Keep it opt-in; do not
-queue or promote it to a default based on the current evidence alone.
+The repository owner accepted this as a default-off release compatibility
+lever after final Vector review on 2026-09-06. Land it through the Mac merge
+queue, but do not promote it to a default without a supported speculative-route
+trajectory battery. Retire the local patch when upstream mlx-lm PR #1817 is
+released and Rapid adopts that provider.

--- a/.agents/handoffs/mla-absorbed-verify.md
+++ b/.agents/handoffs/mla-absorbed-verify.md
@@ -1,0 +1,41 @@
+# MLA absorbed verification handoff
+
+Receiving role: Atlas
+
+Owner: Vector
+
+Host: Mac Studio, Apple M3 Ultra 256 GB
+
+Branch: `vector/mla-absorbed-verify`
+
+PR: pending
+
+## Verified facts
+
+- The exact mlx-lm 0.31.3 MLA implementations for DeepSeek V3, GLM-4 MoE
+  Lite, Kimi Linear, and LongCat Flash can use absorbed attention for qualified
+  multi-token forwards. Unknown source bodies fail closed.
+- Default-off is a literal no-wrap path. `L=1` and caches shorter than 1024
+  tokens retain mlx-lm behavior. An upstream provider disables the local copy.
+- Tiny real MLX layers cover cold and warm behavior for all four architectures.
+- GLM-4.7-Flash-4bit M=3 forwards measured 2.500x at 1K, 6.594x at 4K, and
+  16.180x at 16K. Outputs are numerically close but not bit-exact.
+- A deterministic 4457-token suffix workload improved 4.054x; the two arms
+  produced identical 128-token output, although both diverged from vanilla.
+- Full commands, environment, and exclusions are recorded in
+  `docs/engineering/performance/2026-09-05-mla-absorbed-verify.md`.
+
+## Unresolved questions and risks
+
+- GLM-4.7 is not in Rapid's native MTP allowlist, so current direct product
+  reach is narrow.
+- Multi-token numerical accumulation can change a near-tied greedy choice.
+- Source hashes require deliberate requalification after mlx-lm changes.
+- DeepSeek V3.2 is deliberately excluded to avoid colliding with the existing
+  indexed-attention patch.
+
+## Next concrete action
+
+Atlas should decide whether this experimental compatibility lever is useful
+enough to merge before upstream mlx-lm PR #1817 lands. Keep it opt-in; do not
+queue or promote it to a default based on the current evidence alone.

--- a/.agents/handoffs/mla-absorbed-verify.md
+++ b/.agents/handoffs/mla-absorbed-verify.md
@@ -8,7 +8,7 @@ Host: Mac Studio, Apple M3 Ultra 256 GB
 
 Branch: `vector/mla-absorbed-verify`
 
-PR: pending
+PR: #3110 (Draft)
 
 ## Verified facts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,7 @@ jobs:
             tests/test_glm5_next_processor_patch.py \
             tests/test_glm5_next_forget_gate_quant.py \
             tests/test_glm5_next_runtime_patch.py \
+            tests/test_mla_absorbed_verify.py \
             tests/test_mllm_hybrid_probe.py \
             tests/test_hidream_o1_alias.py \
             tests/test_sdxl_alias.py \

--- a/docs/engineering/performance/2026-09-05-mla-absorbed-verify.md
+++ b/docs/engineering/performance/2026-09-05-mla-absorbed-verify.md
@@ -1,0 +1,123 @@
+# Absorbed MLA for multi-token verification
+
+Date: 2026-09-05
+
+Owner: Vector
+
+## Decision
+
+Carry the pending mlx-lm absorbed-MLA crossover as an experimental,
+fail-closed compatibility patch. It is disabled by default and is limited to
+post-update caches of at least 1024 tokens. Do not promote it to a default
+until a supported speculative route has a larger trajectory-quality battery.
+
+The patch covers the exact mlx-lm 0.31.3 implementations of DeepSeek V3,
+GLM-4 MoE Lite, Kimi Linear, and LongCat Flash MLA. A source-body mismatch is
+skipped. DeepSeek V3.2 remains owned by Rapid's indexed-attention patch and is
+not replaced. The patch retires when mlx-lm exposes its upstream
+`max_absorbed_queries` implementation.
+
+## Mechanism
+
+For latent rank `r`, combined non-positional query/value width `d`, post-update
+cache length `T`, and query width `L`, absorbed MLA is selected only when:
+
+```text
+L < r*d*T / (r*d + T*(2*r - d))
+```
+
+The implementation evaluates the strict crossover with integer arithmetic.
+Cold prefill stays on mlx-lm's materialized path; `L=1` delegates to mlx-lm's
+existing absorbed decode branch. Rapid additionally requires `T >= 1024`,
+based on the end-to-end qualification below.
+
+Enable it explicitly with:
+
+```bash
+RAPID_MLX_MLA_ABSORBED_VERIFY=1 rapid-mlx serve MODEL
+```
+
+## Environment and artifact
+
+- Mac Studio, Apple M3 Ultra, 256 GB unified memory
+- macOS 26.5.2 arm64
+- Python 3.12.14
+- MLX 0.32.2; mlx-lm 0.31.3
+- `mlx-community/GLM-4.7-Flash-4bit`
+- immutable model revision `1454cffb1a21737e162f508e5bc70be9def89276`
+- seed 7, greedy decoding where applicable
+
+The Mini was not used because an unrelated 30B service owned its memory during
+qualification. No process was stopped for this benchmark.
+
+## Warm M=3 forward
+
+Each arm used the same loaded weights and a cloned warm cache. Six samples per
+arm were collected in ABBA order after compilation. The measured unit is one
+full-model three-token forward.
+
+| Context | Stock median | Absorbed median | Speedup | Final argmax |
+| ---: | ---: | ---: | ---: | :---: |
+| 1,024 | 50.795 ms | 20.315 ms | 2.500x | equal |
+| 4,096 | 144.810 ms | 21.961 ms | 6.594x | equal |
+| 16,384 | 517.628 ms | 31.992 ms | 16.180x | equal |
+
+The output is not bit-exact. Final-logit RMS deltas were 2.1763, 1.0086, and
+2.1409 respectively. This is why the switch remains opt-in despite the large
+kernel win.
+
+Reproduction:
+
+```bash
+python3.12 scripts/bench_mla_absorbed_verify.py \
+  --model mlx-community/GLM-4.7-Flash-4bit \
+  --revision 1454cffb1a21737e162f508e5bc70be9def89276 \
+  --contexts 1024 4096 16384 --width 3 --repeats 6 \
+  --oracle-context 4096 --oracle-cases 12 \
+  --suffix-repeats 4 --suffix-max-tokens 128 \
+  --seed 7 --json /tmp/mla-verify.json
+```
+
+## Sequential-decode oracle
+
+At a 4K cache, twelve deterministic random token triples compared both M=3
+paths with three sequential `L=1` target calls:
+
+| Path | Oracle argmax matches | Mean logit RMS to oracle |
+| --- | ---: | ---: |
+| Stock materialized M=3 | 9/12 | 1.3222 |
+| Absorbed M=3 | 11/12 | 1.4416 |
+
+Absorbed MLA matched the sequential argmax more often but had 9.0% higher mean
+RMS. The experiment rejects both “bit-exact” and “always numerically closer”
+claims.
+
+## End-to-end suffix dogfood
+
+Four runs per arm used the existing suffix-decoding harness for 128 generated
+tokens and the benchmark's deterministic 4457-token repeated code-edit prompt.
+
+| Path | Median TPS | Delta vs stock | Diffs vs stock |
+| --- | ---: | ---: | ---: |
+| Stock materialized | 36.02 | baseline | 0 |
+| Absorbed | 146.02 | +305.4% | 0/128 |
+
+Both suffix arms differed from sequential vanilla on 103/128 tokens, while
+they remained identical to each other. This isolates a 4.054x attention-path
+gain without claiming that GLM-4.7 suffix decoding itself is correct. No
+validated short-cache speculative route exists in Rapid today, so the initial
+compatibility patch uses a conservative 1024 cache floor.
+
+## Product scope and risks
+
+Rapid's native MTP allowlist does not currently include GLM-4.7; the direct
+benefit today is limited to explicit long-context suffix use and compatible
+external speculative callers. HY3 uses ordinary attention, not MLA, and does
+not benefit. This is a reusable MLA lever, not an all-model optimization.
+
+The main risks are numerical path changes and drift in copied upstream model
+methods. Default-off behavior installs no wrappers, exact source hashes block
+unknown implementations, and mechanism counters expose absorbed,
+materialized, single-token, and short-cache routing.
+
+Upstream reference: <https://github.com/ml-explore/mlx-lm/pull/1817>

--- a/scripts/bench_metadata.py
+++ b/scripts/bench_metadata.py
@@ -46,6 +46,7 @@ JSON_BENCH_SCRIPTS = frozenset(
         "bench_dflash.py",
         "bench_diffusion_gemma.py",
         "bench_engine_solo.py",
+        "bench_mla_absorbed_verify.py",
         "bench_qwen4_fused_gdn_decode.py",
         "bench_qwen4_fused_gdn_end_to_end.py",
         "bench_qwen4_qsa_block_sparse.py",

--- a/scripts/bench_mla_absorbed_verify.py
+++ b/scripts/bench_mla_absorbed_verify.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Measure stock versus absorbed MLA for a warm multi-token forward.
+
+The two arms share one loaded model and start each timed call from a shallow
+copy of the same immutable MLX cache graph.  Only the supported attention
+classes' ``__call__`` methods are switched between arms.
+
+Example:
+    python3.12 scripts/bench_mla_absorbed_verify.py \
+      --model mlx-community/GLM-4.7-Flash-4bit \
+      --contexts 1024 4096 16384 --width 3 --repeats 6 \
+      --json /tmp/mla-verify.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import platform
+import random
+import statistics
+import sys
+import time
+from pathlib import Path
+
+os.environ["RAPID_MLX_MLA_ABSORBED_VERIFY"] = "1"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mlx.core as mx
+from mlx_lm import load
+from mlx_lm.models import cache as mlx_cache
+
+from vllm_mlx.patches import mla_absorbed_verify as patch
+
+LONG_CODE_EDIT_PROMPT = """You are a code refactoring assistant. Re-emit the
+complete Python module below with one change: rename every local variable
+`total` to `accumulator`. Preserve all other tokens and emit only Python.
+
+""" + "\n\n".join(
+    f"""def compute_score_{index}(records, weights):
+    if not records:
+        return 0.0
+    total = 0.0
+    for record, weight in zip(records, weights):
+        total += float(record.value) * float(weight)
+    if total < 0:
+        return 0.0
+    return total"""
+    for index in range(64)
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--revision")
+    parser.add_argument("--contexts", nargs="+", type=int, default=[1024, 4096])
+    parser.add_argument("--width", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=6)
+    parser.add_argument("--chunk-size", type=int, default=512)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--oracle-context", type=int, default=0)
+    parser.add_argument("--oracle-cases", type=int, default=12)
+    parser.add_argument("--suffix-repeats", type=int, default=0)
+    parser.add_argument("--suffix-max-tokens", type=int, default=128)
+    parser.add_argument("--json", type=Path)
+    return parser.parse_args()
+
+
+def _set_arm(targets: dict, originals: dict, arm: str) -> None:
+    for key, cls in targets.items():
+        cls.__call__ = originals[key] if arm == "stock" else targets[key].rapid_call
+
+
+def _clone_cache(cache):
+    """Clone mutable cache containers while sharing immutable MLX arrays."""
+    if hasattr(cache, "shape") and hasattr(cache, "dtype"):
+        return cache
+    if isinstance(cache, list):
+        return [_clone_cache(value) for value in cache]
+    if isinstance(cache, tuple):
+        return tuple(_clone_cache(value) for value in cache)
+    if isinstance(cache, dict):
+        return {key: _clone_cache(value) for key, value in cache.items()}
+
+    cloned = copy.copy(cache)
+    # CacheList owns nested cache objects; ArraysCache owns a mutable list.
+    for attribute in ("caches", "cache"):
+        if hasattr(cache, attribute):
+            setattr(cloned, attribute, _clone_cache(getattr(cache, attribute)))
+    return cloned
+
+
+def _timed_forward(model, tokens, cache) -> tuple[float, object]:
+    started = time.perf_counter()
+    logits = model(tokens, cache=cache)
+    mx.eval(logits)
+    return (time.perf_counter() - started) * 1000, logits
+
+
+def _prefill(model, token_ids: list[int], chunk_size: int):
+    cache = mlx_cache.make_prompt_cache(model)
+    for start in range(0, len(token_ids), chunk_size):
+        logits = model(
+            mx.array(token_ids[start : start + chunk_size], mx.uint32)[None],
+            cache=cache,
+        )
+        mx.eval(logits)
+    return cache
+
+
+def _logit_distance(value, oracle) -> dict:
+    delta = value[:, -1].astype(mx.float32) - oracle[:, -1].astype(mx.float32)
+    mx.eval(delta)
+    return {
+        "max_abs": float(mx.max(mx.abs(delta))),
+        "rms": float(mx.sqrt(mx.mean(mx.square(delta)))),
+        "argmax_equal": bool(
+            mx.array_equal(
+                mx.argmax(value[:, -1], -1), mx.argmax(oracle[:, -1], -1)
+            ).item()
+        ),
+    }
+
+
+def _token_differences(left: list[int], right: list[int]) -> int:
+    return abs(len(left) - len(right)) + sum(a != b for a, b in zip(left, right))
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.width < 2 or args.repeats < 2 or any(c < 1 for c in args.contexts):
+        raise SystemExit("width, repeats, and contexts must be positive; width >= 2")
+
+    patch.install_mla_absorbed_verify()
+    stats = patch.mla_absorbed_verify_stats()
+    if stats["provider"] != "rapid":
+        raise SystemExit(f"Rapid MLA provider is not active: {stats}")
+
+    from mlx_lm.models import mla
+
+    originals = mla._RAPID_MLX_MLA_ABSORBED_ORIGINALS
+    targets = {}
+    for module_name, class_name in originals:
+        module = __import__(f"mlx_lm.models.{module_name}", fromlist=[class_name])
+        cls = getattr(module, class_name)
+        cls.rapid_call = cls.__call__
+        targets[(module_name, class_name)] = cls
+
+    mx.random.seed(args.seed)
+    model, tokenizer = load(args.model, revision=args.revision)
+    active_classes = tuple(targets.values())
+    if not any(isinstance(module, active_classes) for module in model.modules()):
+        supported = ", ".join(f"{mod}.{cls}" for mod, cls in sorted(targets))
+        raise SystemExit(
+            f"loaded model does not contain a patched MLA class; supported: {supported}"
+        )
+    seed_ids = tokenizer.encode(" reproducible MLA benchmark")
+    if not seed_ids:
+        raise SystemExit("tokenizer produced no input IDs")
+    verify = mx.array(
+        [seed_ids[index % len(seed_ids)] for index in range(args.width)], mx.uint32
+    )[None]
+
+    rows = []
+    for context in args.contexts:
+        repeated = [seed_ids[index % len(seed_ids)] for index in range(context)]
+        _set_arm(targets, originals, "stock")
+        base_cache = _prefill(model, repeated, args.chunk_size)
+
+        # Compile both shapes before sampling. ABBA order counters slow drift.
+        arm_logits = {}
+        for arm in ("stock", "rapid"):
+            _set_arm(targets, originals, arm)
+            _, arm_logits[arm] = _timed_forward(model, verify, _clone_cache(base_cache))
+        samples = {"stock": [], "rapid": []}
+        order = ("stock", "rapid", "rapid", "stock")
+        while len(samples["stock"]) < args.repeats:
+            for arm in order:
+                if len(samples[arm]) >= args.repeats:
+                    continue
+                _set_arm(targets, originals, arm)
+                elapsed, arm_logits[arm] = _timed_forward(
+                    model, verify, _clone_cache(base_cache)
+                )
+                samples[arm].append(round(elapsed, 3))
+
+        stock = arm_logits["stock"][:, -1].astype(mx.float32)
+        rapid = arm_logits["rapid"][:, -1].astype(mx.float32)
+        delta = stock - rapid
+        mx.eval(delta)
+        stock_median = statistics.median(samples["stock"])
+        rapid_median = statistics.median(samples["rapid"])
+        rows.append(
+            {
+                "context": context,
+                "width": args.width,
+                "stock_ms": samples["stock"],
+                "rapid_ms": samples["rapid"],
+                "stock_median_ms": stock_median,
+                "rapid_median_ms": rapid_median,
+                "speedup": stock_median / rapid_median,
+                "max_abs_logit": float(mx.max(mx.abs(delta))),
+                "rms_logit": float(mx.sqrt(mx.mean(mx.square(delta)))),
+                "argmax_equal": bool(
+                    mx.array_equal(mx.argmax(stock, -1), mx.argmax(rapid, -1)).item()
+                ),
+            }
+        )
+
+    oracle_result = None
+    if args.oracle_context:
+        _set_arm(targets, originals, "stock")
+        repeated = [
+            seed_ids[index % len(seed_ids)] for index in range(args.oracle_context)
+        ]
+        base_cache = _prefill(model, repeated, args.chunk_size)
+        rng = random.Random(args.seed)
+        vocab_size = int(getattr(tokenizer, "vocab_size", 65536))
+        oracle_rows = []
+        for case in range(args.oracle_cases):
+            ids = [rng.randrange(vocab_size) for _ in range(args.width)]
+            tokens = mx.array(ids, mx.uint32)[None]
+            _set_arm(targets, originals, "stock")
+            stock = model(tokens, cache=_clone_cache(base_cache))
+            oracle_cache = _clone_cache(base_cache)
+            oracle = None
+            for token_id in ids:
+                oracle = model(mx.array([[token_id]], mx.uint32), cache=oracle_cache)
+            _set_arm(targets, originals, "rapid")
+            rapid = model(tokens, cache=_clone_cache(base_cache))
+            mx.eval(stock, rapid, oracle)
+            oracle_rows.append(
+                {
+                    "case": case,
+                    "tokens": ids,
+                    "stock": _logit_distance(stock, oracle),
+                    "rapid": _logit_distance(rapid, oracle),
+                }
+            )
+        oracle_result = {
+            "context": args.oracle_context,
+            "cases": args.oracle_cases,
+            "stock_argmax_matches": sum(
+                r["stock"]["argmax_equal"] for r in oracle_rows
+            ),
+            "rapid_argmax_matches": sum(
+                r["rapid"]["argmax_equal"] for r in oracle_rows
+            ),
+            "stock_mean_rms": statistics.mean(r["stock"]["rms"] for r in oracle_rows),
+            "rapid_mean_rms": statistics.mean(r["rapid"]["rms"] for r in oracle_rows),
+            "rows": oracle_rows,
+        }
+
+    suffix_result = None
+    if args.suffix_repeats:
+        from scripts.bench_suffix_decoding import _run_suffix, _run_vanilla
+
+        _set_arm(targets, originals, "stock")
+        vanilla = _run_vanilla(
+            model, tokenizer, LONG_CODE_EDIT_PROMPT, args.suffix_max_tokens
+        )
+        runs = {"stock": [], "rapid": []}
+        outputs = {}
+        for arm in ("stock", "rapid"):
+            _set_arm(targets, originals, arm)
+            for _ in range(args.suffix_repeats):
+                run = _run_suffix(
+                    model,
+                    tokenizer,
+                    LONG_CODE_EDIT_PROMPT,
+                    args.suffix_max_tokens,
+                    max_draft=8,
+                    max_suffix=4,
+                    min_conf=0.3,
+                )
+                runs[arm].append(run.tps)
+                outputs[arm] = run.out_tokens
+        stock_median = statistics.median(runs["stock"])
+        rapid_median = statistics.median(runs["rapid"])
+        suffix_result = {
+            "prompt_tokens": len(tokenizer.encode(LONG_CODE_EDIT_PROMPT)),
+            "completion_tokens": args.suffix_max_tokens,
+            "vanilla_tps": vanilla.tps,
+            "stock_tps": runs["stock"],
+            "rapid_tps": runs["rapid"],
+            "stock_median_tps": stock_median,
+            "rapid_median_tps": rapid_median,
+            "speedup": rapid_median / stock_median,
+            "vanilla_output_tokens": len(vanilla.out_tokens),
+            "stock_output_tokens": len(outputs["stock"]),
+            "rapid_output_tokens": len(outputs["rapid"]),
+            "stock_vs_vanilla_diffs": _token_differences(
+                outputs["stock"], vanilla.out_tokens
+            ),
+            "rapid_vs_vanilla_diffs": _token_differences(
+                outputs["rapid"], vanilla.out_tokens
+            ),
+            "stock_vs_rapid_diffs": _token_differences(
+                outputs["stock"], outputs["rapid"]
+            ),
+        }
+
+    result = {
+        "model": args.model,
+        "revision": args.revision,
+        "mlx": mx.__version__,
+        "platform": platform.platform(),
+        "seed": args.seed,
+        "rows": rows,
+        "oracle": oracle_result,
+        "suffix": suffix_result,
+        "stats": patch.mla_absorbed_verify_stats(),
+    }
+    rendered = json.dumps(result, indent=2)
+    print(rendered)
+    if args.json:
+        args.json.write_text(rendered + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_mla_absorbed_verify.py
+++ b/scripts/bench_mla_absorbed_verify.py
@@ -131,8 +131,25 @@ def _token_differences(left: list[int], right: list[int]) -> int:
 
 def main() -> None:
     args = _parse_args()
-    if args.width < 2 or args.repeats < 2 or any(c < 1 for c in args.contexts):
-        raise SystemExit("width, repeats, and contexts must be positive; width >= 2")
+    invalid = []
+    if args.width < 2:
+        invalid.append("width must be >= 2")
+    if args.repeats < 2:
+        invalid.append("repeats must be >= 2")
+    if any(context < 1 for context in args.contexts):
+        invalid.append("contexts must be positive")
+    if args.chunk_size < 1:
+        invalid.append("chunk-size must be positive")
+    if args.oracle_context < 0:
+        invalid.append("oracle-context must be non-negative")
+    if args.oracle_context and args.oracle_cases < 1:
+        invalid.append("oracle-cases must be positive when oracle is enabled")
+    if args.suffix_repeats < 0:
+        invalid.append("suffix-repeats must be non-negative")
+    if args.suffix_repeats and args.suffix_max_tokens < 1:
+        invalid.append("suffix-max-tokens must be positive when suffix is enabled")
+    if invalid:
+        raise SystemExit("; ".join(invalid))
 
     patch.install_mla_absorbed_verify()
     stats = patch.mla_absorbed_verify_stats()

--- a/scripts/bench_mla_absorbed_verify.py
+++ b/scripts/bench_mla_absorbed_verify.py
@@ -25,6 +25,7 @@ import time
 from pathlib import Path
 
 os.environ["RAPID_MLX_MLA_ABSORBED_VERIFY"] = "1"
+os.environ["RAPID_MLX_MLA_ABSORBED_VERIFY_STATS"] = "1"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import mlx.core as mx
@@ -129,6 +130,12 @@ def _token_differences(left: list[int], right: list[int]) -> int:
     return abs(len(left) - len(right)) + sum(a != b for a, b in zip(left, right))
 
 
+def _require_absorbed(before: int, label: str) -> None:
+    after = patch.mla_absorbed_verify_stats()["absorbed"]
+    if after <= before:
+        raise RuntimeError(f"Rapid arm did not use absorbed MLA during {label}")
+
+
 def main() -> None:
     args = _parse_args()
     invalid = []
@@ -191,7 +198,10 @@ def main() -> None:
         arm_logits = {}
         for arm in ("stock", "rapid"):
             _set_arm(targets, originals, arm)
+            absorbed_before = patch.mla_absorbed_verify_stats()["absorbed"]
             _, arm_logits[arm] = _timed_forward(model, verify, _clone_cache(base_cache))
+            if arm == "rapid":
+                _require_absorbed(absorbed_before, f"{context}-token warmup")
         samples = {"stock": [], "rapid": []}
         order = ("stock", "rapid", "rapid", "stock")
         while len(samples["stock"]) < args.repeats:
@@ -199,9 +209,12 @@ def main() -> None:
                 if len(samples[arm]) >= args.repeats:
                     continue
                 _set_arm(targets, originals, arm)
+                absorbed_before = patch.mla_absorbed_verify_stats()["absorbed"]
                 elapsed, arm_logits[arm] = _timed_forward(
                     model, verify, _clone_cache(base_cache)
                 )
+                if arm == "rapid":
+                    _require_absorbed(absorbed_before, f"{context}-token sample")
                 samples[arm].append(round(elapsed, 3))
 
         stock = arm_logits["stock"][:, -1].astype(mx.float32)
@@ -247,8 +260,10 @@ def main() -> None:
             for token_id in ids:
                 oracle = model(mx.array([[token_id]], mx.uint32), cache=oracle_cache)
             _set_arm(targets, originals, "rapid")
+            absorbed_before = patch.mla_absorbed_verify_stats()["absorbed"]
             rapid = model(tokens, cache=_clone_cache(base_cache))
             mx.eval(stock, rapid, oracle)
+            _require_absorbed(absorbed_before, f"oracle case {case}")
             oracle_rows.append(
                 {
                     "case": case,
@@ -280,13 +295,14 @@ def main() -> None:
             model, tokenizer, LONG_CODE_EDIT_PROMPT, args.suffix_max_tokens
         )
         runs = {"stock": [], "rapid": []}
-        outputs = {}
+        outputs = {"stock": [], "rapid": []}
         order = ("stock", "rapid", "rapid", "stock")
         while len(runs["stock"]) < args.suffix_repeats:
             for arm in order:
                 if len(runs[arm]) >= args.suffix_repeats:
                     continue
                 _set_arm(targets, originals, arm)
+                absorbed_before = patch.mla_absorbed_verify_stats()["absorbed"]
                 run = _run_suffix(
                     model,
                     tokenizer,
@@ -297,7 +313,18 @@ def main() -> None:
                     min_conf=0.3,
                 )
                 runs[arm].append(run.tps)
-                outputs[arm] = run.out_tokens
+                outputs[arm].append(run.out_tokens)
+                if arm == "rapid":
+                    _require_absorbed(absorbed_before, "suffix repetition")
+        for arm, repetitions in outputs.items():
+            if any(tokens != repetitions[0] for tokens in repetitions[1:]):
+                raise RuntimeError(f"{arm} suffix output changed between repetitions")
+        paired_diffs = [
+            _token_differences(stock, rapid)
+            for stock, rapid in zip(outputs["stock"], outputs["rapid"])
+        ]
+        stock_output = outputs["stock"][0]
+        rapid_output = outputs["rapid"][0]
         stock_median = statistics.median(runs["stock"])
         rapid_median = statistics.median(runs["rapid"])
         suffix_result = {
@@ -310,17 +337,16 @@ def main() -> None:
             "rapid_median_tps": rapid_median,
             "speedup": rapid_median / stock_median,
             "vanilla_output_tokens": len(vanilla.out_tokens),
-            "stock_output_tokens": len(outputs["stock"]),
-            "rapid_output_tokens": len(outputs["rapid"]),
+            "stock_output_tokens": len(stock_output),
+            "rapid_output_tokens": len(rapid_output),
             "stock_vs_vanilla_diffs": _token_differences(
-                outputs["stock"], vanilla.out_tokens
+                stock_output, vanilla.out_tokens
             ),
             "rapid_vs_vanilla_diffs": _token_differences(
-                outputs["rapid"], vanilla.out_tokens
+                rapid_output, vanilla.out_tokens
             ),
-            "stock_vs_rapid_diffs": _token_differences(
-                outputs["stock"], outputs["rapid"]
-            ),
+            "stock_vs_rapid_diffs": paired_diffs[0],
+            "stock_vs_rapid_diffs_by_repeat": paired_diffs,
         }
 
     result = {

--- a/scripts/bench_mla_absorbed_verify.py
+++ b/scripts/bench_mla_absorbed_verify.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Measure stock versus absorbed MLA for a warm multi-token forward.
 
-The two arms share one loaded model and start each timed call from a shallow
-copy of the same immutable MLX cache graph.  Only the supported attention
+The two arms share one loaded model and start each timed call from cloned
+mutable cache containers that share the same immutable MLX arrays. Only the supported attention
 classes' ``__call__`` methods are switched between arms.
 
 Example:
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import copy
-import json
 import os
 import platform
 import random
@@ -32,6 +31,7 @@ import mlx.core as mx
 from mlx_lm import load
 from mlx_lm.models import cache as mlx_cache
 
+from scripts.bench_metadata import format_bench_json, write_bench_json
 from vllm_mlx.patches import mla_absorbed_verify as patch
 
 LONG_CODE_EDIT_PROMPT = """You are a code refactoring assistant. Re-emit the
@@ -264,9 +264,12 @@ def main() -> None:
         )
         runs = {"stock": [], "rapid": []}
         outputs = {}
-        for arm in ("stock", "rapid"):
-            _set_arm(targets, originals, arm)
-            for _ in range(args.suffix_repeats):
+        order = ("stock", "rapid", "rapid", "stock")
+        while len(runs["stock"]) < args.suffix_repeats:
+            for arm in order:
+                if len(runs[arm]) >= args.suffix_repeats:
+                    continue
+                _set_arm(targets, originals, arm)
                 run = _run_suffix(
                     model,
                     tokenizer,
@@ -314,10 +317,10 @@ def main() -> None:
         "suffix": suffix_result,
         "stats": patch.mla_absorbed_verify_stats(),
     }
-    rendered = json.dumps(result, indent=2)
+    rendered = format_bench_json(result, __file__)
     print(rendered)
     if args.json:
-        args.json.write_text(rendered + "\n")
+        write_bench_json(args.json, result, __file__)
 
 
 if __name__ == "__main__":

--- a/scripts/bench_mla_absorbed_verify.py
+++ b/scripts/bench_mla_absorbed_verify.py
@@ -136,6 +136,27 @@ def _require_absorbed(before: int, label: str) -> None:
         raise RuntimeError(f"Rapid arm did not use absorbed MLA during {label}")
 
 
+def _validate_absorbed_point(context: int, width: int, modules: list) -> None:
+    cache_len = context + width
+    if cache_len < patch.MIN_CACHE_LENGTH:
+        raise SystemExit(
+            f"context={context}, width={width} has post-update cache {cache_len}; "
+            f"absorbed MLA requires at least {patch.MIN_CACHE_LENGTH}"
+        )
+    for module in modules:
+        limit = patch.max_absorbed_queries(
+            int(module.kv_lora_rank),
+            int(module.qk_nope_head_dim),
+            int(module.v_head_dim),
+            cache_len,
+        )
+        if width > limit:
+            raise SystemExit(
+                f"context={context}, width={width} exceeds absorbed MLA "
+                f"crossover {limit} for {type(module).__name__}"
+            )
+
+
 def main() -> None:
     args = _parse_args()
     invalid = []
@@ -176,11 +197,18 @@ def main() -> None:
     mx.random.seed(args.seed)
     model, tokenizer = load(args.model, revision=args.revision)
     active_classes = tuple(targets.values())
-    if not any(isinstance(module, active_classes) for module in model.modules()):
+    active_modules = [
+        module for module in model.modules() if isinstance(module, active_classes)
+    ]
+    if not active_modules:
         supported = ", ".join(f"{mod}.{cls}" for mod, cls in sorted(targets))
         raise SystemExit(
             f"loaded model does not contain a patched MLA class; supported: {supported}"
         )
+    for context in args.contexts:
+        _validate_absorbed_point(context, args.width, active_modules)
+    if args.oracle_context:
+        _validate_absorbed_point(args.oracle_context, args.width, active_modules)
     seed_ids = tokenizer.encode(" reproducible MLA benchmark")
     if not seed_ids:
         raise SystemExit("tokenizer produced no input IDs")
@@ -329,7 +357,7 @@ def main() -> None:
         rapid_median = statistics.median(runs["rapid"])
         suffix_result = {
             "prompt_tokens": len(tokenizer.encode(LONG_CODE_EDIT_PROMPT)),
-            "completion_tokens": args.suffix_max_tokens,
+            "max_completion_tokens": args.suffix_max_tokens,
             "vanilla_tps": vanilla.tps,
             "stock_tps": runs["stock"],
             "rapid_tps": runs["rapid"],

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -153,6 +153,14 @@ def test_qwen4_fused_gdn_coverage_runs_on_apple_silicon() -> None:
     assert "tests/test_qsa_indexed_splitk.py" in apple_run
 
 
+def test_mla_absorbed_verify_coverage_runs_on_apple_silicon() -> None:
+    """MLX-only absorbed-MLA paths must contribute to changed-line coverage."""
+    _, workflow = _workflow()
+    apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
+
+    assert "tests/test_mla_absorbed_verify.py" in apple_run
+
+
 def test_hidream_runtime_coverage_runs_on_apple_silicon() -> None:
     """The MLX-only image runtime must contribute to the coverage union."""
     _, workflow = _workflow()

--- a/tests/test_mla_absorbed_verify.py
+++ b/tests/test_mla_absorbed_verify.py
@@ -199,6 +199,27 @@ print(json.dumps(stats))
     assert stats["unchanged"] is True
 
 
+def test_unqualified_mlx_lm_version_fails_closed() -> None:
+    stats = _run_install_probe(
+        """
+import importlib.metadata
+import json
+from mlx_lm.models import deepseek_v3
+original = deepseek_v3.DeepseekV3Attention.__call__
+real_version = importlib.metadata.version
+importlib.metadata.version = lambda name: "0.31.4" if name == "mlx-lm" else real_version(name)
+from vllm_mlx.patches.mla_absorbed_verify import install_mla_absorbed_verify, mla_absorbed_verify_stats
+install_mla_absorbed_verify()
+stats = mla_absorbed_verify_stats()
+stats["unchanged"] = deepseek_v3.DeepseekV3Attention.__call__ is original
+print(json.dumps(stats))
+"""
+    )
+    assert stats["provider"] == "unsupported"
+    assert stats["targets"] == []
+    assert stats["unchanged"] is True
+
+
 def test_deepseek_v32_indexer_patch_is_not_replaced() -> None:
     stats = _run_install_probe(
         """
@@ -384,6 +405,20 @@ def test_patched_attention_matches_stock_contract(
 
     delta = mx.abs(stock.astype(mx.float32) - candidate.astype(mx.float32))
     assert float(mx.max(delta)) < 1e-5
+    assert stock_cache.offset == candidate_cache.offset
+    assert mx.array_equal(stock_cache.keys, candidate_cache.keys).item()
+    assert mx.array_equal(stock_cache.values, candidate_cache.values).item()
+
+    # The verification call must leave an equivalent cache for subsequent
+    # single-token decoding, not merely produce matching immediate logits.
+    follow_x = mx.random.normal((1, 1, 32)).astype(mx.bfloat16)
+    stock_follow = original(attention, follow_x, None, stock_cache)
+    candidate_follow = attention(follow_x, None, candidate_cache)
+    mx.eval(stock_follow, candidate_follow)
+    follow_delta = mx.abs(
+        stock_follow.astype(mx.float32) - candidate_follow.astype(mx.float32)
+    )
+    assert float(mx.max(follow_delta)) < 1e-5
     after_warm = patch.mla_absorbed_verify_stats()
     assert after_warm["absorbed"] == after_cold["absorbed"] + 1
 

--- a/tests/test_mla_absorbed_verify.py
+++ b/tests/test_mla_absorbed_verify.py
@@ -16,6 +16,14 @@ from vllm_mlx.patches.mla_absorbed_verify import (
     max_absorbed_queries,
 )
 
+_HAS_MLX = find_spec("mlx") is not None and find_spec("mlx.core") is not None
+if _HAS_MLX:
+    import mlx.core as mx
+else:  # pragma: no cover - exercised by the no-MLX CI lane
+    mx = None
+
+requires_mlx = pytest.mark.skipif(not _HAS_MLX, reason="requires MLX")
+
 
 def test_asymptotic_thresholds_match_model_geometry() -> None:
     assert max_absorbed_queries(512, 128, 128) == 170
@@ -103,6 +111,8 @@ def test_rapid_gate_requires_qualified_warm_cache() -> None:
 
 
 @pytest.mark.parametrize("enabled", [False, True])
+@requires_mlx
+@pytest.mark.requires_mlx
 def test_real_serve_import_installs_exact_supported_targets(enabled: bool) -> None:
     root = Path(__file__).resolve().parents[1]
     code = """
@@ -164,6 +174,8 @@ def _run_install_probe(code: str, *, enabled: bool = True) -> dict:
     return json.loads(result.stdout.strip().splitlines()[-1])
 
 
+@requires_mlx
+@pytest.mark.requires_mlx
 def test_default_off_does_not_wrap_attention() -> None:
     stats = _run_install_probe(
         """
@@ -182,6 +194,8 @@ print(json.dumps(stats))
     assert stats["unchanged"] is True
 
 
+@requires_mlx
+@pytest.mark.requires_mlx
 def test_unknown_upstream_method_fails_closed_for_that_family() -> None:
     stats = _run_install_probe(
         """
@@ -200,6 +214,8 @@ print(json.dumps(mla_absorbed_verify_stats()))
     assert "glm4_moe_lite.Glm4MoeLiteAttention" in stats["targets"]
 
 
+@requires_mlx
+@pytest.mark.requires_mlx
 def test_upstream_provider_prevents_double_patch() -> None:
     stats = _run_install_probe(
         """
@@ -218,6 +234,8 @@ print(json.dumps(stats))
     assert stats["unchanged"] is True
 
 
+@requires_mlx
+@pytest.mark.requires_mlx
 def test_unqualified_mlx_lm_version_fails_closed() -> None:
     stats = _run_install_probe(
         """
@@ -239,6 +257,8 @@ print(json.dumps(stats))
     assert stats["unchanged"] is True
 
 
+@requires_mlx
+@pytest.mark.requires_mlx
 def test_deepseek_v32_indexer_patch_is_not_replaced() -> None:
     stats = _run_install_probe(
         """
@@ -256,15 +276,6 @@ print(json.dumps(stats))
     )
     assert stats["unchanged"] is True
     assert all(not target.startswith("deepseek_v32.") for target in stats["targets"])
-
-
-_HAS_MLX = find_spec("mlx") is not None and find_spec("mlx.core") is not None
-if _HAS_MLX:
-    import mlx.core as mx
-else:  # pragma: no cover - exercised by the no-MLX CI lane
-    mx = None
-
-requires_mlx = pytest.mark.skipif(not _HAS_MLX, reason="requires MLX")
 
 
 def _isolate_installer_state(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mla_absorbed_verify.py
+++ b/tests/test_mla_absorbed_verify.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.patches.mla_absorbed_verify import (
+    _use_absorbed,
+    latent_length,
+    max_absorbed_queries,
+)
+
+
+def test_asymptotic_thresholds_match_model_geometry() -> None:
+    assert max_absorbed_queries(512, 128, 128) == 170
+    assert max_absorbed_queries(512, 192, 256) == 398
+
+
+def test_threshold_preserves_strict_crossover_inequality() -> None:
+    # r=4, d=4 has an exact asymptotic crossover at L=4. Absorbed MLA must
+    # stop at 3 because equal cost is not a win.
+    assert max_absorbed_queries(4, 2, 2) == 3
+
+
+@pytest.mark.parametrize("query_len", [2, 3, 32, 169, 398])
+def test_cold_cache_rejects_multi_token_absorption(query_len: int) -> None:
+    for dims in ((512, 128, 128), (512, 192, 256)):
+        assert max_absorbed_queries(*dims, cache_len=query_len) < query_len
+
+
+def test_warm_cache_threshold_is_monotonic() -> None:
+    lengths = (256, 1024, 8192, 32768)
+    thresholds = [max_absorbed_queries(512, 128, 128, value) for value in lengths]
+    assert thresholds == sorted(thresholds)
+    assert thresholds[-1] == 169
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        (0, 128, 128, None),
+        (512, 0, 128, None),
+        (512, 128, -1, None),
+        (512, 128, 128, 0),
+        (64, 128, 128, None),
+    ],
+)
+def test_invalid_or_nonbeneficial_geometry_fails_closed(args) -> None:
+    assert max_absorbed_queries(*args) == 1
+
+
+def test_latent_length_plain_and_quantized() -> None:
+    class Array:
+        shape = (1, 1, 37, 8)
+
+    array = Array()
+    assert latent_length(array) == 37
+    assert latent_length((array, object(), object())) == 37
+
+
+def test_latent_length_rejects_missing_sequence_axis() -> None:
+    with pytest.raises(ValueError, match="sequence dimension"):
+        latent_length(object())
+    with pytest.raises(ValueError, match="sequence dimension"):
+        latent_length(type("Scalar", (), {"shape": (1,)})())
+
+
+def test_rapid_gate_requires_qualified_warm_cache() -> None:
+    attention = type(
+        "Attention",
+        (),
+        {"kv_lora_rank": 512, "qk_nope_head_dim": 128, "v_head_dim": 128},
+    )()
+    latent = type("Latent", (), {"shape": (1, 1, 1023, 512)})()
+    assert _use_absorbed(attention, 3, latent) is False
+    latent.shape = (1, 1, 1024, 512)
+    assert _use_absorbed(attention, 3, latent) is True
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_real_serve_import_installs_exact_supported_targets(enabled: bool) -> None:
+    root = Path(__file__).resolve().parents[1]
+    code = """
+import json
+import vllm_mlx.utils.tokenizer
+from vllm_mlx.patches.mla_absorbed_verify import mla_absorbed_verify_stats
+print(json.dumps(mla_absorbed_verify_stats()))
+"""
+    env = os.environ.copy()
+    if enabled:
+        env["RAPID_MLX_MLA_ABSORBED_VERIFY"] = "1"
+    else:
+        env.pop("RAPID_MLX_MLA_ABSORBED_VERIFY", None)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    import json
+
+    stats = json.loads(result.stdout.strip().splitlines()[-1])
+    assert stats["installed"] is True
+    assert stats["enabled"] is enabled
+    if not enabled:
+        assert stats["provider"] in {"disabled", "upstream"}
+        if stats["provider"] == "disabled":
+            assert stats["targets"] == []
+        return
+    assert stats["provider"] in {"rapid", "upstream"}
+    if stats["provider"] == "rapid":
+        assert stats["targets"] == [
+            "deepseek_v3.DeepseekV3Attention",
+            "glm4_moe_lite.Glm4MoeLiteAttention",
+            "kimi_linear.KimiMLAAttention",
+            "longcat_flash.LongcatFlashMLA",
+        ]
+
+
+def _run_install_probe(code: str, *, enabled: bool = True) -> dict:
+    import json
+
+    root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    if enabled:
+        env["RAPID_MLX_MLA_ABSORBED_VERIFY"] = "1"
+    else:
+        env.pop("RAPID_MLX_MLA_ABSORBED_VERIFY", None)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_default_off_does_not_wrap_attention() -> None:
+    stats = _run_install_probe(
+        """
+import json
+from mlx_lm.models import glm4_moe_lite
+original = glm4_moe_lite.Glm4MoeLiteAttention.__call__
+from vllm_mlx.patches.mla_absorbed_verify import install_mla_absorbed_verify, mla_absorbed_verify_stats
+install_mla_absorbed_verify()
+stats = mla_absorbed_verify_stats()
+stats["unchanged"] = glm4_moe_lite.Glm4MoeLiteAttention.__call__ is original
+print(json.dumps(stats))
+""",
+        enabled=False,
+    )
+    assert stats["provider"] == "disabled"
+    assert stats["unchanged"] is True
+
+
+def test_unknown_upstream_method_fails_closed_for_that_family() -> None:
+    stats = _run_install_probe(
+        """
+import json
+from mlx_lm.models import deepseek_v3
+def changed(self, x, mask=None, cache=None):
+    return x
+deepseek_v3.DeepseekV3Attention.__call__ = changed
+from vllm_mlx.patches.mla_absorbed_verify import install_mla_absorbed_verify, mla_absorbed_verify_stats
+install_mla_absorbed_verify()
+print(json.dumps(mla_absorbed_verify_stats()))
+"""
+    )
+    assert stats["provider"] == "rapid"
+    assert "deepseek_v3.DeepseekV3Attention" not in stats["targets"]
+    assert "glm4_moe_lite.Glm4MoeLiteAttention" in stats["targets"]
+
+
+def test_upstream_provider_prevents_double_patch() -> None:
+    stats = _run_install_probe(
+        """
+import json
+from mlx_lm.models import deepseek_v3, mla
+original = deepseek_v3.DeepseekV3Attention.__call__
+mla.max_absorbed_queries = lambda *args, **kwargs: 1
+from vllm_mlx.patches.mla_absorbed_verify import install_mla_absorbed_verify, mla_absorbed_verify_stats
+install_mla_absorbed_verify()
+stats = mla_absorbed_verify_stats()
+stats["unchanged"] = deepseek_v3.DeepseekV3Attention.__call__ is original
+print(json.dumps(stats))
+"""
+    )
+    assert stats["provider"] == "upstream"
+    assert stats["unchanged"] is True
+
+
+def test_deepseek_v32_indexer_patch_is_not_replaced() -> None:
+    stats = _run_install_probe(
+        """
+import json
+from mlx_lm.models import deepseek_v32
+from vllm_mlx.patches.deepseek_v32_indexer_gate import install_deepseek_v32_indexer_gate
+install_deepseek_v32_indexer_gate()
+indexed = deepseek_v32.DeepseekV32Attention.__call__
+from vllm_mlx.patches.mla_absorbed_verify import install_mla_absorbed_verify, mla_absorbed_verify_stats
+install_mla_absorbed_verify()
+stats = mla_absorbed_verify_stats()
+stats["unchanged"] = deepseek_v32.DeepseekV32Attention.__call__ is indexed
+print(json.dumps(stats))
+"""
+    )
+    assert stats["unchanged"] is True
+    assert all(not target.startswith("deepseek_v32.") for target in stats["targets"])
+
+
+mx = pytest.importorskip("mlx.core")
+
+
+def _isolate_installer_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Undo collection-time installs from other test modules."""
+    from mlx_lm.models import mla
+
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    originals = getattr(mla, "_RAPID_MLX_MLA_ABSORBED_ORIGINALS", {})
+    for module_name, class_name in patch._SUPPORTED_SOURCE_HASHES:
+        module = __import__(f"mlx_lm.models.{module_name}", fromlist=[class_name])
+        cls = getattr(module, class_name)
+        monkeypatch.setattr(
+            cls, "__call__", originals.get((module_name, class_name), cls.__call__)
+        )
+        marker = f"_RAPID_MLX_MLA_ABSORBED_{class_name}"
+        if hasattr(module, marker):
+            monkeypatch.delattr(module, marker)
+    if hasattr(mla, "_RAPID_MLX_MLA_ABSORBED_ORIGINALS"):
+        monkeypatch.delattr(mla, "_RAPID_MLX_MLA_ABSORBED_ORIGINALS")
+    monkeypatch.setattr(patch, "_INSTALLED", False)
+    monkeypatch.setattr(patch, "_PROVIDER", "none")
+    monkeypatch.setattr(patch, "_ENABLED", False)
+    monkeypatch.setattr(patch, "_PATCHED_TARGETS", set())
+    monkeypatch.setattr(patch, "_STATS", {key: 0 for key in patch._STATS})
+
+
+def _tiny_attention(module_name: str):
+    if module_name in {"deepseek_v3", "glm4_moe_lite"}:
+        module = __import__(f"mlx_lm.models.{module_name}", fromlist=["ModelArgs"])
+        class_name = (
+            "DeepseekV3Attention"
+            if module_name == "deepseek_v3"
+            else "Glm4MoeLiteAttention"
+        )
+        config = module.ModelArgs(
+            hidden_size=32,
+            num_attention_heads=2,
+            q_lora_rank=16,
+            kv_lora_rank=8,
+            qk_nope_head_dim=4,
+            qk_rope_head_dim=4,
+            v_head_dim=4,
+            attention_bias=False,
+        )
+        return module, class_name, getattr(module, class_name)(config)
+
+    if module_name == "kimi_linear":
+        from mlx_lm.models import kimi_linear as module
+
+        config = module.ModelArgs(
+            model_type="kimi_linear",
+            vocab_size=64,
+            hidden_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            intermediate_size=64,
+            head_dim=8,
+            rope_theta=10000.0,
+            rms_norm_eps=1e-6,
+            linear_attn_config={},
+            model_max_length=256,
+            num_experts=1,
+            moe_intermediate_size=16,
+            kv_lora_rank=8,
+            qk_nope_head_dim=4,
+            qk_rope_head_dim=4,
+            v_head_dim=4,
+        )
+        return module, "KimiMLAAttention", module.KimiMLAAttention(config)
+
+    from mlx_lm.models import longcat_flash as module
+
+    config = module.ModelArgs(
+        model_type="longcat_flash",
+        attention_method="mla",
+        zero_expert_type="none",
+        hidden_size=32,
+        ffn_hidden_size=64,
+        moe_topk=1,
+        expert_ffn_hidden_size=16,
+        n_routed_experts=1,
+        zero_expert_num=0,
+        num_layers=1,
+        vocab_size=64,
+        max_position_embeddings=256,
+        num_attention_heads=2,
+        kv_lora_rank=8,
+        q_lora_rank=16,
+        qk_rope_head_dim=4,
+        qk_nope_head_dim=4,
+        v_head_dim=4,
+        routed_scaling_factor=1.0,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        mla_scale_q_lora=True,
+        mla_scale_kv_lora=True,
+        attention_bias=False,
+    )
+    return module, "LongcatFlashMLA", module.LongcatFlashMLA(config)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["deepseek_v3", "glm4_moe_lite", "kimi_linear", "longcat_flash"],
+)
+def test_patched_attention_matches_stock_contract(
+    monkeypatch: pytest.MonkeyPatch, module_name: str
+) -> None:
+    from mlx_lm.models import mla
+    from mlx_lm.models.base import create_attention_mask
+    from mlx_lm.models.cache import KVCache
+
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    _isolate_installer_state(monkeypatch)
+    mx.random.seed(7)
+    module, class_name, attention = _tiny_attention(module_name)
+    monkeypatch.setenv("RAPID_MLX_MLA_ABSORBED_VERIFY", "1")
+    patch.install_mla_absorbed_verify()
+    original = mla._RAPID_MLX_MLA_ABSORBED_ORIGINALS[(module_name, class_name)]
+
+    # A cold L=3 call must retain the stock materialized branch exactly.
+    cold_x = mx.random.normal((1, 3, 32)).astype(mx.bfloat16)
+    cold_stock = original(attention, cold_x, None, None)
+    before = patch.mla_absorbed_verify_stats()
+    monkeypatch.setattr(patch, "_ENABLED", True)
+    cold_candidate = attention(cold_x, None, None)
+    mx.eval(cold_stock, cold_candidate)
+    assert mx.array_equal(cold_stock, cold_candidate).item()
+    after_cold = patch.mla_absorbed_verify_stats()
+    assert after_cold["materialized"] == before["materialized"] + 1
+
+    # At T=1027, L=3 is below the r=8/d=8 crossover and inside Rapid's
+    # dogfood-qualified long-context window. Compare the absorbed
+    # factorization to stock on cloned warm caches.
+    prefill = mx.random.normal((1, 1024, 32)).astype(mx.bfloat16)
+    stock_cache = KVCache()
+    candidate_cache = KVCache()
+    original(attention, prefill, None, stock_cache)
+    original(attention, prefill, None, candidate_cache)
+    mx.eval(
+        stock_cache.keys,
+        stock_cache.values,
+        candidate_cache.keys,
+        candidate_cache.values,
+    )
+    verify_x = mx.random.normal((1, 3, 32)).astype(mx.bfloat16)
+    stock_mask = create_attention_mask(verify_x, stock_cache, return_array=True)
+    candidate_mask = create_attention_mask(verify_x, candidate_cache, return_array=True)
+    stock = original(attention, verify_x, stock_mask, stock_cache)
+    candidate = attention(verify_x, candidate_mask, candidate_cache)
+    mx.eval(stock, candidate)
+
+    delta = mx.abs(stock.astype(mx.float32) - candidate.astype(mx.float32))
+    assert float(mx.max(delta)) < 1e-5
+    after_warm = patch.mla_absorbed_verify_stats()
+    assert after_warm["absorbed"] == after_cold["absorbed"] + 1
+
+
+def test_disabled_and_single_token_paths_delegate_to_stock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    _isolate_installer_state(monkeypatch)
+    monkeypatch.setenv("RAPID_MLX_MLA_ABSORBED_VERIFY", "1")
+    _, _, attention = _tiny_attention("deepseek_v3")
+    patch.install_mla_absorbed_verify()
+    x = mx.zeros((1, 1, 32), dtype=mx.bfloat16)
+
+    monkeypatch.setattr(patch, "_ENABLED", False)
+    before = patch.mla_absorbed_verify_stats()
+    mx.eval(attention(x))
+    disabled = patch.mla_absorbed_verify_stats()
+    assert disabled["disabled"] == before["disabled"] + 1
+
+    monkeypatch.setattr(patch, "_ENABLED", True)
+    mx.eval(attention(x))
+    enabled = patch.mla_absorbed_verify_stats()
+    assert enabled["single_token"] == disabled["single_token"] + 1

--- a/tests/test_mla_absorbed_verify.py
+++ b/tests/test_mla_absorbed_verify.py
@@ -304,7 +304,7 @@ def _isolate_installer_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(patch, "_STATS", {key: 0 for key in patch._STATS})
 
 
-def _tiny_attention(module_name: str):
+def _tiny_attention(module_name: str, *, q_lora_rank: int | None = 16):
     if module_name in {"deepseek_v3", "glm4_moe_lite"}:
         module = __import__(f"mlx_lm.models.{module_name}", fromlist=["ModelArgs"])
         class_name = (
@@ -315,7 +315,7 @@ def _tiny_attention(module_name: str):
         config = module.ModelArgs(
             hidden_size=32,
             num_attention_heads=2,
-            q_lora_rank=16,
+            q_lora_rank=q_lora_rank,
             kv_lora_rank=8,
             qk_nope_head_dim=4,
             qk_rope_head_dim=4,
@@ -452,6 +452,116 @@ def test_patched_attention_matches_stock_contract(
     assert float(mx.max(follow_delta)) < 1e-5
     after_warm = patch.mla_absorbed_verify_stats()
     assert after_warm["absorbed"] == after_cold["absorbed"] + 1
+
+
+@requires_mlx
+@pytest.mark.requires_mlx
+def test_standard_attention_without_q_lora_matches_stock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mlx_lm.models import mla
+
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    _isolate_installer_state(monkeypatch)
+    monkeypatch.setenv("RAPID_MLX_MLA_ABSORBED_VERIFY", "1")
+    _, class_name, attention = _tiny_attention("deepseek_v3", q_lora_rank=None)
+    patch.install_mla_absorbed_verify()
+    original = mla._RAPID_MLX_MLA_ABSORBED_ORIGINALS[("deepseek_v3", class_name)]
+    x = mx.random.normal((1, 3, 32)).astype(mx.bfloat16)
+
+    stock = original(attention, x, None, None)
+    candidate = attention(x, None, None)
+    mx.eval(stock, candidate)
+
+    assert mx.array_equal(stock, candidate).item()
+
+
+@requires_mlx
+@pytest.mark.requires_mlx
+def test_installer_idempotence_and_default_off_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    _isolate_installer_state(monkeypatch)
+    monkeypatch.delenv("RAPID_MLX_MLA_ABSORBED_VERIFY", raising=False)
+    patch.install_mla_absorbed_verify()
+    assert patch.is_installed() is True
+    assert patch.mla_absorbed_verify_stats()["provider"] == "disabled"
+
+    # A second install is a literal no-op.
+    patch.install_mla_absorbed_verify()
+    assert patch.mla_absorbed_verify_stats()["provider"] == "disabled"
+
+
+@requires_mlx
+@pytest.mark.requires_mlx
+def test_in_process_upstream_provider_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mlx_lm.models import mla
+
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    _isolate_installer_state(monkeypatch)
+    monkeypatch.setattr(mla, "max_absorbed_queries", lambda *args: 1, raising=False)
+    monkeypatch.setenv("RAPID_MLX_MLA_ABSORBED_VERIFY", "1")
+    patch.install_mla_absorbed_verify()
+
+    assert patch.mla_absorbed_verify_stats()["provider"] == "upstream"
+
+
+@requires_mlx
+@pytest.mark.requires_mlx
+def test_in_process_unqualified_version_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    _isolate_installer_state(monkeypatch)
+    monkeypatch.setenv("RAPID_MLX_MLA_ABSORBED_VERIFY", "1")
+    monkeypatch.setattr(patch, "_mlx_lm_version", lambda: None)
+    patch.install_mla_absorbed_verify()
+
+    assert patch.mla_absorbed_verify_stats()["provider"] == "unsupported"
+
+
+@requires_mlx
+@pytest.mark.requires_mlx
+@pytest.mark.parametrize("case", ["missing", "marked", "unknown"])
+def test_in_process_target_compatibility_gates(
+    monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    from mlx_lm.models import deepseek_v3
+
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    _isolate_installer_state(monkeypatch)
+    monkeypatch.setenv("RAPID_MLX_MLA_ABSORBED_VERIFY", "1")
+    monkeypatch.setattr(patch, "_mlx_lm_version", lambda: "0.31.3")
+
+    if case == "missing":
+        targets = {("not_a_real_mlx_lm_model", "MissingAttention"): "hash"}
+    else:
+        key = ("deepseek_v3", "DeepseekV3Attention")
+        targets = {key: "not-the-real-source-hash"}
+        if case == "marked":
+            marker = "_RAPID_MLX_MLA_ABSORBED_DeepseekV3Attention"
+            monkeypatch.setattr(deepseek_v3, marker, True, raising=False)
+    monkeypatch.setattr(patch, "_SUPPORTED_SOURCE_HASHES", targets)
+    patch.install_mla_absorbed_verify()
+
+    stats = patch.mla_absorbed_verify_stats()
+    assert stats["provider"] == "none"
+    if case == "marked":
+        assert stats["targets"] == ("deepseek_v3.DeepseekV3Attention",)
+    else:
+        assert stats["targets"] == ()
+
+
+def test_source_hash_fails_closed_for_uninspectable_callable() -> None:
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    assert patch._source_hash(len) is None
 
 
 @requires_mlx

--- a/tests/test_mla_absorbed_verify.py
+++ b/tests/test_mla_absorbed_verify.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from importlib.util import find_spec
 from pathlib import Path
 
 import pytest
@@ -217,7 +218,13 @@ print(json.dumps(stats))
     assert all(not target.startswith("deepseek_v32.") for target in stats["targets"])
 
 
-mx = pytest.importorskip("mlx.core")
+_HAS_MLX = find_spec("mlx") is not None and find_spec("mlx.core") is not None
+if _HAS_MLX:
+    import mlx.core as mx
+else:  # pragma: no cover - exercised by the no-MLX CI lane
+    mx = None
+
+requires_mlx = pytest.mark.skipif(not _HAS_MLX, reason="requires MLX")
 
 
 def _isolate_installer_state(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -325,6 +332,8 @@ def _tiny_attention(module_name: str):
     "module_name",
     ["deepseek_v3", "glm4_moe_lite", "kimi_linear", "longcat_flash"],
 )
+@requires_mlx
+@pytest.mark.requires_mlx
 def test_patched_attention_matches_stock_contract(
     monkeypatch: pytest.MonkeyPatch, module_name: str
 ) -> None:
@@ -379,6 +388,8 @@ def test_patched_attention_matches_stock_contract(
     assert after_warm["absorbed"] == after_cold["absorbed"] + 1
 
 
+@requires_mlx
+@pytest.mark.requires_mlx
 def test_disabled_and_single_token_paths_delegate_to_stock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_mla_absorbed_verify.py
+++ b/tests/test_mla_absorbed_verify.py
@@ -159,7 +159,7 @@ print(json.dumps(stats))
 """,
         enabled=False,
     )
-    assert stats["provider"] == "disabled"
+    assert stats["provider"] in {"disabled", "upstream"}
     assert stats["unchanged"] is True
 
 

--- a/tests/test_mla_absorbed_verify.py
+++ b/tests/test_mla_absorbed_verify.py
@@ -71,6 +71,25 @@ def test_latent_length_rejects_missing_sequence_axis() -> None:
         latent_length(type("Scalar", (), {"shape": (1,)})())
 
 
+def test_disabled_stats_do_not_acquire_hot_path_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    class ExplodingLock:
+        def __enter__(self):
+            raise AssertionError("disabled counters must not acquire the stats lock")
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(patch, "_STATS_ENABLED", False)
+    monkeypatch.setattr(patch, "_STATS_LOCK", ExplodingLock())
+    before = dict(patch._STATS)
+    patch._increment_stat("forwards")
+    assert before == patch._STATS
+
+
 def test_rapid_gate_requires_qualified_warm_cache() -> None:
     attention = type(
         "Attention",
@@ -269,6 +288,7 @@ def _isolate_installer_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(patch, "_INSTALLED", False)
     monkeypatch.setattr(patch, "_PROVIDER", "none")
     monkeypatch.setattr(patch, "_ENABLED", False)
+    monkeypatch.setattr(patch, "_STATS_ENABLED", True)
     monkeypatch.setattr(patch, "_PATCHED_TARGETS", set())
     monkeypatch.setattr(patch, "_STATS", {key: 0 for key in patch._STATS})
 

--- a/tests/test_mla_absorbed_verify.py
+++ b/tests/test_mla_absorbed_verify.py
@@ -477,3 +477,33 @@ def test_disabled_and_single_token_paths_delegate_to_stock(
     mx.eval(attention(x))
     enabled = patch.mla_absorbed_verify_stats()
     assert enabled["single_token"] == disabled["single_token"] + 1
+
+
+@requires_mlx
+@pytest.mark.requires_mlx
+def test_quantized_cache_shape_delegates_to_stock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.patches import mla_absorbed_verify as patch
+
+    class QuantizedLikeCache:
+        bits = 4
+        offset = 0
+
+        def update_and_fetch(self, keys, values):
+            raise RuntimeError("stock quantized MLA path")
+
+    _isolate_installer_state(monkeypatch)
+    monkeypatch.setenv("RAPID_MLX_MLA_ABSORBED_VERIFY", "1")
+    _, _, attention = _tiny_attention("deepseek_v3")
+    patch.install_mla_absorbed_verify()
+    x = mx.zeros((1, 3, 32), dtype=mx.bfloat16)
+    before = patch.mla_absorbed_verify_stats()
+
+    with pytest.raises(RuntimeError, match="stock quantized MLA path"):
+        attention(x, cache=QuantizedLikeCache())
+
+    after = patch.mla_absorbed_verify_stats()
+    assert after["unsupported_cache"] == before["unsupported_cache"] + 1
+    assert after["absorbed"] == before["absorbed"]
+    assert after["materialized"] == before["materialized"]

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -167,6 +167,12 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # unqualified query shapes, MLX builds, and Metal architectures remain
         # on the existing dense attention implementation.
         "RAPID_MLX_QSA_INDEXED_SPLITK",
+        # Opt-in absorbed MLA factorization for short verification blocks on
+        # an already-selected MLA model. This changes only the attention math
+        # path after a measured cache crossover; it cannot select a model,
+        # parser, tier, or serving lane. Unknown mlx-lm implementations remain
+        # untouched.
+        "RAPID_MLX_MLA_ABSORBED_VERIFY",
         # Opt-out of the blocked-seq GDN prefill Metal kernel
         # (vllm_mlx/gdn_prefill.py). Same shape as DISABLE_FUSED_SAMPLER —
         # a kernel-selection perf toggle computing the exact same

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -173,6 +173,9 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # parser, tier, or serving lane. Unknown mlx-lm implementations remain
         # untouched.
         "RAPID_MLX_MLA_ABSORBED_VERIFY",
+        # Optional diagnostic counters for the MLA benchmark and debugging.
+        # This cannot change model or kernel selection.
+        "RAPID_MLX_MLA_ABSORBED_VERIFY_STATS",
         # Opt-out of the blocked-seq GDN prefill Metal kernel
         # (vllm_mlx/gdn_prefill.py). Same shape as DISABLE_FUSED_SAMPLER —
         # a kernel-selection perf toggle computing the exact same

--- a/vllm_mlx/patches/README.md
+++ b/vllm_mlx/patches/README.md
@@ -20,4 +20,5 @@ for short multi-token forwards. It is opt-in via
 and keeps detailed hot-path counters off unless
 `RAPID_MLX_MLA_ABSORBED_VERIFY_STATS=1` is also set. It
 requires a post-update cache of at least 1024 tokens, and retires itself
-automatically once mlx-lm exposes the upstream helper.
+automatically once mlx-lm exposes the upstream helper. Quantized MLA caches
+remain on mlx-lm's existing path and require separate qualification.

--- a/vllm_mlx/patches/README.md
+++ b/vllm_mlx/patches/README.md
@@ -17,5 +17,7 @@ See `test_install_fires_on_real_serve_import_path` in
 `mla_absorbed_verify.py` carries the pending mlx-lm absorbed-MLA crossover
 for short multi-token forwards. It is opt-in via
 `RAPID_MLX_MLA_ABSORBED_VERIFY=1`, refuses unknown upstream method bodies,
+and keeps detailed hot-path counters off unless
+`RAPID_MLX_MLA_ABSORBED_VERIFY_STATS=1` is also set. It
 requires a post-update cache of at least 1024 tokens, and retires itself
 automatically once mlx-lm exposes the upstream helper.

--- a/vllm_mlx/patches/README.md
+++ b/vllm_mlx/patches/README.md
@@ -13,3 +13,9 @@ therefore needs a subprocess regression test that:
 See `test_install_fires_on_real_serve_import_path` in
 `tests/test_deepseek_v32_indexer_gate.py` and
 `tests/test_qwen3_5_norm_shift.py` for the standing pattern.
+
+`mla_absorbed_verify.py` carries the pending mlx-lm absorbed-MLA crossover
+for short multi-token forwards. It is opt-in via
+`RAPID_MLX_MLA_ABSORBED_VERIFY=1`, refuses unknown upstream method bodies,
+requires a post-update cache of at least 1024 tokens, and retires itself
+automatically once mlx-lm exposes the upstream helper.

--- a/vllm_mlx/patches/mla_absorbed_verify.py
+++ b/vllm_mlx/patches/mla_absorbed_verify.py
@@ -27,6 +27,7 @@ _ENV = "RAPID_MLX_MLA_ABSORBED_VERIFY"
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _MIN_CACHE_LENGTH = 1024
 _LOCK = threading.Lock()
+_STATS_LOCK = threading.Lock()
 _INSTALLED = False
 _PROVIDER = "none"
 _ENABLED = False
@@ -40,6 +41,12 @@ _STATS = {
     "single_token": 0,
     "short_cache": 0,
 }
+
+
+def _increment_stat(name: str) -> None:
+    with _STATS_LOCK:
+        _STATS[name] += 1
+
 
 # Exact mlx-lm 0.31.3 method bodies.  A changed body is not safe to replace
 # with a local replica: it may contain a new cache, mask, or numerical rule.
@@ -174,8 +181,8 @@ def _attention_call(
     cache_len = latent_length(kv_latent)
     absorbed = _use_absorbed(self, L, kv_latent)
     if not absorbed and cache_len < _MIN_CACHE_LENGTH:
-        _STATS["short_cache"] += 1
-    _STATS["absorbed" if absorbed else "materialized"] += 1
+        _increment_stat("short_cache")
+    _increment_stat("absorbed" if absorbed else "materialized")
     if absorbed:
         q_nope = self.embed_q(q_nope)
         k = v = kv_latent
@@ -270,12 +277,12 @@ def install_mla_absorbed_verify() -> None:
             def _patched(
                 self, x, mask=None, cache=None, *, _orig=original, _flavor=flavor
             ):
-                _STATS["forwards"] += 1
+                _increment_stat("forwards")
                 if not _ENABLED:
-                    _STATS["disabled"] += 1
+                    _increment_stat("disabled")
                     return _orig(self, x, mask, cache)
                 if int(x.shape[1]) == 1:
-                    _STATS["single_token"] += 1
+                    _increment_stat("single_token")
                     return _orig(self, x, mask, cache)
                 return _attention_call(self, x, mask, cache, flavor=_flavor)
 
@@ -291,8 +298,10 @@ def install_mla_absorbed_verify() -> None:
 
 def mla_absorbed_verify_stats() -> dict[str, Any]:
     """Return mechanism counters and the active implementation provider."""
+    with _STATS_LOCK:
+        counters = dict(_STATS)
     return {
-        **_STATS,
+        **counters,
         "installed": _INSTALLED,
         "enabled": _ENABLED,
         "provider": _PROVIDER,

--- a/vllm_mlx/patches/mla_absorbed_verify.py
+++ b/vllm_mlx/patches/mla_absorbed_verify.py
@@ -43,6 +43,7 @@ _STATS = {
     "materialized": 0,
     "disabled": 0,
     "single_token": 0,
+    "unsupported_cache": 0,
     "short_cache": 0,
 }
 
@@ -121,7 +122,7 @@ def max_absorbed_queries(
 
 
 def latent_length(kv_latent: Any) -> int:
-    """Read the sequence length from a plain or quantized MLA latent."""
+    """Read the sequence length from an MLA latent representation."""
     array = kv_latent[0] if isinstance(kv_latent, tuple) else kv_latent
     shape = getattr(array, "shape", None)
     if shape is None or len(shape) < 2:
@@ -308,6 +309,12 @@ def install_mla_absorbed_verify() -> None:
                 _increment_stat("forwards")
                 if not _ENABLED:
                     _increment_stat("disabled")
+                    return _orig(self, x, mask, cache)
+                if cache is not None and hasattr(cache, "bits"):
+                    # mlx-lm 0.31.3 MLA attention cannot consume the quantized
+                    # positional-key tuple. Preserve that upstream path rather
+                    # than expanding this BF16 compatibility patch's scope.
+                    _increment_stat("unsupported_cache")
                     return _orig(self, x, mask, cache)
                 if int(x.shape[1]) == 1:
                     _increment_stat("single_token")

--- a/vllm_mlx/patches/mla_absorbed_verify.py
+++ b/vllm_mlx/patches/mla_absorbed_verify.py
@@ -28,7 +28,7 @@ _ENV = "RAPID_MLX_MLA_ABSORBED_VERIFY"
 _STATS_ENV = "RAPID_MLX_MLA_ABSORBED_VERIFY_STATS"
 _QUALIFIED_MLX_LM_VERSION = "0.31.3"
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
-_MIN_CACHE_LENGTH = 1024
+MIN_CACHE_LENGTH = 1024
 _LOCK = threading.Lock()
 _STATS_LOCK = threading.Lock()
 _INSTALLED = False
@@ -132,7 +132,7 @@ def latent_length(kv_latent: Any) -> int:
 
 def _use_absorbed(self: Any, query_len: int, kv_latent: Any) -> bool:
     cache_len = latent_length(kv_latent)
-    if cache_len < _MIN_CACHE_LENGTH:
+    if cache_len < MIN_CACHE_LENGTH:
         return False
     return query_len <= max_absorbed_queries(
         int(self.kv_lora_rank),
@@ -197,7 +197,7 @@ def _attention_call(
 
     cache_len = latent_length(kv_latent)
     absorbed = _use_absorbed(self, L, kv_latent)
-    if not absorbed and cache_len < _MIN_CACHE_LENGTH:
+    if not absorbed and cache_len < MIN_CACHE_LENGTH:
         _increment_stat("short_cache")
     _increment_stat("absorbed" if absorbed else "materialized")
     if absorbed:

--- a/vllm_mlx/patches/mla_absorbed_verify.py
+++ b/vllm_mlx/patches/mla_absorbed_verify.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in absorbed MLA routing for short multi-token forwards.
+
+mlx-lm 0.31.x only uses the absorbed Multi-head Latent Attention (MLA)
+factorization for a single query.  On a warm cache the same factorization is
+cheaper for the small query widths used by speculative verification.  This
+module carries a narrowly version-gated compatibility patch while the
+equivalent upstream change is pending.
+
+Unknown upstream implementations are left untouched.  The patch also becomes
+a no-op once mlx-lm provides its own ``max_absorbed_queries`` helper.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import logging
+import os
+import threading
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_ENV = "RAPID_MLX_MLA_ABSORBED_VERIFY"
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_MIN_CACHE_LENGTH = 1024
+_LOCK = threading.Lock()
+_INSTALLED = False
+_PROVIDER = "none"
+_ENABLED = False
+_PATCHED_TARGETS: set[tuple[str, str]] = set()
+
+_STATS = {
+    "forwards": 0,
+    "absorbed": 0,
+    "materialized": 0,
+    "disabled": 0,
+    "single_token": 0,
+    "short_cache": 0,
+}
+
+# Exact mlx-lm 0.31.3 method bodies.  A changed body is not safe to replace
+# with a local replica: it may contain a new cache, mask, or numerical rule.
+_SUPPORTED_SOURCE_HASHES = {
+    ("deepseek_v3", "DeepseekV3Attention"): (
+        "410c4c4877a477268a04ac7198bfe5f094007f5665c9569b6dd89e17d8e576c5"
+    ),
+    ("glm4_moe_lite", "Glm4MoeLiteAttention"): (
+        "5012a87eb0a3b3450f638c4f3f0d331ee136e1a3a013160f99763fb7798ff93b"
+    ),
+    ("kimi_linear", "KimiMLAAttention"): (
+        "aef564308e14efa43b29813219d3906917167c415aa63ebb0ac173c3f107f7e8"
+    ),
+    ("longcat_flash", "LongcatFlashMLA"): (
+        "740a730d8f0f68108455df90c6af0fa39fba239bdabd92396d6c20e5efa5110a"
+    ),
+}
+
+
+def _feature_enabled() -> bool:
+    return os.environ.get(_ENV, "").strip().lower() in _TRUE_VALUES
+
+
+def max_absorbed_queries(
+    kv_lora_rank: int,
+    qk_nope_head_dim: int,
+    v_head_dim: int,
+    cache_len: int | None = None,
+) -> int:
+    """Return the largest integer query width where absorbed MLA is cheaper.
+
+    With ``r`` as the latent rank, ``d`` as the sum of the non-positional QK
+    and value dimensions, and ``T`` as the post-update cache length, absorbed
+    MLA wins while::
+
+        L < r*d*T / (r*d + T*(2*r - d))
+
+    Integer arithmetic preserves the strict inequality at exact crossover
+    points.  Invalid or unsupported geometry fails closed to single-token
+    decode, which mlx-lm already routes through the absorbed path.
+    """
+    dims = (kv_lora_rank, qk_nope_head_dim, v_head_dim)
+    if any(not isinstance(value, int) or value <= 0 for value in dims):
+        return 1
+
+    d = qk_nope_head_dim + v_head_dim
+    if cache_len is None:
+        numerator = kv_lora_rank * d
+        denominator = 2 * kv_lora_rank - d
+    elif isinstance(cache_len, int) and cache_len > 0:
+        numerator = kv_lora_rank * d * cache_len
+        denominator = kv_lora_rank * d + cache_len * (2 * kv_lora_rank - d)
+    else:
+        return 1
+
+    if numerator <= 0 or denominator <= 0:
+        return 1
+    return max(1, (numerator - 1) // denominator)
+
+
+def latent_length(kv_latent: Any) -> int:
+    """Read the sequence length from a plain or quantized MLA latent."""
+    array = kv_latent[0] if isinstance(kv_latent, tuple) else kv_latent
+    shape = getattr(array, "shape", None)
+    if shape is None or len(shape) < 2:
+        raise ValueError("MLA latent must expose a sequence dimension")
+    return int(shape[-2])
+
+
+def _use_absorbed(self: Any, query_len: int, kv_latent: Any) -> bool:
+    cache_len = latent_length(kv_latent)
+    if cache_len < _MIN_CACHE_LENGTH:
+        return False
+    return query_len <= max_absorbed_queries(
+        int(self.kv_lora_rank),
+        int(self.qk_nope_head_dim),
+        int(self.v_head_dim),
+        cache_len,
+    )
+
+
+def _attention_call(
+    self: Any,
+    x: Any,
+    mask: Any = None,
+    cache: Any = None,
+    *,
+    flavor: str,
+) -> Any:
+    import mlx.core as mx
+    from mlx_lm.models.base import scaled_dot_product_attention
+
+    B, L, _ = x.shape
+    if flavor == "kimi":
+        q = self.q_proj(x).reshape(B, L, self.num_heads, self.q_head_dim)
+        q = q.transpose(0, 2, 1, 3)
+    else:
+        if self.q_lora_rank is None:
+            q = self.q_proj(x)
+        else:
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x)))
+        n_heads = self.num_attention_heads if flavor == "longcat" else self.num_heads
+        q_head_dim = self.qk_head_dim if flavor == "longcat" else self.q_head_dim
+        q = q.reshape(B, L, n_heads, q_head_dim).transpose(0, 2, 1, 3)
+        if flavor == "longcat" and self.mla_scale_q_lora is not None:
+            q = q * self.mla_scale_q_lora
+    q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
+
+    compressed_kv = self.kv_a_proj_with_mqa(x)
+    compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
+    k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
+    kv_latent = self.kv_a_layernorm(compressed_kv)
+    if flavor == "longcat" and self.mla_scale_kv_lora is not None:
+        kv_latent = kv_latent * self.mla_scale_kv_lora
+
+    if flavor != "kimi":
+        offset = cache.offset if cache is not None else 0
+        q_pe = self.rope(q_pe, offset)
+        k_pe = self.rope(k_pe, offset)
+    kv_latent = mx.expand_dims(kv_latent, axis=1)
+    if cache is not None:
+        kv_latent, k_pe = cache.update_and_fetch(kv_latent, k_pe)
+
+    pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+    if mask is not None:
+        pe_scores = mx.where(
+            mask,
+            pe_scores,
+            mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+        )
+
+    cache_len = latent_length(kv_latent)
+    absorbed = _use_absorbed(self, L, kv_latent)
+    if not absorbed and cache_len < _MIN_CACHE_LENGTH:
+        _STATS["short_cache"] += 1
+    _STATS["absorbed" if absorbed else "materialized"] += 1
+    if absorbed:
+        q_nope = self.embed_q(q_nope)
+        k = v = kv_latent
+    else:
+        k = self.embed_q(kv_latent, transpose=False)
+        v = self.unembed_out(kv_latent)
+
+    output = scaled_dot_product_attention(
+        q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
+    )
+    if absorbed:
+        output = self.unembed_out(output)
+    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+    return self.o_proj(output)
+
+
+_FLAVORS = {
+    ("deepseek_v3", "DeepseekV3Attention"): "standard",
+    ("glm4_moe_lite", "Glm4MoeLiteAttention"): "standard",
+    ("kimi_linear", "KimiMLAAttention"): "kimi",
+    ("longcat_flash", "LongcatFlashMLA"): "longcat",
+}
+
+
+def _source_hash(call: Callable[..., Any]) -> str | None:
+    try:
+        source = inspect.getsource(call)
+    except (OSError, TypeError):
+        return None
+    return hashlib.sha256(source.encode()).hexdigest()
+
+
+def install_mla_absorbed_verify() -> None:
+    """Install the compatibility patch once, refusing unknown source shapes."""
+    global _ENABLED, _INSTALLED, _PROVIDER
+
+    with _LOCK:
+        if _INSTALLED:
+            return
+        _ENABLED = _feature_enabled()
+        try:
+            from mlx_lm.models import mla
+        except ImportError:  # pragma: no cover - mlx-lm is a core dependency
+            logger.debug("[mla_absorbed_verify] mlx-lm unavailable; skipping")
+            return
+
+        if hasattr(mla, "max_absorbed_queries"):
+            _PROVIDER = "upstream"
+            _INSTALLED = True
+            return
+        if not _ENABLED:
+            # Default-off must be a literal zero-overhead path: do not wrap
+            # every attention layer merely to rediscover that the flag is off.
+            _PROVIDER = "disabled"
+            _INSTALLED = True
+            return
+
+        originals = getattr(mla, "_RAPID_MLX_MLA_ABSORBED_ORIGINALS", None)
+        if originals is None:
+            originals = {}
+            mla._RAPID_MLX_MLA_ABSORBED_ORIGINALS = originals
+
+        for key, expected_hash in _SUPPORTED_SOURCE_HASHES.items():
+            module_name, class_name = key
+            try:
+                module = __import__(
+                    f"mlx_lm.models.{module_name}", fromlist=[class_name]
+                )
+                cls = getattr(module, class_name)
+            except (ImportError, AttributeError):
+                continue
+
+            marker = f"_RAPID_MLX_MLA_ABSORBED_{class_name}"
+            if getattr(module, marker, False):
+                _PATCHED_TARGETS.add(key)
+                continue
+            original = cls.__call__
+            actual_hash = _source_hash(original)
+            if actual_hash != expected_hash:
+                logger.warning(
+                    "[mla_absorbed_verify] refusing unknown %s.%s implementation "
+                    "(source hash %s)",
+                    module_name,
+                    class_name,
+                    actual_hash or "unavailable",
+                )
+                continue
+
+            originals[key] = original
+            flavor = _FLAVORS[key]
+
+            def _patched(
+                self, x, mask=None, cache=None, *, _orig=original, _flavor=flavor
+            ):
+                _STATS["forwards"] += 1
+                if not _ENABLED:
+                    _STATS["disabled"] += 1
+                    return _orig(self, x, mask, cache)
+                if int(x.shape[1]) == 1:
+                    _STATS["single_token"] += 1
+                    return _orig(self, x, mask, cache)
+                return _attention_call(self, x, mask, cache, flavor=_flavor)
+
+            _patched.__name__ = original.__name__
+            _patched.__qualname__ = original.__qualname__
+            cls.__call__ = _patched
+            setattr(module, marker, True)
+            _PATCHED_TARGETS.add(key)
+
+        _PROVIDER = "rapid" if originals else "none"
+        _INSTALLED = True
+
+
+def mla_absorbed_verify_stats() -> dict[str, Any]:
+    """Return mechanism counters and the active implementation provider."""
+    return {
+        **_STATS,
+        "installed": _INSTALLED,
+        "enabled": _ENABLED,
+        "provider": _PROVIDER,
+        "targets": tuple(f"{module}.{cls}" for module, cls in sorted(_PATCHED_TARGETS)),
+    }
+
+
+def is_installed() -> bool:
+    return _INSTALLED

--- a/vllm_mlx/patches/mla_absorbed_verify.py
+++ b/vllm_mlx/patches/mla_absorbed_verify.py
@@ -172,6 +172,9 @@ def _attention_call(
 
     pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
     if mask is not None:
+        # All four exact supported model wrappers request return_array=True.
+        # Keep the same array-only contract as their hashed upstream attention
+        # methods, which perform this identical mx.where operation.
         pe_scores = mx.where(
             mask,
             pe_scores,

--- a/vllm_mlx/patches/mla_absorbed_verify.py
+++ b/vllm_mlx/patches/mla_absorbed_verify.py
@@ -25,6 +25,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _ENV = "RAPID_MLX_MLA_ABSORBED_VERIFY"
+_STATS_ENV = "RAPID_MLX_MLA_ABSORBED_VERIFY_STATS"
 _QUALIFIED_MLX_LM_VERSION = "0.31.3"
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _MIN_CACHE_LENGTH = 1024
@@ -33,6 +34,7 @@ _STATS_LOCK = threading.Lock()
 _INSTALLED = False
 _PROVIDER = "none"
 _ENABLED = False
+_STATS_ENABLED = os.environ.get(_STATS_ENV, "").strip().lower() in _TRUE_VALUES
 _PATCHED_TARGETS: set[tuple[str, str]] = set()
 
 _STATS = {
@@ -46,6 +48,8 @@ _STATS = {
 
 
 def _increment_stat(name: str) -> None:
+    if not _STATS_ENABLED:
+        return
     with _STATS_LOCK:
         _STATS[name] += 1
 
@@ -328,6 +332,7 @@ def mla_absorbed_verify_stats() -> dict[str, Any]:
         **counters,
         "installed": _INSTALLED,
         "enabled": _ENABLED,
+        "stats_enabled": _STATS_ENABLED,
         "provider": _PROVIDER,
         "targets": tuple(f"{module}.{cls}" for module, cls in sorted(_PATCHED_TARGETS)),
     }

--- a/vllm_mlx/patches/mla_absorbed_verify.py
+++ b/vllm_mlx/patches/mla_absorbed_verify.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Opt-in absorbed MLA routing for short multi-token forwards.
 
-mlx-lm 0.31.x only uses the absorbed Multi-head Latent Attention (MLA)
+mlx-lm 0.31.3 only uses the absorbed Multi-head Latent Attention (MLA)
 factorization for a single query.  On a warm cache the same factorization is
 cheaper for the small query widths used by speculative verification.  This
 module carries a narrowly version-gated compatibility patch while the
@@ -19,11 +19,13 @@ import logging
 import os
 import threading
 from collections.abc import Callable
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 _ENV = "RAPID_MLX_MLA_ABSORBED_VERIFY"
+_QUALIFIED_MLX_LM_VERSION = "0.31.3"
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _MIN_CACHE_LENGTH = 1024
 _LOCK = threading.Lock()
@@ -68,6 +70,13 @@ _SUPPORTED_SOURCE_HASHES = {
 
 def _feature_enabled() -> bool:
     return os.environ.get(_ENV, "").strip().lower() in _TRUE_VALUES
+
+
+def _mlx_lm_version() -> str | None:
+    try:
+        return version("mlx-lm")
+    except PackageNotFoundError:  # pragma: no cover - core dependency in production
+        return None
 
 
 def max_absorbed_queries(
@@ -240,6 +249,18 @@ def install_mla_absorbed_verify() -> None:
             # Default-off must be a literal zero-overhead path: do not wrap
             # every attention layer merely to rediscover that the flag is off.
             _PROVIDER = "disabled"
+            _INSTALLED = True
+            return
+
+        installed_version = _mlx_lm_version()
+        if installed_version != _QUALIFIED_MLX_LM_VERSION:
+            logger.warning(
+                "[mla_absorbed_verify] refusing unqualified mlx-lm version %s "
+                "(expected %s)",
+                installed_version or "unavailable",
+                _QUALIFIED_MLX_LM_VERSION,
+            )
+            _PROVIDER = "unsupported"
             _INSTALLED = True
             return
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -55,14 +55,18 @@ from ..patches.deepseek_v32_indexer_gate import (
 # norm-shift correction on the canonical production model-load path.
 # Idempotent + a no-op on checkpoints whose norm gains are already
 # zero-centered.
+from ..patches.mla_absorbed_verify import (
+    install_mla_absorbed_verify as _install_mla_absorbed_verify,
+)
 from ..patches.qwen3_5_norm_shift import (
     install_qwen3_5_norm_shift_fix as _install_qwen3_5_norm_shift_fix,
 )
 
-# Both installers run below the import block so no module-level import
+# The installers run below the import block so no module-level import
 # follows an executable statement (E402).
 _install_dsv32_indexer_gate()
 _install_qwen3_5_norm_shift_fix()
+_install_mla_absorbed_verify()
 
 # Models that require tokenizer fallback
 FALLBACK_MODELS = [


### PR DESCRIPTION
## Why

mlx-lm 0.31.3 materializes full K/V tensors for every multi-token MLA forward, even when a warm-cache speculative verification block is small enough that absorbed MLA is cheaper. On GLM-4.7-Flash-4bit, the stock M=3 forward grows from 50.8 ms at 1K to 517.6 ms at 16K; the qualified absorbed path measures 20.3–32.0 ms.

Upstream reference: https://github.com/ml-explore/mlx-lm/pull/1817

## Scope

- Add an opt-in `RAPID_MLX_MLA_ABSORBED_VERIFY=1` compatibility patch for exact mlx-lm 0.31.3 DeepSeek V3, GLM-4 MoE Lite, Kimi Linear, and LongCat Flash attention implementations.
- Select absorbed MLA only for multi-token calls that satisfy the analytical cost crossover and have a post-update cache of at least 1024 tokens.
- Fail closed on unknown method bodies, preserve L=1 and cold/short-cache behavior, avoid DeepSeek V3.2's indexed-attention patch, and retire automatically when mlx-lm provides the upstream helper.
- Add mechanism counters, architecture-level MLX parity tests, a pinned A/B benchmark, performance notes, and an Atlas handoff.

## Non-goals

- No default behavior change.
- No claim that GLM-4.7 suffix decoding is a supported or correct speculative route.
- No DeepSeek V3.2, Bailing hybrid, Kimi K3, HY3, image, or diffusion changes.
- No upstream mlx-lm dependency bump.
- No quantized MLA cache enablement; caches exposing mlx-lm's `bits` marker remain on the original attention path pending separate qualification.

## Acceptance

- With the flag absent, supported attention classes are not wrapped.
- With the flag enabled, exact supported mlx-lm methods use absorbed MLA only at the qualified crossover and cache floor.
- Unknown/upstream-changed methods and conflicting DeepSeek V3.2 paths remain untouched.
- The committed benchmark rejects unsupported model families and compares each arm from an isolated warm cache.

## Verification

- Focused MLA, routing, benchmark-metadata, compatibility-patch, and Apple-coverage contract suite — 116 passed after the final hardening follow-up.
- Changed-file Ruff format/check and `git diff --check` — passed.
- CI-equivalent changed-line coverage on Mini — 100% (184/184 changed production lines); the MLX-only test file is explicitly enrolled in the Apple coverage union.
- Multiple adversarial Codex self-review rounds produced compatibility and evidence hardening; the final round reported no blocking issue.
- Pinned GLM-4.7-Flash-4bit dogfood, M=3 full-model forward: 2.500x at 1K, 6.594x at 4K, 16.180x at 16K.
- Deterministic 4457-token suffix A/B: 4.054x, stock and absorbed outputs identical 128/128; both differed from vanilla, so the patch remains opt-in.
- Post-hardening 1K regression smoke: absorbed 141/141, argmax equal, 2.409x median. This short smoke checks mechanism activation and regression only; the six-repeat run above remains the performance claim.
- Second full validation: 22,671 passed; its only seven failures are the Bonsai alias tests. The exact same seven failures reproduce on a clean current `origin/main` checkout, where the other 20 tests in that file pass.
- Final scoped `pr_validate` on `b9da7bfde`: MERGE-SAFE, independent diff review found no blocking issues, lint passed, and 138 targeted tests passed. `full_unit` is transparently skipped in scoped reruns because the immediately preceding full run and clean-main baseline above already isolate its seven failures.

## Behaviour delta

Default: unchanged. With `RAPID_MLX_MLA_ABSORBED_VERIFY=1`, qualified warm multi-token forwards on exact supported mlx-lm 0.31.3 MLA classes may use absorbed factorization instead of materialized K/V.

## Release-note evidence

- GLM-4.7-Flash-4bit, M=3 full-model verify: **2.50x at 1K, 6.59x at 4K, and 16.18x at 16K** versus stock.
- Deterministic 4,457-token suffix: **4.05x**; stock and absorbed output tokens were identical **128/128**.
- Qualified model families: **DeepSeek V3, GLM4 MoE Lite, Kimi Linear, and LongCat Flash** (exact mlx-lm 0.31.3 source bodies; default-off compatibility gate).

## AI assistance disclosure

Codex implemented and repeatedly reviewed the patch, tests, benchmark, and documentation. Verification included real MLX architecture tests, pinned full-model dogfood, test-order isolation, cache-clone checks, lint, coverage, and multiple adversarial review rounds.

## Checklist

- [x] Focused tests pass locally (116 passed)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] New tests were mutation-spot-checked through adversarial review findings
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API
