### PR TITLE
fix(mac): show media models in Community Benchmark

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -90,6 +90,13 @@ struct CommunityBenchmarkModel: Identifiable, Hashable {
         if models.contains(where: { $0.entry.alias == current }) { return current }
         return models.first?.entry.alias ?? ""
     }
+
+    static func resolvedCatalog(
+        product: [ModelEntry]?,
+        fallback: [ModelEntry]
+    ) -> [ModelEntry] {
+        product ?? fallback
+    }
 }
 
 struct CommunityBenchmarkCatalogModel: Decodable, Sendable {
@@ -600,9 +607,20 @@ struct CommunityBenchmarkView: View {
     @State private var receipts: [String: CommunityBenchmarkReceipt] = [:]
     @State private var benchmarkMetadata: [String: CommunityBenchmarkCatalogModel] = [:]
     @State private var benchmarkCLIAvailable = false
+    @State private var productCatalog: [ModelEntry]?
+
+    private var resolvedCatalog: [ModelEntry] {
+        CommunityBenchmarkModel.resolvedCatalog(
+            product: productCatalog,
+            fallback: catalog
+        )
+    }
 
     private var models: [CommunityBenchmarkModel] {
-        CommunityBenchmarkModel.models(from: catalog, metadata: benchmarkMetadata)
+        CommunityBenchmarkModel.models(
+            from: resolvedCatalog,
+            metadata: benchmarkMetadata
+        )
     }
 
     private var selected: CommunityBenchmarkModel? {
@@ -622,6 +640,7 @@ struct CommunityBenchmarkView: View {
         }
         .background(RapidTheme.surfaceCanvas)
         .task {
+            await refreshProductCatalog()
             if selectedAlias.isEmpty { selectedAlias = models.first?.entry.alias ?? "" }
             await refreshBenchmarkCatalog()
             await refreshResults()
@@ -842,7 +861,7 @@ struct CommunityBenchmarkView: View {
     }
 
     private func alias(for repoID: String) -> String {
-        catalog.first { $0.hfRepo == repoID }?.alias ?? repoID
+        resolvedCatalog.first { $0.hfRepo == repoID }?.alias ?? repoID
     }
 
     private func memoryCopy(_ memory: Int, fit: String) -> String {
@@ -867,6 +886,7 @@ struct CommunityBenchmarkView: View {
                     ),
                     onDeferredReap: retainServerDuringDeferredReap
                 )
+                await refreshProductCatalog()
                 await refreshResults()
             } catch is CancellationError {
                 errorMessage = acquiredReservation
@@ -959,6 +979,18 @@ struct CommunityBenchmarkView: View {
         } catch {
             if results.isEmpty { errorMessage = "Couldn’t read local results: \(error.localizedDescription)" }
         }
+    }
+
+    private func refreshProductCatalog() async {
+        guard let binary,
+              let entries = await ModelCatalog.productEntries(binary: binary),
+              !Task.isCancelled
+        else { return }
+        productCatalog = entries
+        selectedAlias = CommunityBenchmarkModel.reconciledSelection(
+            current: selectedAlias,
+            models: models
+        )
     }
 
     private func refreshBenchmarkCatalog() async {

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -39,6 +39,59 @@ struct CommunityBenchmarkModelTests {
         #expect(models.allSatisfy { $0.isFocus })
     }
 
+    @Test("Full product catalog replaces the chat-only launch fallback")
+    func productCatalogFeedIncludesMedia() {
+        let chat = ModelEntry(
+            alias: "qwen3.5-9b-4bit",
+            hfRepo: "mlx-community/qwen",
+            sizeOnDisk: nil,
+            cached: true,
+            taskTypes: [.textGeneration]
+        )
+        let image = ModelEntry(
+            alias: "flux2-klein-4b",
+            hfRepo: "mlx-community/flux",
+            sizeOnDisk: nil,
+            cached: false,
+            taskTypes: [.imageGeneration],
+            operationModes: [.textToImage]
+        )
+        let video = ModelEntry(
+            alias: "wan2.2-ti2v-5b-q8",
+            hfRepo: "mlx-community/wan",
+            sizeOnDisk: nil,
+            cached: false,
+            taskTypes: [.videoGeneration],
+            operationModes: [.textToVideo]
+        )
+
+        let catalog = CommunityBenchmarkModel.resolvedCatalog(
+            product: [chat, image, video],
+            fallback: [chat]
+        )
+
+        #expect(Set(CommunityBenchmarkModel.models(from: catalog).map(\.entry.alias)) == [
+            chat.alias, image.alias, video.alias,
+        ])
+    }
+
+    @Test("Older runtimes retain the launch catalog fallback")
+    func productCatalogFeedFallsBack() {
+        let chat = ModelEntry(
+            alias: "legacy-chat",
+            hfRepo: nil,
+            sizeOnDisk: nil,
+            cached: true
+        )
+
+        #expect(
+            CommunityBenchmarkModel.resolvedCatalog(
+                product: nil,
+                fallback: [chat]
+            ) == [chat]
+        )
+    }
+
     @Test("Legacy catalog rows remain usable during the atomic migration")
     func legacyFallback() throws {
         let text = ModelEntry(


### PR DESCRIPTION
## Summary

- load the complete atomic product catalog when the Community Benchmark page opens
- keep the existing launch catalog as a compatibility fallback for older runtimes
- refresh catalog cache state after a successful benchmark download
- cover image/video feed selection and fallback behavior with focused tests

## User impact

Desktop users can select supported image and video models in Community Benchmark and see their protocol, memory-fit, focus, and download state.

## Scope

This changes only the Desktop Community Benchmark catalog feed. It does not change benchmark protocols, runners, model support, or other model pickers.

## Verification

- `swift test --filter CommunityBenchmarkModelTests` (19 passed)
- `swift test --filter 'AtomicModelCatalogTests|ImageCatalogTests|CommunityBenchmarkModelTests'` (43 passed)\n- Debug Desktop AX dogfood with the bundled runtime: picker exposed `flux2-klein-4b`, `qwen-image`, `z-image-turbo`, and `wan2.2-ti2v-5b-q8`; Run locally remained enabled\n- `git diff --check`\n\nCloses #3102