### PR TITLE
docs(image): publish release dogfood matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,50 @@ With a server running (step 2), this patches Claude Code's local config (`~/.cla
 
 ---
 
+## Image generation
+
+Generate images locally from the Desktop **Images** tab or the
+OpenAI-compatible Images API. Install the image runtime when using the CLI:
+
+```bash
+pip install 'rapid-mlx[image]'
+rapid-mlx serve flux2-klein-4b
+```
+
+```bash
+curl http://localhost:8000/v1/images/generations \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"flux2-klein-4b","prompt":"A red sailboat on an alpine lake","size":"1024x1024","seed":42}'
+```
+
+`flux2-klein-4b` is the recommended starting point. Download sizes are the
+currently cataloged model payloads; minimum unified memory includes practical
+headroom for macOS and the serving process. Omit `steps` to use the validated
+family default shown below.
+
+<!-- image-model-matrix:start -->
+| Alias | Best fit | Modes | Download | Minimum unified memory | Default steps |
+| --- | --- | --- | ---: | ---: | ---: |
+| `flux2-klein-4b` | Recommended; fast everyday images | Generate + edit | 4.3 GiB | 12 GB | 4 |
+| `bonsai-image-4b-2bit` | Smallest download | Generate | 3.6 GiB | 12 GB | 4 |
+| `z-image-turbo` | Photorealistic images | Generate | 5.5 GiB | 16 GB | 8 |
+| `flux-schnell` | FLUX.1 compatibility | Generate | 9.0 GiB | 16 GB | 4 |
+| `sdxl-base` | SDXL compatibility | Generate | 6.5 GiB | 16 GB | 30 |
+| `flux2-klein-4b-bf16` | Explicit full-precision Klein path | Generate + edit | 14.9 GiB | 32 GB | 4 |
+| `hidream-o1-dev` | Complex compositions | Generate | 16.4 GiB | 32 GB | 28 |
+| `sd35-large-4bit` | Stable Diffusion 3.5 | Generate | 15.3 GiB | 32 GB | 28 |
+| `qwen-image` | Text inside images | Generate | 28.9 GiB | 64 GB | 20 |
+<!-- image-model-matrix:end -->
+
+Image work is single-flight: one generation runs at a time so two diffusion
+pipelines cannot exhaust unified memory. Model weights retain their own
+licenses and use restrictions; review the upstream model card before commercial
+deployment.
+
+→ [Release dogfood coverage and reproducible acceptance contract](docs/engineering/operations/image-release-dogfood-matrix.md)
+
+---
+
 ## Video generation
 
 Run text-to-video or image-to-video locally through the OpenAI-compatible
@@ -352,7 +396,7 @@ reached a 27.1 GB MLX allocator peak before non-MLX process and macOS memory;
 on a 32 GB Mac, reduce context/cache use or choose a larger-memory machine.
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
-→ [Every alias, quant, and family (170 text + 2 text-diffusion + 2 image + 8 video + 44 audio aliases, 226 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
+→ [Every alias, quant, and family (186 text + 9 image + 10 video + 44 audio aliases, 249 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
 
 ---
 

--- a/docs/engineering/operations/README.md
+++ b/docs/engineering/operations/README.md
@@ -3,3 +3,6 @@
 Store repeatable runbooks here. Production-facing procedures must state
 prerequisites, verification, observability, rollback, and authorization gates.
 
+- [Image release dogfood matrix](image-release-dogfood-matrix.md) — exact-candidate
+  real-weight, API, recovery, and Desktop acceptance for every built-in image
+  alias.

--- a/docs/engineering/operations/image-release-dogfood-matrix.md
+++ b/docs/engineering/operations/image-release-dogfood-matrix.md
@@ -1,0 +1,99 @@
+# Image release dogfood matrix
+
+This is the acceptance contract for the built-in image aliases shipped by
+Rapid-MLX. It is a release-operator checklist, not a claim that an old run
+qualifies a new binary. Every release candidate needs evidence from its exact
+wheel or Desktop sidecar and exact model revisions.
+
+The automated release build currently exercises one real FLUX.2 Klein model
+through the assembled Desktop sidecar. The remaining rows are explicit manual
+release checks until equivalent artifact-bound automation exists. A historical
+receipt proves that a path has worked; it never replaces the current-candidate
+column.
+
+## Candidate matrix
+
+<!-- image-release-matrix:start -->
+| Alias | Runtime family | Required operation | Exact-candidate proof | Historical real-weight receipt |
+| --- | --- | --- | --- | --- |
+| `flux2-klein-4b` | mflux / FLUX.2 Klein q4 | Generate + edit | Required; generation is automated in the release sidecar | [Mini release-readiness dogfood](2026-08-22-mini-release-readiness-dogfood.md) |
+| `bonsai-image-4b-2bit` | Native Bonsai | Generate | Required manually | [Bonsai Image 4B 2-bit dogfood](../performance/2026-09-05-bonsai-image-4b-2bit-dogfood.md) |
+| `z-image-turbo` | mflux / Z-Image | Generate | Required manually | [Initial real-weight qualification](https://github.com/raullenchai/Rapid-MLX/commit/056ebe79b9904dd432049a550b1bf6c3b298783d) |
+| `flux-schnell` | mflux / FLUX.1 Schnell | Generate | Required manually | [FLUX.1 Schnell dogfood](../performance/2026-09-04-flux1-schnell-dogfood.md) |
+| `sdxl-base` | Native SDXL | Generate | Required manually | [SDXL Base dogfood](../performance/2026-09-05-sdxl-base-dogfood.md) |
+| `flux2-klein-4b-bf16` | mflux / FLUX.2 Klein BF16 | Generate + edit | Required manually | [Klein precision qualification](../performance/2026-09-04-image-weight-precision.md) |
+| `hidream-o1-dev` | Native HiDream | Generate | Required manually | [HiDream-O1 Dev dogfood](../performance/2026-09-04-hidream-o1-dev-dogfood.md) |
+| `sd35-large-4bit` | Native SD3.5 | Generate | Required manually | [SD3.5 Large dogfood](../performance/2026-09-05-sd35-large-dogfood.md) |
+| `qwen-image` | mflux / Qwen Image | Generate | Required manually | [Pinned-checkpoint real server qualification](https://github.com/raullenchai/Rapid-MLX/pull/2157) |
+<!-- image-release-matrix:end -->
+
+## Required evidence per row
+
+A row passes only when one evidence bundle records all of the following:
+
+1. Candidate identity: release version, full source SHA, wheel or sidecar
+   checksum, Apple chip, physical unified memory, macOS version, Python, MLX,
+   and image-runtime versions.
+2. Artifact identity: alias, repository, immutable revision, audited download
+   bytes, and a successful offline completeness check. Auxiliary repositories
+   count as part of the checkpoint.
+3. Cold path: start the exact candidate with no other model resident; require
+   `/health` to report `ready=true` and `engine_type=image`.
+4. Default request: omit `steps`, call `/v1/images/generations`, require HTTP
+   200, exactly one base64 payload, a decodable non-uniform RGB/RGBA PNG at the
+   requested dimensions, and progress that reaches the catalog default.
+5. Warm path: repeat in the same server, then restart offline from the verified
+   cache. Record request time, peak process footprint, swap, and any memory
+   warning. Both requests and the restart must succeed.
+6. Recovery: cancel during denoising, require the request to terminate without
+   an orphan process, then generate successfully from the same server.
+7. Capability-specific path: aliases marked **Generate + edit** must also call
+   `/v1/images/edits` with a real input image and verify that the output follows
+   the instruction. Generation-only aliases must remain absent from the edit
+   picker and reject the edit route.
+
+Do not substitute a two-step or reduced-resolution import smoke for the
+default-request result. Short probes are useful for lifecycle debugging, but
+they do not establish product quality or the published memory floor.
+
+## Product-level checks
+
+After every row passes the API contract, validate the release-shaped Desktop
+once against the same sidecar:
+
+- the Images picker contains exactly the current atomic image roster;
+- RAM fit, download size, operation mode, and default steps agree with
+  `rapid-mlx models --json`;
+- Download → Start → Generate reaches progress and a visible gallery result;
+- changing aspect ratio changes the requested dimensions;
+- edit-capable and generation-only picker partitions are correct;
+- Stop/cancel returns to an actionable state and a subsequent render works;
+- quitting Desktop leaves no candidate-owned server or model process.
+
+The deterministic `image-generation` GUI journey covers these interaction
+states with a fake sidecar on every relevant Desktop change. At least one real
+model must still traverse the release-shaped Desktop for a release candidate;
+the fake journey cannot prove model packaging, Metal execution, or PNG quality.
+
+## Recording a release result
+
+Store the completed evidence under `docs/engineering/operations/` or
+`docs/engineering/performance/` and include:
+
+```text
+Candidate: <version> @ <full SHA>
+Artifact: <wheel/sidecar path and SHA-256>
+Host: <chip>, <RAM>, <macOS>, <power mode>
+Alias: <alias> -> <repo>@<revision>
+Cold default: <size>, <steps selected>, <seconds>, <PNG bytes>, <peak>, <swap>
+Warm default: <seconds>, <PNG bytes>
+Offline restart: PASS/FAIL
+Cancellation recovery: PASS/FAIL
+Edit path or generation-only rejection: PASS/FAIL
+Desktop: PASS/FAIL/not run with reason
+Verdict: PASS/BLOCKED, with issue link for every failure or waiver
+```
+
+Keep raw logs and generated images as release artifacts when practical. Do not
+commit model weights, machine-specific cache paths, credentials, or raw chat
+transcripts.

--- a/tests/test_readme_image_matrix.py
+++ b/tests/test_readme_image_matrix.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Keep the README image matrix aligned with the shipping alias catalog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from vllm_mlx.cli import _available_models_json_payload
+
+ROOT = Path(__file__).resolve().parents[1]
+START = "<!-- image-model-matrix:start -->"
+END = "<!-- image-model-matrix:end -->"
+RELEASE_START = "<!-- image-release-matrix:start -->"
+RELEASE_END = "<!-- image-release-matrix:end -->"
+
+
+def _matrix_rows() -> dict[str, list[str]]:
+    readme = (ROOT / "README.md").read_text()
+    assert readme.count(START) == 1
+    assert readme.count(END) == 1
+    table = readme.split(START, 1)[1].split(END, 1)[0]
+    rows: dict[str, list[str]] = {}
+    for line in table.splitlines():
+        if not line.startswith("| `"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        alias = cells[0].strip("`")
+        assert alias not in rows, f"duplicate README image alias: {alias}"
+        rows[alias] = cells
+    return rows
+
+
+def _gib(size_bytes: int) -> str:
+    return f"{size_bytes / 1024**3:.1f} GiB"
+
+
+def _release_matrix_aliases() -> set[str]:
+    runbook = (
+        ROOT / "docs/engineering/operations/image-release-dogfood-matrix.md"
+    ).read_text()
+    assert runbook.count(RELEASE_START) == 1
+    assert runbook.count(RELEASE_END) == 1
+    table = runbook.split(RELEASE_START, 1)[1].split(RELEASE_END, 1)[0]
+    return {
+        line.split("|", 2)[1].strip().strip("`")
+        for line in table.splitlines()
+        if line.startswith("| `")
+    }
+
+
+def test_readme_image_matrix_matches_shipping_catalog() -> None:
+    catalog = {
+        entry["alias"]: entry for entry in _available_models_json_payload()["image"]
+    }
+    atomic = {
+        entry["alias"]: entry["capabilities"]["operation_modes"]
+        for entry in _available_models_json_payload()["atomic"]["snapshot"]["aliases"]
+        if entry["alias"] in catalog
+    }
+    rows = _matrix_rows()
+
+    assert set(rows) == set(catalog)
+    assert _release_matrix_aliases() == set(catalog)
+    assert next(iter(rows)) == "flux2-klein-4b"
+    for alias, entry in catalog.items():
+        cells = rows[alias]
+        assert len(cells) == 6
+        expected_modes = (
+            "Generate + edit" if "image_to_image" in atomic[alias] else "Generate"
+        )
+        assert cells[2] == expected_modes
+        assert cells[3] == _gib(entry["size_bytes"])
+        assert cells[4] == f"{entry['min_memory_gb']:g} GB"
+        assert cells[5] == str(entry["default_steps"])
+
+
+def test_readme_alias_totals_match_shipping_catalog() -> None:
+    payload = _available_models_json_payload()
+    counts = {kind: len(payload[kind]) for kind in ("text", "image", "video", "audio")}
+    total = sum(counts.values())
+    expected = (
+        f"{counts['text']} text + {counts['image']} image + "
+        f"{counts['video']} video + {counts['audio']} audio aliases, {total} total"
+    )
+
+    assert expected in (ROOT / "README.md").read_text()


### PR DESCRIPTION
## Summary

- add a README image-generation quick start and complete nine-alias selection matrix
- document an exact-candidate real-weight, API, recovery, and Desktop acceptance contract
- distinguish historical qualification receipts from current release proof and the existing automated sidecar representative
- add drift tests that keep both matrices, capability modes, download sizes, RAM floors, default steps, and aggregate alias counts aligned with the shipping catalog

## User impact

Users can choose an image model based on capability, download size, memory fit, and expected default work instead of discovering these constraints after download. Release operators get one fail-closed checklist for every advertised alias.

## Scope

Documentation and documentation-contract tests only. This does not add a model, change runtime behavior, expand automated release gates, cut a release, or deploy anything.

## Verification

- `python3.12 -m pytest tests/test_readme_image_matrix.py tests/test_cli_models_json.py tests/test_atomic_model_catalog.py tests/test_sidecar_image_smoke.py -q` (52 passed)
- `python3.12 -m ruff check tests/test_readme_image_matrix.py`
- `python3.12 -m ruff format --check tests/test_readme_image_matrix.py`
- `git diff --check`