### PR TITLE
feat(image): ship Qwen Image Edit as a curated model

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ curl http://localhost:8000/v1/images/generations \
   -d '{"model":"flux2-klein-4b","prompt":"A red sailboat on an alpine lake","size":"1024x1024","seed":42}'
 ```
 
+Edit an existing PNG or JPEG with the edit-specialized model:
+
+In one terminal:
+
+```bash
+rapid-mlx serve qwen-image-edit
+```
+
+In another terminal:
+
+```bash
+curl http://localhost:8000/v1/images/edits \
+  -F image=@input.png \
+  -F model=qwen-image-edit \
+  -F 'prompt=Change the sky to a warm sunset' \
+  -F response_format=b64_json
+```
+
 `flux2-klein-4b` is the recommended starting point. Download sizes are the
 currently cataloged model payloads; minimum unified memory includes practical
 headroom for macOS and the serving process. Omit `steps` to use the validated
@@ -180,6 +198,7 @@ family default shown below.
 | `hidream-o1-dev` | Complex compositions | Generate | 16.4 GiB | 32 GB | 28 |
 | `sd35-large-4bit` | Stable Diffusion 3.5 | Generate | 15.3 GiB | 32 GB | 28 |
 | `qwen-image` | Text inside images | Generate | 28.9 GiB | 64 GB | 20 |
+| `qwen-image-edit` | Precise instruction edits and text changes | Edit | 34.9 GiB | 96 GB | 20 |
 <!-- image-model-matrix:end -->
 
 Image work is single-flight: one generation runs at a time so two diffusion
@@ -396,7 +415,7 @@ reached a 27.1 GB MLX allocator peak before non-MLX process and macOS memory;
 on a 32 GB Mac, reduce context/cache use or choose a larger-memory machine.
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
-→ [Every alias, quant, and family (186 text + 9 image + 10 video + 44 audio aliases, 249 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
+→ [Every alias, quant, and family (186 text + 10 image + 10 video + 44 audio aliases, 250 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
 
 ---
 

--- a/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ImageCatalogTests.swift
@@ -23,7 +23,7 @@ struct ImageCatalogTests {
       ────────────────────────────
       ltx-2.3-mlx-q4        24.0 GiB   [video:gen] notapalindrome/ltx23-mlx-av-q4
 
-      Image models (7 aliases)
+      Image models (8 aliases)
       ────────────────────────────
       Alias                 Size       Kind        HF id
       ────────────────────────────
@@ -34,12 +34,13 @@ struct ImageCatalogTests {
       hidream-o1-dev       16.4 GiB    [image:gen] mlx-community/HiDream-O1-Image-Dev-mlx-bf16
       sdxl-base             6.5 GiB     [image:gen] stabilityai/stable-diffusion-xl-base-1.0
       sd35-large-4bit       15.3 GiB    [image:gen] argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized
+      qwen-image-edit       34.9 GiB    [image:edit] OsaurusAI/Qwen-Image-Edit-mflux-q8
     """
 
     @Test("parseImageRows extracts image rows and their operation")
     func parsesImageRows() {
         let rows = ModelCatalog.parseImageRows(Self.sample)
-        #expect(rows.count == 7)
+        #expect(rows.count == 8)
 
         let aliases = rows.map(\.alias)
         #expect(aliases.contains("flux2-klein-4b"))
@@ -49,6 +50,7 @@ struct ImageCatalogTests {
         #expect(aliases.contains("sdxl-base"))
         #expect(aliases.contains("sd35-large-4bit"))
         #expect(aliases.contains("flux-schnell"))
+        #expect(aliases.contains("qwen-image-edit"))
         // No chat / video alias leaks in.
         #expect(!aliases.contains("qwen3.6-27b-4bit"))
         #expect(!aliases.contains("ltx-2.3-mlx-q4"))
@@ -75,6 +77,10 @@ struct ImageCatalogTests {
         let schnell = rows.first { $0.alias == "flux-schnell" }
         #expect(schnell?.hfRepo == "mflux-community/flux-1-schnell-mflux-q4")
         #expect(schnell?.capability == .generation)
+        let qwenEdit = rows.first { $0.alias == "qwen-image-edit" }
+        #expect(qwenEdit?.hfRepo == "OsaurusAI/Qwen-Image-Edit-mflux-q8")
+        #expect(qwenEdit?.size == "34.9 GiB")
+        #expect(qwenEdit?.capability == .editing)
     }
 
     @Test("complete mflux caches are marked downloaded in Images")
@@ -90,6 +96,7 @@ struct ImageCatalogTests {
                 "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
                 "stabilityai/stable-diffusion-xl-base-1.0",
                 "argmaxinc/mlx-stable-diffusion-3.5-large-4bit-quantized",
+                "OsaurusAI/Qwen-Image-Edit-mflux-q8",
             ]
         )
 
@@ -102,6 +109,9 @@ struct ImageCatalogTests {
         #expect(cached.first { $0.alias == "sdxl-base" }?.cached == true)
         #expect(cached.first { $0.alias == "sd35-large-4bit" }?.cached == true)
         #expect(cached.first { $0.alias == "flux-schnell" }?.cached == true)
+        let qwenEdit = cached.first { $0.alias == "qwen-image-edit" }
+        #expect(qwenEdit?.cached == true)
+        #expect(qwenEdit?.imageCapability == .editing)
     }
 
     @Test("image JSON exposes validated minimum-memory floors")
@@ -154,5 +164,6 @@ struct ImageCatalogTests {
         #expect(excluded.contains("sdxl-base"))
         #expect(excluded.contains("sd35-large-4bit"))
         #expect(excluded.contains("flux-schnell"))
+        #expect(excluded.contains("qwen-image-edit"))
     }
 }

--- a/docs/engineering/operations/image-release-dogfood-matrix.md
+++ b/docs/engineering/operations/image-release-dogfood-matrix.md
@@ -25,6 +25,7 @@ column.
 | `hidream-o1-dev` | Native HiDream | Generate | Required manually | [HiDream-O1 Dev dogfood](../performance/2026-09-04-hidream-o1-dev-dogfood.md) |
 | `sd35-large-4bit` | Native SD3.5 | Generate | Required manually | [SD3.5 Large dogfood](../performance/2026-09-05-sd35-large-dogfood.md) |
 | `qwen-image` | mflux / Qwen Image | Generate | Required manually | [Pinned-checkpoint real server qualification](https://github.com/raullenchai/Rapid-MLX/pull/2157) |
+| `qwen-image-edit` | mflux / Qwen Image Edit 2509 q8 | Edit | Required manually | [Qwen Image Edit dogfood](../performance/2026-09-05-qwen-image-edit-dogfood.md) |
 <!-- image-release-matrix:end -->
 
 ## Required evidence per row
@@ -39,18 +40,22 @@ A row passes only when one evidence bundle records all of the following:
    count as part of the checkpoint.
 3. Cold path: start the exact candidate with no other model resident; require
    `/health` to report `ready=true` and `engine_type=image`.
-4. Default request: omit `steps`, call `/v1/images/generations`, require HTTP
-   200, exactly one base64 payload, a decodable non-uniform RGB/RGBA PNG at the
-   requested dimensions, and progress that reaches the catalog default.
+4. Default request: omit `steps` and use the operation declared by the row.
+   Generation aliases call `/v1/images/generations`; edit-only aliases call
+   `/v1/images/edits` with a real source image. Require HTTP 200, exactly one
+   base64 payload, a decodable non-uniform RGB/RGBA PNG, and progress that
+   reaches the catalog default.
 5. Warm path: repeat in the same server, then restart offline from the verified
    cache. Record request time, peak process footprint, swap, and any memory
    warning. Both requests and the restart must succeed.
 6. Recovery: cancel during denoising, require the request to terminate without
-   an orphan process, then generate successfully from the same server.
-7. Capability-specific path: aliases marked **Generate + edit** must also call
-   `/v1/images/edits` with a real input image and verify that the output follows
-   the instruction. Generation-only aliases must remain absent from the edit
-   picker and reject the edit route.
+   an orphan process, then rerun the row's declared operation successfully from
+   the same server.
+7. Capability-specific path: aliases marked **Generate + edit** must exercise
+   both endpoints with a real input image and verify that the edit follows the
+   instruction. Edit-only aliases must remain absent from the generation picker
+   and reject the generation route. Generation-only aliases must remain absent
+   from the edit picker and reject the edit route.
 
 Do not substitute a two-step or reduced-resolution import smoke for the
 default-request result. Short probes are useful for lifecycle debugging, but

--- a/docs/engineering/performance/2026-09-05-qwen-image-edit-dogfood.md
+++ b/docs/engineering/performance/2026-09-05-qwen-image-edit-dogfood.md
@@ -1,0 +1,68 @@
+# Qwen Image Edit q8 release dogfood (2026-09-05)
+
+## Candidate and environment
+
+- Alias: `qwen-image-edit`
+- Repository: `OsaurusAI/Qwen-Image-Edit-mflux-q8`
+- Revision: `a458969f2a612433cf036bfc3d8d818ceba29fab`
+- Cataloged payload: 37,472,689,129 bytes (34.9 GiB)
+- Runtime: Rapid-MLX 0.13.4 from the candidate worktree, Python 3.12.14,
+  mflux 0.19.1, MLX 0.32.2
+- Desktop candidate: Rapid-MLX Desktop 0.13.4 with its packaged mflux 0.19.0,
+  launched with `RAPID_BIN` pointing to the candidate worktree environment
+- Host: Apple M3 Ultra Mac Studio, 256 GB unified memory, macOS 26.5.2
+- Source: `docs/assets/logo.png` (683 x 606 PNG)
+- License provenance: the pinned checkpoint card declares Apache-2.0 and names
+  the Qwen Image Edit 2509 source model
+
+The public minimum is 96 GB rather than 64 GB. The measured server peak already
+exceeds a 64 GB machine before allowing useful headroom for macOS and the
+Desktop app.
+
+## Reproduction
+
+Create an isolated environment so an older globally installed mflux does not
+change the result:
+
+```bash
+uv venv /private/tmp/rapid-qwen-edit-venv --python python3.12
+uv pip install --python /private/tmp/rapid-qwen-edit-venv/bin/python -e '.[image]'
+/usr/bin/time -l /private/tmp/rapid-qwen-edit-venv/bin/rapid-mlx pull qwen-image-edit
+/usr/bin/time -l /private/tmp/rapid-qwen-edit-venv/bin/rapid-mlx serve \
+  qwen-image-edit --host 127.0.0.1 --port 8127
+```
+
+The default edit omitted `steps` deliberately:
+
+```bash
+curl --fail-with-body --max-time 1800 \
+  http://127.0.0.1:8127/v1/images/edits \
+  -F image=@docs/assets/logo.png \
+  -F model=qwen-image-edit \
+  -F 'prompt=Place this cheetah logo on a clean warm sunset background while preserving the cheetah shape and black line art' \
+  -F response_format=b64_json \
+  -o /private/tmp/qwen-edit-response.json
+```
+
+Inspect the live process after the request with `vmmap -summary <pid>`. Restart
+with `HF_HUB_OFFLINE=1` and repeat an edit to exercise the verified local cache.
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Exact cold pull | 34.9 GiB in 5m 6s; pinned snapshot path matched the revision |
+| Cold default edit | HTTP 200; 20/20 steps; 174.98 s |
+| Warm default edit | HTTP 200; 20/20 steps; 173.65 s |
+| Output | Decodable non-uniform RGB PNG, 672 x 592 |
+| Visual instruction | Warm-sunset and cool-moonlight edits both preserved the cheetah subject and line art |
+| Peak server footprint | 70,506,019,848 bytes (65.66 GiB), zero process swap |
+| Cancellation | Cancelled at step 3; HTTP 200 with `cancelled=true`; next default edit succeeded |
+| Wrong endpoint | `/v1/images/generations` returned 409 `wrong_image_endpoint` |
+| Offline restart | `HF_HUB_OFFLINE=1`; model card and a one-step edit returned HTTP 200 |
+| Discovery | Alias and repository id both reported `capabilities=["image.editing"]` |
+| Desktop | Imported the source, selected the cached alias, started its sidecar, displayed 1-20 step progress and ETA, and added the completed edit as selected gallery item 1 |
+
+The resident-model admission charge is 68 GiB, just above the measured peak.
+The catalog minimum is 96 GB so users retain operating-system and application
+headroom instead of discovering the incompatibility after a 34.9 GiB download.

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -196,6 +196,10 @@ def test_models_command_sections_image_aliases_out_of_the_text_table():
     assert "[image:both]" in klein_row
     schnell_row = next(ln for ln in image_section.splitlines() if "flux-schnell" in ln)
     assert "[image:gen]" in schnell_row
+    qwen_edit_row = next(
+        ln for ln in image_section.splitlines() if "qwen-image-edit" in ln
+    )
+    assert "[image:edit]" in qwen_edit_row
 
 
 def test_models_command_shows_capability_columns():

--- a/tests/test_qwen_image_edit_alias.py
+++ b/tests/test_qwen_image_edit_alias.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Product contracts for the revision-pinned Qwen Image Edit alias."""
+
+from __future__ import annotations
+
+from vllm_mlx import _download_gate
+from vllm_mlx.catalog import build_catalog_bundle
+from vllm_mlx.image.engine import ImageGenerationEngine
+from vllm_mlx.model_aliases import resolve_profile
+from vllm_mlx.model_sizes import size_bytes
+from vllm_mlx.routes.models import _detect_capabilities
+from vllm_mlx.runtime.resident_models import estimate_model_bytes
+
+ALIAS = "qwen-image-edit"
+REPO = "OsaurusAI/Qwen-Image-Edit-mflux-q8"
+REVISION = "a458969f2a612433cf036bfc3d8d818ceba29fab"
+SIZE = 37_472_689_129
+_GIB = 1024**3
+
+
+def test_alias_is_edit_only_and_uses_the_quality_quantization() -> None:
+    profile = resolve_profile(ALIAS)
+    assert profile is not None
+    assert profile.hf_path == REPO
+    assert profile.modality == "image-gen"
+    assert profile.min_memory_gb == 96
+
+    engine = ImageGenerationEngine(profile.hf_path)
+    assert engine.family == "qwen-image-edit"
+    assert engine.supports_generation is False
+    assert engine.supports_editing is True
+    assert engine.default_edit_steps == 20
+    assert engine.default_edit_guidance == 4.0
+    assert engine._prequantized is True  # noqa: SLF001
+    assert engine._quantize is None  # noqa: SLF001
+
+
+def test_alias_pins_download_size_revision_and_conservative_budget() -> None:
+    assert _download_gate.IMAGE_MODEL_REVISIONS[REPO] == REVISION
+    assert size_bytes(REPO) == SIZE
+    for name in (ALIAS, REPO, "/models/qwen_image_edit"):
+        assert estimate_model_bytes(name) == int(68.0 * _GIB)
+
+
+def test_atomic_catalog_exposes_only_image_to_image() -> None:
+    bundle = build_catalog_bundle()
+    record = next(
+        alias for alias in bundle["snapshot"]["aliases"] if alias["alias"] == ALIAS
+    )
+    capabilities = record["capabilities"]
+    assert capabilities["runtime_adapter"] == "mflux"
+    assert capabilities["operation_modes"] == ["image_to_image"]
+
+
+def test_openai_model_card_advertises_editing_not_generation() -> None:
+    for model_id in (ALIAS, REPO):
+        capabilities = _detect_capabilities(
+            model_id,
+            profile_modality="image-gen",
+        )
+        assert capabilities == ["image.editing"]
+
+    assert _detect_capabilities(
+        "acme/qwen-image-edit-plus",
+        profile_modality="image-gen",
+    ) == ["image.generation"]
+
+
+def test_cold_load_fetches_the_pinned_revision(monkeypatch) -> None:
+    engine = ImageGenerationEngine(REPO)
+    monkeypatch.setattr(
+        "vllm_mlx._download_gate.mflux_local_snapshot", lambda _repo: None
+    )
+    monkeypatch.setattr(engine, "_verify_weights_complete", lambda: None)
+    calls = []
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda repo_id, **kwargs: calls.append((repo_id, kwargs)) or "/pinned/model",
+    )
+
+    assert engine._model_path_for_mflux() == "/pinned/model"  # noqa: SLF001
+    assert calls == [(REPO, {"revision": REVISION})]

--- a/tests/test_readme_image_matrix.py
+++ b/tests/test_readme_image_matrix.py
@@ -65,9 +65,13 @@ def test_readme_image_matrix_matches_shipping_catalog() -> None:
     for alias, entry in catalog.items():
         cells = rows[alias]
         assert len(cells) == 6
-        expected_modes = (
-            "Generate + edit" if "image_to_image" in atomic[alias] else "Generate"
-        )
+        operations = set(atomic[alias])
+        if {"text_to_image", "image_to_image"}.issubset(operations):
+            expected_modes = "Generate + edit"
+        elif "image_to_image" in operations:
+            expected_modes = "Edit"
+        else:
+            expected_modes = "Generate"
         assert cells[2] == expected_modes
         assert cells[3] == _gib(entry["size_bytes"])
         assert cells[4] == f"{entry['min_memory_gb']:g} GB"

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1435,6 +1435,7 @@ IMAGE_MODEL_REVISIONS: dict[str, str] = {
     "mflux-community/flux-1-schnell-mflux-q4": "bcdbe817ad51175959b2e691e64eca626db30558",
     "mflux-community/flux2-klein-4b-mflux-bf16": "4d8e1bae8eb47c7766705de2cda7dabd6cc4ba67",
     "mflux-community/qwen-image-mflux-q6": "c628fe4392d963557c3013c2709e6d3b67bca79d",
+    "OsaurusAI/Qwen-Image-Edit-mflux-q8": "a458969f2a612433cf036bfc3d8d818ceba29fab",
     HIDREAM_O1_REPO: HIDREAM_O1_REVISION,
     SDXL_REPO: SDXL_REVISION,
     BONSAI_IMAGE_REPO: BONSAI_IMAGE_REVISION,

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -2032,6 +2032,18 @@
     "suffix_decoding_tier": "unknown",
     "min_memory_gb": 64
   },
+  "qwen-image-edit": {
+    "hf_path": "OsaurusAI/Qwen-Image-Edit-mflux-q8",
+    "modality": "image-gen",
+    "tool_call_parser": null,
+    "reasoning_parser": null,
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": false,
+    "suffix_decoding_tier": "unknown",
+    "min_memory_gb": 96
+  },
   "hidream-o1-dev": {
     "hf_path": "mlx-community/HiDream-O1-Image-Dev-mlx-bf16",
     "modality": "image-gen",

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -7,6 +7,7 @@
     "Jackrong/MLX-Qwopus3.5-27B-v3-8bit": null,
     "Jackrong/MLX-Qwopus3.5-9B-v3-4bit": 5058235850,
     "LiquidAI/LFM2.5-2.6B-MLX": 1601103345,
+    "OsaurusAI/Qwen-Image-Edit-mflux-q8": 37472689129,
     "Runpod/FLUX.2-klein-4B-mflux-4bit": 4619695783,
     "Vontra/DeepSeek-V4-Flash-0731-MXFP4-MLX": 167094577743,
     "Vontra/GLM-5.3-Flash-MLX-4bit-MTP": 181741731388,

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -671,6 +671,17 @@ def _detect_capabilities(
         return ["video.generation"]
 
     if profile_modality == "image-gen":
+        # Qwen Image Edit is deliberately edit-only: advertising the legacy
+        # generation capability makes discovery clients select an endpoint the
+        # server rejects with ``wrong_image_endpoint``. Match both the public
+        # alias and its pinned HF id without changing existing generation and
+        # dual-capability model wire contracts in this scoped addition.
+        folded = model_id.casefold().replace("_", "-")
+        if folded in {
+            "qwen-image-edit",
+            "osaurusai/qwen-image-edit-mflux-q8",
+        }:
+            return ["image.editing"]
         return ["image.generation"]
 
     caps: list[str] = ["text"]

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -575,6 +575,14 @@ def estimate_model_bytes(model_name: str) -> int:
         # measurements, while the public alias requires a 32 GiB Mac.
         "sd35-large": 20.0,
         "stable-diffusion-3.5": 20.0,
+        # Qwen-Image-Edit 2509 with an 8-bit transformer and full-precision
+        # text encoder. The 34.9 GiB fixed payload needs additional room for
+        # source-image conditioning, denoising activations, VAE decode, and
+        # output encoding. A real default 20-step edit peaked at 65.66 GiB;
+        # charge 68 GiB so admission retains a small runtime margin. The
+        # public alias requires a 96 GiB Mac for macOS/application headroom.
+        "qwen-image-edit": 68.0,
+        "qwen_image_edit": 68.0,
         # 6-bit-transformer Qwen-Image (20B) — measured peak RSS during a
         # real generation at 1024x1024 (mflux-community/qwen-image-mflux-q6,
         # the API/GUI default resolution; `/usr/bin/time -l`): ~55.7 GiB.
@@ -588,14 +596,6 @@ def estimate_model_bytes(model_name: str) -> int:
     }
     for token, gib in known_image_gib.items():
         if token not in folded:
-            continue
-        if token == "qwen-image" and "qwen-image-edit" in folded:
-            # "qwen-image" is a substring of "qwen-image-edit" — this charge
-            # was measured against the txt2img family only (see the comment
-            # above), and the edit variant's extra image-conditioning input
-            # makes its real footprint unverified, not merely "the same
-            # number". Falls through to the generic param-count estimate
-            # below rather than asserting an unmeasured number.
             continue
         return int(gib * _GIB)
 


### PR DESCRIPTION
## Summary

- Add `qwen-image-edit` as a revision-pinned q8 image-editing alias for pull, serve, model discovery, and the existing Desktop Images flow.
- Advertise edit-only capability consistently in the atomic catalog, CLI, `/v1/models`, README, and Desktop picker.
- Record the exact 34.9 GiB payload, measured 68 GiB resident charge, and a 96 GB minimum-memory tier.
- Add release dogfood evidence and anti-drift regression coverage.

## Why

Rapid-MLX already has the image-edit runtime and secure multipart API, but users cannot select a supported, stable checkpoint by alias. This addition makes that existing workflow discoverable and reproducible because the checkpoint revision, footprint, operation mode, and defaults are all product-owned contracts.

## Scope

Allowed scope is one curated edit-only alias plus the catalog, discovery, documentation, memory-admission, Desktop parsing, and tests required to ship it safely.

## Explicit non-goals

- No new image backend, endpoint, scheduler, or Desktop screen.
- No multi-image editing or inpainting expansion.
- No other model aliases.
- No release or deployment action.

## Acceptance criteria

- `rapid-mlx pull/serve qwen-image-edit` resolves the exact pinned q8 checkpoint.
- Generation requests reject with the existing wrong-endpoint contract; multipart edits succeed with the 20-step default.
- `/v1/models` reports `image.editing`, and Desktop exposes the alias only after entering edit mode.
- Memory guidance prevents 64 GB machines from accepting a measured 65.66 GiB peak working set.
- README and the release matrix cannot drift from the shipping catalog.

## Verification

- [x] Real cold pull: 34.9 GiB in 5m 6s at the pinned revision.
- [x] Real cold and warm default edits: HTTP 200, 20/20 steps, 174.98 s and 173.65 s.
- [x] Visual dogfood: two prompts changed the background while preserving the source subject and line art.
- [x] Cancellation at step 3, recovery edit, wrong-endpoint rejection, and offline restart passed.
- [x] Desktop candidate imported a PNG, selected and started the alias, displayed live 1-20 progress/ETA, and stored the result as selected gallery item 1.
- [x] Packaged sidecar lists `qwen-image-edit [image:edit]`.
- [x] 243 focused Server tests and 28 focused Desktop tests passed; lint passed.
- [x] Full Python suite: 22,688 passed, 240 skipped, 6 xfailed; one tokenizer-cache integration failure reproduced unchanged on the parent commit.
- [x] Three scope-locked self-adversarial review rounds completed.