### PR TITLE
fix(cli): resolve alias profile before subfolder path in serve auto-config (#3114)

### DIFF
--- a/tests/test_alias_subfolder.py
+++ b/tests/test_alias_subfolder.py
@@ -970,3 +970,32 @@ def test_local_snapshot_uses_one_complete_immutable_revision_without_main_ref(
 
     resolved = tok._local_snapshot_if_cached("mlx-community/Qwen3.5-2B-MLX-4bit")
     assert resolved == str(snapshot)
+
+
+# --- #3114: serve auto-config must resolve the alias profile, not the
+# subfolder-joined snapshot path -------------------------------------------
+
+
+def test_auto_config_key_keeps_alias_identity_for_subfolder_alias():
+    from vllm_mlx.cli import _auto_config_lookup_key
+    from vllm_mlx.model_auto_config import detect_model_config
+
+    assert _auto_config_lookup_key(ALIAS) == ALIAS
+    assert _auto_config_lookup_key(REPO) == REPO
+    cfg = detect_model_config(_auto_config_lookup_key(ALIAS))
+    assert cfg is not None
+    assert (cfg.tool_call_parser, cfg.reasoning_parser) == ("lfm", "qwen3")
+
+
+def test_auto_config_key_resolves_checkpoint_for_profile_less_repo(monkeypatch):
+    from vllm_mlx import cli as cli_mod
+    from vllm_mlx.utils import tokenizer as tok
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        tok,
+        "_resolve_subfolder_checkpoint",
+        lambda name: calls.append(name) or "/snap/4bit",
+    )
+    assert cli_mod._auto_config_lookup_key("someone/no-such-alias-repo") == "/snap/4bit"
+    assert calls == ["someone/no-such-alias-repo"]

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3185,6 +3185,29 @@ def _resolve_turboquant_with_mtp_policy(
     return resolve_turboquant_mode_default(args, model_name=model_name, **detection)
 
 
+def _auto_config_lookup_key(config_identity: str) -> str:
+    """Return the key ``detect_model_config`` should resolve for ``serve``.
+
+    A curated alias (or its ``hf_path``) resolves its profile by name, and
+    the profile is the single source of truth for parser/cache defaults.
+    Joining the catalog subfolder onto the cached snapshot first (#2558)
+    produced a local ``…/snapshots/<sha>/<subfolder>`` path that no profile
+    matches, so the only subfolder alias (``lfm2.5-2.6b-4bit``) silently
+    lost its ``tool_call_parser``/``reasoning_parser`` (#3114). Only a
+    profile-less identity — a bare multi-variant repo selected via
+    ``pull --bits/--format`` — needs the concrete checkpoint directory so
+    the metadata fallback reads a real ``config.json`` instead of the
+    config-less repository root.
+    """
+    from .model_aliases import resolve_profile
+
+    if resolve_profile(config_identity) is not None:
+        return config_identity
+    from .utils.tokenizer import _resolve_subfolder_checkpoint
+
+    return _resolve_subfolder_checkpoint(config_identity)
+
+
 def serve_command(args):
     """Start the OpenAI-compatible server."""
     import logging
@@ -3624,11 +3647,8 @@ def serve_command(args):
             # checkpoint, not the config-less repository root. Preserve an
             # explicit alias because its catalog subfolder outranks a repo
             # marker by contract.
-            from .utils.tokenizer import _resolve_subfolder_checkpoint
-
             config_identity = getattr(args, "_original_alias", None) or args.model
-            config_path = _resolve_subfolder_checkpoint(config_identity)
-            auto_config = detect_model_config(config_path)
+            auto_config = detect_model_config(_auto_config_lookup_key(config_identity))
         except Exception as e:
             if not non_fatal:
                 raise


### PR DESCRIPTION
Closes #3114.

## Problem
`rapid-mlx serve lfm2.5-2.6b-4bit` booted with `Features: gc-control, cors: *` — no `tools: lfm, reasoning: qwen3`. Tool calls came back as the raw pythonic text `[get_weather(city='Tokyo')]` with `tool_calls: null`, and thinking streamed inside `content`. Found in the 0.13.5 pre-release fresh-venv roster smoke; same code shipped in 0.13.4 (introduced by #2558).

## Root cause
`resolve_auto_config()` called `_resolve_subfolder_checkpoint(config_identity)` first and handed the resulting local `…/snapshots/<sha>/4bit` path to `detect_model_config`, whose stage-1 alias-profile lookup cannot match a local path. `lfm2.5-2.6b-4bit` is the only subfolder alias in `aliases.json`, so it was the only alias affected.

## Fix
New `_auto_config_lookup_key(config_identity)` in `cli.py`: if `resolve_profile(config_identity)` matches (alias name or hf_path), keep the identity so the profile stays the SSOT; otherwise (profile-less bare multi-variant repo selected via `pull --bits`) resolve the concrete checkpoint directory as before, so the metadata fallback still reads a real `config.json`.

## Verification
- `tests/test_alias_subfolder.py`: two new tests — alias/hf_path keep identity and resolve to `("lfm", "qwen3")`; profile-less repo goes through `_resolve_subfolder_checkpoint` (both branches covered).
- `pytest tests/test_alias_subfolder.py tests/test_no_mllm_flag.py tests/test_model_auto_config.py` → 435 passed.
- Manual: with explicit `--enable-auto-tool-choice --tool-call-parser lfm --reasoning-parser qwen3` the same server parsed the tool call (`{"city": "Tokyo"}`) and separated 1569 chars of reasoning; this PR makes that the default again. Fresh-venv boot re-check after CI is in the dogfood notes.