### PR TITLE
fix(catalog): give embedding aliases their own task type; count cached models in quickstart (#3116)

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -1100,10 +1100,12 @@ enum ModelCatalog {
                     return operations.contains(.embed)
                 }
             }) else { return nil }
-            // An embeddings-only alias has no Desktop surface: it is neither a
-            // chat, image, audio nor video model. Skip the row rather than
-            // let the `kind` fallback file it under Chat (#3116).
-            if tasks == [.embedding] {
+            // An embedding alias has no Desktop surface: it is neither a
+            // chat, image, audio nor video model. Skip any row that carries
+            // the task — a hypothetical `embedding` + `text_generation` combo
+            // included — rather than let the `kind` fallback file it under
+            // Chat (#3116, codex).
+            if tasks.contains(.embedding) {
                 continue
             }
             let kind: ModelKind

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelCatalog.swift
@@ -30,6 +30,10 @@ enum ModelTask: String, Sendable, Hashable {
     case videoGeneration = "video_generation"
     case speechSynthesis = "speech_synthesis"
     case speechRecognition = "speech_recognition"
+    /// Sentence embeddings (embeddinggemma). Desktop has no embeddings
+    /// surface, so an alias advertising only this task is parsed (the
+    /// envelope stays valid) and then left out of every picker (#3116).
+    case embedding
 }
 
 enum ModelOperation: String, Sendable, Hashable {
@@ -47,6 +51,7 @@ enum ModelOperation: String, Sendable, Hashable {
     case transcription
     case translation
     case forcedAlignment = "forced_alignment"
+    case embed
 }
 
 /// The user-facing operation an audio checkpoint can actually perform.
@@ -1091,8 +1096,16 @@ enum ModelCatalog {
                     return !operations.isDisjoint(with: [
                         .transcription, .translation, .forcedAlignment,
                     ])
+                case .embedding:
+                    return operations.contains(.embed)
                 }
             }) else { return nil }
+            // An embeddings-only alias has no Desktop surface: it is neither a
+            // chat, image, audio nor video model. Skip the row rather than
+            // let the `kind` fallback file it under Chat (#3116).
+            if tasks == [.embedding] {
+                continue
+            }
             let kind: ModelKind
             if tasks.contains(.imageGeneration) {
                 kind = .image

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -2227,15 +2227,27 @@ struct QuickstartView: View {
         case chooseFirst
         /// State 05 — a bigger model is picked, so the cost is compared.
         case biggerAndCost
-        /// State 06 — the pick is already in the shared cache.
-        case alreadyHere
+        /// State 06 — the pick is already in the shared cache. Carries how
+        /// many cached rows the chooser shows, so the heading can count
+        /// honestly: "One is already here." over six rows was a lie (#3116).
+        case alreadyHere(cachedCount: Int)
 
         var title: String {
             switch self {
             case .chooseFirst:   return "Choose your\nfirst model"
             case .biggerAndCost: return "Bigger, and\nwhat it costs"
+            case .alreadyHere(let count) where count > 1:
+                return "\(Self.spelledCount(count)) are already\nhere."
             case .alreadyHere:   return "One is already\nhere."
             }
+        }
+
+        /// Small counts read as words in a display title; beyond ten the
+        /// numeral is clearer than "Fourteen".
+        static func spelledCount(_ count: Int) -> String {
+            let words = ["Zero", "One", "Two", "Three", "Four", "Five",
+                         "Six", "Seven", "Eight", "Nine", "Ten"]
+            return count < words.count ? words[count] : String(count)
         }
     }
 
@@ -2250,10 +2262,11 @@ struct QuickstartView: View {
     static func selectionNarrative(
         alias: String,
         cachedModels: [ModelEntry],
-        comparableTradeUps: [QuickstartModelChoice]
+        comparableTradeUps: [QuickstartModelChoice],
+        cachedRowCount: Int = 1
     ) -> SelectionNarrative {
         if canStartWithoutDownload(alias: alias, cachedModels: cachedModels) {
-            return .alreadyHere
+            return .alreadyHere(cachedCount: max(1, cachedRowCount))
         }
         let isTradeUp = comparableTradeUps.contains { $0.alias == alias }
         if isTradeUp, comparableTradeUps.count >= 2 {
@@ -2273,6 +2286,9 @@ struct QuickstartView: View {
         case .biggerAndCost:
             return "The difference is download size and how much memory the model "
                 + "holds while it runs, against this Mac's \(wholeGB(hardware.physicalRAMGB))."
+        case .alreadyHere(let count) where count > 1:
+            return "Another MLX app already downloaded these models into the shared "
+                + "Hugging Face cache. Picking one of them skips the download entirely."
         case .alreadyHere:
             return "Another MLX app already downloaded this model into the shared "
                 + "Hugging Face cache. Picking it skips the download entirely."
@@ -2338,7 +2354,8 @@ struct QuickstartView: View {
         let narrative = Self.selectionNarrative(
             alias: coordinator.selection.alias,
             cachedModels: cachedModels,
-            comparableTradeUps: list.tradeUps
+            comparableTradeUps: list.tradeUps,
+            cachedRowCount: list.cached.count
         )
         step2Scaffold {
             step2Columns(

--- a/apps/rapid-mac/Tests/RapidTests/AtomicModelCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AtomicModelCatalogTests.swift
@@ -428,6 +428,53 @@ struct AtomicModelCatalogTests {
         #expect(preset.isDefaultEnabled)
     }
 
+    private static func embeddingRow(operation: String) -> [String: Any] {
+        [
+            "schema_version": 2,
+            "alias": "embed",
+            "origin": "builtin",
+            "target": ["registry_model_id": "legacy/hf/chat", "resolution_status": "unresolved"],
+            "capabilities": [
+                "task_types": ["embedding"],
+                "is_text_only": false,
+                "operation_modes": [operation],
+                "runtime_adapter": "mlx_embeddings",
+            ],
+            "availability": ["cli": true, "server": true, "desktop": true, "website": true],
+            "default_execution_preset_id": NSNull(),
+            "execution_presets": [],
+        ]
+    }
+
+    private static func withEmbeddingRow(operation: String) -> String {
+        mutated { root in
+            var atomic = root["atomic"] as! [String: Any]
+            var snapshot = atomic["snapshot"] as! [String: Any]
+            var aliases = snapshot["aliases"] as! [[String: Any]]
+            aliases.append(embeddingRow(operation: operation))
+            snapshot["aliases"] = aliases
+            atomic["snapshot"] = snapshot
+            root["atomic"] = atomic
+        }
+    }
+
+    @Test("an embeddings-only alias keeps the envelope valid and is left out of every picker")
+    func embeddingAliasIsParsedAndOmitted() {
+        // #3116: embeddinggemma now advertises `embedding`/`embed`. The
+        // envelope must not fall back to the legacy projection (which would
+        // file it under Chat again), and the row must reach no Desktop picker.
+        let entries = ModelCatalog.parseAtomicModelEntriesJSON(
+            Self.withEmbeddingRow(operation: "embed")
+        )
+        #expect(entries != nil)
+        #expect(entries?.contains { $0.alias == "embed" } == false)
+        #expect(entries?.contains { $0.alias == "chat" } == true)
+        // An embedding task paired with a chat operation is still malformed.
+        #expect(ModelCatalog.parseAtomicModelEntriesJSON(
+            Self.withEmbeddingRow(operation: "chat")
+        ) == nil)
+    }
+
     @Test("unknown atomic tasks fail closed into the legacy downgrade path")
     func unknownTaskRejectsAtomicEnvelope() {
         let future = Self.signed(Self.payload.replacingOccurrences(

--- a/apps/rapid-mac/Tests/RapidTests/AtomicModelCatalogTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AtomicModelCatalogTests.swift
@@ -428,16 +428,20 @@ struct AtomicModelCatalogTests {
         #expect(preset.isDefaultEnabled)
     }
 
-    private static func embeddingRow(operation: String) -> [String: Any] {
+    private static func embeddingRow(
+        operation: String,
+        tasks: [String] = ["embedding"],
+        operations: [String]? = nil
+    ) -> [String: Any] {
         [
             "schema_version": 2,
             "alias": "embed",
             "origin": "builtin",
             "target": ["registry_model_id": "legacy/hf/chat", "resolution_status": "unresolved"],
             "capabilities": [
-                "task_types": ["embedding"],
+                "task_types": tasks,
                 "is_text_only": false,
-                "operation_modes": [operation],
+                "operation_modes": operations ?? [operation],
                 "runtime_adapter": "mlx_embeddings",
             ],
             "availability": ["cli": true, "server": true, "desktop": true, "website": true],
@@ -446,12 +450,18 @@ struct AtomicModelCatalogTests {
         ]
     }
 
-    private static func withEmbeddingRow(operation: String) -> String {
+    private static func withEmbeddingRow(
+        operation: String,
+        tasks: [String] = ["embedding"],
+        operations: [String]? = nil
+    ) -> String {
         mutated { root in
             var atomic = root["atomic"] as! [String: Any]
             var snapshot = atomic["snapshot"] as! [String: Any]
             var aliases = snapshot["aliases"] as! [[String: Any]]
-            aliases.append(embeddingRow(operation: operation))
+            aliases.append(embeddingRow(
+                operation: operation, tasks: tasks, operations: operations
+            ))
             snapshot["aliases"] = aliases
             atomic["snapshot"] = snapshot
             root["atomic"] = atomic
@@ -473,6 +483,18 @@ struct AtomicModelCatalogTests {
         #expect(ModelCatalog.parseAtomicModelEntriesJSON(
             Self.withEmbeddingRow(operation: "chat")
         ) == nil)
+        // A schema-valid `embedding` + `text_generation` combination must not
+        // slip into Chat either (codex on #3128): any row carrying the
+        // embedding task stays out of every picker.
+        let combined = ModelCatalog.parseAtomicModelEntriesJSON(
+            Self.withEmbeddingRow(
+                operation: "embed",
+                tasks: ["embedding", "text_generation"],
+                operations: ["embed", "chat"]
+            )
+        )
+        #expect(combined != nil)
+        #expect(combined?.contains { $0.alias == "embed" } == false)
     }
 
     @Test("unknown atomic tasks fail closed into the legacy downgrade path")

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -458,8 +458,34 @@ struct OnboardingDirectionDTests {
             cachedModels: [Self.cachedEntry(bigCached.alias)],
             comparableTradeUps: Self.tradeUps
         )
-        #expect(narrative == .alreadyHere)
+        #expect(narrative == .alreadyHere(cachedCount: 1))
         #expect(narrative.title == "One is already\nhere.")
+    }
+
+    @Test("Several cached rows are counted in the heading, not called one")
+    func severalCachedRowsAreCounted() {
+        // 0.13.5 dogfood (#3116): six rows under "ALREADY ON THIS MAC" sat
+        // beneath "One is already here." The heading must count what the
+        // list beside it shows, and the subtitle must speak in the plural.
+        let cached = Self.tradeUps.last!
+        let narrative = QuickstartView.selectionNarrative(
+            alias: cached.alias,
+            cachedModels: [Self.cachedEntry(cached.alias)],
+            comparableTradeUps: Self.tradeUps,
+            cachedRowCount: 6
+        )
+        #expect(narrative == .alreadyHere(cachedCount: 6))
+        #expect(narrative.title == "Six are already\nhere.")
+        #expect(QuickstartView.selectionSubtitle(narrative, hardware: Self.hardware32)
+            .contains("these models"))
+        #expect(QuickstartView.SelectionNarrative.alreadyHere(cachedCount: 14).title
+            == "14 are already\nhere.")
+        // A single row keeps the original singular copy verbatim.
+        #expect(QuickstartView.SelectionNarrative.alreadyHere(cachedCount: 1).title
+            == "One is already\nhere.")
+        #expect(QuickstartView.selectionSubtitle(
+            .alreadyHere(cachedCount: 1), hardware: Self.hardware32
+        ).contains("this model"))
     }
 
     @Test("Every narrative carries its own subtitle")
@@ -468,10 +494,10 @@ struct OnboardingDirectionDTests {
         let subtitles = Set([
             QuickstartView.SelectionNarrative.chooseFirst,
             .biggerAndCost,
-            .alreadyHere,
+            .alreadyHere(cachedCount: 1),
         ].map { QuickstartView.selectionSubtitle($0, hardware: hardware) })
         #expect(subtitles.count == 3, "each narrative must explain its own case")
-        #expect(QuickstartView.selectionSubtitle(.alreadyHere, hardware: hardware)
+        #expect(QuickstartView.selectionSubtitle(.alreadyHere(cachedCount: 1), hardware: hardware)
             .contains("skips the download"))
         #expect(QuickstartView.selectionSubtitle(.biggerAndCost, hardware: hardware)
             .contains("32 GB"), "the comparison names this Mac's memory")

--- a/proto/model-catalog/v2/model-alias.schema.json
+++ b/proto/model-catalog/v2/model-alias.schema.json
@@ -36,10 +36,10 @@
       "type": "object", "additionalProperties": false,
       "required": ["task_types", "is_text_only"],
       "properties": {
-        "task_types": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["text_generation", "vision_language", "image_generation", "video_generation", "speech_synthesis", "speech_recognition"]}},
+        "task_types": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["text_generation", "vision_language", "image_generation", "video_generation", "speech_synthesis", "speech_recognition", "embedding"]}},
         "is_text_only": {"type": "boolean", "description": "Compatibility safety pin consumed by current launch policy; explicit rather than inferred from task taxonomy."},
         "generation_modes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["text_to_image", "image_to_image", "inpainting", "text_to_video", "image_to_video", "video_to_video"]}, "deprecated": true, "description": "Deprecated v1 spelling. v2 consumers accept it only as a migration fallback when operation_modes is absent."},
-        "operation_modes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["chat", "image_understanding", "text_to_image", "image_to_image", "inpainting", "text_to_video", "image_to_video", "video_to_video", "preset_voice", "voice_cloning", "voice_design", "transcription", "translation", "forced_alignment"]}},
+        "operation_modes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["chat", "image_understanding", "text_to_image", "image_to_image", "inpainting", "text_to_video", "image_to_video", "video_to_video", "preset_voice", "voice_cloning", "voice_design", "transcription", "translation", "forced_alignment", "embed"]}},
         "runtime_adapter": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[a-z0-9][a-z0-9._/-]*$"},
         "tool_call_parser": {"type": "string", "minLength": 1, "maxLength": 64},
         "reasoning_parser": {"type": "string", "minLength": 1, "maxLength": 64},

--- a/tests/test_embedding_alias_catalog_3116.py
+++ b/tests/test_embedding_alias_catalog_3116.py
@@ -1,0 +1,105 @@
+"""#3116: sentence-embedding aliases must not be advertised as chat models.
+
+embeddinggemma ships in ``aliases.json`` so ``--embedding-model`` can resolve
+the short name, but the atomic catalog projected it as
+``text_generation``/``chat`` — the only vocabulary it had — so every first-chat
+picker (Desktop quickstart, Community Benchmark) offered it as a model that
+could answer. These tests pin the new ``embedding`` modality end to end.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx import cli
+from vllm_mlx.catalog.legacy import build_legacy_catalog_snapshot
+from vllm_mlx.catalog.validation import (
+    _TASK_OPERATIONS,
+    CatalogValidationError,
+    ContractValidator,
+)
+from vllm_mlx.model_aliases import resolve_profile
+from vllm_mlx.routes import models as models_route
+
+ROOT = Path(__file__).resolve().parents[1]
+EMBEDDING_ALIASES = ("embeddinggemma-300m-6bit", "embeddinggemma-300m-8bit")
+
+
+@pytest.mark.parametrize("alias", EMBEDDING_ALIASES)
+def test_embedding_aliases_carry_the_embedding_modality(alias):
+    profile = resolve_profile(alias)
+    assert profile is not None
+    assert profile.modality == "embedding"
+    assert profile.supports_image_input is False
+
+
+def test_legacy_projection_gives_embedding_aliases_their_own_task():
+    snapshot = build_legacy_catalog_snapshot()
+    ContractValidator().validate_catalog_snapshot(snapshot)
+    aliases = {item["alias"]: item for item in snapshot["aliases"]}
+    for alias in EMBEDDING_ALIASES:
+        capabilities = aliases[alias]["capabilities"]
+        assert capabilities["task_types"] == ["embedding"]
+        assert capabilities["operation_modes"] == ["embed"]
+        assert capabilities["runtime_adapter"] == "mlx_embeddings"
+    # The chat vocabulary is untouched for a real chat alias.
+    assert aliases["qwen3.5-4b-4bit"]["capabilities"]["task_types"] == [
+        "text_generation"
+    ]
+
+
+def test_embedding_task_only_pairs_with_the_embed_operation():
+    assert _TASK_OPERATIONS["embedding"] == {"embed"}
+    snapshot = build_legacy_catalog_snapshot()
+    alias = next(a for a in snapshot["aliases"] if a["alias"] == EMBEDDING_ALIASES[0])
+    alias["capabilities"]["operation_modes"] = ["chat"]
+    with pytest.raises(CatalogValidationError):
+        ContractValidator().validate_catalog_snapshot(snapshot)
+
+
+def test_alias_schema_and_proto_admit_the_embedding_vocabulary():
+    for path in (
+        ROOT / "proto" / "model-catalog" / "v2" / "model-alias.schema.json",
+        ROOT / "vllm_mlx" / "catalog" / "schemas" / "model-alias.schema.json",
+    ):
+        schema = json.loads(path.read_text())
+        capabilities = schema["properties"]["capabilities"]["properties"]
+        assert "embedding" in capabilities["task_types"]["items"]["enum"]
+        assert "embed" in capabilities["operation_modes"]["items"]["enum"]
+
+
+def test_models_route_tags_embedding_alias_exclusively(monkeypatch):
+    monkeypatch.setattr(models_route, "_locked_embedding_id", lambda: None)
+    caps = models_route._detect_capabilities(
+        "mlx-community/embeddinggemma-300m-6bit", profile_modality="embedding"
+    )
+    assert caps == ["embedding"]
+    # Wire modality stays "text" (F-D01): the tag distinguishes the lane.
+    assert (
+        models_route._reported_modality(
+            "mlx-community/embeddinggemma-300m-6bit", "embedding"
+        )
+        == "text"
+    )
+
+
+def test_serve_rejects_embedding_alias_with_the_embedding_model_hint(capsys):
+    profile = SimpleNamespace(modality="embedding")
+    with pytest.raises(SystemExit) as exc_info:
+        cli._reject_embedding_alias_serve(profile, "embeddinggemma-300m-6bit")
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "sentence-embedding alias" in err
+    assert "--embedding-model embeddinggemma-300m-6bit" in err
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [None, SimpleNamespace(modality="text"), SimpleNamespace(modality="image-gen")],
+)
+def test_serve_guard_ignores_every_other_alias(profile):
+    cli._reject_embedding_alias_serve(profile, "qwen3.5-4b-4bit")

--- a/tests/test_embedding_alias_catalog_3116.py
+++ b/tests/test_embedding_alias_catalog_3116.py
@@ -97,6 +97,37 @@ def test_serve_rejects_embedding_alias_with_the_embedding_model_hint(capsys):
     assert "--embedding-model embeddinggemma-300m-6bit" in err
 
 
+def test_serve_command_exits_before_any_model_work_for_embedding_alias(
+    monkeypatch, capsys
+):
+    """codex #3128: pin the ``serve_command`` wiring, not just the helper.
+
+    Anything past the guard is a bug here, so the first post-guard step the
+    audio boot-check test also uses (the upgrade prompt) is turned into a
+    tripwire.
+    """
+    from argparse import Namespace
+
+    from vllm_mlx import _version_check
+
+    def _past_the_guard(*_a, **_kw):
+        raise AssertionError("serve_command ran past the embedding guard")
+
+    monkeypatch.setattr(_version_check, "prompt_upgrade_if_available", _past_the_guard)
+    args = Namespace(
+        model="embeddinggemma-300m-6bit",
+        embedding_model=None,
+        no_mllm=False,
+        mllm=False,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        cli.serve_command(args)
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "sentence-embedding alias" in err
+    assert "--embedding-model embeddinggemma-300m-6bit" in err
+
+
 @pytest.mark.parametrize(
     "profile",
     [None, SimpleNamespace(modality="text"), SimpleNamespace(modality="image-gen")],

--- a/tests/test_modality_field.py
+++ b/tests/test_modality_field.py
@@ -86,7 +86,7 @@ class TestModalityValidation:
         # is the trigger to do that work. ``image-gen`` joined when the
         # mflux image lane (runtime/image_lane.py) landed.
         assert (
-            frozenset({"text", "text-diffusion", "video-gen", "image-gen"})
+            frozenset({"text", "text-diffusion", "video-gen", "image-gen", "embedding"})
             == _VALID_MODALITIES
         )
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -2070,6 +2070,7 @@
   },
   "embeddinggemma-300m-6bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-6bit",
+    "modality": "embedding",
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,
@@ -2079,6 +2080,7 @@
   },
   "embeddinggemma-300m-8bit": {
     "hf_path": "mlx-community/embeddinggemma-300m-8bit",
+    "modality": "embedding",
     "tool_call_parser": null,
     "reasoning_parser": null,
     "is_hybrid": false,

--- a/vllm_mlx/catalog/legacy.py
+++ b/vllm_mlx/catalog/legacy.py
@@ -62,6 +62,11 @@ def _main_capabilities(profile: Any) -> dict[str, Any]:
             ["chat", "image_understanding"],
             "mlx_vlm",
         )
+    elif modality == "embedding":
+        # Sentence-embedding checkpoints have no chat surface; advertising
+        # ``text_generation`` here put embeddinggemma into every first-chat
+        # picker (#3116).
+        tasks, operations, adapter = ["embedding"], ["embed"], "mlx_embeddings"
     else:
         tasks, operations = ["text_generation"], ["chat"]
         if bool(getattr(profile, "supports_image_input", False)):

--- a/vllm_mlx/catalog/schemas/model-alias.schema.json
+++ b/vllm_mlx/catalog/schemas/model-alias.schema.json
@@ -36,10 +36,10 @@
       "type": "object", "additionalProperties": false,
       "required": ["task_types", "is_text_only"],
       "properties": {
-        "task_types": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["text_generation", "vision_language", "image_generation", "video_generation", "speech_synthesis", "speech_recognition"]}},
+        "task_types": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["text_generation", "vision_language", "image_generation", "video_generation", "speech_synthesis", "speech_recognition", "embedding"]}},
         "is_text_only": {"type": "boolean", "description": "Compatibility safety pin consumed by current launch policy; explicit rather than inferred from task taxonomy."},
         "generation_modes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["text_to_image", "image_to_image", "inpainting", "text_to_video", "image_to_video", "video_to_video"]}, "deprecated": true, "description": "Deprecated v1 spelling. v2 consumers accept it only as a migration fallback when operation_modes is absent."},
-        "operation_modes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["chat", "image_understanding", "text_to_image", "image_to_image", "inpainting", "text_to_video", "image_to_video", "video_to_video", "preset_voice", "voice_cloning", "voice_design", "transcription", "translation", "forced_alignment"]}},
+        "operation_modes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"enum": ["chat", "image_understanding", "text_to_image", "image_to_image", "inpainting", "text_to_video", "image_to_video", "video_to_video", "preset_voice", "voice_cloning", "voice_design", "transcription", "translation", "forced_alignment", "embed"]}},
         "runtime_adapter": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[a-z0-9][a-z0-9._/-]*$"},
         "tool_call_parser": {"type": "string", "minLength": 1, "maxLength": 64},
         "reasoning_parser": {"type": "string", "minLength": 1, "maxLength": 64},

--- a/vllm_mlx/catalog/validation.py
+++ b/vllm_mlx/catalog/validation.py
@@ -32,6 +32,7 @@ _TASK_OPERATIONS = {
     "video_generation": {"text_to_video", "image_to_video", "video_to_video"},
     "speech_synthesis": {"preset_voice", "voice_cloning", "voice_design"},
     "speech_recognition": {"transcription", "translation", "forced_alignment"},
+    "embedding": {"embed"},
 }
 
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3034,6 +3034,25 @@ def _needs_bounded_trim_free_reuse(
     return is_deepseek_v4_0731(model_name)
 
 
+def _reject_embedding_alias_serve(profile, model_name: str) -> None:
+    """Exit 2 when ``serve`` is pointed at a sentence-embedding alias.
+
+    embeddinggemma has no chat surface; loading it on the text lane boots a
+    server whose every chat request fails. Point the operator at
+    ``--embedding-model``, which is how the engine actually serves it (#3116).
+    """
+    if profile is None or getattr(profile, "modality", "text") != "embedding":
+        return
+    print(
+        f"error: '{model_name}' is a sentence-embedding alias and has no chat "
+        "surface, so it cannot be served as the main model.\n"
+        "Serve a chat model and attach it as the embeddings backend instead:\n"
+        f"    rapid-mlx serve <chat-alias> --embedding-model {model_name}",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
 def _serve_will_run_on_mllm_lane(args) -> bool:
     """Whether ``serve`` will actually run this model on the MLLM/VLM
     continuous-batching lane — the ONLY lane that needs the optional
@@ -3242,6 +3261,9 @@ def serve_command(args):
         getattr(args, "_original_alias", None) or getattr(args, "model", "")
     )
     _is_wan_video = False
+    _reject_embedding_alias_serve(
+        _serve_profile, getattr(args, "_original_alias", None) or args.model
+    )
     from ._download_gate import IMAGE_MODEL_DATA_FILES
 
     _owns_pinned_image_download = bool(

--- a/vllm_mlx/model_aliases.py
+++ b/vllm_mlx/model_aliases.py
@@ -36,7 +36,7 @@ from .model_profile import (
 # loud right now — otherwise an aliases.json typo would pass schema validation
 # and crash at request time with an unrouted lane (pr_validate codex r13 NIT).
 _VALID_MODALITIES: frozenset[str] = frozenset(
-    {"text", "text-diffusion", "video-gen", "image-gen"}
+    {"text", "text-diffusion", "video-gen", "image-gen", "embedding"}
 )
 _RESERVED_MODALITIES: frozenset[str] = frozenset({"vision"})
 

--- a/vllm_mlx/model_profile.py
+++ b/vllm_mlx/model_profile.py
@@ -55,7 +55,12 @@ from typing import Literal, get_args
 # Adding a new value requires editing this Literal AND the dispatch table
 # in cli.py / routes/models.py so the surface-level UX (info, ls, chat)
 # doesn't silently expose LLM-only columns on a non-LLM alias.
-Modality = Literal["text", "text-diffusion", "vision", "image-gen", "video-gen"]
+# ``"embedding"`` marks a sentence-embedding checkpoint (embeddinggemma):
+# it is served through ``--embedding-model`` and never has a chat surface,
+# so catalogs must not advertise it as a text-generation model (#3116).
+Modality = Literal[
+    "text", "text-diffusion", "vision", "image-gen", "video-gen", "embedding"
+]
 VideoGenerationMode = Literal["text-to-video", "image-to-video"]
 VIDEO_GENERATION_MODES: tuple[VideoGenerationMode, ...] = get_args(VideoGenerationMode)
 

--- a/vllm_mlx/routes/models.py
+++ b/vllm_mlx/routes/models.py
@@ -466,6 +466,10 @@ def _reported_modality(
     bypass the detector entirely so existing dispatched lanes still
     advertise their canonical value.
     """
+    if profile_modality == "embedding":
+        # Embedding models accept text input; the ``"embedding"`` capability
+        # tag is what distinguishes the lane on the wire (F-D01).
+        return _reported_modality_for_embedding()
     if profile_modality != "text":
         return profile_modality
     if is_text_only:
@@ -665,6 +669,11 @@ def _detect_capabilities(
         # ``"embedding"`` exclusively. Combining it with ``"text"``
         # would mislead clients into routing chat traffic at the
         # embedding model id — the chat surface is not wired.
+        return ["embedding"]
+
+    if profile_modality == "embedding":
+        # Curated embedding alias (embeddinggemma): same exclusive tag as the
+        # locked ``--embedding-model`` entry — no chat surface (#3116).
         return ["embedding"]
 
     if profile_modality == "video-gen":


### PR DESCRIPTION
## Summary
0.13.5 pre-release dogfood (#3116) found two things on quickstart step 2: the heading said "One is already here." above six cached rows, and `embeddinggemma-300m-6bit` (embeddings-only) was offered as a first chat model "ready to start".

The root cause of the second one is in the engine: the atomic catalog had no vocabulary for sentence-embedding checkpoints, so `_main_capabilities` projected embeddinggemma as `text_generation`/`chat` and every chat-capable filter (`supports(.chat)`, Community Benchmark picker) let it through.

**Engine**
- New `modality: "embedding"` (`ModelProfile.Modality`, `_VALID_MODALITIES`), set on both `embeddinggemma-300m-*` aliases.
- Legacy projection emits `task_types: ["embedding"]`, `operation_modes: ["embed"]`, `runtime_adapter: "mlx_embeddings"`; `_TASK_OPERATIONS` and the model-alias schema (proto v2 + packaged copy, exact-copy test still green) admit the pair.
- `/v1/models`: the curated alias is tagged `["embedding"]` exclusively (same as the locked `--embedding-model` entry) and reports wire modality `text` per F-D01.
- `rapid-mlx serve embeddinggemma-300m-6bit` now exits 2 with `rapid-mlx serve <chat-alias> --embedding-model embeddinggemma-300m-6bit` instead of booting a chat server that cannot answer.

**Desktop**
- `ModelTask.embedding` / `ModelOperation.embed`: the atomic envelope stays valid (no silent fallback to the legacy projection, which would file it under Chat again) and an embeddings-only row is skipped because Desktop has no embeddings surface. Unknown tasks still fail closed.
- Quickstart `SelectionNarrative.alreadyHere(cachedCount:)`: "Six are already here." / "these models … Picking one of them" when several cached rows are shown; a single row keeps the original copy verbatim.

## Test plan
- `tests/test_embedding_alias_catalog_3116.py` (10): profile modality, legacy projection + `ContractValidator`, task/operation mismatch rejected, schema enums, `/v1/models` tag + wire modality, serve guard exit 2 with hint, guard ignores other aliases.
- `test_atomic_model_catalog.py`, `test_modality_field.py`, `test_audio_boot_check.py`, `test_request_time_alias_resolution.py`, `test_speculative_request_policy.py` + `-k "catalog or modality or embedding or models_route"` (574 passed locally).
- Swift: `AtomicModelCatalogTests` (embedding row parsed and omitted; `embedding`+`chat` rejected), `OnboardingDirectionDTests` (new "Several cached rows are counted" test), quickstart/cached-model suites: 123 passed. Full `swift test` on this Studio: the only failures are wall-clock/subprocess timing suites (SSEDeltaCoalescer, gh-star timeout, golden journeys) under heavy shared GPU/CPU load, untouched by this diff — CI desktop-tests is authoritative.
- Manual: `python -m vllm_mlx.cli serve embeddinggemma-300m-6bit` exits in under a second with the hint; `models --json` shows `task_types: ["embedding"]` for both aliases and `text_generation` for chat aliases.

Closes #3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)