### PR TITLE
feat(service): harden Always-on Rapid Engine lifecycle

### DIFF
--- a/.agents/handoffs/atlas-always-on-p0.md
+++ b/.agents/handoffs/atlas-always-on-p0.md
@@ -1,0 +1,57 @@
+# Atlas handoff: Always-on service P0
+
+- **Owner:** Atlas
+- **Branch:** `atlas/always-on-p0`
+- **Base:** `origin/main` at `b915cadf`
+- **Host:** local Apple silicon Mac
+- **Scope:** reliable system-service configuration, credentials, bounded logs,
+  diagnostics, and upgrade rollback
+
+## Implemented facts
+
+- LaunchDaemon definitions now invoke a stable `service run --config` entry
+  point instead of embedding model/runtime flags.
+- Active, pending, and previous JSON definitions live outside the replaceable
+  venv under root-owned system Application Support. They are schema-validated,
+  atomically replaced, and forbidden from containing API-key flags.
+- `service configure` stages without disrupting the active engine;
+  `service apply` promotes only after validation and restores the prior config
+  and service when bootstrap/readiness fails.
+- `service credential` reads keys only from stdin into a service-owned 0600
+  non-symlink file. The runtime injects the key via environment immediately
+  before spawning the server; status/config never reveal its value.
+- The runtime supervises the server, forwards termination signals, and bounds
+  stdout/stderr by size, backup count, and age.
+- `service upgrade` snapshots the installed environment, upgrades as the
+  service account, gates acceptance on launchd `/readyz`, and restores the
+  snapshot on failure.
+- Status reports config digest/error/pending state, credential presence,
+  launchd state/run count, and suspected startup failure loops.
+
+## Verification
+
+- `ruff check`: pass
+- focused mypy with skipped external imports: 14 service modules, pass
+- service/config/assets tests: 142 passed
+- wider CLI selection: 166 passed; two environment-only failures remain
+  (subprocess argcomplete returned no aliases and local Python lacks pydantic).
+
+## Remaining work
+
+- Run the real install/configure/apply/credential/upgrade/reboot matrix on a
+  sacrificial supported Mac before merge; unit tests never mutate launchd.
+- Connect service config into the planned global `EffectiveRuntimeConfig`
+  provenance DTO when that migration begins.
+- Empty-engine boot, request-driven model loading, and automatic memory-pressure
+  budgets belong to the adaptive multi-model residency milestone, not this
+  lifecycle patch.
+- Release-directory/symlink upgrades could reduce downtime further; this P0
+  uses the documented in-place environment snapshot because it preserves the
+  existing installer contract.
+
+## Rollback
+
+Legacy argv-in-plist installations remain readable by status/restart. Rolling
+the code back after installing a config-backed plist requires
+uninstall/reinstall with the older CLI; models, caches, credentials, and logs
+are intentionally preserved.

--- a/docs/engineering/decisions/2026-09-05-always-on-service-configuration.md
+++ b/docs/engineering/decisions/2026-09-05-always-on-service-configuration.md
@@ -1,0 +1,60 @@
+# Always-on service configuration and transactional apply
+
+- **Status:** Accepted for implementation
+- **Owner:** Atlas
+- **Date:** 2026-09-05
+
+## Context
+
+The first `rapid-mlx service` release encoded its model, bind, and runtime flags
+directly in a root-owned LaunchDaemon plist. A change required
+uninstall/install, while overwriting the plist without re-bootstrap created
+split-brain between the file and launchd's in-memory job. Secrets were correctly
+refused but there was no supported authenticated headless deployment.
+
+oMLX demonstrates the usability value of persisted settings, but its reported
+stale-restart and invalid-setting crash-loop failures show that persistence
+without a validation and activation boundary is insufficient. vLLM and SGLang
+reinforce that readiness, metrics, and explicit effective launch parameters are
+part of the production contract rather than UI-only state.
+
+## Decision
+
+The plist is a stable bootstrap definition. It invokes
+`rapid-mlx service run --config <absolute path>` and contains neither model
+settings nor credentials. The config is versioned JSON, atomically written
+under system Application Support, root-owned, and non-writable to other users.
+It remains readable for unprivileged status diagnostics and deliberately lives
+outside the replaceable Python virtual environment.
+
+Configuration changes use two phases:
+
+1. `service configure` validates and writes a pending candidate.
+2. `service apply` saves the active definition, stops the job, promotes the
+   candidate, bootstraps it, and gates success on `/readyz`. Any failure restores
+   and starts the previous definition.
+
+An optional API key lives in a separate mode-0600 non-symlink credential file.
+The runtime launcher reads it immediately before `execve` and exposes it only as
+`RAPID_MLX_API_KEY` to the server process. Config and status surfaces reveal
+only whether a credential exists.
+
+## Consequences
+
+- Normal model, bind, and serve-flag changes do not rewrite privileged launchd
+  state and cannot silently take effect only after reboot.
+- Invalid candidates never disturb the active service; unhealthy candidates
+  have a deterministic rollback target.
+- The service-level schema is deliberately narrower than the planned global
+  `EffectiveRuntimeConfig`. A later adapter should feed this source into that
+  resolver rather than create competing precedence rules.
+- Service-account and executable changes remain uninstall/install operations.
+- The stable runtime supervises the server process and bounds stdout/stderr by
+  size, backup count, and age. Release-directory upgrades remain separate
+  operational work and should not be hidden inside this config transaction.
+
+## Rollback
+
+The prior argv-in-plist form remains readable by status/restart for installed
+legacy services. Code rollback requires uninstall/install because an older CLI
+does not implement the stable `service run` entry point.

--- a/docs/engineering/decisions/README.md
+++ b/docs/engineering/decisions/README.md
@@ -7,6 +7,7 @@ alternatives considered, consequences, owner, and date.
 
 | Date | Decision | Status |
 | --- | --- | --- |
+| 2026-09-05 | [Always-on service configuration and transactional apply](2026-09-05-always-on-service-configuration.md) | Accepted for implementation |
 | 2026-08-22 | [Model management and performance decision SSOT](2026-08-22-model-management-performance-ssot.md) | Accepted direction; incremental rollout |
 | 2026-08-31 | [Community benchmark wire contract v1](2026-08-31-community-benchmark-wire-contract.md) | Accepted contract |
 | 2026-08-31 | [Community Benchmark local workspace](2026-08-31-community-benchmark-local-workspace.md) | Internal beta |

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -40,12 +40,48 @@ rapid-mlx service install --service-user serveuser \
 
 Pass advanced non-secret server options after a `--` separator, for example
 `-- --max-num-seqs 4`. Use the service command's own `--host` and `--port`
-options for binding; secret-bearing flags are intentionally rejected.
+options for binding; secret-bearing flags are intentionally rejected. The
+installed plist contains only a stable `service run --config ...` invocation.
+The versioned, root-owned JSON definition under
+`/Library/Application Support/Rapid-MLX/Services/` is the effective source of
+truth. It is readable for diagnostics but not writable without root and is
+strictly validated to exclude secrets. Keeping it outside the Python runtime
+also lets a venv rebuild leave service configuration untouched.
 
-Changing an installed definition is explicit: run `service uninstall`, then
-`service install` with the new settings. Uninstalling preserves models, cache,
-and logs. The installer refuses to overwrite an existing plist because launchd
-would otherwise keep the old in-memory configuration until reboot.
+Change an installed definition as a two-step transaction. `configure` validates
+and stages a candidate but does not disturb the running server. `apply` swaps
+the candidate into place, restarts, and requires `/readyz`; if bootstrap or
+readiness fails it restores the previous config and service.
+
+An installation created by the original argv-in-plist service release has no
+versioned config yet. Migrate it once with `service uninstall` followed by
+`service install`; this preserves its models, caches, credentials, and logs.
+
+```bash
+sudo rapid-mlx service configure \
+  --model qwen3.5-9b-4bit --port 9000 -- --max-num-seqs 8
+sudo rapid-mlx service apply --dry-run
+sudo rapid-mlx service apply
+rapid-mlx service config
+```
+
+To clear advanced serve flags, use `service configure --clear-serve-args`.
+Changing the service account or executable still requires uninstall/install,
+because those are security boundaries rather than runtime preferences.
+
+For API authentication, send the key over stdin to a private credential file.
+It never appears in argv, the plist, shell history, `service config`, or status:
+
+```bash
+security find-generic-password -w -s rapid-mlx-api-key | \
+  sudo rapid-mlx service credential set
+sudo rapid-mlx service restart
+rapid-mlx service credential status
+```
+
+Use `sudo rapid-mlx service credential unset` followed by restart to disable
+authentication. The service refuses to start if the credential is a symlink,
+owned by another uid, or accessible by group/others.
 
 Day-to-day operations:
 
@@ -56,6 +92,25 @@ rapid-mlx service logs                   # tail daemon logs
 rapid-mlx service logs --follow          # stream, across KeepAlive restarts
 sudo rapid-mlx service restart           # kickstart + wait until healthy
 ```
+
+The stable runtime captures server stdout and stderr through bounded rotating
+logs. Defaults are 100 MiB per active stream, five backups, and seven-day
+retention. Stage different limits with `service configure --log-max-mb`,
+`--log-backup-count`, and `--log-retention-days`, then apply them normally.
+
+Upgrade the service with the same health gate and rollback behavior. The
+command freezes the working environment before stopping the server, runs the
+package upgrade as the service account, diagnoses it with `doctor`, and only
+accepts it after launchd `/readyz` succeeds. On failure it restores the frozen
+environment and starts the previous service.
+
+```bash
+sudo rapid-mlx service upgrade --dry-run
+sudo rapid-mlx service upgrade --version 0.13.5 --extras vision,embeddings
+```
+
+Declaring extras reasserts the appliance's intended optional features. The
+rollback requirements snapshot is mode 0600 under the service config directory.
 
 Remove the service (models, cache, and logs are left in place):
 
@@ -328,10 +383,10 @@ environment, or logs.
 ## Known limits
 
 - `rapid-mlx service` requires a pre-existing non-administrator service
-  account and an administrator to run `install`/`uninstall`; it does not
-  create system users or rotate logs automatically.
-- Rapid-MLX does not rotate the two log files. Configure your existing log
-  collector or rotation policy and monitor free disk space.
+  account and an administrator to run mutating commands; it does not create
+  system users.
+- Runtime stdout/stderr are bounded automatically, but an external collector is
+  still recommended for durable centralized history and alerting.
 - A full application update causes downtime while the daemon is booted out.
 - FileVault-protected cold boots require an unlock before the system can reach
   the state in which this daemon runs.

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -133,6 +133,31 @@ def test_service_macos_guard():
         sys.platform = real_platform
 
 
+@pytest.mark.parametrize(
+    ("verb", "module_name", "handler_name"),
+    [
+        ("configure", "configure", "configure_command"),
+        ("apply", "configure", "apply_command"),
+        ("config", "configure", "config_show_command"),
+        ("credential", "configure", "credential_command"),
+        ("run", "runtime", "run_command"),
+        ("upgrade", "upgrade", "upgrade_command"),
+    ],
+)
+def test_new_service_verbs_dispatch(monkeypatch, verb, module_name, handler_name):
+    import importlib
+
+    import vllm_mlx.headless_service.cli as svc_cli
+
+    module = importlib.import_module(f"vllm_mlx.headless_service.{module_name}")
+    called = []
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(module, handler_name, lambda args: called.append(args) or 0)
+    args = types.SimpleNamespace(service_command=verb, label=None)
+    svc_cli.service_command(args)
+    assert called == [args]
+
+
 # ---------------------------------------------------------------------------
 # Service-account validation (monkeypatched account DB).
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -218,6 +218,14 @@ def _valid_user_monkeypatch(monkeypatch):
         "home_for_user",
         staticmethod(lambda u: Path("/Users/serveuser") if u == "serveuser" else None),
     )
+    # Existing install transaction tests exercise launchd/plist rollback, not
+    # account-owned config persistence. Keep their fake /Users path hermetic;
+    # dedicated config tests below cover the atomic writer itself.
+    monkeypatch.setattr(
+        ins_mod,
+        "_install_service_config",
+        staticmethod(lambda **_kwargs: None),
+    )
     # validate_service_account requires the service-user binary to exist.
     monkeypatch.setattr(
         ins_mod,
@@ -821,12 +829,16 @@ def test_kickstart_status_subprocess_error(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _fake_launchctl_print(pid=None, last_exit=None):
+def _fake_launchctl_print(pid=None, last_exit=None, state=None, runs=None):
     lines = ["com.rapidmlx.server = {", "    active count = 1"]
     if pid is not None:
         lines.append(f"    pid = {pid}")
     if last_exit is not None:
         lines.append(f"    last exit code = {last_exit}")
+    if state is not None:
+        lines.append(f"    state = {state}")
+    if runs is not None:
+        lines.append(f"    runs = {runs}")
     lines.append("}")
     return "\n".join(lines)
 
@@ -840,6 +852,10 @@ def test_parse_pid_and_last_exit():
     assert st._parse_pid(None) is None
     assert st._parse_pid("no pid here") is None
     assert st._parse_last_exit(None) is None
+    assert st._parse_last_exit(_fake_launchctl_print(last_exit=-9)) == -9
+    details = _fake_launchctl_print(state="running", runs=3)
+    assert st._parse_launchd_field(details, "state") == "running"
+    assert st._parse_launchd_field(details, "runs") == "3"
 
 
 def test_collect_status_full_branch(monkeypatch, plist_kwargs, tmp_path):

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import stat
+import types
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.cli import build_parser
+from vllm_mlx.headless_service.config import (
+    SCHEMA_VERSION,
+    ServiceConfig,
+    ServiceConfigError,
+    assert_private_file,
+    atomic_write,
+    config_bytes,
+    config_digest,
+    load_config,
+    pending_config_path,
+)
+from vllm_mlx.headless_service.plist import build_plist_dict
+
+
+def _config(**updates) -> ServiceConfig:
+    values = {
+        "schema_version": SCHEMA_VERSION,
+        "label": "com.rapidmlx.server",
+        "service_user": "serveuser",
+        "executable": "/Users/serveuser/.local/bin/rapid-mlx",
+        "model": "qwen3.5-4b-4bit",
+        "host": "127.0.0.1",
+        "port": 8000,
+        "serve_args": ("--max-num-seqs", "4"),
+    }
+    values.update(updates)
+    return ServiceConfig(**values).validated()
+
+
+def test_service_config_round_trip_and_digest(tmp_path):
+    path = tmp_path / "service.json"
+    config = _config()
+    atomic_write(path, (json.dumps(config.to_dict()) + "\n").encode())
+    loaded = load_config(path)
+    assert loaded == config
+    assert config_digest(loaded) == config_digest(config)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"schema_version": 999}, "unsupported"),
+        ({"port": 0}, "port"),
+        ({"executable": "rapid-mlx"}, "absolute"),
+        ({"serve_args": ("--api-key=leak",)}, "API key"),
+        ({"log_retention_days": 0}, "at least 1"),
+    ],
+)
+def test_service_config_rejects_unsafe_values(updates, message):
+    with pytest.raises(ServiceConfigError, match=message):
+        _config(**updates)
+
+
+def test_service_config_rejects_unknown_fields():
+    raw = _config().to_dict()
+    raw["typo_port"] = 9000
+    with pytest.raises(ServiceConfigError, match="unknown"):
+        ServiceConfig.from_dict(raw)
+
+
+def test_service_config_rejects_string_serve_args():
+    raw = _config().to_dict()
+    raw["serve_args"] = "--max-num-seqs 4"
+    with pytest.raises(ServiceConfigError, match="array of strings"):
+        ServiceConfig.from_dict(raw)
+
+
+def test_atomic_write_replaces_whole_file(tmp_path):
+    path = tmp_path / "config.json"
+    atomic_write(path, b"old\n")
+    atomic_write(path, b"new\n")
+    assert path.read_bytes() == b"new\n"
+    assert not list(tmp_path.glob(".config.json.*"))
+
+
+def test_private_file_guard(tmp_path):
+    path = tmp_path / "credential"
+    path.write_text("secret\n")
+    path.chmod(0o600)
+    assert_private_file(path, expected_uid=os.getuid())
+    path.chmod(0o640)
+    with pytest.raises(ServiceConfigError, match="group or others"):
+        assert_private_file(path)
+
+
+def test_config_backed_plist_contains_no_model_flags_or_secret(tmp_path):
+    config_path = tmp_path / "service.json"
+    plist = build_plist_dict(
+        label="com.rapidmlx.server",
+        user="serveuser",
+        executable="/Users/serveuser/.local/bin/rapid-mlx",
+        model="qwen3.5-4b-4bit",
+        home=Path("/Users/serveuser"),
+        log_dir=Path("/Users/serveuser/Library/Logs/Rapid-MLX"),
+        config_path=config_path,
+    )
+    assert plist["ProgramArguments"] == [
+        "/Users/serveuser/.local/bin/rapid-mlx",
+        "service",
+        "run",
+        "--config",
+        str(config_path),
+    ]
+    serialized = repr(plist)
+    assert "qwen3.5-4b-4bit" not in serialized
+    assert "RAPID_MLX_API_KEY" not in serialized
+
+
+def test_configure_cli_parses_candidate_fields():
+    args = build_parser().parse_args(
+        [
+            "service",
+            "configure",
+            "--model",
+            "mlx-community/new-model",
+            "--port",
+            "9000",
+            "--",
+            "--max-num-seqs",
+            "8",
+        ]
+    )
+    assert args.model == "mlx-community/new-model"
+    assert args.port == 9000
+    assert args.serve_args == ["--", "--max-num-seqs", "8"]
+
+
+def test_runtime_loads_private_credential_and_supervises(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import runtime
+
+    credential = tmp_path / "api-key"
+    credential.write_text("sk-test\n")
+    credential.chmod(0o600)
+    config = _config(
+        service_user="runner",
+        executable="/opt/rapid-mlx",
+        credential_file=str(credential),
+    )
+    config_file = tmp_path / "service.json"
+    atomic_write(config_file, (json.dumps(config.to_dict()) + "\n").encode())
+    monkeypatch.setattr(
+        runtime.pwd,
+        "getpwnam",
+        lambda _user: types.SimpleNamespace(pw_uid=os.getuid()),
+    )
+    observed = {}
+
+    def fake_supervise(argv, env, runtime_config):
+        observed.update(argv=argv, env=env, config=runtime_config)
+        return 23
+
+    monkeypatch.setattr(runtime, "_supervise", fake_supervise)
+    assert runtime.run_command(types.SimpleNamespace(config=str(config_file))) == 23
+    assert observed["argv"][-2:] == ["--max-num-seqs", "4"]
+    assert observed["env"]["RAPID_MLX_API_KEY"] == "sk-test"
+
+
+def test_rotating_log_bounds_backups(tmp_path):
+    from vllm_mlx.headless_service.rotating_logs import RotatingLog
+
+    path = tmp_path / "server.stdout.log"
+    sink = RotatingLog(path, max_bytes=8, backup_count=2, retention_days=7)
+    for payload in (b"12345678", b"abcdefgh", b"ABCDEFGH", b"87654321"):
+        sink.write(payload)
+    sink.close()
+    assert path.read_bytes() == b"87654321"
+    backups = list(tmp_path.glob("server.stdout.log.*"))
+    assert len(backups) <= 2
+    assert all(item.stat().st_size == 8 for item in backups)
+
+
+def test_runtime_refuses_world_readable_credential(monkeypatch, tmp_path, capsys):
+    from vllm_mlx.headless_service import runtime
+
+    credential = tmp_path / "api-key"
+    credential.write_text("sk-test\n")
+    credential.chmod(0o644)
+    config = _config(service_user="runner", credential_file=str(credential))
+    config_file = tmp_path / "service.json"
+    atomic_write(config_file, (json.dumps(config.to_dict()) + "\n").encode())
+    monkeypatch.setattr(
+        runtime.pwd,
+        "getpwnam",
+        lambda _user: types.SimpleNamespace(pw_uid=os.getuid()),
+    )
+    assert runtime.run_command(types.SimpleNamespace(config=str(config_file))) == 78
+    assert "group or others" in capsys.readouterr().err
+
+
+def _installed_config(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import config as config_module
+    from vllm_mlx.headless_service import configure
+
+    home = tmp_path / "home"
+    monkeypatch.setattr(
+        config_module, "SERVICE_CONFIG_ROOT", tmp_path / "system-config"
+    )
+    current_path = config_module.config_path(home)
+    current = _config(service_user="runner")
+    atomic_write(current_path, config_bytes(current))
+    monkeypatch.setattr(
+        configure,
+        "installed_identity",
+        lambda _label: ("runner", home, current_path),
+    )
+    monkeypatch.setattr(
+        configure,
+        "_account",
+        lambda _user: types.SimpleNamespace(pw_uid=os.getuid(), pw_gid=os.getgid()),
+    )
+    return configure, home, current_path, current
+
+
+def test_configure_stages_without_touching_active(monkeypatch, tmp_path):
+    configure, home, current_path, current = _installed_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    args = types.SimpleNamespace(
+        label=None,
+        dry_run=False,
+        model="new-model",
+        host=None,
+        port=9000,
+        log_retention_days=None,
+        log_max_mb=None,
+        log_backup_count=None,
+        clear_serve_args=False,
+        serve_args=["--", "--max-num-seqs", "8"],
+    )
+    assert configure.configure_command(args) == 0
+    assert load_config(current_path) == current
+    candidate = load_config(pending_config_path(home))
+    assert candidate.model == "new-model"
+    assert candidate.port == 9000
+    assert candidate.serve_args == ("--max-num-seqs", "8")
+
+
+def test_apply_promotes_healthy_candidate(monkeypatch, tmp_path):
+    configure, home, current_path, _ = _installed_config(monkeypatch, tmp_path)
+    pending = pending_config_path(home)
+    candidate = _config(service_user="runner", model="new-model", port=9000)
+    atomic_write(pending, config_bytes(candidate))
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    monkeypatch.setattr(configure, "_port_busy", lambda _host, _port: False)
+    monkeypatch.setattr(configure, "_bootout", lambda _label: None)
+    monkeypatch.setattr(
+        configure,
+        "_bootstrap",
+        lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(configure, "_wait_ready", lambda _host, _port: True)
+    assert (
+        configure.apply_command(types.SimpleNamespace(label=None, dry_run=False)) == 0
+    )
+    assert load_config(current_path) == candidate
+    assert not pending.exists()
+
+
+def test_apply_restores_previous_config_when_candidate_is_unhealthy(
+    monkeypatch, tmp_path, capsys
+):
+    configure, home, current_path, current = _installed_config(monkeypatch, tmp_path)
+    candidate = _config(service_user="runner", model="bad-model", port=9000)
+    atomic_write(pending_config_path(home), config_bytes(candidate))
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    monkeypatch.setattr(configure, "_port_busy", lambda _host, _port: False)
+    monkeypatch.setattr(configure, "_bootout", lambda _label: None)
+    boot_count = 0
+
+    def bootstrap(_label):
+        nonlocal boot_count
+        boot_count += 1
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(configure, "_bootstrap", bootstrap)
+    monkeypatch.setattr(
+        configure,
+        "_wait_ready",
+        lambda _host, port: port == current.port,
+    )
+    assert (
+        configure.apply_command(types.SimpleNamespace(label=None, dry_run=False)) == 2
+    )
+    assert load_config(current_path) == current
+    assert boot_count == 2
+    assert "previous service restored" in capsys.readouterr().err
+
+
+def test_credential_set_never_prints_secret(monkeypatch, tmp_path, capsys):
+    configure, home, _, _ = _installed_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    monkeypatch.setattr(configure.sys, "stdin", io.StringIO("sk-sensitive\n"))
+    args = types.SimpleNamespace(
+        label=None,
+        credential_command="set",
+    )
+    assert configure.credential_command(args) == 0
+    captured = capsys.readouterr()
+    assert "sk-sensitive" not in captured.out + captured.err
+    path = home / ".rapid-mlx-secrets" / "com.rapidmlx.server.credential"
+    assert path.read_text() == "sk-sensitive\n"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+
+
+@pytest.mark.parametrize(
+    ("version", "extras", "expected"),
+    [
+        (None, None, "rapid-mlx"),
+        ("0.13.5", "vision,embeddings", "rapid-mlx[vision,embeddings]==0.13.5"),
+    ],
+)
+def test_upgrade_target_is_constrained(version, extras, expected):
+    from vllm_mlx.headless_service.upgrade import _target
+
+    assert _target(version, extras) == expected
+    with pytest.raises(ServiceConfigError):
+        _target("1.0 --index-url evil", extras)
+
+
+def test_upgrade_success_snapshots_before_mutation(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import upgrade
+
+    configure, home, _, _ = _installed_config(monkeypatch, tmp_path)
+    python = home / ".rapid-mlx" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\n")
+    python.chmod(0o700)
+    monkeypatch.setattr(upgrade, "is_root", lambda: True)
+    monkeypatch.setattr(upgrade, "_account", configure._account)
+    events = []
+
+    def as_user(_user, argv, *, timeout):
+        del timeout
+        events.append(tuple(argv))
+        if argv[-2:] == ["pip", "freeze"]:
+            return types.SimpleNamespace(
+                returncode=0, stdout="rapid-mlx==0.13.4\n", stderr=""
+            )
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(upgrade, "_as_user", as_user)
+    monkeypatch.setattr(upgrade, "_bootout", lambda _label: events.append(("bootout",)))
+    monkeypatch.setattr(
+        upgrade,
+        "_bootstrap",
+        lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(upgrade, "_wait_ready", lambda _host, _port: True)
+    args = types.SimpleNamespace(
+        label=None,
+        dry_run=False,
+        version="0.13.5",
+        extras="vision",
+        pre=False,
+    )
+    assert upgrade.upgrade_command(args) == 0
+    assert events[0][-2:] == ("pip", "freeze")
+    assert events[1] == ("bootout",)
+    assert any("rapid-mlx[vision]==0.13.5" in event for event in events)
+    snapshot = (
+        tmp_path / "system-config" / "com.rapidmlx.server.previous-requirements.txt"
+    )
+    assert snapshot.read_text() == "rapid-mlx==0.13.4\n"
+
+
+def test_upgrade_rolls_back_after_readiness_failure(monkeypatch, tmp_path, capsys):
+    from vllm_mlx.headless_service import upgrade
+
+    configure, home, _, _ = _installed_config(monkeypatch, tmp_path)
+    python = home / ".rapid-mlx" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\n")
+    python.chmod(0o700)
+    monkeypatch.setattr(upgrade, "is_root", lambda: True)
+    monkeypatch.setattr(upgrade, "_account", configure._account)
+
+    def as_user(_user, argv, *, timeout):
+        del timeout
+        stdout = "rapid-mlx==0.13.4\n" if argv[-2:] == ["pip", "freeze"] else ""
+        return types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(upgrade, "_as_user", as_user)
+    monkeypatch.setattr(upgrade, "_bootout", lambda _label: None)
+    monkeypatch.setattr(
+        upgrade,
+        "_bootstrap",
+        lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(upgrade, "_wait_ready", lambda _host, _port: False)
+    monkeypatch.setattr(upgrade, "_restore", lambda **_kwargs: True)
+    args = types.SimpleNamespace(
+        label=None,
+        dry_run=False,
+        version=None,
+        extras=None,
+        pre=False,
+    )
+    assert upgrade.upgrade_command(args) == 2
+    assert "previous environment restored" in capsys.readouterr().err

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -20,6 +20,7 @@ from vllm_mlx.headless_service.config import (
     config_digest,
     load_config,
     pending_config_path,
+    private_file_present,
 )
 from vllm_mlx.headless_service.plist import build_plist_dict
 
@@ -410,3 +411,821 @@ def test_upgrade_rolls_back_after_readiness_failure(monkeypatch, tmp_path, capsy
     )
     assert upgrade.upgrade_command(args) == 2
     assert "previous environment restored" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"service_user": "root"}, "non-root"),
+        ({"model": ""}, "model"),
+        ({"host": "bad host"}, "host"),
+        ({"log_max_mb": 0}, "at least 1"),
+        ({"log_backup_count": 0}, "at least 1"),
+        ({"serve_args": ("bad\0arg",)}, "NUL"),
+        ({"credential_file": "relative"}, "absolute"),
+    ],
+)
+def test_service_config_rejects_remaining_invalid_values(updates, message):
+    with pytest.raises(ServiceConfigError, match=message):
+        _config(**updates)
+
+
+@pytest.mark.parametrize("payload", ["[]", "{"])
+def test_load_config_rejects_invalid_json_shapes(tmp_path, payload):
+    path = tmp_path / "bad.json"
+    path.write_text(payload)
+    with pytest.raises(ServiceConfigError):
+        load_config(path)
+
+
+def test_atomic_write_owner_and_cleanup_paths(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import config as config_module
+
+    path = tmp_path / "owned"
+    ownership = []
+    monkeypatch.setattr(
+        config_module.os,
+        "fchown",
+        lambda fd, uid, gid: ownership.append((fd, uid, gid)),
+    )
+    atomic_write(path, b"ok", uid=123, gid=None)
+    assert ownership[0][1:] == (123, -1)
+
+    real_replace = config_module.os.replace
+    monkeypatch.setattr(
+        config_module.os,
+        "replace",
+        lambda *_args: (_ for _ in ()).throw(OSError("replace failed")),
+    )
+    with pytest.raises(OSError, match="replace failed"):
+        atomic_write(tmp_path / "failed", b"no")
+    assert not list(tmp_path.glob(".failed.*"))
+    monkeypatch.setattr(config_module.os, "replace", real_replace)
+
+
+def test_definition_and_secret_directory_helpers(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import config as config_module
+
+    monkeypatch.setattr(config_module, "SERVICE_CONFIG_ROOT", tmp_path / "definitions")
+    monkeypatch.setattr(config_module.os, "geteuid", lambda: 0)
+    chowns = []
+    monkeypatch.setattr(
+        config_module.os,
+        "chown",
+        lambda path, uid, gid: chowns.append((path, uid, gid)),
+    )
+    target = config_module.ensure_config_dir(tmp_path, uid=501, gid=20)
+    assert target.is_dir() and stat.S_IMODE(target.stat().st_mode) == 0o755
+    secret_dir = config_module.ensure_credential_dir(tmp_path, uid=501, gid=20)
+    assert secret_dir.is_dir() and stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
+    assert chowns == [(target, 0, 0), (secret_dir, 501, 20)]
+
+    calls = []
+    monkeypatch.setattr(
+        config_module, "atomic_write", lambda *a, **k: calls.append((a, k))
+    )
+    config_module.atomic_write_definition(tmp_path / "x", b"data")
+    assert calls[0][1]["uid"] == calls[0][1]["gid"] == 0
+
+
+def test_private_file_guards_and_presence(monkeypatch, tmp_path):
+    missing = tmp_path / "missing"
+    with pytest.raises(ServiceConfigError, match="cannot inspect"):
+        assert_private_file(missing)
+
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    with pytest.raises(ServiceConfigError, match="regular"):
+        assert_private_file(directory)
+
+    owned = tmp_path / "owned"
+    owned.write_text("secret")
+    owned.chmod(0o600)
+    with pytest.raises(ServiceConfigError, match="owned by"):
+        assert_private_file(owned, expected_uid=os.getuid() + 1)
+    assert private_file_present(owned) is True
+    assert private_file_present(missing) is False
+
+    monkeypatch.setattr(
+        Path, "stat", lambda _self: (_ for _ in ()).throw(PermissionError())
+    )
+    assert private_file_present(owned) is None
+
+
+def _configure_args(**updates):
+    values = dict(
+        label=None,
+        dry_run=False,
+        model=None,
+        host=None,
+        port=None,
+        log_retention_days=None,
+        log_max_mb=None,
+        log_backup_count=None,
+        clear_serve_args=False,
+        serve_args=None,
+    )
+    values.update(updates)
+    return types.SimpleNamespace(**values)
+
+
+def test_configure_dry_run_clear_and_error_paths(monkeypatch, tmp_path, capsys):
+    from vllm_mlx.headless_service import configure
+
+    module, _, _, _ = _installed_config(monkeypatch, tmp_path)
+    assert (
+        module.configure_command(_configure_args(dry_run=True, clear_serve_args=True))
+        == 0
+    )
+    assert '"serve_args": []' in capsys.readouterr().out
+
+    monkeypatch.setattr(module, "is_root", lambda: False)
+    assert module.configure_command(_configure_args()) == 1
+    monkeypatch.setattr(module, "is_root", lambda: True)
+    monkeypatch.setattr(
+        module,
+        "atomic_write_definition",
+        lambda *_a: (_ for _ in ()).throw(OSError("disk")),
+    )
+    assert module.configure_command(_configure_args()) == 2
+
+    monkeypatch.setattr(configure, "installed_identity", lambda _label: None)
+    assert configure.configure_command(_configure_args()) == 1
+
+
+def test_configure_launchctl_wrappers(monkeypatch):
+    from vllm_mlx.headless_service import configure
+
+    calls = []
+    monkeypatch.setattr(
+        configure.subprocess,
+        "run",
+        lambda argv, **kwargs: (
+            calls.append((argv, kwargs)) or types.SimpleNamespace(returncode=0)
+        ),
+    )
+    assert configure._bootstrap("com.rapidmlx.server").returncode == 0
+    configure._bootout("com.rapidmlx.server")
+    assert calls[0][0][1] == "bootstrap" and calls[1][0][1] == "bootout"
+
+
+def test_apply_validation_dry_run_and_nonroot(monkeypatch, tmp_path, capsys):
+    configure, home, _, current = _installed_config(monkeypatch, tmp_path)
+    pending = pending_config_path(home)
+
+    atomic_write(pending, config_bytes(current.updated(service_user="other")))
+    assert configure.apply_command(_configure_args()) == 1
+    atomic_write(pending, config_bytes(current.updated(executable="/other/rapid-mlx")))
+    assert configure.apply_command(_configure_args()) == 1
+    atomic_write(pending, config_bytes(current.updated(port=9000)))
+    monkeypatch.setattr(configure, "_port_busy", lambda *_a: True)
+    assert configure.apply_command(_configure_args()) == 1
+    monkeypatch.setattr(configure, "_port_busy", lambda *_a: False)
+    assert configure.apply_command(_configure_args(dry_run=True)) == 0
+    assert "restore previous" in capsys.readouterr().out
+    monkeypatch.setattr(configure, "is_root", lambda: False)
+    assert configure.apply_command(_configure_args()) == 1
+
+
+def test_apply_bootstrap_and_rollback_failure_paths(monkeypatch, tmp_path, capsys):
+    configure, home, current_path, current = _installed_config(monkeypatch, tmp_path)
+    atomic_write(pending_config_path(home), config_bytes(current.updated(model="next")))
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    monkeypatch.setattr(configure, "_bootout", lambda _label: None)
+    monkeypatch.setattr(
+        configure,
+        "_bootstrap",
+        lambda _label: types.SimpleNamespace(returncode=1, stdout="", stderr="boom"),
+    )
+    assert configure.apply_command(_configure_args()) == 2
+    assert "ROLLBACK FAILED" in capsys.readouterr().err
+    assert load_config(current_path) == current
+
+
+def test_config_show_and_credential_command_paths(monkeypatch, tmp_path, capsys):
+    configure, home, _, current = _installed_config(monkeypatch, tmp_path)
+    atomic_write(pending_config_path(home), config_bytes(current.updated(model="next")))
+    assert configure.config_show_command(types.SimpleNamespace(label=None)) == 0
+    assert json.loads(capsys.readouterr().out)["pending"]["model"] == "next"
+
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="status")
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["configured"] is False
+
+    monkeypatch.setattr(configure, "is_root", lambda: False)
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="unset")
+        )
+        == 1
+    )
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="unset")
+        )
+        == 0
+    )
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="bogus")
+        )
+        == 2
+    )
+
+
+@pytest.mark.parametrize("secret", ["", "one\ntwo\n"])
+def test_credential_rejects_invalid_input(monkeypatch, tmp_path, secret):
+    configure, _, _, _ = _installed_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    monkeypatch.setattr(configure.sys, "stdin", io.StringIO(secret))
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="set")
+        )
+        == 1
+    )
+
+
+def test_credential_rejects_tty_and_write_failure(monkeypatch, tmp_path):
+    configure, _, _, _ = _installed_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    tty = io.StringIO("secret\n")
+    tty.isatty = lambda: True
+    monkeypatch.setattr(configure.sys, "stdin", tty)
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="set")
+        )
+        == 1
+    )
+
+    stream = io.StringIO("secret\n")
+    monkeypatch.setattr(configure.sys, "stdin", stream)
+    monkeypatch.setattr(
+        configure,
+        "ensure_credential_dir",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk")),
+    )
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="set")
+        )
+        == 2
+    )
+
+
+def test_runtime_stream_copy_success_and_log_failure(monkeypatch, capsys):
+    from vllm_mlx.headless_service import runtime
+
+    class Source:
+        def __init__(self, chunks):
+            self.chunks = iter(chunks)
+            self.closed = False
+
+        def read(self, _size):
+            return next(self.chunks, b"")
+
+        def close(self):
+            self.closed = True
+
+    class Child:
+        terminated = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+    writes = []
+    source = Source([b"a", b""])
+    runtime._copy_stream(source, types.SimpleNamespace(write=writes.append), Child())
+    assert writes == [b"a"] and source.closed
+
+    child = Child()
+    source = Source([b"bad", b"drain", b""])
+    sink = types.SimpleNamespace(
+        write=lambda _data: (_ for _ in ()).throw(OSError("full"))
+    )
+    runtime._copy_stream(source, sink, child)
+    assert child.terminated and source.closed
+    assert "log write failed" in capsys.readouterr().err
+
+
+def test_runtime_supervisor_forwards_signals_and_closes(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import runtime
+
+    monkeypatch.setattr(runtime, "log_dir_for", lambda _user: tmp_path)
+    logs = []
+
+    class Log:
+        def __init__(self, path, **options):
+            self.path, self.options, self.closed = path, options, False
+            logs.append(self)
+
+        def write(self, _data):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    handlers = {}
+
+    def fake_signal(signum, handler):
+        previous = handlers.get(signum, f"old-{signum}")
+        handlers[signum] = handler
+        if callable(handler) and not any(
+            callable(value) for value in handlers.values() if value is not handler
+        ):
+            handler(signum, None)
+        return previous
+
+    class Pipe(io.BytesIO):
+        pass
+
+    class Child:
+        def __init__(self, *_args, **_kwargs):
+            self.stdout, self.stderr = Pipe(b"out"), Pipe(b"err")
+            self.signals = []
+
+        def poll(self):
+            return None
+
+        def send_signal(self, signum):
+            self.signals.append(signum)
+
+        def wait(self):
+            handlers[__import__("signal").SIGTERM](__import__("signal").SIGTERM, None)
+            return -15
+
+    class Thread:
+        def __init__(self, target, args, daemon):
+            del daemon
+            self.target, self.args = target, args
+
+        def start(self):
+            self.target(*self.args)
+
+        def join(self, timeout):
+            assert timeout == 5
+
+    monkeypatch.setattr(runtime, "RotatingLog", Log)
+    monkeypatch.setattr(runtime.signal, "signal", fake_signal)
+    monkeypatch.setattr(runtime.subprocess, "Popen", Child)
+    monkeypatch.setattr(runtime.threading, "Thread", Thread)
+    assert runtime._supervise(["rapid-mlx"], {}, _config(service_user="runner")) == 143
+    assert all(log.closed for log in logs)
+
+
+def test_runtime_supervisor_requires_log_home(monkeypatch):
+    from vllm_mlx.headless_service import runtime
+
+    monkeypatch.setattr(runtime, "log_dir_for", lambda _user: None)
+    with pytest.raises(ServiceConfigError, match="log directory"):
+        runtime._supervise([], {}, _config())
+
+
+@pytest.mark.parametrize("credential", [None, "bad\nvalue\n"])
+def test_runtime_rejects_uid_or_bad_credential(monkeypatch, tmp_path, credential):
+    from vllm_mlx.headless_service import runtime
+
+    path = tmp_path / "credential"
+    if credential is not None:
+        path.write_text(credential)
+        path.chmod(0o600)
+    config = _config(
+        service_user="runner", credential_file=str(path) if credential else None
+    )
+    config_file = tmp_path / "service.json"
+    atomic_write(config_file, config_bytes(config))
+    uid = os.getuid() + 1 if credential is None else os.getuid()
+    monkeypatch.setattr(
+        runtime.pwd, "getpwnam", lambda _user: types.SimpleNamespace(pw_uid=uid)
+    )
+    assert runtime.run_command(types.SimpleNamespace(config=str(config_file))) == 78
+
+
+def test_rotating_log_defensive_paths(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import rotating_logs
+
+    sink = rotating_logs.RotatingLog(
+        tmp_path / "server.log", max_bytes=8, backup_count=1, retention_days=1
+    )
+    sink.write(b"")
+    backup = tmp_path / "server.log.old"
+    backup.write_bytes(b"old")
+    os.utime(backup, (0, 0))
+    sink._purge()
+    assert not backup.exists()
+
+    class BadTell(io.BytesIO):
+        def tell(self):
+            raise OSError("unknown")
+
+    sink.path.write_bytes(b"1234")
+    sink._handle = BadTell()
+    sink.write(b"x")
+    sink.close()
+
+    real_fstat = rotating_logs.os.fstat
+    monkeypatch.setattr(
+        rotating_logs.os,
+        "fstat",
+        lambda _fd: types.SimpleNamespace(st_mode=stat.S_IFDIR),
+    )
+    with pytest.raises(OSError, match="non-regular"):
+        sink._open()
+    monkeypatch.setattr(rotating_logs.os, "fstat", real_fstat)
+
+
+@pytest.mark.parametrize(
+    ("plist", "home", "expected"),
+    [
+        ({"UserName": ""}, None, None),
+        ({"UserName": "runner"}, None, None),
+        (
+            {
+                "UserName": "runner",
+                "EnvironmentVariables": {"HOME": "/Users/runner"},
+                "ProgramArguments": ["rapid-mlx", "run", "--config", "/cfg.json"],
+            },
+            None,
+            Path("/cfg.json"),
+        ),
+    ],
+)
+def test_installed_identity_variants(monkeypatch, plist, home, expected):
+    from vllm_mlx.headless_service import definition
+
+    monkeypatch.setattr(definition, "installed_plist", lambda _label: plist)
+    monkeypatch.setattr(definition, "home_for_user", lambda _user: home)
+    result = definition.installed_identity()
+    assert (result[2] if result else None) == expected
+
+
+def test_restart_reads_config_backed_bind(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import restart
+
+    path = tmp_path / "service.json"
+    atomic_write(path, config_bytes(_config(host="0.0.0.0", port=9000)))
+    monkeypatch.setattr(
+        "vllm_mlx.headless_service.definition.installed_identity",
+        lambda _label: ("runner", tmp_path, path),
+    )
+    assert restart._declared_bind("com.rapidmlx.server") == ("0.0.0.0", 9000)
+
+
+def test_configure_remaining_error_paths(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import configure
+
+    monkeypatch.setattr(
+        configure.pwd, "getpwnam", lambda _user: (_ for _ in ()).throw(KeyError())
+    )
+    with pytest.raises(ServiceConfigError, match="no longer exists"):
+        configure._account("gone")
+
+    module, home, _, current = _installed_config(monkeypatch, tmp_path)
+    atomic_write(pending_config_path(home), config_bytes(current.updated(model="next")))
+    monkeypatch.setattr(module, "is_root", lambda: True)
+    monkeypatch.setattr(
+        module,
+        "_account",
+        lambda _user: (_ for _ in ()).throw(ServiceConfigError("gone")),
+    )
+    assert module.apply_command(_configure_args()) == 1
+
+    monkeypatch.setattr(module, "installed_identity", lambda _label: None)
+    assert module.config_show_command(types.SimpleNamespace(label=None)) == 1
+    assert (
+        module.credential_command(
+            types.SimpleNamespace(label=None, credential_command="status")
+        )
+        == 1
+    )
+
+
+def test_apply_restore_and_pending_unlink_oserrors(monkeypatch, tmp_path):
+    configure, home, current_path, current = _installed_config(monkeypatch, tmp_path)
+    pending = pending_config_path(home)
+    atomic_write(pending, config_bytes(current.updated(model="next")))
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    monkeypatch.setattr(configure, "_bootout", lambda _label: None)
+    calls = 0
+
+    def write(path, data):
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise OSError("restore disk failure")
+        atomic_write(path, data)
+
+    monkeypatch.setattr(configure, "atomic_write_definition", write)
+    monkeypatch.setattr(
+        configure,
+        "_bootstrap",
+        lambda _label: types.SimpleNamespace(returncode=1, stdout="", stderr="bad"),
+    )
+    assert configure.apply_command(_configure_args()) == 2
+
+    atomic_write(current_path, config_bytes(current))
+    atomic_write(pending, config_bytes(current.updated(model="good")))
+    monkeypatch.setattr(
+        configure,
+        "atomic_write_definition",
+        lambda path, data: atomic_write(path, data),
+    )
+    monkeypatch.setattr(
+        configure,
+        "_bootstrap",
+        lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(configure, "_wait_ready", lambda *_a: True)
+    real_unlink = Path.unlink
+    monkeypatch.setattr(
+        Path, "unlink", lambda *_a, **_k: (_ for _ in ()).throw(OSError("busy"))
+    )
+    assert configure.apply_command(_configure_args()) == 0
+    monkeypatch.setattr(Path, "unlink", real_unlink)
+
+
+def test_credential_unset_oserror(monkeypatch, tmp_path):
+    configure, _, _, _ = _installed_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    monkeypatch.setattr(
+        Path, "unlink", lambda *_a, **_k: (_ for _ in ()).throw(OSError("busy"))
+    )
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="unset")
+        )
+        == 2
+    )
+
+
+def test_install_service_config_helper(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import config as config_module
+    from vllm_mlx.headless_service import install
+
+    monkeypatch.setattr(config_module, "SERVICE_CONFIG_ROOT", tmp_path / "definitions")
+    monkeypatch.setattr(
+        "pwd.getpwnam",
+        lambda _user: types.SimpleNamespace(pw_uid=os.getuid(), pw_gid=os.getgid()),
+    )
+    path = tmp_path / "definitions" / "service.json"
+    install._install_service_config(user="runner", home=tmp_path, path=path, data=b"{}")
+    assert path.read_bytes() == b"{}"
+
+
+def test_status_config_and_human_diagnostics(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import definition, status
+
+    config_file = tmp_path / "service.json"
+    credential = tmp_path / "credential"
+    credential.write_text("secret\n")
+    credential.chmod(0o600)
+    effective = _config(
+        service_user="runner",
+        host="127.0.0.2",
+        port=9000,
+        credential_file=str(credential),
+    )
+    atomic_write(config_file, config_bytes(effective))
+    plist = {
+        "UserName": "runner",
+        "ProgramArguments": ["/bin/rapid-mlx", "run", "--config", str(config_file)],
+    }
+    print_out = "state = running\nruns = 4\nlast exit code = 7\n"
+    monkeypatch.setattr(status, "_launchctl_print", lambda _label: print_out)
+    monkeypatch.setattr(status, "_read_installed_plist", lambda _label: plist)
+    monkeypatch.setattr(
+        definition,
+        "installed_identity",
+        lambda _label: ("runner", tmp_path, config_file),
+    )
+    monkeypatch.setattr(status, "_endpoint_health", lambda *_a: (True, True))
+    monkeypatch.setattr(status, "_port_busy", lambda *_a: True)
+    data = status.collect_status()
+    assert data["config_sha256"] == config_digest(effective)
+    assert data["credential_configured"] is True
+
+    data.update(
+        pid=None,
+        crash_loop_suspected=True,
+        config_error="bad config",
+        pending_config=True,
+        credential_configured=None,
+        log_dir=str(tmp_path),
+    )
+    rendered = status._render_human(data)
+    assert "startup failure" in rendered
+    assert "PENDING changes" in rendered
+    assert "unknown (run status with sudo)" in rendered
+
+    config_file.write_text("{")
+    broken = status.collect_status()
+    assert broken["config_error"]
+
+
+def _upgrade_fixture(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import upgrade
+
+    configure, home, _, _ = _installed_config(monkeypatch, tmp_path)
+    python = home / ".rapid-mlx" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\n")
+    python.chmod(0o700)
+    monkeypatch.setattr(upgrade, "_account", configure._account)
+    return upgrade, python
+
+
+def test_upgrade_helpers(monkeypatch, tmp_path):
+    upgrade, python = _upgrade_fixture(monkeypatch, tmp_path)
+    with pytest.raises(ServiceConfigError, match="extras"):
+        upgrade._target(None, "bad,extra!")
+    calls = []
+    monkeypatch.setattr(
+        upgrade.subprocess,
+        "run",
+        lambda argv, **kwargs: (
+            calls.append((argv, kwargs)) or types.SimpleNamespace(returncode=0)
+        ),
+    )
+    upgrade._as_user("runner", ["cmd"], timeout=7)
+    assert calls[0][0][:4] == ["/usr/bin/sudo", "-u", "runner", "-H"]
+
+    monkeypatch.setattr(upgrade, "_bootout", lambda label: calls.append((label, {})))
+    monkeypatch.setattr(
+        upgrade, "_as_user", lambda *_a, **_k: types.SimpleNamespace(returncode=1)
+    )
+    assert not upgrade._restore(
+        user="runner",
+        python=python,
+        requirements=tmp_path / "r",
+        label="label",
+        host="h",
+        port=1,
+    )
+    monkeypatch.setattr(
+        upgrade, "_as_user", lambda *_a, **_k: types.SimpleNamespace(returncode=0)
+    )
+    monkeypatch.setattr(
+        upgrade, "_bootstrap", lambda _label: types.SimpleNamespace(returncode=0)
+    )
+    monkeypatch.setattr(upgrade, "_wait_ready", lambda *_a: True)
+    assert upgrade._restore(
+        user="runner",
+        python=python,
+        requirements=tmp_path / "r",
+        label="label",
+        host="h",
+        port=1,
+    )
+
+
+def test_upgrade_preflight_failure_paths(monkeypatch, tmp_path):
+    upgrade, python = _upgrade_fixture(monkeypatch, tmp_path)
+    args = types.SimpleNamespace(
+        label=None, dry_run=False, version=None, extras=None, pre=False
+    )
+    real_identity = upgrade._identity_or_error
+    monkeypatch.setattr(
+        upgrade,
+        "_identity_or_error",
+        lambda _label: (_ for _ in ()).throw(ServiceConfigError("missing")),
+    )
+    assert upgrade.upgrade_command(args) == 1
+    monkeypatch.setattr(upgrade, "_identity_or_error", real_identity)
+
+    upgrade, python = _upgrade_fixture(monkeypatch, tmp_path / "second")
+    python.unlink()
+    assert upgrade.upgrade_command(args) == 1
+
+    upgrade, _ = _upgrade_fixture(monkeypatch, tmp_path / "third")
+    assert (
+        upgrade.upgrade_command(
+            types.SimpleNamespace(**{**vars(args), "dry_run": True})
+        )
+        == 0
+    )
+    monkeypatch.setattr(upgrade, "is_root", lambda: False)
+    assert upgrade.upgrade_command(args) == 1
+
+
+def test_upgrade_snapshot_and_install_failure_paths(monkeypatch, tmp_path, capsys):
+    upgrade, _ = _upgrade_fixture(monkeypatch, tmp_path)
+    args = types.SimpleNamespace(
+        label=None, dry_run=False, version=None, extras=None, pre=True
+    )
+    monkeypatch.setattr(upgrade, "is_root", lambda: True)
+    monkeypatch.setattr(
+        upgrade,
+        "_as_user",
+        lambda *_a, **_k: types.SimpleNamespace(
+            returncode=1, stdout="", stderr="freeze"
+        ),
+    )
+    assert upgrade.upgrade_command(args) == 2
+
+    responses = iter(
+        [
+            types.SimpleNamespace(returncode=0, stdout="pkg==1\n", stderr=""),
+            types.SimpleNamespace(returncode=1, stdout="", stderr="install"),
+        ]
+    )
+    monkeypatch.setattr(upgrade, "_as_user", lambda *_a, **_k: next(responses))
+    monkeypatch.setattr(upgrade, "_bootout", lambda _label: None)
+    monkeypatch.setattr(upgrade, "_restore", lambda **_k: False)
+    assert upgrade.upgrade_command(args) == 2
+    assert "ROLLBACK FAILED" in capsys.readouterr().err
+
+
+def test_upgrade_snapshot_write_and_doctor_warning(monkeypatch, tmp_path, capsys):
+    upgrade, _ = _upgrade_fixture(monkeypatch, tmp_path)
+    args = types.SimpleNamespace(
+        label=None, dry_run=False, version=None, extras=None, pre=False
+    )
+    monkeypatch.setattr(upgrade, "is_root", lambda: True)
+    monkeypatch.setattr(
+        upgrade,
+        "_as_user",
+        lambda *_a, **_k: types.SimpleNamespace(
+            returncode=0, stdout="pkg==1\n", stderr=""
+        ),
+    )
+    real_atomic_write = upgrade.atomic_write
+    monkeypatch.setattr(
+        upgrade,
+        "atomic_write",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk")),
+    )
+    assert upgrade.upgrade_command(args) == 2
+    monkeypatch.setattr(upgrade, "atomic_write", real_atomic_write)
+
+    upgrade, _ = _upgrade_fixture(monkeypatch, tmp_path / "doctor")
+    monkeypatch.setattr(upgrade, "is_root", lambda: True)
+    responses = iter(
+        [
+            types.SimpleNamespace(returncode=0, stdout="pkg==1\n", stderr=""),
+            types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+            types.SimpleNamespace(returncode=1, stdout="", stderr="doctor"),
+        ]
+    )
+    monkeypatch.setattr(upgrade, "_as_user", lambda *_a, **_k: next(responses))
+    monkeypatch.setattr(upgrade, "_bootout", lambda _label: None)
+    monkeypatch.setattr(
+        upgrade, "_bootstrap", lambda _label: types.SimpleNamespace(returncode=0)
+    )
+    monkeypatch.setattr(upgrade, "_wait_ready", lambda *_a: True)
+    assert upgrade.upgrade_command(args) == 0
+    assert "doctor" in capsys.readouterr().err
+
+
+def test_atomic_write_cleanup_tolerates_unlink_failure(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import config as config_module
+
+    monkeypatch.setattr(
+        config_module.os,
+        "replace",
+        lambda *_a: (_ for _ in ()).throw(OSError("replace")),
+    )
+    monkeypatch.setattr(
+        Path, "unlink", lambda *_a, **_k: (_ for _ in ()).throw(OSError("unlink"))
+    )
+    with pytest.raises(OSError, match="replace"):
+        atomic_write(tmp_path / "target", b"data")
+
+
+def test_rotating_log_purge_tolerates_filesystem_error(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service.rotating_logs import RotatingLog
+
+    sink = RotatingLog(tmp_path / "log", max_bytes=1, backup_count=1, retention_days=1)
+    backup = tmp_path / "log.old"
+    backup.write_bytes(b"old")
+    os.utime(backup, (0, 0))
+    monkeypatch.setattr(
+        Path, "unlink", lambda *_a, **_k: (_ for _ in ()).throw(OSError("busy"))
+    )
+    sink._purge()
+
+
+def test_install_rejects_invalid_generated_definition(monkeypatch):
+    from vllm_mlx.headless_service import common, install
+
+    monkeypatch.setattr(install, "validate_service_account", lambda _user: None)
+    monkeypatch.setattr(common, "home_for_user", lambda _user: Path("/Users/runner"))
+    monkeypatch.setattr(install, "resolve_executable", lambda _home: "/bin/rapid-mlx")
+    args = types.SimpleNamespace(
+        label="invalid/label",
+        model="model",
+        service_user="runner",
+        host="127.0.0.1",
+        port=8000,
+        serve_args=[],
+        dry_run=True,
+    )
+    assert install.install_command(args) == 1

--- a/vllm_mlx/headless_service/__init__.py
+++ b/vllm_mlx/headless_service/__init__.py
@@ -13,6 +13,12 @@ service) behind commands an operator can run:
 * ``rapid-mlx service logs`` — tail the daemon stdout/stderr logs.
 * ``rapid-mlx service restart`` — kickstart the daemon and wait for
   readiness.
+* ``rapid-mlx service configure/apply`` — stage and health-gate versioned
+  configuration with automatic rollback.
+* ``rapid-mlx service credential`` — store API authentication outside the
+  plist and process arguments.
+* ``rapid-mlx service upgrade`` — snapshot the Python environment and restore
+  it if the upgraded launchd service fails readiness.
 * ``rapid-mlx service uninstall`` — ``bootout`` + remove the plist
   without touching models, cache, or logs.
 

--- a/vllm_mlx/headless_service/cli.py
+++ b/vllm_mlx/headless_service/cli.py
@@ -8,18 +8,22 @@ This module exposes:
   top-level argparse tree.
 * :func:`service_command` — the argparse dispatch entry point.
 
-The subcommand has five shapes:
+The subcommand supports these lifecycle shapes:
 
 * ``rapid-mlx service install [--service-user U] [--model M] [serve options]
   [--dry-run]`` — validate + bootstrap the daemon.
 * ``rapid-mlx service status [--json]`` — launchd / pid / endpoint health.
 * ``rapid-mlx service logs [--follow] [--tail N]`` — tail daemon logs.
 * ``rapid-mlx service restart [--dry-run]`` — kickstart + wait health.
+* ``rapid-mlx service configure`` / ``apply`` — stage then atomically activate
+  a versioned definition with health-gated rollback.
+* ``rapid-mlx service credential`` — manage API auth without argv/plist leaks.
+* ``rapid-mlx service upgrade`` — snapshot, upgrade, health-gate, and rollback.
 * ``rapid-mlx service uninstall [--dry-run]`` — bootout + remove plist.
 
-``--dry-run`` is accepted on every mutating verb (install/restart/uninstall)
-so the operator can rehearse without touching the system; ``status``/``logs``
-are read-only and never take it.
+``--dry-run`` is accepted on install, configure, apply, upgrade, restart, and
+uninstall so the operator can rehearse without touching the system;
+``status``/``config``/``logs`` are read-only.
 """
 
 from __future__ import annotations
@@ -45,7 +49,8 @@ def register(subparsers) -> None:
             "Install, inspect, and remove Rapid-MLX as an unattended system "
             "launchd daemon — the supported path for an always-on Mac mini "
             "inference appliance that boots before any GUI login. "
-            "Sub-commands: install, status, logs, restart, uninstall."
+            "Sub-commands: install, configure, apply, config, credential, "
+            "upgrade, status, logs, restart, uninstall."
         ),
     )
     svc = p.add_subparsers(dest="service_command", help="Service sub-command")
@@ -123,6 +128,62 @@ def register(subparsers) -> None:
         help="Remove the launchd registration and plist (never "
         "deletes models/cache/logs without separate confirmation)",
     )
+
+    configure = svc.add_parser(
+        "configure",
+        help="Validate and stage a candidate service definition",
+    )
+    configure.add_argument("--model", default=None)
+    configure.add_argument("--host", default=None)
+    configure.add_argument("--port", type=_port_arg, default=None)
+    configure.add_argument("--log-retention-days", type=int, default=None)
+    configure.add_argument("--log-max-mb", type=int, default=None)
+    configure.add_argument("--log-backup-count", type=int, default=None)
+    configure.add_argument(
+        "--clear-serve-args",
+        action="store_true",
+        help="Remove all previously configured advanced serve options.",
+    )
+    configure.add_argument(
+        "serve_args",
+        nargs=argparse.REMAINDER,
+        help="Replacement non-secret serve flags after `--`.",
+    )
+    configure.add_argument("--dry-run", action="store_true")
+
+    apply = svc.add_parser(
+        "apply", help="Activate the staged definition with health-gated rollback"
+    )
+    apply.add_argument("--dry-run", action="store_true")
+
+    config = svc.add_parser("config", help="Show active and pending definitions")
+
+    credential = svc.add_parser(
+        "credential", help="Manage the service API key through a mode-600 file"
+    )
+    cred = credential.add_subparsers(dest="credential_command", required=True)
+    cred.add_parser("set", help="Read one API key from stdin and store it securely")
+    cred.add_parser("status", help="Report whether a credential is configured")
+    cred.add_parser("unset", help="Remove the configured API key")
+
+    upgrade = svc.add_parser(
+        "upgrade", help="Upgrade the service runtime with health-gated rollback"
+    )
+    upgrade.add_argument(
+        "--version", default=None, help="Exact Rapid-MLX version (default: latest)"
+    )
+    upgrade.add_argument(
+        "--extras",
+        default=None,
+        help="Comma-separated extras to assert, for example vision,embeddings",
+    )
+    upgrade.add_argument("--pre", action="store_true", help="Allow prereleases")
+    upgrade.add_argument("--dry-run", action="store_true")
+
+    # Internal stable entry point used by launchd. It is intentionally hidden
+    # from help: operators manage the service through the public verbs above.
+    run = svc.add_parser("run", help="Internal config-backed launchd runtime")
+    run.add_argument("--config", required=True)
     uninstall.add_argument(
         "--dry-run",
         action="store_true",
@@ -131,7 +192,19 @@ def register(subparsers) -> None:
 
     # Optional --label override is useful for multiple appliances; default
     # (com.rapidmlx.server) matches the documented contract.
-    for sub in (install, status, logs, restart, uninstall):
+    for sub in (
+        install,
+        configure,
+        apply,
+        config,
+        credential,
+        upgrade,
+        status,
+        logs,
+        restart,
+        uninstall,
+        run,
+    ):
         sub.add_argument(
             "--label",
             type=str,
@@ -210,10 +283,35 @@ def service_command(args) -> None:
         from .install import uninstall_command
 
         code = uninstall_command(args)
+    elif sub == "configure":
+        from .configure import configure_command
+
+        code = configure_command(args)
+    elif sub == "apply":
+        from .configure import apply_command
+
+        code = apply_command(args)
+    elif sub == "config":
+        from .configure import config_show_command
+
+        code = config_show_command(args)
+    elif sub == "credential":
+        from .configure import credential_command
+
+        code = credential_command(args)
+    elif sub == "run":
+        from .runtime import run_command
+
+        code = run_command(args)
+    elif sub == "upgrade":
+        from .upgrade import upgrade_command
+
+        code = upgrade_command(args)
     else:
         # argparse enforces a required service_command, so this is defensive.
         print(
-            "error: expected one of install/status/logs/restart/uninstall",
+            "error: expected one of install/status/logs/restart/uninstall "
+            "or configure/apply/config/credential",
             file=sys.stderr,
         )
         code = 2

--- a/vllm_mlx/headless_service/config.py
+++ b/vllm_mlx/headless_service/config.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Versioned, atomic configuration for the always-on macOS service.
+
+The LaunchDaemon points at a stable config path instead of embedding the
+effective ``serve`` invocation in its plist.  Operators stage a candidate with
+``service configure`` and promote it with ``service apply``.  The split keeps a
+bad edit from putting launchd into a crash loop and gives apply a known-good
+file to restore when the readiness gate fails.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from .common import DEFAULT_LABEL
+
+SCHEMA_VERSION = 1
+SERVICE_CONFIG_ROOT = Path("/Library/Application Support/Rapid-MLX/Services")
+DEFAULT_LOG_RETENTION_DAYS = 7
+DEFAULT_LOG_MAX_MB = 100
+DEFAULT_LOG_BACKUP_COUNT = 5
+
+
+class ServiceConfigError(ValueError):
+    """A persisted service definition is missing, unsafe, or invalid."""
+
+
+@dataclass(frozen=True)
+class ServiceConfig:
+    schema_version: int
+    label: str
+    service_user: str
+    executable: str
+    model: str
+    host: str = "127.0.0.1"
+    port: int = 8000
+    serve_args: tuple[str, ...] = ()
+    credential_file: str | None = None
+    log_retention_days: int = DEFAULT_LOG_RETENTION_DAYS
+    log_max_mb: int = DEFAULT_LOG_MAX_MB
+    log_backup_count: int = DEFAULT_LOG_BACKUP_COUNT
+
+    def validated(self) -> ServiceConfig:
+        from .common import validate_label
+        from .install import refuse_secret_flags
+
+        if self.schema_version != SCHEMA_VERSION:
+            raise ServiceConfigError(
+                f"unsupported service config schema {self.schema_version}; "
+                f"this Rapid-MLX supports schema {SCHEMA_VERSION}"
+            )
+        validate_label(self.label)
+        if not self.service_user or self.service_user == "root":
+            raise ServiceConfigError("service_user must be a non-root account")
+        executable = Path(self.executable)
+        if not executable.is_absolute():
+            raise ServiceConfigError("executable must be an absolute path")
+        if not self.model or "\0" in self.model:
+            raise ServiceConfigError("model must not be empty")
+        if not self.host or "\0" in self.host or any(ch.isspace() for ch in self.host):
+            raise ServiceConfigError(
+                "host must be a non-empty address without whitespace"
+            )
+        if not 1 <= self.port <= 65535:
+            raise ServiceConfigError("port must be in [1, 65535]")
+        if self.log_retention_days < 1:
+            raise ServiceConfigError("log_retention_days must be at least 1")
+        if self.log_max_mb < 1:
+            raise ServiceConfigError("log_max_mb must be at least 1")
+        if self.log_backup_count < 1:
+            raise ServiceConfigError("log_backup_count must be at least 1")
+        try:
+            refuse_secret_flags(self.serve_args)
+        except Exception as exc:
+            raise ServiceConfigError(str(exc)) from None
+        if any("\0" in token for token in self.serve_args):
+            raise ServiceConfigError("serve_args must not contain NUL bytes")
+        if self.credential_file is not None:
+            credential = Path(self.credential_file)
+            if not credential.is_absolute():
+                raise ServiceConfigError("credential_file must be an absolute path")
+        return self
+
+    def updated(self, **changes: Any) -> ServiceConfig:
+        return replace(self, **changes).validated()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "label": self.label,
+            "service_user": self.service_user,
+            "executable": self.executable,
+            "model": self.model,
+            "host": self.host,
+            "port": self.port,
+            "serve_args": list(self.serve_args),
+            "credential_file": self.credential_file,
+            "log_retention_days": self.log_retention_days,
+            "log_max_mb": self.log_max_mb,
+            "log_backup_count": self.log_backup_count,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> ServiceConfig:
+        allowed = {
+            "schema_version",
+            "label",
+            "service_user",
+            "executable",
+            "model",
+            "host",
+            "port",
+            "serve_args",
+            "credential_file",
+            "log_retention_days",
+            "log_max_mb",
+            "log_backup_count",
+        }
+        unknown = sorted(set(raw) - allowed)
+        if unknown:
+            raise ServiceConfigError(
+                f"unknown service config fields: {', '.join(unknown)}"
+            )
+        try:
+            raw_serve_args = raw.get("serve_args", [])
+            if not isinstance(raw_serve_args, list) or not all(
+                isinstance(item, str) for item in raw_serve_args
+            ):
+                raise TypeError("serve_args must be an array of strings")
+            config = cls(
+                schema_version=int(raw["schema_version"]),
+                label=str(raw["label"]),
+                service_user=str(raw["service_user"]),
+                executable=str(raw["executable"]),
+                model=str(raw["model"]),
+                host=str(raw.get("host", "127.0.0.1")),
+                port=int(raw.get("port", 8000)),
+                serve_args=tuple(raw_serve_args),
+                credential_file=(
+                    str(raw["credential_file"])
+                    if raw.get("credential_file") is not None
+                    else None
+                ),
+                log_retention_days=int(
+                    raw.get("log_retention_days", DEFAULT_LOG_RETENTION_DAYS)
+                ),
+                log_max_mb=int(raw.get("log_max_mb", DEFAULT_LOG_MAX_MB)),
+                log_backup_count=int(
+                    raw.get("log_backup_count", DEFAULT_LOG_BACKUP_COUNT)
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ServiceConfigError(f"malformed service config: {exc}") from None
+        return config.validated()
+
+
+def config_dir(home: Path) -> Path:
+    # Keep account context explicit in callers, but store the definition away
+    # from the replaceable ~/.rapid-mlx virtual environment.
+    del home
+    return SERVICE_CONFIG_ROOT
+
+
+def config_path(home: Path, label: str = DEFAULT_LABEL) -> Path:
+    return config_dir(home) / f"{label}.json"
+
+
+def pending_config_path(home: Path, label: str = DEFAULT_LABEL) -> Path:
+    return config_dir(home) / f"{label}.pending.json"
+
+
+def backup_config_path(home: Path, label: str = DEFAULT_LABEL) -> Path:
+    return config_dir(home) / f"{label}.previous.json"
+
+
+def credential_path(home: Path, label: str = DEFAULT_LABEL) -> Path:
+    return home / ".rapid-mlx-secrets" / f"{label}.credential"
+
+
+def load_config(path: Path) -> ServiceConfig:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise ServiceConfigError(f"service config does not exist: {path}") from None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ServiceConfigError(f"cannot read service config {path}: {exc}") from None
+    if not isinstance(raw, dict):
+        raise ServiceConfigError("service config root must be an object")
+    return ServiceConfig.from_dict(raw)
+
+
+def config_bytes(config: ServiceConfig) -> bytes:
+    config.validated()
+    return (json.dumps(config.to_dict(), indent=2, sort_keys=True) + "\n").encode()
+
+
+def config_digest(config: ServiceConfig) -> str:
+    return hashlib.sha256(config_bytes(config)).hexdigest()
+
+
+def atomic_write(
+    path: Path,
+    data: bytes,
+    *,
+    mode: int = 0o600,
+    uid: int | None = None,
+    gid: int | None = None,
+) -> None:
+    """Durably replace ``path`` without exposing a partial definition."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    fd, raw_tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp = Path(raw_tmp)
+    try:
+        os.fchmod(fd, mode)
+        if uid is not None or gid is not None:
+            os.fchown(
+                fd, uid if uid is not None else -1, gid if gid is not None else -1
+            )
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        dir_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_definition(path: Path, data: bytes) -> None:
+    """Write a non-secret system definition root-owned in production."""
+    owner = 0 if os.geteuid() == 0 else None
+    atomic_write(path, data, mode=0o644, uid=owner, gid=owner)
+
+
+def ensure_config_dir(home: Path, *, uid: int, gid: int) -> Path:
+    """Create the root-owned, non-secret service definition directory."""
+    del uid, gid
+    target = config_dir(home)
+    target.mkdir(mode=0o755, parents=True, exist_ok=True)
+    os.chmod(target, 0o755)
+    if os.geteuid() == 0:
+        os.chown(target, 0, 0)
+    return target
+
+
+def ensure_credential_dir(home: Path, *, uid: int, gid: int) -> Path:
+    """Create the private secret directory traversable by the service only."""
+    target = credential_path(home).parent
+    target.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(target, 0o700)
+    os.chown(target, uid, gid)
+    return target
+
+
+def assert_private_file(path: Path, *, expected_uid: int | None = None) -> None:
+    """Refuse a credential that is symlinked, group/world-readable, or foreign."""
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise ServiceConfigError(
+            f"cannot inspect credential file {path}: {exc}"
+        ) from None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise ServiceConfigError("credential file must be a regular, non-symlink file")
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        raise ServiceConfigError(
+            "credential file must not be accessible by group or others"
+        )
+    if expected_uid is not None and info.st_uid != expected_uid:
+        raise ServiceConfigError(
+            f"credential file is owned by uid {info.st_uid}, expected {expected_uid}"
+        )
+
+
+def private_file_present(path: Path) -> bool | None:
+    """Return presence, or ``None`` when permissions prevent inspection."""
+    try:
+        return stat.S_ISREG(path.stat().st_mode)
+    except PermissionError:
+        return None
+    except OSError:
+        return False

--- a/vllm_mlx/headless_service/configure.py
+++ b/vllm_mlx/headless_service/configure.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage, inspect, and transactionally apply service configuration."""
+
+from __future__ import annotations
+
+import json
+import pwd
+import subprocess
+import sys
+from pathlib import Path
+
+from .common import DEFAULT_DOMAIN, DEFAULT_LABEL
+from .config import (
+    ServiceConfigError,
+    atomic_write,
+    atomic_write_definition,
+    backup_config_path,
+    config_bytes,
+    config_digest,
+    credential_path,
+    ensure_credential_dir,
+    load_config,
+    pending_config_path,
+    private_file_present,
+)
+from .definition import installed_identity
+from .install import _plist_path, _port_busy, _wait_ready, is_root
+
+
+def _identity_or_error(label: str) -> tuple[str, Path, Path]:
+    identity = installed_identity(label)
+    if identity is None:
+        raise ServiceConfigError(
+            f"service {label} has no readable installed definition; install it first"
+        )
+    return identity
+
+
+def _account(user: str):
+    try:
+        return pwd.getpwnam(user)
+    except KeyError:
+        raise ServiceConfigError(
+            f"configured service account {user!r} no longer exists"
+        ) from None
+
+
+def configure_command(args) -> int:
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    dry_run = bool(getattr(args, "dry_run", False))
+    try:
+        user, home, current_path = _identity_or_error(label)
+        current = load_config(current_path)
+        updates = {}
+        for arg_name in (
+            "model",
+            "host",
+            "port",
+            "log_retention_days",
+            "log_max_mb",
+            "log_backup_count",
+        ):
+            value = getattr(args, arg_name, None)
+            if value is not None:
+                updates[arg_name] = value
+        raw_serve_args = getattr(args, "serve_args", None)
+        if getattr(args, "clear_serve_args", False):
+            updates["serve_args"] = ()
+        elif raw_serve_args:
+            values = tuple(raw_serve_args)
+            if values[:1] == ("--",):
+                values = values[1:]
+            updates["serve_args"] = values
+        candidate = current.updated(**updates)
+    except ServiceConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    rendered = config_bytes(candidate)
+    pending = pending_config_path(home, label)
+    if dry_run:
+        print("Dry run — validated candidate config (not staged):")
+        print(rendered.decode(), end="")
+        return 0
+    if not is_root():
+        print(
+            "error: staging system service configuration requires root; re-run with sudo.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        account = _account(user)
+        atomic_write_definition(pending, rendered)
+    except (OSError, ServiceConfigError) as exc:
+        print(f"error: could not stage {pending}: {exc}", file=sys.stderr)
+        return 2
+    print(f"staged {pending} ({config_digest(candidate)[:12]}).")
+    print("Run `sudo rapid-mlx service apply` to activate it with rollback protection.")
+    return 0
+
+
+def _bootstrap(label: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["launchctl", "bootstrap", DEFAULT_DOMAIN, str(_plist_path(label))],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _bootout(label: str) -> None:
+    subprocess.run(
+        ["launchctl", "bootout", f"{DEFAULT_DOMAIN}/{label}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def apply_command(args) -> int:
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    dry_run = bool(getattr(args, "dry_run", False))
+    try:
+        user, home, current_path = _identity_or_error(label)
+        current = load_config(current_path)
+        pending_path = pending_config_path(home, label)
+        candidate = load_config(pending_path)
+        if candidate.label != current.label or candidate.service_user != user:
+            raise ServiceConfigError(
+                "pending config cannot change label or service account"
+            )
+        if candidate.executable != current.executable:
+            raise ServiceConfigError(
+                "pending config cannot change the service executable"
+            )
+    except ServiceConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if (candidate.host, candidate.port) != (current.host, current.port) and _port_busy(
+        candidate.host, candidate.port
+    ):
+        print(
+            f"error: candidate endpoint {candidate.host}:{candidate.port} is already in use.",
+            file=sys.stderr,
+        )
+        return 1
+    if dry_run:
+        print(
+            f"[DRY-RUN] validate {pending_path}\n"
+            f"[DRY-RUN] bootout {DEFAULT_DOMAIN}/{label}\n"
+            f"[DRY-RUN] promote candidate {config_digest(candidate)[:12]}\n"
+            f"[DRY-RUN] bootstrap {_plist_path(label)} and require /readyz\n"
+            "[DRY-RUN] restore previous config and service on any failure"
+        )
+        return 0
+    if not is_root():
+        print(
+            "error: applying system service configuration requires root; re-run with sudo.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        account = _account(user)
+    except ServiceConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    previous = config_bytes(current)
+    candidate_bytes = config_bytes(candidate)
+    backup = backup_config_path(home, label)
+    try:
+        atomic_write_definition(backup, previous)
+        _bootout(label)
+        atomic_write_definition(current_path, candidate_bytes)
+        boot = _bootstrap(label)
+        if boot.returncode != 0:
+            raise ServiceConfigError(
+                f"launchctl bootstrap failed: {boot.stderr.strip() or boot.stdout.strip()}"
+            )
+        if not _wait_ready(candidate.host, candidate.port):
+            raise ServiceConfigError(
+                f"candidate did not become ready on {candidate.host}:{candidate.port} within 120s"
+            )
+    except (OSError, ServiceConfigError) as exc:
+        _bootout(label)
+        try:
+            atomic_write_definition(current_path, previous)
+            rollback = _bootstrap(label)
+            rollback_ok = rollback.returncode == 0 and _wait_ready(
+                current.host, current.port
+            )
+        except OSError:
+            rollback_ok = False
+        state = "previous service restored" if rollback_ok else "ROLLBACK FAILED"
+        print(f"error: apply failed: {exc}; {state}.", file=sys.stderr)
+        return 2
+
+    try:
+        pending_path.unlink()
+    except OSError:
+        pass
+    print(
+        f"applied {config_digest(candidate)[:12]}; {label} is ready on "
+        f"{candidate.host}:{candidate.port}. Previous config: {backup}"
+    )
+    return 0
+
+
+def config_show_command(args) -> int:
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    try:
+        _, home, current_path = _identity_or_error(label)
+        current = load_config(current_path)
+        pending = pending_config_path(home, label)
+        payload = {
+            "active": current.to_dict(),
+            "active_digest": config_digest(current),
+            "pending": load_config(pending).to_dict() if pending.exists() else None,
+        }
+    except ServiceConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def credential_command(args) -> int:
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    action = getattr(args, "credential_command", None)
+    try:
+        user, home, _ = _identity_or_error(label)
+    except ServiceConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    path = credential_path(home, label)
+    if action == "status":
+        print(json.dumps({"configured": private_file_present(path), "path": str(path)}))
+        return 0
+    if not is_root():
+        print(
+            "error: changing a system service credential requires root; re-run with sudo.",
+            file=sys.stderr,
+        )
+        return 1
+    if action == "unset":
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            print(f"error: could not remove credential: {exc}", file=sys.stderr)
+            return 2
+        print("service API credential removed; restart the service to disable auth.")
+        return 0
+    if action != "set":
+        print("error: expected credential set/status/unset", file=sys.stderr)
+        return 2
+    if sys.stdin.isatty():
+        print(
+            "error: credential set reads one line from stdin; pipe it from a secret manager "
+            "or enter it with terminal echo disabled.",
+            file=sys.stderr,
+        )
+        return 1
+    secret_input = sys.stdin.read()
+    secret = secret_input.removesuffix("\n").removesuffix("\r")
+    if not secret or "\n" in secret or "\r" in secret:
+        print("error: credential must be exactly one non-empty line", file=sys.stderr)
+        return 1
+    try:
+        account = _account(user)
+        ensure_credential_dir(home, uid=account.pw_uid, gid=account.pw_gid)
+        atomic_write(
+            path,
+            (secret + "\n").encode(),
+            uid=account.pw_uid,
+            gid=account.pw_gid,
+        )
+    except (OSError, ServiceConfigError) as exc:
+        print(f"error: could not store credential: {exc}", file=sys.stderr)
+        return 2
+    print("service API credential stored with mode 0600; restart to activate it.")
+    return 0

--- a/vllm_mlx/headless_service/definition.py
+++ b/vllm_mlx/headless_service/definition.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inspection helpers for an installed LaunchDaemon definition."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .common import DEFAULT_LABEL, home_for_user
+
+
+def installed_plist(label: str = DEFAULT_LABEL) -> dict | None:
+    from .install import _plist_path
+    from .plist import parse_plist
+
+    path = _plist_path(label)
+    if not path.is_file():
+        return None
+    try:
+        return parse_plist(path.read_bytes())
+    except Exception:
+        return None
+
+
+def installed_identity(label: str = DEFAULT_LABEL) -> tuple[str, Path, Path] | None:
+    """Return ``(user, home, config_path)`` from the installed plist."""
+    plist = installed_plist(label)
+    if not plist:
+        return None
+    user = plist.get("UserName")
+    if not isinstance(user, str) or not user:
+        return None
+    environment = plist.get("EnvironmentVariables") or {}
+    raw_home = environment.get("HOME")
+    home = Path(raw_home) if isinstance(raw_home, str) else home_for_user(user)
+    if home is None:
+        return None
+    argv = plist.get("ProgramArguments") or []
+    raw_config = None
+    for index, token in enumerate(argv[:-1]):
+        if token == "--config":
+            raw_config = argv[index + 1]
+            break
+    if isinstance(raw_config, str):
+        config = Path(raw_config)
+    else:
+        from .config import config_path
+
+        config = config_path(home, label)
+    return user, home, config

--- a/vllm_mlx/headless_service/install.py
+++ b/vllm_mlx/headless_service/install.py
@@ -179,6 +179,7 @@ def _build_plist_bytes(
     host: str,
     port: int,
     serve_args: tuple[str, ...],
+    config_path: Path | None = None,
 ) -> bytes:
     log_dir = log_dir_for(user)
     if log_dir is None:
@@ -193,6 +194,7 @@ def _build_plist_bytes(
         host=host,
         port=port,
         serve_args=serve_args,
+        config_path=config_path,
     )
     return serialize_plist(config)
 
@@ -235,6 +237,7 @@ def _mutation_list(
     port: int,
 ) -> list[str]:
     return [
+        "write versioned service config atomically (mode 600)",
         f"write secure temporary plist ({len(plist_buf)} bytes, mode 600)",
         "validate temporary plist with plutil -lint",
         f"install -o root -g wheel -m 644 temporary plist -> {plist_path}",
@@ -262,6 +265,17 @@ def _stage_plist(plist_buf: bytes) -> Path:
             pass
         raise
     return Path(raw_path)
+
+
+def _install_service_config(*, user: str, home: Path, path: Path, data: bytes) -> None:
+    """Install a root-owned readable config; it is validated secret-free."""
+    import pwd
+
+    from .config import atomic_write_definition, ensure_config_dir
+
+    account = pwd.getpwnam(user)
+    ensure_config_dir(home, uid=account.pw_uid, gid=account.pw_gid)
+    atomic_write_definition(path, data)
 
 
 def _readyz_ready(host: str, port: int) -> bool:
@@ -406,6 +420,30 @@ def install_command(args) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
+    from .config import (
+        SCHEMA_VERSION,
+        ServiceConfig,
+        config_bytes,
+        config_path,
+        credential_path,
+    )
+
+    try:
+        service_config = ServiceConfig(
+            schema_version=SCHEMA_VERSION,
+            label=label,
+            service_user=user,
+            executable=executable,
+            model=model,
+            host=host,
+            port=port,
+            serve_args=serve_args,
+            credential_file=str(credential_path(home, label)),
+        ).validated()
+    except ValueError as exc:
+        print(f"error: invalid service configuration: {exc}", file=sys.stderr)
+        return 1
+    service_config_path = config_path(home, label)
     plist_buf = _build_plist_bytes(
         label=label,
         user=user,
@@ -415,6 +453,7 @@ def install_command(args) -> int:
         host=host,
         port=port,
         serve_args=serve_args,
+        config_path=service_config_path,
     )
     plist_path = _plist_path(label)
 
@@ -493,8 +532,19 @@ def install_command(args) -> int:
     # so a failure below can roll back BOTH the loaded job AND the plist
     # file (a plist left in /Library/LaunchDaemons auto-loads on reboot).
     persistent_write_attempted = False
+    config_write_attempted = False
     staged: Path | None = None
     try:
+        # The stable plist only names this file. Configuration can later be
+        # staged and applied transactionally without rewriting root-owned
+        # launchd state.
+        config_write_attempted = True
+        _install_service_config(
+            user=user,
+            home=home,
+            path=service_config_path,
+            data=config_bytes(service_config),
+        )
         # Stage + lint. check=False so a lint failure surfaces its specific
         # message instead of a generic "install step failed" traceback.
         staged = _stage_plist(plist_buf)
@@ -558,6 +608,11 @@ def install_command(args) -> int:
                     "from auto-starting on reboot",
                     file=sys.stderr,
                 )
+        if config_write_attempted:
+            try:
+                service_config_path.unlink()
+            except OSError:
+                pass
         if isinstance(exc, ServiceInstallError):
             print(f"error: {exc}", file=sys.stderr)
         else:

--- a/vllm_mlx/headless_service/plist.py
+++ b/vllm_mlx/headless_service/plist.py
@@ -85,6 +85,7 @@ def build_plist_dict(
     host: str = "127.0.0.1",
     port: int = 8000,
     serve_args: tuple[str, ...] | None = None,
+    config_path: Path | None = None,
 ) -> dict:
     """Build the plist dict for a system LaunchDaemon.
 
@@ -102,8 +103,12 @@ def build_plist_dict(
     return {
         "Label": label,
         "UserName": user,
-        "ProgramArguments": serve_argv(
-            executable, model, host=host, port=port, serve_args=serve_args
+        "ProgramArguments": (
+            [executable, "service", "run", "--config", str(config_path)]
+            if config_path is not None
+            else serve_argv(
+                executable, model, host=host, port=port, serve_args=serve_args
+            )
         ),
         "WorkingDirectory": str(home),
         "EnvironmentVariables": environment,

--- a/vllm_mlx/headless_service/restart.py
+++ b/vllm_mlx/headless_service/restart.py
@@ -22,6 +22,17 @@ from .install import _wait_ready
 
 def _declared_bind(label: str) -> tuple[str, int] | None:
     """The ``(host, port)`` the installed plist declares, if readable."""
+    from .config import load_config
+    from .definition import installed_identity
+
+    identity = installed_identity(label)
+    if identity is not None:
+        try:
+            effective_config = load_config(identity[2])
+            return effective_config.host, effective_config.port
+        except Exception:
+            pass
+
     from .install import _plist_path
     from .plist import parse_plist
 
@@ -29,10 +40,10 @@ def _declared_bind(label: str) -> tuple[str, int] | None:
     if not plist_path.is_file():
         return None
     try:
-        config = parse_plist(plist_path.read_bytes())
+        plist_config = parse_plist(plist_path.read_bytes())
     except Exception:
         return None
-    argv = config.get("ProgramArguments") or []
+    argv = plist_config.get("ProgramArguments") or []
     host, port = None, None
     for i, tok in enumerate(argv[:-1]):
         if tok == "--host" and i + 1 < len(argv):

--- a/vllm_mlx/headless_service/rotating_logs.py
+++ b/vllm_mlx/headless_service/rotating_logs.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded stdout/stderr capture for the long-lived service runtime."""
+
+from __future__ import annotations
+
+import os
+import stat
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import BinaryIO
+
+
+class RotatingLog:
+    """A small dependency-free size/age/count rotating binary sink."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        max_bytes: int,
+        backup_count: int,
+        retention_days: int,
+    ) -> None:
+        self.path = path
+        self.max_bytes = max_bytes
+        self.backup_count = backup_count
+        self.retention_days = retention_days
+        self._handle: BinaryIO | None = None
+        self._lock = threading.Lock()
+        path.parent.mkdir(mode=0o750, parents=True, exist_ok=True)
+        os.chmod(path.parent, 0o750)
+        self._purge()
+
+    def _open(self) -> BinaryIO:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(self.path, flags, 0o640)
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            os.close(fd)
+            raise OSError(f"refusing non-regular log target: {self.path}")
+        return os.fdopen(fd, "ab", buffering=0)
+
+    def _backups(self) -> list[Path]:
+        return sorted(
+            self.path.parent.glob(f"{self.path.name}.*"),
+            key=lambda item: item.stat().st_mtime,
+            reverse=True,
+        )
+
+    def _purge(self) -> None:
+        now = datetime.now(timezone.utc).timestamp()
+        max_age = self.retention_days * 86400
+        for index, backup in enumerate(self._backups()):
+            try:
+                if index >= self.backup_count or now - backup.stat().st_mtime > max_age:
+                    backup.unlink()
+            except OSError:
+                continue
+
+    def _rotate(self) -> None:
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+        if self.path.exists():
+            stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+            self.path.replace(self.path.with_name(f"{self.path.name}.{stamp}"))
+        self._purge()
+
+    def write(self, data: bytes) -> None:
+        if not data:
+            return
+        with self._lock:
+            if self._handle is None:
+                self._handle = self._open()
+            try:
+                size = self._handle.tell()
+            except OSError:
+                size = self.path.stat().st_size if self.path.exists() else 0
+            if size and size + len(data) > self.max_bytes:
+                self._rotate()
+                self._handle = self._open()
+            self._handle.write(data)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._handle is not None:
+                self._handle.close()
+                self._handle = None

--- a/vllm_mlx/headless_service/runtime.py
+++ b/vllm_mlx/headless_service/runtime.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stable LaunchDaemon entry point backed by :class:`ServiceConfig`."""
+
+from __future__ import annotations
+
+import os
+import pwd
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+from .common import STDERR_LOG_NAME, STDOUT_LOG_NAME, log_dir_for
+from .config import ServiceConfigError, assert_private_file, load_config
+from .rotating_logs import RotatingLog
+
+
+def _copy_stream(source, sink: RotatingLog, child: subprocess.Popen) -> None:
+    try:
+        while chunk := source.read(65536):
+            try:
+                sink.write(chunk)
+            except OSError as exc:
+                # Never leave the model process blocked forever on a full or
+                # unwritable log pipe. A clean service restart is observable
+                # and recoverable; a wedged inference endpoint is not.
+                print(f"error: service log write failed: {exc}", file=sys.stderr)
+                if child.poll() is None:
+                    child.terminate()
+                for _ in iter(lambda: source.read(65536), b""):
+                    pass
+                break
+    finally:
+        source.close()
+
+
+def _supervise(argv: list[str], env: dict[str, str], config) -> int:
+    log_dir = log_dir_for(config.service_user)
+    if log_dir is None:
+        raise ServiceConfigError("cannot resolve service log directory")
+    log_options = {
+        "max_bytes": config.log_max_mb * 1024 * 1024,
+        "backup_count": config.log_backup_count,
+        "retention_days": config.log_retention_days,
+    }
+    stdout = RotatingLog(log_dir / STDOUT_LOG_NAME, **log_options)
+    stderr = RotatingLog(log_dir / STDERR_LOG_NAME, **log_options)
+    child: subprocess.Popen | None = None
+    requested_signal: int | None = None
+
+    def forward(signum, _frame) -> None:
+        nonlocal requested_signal
+        requested_signal = signum
+        if child is not None and child.poll() is None:
+            child.send_signal(signum)
+
+    previous_handlers = {}
+    for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        previous_handlers[signum] = signal.signal(signum, forward)
+    try:
+        child = subprocess.Popen(
+            argv,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
+        if requested_signal is not None:
+            child.send_signal(requested_signal)
+        assert child.stdout is not None and child.stderr is not None
+        pumps = [
+            threading.Thread(
+                target=_copy_stream, args=(child.stdout, stdout, child), daemon=True
+            ),
+            threading.Thread(
+                target=_copy_stream, args=(child.stderr, stderr, child), daemon=True
+            ),
+        ]
+        for pump in pumps:
+            pump.start()
+        return_code = child.wait()
+        for pump in pumps:
+            pump.join(timeout=5)
+        return return_code if return_code >= 0 else 128 - return_code
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        stdout.close()
+        stderr.close()
+
+
+def run_command(args) -> int:
+    path = Path(args.config)
+    try:
+        config = load_config(path)
+        account = pwd.getpwnam(config.service_user)
+        if os.geteuid() != account.pw_uid:
+            raise ServiceConfigError(
+                f"service runtime uid {os.geteuid()} does not match configured "
+                f"account {config.service_user} ({account.pw_uid})"
+            )
+        env = os.environ.copy()
+        env.pop("RAPID_MLX_API_KEY", None)
+        if config.credential_file:
+            secret_path = Path(config.credential_file)
+            if secret_path.exists():
+                assert_private_file(secret_path, expected_uid=account.pw_uid)
+                secret = secret_path.read_text(encoding="utf-8").strip()
+                if not secret or "\n" in secret or "\r" in secret:
+                    raise ServiceConfigError(
+                        "credential file must contain one non-empty line"
+                    )
+                env["RAPID_MLX_API_KEY"] = secret
+        argv = [
+            config.executable,
+            "serve",
+            config.model,
+            "--host",
+            config.host,
+            "--port",
+            str(config.port),
+            *config.serve_args,
+        ]
+        return _supervise(argv, env, config)
+    except (KeyError, OSError, ServiceConfigError) as exc:
+        print(f"error: cannot start Rapid-MLX service: {exc}", file=sys.stderr)
+        return 78  # EX_CONFIG

--- a/vllm_mlx/headless_service/status.py
+++ b/vllm_mlx/headless_service/status.py
@@ -18,6 +18,7 @@ owner / model / port / healthy / log paths / last launchd exit).
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -66,9 +67,20 @@ def _parse_last_exit(print_out: str | None) -> int | None:
         return None
     for line in print_out.splitlines():
         if "last exit code" in line.lower():
-            digits = "".join(ch for ch in line.split("=", 1)[1] if ch.isdigit())
-            if digits:
-                return int(digits)
+            match = re.search(r"-?\d+", line.split("=", 1)[1])
+            if match:
+                return int(match.group())
+    return None
+
+
+def _parse_launchd_field(print_out: str | None, field: str) -> str | None:
+    if not print_out:
+        return None
+    prefix = f"{field.lower()} ="
+    for line in print_out.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith(prefix):
+            return stripped.split("=", 1)[1].strip() or None
     return None
 
 
@@ -127,19 +139,53 @@ def collect_status(
     registered = print_out is not None
     pid = _parse_pid(print_out)
     last_exit = _parse_last_exit(print_out)
+    launchd_state = _parse_launchd_field(print_out, "state")
+    raw_runs = _parse_launchd_field(print_out, "runs")
+    runs = int(raw_runs) if raw_runs and raw_runs.isdigit() else None
     plist = _read_installed_plist(label)
 
     model = port_declared = host_declared = None
+    config_file = config_sha256 = config_error = None
+    pending_config = False
+    credential_configured: bool | None = False
     if plist:
         argv = plist.get("ProgramArguments") or []
         # argv shape: [<bin>, "serve", <model>, ...]
-        if len(argv) >= 3 and argv[0].endswith("rapid-mlx"):
+        if len(argv) >= 3 and argv[0].endswith("rapid-mlx") and argv[1] == "serve":
             model = argv[2] if len(argv) > 2 else None
             for i, tok in enumerate(argv[:-1]):
                 if tok == "--port" and i + 1 < len(argv):
                     port_declared = argv[i + 1]
                 if tok == "--host" and i + 1 < len(argv):
                     host_declared = argv[i + 1]
+
+        # New definitions use a stable config-backed launcher. Keep the argv
+        # parser above for installations created by the first service release.
+        from .config import (
+            config_digest,
+            load_config,
+            pending_config_path,
+            private_file_present,
+        )
+        from .definition import installed_identity
+
+        identity = installed_identity(label)
+        if identity is not None:
+            config_file = str(identity[2])
+            try:
+                effective = load_config(identity[2])
+                model = effective.model
+                host_declared = effective.host
+                port_declared = effective.port
+                config_sha256 = config_digest(effective)
+                pending_config = pending_config_path(identity[1], label).is_file()
+                credential_configured = (
+                    private_file_present(Path(effective.credential_file))
+                    if effective.credential_file
+                    else False
+                )
+            except Exception as exc:
+                config_error = str(exc)
 
     # Probe the bind the plist declares (fall back to CLI defaults) — probing
     # the CLI default while the service actually listens elsewhere would report
@@ -161,7 +207,9 @@ def collect_status(
         except (subprocess.SubprocessError, OSError):
             owner = None
 
-    log_dir = log_dir_for(user) if user else None
+    declared_user = plist.get("UserName") if plist else None
+    effective_user = user or (declared_user if isinstance(declared_user, str) else None)
+    log_dir = log_dir_for(effective_user) if effective_user else None
     return {
         "label": label,
         "domain": DEFAULT_DOMAIN,
@@ -169,6 +217,11 @@ def collect_status(
         "pid": pid,
         "owner": owner,
         "last_exit": last_exit,
+        "launchd_state": launchd_state,
+        "runs": runs,
+        "crash_loop_suspected": bool(
+            registered and pid is None and last_exit not in (None, 0)
+        ),
         "model": model,
         "host": effective_host,
         "port": effective_port,
@@ -178,6 +231,11 @@ def collect_status(
         "plist": str(_plist_path(label)),
         "log_dir": str(log_dir) if log_dir else None,
         "plist_present": Path(_plist_path(label)).is_file(),
+        "config_file": config_file,
+        "config_sha256": config_sha256,
+        "config_error": config_error,
+        "pending_config": pending_config,
+        "credential_configured": credential_configured,
     }
 
 
@@ -194,8 +252,33 @@ def _render_human(s: dict) -> str:
         lines.append("  pid:                   (no live process)")
     if s["last_exit"] is not None:
         lines.append(f"  last launchd exit:     {s['last_exit']}")
+    if s.get("launchd_state") or s.get("runs") is not None:
+        lines.append(
+            f"  launchd details:       state={s.get('launchd_state') or 'unknown'} "
+            f"runs={s.get('runs') if s.get('runs') is not None else 'unknown'}"
+        )
+    if s.get("crash_loop_suspected"):
+        lines.append(
+            "  warning:               repeated startup failure suspected; inspect logs"
+        )
     if s["model"]:
         lines.append(f"  model:                 {s['model']}")
+    if s.get("config_file"):
+        digest = (s.get("config_sha256") or "invalid")[:12]
+        staged = " (PENDING changes)" if s.get("pending_config") else ""
+        lines.append(f"  config:                {s['config_file']} [{digest}]{staged}")
+    if s.get("config_error"):
+        lines.append(f"  config error:          {s['config_error']}")
+    if s.get("config_file"):
+        credential_state = s.get("credential_configured")
+        auth_label = (
+            "credential file"
+            if credential_state is True
+            else "disabled"
+            if credential_state is False
+            else "unknown (run status with sudo)"
+        )
+        lines.append("  authentication:        " + auth_label)
     lines.append(f"  endpoint:              http://{s['host']}:{s['port']}")
     lines.append(
         f"  health:                livez={'ok' if s['livez'] else 'down'} "

--- a/vllm_mlx/headless_service/upgrade.py
+++ b/vllm_mlx/headless_service/upgrade.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Health-gated in-place service upgrade with dependency rollback."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from .common import DEFAULT_LABEL
+from .config import ServiceConfigError, atomic_write, load_config
+from .configure import _account, _bootout, _bootstrap, _identity_or_error
+from .install import _wait_ready, is_root
+
+
+def _target(version: str | None, extras: str | None) -> str:
+    if version is not None and not re.fullmatch(r"[A-Za-z0-9.!+_-]+", version):
+        raise ServiceConfigError("version contains unsupported characters")
+    if extras is not None and not re.fullmatch(
+        r"[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*", extras
+    ):
+        raise ServiceConfigError("extras must be a comma-separated list of names")
+    suffix = f"[{extras}]" if extras else ""
+    pin = f"=={version}" if version else ""
+    return f"rapid-mlx{suffix}{pin}"
+
+
+def _as_user(
+    user: str,
+    argv: list[str],
+    *,
+    timeout: int,
+) -> subprocess.CompletedProcess:
+    """Run through macOS sudo so HOME/groups match the service account."""
+    return subprocess.run(
+        ["/usr/bin/sudo", "-u", user, "-H", *argv],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _restore(
+    *,
+    user: str,
+    python: Path,
+    requirements: Path,
+    label: str,
+    host: str,
+    port: int,
+) -> bool:
+    _bootout(label)
+    restored = _as_user(
+        user,
+        [
+            str(python),
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "-r",
+            str(requirements),
+        ],
+        timeout=1800,
+    )
+    if restored.returncode != 0:
+        return False
+    boot = _bootstrap(label)
+    return boot.returncode == 0 and _wait_ready(host, port)
+
+
+def upgrade_command(args) -> int:
+    label = getattr(args, "label", None) or DEFAULT_LABEL
+    dry_run = bool(getattr(args, "dry_run", False))
+    try:
+        user, home, current_path = _identity_or_error(label)
+        config = load_config(current_path)
+        account = _account(user)
+        target = _target(getattr(args, "version", None), getattr(args, "extras", None))
+    except ServiceConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    python = home / ".rapid-mlx" / "bin" / "python"
+    if not python.is_file() or not os.access(python, os.X_OK):
+        print(
+            f"error: service runtime Python is missing or not executable: {python}",
+            file=sys.stderr,
+        )
+        return 1
+    requirements = current_path.parent / f"{label}.previous-requirements.txt"
+    plan = [
+        f"freeze current environment -> {requirements}",
+        f"bootout system/{label}",
+        f"install {target} as {user}",
+        "run rapid-mlx doctor (diagnostic)",
+        f"bootstrap and require {config.host}:{config.port}/readyz",
+        "restore frozen environment and old service on any failure",
+    ]
+    if dry_run:
+        print("Dry run — would perform these upgrade steps:")
+        for step in plan:
+            print(f"  [DRY-RUN] {step}")
+        return 0
+    if not is_root():
+        print(
+            "error: upgrading a system service requires root; re-run with sudo.",
+            file=sys.stderr,
+        )
+        return 1
+
+    frozen = _as_user(user, [str(python), "-m", "pip", "freeze"], timeout=120)
+    if frozen.returncode != 0 or not frozen.stdout.strip():
+        print(
+            f"error: could not snapshot the service environment: {frozen.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        atomic_write(
+            requirements,
+            frozen.stdout.encode(),
+            uid=account.pw_uid,
+            gid=account.pw_gid,
+        )
+    except OSError as exc:
+        print(f"error: could not save rollback snapshot: {exc}", file=sys.stderr)
+        return 2
+
+    _bootout(label)
+    install_argv = [str(python), "-m", "pip", "install", "--upgrade"]
+    if getattr(args, "pre", False):
+        install_argv.append("--pre")
+    install_argv.append(target)
+    upgraded = _as_user(user, install_argv, timeout=1800)
+    if upgraded.returncode == 0:
+        doctor = _as_user(user, [config.executable, "doctor"], timeout=180)
+        if doctor.returncode != 0:
+            print(
+                "warning: upgraded `rapid-mlx doctor` reported issues; "
+                "the real launchd readiness gate will decide acceptance.",
+                file=sys.stderr,
+            )
+        boot = _bootstrap(label)
+        healthy = boot.returncode == 0 and _wait_ready(config.host, config.port)
+    else:
+        healthy = False
+
+    if healthy:
+        print(
+            f"upgraded {label} to {target}; service is ready. Rollback snapshot: "
+            f"{requirements}"
+        )
+        return 0
+
+    reason = upgraded.stderr.strip() if upgraded.returncode else "readiness gate failed"
+    rollback_ok = _restore(
+        user=user,
+        python=python,
+        requirements=requirements,
+        label=label,
+        host=config.host,
+        port=config.port,
+    )
+    state = "previous environment restored" if rollback_ok else "ROLLBACK FAILED"
+    print(f"error: upgrade failed ({reason}); {state}.", file=sys.stderr)
+    return 2


### PR DESCRIPTION
## Why / outcome

This PR turns the experimental headless LaunchDaemon into the P0 foundation for an **Always-on Rapid Engine**: a stable macOS system service whose configuration, credentials, logs, restarts, and runtime upgrades can be operated without rewriting the launchd plist or exposing secrets.

The service remains available before GUI login, launchd remains the single process-lifecycle authority, and every configuration or runtime upgrade is accepted only after the real `/readyz` gate succeeds. Failed changes automatically restore the last known-good state.

## User-facing commands

```bash
# Install once using a dedicated non-admin account.
sudo rapid-mlx service install \
  --service-user serveuser \
  --model mlx-community/Qwen3.5-4B-4bit

# Stage configuration without disturbing the running engine.
sudo rapid-mlx service configure \
  --model mlx-community/Qwen3.5-9B-4bit \
  --port 8001 \
  --log-retention-days 14 \
  --log-max-mb 200 \
  --log-backup-count 7 \
  -- --max-num-seqs 8

# Preview or atomically activate the staged definition.
sudo rapid-mlx service apply --dry-run
sudo rapid-mlx service apply

# Inspect active/pending definitions and operational state.
rapid-mlx service config
rapid-mlx service status
rapid-mlx service status --json

# Manage API authentication without putting the key in shell argv/plist/config.
printf '%s\n' "$RAPID_MLX_API_KEY" | sudo rapid-mlx service credential set
rapid-mlx service credential status
sudo rapid-mlx service credential unset

# Upgrade the isolated service runtime with automatic dependency rollback.
sudo rapid-mlx service upgrade --version 0.13.5
sudo rapid-mlx service upgrade --extras vision,embeddings
```

`rapid-mlx service run --config …` is an internal stable entry point used by launchd; operators should use the public lifecycle commands above.

## Completed implementation

### 1. Stable, versioned service definition

- Replaces model/bind/serve flags embedded in `ProgramArguments` with a stable `rapid-mlx service run --config <path>` launcher.
- Stores the non-secret definition under `/Library/Application Support/Rapid-MLX/Services`, outside the replaceable `~/.rapid-mlx` virtual environment.
- Introduces schema versioning, strict unknown-field rejection, range/type validation, absolute-path validation, label validation, and explicit rejection of API-key/bind overrides in passthrough arguments.
- Writes active, pending, previous, and rollback requirement files through durable same-directory temporary files, `fsync`, and atomic replacement.
- Exposes a deterministic SHA-256 digest for identifying the effective configuration in support/debug reports.

### 2. Two-phase configuration with health-gated rollback

- `service configure` validates and stages a candidate without touching the live service.
- `service apply` refuses identity/executable changes and detects endpoint collisions before mutation.
- Apply saves the known-good definition, stops the old job, promotes the candidate, bootstraps launchd, and waits for the model-aware `/readyz` contract.
- A failed bootstrap or readiness gate restores the previous config and relaunches the previous service; output clearly distinguishes a successful restore from `ROLLBACK FAILED`.
- Mutating flows provide `--dry-run` plans where applicable.

### 3. Secret-safe API credentials

- Adds `service credential set/status/unset`.
- `set` accepts exactly one non-empty line on stdin; the API key is never accepted as a command argument and is never printed.
- Stores credentials below the service account's private `~/.rapid-mlx-secrets` directory with mode `0700` on the directory and `0600` on the file.
- The runtime rejects symlinks, non-regular files, group/world access, foreign ownership, and malformed multi-line credentials.
- The child server receives the key only through `RAPID_MLX_API_KEY`; inherited values are cleared when no valid configured credential is present.

### 4. Supervised runtime and bounded logs

- Adds a small launchd-facing supervisor that loads the validated definition and verifies it is running as the configured service UID.
- Starts `rapid-mlx serve` without a shell, pumps stdout/stderr into separate rotating files, and forwards `SIGTERM`, `SIGINT`, and `SIGHUP` to the child.
- Converts signal exits to conventional shell exit codes so launchd diagnostics remain intelligible.
- Adds dependency-free log rotation bounded by size, backup count, and retention age; log targets use non-following opens where the platform supports them.
- A log-write failure terminates the child instead of allowing a full pipe to wedge the inference endpoint indefinitely; launchd can then restart it under the existing KeepAlive policy.

### 5. Health-gated runtime upgrades

- `service upgrade` snapshots the service environment with `pip freeze` before mutation.
- Runs package operations as the dedicated service user with the correct HOME instead of installing as root.
- Supports an exact version, optional extras, and prereleases while rejecting unsafe version/extras syntax.
- Runs `rapid-mlx doctor` as a diagnostic, then bootstraps the service and requires `/readyz` before accepting the upgrade.
- On install/bootstrap/readiness failure, force-reinstalls the frozen dependency set and restores the previous service; reports whether rollback itself succeeded.

### 6. Operational status and diagnosis

- Enriches text and JSON status with the config path/digest/error, pending-change state, credential presence, launchd state, run count, last exit, and a crash-loop suspicion hint.
- Status probes the endpoint declared by the effective config, avoiding false failures when it differs from CLI defaults.
- Keeps existing pid/owner, live/readiness, port, plist, and log-path diagnostics.

### 7. Compatibility and migration

- Existing argv-in-plist installations remain readable by `status` and `restart`.
- A one-time `service uninstall` followed by `service install` opts an existing machine into the config-backed launcher.
- Uninstall still removes only launchd registration/plist; models, caches, logs, credentials, and user data are not silently deleted.
- Configuration schema decisions and operator procedures are documented in the new guide and ADR.

## Safety invariants

- The LaunchDaemon plist and service JSON contain no API key.
- Service execution remains under a dedicated non-root, non-admin account.
- launchd owns restart policy; the runtime does not create a competing daemonization loop.
- Active configuration is never partially written.
- Candidate config and runtime upgrades are committed only after `/readyz` confirms the model can serve traffic.
- Failure paths preserve or restore a last known-good definition/environment and surface rollback failure loudly.

## Verification

Local verification before opening the PR:

- 190 focused service/config/asset tests passed after adding explicit failure-recovery coverage.
- Ruff passed for all touched Python.
- Focused mypy passed for all 14 `headless_service` modules with external imports skipped.
- A wider selected CLI run reached 166 passes; its two local-only failures were environment setup issues (argcomplete subprocess discovery and missing pydantic), while the corresponding GitHub test matrix subsequently passed.

GitHub CI on the PR head:

- Linux test matrix passed on Python 3.10, 3.11, and 3.12.
- Apple Silicon tests passed on a native arm64 runner.
- Lint, type-check, engine contracts, MLX boundary guard, rapid-mac build, desktop tests, accessibility checks, version-bump guard, and PR validation passed.
- PR validation classified the change as **MERGE-SAFE** with medium blast radius.
- Changed-lines coverage passed in GitHub at 100% on commit `c6bf3960`: 738 changed executable lines, 0 missing. The aggregate `tests` gate and every required mac/desktop/version check are green.

## Queue admission

- Added `merge-ready-mac` after the full PR-head CI completed successfully.
- `merge-ready-head` authorized the exact commit `c6bf3960`.
- Mergify confirmed on 2026-09-06: **“This pull request is already queued”** and applied the `queued` label for `mac-batch`.

## Release-notes draft

**Always-on Rapid Engine (P0 service reliability).** Rapid-MLX's macOS LaunchDaemon now uses a stable, versioned configuration outside its replaceable runtime. Operators can stage and atomically apply model/server changes with readiness-gated rollback, manage API credentials through a private mode-0600 file, inspect richer launchd/config/auth health, use bounded rotating logs, and upgrade the service environment with automatic dependency rollback. Existing headless installations remain diagnosable and can migrate with a one-time uninstall/install; models and caches are preserved.

## Explicitly out of scope / follow-ups

This PR establishes reliable system-service lifecycle primitives. It does not yet implement adaptive model residency, demand-based wake/sleep, memory-pressure eviction, multi-model routing, automatic binary update policy, or a GUI service console. Those remain follow-up work on top of this P0 foundation.

## Qualification inheritance and incremental follow-up

Required CI is green and the PR entered the `mac-batch` queue on 2026-09-06. Baseline LaunchDaemon behavior is **already hardware-qualified by PR #2952** on M2 Pro and M4 Pro: system-domain launchd operation, KeepAlive PID replacement, runtime update with extras preserved, full reboot with `CONSOLE=root` and zero logged-in users, plus post-reboot `/livez`, `/readyz`, `/v1/models`, and chat-completion checks.

This PR does not need to repeat that qualification program. Its only optional incremental hardware evidence is for newly introduced paths that #2952 could not cover: config-backed `configure/apply` rollback, credential-file activation/removal, bounded rotating logs, and the new `service upgrade` dependency rollback. These are already covered hermetically and at 100% changed-lines coverage; a short post-merge appliance rehearsal may be recorded without blocking or duplicating the #2952 launchd qualification.




