### PR TITLE
perf(image): report measured denoise throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ family default shown below.
 | `qwen-image` | Text inside images | Generate | 28.9 GiB | 64 GB | 20 |
 <!-- image-model-matrix:end -->
 
+At 1024×1024 with the four-step Klein default, measured warm generation was
+about **9.2 seconds per image on an M3 Ultra**. On a 32 GB M2 Pro, the q4 path
+measured a 52.7-second median; explicitly selecting
+`flux2-klein-4b-bf16` reduced that median to 41.8 seconds (1.26× throughput).
+The eight-step `z-image-turbo` baseline was about 34 seconds on the M3 Ultra
+and 150 seconds on the M2 Pro.
+The q4 alias remains the predictable default; on the measured 32 GB M2 Pro,
+use the larger 14.9 GiB BF16 alias when latency matters. Exact results depend
+on resolution, power/thermal state, and other workloads. The server completion
+log reports total time and, when the backend exposes exact loop boundaries,
+measured denoise `s/step`. For the qualified 1024-square Klein shape it also
+reports estimated achieved TFLOPS; unavailable or unqualified values are never
+fabricated.
+
+→ [Reproducible precision benchmark and methodology](docs/engineering/performance/2026-09-04-image-weight-precision.md)
+
 Image work is single-flight: one generation runs at a time so two diffusion
 pipelines cannot exhaust unified memory. Model weights retain their own
 licenses and use restrictions; review the upstream model card before commercial

--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -4,6 +4,18 @@ Issue [#3058](https://github.com/raullenchai/Rapid-MLX/issues/3058)
 measured FLUX.2 Klein 4B at 1024×1024, four steps, with the same prompt and
 seed on an otherwise-idle 32 GB M2 Pro Mac mini:
 
+The broader issue baseline used Rapid-MLX 0.13.4, mflux 0.19.1, macOS 26.5.2,
+six prompts per model, and observed under 3% variance:
+
+| Model and default | M3 Ultra 256 GB | M2 Pro 32 GB |
+|---|---:|---:|
+| FLUX.2 Klein q4, 1024 square, 4 steps | 9.2 s | 52 s |
+| Z-Image Turbo q4, 1024 square, 8 steps | 34 s | 150 s |
+
+Those cross-machine values are user-expectation baselines, not a controlled
+hardware comparison: the machines have different GPU resources. The precision
+comparison below changes weights on the same M2 Pro workload.
+
 | Weight path | Wall time per image |
 |---|---:|
 | BFL bf16 | 44.0 / 47.4 s |
@@ -59,8 +71,30 @@ loads it through `model_path`, and passes `quantize=None`. The q4 alias and all
 other models are unchanged. A range-read of the pinned snapshot's first
 transformer shard found 69 tensors, all declared `BF16`, and no `.scales` or
 `.biases` quantization auxiliaries. Automatic chip selection is deliberately
-deferred until broader M1/M2 family coverage exists; the one measured M2 Pro
-working set is not enough to define a safe hardware policy.
+not adopted: the one measured M2 Pro working set is not enough to define a safe
+M1/M2-family policy, and silently changing the public alias would also change
+its download size, memory demand, and output bytes. The explicit BF16 alias is
+the stable policy until each additional hardware/model combination has
+independent qualification.
+
+## Completion telemetry
+
+The Images generation route logs one completion line per image. mflux exposes
+callbacks after prompt encoding and after the final synchronized denoise step,
+so this measurement adds no evaluation barrier to the hot path and keeps model
+load, prompt encoding, VAE decode, PNG encoding, and base64 work separate from
+the denoise-only rate:
+
+```text
+Image generation: model=... family=flux2-klein image=1/1 size=1024x1024 steps=4 total=...s denoise=11.20s (2.80 s/step, ~13.6 estimated TFLOPS)
+```
+
+The TFLOPS value is an operation-count estimate, not a hardware counter. It is
+emitted only for FLUX.2 Klein at 1024 square, using the issue's approximately
+38 TFLOP per denoise-step derivation divided by measured seconds per step. Other
+families and sizes still report exact total time; backends without both denoise
+boundaries say `denoise timing unavailable` rather than re-labelling
+end-to-end time or extrapolating an unqualified FLOP count.
 
 ## Reproduction checklist
 

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -415,6 +415,29 @@ def test_mflux_reporter_records_denoise_only_timing(monkeypatch):
     }
 
 
+def test_finish_denoise_without_start_is_a_noop():
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+
+    engine._finish_denoise(4)
+
+    assert engine.performance_snapshot() == {
+        "denoise_seconds": None,
+        "denoise_steps": 0,
+    }
+
+
+def test_generate_with_performance_pairs_bytes_and_snapshot(monkeypatch):
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    engine._last_denoise_seconds = 8.0
+    engine._last_denoise_steps = 4
+    monkeypatch.setattr(engine, "generate", lambda **kwargs: b"png")
+
+    png_bytes, performance = engine.generate_with_performance(prompt="a fox")
+
+    assert png_bytes == b"png"
+    assert performance == {"denoise_seconds": 8.0, "denoise_steps": 4}
+
+
 def test_new_generation_clears_stale_denoise_timing():
     engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
     engine._last_denoise_seconds = 11.2
@@ -539,6 +562,20 @@ def test_image_adapter_residency_without_mode_preserves_family_default(monkeypat
     engine.ensure_resident()
 
     assert modes == [None]
+
+
+def test_image_adapter_delegates_atomic_performance_methods(monkeypatch):
+    engine = ImageEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    expected = {"denoise_seconds": 8.0, "denoise_steps": 4}
+    monkeypatch.setattr(engine._engine, "performance_snapshot", lambda: expected)
+    monkeypatch.setattr(
+        engine._engine,
+        "generate_with_performance",
+        lambda **kwargs: (b"png", expected),
+    )
+
+    assert engine.performance_snapshot() == expected
+    assert engine.generate_with_performance(prompt="a fox") == (b"png", expected)
 
 
 # --------------------------------------------------------------------------- #
@@ -696,6 +733,44 @@ def test_route_logs_measured_klein_step_throughput(client, monkeypatch, caplog):
     assert "denoise=11.20s (2.80 s/step" in message
     assert "~13.6 estimated TFLOPS" in message
     assert "private prompt" not in message
+
+
+def test_route_prefers_atomic_generation_and_performance(client, monkeypatch):
+    engine = _FakeImageEngine(performance={"denoise_seconds": 4.0, "denoise_steps": 4})
+    atomic_calls = []
+
+    def _generate_with_performance(**kwargs):
+        atomic_calls.append(kwargs)
+        return engine.generate(**kwargs), engine.performance
+
+    engine.generate_with_performance = _generate_with_performance
+    _patch_engine(monkeypatch, engine)
+
+    resp = client.post("/v1/images/generations", json={"prompt": "a fox", "seed": 42})
+
+    assert resp.status_code == 200
+    assert atomic_calls[0]["prompt"] == "a fox"
+
+
+def test_route_ignores_legacy_performance_snapshot_failure(client, monkeypatch, caplog):
+    engine = _FakeImageEngine()
+
+    def _broken_snapshot():
+        raise RuntimeError("optional telemetry failed")
+
+    monkeypatch.setattr(engine, "performance_snapshot", _broken_snapshot)
+    _patch_engine(monkeypatch, engine)
+
+    with caplog.at_level("INFO", logger="vllm_mlx.routes.images"):
+        resp = client.post("/v1/images/generations", json={"prompt": "a fox"})
+
+    assert resp.status_code == 200
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("Image generation:")
+    )
+    assert message.endswith("(denoise timing unavailable)")
 
 
 def test_route_does_not_extrapolate_tflops_to_other_models(client, monkeypatch, caplog):

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -398,6 +398,37 @@ def test_progress_snapshot_shape():
     assert snap["family"] == "flux2-klein"
 
 
+def test_mflux_reporter_records_denoise_only_timing(monkeypatch):
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    ticks = iter((10.0, 21.2))
+    monkeypatch.setattr("vllm_mlx.image.engine.time.perf_counter", lambda: next(ticks))
+
+    class _Cfg:
+        num_inference_steps = 4
+
+    engine._reporter.call_before_loop(config=_Cfg())
+    engine._reporter.call_after_loop(config=_Cfg())
+
+    assert engine.performance_snapshot() == {
+        "denoise_seconds": pytest.approx(11.2),
+        "denoise_steps": 4,
+    }
+
+
+def test_new_generation_clears_stale_denoise_timing():
+    engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
+    engine._last_denoise_seconds = 11.2
+    engine._last_denoise_steps = 4
+    engine._model = _FakeModel()  # no callback boundaries in this test double
+
+    engine.generate(prompt="a fox", num_inference_steps=4, seed=1)
+
+    assert engine.performance_snapshot() == {
+        "denoise_seconds": None,
+        "denoise_steps": 0,
+    }
+
+
 def test_generate_resets_progress_and_registers_reporter():
     engine = ImageGenerationEngine("Runpod/FLUX.2-klein-4B-mflux-4bit")
 
@@ -516,9 +547,22 @@ def test_image_adapter_residency_without_mode_preserves_family_default(monkeypat
 class _FakeImageEngine:
     is_image_gen = True
 
-    def __init__(self, is_edit=False, default_steps=4):
+    def __init__(
+        self,
+        is_edit=False,
+        default_steps=4,
+        *,
+        family="flux2-klein",
+        performance=None,
+    ):
         self.is_edit = is_edit
         self.default_steps = default_steps
+        self.family = family
+        self.model_name = "repo/fake-image"
+        self.performance = performance or {
+            "denoise_seconds": None,
+            "denoise_steps": 0,
+        }
         self.seeds = []
         self.image_paths_seen = []
         self.dims_seen = []
@@ -533,6 +577,9 @@ class _FakeImageEngine:
             "elapsed_ms": 1200,
             "family": "flux2-klein",
         }
+
+    def performance_snapshot(self):
+        return self.performance
 
     def request_cancel(self):
         self.cancelled = True
@@ -625,6 +672,112 @@ def test_route_happy_path_returns_b64(client, monkeypatch):
     assert raw.startswith(_PNG_MAGIC)
 
 
+def test_route_logs_measured_klein_step_throughput(client, monkeypatch, caplog):
+    engine = _FakeImageEngine(performance={"denoise_seconds": 11.2, "denoise_steps": 4})
+    _patch_engine(monkeypatch, engine)
+
+    with caplog.at_level("INFO", logger="vllm_mlx.routes.images"):
+        resp = client.post(
+            "/v1/images/generations",
+            json={
+                "prompt": "private prompt must not reach logs",
+                "size": "1024x1024",
+                "steps": 4,
+            },
+        )
+
+    assert resp.status_code == 200
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("Image generation:")
+    )
+    assert "size=1024x1024 steps=4" in message
+    assert "denoise=11.20s (2.80 s/step" in message
+    assert "~13.6 estimated TFLOPS" in message
+    assert "private prompt" not in message
+
+
+def test_route_does_not_extrapolate_tflops_to_other_models(client, monkeypatch, caplog):
+    engine = _FakeImageEngine(
+        family="z-image",
+        default_steps=8,
+        performance={"denoise_seconds": 16.0, "denoise_steps": 8},
+    )
+    _patch_engine(monkeypatch, engine)
+
+    with caplog.at_level("INFO", logger="vllm_mlx.routes.images"):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"prompt": "a fox", "size": "1024x1024"},
+        )
+
+    assert resp.status_code == 200
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("Image generation:")
+    )
+    assert "denoise=16.00s (2.00 s/step)" in message
+    assert "TFLOPS" not in message
+
+
+def test_route_does_not_extrapolate_tflops_to_other_sizes(client, monkeypatch, caplog):
+    engine = _FakeImageEngine(performance={"denoise_seconds": 8.0, "denoise_steps": 4})
+    _patch_engine(monkeypatch, engine)
+
+    with caplog.at_level("INFO", logger="vllm_mlx.routes.images"):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"prompt": "a fox", "size": "768x768", "steps": 4},
+        )
+
+    assert resp.status_code == 200
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("Image generation:")
+    )
+    assert "denoise=8.00s (2.00 s/step)" in message
+    assert "TFLOPS" not in message
+
+
+def test_route_keeps_successful_image_when_performance_logging_fails(
+    client, monkeypatch
+):
+    engine = _FakeImageEngine(performance={"denoise_seconds": 4.0, "denoise_steps": 4})
+    _patch_engine(monkeypatch, engine)
+    monkeypatch.setattr(
+        "vllm_mlx.routes.images._log_image_performance",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("telemetry")),
+    )
+
+    resp = client.post("/v1/images/generations", json={"prompt": "a fox", "seed": 42})
+
+    assert resp.status_code == 200
+    assert base64.b64decode(resp.json()["data"][0]["b64_json"]).startswith(_PNG_MAGIC)
+
+
+@pytest.mark.parametrize("bad_seconds", [0.0, float("nan"), float("inf")])
+def test_route_rejects_invalid_denoise_timing(client, monkeypatch, caplog, bad_seconds):
+    engine = _FakeImageEngine(
+        performance={"denoise_seconds": bad_seconds, "denoise_steps": 4}
+    )
+    _patch_engine(monkeypatch, engine)
+
+    with caplog.at_level("INFO", logger="vllm_mlx.routes.images"):
+        resp = client.post("/v1/images/generations", json={"prompt": "a fox"})
+
+    assert resp.status_code == 200
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("Image generation:")
+    )
+    assert message.endswith("(denoise timing unavailable)")
+    assert "TFLOPS" not in message
+
+
 def test_route_selects_resident_image_engine_by_model(client, monkeypatch):
     from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
 
@@ -660,6 +813,30 @@ def test_route_multi_image_offsets_seed(client, monkeypatch):
     assert resp.status_code == 200
     assert len(resp.json()["data"]) == 3
     assert engine.seeds == [100, 101, 102]  # per-index seed offset
+
+
+def test_route_logs_each_completed_image_in_multi_image_request(
+    client, monkeypatch, caplog
+):
+    engine = _FakeImageEngine(performance={"denoise_seconds": 4.0, "denoise_steps": 4})
+    _patch_engine(monkeypatch, engine)
+
+    with caplog.at_level("INFO", logger="vllm_mlx.routes.images"):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"prompt": "three foxes", "n": 3, "seed": 100},
+        )
+
+    assert resp.status_code == 200
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("Image generation:")
+    ]
+    assert len(messages) == 3
+    assert all(
+        f"image={index}/3" in message for index, message in enumerate(messages, start=1)
+    )
 
 
 def test_progress_endpoint_returns_snapshot(client, monkeypatch):

--- a/vllm_mlx/image/engine.py
+++ b/vllm_mlx/image/engine.py
@@ -60,7 +60,7 @@ _QUANT_TAG_RE = re.compile(
 
 # mflux/Metal graphs are not re-entrant — a single process-wide lock serializes
 # every generation exactly like the video lane's ``_PROCESS_GENERATION_LOCK``.
-_PROCESS_GENERATION_LOCK = threading.Lock()
+_PROCESS_GENERATION_LOCK = threading.RLock()
 
 # Default quantization for the on-load quantize path. 4-bit is the 32GB sweet
 # spot (FLUX.1-schnell ~9GB, Qwen-Image ~12GB resident at q4).
@@ -100,6 +100,14 @@ class _ProgressReporter:
     def __init__(self, engine: ImageGenerationEngine) -> None:
         self._engine = engine
 
+    def call_before_loop(self, **kwargs) -> None:  # noqa: ANN003
+        """Start the denoise-only clock after prompt encoding."""
+        config = kwargs.get("config")
+        total = getattr(config, "num_inference_steps", 0) or self._engine._progress.get(
+            "total", 0
+        )
+        self._engine._start_denoise(int(total))
+
     def call_in_loop(self, t, seed, prompt, latents, config, time_steps) -> None:  # noqa: ANN001
         engine = self._engine
         total = getattr(config, "num_inference_steps", 0) or engine._progress.get(
@@ -113,6 +121,14 @@ class _ProgressReporter:
         engine._progress["total"] = int(total)
         if engine._is_cancelled():
             raise ImageGenerationCancelled("Generation cancelled.")
+
+    def call_after_loop(self, **kwargs) -> None:  # noqa: ANN003
+        """Stop the clock after the final synchronized denoise step."""
+        config = kwargs.get("config")
+        total = getattr(config, "num_inference_steps", 0) or self._engine._progress.get(
+            "total", 0
+        )
+        self._engine._finish_denoise(int(total))
 
 
 def _detect_family(model_name: str) -> str:
@@ -248,6 +264,13 @@ class ImageGenerationEngine:
             "total": 0,
             "started_at": 0.0,
         }
+        # mflux exposes callback boundaries after prompt encoding and after the
+        # final synchronized denoise step. Keep that clock separate from the
+        # user-facing wall clock so completion logs can report real s/step
+        # without adding an mx.eval synchronization to the hot path.
+        self._denoise_started_at: float | None = None
+        self._last_denoise_seconds: float | None = None
+        self._last_denoise_steps = 0
         # Cancellation is scoped by a monotonic run sequence rather than a bare
         # boolean, so a cancel is tied to a specific render and can never be
         # clobbered by the next request arming itself. ``_active_seq`` is the
@@ -265,6 +288,19 @@ class ImageGenerationEngine:
         """True when the in-flight run has an outstanding cancel request."""
         with self._state_lock:
             return self._active_seq > 0 and self._cancel_seq >= self._active_seq
+
+    def _start_denoise(self, total: int) -> None:
+        self._denoise_started_at = time.perf_counter()
+        self._last_denoise_seconds = None
+        self._last_denoise_steps = max(0, int(total))
+
+    def _finish_denoise(self, total: int) -> None:
+        started = self._denoise_started_at
+        if started is None:
+            return
+        self._last_denoise_seconds = max(0.0, time.perf_counter() - started)
+        self._last_denoise_steps = max(0, int(total))
+        self._denoise_started_at = None
 
     def _model_path_for_mflux(self) -> str | None:
         """``model_path`` to hand mflux: a local directory whenever we have one.
@@ -802,6 +838,30 @@ class ImageGenerationEngine:
             "family": self.family,
         }
 
+    def performance_snapshot(self) -> dict[str, float | int | None]:
+        """Return timing for the last fully completed denoise loop.
+
+        This is an internal logging surface, not part of the Images API. Native
+        backends that do not expose both loop boundaries report ``None`` rather
+        than mixing prompt/VAE time into a value labelled denoise throughput.
+        """
+        return {
+            "denoise_seconds": self._last_denoise_seconds,
+            "denoise_steps": self._last_denoise_steps,
+        }
+
+    def generate_with_performance(
+        self, **kwargs
+    ) -> tuple[bytes, dict[str, float | int | None]]:  # noqa: ANN003
+        """Generate and capture its timing before another render can start."""
+        # ``generate`` takes this same process-wide RLock. The outer acquisition
+        # deliberately keeps the last-run snapshot paired with these PNG bytes;
+        # without it, a queued request could reset or replace the timing between
+        # ``generate`` returning and the route reading the snapshot.
+        with self._lock:
+            png_bytes = self.generate(**kwargs)
+            return png_bytes, self.performance_snapshot()
+
     def generate(
         self,
         *,
@@ -949,6 +1009,9 @@ class ImageGenerationEngine:
                 total=int(num_inference_steps),
                 started_at=time.time(),
             )
+            self._denoise_started_at = None
+            self._last_denoise_seconds = None
+            self._last_denoise_steps = 0
             try:
                 if self.family == "hidream-o1-dev":
                     self._validate_hidream_prompt_tokens(prompt)

--- a/vllm_mlx/routes/images.py
+++ b/vllm_mlx/routes/images.py
@@ -29,6 +29,10 @@ _MAX_EDIT_IMAGE_PIXELS = 40_000_000
 # slack), enforced BEFORE FastAPI spools the body to disk.
 _IMAGE_EDIT_REQUEST_BYTES = _MAX_EDIT_IMAGE_BYTES + 1024 * 1024
 _OVERSIZE_DETAIL = "image edit request body exceeds the 25 MB limit"
+# Issue #3058 derives about 38 TFLOP per denoise step for dense FLUX.2 Klein
+# at 1024 square. It is the only model/shape with a reviewed operation-count
+# estimate, so logs must not extrapolate this value to other families or sizes.
+_KLEIN_1024_TFLOP_PER_STEP = 38.0
 
 
 class _ImageBodyTooLargeError(Exception):
@@ -207,14 +211,16 @@ def _image_engine(model_name: str = ""):
     return img_engine
 
 
-def _generate_one(img_engine, request: ImageGenerationRequest, seed: int) -> bytes:
+def _generate_one(
+    img_engine, request: ImageGenerationRequest, seed: int
+) -> tuple[bytes, dict]:
     """Blocking single-image render — runs off the event loop."""
     width, height = request.dimensions()
     # Step count is family-aware: a distilled model (Klein/schnell, 4 steps)
     # would waste wall-clock at 20 and a non-distilled one (Qwen, 20) would be
     # noise at 4. The engine advertises the right default per family.
     default_steps = getattr(img_engine, "default_steps", 4)
-    return img_engine.generate(
+    kwargs = dict(
         prompt=request.prompt,
         width=width,
         height=height,
@@ -227,6 +233,60 @@ def _generate_one(img_engine, request: ImageGenerationRequest, seed: int) -> byt
         guidance=request.guidance,
         negative_prompt=request.negative_prompt,
     )
+    generate_with_performance = getattr(img_engine, "generate_with_performance", None)
+    if callable(generate_with_performance):
+        return generate_with_performance(**kwargs)
+    png_bytes = img_engine.generate(**kwargs)
+    snapshot_fn = getattr(img_engine, "performance_snapshot", None)
+    try:
+        snapshot = snapshot_fn() if callable(snapshot_fn) else {}
+    except Exception:  # noqa: BLE001 — optional telemetry must not fail an image
+        snapshot = {}
+    return png_bytes, snapshot if isinstance(snapshot, dict) else {}
+
+
+def _log_image_performance(
+    img_engine,
+    *,
+    performance: dict,
+    image_index: int,
+    image_count: int,
+    width: int,
+    height: int,
+    steps: int,
+    total_seconds: float,
+) -> None:
+    """Log one completed image without exposing its prompt or response bytes."""
+    model_name = str(getattr(img_engine, "model_name", "unknown"))
+    family = str(getattr(img_engine, "family", "unknown"))
+    denoise_seconds = performance.get("denoise_seconds")
+    denoise_steps = performance.get("denoise_steps")
+    prefix = (
+        f"Image generation: model={model_name} family={family} "
+        f"image={image_index}/{image_count} size={width}x{height} steps={steps} "
+        f"total={total_seconds:.2f}s"
+    )
+    if (
+        not isinstance(denoise_seconds, (int, float))
+        or isinstance(denoise_seconds, bool)
+        or not math.isfinite(denoise_seconds)
+        or denoise_seconds <= 0
+        or denoise_steps != steps
+        or steps <= 0
+    ):
+        logger.info("%s (denoise timing unavailable)", prefix)
+        return
+
+    seconds_per_step = float(denoise_seconds) / steps
+    suffix = f" denoise={float(denoise_seconds):.2f}s ({seconds_per_step:.2f} s/step"
+    if family == "flux2-klein" and width == 1024 and height == 1024:
+        estimated_tflops = (
+            _KLEIN_1024_TFLOP_PER_STEP / seconds_per_step
+            if seconds_per_step > 0
+            else 0.0
+        )
+        suffix += f", ~{estimated_tflops:.1f} estimated TFLOPS"
+    logger.info("%s%s)", prefix, suffix)
 
 
 @router.post("/v1/images/generations")
@@ -285,9 +345,16 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
 
     data = []
     cancelled = False
+    width, height = request.dimensions()
+    steps = (
+        request.steps
+        if request.steps is not None
+        else int(getattr(img_engine, "default_steps", 4))
+    )
     for index in range(request.n):
+        image_started = time.perf_counter()
         try:
-            png_bytes = await run_to_completion(
+            png_bytes, performance = await run_to_completion(
                 _generate_one, img_engine, request, (base_seed + index) & 0x7FFFFFFF
             )
         except ImageGenerationCancelled:
@@ -307,6 +374,19 @@ async def create_image(request: ImageGenerationRequest = Body(...)):
                 },
             ) from exc
         data.append({"b64_json": base64.b64encode(png_bytes).decode("ascii")})
+        try:
+            _log_image_performance(
+                img_engine,
+                performance=performance,
+                image_index=index + 1,
+                image_count=request.n,
+                width=width,
+                height=height,
+                steps=steps,
+                total_seconds=time.perf_counter() - image_started,
+            )
+        except Exception:  # noqa: BLE001 — telemetry must never fail the response
+            logger.warning("image performance telemetry failed", exc_info=True)
 
     return {"created": int(time.time()), "data": data, "cancelled": cancelled}
 

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -133,6 +133,16 @@ class ImageEngine:
         """Live denoise progress for the single in-flight render."""
         return self._engine.progress_snapshot()
 
+    def performance_snapshot(self) -> dict[str, float | int | None]:
+        """Timing for the last fully completed denoise loop."""
+        return self._engine.performance_snapshot()
+
+    def generate_with_performance(
+        self, **kwargs
+    ) -> tuple[bytes, dict[str, float | int | None]]:  # noqa: ANN003
+        """Generate one image and atomically return its denoise timing."""
+        return self._engine.generate_with_performance(**kwargs)
+
     def generate(
         self,
         *,


### PR DESCRIPTION
## Intention

Make image-generation performance visible and reproducible for users and operators, and finish the remaining scoped work from #3058.

## What changed

- measures the denoise loop at existing backend callback boundaries, without adding a synchronization barrier
- logs total completion time and measured denoise seconds per step for each completed image
- reports estimated achieved TFLOPS only for the qualified FLUX.2 Klein 1024×1024 workload
- reports timing as unavailable when exact loop boundaries or valid measurements are absent
- documents measured 1024×1024 expectations and the explicit M2 Pro BF16 option
- records why the public q4 alias remains stable instead of silently switching precision by hardware

## Scope and non-goals

- no Images API response changes
- no prompt or output bytes in telemetry
- no model defaults, aliases, downloads, scheduling, or generated output changes
- no TFLOPS extrapolation to unqualified models or resolutions
- no automatic hardware/precision policy from a single qualified M2 Pro data point

## Acceptance evidence

- real 1024×1024 four-step Klein generation returned HTTP 200 and a valid PNG
- completion log matched the backend's four-step denoise duration and reported 2.92 s/step
- telemetry failure is covered as non-fatal
- invalid, missing, cross-model, cross-resolution, and multi-image cases are covered
- `248 passed` across image lane, precision policy, README matrix, and residency tests
- Ruff formatting/lint and `git diff --check` pass

Closes #3058

