### PR TITLE
Opt-in compiled-decode-replay plain-decode lane (dense MoE, e.g. 35B)

### DIFF
--- a/tests/test_model_runner_compiled_decode.py
+++ b/tests/test_model_runner_compiled_decode.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the compiled-decode-replay lane gate in ``model_runner``.
+
+These are CPU-only and do not load a model. They cover the fail-closed
+eligibility gate, the manifest requirement, the warm-restore plan decision,
+and the publish-back discipline. Device correctness (bit-identity to eager,
+engagement, warm-restore TTFT, throughput) is covered by the GPU gate script,
+not here.
+"""
+
+import types
+
+import pytest
+
+from vllm_mlx import model_runner as mr
+from vllm_mlx.model_runner import MLXModelRunner
+
+
+def _runner(*, enabled=True, vllm_config=None):
+    """A runner with the compiled-lane attributes set, bypassing model load."""
+    r = MLXModelRunner.__new__(MLXModelRunner)
+    r._enable_compiled_decode = enabled
+    r.model = None
+    r._compiled_apc_tokens = None
+    r._compiled_apc_cache = None
+    r.vllm_config = vllm_config or types.SimpleNamespace(speculative_config=None)
+    return r
+
+
+def _params(**kw):
+    kw.setdefault("temperature", 0.0)
+    kw.setdefault("top_p", 1.0)
+    kw.setdefault("n", 1)
+    return types.SimpleNamespace(**kw)
+
+
+def test_env_truthy():
+    assert mr._env_truthy("1")
+    assert mr._env_truthy("true")
+    assert mr._env_truthy("YES")
+    for falsey in ("", "0", "false", "no", "off", None):
+        assert not mr._env_truthy(falsey)
+
+
+def test_disabled_lane_declines(monkeypatch):
+    monkeypatch.delenv(mr._COMPILED_QUALIFICATION_ENV, raising=False)
+    r = _runner(enabled=False)
+    reason = r._compiled_decode_decline_reason([1, 2, 3], _params(), 16)
+    assert reason == "compiled-decode lane disabled"
+    assert r._plan_compiled_decode([1, 2, 3], _params(), 16) is None
+
+
+def test_manifest_required(monkeypatch):
+    monkeypatch.delenv(mr._COMPILED_QUALIFICATION_ENV, raising=False)
+    r = _runner(enabled=True)
+    reason = r._compiled_decode_decline_reason([1, 2, 3], _params(), 16)
+    # Either the build lacks the compiled surface, or (surface present) the
+    # missing manifest is the blocker. Both are fail-closed to eager.
+    available, _ = mr._compiled_decode_available()
+    if available:
+        assert "qualification manifest" in reason
+    else:
+        assert reason is not None
+
+
+def _require_surface():
+    available, why = mr._compiled_decode_available()
+    if not available:
+        pytest.skip(f"mlx-lm compiled-decode surface unavailable: {why}")
+
+
+def test_speculative_declined(monkeypatch):
+    _require_surface()
+    monkeypatch.setenv(mr._COMPILED_QUALIFICATION_ENV, "/tmp/fake-manifest.json")
+    r = _runner(enabled=True, vllm_config=types.SimpleNamespace(
+        speculative_config=object()
+    ))
+    reason = r._compiled_decode_decline_reason([1, 2, 3], _params(), 16)
+    assert "speculative" in reason
+
+
+def test_batched_declined(monkeypatch):
+    _require_surface()
+    monkeypatch.setenv(mr._COMPILED_QUALIFICATION_ENV, "/tmp/fake-manifest.json")
+    r = _runner(enabled=True)
+    assert "width 1" in r._compiled_decode_decline_reason([1, 2], _params(n=2), 16)
+    assert "width 1" in r._compiled_decode_decline_reason(
+        [1, 2], _params(best_of=4), 16
+    )
+
+
+def test_prompt_lookup_declined(monkeypatch):
+    _require_surface()
+    monkeypatch.setenv(mr._COMPILED_QUALIFICATION_ENV, "/tmp/fake-manifest.json")
+    monkeypatch.setenv("VLLM_MLX_PROMPT_LOOKUP", "1")
+    r = _runner(enabled=True)
+    assert "PLD" in r._compiled_decode_decline_reason([1, 2, 3], _params(), 16)
+
+
+def test_kv_bits_declined(monkeypatch):
+    _require_surface()
+    monkeypatch.setenv(mr._COMPILED_QUALIFICATION_ENV, "/tmp/fake-manifest.json")
+    r = _runner(enabled=True)
+    assert "kv_bits" in r._compiled_decode_decline_reason(
+        [1, 2, 3], _params(kv_bits=4), 16
+    )
+    assert "max_kv_size" in r._compiled_decode_decline_reason(
+        [1, 2, 3], _params(max_kv_size=2048), 16
+    )
+
+
+def test_out_of_policy_context_declined(monkeypatch):
+    _require_surface()
+    monkeypatch.setenv(mr._COMPILED_QUALIFICATION_ENV, "/tmp/fake-manifest.json")
+    monkeypatch.delenv("MLX_LM_COMPILED_DECODE_CONTEXT_POLICY", raising=False)
+    r = _runner(enabled=True)
+    # short profile stops at 4096; 5000 + 16 exceeds it.
+    reason = r._compiled_decode_decline_reason(list(range(5000)), _params(), 16)
+    assert reason is not None and "short" in reason
+
+
+def test_plan_warm_restore_hit_reuses_stored_cache(monkeypatch):
+    """A stored prefix that this request extends reuses the stored cache and
+    feeds only the suffix, without touching make_prompt_cache."""
+    _require_surface()
+    monkeypatch.setenv(mr._COMPILED_QUALIFICATION_ENV, "/tmp/fake-manifest.json")
+    r = _runner(enabled=True)
+    sentinel_cache = ["STORED-CACHE"]
+    r._compiled_apc_tokens = (1, 2, 3)
+    r._compiled_apc_cache = sentinel_cache
+
+    # Guard: the hit branch must not call make_prompt_cache.
+    import mlx_lm.models.cache as cache_mod
+
+    def _boom(*a, **k):  # pragma: no cover - only fires on a bug
+        raise AssertionError("make_prompt_cache must not run on a warm hit")
+
+    monkeypatch.setattr(cache_mod, "make_prompt_cache", _boom)
+
+    plan = r._plan_compiled_decode([1, 2, 3, 4, 5], _params(), 16)
+    assert plan is not None
+    assert plan["hit"] is True
+    assert plan["cache"] is sentinel_cache
+    assert plan["feed"] == [4, 5]
+    assert plan["prefix_len"] == 3
+    # The reference is cleared while in flight (re-published on finish).
+    assert r._compiled_apc_cache is None
+    assert r._compiled_apc_tokens is None
+
+
+def test_plan_no_hit_on_divergent_prefix(monkeypatch):
+    _require_surface()
+    monkeypatch.setenv(mr._COMPILED_QUALIFICATION_ENV, "/tmp/fake-manifest.json")
+    r = _runner(enabled=True)
+    r._compiled_apc_tokens = (1, 2, 9)
+    r._compiled_apc_cache = ["STORED"]
+
+    import mlx_lm.models.cache as cache_mod
+
+    monkeypatch.setattr(cache_mod, "make_prompt_cache", lambda *a, **k: ["FRESH"])
+    plan = r._plan_compiled_decode([1, 2, 3, 4], _params(), 16)
+    assert plan is not None and plan["hit"] is False
+    assert plan["cache"] == ["FRESH"]
+    assert plan["feed"] == [1, 2, 3, 4]
+
+
+def test_publish_back_converts_ring_to_stock():
+    """Publish-back stores the stock KVCache form, never a RingKVCache."""
+    from mlx_lm.models.cache import KVCache, RingKVCache
+
+    r = _runner(enabled=True)
+    ring = RingKVCache()  # empty is fine: to_kv_cache() returns an empty KVCache
+    arrays_like = object()
+    plan = {"cache": [ring, arrays_like], "feed": [4], "hit": False, "prefix_len": 0}
+    r._record_compiled_result(
+        plan, [1, 2, 3], [4], status={"used": True, "decline_reason": None}
+    )
+    assert r._compiled_apc_tokens == (1, 2, 3, 4)
+    assert r._compiled_apc_cache is not None
+    assert isinstance(r._compiled_apc_cache[0], KVCache)
+    assert not any(isinstance(c, RingKVCache) for c in r._compiled_apc_cache)
+    assert r._compiled_apc_cache[1] is arrays_like

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2945,6 +2945,27 @@ def serve_command(args):
         print(f"MCP config: {args.mcp_config}")
         os.environ["RAPID_MLX_MCP_CONFIG"] = args.mcp_config
 
+    # Compiled-decode-replay lane: translate the CLI flags into the env the
+    # model runner and mlx-lm read. The lane is env-gated (like the deployed
+    # serve wrapper's mlx-lm levers) so it needs no VllmConfig plumbing.
+    if getattr(args, "compiled_decode", False):
+        os.environ["VLLM_MLX_COMPILED_DECODE"] = "1"
+        # Enablement here is opt-in; keep mlx-lm's own default-on behavior for
+        # the underlying replay unless the operator overrode it explicitly.
+        os.environ.setdefault("MLX_LM_COMPILED_DECODE", "1")
+        print("Compiled-decode-replay lane: enabled")
+    if getattr(args, "compiled_decode_qualification", None):
+        os.environ["MLX_LM_COMPILED_DECODE_QUALIFICATION"] = (
+            args.compiled_decode_qualification
+        )
+        print(
+            f"Compiled-decode qualification: {args.compiled_decode_qualification}"
+        )
+    if getattr(args, "compiled_decode_context_policy", None):
+        os.environ["MLX_LM_COMPILED_DECODE_CONTEXT_POLICY"] = (
+            args.compiled_decode_context_policy
+        )
+
     # Pre-load embedding model if specified.
     #
     # H-08 install guard + D-EMBED-ALIAS alias-resolution + clean
@@ -7176,6 +7197,47 @@ Examples:
             "workloads. An identical exact re-request of a rotated "
             "sliding-window prompt falls back to a full prefill (byte-equal to "
             "cold)."
+        ),
+    )
+    # Compiled-decode-replay lane (opt-in, plain width-1 decode). Traces the
+    # decode step once with mx.compile and replays it instead of rebuilding the
+    # per-token graph, on a shape-stable RingKVCache. Exact (bit-identical to
+    # eager on the qualified class-1 bucket ladder) and single-digit percent;
+    # it declines cleanly to eager for anything it does not cover, and refuses
+    # to serve compiled without a bound reviewed-qualification manifest.
+    # Requires an mlx-lm build that exposes the compiled-decode surface.
+    serve_parser.add_argument(
+        "--compiled-decode",
+        action="store_true",
+        help=(
+            "Enable the compiled-decode-replay lane for plain width-1 decode "
+            "(opt-in; default disabled). Requires --compiled-decode-"
+            "qualification and an mlx-lm build with compiled replay. Declines "
+            "cleanly to eager for quantized/rotating caches, batched/"
+            "speculative/prompt-lookup requests, and out-of-policy contexts."
+        ),
+    )
+    serve_parser.add_argument(
+        "--compiled-decode-qualification",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to the operator-approved compiled-decode serving manifest "
+            "(binds MLX_LM_COMPILED_DECODE_QUALIFICATION). The lane will not "
+            "serve compiled replay without it."
+        ),
+    )
+    serve_parser.add_argument(
+        "--compiled-decode-context-policy",
+        type=str,
+        choices=["short", "memory", "latency", "long"],
+        default=None,
+        help=(
+            "Compiled-decode context policy (binds "
+            "MLX_LM_COMPILED_DECODE_CONTEXT_POLICY): short=4096 (default), "
+            "memory/latency=16384, long=262144. Contexts beyond the policy "
+            "limit decode eagerly."
         ),
     )
     # Opt-in prompt-deterministic RESPONSE CACHE (exact-match short-circuit).

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -11,6 +11,7 @@ Includes low-level optimizations:
 """
 
 import logging
+import os
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -58,6 +59,56 @@ class MLXModelRunnerOutput:
     generation_time_s: float = 0.0
 
 
+# --------------------------------------------------------------------------
+# Compiled-decode-replay lane (opt-in, fail-closed to eager generate_step)
+# --------------------------------------------------------------------------
+#
+# mlx-lm's ``generate_step`` can trace the width-1 decode step once with
+# ``mx.compile`` and replay it instead of rebuilding ~250 kernels per token
+# (``mlx_lm.compiled_decode``). The gain is exact (bit-identical to eager on
+# the qualified class-1 bucket ladder) and single-digit percent, because
+# decode is near the memory-bandwidth floor. This lane is OFF by default; when
+# on, it declines cleanly to eager for anything it does not cover (a quantized
+# or rotating cache, batched/speculative/PLD requests, an out-of-policy
+# context, or a build whose mlx-lm lacks the module). It is a plain-decode
+# accelerator only.
+_COMPILED_DECODE_ENV = "VLLM_MLX_COMPILED_DECODE"
+_COMPILED_QUALIFICATION_ENV = "MLX_LM_COMPILED_DECODE_QUALIFICATION"
+
+
+def _env_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _compiled_decode_available() -> tuple[bool, str | None]:
+    """Whether the loaded mlx-lm exposes the compiled-decode surface.
+
+    A build without the module (or with an older module missing the
+    request-private plumbing) declines the lane; the request still serves on
+    the eager path.
+    """
+    try:
+        from mlx_lm.compiled_decode import (  # noqa: F401
+            compiled_decode_context_policy,
+            model_is_compilable,
+        )
+        from mlx_lm.generate import generate_step  # noqa: F401
+    except Exception as exc:  # ImportError, or a partial/old module
+        return False, f"mlx-lm build has no compiled-decode surface ({exc})"
+    # The request-private prompt-cache argument is required to engage compiled
+    # replay without leaking RingKVCache's class into a shared cache. Older
+    # builds route the same call through the eager path, which is still correct.
+    import inspect
+
+    try:
+        params = inspect.signature(generate_step).parameters
+    except (TypeError, ValueError):
+        return False, "mlx-lm generate_step signature is not introspectable"
+    if "compiled_decode" not in params or "_prompt_cache_is_request_private" not in params:
+        return False, "mlx-lm generate_step predates request-private compiled replay"
+    return True, None
+
+
 class MLXModelRunner:
     """
     Model runner that uses mlx-lm for inference.
@@ -73,13 +124,25 @@ class MLXModelRunner:
     - Prefill chunking for L2 cache utilization
     """
 
-    def __init__(self, vllm_config: "VllmConfig", enable_optimizations: bool = True):
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        enable_optimizations: bool = True,
+        enable_compiled_decode: bool | None = None,
+    ):
         """
         Initialize MLX model runner.
 
         Args:
             vllm_config: vLLM configuration
             enable_optimizations: Whether to enable low-level optimizations
+            enable_compiled_decode: Opt into the compiled-decode-replay
+                plain-decode lane. ``None`` reads ``VLLM_MLX_COMPILED_DECODE``
+                (the ``serve`` CLI sets it from ``--compiled-decode``); the
+                default is off. Enabling it never forces compiled replay: the
+                lane still declines per request to the eager path for anything
+                it does not cover, and refuses to serve compiled without a
+                bound reviewed-qualification manifest.
         """
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -97,6 +160,21 @@ class MLXModelRunner:
         # Cache for prompt processing
         self._prompt_cache = None
 
+        # Compiled-decode-replay lane (opt-in, fail-closed to eager). When
+        # enabled, plain width-1 decode is routed through mlx-lm's compiled
+        # replay path with a request-private cache.
+        if enable_compiled_decode is None:
+            enable_compiled_decode = _env_truthy(os.environ.get(_COMPILED_DECODE_ENV))
+        self._enable_compiled_decode = bool(enable_compiled_decode)
+        # Single-entry APC (publish-back on hit): the stock-cache form of the
+        # last compiled turn's KV, plus the exact token ids it covers, so a
+        # later turn that extends the same prefix warm-restores instead of
+        # re-prefilling. The RingKVCache the compiled step owns is
+        # request-private and is NEVER stored here (mirrors the mlx-lm server's
+        # publish-back discipline: the APC only ever holds a stock KVCache).
+        self._compiled_apc_tokens: tuple[int, ...] | None = None
+        self._compiled_apc_cache: list | None = None
+
         # KV cache blocks
         self._num_cache_blocks = 0
 
@@ -113,6 +191,10 @@ class MLXModelRunner:
         logger.info(f"MLXModelRunner initialized for model: {self.model_config.model}")
         logger.info(
             f"Low-level optimizations: {'ENABLED' if enable_optimizations else 'disabled'}"
+        )
+        logger.info(
+            "Compiled-decode-replay lane: "
+            f"{'ENABLED (opt-in)' if self._enable_compiled_decode else 'disabled'}"
         )
 
     def load_model(self) -> None:
@@ -349,6 +431,174 @@ class MLXModelRunner:
 
         return logits, cache
 
+    def _compiled_decode_decline_reason(
+        self,
+        prompt_token_ids: list[int],
+        sampling_params: Any,
+        max_tokens: int,
+    ) -> str | None:
+        """Why this request may NOT use the compiled-replay lane, or ``None``.
+
+        Returns a reason string for anything the lane does not cover; the
+        caller then serves the request on the eager path. This gate is
+        deliberately conservative and mirrors ``generate_step``'s own
+        preconditions so a declined request never allocates a private cache
+        it will not use.
+        """
+        if not self._enable_compiled_decode:
+            return "compiled-decode lane disabled"
+        available, why = _compiled_decode_available()
+        if not available:
+            return why
+        # The lane must NOT serve compiled without an operator-approved,
+        # loader-bound checkpoint manifest. Family eligibility alone is only
+        # for direct research use of CompiledDecodeStep. mlx-lm binds a
+        # manifest either from a file (MLX_LM_COMPILED_DECODE_QUALIFICATION,
+        # set by --compiled-decode-qualification) or from an in-process
+        # registered serving record; honor both, but hard-decline when neither
+        # is present. generate_step remains the authoritative gate — it
+        # verifies the bound manifest against the loaded weights and declines
+        # to eager if it does not match, so this check never hashes weights.
+        manifest = os.environ.get(_COMPILED_QUALIFICATION_ENV, "").strip()
+        if not manifest:
+            try:
+                from mlx_lm import compiled_qualification as _cq
+
+                registered = bool(getattr(_cq, "SERVING_QUALIFICATIONS", {}))
+            except Exception:
+                registered = False
+            if not registered:
+                return (
+                    "no reviewed qualification manifest bound "
+                    f"({_COMPILED_QUALIFICATION_ENV} unset and no registered "
+                    "serving record; pass --compiled-decode-qualification)"
+                )
+        if max_tokens is not None and 0 <= max_tokens < 1:
+            return "no decode step requested (max_tokens < 1)"
+        # Width-1, batch-1, non-speculative only.
+        if getattr(sampling_params, "n", 1) not in (None, 1):
+            return "n>1 (compiled replay is width 1, batch 1)"
+        if (getattr(sampling_params, "best_of", 1) or 1) > 1:
+            return "best_of>1 (compiled replay is width 1, batch 1)"
+        if getattr(self.vllm_config, "speculative_config", None) is not None:
+            return "speculative decoding is configured (not shape-stable)"
+        if _env_truthy(os.environ.get("VLLM_MLX_PROMPT_LOOKUP")):
+            return "prompt-lookup (PLD) is enabled (not shape-stable)"
+        # A quantized / bounded KV cache is not shape-stable. This runner never
+        # passes kv_bits/max_kv_size to generate_step, but decline defensively
+        # if a caller ever wires them onto the sampling params.
+        if getattr(sampling_params, "kv_bits", None) is not None:
+            return "kv_bits (a quantized cache is not shape-stable)"
+        if getattr(sampling_params, "max_kv_size", None) is not None:
+            return "max_kv_size (rotating caches are not shape-stable)"
+        # Context must be within the configured compiled context policy. The
+        # env default is ``short`` (4096); generate_step re-checks this too.
+        try:
+            from mlx_lm.compiled_decode import compiled_decode_context_policy
+
+            budget = 0 if max_tokens is None or max_tokens < 0 else max_tokens
+            why, _policy = compiled_decode_context_policy(
+                len(prompt_token_ids), budget
+            )
+        except Exception as exc:
+            return f"context policy check failed ({exc})"
+        if why is not None:
+            return why
+        return None
+
+    def _plan_compiled_decode(
+        self,
+        prompt_token_ids: list[int],
+        sampling_params: Any,
+        max_tokens: int,
+    ) -> dict | None:
+        """Build the compiled-lane plan (cache + tokens to feed), or ``None``.
+
+        On a warm-restore hit the stored stock cache from the previous compiled
+        turn is reused and only the new suffix is prefilled; otherwise a fresh
+        request-private cache is created. Returning ``None`` means serve eager.
+        """
+        reason = self._compiled_decode_decline_reason(
+            prompt_token_ids, sampling_params, max_tokens
+        )
+        if reason is not None:
+            logger.debug("compiled decode declined: %s", reason)
+            return None
+
+        from mlx_lm.models.cache import make_prompt_cache
+
+        tokens = tuple(prompt_token_ids)
+        # Warm restore: the previous compiled turn's cache is reusable when its
+        # covered tokens are a strict prefix of this request and at least one
+        # new token remains to prefill. The stored form is a stock KVCache list
+        # (never a RingKVCache), which generate_step re-converts in place.
+        stored_tokens = self._compiled_apc_tokens
+        stored_cache = self._compiled_apc_cache
+        if (
+            stored_cache is not None
+            and stored_tokens is not None
+            and 0 < len(stored_tokens) < len(tokens)
+            and tokens[: len(stored_tokens)] == stored_tokens
+        ):
+            prefix_len = len(stored_tokens)
+            # Hand the stored list to generate_step, which mutates it in place.
+            # Clear our reference so a mid-flight failure cannot leave a stale,
+            # half-converted cache visible to the next turn; we re-publish on
+            # a clean finish.
+            self._compiled_apc_tokens = None
+            self._compiled_apc_cache = None
+            return {
+                "cache": stored_cache,
+                "feed": list(tokens[prefix_len:]),
+                "hit": True,
+                "prefix_len": prefix_len,
+            }
+        return {
+            "cache": make_prompt_cache(self.model),
+            "feed": list(tokens),
+            "hit": False,
+            "prefix_len": 0,
+        }
+
+    def _record_compiled_result(
+        self,
+        plan: dict,
+        prompt_token_ids: list[int],
+        generated_ids: list[int],
+        status: dict | None,
+    ) -> None:
+        """Publish the finished turn's cache back for later warm restore.
+
+        Mirrors the mlx-lm server's publish-back discipline: convert any
+        RingKVCache to its stock KVCache form (the APC never holds a
+        RingKVCache) and record the exact tokens it covers. A turn that
+        declined compiled still leaves a valid stock cache, so it is published
+        too, preserving prefix reuse across a policy-driven decline.
+        """
+        used = bool(status and status.get("used"))
+        if status is not None and not used and status.get("decline_reason"):
+            logger.debug(
+                "compiled decode declined at prefill: %s",
+                status.get("decline_reason"),
+            )
+        try:
+            from mlx_lm.models.cache import RingKVCache
+
+            cache = plan["cache"]
+            published = [
+                c.to_kv_cache() if isinstance(c, RingKVCache) else c for c in cache
+            ]
+            if any(isinstance(c, RingKVCache) for c in published):
+                raise RuntimeError("a RingKVCache must never be published")
+            self._compiled_apc_cache = published
+            self._compiled_apc_tokens = tuple(prompt_token_ids) + tuple(generated_ids)
+        except Exception as exc:
+            # Never let publish-back break generation; just skip the warm-restore
+            # opportunity for the next turn.
+            logger.debug("compiled decode publish-back skipped: %s", exc)
+            self._compiled_apc_cache = None
+            self._compiled_apc_tokens = None
+
     def _generate_for_request(
         self,
         prompt_token_ids: list[int],
@@ -360,6 +610,7 @@ class MLXModelRunner:
 
         Uses optimizations when enabled:
         - Prefill chunking for long prompts
+        - Compiled-decode-replay lane for plain width-1 decode (opt-in)
 
         Args:
             prompt_token_ids: Input token IDs
@@ -386,18 +637,37 @@ class MLXModelRunner:
             top_p = getattr(sampling_params, "top_p", 0.9)
             sampler = make_sampler(temp=temp, top_p=top_p)
 
-            # Convert token IDs to MLX array
-            prompt = mx.array(prompt_token_ids)
+            # Decide whether this request may use the compiled-replay lane.
+            plan = self._plan_compiled_decode(
+                prompt_token_ids, sampling_params, max_tokens
+            )
+
+            gen_kwargs: dict[str, Any] = dict(
+                prompt=mx.array(prompt_token_ids if plan is None else plan["feed"]),
+                model=self.model,
+                max_tokens=max_tokens,
+                sampler=sampler,
+            )
+            status: dict | None = None
+            if plan is not None:
+                # A request-private cache lets generate_step convert to a
+                # RingKVCache and replay a traced step without leaking that
+                # numerical/performance class into any shared cache. Any
+                # decline inside generate_step falls back to the eager step
+                # for this same request — the lane is fail-closed by
+                # construction.
+                status = {}
+                gen_kwargs.update(
+                    prompt_cache=plan["cache"],
+                    _prompt_cache_is_request_private=True,
+                    compiled_decode=True,
+                    _compiled_decode_status=status,
+                )
 
             generated_ids = []
 
             # Generate tokens
-            for token_info in generate_step(
-                prompt=prompt,
-                model=self.model,
-                max_tokens=max_tokens,
-                sampler=sampler,
-            ):
+            for token_info in generate_step(**gen_kwargs):
                 if hasattr(token_info, "token"):
                     generated_ids.append(token_info.token)
                 elif isinstance(token_info, tuple) and len(token_info) > 0:
@@ -406,10 +676,19 @@ class MLXModelRunner:
                 if len(generated_ids) >= max_tokens:
                     break
 
+            if plan is not None:
+                self._record_compiled_result(
+                    plan, prompt_token_ids, generated_ids, status
+                )
+
             return generated_ids
 
         except Exception as e:
             logger.error(f"Generation failed: {e}")
+            # A compiled attempt that raised may have left a poisoned/partial
+            # cache; drop the warm-restore entry so the next turn re-prefills.
+            self._compiled_apc_cache = None
+            self._compiled_apc_tokens = None
             return []
 
     def _continue_generation(self, req_id: str) -> list[int]:
@@ -458,6 +737,7 @@ class MLXModelRunner:
             info["optimizations"] = {
                 "kernel_fusion": False,
                 "memory_optimized": self._optimizations_applied,
+                "compiled_decode": self._enable_compiled_decode,
             }
 
             if self._hardware_info:


### PR DESCRIPTION
### Add an opt-in compiled-decode-replay lane for plain width-1 decode

**What this adds.** A fail-closed compiled-decode-replay lane in the MLX model runner. When enabled and the underlying mlx-lm build exposes the compiled-decode surface, plain width-1 batch-1 decode is routed through mlx-lm's compiled replay path on a shape-stable cache: the decode step is traced once with `mx.compile` and replayed every token, instead of rebuilding and dispatching the per-token graph (~250 kernels) each step. Sampling stays outside the traced function, exactly as the eager loop reads it.

Three small pieces in `vllm_mlx/model_runner.py`:

1. **An eligibility gate** (`_compiled_decode_decline_reason`) that returns a reason for anything the lane does not cover, so the request serves eager: a quantized/rotating cache (`kv_bits`/`max_kv_size`), a batched request (`n>1`/`best_of>1`), speculative decoding, prompt-lookup (PLD), or a context outside the compiled context policy.
2. **A cache plan** (`_plan_compiled_decode`) that builds a request-private cache (or reuses the previous turn's, see prefix caching below) and decides which tokens to prefill.
3. **Publish-back** (`_record_compiled_result`) that records the finished turn's KV for later reuse.

It routes through `generate_step(compiled_decode=True, _prompt_cache_is_request_private=True, ...)`. The request-private cache is the key: it lets replay own a `RingKVCache` for the request without leaking that numerical/performance class into any shared cache, and any decline inside `generate_step` falls back to the eager step for the same request. Fail-closed by construction.

**Why it is worth adding.**

- **It is exact.** On the qualified class-1 bucket ladder (which carries both the 1023 bucket — sub-1024 live lengths stay on the single-pass SDPA kernel, as eager does — and the 1024 bucket, so a cache of exactly 1024 keys is not padded into a 2048 slab) the replayed step is **bit-identical to eager at every qualified operating point and every bucket growth boundary**. Not an approximation with a tolerance; an equality.
- **It composes with prefix caching.** A naive "flip on compiled" that declined on prefix-cache hits was measured as a ~27% multi-turn regression (every hit fell back to a cold prefill). Publishing the compiled turn's KV back in its stock cache form and warm-restoring it on the next turn turned that into a ~1.077x whole-conversation win and removes the regression.
- **It is cheap and always-declinable.** Replay removes per-token graph rebuild and dispatch, which is on the order of the dispatch floor itself at width 1.

**Measured (class-1, exact), on a ~3B-active dense MoE at 4-bit.**

- Single-request decode: **1.04–1.10x** at 2K–8K context, still **1.07x** at 32K.
- Multi-turn with publish-back + warm restore: **~1.077x** whole-conversation vs eager, and it prevents the ~27% regression a compiled-on-hit-decline would cause.
- Snapshot: ~136 tok/s at 0.5K; five six-turn sessions (30 turns) in ~7.2 s with compiled replay and prefix-cache warm restore engaged on all 30 turns.

The win is single-digit percent on purpose: decode on this model is near the memory-bandwidth floor, so removing launch/dispatch overhead is the whole available headroom. This lane buys that headroom exactly, at no numerical cost.

**Non-goals / honest limits.** Compiled replay needs shape-stable caches, so the lane declines cleanly to eager for: quantized KV (`kv_bits`) and bounded/rotating KV (`max_kv_size`); external-draft, prompt-lookup (PLD), and self-MTP / speculative requests (a speculating cache stashes a Python rollback closure that tracing would capture); batched (`n>1`) decode; contexts beyond the configured policy; input-embeddings requests. Each keeps the eager path and produces identical output; the lane never makes a request wrong, only faster where it applies.

### Configuration

New `serve` flags (all default off / unset):

- `--compiled-decode` — enable the lane (opt-in).
- `--compiled-decode-qualification PATH` — bind the reviewed serving manifest. The lane refuses to serve compiled replay without it; family eligibility alone is not enough.
- `--compiled-decode-context-policy {short,memory,latency,long}` — context budget: `short`=4096 (default), `memory`/`latency`=16384, `long`=262144. Contexts beyond the policy limit decode eagerly.

These set the environment the runner and mlx-lm read, matching the env-gated style of the other decode levers. The runner also accepts an `enable_compiled_decode` constructor argument for embedding.

### Dependency

This lane calls into an mlx-lm build that exposes the compiled-decode surface (a `RingKVCache`-backed traced replay, the class-1 bucket ladder, the context-policy resolver, the reviewed-qualification gate, and the request-private `generate_step` arguments). The change is **import-guarded**: on a build without that surface (including one predating the request-private `generate_step` arguments) the availability probe returns false and every request serves eager — the lane is a no-op. It lands cleanly and only activates once the runtime resolves a build that carries the surface. The corresponding mlx-lm modules are now published for review at https://github.com/pierre427/rapid-mlx-decode-lane-deps — review-grade (the new additive modules, not the divergent core-file wiring); see its README for the exact integration surface the host build must expose. Happy to walk through a full build directly.

### Tests

`tests/test_model_runner_compiled_decode.py` (CPU-only): the fail-closed gate (disabled, missing manifest, speculative, batched, PLD, kv_bits/max_kv_size, out-of-policy context), the warm-restore plan decision (hit reuses the stored cache and feeds only the suffix; a divergent prefix takes a fresh cache), and the publish-back conversion (a `RingKVCache` is stored in its stock `KVCache` form, never as a `RingKVCache`; a recurrent-state cache passes through).

**Device gate (dense MoE, greedy), all pass:** (a) compiled engages, no decline; (b) the token stream is **bit-identical to eager `generate_step`** on the same prompt (class-1 equality); (c) a prefix-hit turn warm-restores with compiled still engaged (warm 0.304 s vs cold 0.370 s on the same turn); (d) 128.5 vs 118.7 tok/s single-request decode = **1.082x**, in the expected band; (e) a `kv_bits` request, a speculative request, and a no-manifest run each bypass to eager cleanly.
