### PR TITLE
Opt-in plain-decode megakernel lane (Flash-Next + dense MoE)

### DIFF
--- a/tests/test_megakernel_decode_lane.py
+++ b/tests/test_megakernel_decode_lane.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the opt-in plain-decode megakernel lane gate.
+
+The lane's kernel lives in the mlx-lm build, not here, so these tests are
+pure: they exercise Rapid's *decision surface* (config parsing, capability
+probe, per-model arming, and the width-1-plain routing gate) with hand-built
+fakes, never loading a model or touching the GPU. The design contract under
+test is fail-closed — every path that cannot use the lane must leave the
+ordinary ``generate_step`` decode in place.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_mlx import _megakernel_decode_lane as mk
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    mk.reset_for_tests()
+    yield
+    mk.reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# MegakernelLaneConfig.from_env
+# ---------------------------------------------------------------------------
+def test_config_defaults_off():
+    cfg = mk.MegakernelLaneConfig.from_env({})
+    assert cfg.enabled is False
+    assert cfg.geometry == "auto"
+    assert cfg.max_context == 0
+
+
+def test_config_reads_env():
+    cfg = mk.MegakernelLaneConfig.from_env(
+        {
+            mk.ENV_ENABLE: "1",
+            mk.ENV_GEOMETRY: "Qwen4_Exp",
+            mk.ENV_MAX_CONTEXT: "65536",
+        }
+    )
+    assert cfg.enabled is True
+    assert cfg.geometry == "qwen4_exp"  # normalised to lower-case
+    assert cfg.max_context == 65536
+
+
+def test_config_bad_max_context_is_zero():
+    cfg = mk.MegakernelLaneConfig.from_env(
+        {mk.ENV_ENABLE: "1", mk.ENV_MAX_CONTEXT: "not-a-number"}
+    )
+    assert cfg.max_context == 0
+
+
+@pytest.mark.parametrize("raw,expected", [("1", True), ("true", True),
+                                          ("on", True), ("yes", True),
+                                          ("0", False), ("off", False),
+                                          ("", False), (None, False)])
+def test_truthy(raw, expected):
+    assert mk._truthy(raw) is expected
+
+
+# ---------------------------------------------------------------------------
+# configure_process_env — only enables, never disables
+# ---------------------------------------------------------------------------
+def test_configure_process_env_noop_when_disabled(monkeypatch):
+    monkeypatch.delenv(mk._MLX_MASTER_ENV, raising=False)
+    mk.configure_process_env(mk.MegakernelLaneConfig(enabled=False))
+    import os
+
+    assert mk._MLX_MASTER_ENV not in os.environ
+
+
+def test_configure_process_env_sets_switches(monkeypatch):
+    import os
+
+    for name in (mk._MLX_MASTER_ENV, mk._MLX_LANE_ENV, mk._MLX_MAX_WIDTH_ENV):
+        monkeypatch.delenv(name, raising=False)
+    mk.configure_process_env(mk.MegakernelLaneConfig(enabled=True))
+    assert os.environ[mk._MLX_MASTER_ENV] == "1"
+    assert os.environ[mk._MLX_LANE_ENV] == "1"
+    assert os.environ[mk._MLX_MAX_WIDTH_ENV] == "1"
+
+
+def test_configure_process_env_does_not_clobber_operator_value(monkeypatch):
+    import os
+
+    monkeypatch.setenv(mk._MLX_MASTER_ENV, "0")  # operator turned it off
+    mk.configure_process_env(mk.MegakernelLaneConfig(enabled=True))
+    assert os.environ[mk._MLX_MASTER_ENV] == "0"  # setdefault leaves it
+
+
+# ---------------------------------------------------------------------------
+# enable_for_model — fail-closed arming
+# ---------------------------------------------------------------------------
+def _fake_model(model_type):
+    return SimpleNamespace(
+        language_model=SimpleNamespace(args=SimpleNamespace(model_type=model_type))
+    )
+
+
+def test_enable_disabled_config():
+    d = mk.enable_for_model(mk.MegakernelLaneConfig(enabled=False), _fake_model("x"))
+    assert d.route is False
+
+
+def test_enable_unavailable_build(monkeypatch):
+    monkeypatch.setattr(mk, "lane_available", lambda: False)
+    d = mk.enable_for_model(mk.MegakernelLaneConfig(enabled=True), _fake_model("x"))
+    assert d.route is False
+    assert "stock wheel" in d.reason
+    assert mk.snapshot_counters()["rapid_mlx_megakernel_lane_unavailable_total"] == 1
+
+
+def test_enable_no_geometry(monkeypatch):
+    monkeypatch.setattr(mk, "lane_available", lambda: True)
+    monkeypatch.setattr(mk, "geometry_name_for_model", lambda m: None)
+    d = mk.enable_for_model(mk.MegakernelLaneConfig(enabled=True), _fake_model("llama"))
+    assert d.route is False
+    assert "no registered megakernel geometry" in d.reason
+
+
+def test_enable_geometry_mismatch(monkeypatch):
+    monkeypatch.setattr(mk, "lane_available", lambda: True)
+    monkeypatch.setattr(mk, "geometry_name_for_model", lambda m: "qwen4_exp")
+    cfg = mk.MegakernelLaneConfig(enabled=True, geometry="qwen36_35b_a3b")
+    d = mk.enable_for_model(cfg, _fake_model("qwen4_exp_text"))
+    assert d.route is False
+    assert "does not match" in d.reason
+
+
+def test_enable_auto_geometry_arms(monkeypatch):
+    monkeypatch.setattr(mk, "lane_available", lambda: True)
+    monkeypatch.setattr(mk, "geometry_name_for_model", lambda m: "qwen4_exp")
+    d = mk.enable_for_model(mk.MegakernelLaneConfig(enabled=True), _fake_model("q"))
+    assert d.route is True
+    assert "qwen4_exp" in d.reason
+
+
+def test_enable_pinned_geometry_match(monkeypatch):
+    monkeypatch.setattr(mk, "lane_available", lambda: True)
+    monkeypatch.setattr(mk, "geometry_name_for_model", lambda m: "qwen36_35b_a3b")
+    cfg = mk.MegakernelLaneConfig(enabled=True, geometry="qwen36_35b_a3b")
+    d = mk.enable_for_model(cfg, _fake_model("qwen3_5_moe_text"))
+    assert d.route is True
+
+
+# ---------------------------------------------------------------------------
+# route_decision — width-1 plain gate
+# ---------------------------------------------------------------------------
+def _plain_params():
+    return SimpleNamespace(temperature=0.7, top_p=0.9)
+
+
+def _route(**over):
+    base = dict(
+        config=mk.MegakernelLaneConfig(enabled=True),
+        armed=True,
+        context_len=1000,
+        max_tokens=128,
+        batch_size=1,
+        is_speculative=False,
+        sampling_params=_plain_params(),
+        capacity=262144,
+    )
+    base.update(over)
+    cfg = base.pop("config")
+    return mk.route_decision(cfg, **base)
+
+
+def test_route_plain_within_profile():
+    assert _route().route is True
+
+
+def test_route_not_armed():
+    assert _route(armed=False).route is False
+
+
+def test_route_batch_declined():
+    d = _route(batch_size=4)
+    assert d.route is False and "batch" in d.reason
+    assert mk.snapshot_counters()["rapid_mlx_megakernel_lane_declined_total"] == 1
+
+
+def test_route_speculative_declined():
+    d = _route(is_speculative=True)
+    assert d.route is False and "speculative" in d.reason
+
+
+@pytest.mark.parametrize("attr", ["guided_json", "guided_grammar", "guided_regex",
+                                  "guided_choice", "grammar", "logits_processors",
+                                  "response_format"])
+def test_route_tool_constrained_declined(attr):
+    params = SimpleNamespace(temperature=0.7, top_p=0.9)
+    setattr(params, attr, object())
+    d = _route(sampling_params=params)
+    assert d.route is False and (
+        "tools" in d.reason or "guided" in d.reason
+    )
+
+
+def test_route_over_capacity_declined():
+    d = _route(context_len=262100, max_tokens=100, capacity=262144)
+    assert d.route is False and "capacity" in d.reason
+
+
+def test_route_over_operator_cap_declined():
+    cfg = mk.MegakernelLaneConfig(enabled=True, max_context=8192)
+    d = _route(config=cfg, context_len=9000)
+    assert d.route is False and "operator cap" in d.reason
+
+
+def test_route_unbounded_max_tokens_ok():
+    # max_tokens<=0 (unbounded) must not blow the capacity projection.
+    assert _route(max_tokens=-1).route is True
+
+
+# ---------------------------------------------------------------------------
+# note_engagement — counter bookkeeping from generate_step's status dict
+# ---------------------------------------------------------------------------
+def test_note_engagement_used():
+    assert mk.note_engagement({"used": True, "geometry": "qwen4_exp"}) is True
+    assert mk.snapshot_counters()["rapid_mlx_megakernel_lane_engaged_total"] == 1
+
+
+def test_note_engagement_declined():
+    assert mk.note_engagement({"decline_reason": "another lane active"}) is False
+    assert mk.snapshot_counters()["rapid_mlx_megakernel_lane_declined_total"] == 1
+
+
+def test_note_engagement_empty():
+    assert mk.note_engagement(None) is False
+    assert mk.note_engagement({}) is False
+    assert mk.snapshot_counters()["rapid_mlx_megakernel_lane_declined_total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# lane_available — probe is honest about the installed build
+# ---------------------------------------------------------------------------
+def test_lane_available_is_bool():
+    assert isinstance(mk.lane_available(), bool)

--- a/vllm_mlx/_megakernel_decode_lane.py
+++ b/vllm_mlx/_megakernel_decode_lane.py
@@ -1,0 +1,381 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in plain-decode lane on the whole-token persistent megakernel.
+
+Background
+----------
+Some mlx-lm builds ship a *plain-decode megakernel*: after a stock prefill,
+every further token of a width-1, non-speculative completion runs as one
+persistent Metal dispatch (the layer chain plus ``lm_head`` inside the kernel),
+instead of the per-op eager graph mlx-lm normally replays each step. The lane
+lives entirely inside ``mlx_lm.generate.generate_step`` — when the build's
+``mlx_lm.megakernel_lane`` module is present, the master switch is on, and the
+request is width-1 plain (no KV quantization, no rotating/paged cache, no
+caller-owned session cache, batch=1), ``generate_step`` attaches the lane on
+its own and drives it through its normal decode loop. Rapid never has to
+reimplement the loop; it only has to (a) recognise a megakernel-capable model,
+(b) flip the build's master switch, (c) keep speculative / tool-constrained /
+batched requests off the lane, and (d) observe engagement for logging.
+
+Value, honestly
+---------------
+The megakernel is Rapid's *fastest plain (non-speculative) decode lane* — it is
+for when self-MTP is off or ineffective (temperature sampling, tool-constrained
+generation, low draft acceptance). It is **not** a speculative-decode
+replacement: on the Flash-Next (qwen4_exp) geometry the lane decodes plain at
+~59.5 tok/s (1.68-1.81x the stock plain path) but does **not** beat that model's
+own self-MTP (66-70 tok/s); on the dense 35B (qwen3_5_moe) geometry it decodes
+plain at ~118 tok/s but does not beat a compiled-replay decode. So the lane is
+routed only for width-1 plain requests, and speculative requests fall through to
+their existing path untouched.
+
+Why a build dependency, not vendored code
+-----------------------------------------
+The kernel, its geometries, and the mixed-precision (4/6-bit) expert decode the
+dense checkpoint needs are ~8k lines that live in the mlx-lm build, not here.
+Rapid depends on a build that exposes ``mlx_lm.megakernel_lane`` and the
+``megakernel_geometry`` registry; when the installed mlx-lm has neither (the
+stock wheel), this module reports "unavailable" and every entry point is a
+silent no-op — the runner uses the ordinary ``generate_step`` path exactly as
+before. See the PR description for the required build.
+
+Fail-closed contract
+--------------------
+Every decision here defaults to OFF. The lane is enabled for a request only
+when ALL hold:
+
+* the operator opted in (``RAPID_MEGAKERNEL_DECODE_LANE=1`` / CLI flag);
+* the installed mlx-lm exposes the lane (import probe succeeds);
+* the loaded model's ``model_type`` maps to a ``MegakernelGeometry`` (and, if
+  the operator pinned a geometry, it matches);
+* the request is width-1 plain: batch=1, no speculative config, no
+  logit-constraining tools/guided decoding;
+* the projected end position (context + max_tokens) is within the geometry's
+  profile.
+
+Any failure returns a reason and leaves the stock decode path in place. The
+lane itself is additionally self-gating and fail-closed inside mlx-lm: it
+declines (never crashes the request) on a poisoned pack, an unsupported device,
+or an out-of-profile context, and the runner then decodes eagerly.
+
+Counters mirror the ``_mxfp4_moe_guardrail`` pattern — plain module-level ints
+behind a lock, snapshot exposed for ``routes/metrics.py`` — so the metrics
+surface stays uniform and no default Prometheus registry is touched.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---- Operator-facing environment switches ----------------------------
+# The CLI flags (``--megakernel-decode-lane`` / ``--megakernel-geometry``)
+# set these before the engine loads the model; the runner reads them at
+# construction. Keeping the CLI→runner hop in env vars keeps the flag
+# plumbing shallow and the default OFF everywhere it is not set.
+ENV_ENABLE = "RAPID_MEGAKERNEL_DECODE_LANE"
+ENV_GEOMETRY = "RAPID_MEGAKERNEL_GEOMETRY"
+ENV_MAX_CONTEXT = "RAPID_MEGAKERNEL_MAX_CONTEXT"
+
+# mlx-lm build switches the lane reads. We flip these (in addition to the
+# in-process ``set_qwen4_megakernel`` toggle) so a build that captured the
+# master flag at import still honours a late enable.
+_MLX_MASTER_ENV = "MLX_QWEN4_MEGAKERNEL"
+_MLX_LANE_ENV = "MLX_QWEN4_MEGAKERNEL_LANE"
+_MLX_MAX_WIDTH_ENV = "MLX_QWEN4_MEGAKERNEL_MAX_WIDTH"
+
+# ---- Process-local counters (Prometheus-style, never decrease) --------
+_lock = threading.Lock()
+_lane_engaged_total = 0
+_lane_declined_total = 0
+_lane_unavailable_total = 0
+
+
+def _truthy(raw: str | None) -> bool:
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "on", "yes"}
+
+
+@dataclass(frozen=True)
+class MegakernelLaneConfig:
+    """Operator intent for the plain-decode megakernel lane.
+
+    Constructed once at runner init from the environment the CLI populated.
+    ``geometry`` is ``"auto"`` (accept whichever geometry the model maps to)
+    or a pinned geometry name (``"qwen4_exp"`` / ``"qwen36_35b_a3b"``) that
+    the loaded model must match, else the lane stays off and logs why.
+    ``max_context`` optionally caps the context the lane is allowed for
+    (0 = defer entirely to the geometry's own profile).
+    """
+
+    enabled: bool = False
+    geometry: str = "auto"
+    max_context: int = 0
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "MegakernelLaneConfig":
+        env = env if env is not None else os.environ
+        try:
+            max_context = int(env.get(ENV_MAX_CONTEXT, "0") or "0")
+        except ValueError:
+            max_context = 0
+        return cls(
+            enabled=_truthy(env.get(ENV_ENABLE)),
+            geometry=(env.get(ENV_GEOMETRY) or "auto").strip().lower(),
+            max_context=max(0, max_context),
+        )
+
+
+@dataclass(frozen=True)
+class LaneDecision:
+    """Outcome of a per-request routing decision."""
+
+    route: bool
+    reason: str
+
+
+def snapshot_counters() -> dict[str, int]:
+    """Point-in-time counter values for ``routes/metrics.py``."""
+    with _lock:
+        return {
+            "rapid_mlx_megakernel_lane_engaged_total": _lane_engaged_total,
+            "rapid_mlx_megakernel_lane_declined_total": _lane_declined_total,
+            "rapid_mlx_megakernel_lane_unavailable_total": _lane_unavailable_total,
+        }
+
+
+def reset_for_tests() -> None:
+    """Zero the counters between test cases (mirrors the guardrail helper)."""
+    global _lane_engaged_total, _lane_declined_total, _lane_unavailable_total
+    with _lock:
+        _lane_engaged_total = 0
+        _lane_declined_total = 0
+        _lane_unavailable_total = 0
+
+
+def _bump_engaged() -> None:
+    global _lane_engaged_total
+    with _lock:
+        _lane_engaged_total += 1
+
+
+def _bump_declined() -> None:
+    global _lane_declined_total
+    with _lock:
+        _lane_declined_total += 1
+
+
+def _bump_unavailable() -> None:
+    global _lane_unavailable_total
+    with _lock:
+        _lane_unavailable_total += 1
+
+
+def lane_available() -> bool:
+    """Whether the installed mlx-lm exposes the plain-decode megakernel lane.
+
+    Pure import probe — no pack, no device touch, no engine mutation. The
+    stock mlx-lm wheel has neither module and returns ``False`` so every
+    caller degrades to the ordinary decode path.
+    """
+    try:
+        import mlx_lm.megakernel_lane  # noqa: F401
+        import mlx_lm.models.megakernel_geometry  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def geometry_name_for_model(model: Any) -> str | None:
+    """The megakernel geometry name the loaded model maps to, or ``None``.
+
+    Resolves the text model's ``model_type`` through the build's geometry
+    registry (``geometry_for_model_type``). Returns ``None`` for any model
+    the megakernel does not describe, and for any build without the registry.
+    """
+    try:
+        from mlx_lm.models.megakernel_geometry import geometry_for_model_type
+    except Exception:
+        return None
+    text_model = getattr(model, "language_model", model)
+    args = getattr(text_model, "args", None)
+    model_type = getattr(args, "model_type", None)
+    if not isinstance(model_type, str):
+        return None
+    geometry = geometry_for_model_type(model_type)
+    return geometry.name if geometry is not None else None
+
+
+def geometry_profile_capacity(model: Any) -> int | None:
+    """Max position count the mapped geometry admits (``max_position_embeddings``)."""
+    try:
+        from mlx_lm.models.megakernel_geometry import geometry_for_model_type
+    except Exception:
+        return None
+    text_model = getattr(model, "language_model", model)
+    args = getattr(text_model, "args", None)
+    model_type = getattr(args, "model_type", None)
+    if not isinstance(model_type, str):
+        return None
+    geometry = geometry_for_model_type(model_type)
+    if geometry is None:
+        return None
+    return int(getattr(geometry, "max_position_embeddings", 0)) or None
+
+
+def configure_process_env(config: MegakernelLaneConfig) -> None:
+    """Flip the mlx-lm build's master switches for an opted-in run.
+
+    Idempotent and only ever *enables* — it never disables a switch the
+    operator set by hand. Called once, before the model loads, so a build
+    that captures ``MLX_QWEN4_MEGAKERNEL`` at import sees it on. A separate
+    in-process ``set_qwen4_megakernel(True)`` in :func:`enable_for_model`
+    covers builds already imported by the time we run.
+    """
+    if not config.enabled:
+        return
+    os.environ.setdefault(_MLX_MASTER_ENV, "1")
+    os.environ.setdefault(_MLX_LANE_ENV, "1")
+    # The plain lane is width-1 by construction; pin the build's width so a
+    # stray dual-width default can never widen this lane.
+    os.environ.setdefault(_MLX_MAX_WIDTH_ENV, "1")
+
+
+def enable_for_model(config: MegakernelLaneConfig, model: Any) -> LaneDecision:
+    """Decide whether the lane can serve this loaded model, and arm the build.
+
+    Returns a :class:`LaneDecision`. On ``route=True`` the build's master
+    switch is armed (env + ``set_qwen4_megakernel(True)``) and the runner may
+    pass a status dict to ``generate_step`` for width-1 plain requests. Every
+    negative path is a clean no-op that leaves the stock decode in place.
+    """
+    if not config.enabled:
+        return LaneDecision(False, "megakernel decode lane not enabled")
+    if not lane_available():
+        _bump_unavailable()
+        return LaneDecision(
+            False,
+            "installed mlx-lm does not expose the megakernel lane "
+            "(stock wheel); using generate_step",
+        )
+    name = geometry_name_for_model(model)
+    if name is None:
+        return LaneDecision(
+            False, "loaded model has no registered megakernel geometry"
+        )
+    if config.geometry != "auto" and config.geometry != name:
+        return LaneDecision(
+            False,
+            f"pinned geometry {config.geometry!r} does not match the loaded "
+            f"model's geometry {name!r}",
+        )
+    # Arm the in-process master flag for builds imported before
+    # ``configure_process_env`` ran. Import-guarded: a build without the
+    # toggle simply relies on the env switch.
+    try:
+        from mlx_lm.models.qwen4_megakernel import set_qwen4_megakernel
+
+        set_qwen4_megakernel(True)
+    except Exception:
+        pass
+    return LaneDecision(True, f"megakernel lane armed for geometry {name!r}")
+
+
+def _has_constraining_tools(sampling_params: Any) -> bool:
+    """Whether the request constrains logits mid-generation (tools/guided).
+
+    Such a request must NOT ride the lane: the megakernel emits its own
+    logits per step and does not expose the per-step logit-processor hook a
+    grammar/tool constraint needs. Detection is conservative — any sign of a
+    guided-decoding / grammar / tool-choice constraint routes to the eager
+    path. Unknown shapes are treated as constraining (fail-closed).
+    """
+    if sampling_params is None:
+        return False
+    for attr in (
+        "guided_decoding",
+        "guided_grammar",
+        "guided_json",
+        "guided_regex",
+        "guided_choice",
+        "grammar",
+        "logits_processors",
+        "response_format",
+    ):
+        value = getattr(sampling_params, attr, None)
+        if value:
+            return True
+    return False
+
+
+def route_decision(
+    config: MegakernelLaneConfig,
+    *,
+    armed: bool,
+    context_len: int,
+    max_tokens: int,
+    batch_size: int,
+    is_speculative: bool,
+    sampling_params: Any,
+    capacity: int | None,
+) -> LaneDecision:
+    """Per-request width-1-plain gate. Returns whether to route to the lane.
+
+    ``armed`` is the result of :func:`enable_for_model` for the loaded model.
+    Every guard below fails closed to the stock decode path.
+    """
+    if not armed:
+        return LaneDecision(False, "lane not armed for this model")
+    if batch_size != 1:
+        _bump_declined()
+        return LaneDecision(False, f"batch size {batch_size} != 1")
+    if is_speculative:
+        _bump_declined()
+        return LaneDecision(False, "speculative request keeps its own path")
+    if _has_constraining_tools(sampling_params):
+        _bump_declined()
+        return LaneDecision(False, "logit-constraining tools/guided decoding")
+    # Context-in-profile: the projected end position must fit the geometry's
+    # own capacity and any operator-set cap.
+    projected = context_len + (max_tokens if max_tokens and max_tokens > 0 else 0) + 1
+    if capacity is not None and projected > capacity:
+        _bump_declined()
+        return LaneDecision(
+            False,
+            f"projected end position {projected} exceeds geometry capacity {capacity}",
+        )
+    if config.max_context and context_len > config.max_context:
+        _bump_declined()
+        return LaneDecision(
+            False,
+            f"context {context_len} exceeds operator cap {config.max_context}",
+        )
+    return LaneDecision(True, "width-1 plain request within profile")
+
+
+def new_status_dict() -> dict[str, Any]:
+    """A fresh status dict to hand ``generate_step`` as ``_megakernel_status``."""
+    return {}
+
+
+def note_engagement(status: dict[str, Any] | None) -> bool:
+    """Record whether the lane actually engaged for a completed request.
+
+    ``generate_step`` writes ``used=True`` into the status dict when the lane
+    attaches, or ``decline_reason`` when it self-declines (out-of-profile,
+    poisoned, another lane active). We bump the matching counter and return
+    whether it engaged, for the runner's debug log.
+    """
+    if not status:
+        _bump_declined()
+        return False
+    if status.get("used"):
+        _bump_engaged()
+        return True
+    _bump_declined()
+    return False

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2189,6 +2189,21 @@ def serve_command(args):
 
     install_parent_watchdog(resolve_expected_ppid(getattr(args, "watchdog_ppid", None)))
 
+    # Plain-decode megakernel lane (opt-in, default OFF). Translate the CLI
+    # flags into the environment the model runner reads at construction, before
+    # the engine loads the model — an mlx-lm build that captures its master
+    # switch at import then sees it on. This is a no-op unless the operator
+    # passed --megakernel-decode-lane, and the runner is fail-closed to the
+    # ordinary decode path on any build/model/request that cannot use the lane.
+    if getattr(args, "megakernel_decode_lane", False):
+        from ._megakernel_decode_lane import (
+            ENV_ENABLE as _MK_ENV_ENABLE,
+            ENV_GEOMETRY as _MK_ENV_GEOMETRY,
+        )
+
+        os.environ[_MK_ENV_ENABLE] = "1"
+        os.environ[_MK_ENV_GEOMETRY] = getattr(args, "megakernel_geometry", "auto")
+
     _arg_max_tokens = getattr(args, "max_tokens", None)
     _max_tokens_is_explicit = _arg_max_tokens is not None
     effective_max_tokens = _arg_max_tokens if _arg_max_tokens is not None else 32768
@@ -7118,6 +7133,35 @@ Examples:
     )
     serve_parser.add_argument(
         "--completion-batch-size", type=int, default=32, help="Completion batch size"
+    )
+    serve_parser.add_argument(
+        "--megakernel-decode-lane",
+        action="store_true",
+        default=False,
+        help=(
+            "Opt in to the plain-decode megakernel lane (default OFF). This is "
+            "the fastest NON-speculative decode path — for temperature "
+            "sampling, tool-constrained, or low-acceptance requests where "
+            "self-MTP is off or ineffective. It is NOT a speculative-decode "
+            "replacement (it does not beat Flash-Next self-MTP). Requires an "
+            "mlx-lm build that exposes the megakernel lane; on a stock build, "
+            "or for a model with no megakernel geometry, or for a "
+            "speculative/tool/batched request, decode falls back to the "
+            "ordinary path with no change. Only width-1 plain requests within "
+            "the geometry's context profile ride the lane."
+        ),
+    )
+    serve_parser.add_argument(
+        "--megakernel-geometry",
+        type=str,
+        default="auto",
+        choices=["auto", "qwen4_exp", "qwen36_35b_a3b"],
+        help=(
+            "Pin the megakernel geometry the loaded model must match, or "
+            "'auto' (default) to accept whichever geometry the model maps to. "
+            "A mismatch leaves the lane off (fail-closed). Only meaningful "
+            "with --megakernel-decode-lane."
+        ),
     )
     serve_parser.add_argument(
         "--enable-prefix-cache",

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 import mlx.core as mx
 
+from vllm_mlx import _megakernel_decode_lane as _mk_lane
 from vllm_mlx.patches.deepseek_v32_indexer_gate import (
     install_deepseek_v32_indexer_gate as _install_dsv32_indexer_gate,
 )
@@ -102,6 +103,32 @@ class MLXModelRunner:
 
         # Optimization settings
         self._enable_optimizations = enable_optimizations
+
+        # Opt-in plain-decode megakernel lane (default OFF, fail-closed to
+        # generate_step). Config comes from the environment the CLI populated
+        # (``--megakernel-decode-lane`` / ``--megakernel-geometry``). The
+        # per-model arming decision is taken in ``load_model`` once the model
+        # is resident; until then no lane is possible.
+        self._megakernel_config = _mk_lane.MegakernelLaneConfig.from_env()
+        self._megakernel_decision = _mk_lane.LaneDecision(
+            False, "model not loaded"
+        )
+        # A runner in engine-level speculative mode never uses the plain lane:
+        # the lane is the fastest *non-speculative* path, not a spec replacement.
+        self._speculative_engine = (
+            getattr(vllm_config, "speculative_config", None) is not None
+        )
+        if self._megakernel_config.enabled:
+            # Flip the build's master switch before the model loads so a build
+            # that captures it at import sees it on. No-op if not opted in.
+            _mk_lane.configure_process_env(self._megakernel_config)
+            logger.info(
+                "Megakernel decode lane requested (geometry=%s, max_context=%s); "
+                "arming deferred to load_model",
+                self._megakernel_config.geometry,
+                self._megakernel_config.max_context or "geometry-profile",
+            )
+
         self._hardware_info = None  # Detected hardware profile
         # Set True only after ``_apply_optimizations`` completes without
         # raising. ``_hardware_info`` being populated is NOT proof of
@@ -146,6 +173,26 @@ class MLXModelRunner:
             # Apply low-level optimizations
             if self._enable_optimizations:
                 self._apply_optimizations()
+
+            # Arm the megakernel decode lane for this model, if opted in. This
+            # is fail-closed: a stock mlx-lm (no lane module), a model with no
+            # registered geometry, or a geometry mismatch all leave the stock
+            # generate_step path in place. When the runner is in engine-level
+            # speculative mode the plain lane is intentionally never armed.
+            if self._speculative_engine:
+                self._megakernel_decision = _mk_lane.LaneDecision(
+                    False, "runner is in speculative mode; plain lane not used"
+                )
+            else:
+                self._megakernel_decision = _mk_lane.enable_for_model(
+                    self._megakernel_config, self.model
+                )
+            if self._megakernel_config.enabled:
+                logger.info(
+                    "Megakernel decode lane: %s (%s)",
+                    "ARMED" if self._megakernel_decision.route else "not armed",
+                    self._megakernel_decision.reason,
+                )
 
         except ImportError:
             raise ImportError(
@@ -389,15 +436,58 @@ class MLXModelRunner:
             # Convert token IDs to MLX array
             prompt = mx.array(prompt_token_ids)
 
+            # Decide whether this request rides the plain-decode megakernel
+            # lane. Fail-closed: any negative decision uses generate_step
+            # exactly as before. The lane itself lives inside generate_step —
+            # when armed and the request is width-1 plain, generate_step
+            # attaches it and drives it through this same loop; we only pass a
+            # status dict so we can observe engagement. Passing the status is a
+            # no-op on a stock mlx-lm that does not accept the kwarg.
+            capacity = (
+                _mk_lane.geometry_profile_capacity(self.model)
+                if self._megakernel_decision.route
+                else None
+            )
+            lane_route = _mk_lane.route_decision(
+                self._megakernel_config,
+                armed=self._megakernel_decision.route,
+                context_len=len(prompt_token_ids),
+                max_tokens=max_tokens,
+                batch_size=1,
+                is_speculative=self._speculative_engine,
+                sampling_params=sampling_params,
+                capacity=capacity,
+            )
+            step_kwargs: dict[str, Any] = {}
+            mk_status: dict[str, Any] | None = None
+            if lane_route.route:
+                mk_status = _mk_lane.new_status_dict()
+                step_kwargs["_megakernel_status"] = mk_status
+            elif self._megakernel_config.enabled and self._megakernel_decision.route:
+                logger.debug("megakernel lane not routed: %s", lane_route.reason)
+
             generated_ids = []
 
             # Generate tokens
-            for token_info in generate_step(
-                prompt=prompt,
-                model=self.model,
-                max_tokens=max_tokens,
-                sampler=sampler,
-            ):
+            try:
+                token_stream = generate_step(
+                    prompt=prompt,
+                    model=self.model,
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                    **step_kwargs,
+                )
+            except TypeError:
+                # A stock mlx-lm build does not accept ``_megakernel_status``.
+                # Retry on the plain path so the lane never becomes a hard dep.
+                mk_status = None
+                token_stream = generate_step(
+                    prompt=prompt,
+                    model=self.model,
+                    max_tokens=max_tokens,
+                    sampler=sampler,
+                )
+            for token_info in token_stream:
                 if hasattr(token_info, "token"):
                     generated_ids.append(token_info.token)
                 elif isinstance(token_info, tuple) and len(token_info) > 0:
@@ -405,6 +495,17 @@ class MLXModelRunner:
 
                 if len(generated_ids) >= max_tokens:
                     break
+
+            # Record whether the lane actually engaged (generate_step writes
+            # ``used``/``decline_reason`` into the status dict). Observability
+            # only — never changes the tokens returned.
+            if mk_status is not None:
+                engaged = _mk_lane.note_engagement(mk_status)
+                logger.debug(
+                    "megakernel lane %s: %s",
+                    "engaged" if engaged else "declined",
+                    mk_status.get("decline_reason") or mk_status.get("geometry"),
+                )
 
             return generated_ids
 
@@ -458,6 +559,17 @@ class MLXModelRunner:
             info["optimizations"] = {
                 "kernel_fusion": False,
                 "memory_optimized": self._optimizations_applied,
+            }
+
+            # Plain-decode megakernel lane status (opt-in). ``armed`` means the
+            # loaded model mapped to a geometry and the build exposes the lane;
+            # per-request engagement is reported by the counters snapshot.
+            info["megakernel_lane"] = {
+                "enabled": self._megakernel_config.enabled,
+                "armed": self._megakernel_decision.route,
+                "reason": self._megakernel_decision.reason,
+                "geometry": _mk_lane.geometry_name_for_model(self.model),
+                "counters": _mk_lane.snapshot_counters(),
             }
 
             if self._hardware_info:

--- a/vllm_mlx/model_runner.py
+++ b/vllm_mlx/model_runner.py
@@ -487,14 +487,26 @@ class MLXModelRunner:
                     max_tokens=max_tokens,
                     sampler=sampler,
                 )
-            for token_info in token_stream:
-                if hasattr(token_info, "token"):
-                    generated_ids.append(token_info.token)
-                elif isinstance(token_info, tuple) and len(token_info) > 0:
-                    generated_ids.append(token_info[0])
+            try:
+                for token_info in token_stream:
+                    if hasattr(token_info, "token"):
+                        generated_ids.append(token_info.token)
+                    elif isinstance(token_info, tuple) and len(token_info) > 0:
+                        generated_ids.append(token_info[0])
 
-                if len(generated_ids) >= max_tokens:
-                    break
+                    if len(generated_ids) >= max_tokens:
+                        break
+            finally:
+                # Deterministically close the generator. generate_step owns the
+                # megakernel lane's process-wide lock and its device-acknowledged
+                # transaction; closing here raises GeneratorExit into its
+                # ``finally`` so the lane drains/commits and releases the lock
+                # immediately, instead of leaving it held until GC — which would
+                # make the NEXT request decline ("another megakernel lane is
+                # active"). No-op for the ordinary eager generator.
+                close = getattr(token_stream, "close", None)
+                if callable(close):
+                    close()
 
             # Record whether the lane actually engaged (generate_step writes
             # ``used``/``decline_reason`` into the status dict). Observability


### PR DESCRIPTION
### Add an opt-in plain-decode megakernel lane (Flash-Next + dense MoE)

**What this adds.** An opt-in, fail-closed plain-decode lane for models that map to a megakernel geometry. When enabled, width-1 non-speculative completions decode through a whole-token persistent Metal kernel instead of the per-op eager graph; every other request, model, or build falls back to `generate_step` exactly as today.

The lane itself lives inside `mlx_lm.generate.generate_step`: when the installed mlx-lm build exposes it and the master switch is on, `generate_step` attaches the lane for eligible requests and drives it through its normal decode loop. So the runner-side change is deliberately thin:

- **`vllm_mlx/_megakernel_decode_lane.py`** (new) — config, capability probe, per-model arming, the width-1-plain routing gate, and process-local counters, in the same shape as the existing guardrail module.
- **`vllm_mlx/model_runner.py`** — reads the config at construction, arms the build for a megakernel-capable model at load, and for a width-1 plain request passes a status dict to `generate_step` so engagement is observable; a stock mlx-lm that does not accept the kwarg is retried on the plain path (never a hard dependency). It also deterministically closes the decode generator so the lane's process-wide lock and device transaction release immediately.
- **`vllm_mlx/cli.py`** — two `serve` flags (below), default OFF.
- **`tests/test_megakernel_decode_lane.py`** (new) — 38 CPU unit tests.

Diffstat: 4 files, +806 / −13. No model code is vendored into the runner.

### Value, stated honestly

The megakernel is the **fastest plain (non-speculative) decode lane** — for when self-MTP is off or ineffective: temperature sampling, tool-constrained generation, low draft acceptance. It is **not** a speculative-decode replacement.

Flash-Next (M5 Max, 4-bit):

| Path | Plain decode tok/s | Note |
|---|---|---|
| Megakernel plain lane | ~59.5 warm steady-state | 1.68–1.81x stock plain |
| Stock plain (`generate_step`) | ~33–36 | baseline |
| Self-MTP (existing path) | 66–70 | faster than this lane |

**Non-goals:** it does not beat self-MTP and does not replace it; it is routed only for width-1 plain requests, and speculative requests keep their existing path untouched. It is the floor-raiser for the non-speculative case, not a new ceiling.

### Also covers the dense MoE geometry

The same lane serves the dense (`qwen3_5_moe`) geometry via `--megakernel-geometry auto` (or the explicit name); both geometries share one hook and one flag, so they land as one change. Dense CPU geometry-arming is verified; a bounded device A/B on the dense model is the one remaining pre-merge check — the Flash-Next device numbers above are the primary evidence.

### Config flags (default OFF)

- `--megakernel-decode-lane` — opt in. Default OFF. On a build without the lane it is a silent no-op.
- `--megakernel-geometry {auto,qwen4_exp,qwen36_35b_a3b}` — select or auto-detect the geometry.

### Dependency

The lane requires an mlx-lm build that exposes the megakernel decode path and a per-device primitives calibration keyed to the mlx-core version. On a build without that surface, or on an mlx core with no cached calibration entry, the lane declines cleanly and every request serves eager — so it is safe to merge ahead of the runtime that carries it. The corresponding mlx-lm modules are now published for review at https://github.com/pierre427/rapid-mlx-decode-lane-deps — review-grade (the new additive modules, not the divergent core-file wiring); see its README for the exact integration surface the host build must expose. Happy to walk through a full build directly.

### Correctness and fail-closed behavior

Device check on Flash-Next: the lane engages, greedy tokens are **bit-identical to stock for the first 128 tokens** and then diverge only at a documented near-tie boundary (the lane's own numerical class, never a wrong commit); tool / guided-JSON requests and speculative requests bypass cleanly; a stock mlx-lm and an uncalibrated core both decline with no crash. 38/38 lane tests plus the neighboring model-runner suites pass.
