### PR TITLE
fix(benchmark): print decode tok/s with the board's (N-1)/window formula

### DIFF
--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -2923,7 +2923,7 @@ def test_cli_run_prints_local_only_confirmation(
 
 
 def test_summarize_measurements_matches_the_board_decode_formula() -> None:
-    """``(N - 1) / window`` like rapidmlx.com; ``N == 1`` falls back to ``N``."""
+    """``(N - 1) / window`` like rapidmlx.com; ``N < 2`` has no decode rate."""
     run = {
         "measurements": [
             {
@@ -2952,10 +2952,13 @@ def test_summarize_measurements_matches_the_board_decode_formula() -> None:
     }
     lines = community_cli.summarize_measurements(run)
     assert lines[0].startswith("  pp512-tg128         45.5 tok/s decode")
-    assert lines[1].startswith("  single               2.0 tok/s decode")
-    # A zero-token sample has no decode rate: it falls back to wall time
-    # instead of being shown as positive throughput.
-    assert lines[2].startswith("  empty               0.60 s per run")
+    # Fewer than two output tokens means no inter-token interval: the board
+    # shows no decode rate for such a sample and neither does the CLI. The
+    # one-token case carries no wall time either, so it produces no line;
+    # the zero-token case falls back to wall time.
+    assert all("single" not in line for line in lines)
+    assert lines[1].startswith("  empty               0.60 s per run")
+    assert len(lines) == 2
 
 
 def test_summarize_measurements_reports_wall_time_for_image_and_video() -> None:

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -2910,12 +2910,41 @@ def test_cli_run_prints_local_only_confirmation(
     # The user must see their numbers without opening the JSON (0.13.5 dogfood
     # F3): median decode throughput and TTFT per case, completed rounds only.
     assert "pp512-tg128" in out
-    assert "128.0 tok/s decode" in out  # median of 128, 100, 128 tok/s
+    # (128 - 1) / 1.0 s, 127 / 1.28 s, 127 / 1.0 s -> median 127.0. The
+    # ``- 1`` is the board's formula; ``128.0`` here would mean the CLI and
+    # the website disagree on the same run again.
+    assert "127.0 tok/s decode" in out
+    assert "128.0 tok/s" not in out
     assert "TTFT    460 ms" in out
     assert "(3 rounds)" in out
     assert "pp2048-tg512" not in out
     assert "Nothing was uploaded." in out
     assert "Share it: rapid-mlx benchmark share abc-123" in out
+
+
+def test_summarize_measurements_matches_the_board_decode_formula() -> None:
+    """``(N - 1) / window`` like rapidmlx.com; ``N == 1`` falls back to ``N``."""
+    run = {
+        "measurements": [
+            {
+                "case_id": "pp512-tg128",
+                "completed": True,
+                "output_tokens": 128,
+                "decode_duration_ms": 2794.0,
+                "ttft_ms": 813.0,
+            },
+            {
+                "case_id": "single",
+                "completed": True,
+                "output_tokens": 1,
+                "decode_duration_ms": 500.0,
+                "ttft_ms": 100.0,
+            },
+        ]
+    }
+    lines = community_cli.summarize_measurements(run)
+    assert lines[0].startswith("  pp512-tg128         45.5 tok/s decode")
+    assert lines[1].startswith("  single               2.0 tok/s decode")
 
 
 def test_summarize_measurements_reports_wall_time_for_image_and_video() -> None:

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -2923,7 +2923,7 @@ def test_cli_run_prints_local_only_confirmation(
 
 
 def test_summarize_measurements_matches_the_board_decode_formula() -> None:
-    """``(N - 1) / window`` like rapidmlx.com; ``N < 2`` has no decode rate."""
+    """``(N - 1) / window`` exactly like rapidmlx.com, including ``N == 1``."""
     run = {
         "measurements": [
             {
@@ -2952,13 +2952,12 @@ def test_summarize_measurements_matches_the_board_decode_formula() -> None:
     }
     lines = community_cli.summarize_measurements(run)
     assert lines[0].startswith("  pp512-tg128         45.5 tok/s decode")
-    # Fewer than two output tokens means no inter-token interval: the board
-    # shows no decode rate for such a sample and neither does the CLI. The
-    # one-token case carries no wall time either, so it produces no line;
-    # the zero-token case falls back to wall time.
-    assert all("single" not in line for line in lines)
-    assert lines[1].startswith("  empty               0.60 s per run")
-    assert len(lines) == 2
+    # The board computes (1 - 1) / window = 0 for a one-token sample and
+    # displays it; the CLI prints the same number rather than inventing one.
+    assert lines[1].startswith("  single               0.0 tok/s decode")
+    # No output tokens means no rate at all: falls back to wall time.
+    assert lines[2].startswith("  empty               0.60 s per run")
+    assert len(lines) == 3
 
 
 def test_summarize_measurements_reports_wall_time_for_image_and_video() -> None:

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -2940,11 +2940,22 @@ def test_summarize_measurements_matches_the_board_decode_formula() -> None:
                 "decode_duration_ms": 500.0,
                 "ttft_ms": 100.0,
             },
+            {
+                "case_id": "empty",
+                "completed": True,
+                "output_tokens": 0,
+                "decode_duration_ms": 500.0,
+                "ttft_ms": 100.0,
+                "total_duration_ms": 600.0,
+            },
         ]
     }
     lines = community_cli.summarize_measurements(run)
     assert lines[0].startswith("  pp512-tg128         45.5 tok/s decode")
     assert lines[1].startswith("  single               2.0 tok/s decode")
+    # A zero-token sample has no decode rate: it falls back to wall time
+    # instead of being shown as positive throughput.
+    assert lines[2].startswith("  empty               0.60 s per run")
 
 
 def test_summarize_measurements_reports_wall_time_for_image_and_video() -> None:

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -88,18 +88,17 @@ def summarize_measurements(run: dict[str, Any]) -> list[str]:
     lines: list[str] = []
     for case_id, samples in by_case.items():
         # Same formula as the board (rapidmlx.com) and the standardized
-        # ``bench`` runner: the first token lands at ``ttft_ms``, so the
-        # decode window covers ``output_tokens - 1`` tokens (llama.cpp
-        # ``tg`` / vLLM TPOT semantics). A sample with fewer than two output
-        # tokens has no inter-token interval and therefore no decode rate;
-        # it is left out rather than shown as a number the board would not
-        # show. Printing ``N / window`` here made the CLI read 45.8 tok/s
-        # for a run the site then showed as 45.5.
+        # ``bench`` runner, applied literally: ``(output_tokens - 1) /
+        # decode_window`` — the first token lands at ``ttft_ms`` (llama.cpp
+        # ``tg`` / vLLM TPOT semantics). A one-token sample therefore reads
+        # 0.0 tok/s here exactly as it does on the board; only samples with
+        # no output tokens carry no rate at all. Printing ``N / window``
+        # made the CLI read 45.8 tok/s for a run the site showed as 45.5.
         decode = [
             (s["output_tokens"] - 1) / (s["decode_duration_ms"] / 1000.0)
             for s in samples
             if isinstance(s.get("output_tokens"), int | float)
-            and s["output_tokens"] >= 2
+            and s["output_tokens"] >= 1
             and isinstance(s.get("decode_duration_ms"), int | float)
             and s["decode_duration_ms"] > 0
         ]

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -87,16 +87,20 @@ def summarize_measurements(run: dict[str, Any]) -> list[str]:
             by_case.setdefault(case_id, []).append(sample)
     lines: list[str] = []
     for case_id, samples in by_case.items():
-        # Same formula as the board (rapidmlx.com) and the legacy
+        # Same formula as the board (rapidmlx.com) and the standardized
         # ``bench`` runner: the first token lands at ``ttft_ms``, so the
         # decode window covers ``output_tokens - 1`` tokens (llama.cpp
-        # ``tg`` / vLLM TPOT semantics). ``N == 1`` falls back to ``N``
-        # to avoid a 0/0. Printing ``N / window`` here made the CLI read
-        # 45.8 tok/s for a run the site then showed as 45.5.
+        # ``tg`` / vLLM TPOT semantics). A single-token completion has no
+        # inter-token window, so ``N == 1`` reports ``N / window`` like the
+        # runner; zero-token samples carry no rate and are skipped.
+        # Printing ``N / window`` here made the CLI read 45.8 tok/s for a
+        # run the site then showed as 45.5.
         decode = [
-            max(s["output_tokens"] - 1, 1) / (s["decode_duration_ms"] / 1000.0)
+            (s["output_tokens"] - 1 if s["output_tokens"] > 1 else 1)
+            / (s["decode_duration_ms"] / 1000.0)
             for s in samples
             if isinstance(s.get("output_tokens"), int | float)
+            and s["output_tokens"] >= 1
             and isinstance(s.get("decode_duration_ms"), int | float)
             and s["decode_duration_ms"] > 0
         ]

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -90,17 +90,16 @@ def summarize_measurements(run: dict[str, Any]) -> list[str]:
         # Same formula as the board (rapidmlx.com) and the standardized
         # ``bench`` runner: the first token lands at ``ttft_ms``, so the
         # decode window covers ``output_tokens - 1`` tokens (llama.cpp
-        # ``tg`` / vLLM TPOT semantics). A single-token completion has no
-        # inter-token window, so ``N == 1`` reports ``N / window`` like the
-        # runner; zero-token samples carry no rate and are skipped.
-        # Printing ``N / window`` here made the CLI read 45.8 tok/s for a
-        # run the site then showed as 45.5.
+        # ``tg`` / vLLM TPOT semantics). A sample with fewer than two output
+        # tokens has no inter-token interval and therefore no decode rate;
+        # it is left out rather than shown as a number the board would not
+        # show. Printing ``N / window`` here made the CLI read 45.8 tok/s
+        # for a run the site then showed as 45.5.
         decode = [
-            (s["output_tokens"] - 1 if s["output_tokens"] > 1 else 1)
-            / (s["decode_duration_ms"] / 1000.0)
+            (s["output_tokens"] - 1) / (s["decode_duration_ms"] / 1000.0)
             for s in samples
             if isinstance(s.get("output_tokens"), int | float)
-            and s["output_tokens"] >= 1
+            and s["output_tokens"] >= 2
             and isinstance(s.get("decode_duration_ms"), int | float)
             and s["decode_duration_ms"] > 0
         ]

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -68,7 +68,8 @@ def _run_model_label(run: dict[str, Any]) -> str:
 def summarize_measurements(run: dict[str, Any]) -> list[str]:
     """One line per case with the numbers a user actually wants to see.
 
-    Text cases report median decode throughput and time-to-first-token; image
+    Text cases report median decode throughput (``(output_tokens - 1) /
+    decode_duration``, the board's formula) and time-to-first-token; image
     and video cases report the median wall time. Medians over completed rounds
     only, matching how the board aggregates. Returns ``[]`` when the run has
     no completed measurements so callers can fall back to the raw record.
@@ -86,8 +87,14 @@ def summarize_measurements(run: dict[str, Any]) -> list[str]:
             by_case.setdefault(case_id, []).append(sample)
     lines: list[str] = []
     for case_id, samples in by_case.items():
+        # Same formula as the board (rapidmlx.com) and the legacy
+        # ``bench`` runner: the first token lands at ``ttft_ms``, so the
+        # decode window covers ``output_tokens - 1`` tokens (llama.cpp
+        # ``tg`` / vLLM TPOT semantics). ``N == 1`` falls back to ``N``
+        # to avoid a 0/0. Printing ``N / window`` here made the CLI read
+        # 45.8 tok/s for a run the site then showed as 45.5.
         decode = [
-            s["output_tokens"] / (s["decode_duration_ms"] / 1000.0)
+            max(s["output_tokens"] - 1, 1) / (s["decode_duration_ms"] / 1000.0)
             for s in samples
             if isinstance(s.get("output_tokens"), int | float)
             and isinstance(s.get("decode_duration_ms"), int | float)


### PR DESCRIPTION
## Why

Dogfood on an M3 Pro (2026-09-05): `rapid-mlx benchmark run qwen3.5-4b-4bit` printed `45.8 tok/s decode`; after `share`, rapidmlx.com showed the same run as `45.5 tok/s` (9B: `26.0` vs `25.8`). A contributor's first reaction is "the site changed my number".

The CLI summary (added in #3101) divided all `output_tokens` by the decode window. The website (`(row.output_tokens - 1) * 1000 / row.decode_duration_ms`), the legacy `bench` runner and `community-benchmarks/README.md` all use `(N − 1) / window`, because the first token lands at `ttft_ms` (llama.cpp `tg` / vLLM TPOT semantics).

## Summary

- `summarize_measurements` uses `(output_tokens - 1) / decode_duration` for every sample with output tokens — literally the board formula, so a one-token sample reads 0.0 tok/s on both; zero-token samples carry no rate.
- Output-only change: `--json`, the archived run and the upload payload are byte-for-byte unchanged.

## Reproduction

Same archived runs, before → after:

```
174f47b7  pp512-tg128  45.8 → 45.5 tok/s   (site: 45.5)
c323a717  pp512-tg128  26.0 → 25.8 tok/s   (site: 25.8)
```

## Test plan

- [x] `pytest tests/test_community_benchmark_workspace.py tests/test_cli_bench.py` → 201 passed
- [x] Existing summary test updated to the board formula (`127.0`, and asserts the old `128.0` is gone); new test pins `(N-1)/window` on a real-shaped sample, the one-token 0.0 case and the zero-token fallback
- [x] `ruff check` / `ruff format --check` / `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019A88kUrTwWXNnbhhXbSPcx