### PR TITLE
fix(benchmark): make the Community Benchmark CLI legible end to end

### DIFF
--- a/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
+++ b/docs/engineering/decisions/2026-08-31-community-benchmark-local-workspace.md
@@ -13,7 +13,7 @@ metadata on the selected model, not separate navigation tabs.
 The initial commands are:
 
 ```text
-rapid-mlx benchmark catalog [--memory-gib N] [--json]
+rapid-mlx benchmark catalog [--memory-gib N] [--all] [--json]
 rapid-mlx benchmark plan MODEL [--json]
 rapid-mlx benchmark run MODEL [--json]
 rapid-mlx benchmark results [--limit N] [--json]

--- a/tests/headless_mlx/test_community_bench_text_lane.py
+++ b/tests/headless_mlx/test_community_bench_text_lane.py
@@ -100,7 +100,7 @@ def test_text_lane_converts_engine_result_and_reaps_executor(
     monkeypatch.setattr(local_runner, "run_conditions", probe)
 
     async def standardized(
-        engine, tokenizer, *, sampling: str, registered_token_ids: bool
+        engine, tokenizer, *, sampling: str, registered_token_ids: bool, on_round=None
     ) -> BenchResult:
         assert sampling == "greedy"
         assert registered_token_ids is True

--- a/tests/test_community_bench.py
+++ b/tests/test_community_bench.py
@@ -260,6 +260,29 @@ def test_registered_bucket_feeds_token_ids_directly(monkeypatch) -> None:
     assert observed == [prompt_ids] * 6  # one warmup + five measured rounds
     assert len(result.rounds_raw) == 5
 
+    # The optional observer sees every round, warmup included, labelled with
+    # the registered case id shape so a CLI can print progress.
+    seen: list[tuple[str, str, int, int]] = []
+    result, _ = asyncio.run(
+        runner._run_bucket(
+            object(),
+            _Tokenizer(),
+            lambda max_tokens: object(),
+            8,
+            4,
+            registered_token_ids=True,
+            on_round=lambda label, phase, index, total, round_result: (
+                seen.append((label, phase, index, total))
+                if isinstance(round_result, runner.RoundResult)
+                else None
+            ),
+        )
+    )
+    assert seen == [("pp8-tg4", "warmup", 1, 1)] + [
+        ("pp8-tg4", "measured", index, 5) for index in range(1, 6)
+    ]
+    assert len(result.rounds_raw) == 5
+
 
 def test_prompt_hash_stable() -> None:
     from vllm_mlx.community_bench.runner import _prompt_hash

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -3109,13 +3109,22 @@ def test_cli_catalog_recommends_focus_models_when_memory_is_unknown(
     assert community_cli.benchmark_command(args) == 0
     out = capsys.readouterr().out
     assert "★ focus-model" in out
-    assert "0 more models" in out
+    # The heading must not claim a fit that was never computed.
+    assert "memory fit unknown" in out
+    assert "fit this Mac" not in out
+    assert "0 more models have a registered protocol (fit unknown)" in out
 
     monkeypatch.setattr(
         community_cli, "benchmark_catalog", lambda **kwargs: {"models": []}
     )
     assert community_cli.benchmark_command(args) == 0
-    assert "none of the focus models fit" in capsys.readouterr().out
+    assert "(no focus models in this catalog)" in capsys.readouterr().out
+
+    monkeypatch.setattr(community_cli, "host_memory_gib", lambda: 8)
+    assert community_cli.benchmark_command(args) == 0
+    out = capsys.readouterr().out
+    assert "Recommended (★ focus models that fit this Mac)" in out
+    assert "none of the focus models fit this Mac's memory" in out
 
 
 def test_cli_catalog_defaults_memory_to_this_mac(
@@ -3265,11 +3274,15 @@ def test_cli_plan_memory_and_download_lines_cover_every_verdict(
     plan["model"]["estimated_memory_gib"] = None
     plan["model"]["memory_fit"] = "unknown"
     del plan["memory_gib"]
-    del plan["model_cached"]
+    plan["model_cached"] = None  # probe was inconclusive: say so, do not guess
     assert community_cli.benchmark_command(args) == 0
     out = capsys.readouterr().out
     assert "Memory:   unknown (no estimate for this model)" in out
-    assert "Download:" not in out
+    assert "Download: could not verify the local cache" in out
+
+    del plan["model_cached"]
+    assert community_cli.benchmark_command(args) == 0
+    assert "Download:" not in capsys.readouterr().out
 
 
 def test_cli_results_prints_empty_hint_then_rows(
@@ -5061,6 +5074,13 @@ def test_text_measurements_reports_model_load_stage(
     assert observed["on_round"] is None
     assert lines == []
 
+    # An inconclusive cache probe is reported as such, not as "cached".
+    monkeypatch.setattr(local_runner, "model_is_cached", lambda repo_id: None)
+    asyncio.run(local_runner._text_measurements("org/model", progress=lines.append))
+    assert lines[0] == (
+        "Loading org/model (cache state unknown; downloads anything missing)..."
+    )
+
 
 def test_describe_case_covers_every_registered_shape() -> None:
     text, image, video = (
@@ -5089,16 +5109,28 @@ def test_plan_for_alias_adds_memory_fit_and_cache_state_without_downloading(
     assert "model_cached" not in base
     assert base["model"]["memory_fit"] == "unknown"
 
-    import vllm_mlx._download_gate as gate
+    # The probe is the modality-aware one behind ``models --cached`` (mflux
+    # image and Wan video layouts are not the text ``model*.safetensors``
+    # rule), and an inconclusive probe stays inconclusive.
+    import vllm_mlx.cli as top_cli
 
-    monkeypatch.setattr(gate, "is_repo_cached", lambda repo_id: True)
-    assert workspace_module.model_is_cached("org/model") is True
+    probed: list[str] = []
+
+    def runnability(repo_id: str):
+        probed.append(repo_id)
+        return {"org/cached": True, "org/absent": False}.get(repo_id)
+
+    monkeypatch.setattr(top_cli, "_cache_runnability", runnability)
+    assert workspace_module.model_is_cached("org/cached") is True
+    assert workspace_module.model_is_cached("org/absent") is False
+    assert workspace_module.model_is_cached("org/inconclusive") is None
+    assert probed == ["org/cached", "org/absent", "org/inconclusive"]
 
     def boom(repo_id: str) -> bool:
-        raise OSError("cache unreadable")
+        raise RuntimeError("probe crashed")
 
-    monkeypatch.setattr(gate, "is_repo_cached", boom)
-    assert workspace_module.model_is_cached("org/model") is False
+    monkeypatch.setattr(top_cli, "_cache_runnability", boom)
+    assert workspace_module.model_is_cached("org/model") is None
 
     calls: list[str] = []
 
@@ -5128,6 +5160,28 @@ def test_benchmark_catalog_parser_accepts_all_flag() -> None:
 def test_format_duration_is_human_scale() -> None:
     assert local_runner._format_duration(0.4) == "0 s"
     assert local_runner._format_duration(45.4) == "45 s"
+    assert local_runner._format_duration(59.6) == "1 min"  # never "60 s"
     assert local_runner._format_duration(60) == "1 min"
     assert local_runner._format_duration(190.2) == "3 min 10 s"
+    assert local_runner._format_duration(3599.6) == "60 min"
     assert local_runner._format_duration(-5) == "0 s"
+
+
+def test_progress_sink_never_aborts_the_benchmark(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A closed or broken stderr is a presentation problem, not a failed run."""
+
+    class BrokenStream(io.StringIO):
+        def write(self, text: str) -> int:
+            raise BrokenPipeError("stderr consumer went away")
+
+    monkeypatch.setattr(sys, "stderr", BrokenStream())
+    community_cli._progress_to_stderr("pp512-tg128      round 1/5")
+
+    class ClosedStream(io.StringIO):
+        def write(self, text: str) -> int:
+            raise ValueError("I/O operation on closed file")
+
+    monkeypatch.setattr(sys, "stderr", ClosedStream())
+    community_cli._progress_to_stderr("pp512-tg128      round 2/5")

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import builtins
 import contextlib
+import hashlib
 import io
 import json
 import multiprocessing
@@ -49,6 +50,7 @@ from vllm_mlx.community_bench.upload import SubmitError
 from vllm_mlx.community_bench.workspace import (
     LocalRunArchive,
     benchmark_catalog,
+    describe_case,
     plan_for_alias,
 )
 
@@ -376,10 +378,16 @@ def test_atomic_upload_decline_has_no_disk_or_network_side_effect(
     assert not (tmp_path / "bench-install-id").exists()
     assert "observes the source IP" in output.getvalue()
     assert "does not put it in the benchmark record" in output.getvalue()
-    exact_body = benchmark_upload.submission_body(
-        {**run, "install_id": "a" * 12}
-    ).decode()
-    assert exact_body in output.getvalue()
+    # The consent shows a readable (indent=2) rendering of exactly the wire
+    # document plus the digest of the single-line body that is actually sent.
+    wire = {**run, "install_id": "a" * 12}
+    exact_body = benchmark_upload.submission_body(wire)
+    shown = output.getvalue()
+    assert json.dumps(wire, indent=2) in shown
+    assert exact_body.decode() not in shown  # no 5 KB single-line dump
+    assert f"{len(exact_body)} bytes" in shown
+    assert f"sha256:{hashlib.sha256(exact_body).hexdigest()}" in shown
+    assert atomic_upload.preview_run(run, install_id="a" * 12)["body_digest"] in shown
 
 
 def test_atomic_upload_rejects_cleartext_explicit_destination(
@@ -1271,7 +1279,7 @@ def test_run_local_archives_registered_token_drift_as_failure(
     measurements = _text_run()["measurements"]
     measurements[0]["prompt_tokens"] = 510
 
-    async def drifted_measurements(repo_id: str):
+    async def drifted_measurements(repo_id: str, **kwargs):
         return measurements, 32768
 
     monkeypatch.setattr(local_runner, "_text_measurements", drifted_measurements)
@@ -1765,8 +1773,12 @@ def test_run_local_executes_image_protocol_and_excludes_warmup(
         local_runner, "_is_dedicated_process_group_leader", lambda: True
     )
 
+    progress: list[str] = []
     run = local_runner.run_local(
-        "example-image", archive=archive, inherit_process_group=True
+        "example-image",
+        archive=archive,
+        inherit_process_group=True,
+        progress=progress.append,
     )
 
     assert len(calls) == 2  # one warmup plus one measured round
@@ -1776,6 +1788,13 @@ def test_run_local_executes_image_protocol_and_excludes_warmup(
     ]
     assert run["machine"]["conditions_before"]["thermal_state"] == "nominal"
     assert run["machine"]["conditions_after"]["thermal_state"] == "serious"
+    # A user watching the terminal sees the server boot and each round,
+    # warmup included, with the round's wall time.
+    assert progress[0].startswith("Benchmarking example-image (image_generation)")
+    assert progress[1].startswith("Starting local image server for example-image")
+    assert any(line.startswith("Server ready in ") for line in progress)
+    assert progress[-2] == "t2i-1024-square  warmup   1 s"
+    assert progress[-1] == "t2i-1024-square  round 1/1  2 s"
     assert calls[0]["url"] == "http://local/v1/images/generations"
     assert calls[0]["json"] == {
         "model": "example-image",
@@ -1874,7 +1893,9 @@ def test_run_local_without_flag_never_consults_group_topology(
     )
     observed: dict[str, bool] = {}
 
-    def run_image(alias: str, *, isolate_process_group: bool) -> list[dict]:
+    def run_image(
+        alias: str, *, isolate_process_group: bool, progress=None
+    ) -> list[dict]:
         observed["isolate_process_group"] = isolate_process_group
         return [
             {
@@ -2075,7 +2096,10 @@ def test_run_local_executes_video_protocol_and_polls_to_completion(
     timings = iter((10.0, 15.0))
     monkeypatch.setattr(local_runner.time, "perf_counter", lambda: next(timings))
 
-    run = local_runner.run_local("example-video", archive=archive)
+    progress: list[str] = []
+    run = local_runner.run_local(
+        "example-video", archive=archive, progress=progress.append
+    )
 
     assert events == [
         "probe(served=False, requests=0)",
@@ -2085,6 +2109,9 @@ def test_run_local_executes_video_protocol_and_polls_to_completion(
     assert run["machine"]["conditions_after"]["thermal_state"] == "serious"
 
     assert serve_options["extra_env"] == {"RAPID_MLX_WAN_STEPS": "20"}
+    assert progress[1].startswith("Starting local video server for example-video")
+    assert progress[-2] == "t2v-480p-81f     round 1/1  generating..."
+    assert progress[-1] == "t2v-480p-81f     round 1/1  5 s"
     assert posts == [
         {
             "url": "http://local/v1/videos",
@@ -2649,7 +2676,7 @@ def test_run_local_does_not_infer_cancellation_from_error_text(
     monkeypatch.setattr(
         local_runner,
         "_run_video",
-        lambda alias, *, isolate_process_group: (_ for _ in ()).throw(
+        lambda alias, **kwargs: (_ for _ in ()).throw(
             RuntimeError("backend cancelled an internal request")
         ),
     )
@@ -2780,9 +2807,10 @@ def test_run_local_converts_text_engine_result_to_atomic_measurements(
             pass
 
     async def standardized(
-        engine, tokenizer, *, sampling: str, registered_token_ids: bool
+        engine, tokenizer, *, sampling: str, registered_token_ids: bool, on_round=None
     ) -> BenchResult:
         assert sampling == "greedy"
+        assert on_round is None  # no progress sink, no observer
         assert registered_token_ids is True
         short = [RoundResult(100, 200, 10, prompt_tokens=512, output_tokens=128)] * 5
         long = [RoundResult(50, 150, 20, prompt_tokens=2048, output_tokens=512)] * 5
@@ -2990,30 +3018,104 @@ def test_cli_catalog_prints_focus_marker_and_run_hint(
         lambda **kwargs: {
             "models": [
                 {
-                    "alias": "focus-model",
+                    "alias": "big-focus-model",
                     "task_type": "text_generation",
                     "memory_fit": "does_not_fit",
+                    "estimated_memory_gib": 64,
                     "focus": True,
                 },
                 {
-                    "alias": "other-model",
+                    "alias": "focus-model",
+                    "task_type": "text_generation",
+                    "memory_fit": "fits",
+                    "estimated_memory_gib": 6,
+                    "focus": True,
+                },
+                {
+                    "alias": "aaa-other-model",
                     "task_type": "image_generation",
                     "memory_fit": "fits",
+                    "estimated_memory_gib": 4,
+                    "focus": False,
+                },
+                {
+                    "alias": "zzz-other-model",
+                    "task_type": "image_generation",
+                    "memory_fit": "unknown",
+                    "estimated_memory_gib": None,
                     "focus": False,
                 },
             ]
         },
     )
-    args = SimpleNamespace(benchmark_action="catalog", memory_gib=8, json=False)
+    args = SimpleNamespace(
+        benchmark_action="catalog", memory_gib=8, json=False, all=False
+    )
 
     assert community_cli.benchmark_command(args) == 0
     out = capsys.readouterr().out
     assert "Community Benchmark models (local by default)" in out
     assert "Fit column assumes 8 GB (--memory-gib), not this Mac's memory" in out
     assert "This Mac:" not in out
+    # Recommended = focus models that fit, listed first under a heading; the
+    # long tail is summarised, not dumped, unless --all is passed.
+    assert "Recommended" in out
     assert "★ focus-model" in out
-    assert "does not fit" in out
+    assert "~6 GB  fits" in out
+    assert "big-focus-model" not in out
+    assert "aaa-other-model" not in out
+    assert "3 more models have a registered protocol (1 fit this Mac)" in out
+    assert "catalog --all" in out
     assert "Run: rapid-mlx benchmark run <model>" in out
+
+    args.all = True
+    assert community_cli.benchmark_command(args) == 0
+    out = capsys.readouterr().out
+    assert out.index("Recommended") < out.index("★ focus-model")
+    assert out.index("★ focus-model") < out.index("All other models")
+    assert out.index("All other models") < out.index("★ big-focus-model")
+    assert "~64 GB  does not fit" in out
+    assert "aaa-other-model" in out
+    assert "zzz-other-model" in out
+    assert "   ?  unknown" in out
+    assert "more models have a registered protocol" not in out
+
+
+def test_cli_catalog_recommends_focus_models_when_memory_is_unknown(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Without a fit verdict a focus model is still worth recommending; only a
+    known does-not-fit demotes it."""
+    _cli_archive(monkeypatch, SimpleNamespace())
+    monkeypatch.setattr(
+        community_cli,
+        "benchmark_catalog",
+        lambda **kwargs: {
+            "models": [
+                {
+                    "alias": "focus-model",
+                    "task_type": "text_generation",
+                    "memory_fit": "unknown",
+                    "estimated_memory_gib": 6,
+                    "focus": True,
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(community_cli, "host_memory_gib", lambda: None)
+    args = SimpleNamespace(
+        benchmark_action="catalog", memory_gib=None, json=False, all=False
+    )
+    assert community_cli.benchmark_command(args) == 0
+    out = capsys.readouterr().out
+    assert "★ focus-model" in out
+    assert "0 more models" in out
+
+    monkeypatch.setattr(
+        community_cli, "benchmark_catalog", lambda **kwargs: {"models": []}
+    )
+    assert community_cli.benchmark_command(args) == 0
+    assert "none of the focus models fit" in capsys.readouterr().out
 
 
 def test_cli_catalog_defaults_memory_to_this_mac(
@@ -3030,7 +3132,9 @@ def test_cli_catalog_defaults_memory_to_this_mac(
 
     monkeypatch.setattr(community_cli, "benchmark_catalog", fake_catalog)
     monkeypatch.setattr(community_cli, "host_memory_gib", lambda: 48)
-    args = SimpleNamespace(benchmark_action="catalog", memory_gib=None, json=False)
+    args = SimpleNamespace(
+        benchmark_action="catalog", memory_gib=None, json=False, all=False
+    )
 
     assert community_cli.benchmark_command(args) == 0
     assert seen == {"memory_gib": 48}
@@ -3072,33 +3176,106 @@ def test_cli_plan_prints_protocol_and_local_storage(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _cli_archive(monkeypatch, SimpleNamespace())
-    monkeypatch.setattr(
-        community_cli,
-        "plan_for_alias",
-        lambda alias: {
+    seen: dict[str, object] = {}
+
+    def fake_plan(alias, **kwargs):
+        seen.update(kwargs)
+        return {
             "model": {
                 "alias": alias,
+                "repo_id": "mlx-community/example-text",
                 "task_type": "text_generation",
                 "protocol_id": "rapid-community-speed",
+                "estimated_memory_gib": 6,
+                "memory_estimate_source": "artifact_size_fallback",
+                "memory_fit": "fits",
             },
-            "workload": {"protocol_version": 2},
-        },
-    )
+            "workload": {
+                "protocol_version": 2,
+                "cases": registered_workload("text_generation")["cases"],
+            },
+            "memory_gib": 18,
+            "model_cached": False,
+        }
+
+    monkeypatch.setattr(community_cli, "plan_for_alias", fake_plan)
+    monkeypatch.setattr(community_cli, "host_memory_gib", lambda: 18)
     args = SimpleNamespace(
         benchmark_action="plan", benchmark_model="example-text", json=False
     )
 
     assert community_cli.benchmark_command(args) == 0
     out = capsys.readouterr().out
-    assert "Model:    example-text" in out
+    assert seen == {"memory_gib": 18, "check_cache": True}
+    assert "Model:    example-text  (mlx-community/example-text)" in out
     assert "Protocol: rapid-community-speed v2" in out
+    # Every case with its token plan and rounds, so "plan" actually plans.
+    assert "Cases:    2" in out
+    assert (
+        "pp512-tg128      512 prompt tokens -> 128 output tokens   "
+        "(1 warmup + 5 measured)"
+    ) in out
+    assert "pp2048-tg512     2048 prompt tokens -> 512 output tokens" in out
+    assert (
+        "Memory:   ~6 GB estimated (from download size); fits this Mac (18 GB)" in out
+    )
+    assert "Download: not cached yet; `benchmark run` downloads it" in out
     assert (
         "Storage:  local; upload requires a separate share command and consent" in out
     )
+    assert "Nothing is uploaded by this command or by `benchmark run`." in out
+
+    # JSON keeps the original keys and only gains the new ones.
+    args.json = True
+    assert community_cli.benchmark_command(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["model"]["alias"] == "example-text"
+    assert payload["workload"]["protocol_version"] == 2
+    assert payload["memory_gib"] == 18
+    assert payload["model_cached"] is False
+
+
+def test_cli_plan_memory_and_download_lines_cover_every_verdict(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _cli_archive(monkeypatch, SimpleNamespace())
+    plan = {
+        "model": {
+            "alias": "m",
+            "task_type": "image_generation",
+            "protocol_id": "rapid-image-speed",
+            "estimated_memory_gib": 64,
+            "memory_estimate_source": "profile_minimum",
+            "memory_fit": "does_not_fit",
+        },
+        "workload": {"protocol_version": 1, "cases": []},
+        "memory_gib": 18,
+        "model_cached": True,
+    }
+    monkeypatch.setattr(community_cli, "plan_for_alias", lambda alias, **kw: plan)
+    monkeypatch.setattr(community_cli, "host_memory_gib", lambda: 18)
+    args = SimpleNamespace(benchmark_action="plan", benchmark_model="m", json=False)
+
+    assert community_cli.benchmark_command(args) == 0
+    out = capsys.readouterr().out
+    assert "Memory:   ~64 GB estimated; does NOT fit this Mac (18 GB)" in out
+    assert "Download: already in the local Hugging Face cache" in out
+    assert "Cases:" not in out
+
+    plan["model"]["estimated_memory_gib"] = None
+    plan["model"]["memory_fit"] = "unknown"
+    del plan["memory_gib"]
+    del plan["model_cached"]
+    assert community_cli.benchmark_command(args) == 0
+    out = capsys.readouterr().out
+    assert "Memory:   unknown (no estimate for this model)" in out
+    assert "Download:" not in out
 
 
 def test_cli_results_prints_empty_hint_then_rows(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    pin_timezone,
 ) -> None:
     rows: list[dict] = []
 
@@ -3110,6 +3287,7 @@ def test_cli_results_prints_empty_hint_then_rows(
             return None
 
     _cli_archive(monkeypatch, Archive())
+    pin_timezone("America/Los_Angeles")
     args = SimpleNamespace(benchmark_action="results", limit=None, json=False)
 
     assert community_cli.benchmark_command(args) == 0
@@ -3141,6 +3319,9 @@ def test_cli_results_prints_empty_hint_then_rows(
     assert "completed" in out
     # A run list without the model is unusable (0.13.5 dogfood F2).
     assert "mlx-community/Qwen3.5-9B-4bit" in out
+    # Timestamps are shown on the user's clock, not raw UTC ISO-8601.
+    assert "2026-08-31 17:00 local" in out
+    assert "2026-09-01T00:00:00Z" not in out
 
     rows.append(
         {
@@ -3154,7 +3335,7 @@ def test_cli_results_prints_empty_hint_then_rows(
     out = capsys.readouterr().out
     assert (
         "00000000-0000-4000-8000-000000000002  image_generation   failed"
-        "     2026-09-01T00:00:01Z  -\n"
+        "     2026-08-31 17:00 local  -\n"
     ) in out
 
     # The primary component wins even when an auxiliary component (e.g. a
@@ -3206,8 +3387,51 @@ def test_cli_results_prints_empty_hint_then_rows(
     assert community_cli.benchmark_command(args) == 0
     out = capsys.readouterr().out
     assert "00000000-0000-4000-8000-000000000004" in out
-    assert "2026-09-01T00:00:03Z  -\n" in out
+    assert "2026-08-31 17:00 local  -\n" in out
     assert "org/draft" not in out
+
+    # --json is untouched: the archived UTC instant is what callers parse.
+    args.json = True
+    assert community_cli.benchmark_command(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["runs"][0]["completed_at"] == "2026-09-01T00:00:00Z"
+
+
+@pytest.fixture
+def pin_timezone(monkeypatch: pytest.MonkeyPatch):
+    """Make ``datetime.astimezone()`` deterministic for one test.
+
+    libc caches the zone, so restoring ``TZ`` alone is not enough; the
+    teardown puts the previous value back and re-runs ``tzset`` before the
+    monkeypatch fixture unwinds.
+    """
+
+    previous = os.environ.get("TZ")
+
+    def pin(zone: str) -> None:
+        monkeypatch.setenv("TZ", zone)
+        time.tzset()
+
+    yield pin
+    if previous is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = previous
+    time.tzset()
+
+
+def test_cli_local_time_rendering_edge_cases(pin_timezone) -> None:
+    pin_timezone("Asia/Tokyo")
+    assert community_cli._local_time("2026-09-06T04:33:13.950359Z") == (
+        "2026-09-06 13:33 local"
+    )
+    assert community_cli._local_time("2026-09-06T04:33:13+02:00") == (
+        "2026-09-06 11:33 local"
+    )
+    # Not an instant: shown verbatim rather than guessed.
+    assert community_cli._local_time("2026-09-06T04:33:13") == "2026-09-06T04:33:13"
+    assert community_cli._local_time("yesterday") == "yesterday"
+    assert community_cli._local_time(None) == "-"
 
 
 def test_cli_inspect_prints_full_json_without_flag(
@@ -4618,3 +4842,292 @@ def test_run_bucket_selects_registered_or_synthetic_prompts(
     assert len(synthetic_ids) == 8
     assert observed == [("synthetic prompt text", False)] * 6
     assert len(result.rounds_raw) == 5
+
+
+# ---------------------------------------------------------------------------
+# Run progress (stderr only) and plan/catalog helpers
+# ---------------------------------------------------------------------------
+
+
+def test_cli_run_streams_progress_to_stderr_only_in_text_mode(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _cli_archive(monkeypatch, SimpleNamespace())
+    seen: list[object] = []
+
+    def fake_run_local(alias, **kwargs):
+        progress = kwargs.get("progress")
+        seen.append(progress)
+        if progress is not None:
+            progress("pp512-tg128      warmup")
+            progress("pp512-tg128      round 1/5    46.1 tok/s")
+        return {"run_id": "abc-123", "measurements": []}
+
+    monkeypatch.setattr(community_cli, "run_local", fake_run_local)
+    args = SimpleNamespace(
+        benchmark_action="run",
+        benchmark_model="example-text",
+        inherit_process_group=False,
+        json=False,
+    )
+    assert community_cli.benchmark_command(args) == 0
+    captured = capsys.readouterr()
+    assert callable(seen[-1])
+    assert "pp512-tg128      round 1/5    46.1 tok/s" in captured.err
+    assert "round 1/5" not in captured.out
+    assert "Saved local result abc-123" in captured.out
+
+    # --json: stdout is exactly one JSON document and nothing is written to
+    # stderr, which the Desktop app surfaces verbatim on a non-zero exit.
+    args.json = True
+    assert community_cli.benchmark_command(args) == 0
+    captured = capsys.readouterr()
+    assert seen[-1] is None
+    assert json.loads(captured.out) == {"run_id": "abc-123", "measurements": []}
+    assert captured.err == ""
+
+
+def test_run_local_announces_plan_and_forwards_progress(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    archive = LocalRunArchive(tmp_path)
+    monkeypatch.setattr(
+        local_runner,
+        "plan_for_alias",
+        lambda alias: {
+            "model": {
+                "alias": alias,
+                "repo_id": "mlx-community/example-image-model",
+                "task_type": "image_generation",
+            },
+            "workload": registered_workload("image_generation"),
+        },
+    )
+    monkeypatch.setattr(
+        local_runner,
+        "collect",
+        lambda: (
+            Hardware("Apple M4 Pro", 24, 12, 16),
+            Software("15.6", "0.13.2", "0.32.1", "3.12.1"),
+        ),
+    )
+
+    def run_image(alias, *, isolate_process_group, progress=None):
+        progress("t2i-1024-square  round 1/1  12 s")
+        return _image_run()["measurements"]
+
+    monkeypatch.setattr(local_runner, "_run_image", run_image)
+    lines: list[str] = []
+
+    local_runner.run_local("example-image", archive=archive, progress=lines.append)
+
+    assert lines[0] == (
+        "Benchmarking example-image (image_generation): 1 case, "
+        "1 warmup + 1 measured rounds in total"
+    )
+    assert lines[1] == "  " + describe_case(
+        registered_workload("image_generation")["cases"][0]
+    )
+    assert lines[-1] == "t2i-1024-square  round 1/1  12 s"
+
+    # Without a sink nothing is announced and the runner still works.
+    monkeypatch.setattr(
+        local_runner,
+        "_run_image",
+        lambda alias, **kwargs: _image_run()["measurements"],
+    )
+    local_runner.run_local("example-image", archive=archive)
+
+
+def test_text_round_observer_reports_rounds_and_estimates_remaining_time() -> None:
+    cases = registered_workload("text_generation")["cases"]
+    lines: list[str] = []
+    observe = local_runner._text_round_observer(lines.append, cases)
+    # 512 prompt tokens at 1024 tok/s = 0.5 s prefill; 128 output at 50 tok/s
+    # = 2.56 s decode. Remaining after this warmup: 5 short rounds x 3.06 s +
+    # 6 long rounds x (2 s + 10.24 s) = 15.3 + 73.44 = 88.74 s.
+    warmup = RoundResult(decode_tps=50.0, prefill_tps=1024.0, ttft_ms=500.0)
+    observe("pp512-tg128", "warmup", 1, 1, warmup)
+    assert lines == [
+        "pp512-tg128      warmup",
+        "Estimated time remaining: ~1 min 29 s (from the warmup rate)",
+    ]
+    observe("pp512-tg128", "measured", 3, 5, RoundResult(46.06, 900.0, 480.0))
+    assert lines[-1] == "pp512-tg128      round 3/5    46.1 tok/s"
+    # The estimate is printed once; the long case's warmup does not repeat it.
+    observe("pp2048-tg512", "warmup", 1, 1, warmup)
+    assert lines[-1] == "pp2048-tg512     warmup"
+    assert sum("Estimated" in line for line in lines) == 1
+
+    assert local_runner._estimate_remaining_s(
+        cases, RoundResult(50.0, 1024.0, 1.0), done_label="pp512-tg128"
+    ) == pytest.approx(88.74)
+    assert (
+        local_runner._estimate_remaining_s(
+            cases, RoundResult(0.0, 1024.0, 1.0), done_label="pp512-tg128"
+        )
+        is None
+    )
+    # A multi-warmup protocol numbers its warmups; a missing rate is skipped.
+    lines.clear()
+    observe = local_runner._text_round_observer(lines.append, cases)
+    observe("pp512-tg128", "warmup", 2, 3, object())
+    observe("pp512-tg128", "measured", 1, 5, object())
+    assert lines == ["pp512-tg128      warmup 2/3", "pp512-tg128      round 1/5"]
+
+
+def test_text_measurements_reports_model_load_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The load/download stage is the longest silent part of a run."""
+    lines: list[str] = []
+    cases = registered_workload("text_generation")["cases"]
+
+    class FakeExecutor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def submit(self, fn, *args):
+            return SimpleNamespace(result=lambda: fn(*args))
+
+        def shutdown(self, **kwargs):
+            pass
+
+    class FakeEngine:
+        engine = object()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    fake_engine_core = types.SimpleNamespace(
+        AsyncEngineCore=lambda *args, **kwargs: FakeEngine(),
+        EngineConfig=lambda **kwargs: None,
+        _init_mlx_step_thread=lambda: None,
+    )
+    fake_scheduler = types.SimpleNamespace(SchedulerConfig=lambda **kwargs: None)
+    fake_helpers = types.SimpleNamespace(get_model_max_context=lambda engine: 4096)
+    fake_tokenizer = types.SimpleNamespace(
+        load_model_with_fallback=lambda repo_id: (object(), object())
+    )
+    monkeypatch.setitem(sys.modules, "vllm_mlx.engine_core", fake_engine_core)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.scheduler", fake_scheduler)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.service.helpers", fake_helpers)
+    monkeypatch.setitem(sys.modules, "vllm_mlx.utils.tokenizer", fake_tokenizer)
+    monkeypatch.setattr(
+        local_runner.concurrent.futures, "ThreadPoolExecutor", FakeExecutor
+    )
+    monkeypatch.setattr(local_runner, "model_is_cached", lambda repo_id: False)
+    observed: dict[str, object] = {}
+
+    async def fake_bench(
+        engine, tokenizer, *, sampling, registered_token_ids, on_round
+    ):
+        observed["on_round"] = on_round
+        if on_round is not None:
+            on_round("pp512-tg128", "measured", 1, 5, RoundResult(50.0, 500.0, 100.0))
+        rounds = [
+            RoundResult(50.0, 500.0, 100.0, prompt_tokens=p, output_tokens=o)
+            for _ in range(5)
+        ]
+        return BenchResult(
+            short=BucketResult(rounds_raw=[r for r in rounds[:5]]),
+            long=BucketResult(rounds_raw=[r for r in rounds[:5]]),
+            peak_ram_mb=1234,
+            prompt_hash="0" * 16,
+            sampling=sampling,
+        )
+
+    p, o = cases[0]["target_prompt_tokens"], cases[0]["target_output_tokens"]
+    monkeypatch.setattr(bench_runner, "run_standardized_bench", fake_bench)
+
+    measurements, context = asyncio.run(
+        local_runner._text_measurements("org/model", progress=lines.append)
+    )
+    assert context == 4096
+    assert lines[0] == (
+        "Loading org/model (not cached yet; downloading from Hugging Face first)..."
+    )
+    assert lines[1].startswith("Model loaded in ")
+    assert lines[2] == "pp512-tg128      round 1/5    50.0 tok/s"
+    assert callable(observed["on_round"])
+
+    # No sink: no observer is installed and nothing is logged.
+    monkeypatch.setattr(local_runner, "model_is_cached", lambda repo_id: True)
+    lines.clear()
+    asyncio.run(local_runner._text_measurements("org/model"))
+    assert observed["on_round"] is None
+    assert lines == []
+
+
+def test_describe_case_covers_every_registered_shape() -> None:
+    text, image, video = (
+        registered_workload(task)["cases"][0]
+        for task in ("text_generation", "image_generation", "video_generation")
+    )
+    assert describe_case(text) == (
+        "pp512-tg128      512 prompt tokens -> 128 output tokens   "
+        "(1 warmup + 5 measured)"
+    )
+    assert describe_case(image) == (
+        "t2i-1024-square  1024x1024, 20 steps, 1 image   (1 warmup + 1 measured)"
+    )
+    assert describe_case(video) == (
+        "t2v-480p-81f     832x480, 81 frames @ 24 fps, 20 steps   "
+        "(0 warmup + 1 measured)"
+    )
+    assert describe_case({**image, "image_count": 4}).count("4 images") == 1
+
+
+def test_plan_for_alias_adds_memory_fit_and_cache_state_without_downloading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = plan_for_alias("qwen3.5-9b-4bit")
+    assert "memory_gib" not in base
+    assert "model_cached" not in base
+    assert base["model"]["memory_fit"] == "unknown"
+
+    import vllm_mlx._download_gate as gate
+
+    monkeypatch.setattr(gate, "is_repo_cached", lambda repo_id: True)
+    assert workspace_module.model_is_cached("org/model") is True
+
+    def boom(repo_id: str) -> bool:
+        raise OSError("cache unreadable")
+
+    monkeypatch.setattr(gate, "is_repo_cached", boom)
+    assert workspace_module.model_is_cached("org/model") is False
+
+    calls: list[str] = []
+
+    def probe(repo_id: str) -> bool:
+        calls.append(repo_id)
+        return True
+
+    monkeypatch.setattr(workspace_module, "model_is_cached", probe)
+    plan = plan_for_alias("qwen3.5-9b-4bit", memory_gib=4, check_cache=True)
+    assert plan["memory_gib"] == 4
+    assert plan["model"]["memory_fit"] == "does_not_fit"
+    assert plan["model_cached"] is True
+    assert calls == [plan["model"]["repo_id"]]
+    # Everything the v1 plan had is still there.
+    assert set(base) <= set(plan)
+
+
+def test_benchmark_catalog_parser_accepts_all_flag() -> None:
+    from vllm_mlx.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["benchmark", "catalog", "--all"])
+    assert args.all is True
+    assert parser.parse_args(["benchmark", "catalog"]).all is False
+
+
+def test_format_duration_is_human_scale() -> None:
+    assert local_runner._format_duration(0.4) == "0 s"
+    assert local_runner._format_duration(45.4) == "45 s"
+    assert local_runner._format_duration(60) == "1 min"
+    assert local_runner._format_duration(190.2) == "3 min 10 s"
+    assert local_runner._format_duration(-5) == "0 s"

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -4984,6 +4984,33 @@ def test_run_local_announces_plan_and_forwards_progress(
     )
     local_runner.run_local("example-image", archive=archive)
 
+    # A sink that blows up (closed pipe, encoding error, a buggy caller) is a
+    # presentation problem: the benchmark still completes and is archived as
+    # completed, whichever stage raised.
+    def run_image_with_progress(alias, *, isolate_process_group, progress=None):
+        local_runner._report(progress, "t2i-1024-square  round 1/1  12 s")
+        return _image_run()["measurements"]
+
+    monkeypatch.setattr(local_runner, "_run_image", run_image_with_progress)
+    attempts: list[str] = []
+
+    def exploding_sink(line: str) -> None:
+        attempts.append(line)
+        raise BrokenPipeError("stderr went away")
+
+    run = local_runner.run_local(
+        "example-image", archive=archive, progress=exploding_sink
+    )
+    assert run["outcome"]["status"] == "completed"
+    assert archive.get(run["run_id"])["outcome"]["status"] == "completed"
+    assert len(attempts) == 3  # plan header, case line, round line all attempted
+
+    # The observer path is guarded the same way.
+    observe = local_runner._text_round_observer(exploding_sink, [])
+    observe("pp512-tg128", "warmup", 1, 1, RoundResult(50.0, 500.0, 100.0))
+    observe("pp512-tg128", "measured", 1, 5, RoundResult(50.0, 500.0, 100.0))
+    local_runner._stage_finished(exploding_sink, 0.0, "Server ready")
+
 
 def test_text_round_observer_reports_rounds_and_estimates_remaining_time() -> None:
     cases = registered_workload("text_generation")["cases"]

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -3045,6 +3045,13 @@ def test_cli_catalog_prints_focus_marker_and_run_hint(
                     "estimated_memory_gib": None,
                     "focus": False,
                 },
+                {
+                    "alias": "unknown-focus-model",
+                    "task_type": "text_generation",
+                    "memory_fit": "unknown",
+                    "estimated_memory_gib": None,
+                    "focus": True,
+                },
             ]
         },
     )
@@ -3063,8 +3070,11 @@ def test_cli_catalog_prints_focus_marker_and_run_hint(
     assert "★ focus-model" in out
     assert "~6 GB  fits" in out
     assert "big-focus-model" not in out
+    # Memory is known, so a focus model with no estimate is not a verified
+    # fit and must not be recommended as one.
+    assert "unknown-focus-model" not in out
     assert "aaa-other-model" not in out
-    assert "3 more models have a registered protocol (1 fit this Mac)" in out
+    assert "4 more models have a registered protocol (1 fit this Mac)" in out
     assert "catalog --all" in out
     assert "Run: rapid-mlx benchmark run <model>" in out
 
@@ -3077,6 +3087,7 @@ def test_cli_catalog_prints_focus_marker_and_run_hint(
     assert "~64 GB  does not fit" in out
     assert "aaa-other-model" in out
     assert "zzz-other-model" in out
+    assert "★ unknown-focus-model" in out
     assert "   ?  unknown" in out
     assert "more models have a registered protocol" not in out
 
@@ -4856,6 +4867,28 @@ def test_run_bucket_selects_registered_or_synthetic_prompts(
     assert observed == [("synthetic prompt text", False)] * 6
     assert len(result.rounds_raw) == 5
 
+    # The optional observer sees every round, warmup included, labelled with
+    # the registered case-id shape so the CLI can print progress. (Kept in
+    # this no-MLX file so the Linux coverage lane exercises the hook.)
+    seen: list[tuple[str, str, int, int, float]] = []
+    result, _ = asyncio.run(
+        bench_runner._run_bucket(
+            object(),
+            SyntheticTokenizer(),
+            lambda max_tokens: object(),
+            8,
+            4,
+            registered_token_ids=False,
+            on_round=lambda label, phase, index, total, round_result: seen.append(
+                (label, phase, index, total, round_result.decode_tps)
+            ),
+        )
+    )
+    assert seen == [("pp8-tg4", "warmup", 1, 1, 1)] + [
+        ("pp8-tg4", "measured", index, 5, 1) for index in range(1, 6)
+    ]
+    assert len(result.rounds_raw) == 5
+
 
 # ---------------------------------------------------------------------------
 # Run progress (stderr only) and plan/catalog helpers
@@ -5080,6 +5113,11 @@ def test_text_measurements_reports_model_load_stage(
     assert lines[0] == (
         "Loading org/model (cache state unknown; downloads anything missing)..."
     )
+
+    lines.clear()
+    monkeypatch.setattr(local_runner, "model_is_cached", lambda repo_id: True)
+    asyncio.run(local_runner._text_measurements("org/model", progress=lines.append))
+    assert lines[0] == "Loading org/model (from the local Hugging Face cache)..."
 
 
 def test_describe_case_covers_every_registered_shape() -> None:

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -1325,7 +1325,8 @@ def test_run_local_records_conditions_before_and_after_the_measurements(
         order.append("conditions")
         return next(snapshots)
 
-    async def fake_measurements(repo_id: str):
+    async def fake_measurements(repo_id: str, *, progress=None):
+        assert progress is None
         order.append("measure")
         # The real helper records the "after" snapshot while the model is
         # still resident, i.e. before its engine context tears down.
@@ -1366,7 +1367,8 @@ def test_after_snapshot_is_never_taken_once_the_model_is_gone(
             "available_memory_mib": 9000,
         }
 
-    async def silent_measurements(repo_id: str):
+    async def silent_measurements(repo_id: str, *, progress=None):
+        assert progress is None
         return _text_run()["measurements"], 32768
 
     monkeypatch.setattr(local_runner, "run_conditions", counting_conditions)
@@ -1441,7 +1443,8 @@ def test_image_runs_capture_conditions_inside_the_server_context(
     monkeypatch.setattr(local_runner, "run_conditions", lambda: next(snapshots))
     measurements = _image_run()["measurements"]
 
-    def fake_image(alias: str, *, isolate_process_group: bool):
+    def fake_image(alias: str, *, isolate_process_group: bool, progress=None):
+        assert progress is None
         local_runner._record_conditions_after()
         return measurements
 

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -12352,6 +12352,11 @@ Examples:
         "catalog", help="List models with a registered benchmark protocol"
     )
     community_catalog.add_argument("--memory-gib", type=positive_int, default=None)
+    community_catalog.add_argument(
+        "--all",
+        action="store_true",
+        help="List every model, not only the recommended ones (text mode)",
+    )
     community_catalog.add_argument("--json", action="store_true")
     community_plan = community_subparsers.add_parser(
         "plan", help="Preview the exact local workload for a model"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -12351,23 +12351,44 @@ Examples:
     community_catalog = community_subparsers.add_parser(
         "catalog", help="List models with a registered benchmark protocol"
     )
-    community_catalog.add_argument("--memory-gib", type=positive_int, default=None)
+    community_catalog.add_argument(
+        "--memory-gib",
+        type=positive_int,
+        default=None,
+        help="Compute the fit column for a Mac with this much unified memory instead of this one",
+    )
     community_catalog.add_argument(
         "--all",
         action="store_true",
-        help="List every model, not only the recommended ones (text mode)",
+        help="List every model with a protocol, not only the recommended ones",
     )
-    community_catalog.add_argument("--json", action="store_true")
+    community_catalog.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of the text summary",
+    )
     community_plan = community_subparsers.add_parser(
         "plan", help="Preview the exact local workload for a model"
     )
-    community_plan.add_argument("benchmark_model")
-    community_plan.add_argument("--json", action="store_true")
+    community_plan.add_argument(
+        "benchmark_model", help="Model alias from `rapid-mlx benchmark catalog`"
+    )
+    community_plan.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of the text summary",
+    )
     community_run = community_subparsers.add_parser(
         "run", help="Run the registered protocol and save the result locally"
     )
-    community_run.add_argument("benchmark_model")
-    community_run.add_argument("--json", action="store_true")
+    community_run.add_argument(
+        "benchmark_model", help="Model alias from `rapid-mlx benchmark catalog`"
+    )
+    community_run.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of the text summary",
+    )
     community_run.add_argument(
         "--inherit-process-group",
         action="store_true",
@@ -12379,16 +12400,30 @@ Examples:
     community_results.add_argument(
         "--limit", type=positive_int, default=None, help="Return only the latest N runs"
     )
-    community_results.add_argument("--json", action="store_true")
+    community_results.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of the text summary",
+    )
     community_inspect = community_subparsers.add_parser(
         "inspect", help="Print one locally saved benchmark result"
     )
-    community_inspect.add_argument("run_id")
-    community_inspect.add_argument("--json", action="store_true")
+    community_inspect.add_argument(
+        "run_id",
+        help="Run id printed by `benchmark run` or listed by `benchmark results`",
+    )
+    community_inspect.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of the text summary",
+    )
     community_share = community_subparsers.add_parser(
         "share", help="Explicitly upload one locally saved benchmark result"
     )
-    community_share.add_argument("run_id")
+    community_share.add_argument(
+        "run_id",
+        help="Run id printed by `benchmark run` or listed by `benchmark results`",
+    )
     community_share.add_argument(
         "--yes",
         action="store_true",
@@ -12415,7 +12450,11 @@ Examples:
         "--target",
         help=argparse.SUPPRESS,
     )
-    community_share.add_argument("--json", action="store_true")
+    community_share.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of the text summary",
+    )
 
     # Models command. ``ls`` is registered as a top-level alias that
     # defaults to ``models --cached`` (the locally-cached view) — two

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -33,11 +33,22 @@ class AtomicUploadAcceptance:
 def _ask_consent(
     payload: dict[str, Any], *, target: str, stdin: TextIO, stdout: TextIO
 ) -> bool:
+    body = submission_body(payload)
+    body_digest = f"sha256:{hashlib.sha256(body).hexdigest()}"
     print("", file=stdout)
     print(f"About to upload this benchmark to {target}:", file=stdout)
     print("=" * 72, file=stdout)
-    print(submission_body(payload).decode("utf-8"), file=stdout)
+    # Pretty-print the same document (same key order, same escaping) so a
+    # human can actually read it; the wire body is its single-line form.
+    print(json.dumps(payload, indent=2), file=stdout)
     print("=" * 72, file=stdout)
+    print(
+        f"Wire body: the single-line JSON serialization of exactly this "
+        f"document, {len(body)} bytes, {body_digest}. "
+        "`rapid-mlx benchmark share <run> --preview --json` prints those exact "
+        "bytes as payload_json with the same body_digest.",
+        file=stdout,
+    )
     print(
         "Everything shown above leaves this Mac. It includes model source, "
         "Mac configuration, OS/runtime versions, execution settings, timings, "

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -110,14 +110,17 @@ def _print_catalog(value: dict[str, Any], *, show_all: bool) -> None:
             f"{memory:>7}  {fit}"
         )
 
-    # Recommended = focus models not known to exceed this Mac's memory. With
-    # no memory figure every fit is unknown, and the heading must say so
-    # rather than promise a fit nobody checked.
+    # Recommended = focus models verified to fit this Mac. With no memory
+    # figure every fit is unknown; focus models are still listed first, but
+    # the heading says the fit was not checked rather than promising one.
     memory_known = isinstance(memory_gib, int)
     recommended: list[dict[str, Any]] = []
     rest: list[dict[str, Any]] = []
     for model in value["models"]:
-        if model.get("focus") and model.get("memory_fit") != "does_not_fit":
+        fit = model.get("memory_fit")
+        if model.get("focus") and (
+            fit == "fits" if memory_known else fit != "does_not_fit"
+        ):
             recommended.append(model)
         else:
             rest.append(model)

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -6,13 +6,19 @@ from __future__ import annotations
 import json
 import statistics
 import sys
+from datetime import datetime
 from typing import Any
 from urllib.parse import quote
 
 from .atomic_upload import preview_run, upload_run
 from .hardware import host_memory_gib
 from .local_runner import LocalBenchmarkError, run_local
-from .workspace import LocalRunArchive, benchmark_catalog, plan_for_alias
+from .workspace import (
+    LocalRunArchive,
+    benchmark_catalog,
+    describe_case,
+    plan_for_alias,
+)
 
 _LEADERBOARD_URL = "https://rapidmlx.com/leaderboard"
 _CONTRIBUTOR_BASE_URL = f"{_LEADERBOARD_URL}/contributors"
@@ -33,6 +39,121 @@ def _contributor_profile(receipt: dict[str, Any]) -> tuple[str, str] | None:
 
 def _print_json(value: Any) -> None:
     print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _progress_to_stderr(line: str) -> None:
+    """Human progress goes to stderr so stdout stays a clean result stream."""
+
+    print(line, file=sys.stderr, flush=True)
+
+
+def _local_time(timestamp: Any) -> str:
+    """Render an archived UTC timestamp in the user's local clock.
+
+    Falls back to the raw value when it is not an ISO-8601 instant so a
+    hand-edited archive still lists.
+    """
+
+    if not isinstance(timestamp, str):
+        return "-"
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return timestamp
+    if parsed.tzinfo is None:
+        return timestamp
+    return parsed.astimezone().strftime("%Y-%m-%d %H:%M local")
+
+
+def _memory_line(model: dict[str, Any], memory_gib: Any) -> str:
+    estimate = model.get("estimated_memory_gib")
+    fit = model.get("memory_fit")
+    if not isinstance(estimate, int):
+        return "unknown (no estimate for this model)"
+    line = f"~{estimate} GB estimated"
+    if model.get("memory_estimate_source") == "artifact_size_fallback":
+        line += " (from download size)"
+    if isinstance(memory_gib, int) and fit == "fits":
+        line += f"; fits this Mac ({memory_gib} GB)"
+    elif isinstance(memory_gib, int) and fit == "does_not_fit":
+        line += f"; does NOT fit this Mac ({memory_gib} GB)"
+    return line
+
+
+def _print_catalog(value: dict[str, Any], *, show_all: bool) -> None:
+    print("Community Benchmark models (local by default)")
+    memory_gib = value.get("memory_gib")
+    if isinstance(memory_gib, int) and value.get("memory_source") == "override":
+        print(
+            f"Fit column assumes {memory_gib} GB (--memory-gib), "
+            "not this Mac's memory\n"
+        )
+    elif isinstance(memory_gib, int):
+        print(f"This Mac: {memory_gib} GB unified memory (fit column below)\n")
+    else:
+        print("This Mac: memory unknown; pass --memory-gib to fill the fit column\n")
+
+    def row(model: dict[str, Any]) -> str:
+        marker = "★" if model.get("focus") else " "
+        fit = str(model.get("memory_fit", "unknown")).replace("_", " ")
+        estimate = model.get("estimated_memory_gib")
+        memory = f"~{estimate} GB" if isinstance(estimate, int) else "?"
+        return (
+            f" {marker} {model['alias']:<32} {model['task_type']:<18} "
+            f"{memory:>7}  {fit}"
+        )
+
+    # Recommended = focus models not known to exceed this Mac's memory.
+    recommended: list[dict[str, Any]] = []
+    rest: list[dict[str, Any]] = []
+    for model in value["models"]:
+        if model.get("focus") and model.get("memory_fit") != "does_not_fit":
+            recommended.append(model)
+        else:
+            rest.append(model)
+    print("Recommended (★ focus models that fit this Mac)")
+    if recommended:
+        for model in recommended:
+            print(row(model))
+    else:
+        print("   (none of the focus models fit this Mac's memory)")
+    if show_all:
+        print("\nAll other models")
+        for model in rest:
+            print(row(model))
+    else:
+        fitting = sum(1 for m in rest if m.get("memory_fit") == "fits")
+        print(
+            f"\n{len(rest)} more models have a registered protocol "
+            f"({fitting} fit this Mac); list them with "
+            "rapid-mlx benchmark catalog --all"
+        )
+    print("\nRun: rapid-mlx benchmark run <model>")
+
+
+def _print_plan(value: dict[str, Any]) -> None:
+    model = value["model"]
+    workload = value.get("workload", {})
+    repo = model.get("repo_id")
+    print(f"Model:    {model['alias']}" + (f"  ({repo})" if repo else ""))
+    print(f"Task:     {model['task_type']}")
+    print(f"Protocol: {model['protocol_id']} v{workload.get('protocol_version', '?')}")
+    cases = workload.get("cases", [])
+    if cases:
+        print(f"Cases:    {len(cases)} (run in this order)")
+        for case in cases:
+            print(f"  {describe_case(case)}")
+    print(f"Memory:   {_memory_line(model, value.get('memory_gib'))}")
+    cached = value.get("model_cached")
+    if cached is True:
+        print("Download: already in the local Hugging Face cache; nothing to fetch")
+    elif cached is False:
+        print(
+            "Download: not cached yet; `benchmark run` downloads it from "
+            "Hugging Face first"
+        )
+    print("Storage:  local; upload requires a separate share command and consent")
+    print("Nothing is uploaded by this command or by `benchmark run`.")
 
 
 def _run_model_label(run: dict[str, Any]) -> str:
@@ -165,12 +286,20 @@ def benchmark_command(args) -> int:
             value["memory_gib"] = memory_gib
             value["memory_source"] = memory_source
         elif action == "plan":
-            value = plan_for_alias(args.benchmark_model)
+            value = plan_for_alias(
+                args.benchmark_model,
+                memory_gib=host_memory_gib(),
+                check_cache=True,
+            )
         elif action == "run":
             value = run_local(
                 args.benchmark_model,
                 archive=archive,
                 inherit_process_group=getattr(args, "inherit_process_group", False),
+                # Progress is for a human watching a terminal. Under --json
+                # stderr stays reserved for the failure document the Desktop
+                # app surfaces verbatim on a non-zero exit.
+                progress=None if args.json else _progress_to_stderr,
             )
         elif action == "results":
             runs = archive.list(limit=getattr(args, "limit", None))
@@ -225,32 +354,9 @@ def benchmark_command(args) -> int:
     if args.json:
         _print_json(value)
     elif action == "catalog":
-        print("Community Benchmark models (local by default)")
-        memory_gib = value.get("memory_gib")
-        if isinstance(memory_gib, int) and value.get("memory_source") == "override":
-            print(
-                f"Fit column assumes {memory_gib} GB (--memory-gib), "
-                "not this Mac's memory\n"
-            )
-        elif isinstance(memory_gib, int):
-            print(f"This Mac: {memory_gib} GB unified memory (fit column below)\n")
-        else:
-            print(
-                "This Mac: memory unknown; pass --memory-gib to fill the fit column\n"
-            )
-        for model in value["models"]:
-            marker = "★" if model["focus"] else " "
-            fit = model["memory_fit"].replace("_", " ")
-            print(f" {marker} {model['alias']:<32} {model['task_type']:<18} {fit}")
-        print("\nRun: rapid-mlx benchmark run <model>")
+        _print_catalog(value, show_all=getattr(args, "all", False))
     elif action == "plan":
-        model = value["model"]
-        print(f"Model:    {model['alias']}")
-        print(f"Task:     {model['task_type']}")
-        print(
-            f"Protocol: {model['protocol_id']} v{value['workload']['protocol_version']}"
-        )
-        print("Storage:  local; upload requires a separate share command and consent")
+        _print_plan(value)
     elif action == "results":
         runs = value["runs"]
         if not runs:
@@ -258,7 +364,8 @@ def benchmark_command(args) -> int:
         for run in runs:
             print(
                 f"{run['run_id']}  {run['workload']['task_type']:<18} "
-                f"{run['outcome']['status']:<10} {run['completed_at']}  "
+                f"{run['outcome']['status']:<10} "
+                f"{_local_time(run.get('completed_at'))}  "
                 f"{_run_model_label(run)}"
             )
     elif action == "inspect":

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -42,9 +42,16 @@ def _print_json(value: Any) -> None:
 
 
 def _progress_to_stderr(line: str) -> None:
-    """Human progress goes to stderr so stdout stays a clean result stream."""
+    """Human progress goes to stderr so stdout stays a clean result stream.
 
-    print(line, file=sys.stderr, flush=True)
+    Presentation must never abort a benchmark: a closed or broken stderr
+    (``2> >(head -n 3)``) is swallowed rather than raised into the runner.
+    """
+
+    try:
+        print(line, file=sys.stderr, flush=True)
+    except (OSError, ValueError):
+        pass
 
 
 def _local_time(timestamp: Any) -> str:
@@ -103,7 +110,10 @@ def _print_catalog(value: dict[str, Any], *, show_all: bool) -> None:
             f"{memory:>7}  {fit}"
         )
 
-    # Recommended = focus models not known to exceed this Mac's memory.
+    # Recommended = focus models not known to exceed this Mac's memory. With
+    # no memory figure every fit is unknown, and the heading must say so
+    # rather than promise a fit nobody checked.
+    memory_known = isinstance(memory_gib, int)
     recommended: list[dict[str, Any]] = []
     rest: list[dict[str, Any]] = []
     for model in value["models"]:
@@ -111,22 +121,27 @@ def _print_catalog(value: dict[str, Any], *, show_all: bool) -> None:
             recommended.append(model)
         else:
             rest.append(model)
-    print("Recommended (★ focus models that fit this Mac)")
+    if memory_known:
+        print("Recommended (★ focus models that fit this Mac)")
+    else:
+        print("Recommended (★ focus models; memory fit unknown, see --memory-gib)")
     if recommended:
         for model in recommended:
             print(row(model))
-    else:
+    elif memory_known:
         print("   (none of the focus models fit this Mac's memory)")
+    else:
+        print("   (no focus models in this catalog)")
     if show_all:
         print("\nAll other models")
         for model in rest:
             print(row(model))
     else:
         fitting = sum(1 for m in rest if m.get("memory_fit") == "fits")
+        verdict = f"{fitting} fit this Mac" if memory_known else "fit unknown"
         print(
             f"\n{len(rest)} more models have a registered protocol "
-            f"({fitting} fit this Mac); list them with "
-            "rapid-mlx benchmark catalog --all"
+            f"({verdict}); list them with rapid-mlx benchmark catalog --all"
         )
     print("\nRun: rapid-mlx benchmark run <model>")
 
@@ -151,6 +166,11 @@ def _print_plan(value: dict[str, Any]) -> None:
         print(
             "Download: not cached yet; `benchmark run` downloads it from "
             "Hugging Face first"
+        )
+    elif "model_cached" in value:
+        print(
+            "Download: could not verify the local cache; `benchmark run` "
+            "downloads anything that is missing"
         )
     print("Storage:  local; upload requires a separate share command and consent")
     print("Nothing is uploaded by this command or by `benchmark run`.")

--- a/vllm_mlx/community_bench/local_runner.py
+++ b/vllm_mlx/community_bench/local_runner.py
@@ -47,7 +47,10 @@ def _record_conditions_after() -> None:
 
 
 from .run_builder import build_run, execution_config, utc_now
-from .workspace import LocalRunArchive, plan_for_alias
+from .workspace import LocalRunArchive, describe_case, model_is_cached, plan_for_alias
+
+# Human-readable progress sink (one line per call, no trailing newline).
+Progress = Callable[[str], None]
 
 _VIDEO_JOB_TIMEOUT_S = 3600.0
 _VIDEO_POLL_INTERVAL_S = 1.0
@@ -519,8 +522,40 @@ def _validated_video_artifact(
         )
 
 
+def _format_duration(seconds: float) -> str:
+    """``~45 s`` / ``~3 min 10 s`` for estimates and elapsed stage times."""
+
+    seconds = max(0.0, seconds)
+    if seconds < 60:
+        return f"{seconds:.0f} s"
+    minutes, rest = divmod(int(round(seconds)), 60)
+    return f"{minutes} min {rest} s" if rest else f"{minutes} min"
+
+
+def _report(progress: Progress | None, line: str) -> None:
+    if progress is not None:
+        progress(line)
+
+
+def _stage_started(progress: Progress | None) -> float | None:
+    """Clock a display-only stage; reads no clock when nobody is watching."""
+
+    return time.monotonic() if progress is not None else None
+
+
+def _stage_finished(
+    progress: Progress | None, started: float | None, what: str
+) -> None:
+    if progress is None or started is None:
+        return
+    progress(f"{what} in {_format_duration(time.monotonic() - started)}")
+
+
 def _run_image(
-    alias: str, *, isolate_process_group: bool = True
+    alias: str,
+    *,
+    isolate_process_group: bool = True,
+    progress: Progress | None = None,
 ) -> list[dict[str, Any]]:
     from vllm_mlx.bench._server import serve
 
@@ -537,11 +572,14 @@ def _run_image(
         "seed": case["seed"],
     }
     measurements: list[dict[str, Any]] = []
+    _report(progress, f"Starting local image server for {alias} (loads the model)...")
+    boot_started = _stage_started(progress)
     with serve(
         alias,
         boot_timeout_s=600,
         isolate_process_group=isolate_process_group,
     ) as server:
+        _stage_finished(progress, boot_started, "Server ready")
         endpoint = f"{server['base_url']}/images/generations"
         total = case["warmup_rounds"] + case["measured_rounds"]
         for index in range(total):
@@ -552,6 +590,19 @@ def _run_image(
             duration_ms = (time.perf_counter() - started) * 1000
             if result.get("cancelled", False):
                 raise BenchmarkCancelledError("image benchmark was cancelled")
+            if index < case["warmup_rounds"]:
+                _report(
+                    progress,
+                    f"{case['case_id']:<16} warmup   "
+                    f"{_format_duration(duration_ms / 1000)}",
+                )
+            else:
+                _report(
+                    progress,
+                    f"{case['case_id']:<16} round "
+                    f"{index - case['warmup_rounds'] + 1}/{case['measured_rounds']}  "
+                    f"{_format_duration(duration_ms / 1000)}",
+                )
             if index >= case["warmup_rounds"]:
                 image_count = _validated_image_count(
                     result, width=case["width"], height=case["height"]
@@ -577,7 +628,10 @@ def _run_image(
 
 
 def _run_video(
-    alias: str, *, isolate_process_group: bool = True
+    alias: str,
+    *,
+    isolate_process_group: bool = True,
+    progress: Progress | None = None,
 ) -> list[dict[str, Any]]:
     from vllm_mlx.bench._server import serve
 
@@ -592,6 +646,8 @@ def _run_video(
         "seed": str(case["seed"]),
         "guidance_scale": str(case["guidance_millionths"] / 1_000_000),
     }
+    _report(progress, f"Starting local video server for {alias} (loads the model)...")
+    boot_started = _stage_started(progress)
     with serve(
         alias,
         boot_timeout_s=900,
@@ -600,6 +656,8 @@ def _run_video(
         extra_env={"RAPID_MLX_WAN_STEPS": str(case["steps"])},
         isolate_process_group=isolate_process_group,
     ) as server:
+        _stage_finished(progress, boot_started, "Server ready")
+        _report(progress, f"{case['case_id']:<16} round 1/1  generating...")
         started = time.perf_counter()
         response = requests.post(
             f"{server['base_url']}/videos", data=payload, timeout=30
@@ -636,6 +694,10 @@ def _run_video(
                 )
             )
         duration_ms = (time.perf_counter() - started) * 1000
+        _report(
+            progress,
+            f"{case['case_id']:<16} round 1/1  {_format_duration(duration_ms / 1000)}",
+        )
         expected_size = f"{case['width']}x{case['height']}"
         if (
             job.get("size") != expected_size
@@ -672,7 +734,71 @@ def _run_video(
         ]
 
 
-async def _text_measurements(repo_id: str) -> tuple[list[dict[str, Any]], int]:
+def _estimate_remaining_s(
+    cases: list[dict[str, Any]],
+    sample: Any,
+    *,
+    done_label: str,
+) -> float | None:
+    """Project total remaining wall time from the first completed round.
+
+    Uses the observed prefill and decode rates of ``sample`` (a
+    ``RoundResult``) to price every remaining round of every case, so the
+    long case is weighted by its own token counts rather than assumed to
+    cost the same as the short one. Returns ``None`` when rates are missing.
+    """
+
+    prefill_tps = getattr(sample, "prefill_tps", None)
+    decode_tps = getattr(sample, "decode_tps", None)
+    if not (
+        isinstance(prefill_tps, int | float)
+        and isinstance(decode_tps, int | float)
+        and prefill_tps > 0
+        and decode_tps > 0
+    ):
+        return None
+    remaining = 0.0
+    for case in cases:
+        rounds = int(case.get("warmup_rounds", 0)) + int(case.get("measured_rounds", 0))
+        if case.get("case_id") == done_label:
+            rounds -= 1
+        per_round = (
+            case.get("target_prompt_tokens", 0) / prefill_tps
+            + case.get("target_output_tokens", 0) / decode_tps
+        )
+        remaining += max(0, rounds) * per_round
+    return remaining
+
+
+def _text_round_observer(progress: Progress, cases: list[dict[str, Any]]):
+    """Build the per-round progress callback for the text protocol."""
+
+    estimated = False
+
+    def on_round(label: str, phase: str, index: int, total: int, result: Any) -> None:
+        nonlocal estimated
+        if phase == "warmup":
+            suffix = f" {index}/{total}" if total > 1 else ""
+            progress(f"{label:<16} warmup{suffix}")
+            if not estimated:
+                estimated = True
+                remaining = _estimate_remaining_s(cases, result, done_label=label)
+                if remaining is not None:
+                    progress(
+                        "Estimated time remaining: "
+                        f"~{_format_duration(remaining)} (from the warmup rate)"
+                    )
+            return
+        tps = getattr(result, "decode_tps", None)
+        rate = f"  {tps:6.1f} tok/s" if isinstance(tps, int | float) else ""
+        progress(f"{label:<16} round {index}/{total}{rate}")
+
+    return on_round
+
+
+async def _text_measurements(
+    repo_id: str, *, progress: Progress | None = None
+) -> tuple[list[dict[str, Any]], int]:
     from vllm_mlx.engine_core import (
         AsyncEngineCore,
         EngineConfig,
@@ -684,11 +810,21 @@ async def _text_measurements(repo_id: str) -> tuple[list[dict[str, Any]], int]:
 
     from .runner import _reported_token_count, run_standardized_bench
 
+    workload = registered_workload("text_generation")
     executor = concurrent.futures.ThreadPoolExecutor(
         max_workers=1, thread_name_prefix="mlx-step", initializer=_init_mlx_step_thread
     )
     try:
+        if progress is not None:
+            source = (
+                "from the local Hugging Face cache"
+                if model_is_cached(repo_id)
+                else "not cached yet; downloading from Hugging Face first"
+            )
+            progress(f"Loading {repo_id} ({source})...")
+        load_started = _stage_started(progress)
         model, tokenizer = executor.submit(load_model_with_fallback, repo_id).result()
+        _stage_finished(progress, load_started, "Model loaded")
         scheduler = SchedulerConfig(
             max_num_seqs=1,
             max_concurrent_requests=1,
@@ -707,6 +843,11 @@ async def _text_measurements(repo_id: str) -> tuple[list[dict[str, Any]], int]:
                 tokenizer,
                 sampling="greedy",
                 registered_token_ids=True,
+                on_round=(
+                    _text_round_observer(progress, workload["cases"])
+                    if progress is not None
+                    else None
+                ),
             )
             _record_conditions_after()
     finally:
@@ -719,7 +860,6 @@ async def _text_measurements(repo_id: str) -> tuple[list[dict[str, Any]], int]:
         # boundary for native MLX calls that cannot be interrupted in-process.
         executor.shutdown(wait=True, cancel_futures=True)
 
-    workload = registered_workload("text_generation")
     buckets = (result.short, result.long)
     measurements: list[dict[str, Any]] = []
     peak = result.peak_ram_mb
@@ -771,13 +911,37 @@ def _is_dedicated_process_group_leader() -> bool:
         return False
 
 
+def _announce_plan(progress: Progress | None, plan: dict[str, Any]) -> None:
+    """Print what is about to run so a multi-minute run is never silent."""
+
+    if progress is None:
+        return
+    model = plan["model"]
+    cases = plan.get("workload", {}).get("cases", [])
+    warmup = sum(int(case.get("warmup_rounds", 0)) for case in cases)
+    measured = sum(int(case.get("measured_rounds", 0)) for case in cases)
+    progress(
+        f"Benchmarking {model['alias']} ({model['task_type']}): "
+        f"{len(cases)} case{'s' if len(cases) != 1 else ''}, "
+        f"{warmup} warmup + {measured} measured rounds in total"
+    )
+    for case in cases:
+        progress(f"  {describe_case(case)}")
+
+
 def run_local(
     alias: str,
     *,
     archive: LocalRunArchive | None = None,
     inherit_process_group: bool = False,
+    progress: Progress | None = None,
 ) -> dict[str, Any]:
-    """Run a registered protocol, validate it, and save it locally only."""
+    """Run a registered protocol, validate it, and save it locally only.
+
+    ``progress`` receives short human-readable status lines (model load,
+    per-round throughput, time estimate). It is never given the result and
+    nothing is written to stdout here, so ``--json`` callers stay clean.
+    """
 
     if inherit_process_group and not _is_dedicated_process_group_leader():
         raise LocalBenchmarkError(
@@ -806,6 +970,7 @@ def run_local(
     conditions_after = None
     measurements_completed = False
     destination = archive or LocalRunArchive.default()
+    _announce_plan(progress, plan)
     try:
         hardware, software = collect()
         # Snapshot the volatile machine state (power, thermal, memory
@@ -817,15 +982,19 @@ def run_local(
         try:
             if task_type == "text_generation":
                 measurements, context_length = asyncio.run(
-                    _text_measurements(model["repo_id"])
+                    _text_measurements(model["repo_id"], progress=progress)
                 )
             elif task_type == "image_generation":
                 measurements = _run_image(
-                    alias, isolate_process_group=not inherit_process_group
+                    alias,
+                    isolate_process_group=not inherit_process_group,
+                    progress=progress,
                 )
             elif task_type == "video_generation":
                 measurements = _run_video(
-                    alias, isolate_process_group=not inherit_process_group
+                    alias,
+                    isolate_process_group=not inherit_process_group,
+                    progress=progress,
                 )
         finally:
             # Disarm on every path (success, failure, cancellation) so a
@@ -913,4 +1082,4 @@ def run_local(
     return run
 
 
-__all__ = ["LocalBenchmarkError", "run_local"]
+__all__ = ["LocalBenchmarkError", "Progress", "run_local"]

--- a/vllm_mlx/community_bench/local_runner.py
+++ b/vllm_mlx/community_bench/local_runner.py
@@ -525,10 +525,10 @@ def _validated_video_artifact(
 def _format_duration(seconds: float) -> str:
     """``~45 s`` / ``~3 min 10 s`` for estimates and elapsed stage times."""
 
-    seconds = max(0.0, seconds)
-    if seconds < 60:
-        return f"{seconds:.0f} s"
-    minutes, rest = divmod(int(round(seconds)), 60)
+    whole = int(round(max(0.0, seconds)))
+    if whole < 60:
+        return f"{whole} s"
+    minutes, rest = divmod(whole, 60)
     return f"{minutes} min {rest} s" if rest else f"{minutes} min"
 
 
@@ -816,11 +816,13 @@ async def _text_measurements(
     )
     try:
         if progress is not None:
-            source = (
-                "from the local Hugging Face cache"
-                if model_is_cached(repo_id)
-                else "not cached yet; downloading from Hugging Face first"
-            )
+            cached = model_is_cached(repo_id)
+            if cached is True:
+                source = "from the local Hugging Face cache"
+            elif cached is False:
+                source = "not cached yet; downloading from Hugging Face first"
+            else:
+                source = "cache state unknown; downloads anything missing"
             progress(f"Loading {repo_id} ({source})...")
         load_started = _stage_started(progress)
         model, tokenizer = executor.submit(load_model_with_fallback, repo_id).result()

--- a/vllm_mlx/community_bench/local_runner.py
+++ b/vllm_mlx/community_bench/local_runner.py
@@ -533,8 +533,19 @@ def _format_duration(seconds: float) -> str:
 
 
 def _report(progress: Progress | None, line: str) -> None:
-    if progress is not None:
+    """Hand one line to the progress sink; a failing sink is never fatal.
+
+    Progress is presentation. A closed pipe, an encoding error, or a buggy
+    sink must not abort a benchmark that is otherwise measuring correctly,
+    let alone archive it as failed, so every sink call goes through here.
+    """
+
+    if progress is None:
+        return
+    try:
         progress(line)
+    except Exception:
+        pass
 
 
 def _stage_started(progress: Progress | None) -> float | None:
@@ -548,7 +559,7 @@ def _stage_finished(
 ) -> None:
     if progress is None or started is None:
         return
-    progress(f"{what} in {_format_duration(time.monotonic() - started)}")
+    _report(progress, f"{what} in {_format_duration(time.monotonic() - started)}")
 
 
 def _run_image(
@@ -779,19 +790,20 @@ def _text_round_observer(progress: Progress, cases: list[dict[str, Any]]):
         nonlocal estimated
         if phase == "warmup":
             suffix = f" {index}/{total}" if total > 1 else ""
-            progress(f"{label:<16} warmup{suffix}")
+            _report(progress, f"{label:<16} warmup{suffix}")
             if not estimated:
                 estimated = True
                 remaining = _estimate_remaining_s(cases, result, done_label=label)
                 if remaining is not None:
-                    progress(
+                    _report(
+                        progress,
                         "Estimated time remaining: "
-                        f"~{_format_duration(remaining)} (from the warmup rate)"
+                        f"~{_format_duration(remaining)} (from the warmup rate)",
                     )
             return
         tps = getattr(result, "decode_tps", None)
         rate = f"  {tps:6.1f} tok/s" if isinstance(tps, int | float) else ""
-        progress(f"{label:<16} round {index}/{total}{rate}")
+        _report(progress, f"{label:<16} round {index}/{total}{rate}")
 
     return on_round
 
@@ -823,7 +835,7 @@ async def _text_measurements(
                 source = "not cached yet; downloading from Hugging Face first"
             else:
                 source = "cache state unknown; downloads anything missing"
-            progress(f"Loading {repo_id} ({source})...")
+            _report(progress, f"Loading {repo_id} ({source})...")
         load_started = _stage_started(progress)
         model, tokenizer = executor.submit(load_model_with_fallback, repo_id).result()
         _stage_finished(progress, load_started, "Model loaded")
@@ -922,13 +934,14 @@ def _announce_plan(progress: Progress | None, plan: dict[str, Any]) -> None:
     cases = plan.get("workload", {}).get("cases", [])
     warmup = sum(int(case.get("warmup_rounds", 0)) for case in cases)
     measured = sum(int(case.get("measured_rounds", 0)) for case in cases)
-    progress(
+    _report(
+        progress,
         f"Benchmarking {model['alias']} ({model['task_type']}): "
         f"{len(cases)} case{'s' if len(cases) != 1 else ''}, "
-        f"{warmup} warmup + {measured} measured rounds in total"
+        f"{warmup} warmup + {measured} measured rounds in total",
     )
     for case in cases:
-        progress(f"  {describe_case(case)}")
+        _report(progress, f"  {describe_case(case)}")
 
 
 def run_local(

--- a/vllm_mlx/community_bench/runner.py
+++ b/vllm_mlx/community_bench/runner.py
@@ -32,6 +32,7 @@ import hashlib
 import random
 import statistics
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from . import PROMPT_SEED, SCHEMA_VERSION
@@ -55,6 +56,12 @@ class RoundResult:
     peak_ram_mb: int | None = None
     prompt_tokens: int | None = None
     output_tokens: int | None = None
+
+
+# Progress observer: ``(case_label, phase, index, total, result)`` where
+# ``phase`` is ``"warmup"`` or ``"measured"`` and ``index`` is 1-based.
+# ``case_label`` matches the registered case ids (``pp512-tg128``).
+RoundObserver = Callable[[str, str, int, int, RoundResult], None]
 
 
 @dataclass(frozen=True)
@@ -351,12 +358,16 @@ async def _run_bucket(
     *,
     reset_peak_after_warmup: bool = False,
     registered_token_ids: bool = False,
+    on_round: RoundObserver | None = None,
 ) -> tuple[BucketResult, list[int]]:
     """Run one bucket: warmup + 5 measured rounds.
 
     Returns the measured rounds plus the actual prompt token IDs used
-    (so callers can hash them for ``prompt_hash``).
+    (so callers can hash them for ``prompt_hash``). ``on_round`` is
+    notified after every completed round, warmup included, so a CLI can
+    show progress; it must not raise.
     """
+    label = f"pp{target_prompt_tokens}-tg{max_tokens}"
     if registered_token_ids:
         prompt_ids = _build_registered_token_ids(
             tokenizer, target_prompt_tokens, PROMPT_SEED
@@ -370,8 +381,8 @@ async def _run_bucket(
 
     # Warmup rounds (discarded — first-pass JIT + kernel cache warm-up
     # dominates these and would skew the median).
-    for _ in range(ROUNDS_WARMUP):
-        await _run_one_round(
+    for index in range(1, ROUNDS_WARMUP + 1):
+        warmup = await _run_one_round(
             engine,
             prompt,
             sampling,
@@ -379,6 +390,8 @@ async def _run_bucket(
             max_tokens,
             require_observed_counts=registered_token_ids,
         )
+        if on_round is not None:
+            on_round(label, "warmup", index, ROUNDS_WARMUP, warmup)
 
     # Reset the Metal peak-memory counter AFTER warmup, immediately
     # before the measured rounds. Resetting upstream of warmup (the
@@ -393,7 +406,7 @@ async def _run_bucket(
         _reset_peak_ram()
 
     measured: list[RoundResult] = []
-    for _ in range(ROUNDS_MEASURED):
+    for index in range(1, ROUNDS_MEASURED + 1):
         measured.append(
             await _run_one_round(
                 engine,
@@ -404,6 +417,8 @@ async def _run_bucket(
                 require_observed_counts=registered_token_ids,
             )
         )
+        if on_round is not None:
+            on_round(label, "measured", index, ROUNDS_MEASURED, measured[-1])
 
     return BucketResult(rounds_raw=measured), prompt_ids
 
@@ -455,6 +470,7 @@ async def run_standardized_bench(
     sampling: str = "greedy",
     *,
     registered_token_ids: bool = False,
+    on_round: RoundObserver | None = None,
 ) -> BenchResult:
     """Run the full short+long standardized bench against a loaded engine.
 
@@ -481,6 +497,7 @@ async def run_standardized_bench(
         SHORT_MAX_TOKENS,
         reset_peak_after_warmup=True,
         registered_token_ids=registered_token_ids,
+        on_round=on_round,
     )
     long_result, long_ids = await _run_bucket(
         engine,
@@ -489,6 +506,7 @@ async def run_standardized_bench(
         LONG_PROMPT_TOKENS,
         LONG_MAX_TOKENS,
         registered_token_ids=registered_token_ids,
+        on_round=on_round,
     )
 
     peak_ram = _read_peak_ram_mb()

--- a/vllm_mlx/community_bench/workspace.py
+++ b/vllm_mlx/community_bench/workspace.py
@@ -242,11 +242,65 @@ def benchmark_catalog(*, memory_gib: int | None = None) -> dict[str, Any]:
     }
 
 
-def plan_for_alias(alias_name: str) -> dict[str, Any]:
-    catalog = benchmark_catalog()
+def describe_case(case: dict[str, Any]) -> str:
+    """One human-readable line for a registered workload case.
+
+    Text cases read ``pp512-tg128   512 prompt -> 128 output tokens``; image
+    and video cases describe their geometry. Every line ends with the round
+    plan so a user knows how much work one case is before starting it.
+    """
+
+    case_id = str(case.get("case_id", "?"))
+    if "target_prompt_tokens" in case:
+        detail = (
+            f"{case['target_prompt_tokens']} prompt tokens -> "
+            f"{case['target_output_tokens']} output tokens"
+        )
+    elif "frames" in case:
+        fps = case.get("fps_milli", 0) / 1000
+        detail = (
+            f"{case['width']}x{case['height']}, {case['frames']} frames @ {fps:g} fps, "
+            f"{case['steps']} steps"
+        )
+    elif "width" in case:
+        count = case.get("image_count", 1)
+        detail = (
+            f"{case['width']}x{case['height']}, {case['steps']} steps, "
+            f"{count} image{'s' if count != 1 else ''}"
+        )
+    else:  # pragma: no cover - every registered protocol has a known shape
+        detail = "registered case"
+    warmup = int(case.get("warmup_rounds", 0))
+    measured = int(case.get("measured_rounds", 0))
+    return f"{case_id:<16} {detail}   ({warmup} warmup + {measured} measured)"
+
+
+def model_is_cached(repo_id: str) -> bool:
+    """True when the Hugging Face snapshot is complete in the local cache."""
+
+    from vllm_mlx._download_gate import is_repo_cached
+
+    try:
+        return bool(is_repo_cached(repo_id))
+    except Exception:
+        return False
+
+
+def plan_for_alias(
+    alias_name: str, *, memory_gib: int | None = None, check_cache: bool = False
+) -> dict[str, Any]:
+    """Describe the exact local workload for one alias.
+
+    ``memory_gib`` fills the model's ``memory_fit`` the same way the catalog
+    does. ``check_cache`` adds ``model_cached`` (whether the weights are
+    already in the local Hugging Face cache); it touches only the local
+    filesystem and never downloads anything.
+    """
+
+    catalog = benchmark_catalog(memory_gib=memory_gib)
     for entry in catalog["models"]:
         if entry["alias"] == alias_name:
-            return {
+            plan = {
                 "schema_version": 1,
                 "model": entry,
                 "workload": registered_workload(entry["task_type"]),
@@ -256,6 +310,11 @@ def plan_for_alias(alias_name: str) -> dict[str, Any]:
                     "upload": "explicit_consent_only",
                 },
             }
+            if memory_gib is not None:
+                plan["memory_gib"] = memory_gib
+            if check_cache:
+                plan["model_cached"] = model_is_cached(entry["repo_id"])
+            return plan
     raise ValueError(f"unknown or unsupported benchmark model {alias_name!r}")
 
 

--- a/vllm_mlx/community_bench/workspace.py
+++ b/vllm_mlx/community_bench/workspace.py
@@ -275,15 +275,23 @@ def describe_case(case: dict[str, Any]) -> str:
     return f"{case_id:<16} {detail}   ({warmup} warmup + {measured} measured)"
 
 
-def model_is_cached(repo_id: str) -> bool:
-    """True when the Hugging Face snapshot is complete in the local cache."""
+def model_is_cached(repo_id: str) -> bool | None:
+    """Tri-state: the weights are complete in the local cache (``True``),
+    definitively absent (``False``), or the probe was inconclusive (``None``).
 
-    from vllm_mlx._download_gate import is_repo_cached
+    Delegates to the modality-aware probe behind ``rapid-mlx models
+    --cached`` so mflux image and Wan/split video checkpoints, whose weights
+    live in component subdirectories, are judged by their own layout rather
+    than by the text-only ``model*.safetensors`` rule. Never downloads.
+    """
 
     try:
-        return bool(is_repo_cached(repo_id))
+        from vllm_mlx.cli import _cache_runnability
+
+        verdict = _cache_runnability(repo_id)
     except Exception:
-        return False
+        return None
+    return verdict if isinstance(verdict, bool) else None
 
 
 def plan_for_alias(
@@ -292,8 +300,8 @@ def plan_for_alias(
     """Describe the exact local workload for one alias.
 
     ``memory_gib`` fills the model's ``memory_fit`` the same way the catalog
-    does. ``check_cache`` adds ``model_cached`` (whether the weights are
-    already in the local Hugging Face cache); it touches only the local
+    does. ``check_cache`` adds ``model_cached`` (``True``/``False``, or
+    ``None`` when the cache could not be probed); it touches only the local
     filesystem and never downloads anything.
     """
 


### PR DESCRIPTION
## Why

Dogfooding `rapid-mlx benchmark` on an M3 Pro (18 GB) surfaced five pieces of terminal friction that make the Community Benchmark feel broken even though every command is correct: `run` is silent for 2–3 minutes, `plan` does not actually tell you what will run or whether it fits, `catalog` dumps ~200 rows, `share` asks for consent over a 5 KB single-line JSON blob nobody can read, and `results` shows UTC ISO timestamps that disagree with the wall clock.

## Summary

Engine-only CLI/UX change; the upload payload, receipt, run-record schema and digests are untouched, and every `--json` output either stays byte-identical or only gains keys.

- **`benchmark run`** streams short progress lines to **stderr** (never stdout): the plan (cases × warmup/measured rounds), model load/download stage with elapsed time, one line per warmup and measured round with decode tok/s, and an estimated remaining time computed from the first warmup's prefill/decode rates. `run_standardized_bench` / `_run_bucket` gain an optional `on_round` observer (default `None`, no behaviour change; the decode formula is untouched). Under `--json` no progress is emitted at all, so the Desktop contract (single JSON document on stdout, stderr reserved for the failure document) is unchanged.
- **`benchmark plan`** lists every case (prompt → output tokens, or geometry for image/video, warmup + measured rounds), the memory estimate and fit against this Mac, whether the weights are already in the local Hugging Face cache (filesystem check only, never downloads), and that nothing is uploaded. `--json` gains `memory_gib` and `model_cached` only.
- **`benchmark catalog`** (text) prints a `Recommended` section (★ focus models that fit this Mac) and summarises the long tail (`N more models … (M fit this Mac)`); new `--all` lists everything with a memory column. `--json` unchanged. The "This Mac: N GB" header from #3101 is kept.
- **`benchmark share`** consent shows an `indent=2` rendering of exactly the wire document (same key order, same escaping) followed by the byte count and `sha256` of the single-line wire body — the same `body_digest` that `share --preview --json` prints. `submission_body()` and what is uploaded are unchanged.
- **`benchmark results`** (text) renders `completed_at` in the local clock (`2026-09-05 21:33 local`); `--json` untouched.

## Non-goals

- No change to the decode tok/s formula in `summarize_measurements` (separate PR).
- No change to upload payload, receipt, run record schema, digests, or the Desktop `--json` contracts.
- No Mac app changes.

## Reproduction

All on an M3 Pro 18 GB, `qwen3.5-4b-4bit` already in the HF cache.

**1. `benchmark run qwen3.5-4b-4bit`** (1 min 55 s)

Before — stdout empty for the whole run, stderr only the mlx deprecation warning, then:
```
Saved local result 8a3bf534-f493-4cbe-bc8c-73fc58a8b098
  pp512-tg128         45.8 tok/s decode   TTFT    804 ms   (5 rounds)
  pp2048-tg512        44.6 tok/s decode   TTFT   3145 ms   (5 rounds)
Nothing was uploaded.
Share it: rapid-mlx benchmark share 8a3bf534-...
```

After — stderr while it runs (stdout is the same summary as before):
```
Benchmarking qwen3.5-4b-4bit (text_generation): 2 cases, 2 warmup + 10 measured rounds in total
  pp512-tg128      512 prompt tokens -> 128 output tokens   (1 warmup + 5 measured)
  pp2048-tg512     2048 prompt tokens -> 512 output tokens   (1 warmup + 5 measured)
Loading mlx-community/Qwen3.5-4B-MLX-4bit (from the local Hugging Face cache)...
Model loaded in 3 s
pp512-tg128      warmup
Estimated time remaining: ~2 min 4 s (from the warmup rate)
pp512-tg128      round 1/5    41.2 tok/s
pp512-tg128      round 2/5    47.1 tok/s
...
pp2048-tg512     warmup
pp2048-tg512     round 1/5    44.8 tok/s
...
pp2048-tg512     round 5/5    45.8 tok/s
```
(actual time from warmup to completion: ~1 min 50 s.)

`benchmark run qwen3.5-4b-4bit --json` after: stdout parses as exactly one JSON document (6593 bytes, `outcome.status == "completed"`), stderr contains only the two mlx deprecation warnings — no progress lines.

**2. `benchmark plan qwen3.5-4b-4bit`**

Before (4 lines):
```
Model:    qwen3.5-4b-4bit
Task:     text_generation
Protocol: rapid-community-speed v2
Storage:  local; upload requires a separate share command and consent
```
After:
```
Model:    qwen3.5-4b-4bit  (mlx-community/Qwen3.5-4B-MLX-4bit)
Task:     text_generation
Protocol: rapid-community-speed v2
Cases:    2 (run in this order)
  pp512-tg128      512 prompt tokens -> 128 output tokens   (1 warmup + 5 measured)
  pp2048-tg512     2048 prompt tokens -> 512 output tokens   (1 warmup + 5 measured)
Memory:   ~5 GB estimated (from download size); fits this Mac (18 GB)
Download: already in the local Hugging Face cache; nothing to fetch
Storage:  local; upload requires a separate share command and consent
Nothing is uploaded by this command or by `benchmark run`.
```
`plan --json`: previous keys unchanged, plus `memory_gib: 18`, `model_cached: true`, and `model.memory_fit` now filled (`fits`) instead of `unknown`.

**3. `benchmark catalog`**

Before: 203 lines; the 7 ★ rows (including two that do not fit) followed by 191 more rows.
After (11 lines):
```
Community Benchmark models (local by default)
This Mac: 18 GB unified memory (fit column below)

Recommended (★ focus models that fit this Mac)
 ★ flux2-klein-4b                   image_generation    ~12 GB  fits
 ★ gemma-4-e4b-4bit                 text_generation      ~7 GB  fits
 ★ qwen3.5-9b-4bit                  text_generation      ~8 GB  fits
 ★ qwen3.8-27b-4bit                 text_generation     ~18 GB  fits
 ★ z-image-turbo                    image_generation    ~16 GB  fits

193 more models have a registered protocol (114 fit this Mac); list them with rapid-mlx benchmark catalog --all

Run: rapid-mlx benchmark run <model>
```
`catalog --all`: 206 lines, all models. `catalog --json`: still 198 models, unchanged.

**4. `benchmark share 174f47b7-…`** consent (reproduced with `post_submission` stubbed and answering `n`, so nothing was sent)

Before: line 4 of the prompt is the whole 5209-character wire body on one line.
After: the same document pretty-printed (indent=2, 240 lines) and then
```
Wire body: the single-line JSON serialization of exactly this document, 5209 bytes, sha256:309a147bf3372e2d7877f5dbbfc018ece08df07bcbea51b32dc9caf028605bfb. `rapid-mlx benchmark share <run> --preview --json` prints those exact bytes as payload_json with the same body_digest.
```
`share 174f47b7-… --preview --json` reports the identical `body_digest` `sha256:309a147b…`.

**5. `benchmark results`**

Before: `... completed  2026-09-06T04:33:13.950359Z  mlx-community/Qwen3.5-4B-MLX-4bit` (local clock said 21:33).
After: `... completed  2026-09-05 21:33 local  mlx-community/Qwen3.5-4B-MLX-4bit`; `results --json` still carries the raw `completed_at`.

## Test plan

- [x] `PYTHONPATH=$PWD python -m pytest tests/test_community_benchmark_workspace.py tests/test_community_bench.py tests/test_cli_bench.py -q` — 307 passed (12 new tests; 6 existing ones updated for the new text output and the extra keyword arguments).
- [x] Mutation-checked every new assertion: reverting each behaviour (progress under `--json`, raw `completed_at`, single-line consent body, missing `Recommended` heading, non-fitting focus models recommended, missing warmup observer, missing `memory_gib`, wrong remaining-time arithmetic, missing model-load line, missing plan cases, renamed `--all`) turns exactly the corresponding test red.
- [x] `ruff check` + `ruff format` clean on all changed files.
- [x] Real runs on this Mac: `benchmark run qwen3.5-4b-4bit` (text and `--json`), `plan`, `catalog`, `catalog --all`, `results`, `share --preview --json`; consent output reproduced with the upload stubbed. No `share` without `--preview` was executed.

## Behaviour delta

- `benchmark run` (text mode): silent → progress on stderr. `--json`: unchanged.
- `benchmark catalog` (text mode): full list → Recommended + summary; `--all` restores the full list. `--json`: unchanged.
- `benchmark results` (text mode): UTC ISO → local time. `--json`: unchanged.
- `benchmark share` consent: single-line body → pretty-printed document + wire-body byte count and digest.

## AI assistance disclosure

Claude (Claude Code) wrote the implementation and tests in `vllm_mlx/community_bench/{cli,local_runner,runner,workspace,atomic_upload}.py`, `vllm_mlx/cli.py`, `tests/test_community_benchmark_workspace.py`, `tests/test_community_bench.py`; verified by the reproduction runs above, the targeted test files, and mutation checks. Independent Codex review rounds are recorded in the comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019A88kUrTwWXNnbhhXbSPcx
