### PR TITLE
perf(qwen4): add opt-in fp32 fast RMSNorm

### DIFF
--- a/.agents/handoffs/qwen4-fast-rmsnorm.md
+++ b/.agents/handoffs/qwen4-fast-rmsnorm.md
@@ -1,0 +1,41 @@
+# Qwen4 fp32-input fast RMSNorm handoff
+
+Receiving role: Atlas
+
+Owner / host: Vector / Studio, with M2 Pro Mini microbenchmark
+
+Branch / PR: `vector/qwen4-fast-rmsnorm`, PR #3151
+
+## Verified facts
+
+- The route is opt-in through `RAPID_MLX_QWEN4_FAST_RMSNORM=1`, limited to
+  widths `<= 8`, and confined to the vendored Qwen4-Exp text model.
+- M3 Ultra production-shape micro speedups are 1.105x, 1.109x, and 1.117x;
+  M2 Pro results are 1.103x, 1.126x, and 1.124x.
+- Over 1,310,720 elements, fp64 RMS-error ratio is 1.000000000066x for the
+  fp32-input candidate versus 1.413971716665x for the rejected bf16-input arm.
+- The QSA synthetic singleton now carries the real parent forward width, so a
+  wide prefill cannot enter the narrow route.
+- 156 focused tests, ruff check/format, compileall, and diff check passed.
+- Full method, raw summary ranges, commands, and limitations are in
+  `docs/engineering/performance/2026-09-06-qwen4-fast-rmsnorm.md`.
+
+## Unresolved questions and risks
+
+- The handoff source reports +4.2% decode at 1K and +3.9% at 16K, but Vector
+  did not independently rerun the 106 GB artifact because no safe resident
+  storage was available. These remain inherited rather than Rapid-owned e2e
+  claims.
+- Exactness is class 3. The PR must remain opt-in unless a named owner accepts
+  the fidelity scope plus a resident-artifact greedy/digest gate.
+- The independent spark2 review loop could not run because its Codex refresh
+  token is revoked (401). No LGTM was posted; local adversarial review is not a
+  substitute for that required independent pass.
+
+## Next concrete action
+
+1. Re-authenticate Codex on spark2 and rerun `pr-review 3151` to LGTM.
+2. On a host where revision `dcf657e4acda2aae72da99cde65b6c491cd96998`
+   is already resident, run the committed 1K/16K interleaved real-model gate.
+3. Atlas decides whether the independently reproduced kernel and accuracy
+   evidence is sufficient to merge the default-off route before that e2e rerun.

--- a/.agents/handoffs/qwen4-fast-rmsnorm.md
+++ b/.agents/handoffs/qwen4-fast-rmsnorm.md
@@ -16,7 +16,7 @@ Branch / PR: `vector/qwen4-fast-rmsnorm`, PR #3151
   fp32-input candidate versus 1.413971716665x for the rejected bf16-input arm.
 - The QSA synthetic singleton now carries the real parent forward width, so a
   wide prefill cannot enter the narrow route.
-- 156 focused tests, ruff check/format, compileall, and diff check passed.
+- 157 focused tests, ruff check/format, compileall, and diff check passed.
 - Full method, raw summary ranges, commands, and limitations are in
   `docs/engineering/performance/2026-09-06-qwen4-fast-rmsnorm.md`.
 
@@ -28,14 +28,13 @@ Branch / PR: `vector/qwen4-fast-rmsnorm`, PR #3151
   claims.
 - Exactness is class 3. The PR must remain opt-in unless a named owner accepts
   the fidelity scope plus a resident-artifact greedy/digest gate.
-- The independent spark2 review loop could not run because its Codex refresh
-  token is revoked (401). No LGTM was posted; local adversarial review is not a
-  substitute for that required independent pass.
+- Final Codex self-review on the exact PR head found no blocking correctness,
+  routing, scope, benchmark, or documentation issue. The repository owner
+  explicitly selected this review path instead of the unavailable spark2 loop.
 
 ## Next concrete action
 
-1. Re-authenticate Codex on spark2 and rerun `pr-review 3151` to LGTM.
-2. On a host where revision `dcf657e4acda2aae72da99cde65b6c491cd96998`
+1. On a host where revision `dcf657e4acda2aae72da99cde65b6c491cd96998`
    is already resident, run the committed 1K/16K interleaved real-model gate.
-3. Atlas decides whether the independently reproduced kernel and accuracy
+2. Atlas decides whether the independently reproduced kernel and accuracy
    evidence is sufficient to merge the default-off route before that e2e rerun.

--- a/docs/engineering/performance/2026-09-06-qwen4-fast-rmsnorm.md
+++ b/docs/engineering/performance/2026-09-06-qwen4-fast-rmsnorm.md
@@ -1,0 +1,131 @@
+# Qwen4 fp32-input fast RMSNorm qualification
+
+Date: 2026-09-06
+
+Owner: Vector
+
+Branch: `vector/qwen4-fast-rmsnorm`, based on `c18faeb0f`
+
+## Outcome
+
+The fp32-input `mx.fast.rms_norm` route is a real narrow-decode kernel lever
+for the Qwen4-Exp architecture used by Qwen3.8 Flash-Next. Across the three
+production tensor shapes, an interleaved microbenchmark measured 1.105--1.117x
+on an M3 Ultra and 1.103--1.126x on an M2 Pro. The route remains opt-in and is
+limited to forward widths at or below eight; wider prefill stays on the stock
+explicit fp32 reduction.
+
+This is exactness class 3 because the fast reduction may reorder floating-point
+operations. Against an fp64 reference over 1,310,720 elements, the candidate's
+RMS-error ratio to stock was `1.000000000066`. The rejected bf16-input variant
+was `1.413971716665x` farther from fp64 and changed 25.3912% of elements. The
+candidate changed 0.000229% of elements. This independently reproduces the
+discriminator in the external performance handoff and is why the upcast must
+remain before `mx.fast.rms_norm`.
+
+The handoff's real-model end-to-end results are +4.2% decode at 1K and +3.9% at
+16K, with prefill unchanged and 147 RMSNorm calls per token. Those two numbers
+are inherited evidence, not an independent Rapid rerun. The immutable
+Flash-Next artifact is 28 shards totaling about 106 GB; it was no longer local,
+the Studio system volume had 46 GB free, and both attached external volumes
+blocked on basic writes. A Mini download plus transfer was abandoned after its
+measured transfer rate projected roughly 2.5 hours. No end-to-end number from
+that incomplete attempt is claimed here.
+
+## Implementation boundary
+
+- `RAPID_MLX_QWEN4_FAST_RMSNORM=1` selects `fast_fp32`; the default is `stock`.
+- Every eligible input is upcast to fp32 before entering the fast kernel.
+- The additive zero-centered checkpoint weight is multiplied in fp32 after the
+  kernel, preserving grouped HC and PLE weights.
+- The route is admitted only for sequence widths `<= 8`.
+- QSA compressed-key normalization passes the parent forward width explicitly;
+  its synthetic singleton axis cannot accidentally admit prefill.
+- Mode counts, fast-call counts, and wide-input declines provide a mechanism
+  receipt without synchronizing device arrays.
+- The change is confined to the vendored Qwen4-Exp text model. Gemma diffusion
+  and other model families are unaffected.
+
+## Environment and method
+
+| Component | Studio | Mini |
+| --- | --- | --- |
+| Hardware | Apple M3 Ultra, 256 GB | Apple M2 Pro, 32 GB |
+| macOS | 26.5.2 (25F84) | 26.5.2 (25F84) |
+| Python | 3.12.13 | 3.12 via `uv` |
+| MLX | 0.32.2 | 0.32.2 |
+| Input / weight dtype | bf16 / bf16 | bf16 / bf16 |
+| Seed | 3058 | 3058 |
+| Warmup | 30 calls per arm | 30 calls per arm |
+| Timing | 7 AB/BA repeats, 400 evaluated calls each | same |
+| Accuracy | 128 cases, 1,310,720 elements, fp64 reference | same |
+
+The three shapes represent grouped hyperconnection/PLE normalization
+(`[1,1,4,2560]`), hidden-state normalization (`[1,1,2560]`), and 24-head QSA
+normalization (`[1,1,24,256]`). Each timing fences the returned array with
+`mx.eval`, so it measures an individual eager call rather than constructing one
+large lazy graph.
+
+Reproduce on either host:
+
+```bash
+python3.12 scripts/bench_qwen4_fast_rmsnorm.py \
+  --micro-only \
+  --micro-repeats 7 \
+  --micro-iterations 400 \
+  --error-cases 128 \
+  --output /private/tmp/qwen4-fast-rmsnorm.json
+```
+
+The uncompleted real-model gate is retained for a future host with the artifact
+already resident:
+
+```bash
+python3.12 scripts/bench_qwen4_fast_rmsnorm.py \
+  --model /path/to/dcf657e4acda2aae72da99cde65b6c491cd96998 \
+  --prompt-tokens 1024 16384 \
+  --max-tokens 128 \
+  --repeats 3 \
+  --output /private/tmp/qwen4-fast-rmsnorm-e2e.json
+```
+
+That gate alternates stock/fast order, requires identical greedy token digests,
+records TTFT and decode separately, and asserts that fast calls occur only in
+the candidate arm while the wide prefill decline is observed.
+
+## Results
+
+Times are median microseconds per evaluated call. Parentheses contain the raw
+sample range; speedup is `stock / fast_fp32`.
+
+| Host / shape | Stock us | Fast fp32 us | Speedup |
+| --- | ---: | ---: | ---: |
+| M3 Ultra / HC 4x2560 | 236.346 (231.745--297.598) | 213.844 (200.372--229.139) | 1.105x |
+| M3 Ultra / hidden 2560 | 240.289 (233.455--283.664) | 216.599 (208.727--263.329) | 1.109x |
+| M3 Ultra / QSA 24x256 | 243.489 (235.179--274.660) | 217.908 (206.258--223.772) | 1.117x |
+| M2 Pro / HC 4x2560 | 189.730 (186.219--229.266) | 171.952 (170.413--181.603) | 1.103x |
+| M2 Pro / hidden 2560 | 187.832 (185.466--193.445) | 166.862 (164.843--175.263) | 1.126x |
+| M2 Pro / QSA 24x256 | 193.117 (183.082--194.403) | 171.867 (164.301--174.919) | 1.124x |
+
+| Accuracy result | Value |
+| --- | ---: |
+| Stock RMS error to fp64 | 0.001663547813861649 |
+| Fast fp32 RMS error to fp64 | 0.001663547813971471 |
+| Bad bf16 RMS error to fp64 | 0.002352209558120544 |
+| Fast fp32 / stock error | 1.000000000066x |
+| Bad bf16 / stock error | 1.413971716665x |
+| Fast fp32 elements different from stock | 0.0002289% |
+| Bad bf16 elements different from stock | 25.3911591% |
+
+## Review gates
+
+The first adversarial pass rejected a non-interleaved version of the micro
+harness after a busy Studio run made one shape appear 0.6% slower. Alternating
+AB/BA order restored stable positive results on all six host/shape pairs. The
+second pass checked every call site and found the synthetic QSA singleton; the
+explicit parent-width override is the resulting fix. The third pass removed
+counter and sequence-width work from the default stock path.
+
+Promotion beyond opt-in requires a resident-artifact real-model rerun and named
+acceptance of the class-3 scope. The current evidence supports landing the
+guarded implementation and benchmark tooling, but not enabling it by default.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -6,6 +6,7 @@ summary statistics, and limitations.
 
 ## Reports
 
+- [Qwen4 fp32-input fast RMSNorm qualification](2026-09-06-qwen4-fast-rmsnorm.md)
 - [Qwen4 block-sparse QSA prefill qualification](2026-09-04-qwen4-qsa-block-sparse-prefill.md)
 - [Qwen4 fused GDN single-token decode](2026-09-01-qwen4-fused-gdn-decode.md)
 - [Gemma 4 12B engine comparison on M2 Pro](2026-08-21-gemma4-12b-engine-comparison.md)

--- a/scripts/bench_metadata.py
+++ b/scripts/bench_metadata.py
@@ -48,6 +48,7 @@ JSON_BENCH_SCRIPTS = frozenset(
         "bench_engine_solo.py",
         "bench_qwen4_fused_gdn_decode.py",
         "bench_qwen4_fused_gdn_end_to_end.py",
+        "bench_qwen4_fast_rmsnorm.py",
         "bench_qwen4_qsa_block_sparse.py",
         "bench_service_prefill.py",
         "bench_readme_refresh.py",

--- a/scripts/bench_qwen4_fast_rmsnorm.py
+++ b/scripts/bench_qwen4_fast_rmsnorm.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Interleaved real-model gate for Qwen4 fp32-input fast RMSNorm."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import statistics
+import time
+from pathlib import Path
+
+try:
+    from scripts.bench_metadata import format_bench_json, write_bench_json
+except ImportError:  # direct `python scripts/bench_*.py` execution
+    from bench_metadata import format_bench_json, write_bench_json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--micro-only", action="store_true")
+    parser.add_argument("--prompt-tokens", type=int, nargs="+", default=[1024, 16384])
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--micro-repeats", type=int, default=7)
+    parser.add_argument("--micro-iterations", type=int, default=400)
+    parser.add_argument("--error-cases", type=int, default=128)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def counter_delta(after: dict[str, int], before: dict[str, int]) -> dict[str, int]:
+    reasons = set(before) | set(after)
+    return {
+        reason: delta
+        for reason in sorted(reasons)
+        if (delta := after.get(reason, 0) - before.get(reason, 0))
+    }
+
+
+def build_prompt(tokenizer, target_tokens: int):
+    seed = tokenizer.encode(
+        "Summarize the performance engineering evidence carefully. ",
+        add_special_tokens=False,
+    )
+    if not seed:
+        raise RuntimeError("tokenizer produced an empty benchmark seed")
+    repeated = (seed * ((target_tokens + len(seed) - 1) // len(seed)))[:target_tokens]
+    return repeated
+
+
+def run_micro(args):
+    if args.micro_repeats < 1 or args.micro_iterations < 1 or args.error_cases < 1:
+        raise SystemExit("micro repeat, iteration, and error counts must be positive")
+
+    import mlx.core as mx
+    import numpy as np
+
+    mx.set_default_device(mx.gpu)
+    rng = np.random.default_rng(3058)
+
+    def stock(x, weight, eps=1e-6):
+        normalized = x.astype(mx.float32)
+        normalized *= mx.rsqrt(
+            mx.mean(mx.square(normalized), axis=-1, keepdims=True) + eps
+        )
+        return (normalized * (1 + weight.astype(mx.float32))).astype(x.dtype)
+
+    def fast_fp32(x, weight, eps=1e-6):
+        normalized = mx.fast.rms_norm(x.astype(mx.float32), None, eps)
+        return (normalized * (1 + weight.astype(mx.float32))).astype(x.dtype)
+
+    def bad_bf16(x, weight, eps=1e-6):
+        normalized = mx.fast.rms_norm(x, None, eps).astype(mx.float32)
+        return (normalized * (1 + weight.astype(mx.float32))).astype(x.dtype)
+
+    def time_shape(shape, weight_shape):
+        inputs = mx.array(rng.normal(size=shape).astype(np.float32), dtype=mx.bfloat16)
+        weight = mx.array(
+            rng.normal(0, 0.05, size=weight_shape).astype(np.float32),
+            dtype=mx.bfloat16,
+        )
+        for function in (stock, fast_fp32):
+            for _ in range(30):
+                mx.eval(function(inputs, weight))
+        samples = {"stock": [], "fast_fp32": []}
+        orders = (
+            (("stock", stock), ("fast_fp32", fast_fp32)),
+            (("fast_fp32", fast_fp32), ("stock", stock)),
+        )
+        for repeat in range(args.micro_repeats):
+            for name, function in orders[repeat % len(orders)]:
+                started = time.perf_counter()
+                for _ in range(args.micro_iterations):
+                    mx.eval(function(inputs, weight))
+                samples[name].append(
+                    (time.perf_counter() - started) * 1e6 / args.micro_iterations
+                )
+        rows = {
+            name: {
+                "samples_microseconds": values,
+                "median_microseconds": statistics.median(values),
+            }
+            for name, values in samples.items()
+        }
+        rows["speedup"] = (
+            rows["stock"]["median_microseconds"]
+            / rows["fast_fp32"]["median_microseconds"]
+        )
+        return rows
+
+    squared_errors = {name: 0.0 for name in ("stock", "fast_fp32", "bad_bf16")}
+    differences = {name: 0 for name in ("fast_fp32", "bad_bf16")}
+    elements = 0
+    for _ in range(args.error_cases):
+        inputs = mx.array(
+            rng.normal(size=(4, 2560)).astype(np.float32), dtype=mx.bfloat16
+        )
+        weight = mx.array(
+            rng.normal(0, 0.05, size=(4, 2560)).astype(np.float32),
+            dtype=mx.bfloat16,
+        )
+        input64 = np.asarray(inputs.astype(mx.float32)).astype(np.float64)
+        weight64 = np.asarray(weight.astype(mx.float32)).astype(np.float64)
+        reference = input64 / np.sqrt(
+            np.mean(input64**2, axis=-1, keepdims=True) + 1e-6
+        )
+        reference *= 1 + weight64
+        outputs = {
+            name: np.asarray(function(inputs, weight).astype(mx.float32))
+            for name, function in (
+                ("stock", stock),
+                ("fast_fp32", fast_fp32),
+                ("bad_bf16", bad_bf16),
+            )
+        }
+        for name, output in outputs.items():
+            squared_errors[name] += float(
+                np.sum((output.astype(np.float64) - reference) ** 2)
+            )
+        for name in differences:
+            differences[name] += int(
+                np.count_nonzero(outputs[name] != outputs["stock"])
+            )
+        elements += outputs["stock"].size
+
+    rms_errors = {
+        name: (error / elements) ** 0.5 for name, error in squared_errors.items()
+    }
+    return {
+        "mode": "micro",
+        "environment": {
+            "host": platform.node(),
+            "platform": platform.platform(),
+            "mlx": mx.__version__,
+        },
+        "method": {
+            "warmup_iterations": 30,
+            "timed_repeats": args.micro_repeats,
+            "iterations_per_repeat": args.micro_iterations,
+            "error_cases": args.error_cases,
+            "seed": 3058,
+        },
+        "timings": {
+            "hc_grouped_4x2560": time_shape((1, 1, 4, 2560), (4, 2560)),
+            "hidden_2560": time_shape((1, 1, 2560), (2560,)),
+            "qsa_24x256": time_shape((1, 1, 24, 256), (256,)),
+        },
+        "fp64": {
+            "elements": elements,
+            "rms_errors": rms_errors,
+            "ratio_fast_fp32_to_stock": rms_errors["fast_fp32"] / rms_errors["stock"],
+            "ratio_bad_bf16_to_stock": rms_errors["bad_bf16"] / rms_errors["stock"],
+            "different_fraction": {
+                name: count / elements for name, count in differences.items()
+            },
+        },
+        "correctness": {
+            "passed": rms_errors["fast_fp32"] / rms_errors["stock"] < 1.01
+            and rms_errors["bad_bf16"] / rms_errors["stock"] > 1.3
+        },
+    }
+
+
+def run(args):
+    if args.max_tokens < 2:
+        raise SystemExit("--max-tokens must be at least 2")
+    if args.repeats < 1:
+        raise SystemExit("--repeats must be at least 1")
+    if any(length <= 8 for length in args.prompt_tokens):
+        raise SystemExit("--prompt-tokens values must exceed the decode-width gate")
+
+    import mlx.core as mx
+    from mlx_lm.generate import generate_step
+    from mlx_lm.sample_utils import make_sampler
+    from mlx_lm.utils import load
+
+    from vllm_mlx.models.qwen4_exp import (
+        qwen4_fast_rmsnorm_stats,
+        set_qwen4_fast_rmsnorm_mode,
+    )
+    from vllm_mlx.utils.tokenizer import _register_vendored_archs
+
+    _register_vendored_archs()
+    mx.set_default_device(mx.gpu)
+    if args.model is None:
+        raise SystemExit("--model is required unless --micro-only is set")
+    model, tokenizer = load(str(args.model.resolve()))
+    model.eval()
+    sampler = make_sampler(temp=0.0)
+
+    observations = []
+    orders = (("stock", "fast_fp32"), ("fast_fp32", "stock"))
+    for target_tokens in args.prompt_tokens:
+        prompt = mx.array(build_prompt(tokenizer, target_tokens))
+        for repeat in range(args.repeats):
+            for mode in orders[repeat % len(orders)]:
+                resident_norms = set_qwen4_fast_rmsnorm_mode(model, mode)
+                before = qwen4_fast_rmsnorm_stats(model)
+                tokens = []
+                started = time.perf_counter()
+                first_token_at = None
+                for token, _ in generate_step(
+                    prompt,
+                    model,
+                    max_tokens=args.max_tokens,
+                    sampler=sampler,
+                ):
+                    if first_token_at is None:
+                        first_token_at = time.perf_counter()
+                    tokens.append(int(token))
+                ended = time.perf_counter()
+                after = qwen4_fast_rmsnorm_stats(model)
+                if len(tokens) < 2 or first_token_at is None:
+                    raise RuntimeError(
+                        f"generation produced {len(tokens)} tokens; need at least 2"
+                    )
+                fast_calls = after["fast_calls"] - before["fast_calls"]
+                declines = after["declines"] - before["declines"]
+                decline_reasons = counter_delta(
+                    after["decline_reasons"], before["decline_reasons"]
+                )
+                path_engaged = (
+                    fast_calls == 0 and declines == 0
+                    if mode == "stock"
+                    else fast_calls > 0
+                    and declines > 0
+                    and decline_reasons == {"sequence_too_wide": declines}
+                )
+                decode_seconds = ended - first_token_at
+                observations.append(
+                    {
+                        "mode": mode,
+                        "prompt_tokens": target_tokens,
+                        "repeat": repeat + 1,
+                        "generated_tokens": len(tokens),
+                        "token_sha256": hashlib.sha256(
+                            json.dumps(tokens, separators=(",", ":")).encode()
+                        ).hexdigest(),
+                        "ttft_seconds": first_token_at - started,
+                        "decode_seconds": decode_seconds,
+                        "decode_tokens_per_second": (len(tokens) - 1) / decode_seconds,
+                        "resident_norms": resident_norms,
+                        "fast_calls": fast_calls,
+                        "declines": declines,
+                        "decline_reasons": decline_reasons,
+                        "path_engaged": path_engaged,
+                    }
+                )
+                mx.clear_cache()
+
+    summaries = {}
+    correctness = True
+    for target_tokens in args.prompt_tokens:
+        rows = [item for item in observations if item["prompt_tokens"] == target_tokens]
+        hashes = {item["token_sha256"] for item in rows}
+        path_engaged = all(item["path_engaged"] for item in rows)
+        medians = {
+            mode: statistics.median(
+                item["decode_tokens_per_second"]
+                for item in rows
+                if item["mode"] == mode
+            )
+            for mode in ("stock", "fast_fp32")
+        }
+        summaries[str(target_tokens)] = {
+            "token_exact": len(hashes) == 1,
+            "path_engaged": path_engaged,
+            "token_hashes": sorted(hashes),
+            "median_decode_tokens_per_second": medians,
+            "median_speedup_percent": 100.0
+            * (medians["fast_fp32"] / medians["stock"] - 1.0),
+        }
+        correctness &= len(hashes) == 1 and path_engaged
+
+    return {
+        "correctness": {"passed": correctness},
+        "summaries": summaries,
+        "observations": observations,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    result = run_micro(args) if args.micro_only else run(args)
+    payload = format_bench_json(result, __file__, indent=2, sort_keys=True)
+    print(payload)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        write_bench_json(args.output, result, __file__, indent=2, sort_keys=True)
+    return 0 if result["correctness"]["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -185,6 +185,10 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # bit-exact kernel for an already-selected model and falls back for
         # unsupported shapes; it does not select a model, parser, or lane.
         "RAPID_MLX_QWEN4_FUSED_GDN_DECODE",
+        # Opt-in fp32-input fast RMSNorm for narrow Qwen4 decode/verify. This
+        # changes only the normalization implementation after model selection;
+        # prefill and other model families retain their existing path.
+        "RAPID_MLX_QWEN4_FAST_RMSNORM",
         # Opt-in re-quantization of the lm_head when serving fp8-block
         # checkpoints through the load-time mxfp8 repack
         # (vllm_mlx/fp8_repack.py). A precision/speed knob on an

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -1330,6 +1330,24 @@ def test_qsa_batch_prefill_builds_mask_before_kv_update(monkeypatch):
     assert observed == [(5, 5)]
 
 
+def test_qsa_prefill_synthetic_singleton_cannot_enter_fast_rms_norm():
+    args = _args(indexer_budget=8, indexer_compress_ratio=2)
+    indexer = QSAIndexer(args)
+    qwen4_exp.set_qwen4_fast_rmsnorm_mode(indexer, "fast_fp32")
+    selected = indexer(
+        mx.zeros((1, 65, args.hidden_size), dtype=mx.bfloat16),
+        QSAIndexCache(compress_ratio=2),
+        physical_kv_length=65,
+    )
+    assert selected is not None
+    mx.eval(selected.token_indices, selected.valid)
+
+    stats = qwen4_exp.qwen4_fast_rmsnorm_stats(indexer)
+    assert stats["fast_calls"] == 0
+    assert stats["declines"] > 0
+    assert stats["decline_reasons"] == {"sequence_too_wide": stats["declines"]}
+
+
 def test_scheduler_mid_prefill_restores_qsa_cachelist():
     """The live restore path recognizes the same vendored QSA side-cache."""
     from vllm_mlx.scheduler import Scheduler

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -218,6 +218,104 @@ def test_zero_centered_rms_norm_rejects_partial_group():
         ZeroCenteredRMSNorm(7, group_size=4)
 
 
+def test_zero_centered_fast_rms_norm_uses_fp32_and_matches_stock(monkeypatch):
+    rng = np.random.default_rng(23)
+    norm = ZeroCenteredRMSNorm(8, group_size=4, eps=1e-6)
+    norm.weight = mx.array(rng.normal(0, 0.1, (8,)).astype(np.float32))
+    inputs = mx.array(rng.normal(size=(1, 2, 8)).astype(np.float16))
+
+    stock = norm(inputs)
+    seen_dtypes = []
+    original_fast_rms_norm = mx.fast.rms_norm
+
+    def record_fast_rms_norm(x, weight, eps):
+        seen_dtypes.append((x.dtype, weight))
+        return original_fast_rms_norm(x, weight, eps)
+
+    monkeypatch.setattr(mx.fast, "rms_norm", record_fast_rms_norm)
+    norm.set_fast_rmsnorm_mode("fast_fp32")
+    fast = norm(inputs)
+    mx.eval(stock, fast)
+
+    assert seen_dtypes == [(mx.float32, None)]
+    assert fast.dtype == inputs.dtype
+    assert norm.fast_rmsnorm_calls == 1
+    np.testing.assert_allclose(np.asarray(fast), np.asarray(stock), rtol=2e-3, atol=2e-3)
+
+
+def test_zero_centered_fast_rms_norm_declines_wide_parent_forward(monkeypatch):
+    norm = ZeroCenteredRMSNorm(4)
+    norm.set_fast_rmsnorm_mode("fast_fp32")
+
+    def unexpected_fast_rms_norm(*_args, **_kwargs):
+        raise AssertionError("wide prefill must remain on the stock RMSNorm path")
+
+    monkeypatch.setattr(mx.fast, "rms_norm", unexpected_fast_rms_norm)
+    output = norm(mx.ones((2, 1, 4)), sequence_length=16)
+    mx.eval(output)
+
+    assert norm.fast_rmsnorm_calls == 0
+    assert norm.fast_rmsnorm_declines == 1
+    assert norm.fast_rmsnorm_decline_reasons == {"sequence_too_wide": 1}
+
+
+def test_zero_centered_fast_fp32_avoids_bf16_extra_rounding():
+    rng = np.random.default_rng(3058)
+    norm = ZeroCenteredRMSNorm(256, eps=1e-6)
+    norm.weight = mx.array(
+        rng.normal(0, 0.05, size=(256,)).astype(np.float32), dtype=mx.bfloat16
+    )
+    inputs = mx.array(
+        rng.normal(size=(1, 8, 256)).astype(np.float32), dtype=mx.bfloat16
+    )
+
+    stock = norm(inputs)
+    norm.set_fast_rmsnorm_mode("fast_fp32")
+    candidate = norm(inputs)
+    bad = (
+        mx.fast.rms_norm(inputs, None, norm.eps).astype(mx.float32)
+        * (1 + norm.weight.astype(mx.float32))
+    ).astype(inputs.dtype)
+    mx.eval(stock, candidate, bad)
+
+    x64 = np.asarray(inputs.astype(mx.float32)).astype(np.float64)
+    weight64 = np.asarray(norm.weight.astype(mx.float32)).astype(np.float64)
+    reference = x64 / np.sqrt(np.mean(x64**2, axis=-1, keepdims=True) + norm.eps)
+    reference *= 1 + weight64
+
+    def rms_error(value):
+        delta = np.asarray(value.astype(mx.float32)).astype(np.float64) - reference
+        return float(np.sqrt(np.mean(delta**2)))
+
+    stock_error = rms_error(stock)
+    candidate_error = rms_error(candidate)
+    bad_error = rms_error(bad)
+    assert candidate_error / stock_error == pytest.approx(1.0, rel=1e-5)
+    assert bad_error / stock_error > 1.3
+
+
+def test_qwen4_fast_rms_norm_mode_and_stats_cover_all_resident_norms():
+    layer = GatedResidual(_args())
+    with pytest.raises(ValueError, match="unknown fast RMSNorm mode"):
+        qwen4_exp.set_qwen4_fast_rmsnorm_mode(layer, "bf16")
+    assert qwen4_exp.qwen4_fast_rmsnorm_mode_counts(layer) == {
+        "stock": 1,
+        "fast_fp32": 0,
+    }
+    assert qwen4_exp.set_qwen4_fast_rmsnorm_mode(layer, "fast_fp32") == 1
+    layer.hc_norm(mx.ones((1, 1, 32)))
+    layer.hc_norm(mx.ones((1, 9, 32)))
+    assert qwen4_exp.qwen4_fast_rmsnorm_mode_counts(layer) == {
+        "stock": 0,
+        "fast_fp32": 1,
+    }
+    assert qwen4_exp.qwen4_fast_rmsnorm_stats(layer) == {
+        "fast_calls": 1,
+        "declines": 1,
+        "decline_reasons": {"sequence_too_wide": 1},
+    }
+
+
 def test_gated_residual_matches_reference_equations():
     args = _args()
     layer = GatedResidual(args)

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -240,7 +240,9 @@ def test_zero_centered_fast_rms_norm_uses_fp32_and_matches_stock(monkeypatch):
     assert seen_dtypes == [(mx.float32, None)]
     assert fast.dtype == inputs.dtype
     assert norm.fast_rmsnorm_calls == 1
-    np.testing.assert_allclose(np.asarray(fast), np.asarray(stock), rtol=2e-3, atol=2e-3)
+    np.testing.assert_allclose(
+        np.asarray(fast), np.asarray(stock), rtol=2e-3, atol=2e-3
+    )
 
 
 def test_zero_centered_fast_rms_norm_declines_wide_parent_forward(monkeypatch):

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -216,6 +216,8 @@ def test_zero_centered_grouped_rms_norm_matches_numpy():
 def test_zero_centered_rms_norm_rejects_partial_group():
     with pytest.raises(ValueError, match="divide the feature width"):
         ZeroCenteredRMSNorm(7, group_size=4)
+    with pytest.raises(ValueError, match="unknown fast RMSNorm mode"):
+        ZeroCenteredRMSNorm(4).set_fast_rmsnorm_mode("bf16")
 
 
 def test_zero_centered_fast_rms_norm_uses_fp32_and_matches_stock(monkeypatch):

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -58,6 +58,13 @@ _FUSED_GDN_MODES = ("stock", "fused")
 _FUSED_GDN_DEFAULT = os.environ.get(
     "RAPID_MLX_QWEN4_FUSED_GDN_DECODE", "0"
 ).strip().lower() in {"1", "true", "yes", "on"}
+_FAST_RMSNORM_MODES = ("stock", "fast_fp32")
+_FAST_RMSNORM_DEFAULT = (
+    "fast_fp32"
+    if os.environ.get("RAPID_MLX_QWEN4_FAST_RMSNORM", "0").strip().lower()
+    in {"1", "true", "yes", "on"}
+    else "stock"
+)
 
 
 @dataclass
@@ -232,8 +239,31 @@ class ZeroCenteredRMSNorm(nn.Module):
         self.weight = mx.zeros((dim,))
         self.group_size = group_size
         self.eps = eps
+        self.fast_rmsnorm_mode = _FAST_RMSNORM_DEFAULT
+        self.fast_rmsnorm_calls = 0
+        self.fast_rmsnorm_declines = 0
+        self.fast_rmsnorm_decline_reasons: dict[str, int] = {}
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def set_fast_rmsnorm_mode(self, mode: str) -> None:
+        if mode not in _FAST_RMSNORM_MODES:
+            raise ValueError(
+                f"unknown fast RMSNorm mode {mode!r}; "
+                f"expected one of {_FAST_RMSNORM_MODES}"
+            )
+        self.fast_rmsnorm_mode = mode
+
+    def _record_fast_rmsnorm_decline(self, reason: str) -> None:
+        self.fast_rmsnorm_declines += 1
+        self.fast_rmsnorm_decline_reasons[reason] = (
+            self.fast_rmsnorm_decline_reasons.get(reason, 0) + 1
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        *,
+        sequence_length: int | None = None,
+    ) -> mx.array:
         original_shape = x.shape
         if self.group_size is not None:
             x = x.reshape(*x.shape[:-1], -1, self.group_size)
@@ -242,9 +272,24 @@ class ZeroCenteredRMSNorm(nn.Module):
             weight = self.weight
         dtype = x.dtype
         normalized = x.astype(mx.float32)
-        normalized = normalized * mx.rsqrt(
-            mx.mean(mx.square(normalized), axis=-1, keepdims=True) + self.eps
-        )
+        if self.fast_rmsnorm_mode == "fast_fp32":
+            if sequence_length is None:
+                sequence_length = int(x.shape[1] if x.ndim >= 3 else x.shape[0])
+            if sequence_length <= 8:
+                # The input must stay fp32. Passing bf16 directly introduces
+                # an additional rounding boundary before the zero-centered
+                # weight multiply and is observably less accurate than stock.
+                normalized = mx.fast.rms_norm(normalized, None, self.eps)
+                self.fast_rmsnorm_calls += 1
+            else:
+                self._record_fast_rmsnorm_decline("sequence_too_wide")
+                normalized = normalized * mx.rsqrt(
+                    mx.mean(mx.square(normalized), axis=-1, keepdims=True) + self.eps
+                )
+        else:
+            normalized = normalized * mx.rsqrt(
+                mx.mean(mx.square(normalized), axis=-1, keepdims=True) + self.eps
+            )
         normalized = normalized * (1.0 + weight.astype(mx.float32))
         return normalized.astype(dtype).reshape(original_shape)
 
@@ -683,6 +728,51 @@ def qwen4_fused_gdn_stats(model: nn.Module) -> dict[str, Any]:
     return stats
 
 
+def set_qwen4_fast_rmsnorm_mode(model: nn.Module, mode: str) -> int:
+    """Switch every zero-centered Qwen4 RMSNorm between stock and fast fp32."""
+    if mode not in _FAST_RMSNORM_MODES:
+        raise ValueError(
+            f"unknown fast RMSNorm mode {mode!r}; "
+            f"expected one of {_FAST_RMSNORM_MODES}"
+        )
+    norms = [
+        module
+        for _, module in model.named_modules()
+        if isinstance(module, ZeroCenteredRMSNorm)
+    ]
+    for norm in norms:
+        norm.set_fast_rmsnorm_mode(mode)
+    return len(norms)
+
+
+def qwen4_fast_rmsnorm_mode_counts(model: nn.Module) -> dict[str, int]:
+    """Return current fast RMSNorm modes without evaluating model arrays."""
+    counts = {mode: 0 for mode in _FAST_RMSNORM_MODES}
+    for _, module in model.named_modules():
+        if isinstance(module, ZeroCenteredRMSNorm):
+            counts[module.fast_rmsnorm_mode] += 1
+    return counts
+
+
+def qwen4_fast_rmsnorm_stats(model: nn.Module) -> dict[str, Any]:
+    """Aggregate fast RMSNorm route and fail-closed counters."""
+    stats: dict[str, Any] = {
+        "fast_calls": 0,
+        "declines": 0,
+        "decline_reasons": {},
+    }
+    for _, module in model.named_modules():
+        if not isinstance(module, ZeroCenteredRMSNorm):
+            continue
+        stats["fast_calls"] += module.fast_rmsnorm_calls
+        stats["declines"] += module.fast_rmsnorm_declines
+        for reason, count in module.fast_rmsnorm_decline_reasons.items():
+            stats["decline_reasons"][reason] = (
+                stats["decline_reasons"].get(reason, 0) + count
+            )
+    return stats
+
+
 def apply_rotary_positions(
     x: mx.array,
     positions: mx.array,
@@ -934,7 +1024,12 @@ class QSAIndexer(nn.Module):
         ).transpose(0, 2, 1, 3)
 
         def transform_group(group: mx.array, start: int) -> mx.array:
-            normalized = self.k_layernorm(group[:, None, :])[:, 0, :]
+            # The singleton axis is synthetic: preserve the parent forward's
+            # real width so prefill cannot accidentally enter the decode-only
+            # fast RMSNorm route.
+            normalized = self.k_layernorm(
+                group[:, None, :], sequence_length=length
+            )[:, 0, :]
             return apply_qwen4_exp_rope(
                 normalized[:, None, None, :],
                 mx.array([[start]], dtype=mx.int64),

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -732,8 +732,7 @@ def set_qwen4_fast_rmsnorm_mode(model: nn.Module, mode: str) -> int:
     """Switch every zero-centered Qwen4 RMSNorm between stock and fast fp32."""
     if mode not in _FAST_RMSNORM_MODES:
         raise ValueError(
-            f"unknown fast RMSNorm mode {mode!r}; "
-            f"expected one of {_FAST_RMSNORM_MODES}"
+            f"unknown fast RMSNorm mode {mode!r}; expected one of {_FAST_RMSNORM_MODES}"
         )
     norms = [
         module
@@ -1027,9 +1026,9 @@ class QSAIndexer(nn.Module):
             # The singleton axis is synthetic: preserve the parent forward's
             # real width so prefill cannot accidentally enter the decode-only
             # fast RMSNorm route.
-            normalized = self.k_layernorm(
-                group[:, None, :], sequence_length=length
-            )[:, 0, :]
+            normalized = self.k_layernorm(group[:, None, :], sequence_length=length)[
+                :, 0, :
+            ]
             return apply_qwen4_exp_rope(
                 normalized[:, None, None, :],
                 mx.array([[start]], dtype=mx.int64),


### PR DESCRIPTION
## Summary

- add an opt-in fast_fp32 RMSNorm route for Qwen4-Exp decode/verify widths <= 8
- preserve the fp32 input boundary and keep wider prefill on the stock reduction
- expose mode/path receipts and add a reproducible micro + real-model benchmark harness
- record the independent two-host qualification and its limits

## Release-note evidence

Independent AB/BA microbenchmark, MLX 0.32.2, bf16 activations/weights:

| Host | HC 4x2560 | hidden 2560 | QSA 24x256 |
| --- | ---: | ---: | ---: |
| M3 Ultra | 1.105x | 1.109x | 1.117x |
| M2 Pro | 1.103x | 1.126x | 1.124x |

Across 1,310,720 elements, fp64 RMS-error ratio candidate/stock was 1.000000000066. The rejected bf16-input variant was 1.413971716665x farther from fp64 and changed 25.3912% of elements.

The contributor handoff reports real-model decode +4.2% at 1K and +3.9% at 16K, with prefill unchanged. Those are explicitly recorded as inherited evidence, not a Rapid rerun: the 106 GB immutable artifact was not resident and available storage could not hold it safely. The implementation therefore remains opt-in.

## Safety

- exactness class 3; no default enablement
- QSA synthetic singleton passes the real parent width, preventing prefill misrouting
- default stock mode performs no telemetry writes or width calculation
- scope is only the vendored Qwen4-Exp text model; other families are unchanged

## Validation

- 157 focused tests passed
- ruff passed on all changed Python files
- compileall passed
- diff check passed
- reproducible report: docs/engineering/performance/2026-09-06-qwen4-fast-rmsnorm.md