### PR TITLE
feat(desktop): add scoped macOS Computer Use adapter

### DIFF
--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -28,6 +28,8 @@
 	<string>AccentColor</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSScreenCaptureUsageDescription</key>
+	<string>Rapid captures only the window you select while a local Computer Use task is running. Screenshots stay on this Mac.</string>
 	<!--
 	Dictation records from the microphone only while the user is holding a
 	recording session open (hotkey pressed once to start, once to stop). Audio

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -10,7 +10,10 @@ enum MacOSComputerUseActuationError: Error, Equatable {
     case targetNotFrontmost
     case targetChanged
     case targetOccluded
-    case eventCreationFailed
+    case elementUnavailable
+    case elementChanged
+    case elementActionUnsupported
+    case elementActionFailed
 }
 
 protocol ComputerUseTargetProbing: Sendable {
@@ -18,15 +21,10 @@ protocol ComputerUseTargetProbing: Sendable {
         -> WorkflowInteractionTarget
 }
 
-protocol ComputerUseContentProbing: Sendable {
-    func currentObservation(for expected: WorkflowInteractionTarget) async throws
-        -> WorkflowObservation
-}
-
 protocol ComputerUseInputEmitting: Sendable {
     func emit(
         _ payload: WorkflowActionPayload,
-        in target: WorkflowInteractionTarget
+        verifiedAgainst observation: WorkflowObservation
     ) async throws
 }
 
@@ -42,18 +40,15 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
 
     private let permissionReader: PermissionReader
     private let targetProbe: any ComputerUseTargetProbing
-    private let contentProbe: any ComputerUseContentProbing
     private let inputEmitter: any ComputerUseInputEmitting
 
     init(
         targetProbe: any ComputerUseTargetProbing = CGWindowComputerUseTargetProbe(),
-        contentProbe: any ComputerUseContentProbing =
-            ScreenCaptureKitComputerUseContentProbe(),
-        inputEmitter: any ComputerUseInputEmitting = CGEventComputerUseInputEmitter(),
+        inputEmitter: any ComputerUseInputEmitting =
+            AXComputerUseInputEmitter(),
         permissionReader: @escaping PermissionReader = MacAutomationPermissions.snapshot
     ) {
         self.targetProbe = targetProbe
-        self.contentProbe = contentProbe
         self.inputEmitter = inputEmitter
         self.permissionReader = permissionReader
     }
@@ -98,23 +93,14 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
         ) else {
             throw MacOSComputerUseActuationError.targetChanged
         }
-        // Capture once more after the target preflight. A matching frame alone
-        // is insufficient: controls can move while the window identity and
-        // geometry remain unchanged. Do not emit coordinates grounded against
-        // pixels that are no longer current.
-        let finalObservation = try await contentProbe.currentObservation(
-            for: currentObservation.target
+        // The production emitter binds the click to one Accessibility element,
+        // re-captures the exact window, then re-resolves and presses that same
+        // semantic element. The preflight here keeps alternate emitters
+        // testable and rejects drift before entering the input layer.
+        try await inputEmitter.emit(
+            action.payload,
+            verifiedAgainst: currentObservation
         )
-        try Task.checkCancellation()
-        guard currentObservation.representsSameInteractionState(
-            as: finalObservation
-        ) else {
-            throw MacOSComputerUseActuationError.staleObservation
-        }
-        // The production emitter repeats this probe synchronously in the same
-        // MainActor turn as each CGEvent post. The preflight here keeps all
-        // emitters testable and rejects drift before entering the input layer.
-        try await inputEmitter.emit(action.payload, in: currentObservation.target)
     }
 
     private static func isSafeForWindowActuation(
@@ -122,58 +108,15 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
     ) -> Bool {
         guard payload.isStructurallyValid else { return false }
         if case .click(let x, let y) = payload {
-            // 0 and 1 are window edges, not interior points. A CGEvent at
-            // maxX/maxY can belong to the adjacent or underlying window.
+            // 0 and 1 are window edges, not interior points. A coordinate at
+            // maxX/maxY can resolve to an adjacent or underlying element.
             return x > 0 && x < 1 && y > 0 && y < 1
         }
-        // Public macOS event APIs can target a process, but not one exact
-        // window inside that process. Until a semantic Accessibility adapter
-        // can bind text/key input to a verified element in this window, these
+        // Public keyboard event APIs can target a process, but not one exact
+        // window inside that process. Until semantic Accessibility input can
+        // bind text/key actions to a verified element in this window, these
         // payloads must fail closed rather than rely on focus timing.
         return false
-    }
-}
-
-/// Performs the final content-revision check without retaining another image.
-struct ScreenCaptureKitComputerUseContentProbe: ComputerUseContentProbing {
-    private let captureSource: any ComputerUseWindowCapturing
-
-    init(
-        captureSource: any ComputerUseWindowCapturing =
-            ScreenCaptureKitComputerUseCapture()
-    ) {
-        self.captureSource = captureSource
-    }
-
-    func currentObservation(
-        for expected: WorkflowInteractionTarget
-    ) async throws -> WorkflowObservation {
-        guard let windowID = CGWindowID(expected.windowIdentifier), windowID != 0 else {
-            throw MacOSComputerUseActuationError.targetUnavailable
-        }
-        let captured = try await captureSource.capture(
-            ComputerUseWindowSelection(
-                bundleIdentifier: expected.bundleIdentifier,
-                processIdentifier: expected.processIdentifier,
-                windowID: windowID
-            )
-        )
-        try Task.checkCancellation()
-        guard captured.isStructurallyValid,
-              MacOSComputerUseWindowIdentity.targetsMatch(
-                captured.target,
-                expected
-              )
-        else {
-            throw MacOSComputerUseActuationError.targetChanged
-        }
-        return WorkflowObservation(
-            target: captured.target,
-            contentRevision: MacOSComputerUseObserver.contentRevision(
-                target: captured.target,
-                pngData: captured.artifact.pngData
-            )
-        )
     }
 }
 
@@ -262,131 +205,152 @@ struct CGWindowComputerUseTargetProbe: ComputerUseTargetProbing {
     }
 }
 
-/// Narrow CGEvent adapter for process-bound clicks in one verified window.
-struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
-    typealias TargetReader = @MainActor @Sendable (
-        WorkflowInteractionTarget
-    ) throws -> WorkflowInteractionTarget
-    typealias CancellationCheck = @MainActor @Sendable () throws -> Void
-    typealias WindowAtPointReader = @MainActor @Sendable (CGPoint) -> String?
-    typealias EventPoster = @MainActor @Sendable (CGEvent, pid_t) -> Void
+struct ComputerUseElementFingerprint: Equatable, Sendable {
+    let role: String
+    let subrole: String?
+    let identifier: String?
+    let title: String?
+    let frame: WorkflowWindowFrame
+}
 
-    private let targetReader: TargetReader
-    private let cancellationCheck: CancellationCheck
-    private let windowAtPointReader: WindowAtPointReader
-    private let eventPoster: EventPoster
+/// Element-bound click adapter. A coordinate is used only to resolve the
+/// current Accessibility element; input is delivered with AXPress to that
+/// element rather than through the global pointer event stream.
+struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
+    typealias ElementBoundary = @MainActor @Sendable (
+        WorkflowActionPayload,
+        WorkflowInteractionTarget,
+        ComputerUseElementFingerprint?
+    ) throws -> ComputerUseElementFingerprint
+
+    private let captureSource: any ComputerUseWindowCapturing
+    private let elementBoundary: ElementBoundary
 
     init(
-        targetReader: @escaping TargetReader = {
-            try CGWindowComputerUseTargetProbe.currentTargetSynchronously(for: $0)
-        },
-        cancellationCheck: @escaping CancellationCheck = { try Task.checkCancellation() },
-        windowAtPointReader: @escaping WindowAtPointReader = {
-            MacOSComputerUseWindowIdentity.topmostWindowIdentifier(at: $0)
-        },
-        eventPoster: @escaping EventPoster = { event, processIdentifier in
-            event.postToPid(processIdentifier)
-        }
+        captureSource: any ComputerUseWindowCapturing =
+            ScreenCaptureKitComputerUseCapture(),
+        elementBoundary: @escaping ElementBoundary = Self.resolveAndOptionallyPress
     ) {
-        self.targetReader = targetReader
-        self.cancellationCheck = cancellationCheck
-        self.windowAtPointReader = windowAtPointReader
-        self.eventPoster = eventPoster
+        self.captureSource = captureSource
+        self.elementBoundary = elementBoundary
     }
 
     func emit(
         _ payload: WorkflowActionPayload,
-        in target: WorkflowInteractionTarget
+        verifiedAgainst observation: WorkflowObservation
     ) async throws {
         try Task.checkCancellation()
+        let target = observation.target
+        let fingerprint = try await MainActor.run {
+            try elementBoundary(payload, target, nil)
+        }
+
+        guard let windowID = CGWindowID(target.windowIdentifier), windowID != 0 else {
+            throw MacOSComputerUseActuationError.targetUnavailable
+        }
+        let captured = try await captureSource.capture(
+            ComputerUseWindowSelection(
+                bundleIdentifier: target.bundleIdentifier,
+                processIdentifier: target.processIdentifier,
+                windowID: windowID
+            )
+        )
+        try Task.checkCancellation()
+        guard captured.isStructurallyValid,
+              MacOSComputerUseWindowIdentity.targetsMatch(captured.target, target)
+        else {
+            throw MacOSComputerUseActuationError.targetChanged
+        }
+        let finalRevision = MacOSComputerUseObserver.contentRevision(
+            target: captured.target,
+            pngData: captured.artifact.pngData
+        )
+        guard finalRevision == observation.contentRevision else {
+            throw MacOSComputerUseActuationError.staleObservation
+        }
 
         try await MainActor.run {
-            guard let source = CGEventSource(stateID: .combinedSessionState) else {
-                throw MacOSComputerUseActuationError.eventCreationFailed
-            }
-
-            switch payload {
-            case .click(let normalizedX, let normalizedY):
-                let initial = try Self.requireCurrent(
-                    target,
-                    using: targetReader,
-                    cancellationCheck: cancellationCheck
-                )
-                let point = try Self.clickPoint(
-                    normalizedX: normalizedX,
-                    normalizedY: normalizedY,
-                    in: initial.windowFrame
-                )
-                guard let down = CGEvent(
-                    mouseEventSource: source,
-                    mouseType: .leftMouseDown,
-                    mouseCursorPosition: point,
-                    mouseButton: .left
-                ),
-                    let up = CGEvent(
-                        mouseEventSource: source,
-                        mouseType: .leftMouseUp,
-                        mouseCursorPosition: point,
-                        mouseButton: .left
-                    )
-                else {
-                    throw MacOSComputerUseActuationError.eventCreationFailed
-                }
-                try Self.post(
-                    down,
-                    at: point,
-                    expected: target,
-                    targetReader: targetReader,
-                    cancellationCheck: cancellationCheck,
-                    windowAtPointReader: windowAtPointReader,
-                    eventPoster: eventPoster
-                )
-                do {
-                    try Self.post(
-                        up,
-                        at: point,
-                        expected: target,
-                        targetReader: targetReader,
-                        cancellationCheck: cancellationCheck,
-                        windowAtPointReader: windowAtPointReader,
-                        eventPoster: eventPoster
-                    )
-                } catch {
-                    // Once mouse-down has reached the selected process, always
-                    // balance its button state. Leaving it held can turn later
-                    // user movement into an unintended drag. This cleanup is
-                    // still process-bound; the original validation error is
-                    // preserved so the workflow cannot advance.
-                    eventPoster(up, target.processIdentifier)
-                    throw error
-                }
-
-            case .typeText, .keyPress:
-                throw MacOSComputerUseActuationError.invalidAction
-            }
+            try Task.checkCancellation()
+            _ = try elementBoundary(payload, target, fingerprint)
         }
     }
 
     @MainActor
-    private static func post(
-        _ event: CGEvent,
-        at point: CGPoint,
-        expected: WorkflowInteractionTarget,
-        targetReader: TargetReader,
-        cancellationCheck: CancellationCheck,
-        windowAtPointReader: WindowAtPointReader,
-        eventPoster: EventPoster
-    ) throws {
-        _ = try requireCurrent(
-            expected,
-            using: targetReader,
-            cancellationCheck: cancellationCheck
+    private static func resolveAndOptionallyPress(
+        _ payload: WorkflowActionPayload,
+        _ expected: WorkflowInteractionTarget,
+        _ requiredFingerprint: ComputerUseElementFingerprint?
+    ) throws -> ComputerUseElementFingerprint {
+        guard case .click(let normalizedX, let normalizedY) = payload else {
+            throw MacOSComputerUseActuationError.invalidAction
+        }
+        let current = try CGWindowComputerUseTargetProbe
+            .currentTargetSynchronously(for: expected)
+        guard MacOSComputerUseWindowIdentity.targetsMatch(current, expected) else {
+            throw MacOSComputerUseActuationError.targetChanged
+        }
+        let point = try clickPoint(
+            normalizedX: normalizedX,
+            normalizedY: normalizedY,
+            in: current.windowFrame
         )
-        guard windowAtPointReader(point) == expected.windowIdentifier else {
+        guard MacOSComputerUseWindowIdentity.topmostWindowIdentifier(at: point)
+                == expected.windowIdentifier
+        else {
             throw MacOSComputerUseActuationError.targetOccluded
         }
-        try cancellationCheck()
-        eventPoster(event, expected.processIdentifier)
+        try Task.checkCancellation()
+
+        let application = AXUIElementCreateApplication(expected.processIdentifier)
+        var focusedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            application,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedValue
+        ) == .success,
+            let focusedValue,
+            CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
+        else {
+            throw MacOSComputerUseActuationError.targetNotFrontmost
+        }
+        let focusedWindow = unsafeDowncast(focusedValue, to: AXUIElement.self)
+
+        var element: AXUIElement?
+        guard AXUIElementCopyElementAtPosition(
+            application,
+            Float(point.x),
+            Float(point.y),
+            &element
+        ) == .success,
+            let element,
+            elementBelongsToWindow(element, focusedWindow: focusedWindow)
+        else {
+            throw MacOSComputerUseActuationError.elementUnavailable
+        }
+        guard elementSupportsPress(element) else {
+            throw MacOSComputerUseActuationError.elementActionUnsupported
+        }
+        var elementPID: pid_t = 0
+        guard AXUIElementGetPid(element, &elementPID) == .success,
+              elementPID == expected.processIdentifier
+        else {
+            throw MacOSComputerUseActuationError.elementUnavailable
+        }
+        let fingerprint = try elementFingerprint(element)
+        if let requiredFingerprint {
+            guard fingerprint == requiredFingerprint else {
+                throw MacOSComputerUseActuationError.elementChanged
+            }
+            try Task.checkCancellation()
+            guard AXUIElementPerformAction(
+                element,
+                kAXPressAction as CFString
+            ) == .success
+            else {
+                throw MacOSComputerUseActuationError.elementActionFailed
+            }
+        }
+        return fingerprint
     }
 
     static func clickPoint(
@@ -411,16 +375,106 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
     }
 
     @MainActor
-    private static func requireCurrent(
-        _ expected: WorkflowInteractionTarget,
-        using targetReader: TargetReader,
-        cancellationCheck: CancellationCheck
-    ) throws -> WorkflowInteractionTarget {
-        let current = try targetReader(expected)
-        guard MacOSComputerUseWindowIdentity.targetsMatch(current, expected) else {
-            throw MacOSComputerUseActuationError.targetChanged
+    private static func elementBelongsToWindow(
+        _ element: AXUIElement,
+        focusedWindow: AXUIElement
+    ) -> Bool {
+        var current = element
+        for _ in 0 ..< 64 {
+            if CFEqual(current, focusedWindow) { return true }
+            var parentValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(
+                current,
+                kAXParentAttribute as CFString,
+                &parentValue
+            ) == .success,
+                let parentValue,
+                CFGetTypeID(parentValue) == AXUIElementGetTypeID()
+            else { return false }
+            current = unsafeDowncast(parentValue, to: AXUIElement.self)
         }
-        try cancellationCheck()
-        return current
+        return false
+    }
+
+    @MainActor
+    private static func elementSupportsPress(_ element: AXUIElement) -> Bool {
+        var names: CFArray?
+        guard AXUIElementCopyActionNames(element, &names) == .success,
+              let actions = names as? [String]
+        else { return false }
+        return actions.contains(kAXPressAction as String)
+    }
+
+    @MainActor
+    private static func elementFingerprint(
+        _ element: AXUIElement
+    ) throws -> ComputerUseElementFingerprint {
+        guard let role = stringAttribute(kAXRoleAttribute as CFString, from: element),
+              let frame = elementFrame(element)
+        else {
+            throw MacOSComputerUseActuationError.elementUnavailable
+        }
+        return ComputerUseElementFingerprint(
+            role: role,
+            subrole: stringAttribute(kAXSubroleAttribute as CFString, from: element),
+            identifier: stringAttribute(kAXIdentifierAttribute as CFString, from: element),
+            title: stringAttribute(kAXTitleAttribute as CFString, from: element),
+            frame: frame
+        )
+    }
+
+    @MainActor
+    private static func stringAttribute(
+        _ attribute: CFString,
+        from element: AXUIElement
+    ) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else {
+            return nil
+        }
+        return value as? String
+    }
+
+    @MainActor
+    private static func elementFrame(
+        _ element: AXUIElement
+    ) -> WorkflowWindowFrame? {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+            AXUIElementCopyAttributeValue(
+                element,
+                kAXSizeAttribute as CFString,
+                &sizeValue
+            ) == .success,
+            let positionValue,
+            let sizeValue,
+            CFGetTypeID(positionValue) == AXValueGetTypeID(),
+            CFGetTypeID(sizeValue) == AXValueGetTypeID()
+        else { return nil }
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(
+            unsafeDowncast(positionValue, to: AXValue.self),
+            .cgPoint,
+            &origin
+        ),
+            AXValueGetValue(
+                unsafeDowncast(sizeValue, to: AXValue.self),
+                .cgSize,
+                &size
+            )
+        else { return nil }
+        let frame = WorkflowWindowFrame(
+            x: origin.x,
+            y: origin.y,
+            width: size.width,
+            height: size.height
+        )
+        return frame.isStructurallyValid ? frame : nil
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -18,6 +18,11 @@ protocol ComputerUseTargetProbing: Sendable {
         -> WorkflowInteractionTarget
 }
 
+protocol ComputerUseContentProbing: Sendable {
+    func currentObservation(for expected: WorkflowInteractionTarget) async throws
+        -> WorkflowObservation
+}
+
 protocol ComputerUseInputEmitting: Sendable {
     func emit(
         _ payload: WorkflowActionPayload,
@@ -37,14 +42,18 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
 
     private let permissionReader: PermissionReader
     private let targetProbe: any ComputerUseTargetProbing
+    private let contentProbe: any ComputerUseContentProbing
     private let inputEmitter: any ComputerUseInputEmitting
 
     init(
         targetProbe: any ComputerUseTargetProbing = CGWindowComputerUseTargetProbe(),
+        contentProbe: any ComputerUseContentProbing =
+            ScreenCaptureKitComputerUseContentProbe(),
         inputEmitter: any ComputerUseInputEmitting = CGEventComputerUseInputEmitter(),
         permissionReader: @escaping PermissionReader = MacAutomationPermissions.snapshot
     ) {
         self.targetProbe = targetProbe
+        self.contentProbe = contentProbe
         self.inputEmitter = inputEmitter
         self.permissionReader = permissionReader
     }
@@ -89,6 +98,19 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
         ) else {
             throw MacOSComputerUseActuationError.targetChanged
         }
+        // Capture once more after the target preflight. A matching frame alone
+        // is insufficient: controls can move while the window identity and
+        // geometry remain unchanged. Do not emit coordinates grounded against
+        // pixels that are no longer current.
+        let finalObservation = try await contentProbe.currentObservation(
+            for: currentObservation.target
+        )
+        try Task.checkCancellation()
+        guard currentObservation.representsSameInteractionState(
+            as: finalObservation
+        ) else {
+            throw MacOSComputerUseActuationError.staleObservation
+        }
         // The production emitter repeats this probe synchronously in the same
         // MainActor turn as each CGEvent post. The preflight here keeps all
         // emitters testable and rejects drift before entering the input layer.
@@ -109,6 +131,49 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
         // can bind text/key input to a verified element in this window, these
         // payloads must fail closed rather than rely on focus timing.
         return false
+    }
+}
+
+/// Performs the final content-revision check without retaining another image.
+struct ScreenCaptureKitComputerUseContentProbe: ComputerUseContentProbing {
+    private let captureSource: any ComputerUseWindowCapturing
+
+    init(
+        captureSource: any ComputerUseWindowCapturing =
+            ScreenCaptureKitComputerUseCapture()
+    ) {
+        self.captureSource = captureSource
+    }
+
+    func currentObservation(
+        for expected: WorkflowInteractionTarget
+    ) async throws -> WorkflowObservation {
+        guard let windowID = CGWindowID(expected.windowIdentifier), windowID != 0 else {
+            throw MacOSComputerUseActuationError.targetUnavailable
+        }
+        let captured = try await captureSource.capture(
+            ComputerUseWindowSelection(
+                bundleIdentifier: expected.bundleIdentifier,
+                processIdentifier: expected.processIdentifier,
+                windowID: windowID
+            )
+        )
+        try Task.checkCancellation()
+        guard captured.isStructurallyValid,
+              MacOSComputerUseWindowIdentity.targetsMatch(
+                captured.target,
+                expected
+              )
+        else {
+            throw MacOSComputerUseActuationError.targetChanged
+        }
+        return WorkflowObservation(
+            target: captured.target,
+            contentRevision: MacOSComputerUseObserver.contentRevision(
+                target: captured.target,
+                pngData: captured.artifact.pngData
+            )
+        )
     }
 }
 
@@ -242,7 +307,7 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
 
             switch payload {
             case .click(let normalizedX, let normalizedY):
-                let current = try Self.requireCurrent(
+                let initial = try Self.requireCurrent(
                     target,
                     using: targetReader,
                     cancellationCheck: cancellationCheck
@@ -250,7 +315,7 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 let point = try Self.clickPoint(
                     normalizedX: normalizedX,
                     normalizedY: normalizedY,
-                    in: current.windowFrame
+                    in: initial.windowFrame
                 )
                 guard let down = CGEvent(
                     mouseEventSource: source,
@@ -267,17 +332,51 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 else {
                     throw MacOSComputerUseActuationError.eventCreationFailed
                 }
-                guard windowAtPointReader(point) == target.windowIdentifier else {
-                    throw MacOSComputerUseActuationError.targetOccluded
-                }
-                try cancellationCheck()
-                eventPoster(down, target.processIdentifier)
-                eventPoster(up, target.processIdentifier)
+                try Self.post(
+                    down,
+                    at: point,
+                    expected: target,
+                    targetReader: targetReader,
+                    cancellationCheck: cancellationCheck,
+                    windowAtPointReader: windowAtPointReader,
+                    eventPoster: eventPoster
+                )
+                try Self.post(
+                    up,
+                    at: point,
+                    expected: target,
+                    targetReader: targetReader,
+                    cancellationCheck: cancellationCheck,
+                    windowAtPointReader: windowAtPointReader,
+                    eventPoster: eventPoster
+                )
 
             case .typeText, .keyPress:
                 throw MacOSComputerUseActuationError.invalidAction
             }
         }
+    }
+
+    @MainActor
+    private static func post(
+        _ event: CGEvent,
+        at point: CGPoint,
+        expected: WorkflowInteractionTarget,
+        targetReader: TargetReader,
+        cancellationCheck: CancellationCheck,
+        windowAtPointReader: WindowAtPointReader,
+        eventPoster: EventPoster
+    ) throws {
+        _ = try requireCurrent(
+            expected,
+            using: targetReader,
+            cancellationCheck: cancellationCheck
+        )
+        guard windowAtPointReader(point) == expected.windowIdentifier else {
+            throw MacOSComputerUseActuationError.targetOccluded
+        }
+        try cancellationCheck()
+        eventPoster(event, expected.processIdentifier)
     }
 
     static func clickPoint(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -351,20 +351,20 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
         permissionReader: PermissionReader,
         targetValidator: TargetValidator
     ) throws {
-        let currentBinding = try resolver(payload, target)
-        guard requiredBinding.representsSameElement(as: currentBinding) else {
-            throw MacOSComputerUseActuationError.elementChanged
-        }
         let permissions = permissionReader()
         guard permissions.isReadyForComputerUse else {
             throw MacOSComputerUseActuationError.permissionMissing(
                 permissions.missingForComputerUse
             )
         }
-        // Keep this as the last fallible validation before AXPress. Element
-        // resolution and permission reads can take long enough for another app
-        // to move in front of the selected window.
+        // Recheck the target before resolving the element because either set
+        // of cross-process queries can observe drift. The production resolver
+        // defensively repeats this target check after its AX queries as well.
         try targetValidator(payload, target)
+        let currentBinding = try resolver(payload, target)
+        guard requiredBinding.representsSameElement(as: currentBinding) else {
+            throw MacOSComputerUseActuationError.elementChanged
+        }
         try performer(currentBinding)
     }
 
@@ -454,6 +454,10 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
             throw MacOSComputerUseActuationError.elementUnavailable
         }
         let fingerprint = try elementFingerprint(element)
+        // AX queries above may take long enough for focus, geometry, or
+        // occlusion to change. Make the target check the resolver's final
+        // cross-process operation before returning the newly bound element.
+        try validateTarget(payload, expected)
         return ComputerUseElementBinding(
             fingerprint: fingerprint,
             element: element

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -52,14 +52,21 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
 
     func perform(
         _ action: GroundedWorkflowAction,
-        against currentObservation: WorkflowObservation
+        groundedAgainst groundingObservation: WorkflowObservation,
+        currentObservation: WorkflowObservation
     ) async throws {
         try Task.checkCancellation()
-        // The workflow kernel binds the action to its grounding observation,
-        // then deliberately passes a fresh, equivalent observation here. Its
-        // UUID is expected to differ; target/content equivalence was checked
-        // at that orchestration boundary.
-        guard currentObservation.isStructurallyValid else {
+        // The kernel deliberately re-observes before actuation, so the two
+        // observation UUIDs differ. Carry both states across this boundary so
+        // the adapter can independently verify the action's original binding
+        // and the fresh observation's target/content equivalence.
+        guard groundingObservation.isStructurallyValid,
+              currentObservation.isStructurallyValid,
+              action.observationID == groundingObservation.id,
+              groundingObservation.representsSameInteractionState(
+                as: currentObservation
+              )
+        else {
             throw MacOSComputerUseActuationError.staleObservation
         }
         guard Self.isSafeForWindowActuation(action.payload) else {

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -202,10 +202,12 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
     ) throws -> WorkflowInteractionTarget
     typealias CancellationCheck = @MainActor @Sendable () throws -> Void
     typealias WindowAtPointReader = @MainActor @Sendable (CGPoint) -> String?
+    typealias EventPoster = @MainActor @Sendable (CGEvent, pid_t) -> Void
 
     private let targetReader: TargetReader
     private let cancellationCheck: CancellationCheck
     private let windowAtPointReader: WindowAtPointReader
+    private let eventPoster: EventPoster
 
     init(
         targetReader: @escaping TargetReader = {
@@ -214,11 +216,15 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
         cancellationCheck: @escaping CancellationCheck = { try Task.checkCancellation() },
         windowAtPointReader: @escaping WindowAtPointReader = {
             MacOSComputerUseWindowIdentity.topmostWindowIdentifier(at: $0)
+        },
+        eventPoster: @escaping EventPoster = { event, processIdentifier in
+            event.postToPid(processIdentifier)
         }
     ) {
         self.targetReader = targetReader
         self.cancellationCheck = cancellationCheck
         self.windowAtPointReader = windowAtPointReader
+        self.eventPoster = eventPoster
     }
 
     private static let keyCodes: [String: CGKeyCode] = [
@@ -295,8 +301,8 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                     throw MacOSComputerUseActuationError.targetOccluded
                 }
                 try cancellationCheck()
-                down.post(tap: .cgAnnotatedSessionEventTap)
-                up.post(tap: .cgAnnotatedSessionEventTap)
+                eventPoster(down, target.processIdentifier)
+                eventPoster(up, target.processIdentifier)
 
             case .typeText:
                 // CGEvent accepts UTF-16. Scalar-safe chunks keep text off the
@@ -329,8 +335,8 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                         stringLength: chunk.count,
                         unicodeString: chunk
                     )
-                    down.post(tap: .cgAnnotatedSessionEventTap)
-                    up.post(tap: .cgAnnotatedSessionEventTap)
+                    eventPoster(down, target.processIdentifier)
+                    eventPoster(up, target.processIdentifier)
                 }
 
             case .keyPress(let key, let modifiers):
@@ -373,8 +379,8 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                     using: targetReader,
                     cancellationCheck: cancellationCheck
                 )
-                down.post(tap: .cgAnnotatedSessionEventTap)
-                up.post(tap: .cgAnnotatedSessionEventTap)
+                eventPoster(down, target.processIdentifier)
+                eventPoster(up, target.processIdentifier)
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -213,6 +213,24 @@ struct ComputerUseElementFingerprint: Equatable, Sendable {
     let frame: WorkflowWindowFrame
 }
 
+/// Main-actor token that retains the exact Accessibility object resolved
+/// before the final window capture. Metadata is kept as a second, defensive
+/// check, but is not sufficient by itself: a replacement control can expose
+/// identical role, title, identifier, and geometry.
+@MainActor
+final class ComputerUseElementBinding {
+    let fingerprint: ComputerUseElementFingerprint
+    fileprivate let element: AXUIElement?
+
+    init(
+        fingerprint: ComputerUseElementFingerprint,
+        element: AXUIElement? = nil
+    ) {
+        self.fingerprint = fingerprint
+        self.element = element
+    }
+}
+
 /// Element-bound click adapter. A coordinate is used only to resolve the
 /// current Accessibility element; input is delivered with AXPress to that
 /// element rather than through the global pointer event stream.
@@ -220,8 +238,8 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
     typealias ElementBoundary = @MainActor @Sendable (
         WorkflowActionPayload,
         WorkflowInteractionTarget,
-        ComputerUseElementFingerprint?
-    ) throws -> ComputerUseElementFingerprint
+        ComputerUseElementBinding?
+    ) throws -> ComputerUseElementBinding
 
     private let captureSource: any ComputerUseWindowCapturing
     private let elementBoundary: ElementBoundary
@@ -241,7 +259,7 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
     ) async throws {
         try Task.checkCancellation()
         let target = observation.target
-        let fingerprint = try await MainActor.run {
+        let binding = try await MainActor.run {
             try elementBoundary(payload, target, nil)
         }
 
@@ -271,7 +289,7 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
 
         try await MainActor.run {
             try Task.checkCancellation()
-            _ = try elementBoundary(payload, target, fingerprint)
+            _ = try elementBoundary(payload, target, binding)
         }
     }
 
@@ -279,8 +297,8 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
     private static func resolveAndOptionallyPress(
         _ payload: WorkflowActionPayload,
         _ expected: WorkflowInteractionTarget,
-        _ requiredFingerprint: ComputerUseElementFingerprint?
-    ) throws -> ComputerUseElementFingerprint {
+        _ requiredBinding: ComputerUseElementBinding?
+    ) throws -> ComputerUseElementBinding {
         guard case .click(let normalizedX, let normalizedY) = payload else {
             throw MacOSComputerUseActuationError.invalidAction
         }
@@ -337,8 +355,10 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
             throw MacOSComputerUseActuationError.elementUnavailable
         }
         let fingerprint = try elementFingerprint(element)
-        if let requiredFingerprint {
-            guard fingerprint == requiredFingerprint else {
+        if let requiredBinding {
+            guard fingerprint == requiredBinding.fingerprint,
+                  requiredBinding.element.map({ CFEqual($0, element) }) ?? true
+            else {
                 throw MacOSComputerUseActuationError.elementChanged
             }
             try Task.checkCancellation()
@@ -350,7 +370,10 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
                 throw MacOSComputerUseActuationError.elementActionFailed
             }
         }
-        return fingerprint
+        return ComputerUseElementBinding(
+            fingerprint: fingerprint,
+            element: element
+        )
     }
 
     static func clickPoint(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -244,10 +244,15 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
 
             switch payload {
             case .click(let normalizedX, let normalizedY):
-                let frame = target.windowFrame
-                let point = CGPoint(
-                    x: frame.x + normalizedX * frame.width,
-                    y: frame.y + normalizedY * frame.height
+                let current = try Self.requireCurrent(
+                    target,
+                    using: targetReader,
+                    cancellationCheck: cancellationCheck
+                )
+                let point = try Self.clickPoint(
+                    normalizedX: normalizedX,
+                    normalizedY: normalizedY,
+                    in: current.windowFrame
                 )
                 guard let down = CGEvent(
                     mouseEventSource: source,
@@ -264,12 +269,7 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 else {
                     throw MacOSComputerUseActuationError.eventCreationFailed
                 }
-                try Task.checkCancellation()
-                try Self.requireCurrent(
-                    target,
-                    using: targetReader,
-                    cancellationCheck: cancellationCheck
-                )
+                try cancellationCheck()
                 down.post(tap: .cgAnnotatedSessionEventTap)
                 up.post(tap: .cgAnnotatedSessionEventTap)
 
@@ -278,7 +278,7 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 // clipboard without splitting surrogate pairs between events.
                 for chunk in textChunks {
                     try Task.checkCancellation()
-                    try Self.requireCurrent(
+                    _ = try Self.requireCurrent(
                         target,
                         using: targetReader,
                         cancellationCheck: cancellationCheck
@@ -335,7 +335,7 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 down.flags = flags
                 up.flags = flags
                 try Task.checkCancellation()
-                try Self.requireCurrent(
+                _ = try Self.requireCurrent(
                     target,
                     using: targetReader,
                     cancellationCheck: cancellationCheck
@@ -368,16 +368,38 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
         return chunks
     }
 
+    static func clickPoint(
+        normalizedX: Double,
+        normalizedY: Double,
+        in frame: WorkflowWindowFrame
+    ) throws -> CGPoint {
+        let point = CGPoint(
+            x: frame.x + normalizedX * frame.width,
+            y: frame.y + normalizedY * frame.height
+        )
+        // A mathematically interior normalized value can round onto a pixel at
+        // the frame boundary. Never let that event escape the live window.
+        guard point.x > frame.x,
+              point.x < frame.x + frame.width,
+              point.y > frame.y,
+              point.y < frame.y + frame.height
+        else {
+            throw MacOSComputerUseActuationError.invalidAction
+        }
+        return point
+    }
+
     @MainActor
     private static func requireCurrent(
         _ expected: WorkflowInteractionTarget,
         using targetReader: TargetReader,
         cancellationCheck: CancellationCheck
-    ) throws {
+    ) throws -> WorkflowInteractionTarget {
         let current = try targetReader(expected)
         guard MacOSComputerUseWindowIdentity.targetsMatch(current, expected) else {
             throw MacOSComputerUseActuationError.targetChanged
         }
         try cancellationCheck()
+        return current
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -229,28 +229,47 @@ final class ComputerUseElementBinding {
         self.fingerprint = fingerprint
         self.element = element
     }
+
+    func representsSameElement(as other: ComputerUseElementBinding) -> Bool {
+        guard fingerprint == other.fingerprint else { return false }
+        switch (element, other.element) {
+        case let (original?, current?):
+            return CFEqual(original, current)
+        case (nil, nil):
+            // Synthetic bindings exist only behind the injected unit-test
+            // boundary. Preserve identity semantics there as well.
+            return self === other
+        default:
+            return false
+        }
+    }
 }
 
 /// Element-bound click adapter. A coordinate is used only to resolve the
 /// current Accessibility element; input is delivered with AXPress to that
 /// element rather than through the global pointer event stream.
 struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
-    typealias ElementBoundary = @MainActor @Sendable (
+    typealias ElementResolver = @MainActor @Sendable (
         WorkflowActionPayload,
-        WorkflowInteractionTarget,
-        ComputerUseElementBinding?
+        WorkflowInteractionTarget
     ) throws -> ComputerUseElementBinding
+    typealias ElementPerformer = @MainActor @Sendable (
+        ComputerUseElementBinding
+    ) throws -> Void
 
     private let captureSource: any ComputerUseWindowCapturing
-    private let elementBoundary: ElementBoundary
+    private let elementResolver: ElementResolver
+    private let elementPerformer: ElementPerformer
 
     init(
         captureSource: any ComputerUseWindowCapturing =
             ScreenCaptureKitComputerUseCapture(),
-        elementBoundary: @escaping ElementBoundary = Self.resolveAndOptionallyPress
+        elementResolver: @escaping ElementResolver = Self.resolve,
+        elementPerformer: @escaping ElementPerformer = Self.performPress
     ) {
         self.captureSource = captureSource
-        self.elementBoundary = elementBoundary
+        self.elementResolver = elementResolver
+        self.elementPerformer = elementPerformer
     }
 
     func emit(
@@ -260,7 +279,7 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
         try Task.checkCancellation()
         let target = observation.target
         let binding = try await MainActor.run {
-            try elementBoundary(payload, target, nil)
+            try elementResolver(payload, target)
         }
 
         guard let windowID = CGWindowID(target.windowIdentifier), windowID != 0 else {
@@ -289,15 +308,19 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
 
         try await MainActor.run {
             try Task.checkCancellation()
-            _ = try elementBoundary(payload, target, binding)
+            let currentBinding = try elementResolver(payload, target)
+            guard binding.representsSameElement(as: currentBinding) else {
+                throw MacOSComputerUseActuationError.elementChanged
+            }
+            try Task.checkCancellation()
+            try elementPerformer(currentBinding)
         }
     }
 
     @MainActor
-    private static func resolveAndOptionallyPress(
+    private static func resolve(
         _ payload: WorkflowActionPayload,
-        _ expected: WorkflowInteractionTarget,
-        _ requiredBinding: ComputerUseElementBinding?
+        _ expected: WorkflowInteractionTarget
     ) throws -> ComputerUseElementBinding {
         guard case .click(let normalizedX, let normalizedY) = payload else {
             throw MacOSComputerUseActuationError.invalidAction
@@ -355,25 +378,26 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
             throw MacOSComputerUseActuationError.elementUnavailable
         }
         let fingerprint = try elementFingerprint(element)
-        if let requiredBinding {
-            guard fingerprint == requiredBinding.fingerprint,
-                  requiredBinding.element.map({ CFEqual($0, element) }) ?? true
-            else {
-                throw MacOSComputerUseActuationError.elementChanged
-            }
-            try Task.checkCancellation()
-            guard AXUIElementPerformAction(
-                element,
-                kAXPressAction as CFString
-            ) == .success
-            else {
-                throw MacOSComputerUseActuationError.elementActionFailed
-            }
-        }
         return ComputerUseElementBinding(
             fingerprint: fingerprint,
             element: element
         )
+    }
+
+    @MainActor
+    private static func performPress(
+        _ binding: ComputerUseElementBinding
+    ) throws {
+        guard let element = binding.element else {
+            throw MacOSComputerUseActuationError.elementUnavailable
+        }
+        guard AXUIElementPerformAction(
+            element,
+            kAXPressAction as CFString
+        ) == .success
+        else {
+            throw MacOSComputerUseActuationError.elementActionFailed
+        }
     }
 
     static func clickPoint(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -341,15 +341,25 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                     windowAtPointReader: windowAtPointReader,
                     eventPoster: eventPoster
                 )
-                try Self.post(
-                    up,
-                    at: point,
-                    expected: target,
-                    targetReader: targetReader,
-                    cancellationCheck: cancellationCheck,
-                    windowAtPointReader: windowAtPointReader,
-                    eventPoster: eventPoster
-                )
+                do {
+                    try Self.post(
+                        up,
+                        at: point,
+                        expected: target,
+                        targetReader: targetReader,
+                        cancellationCheck: cancellationCheck,
+                        windowAtPointReader: windowAtPointReader,
+                        eventPoster: eventPoster
+                    )
+                } catch {
+                    // Once mouse-down has reached the selected process, always
+                    // balance its button state. Leaving it held can turn later
+                    // user movement into an unintended drag. This cleanup is
+                    // still process-bound; the original validation error is
+                    // preserved so the workflow cannot advance.
+                    eventPoster(up, target.processIdentifier)
+                    throw error
+                }
 
             case .typeText, .keyPress:
                 throw MacOSComputerUseActuationError.invalidAction

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -1,0 +1,267 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+enum MacOSComputerUseActuationError: Error, Equatable {
+    case permissionMissing([MacAutomationPermission])
+    case invalidAction
+    case staleObservation
+    case targetUnavailable
+    case targetNotFrontmost
+    case targetChanged
+    case unsupportedKey
+    case eventCreationFailed
+}
+
+protocol ComputerUseTargetProbing: Sendable {
+    func currentTarget(for expected: WorkflowInteractionTarget) async throws
+        -> WorkflowInteractionTarget
+}
+
+protocol ComputerUseInputEmitting: Sendable {
+    func emit(
+        _ payload: WorkflowActionPayload,
+        in target: WorkflowInteractionTarget
+    ) async throws
+}
+
+/// Production action boundary for local Computer Use.
+///
+/// The executor already re-observes immediately before calling this adapter.
+/// The adapter intentionally repeats the safety checks at the final input
+/// boundary: permission, observation identity, foreground process, exact
+/// window identity, and window geometry must all still match. It never
+/// activates an app or searches for a similar window on the user's behalf.
+actor MacOSComputerUseActuator: LocalWorkflowActuating {
+    typealias PermissionReader = @Sendable () -> MacAutomationPermissionSnapshot
+
+    private let permissionReader: PermissionReader
+    private let targetProbe: any ComputerUseTargetProbing
+    private let inputEmitter: any ComputerUseInputEmitting
+
+    init(
+        targetProbe: any ComputerUseTargetProbing = CGWindowComputerUseTargetProbe(),
+        inputEmitter: any ComputerUseInputEmitting = CGEventComputerUseInputEmitter(),
+        permissionReader: @escaping PermissionReader = MacAutomationPermissions.snapshot
+    ) {
+        self.targetProbe = targetProbe
+        self.inputEmitter = inputEmitter
+        self.permissionReader = permissionReader
+    }
+
+    func perform(
+        _ action: GroundedWorkflowAction,
+        against currentObservation: WorkflowObservation
+    ) async throws {
+        try Task.checkCancellation()
+        guard currentObservation.isStructurallyValid,
+              action.observationID == currentObservation.id
+        else {
+            throw MacOSComputerUseActuationError.staleObservation
+        }
+        guard action.payload.isStructurallyValid else {
+            throw MacOSComputerUseActuationError.invalidAction
+        }
+
+        let permissions = permissionReader()
+        guard permissions.isReadyForComputerUse else {
+            throw MacOSComputerUseActuationError.permissionMissing(
+                permissions.missingForComputerUse
+            )
+        }
+
+        let liveTarget = try await targetProbe.currentTarget(
+            for: currentObservation.target
+        )
+        try Task.checkCancellation()
+        guard Self.matches(liveTarget, currentObservation.target) else {
+            throw MacOSComputerUseActuationError.targetChanged
+        }
+        try await inputEmitter.emit(action.payload, in: liveTarget)
+    }
+
+    private static func matches(
+        _ live: WorkflowInteractionTarget,
+        _ observed: WorkflowInteractionTarget
+    ) -> Bool {
+        guard live.bundleIdentifier == observed.bundleIdentifier,
+              live.processIdentifier == observed.processIdentifier,
+              live.windowIdentifier == observed.windowIdentifier
+        else { return false }
+
+        let lhs = live.windowFrame
+        let rhs = observed.windowFrame
+        let tolerance = 0.5
+        return abs(lhs.x - rhs.x) <= tolerance
+            && abs(lhs.y - rhs.y) <= tolerance
+            && abs(lhs.width - rhs.width) <= tolerance
+            && abs(lhs.height - rhs.height) <= tolerance
+    }
+}
+
+/// Reads one exact CGWindow entry and requires its owner to remain frontmost.
+/// This is a probe only; it has no activation or focus-changing side effects.
+struct CGWindowComputerUseTargetProbe: ComputerUseTargetProbing {
+    func currentTarget(for expected: WorkflowInteractionTarget) async throws
+        -> WorkflowInteractionTarget
+    {
+        try Task.checkCancellation()
+        guard let windowID = CGWindowID(expected.windowIdentifier), windowID != 0 else {
+            throw MacOSComputerUseActuationError.targetUnavailable
+        }
+
+        return try await MainActor.run {
+            guard NSWorkspace.shared.frontmostApplication?.processIdentifier
+                    == expected.processIdentifier
+            else {
+                throw MacOSComputerUseActuationError.targetNotFrontmost
+            }
+            guard let records = CGWindowListCopyWindowInfo(
+                [.optionIncludingWindow, .excludeDesktopElements],
+                windowID
+            ) as? [[CFString: Any]],
+                let record = records.first,
+                let ownerPID = record[kCGWindowOwnerPID] as? NSNumber,
+                ownerPID.int32Value == expected.processIdentifier,
+                let bounds = record[kCGWindowBounds] as? [String: NSNumber],
+                let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary),
+                frame.width > 0,
+                frame.height > 0,
+                let application = NSRunningApplication(
+                    processIdentifier: expected.processIdentifier
+                ),
+                let bundleIdentifier = application.bundleIdentifier
+            else {
+                throw MacOSComputerUseActuationError.targetUnavailable
+            }
+
+            return WorkflowInteractionTarget(
+                bundleIdentifier: bundleIdentifier,
+                processIdentifier: expected.processIdentifier,
+                windowIdentifier: String(windowID),
+                windowFrame: WorkflowWindowFrame(
+                    x: frame.origin.x,
+                    y: frame.origin.y,
+                    width: frame.width,
+                    height: frame.height
+                )
+            )
+        }
+    }
+}
+
+/// Narrow CGEvent adapter. It supports only the three payloads authored by the
+/// workflow kernel and an explicit key/modifier allowlist.
+struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
+    private static let keyCodes: [String: CGKeyCode] = [
+        "return": 36,
+        "tab": 48,
+        "space": 49,
+        "delete": 51,
+        "escape": 53,
+        "left": 123,
+        "right": 124,
+        "down": 125,
+        "up": 126,
+    ]
+    private static let modifierFlags: [String: CGEventFlags] = [
+        "command": .maskCommand,
+        "shift": .maskShift,
+        "option": .maskAlternate,
+        "control": .maskControl,
+    ]
+
+    func emit(
+        _ payload: WorkflowActionPayload,
+        in target: WorkflowInteractionTarget
+    ) async throws {
+        try Task.checkCancellation()
+        guard let source = CGEventSource(stateID: .combinedSessionState) else {
+            throw MacOSComputerUseActuationError.eventCreationFailed
+        }
+
+        switch payload {
+        case .click(let normalizedX, let normalizedY):
+            let frame = target.windowFrame
+            let point = CGPoint(
+                x: frame.x + normalizedX * frame.width,
+                y: frame.y + normalizedY * frame.height
+            )
+            guard let down = CGEvent(
+                mouseEventSource: source,
+                mouseType: .leftMouseDown,
+                mouseCursorPosition: point,
+                mouseButton: .left
+            ),
+                let up = CGEvent(
+                    mouseEventSource: source,
+                    mouseType: .leftMouseUp,
+                    mouseCursorPosition: point,
+                    mouseButton: .left
+                )
+            else {
+                throw MacOSComputerUseActuationError.eventCreationFailed
+            }
+            try Task.checkCancellation()
+            down.post(tap: .cgAnnotatedSessionEventTap)
+            up.post(tap: .cgAnnotatedSessionEventTap)
+
+        case .typeText(let text):
+            // CGEvent accepts UTF-16. Chunking bounds each event while keeping
+            // text off the clipboard, so existing clipboard contents remain
+            // untouched and no global pasteboard observer receives the value.
+            let units = Array(text.utf16)
+            for start in stride(from: 0, to: units.count, by: 1_024) {
+                try Task.checkCancellation()
+                let chunk = Array(units[start ..< min(start + 1_024, units.count)])
+                guard let down = CGEvent(
+                    keyboardEventSource: source,
+                    virtualKey: 0,
+                    keyDown: true
+                ),
+                    let up = CGEvent(
+                        keyboardEventSource: source,
+                        virtualKey: 0,
+                        keyDown: false
+                    )
+                else {
+                    throw MacOSComputerUseActuationError.eventCreationFailed
+                }
+                down.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: chunk)
+                up.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: chunk)
+                down.post(tap: .cgAnnotatedSessionEventTap)
+                up.post(tap: .cgAnnotatedSessionEventTap)
+            }
+
+        case .keyPress(let key, let modifiers):
+            guard let keyCode = Self.keyCodes[key.lowercased()] else {
+                throw MacOSComputerUseActuationError.unsupportedKey
+            }
+            var flags: CGEventFlags = []
+            for modifier in modifiers {
+                guard let flag = Self.modifierFlags[modifier.lowercased()] else {
+                    throw MacOSComputerUseActuationError.unsupportedKey
+                }
+                flags.insert(flag)
+            }
+            guard let down = CGEvent(
+                keyboardEventSource: source,
+                virtualKey: keyCode,
+                keyDown: true
+            ),
+                let up = CGEvent(
+                    keyboardEventSource: source,
+                    virtualKey: keyCode,
+                    keyDown: false
+                )
+            else {
+                throw MacOSComputerUseActuationError.eventCreationFailed
+            }
+            down.flags = flags
+            up.flags = flags
+            try Task.checkCancellation()
+            down.post(tap: .cgAnnotatedSessionEventTap)
+            up.post(tap: .cgAnnotatedSessionEventTap)
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -314,13 +314,32 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
 
         try await MainActor.run {
             try Task.checkCancellation()
-            let currentBinding = try elementResolver(payload, target)
-            guard binding.representsSameElement(as: currentBinding) else {
-                throw MacOSComputerUseActuationError.elementChanged
-            }
-            try Task.checkCancellation()
-            try elementPerformer(currentBinding)
+            try Self.revalidateAndPerform(
+                payload,
+                target: target,
+                requiredBinding: binding,
+                resolver: elementResolver,
+                performer: elementPerformer
+            )
         }
+    }
+
+    /// Keeps the final focus/window/occlusion/element resolution and AX action
+    /// in one synchronous MainActor operation. There is deliberately no
+    /// suspension or cancellation check between the last validation and input.
+    @MainActor
+    private static func revalidateAndPerform(
+        _ payload: WorkflowActionPayload,
+        target: WorkflowInteractionTarget,
+        requiredBinding: ComputerUseElementBinding,
+        resolver: ElementResolver,
+        performer: ElementPerformer
+    ) throws {
+        let currentBinding = try resolver(payload, target)
+        guard requiredBinding.representsSameElement(as: currentBinding) else {
+            throw MacOSComputerUseActuationError.elementChanged
+        }
+        try performer(currentBinding)
     }
 
     @MainActor

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -238,6 +238,14 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
         "option": .maskAlternate,
         "control": .maskControl,
     ]
+    private static let allowedKeyChords: Set<String> = [
+        "return", "tab", "space", "delete", "escape",
+        "left", "right", "down", "up",
+        "shift+tab",
+        "shift+left", "shift+right", "shift+down", "shift+up",
+        "option+left", "option+right",
+        "command+left", "command+right", "command+down", "command+up",
+    ]
 
     func emit(
         _ payload: WorkflowActionPayload,
@@ -326,12 +334,20 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 }
 
             case .keyPress(let key, let modifiers):
-                guard let keyCode = Self.keyCodes[key.lowercased()] else {
+                let normalizedKey = key.lowercased()
+                let normalizedModifiers = modifiers.map { $0.lowercased() }
+                guard Set(normalizedModifiers).count == normalizedModifiers.count,
+                      let keyCode = Self.keyCodes[normalizedKey],
+                      normalizedModifiers.allSatisfy({ Self.modifierFlags[$0] != nil }),
+                      Self.allowedKeyChords.contains(
+                        (normalizedModifiers.sorted() + [normalizedKey]).joined(separator: "+")
+                      )
+                else {
                     throw MacOSComputerUseActuationError.unsupportedKey
                 }
                 var flags: CGEventFlags = []
-                for modifier in modifiers {
-                    guard let flag = Self.modifierFlags[modifier.lowercased()] else {
+                for modifier in normalizedModifiers {
+                    guard let flag = Self.modifierFlags[modifier] else {
                         throw MacOSComputerUseActuationError.unsupportedKey
                     }
                     flags.insert(flag)

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -261,23 +261,30 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
     typealias ElementPerformer = @MainActor @Sendable (
         ComputerUseElementBinding
     ) throws -> Void
+    typealias TargetValidator = @MainActor @Sendable (
+        WorkflowActionPayload,
+        WorkflowInteractionTarget
+    ) throws -> Void
 
     private let captureSource: any ComputerUseWindowCapturing
     private let elementResolver: ElementResolver
     private let elementPerformer: ElementPerformer
     private let permissionReader: PermissionReader
+    private let targetValidator: TargetValidator
 
     init(
         captureSource: any ComputerUseWindowCapturing =
             ScreenCaptureKitComputerUseCapture(),
         elementResolver: @escaping ElementResolver = Self.resolve,
         elementPerformer: @escaping ElementPerformer = Self.performPress,
-        permissionReader: @escaping PermissionReader = MacAutomationPermissions.snapshot
+        permissionReader: @escaping PermissionReader = MacAutomationPermissions.snapshot,
+        targetValidator: @escaping TargetValidator = Self.validateTarget
     ) {
         self.captureSource = captureSource
         self.elementResolver = elementResolver
         self.elementPerformer = elementPerformer
         self.permissionReader = permissionReader
+        self.targetValidator = targetValidator
     }
 
     func emit(
@@ -325,7 +332,8 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
                 requiredBinding: binding,
                 resolver: elementResolver,
                 performer: elementPerformer,
-                permissionReader: permissionReader
+                permissionReader: permissionReader,
+                targetValidator: targetValidator
             )
         }
     }
@@ -340,7 +348,8 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
         requiredBinding: ComputerUseElementBinding,
         resolver: ElementResolver,
         performer: ElementPerformer,
-        permissionReader: PermissionReader
+        permissionReader: PermissionReader,
+        targetValidator: TargetValidator
     ) throws {
         let currentBinding = try resolver(payload, target)
         guard requiredBinding.representsSameElement(as: currentBinding) else {
@@ -352,7 +361,36 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
                 permissions.missingForComputerUse
             )
         }
+        // Keep this as the last fallible validation before AXPress. Element
+        // resolution and permission reads can take long enough for another app
+        // to move in front of the selected window.
+        try targetValidator(payload, target)
         try performer(currentBinding)
+    }
+
+    @MainActor
+    private static func validateTarget(
+        _ payload: WorkflowActionPayload,
+        _ expected: WorkflowInteractionTarget
+    ) throws {
+        guard case .click(let normalizedX, let normalizedY) = payload else {
+            throw MacOSComputerUseActuationError.invalidAction
+        }
+        let current = try CGWindowComputerUseTargetProbe
+            .currentTargetSynchronously(for: expected)
+        guard MacOSComputerUseWindowIdentity.targetsMatch(current, expected) else {
+            throw MacOSComputerUseActuationError.targetChanged
+        }
+        let point = try clickPoint(
+            normalizedX: normalizedX,
+            normalizedY: normalizedY,
+            in: current.windowFrame
+        )
+        guard MacOSComputerUseWindowIdentity.topmostWindowIdentifier(at: point)
+                == expected.windowIdentifier
+        else {
+            throw MacOSComputerUseActuationError.targetOccluded
+        }
     }
 
     @MainActor

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -169,7 +169,9 @@ struct CGWindowComputerUseTargetProbe: ComputerUseTargetProbing {
             let application = NSRunningApplication(
                 processIdentifier: expected.processIdentifier
             ),
-            let bundleIdentifier = application.bundleIdentifier
+            let bundleIdentifier = application.bundleIdentifier,
+            let launchDate = application.launchDate,
+            launchDate == expected.processLaunchDate
         else {
             throw MacOSComputerUseActuationError.targetUnavailable
         }
@@ -194,6 +196,7 @@ struct CGWindowComputerUseTargetProbe: ComputerUseTargetProbing {
         return WorkflowInteractionTarget(
             bundleIdentifier: bundleIdentifier,
             processIdentifier: expected.processIdentifier,
+            processLaunchDate: launchDate,
             windowIdentifier: String(windowID),
             windowFrame: WorkflowWindowFrame(
                 x: frame.origin.x,
@@ -282,13 +285,16 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
             try elementResolver(payload, target)
         }
 
-        guard let windowID = CGWindowID(target.windowIdentifier), windowID != 0 else {
+        guard let windowID = CGWindowID(target.windowIdentifier), windowID != 0,
+              let processLaunchDate = target.processLaunchDate
+        else {
             throw MacOSComputerUseActuationError.targetUnavailable
         }
         let captured = try await captureSource.capture(
             ComputerUseWindowSelection(
                 bundleIdentifier: target.bundleIdentifier,
                 processIdentifier: target.processIdentifier,
+                processLaunchDate: processLaunchDate,
                 windowID: windowID
             )
         )

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -74,28 +74,16 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
             for: currentObservation.target
         )
         try Task.checkCancellation()
-        guard Self.matches(liveTarget, currentObservation.target) else {
+        guard MacOSComputerUseWindowIdentity.targetsMatch(
+            liveTarget,
+            currentObservation.target
+        ) else {
             throw MacOSComputerUseActuationError.targetChanged
         }
-        try await inputEmitter.emit(action.payload, in: liveTarget)
-    }
-
-    private static func matches(
-        _ live: WorkflowInteractionTarget,
-        _ observed: WorkflowInteractionTarget
-    ) -> Bool {
-        guard live.bundleIdentifier == observed.bundleIdentifier,
-              live.processIdentifier == observed.processIdentifier,
-              live.windowIdentifier == observed.windowIdentifier
-        else { return false }
-
-        let lhs = live.windowFrame
-        let rhs = observed.windowFrame
-        let tolerance = 0.5
-        return abs(lhs.x - rhs.x) <= tolerance
-            && abs(lhs.y - rhs.y) <= tolerance
-            && abs(lhs.width - rhs.width) <= tolerance
-            && abs(lhs.height - rhs.height) <= tolerance
+        // The production emitter repeats this probe synchronously in the same
+        // MainActor turn as each CGEvent post. The preflight here keeps all
+        // emitters testable and rejects drift before entering the input layer.
+        try await inputEmitter.emit(action.payload, in: currentObservation.target)
     }
 }
 
@@ -111,72 +99,96 @@ struct CGWindowComputerUseTargetProbe: ComputerUseTargetProbing {
         }
 
         return try await MainActor.run {
-            guard NSWorkspace.shared.frontmostApplication?.processIdentifier
-                    == expected.processIdentifier
-            else {
-                throw MacOSComputerUseActuationError.targetNotFrontmost
-            }
-            guard let focusedFrame = MacOSComputerUseWindowIdentity.focusedWindowFrame(
-                processIdentifier: expected.processIdentifier
-            ) else {
-                throw MacOSComputerUseActuationError.targetNotFrontmost
-            }
-            guard let records = CGWindowListCopyWindowInfo(
-                [.optionOnScreenOnly, .excludeDesktopElements],
-                kCGNullWindowID
-            ) as? [[CFString: Any]],
-                let record = records.first(where: {
-                    ($0[kCGWindowNumber] as? NSNumber)?.uint32Value == windowID
-                }),
-                let ownerPID = record[kCGWindowOwnerPID] as? NSNumber,
-                ownerPID.int32Value == expected.processIdentifier,
-                let bounds = record[kCGWindowBounds] as? [String: NSNumber],
-                let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary),
-                frame.width > 0,
-                frame.height > 0,
-                let application = NSRunningApplication(
-                    processIdentifier: expected.processIdentifier
-                ),
-                let bundleIdentifier = application.bundleIdentifier
-            else {
-                throw MacOSComputerUseActuationError.targetUnavailable
-            }
-
-            let focusedCandidates = records.filter { record in
-                guard let ownerPID = record[kCGWindowOwnerPID] as? NSNumber,
-                      ownerPID.int32Value == expected.processIdentifier,
-                      let bounds = record[kCGWindowBounds] as? [String: NSNumber],
-                      let frame = CGRect(
-                        dictionaryRepresentation: bounds as CFDictionary
-                      )
-                else { return false }
-                return MacOSComputerUseWindowIdentity.framesMatch(frame, focusedFrame)
-            }
-            guard focusedCandidates.count == 1,
-                  (focusedCandidates[0][kCGWindowNumber] as? NSNumber)?.uint32Value
-                    == windowID
-            else {
-                throw MacOSComputerUseActuationError.targetNotFrontmost
-            }
-
-            return WorkflowInteractionTarget(
-                bundleIdentifier: bundleIdentifier,
-                processIdentifier: expected.processIdentifier,
-                windowIdentifier: String(windowID),
-                windowFrame: WorkflowWindowFrame(
-                    x: frame.origin.x,
-                    y: frame.origin.y,
-                    width: frame.width,
-                    height: frame.height
-                )
-            )
+            try Self.currentTargetSynchronously(for: expected)
         }
+    }
+
+    @MainActor
+    static func currentTargetSynchronously(
+        for expected: WorkflowInteractionTarget
+    ) throws -> WorkflowInteractionTarget {
+        guard let windowID = CGWindowID(expected.windowIdentifier), windowID != 0 else {
+            throw MacOSComputerUseActuationError.targetUnavailable
+        }
+        guard NSWorkspace.shared.frontmostApplication?.processIdentifier
+                == expected.processIdentifier
+        else {
+            throw MacOSComputerUseActuationError.targetNotFrontmost
+        }
+        guard let focusedFrame = MacOSComputerUseWindowIdentity.focusedWindowFrame(
+            processIdentifier: expected.processIdentifier
+        ) else {
+            throw MacOSComputerUseActuationError.targetNotFrontmost
+        }
+        guard let records = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[CFString: Any]],
+            let record = records.first(where: {
+                ($0[kCGWindowNumber] as? NSNumber)?.uint32Value == windowID
+            }),
+            let ownerPID = record[kCGWindowOwnerPID] as? NSNumber,
+            ownerPID.int32Value == expected.processIdentifier,
+            let bounds = record[kCGWindowBounds] as? [String: NSNumber],
+            let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary),
+            frame.width > 0,
+            frame.height > 0,
+            let application = NSRunningApplication(
+                processIdentifier: expected.processIdentifier
+            ),
+            let bundleIdentifier = application.bundleIdentifier
+        else {
+            throw MacOSComputerUseActuationError.targetUnavailable
+        }
+
+        let focusedCandidates = records.filter { record in
+            guard let ownerPID = record[kCGWindowOwnerPID] as? NSNumber,
+                  ownerPID.int32Value == expected.processIdentifier,
+                  let bounds = record[kCGWindowBounds] as? [String: NSNumber],
+                  let frame = CGRect(
+                    dictionaryRepresentation: bounds as CFDictionary
+                  )
+            else { return false }
+            return MacOSComputerUseWindowIdentity.framesMatch(frame, focusedFrame)
+        }
+        guard focusedCandidates.count == 1,
+              (focusedCandidates[0][kCGWindowNumber] as? NSNumber)?.uint32Value
+                == windowID
+        else {
+            throw MacOSComputerUseActuationError.targetNotFrontmost
+        }
+
+        return WorkflowInteractionTarget(
+            bundleIdentifier: bundleIdentifier,
+            processIdentifier: expected.processIdentifier,
+            windowIdentifier: String(windowID),
+            windowFrame: WorkflowWindowFrame(
+                x: frame.origin.x,
+                y: frame.origin.y,
+                width: frame.width,
+                height: frame.height
+            )
+        )
     }
 }
 
 /// Narrow CGEvent adapter. It supports only the three payloads authored by the
 /// workflow kernel and an explicit key/modifier allowlist.
 struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
+    typealias TargetReader = @MainActor @Sendable (
+        WorkflowInteractionTarget
+    ) throws -> WorkflowInteractionTarget
+
+    private let targetReader: TargetReader
+
+    init(
+        targetReader: @escaping TargetReader = {
+            try CGWindowComputerUseTargetProbe.currentTargetSynchronously(for: $0)
+        }
+    ) {
+        self.targetReader = targetReader
+    }
+
     private static let keyCodes: [String: CGKeyCode] = [
         "return": 36,
         "tab": 48,
@@ -200,92 +212,140 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
         in target: WorkflowInteractionTarget
     ) async throws {
         try Task.checkCancellation()
-        guard let source = CGEventSource(stateID: .combinedSessionState) else {
-            throw MacOSComputerUseActuationError.eventCreationFailed
+        let textChunks: [[UniChar]]
+        if case .typeText(let text) = payload {
+            textChunks = Self.unicodeChunks(for: text)
+        } else {
+            textChunks = []
         }
 
-        switch payload {
-        case .click(let normalizedX, let normalizedY):
-            let frame = target.windowFrame
-            let point = CGPoint(
-                x: frame.x + normalizedX * frame.width,
-                y: frame.y + normalizedY * frame.height
-            )
-            guard let down = CGEvent(
-                mouseEventSource: source,
-                mouseType: .leftMouseDown,
-                mouseCursorPosition: point,
-                mouseButton: .left
-            ),
-                let up = CGEvent(
-                    mouseEventSource: source,
-                    mouseType: .leftMouseUp,
-                    mouseCursorPosition: point,
-                    mouseButton: .left
-                )
-            else {
+        try await MainActor.run {
+            guard let source = CGEventSource(stateID: .combinedSessionState) else {
                 throw MacOSComputerUseActuationError.eventCreationFailed
             }
-            try Task.checkCancellation()
-            down.post(tap: .cgAnnotatedSessionEventTap)
-            up.post(tap: .cgAnnotatedSessionEventTap)
 
-        case .typeText(let text):
-            // CGEvent accepts UTF-16. Chunking bounds each event while keeping
-            // text off the clipboard, so existing clipboard contents remain
-            // untouched and no global pasteboard observer receives the value.
-            let units = Array(text.utf16)
-            for start in stride(from: 0, to: units.count, by: 1_024) {
+            switch payload {
+            case .click(let normalizedX, let normalizedY):
+                let frame = target.windowFrame
+                let point = CGPoint(
+                    x: frame.x + normalizedX * frame.width,
+                    y: frame.y + normalizedY * frame.height
+                )
+                guard let down = CGEvent(
+                    mouseEventSource: source,
+                    mouseType: .leftMouseDown,
+                    mouseCursorPosition: point,
+                    mouseButton: .left
+                ),
+                    let up = CGEvent(
+                        mouseEventSource: source,
+                        mouseType: .leftMouseUp,
+                        mouseCursorPosition: point,
+                        mouseButton: .left
+                    )
+                else {
+                    throw MacOSComputerUseActuationError.eventCreationFailed
+                }
                 try Task.checkCancellation()
-                let chunk = Array(units[start ..< min(start + 1_024, units.count)])
+                try Self.requireCurrent(target, using: targetReader)
+                down.post(tap: .cgAnnotatedSessionEventTap)
+                up.post(tap: .cgAnnotatedSessionEventTap)
+
+            case .typeText:
+                // CGEvent accepts UTF-16. Scalar-safe chunks keep text off the
+                // clipboard without splitting surrogate pairs between events.
+                for chunk in textChunks {
+                    try Task.checkCancellation()
+                    try Self.requireCurrent(target, using: targetReader)
+                    guard let down = CGEvent(
+                        keyboardEventSource: source,
+                        virtualKey: 0,
+                        keyDown: true
+                    ),
+                        let up = CGEvent(
+                            keyboardEventSource: source,
+                            virtualKey: 0,
+                            keyDown: false
+                        )
+                    else {
+                        throw MacOSComputerUseActuationError.eventCreationFailed
+                    }
+                    down.keyboardSetUnicodeString(
+                        stringLength: chunk.count,
+                        unicodeString: chunk
+                    )
+                    up.keyboardSetUnicodeString(
+                        stringLength: chunk.count,
+                        unicodeString: chunk
+                    )
+                    down.post(tap: .cgAnnotatedSessionEventTap)
+                    up.post(tap: .cgAnnotatedSessionEventTap)
+                }
+
+            case .keyPress(let key, let modifiers):
+                guard let keyCode = Self.keyCodes[key.lowercased()] else {
+                    throw MacOSComputerUseActuationError.unsupportedKey
+                }
+                var flags: CGEventFlags = []
+                for modifier in modifiers {
+                    guard let flag = Self.modifierFlags[modifier.lowercased()] else {
+                        throw MacOSComputerUseActuationError.unsupportedKey
+                    }
+                    flags.insert(flag)
+                }
                 guard let down = CGEvent(
                     keyboardEventSource: source,
-                    virtualKey: 0,
+                    virtualKey: keyCode,
                     keyDown: true
                 ),
                     let up = CGEvent(
                         keyboardEventSource: source,
-                        virtualKey: 0,
+                        virtualKey: keyCode,
                         keyDown: false
                     )
                 else {
                     throw MacOSComputerUseActuationError.eventCreationFailed
                 }
-                down.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: chunk)
-                up.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: chunk)
+                down.flags = flags
+                up.flags = flags
+                try Task.checkCancellation()
+                try Self.requireCurrent(target, using: targetReader)
                 down.post(tap: .cgAnnotatedSessionEventTap)
                 up.post(tap: .cgAnnotatedSessionEventTap)
             }
+        }
+    }
 
-        case .keyPress(let key, let modifiers):
-            guard let keyCode = Self.keyCodes[key.lowercased()] else {
-                throw MacOSComputerUseActuationError.unsupportedKey
+    static func unicodeChunks(
+        for text: String,
+        maximumUTF16Units: Int = 1_024
+    ) -> [[UniChar]] {
+        precondition(maximumUTF16Units >= 2)
+        var chunks: [[UniChar]] = []
+        var current: [UniChar] = []
+        current.reserveCapacity(maximumUTF16Units)
+
+        for scalar in text.unicodeScalars {
+            let units = Array(String(scalar).utf16)
+            if current.count + units.count > maximumUTF16Units {
+                chunks.append(current)
+                current = []
+                current.reserveCapacity(maximumUTF16Units)
             }
-            var flags: CGEventFlags = []
-            for modifier in modifiers {
-                guard let flag = Self.modifierFlags[modifier.lowercased()] else {
-                    throw MacOSComputerUseActuationError.unsupportedKey
-                }
-                flags.insert(flag)
-            }
-            guard let down = CGEvent(
-                keyboardEventSource: source,
-                virtualKey: keyCode,
-                keyDown: true
-            ),
-                let up = CGEvent(
-                    keyboardEventSource: source,
-                    virtualKey: keyCode,
-                    keyDown: false
-                )
-            else {
-                throw MacOSComputerUseActuationError.eventCreationFailed
-            }
-            down.flags = flags
-            up.flags = flags
-            try Task.checkCancellation()
-            down.post(tap: .cgAnnotatedSessionEventTap)
-            up.post(tap: .cgAnnotatedSessionEventTap)
+            current.append(contentsOf: units)
+        }
+        if !current.isEmpty { chunks.append(current) }
+        return chunks
+    }
+
+    @MainActor
+    private static func requireCurrent(
+        _ expected: WorkflowInteractionTarget,
+        using targetReader: TargetReader
+    ) throws {
+        let current = try targetReader(expected)
+        guard MacOSComputerUseWindowIdentity.targetsMatch(current, expected) else {
+            throw MacOSComputerUseActuationError.targetChanged
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -10,7 +10,6 @@ enum MacOSComputerUseActuationError: Error, Equatable {
     case targetNotFrontmost
     case targetChanged
     case targetOccluded
-    case unsupportedKey
     case eventCreationFailed
 }
 
@@ -105,7 +104,11 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
             // maxX/maxY can belong to the adjacent or underlying window.
             return x > 0 && x < 1 && y > 0 && y < 1
         }
-        return true
+        // Public macOS event APIs can target a process, but not one exact
+        // window inside that process. Until a semantic Accessibility adapter
+        // can bind text/key input to a verified element in this window, these
+        // payloads must fail closed rather than rely on focus timing.
+        return false
     }
 }
 
@@ -194,8 +197,7 @@ struct CGWindowComputerUseTargetProbe: ComputerUseTargetProbing {
     }
 }
 
-/// Narrow CGEvent adapter. It supports only the three payloads authored by the
-/// workflow kernel and an explicit key/modifier allowlist.
+/// Narrow CGEvent adapter for process-bound clicks in one verified window.
 struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
     typealias TargetReader = @MainActor @Sendable (
         WorkflowInteractionTarget
@@ -227,43 +229,11 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
         self.eventPoster = eventPoster
     }
 
-    private static let keyCodes: [String: CGKeyCode] = [
-        "return": 36,
-        "tab": 48,
-        "space": 49,
-        "delete": 51,
-        "escape": 53,
-        "left": 123,
-        "right": 124,
-        "down": 125,
-        "up": 126,
-    ]
-    private static let modifierFlags: [String: CGEventFlags] = [
-        "command": .maskCommand,
-        "shift": .maskShift,
-        "option": .maskAlternate,
-        "control": .maskControl,
-    ]
-    private static let allowedKeyChords: Set<String> = [
-        "return", "tab", "space", "delete", "escape",
-        "left", "right", "down", "up",
-        "shift+tab",
-        "shift+left", "shift+right", "shift+down", "shift+up",
-        "option+left", "option+right",
-        "command+left", "command+right", "command+down", "command+up",
-    ]
-
     func emit(
         _ payload: WorkflowActionPayload,
         in target: WorkflowInteractionTarget
     ) async throws {
         try Task.checkCancellation()
-        let textChunks: [[UniChar]]
-        if case .typeText(let text) = payload {
-            textChunks = Self.unicodeChunks(for: text)
-        } else {
-            textChunks = []
-        }
 
         try await MainActor.run {
             guard let source = CGEventSource(stateID: .combinedSessionState) else {
@@ -304,107 +274,10 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 eventPoster(down, target.processIdentifier)
                 eventPoster(up, target.processIdentifier)
 
-            case .typeText:
-                // CGEvent accepts UTF-16. Scalar-safe chunks keep text off the
-                // clipboard without splitting surrogate pairs between events.
-                for chunk in textChunks {
-                    try Task.checkCancellation()
-                    _ = try Self.requireCurrent(
-                        target,
-                        using: targetReader,
-                        cancellationCheck: cancellationCheck
-                    )
-                    guard let down = CGEvent(
-                        keyboardEventSource: source,
-                        virtualKey: 0,
-                        keyDown: true
-                    ),
-                        let up = CGEvent(
-                            keyboardEventSource: source,
-                            virtualKey: 0,
-                            keyDown: false
-                        )
-                    else {
-                        throw MacOSComputerUseActuationError.eventCreationFailed
-                    }
-                    down.keyboardSetUnicodeString(
-                        stringLength: chunk.count,
-                        unicodeString: chunk
-                    )
-                    up.keyboardSetUnicodeString(
-                        stringLength: chunk.count,
-                        unicodeString: chunk
-                    )
-                    eventPoster(down, target.processIdentifier)
-                    eventPoster(up, target.processIdentifier)
-                }
-
-            case .keyPress(let key, let modifiers):
-                let normalizedKey = key.lowercased()
-                let normalizedModifiers = modifiers.map { $0.lowercased() }
-                guard Set(normalizedModifiers).count == normalizedModifiers.count,
-                      let keyCode = Self.keyCodes[normalizedKey],
-                      normalizedModifiers.allSatisfy({ Self.modifierFlags[$0] != nil }),
-                      Self.allowedKeyChords.contains(
-                        (normalizedModifiers.sorted() + [normalizedKey]).joined(separator: "+")
-                      )
-                else {
-                    throw MacOSComputerUseActuationError.unsupportedKey
-                }
-                var flags: CGEventFlags = []
-                for modifier in normalizedModifiers {
-                    guard let flag = Self.modifierFlags[modifier] else {
-                        throw MacOSComputerUseActuationError.unsupportedKey
-                    }
-                    flags.insert(flag)
-                }
-                guard let down = CGEvent(
-                    keyboardEventSource: source,
-                    virtualKey: keyCode,
-                    keyDown: true
-                ),
-                    let up = CGEvent(
-                        keyboardEventSource: source,
-                        virtualKey: keyCode,
-                        keyDown: false
-                    )
-                else {
-                    throw MacOSComputerUseActuationError.eventCreationFailed
-                }
-                down.flags = flags
-                up.flags = flags
-                try Task.checkCancellation()
-                _ = try Self.requireCurrent(
-                    target,
-                    using: targetReader,
-                    cancellationCheck: cancellationCheck
-                )
-                eventPoster(down, target.processIdentifier)
-                eventPoster(up, target.processIdentifier)
+            case .typeText, .keyPress:
+                throw MacOSComputerUseActuationError.invalidAction
             }
         }
-    }
-
-    static func unicodeChunks(
-        for text: String,
-        maximumUTF16Units: Int = 1_024
-    ) -> [[UniChar]] {
-        precondition(maximumUTF16Units >= 2)
-        var chunks: [[UniChar]] = []
-        var current: [UniChar] = []
-        current.reserveCapacity(maximumUTF16Units)
-
-        for scalar in text.unicodeScalars {
-            let units = Array(String(scalar).utf16)
-            if current.count + units.count > maximumUTF16Units {
-                chunks.append(current)
-                current = []
-                current.reserveCapacity(maximumUTF16Units)
-            }
-            current.append(contentsOf: units)
-        }
-        if !current.isEmpty { chunks.append(current) }
-        return chunks
     }
 
     static func clickPoint(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -116,11 +116,18 @@ struct CGWindowComputerUseTargetProbe: ComputerUseTargetProbing {
             else {
                 throw MacOSComputerUseActuationError.targetNotFrontmost
             }
+            guard let focusedFrame = MacOSComputerUseWindowIdentity.focusedWindowFrame(
+                processIdentifier: expected.processIdentifier
+            ) else {
+                throw MacOSComputerUseActuationError.targetNotFrontmost
+            }
             guard let records = CGWindowListCopyWindowInfo(
-                [.optionIncludingWindow, .excludeDesktopElements],
-                windowID
+                [.optionOnScreenOnly, .excludeDesktopElements],
+                kCGNullWindowID
             ) as? [[CFString: Any]],
-                let record = records.first,
+                let record = records.first(where: {
+                    ($0[kCGWindowNumber] as? NSNumber)?.uint32Value == windowID
+                }),
                 let ownerPID = record[kCGWindowOwnerPID] as? NSNumber,
                 ownerPID.int32Value == expected.processIdentifier,
                 let bounds = record[kCGWindowBounds] as? [String: NSNumber],
@@ -133,6 +140,23 @@ struct CGWindowComputerUseTargetProbe: ComputerUseTargetProbing {
                 let bundleIdentifier = application.bundleIdentifier
             else {
                 throw MacOSComputerUseActuationError.targetUnavailable
+            }
+
+            let focusedCandidates = records.filter { record in
+                guard let ownerPID = record[kCGWindowOwnerPID] as? NSNumber,
+                      ownerPID.int32Value == expected.processIdentifier,
+                      let bounds = record[kCGWindowBounds] as? [String: NSNumber],
+                      let frame = CGRect(
+                        dictionaryRepresentation: bounds as CFDictionary
+                      )
+                else { return false }
+                return MacOSComputerUseWindowIdentity.framesMatch(frame, focusedFrame)
+            }
+            guard focusedCandidates.count == 1,
+                  (focusedCandidates[0][kCGWindowNumber] as? NSNumber)?.uint32Value
+                    == windowID
+            else {
+                throw MacOSComputerUseActuationError.targetNotFrontmost
             }
 
             return WorkflowInteractionTarget(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -252,6 +252,8 @@ final class ComputerUseElementBinding {
 /// current Accessibility element; input is delivered with AXPress to that
 /// element rather than through the global pointer event stream.
 struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
+    typealias PermissionReader = @MainActor @Sendable ()
+        -> MacAutomationPermissionSnapshot
     typealias ElementResolver = @MainActor @Sendable (
         WorkflowActionPayload,
         WorkflowInteractionTarget
@@ -263,16 +265,19 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
     private let captureSource: any ComputerUseWindowCapturing
     private let elementResolver: ElementResolver
     private let elementPerformer: ElementPerformer
+    private let permissionReader: PermissionReader
 
     init(
         captureSource: any ComputerUseWindowCapturing =
             ScreenCaptureKitComputerUseCapture(),
         elementResolver: @escaping ElementResolver = Self.resolve,
-        elementPerformer: @escaping ElementPerformer = Self.performPress
+        elementPerformer: @escaping ElementPerformer = Self.performPress,
+        permissionReader: @escaping PermissionReader = MacAutomationPermissions.snapshot
     ) {
         self.captureSource = captureSource
         self.elementResolver = elementResolver
         self.elementPerformer = elementPerformer
+        self.permissionReader = permissionReader
     }
 
     func emit(
@@ -319,7 +324,8 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
                 target: target,
                 requiredBinding: binding,
                 resolver: elementResolver,
-                performer: elementPerformer
+                performer: elementPerformer,
+                permissionReader: permissionReader
             )
         }
     }
@@ -333,11 +339,18 @@ struct AXComputerUseInputEmitter: ComputerUseInputEmitting {
         target: WorkflowInteractionTarget,
         requiredBinding: ComputerUseElementBinding,
         resolver: ElementResolver,
-        performer: ElementPerformer
+        performer: ElementPerformer,
+        permissionReader: PermissionReader
     ) throws {
         let currentBinding = try resolver(payload, target)
         guard requiredBinding.representsSameElement(as: currentBinding) else {
             throw MacOSComputerUseActuationError.elementChanged
+        }
+        let permissions = permissionReader()
+        guard permissions.isReadyForComputerUse else {
+            throw MacOSComputerUseActuationError.permissionMissing(
+                permissions.missingForComputerUse
+            )
         }
         try performer(currentBinding)
     }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -9,6 +9,7 @@ enum MacOSComputerUseActuationError: Error, Equatable {
     case targetUnavailable
     case targetNotFrontmost
     case targetChanged
+    case targetOccluded
     case unsupportedKey
     case eventCreationFailed
 }
@@ -193,18 +194,24 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
         WorkflowInteractionTarget
     ) throws -> WorkflowInteractionTarget
     typealias CancellationCheck = @MainActor @Sendable () throws -> Void
+    typealias WindowAtPointReader = @MainActor @Sendable (CGPoint) -> String?
 
     private let targetReader: TargetReader
     private let cancellationCheck: CancellationCheck
+    private let windowAtPointReader: WindowAtPointReader
 
     init(
         targetReader: @escaping TargetReader = {
             try CGWindowComputerUseTargetProbe.currentTargetSynchronously(for: $0)
         },
-        cancellationCheck: @escaping CancellationCheck = { try Task.checkCancellation() }
+        cancellationCheck: @escaping CancellationCheck = { try Task.checkCancellation() },
+        windowAtPointReader: @escaping WindowAtPointReader = {
+            MacOSComputerUseWindowIdentity.topmostWindowIdentifier(at: $0)
+        }
     ) {
         self.targetReader = targetReader
         self.cancellationCheck = cancellationCheck
+        self.windowAtPointReader = windowAtPointReader
     }
 
     private static let keyCodes: [String: CGKeyCode] = [
@@ -268,6 +275,9 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                     )
                 else {
                     throw MacOSComputerUseActuationError.eventCreationFailed
+                }
+                guard windowAtPointReader(point) == target.windowIdentifier else {
+                    throw MacOSComputerUseActuationError.targetOccluded
                 }
                 try cancellationCheck()
                 down.post(tap: .cgAnnotatedSessionEventTap)

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseActuation.swift
@@ -54,12 +54,14 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
         against currentObservation: WorkflowObservation
     ) async throws {
         try Task.checkCancellation()
-        guard currentObservation.isStructurallyValid,
-              action.observationID == currentObservation.id
-        else {
+        // The workflow kernel binds the action to its grounding observation,
+        // then deliberately passes a fresh, equivalent observation here. Its
+        // UUID is expected to differ; target/content equivalence was checked
+        // at that orchestration boundary.
+        guard currentObservation.isStructurallyValid else {
             throw MacOSComputerUseActuationError.staleObservation
         }
-        guard action.payload.isStructurallyValid else {
+        guard Self.isSafeForWindowActuation(action.payload) else {
             throw MacOSComputerUseActuationError.invalidAction
         }
 
@@ -84,6 +86,18 @@ actor MacOSComputerUseActuator: LocalWorkflowActuating {
         // MainActor turn as each CGEvent post. The preflight here keeps all
         // emitters testable and rejects drift before entering the input layer.
         try await inputEmitter.emit(action.payload, in: currentObservation.target)
+    }
+
+    private static func isSafeForWindowActuation(
+        _ payload: WorkflowActionPayload
+    ) -> Bool {
+        guard payload.isStructurallyValid else { return false }
+        if case .click(let x, let y) = payload {
+            // 0 and 1 are window edges, not interior points. A CGEvent at
+            // maxX/maxY can belong to the adjacent or underlying window.
+            return x > 0 && x < 1 && y > 0 && y < 1
+        }
+        return true
     }
 }
 
@@ -178,15 +192,19 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
     typealias TargetReader = @MainActor @Sendable (
         WorkflowInteractionTarget
     ) throws -> WorkflowInteractionTarget
+    typealias CancellationCheck = @MainActor @Sendable () throws -> Void
 
     private let targetReader: TargetReader
+    private let cancellationCheck: CancellationCheck
 
     init(
         targetReader: @escaping TargetReader = {
             try CGWindowComputerUseTargetProbe.currentTargetSynchronously(for: $0)
-        }
+        },
+        cancellationCheck: @escaping CancellationCheck = { try Task.checkCancellation() }
     ) {
         self.targetReader = targetReader
+        self.cancellationCheck = cancellationCheck
     }
 
     private static let keyCodes: [String: CGKeyCode] = [
@@ -247,7 +265,11 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                     throw MacOSComputerUseActuationError.eventCreationFailed
                 }
                 try Task.checkCancellation()
-                try Self.requireCurrent(target, using: targetReader)
+                try Self.requireCurrent(
+                    target,
+                    using: targetReader,
+                    cancellationCheck: cancellationCheck
+                )
                 down.post(tap: .cgAnnotatedSessionEventTap)
                 up.post(tap: .cgAnnotatedSessionEventTap)
 
@@ -256,7 +278,11 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 // clipboard without splitting surrogate pairs between events.
                 for chunk in textChunks {
                     try Task.checkCancellation()
-                    try Self.requireCurrent(target, using: targetReader)
+                    try Self.requireCurrent(
+                        target,
+                        using: targetReader,
+                        cancellationCheck: cancellationCheck
+                    )
                     guard let down = CGEvent(
                         keyboardEventSource: source,
                         virtualKey: 0,
@@ -309,7 +335,11 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
                 down.flags = flags
                 up.flags = flags
                 try Task.checkCancellation()
-                try Self.requireCurrent(target, using: targetReader)
+                try Self.requireCurrent(
+                    target,
+                    using: targetReader,
+                    cancellationCheck: cancellationCheck
+                )
                 down.post(tap: .cgAnnotatedSessionEventTap)
                 up.post(tap: .cgAnnotatedSessionEventTap)
             }
@@ -341,11 +371,13 @@ struct CGEventComputerUseInputEmitter: ComputerUseInputEmitting {
     @MainActor
     private static func requireCurrent(
         _ expected: WorkflowInteractionTarget,
-        using targetReader: TargetReader
+        using targetReader: TargetReader,
+        cancellationCheck: CancellationCheck
     ) throws {
         let current = try targetReader(expected)
         guard MacOSComputerUseWindowIdentity.targetsMatch(current, expected) else {
             throw MacOSComputerUseActuationError.targetChanged
         }
+        try cancellationCheck()
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
@@ -1,0 +1,249 @@
+import AppKit
+import CryptoKit
+import Foundation
+import ScreenCaptureKit
+
+/// A window the user explicitly allowed one Computer Use step to observe.
+/// Window IDs are session-scoped and are never treated as durable selectors.
+struct ComputerUseWindowSelection: Equatable, Sendable {
+    let bundleIdentifier: String
+    let windowID: CGWindowID
+
+    var isStructurallyValid: Bool {
+        !bundleIdentifier.isEmpty && windowID != 0
+    }
+}
+
+/// Ephemeral pixels for a single ``WorkflowObservation``. This deliberately is
+/// not Codable: screenshots may be given to the local grounder during a run,
+/// but they must not enter workflow persistence or the audit ledger.
+struct ComputerUseObservationArtifact: Equatable, Sendable {
+    let pngData: Data
+    let pixelWidth: Int
+    let pixelHeight: Int
+
+    var isStructurallyValid: Bool {
+        !pngData.isEmpty && pixelWidth > 0 && pixelHeight > 0
+    }
+}
+
+struct ComputerUseCapturedWindow: Equatable, Sendable {
+    let target: WorkflowInteractionTarget
+    let artifact: ComputerUseObservationArtifact
+
+    var isStructurallyValid: Bool {
+        target.windowFrame.isStructurallyValid && artifact.isStructurallyValid
+    }
+}
+
+enum MacOSComputerUseObservationError: Error, Equatable {
+    case permissionMissing([MacAutomationPermission])
+    case targetNotConfigured
+    case targetUnavailable
+    case targetNotFrontmost
+    case invalidCapture
+}
+
+protocol ComputerUseWindowCapturing: Sendable {
+    func capture(_ selection: ComputerUseWindowSelection) async throws
+        -> ComputerUseCapturedWindow
+}
+
+/// Memory-only bridge between the observer and a later local visual grounder.
+/// A small FIFO cap prevents a long or failed run from retaining desktop
+/// screenshots indefinitely.
+actor ComputerUseObservationVault {
+    private let maximumArtifacts: Int
+    private var artifacts: [UUID: ComputerUseObservationArtifact] = [:]
+    private var insertionOrder: [UUID] = []
+
+    init(maximumArtifacts: Int = 6) {
+        self.maximumArtifacts = max(1, maximumArtifacts)
+    }
+
+    func store(_ artifact: ComputerUseObservationArtifact, for id: UUID) {
+        if artifacts[id] == nil { insertionOrder.append(id) }
+        artifacts[id] = artifact
+        while insertionOrder.count > maximumArtifacts {
+            let evicted = insertionOrder.removeFirst()
+            artifacts.removeValue(forKey: evicted)
+        }
+    }
+
+    func artifact(for id: UUID) -> ComputerUseObservationArtifact? {
+        artifacts[id]
+    }
+
+    func removeAll() {
+        artifacts.removeAll(keepingCapacity: false)
+        insertionOrder.removeAll(keepingCapacity: false)
+    }
+}
+
+/// Production ``LocalWorkflowObserving`` adapter. It rechecks both TCC grants
+/// for every observation and resolves the target from the compiled step ID.
+/// The caller must populate this map from an explicit per-run window choice;
+/// the observer never falls back to the whole desktop or a similarly titled
+/// window.
+actor MacOSComputerUseObserver: LocalWorkflowObserving {
+    typealias PermissionReader = @Sendable () -> MacAutomationPermissionSnapshot
+
+    private let selections: [String: ComputerUseWindowSelection]
+    private let permissionReader: PermissionReader
+    private let captureSource: any ComputerUseWindowCapturing
+    private let vault: ComputerUseObservationVault
+
+    init(
+        selections: [String: ComputerUseWindowSelection],
+        vault: ComputerUseObservationVault,
+        captureSource: any ComputerUseWindowCapturing = ScreenCaptureKitComputerUseCapture(),
+        permissionReader: @escaping PermissionReader = MacAutomationPermissions.snapshot
+    ) {
+        self.selections = selections
+        self.vault = vault
+        self.captureSource = captureSource
+        self.permissionReader = permissionReader
+    }
+
+    func observe(for step: LocalWorkflowStep) async throws -> WorkflowObservation {
+        try Task.checkCancellation()
+        let permissions = permissionReader()
+        guard permissions.isReadyForComputerUse else {
+            throw MacOSComputerUseObservationError.permissionMissing(
+                permissions.missingForComputerUse
+            )
+        }
+        guard let selection = selections[step.id], selection.isStructurallyValid else {
+            throw MacOSComputerUseObservationError.targetNotConfigured
+        }
+
+        let captured = try await captureSource.capture(selection)
+        try Task.checkCancellation()
+        guard captured.isStructurallyValid,
+              captured.target.bundleIdentifier == selection.bundleIdentifier,
+              captured.target.windowIdentifier == String(selection.windowID)
+        else {
+            throw MacOSComputerUseObservationError.invalidCapture
+        }
+
+        let id = UUID()
+        let observation = WorkflowObservation(
+            id: id,
+            target: captured.target,
+            contentRevision: Self.contentRevision(
+                target: captured.target,
+                pngData: captured.artifact.pngData
+            )
+        )
+        await vault.store(captured.artifact, for: id)
+        return observation
+    }
+
+    private static func contentRevision(
+        target: WorkflowInteractionTarget,
+        pngData: Data
+    ) -> String {
+        var bytes = Data(
+            "\(target.bundleIdentifier)|\(target.processIdentifier)|"
+                .utf8
+        )
+        bytes.append(Data("\(target.windowIdentifier)|".utf8))
+        let frame = target.windowFrame
+        bytes.append(Data("\(frame.x)|\(frame.y)|\(frame.width)|\(frame.height)|".utf8))
+        bytes.append(pngData)
+        return SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// ScreenCaptureKit implementation restricted to one exact, on-screen window.
+/// It rejects background/focus drift rather than bringing an app forward as a
+/// hidden side effect of observation.
+struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
+    func capture(_ selection: ComputerUseWindowSelection) async throws
+        -> ComputerUseCapturedWindow
+    {
+        guard selection.isStructurallyValid else {
+            throw MacOSComputerUseObservationError.targetNotConfigured
+        }
+        try Task.checkCancellation()
+
+        let frontmost = await MainActor.run {
+            let app = NSWorkspace.shared.frontmostApplication
+            return (app?.bundleIdentifier, app?.processIdentifier)
+        }
+        guard frontmost.0 == selection.bundleIdentifier else {
+            throw MacOSComputerUseObservationError.targetNotFrontmost
+        }
+
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            true,
+            onScreenWindowsOnly: true
+        )
+        try Task.checkCancellation()
+        guard let window = content.windows.first(where: {
+            $0.windowID == selection.windowID
+                && $0.owningApplication?.bundleIdentifier == selection.bundleIdentifier
+        }),
+            let application = window.owningApplication,
+            application.processID == frontmost.1,
+            window.isOnScreen
+        else {
+            throw MacOSComputerUseObservationError.targetUnavailable
+        }
+
+        let frame = window.frame
+        guard frame.origin.x.isFinite, frame.origin.y.isFinite,
+              frame.width.isFinite, frame.height.isFinite,
+              frame.width > 0, frame.height > 0
+        else {
+            throw MacOSComputerUseObservationError.invalidCapture
+        }
+
+        let output = Self.outputSize(for: frame.size)
+        let configuration = SCStreamConfiguration()
+        configuration.width = output.width
+        configuration.height = output.height
+        configuration.showsCursor = false
+        configuration.ignoreShadowsSingleWindow = true
+
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let image = try await SCScreenshotManager.captureImage(
+            contentFilter: filter,
+            configuration: configuration
+        )
+        try Task.checkCancellation()
+        guard let png = NSBitmapImageRep(cgImage: image).representation(
+            using: .png,
+            properties: [:]
+        ) else {
+            throw MacOSComputerUseObservationError.invalidCapture
+        }
+
+        return ComputerUseCapturedWindow(
+            target: WorkflowInteractionTarget(
+                bundleIdentifier: selection.bundleIdentifier,
+                processIdentifier: application.processID,
+                windowIdentifier: String(selection.windowID),
+                windowFrame: WorkflowWindowFrame(
+                    x: frame.origin.x,
+                    y: frame.origin.y,
+                    width: frame.width,
+                    height: frame.height
+                )
+            ),
+            artifact: ComputerUseObservationArtifact(
+                pngData: png,
+                pixelWidth: image.width,
+                pixelHeight: image.height
+            )
+        )
+    }
+
+    private static func outputSize(for source: CGSize) -> (width: Int, height: Int) {
+        let scale = min(1, min(1280 / source.width, 720 / source.height))
+        return (
+            max(1, Int((source.width * scale).rounded())),
+            max(1, Int((source.height * scale).rounded()))
+        )
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
@@ -174,6 +174,13 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
         guard frontmost.0 == selection.bundleIdentifier else {
             throw MacOSComputerUseObservationError.targetNotFrontmost
         }
+        guard let processIdentifier = frontmost.1,
+              let focusedFrame = MacOSComputerUseWindowIdentity.focusedWindowFrame(
+                processIdentifier: processIdentifier
+              )
+        else {
+            throw MacOSComputerUseObservationError.targetNotFrontmost
+        }
 
         let content = try await SCShareableContent.excludingDesktopWindows(
             true,
@@ -185,10 +192,21 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
                 && $0.owningApplication?.bundleIdentifier == selection.bundleIdentifier
         }),
             let application = window.owningApplication,
-            application.processID == frontmost.1,
+            application.processID == processIdentifier,
             window.isOnScreen
         else {
             throw MacOSComputerUseObservationError.targetUnavailable
+        }
+
+        let focusedCandidates = content.windows.filter {
+            $0.isOnScreen
+                && $0.owningApplication?.processID == processIdentifier
+                && MacOSComputerUseWindowIdentity.framesMatch($0.frame, focusedFrame)
+        }
+        guard focusedCandidates.count == 1,
+              focusedCandidates[0].windowID == selection.windowID
+        else {
+            throw MacOSComputerUseObservationError.targetNotFrontmost
         }
 
         let frame = window.frame

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
@@ -8,10 +8,12 @@ import ScreenCaptureKit
 struct ComputerUseWindowSelection: Equatable, Sendable {
     let bundleIdentifier: String
     let processIdentifier: pid_t
+    let processLaunchDate: Date
     let windowID: CGWindowID
 
     var isStructurallyValid: Bool {
         !bundleIdentifier.isEmpty && processIdentifier > 0 && windowID != 0
+            && processLaunchDate.timeIntervalSinceReferenceDate.isFinite
     }
 }
 
@@ -149,6 +151,9 @@ actor MacOSComputerUseObserver: LocalWorkflowObserving {
             "\(target.bundleIdentifier)|\(target.processIdentifier)|"
                 .utf8
         )
+        bytes.append(
+            Data("\(target.processLaunchDate?.timeIntervalSinceReferenceDate.bitPattern ?? 0)|".utf8)
+        )
         bytes.append(Data("\(target.windowIdentifier)|".utf8))
         let frame = target.windowFrame
         bytes.append(Data("\(frame.x)|\(frame.y)|\(frame.width)|\(frame.height)|".utf8))
@@ -172,6 +177,7 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
     struct ForegroundRecord: Equatable, Sendable {
         let bundleIdentifier: String?
         let processIdentifier: pid_t?
+        let processLaunchDate: Date?
         let focusedFrame: CGRect?
     }
 
@@ -265,6 +271,7 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
             return (
                 application?.bundleIdentifier,
                 processIdentifier,
+                application?.launchDate,
                 processIdentifier.flatMap {
                     MacOSComputerUseWindowIdentity.focusedWindowFrame(
                         processIdentifier: $0
@@ -286,7 +293,8 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
             foreground: ForegroundRecord(
                 bundleIdentifier: foreground.0,
                 processIdentifier: foreground.1,
-                focusedFrame: foreground.2
+                processLaunchDate: foreground.2,
+                focusedFrame: foreground.3
             ),
             windows: records
         )
@@ -311,6 +319,7 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
     ) throws -> WorkflowInteractionTarget {
         guard foreground.bundleIdentifier == selection.bundleIdentifier,
               foreground.processIdentifier == selection.processIdentifier,
+              foreground.processLaunchDate == selection.processLaunchDate,
               let focusedFrame = foreground.focusedFrame
         else {
             throw MacOSComputerUseObservationError.targetNotFrontmost
@@ -336,6 +345,7 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
         return WorkflowInteractionTarget(
             bundleIdentifier: selection.bundleIdentifier,
             processIdentifier: selection.processIdentifier,
+            processLaunchDate: selection.processLaunchDate,
             windowIdentifier: String(selection.windowID),
             windowFrame: WorkflowWindowFrame(
                 x: window.frame.origin.x,
@@ -352,6 +362,7 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
     ) -> Bool {
         target.bundleIdentifier == selection.bundleIdentifier
             && target.processIdentifier == selection.processIdentifier
+            && target.processLaunchDate == selection.processLaunchDate
             && target.windowIdentifier == String(selection.windowID)
     }
 

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
@@ -7,10 +7,11 @@ import ScreenCaptureKit
 /// Window IDs are session-scoped and are never treated as durable selectors.
 struct ComputerUseWindowSelection: Equatable, Sendable {
     let bundleIdentifier: String
+    let processIdentifier: pid_t
     let windowID: CGWindowID
 
     var isStructurallyValid: Bool {
-        !bundleIdentifier.isEmpty && windowID != 0
+        !bundleIdentifier.isEmpty && processIdentifier > 0 && windowID != 0
     }
 }
 
@@ -121,6 +122,7 @@ actor MacOSComputerUseObserver: LocalWorkflowObserving {
         try Task.checkCancellation()
         guard captured.isStructurallyValid,
               captured.target.bundleIdentifier == selection.bundleIdentifier,
+              captured.target.processIdentifier == selection.processIdentifier,
               captured.target.windowIdentifier == String(selection.windowID)
         else {
             throw MacOSComputerUseObservationError.invalidCapture
@@ -239,7 +241,7 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
             )
         }
         guard foreground.0 == selection.bundleIdentifier,
-              let processIdentifier = foreground.1,
+              foreground.1 == selection.processIdentifier,
               let focusedFrame = foreground.2
         else {
             throw MacOSComputerUseObservationError.targetNotFrontmost
@@ -247,16 +249,17 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
         guard let window = content.windows.first(where: {
             $0.windowID == selection.windowID
                 && $0.owningApplication?.bundleIdentifier == selection.bundleIdentifier
+                && $0.owningApplication?.processID == selection.processIdentifier
         }),
             let application = window.owningApplication,
-            application.processID == processIdentifier,
+            application.processID == selection.processIdentifier,
             window.isOnScreen
         else {
             throw MacOSComputerUseObservationError.targetUnavailable
         }
         let focusedCandidates = content.windows.filter {
             $0.isOnScreen
-                && $0.owningApplication?.processID == processIdentifier
+                && $0.owningApplication?.processID == selection.processIdentifier
                 && MacOSComputerUseWindowIdentity.framesMatch($0.frame, focusedFrame)
         }
         guard focusedCandidates.count == 1,
@@ -270,7 +273,7 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
             window: window,
             target: WorkflowInteractionTarget(
                 bundleIdentifier: selection.bundleIdentifier,
-                processIdentifier: processIdentifier,
+                processIdentifier: selection.processIdentifier,
                 windowIdentifier: String(selection.windowID),
                 windowFrame: WorkflowWindowFrame(
                     x: frame.origin.x,

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
@@ -161,9 +161,45 @@ actor MacOSComputerUseObserver: LocalWorkflowObserving {
 /// It rejects background/focus drift rather than bringing an app forward as a
 /// hidden side effect of observation.
 struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
-    private struct ResolvedWindow {
-        let window: SCWindow
+    struct WindowRecord: Equatable, Sendable {
+        let windowID: CGWindowID
+        let bundleIdentifier: String?
+        let processIdentifier: pid_t?
+        let frame: CGRect
+        let isOnScreen: Bool
+    }
+
+    struct ForegroundRecord: Equatable, Sendable {
+        let bundleIdentifier: String?
+        let processIdentifier: pid_t?
+        let focusedFrame: CGRect?
+    }
+
+    // SCWindow is an immutable system descriptor but is not annotated Sendable.
+    // The wrapper never mutates it and passes it only to ScreenCaptureKit's
+    // async screenshot API; all security decisions use the Sendable target.
+    struct ResolvedWindow: @unchecked Sendable {
+        let window: SCWindow?
         let target: WorkflowInteractionTarget
+    }
+
+    typealias WindowResolver = @Sendable (
+        ComputerUseWindowSelection
+    ) async throws -> ResolvedWindow
+    typealias ImageCapturer = @Sendable (
+        ResolvedWindow,
+        CGSize
+    ) async throws -> ComputerUseObservationArtifact
+
+    private let windowResolver: WindowResolver
+    private let imageCapturer: ImageCapturer
+
+    init(
+        windowResolver: @escaping WindowResolver = Self.resolve,
+        imageCapturer: @escaping ImageCapturer = Self.captureImage
+    ) {
+        self.windowResolver = windowResolver
+        self.imageCapturer = imageCapturer
     }
 
     func capture(_ selection: ComputerUseWindowSelection) async throws
@@ -173,8 +209,17 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
             throw MacOSComputerUseObservationError.targetNotConfigured
         }
         try Task.checkCancellation()
-        let before = try await Self.resolve(selection)
-        let frame = before.window.frame
+        let before = try await windowResolver(selection)
+        guard Self.target(before.target, matches: selection) else {
+            throw MacOSComputerUseObservationError.invalidCapture
+        }
+        let targetFrame = before.target.windowFrame
+        let frame = CGRect(
+            x: targetFrame.x,
+            y: targetFrame.y,
+            width: targetFrame.width,
+            height: targetFrame.height
+        )
         guard frame.origin.x.isFinite, frame.origin.y.isFinite,
               frame.width.isFinite, frame.height.isFinite,
               frame.width > 0, frame.height > 0
@@ -183,39 +228,26 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
         }
 
         let output = Self.outputSize(for: frame.size)
-        let configuration = SCStreamConfiguration()
-        configuration.width = output.width
-        configuration.height = output.height
-        configuration.showsCursor = false
-        configuration.ignoreShadowsSingleWindow = true
-
-        let filter = SCContentFilter(desktopIndependentWindow: before.window)
-        let image = try await SCScreenshotManager.captureImage(
-            contentFilter: filter,
-            configuration: configuration
+        let artifact = try await imageCapturer(
+            before,
+            CGSize(width: output.width, height: output.height)
         )
         try Task.checkCancellation()
-        let after = try await Self.resolve(selection)
-        guard MacOSComputerUseWindowIdentity.targetsMatch(
+        let after = try await windowResolver(selection)
+        guard Self.target(after.target, matches: selection),
+              MacOSComputerUseWindowIdentity.targetsMatch(
             before.target,
             after.target
         ) else {
             throw MacOSComputerUseObservationError.invalidCapture
         }
-        guard let png = NSBitmapImageRep(cgImage: image).representation(
-            using: .png,
-            properties: [:]
-        ) else {
+        guard artifact.isStructurallyValid else {
             throw MacOSComputerUseObservationError.invalidCapture
         }
 
         return ComputerUseCapturedWindow(
             target: after.target,
-            artifact: ComputerUseObservationArtifact(
-                pngData: png,
-                pixelWidth: image.width,
-                pixelHeight: image.height
-            )
+            artifact: artifact
         )
     }
 
@@ -240,26 +272,60 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
                 }
             )
         }
-        guard foreground.0 == selection.bundleIdentifier,
-              foreground.1 == selection.processIdentifier,
-              let focusedFrame = foreground.2
-        else {
-            throw MacOSComputerUseObservationError.targetNotFrontmost
+        let records = content.windows.map {
+            WindowRecord(
+                windowID: $0.windowID,
+                bundleIdentifier: $0.owningApplication?.bundleIdentifier,
+                processIdentifier: $0.owningApplication?.processID,
+                frame: $0.frame,
+                isOnScreen: $0.isOnScreen
+            )
         }
+        let target = try validatedTarget(
+            selection,
+            foreground: ForegroundRecord(
+                bundleIdentifier: foreground.0,
+                processIdentifier: foreground.1,
+                focusedFrame: foreground.2
+            ),
+            windows: records
+        )
         guard let window = content.windows.first(where: {
             $0.windowID == selection.windowID
                 && $0.owningApplication?.bundleIdentifier == selection.bundleIdentifier
                 && $0.owningApplication?.processID == selection.processIdentifier
-        }),
-            let application = window.owningApplication,
-            application.processID == selection.processIdentifier,
-            window.isOnScreen
-        else {
+                && $0.isOnScreen
+        }) else {
             throw MacOSComputerUseObservationError.targetUnavailable
         }
-        let focusedCandidates = content.windows.filter {
+        return ResolvedWindow(
+            window: window,
+            target: target
+        )
+    }
+
+    static func validatedTarget(
+        _ selection: ComputerUseWindowSelection,
+        foreground: ForegroundRecord,
+        windows: [WindowRecord]
+    ) throws -> WorkflowInteractionTarget {
+        guard foreground.bundleIdentifier == selection.bundleIdentifier,
+              foreground.processIdentifier == selection.processIdentifier,
+              let focusedFrame = foreground.focusedFrame
+        else {
+            throw MacOSComputerUseObservationError.targetNotFrontmost
+        }
+        guard let window = windows.first(where: {
+            $0.windowID == selection.windowID
+                && $0.bundleIdentifier == selection.bundleIdentifier
+                && $0.processIdentifier == selection.processIdentifier
+                && $0.isOnScreen
+        }) else {
+            throw MacOSComputerUseObservationError.targetUnavailable
+        }
+        let focusedCandidates = windows.filter {
             $0.isOnScreen
-                && $0.owningApplication?.processID == selection.processIdentifier
+                && $0.processIdentifier == selection.processIdentifier
                 && MacOSComputerUseWindowIdentity.framesMatch($0.frame, focusedFrame)
         }
         guard focusedCandidates.count == 1,
@@ -267,21 +333,55 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
         else {
             throw MacOSComputerUseObservationError.targetNotFrontmost
         }
-
-        let frame = window.frame
-        return ResolvedWindow(
-            window: window,
-            target: WorkflowInteractionTarget(
-                bundleIdentifier: selection.bundleIdentifier,
-                processIdentifier: selection.processIdentifier,
-                windowIdentifier: String(selection.windowID),
-                windowFrame: WorkflowWindowFrame(
-                    x: frame.origin.x,
-                    y: frame.origin.y,
-                    width: frame.width,
-                    height: frame.height
-                )
+        return WorkflowInteractionTarget(
+            bundleIdentifier: selection.bundleIdentifier,
+            processIdentifier: selection.processIdentifier,
+            windowIdentifier: String(selection.windowID),
+            windowFrame: WorkflowWindowFrame(
+                x: window.frame.origin.x,
+                y: window.frame.origin.y,
+                width: window.frame.width,
+                height: window.frame.height
             )
+        )
+    }
+
+    private static func target(
+        _ target: WorkflowInteractionTarget,
+        matches selection: ComputerUseWindowSelection
+    ) -> Bool {
+        target.bundleIdentifier == selection.bundleIdentifier
+            && target.processIdentifier == selection.processIdentifier
+            && target.windowIdentifier == String(selection.windowID)
+    }
+
+    private static func captureImage(
+        _ resolved: ResolvedWindow,
+        _ outputSize: CGSize
+    ) async throws -> ComputerUseObservationArtifact {
+        guard let window = resolved.window else {
+            throw MacOSComputerUseObservationError.targetUnavailable
+        }
+        let configuration = SCStreamConfiguration()
+        configuration.width = Int(outputSize.width)
+        configuration.height = Int(outputSize.height)
+        configuration.showsCursor = false
+        configuration.ignoreShadowsSingleWindow = true
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let image = try await SCScreenshotManager.captureImage(
+            contentFilter: filter,
+            configuration: configuration
+        )
+        guard let png = NSBitmapImageRep(cgImage: image).representation(
+            using: .png,
+            properties: [:]
+        ) else {
+            throw MacOSComputerUseObservationError.invalidCapture
+        }
+        return ComputerUseObservationArtifact(
+            pngData: png,
+            pixelWidth: image.width,
+            pixelHeight: image.height
         )
     }
 

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
@@ -141,7 +141,7 @@ actor MacOSComputerUseObserver: LocalWorkflowObserving {
         return observation
     }
 
-    private static func contentRevision(
+    static func contentRevision(
         target: WorkflowInteractionTarget,
         pngData: Data
     ) -> String {

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
@@ -125,6 +125,7 @@ actor MacOSComputerUseObserver: LocalWorkflowObserving {
         guard captured.isStructurallyValid,
               captured.target.bundleIdentifier == selection.bundleIdentifier,
               captured.target.processIdentifier == selection.processIdentifier,
+              captured.target.processLaunchDate == selection.processLaunchDate,
               captured.target.windowIdentifier == String(selection.windowID)
         else {
             throw MacOSComputerUseObservationError.invalidCapture

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseObservation.swift
@@ -159,6 +159,11 @@ actor MacOSComputerUseObserver: LocalWorkflowObserving {
 /// It rejects background/focus drift rather than bringing an app forward as a
 /// hidden side effect of observation.
 struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
+    private struct ResolvedWindow {
+        let window: SCWindow
+        let target: WorkflowInteractionTarget
+    }
+
     func capture(_ selection: ComputerUseWindowSelection) async throws
         -> ComputerUseCapturedWindow
     {
@@ -166,50 +171,8 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
             throw MacOSComputerUseObservationError.targetNotConfigured
         }
         try Task.checkCancellation()
-
-        let frontmost = await MainActor.run {
-            let app = NSWorkspace.shared.frontmostApplication
-            return (app?.bundleIdentifier, app?.processIdentifier)
-        }
-        guard frontmost.0 == selection.bundleIdentifier else {
-            throw MacOSComputerUseObservationError.targetNotFrontmost
-        }
-        guard let processIdentifier = frontmost.1,
-              let focusedFrame = MacOSComputerUseWindowIdentity.focusedWindowFrame(
-                processIdentifier: processIdentifier
-              )
-        else {
-            throw MacOSComputerUseObservationError.targetNotFrontmost
-        }
-
-        let content = try await SCShareableContent.excludingDesktopWindows(
-            true,
-            onScreenWindowsOnly: true
-        )
-        try Task.checkCancellation()
-        guard let window = content.windows.first(where: {
-            $0.windowID == selection.windowID
-                && $0.owningApplication?.bundleIdentifier == selection.bundleIdentifier
-        }),
-            let application = window.owningApplication,
-            application.processID == processIdentifier,
-            window.isOnScreen
-        else {
-            throw MacOSComputerUseObservationError.targetUnavailable
-        }
-
-        let focusedCandidates = content.windows.filter {
-            $0.isOnScreen
-                && $0.owningApplication?.processID == processIdentifier
-                && MacOSComputerUseWindowIdentity.framesMatch($0.frame, focusedFrame)
-        }
-        guard focusedCandidates.count == 1,
-              focusedCandidates[0].windowID == selection.windowID
-        else {
-            throw MacOSComputerUseObservationError.targetNotFrontmost
-        }
-
-        let frame = window.frame
+        let before = try await Self.resolve(selection)
+        let frame = before.window.frame
         guard frame.origin.x.isFinite, frame.origin.y.isFinite,
               frame.width.isFinite, frame.height.isFinite,
               frame.width > 0, frame.height > 0
@@ -224,12 +187,19 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
         configuration.showsCursor = false
         configuration.ignoreShadowsSingleWindow = true
 
-        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let filter = SCContentFilter(desktopIndependentWindow: before.window)
         let image = try await SCScreenshotManager.captureImage(
             contentFilter: filter,
             configuration: configuration
         )
         try Task.checkCancellation()
+        let after = try await Self.resolve(selection)
+        guard MacOSComputerUseWindowIdentity.targetsMatch(
+            before.target,
+            after.target
+        ) else {
+            throw MacOSComputerUseObservationError.invalidCapture
+        }
         guard let png = NSBitmapImageRep(cgImage: image).representation(
             using: .png,
             properties: [:]
@@ -238,9 +208,69 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
         }
 
         return ComputerUseCapturedWindow(
+            target: after.target,
+            artifact: ComputerUseObservationArtifact(
+                pngData: png,
+                pixelWidth: image.width,
+                pixelHeight: image.height
+            )
+        )
+    }
+
+    private static func resolve(
+        _ selection: ComputerUseWindowSelection
+    ) async throws -> ResolvedWindow {
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            true,
+            onScreenWindowsOnly: true
+        )
+        try Task.checkCancellation()
+        let foreground = await MainActor.run {
+            let application = NSWorkspace.shared.frontmostApplication
+            let processIdentifier = application?.processIdentifier
+            return (
+                application?.bundleIdentifier,
+                processIdentifier,
+                processIdentifier.flatMap {
+                    MacOSComputerUseWindowIdentity.focusedWindowFrame(
+                        processIdentifier: $0
+                    )
+                }
+            )
+        }
+        guard foreground.0 == selection.bundleIdentifier,
+              let processIdentifier = foreground.1,
+              let focusedFrame = foreground.2
+        else {
+            throw MacOSComputerUseObservationError.targetNotFrontmost
+        }
+        guard let window = content.windows.first(where: {
+            $0.windowID == selection.windowID
+                && $0.owningApplication?.bundleIdentifier == selection.bundleIdentifier
+        }),
+            let application = window.owningApplication,
+            application.processID == processIdentifier,
+            window.isOnScreen
+        else {
+            throw MacOSComputerUseObservationError.targetUnavailable
+        }
+        let focusedCandidates = content.windows.filter {
+            $0.isOnScreen
+                && $0.owningApplication?.processID == processIdentifier
+                && MacOSComputerUseWindowIdentity.framesMatch($0.frame, focusedFrame)
+        }
+        guard focusedCandidates.count == 1,
+              focusedCandidates[0].windowID == selection.windowID
+        else {
+            throw MacOSComputerUseObservationError.targetNotFrontmost
+        }
+
+        let frame = window.frame
+        return ResolvedWindow(
+            window: window,
             target: WorkflowInteractionTarget(
                 bundleIdentifier: selection.bundleIdentifier,
-                processIdentifier: application.processID,
+                processIdentifier: processIdentifier,
                 windowIdentifier: String(selection.windowID),
                 windowFrame: WorkflowWindowFrame(
                     x: frame.origin.x,
@@ -248,11 +278,6 @@ struct ScreenCaptureKitComputerUseCapture: ComputerUseWindowCapturing {
                     width: frame.width,
                     height: frame.height
                 )
-            ),
-            artifact: ComputerUseObservationArtifact(
-                pngData: png,
-                pixelWidth: image.width,
-                pixelHeight: image.height
             )
         )
     }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
@@ -91,6 +91,7 @@ enum MacOSComputerUseWindowIdentity {
     ) -> Bool {
         guard lhs.bundleIdentifier == rhs.bundleIdentifier,
               lhs.processIdentifier == rhs.processIdentifier,
+              lhs.processLaunchDate == rhs.processLaunchDate,
               lhs.windowIdentifier == rhs.windowIdentifier
         else { return false }
         return framesMatch(lhs.windowFrame.cgRect, rhs.windowFrame.cgRect)

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
@@ -61,4 +61,21 @@ enum MacOSComputerUseWindowIdentity {
             && abs(lhs.width - rhs.width) <= tolerance
             && abs(lhs.height - rhs.height) <= tolerance
     }
+
+    static func targetsMatch(
+        _ lhs: WorkflowInteractionTarget,
+        _ rhs: WorkflowInteractionTarget
+    ) -> Bool {
+        guard lhs.bundleIdentifier == rhs.bundleIdentifier,
+              lhs.processIdentifier == rhs.processIdentifier,
+              lhs.windowIdentifier == rhs.windowIdentifier
+        else { return false }
+        return framesMatch(lhs.windowFrame.cgRect, rhs.windowFrame.cgRect)
+    }
+}
+
+private extension WorkflowWindowFrame {
+    var cgRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
@@ -6,6 +6,29 @@ import CoreGraphics
 /// CGWindow number, so Computer Use binds its frame to exactly one CGWindow;
 /// ambiguous same-frame windows fail closed.
 enum MacOSComputerUseWindowIdentity {
+    /// Returns the first visible window in Core Graphics front-to-back order
+    /// whose bounds contain the global point. Conservatively treating any
+    /// visible overlay as an occluder prevents a global click from reaching a
+    /// window other than the one the user selected.
+    static func topmostWindowIdentifier(at point: CGPoint) -> String? {
+        guard let records = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[CFString: Any]]
+        else { return nil }
+
+        for record in records {
+            guard let number = record[kCGWindowNumber] as? NSNumber,
+                  let bounds = record[kCGWindowBounds] as? [String: NSNumber],
+                  let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary),
+                  frame.contains(point),
+                  ((record[kCGWindowAlpha] as? NSNumber)?.doubleValue ?? 1) > 0
+            else { continue }
+            return String(number.uint32Value)
+        }
+        return nil
+    }
+
     static func focusedWindowFrame(processIdentifier: pid_t) -> CGRect? {
         let application = AXUIElementCreateApplication(processIdentifier)
         var focusedValue: CFTypeRef?

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
@@ -1,0 +1,64 @@
+import ApplicationServices
+import CoreGraphics
+
+/// Accessibility is the public macOS boundary that identifies the focused
+/// window inside an otherwise-frontmost process. It does not expose a public
+/// CGWindow number, so Computer Use binds its frame to exactly one CGWindow;
+/// ambiguous same-frame windows fail closed.
+enum MacOSComputerUseWindowIdentity {
+    static func focusedWindowFrame(processIdentifier: pid_t) -> CGRect? {
+        let application = AXUIElementCreateApplication(processIdentifier)
+        var focusedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            application,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedValue
+        ) == .success,
+            let focusedValue,
+            CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
+        else { return nil }
+
+        let focused = unsafeDowncast(focusedValue, to: AXUIElement.self)
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            focused,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+            AXUIElementCopyAttributeValue(
+                focused,
+                kAXSizeAttribute as CFString,
+                &sizeValue
+            ) == .success,
+            let positionValue,
+            let sizeValue,
+            CFGetTypeID(positionValue) == AXValueGetTypeID(),
+            CFGetTypeID(sizeValue) == AXValueGetTypeID()
+        else { return nil }
+
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(
+            unsafeDowncast(positionValue, to: AXValue.self),
+            .cgPoint,
+            &origin
+        ),
+            AXValueGetValue(
+                unsafeDowncast(sizeValue, to: AXValue.self),
+                .cgSize,
+                &size
+            )
+        else { return nil }
+        let frame = CGRect(origin: origin, size: size)
+        return frame.width > 0 && frame.height > 0 ? frame : nil
+    }
+
+    static func framesMatch(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+        let tolerance = 0.5
+        return abs(lhs.origin.x - rhs.origin.x) <= tolerance
+            && abs(lhs.origin.y - rhs.origin.y) <= tolerance
+            && abs(lhs.width - rhs.width) <= tolerance
+            && abs(lhs.height - rhs.height) <= tolerance
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationHotkey.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationHotkey.swift
@@ -89,7 +89,9 @@ final class DictationHotkey {
     // MARK: - Permission
 
     /// Whether the process may install a listening event tap.
-    static var hasAccessibilityPermission: Bool { AXIsProcessTrusted() }
+    static var hasAccessibilityPermission: Bool {
+        MacAutomationPermissions.isGranted(.accessibility)
+    }
 
     /// Ask the system to show the Accessibility prompt. Returns the trust state
     /// *at call time* — macOS grants asynchronously, and the app must be
@@ -97,20 +99,13 @@ final class DictationHotkey {
     /// treat `false` as final.
     @discardableResult
     static func requestAccessibilityPermission() -> Bool {
-        // The SDK exposes `kAXTrustedCheckOptionPrompt` as a mutable global,
-        // which Swift 6 rejects as shared mutable state. Its value is a stable
-        // documented constant, so spell it directly.
-        let key = "AXTrustedCheckOptionPrompt" as CFString
-        return AXIsProcessTrustedWithOptions([key: true] as CFDictionary)
+        MacAutomationPermissions.request(.accessibility)
     }
 
     /// Opens the exact Accessibility pane. The prompt above only appears once per
     /// app version, so returning users need a direct route.
     static func openAccessibilitySettings() {
-        guard let url = URL(
-            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-        ) else { return }
-        NSWorkspace.shared.open(url)
+        MacAutomationPermissions.openSettings(for: .accessibility)
     }
 
     // MARK: - Lifecycle

--- a/apps/rapid-mac/Sources/Rapid/Dictation/DictationHotkey.swift
+++ b/apps/rapid-mac/Sources/Rapid/Dictation/DictationHotkey.swift
@@ -105,7 +105,7 @@ final class DictationHotkey {
     /// Opens the exact Accessibility pane. The prompt above only appears once per
     /// app version, so returning users need a direct route.
     static func openAccessibilitySettings() {
-        MacAutomationPermissions.openSettings(for: .accessibility)
+        MacAutomationPermissions.openSystemPrivacyPane(for: .accessibility)
     }
 
     // MARK: - Lifecycle

--- a/apps/rapid-mac/Sources/Rapid/Services/MacAutomationPermissions.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/MacAutomationPermissions.swift
@@ -1,0 +1,90 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+/// macOS privacy grants used when Rapid observes or controls another app.
+///
+/// Checking a grant is side-effect free. Requesting one is deliberately kept
+/// separate so merely enabling an experimental feature never opens a system
+/// prompt or settings pane.
+enum MacAutomationPermission: String, CaseIterable, Equatable, Sendable {
+    case screenRecording
+    case accessibility
+
+    var title: String {
+        switch self {
+        case .screenRecording: "Screen Recording"
+        case .accessibility: "Accessibility"
+        }
+    }
+}
+
+struct MacAutomationPermissionSnapshot: Equatable, Sendable {
+    let screenRecording: Bool
+    let accessibility: Bool
+
+    func isGranted(_ permission: MacAutomationPermission) -> Bool {
+        switch permission {
+        case .screenRecording: screenRecording
+        case .accessibility: accessibility
+        }
+    }
+
+    var missingForComputerUse: [MacAutomationPermission] {
+        // Observation comes before action in every Computer Use run, so keep
+        // Screen Recording first in both setup copy and VoiceOver order.
+        MacAutomationPermission.allCases.filter { !isGranted($0) }
+    }
+
+    var isReadyForComputerUse: Bool { missingForComputerUse.isEmpty }
+}
+
+/// Thin system boundary shared by Dictation and Computer Use.
+///
+/// The TCC APIs do not distinguish "not asked" from "denied" here. Product
+/// UI therefore says "Not allowed" and offers the exact Settings pane instead
+/// of claiming a state macOS has not exposed to us.
+enum MacAutomationPermissions {
+    static func snapshot() -> MacAutomationPermissionSnapshot {
+        MacAutomationPermissionSnapshot(
+            screenRecording: CGPreflightScreenCaptureAccess(),
+            accessibility: AXIsProcessTrusted()
+        )
+    }
+
+    static func isGranted(_ permission: MacAutomationPermission) -> Bool {
+        snapshot().isGranted(permission)
+    }
+
+    /// Requests exactly one capability in direct response to a user action.
+    /// The returned value is only the state at call completion; callers must
+    /// refresh after the user changes System Settings and after app relaunch.
+    @discardableResult
+    static func request(_ permission: MacAutomationPermission) -> Bool {
+        switch permission {
+        case .screenRecording:
+            return CGRequestScreenCaptureAccess()
+        case .accessibility:
+            // Swift 6 treats the SDK's exported CFString as shared mutable
+            // state. Its documented literal value is stable.
+            let key = "AXTrustedCheckOptionPrompt" as CFString
+            return AXIsProcessTrustedWithOptions([key: true] as CFDictionary)
+        }
+    }
+
+    @MainActor
+    static func openSettings(for permission: MacAutomationPermission) {
+        let anchor: String
+        switch permission {
+        case .screenRecording:
+            anchor = "Privacy_ScreenCapture"
+        case .accessibility:
+            anchor = "Privacy_Accessibility"
+        }
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?\(anchor)"
+        ) else { return }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Services/MacAutomationPermissions.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/MacAutomationPermissions.swift
@@ -74,7 +74,7 @@ enum MacAutomationPermissions {
     }
 
     @MainActor
-    static func openSettings(for permission: MacAutomationPermission) {
+    static func openSystemPrivacyPane(for permission: MacAutomationPermission) {
         let anchor: String
         switch permission {
         case .screenRecording:

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowExecutor.swift
@@ -14,7 +14,8 @@ protocol LocalWorkflowGrounding: Sendable {
 protocol LocalWorkflowActuating: Sendable {
     func perform(
         _ action: GroundedWorkflowAction,
-        against currentObservation: WorkflowObservation
+        groundedAgainst groundingObservation: WorkflowObservation,
+        currentObservation: WorkflowObservation
     ) async throws
 }
 
@@ -489,7 +490,11 @@ actor LocalWorkflowExecutor {
 
         if Task.isCancelled { throw CancellationError() }
         do {
-            try await actuator.perform(action, against: current)
+            try await actuator.perform(
+                action,
+                groundedAgainst: observed,
+                currentObservation: current
+            )
         } catch is CancellationError {
             throw WorkflowKernelError.cancelled(actionMayHaveOccurred: true)
         } catch {

--- a/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowModels.swift
+++ b/apps/rapid-mac/Sources/Rapid/Workflows/LocalWorkflowModels.swift
@@ -77,8 +77,25 @@ struct WorkflowWindowFrame: Codable, Equatable, Sendable {
 struct WorkflowInteractionTarget: Codable, Equatable, Sendable {
     let bundleIdentifier: String
     let processIdentifier: Int32
+    /// Computer Use binds this to the selected app launch. Other workflow
+    /// adapters may leave it nil when process-restart identity is irrelevant.
+    let processLaunchDate: Date?
     let windowIdentifier: String
     let windowFrame: WorkflowWindowFrame
+
+    init(
+        bundleIdentifier: String,
+        processIdentifier: Int32,
+        processLaunchDate: Date? = nil,
+        windowIdentifier: String,
+        windowFrame: WorkflowWindowFrame
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.processIdentifier = processIdentifier
+        self.processLaunchDate = processLaunchDate
+        self.windowIdentifier = windowIdentifier
+        self.windowFrame = windowFrame
+    }
 }
 
 /// Metadata for one screen observation. Pixel data and accessibility contents

--- a/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalWorkflowExecutorTests.swift
@@ -815,7 +815,8 @@ private actor RecordingWorkflowActuator: LocalWorkflowActuating {
 
     func perform(
         _ action: GroundedWorkflowAction,
-        against _: WorkflowObservation
+        groundedAgainst _: WorkflowObservation,
+        currentObservation _: WorkflowObservation
     ) async throws {
         actions.append(action)
     }
@@ -827,7 +828,8 @@ private actor BlockingWorkflowActuator: LocalWorkflowActuating {
 
     func perform(
         _: GroundedWorkflowAction,
-        against _: WorkflowObservation
+        groundedAgainst _: WorkflowObservation,
+        currentObservation _: WorkflowObservation
     ) async throws {
         await blocked.open()
         await released.wait()

--- a/apps/rapid-mac/Tests/RapidTests/MacAutomationPermissionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacAutomationPermissionsTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import Rapid
+
+@Suite("Mac automation permissions")
+struct MacAutomationPermissionsTests {
+    @Test("Computer Use requires both observation and control grants")
+    func readinessRequiresBoth() {
+        let none = MacAutomationPermissionSnapshot(
+            screenRecording: false,
+            accessibility: false
+        )
+        #expect(none.missingForComputerUse == [.screenRecording, .accessibility])
+        #expect(!none.isReadyForComputerUse)
+
+        let observationOnly = MacAutomationPermissionSnapshot(
+            screenRecording: true,
+            accessibility: false
+        )
+        #expect(observationOnly.missingForComputerUse == [.accessibility])
+        #expect(!observationOnly.isReadyForComputerUse)
+
+        let controlOnly = MacAutomationPermissionSnapshot(
+            screenRecording: false,
+            accessibility: true
+        )
+        #expect(controlOnly.missingForComputerUse == [.screenRecording])
+        #expect(!controlOnly.isReadyForComputerUse)
+
+        let ready = MacAutomationPermissionSnapshot(
+            screenRecording: true,
+            accessibility: true
+        )
+        #expect(ready.missingForComputerUse.isEmpty)
+        #expect(ready.isReadyForComputerUse)
+    }
+
+    @Test("Individual grant lookup is stable")
+    func individualLookup() {
+        let snapshot = MacAutomationPermissionSnapshot(
+            screenRecording: true,
+            accessibility: false
+        )
+        #expect(snapshot.isGranted(.screenRecording))
+        #expect(!snapshot.isGranted(.accessibility))
+        #expect(MacAutomationPermission.screenRecording.title == "Screen Recording")
+        #expect(MacAutomationPermission.accessibility.title == "Accessibility")
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -305,32 +305,40 @@ struct MacOSComputerUseActuationTests {
         #expect(recorder.processIdentifiers == [42, 42])
     }
 
-    @Test("Destructive modifier combinations are rejected before input")
-    @MainActor
-    func destructiveKeyChordIsRejected() async {
-        let expected = Self.observation().target
-        let emitter = CGEventComputerUseInputEmitter(targetReader: { $0 })
+    @Test("Window-unbound keyboard payloads fail before desktop access", arguments: [
+        WorkflowActionPayload.typeText("draft"),
+        WorkflowActionPayload.keyPress(key: "tab", modifiers: []),
+        WorkflowActionPayload.keyPress(
+            key: "delete",
+            modifiers: ["command", "option"]
+        ),
+    ])
+    func keyboardPayloadsFailClosed(payload: WorkflowActionPayload) async {
+        let observation = Self.observation()
+        let probe = TargetProbe(result: .success(observation.target))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+        let action = GroundedWorkflowAction(
+            observationID: observation.id,
+            payload: payload,
+            source: .visualGrounding,
+            safeSummary: "Keyboard input",
+            risk: .localChange
+        )
 
-        await #expect(throws: MacOSComputerUseActuationError.unsupportedKey) {
-            try await emitter.emit(
-                .keyPress(key: "delete", modifiers: ["command", "option"]),
-                in: expected
+        await #expect(throws: MacOSComputerUseActuationError.invalidAction) {
+            try await actuator.perform(
+                action,
+                groundedAgainst: observation,
+                currentObservation: observation
             )
         }
-    }
-
-    @Test("Duplicate modifiers cannot bypass the complete-chord allowlist")
-    @MainActor
-    func duplicateModifiersAreRejected() async {
-        let expected = Self.observation().target
-        let emitter = CGEventComputerUseInputEmitter(targetReader: { $0 })
-
-        await #expect(throws: MacOSComputerUseActuationError.unsupportedKey) {
-            try await emitter.emit(
-                .keyPress(key: "tab", modifiers: ["shift", "shift"]),
-                in: expected
-            )
-        }
+        #expect(await probe.callCount == 0)
+        #expect(await emitter.emissions.isEmpty)
     }
 
     @Test("Click coordinates use the tolerated live frame")
@@ -363,16 +371,6 @@ struct MacOSComputerUseActuationTests {
                 in: frame
             )
         }
-    }
-
-    @Test("Unicode chunks never split a surrogate pair")
-    func unicodeChunksPreserveScalars() {
-        let text = String(repeating: "a", count: 1_023) + "😀" + "b"
-        let chunks = CGEventComputerUseInputEmitter.unicodeChunks(for: text)
-
-        #expect(chunks.map(\.count) == [1_023, 3])
-        #expect(chunks.allSatisfy { $0.count <= 1_024 })
-        #expect(String(decoding: chunks.flatMap { $0 }, as: UTF16.self) == text)
     }
 
     private static func observation() -> WorkflowObservation {

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -245,7 +245,8 @@ struct MacOSComputerUseActuationTests {
             },
             elementPerformer: { binding in
                 recorder.performed.append(binding)
-            }
+            },
+            permissionReader: Self.granted
         )
 
         try await emitter.emit(
@@ -280,7 +281,8 @@ struct MacOSComputerUseActuationTests {
             },
             elementPerformer: { binding in
                 recorder.performed.append(binding)
-            }
+            },
+            permissionReader: Self.granted
         )
 
         await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
@@ -309,7 +311,8 @@ struct MacOSComputerUseActuationTests {
             },
             elementPerformer: { binding in
                 recorder.performed.append(binding)
-            }
+            },
+            permissionReader: Self.granted
         )
 
         await #expect(throws: MacOSComputerUseActuationError.elementChanged) {
@@ -338,10 +341,42 @@ struct MacOSComputerUseActuationTests {
             },
             elementPerformer: { binding in
                 recorder.performed.append(binding)
-            }
+            },
+            permissionReader: Self.granted
         )
 
         await #expect(throws: MacOSComputerUseActuationError.targetNotFrontmost) {
+            try await emitter.emit(
+                .click(normalizedX: 0.25, normalizedY: 0.75),
+                verifiedAgainst: fixture.observation
+            )
+        }
+        #expect(recorder.calls.count == 2)
+        #expect(recorder.performed.isEmpty)
+    }
+
+    @Test("Permission revoked at the final boundary prevents AXPress")
+    @MainActor
+    func finalPermissionRevocationPreventsPress() async {
+        let fixture = Self.captureFixture()
+        let recorder = ElementBoundaryRecorder()
+        let emitter = AXComputerUseInputEmitter(
+            captureSource: ActuationCaptureStub(result: fixture.capture),
+            elementResolver: { payload, target in
+                recorder.calls.append(.init(payload: payload, target: target))
+                return recorder.binding
+            },
+            elementPerformer: { binding in
+                recorder.performed.append(binding)
+            },
+            permissionReader: {
+                .init(screenRecording: true, accessibility: false)
+            }
+        )
+
+        await #expect(
+            throws: MacOSComputerUseActuationError.permissionMissing([.accessibility])
+        ) {
             try await emitter.emit(
                 .click(normalizedX: 0.25, normalizedY: 0.75),
                 verifiedAgainst: fixture.observation
@@ -440,6 +475,10 @@ struct MacOSComputerUseActuationTests {
             safeSummary: "Click draft",
             risk: .localChange
         )
+    }
+
+    private static func granted() -> MacAutomationPermissionSnapshot {
+        .init(screenRecording: true, accessibility: true)
     }
 
     private static func captureFixture() -> (

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -182,10 +182,28 @@ struct MacOSComputerUseActuationTests {
         let expected = Self.observation().target
         let emitter = CGEventComputerUseInputEmitter(
             targetReader: { $0 },
-            cancellationCheck: { throw CancellationError() }
+            cancellationCheck: { throw CancellationError() },
+            windowAtPointReader: { _ in expected.windowIdentifier }
         )
 
         await #expect(throws: CancellationError.self) {
+            try await emitter.emit(
+                .click(normalizedX: 0.25, normalizedY: 0.75),
+                in: expected
+            )
+        }
+    }
+
+    @Test("An overlay at the click point prevents global input")
+    @MainActor
+    func occludingWindowStopsClick() async {
+        let expected = Self.observation().target
+        let emitter = CGEventComputerUseInputEmitter(
+            targetReader: { $0 },
+            windowAtPointReader: { _ in "999" }
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.targetOccluded) {
             try await emitter.emit(
                 .click(normalizedX: 0.25, normalizedY: 0.75),
                 in: expected

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -16,6 +16,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(currentObservation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -37,6 +38,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(groundingObservation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -70,6 +72,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(groundingObservation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -82,6 +85,34 @@ struct MacOSComputerUseActuationTests {
             )
         }
         #expect(await probe.callCount == 0)
+        #expect(await emitter.emissions.isEmpty)
+    }
+
+    @Test("Content drift during the final capture prevents the click")
+    func finalContentDriftIsRejected() async {
+        let observation = Self.observation()
+        let changed = WorkflowObservation(
+            target: observation.target,
+            contentRevision: "changed-at-final-boundary"
+        )
+        let probe = TargetProbe(result: .success(observation.target))
+        let contentProbe = ContentProbe(result: .success(changed))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            contentProbe: contentProbe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
+            try await actuator.perform(
+                Self.action(for: observation),
+                groundedAgainst: observation,
+                currentObservation: observation
+            )
+        }
+        #expect(await contentProbe.callCount == 1)
         #expect(await emitter.emissions.isEmpty)
     }
 
@@ -101,6 +132,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(groundedObservation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -122,6 +154,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: false) }
         )
@@ -152,6 +185,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -173,6 +207,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -207,6 +242,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -305,6 +341,32 @@ struct MacOSComputerUseActuationTests {
         #expect(recorder.processIdentifiers == [42, 42])
     }
 
+    @Test("A target change after mouse-down suppresses mouse-up")
+    @MainActor
+    func mouseUpRevalidatesTarget() async {
+        let expected = Self.observation().target
+        let moved = WorkflowInteractionTarget(
+            bundleIdentifier: expected.bundleIdentifier,
+            processIdentifier: expected.processIdentifier,
+            windowIdentifier: expected.windowIdentifier,
+            windowFrame: .init(x: 101, y: 200, width: 800, height: 600)
+        )
+        let state = EventBoundaryState(expected: expected, changed: moved)
+        let emitter = CGEventComputerUseInputEmitter(
+            targetReader: { _ in state.postCount == 0 ? state.expected : state.changed },
+            windowAtPointReader: { _ in expected.windowIdentifier },
+            eventPoster: { _, _ in state.postCount += 1 }
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.targetChanged) {
+            try await emitter.emit(
+                .click(normalizedX: 0.25, normalizedY: 0.75),
+                in: expected
+            )
+        }
+        #expect(state.postCount == 1)
+    }
+
     @Test("Window-unbound keyboard payloads fail before desktop access", arguments: [
         WorkflowActionPayload.typeText("draft"),
         WorkflowActionPayload.keyPress(key: "tab", modifiers: []),
@@ -319,6 +381,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
+            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -401,6 +464,18 @@ private final class PostedEventRecorder {
     var processIdentifiers: [pid_t] = []
 }
 
+@MainActor
+private final class EventBoundaryState {
+    let expected: WorkflowInteractionTarget
+    let changed: WorkflowInteractionTarget
+    var postCount = 0
+
+    init(expected: WorkflowInteractionTarget, changed: WorkflowInteractionTarget) {
+        self.expected = expected
+        self.changed = changed
+    }
+}
+
 private actor TargetProbe: ComputerUseTargetProbing {
     private let result: Result<WorkflowInteractionTarget, Error>
     private(set) var callCount = 0
@@ -412,6 +487,22 @@ private actor TargetProbe: ComputerUseTargetProbing {
     func currentTarget(for _: WorkflowInteractionTarget) async throws
         -> WorkflowInteractionTarget
     {
+        callCount += 1
+        return try result.get()
+    }
+}
+
+private actor ContentProbe: ComputerUseContentProbing {
+    private let result: Result<WorkflowObservation, Error>
+    private(set) var callCount = 0
+
+    init(result: Result<WorkflowObservation, Error>) {
+        self.result = result
+    }
+
+    func currentObservation(
+        for _: WorkflowInteractionTarget
+    ) async throws -> WorkflowObservation {
         callCount += 1
         return try result.get()
     }

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -17,7 +17,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(currentObservation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -39,7 +38,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(groundingObservation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -73,7 +71,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(groundingObservation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -86,34 +83,6 @@ struct MacOSComputerUseActuationTests {
             )
         }
         #expect(await probe.callCount == 0)
-        #expect(await emitter.emissions.isEmpty)
-    }
-
-    @Test("Content drift during the final capture prevents the click")
-    func finalContentDriftIsRejected() async {
-        let observation = Self.observation()
-        let changed = WorkflowObservation(
-            target: observation.target,
-            contentRevision: "changed-at-final-boundary"
-        )
-        let probe = TargetProbe(result: .success(observation.target))
-        let contentProbe = ContentProbe(result: .success(changed))
-        let emitter = InputEmitter()
-        let actuator = MacOSComputerUseActuator(
-            targetProbe: probe,
-            contentProbe: contentProbe,
-            inputEmitter: emitter,
-            permissionReader: { .init(screenRecording: true, accessibility: true) }
-        )
-
-        await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
-            try await actuator.perform(
-                Self.action(for: observation),
-                groundedAgainst: observation,
-                currentObservation: observation
-            )
-        }
-        #expect(await contentProbe.callCount == 1)
         #expect(await emitter.emissions.isEmpty)
     }
 
@@ -133,7 +102,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(groundedObservation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -155,7 +123,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: false) }
         )
@@ -186,7 +153,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -208,7 +174,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -243,7 +208,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -266,118 +230,84 @@ struct MacOSComputerUseActuationTests {
         #expect(await emitter.emissions.isEmpty)
     }
 
-    @Test("The production emitter rechecks target drift at its event boundary")
+    @Test("An unchanged capture presses the same resolved AX element")
     @MainActor
-    func emitterRejectsLastMomentDrift() async {
-        let expected = Self.observation().target
-        let moved = WorkflowInteractionTarget(
-            bundleIdentifier: expected.bundleIdentifier,
-            processIdentifier: expected.processIdentifier,
-            windowIdentifier: expected.windowIdentifier,
-            windowFrame: .init(x: 104, y: 200, width: 800, height: 600)
-        )
-        let emitter = CGEventComputerUseInputEmitter(targetReader: { _ in moved })
-
-        await #expect(throws: MacOSComputerUseActuationError.targetChanged) {
-            try await emitter.emit(
-                .click(normalizedX: 0.25, normalizedY: 0.75),
-                in: expected
-            )
-        }
-    }
-
-    @Test("Cancellation during the final target probe prevents the event")
-    @MainActor
-    func emitterRechecksCancellationAfterProbe() async {
-        let expected = Self.observation().target
-        let recorder = PostedEventRecorder()
-        let emitter = CGEventComputerUseInputEmitter(
-            targetReader: { $0 },
-            cancellationCheck: { throw CancellationError() },
-            windowAtPointReader: { _ in expected.windowIdentifier },
-            eventPoster: { event, processIdentifier in
-                recorder.record(event, processIdentifier: processIdentifier)
-            }
-        )
-
-        await #expect(throws: CancellationError.self) {
-            try await emitter.emit(
-                .click(normalizedX: 0.25, normalizedY: 0.75),
-                in: expected
-            )
-        }
-        #expect(recorder.eventTypes.isEmpty)
-        #expect(recorder.processIdentifiers.isEmpty)
-    }
-
-    @Test("An overlay at the click point prevents global input")
-    @MainActor
-    func occludingWindowStopsClick() async {
-        let expected = Self.observation().target
-        let recorder = PostedEventRecorder()
-        let emitter = CGEventComputerUseInputEmitter(
-            targetReader: { $0 },
-            windowAtPointReader: { _ in "999" },
-            eventPoster: { event, processIdentifier in
-                recorder.record(event, processIdentifier: processIdentifier)
-            }
-        )
-
-        await #expect(throws: MacOSComputerUseActuationError.targetOccluded) {
-            try await emitter.emit(
-                .click(normalizedX: 0.25, normalizedY: 0.75),
-                in: expected
-            )
-        }
-        #expect(recorder.eventTypes.isEmpty)
-        #expect(recorder.processIdentifiers.isEmpty)
-    }
-
-    @Test("Events are delivered only to the selected process")
-    @MainActor
-    func inputDeliveryIsProcessBound() async throws {
-        let expected = Self.observation().target
-        let recorder = PostedEventRecorder()
-        let emitter = CGEventComputerUseInputEmitter(
-            targetReader: { $0 },
-            windowAtPointReader: { _ in expected.windowIdentifier },
-            eventPoster: { event, processIdentifier in
-                recorder.record(event, processIdentifier: processIdentifier)
+    func unchangedCapturePressesBoundElement() async throws {
+        let fixture = Self.captureFixture()
+        let recorder = ElementBoundaryRecorder()
+        let emitter = AXComputerUseInputEmitter(
+            captureSource: ActuationCaptureStub(result: fixture.capture),
+            elementBoundary: { payload, target, required in
+                recorder.calls.append(.init(payload: payload, target: target, required: required))
+                return recorder.fingerprint
             }
         )
 
         try await emitter.emit(
             .click(normalizedX: 0.25, normalizedY: 0.75),
-            in: expected
+            verifiedAgainst: fixture.observation
         )
 
-        #expect(recorder.processIdentifiers == [42, 42])
+        #expect(recorder.calls.count == 2)
+        #expect(recorder.calls[0].required == nil)
+        #expect(recorder.calls[1].required == recorder.fingerprint)
+        #expect(recorder.calls.allSatisfy { $0.target == fixture.observation.target })
     }
 
-    @Test("A target change after mouse-down emits only a balancing mouse-up")
+    @Test("Changed pixels prevent the final AX element boundary")
     @MainActor
-    func mouseUpRevalidatesTarget() async {
-        let expected = Self.observation().target
-        let moved = WorkflowInteractionTarget(
-            bundleIdentifier: expected.bundleIdentifier,
-            processIdentifier: expected.processIdentifier,
-            windowIdentifier: expected.windowIdentifier,
-            windowFrame: .init(x: 101, y: 200, width: 800, height: 600)
+    func changedPixelsPreventPress() async {
+        let fixture = Self.captureFixture()
+        let changedCapture = ComputerUseCapturedWindow(
+            target: fixture.capture.target,
+            artifact: .init(
+                pngData: Data([9, 9, 9]),
+                pixelWidth: fixture.capture.artifact.pixelWidth,
+                pixelHeight: fixture.capture.artifact.pixelHeight
+            )
         )
-        let state = EventBoundaryState(expected: expected, changed: moved)
-        let emitter = CGEventComputerUseInputEmitter(
-            targetReader: { _ in state.postCount == 0 ? state.expected : state.changed },
-            windowAtPointReader: { _ in expected.windowIdentifier },
-            eventPoster: { event, _ in state.postedEventTypes.append(event.type) }
+        let recorder = ElementBoundaryRecorder()
+        let emitter = AXComputerUseInputEmitter(
+            captureSource: ActuationCaptureStub(result: changedCapture),
+            elementBoundary: { payload, target, required in
+                recorder.calls.append(.init(payload: payload, target: target, required: required))
+                return recorder.fingerprint
+            }
         )
 
-        await #expect(throws: MacOSComputerUseActuationError.targetChanged) {
+        await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
             try await emitter.emit(
                 .click(normalizedX: 0.25, normalizedY: 0.75),
-                in: expected
+                verifiedAgainst: fixture.observation
             )
         }
-        #expect(state.postedEventTypes == [.leftMouseDown, .leftMouseUp])
+        #expect(recorder.calls.count == 1)
+        #expect(recorder.calls[0].required == nil)
+    }
+
+    @Test("A changed AX element is rejected at the press boundary")
+    @MainActor
+    func changedElementPreventsPress() async {
+        let fixture = Self.captureFixture()
+        let recorder = ElementBoundaryRecorder()
+        let emitter = AXComputerUseInputEmitter(
+            captureSource: ActuationCaptureStub(result: fixture.capture),
+            elementBoundary: { payload, target, required in
+                recorder.calls.append(.init(payload: payload, target: target, required: required))
+                if required != nil {
+                    throw MacOSComputerUseActuationError.elementChanged
+                }
+                return recorder.fingerprint
+            }
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.elementChanged) {
+            try await emitter.emit(
+                .click(normalizedX: 0.25, normalizedY: 0.75),
+                verifiedAgainst: fixture.observation
+            )
+        }
+        #expect(recorder.calls.count == 2)
     }
 
     @Test("Window-unbound keyboard payloads fail before desktop access", arguments: [
@@ -394,7 +324,6 @@ struct MacOSComputerUseActuationTests {
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
-            contentProbe: ContentProbe(result: .success(observation)),
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
@@ -426,7 +355,7 @@ struct MacOSComputerUseActuationTests {
             height: 599.5
         )
 
-        let point = try CGEventComputerUseInputEmitter.clickPoint(
+        let point = try AXComputerUseInputEmitter.clickPoint(
             normalizedX: 0.25,
             normalizedY: 0.75,
             in: liveFrame
@@ -441,7 +370,7 @@ struct MacOSComputerUseActuationTests {
         let frame = WorkflowWindowFrame(x: 100, y: 200, width: 800, height: 600)
 
         #expect(throws: MacOSComputerUseActuationError.invalidAction) {
-            try CGEventComputerUseInputEmitter.clickPoint(
+            try AXComputerUseInputEmitter.clickPoint(
                 normalizedX: Double.leastNonzeroMagnitude,
                 normalizedY: 0.5,
                 in: frame
@@ -470,30 +399,48 @@ struct MacOSComputerUseActuationTests {
             risk: .localChange
         )
     }
-}
 
-@MainActor
-private final class PostedEventRecorder {
-    var eventTypes: [CGEventType] = []
-    var processIdentifiers: [pid_t] = []
-
-    func record(_ event: CGEvent, processIdentifier: pid_t) {
-        eventTypes.append(event.type)
-        processIdentifiers.append(processIdentifier)
+    private static func captureFixture() -> (
+        observation: WorkflowObservation,
+        capture: ComputerUseCapturedWindow
+    ) {
+        let target = observation().target
+        let artifact = ComputerUseObservationArtifact(
+            pngData: Data([1, 2, 3]),
+            pixelWidth: 800,
+            pixelHeight: 600
+        )
+        let capture = ComputerUseCapturedWindow(target: target, artifact: artifact)
+        return (
+            WorkflowObservation(
+                target: target,
+                contentRevision: MacOSComputerUseObserver.contentRevision(
+                    target: target,
+                    pngData: artifact.pngData
+                )
+            ),
+            capture
+        )
     }
 }
 
 @MainActor
-private final class EventBoundaryState {
-    let expected: WorkflowInteractionTarget
-    let changed: WorkflowInteractionTarget
-    var postedEventTypes: [CGEventType] = []
-    var postCount: Int { postedEventTypes.count }
+private struct ElementBoundaryCall {
+    let payload: WorkflowActionPayload
+    let target: WorkflowInteractionTarget
+    let required: ComputerUseElementFingerprint?
+}
 
-    init(expected: WorkflowInteractionTarget, changed: WorkflowInteractionTarget) {
-        self.expected = expected
-        self.changed = changed
-    }
+@MainActor
+private final class ElementBoundaryRecorder {
+    let fingerprint = ComputerUseElementFingerprint(
+        role: "AXButton",
+        subrole: nil,
+        identifier: "submit",
+        title: "Submit",
+        frame: .init(x: 200, y: 300, width: 80, height: 30)
+    )
+    var calls: [ElementBoundaryCall] = []
 }
 
 private actor TargetProbe: ComputerUseTargetProbing {
@@ -512,29 +459,27 @@ private actor TargetProbe: ComputerUseTargetProbing {
     }
 }
 
-private actor ContentProbe: ComputerUseContentProbing {
-    private let result: Result<WorkflowObservation, Error>
-    private(set) var callCount = 0
-
-    init(result: Result<WorkflowObservation, Error>) {
-        self.result = result
-    }
-
-    func currentObservation(
-        for _: WorkflowInteractionTarget
-    ) async throws -> WorkflowObservation {
-        callCount += 1
-        return try result.get()
-    }
-}
-
 private actor InputEmitter: ComputerUseInputEmitting {
     private(set) var emissions: [WorkflowActionPayload] = []
 
     func emit(
         _ payload: WorkflowActionPayload,
-        in _: WorkflowInteractionTarget
+        verifiedAgainst _: WorkflowObservation
     ) async throws {
         emissions.append(payload)
+    }
+}
+
+private actor ActuationCaptureStub: ComputerUseWindowCapturing {
+    private let result: ComputerUseCapturedWindow
+
+    init(result: ComputerUseCapturedWindow) {
+        self.result = result
+    }
+
+    func capture(_: ComputerUseWindowSelection) async throws
+        -> ComputerUseCapturedWindow
+    {
+        result
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import Testing
 @testable import Rapid
@@ -341,7 +342,7 @@ struct MacOSComputerUseActuationTests {
         #expect(recorder.processIdentifiers == [42, 42])
     }
 
-    @Test("A target change after mouse-down suppresses mouse-up")
+    @Test("A target change after mouse-down emits only a balancing mouse-up")
     @MainActor
     func mouseUpRevalidatesTarget() async {
         let expected = Self.observation().target
@@ -355,7 +356,7 @@ struct MacOSComputerUseActuationTests {
         let emitter = CGEventComputerUseInputEmitter(
             targetReader: { _ in state.postCount == 0 ? state.expected : state.changed },
             windowAtPointReader: { _ in expected.windowIdentifier },
-            eventPoster: { _, _ in state.postCount += 1 }
+            eventPoster: { event, _ in state.postedEventTypes.append(event.type) }
         )
 
         await #expect(throws: MacOSComputerUseActuationError.targetChanged) {
@@ -364,7 +365,7 @@ struct MacOSComputerUseActuationTests {
                 in: expected
             )
         }
-        #expect(state.postCount == 1)
+        #expect(state.postedEventTypes == [.leftMouseDown, .leftMouseUp])
     }
 
     @Test("Window-unbound keyboard payloads fail before desktop access", arguments: [
@@ -468,7 +469,8 @@ private final class PostedEventRecorder {
 private final class EventBoundaryState {
     let expected: WorkflowInteractionTarget
     let changed: WorkflowInteractionTarget
-    var postCount = 0
+    var postedEventTypes: [CGEventType] = []
+    var postCount: Int { postedEventTypes.count }
 
     init(expected: WorkflowInteractionTarget, changed: WorkflowInteractionTarget) {
         self.expected = expected

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -22,11 +22,67 @@ struct MacOSComputerUseActuationTests {
 
         try await actuator.perform(
             Self.action(for: groundedObservation),
-            against: currentObservation
+            groundedAgainst: groundedObservation,
+            currentObservation: currentObservation
         )
 
         let emissions = await emitter.emissions
         #expect(emissions == [.click(normalizedX: 0.25, normalizedY: 0.75)])
+    }
+
+    @Test("A forged action binding is rejected before desktop access")
+    func mismatchedGroundingIDIsRejected() async {
+        let groundingObservation = Self.observation()
+        let probe = TargetProbe(result: .success(groundingObservation.target))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+        let forged = GroundedWorkflowAction(
+            observationID: UUID(),
+            payload: .click(normalizedX: 0.25, normalizedY: 0.75),
+            source: .visualGrounding,
+            safeSummary: "Forged",
+            risk: .readOnly
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
+            try await actuator.perform(
+                forged,
+                groundedAgainst: groundingObservation,
+                currentObservation: groundingObservation
+            )
+        }
+        #expect(await probe.callCount == 0)
+        #expect(await emitter.emissions.isEmpty)
+    }
+
+    @Test("Changed content cannot be substituted at the actuation boundary")
+    func changedGroundingStateIsRejected() async {
+        let groundingObservation = Self.observation()
+        let currentObservation = WorkflowObservation(
+            target: groundingObservation.target,
+            contentRevision: "different-revision"
+        )
+        let probe = TargetProbe(result: .success(groundingObservation.target))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
+            try await actuator.perform(
+                Self.action(for: groundingObservation),
+                groundedAgainst: groundingObservation,
+                currentObservation: currentObservation
+            )
+        }
+        #expect(await probe.callCount == 0)
+        #expect(await emitter.emissions.isEmpty)
     }
 
     @Test("An invalid current observation is rejected before probing the desktop")
@@ -51,7 +107,8 @@ struct MacOSComputerUseActuationTests {
         await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
             try await actuator.perform(
                 Self.action(for: groundedObservation),
-                against: invalidCurrent
+                groundedAgainst: groundedObservation,
+                currentObservation: invalidCurrent
             )
         }
         #expect(await probe.callCount == 0)
@@ -72,7 +129,11 @@ struct MacOSComputerUseActuationTests {
         await #expect(
             throws: MacOSComputerUseActuationError.permissionMissing([.accessibility])
         ) {
-            try await actuator.perform(Self.action(for: observation), against: observation)
+            try await actuator.perform(
+                Self.action(for: observation),
+                groundedAgainst: observation,
+                currentObservation: observation
+            )
         }
         #expect(await probe.callCount == 0)
         #expect(await emitter.emissions.isEmpty)
@@ -96,7 +157,11 @@ struct MacOSComputerUseActuationTests {
         )
 
         await #expect(throws: MacOSComputerUseActuationError.targetChanged) {
-            try await actuator.perform(Self.action(for: observation), against: observation)
+            try await actuator.perform(
+                Self.action(for: observation),
+                groundedAgainst: observation,
+                currentObservation: observation
+            )
         }
         #expect(await emitter.emissions.isEmpty)
     }
@@ -120,7 +185,11 @@ struct MacOSComputerUseActuationTests {
         )
 
         await #expect(throws: MacOSComputerUseActuationError.invalidAction) {
-            try await actuator.perform(invalid, against: observation)
+            try await actuator.perform(
+                invalid,
+                groundedAgainst: observation,
+                currentObservation: observation
+            )
         }
         #expect(await probe.callCount == 0)
         #expect(await emitter.emissions.isEmpty)
@@ -150,7 +219,11 @@ struct MacOSComputerUseActuationTests {
         )
 
         await #expect(throws: MacOSComputerUseActuationError.invalidAction) {
-            try await actuator.perform(action, against: observation)
+            try await actuator.perform(
+                action,
+                groundedAgainst: observation,
+                currentObservation: observation
+            )
         }
         #expect(await probe.callCount == 0)
         #expect(await emitter.emissions.isEmpty)

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -237,9 +237,12 @@ struct MacOSComputerUseActuationTests {
         let recorder = ElementBoundaryRecorder()
         let emitter = AXComputerUseInputEmitter(
             captureSource: ActuationCaptureStub(result: fixture.capture),
-            elementBoundary: { payload, target, required in
-                recorder.calls.append(.init(payload: payload, target: target, required: required))
+            elementResolver: { payload, target in
+                recorder.calls.append(.init(payload: payload, target: target))
                 return recorder.binding
+            },
+            elementPerformer: { binding in
+                recorder.performed.append(binding)
             }
         )
 
@@ -249,9 +252,9 @@ struct MacOSComputerUseActuationTests {
         )
 
         #expect(recorder.calls.count == 2)
-        #expect(recorder.calls[0].required == nil)
-        #expect(recorder.calls[1].required === recorder.binding)
         #expect(recorder.calls.allSatisfy { $0.target == fixture.observation.target })
+        #expect(recorder.performed.count == 1)
+        #expect(recorder.performed[0] === recorder.binding)
     }
 
     @Test("Changed pixels prevent the final AX element boundary")
@@ -269,9 +272,12 @@ struct MacOSComputerUseActuationTests {
         let recorder = ElementBoundaryRecorder()
         let emitter = AXComputerUseInputEmitter(
             captureSource: ActuationCaptureStub(result: changedCapture),
-            elementBoundary: { payload, target, required in
-                recorder.calls.append(.init(payload: payload, target: target, required: required))
+            elementResolver: { payload, target in
+                recorder.calls.append(.init(payload: payload, target: target))
                 return recorder.binding
+            },
+            elementPerformer: { binding in
+                recorder.performed.append(binding)
             }
         )
 
@@ -282,7 +288,7 @@ struct MacOSComputerUseActuationTests {
             )
         }
         #expect(recorder.calls.count == 1)
-        #expect(recorder.calls[0].required == nil)
+        #expect(recorder.performed.isEmpty)
     }
 
     @Test("A changed AX element is rejected at the press boundary")
@@ -290,14 +296,17 @@ struct MacOSComputerUseActuationTests {
     func changedElementPreventsPress() async {
         let fixture = Self.captureFixture()
         let recorder = ElementBoundaryRecorder()
+        let replacement = ComputerUseElementBinding(
+            fingerprint: recorder.binding.fingerprint
+        )
         let emitter = AXComputerUseInputEmitter(
             captureSource: ActuationCaptureStub(result: fixture.capture),
-            elementBoundary: { payload, target, required in
-                recorder.calls.append(.init(payload: payload, target: target, required: required))
-                if required != nil {
-                    throw MacOSComputerUseActuationError.elementChanged
-                }
-                return recorder.binding
+            elementResolver: { payload, target in
+                recorder.calls.append(.init(payload: payload, target: target))
+                return recorder.calls.count == 1 ? recorder.binding : replacement
+            },
+            elementPerformer: { binding in
+                recorder.performed.append(binding)
             }
         )
 
@@ -308,6 +317,7 @@ struct MacOSComputerUseActuationTests {
             )
         }
         #expect(recorder.calls.count == 2)
+        #expect(recorder.performed.isEmpty)
     }
 
     @Test("Window-unbound keyboard payloads fail before desktop access", arguments: [
@@ -428,7 +438,6 @@ struct MacOSComputerUseActuationTests {
 private struct ElementBoundaryCall {
     let payload: WorkflowActionPayload
     let target: WorkflowInteractionTarget
-    let required: ComputerUseElementBinding?
 }
 
 @MainActor
@@ -443,6 +452,7 @@ private final class ElementBoundaryRecorder {
         )
     )
     var calls: [ElementBoundaryCall] = []
+    var performed: [ComputerUseElementBinding] = []
 }
 
 private actor TargetProbe: ComputerUseTargetProbing {

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -290,10 +290,14 @@ struct MacOSComputerUseActuationTests {
     @MainActor
     func emitterRechecksCancellationAfterProbe() async {
         let expected = Self.observation().target
+        let recorder = PostedEventRecorder()
         let emitter = CGEventComputerUseInputEmitter(
             targetReader: { $0 },
             cancellationCheck: { throw CancellationError() },
-            windowAtPointReader: { _ in expected.windowIdentifier }
+            windowAtPointReader: { _ in expected.windowIdentifier },
+            eventPoster: { event, processIdentifier in
+                recorder.record(event, processIdentifier: processIdentifier)
+            }
         )
 
         await #expect(throws: CancellationError.self) {
@@ -302,15 +306,21 @@ struct MacOSComputerUseActuationTests {
                 in: expected
             )
         }
+        #expect(recorder.eventTypes.isEmpty)
+        #expect(recorder.processIdentifiers.isEmpty)
     }
 
     @Test("An overlay at the click point prevents global input")
     @MainActor
     func occludingWindowStopsClick() async {
         let expected = Self.observation().target
+        let recorder = PostedEventRecorder()
         let emitter = CGEventComputerUseInputEmitter(
             targetReader: { $0 },
-            windowAtPointReader: { _ in "999" }
+            windowAtPointReader: { _ in "999" },
+            eventPoster: { event, processIdentifier in
+                recorder.record(event, processIdentifier: processIdentifier)
+            }
         )
 
         await #expect(throws: MacOSComputerUseActuationError.targetOccluded) {
@@ -319,6 +329,8 @@ struct MacOSComputerUseActuationTests {
                 in: expected
             )
         }
+        #expect(recorder.eventTypes.isEmpty)
+        #expect(recorder.processIdentifiers.isEmpty)
     }
 
     @Test("Events are delivered only to the selected process")
@@ -329,8 +341,8 @@ struct MacOSComputerUseActuationTests {
         let emitter = CGEventComputerUseInputEmitter(
             targetReader: { $0 },
             windowAtPointReader: { _ in expected.windowIdentifier },
-            eventPoster: { _, processIdentifier in
-                recorder.processIdentifiers.append(processIdentifier)
+            eventPoster: { event, processIdentifier in
+                recorder.record(event, processIdentifier: processIdentifier)
             }
         )
 
@@ -462,7 +474,13 @@ struct MacOSComputerUseActuationTests {
 
 @MainActor
 private final class PostedEventRecorder {
+    var eventTypes: [CGEventType] = []
     var processIdentifiers: [pid_t] = []
+
+    func record(_ event: CGEvent, processIdentifier: pid_t) {
+        eventTypes.append(event.type)
+        processIdentifiers.append(processIdentifier)
+    }
 }
 
 @MainActor

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -193,6 +193,38 @@ struct MacOSComputerUseActuationTests {
         }
     }
 
+    @Test("Click coordinates use the tolerated live frame")
+    func clickUsesLiveFrame() throws {
+        let liveFrame = WorkflowWindowFrame(
+            x: 100.5,
+            y: 200.5,
+            width: 799.5,
+            height: 599.5
+        )
+
+        let point = try CGEventComputerUseInputEmitter.clickPoint(
+            normalizedX: 0.25,
+            normalizedY: 0.75,
+            in: liveFrame
+        )
+
+        #expect(point.x == 300.375)
+        #expect(point.y == 650.125)
+    }
+
+    @Test("A normalized coordinate that rounds onto the live edge is rejected")
+    func roundedEdgeIsRejected() {
+        let frame = WorkflowWindowFrame(x: 100, y: 200, width: 800, height: 600)
+
+        #expect(throws: MacOSComputerUseActuationError.invalidAction) {
+            try CGEventComputerUseInputEmitter.clickPoint(
+                normalizedX: Double.leastNonzeroMagnitude,
+                normalizedY: 0.5,
+                in: frame
+            )
+        }
+    }
+
     @Test("Unicode chunks never split a surrogate pair")
     func unicodeChunksPreserveScalars() {
         let text = String(repeating: "a", count: 1_023) + "😀" + "b"

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -322,6 +322,35 @@ struct MacOSComputerUseActuationTests {
         #expect(recorder.performed.isEmpty)
     }
 
+    @Test("A focus change at the final resolver prevents AXPress")
+    @MainActor
+    func finalFocusChangePreventsPress() async {
+        let fixture = Self.captureFixture()
+        let recorder = ElementBoundaryRecorder()
+        let emitter = AXComputerUseInputEmitter(
+            captureSource: ActuationCaptureStub(result: fixture.capture),
+            elementResolver: { payload, target in
+                recorder.calls.append(.init(payload: payload, target: target))
+                if recorder.calls.count == 2 {
+                    throw MacOSComputerUseActuationError.targetNotFrontmost
+                }
+                return recorder.binding
+            },
+            elementPerformer: { binding in
+                recorder.performed.append(binding)
+            }
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.targetNotFrontmost) {
+            try await emitter.emit(
+                .click(normalizedX: 0.25, normalizedY: 0.75),
+                verifiedAgainst: fixture.observation
+            )
+        }
+        #expect(recorder.calls.count == 2)
+        #expect(recorder.performed.isEmpty)
+    }
+
     @Test("Window-unbound keyboard payloads fail before desktop access", arguments: [
         WorkflowActionPayload.typeText("draft"),
         WorkflowActionPayload.keyPress(key: "tab", modifiers: []),

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -246,7 +246,8 @@ struct MacOSComputerUseActuationTests {
             elementPerformer: { binding in
                 recorder.performed.append(binding)
             },
-            permissionReader: Self.granted
+            permissionReader: Self.granted,
+            targetValidator: Self.validTarget
         )
 
         try await emitter.emit(
@@ -282,7 +283,8 @@ struct MacOSComputerUseActuationTests {
             elementPerformer: { binding in
                 recorder.performed.append(binding)
             },
-            permissionReader: Self.granted
+            permissionReader: Self.granted,
+            targetValidator: Self.validTarget
         )
 
         await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
@@ -312,7 +314,8 @@ struct MacOSComputerUseActuationTests {
             elementPerformer: { binding in
                 recorder.performed.append(binding)
             },
-            permissionReader: Self.granted
+            permissionReader: Self.granted,
+            targetValidator: Self.validTarget
         )
 
         await #expect(throws: MacOSComputerUseActuationError.elementChanged) {
@@ -342,7 +345,8 @@ struct MacOSComputerUseActuationTests {
             elementPerformer: { binding in
                 recorder.performed.append(binding)
             },
-            permissionReader: Self.granted
+            permissionReader: Self.granted,
+            targetValidator: Self.validTarget
         )
 
         await #expect(throws: MacOSComputerUseActuationError.targetNotFrontmost) {
@@ -371,12 +375,43 @@ struct MacOSComputerUseActuationTests {
             },
             permissionReader: {
                 .init(screenRecording: true, accessibility: false)
-            }
+            },
+            targetValidator: Self.validTarget
         )
 
         await #expect(
             throws: MacOSComputerUseActuationError.permissionMissing([.accessibility])
         ) {
+            try await emitter.emit(
+                .click(normalizedX: 0.25, normalizedY: 0.75),
+                verifiedAgainst: fixture.observation
+            )
+        }
+        #expect(recorder.calls.count == 2)
+        #expect(recorder.performed.isEmpty)
+    }
+
+    @Test("A final occlusion check prevents AXPress")
+    @MainActor
+    func finalOcclusionPreventsPress() async {
+        let fixture = Self.captureFixture()
+        let recorder = ElementBoundaryRecorder()
+        let emitter = AXComputerUseInputEmitter(
+            captureSource: ActuationCaptureStub(result: fixture.capture),
+            elementResolver: { payload, target in
+                recorder.calls.append(.init(payload: payload, target: target))
+                return recorder.binding
+            },
+            elementPerformer: { binding in
+                recorder.performed.append(binding)
+            },
+            permissionReader: Self.granted,
+            targetValidator: { _, _ in
+                throw MacOSComputerUseActuationError.targetOccluded
+            }
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.targetOccluded) {
             try await emitter.emit(
                 .click(normalizedX: 0.25, normalizedY: 0.75),
                 verifiedAgainst: fixture.observation
@@ -480,6 +515,11 @@ struct MacOSComputerUseActuationTests {
     private static func granted() -> MacAutomationPermissionSnapshot {
         .init(screenRecording: true, accessibility: true)
     }
+
+    private static func validTarget(
+        _: WorkflowActionPayload,
+        _: WorkflowInteractionTarget
+    ) {}
 
     private static func captureFixture() -> (
         observation: WorkflowObservation,

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -114,6 +114,36 @@ struct MacOSComputerUseActuationTests {
         #expect(await emitter.emissions.isEmpty)
     }
 
+    @Test("The production emitter rechecks target drift at its event boundary")
+    @MainActor
+    func emitterRejectsLastMomentDrift() async {
+        let expected = Self.observation().target
+        let moved = WorkflowInteractionTarget(
+            bundleIdentifier: expected.bundleIdentifier,
+            processIdentifier: expected.processIdentifier,
+            windowIdentifier: expected.windowIdentifier,
+            windowFrame: .init(x: 104, y: 200, width: 800, height: 600)
+        )
+        let emitter = CGEventComputerUseInputEmitter(targetReader: { _ in moved })
+
+        await #expect(throws: MacOSComputerUseActuationError.targetChanged) {
+            try await emitter.emit(
+                .click(normalizedX: 0.25, normalizedY: 0.75),
+                in: expected
+            )
+        }
+    }
+
+    @Test("Unicode chunks never split a surrogate pair")
+    func unicodeChunksPreserveScalars() {
+        let text = String(repeating: "a", count: 1_023) + "😀" + "b"
+        let chunks = CGEventComputerUseInputEmitter.unicodeChunks(for: text)
+
+        #expect(chunks.map(\.count) == [1_023, 3])
+        #expect(chunks.allSatisfy { $0.count <= 1_024 })
+        #expect(String(decoding: chunks.flatMap { $0 }, as: UTF16.self) == text)
+    }
+
     private static func observation() -> WorkflowObservation {
         WorkflowObservation(
             target: WorkflowInteractionTarget(

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("macOS Computer Use actuation")
+struct MacOSComputerUseActuationTests {
+    @Test("The exact current observation may emit one bounded action")
+    func exactObservationEmits() async throws {
+        let observation = Self.observation()
+        let probe = TargetProbe(result: .success(observation.target))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+
+        try await actuator.perform(Self.action(for: observation), against: observation)
+
+        let emissions = await emitter.emissions
+        #expect(emissions == [.click(normalizedX: 0.25, normalizedY: 0.75)])
+    }
+
+    @Test("Stale model output is rejected before probing the live desktop")
+    func staleObservationIsRejected() async {
+        let observation = Self.observation()
+        let probe = TargetProbe(result: .success(observation.target))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+        let stale = GroundedWorkflowAction(
+            observationID: UUID(),
+            payload: .click(normalizedX: 0.25, normalizedY: 0.75),
+            source: .visualGrounding,
+            safeSummary: "Click draft",
+            risk: .localChange
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
+            try await actuator.perform(stale, against: observation)
+        }
+        #expect(await probe.callCount == 0)
+        #expect(await emitter.emissions.isEmpty)
+    }
+
+    @Test("Revoked permissions stop the action before desktop access")
+    func revokedPermissionStopsAction() async {
+        let observation = Self.observation()
+        let probe = TargetProbe(result: .success(observation.target))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: false) }
+        )
+
+        await #expect(
+            throws: MacOSComputerUseActuationError.permissionMissing([.accessibility])
+        ) {
+            try await actuator.perform(Self.action(for: observation), against: observation)
+        }
+        #expect(await probe.callCount == 0)
+        #expect(await emitter.emissions.isEmpty)
+    }
+
+    @Test("Window movement invalidates coordinates instead of clicking")
+    func movedWindowStopsAction() async {
+        let observation = Self.observation()
+        let moved = WorkflowInteractionTarget(
+            bundleIdentifier: observation.target.bundleIdentifier,
+            processIdentifier: observation.target.processIdentifier,
+            windowIdentifier: observation.target.windowIdentifier,
+            windowFrame: .init(x: 101, y: 200, width: 800, height: 600)
+        )
+        let probe = TargetProbe(result: .success(moved))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.targetChanged) {
+            try await actuator.perform(Self.action(for: observation), against: observation)
+        }
+        #expect(await emitter.emissions.isEmpty)
+    }
+
+    @Test("Invalid payloads fail closed before reading permissions")
+    func invalidPayloadStopsAction() async {
+        let observation = Self.observation()
+        let probe = TargetProbe(result: .success(observation.target))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+        let invalid = GroundedWorkflowAction(
+            observationID: observation.id,
+            payload: .click(normalizedX: .nan, normalizedY: 0.5),
+            source: .visualGrounding,
+            safeSummary: "Invalid",
+            risk: .readOnly
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.invalidAction) {
+            try await actuator.perform(invalid, against: observation)
+        }
+        #expect(await probe.callCount == 0)
+        #expect(await emitter.emissions.isEmpty)
+    }
+
+    private static func observation() -> WorkflowObservation {
+        WorkflowObservation(
+            target: WorkflowInteractionTarget(
+                bundleIdentifier: "com.example.Editor",
+                processIdentifier: 42,
+                windowIdentifier: "7",
+                windowFrame: .init(x: 100, y: 200, width: 800, height: 600)
+            ),
+            contentRevision: "revision"
+        )
+    }
+
+    private static func action(for observation: WorkflowObservation) -> GroundedWorkflowAction {
+        GroundedWorkflowAction(
+            observationID: observation.id,
+            payload: .click(normalizedX: 0.25, normalizedY: 0.75),
+            source: .visualGrounding,
+            safeSummary: "Click draft",
+            risk: .localChange
+        )
+    }
+}
+
+private actor TargetProbe: ComputerUseTargetProbing {
+    private let result: Result<WorkflowInteractionTarget, Error>
+    private(set) var callCount = 0
+
+    init(result: Result<WorkflowInteractionTarget, Error>) {
+        self.result = result
+    }
+
+    func currentTarget(for _: WorkflowInteractionTarget) async throws
+        -> WorkflowInteractionTarget
+    {
+        callCount += 1
+        return try result.get()
+    }
+}
+
+private actor InputEmitter: ComputerUseInputEmitting {
+    private(set) var emissions: [WorkflowActionPayload] = []
+
+    func emit(
+        _ payload: WorkflowActionPayload,
+        in _: WorkflowInteractionTarget
+    ) async throws {
+        emissions.append(payload)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -4,10 +4,15 @@ import Testing
 
 @Suite("macOS Computer Use actuation")
 struct MacOSComputerUseActuationTests {
-    @Test("The exact current observation may emit one bounded action")
-    func exactObservationEmits() async throws {
-        let observation = Self.observation()
-        let probe = TargetProbe(result: .success(observation.target))
+    @Test("A fresh equivalent observation may emit the grounded action")
+    func freshEquivalentObservationEmits() async throws {
+        let groundedObservation = Self.observation()
+        let currentObservation = WorkflowObservation(
+            target: groundedObservation.target,
+            contentRevision: groundedObservation.contentRevision
+        )
+        #expect(groundedObservation.id != currentObservation.id)
+        let probe = TargetProbe(result: .success(currentObservation.target))
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
@@ -15,32 +20,39 @@ struct MacOSComputerUseActuationTests {
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
 
-        try await actuator.perform(Self.action(for: observation), against: observation)
+        try await actuator.perform(
+            Self.action(for: groundedObservation),
+            against: currentObservation
+        )
 
         let emissions = await emitter.emissions
         #expect(emissions == [.click(normalizedX: 0.25, normalizedY: 0.75)])
     }
 
-    @Test("Stale model output is rejected before probing the live desktop")
-    func staleObservationIsRejected() async {
-        let observation = Self.observation()
-        let probe = TargetProbe(result: .success(observation.target))
+    @Test("An invalid current observation is rejected before probing the desktop")
+    func invalidCurrentObservationIsRejected() async {
+        let groundedObservation = Self.observation()
+        let invalidCurrent = WorkflowObservation(
+            target: WorkflowInteractionTarget(
+                bundleIdentifier: groundedObservation.target.bundleIdentifier,
+                processIdentifier: groundedObservation.target.processIdentifier,
+                windowIdentifier: groundedObservation.target.windowIdentifier,
+                windowFrame: .init(x: 0, y: 0, width: 0, height: 600)
+            ),
+            contentRevision: groundedObservation.contentRevision
+        )
+        let probe = TargetProbe(result: .success(groundedObservation.target))
         let emitter = InputEmitter()
         let actuator = MacOSComputerUseActuator(
             targetProbe: probe,
             inputEmitter: emitter,
             permissionReader: { .init(screenRecording: true, accessibility: true) }
         )
-        let stale = GroundedWorkflowAction(
-            observationID: UUID(),
-            payload: .click(normalizedX: 0.25, normalizedY: 0.75),
-            source: .visualGrounding,
-            safeSummary: "Click draft",
-            risk: .localChange
-        )
-
         await #expect(throws: MacOSComputerUseActuationError.staleObservation) {
-            try await actuator.perform(stale, against: observation)
+            try await actuator.perform(
+                Self.action(for: groundedObservation),
+                against: invalidCurrent
+            )
         }
         #expect(await probe.callCount == 0)
         #expect(await emitter.emissions.isEmpty)
@@ -114,6 +126,36 @@ struct MacOSComputerUseActuationTests {
         #expect(await emitter.emissions.isEmpty)
     }
 
+    @Test("Window-edge coordinates are rejected before target probing", arguments: [
+        WorkflowActionPayload.click(normalizedX: 0, normalizedY: 0.5),
+        WorkflowActionPayload.click(normalizedX: 1, normalizedY: 0.5),
+        WorkflowActionPayload.click(normalizedX: 0.5, normalizedY: 0),
+        WorkflowActionPayload.click(normalizedX: 0.5, normalizedY: 1),
+    ])
+    func edgeCoordinatesStopAction(payload: WorkflowActionPayload) async {
+        let observation = Self.observation()
+        let probe = TargetProbe(result: .success(observation.target))
+        let emitter = InputEmitter()
+        let actuator = MacOSComputerUseActuator(
+            targetProbe: probe,
+            inputEmitter: emitter,
+            permissionReader: { .init(screenRecording: true, accessibility: true) }
+        )
+        let action = GroundedWorkflowAction(
+            observationID: observation.id,
+            payload: payload,
+            source: .visualGrounding,
+            safeSummary: "Edge click",
+            risk: .readOnly
+        )
+
+        await #expect(throws: MacOSComputerUseActuationError.invalidAction) {
+            try await actuator.perform(action, against: observation)
+        }
+        #expect(await probe.callCount == 0)
+        #expect(await emitter.emissions.isEmpty)
+    }
+
     @Test("The production emitter rechecks target drift at its event boundary")
     @MainActor
     func emitterRejectsLastMomentDrift() async {
@@ -127,6 +169,23 @@ struct MacOSComputerUseActuationTests {
         let emitter = CGEventComputerUseInputEmitter(targetReader: { _ in moved })
 
         await #expect(throws: MacOSComputerUseActuationError.targetChanged) {
+            try await emitter.emit(
+                .click(normalizedX: 0.25, normalizedY: 0.75),
+                in: expected
+            )
+        }
+    }
+
+    @Test("Cancellation during the final target probe prevents the event")
+    @MainActor
+    func emitterRechecksCancellationAfterProbe() async {
+        let expected = Self.observation().target
+        let emitter = CGEventComputerUseInputEmitter(
+            targetReader: { $0 },
+            cancellationCheck: { throw CancellationError() }
+        )
+
+        await #expect(throws: CancellationError.self) {
             try await emitter.emit(
                 .click(normalizedX: 0.25, normalizedY: 0.75),
                 in: expected

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -93,6 +93,7 @@ struct MacOSComputerUseActuationTests {
             target: WorkflowInteractionTarget(
                 bundleIdentifier: groundedObservation.target.bundleIdentifier,
                 processIdentifier: groundedObservation.target.processIdentifier,
+                processLaunchDate: groundedObservation.target.processLaunchDate,
                 windowIdentifier: groundedObservation.target.windowIdentifier,
                 windowFrame: .init(x: 0, y: 0, width: 0, height: 600)
             ),
@@ -146,6 +147,7 @@ struct MacOSComputerUseActuationTests {
         let moved = WorkflowInteractionTarget(
             bundleIdentifier: observation.target.bundleIdentifier,
             processIdentifier: observation.target.processIdentifier,
+            processLaunchDate: observation.target.processLaunchDate,
             windowIdentifier: observation.target.windowIdentifier,
             windowFrame: .init(x: 101, y: 200, width: 800, height: 600)
         )
@@ -393,6 +395,7 @@ struct MacOSComputerUseActuationTests {
             target: WorkflowInteractionTarget(
                 bundleIdentifier: "com.example.Editor",
                 processIdentifier: 42,
+                processLaunchDate: Date(timeIntervalSinceReferenceDate: 1_000),
                 windowIdentifier: "7",
                 windowFrame: .init(x: 100, y: 200, width: 800, height: 600)
             ),

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -387,7 +387,7 @@ struct MacOSComputerUseActuationTests {
                 verifiedAgainst: fixture.observation
             )
         }
-        #expect(recorder.calls.count == 2)
+        #expect(recorder.calls.count == 1)
         #expect(recorder.performed.isEmpty)
     }
 
@@ -417,7 +417,7 @@ struct MacOSComputerUseActuationTests {
                 verifiedAgainst: fixture.observation
             )
         }
-        #expect(recorder.calls.count == 2)
+        #expect(recorder.calls.count == 1)
         #expect(recorder.performed.isEmpty)
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -239,7 +239,7 @@ struct MacOSComputerUseActuationTests {
             captureSource: ActuationCaptureStub(result: fixture.capture),
             elementBoundary: { payload, target, required in
                 recorder.calls.append(.init(payload: payload, target: target, required: required))
-                return recorder.fingerprint
+                return recorder.binding
             }
         )
 
@@ -250,7 +250,7 @@ struct MacOSComputerUseActuationTests {
 
         #expect(recorder.calls.count == 2)
         #expect(recorder.calls[0].required == nil)
-        #expect(recorder.calls[1].required == recorder.fingerprint)
+        #expect(recorder.calls[1].required === recorder.binding)
         #expect(recorder.calls.allSatisfy { $0.target == fixture.observation.target })
     }
 
@@ -271,7 +271,7 @@ struct MacOSComputerUseActuationTests {
             captureSource: ActuationCaptureStub(result: changedCapture),
             elementBoundary: { payload, target, required in
                 recorder.calls.append(.init(payload: payload, target: target, required: required))
-                return recorder.fingerprint
+                return recorder.binding
             }
         )
 
@@ -297,7 +297,7 @@ struct MacOSComputerUseActuationTests {
                 if required != nil {
                     throw MacOSComputerUseActuationError.elementChanged
                 }
-                return recorder.fingerprint
+                return recorder.binding
             }
         )
 
@@ -428,17 +428,19 @@ struct MacOSComputerUseActuationTests {
 private struct ElementBoundaryCall {
     let payload: WorkflowActionPayload
     let target: WorkflowInteractionTarget
-    let required: ComputerUseElementFingerprint?
+    let required: ComputerUseElementBinding?
 }
 
 @MainActor
 private final class ElementBoundaryRecorder {
-    let fingerprint = ComputerUseElementFingerprint(
-        role: "AXButton",
-        subrole: nil,
-        identifier: "submit",
-        title: "Submit",
-        frame: .init(x: 200, y: 300, width: 80, height: 30)
+    let binding = ComputerUseElementBinding(
+        fingerprint: ComputerUseElementFingerprint(
+            role: "AXButton",
+            subrole: nil,
+            identifier: "submit",
+            title: "Submit",
+            frame: .init(x: 200, y: 300, width: 80, height: 30)
+        )
     )
     var calls: [ElementBoundaryCall] = []
 }

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -284,6 +284,34 @@ struct MacOSComputerUseActuationTests {
         }
     }
 
+    @Test("Destructive modifier combinations are rejected before input")
+    @MainActor
+    func destructiveKeyChordIsRejected() async {
+        let expected = Self.observation().target
+        let emitter = CGEventComputerUseInputEmitter(targetReader: { $0 })
+
+        await #expect(throws: MacOSComputerUseActuationError.unsupportedKey) {
+            try await emitter.emit(
+                .keyPress(key: "delete", modifiers: ["command", "option"]),
+                in: expected
+            )
+        }
+    }
+
+    @Test("Duplicate modifiers cannot bypass the complete-chord allowlist")
+    @MainActor
+    func duplicateModifiersAreRejected() async {
+        let expected = Self.observation().target
+        let emitter = CGEventComputerUseInputEmitter(targetReader: { $0 })
+
+        await #expect(throws: MacOSComputerUseActuationError.unsupportedKey) {
+            try await emitter.emit(
+                .keyPress(key: "tab", modifiers: ["shift", "shift"]),
+                in: expected
+            )
+        }
+    }
+
     @Test("Click coordinates use the tolerated live frame")
     func clickUsesLiveFrame() throws {
         let liveFrame = WorkflowWindowFrame(

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseActuationTests.swift
@@ -284,6 +284,27 @@ struct MacOSComputerUseActuationTests {
         }
     }
 
+    @Test("Events are delivered only to the selected process")
+    @MainActor
+    func inputDeliveryIsProcessBound() async throws {
+        let expected = Self.observation().target
+        let recorder = PostedEventRecorder()
+        let emitter = CGEventComputerUseInputEmitter(
+            targetReader: { $0 },
+            windowAtPointReader: { _ in expected.windowIdentifier },
+            eventPoster: { _, processIdentifier in
+                recorder.processIdentifiers.append(processIdentifier)
+            }
+        )
+
+        try await emitter.emit(
+            .click(normalizedX: 0.25, normalizedY: 0.75),
+            in: expected
+        )
+
+        #expect(recorder.processIdentifiers == [42, 42])
+    }
+
     @Test("Destructive modifier combinations are rejected before input")
     @MainActor
     func destructiveKeyChordIsRejected() async {
@@ -375,6 +396,11 @@ struct MacOSComputerUseActuationTests {
             risk: .localChange
         )
     }
+}
+
+@MainActor
+private final class PostedEventRecorder {
+    var processIdentifiers: [pid_t] = []
 }
 
 private actor TargetProbe: ComputerUseTargetProbing {

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("macOS Computer Use observation")
+struct MacOSComputerUseObservationTests {
+    private let selection = ComputerUseWindowSelection(
+        bundleIdentifier: "com.example.Editor",
+        windowID: 42
+    )
+
+    @Test("Observation requires both contextual grants before capture")
+    func permissionGate() async {
+        let capture = CaptureStub(result: Self.captureResult())
+        let vault = ComputerUseObservationVault()
+        let observer = MacOSComputerUseObserver(
+            selections: ["draft": selection],
+            vault: vault,
+            captureSource: capture,
+            permissionReader: {
+                MacAutomationPermissionSnapshot(
+                    screenRecording: true,
+                    accessibility: false
+                )
+            }
+        )
+
+        do {
+            _ = try await observer.observe(for: Self.step())
+            Issue.record("Expected permission failure")
+        } catch let error as MacOSComputerUseObservationError {
+            #expect(error == .permissionMissing([.accessibility]))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(await capture.callCount == 0)
+    }
+
+    @Test("An exact selected-window capture is metadata-only and retrievable ephemerally")
+    func exactWindowCapture() async throws {
+        let result = Self.captureResult()
+        let capture = CaptureStub(result: result)
+        let vault = ComputerUseObservationVault()
+        let observer = MacOSComputerUseObserver(
+            selections: ["draft": selection],
+            vault: vault,
+            captureSource: capture,
+            permissionReader: Self.granted
+        )
+
+        let first = try await observer.observe(for: Self.step())
+        let second = try await observer.observe(for: Self.step())
+
+        #expect(first.id != second.id)
+        #expect(first.target == result.target)
+        #expect(first.contentRevision == second.contentRevision)
+        #expect(first.contentRevision.count == 64)
+        #expect(await vault.artifact(for: first.id) == result.artifact)
+        #expect(await capture.callCount == 2)
+    }
+
+    @Test("Unknown steps cannot widen observation to another window")
+    func unknownStepFailsClosed() async {
+        let capture = CaptureStub(result: Self.captureResult())
+        let observer = MacOSComputerUseObserver(
+            selections: [:],
+            vault: ComputerUseObservationVault(),
+            captureSource: capture,
+            permissionReader: Self.granted
+        )
+        do {
+            _ = try await observer.observe(for: Self.step())
+            Issue.record("Expected target configuration failure")
+        } catch let error as MacOSComputerUseObservationError {
+            #expect(error == .targetNotConfigured)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(await capture.callCount == 0)
+    }
+
+    @Test("The screenshot vault evicts old pixels and clears all run data")
+    func vaultIsBounded() async {
+        let vault = ComputerUseObservationVault(maximumArtifacts: 2)
+        let one = UUID()
+        let two = UUID()
+        let three = UUID()
+        let artifact = Self.captureResult().artifact
+
+        await vault.store(artifact, for: one)
+        await vault.store(artifact, for: two)
+        await vault.store(artifact, for: three)
+        #expect(await vault.artifact(for: one) == nil)
+        #expect(await vault.artifact(for: two) != nil)
+        #expect(await vault.artifact(for: three) != nil)
+
+        await vault.removeAll()
+        #expect(await vault.artifact(for: two) == nil)
+        #expect(await vault.artifact(for: three) == nil)
+    }
+
+    private static func granted() -> MacAutomationPermissionSnapshot {
+        MacAutomationPermissionSnapshot(
+            screenRecording: true,
+            accessibility: true
+        )
+    }
+
+    private static func step() -> LocalWorkflowStep {
+        LocalWorkflowStep(
+            id: "draft",
+            title: "Draft locally",
+            instruction: "Focus the document",
+            successCriteria: "The document is focused"
+        )
+    }
+
+    private static func captureResult() -> ComputerUseCapturedWindow {
+        ComputerUseCapturedWindow(
+            target: WorkflowInteractionTarget(
+                bundleIdentifier: "com.example.Editor",
+                processIdentifier: 123,
+                windowIdentifier: "42",
+                windowFrame: WorkflowWindowFrame(
+                    x: 10,
+                    y: 20,
+                    width: 800,
+                    height: 600
+                )
+            ),
+            artifact: ComputerUseObservationArtifact(
+                pngData: Data([1, 2, 3, 4]),
+                pixelWidth: 800,
+                pixelHeight: 600
+            )
+        )
+    }
+}
+
+private actor CaptureStub: ComputerUseWindowCapturing {
+    private let result: ComputerUseCapturedWindow
+    private(set) var callCount = 0
+
+    init(result: ComputerUseCapturedWindow) {
+        self.result = result
+    }
+
+    func capture(_ selection: ComputerUseWindowSelection) async throws
+        -> ComputerUseCapturedWindow
+    {
+        callCount += 1
+        return result
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
@@ -6,6 +6,7 @@ import Testing
 struct MacOSComputerUseObservationTests {
     private let selection = ComputerUseWindowSelection(
         bundleIdentifier: "com.example.Editor",
+        processIdentifier: 123,
         windowID: 42
     )
 
@@ -57,6 +58,31 @@ struct MacOSComputerUseObservationTests {
         #expect(first.contentRevision.count == 64)
         #expect(await vault.artifact(for: first.id) == result.artifact)
         #expect(await capture.callCount == 2)
+    }
+
+    @Test("A recycled window ID from a different process is rejected")
+    func recycledWindowIDFailsClosed() async {
+        let original = Self.captureResult()
+        let recycled = ComputerUseCapturedWindow(
+            target: WorkflowInteractionTarget(
+                bundleIdentifier: original.target.bundleIdentifier,
+                processIdentifier: 124,
+                windowIdentifier: original.target.windowIdentifier,
+                windowFrame: original.target.windowFrame
+            ),
+            artifact: original.artifact
+        )
+        let capture = CaptureStub(result: recycled)
+        let observer = MacOSComputerUseObserver(
+            selections: ["draft": selection],
+            vault: ComputerUseObservationVault(),
+            captureSource: capture,
+            permissionReader: Self.granted
+        )
+
+        await #expect(throws: MacOSComputerUseObservationError.invalidCapture) {
+            _ = try await observer.observe(for: Self.step())
+        }
     }
 
     @Test("Unknown steps cannot widen observation to another window")

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
@@ -60,6 +60,143 @@ struct MacOSComputerUseObservationTests {
         #expect(await capture.callCount == 2)
     }
 
+    @Test("ScreenCaptureKit boundary resolves the exact selection before and after pixels")
+    func screenCaptureBoundaryUsesExactSelection() async throws {
+        let target = Self.captureResult().target
+        let resolver = WindowResolverStub(
+            results: [
+                .success(.init(window: nil, target: target)),
+                .success(.init(window: nil, target: target)),
+            ]
+        )
+        let image = ImageCapturerStub(artifact: Self.captureResult().artifact)
+        let capture = ScreenCaptureKitComputerUseCapture(
+            windowResolver: { selection in try await resolver.resolve(selection) },
+            imageCapturer: { resolved, size in
+                await image.capture(resolved, size: size)
+            }
+        )
+
+        let result = try await capture.capture(selection)
+
+        #expect(result == Self.captureResult())
+        #expect(await resolver.selections == [selection, selection])
+        #expect(await image.callCount == 1)
+        #expect(await image.requestedTarget == target)
+        #expect(await image.requestedSize == CGSize(width: 800, height: 600))
+    }
+
+    @Test("A resolver cannot substitute another bundle, process, or window")
+    func screenCaptureBoundaryRejectsSubstitution() async {
+        let original = Self.captureResult().target
+        let substitutions = [
+            WorkflowInteractionTarget(
+                bundleIdentifier: "com.example.Other",
+                processIdentifier: original.processIdentifier,
+                windowIdentifier: original.windowIdentifier,
+                windowFrame: original.windowFrame
+            ),
+            WorkflowInteractionTarget(
+                bundleIdentifier: original.bundleIdentifier,
+                processIdentifier: 999,
+                windowIdentifier: original.windowIdentifier,
+                windowFrame: original.windowFrame
+            ),
+            WorkflowInteractionTarget(
+                bundleIdentifier: original.bundleIdentifier,
+                processIdentifier: original.processIdentifier,
+                windowIdentifier: "99",
+                windowFrame: original.windowFrame
+            ),
+        ]
+
+        for substitution in substitutions {
+            let resolver = WindowResolverStub(
+                results: [.success(.init(window: nil, target: substitution))]
+            )
+            let image = ImageCapturerStub(artifact: Self.captureResult().artifact)
+            let capture = ScreenCaptureKitComputerUseCapture(
+                windowResolver: { selection in try await resolver.resolve(selection) },
+                imageCapturer: { resolved, size in
+                    await image.capture(resolved, size: size)
+                }
+            )
+
+            await #expect(throws: MacOSComputerUseObservationError.invalidCapture) {
+                _ = try await capture.capture(selection)
+            }
+            #expect(await image.callCount == 0)
+        }
+    }
+
+    @Test("Window filtering rejects bundle, process, window, visibility, and focus mismatches")
+    func windowFilteringFailsClosed() {
+        let frame = CGRect(x: 10, y: 20, width: 800, height: 600)
+        let foreground = ScreenCaptureKitComputerUseCapture.ForegroundRecord(
+            bundleIdentifier: selection.bundleIdentifier,
+            processIdentifier: selection.processIdentifier,
+            focusedFrame: frame
+        )
+        let valid = ScreenCaptureKitComputerUseCapture.WindowRecord(
+            windowID: selection.windowID,
+            bundleIdentifier: selection.bundleIdentifier,
+            processIdentifier: selection.processIdentifier,
+            frame: frame,
+            isOnScreen: true
+        )
+        let invalidRecords = [
+            ScreenCaptureKitComputerUseCapture.WindowRecord(
+                windowID: 99,
+                bundleIdentifier: valid.bundleIdentifier,
+                processIdentifier: valid.processIdentifier,
+                frame: frame,
+                isOnScreen: true
+            ),
+            ScreenCaptureKitComputerUseCapture.WindowRecord(
+                windowID: valid.windowID,
+                bundleIdentifier: "com.example.Other",
+                processIdentifier: valid.processIdentifier,
+                frame: frame,
+                isOnScreen: true
+            ),
+            ScreenCaptureKitComputerUseCapture.WindowRecord(
+                windowID: valid.windowID,
+                bundleIdentifier: valid.bundleIdentifier,
+                processIdentifier: 999,
+                frame: frame,
+                isOnScreen: true
+            ),
+            ScreenCaptureKitComputerUseCapture.WindowRecord(
+                windowID: valid.windowID,
+                bundleIdentifier: valid.bundleIdentifier,
+                processIdentifier: valid.processIdentifier,
+                frame: frame,
+                isOnScreen: false
+            ),
+        ]
+
+        for record in invalidRecords {
+            #expect(throws: MacOSComputerUseObservationError.targetUnavailable) {
+                _ = try ScreenCaptureKitComputerUseCapture.validatedTarget(
+                    selection,
+                    foreground: foreground,
+                    windows: [record]
+                )
+            }
+        }
+        #expect(throws: MacOSComputerUseObservationError.targetNotFrontmost) {
+            _ = try ScreenCaptureKitComputerUseCapture.validatedTarget(
+                selection,
+                foreground: .init(
+                    bundleIdentifier: selection.bundleIdentifier,
+                    processIdentifier: selection.processIdentifier,
+                    focusedFrame: CGRect(x: 0, y: 0, width: 10, height: 10)
+                ),
+                windows: [valid]
+            )
+        }
+    }
+
     @Test("A recycled window ID from a different process is rejected")
     func recycledWindowIDFailsClosed() async {
         let original = Self.captureResult()
@@ -176,5 +313,45 @@ private actor CaptureStub: ComputerUseWindowCapturing {
     {
         callCount += 1
         return result
+    }
+}
+
+private actor WindowResolverStub {
+    private var results: [Result<ScreenCaptureKitComputerUseCapture.ResolvedWindow, Error>]
+    private(set) var selections: [ComputerUseWindowSelection] = []
+
+    init(results: [Result<ScreenCaptureKitComputerUseCapture.ResolvedWindow, Error>]) {
+        self.results = results
+    }
+
+    func resolve(_ selection: ComputerUseWindowSelection) throws
+        -> ScreenCaptureKitComputerUseCapture.ResolvedWindow
+    {
+        selections.append(selection)
+        guard !results.isEmpty else {
+            throw MacOSComputerUseObservationError.targetUnavailable
+        }
+        return try results.removeFirst().get()
+    }
+}
+
+private actor ImageCapturerStub {
+    private let artifact: ComputerUseObservationArtifact
+    private(set) var callCount = 0
+    private(set) var requestedTarget: WorkflowInteractionTarget?
+    private(set) var requestedSize: CGSize?
+
+    init(artifact: ComputerUseObservationArtifact) {
+        self.artifact = artifact
+    }
+
+    func capture(
+        _ resolved: ScreenCaptureKitComputerUseCapture.ResolvedWindow,
+        size: CGSize
+    ) -> ComputerUseObservationArtifact {
+        callCount += 1
+        requestedTarget = resolved.target
+        requestedSize = size
+        return artifact
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
@@ -7,6 +7,7 @@ struct MacOSComputerUseObservationTests {
     private let selection = ComputerUseWindowSelection(
         bundleIdentifier: "com.example.Editor",
         processIdentifier: 123,
+        processLaunchDate: Date(timeIntervalSinceReferenceDate: 1_000),
         windowID: 42
     )
 
@@ -93,18 +94,28 @@ struct MacOSComputerUseObservationTests {
             WorkflowInteractionTarget(
                 bundleIdentifier: "com.example.Other",
                 processIdentifier: original.processIdentifier,
+                processLaunchDate: original.processLaunchDate,
                 windowIdentifier: original.windowIdentifier,
                 windowFrame: original.windowFrame
             ),
             WorkflowInteractionTarget(
                 bundleIdentifier: original.bundleIdentifier,
                 processIdentifier: 999,
+                processLaunchDate: original.processLaunchDate,
                 windowIdentifier: original.windowIdentifier,
                 windowFrame: original.windowFrame
             ),
             WorkflowInteractionTarget(
                 bundleIdentifier: original.bundleIdentifier,
                 processIdentifier: original.processIdentifier,
+                processLaunchDate: Date(timeIntervalSinceReferenceDate: 2_000),
+                windowIdentifier: original.windowIdentifier,
+                windowFrame: original.windowFrame
+            ),
+            WorkflowInteractionTarget(
+                bundleIdentifier: original.bundleIdentifier,
+                processIdentifier: original.processIdentifier,
+                processLaunchDate: original.processLaunchDate,
                 windowIdentifier: "99",
                 windowFrame: original.windowFrame
             ),
@@ -135,6 +146,7 @@ struct MacOSComputerUseObservationTests {
         let foreground = ScreenCaptureKitComputerUseCapture.ForegroundRecord(
             bundleIdentifier: selection.bundleIdentifier,
             processIdentifier: selection.processIdentifier,
+            processLaunchDate: selection.processLaunchDate,
             focusedFrame: frame
         )
         let valid = ScreenCaptureKitComputerUseCapture.WindowRecord(
@@ -190,6 +202,19 @@ struct MacOSComputerUseObservationTests {
                 foreground: .init(
                     bundleIdentifier: selection.bundleIdentifier,
                     processIdentifier: selection.processIdentifier,
+                    processLaunchDate: Date(timeIntervalSinceReferenceDate: 2_000),
+                    focusedFrame: frame
+                ),
+                windows: [valid]
+            )
+        }
+        #expect(throws: MacOSComputerUseObservationError.targetNotFrontmost) {
+            _ = try ScreenCaptureKitComputerUseCapture.validatedTarget(
+                selection,
+                foreground: .init(
+                    bundleIdentifier: selection.bundleIdentifier,
+                    processIdentifier: selection.processIdentifier,
+                    processLaunchDate: selection.processLaunchDate,
                     focusedFrame: CGRect(x: 0, y: 0, width: 10, height: 10)
                 ),
                 windows: [valid]
@@ -204,6 +229,7 @@ struct MacOSComputerUseObservationTests {
             target: WorkflowInteractionTarget(
                 bundleIdentifier: original.target.bundleIdentifier,
                 processIdentifier: 124,
+                processLaunchDate: original.target.processLaunchDate,
                 windowIdentifier: original.target.windowIdentifier,
                 windowFrame: original.target.windowFrame
             ),
@@ -283,6 +309,7 @@ struct MacOSComputerUseObservationTests {
             target: WorkflowInteractionTarget(
                 bundleIdentifier: "com.example.Editor",
                 processIdentifier: 123,
+                processLaunchDate: Date(timeIntervalSinceReferenceDate: 1_000),
                 windowIdentifier: "42",
                 windowFrame: WorkflowWindowFrame(
                     x: 10,

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
@@ -60,6 +60,25 @@ struct MacOSComputerUseObservationTests {
         #expect(await capture.callCount == 2)
     }
 
+    @Test("The final content probe hashes one exact selected-window capture")
+    func finalContentProbe() async throws {
+        let result = Self.captureResult()
+        let capture = CaptureStub(result: result)
+        let probe = ScreenCaptureKitComputerUseContentProbe(captureSource: capture)
+
+        let observation = try await probe.currentObservation(for: result.target)
+
+        #expect(observation.target == result.target)
+        #expect(
+            observation.contentRevision
+                == MacOSComputerUseObserver.contentRevision(
+                    target: result.target,
+                    pngData: result.artifact.pngData
+                )
+        )
+        #expect(await capture.callCount == 1)
+    }
+
     @Test("A recycled window ID from a different process is rejected")
     func recycledWindowIDFailsClosed() async {
         let original = Self.captureResult()

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
@@ -248,6 +248,31 @@ struct MacOSComputerUseObservationTests {
         }
     }
 
+    @Test("A recycled PID and window ID from another app launch is rejected")
+    func recycledProcessLaunchFailsClosed() async {
+        let original = Self.captureResult()
+        let recycled = ComputerUseCapturedWindow(
+            target: WorkflowInteractionTarget(
+                bundleIdentifier: original.target.bundleIdentifier,
+                processIdentifier: original.target.processIdentifier,
+                processLaunchDate: Date(timeIntervalSinceReferenceDate: 2_000),
+                windowIdentifier: original.target.windowIdentifier,
+                windowFrame: original.target.windowFrame
+            ),
+            artifact: original.artifact
+        )
+        let observer = MacOSComputerUseObserver(
+            selections: ["draft": selection],
+            vault: ComputerUseObservationVault(),
+            captureSource: CaptureStub(result: recycled),
+            permissionReader: Self.granted
+        )
+
+        await #expect(throws: MacOSComputerUseObservationError.invalidCapture) {
+            _ = try await observer.observe(for: Self.step())
+        }
+    }
+
     @Test("Unknown steps cannot widen observation to another window")
     func unknownStepFailsClosed() async {
         let capture = CaptureStub(result: Self.captureResult())

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseObservationTests.swift
@@ -60,25 +60,6 @@ struct MacOSComputerUseObservationTests {
         #expect(await capture.callCount == 2)
     }
 
-    @Test("The final content probe hashes one exact selected-window capture")
-    func finalContentProbe() async throws {
-        let result = Self.captureResult()
-        let capture = CaptureStub(result: result)
-        let probe = ScreenCaptureKitComputerUseContentProbe(captureSource: capture)
-
-        let observation = try await probe.currentObservation(for: result.target)
-
-        #expect(observation.target == result.target)
-        #expect(
-            observation.contentRevision
-                == MacOSComputerUseObserver.contentRevision(
-                    target: result.target,
-                    pngData: result.artifact.pngData
-                )
-        )
-        #expect(await capture.callCount == 1)
-    }
-
     @Test("A recycled window ID from a different process is rejected")
     func recycledWindowIDFailsClosed() async {
         let original = Self.captureResult()


### PR DESCRIPTION
## Why

Part of #3094. The experimental Computer Use shell and deterministic workflow kernel now exist, but the kernel has no production-safe boundary for observing or controlling another macOS app. Without that boundary, connecting a local GUI model would either require broad desktop capture or permit stale coordinates to act after focus/window drift.

## Scope

- Centralize side-effect-free Accessibility and Screen Recording permission state while preserving Dictation behavior.
- Capture only the exact, explicitly selected, focused window with ScreenCaptureKit; bind the selection to bundle, process, and window identity; downscale to at most 1280×720.
- Keep screenshot pixels in a bounded, memory-only vault and persist only metadata plus a content hash.
- Resolve a bounded click to a press-capable Accessibility element inside the selected focused window, retain that exact element across the final capture, and deliver only `AXPress`.
- Use a final screenshot hash as a pre-action freshness checkpoint, then synchronously recheck permissions, foreground process, focused window, exact window identity, geometry, occlusion, and Accessibility-element identity at the input boundary.

## Non-goals

- No Teach recorder, scheduler, cloud fallback, or model download/catalog work.
- No free-running desktop agent and no whole-desktop capture.
- No text or key injection; public macOS event APIs cannot bind keyboard delivery to one exact window within a process, so those payloads fail closed until a semantic Accessibility adapter exists.
- No starter flow becomes runnable in this PR.
- No automatic publish, send, delete, checkout, payment, or other consequential action.

## Acceptance

- Missing permissions, an unknown step target, an invalid capture, process restart, focus drift, window movement, an occluded click point, a stale/forged grounding state, a changed Accessibility element, a window-unbound keyboard payload, or an invalid action fails closed before input.
- Screenshots cannot enter workflow persistence or the metadata-only audit ledger.
- A click proceeds only after the current pixels match the observed state; at input, the same selected focused window, process launch, geometry, unoccluded point, permissions, and press-capable Accessibility element are revalidated synchronously. Input is delivered with `AXPress`, not a global pointer event. ScreenCaptureKit and Accessibility do not expose a shared atomic transaction, so the screenshot hash is a freshness checkpoint rather than a claim that pixels are locked through the press instant.
- Existing Dictation permission prompts and system privacy routing remain behaviorally unchanged.
- The app bundle carries a clear ScreenCaptureKit privacy usage description.

## Design precedent

The adapter follows the established record/compile/execute pattern used by mature desktop automation systems: workflow orchestration owns progress and policy; the visual model may propose one bounded action; the operating-system adapter independently rebinds that action to current UI state; and verification decides whether execution advances. Stable semantic or deterministic actions remain preferred, with visual coordinates treated as session-scoped, disposable data. This PR adapts that pattern to macOS public APIs and deliberately rejects whole-desktop authority and hidden app activation.

## Verification

- Focused Computer Use, workflow-kernel, and permission suites — 52 tests in 4 suites passed on exact head `13ca4d8b8`.
- Complete Swift suite — 3,496 tests in 302 suites passed on exact head `13ca4d8b8`.
- `swift build -c release` — passed on exact head `13ca4d8b8`.
- `pr_validate` — MERGE-SAFE on exact head `13ca4d8b8`: independent Codex review found no blocking issues; 22,861 Python tests passed, 108 skipped, 22 deselected, 6 expected failures, and 1 expected pass.
- `plutil -lint apps/rapid-mac/Resources/Info.plist` — passed.
- Live Studio probe — the frontmost Rapid window's Accessibility frame matched its unique CGWindow frame (`480,80,1440×900`).
- `git diff --check origin/main...HEAD` — passed.

## AI assistance disclosure

Codex authored and reviewed the permission, observation, focus-binding, actuation, and test files. The implementation was checked against the workflow-kernel contract, compiled in Debug and Release configurations, exercised through focused negative-path tests, and validated with the complete Swift test suite. Review findings were resolved by narrowing authority where macOS cannot provide an exact-window guarantee rather than retaining timing-dependent input behavior.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Applicable Swift tests pass locally; the Python suite is not affected by this Desktop-only diff.
- [x] Formatting and whitespace checked with `git diff --check`.
- [x] Self-validation is running against the opened PR and will be posted before queue authorization.
- [x] Negative controls cover stale/forged grounding, revoked permission, invalid actions, process/window drift, occlusion, changed AX identity, unknown targets, keyboard rejection, and bounded pixel retention.
- [x] No documentation change is needed for an internal adapter that is not user-runnable yet.
- [x] No breaking changes to existing public API.

## Author

@raullenchai
