### PR TITLE
fix(image): accept pinned Klein BF16 single-file weights

### DIFF
--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -198,6 +198,55 @@ def test_bf16_residency_charge_does_not_fall_through_to_q4():
     assert estimate_model_bytes(FLUX2_KLEIN_Q4_ALIAS) < 18 * gib
 
 
+def test_real_bf16_single_file_layout_is_complete(monkeypatch, tmp_path):
+    """The pinned package uses Diffusers single files, not fake shard indexes."""
+
+    import json
+
+    import huggingface_hub.constants
+
+    from vllm_mlx import _download_gate as download_gate
+
+    revision = IMAGE_MODEL_REVISIONS[FLUX2_KLEIN_BF16_REPO]
+    snapshot = (
+        tmp_path
+        / f"models--{FLUX2_KLEIN_BF16_REPO.replace('/', '--')}"
+        / "snapshots"
+        / revision
+    )
+    tokenizer = snapshot / "tokenizer"
+    tokenizer.mkdir(parents=True)
+    (tokenizer / "tokenizer.json").write_text("{}")
+
+    text_encoder = snapshot / "text_encoder"
+    text_encoder.mkdir()
+    text_shard = "model-00001-of-00001.safetensors"
+    (text_encoder / text_shard).write_bytes(b"text weights")
+    (text_encoder / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"tensor": text_shard}})
+    )
+    for component in ("transformer", "vae"):
+        directory = snapshot / component
+        directory.mkdir()
+        (directory / "diffusion_pytorch_model.safetensors").write_bytes(b"weights")
+
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+
+    assert download_gate.mflux_missing_weights(FLUX2_KLEIN_BF16_REPO) == []
+    (snapshot / "transformer" / "diffusion_pytorch_model.safetensors").unlink()
+    assert download_gate.mflux_missing_weights(FLUX2_KLEIN_BF16_REPO) == [
+        "transformer/diffusion_pytorch_model.safetensors"
+    ]
+    outside = tmp_path / "outside-transformer.safetensors"
+    outside.write_bytes(b"borrowed weights")
+    (snapshot / "transformer" / "diffusion_pytorch_model.safetensors").symlink_to(
+        outside
+    )
+    assert download_gate.mflux_missing_weights(FLUX2_KLEIN_BF16_REPO) == [
+        "transformer/diffusion_pytorch_model.safetensors"
+    ]
+
+
 def test_cold_prefetch_keeps_pinned_bf16_revision_through_every_layer(monkeypatch):
     """Do not download moving main and then the pinned 16 GB snapshot again."""
 

--- a/tests/test_image_weight_precision.py
+++ b/tests/test_image_weight_precision.py
@@ -233,10 +233,12 @@ def test_real_bf16_single_file_layout_is_complete(monkeypatch, tmp_path):
     monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
 
     assert download_gate.mflux_missing_weights(FLUX2_KLEIN_BF16_REPO) == []
+    assert download_gate.mflux_local_snapshot(FLUX2_KLEIN_BF16_REPO) == str(snapshot)
     (snapshot / "transformer" / "diffusion_pytorch_model.safetensors").unlink()
     assert download_gate.mflux_missing_weights(FLUX2_KLEIN_BF16_REPO) == [
         "transformer/diffusion_pytorch_model.safetensors"
     ]
+    assert download_gate.mflux_local_snapshot(FLUX2_KLEIN_BF16_REPO) is None
     outside = tmp_path / "outside-transformer.safetensors"
     outside.write_bytes(b"borrowed weights")
     (snapshot / "transformer" / "diffusion_pytorch_model.safetensors").symlink_to(

--- a/vllm_mlx/_download_gate.py
+++ b/vllm_mlx/_download_gate.py
@@ -1516,6 +1516,17 @@ _MFLUX_EXTRA_TOKENIZERS: dict[str, tuple[str, ...]] = {
 _MFLUX_EXTRA_COMPONENTS: dict[str, tuple[str, ...]] = {
     "mflux-community/flux-1-schnell-mflux-q4": ("text_encoder_2",),
 }
+# Most curated mflux checkpoints shard every component behind
+# ``model.safetensors.index.json``.  The pinned Klein BF16 package follows the
+# standard Diffusers single-file spelling for its transformer and VAE instead.
+# Keep this exception revision-bound through ``IMAGE_MODEL_REVISIONS`` rather
+# than accepting an arbitrary lone safetensors file from every repository.
+_MFLUX_SINGLE_FILE_COMPONENTS: dict[str, dict[str, str]] = {
+    "mflux-community/flux2-klein-4b-mflux-bf16": {
+        "transformer": "diffusion_pytorch_model.safetensors",
+        "vae": "diffusion_pytorch_model.safetensors",
+    },
+}
 
 
 def _mflux_snapshot_dir(repo_id: str) -> tuple[str, str] | None:
@@ -1700,6 +1711,12 @@ def mflux_missing_weights(repo_id: str) -> list[str] | None:
     )
     for component in components:
         component_dir = os.path.join(snap_dir, component)
+        single_file = _MFLUX_SINGLE_FILE_COMPONENTS.get(repo_id, {}).get(component)
+        if single_file is not None:
+            single_rel = f"{component}/{single_file}"
+            if not _is_nonempty_repo_file(os.path.join(component_dir, single_file)):
+                missing.append(single_rel)
+            continue
         index_rel = f"{component}/model.safetensors.index.json"
         index_path = os.path.join(component_dir, "model.safetensors.index.json")
         if not _is_nonempty_repo_file(index_path):


### PR DESCRIPTION
## Why

The existing `flux2-klein-4b-bf16` alias points at an immutable package whose transformer and VAE use the standard single-file `diffusion_pytorch_model.safetensors` layout. The generic image completeness gate currently requires shard indexes for every component, so a fully downloaded, supported BF16 checkpoint is rejected before model load.

## Intention and scope

Teach the completeness gate the exact transformer/VAE filenames for this already-pinned repository. Preserve indexed validation for its text encoder and for every other mflux repository.

Non-goals: new formats or repositories, looser generic cache checks, precision defaults or automatic selection, model behavior, UI, release, or deployment.

## Acceptance criteria

- The real pinned BF16 component layout reports complete.
- A missing or repository-escaping single file remains incomplete.
- Existing indexed mflux completeness contracts remain green.
- A real cached BF16 server request succeeds before queue admission.

## Verification

- `206 passed`: `tests/test_image_weight_precision.py` + `tests/test_download_gate.py`
- Ruff and formatting checks pass on both changed files.
- Exact pinned M2 cache now reports `missing=[]` for both q4 and BF16.
- Final-head real cached BF16 request completed successfully; exact artifact and request evidence is recorded below.


## Final merge evidence

- Final-head real-cache verification used wheel SHA-256 `8c4ece191370d74c232f2a921f4e5848bb797927057bd7ba60e3d9fc0f5e7781` on Apple M2 Pro / 32 GiB / macOS 26.5.2, Rapid 0.13.4, mflux 0.19.1, and MLX 0.32.2.
- Both immutable caches were complete: q4 `7ee1b3aa...` and BF16 `4d8e1bae...`.
- The BF16 alias completed a real 512x512 four-step warm-up and measured `/v1/images/generations` request. The measured request returned a valid non-uniform 262,993-byte PNG in 13.651 seconds with SHA-256 `6360cb55...62c7c`.
- This is correctness/completeness evidence, not a new cross-precision performance claim. The broader M1/M2 qualification remains #3173.
- Final targeted validation: 206 passed; the Mergify candidate passed and merged.
