### PR TITLE
fix(benchmark): read peak memory through the undeprecated mlx API

### DIFF
--- a/tests/test_community_bench_peak_memory.py
+++ b/tests/test_community_bench_peak_memory.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``runner`` peak-memory helpers — MLX-free (a fake ``mlx.core`` is
+installed per test), so the hosted Linux lane covers both API spellings."""
+
+from __future__ import annotations
+
+from vllm_mlx.community_bench import runner
+
+
+def test_peak_memory_prefers_the_undeprecated_mlx_api(monkeypatch) -> None:
+    """mlx >= 0.22 spells the counters ``mx.get_peak_memory`` /
+    ``mx.reset_peak_memory``; the ``mx.metal`` spellings print a deprecation
+    line on every call, which used to land inside ``benchmark run`` output."""
+    import sys
+    import types
+
+    calls: list[str] = []
+
+    def install(core) -> None:
+        # ``import mlx.core as mx`` resolves the ``core`` attribute of the
+        # ``mlx`` package first, so both entries must point at the fake.
+        monkeypatch.setitem(sys.modules, "mlx", types.SimpleNamespace(core=core))
+        monkeypatch.setitem(sys.modules, "mlx.core", core)
+
+    metal = types.SimpleNamespace(
+        get_peak_memory=lambda: calls.append("metal.get") or 5 * 1024 * 1024,
+        reset_peak_memory=lambda: calls.append("metal.reset"),
+    )
+    modern = types.SimpleNamespace(
+        get_peak_memory=lambda: calls.append("get") or 3 * 1024 * 1024,
+        reset_peak_memory=lambda: calls.append("reset"),
+        metal=metal,
+    )
+    install(modern)
+    assert runner._read_peak_ram_mb() == 3
+    runner._reset_peak_ram()
+    assert calls == ["get", "reset"]
+
+    legacy = types.SimpleNamespace(metal=metal)
+    install(legacy)
+    calls.clear()
+    assert runner._read_peak_ram_mb() == 5
+    runner._reset_peak_ram()
+    assert calls == ["metal.get", "metal.reset"]
+
+    bare = types.SimpleNamespace()
+    install(bare)
+    assert runner._read_peak_ram_mb() is None
+    runner._reset_peak_ram()
+
+
+def test_peak_memory_helpers_swallow_runtime_errors(monkeypatch) -> None:
+    """A counter that raises (no Metal device, driver error) degrades to
+    ``None`` / a no-op instead of aborting the bench."""
+    import sys
+    import types
+
+    def boom():
+        raise ValueError("no metal device")
+
+    def boom_os():
+        raise OSError("driver")
+
+    core = types.SimpleNamespace(get_peak_memory=boom, reset_peak_memory=boom_os)
+    monkeypatch.setitem(sys.modules, "mlx", types.SimpleNamespace(core=core))
+    monkeypatch.setitem(sys.modules, "mlx.core", core)
+    assert runner._read_peak_ram_mb() is None
+    runner._reset_peak_ram()  # must not raise

--- a/vllm_mlx/community_bench/runner.py
+++ b/vllm_mlx/community_bench/runner.py
@@ -502,6 +502,22 @@ async def run_standardized_bench(
     )
 
 
+def _peak_memory_api(mx, name: str):
+    """Return ``mx.<name>`` (mlx >= 0.22) or the legacy ``mx.metal.<name>``.
+
+    The ``mx.metal`` variants still work but print a deprecation line on
+    every call, which landed in the middle of ``benchmark run`` output.
+    """
+    getter = getattr(mx, name, None)
+    if callable(getter):
+        return getter
+    metal = getattr(mx, "metal", None)
+    if metal is None:
+        return None
+    getter = getattr(metal, name, None)
+    return getter if callable(getter) else None
+
+
 def _read_peak_ram_mb() -> int | None:
     """Peak Metal-backed memory in MiB, if mlx exposes it.
 
@@ -512,11 +528,7 @@ def _read_peak_ram_mb() -> int | None:
     try:
         import mlx.core as mx
 
-        # mlx.core.metal.get_peak_memory() returns bytes
-        peak = getattr(mx, "metal", None)
-        if peak is None:
-            return None
-        getter = getattr(peak, "get_peak_memory", None)
+        getter = _peak_memory_api(mx, "get_peak_memory")
         if getter is None:
             return None
         bytes_ = int(getter())
@@ -526,25 +538,17 @@ def _read_peak_ram_mb() -> int | None:
 
 
 def _reset_peak_ram() -> None:
-    """Zero out the Metal peak-memory counter, best-effort.
+    """Zero out the peak-memory counter, best-effort.
 
-    Called between model-load and the first measured round so the
-    reported ``peak_ram_mb`` reflects bench-time allocation only. If
-    the running mlx doesn't expose ``reset_peak_memory`` (older
-    versions don't), we silently no-op — the reported number then
-    represents process-peak, which is still useful and the schema
-    field is annotated accordingly in the README.
+    Silently no-ops if mlx isn't importable or the running mlx exposes
+    neither ``reset_peak_memory`` spelling.
     """
     try:
         import mlx.core as mx
 
-        metal = getattr(mx, "metal", None)
-        if metal is None:
-            return
-        resetter = getattr(metal, "reset_peak_memory", None)
-        if resetter is None:
-            return
-        resetter()
+        resetter = _peak_memory_api(mx, "reset_peak_memory")
+        if resetter is not None:
+            resetter()
     except (ImportError, AttributeError, ValueError, OSError):
         # Same suppression as _read_peak_ram_mb — peak RAM is an
         # optional field, not worth aborting the bench over.


### PR DESCRIPTION
## Why

Dogfooding `rapid-mlx benchmark run qwen3.5-4b-4bit` on mlx 0.32.2 prints two stray lines in the middle of the run output:

```
pp512-tg128      warmup
Estimated time remaining: ~1 min 53 s (from the warmup rate)
mx.metal.reset_peak_memory is deprecated and will be removed in a future version. Use mx.reset_peak_memory instead.
pp512-tg128      round 1/5    42.8 tok/s
...
mx.metal.get_peak_memory is deprecated and will be removed in a future version. Use mx.get_peak_memory instead.
Saved local result 77e6d3b7-...
```

They come from `community_bench/runner.py`, which only knew the `mx.metal.*` spelling of the peak-memory counters. A first-time contributor reads that as something being wrong with their run.

## What

- `_peak_memory_api(mx, name)` returns `mx.<name>` when mlx exposes it (0.22+) and falls back to `mx.metal.<name>`; `_read_peak_ram_mb` / `_reset_peak_ram` use it. Behaviour on older mlx is unchanged.
- New MLX-free `tests/test_community_bench_peak_memory.py` (fake `mlx` / `mlx.core` modules) covers the new spelling, the legacy fallback, a bare module, and counters that raise.

## Test plan

- [x] `pytest tests/test_community_bench_peak_memory.py tests/test_community_bench.py` — 98 passed
- [x] `rapid-mlx benchmark run qwen3.5-4b-4bit` on the integration build no longer prints the deprecation lines
- [x] ruff clean; mypy budget: no growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019A88kUrTwWXNnbhhXbSPcx
