### PR TITLE
feat(desktop): run first Computer Use flow

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/ComputerUseStarter.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/ComputerUseStarter.swift
@@ -14,6 +14,7 @@ struct ComputerUseStarter: Identifiable, Equatable, Sendable {
     }
 
     enum Availability: Equatable, Sendable {
+        case available
         case comingSoon
         case reserved
     }
@@ -54,7 +55,7 @@ struct ComputerUseStarter: Identifiable, Equatable, Sendable {
             systemImage: "square.and.pencil",
             applications: "TextEdit + browser",
             approvalNote: "Rapid will stop before publishing.",
-            availability: .comingSoon
+            availability: .available
         ),
         ComputerUseStarter(
             kind: .prospectCustomers,

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -257,7 +257,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         }
 
         let documentIdentity = try await browserDocumentIdentity(in: destination)
-        let draft = try await readDraft(from: source.selection)
+        let draft = try await readDraft(from: source)
         guard !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw DraftPostFlowFailure.draftMissing
         }
@@ -266,7 +266,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         }
         try await writeAndVerify(
             draft,
-            from: source.selection,
+            from: source,
             to: destination,
             documentIdentity: documentIdentity
         )
@@ -275,7 +275,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         do {
             try await Self.verifyDefinitivePostMutationState(
                 draft: draft,
-                source: source.selection,
+                source: source,
                 destination: destination,
                 documentIdentity: documentIdentity
             )
@@ -284,10 +284,10 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         }
     }
 
-    private func readDraft(from selection: ComputerUseWindowSelection) async throws -> String {
-        try await focus(selection)
+    private func readDraft(from source: ComputerUseWindowOption) async throws -> String {
+        try await focus(source)
         return try await Self.runAXWork {
-            let window = try Self.exactFocusedWindow(selection)
+            let window = try Self.exactFocusedWindow(source)
             let candidates = try Self.editableElements(in: window)
                 .filter {
                     Self.stringAttribute(
@@ -302,12 +302,11 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private func writeAndVerify(
         _ draft: String,
-        from source: ComputerUseWindowSelection,
+        from source: ComputerUseWindowOption,
         to destination: ComputerUseWindowOption,
         documentIdentity: String
     ) async throws {
-        let selection = destination.selection
-        try await focus(selection)
+        try await focus(destination)
         try Task.checkCancellation()
         try await Self.runAXWork {
             let window = try Self.exactFocusedBrowserWindow(
@@ -420,7 +419,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private static func verifyDefinitivePostMutationState(
         draft: String,
-        source: ComputerUseWindowSelection,
+        source: ComputerUseWindowOption,
         destination: ComputerUseWindowOption,
         documentIdentity: String
     ) async throws {
@@ -440,14 +439,8 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 running.launchDate == selection.processLaunchDate
             else { throw DraftPostFlowFailure.verificationFailed }
             let application = applicationElement(selection.processIdentifier)
-            guard let window = window(matching: selection, in: application),
-                  browserDocumentMatches(
-                    currentTitle: stringAttribute(
-                        kAXTitleAttribute as CFString,
-                        from: window
-                    ),
-                    selectedTitle: destination.windowTitle
-                  ), try currentBrowserDocumentIdentity(in: window) == documentIdentity
+            guard let window = window(matching: destination, in: application),
+                  try currentBrowserDocumentIdentity(in: window) == documentIdentity
             else { throw DraftPostFlowFailure.verificationFailed }
             let composer = try uniqueComposer(in: window)
             guard stringAttribute(
@@ -463,7 +456,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         _ destination: ComputerUseWindowOption,
         documentIdentity: String
     ) throws -> AXUIElement {
-        let window = try exactFocusedWindow(destination.selection)
+        let window = try exactFocusedWindow(destination)
         guard browserDocumentMatches(
             currentTitle: stringAttribute(
             kAXTitleAttribute as CFString,
@@ -496,14 +489,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 running.launchDate == selection.processLaunchDate
             else { throw DraftPostFlowFailure.targetUnavailable }
             let application = Self.applicationElement(selection.processIdentifier)
-            guard let window = Self.window(matching: selection, in: application),
-                  Self.browserDocumentMatches(
-                    currentTitle: Self.stringAttribute(
-                        kAXTitleAttribute as CFString,
-                        from: window
-                    ),
-                    selectedTitle: destination.windowTitle
-                  )
+            guard let window = Self.window(matching: destination, in: application)
             else { throw DraftPostFlowFailure.focusChanged }
             return try Self.currentBrowserDocumentIdentity(in: window)
         }
@@ -533,15 +519,16 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     }
 
     private static func readDraftWithoutFocusing(
-        from selection: ComputerUseWindowSelection
+        from source: ComputerUseWindowOption
     ) throws -> String {
+        let selection = source.selection
         guard let running = NSRunningApplication(
             processIdentifier: selection.processIdentifier
         ), running.bundleIdentifier == selection.bundleIdentifier,
             running.launchDate == selection.processLaunchDate
         else { throw DraftPostFlowFailure.targetUnavailable }
         let application = applicationElement(selection.processIdentifier)
-        guard let window = window(matching: selection, in: application) else {
+        guard let window = window(matching: source, in: application) else {
             throw DraftPostFlowFailure.targetUnavailable
         }
         let candidates = try editableElements(in: window)
@@ -569,7 +556,8 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         }
     }
 
-    private func focus(_ selection: ComputerUseWindowSelection) async throws {
+    private func focus(_ option: ComputerUseWindowOption) async throws {
+        let selection = option.selection
         try Task.checkCancellation()
         try await MainActor.run {
             guard let app = NSRunningApplication(processIdentifier: selection.processIdentifier),
@@ -578,20 +566,21 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             else { throw DraftPostFlowFailure.targetUnavailable }
             app.activate()
             let application = Self.applicationElement(selection.processIdentifier)
-            guard let window = Self.window(matching: selection, in: application),
+            guard let window = Self.window(matching: option, in: application),
                   AXUIElementPerformAction(window, kAXRaiseAction as CFString) == .success
             else { throw DraftPostFlowFailure.targetUnavailable }
         }
         try await Task.sleep(for: .milliseconds(180))
         try Task.checkCancellation()
         try await MainActor.run {
-            _ = try Self.exactFocusedWindow(selection)
+            _ = try Self.exactFocusedWindow(option)
         }
     }
 
     private static func exactFocusedWindow(
-        _ selection: ComputerUseWindowSelection
+        _ option: ComputerUseWindowOption
     ) throws -> AXUIElement {
+        let selection = option.selection
         guard let running = NSRunningApplication(
             processIdentifier: selection.processIdentifier
         ),
@@ -601,7 +590,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 == selection.processIdentifier
         else { throw DraftPostFlowFailure.focusChanged }
         let application = applicationElement(selection.processIdentifier)
-        guard let selected = window(matching: selection, in: application) else {
+        guard let selected = window(matching: option, in: application) else {
             throw DraftPostFlowFailure.targetUnavailable
         }
         var focusedValue: CFTypeRef?
@@ -621,6 +610,22 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         let application = AXUIElementCreateApplication(processIdentifier)
         AXUIElementSetMessagingTimeout(application, 0.35)
         return application
+    }
+
+    private static func window(
+        matching option: ComputerUseWindowOption,
+        in application: AXUIElement
+    ) -> AXUIElement? {
+        guard let candidate = window(matching: option.selection, in: application),
+              browserDocumentMatches(
+                currentTitle: stringAttribute(
+                    kAXTitleAttribute as CFString,
+                    from: candidate
+                ),
+                selectedTitle: option.windowTitle
+              )
+        else { return nil }
+        return candidate
     }
 
     private static func window(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -293,7 +293,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private func readDraft(from selection: ComputerUseWindowSelection) async throws -> String {
         try await focus(selection)
-        return try await Task.detached {
+        return try await Self.runAXWork {
             let window = try Self.exactFocusedWindow(selection)
             let candidates = try Self.editableElements(in: window)
                 .filter {
@@ -304,7 +304,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 }
                 .map { Self.stringAttribute(kAXValueAttribute as CFString, from: $0) }
             return try Self.uniqueDraft(in: candidates)
-        }.value
+        }
     }
 
     private func writeAndVerify(
@@ -316,7 +316,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         let selection = destination.selection
         try await focus(selection)
         try Task.checkCancellation()
-        try await Task.detached {
+        try await Self.runAXWork {
             let window = try Self.exactFocusedBrowserWindow(
                 destination,
                 documentIdentity: documentIdentity
@@ -408,7 +408,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
                 return CFEqual(authorizedComposer, verifiedComposer)
             }
-        }.value
+        }
     }
 
     static func utf8Matches(_ lhs: String, _ rhs: String) -> Bool {
@@ -432,7 +432,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     ) async throws {
         let selection = destination.selection
         try await focus(selection)
-        try await Task.detached {
+        try await Self.runAXWork {
             let window = try Self.exactFocusedBrowserWindow(
                 destination,
                 documentIdentity: documentIdentity
@@ -444,7 +444,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             ).map({ Self.utf8Matches($0, draft) }) == true else {
                 throw DraftPostFlowFailure.verificationFailed
             }
-        }.value
+        }
     }
 
     private static func exactFocusedBrowserWindow(
@@ -476,7 +476,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     private func browserDocumentIdentity(
         in destination: ComputerUseWindowOption
     ) async throws -> String {
-        return try await Task.detached {
+        return try await Self.runAXWork {
             let selection = destination.selection
             guard let running = NSRunningApplication(
                 processIdentifier: selection.processIdentifier
@@ -494,7 +494,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                   )
             else { throw DraftPostFlowFailure.focusChanged }
             return try Self.currentBrowserDocumentIdentity(in: window)
-        }.value
+        }
     }
 
     private static func currentBrowserDocumentIdentity(
@@ -539,6 +539,22 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             }
             .map { stringAttribute(kAXValueAttribute as CFString, from: $0) }
         return try uniqueDraft(in: candidates)
+    }
+
+    private static func runAXWork<Result: Sendable>(
+        _ operation: @escaping @Sendable () throws -> Result
+    ) async throws -> Result {
+        try Task.checkCancellation()
+        return try await withThrowingTaskGroup(of: Result.self) { group in
+            group.addTask {
+                try Task.checkCancellation()
+                return try operation()
+            }
+            guard let result = try await group.next() else {
+                throw CancellationError()
+            }
+            return result
+        }
     }
 
     private func focus(_ selection: ComputerUseWindowSelection) async throws {

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -256,8 +256,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                         from: $0
                     ) == kAXTextAreaRole as String
                 }
-                .compactMap { Self.stringAttribute(kAXValueAttribute as CFString, from: $0) }
-                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                .map { Self.stringAttribute(kAXValueAttribute as CFString, from: $0) }
             return try Self.uniqueDraft(in: candidates)
         }
     }
@@ -473,10 +472,12 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     private static func editableElements(in root: AXUIElement) -> [AXUIElement] {
         var queue: [(AXUIElement, Int)] = [(root, 0)]
         var result: [AXUIElement] = []
+        var visited = Set<AXUIElement>()
         var cursor = 0
-        while cursor < queue.count, cursor < 2_048 {
+        while cursor < queue.count, visited.count < 2_048 {
             let (element, depth) = queue[cursor]
             cursor += 1
+            guard visited.insert(element).inserted else { continue }
             let role = stringAttribute(kAXRoleAttribute as CFString, from: element)
             let subrole = stringAttribute(kAXSubroleAttribute as CFString, from: element)
             if (role == kAXTextAreaRole as String || role == kAXTextFieldRole as String),
@@ -536,12 +537,17 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         ].contains(label)
     }
 
-    static func uniqueDraft(in candidates: [String]) throws -> String {
-        guard let draft = candidates.first else {
-            throw DraftPostFlowFailure.draftMissing
-        }
+    static func uniqueDraft(in candidates: [String?]) throws -> String {
         guard candidates.count == 1 else {
+            if candidates.isEmpty {
+                throw DraftPostFlowFailure.draftMissing
+            }
             throw DraftPostFlowFailure.draftAmbiguous
+        }
+        guard let draft = candidates[0],
+              !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw DraftPostFlowFailure.draftMissing
         }
         return draft
     }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -1,0 +1,568 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import Observation
+import ScreenCaptureKit
+
+struct ComputerUseWindowOption: Identifiable, Equatable, Sendable {
+    let id: String
+    let applicationName: String
+    let windowTitle: String
+    let selection: ComputerUseWindowSelection
+
+    var displayName: String {
+        windowTitle.isEmpty ? applicationName : "\(applicationName) — \(windowTitle)"
+    }
+}
+
+enum ComputerUseWindowCatalogError: Error, Equatable {
+    case permissionsMissing([MacAutomationPermission])
+    case unavailable
+}
+
+protocol ComputerUseWindowListing: Sendable {
+    func windows() async throws -> [ComputerUseWindowOption]
+}
+
+struct MacOSComputerUseWindowCatalog: ComputerUseWindowListing {
+    func windows() async throws -> [ComputerUseWindowOption] {
+        let permissions = MacAutomationPermissions.snapshot()
+        guard permissions.isReadyForComputerUse else {
+            throw ComputerUseWindowCatalogError.permissionsMissing(
+                permissions.missingForComputerUse
+            )
+        }
+        let content: SCShareableContent
+        do {
+            content = try await SCShareableContent.excludingDesktopWindows(
+                true,
+                onScreenWindowsOnly: true
+            )
+        } catch {
+            throw ComputerUseWindowCatalogError.unavailable
+        }
+        let ownPID = getpid()
+        var result: [ComputerUseWindowOption] = []
+        for window in content.windows {
+            guard window.isOnScreen,
+                  window.frame.width >= 240,
+                  window.frame.height >= 160,
+                  let application = window.owningApplication,
+                  application.processID != ownPID,
+                  !application.bundleIdentifier.isEmpty,
+                  let launchDate = await launchDate(for: application.processID)
+            else { continue }
+            result.append(ComputerUseWindowOption(
+                id: "\(application.processID):\(window.windowID)",
+                applicationName: application.applicationName,
+                windowTitle: window.title ?? "",
+                selection: ComputerUseWindowSelection(
+                    bundleIdentifier: application.bundleIdentifier,
+                    processIdentifier: application.processID,
+                    processLaunchDate: launchDate,
+                    windowID: window.windowID
+                )
+            ))
+        }
+        return result.sorted {
+            ($0.applicationName.localizedCaseInsensitiveCompare($1.applicationName) == .orderedAscending)
+                || ($0.applicationName == $1.applicationName
+                    && $0.windowTitle.localizedCaseInsensitiveCompare($1.windowTitle) == .orderedAscending)
+        }
+    }
+
+    @MainActor
+    private func launchDate(for processIdentifier: pid_t) -> Date? {
+        NSRunningApplication(processIdentifier: processIdentifier)?.launchDate
+    }
+}
+
+enum DraftPostFlowFailure: Error, Equatable, Sendable {
+    case sourceIsNotTextEdit
+    case destinationIsNotBrowser
+    case targetUnavailable
+    case focusChanged
+    case draftMissing
+    case draftTooLarge
+    case composerMissing
+    case composerAmbiguous
+    case composerNotEmpty
+    case writeRejected
+    case verificationFailed
+    case permissionMissing
+    case cancelled
+
+    var isRecoverable: Bool {
+        switch self {
+        case .targetUnavailable, .focusChanged:
+            true
+        default:
+            false
+        }
+    }
+
+    var userMessage: String {
+        switch self {
+        case .sourceIsNotTextEdit: "Choose a TextEdit window as the draft source."
+        case .destinationIsNotBrowser: "Choose a supported browser window as the destination."
+        case .targetUnavailable: "A selected window is no longer available."
+        case .focusChanged: "Rapid could not safely focus the selected window."
+        case .draftMissing: "The selected TextEdit document has no readable draft."
+        case .draftTooLarge: "The draft is too large for this preview (64 KB maximum)."
+        case .composerMissing: "No editable post composer was found in the browser window."
+        case .composerAmbiguous: "More than one possible composer was found. Close other editors and try again."
+        case .composerNotEmpty: "The browser composer already contains text. Clear it before running this flow."
+        case .writeRejected: "The browser rejected the local text update."
+        case .verificationFailed: "The browser content did not match the TextEdit draft."
+        case .permissionMissing: "Screen Recording and Accessibility access are required."
+        case .cancelled: "The flow was stopped."
+        }
+    }
+}
+
+struct DraftPostFlowMetrics: Equatable, Sendable {
+    var attempts = 0
+    var automaticRecoveries = 0
+    var humanCorrections = 0
+    var completedSteps = 0
+}
+
+enum DraftPostFlowOutcome: Equatable, Sendable {
+    case readyForReview(DraftPostFlowMetrics)
+    case failed(DraftPostFlowFailure, DraftPostFlowMetrics)
+}
+
+protocol DraftPostFlowDriving: Sendable {
+    func transferDraft(
+        from source: ComputerUseWindowOption,
+        to destination: ComputerUseWindowOption
+    ) async throws
+}
+
+/// Runs one idempotent local transfer with a strict retry budget. The driver
+/// can only populate the composer; publishing is intentionally absent from
+/// this protocol and therefore cannot be reached by recovery logic.
+actor DraftPostFlowCoordinator {
+    private let driver: any DraftPostFlowDriving
+    private let maximumAttempts: Int
+
+    init(driver: any DraftPostFlowDriving, maximumAttempts: Int = 3) {
+        self.driver = driver
+        self.maximumAttempts = min(max(1, maximumAttempts), 3)
+    }
+
+    func run(
+        source: ComputerUseWindowOption,
+        destination: ComputerUseWindowOption
+    ) async -> DraftPostFlowOutcome {
+        var metrics = DraftPostFlowMetrics()
+        for attempt in 1 ... maximumAttempts {
+            if Task.isCancelled {
+                return .failed(.cancelled, metrics)
+            }
+            metrics.attempts = attempt
+            do {
+                try await driver.transferDraft(from: source, to: destination)
+                metrics.completedSteps = 3
+                return .readyForReview(metrics)
+            } catch let failure as DraftPostFlowFailure {
+                guard failure.isRecoverable, attempt < maximumAttempts else {
+                    return .failed(failure, metrics)
+                }
+                metrics.automaticRecoveries += 1
+            } catch is CancellationError {
+                return .failed(.cancelled, metrics)
+            } catch {
+                return .failed(.targetUnavailable, metrics)
+            }
+        }
+        return .failed(.targetUnavailable, metrics)
+    }
+}
+
+/// Accessibility-first implementation for the first bounded starter flow.
+/// The user selects both windows. Rapid reads one TextEdit document, writes an
+/// empty browser composer, verifies the exact value, and stops. No coordinate
+/// action and no publish/send action exists in this adapter.
+struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
+    static let maximumDraftBytes = 65_536
+    private static let textEditBundle = "com.apple.TextEdit"
+    static let browserBundles: Set<String> = [
+        "com.apple.Safari",
+        "com.google.Chrome",
+        "com.google.Chrome.canary",
+        "com.microsoft.edgemac",
+        "company.thebrowser.Browser",
+        "org.mozilla.firefox",
+    ]
+
+    func transferDraft(
+        from source: ComputerUseWindowOption,
+        to destination: ComputerUseWindowOption
+    ) async throws {
+        guard source.selection.bundleIdentifier == Self.textEditBundle else {
+            throw DraftPostFlowFailure.sourceIsNotTextEdit
+        }
+        guard Self.browserBundles.contains(destination.selection.bundleIdentifier) else {
+            throw DraftPostFlowFailure.destinationIsNotBrowser
+        }
+        guard MacAutomationPermissions.snapshot().isReadyForComputerUse else {
+            throw DraftPostFlowFailure.permissionMissing
+        }
+
+        let draft = try await readDraft(from: source.selection)
+        guard !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw DraftPostFlowFailure.draftMissing
+        }
+        guard draft.utf8.count <= Self.maximumDraftBytes else {
+            throw DraftPostFlowFailure.draftTooLarge
+        }
+        try await writeAndVerify(draft, to: destination.selection)
+    }
+
+    private func readDraft(from selection: ComputerUseWindowSelection) async throws -> String {
+        try await focus(selection)
+        return try await MainActor.run {
+            let window = try Self.exactFocusedWindow(selection)
+            let candidates = Self.editableElements(in: window)
+                .compactMap { Self.stringAttribute(kAXValueAttribute as CFString, from: $0) }
+                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            guard let draft = candidates.max(by: { $0.utf8.count < $1.utf8.count }) else {
+                throw DraftPostFlowFailure.draftMissing
+            }
+            return draft
+        }
+    }
+
+    private func writeAndVerify(
+        _ draft: String,
+        to selection: ComputerUseWindowSelection
+    ) async throws {
+        try await focus(selection)
+        try await MainActor.run {
+            let window = try Self.exactFocusedWindow(selection)
+            let composer = try Self.uniqueComposer(in: window)
+            let existing = Self.stringAttribute(kAXValueAttribute as CFString, from: composer) ?? ""
+            guard existing.isEmpty || existing == draft else {
+                throw DraftPostFlowFailure.composerNotEmpty
+            }
+            var settable: DarwinBoolean = false
+            guard AXUIElementIsAttributeSettable(
+                composer,
+                kAXValueAttribute as CFString,
+                &settable
+            ) == .success, settable.boolValue else {
+                throw DraftPostFlowFailure.writeRejected
+            }
+            guard AXUIElementSetAttributeValue(
+                composer,
+                kAXFocusedAttribute as CFString,
+                kCFBooleanTrue
+            ) == .success else {
+                throw DraftPostFlowFailure.writeRejected
+            }
+            // Re-resolve the exact selected window immediately before the
+            // value mutation. Focusing the exact bound editor is allowed, but
+            // it must not have moved focus into another window.
+            let currentWindow = try Self.exactFocusedWindow(selection)
+            let currentComposer = try Self.uniqueComposer(in: currentWindow)
+            guard CFEqual(composer, currentComposer) else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
+            guard AXUIElementSetAttributeValue(
+                currentComposer,
+                kAXValueAttribute as CFString,
+                draft as CFString
+            ) == .success else {
+                throw DraftPostFlowFailure.writeRejected
+            }
+            let verifiedWindow = try Self.exactFocusedWindow(selection)
+            let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
+            guard CFEqual(currentComposer, verifiedComposer),
+                  Self.stringAttribute(
+                    kAXValueAttribute as CFString,
+                    from: verifiedComposer
+                  ) == draft
+            else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
+        }
+    }
+
+    private func focus(_ selection: ComputerUseWindowSelection) async throws {
+        try Task.checkCancellation()
+        try await MainActor.run {
+            guard let app = NSRunningApplication(processIdentifier: selection.processIdentifier),
+                  app.bundleIdentifier == selection.bundleIdentifier,
+                  app.launchDate == selection.processLaunchDate
+            else { throw DraftPostFlowFailure.targetUnavailable }
+            app.activate()
+            let application = AXUIElementCreateApplication(selection.processIdentifier)
+            guard let window = Self.window(matching: selection, in: application),
+                  AXUIElementPerformAction(window, kAXRaiseAction as CFString) == .success
+            else { throw DraftPostFlowFailure.targetUnavailable }
+        }
+        try await Task.sleep(for: .milliseconds(180))
+        try Task.checkCancellation()
+        try await MainActor.run {
+            _ = try Self.exactFocusedWindow(selection)
+        }
+    }
+
+    @MainActor
+    private static func exactFocusedWindow(
+        _ selection: ComputerUseWindowSelection
+    ) throws -> AXUIElement {
+        guard let running = NSRunningApplication(
+            processIdentifier: selection.processIdentifier
+        ),
+            running.bundleIdentifier == selection.bundleIdentifier,
+            running.launchDate == selection.processLaunchDate,
+            NSWorkspace.shared.frontmostApplication?.processIdentifier
+                == selection.processIdentifier
+        else { throw DraftPostFlowFailure.focusChanged }
+        let application = AXUIElementCreateApplication(selection.processIdentifier)
+        guard let selected = window(matching: selection, in: application) else {
+            throw DraftPostFlowFailure.targetUnavailable
+        }
+        var focusedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            application,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedValue
+        ) == .success,
+            let focusedValue,
+            CFGetTypeID(focusedValue) == AXUIElementGetTypeID(),
+            CFEqual(selected, unsafeDowncast(focusedValue, to: AXUIElement.self))
+        else { throw DraftPostFlowFailure.focusChanged }
+        return selected
+    }
+
+    @MainActor
+    private static func window(
+        matching selection: ComputerUseWindowSelection,
+        in application: AXUIElement
+    ) -> AXUIElement? {
+        guard let frame = currentFrame(for: selection) else { return nil }
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            application,
+            kAXWindowsAttribute as CFString,
+            &value
+        ) == .success,
+            let windows = value as? [AXUIElement]
+        else { return nil }
+        let matches = windows.filter {
+            guard let candidate = elementFrame($0) else { return false }
+            return MacOSComputerUseWindowIdentity.framesMatch(candidate, frame)
+        }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    @MainActor
+    private static func currentFrame(
+        for selection: ComputerUseWindowSelection
+    ) -> CGRect? {
+        guard let records = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[CFString: Any]],
+            let record = records.first(where: {
+                ($0[kCGWindowNumber] as? NSNumber)?.uint32Value == selection.windowID
+                    && ($0[kCGWindowOwnerPID] as? NSNumber)?.int32Value
+                        == selection.processIdentifier
+            }),
+            let bounds = record[kCGWindowBounds] as? [String: NSNumber]
+        else { return nil }
+        return CGRect(dictionaryRepresentation: bounds as CFDictionary)
+    }
+
+    @MainActor
+    private static func editableElements(in root: AXUIElement) -> [AXUIElement] {
+        var queue: [(AXUIElement, Int)] = [(root, 0)]
+        var result: [AXUIElement] = []
+        var visited = 0
+        while !queue.isEmpty, visited < 2_048 {
+            let (element, depth) = queue.removeFirst()
+            visited += 1
+            let role = stringAttribute(kAXRoleAttribute as CFString, from: element)
+            let subrole = stringAttribute(kAXSubroleAttribute as CFString, from: element)
+            if (role == kAXTextAreaRole as String || role == kAXTextFieldRole as String),
+               subrole != kAXSecureTextFieldSubrole as String {
+                result.append(element)
+            }
+            guard depth < 32 else { continue }
+            var value: CFTypeRef?
+            if AXUIElementCopyAttributeValue(
+                element,
+                kAXChildrenAttribute as CFString,
+                &value
+            ) == .success,
+                let children = value as? [AXUIElement]
+            {
+                queue.append(contentsOf: children.map { ($0, depth + 1) })
+            }
+        }
+        return result
+    }
+
+    @MainActor
+    private static func composerScore(_ element: AXUIElement) -> Int {
+        let fields = [
+            stringAttribute(kAXTitleAttribute as CFString, from: element),
+            stringAttribute(kAXDescriptionAttribute as CFString, from: element),
+            stringAttribute(kAXHelpAttribute as CFString, from: element),
+            stringAttribute("AXPlaceholderValue" as CFString, from: element),
+        ].compactMap { $0?.lowercased() }.joined(separator: " ")
+        let hints = ["post", "tweet", "what is happening", "what's happening", "compose", "update"]
+        // No generic "first empty field" fallback: that can be a search box
+        // or browser chrome. A composer needs an explicit semantic hint, and
+        // equal matches fail closed rather than relying on tree order.
+        return hints.reduce(0) { $0 + (fields.contains($1) ? 10 : 0) }
+    }
+
+    @MainActor
+    private static func uniqueComposer(in window: AXUIElement) throws -> AXUIElement {
+        let ranked = editableElements(in: window)
+            .map { ($0, composerScore($0)) }
+            .filter { $0.1 > 0 }
+            .sorted { $0.1 > $1.1 }
+        guard let best = ranked.first else {
+            throw DraftPostFlowFailure.composerMissing
+        }
+        if ranked.count > 1, ranked[1].1 == best.1 {
+            throw DraftPostFlowFailure.composerAmbiguous
+        }
+        return best.0
+    }
+
+    @MainActor
+    private static func stringAttribute(
+        _ name: CFString,
+        from element: AXUIElement
+    ) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, name, &value) == .success else {
+            return nil
+        }
+        return value as? String
+    }
+
+    @MainActor
+    private static func elementFrame(_ element: AXUIElement) -> CGRect? {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+            AXUIElementCopyAttributeValue(
+                element,
+                kAXSizeAttribute as CFString,
+                &sizeValue
+            ) == .success,
+            let positionValue,
+            let sizeValue,
+            CFGetTypeID(positionValue) == AXValueGetTypeID(),
+            CFGetTypeID(sizeValue) == AXValueGetTypeID()
+        else { return nil }
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(
+            unsafeDowncast(positionValue, to: AXValue.self),
+            .cgPoint,
+            &origin
+        ), AXValueGetValue(
+            unsafeDowncast(sizeValue, to: AXValue.self),
+            .cgSize,
+            &size
+        ) else { return nil }
+        return CGRect(origin: origin, size: size)
+    }
+}
+
+@MainActor
+@Observable
+final class DraftPostFlowViewModel {
+    enum Phase: Equatable {
+        case loading
+        case ready
+        case running
+        case readyForReview(DraftPostFlowMetrics)
+        case failed(String, DraftPostFlowMetrics?)
+    }
+
+    var phase: Phase = .loading
+    var windows: [ComputerUseWindowOption] = []
+    var sourceID: String?
+    var destinationID: String?
+    private let catalog: any ComputerUseWindowListing
+    private let driver: any DraftPostFlowDriving
+    private var runTask: Task<Void, Never>?
+
+    init(
+        catalog: any ComputerUseWindowListing = MacOSComputerUseWindowCatalog(),
+        driver: any DraftPostFlowDriving = MacOSDraftPostFlowDriver()
+    ) {
+        self.catalog = catalog
+        self.driver = driver
+    }
+
+    var sourceOptions: [ComputerUseWindowOption] {
+        windows.filter { $0.selection.bundleIdentifier == "com.apple.TextEdit" }
+    }
+
+    var destinationOptions: [ComputerUseWindowOption] {
+        windows.filter {
+            MacOSDraftPostFlowDriver.browserBundles.contains(
+                $0.selection.bundleIdentifier
+            )
+        }
+    }
+
+    var canRun: Bool {
+        sourceID != nil && destinationID != nil && phase == .ready
+    }
+
+    func load() async {
+        phase = .loading
+        do {
+            windows = try await catalog.windows()
+            sourceID = sourceOptions.count == 1 ? sourceOptions[0].id : nil
+            phase = .ready
+        } catch let error as ComputerUseWindowCatalogError {
+            switch error {
+            case .permissionsMissing:
+                phase = .failed(DraftPostFlowFailure.permissionMissing.userMessage, nil)
+            case .unavailable:
+                phase = .failed("Rapid could not list the available windows.", nil)
+            }
+        } catch {
+            phase = .failed("Rapid could not list the available windows.", nil)
+        }
+    }
+
+    func run() {
+        guard let source = windows.first(where: { $0.id == sourceID }),
+              let destination = windows.first(where: { $0.id == destinationID })
+        else { return }
+        phase = .running
+        let coordinator = DraftPostFlowCoordinator(driver: driver)
+        runTask = Task { [weak self] in
+            let outcome = await coordinator.run(source: source, destination: destination)
+            guard let self else { return }
+            switch outcome {
+            case .readyForReview(let metrics):
+                self.phase = .readyForReview(metrics)
+            case .failed(let failure, let metrics):
+                self.phase = .failed(failure.userMessage, metrics)
+            }
+        }
+    }
+
+    func stop() {
+        runTask?.cancel()
+        runTask = nil
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -65,9 +65,14 @@ struct MacOSComputerUseWindowCatalog: ComputerUseWindowListing {
             ))
         }
         return result.sorted {
-            ($0.applicationName.localizedCaseInsensitiveCompare($1.applicationName) == .orderedAscending)
-                || ($0.applicationName == $1.applicationName
-                    && $0.windowTitle.localizedCaseInsensitiveCompare($1.windowTitle) == .orderedAscending)
+            let applicationOrder = $0.applicationName.localizedCaseInsensitiveCompare(
+                $1.applicationName
+            )
+            return applicationOrder == .orderedAscending
+                || (applicationOrder == .orderedSame
+                    && $0.windowTitle.localizedCaseInsensitiveCompare(
+                        $1.windowTitle
+                    ) == .orderedAscending)
         }
     }
 
@@ -252,8 +257,13 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         try await MainActor.run {
             let window = try Self.exactFocusedWindow(selection)
             let composer = try Self.uniqueComposer(in: window)
-            let existing = Self.stringAttribute(kAXValueAttribute as CFString, from: composer) ?? ""
-            guard existing.isEmpty || existing == draft else {
+            guard let existing = Self.stringAttribute(
+                kAXValueAttribute as CFString,
+                from: composer
+            ) else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
+            guard existing.isEmpty || Self.utf8Matches(existing, draft) else {
                 throw DraftPostFlowFailure.composerNotEmpty
             }
             var settable: DarwinBoolean = false
@@ -279,6 +289,15 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             guard CFEqual(composer, currentComposer) else {
                 throw DraftPostFlowFailure.verificationFailed
             }
+            guard let currentValue = Self.stringAttribute(
+                kAXValueAttribute as CFString,
+                from: currentComposer
+            ) else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
+            guard currentValue.isEmpty || Self.utf8Matches(currentValue, draft) else {
+                throw DraftPostFlowFailure.composerNotEmpty
+            }
             // This is the final cancellation boundary before the only content
             // mutation. No suspension occurs between this check and the write.
             try Task.checkCancellation()
@@ -299,9 +318,13 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                     && Self.stringAttribute(
                         kAXValueAttribute as CFString,
                         from: verifiedComposer
-                      ) == draft
+                      ).map { Self.utf8Matches($0, draft) } == true
             }
         }
+    }
+
+    static func utf8Matches(_ lhs: String, _ rhs: String) -> Bool {
+        lhs.utf8.elementsEqual(rhs.utf8)
     }
 
     static func verifyAfterMutation(_ verifier: () throws -> Bool) throws {
@@ -406,10 +429,10 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     private static func editableElements(in root: AXUIElement) -> [AXUIElement] {
         var queue: [(AXUIElement, Int)] = [(root, 0)]
         var result: [AXUIElement] = []
-        var visited = 0
-        while !queue.isEmpty, visited < 2_048 {
-            let (element, depth) = queue.removeFirst()
-            visited += 1
+        var cursor = 0
+        while cursor < queue.count, cursor < 2_048 {
+            let (element, depth) = queue[cursor]
+            cursor += 1
             let role = stringAttribute(kAXRoleAttribute as CFString, from: element)
             let subrole = stringAttribute(kAXSubroleAttribute as CFString, from: element)
             if (role == kAXTextAreaRole as String || role == kAXTextFieldRole as String),

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -856,6 +856,7 @@ final class DraftPostFlowViewModel {
     private let catalog: any ComputerUseWindowListing
     private let driver: any DraftPostFlowDriving
     private var runTask: Task<Void, Never>?
+    private var loadGeneration = 0
 
     init(
         catalog: any ComputerUseWindowListing = MacOSComputerUseWindowCatalog(),
@@ -866,7 +867,12 @@ final class DraftPostFlowViewModel {
     }
 
     var sourceOptions: [ComputerUseWindowOption] {
-        windows.filter { $0.selection.bundleIdentifier == "com.apple.TextEdit" }
+        windows.filter {
+            $0.selection.bundleIdentifier == "com.apple.TextEdit"
+                && !$0.windowTitle.trimmingCharacters(
+                    in: .whitespacesAndNewlines
+                ).isEmpty
+        }
     }
 
     var destinationOptions: [ComputerUseWindowOption] {
@@ -894,13 +900,18 @@ final class DraftPostFlowViewModel {
     }
 
     func load() async {
+        loadGeneration += 1
+        let generation = loadGeneration
         phase = .loading
         do {
-            windows = try await catalog.windows()
+            let refreshedWindows = try await catalog.windows()
+            guard generation == loadGeneration else { return }
+            windows = refreshedWindows
             sourceID = nil
             destinationID = nil
             phase = .ready
         } catch let error as ComputerUseWindowCatalogError {
+            guard generation == loadGeneration else { return }
             switch error {
             case .permissionsMissing:
                 phase = .failed(.permissionMissing, nil)
@@ -908,6 +919,7 @@ final class DraftPostFlowViewModel {
                 phase = .failed(.dependencyFailure, nil)
             }
         } catch {
+            guard generation == loadGeneration else { return }
             phase = .failed(.dependencyFailure, nil)
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -127,7 +127,6 @@ enum DraftPostFlowFailure: Error, Equatable, Sendable {
 struct DraftPostFlowMetrics: Equatable, Sendable {
     var attempts = 0
     var automaticRecoveries = 0
-    var humanCorrections = 0
     var completedSteps = 0
 }
 
@@ -249,6 +248,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         to selection: ComputerUseWindowSelection
     ) async throws {
         try await focus(selection)
+        try Task.checkCancellation()
         try await MainActor.run {
             let window = try Self.exactFocusedWindow(selection)
             let composer = try Self.uniqueComposer(in: window)
@@ -279,6 +279,9 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             guard CFEqual(composer, currentComposer) else {
                 throw DraftPostFlowFailure.verificationFailed
             }
+            // This is the final cancellation boundary before the only content
+            // mutation. No suspension occurs between this check and the write.
+            try Task.checkCancellation()
             guard AXUIElementSetAttributeValue(
                 currentComposer,
                 kAXValueAttribute as CFString,
@@ -286,16 +289,28 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             ) == .success else {
                 throw DraftPostFlowFailure.writeRejected
             }
-            let verifiedWindow = try Self.exactFocusedWindow(selection)
-            let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
-            guard CFEqual(currentComposer, verifiedComposer),
-                  Self.stringAttribute(
-                    kAXValueAttribute as CFString,
-                    from: verifiedComposer
-                  ) == draft
-            else {
+            // Once content may have changed, no focus/window error is safe to
+            // retry. Collapse every post-mutation observation failure into a
+            // terminal verification failure.
+            try Self.verifyAfterMutation {
+                let verifiedWindow = try Self.exactFocusedWindow(selection)
+                let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
+                return CFEqual(currentComposer, verifiedComposer)
+                    && Self.stringAttribute(
+                        kAXValueAttribute as CFString,
+                        from: verifiedComposer
+                      ) == draft
+            }
+        }
+    }
+
+    static func verifyAfterMutation(_ verifier: () throws -> Bool) throws {
+        do {
+            guard try verifier() else {
                 throw DraftPostFlowFailure.verificationFailed
             }
+        } catch {
+            throw DraftPostFlowFailure.verificationFailed
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -199,7 +199,6 @@ actor DraftPostFlowCoordinator {
 /// The complete mutation authority granted to the draft flow. Publishing is
 /// structurally impossible because this capability can only focus a composer
 /// and set its draft value.
-@MainActor
 protocol DraftPostComposerActuating: Sendable {
     func focusComposer(_ composer: AXUIElement) throws
     func setDraft(_ draft: String, on composer: AXUIElement) throws
@@ -294,7 +293,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private func readDraft(from selection: ComputerUseWindowSelection) async throws -> String {
         try await focus(selection)
-        return try await MainActor.run {
+        return try await Task.detached {
             let window = try Self.exactFocusedWindow(selection)
             let candidates = try Self.editableElements(in: window)
                 .filter {
@@ -305,7 +304,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 }
                 .map { Self.stringAttribute(kAXValueAttribute as CFString, from: $0) }
             return try Self.uniqueDraft(in: candidates)
-        }
+        }.value
     }
 
     private func writeAndVerify(
@@ -317,7 +316,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         let selection = destination.selection
         try await focus(selection)
         try Task.checkCancellation()
-        try await MainActor.run {
+        try await Task.detached {
             let window = try Self.exactFocusedBrowserWindow(
                 destination,
                 documentIdentity: documentIdentity
@@ -408,12 +407,8 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 )
                 let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
                 return CFEqual(authorizedComposer, verifiedComposer)
-                    && Self.stringAttribute(
-                        kAXValueAttribute as CFString,
-                        from: verifiedComposer
-                      ).map { Self.utf8Matches($0, draft) } == true
             }
-        }
+        }.value
     }
 
     static func utf8Matches(_ lhs: String, _ rhs: String) -> Bool {
@@ -437,7 +432,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     ) async throws {
         let selection = destination.selection
         try await focus(selection)
-        try await MainActor.run {
+        try await Task.detached {
             let window = try Self.exactFocusedBrowserWindow(
                 destination,
                 documentIdentity: documentIdentity
@@ -449,10 +444,9 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             ).map({ Self.utf8Matches($0, draft) }) == true else {
                 throw DraftPostFlowFailure.verificationFailed
             }
-        }
+        }.value
     }
 
-    @MainActor
     private static func exactFocusedBrowserWindow(
         _ destination: ComputerUseWindowOption,
         documentIdentity: String
@@ -482,7 +476,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     private func browserDocumentIdentity(
         in destination: ComputerUseWindowOption
     ) async throws -> String {
-        try await MainActor.run {
+        return try await Task.detached {
             let selection = destination.selection
             guard let running = NSRunningApplication(
                 processIdentifier: selection.processIdentifier
@@ -500,10 +494,9 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                   )
             else { throw DraftPostFlowFailure.focusChanged }
             return try Self.currentBrowserDocumentIdentity(in: window)
-        }
+        }.value
     }
 
-    @MainActor
     private static func currentBrowserDocumentIdentity(
         in window: AXUIElement
     ) throws -> String {
@@ -527,7 +520,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return identity
     }
 
-    @MainActor
     private static func readDraftWithoutFocusing(
         from selection: ComputerUseWindowSelection
     ) throws -> String {
@@ -569,7 +561,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         }
     }
 
-    @MainActor
     private static func exactFocusedWindow(
         _ selection: ComputerUseWindowSelection
     ) throws -> AXUIElement {
@@ -598,14 +589,12 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return selected
     }
 
-    @MainActor
     private static func applicationElement(_ processIdentifier: pid_t) -> AXUIElement {
         let application = AXUIElementCreateApplication(processIdentifier)
         AXUIElementSetMessagingTimeout(application, 0.35)
         return application
     }
 
-    @MainActor
     private static func window(
         matching selection: ComputerUseWindowSelection,
         in application: AXUIElement
@@ -626,7 +615,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return matches.count == 1 ? matches[0] : nil
     }
 
-    @MainActor
     private static func currentFrame(
         for selection: ComputerUseWindowSelection
     ) -> CGRect? {
@@ -644,13 +632,17 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return CGRect(dictionaryRepresentation: bounds as CFDictionary)
     }
 
-    @MainActor
     private static func allElements(in root: AXUIElement) throws -> [AXUIElement] {
         var queue: [(AXUIElement, Int)] = [(root, 0)]
         var result: [AXUIElement] = []
         var visited = Set<AXUIElement>()
         var cursor = 0
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
         while cursor < queue.count, visited.count < 2_048 {
+            guard clock.now < deadline else {
+                throw DraftPostFlowFailure.dependencyFailure
+            }
             let (element, depth) = queue[cursor]
             cursor += 1
             guard visited.insert(element).inserted else { continue }
@@ -678,7 +670,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return result
     }
 
-    @MainActor
     private static func editableElements(in root: AXUIElement) throws -> [AXUIElement] {
         try allElements(in: root).filter { element in
             let role = stringAttribute(kAXRoleAttribute as CFString, from: element)
@@ -688,7 +679,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         }
     }
 
-    @MainActor
     private static func isExplicitComposer(
         _ element: AXUIElement,
         windowFrame: CGRect
@@ -713,7 +703,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return fields.contains(where: isExplicitComposerLabel)
     }
 
-    @MainActor
     private static func boolAttribute(
         _ attribute: CFString,
         from element: AXUIElement
@@ -725,7 +714,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return number.boolValue
     }
 
-    @MainActor
     private static func uniqueComposer(in window: AXUIElement) throws -> AXUIElement {
         guard let windowFrame = elementFrame(window) else {
             throw DraftPostFlowFailure.composerMissing
@@ -772,7 +760,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return draft
     }
 
-    @MainActor
     private static func stringAttribute(
         _ name: CFString,
         from element: AXUIElement
@@ -784,7 +771,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return value as? String
     }
 
-    @MainActor
     private static func elementFrame(_ element: AXUIElement) -> CGRect? {
         var positionValue: CFTypeRef?
         var sizeValue: CFTypeRef?

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -210,7 +210,7 @@ struct AXDraftPostComposerActuator: DraftPostComposerActuating {
             kAXFocusedAttribute as CFString,
             kCFBooleanTrue
         ) == .success else {
-            throw DraftPostFlowFailure.writeRejected
+            throw DraftPostFlowFailure.focusChanged
         }
     }
 
@@ -272,6 +272,10 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         // The destination may now be mutated. Every remaining observation is
         // therefore terminal on failure: recovery must never replay the write.
         do {
+            // Give WebKit and page frameworks a render turn before accepting
+            // the value. A controlled composer that rejects the AX update is
+            // detected by the final re-read instead of producing false success.
+            try await Task.sleep(for: .milliseconds(300))
             let finalSource = try await readDraft(from: source.selection)
             guard Self.utf8Matches(finalSource, draft) else {
                 throw DraftPostFlowFailure.verificationFailed

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -234,11 +234,6 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     private static let textEditBundle = "com.apple.TextEdit"
     static let browserBundles: Set<String> = [
         "com.apple.Safari",
-        "com.google.Chrome",
-        "com.google.Chrome.canary",
-        "com.microsoft.edgemac",
-        "company.thebrowser.Browser",
-        "org.mozilla.firefox",
     ]
     private let actuator: any DraftPostComposerActuating
 
@@ -260,6 +255,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             throw DraftPostFlowFailure.permissionMissing
         }
 
+        let documentIdentity = try await browserDocumentIdentity(in: destination)
         let draft = try await readDraft(from: source.selection)
         guard !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw DraftPostFlowFailure.draftMissing
@@ -267,7 +263,12 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         guard draft.utf8.count <= Self.maximumDraftBytes else {
             throw DraftPostFlowFailure.draftTooLarge
         }
-        try await writeAndVerify(draft, to: destination)
+        try await writeAndVerify(
+            draft,
+            from: source.selection,
+            to: destination,
+            documentIdentity: documentIdentity
+        )
         // The destination may now be mutated. Every remaining observation is
         // therefore terminal on failure: recovery must never replay the write.
         do {
@@ -275,7 +276,11 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             guard Self.utf8Matches(finalSource, draft) else {
                 throw DraftPostFlowFailure.verificationFailed
             }
-            try await verifyComposer(draft, in: destination)
+            try await verifyComposer(
+                draft,
+                in: destination,
+                documentIdentity: documentIdentity
+            )
         } catch {
             throw DraftPostFlowFailure.verificationFailed
         }
@@ -299,13 +304,18 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private func writeAndVerify(
         _ draft: String,
-        to destination: ComputerUseWindowOption
+        from source: ComputerUseWindowSelection,
+        to destination: ComputerUseWindowOption,
+        documentIdentity: String
     ) async throws {
         let selection = destination.selection
         try await focus(selection)
         try Task.checkCancellation()
         try await MainActor.run {
-            let window = try Self.exactFocusedBrowserWindow(destination)
+            let window = try Self.exactFocusedBrowserWindow(
+                destination,
+                documentIdentity: documentIdentity
+            )
             let composer = try Self.uniqueComposer(in: window)
             guard let existing = Self.stringAttribute(
                 kAXValueAttribute as CFString,
@@ -317,7 +327,10 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 throw DraftPostFlowFailure.composerNotEmpty
             }
             if Self.utf8Matches(existing, draft) {
-                let currentWindow = try Self.exactFocusedWindow(selection)
+                let currentWindow = try Self.exactFocusedBrowserWindow(
+                    destination,
+                    documentIdentity: documentIdentity
+                )
                 let currentComposer = try Self.uniqueComposer(in: currentWindow)
                 guard CFEqual(composer, currentComposer),
                       Self.stringAttribute(
@@ -341,7 +354,10 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             // Re-resolve the exact selected window immediately before the
             // value mutation. Focusing the exact bound editor is allowed, but
             // it must not have moved focus into another window.
-            let currentWindow = try Self.exactFocusedBrowserWindow(destination)
+            let currentWindow = try Self.exactFocusedBrowserWindow(
+                destination,
+                documentIdentity: documentIdentity
+            )
             let currentComposer = try Self.uniqueComposer(in: currentWindow)
             guard CFEqual(composer, currentComposer) else {
                 throw DraftPostFlowFailure.verificationFailed
@@ -355,6 +371,10 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             guard currentValue.isEmpty || Self.utf8Matches(currentValue, draft) else {
                 throw DraftPostFlowFailure.composerNotEmpty
             }
+            let currentSource = try Self.readDraftWithoutFocusing(from: source)
+            guard Self.utf8Matches(currentSource, draft) else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
             // This is the final cancellation boundary before the only content
             // mutation. No suspension occurs between this check and the write.
             try Task.checkCancellation()
@@ -363,7 +383,10 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             // retry. Collapse every post-mutation observation failure into a
             // terminal verification failure.
             try Self.verifyAfterMutation {
-                let verifiedWindow = try Self.exactFocusedBrowserWindow(destination)
+                let verifiedWindow = try Self.exactFocusedBrowserWindow(
+                    destination,
+                    documentIdentity: documentIdentity
+                )
                 let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
                 return CFEqual(currentComposer, verifiedComposer)
                     && Self.stringAttribute(
@@ -390,12 +413,16 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private func verifyComposer(
         _ draft: String,
-        in destination: ComputerUseWindowOption
+        in destination: ComputerUseWindowOption,
+        documentIdentity: String
     ) async throws {
         let selection = destination.selection
         try await focus(selection)
         try await MainActor.run {
-            let window = try Self.exactFocusedBrowserWindow(destination)
+            let window = try Self.exactFocusedBrowserWindow(
+                destination,
+                documentIdentity: documentIdentity
+            )
             let composer = try Self.uniqueComposer(in: window)
             guard Self.stringAttribute(
                 kAXValueAttribute as CFString,
@@ -408,7 +435,8 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     @MainActor
     private static func exactFocusedBrowserWindow(
-        _ destination: ComputerUseWindowOption
+        _ destination: ComputerUseWindowOption,
+        documentIdentity: String
     ) throws -> AXUIElement {
         let window = try exactFocusedWindow(destination.selection)
         guard browserDocumentMatches(
@@ -417,7 +445,8 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             from: window
             ),
             selectedTitle: destination.windowTitle
-        ) else {
+        ), try currentBrowserDocumentIdentity(in: window) == documentIdentity
+        else {
             throw DraftPostFlowFailure.focusChanged
         }
         return window
@@ -429,6 +458,76 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     ) -> Bool {
         guard let currentTitle, !selectedTitle.isEmpty else { return false }
         return utf8Matches(currentTitle, selectedTitle)
+    }
+
+    private func browserDocumentIdentity(
+        in destination: ComputerUseWindowOption
+    ) async throws -> String {
+        try await MainActor.run {
+            let selection = destination.selection
+            guard let running = NSRunningApplication(
+                processIdentifier: selection.processIdentifier
+            ), running.bundleIdentifier == selection.bundleIdentifier,
+                running.launchDate == selection.processLaunchDate
+            else { throw DraftPostFlowFailure.targetUnavailable }
+            let application = AXUIElementCreateApplication(selection.processIdentifier)
+            guard let window = Self.window(matching: selection, in: application),
+                  Self.browserDocumentMatches(
+                    currentTitle: Self.stringAttribute(
+                        kAXTitleAttribute as CFString,
+                        from: window
+                    ),
+                    selectedTitle: destination.windowTitle
+                  )
+            else { throw DraftPostFlowFailure.focusChanged }
+            return try Self.currentBrowserDocumentIdentity(in: window)
+        }
+    }
+
+    @MainActor
+    private static func currentBrowserDocumentIdentity(
+        in window: AXUIElement
+    ) throws -> String {
+        guard let windowFrame = elementFrame(window) else {
+            throw DraftPostFlowFailure.composerAmbiguous
+        }
+        let addressFields = allElements(in: window).filter { element in
+            guard stringAttribute(kAXIdentifierAttribute as CFString, from: element)
+                == "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD",
+                boolAttribute(kAXEnabledAttribute as CFString, from: element) == true,
+                let frame = elementFrame(element), windowFrame.intersects(frame)
+            else { return false }
+            return true
+        }
+        guard addressFields.count == 1,
+              let identity = stringAttribute(
+                kAXValueAttribute as CFString,
+                from: addressFields[0]
+              ), !identity.isEmpty
+        else { throw DraftPostFlowFailure.composerAmbiguous }
+        return identity
+    }
+
+    @MainActor
+    private static func readDraftWithoutFocusing(
+        from selection: ComputerUseWindowSelection
+    ) throws -> String {
+        guard let running = NSRunningApplication(
+            processIdentifier: selection.processIdentifier
+        ), running.bundleIdentifier == selection.bundleIdentifier,
+            running.launchDate == selection.processLaunchDate
+        else { throw DraftPostFlowFailure.targetUnavailable }
+        let application = AXUIElementCreateApplication(selection.processIdentifier)
+        guard let window = window(matching: selection, in: application) else {
+            throw DraftPostFlowFailure.targetUnavailable
+        }
+        let candidates = editableElements(in: window)
+            .filter {
+                stringAttribute(kAXRoleAttribute as CFString, from: $0)
+                    == kAXTextAreaRole as String
+            }
+            .map { stringAttribute(kAXValueAttribute as CFString, from: $0) }
+        return try uniqueDraft(in: candidates)
     }
 
     private func focus(_ selection: ComputerUseWindowSelection) async throws {
@@ -520,7 +619,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     }
 
     @MainActor
-    private static func editableElements(in root: AXUIElement) -> [AXUIElement] {
+    private static func allElements(in root: AXUIElement) -> [AXUIElement] {
         var queue: [(AXUIElement, Int)] = [(root, 0)]
         var result: [AXUIElement] = []
         var visited = Set<AXUIElement>()
@@ -529,12 +628,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             let (element, depth) = queue[cursor]
             cursor += 1
             guard visited.insert(element).inserted else { continue }
-            let role = stringAttribute(kAXRoleAttribute as CFString, from: element)
-            let subrole = stringAttribute(kAXSubroleAttribute as CFString, from: element)
-            if (role == kAXTextAreaRole as String || role == kAXTextFieldRole as String),
-               subrole != kAXSecureTextFieldSubrole as String {
-                result.append(element)
-            }
+            result.append(element)
             guard depth < 32 else { continue }
             var value: CFTypeRef?
             if AXUIElementCopyAttributeValue(
@@ -551,7 +645,31 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     }
 
     @MainActor
-    private static func isExplicitComposer(_ element: AXUIElement) -> Bool {
+    private static func editableElements(in root: AXUIElement) -> [AXUIElement] {
+        allElements(in: root).filter { element in
+            let role = stringAttribute(kAXRoleAttribute as CFString, from: element)
+            let subrole = stringAttribute(kAXSubroleAttribute as CFString, from: element)
+            return (role == kAXTextAreaRole as String || role == kAXTextFieldRole as String)
+                && subrole != kAXSecureTextFieldSubrole as String
+        }
+    }
+
+    @MainActor
+    private static func isExplicitComposer(
+        _ element: AXUIElement,
+        windowFrame: CGRect
+    ) -> Bool {
+        guard boolAttribute(kAXEnabledAttribute as CFString, from: element) == true,
+              boolAttribute("AXHidden" as CFString, from: element) != true,
+              let frame = elementFrame(element), frame.width >= 1, frame.height >= 1,
+              windowFrame.intersects(frame)
+        else { return false }
+        var settable: DarwinBoolean = false
+        guard AXUIElementIsAttributeSettable(
+            element,
+            kAXValueAttribute as CFString,
+            &settable
+        ) == .success, settable.boolValue else { return false }
         let fields = [
             stringAttribute(kAXTitleAttribute as CFString, from: element),
             stringAttribute(kAXDescriptionAttribute as CFString, from: element),
@@ -562,8 +680,25 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     }
 
     @MainActor
+    private static func boolAttribute(
+        _ attribute: CFString,
+        from element: AXUIElement
+    ) -> Bool? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success,
+              let number = value as? NSNumber
+        else { return nil }
+        return number.boolValue
+    }
+
+    @MainActor
     private static func uniqueComposer(in window: AXUIElement) throws -> AXUIElement {
-        let matches = editableElements(in: window).filter(isExplicitComposer)
+        guard let windowFrame = elementFrame(window) else {
+            throw DraftPostFlowFailure.composerMissing
+        }
+        let matches = editableElements(in: window).filter {
+            isExplicitComposer($0, windowFrame: windowFrame)
+        }
         guard let match = matches.first else {
             throw DraftPostFlowFailure.composerMissing
         }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -375,10 +375,23 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             guard Self.utf8Matches(currentSource, draft) else {
                 throw DraftPostFlowFailure.verificationFailed
             }
+            let authorizedWindow = try Self.exactFocusedBrowserWindow(
+                destination,
+                documentIdentity: documentIdentity
+            )
+            let authorizedComposer = try Self.uniqueComposer(in: authorizedWindow)
+            guard CFEqual(currentComposer, authorizedComposer),
+                  let authorizedValue = Self.stringAttribute(
+                    kAXValueAttribute as CFString,
+                    from: authorizedComposer
+                  ), authorizedValue.isEmpty
+            else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
             // This is the final cancellation boundary before the only content
             // mutation. No suspension occurs between this check and the write.
             try Task.checkCancellation()
-            try actuator.setDraft(draft, on: currentComposer)
+            try actuator.setDraft(draft, on: authorizedComposer)
             // Once content may have changed, no focus/window error is safe to
             // retry. Collapse every post-mutation observation failure into a
             // terminal verification failure.
@@ -388,7 +401,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                     documentIdentity: documentIdentity
                 )
                 let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
-                return CFEqual(currentComposer, verifiedComposer)
+                return CFEqual(authorizedComposer, verifiedComposer)
                     && Self.stringAttribute(
                         kAXValueAttribute as CFString,
                         from: verifiedComposer
@@ -793,7 +806,7 @@ final class DraftPostFlowViewModel {
         case running
         case stopping
         case readyForReview(DraftPostFlowMetrics)
-        case failed(String, DraftPostFlowMetrics?)
+        case failed(DraftPostFlowFailure, DraftPostFlowMetrics?)
     }
 
     var phase: Phase = .loading
@@ -848,12 +861,12 @@ final class DraftPostFlowViewModel {
         } catch let error as ComputerUseWindowCatalogError {
             switch error {
             case .permissionsMissing:
-                phase = .failed(DraftPostFlowFailure.permissionMissing.userMessage, nil)
+                phase = .failed(.permissionMissing, nil)
             case .unavailable:
-                phase = .failed("Rapid could not list the available windows.", nil)
+                phase = .failed(.dependencyFailure, nil)
             }
         } catch {
-            phase = .failed("Rapid could not list the available windows.", nil)
+            phase = .failed(.dependencyFailure, nil)
         }
     }
 
@@ -874,7 +887,7 @@ final class DraftPostFlowViewModel {
             case .readyForReview(let metrics):
                 self.phase = .readyForReview(metrics)
             case .failed(let failure, let metrics):
-                self.phase = .failed(failure.userMessage, metrics)
+                self.phase = .failed(failure, metrics)
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -868,7 +868,9 @@ final class DraftPostFlowViewModel {
         windows.filter {
             MacOSDraftPostFlowDriver.browserBundles.contains(
                 $0.selection.bundleIdentifier
-            )
+            ) && !$0.windowTitle.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -11,7 +11,10 @@ struct ComputerUseWindowOption: Identifiable, Equatable, Sendable {
     let selection: ComputerUseWindowSelection
 
     var displayName: String {
-        windowTitle.isEmpty ? applicationName : "\(applicationName) — \(windowTitle)"
+        let readableName = windowTitle.isEmpty
+            ? applicationName
+            : "\(applicationName) — \(windowTitle)"
+        return "\(readableName) · Window \(selection.windowID)"
     }
 }
 
@@ -265,6 +268,19 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             }
             guard existing.isEmpty || Self.utf8Matches(existing, draft) else {
                 throw DraftPostFlowFailure.composerNotEmpty
+            }
+            if Self.utf8Matches(existing, draft) {
+                let currentWindow = try Self.exactFocusedWindow(selection)
+                let currentComposer = try Self.uniqueComposer(in: currentWindow)
+                guard CFEqual(composer, currentComposer),
+                      Self.stringAttribute(
+                        kAXValueAttribute as CFString,
+                        from: currentComposer
+                      ).map({ Self.utf8Matches($0, draft) }) == true
+                else {
+                    throw DraftPostFlowFailure.verificationFailed
+                }
+                return
             }
             var settable: DarwinBoolean = false
             guard AXUIElementIsAttributeSettable(
@@ -601,7 +617,7 @@ final class DraftPostFlowViewModel {
         phase = .loading
         do {
             windows = try await catalog.windows()
-            sourceID = sourceOptions.count == 1 ? sourceOptions[0].id : nil
+            sourceID = nil
             destinationID = nil
             phase = .ready
         } catch let error as ComputerUseWindowCatalogError {

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -83,6 +83,7 @@ enum DraftPostFlowFailure: Error, Equatable, Sendable {
     case targetUnavailable
     case focusChanged
     case draftMissing
+    case draftAmbiguous
     case draftTooLarge
     case composerMissing
     case composerAmbiguous
@@ -91,6 +92,7 @@ enum DraftPostFlowFailure: Error, Equatable, Sendable {
     case verificationFailed
     case permissionMissing
     case cancelled
+    case dependencyFailure
 
     var isRecoverable: Bool {
         switch self {
@@ -108,6 +110,7 @@ enum DraftPostFlowFailure: Error, Equatable, Sendable {
         case .targetUnavailable: "A selected window is no longer available."
         case .focusChanged: "Rapid could not safely focus the selected window."
         case .draftMissing: "The selected TextEdit document has no readable draft."
+        case .draftAmbiguous: "More than one TextEdit document editor was found. Close auxiliary editors and try again."
         case .draftTooLarge: "The draft is too large for this preview (64 KB maximum)."
         case .composerMissing: "No editable post composer was found in the browser window."
         case .composerAmbiguous: "More than one possible composer was found. Close other editors and try again."
@@ -116,6 +119,7 @@ enum DraftPostFlowFailure: Error, Equatable, Sendable {
         case .verificationFailed: "The browser content did not match the TextEdit draft."
         case .permissionMissing: "Screen Recording and Accessibility access are required."
         case .cancelled: "The flow was stopped."
+        case .dependencyFailure: "The flow stopped because a local system operation failed."
         }
     }
 }
@@ -173,7 +177,10 @@ actor DraftPostFlowCoordinator {
             } catch is CancellationError {
                 return .failed(.cancelled, metrics)
             } catch {
-                return .failed(.targetUnavailable, metrics)
+                // Only typed, known pre-mutation focus/window failures may
+                // retry. An unknown adapter failure could have happened after
+                // a local mutation, so it must fail closed.
+                return .failed(.dependencyFailure, metrics)
             }
         }
         return .failed(.targetUnavailable, metrics)
@@ -225,12 +232,15 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return try await MainActor.run {
             let window = try Self.exactFocusedWindow(selection)
             let candidates = Self.editableElements(in: window)
+                .filter {
+                    Self.stringAttribute(
+                        kAXRoleAttribute as CFString,
+                        from: $0
+                    ) == kAXTextAreaRole as String
+                }
                 .compactMap { Self.stringAttribute(kAXValueAttribute as CFString, from: $0) }
                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-            guard let draft = candidates.max(by: { $0.utf8.count < $1.utf8.count }) else {
-                throw DraftPostFlowFailure.draftMissing
-            }
-            return draft
+            return try Self.uniqueDraft(in: candidates)
         }
     }
 
@@ -407,33 +417,51 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     }
 
     @MainActor
-    private static func composerScore(_ element: AXUIElement) -> Int {
+    private static func isExplicitComposer(_ element: AXUIElement) -> Bool {
         let fields = [
             stringAttribute(kAXTitleAttribute as CFString, from: element),
             stringAttribute(kAXDescriptionAttribute as CFString, from: element),
             stringAttribute(kAXHelpAttribute as CFString, from: element),
             stringAttribute("AXPlaceholderValue" as CFString, from: element),
-        ].compactMap { $0?.lowercased() }.joined(separator: " ")
-        let hints = ["post", "tweet", "what is happening", "what's happening", "compose", "update"]
-        // No generic "first empty field" fallback: that can be a search box
-        // or browser chrome. A composer needs an explicit semantic hint, and
-        // equal matches fail closed rather than relying on tree order.
-        return hints.reduce(0) { $0 + (fields.contains($1) ? 10 : 0) }
+        ].compactMap { $0 }
+        return fields.contains(where: isExplicitComposerLabel)
     }
 
     @MainActor
     private static func uniqueComposer(in window: AXUIElement) throws -> AXUIElement {
-        let ranked = editableElements(in: window)
-            .map { ($0, composerScore($0)) }
-            .filter { $0.1 > 0 }
-            .sorted { $0.1 > $1.1 }
-        guard let best = ranked.first else {
+        let matches = editableElements(in: window).filter(isExplicitComposer)
+        guard let match = matches.first else {
             throw DraftPostFlowFailure.composerMissing
         }
-        if ranked.count > 1, ranked[1].1 == best.1 {
+        if matches.count > 1 {
             throw DraftPostFlowFailure.composerAmbiguous
         }
-        return best.0
+        return match
+    }
+
+    static func isExplicitComposerLabel(_ raw: String) -> Bool {
+        let label = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "’", with: "'")
+        return [
+            "post text",
+            "compose post",
+            "write your post",
+            "what is happening?",
+            "what's happening?",
+            "what is on your mind?",
+            "what's on your mind?",
+        ].contains(label)
+    }
+
+    static func uniqueDraft(in candidates: [String]) throws -> String {
+        guard let draft = candidates.first else {
+            throw DraftPostFlowFailure.draftMissing
+        }
+        guard candidates.count == 1 else {
+            throw DraftPostFlowFailure.draftAmbiguous
+        }
+        return draft
     }
 
     @MainActor
@@ -522,7 +550,13 @@ final class DraftPostFlowViewModel {
     }
 
     var canRun: Bool {
-        sourceID != nil && destinationID != nil && phase == .ready
+        guard phase == .ready,
+              let sourceID,
+              let destinationID,
+              sourceID != destinationID
+        else { return false }
+        return sourceOptions.contains(where: { $0.id == sourceID })
+            && destinationOptions.contains(where: { $0.id == destinationID })
     }
 
     func load() async {
@@ -530,6 +564,7 @@ final class DraftPostFlowViewModel {
         do {
             windows = try await catalog.windows()
             sourceID = sourceOptions.count == 1 ? sourceOptions[0].id : nil
+            destinationID = nil
             phase = .ready
         } catch let error as ComputerUseWindowCatalogError {
             switch error {
@@ -551,7 +586,9 @@ final class DraftPostFlowViewModel {
         let coordinator = DraftPostFlowCoordinator(driver: driver)
         runTask = Task { [weak self] in
             let outcome = await coordinator.run(source: source, destination: destination)
-            guard let self else { return }
+            // Dismissing the sheet owns cancellation. Do not let the completed
+            // task race with stop() and overwrite the cancellation state.
+            guard !Task.isCancelled, let self else { return }
             switch outcome {
             case .readyForReview(let metrics):
                 self.phase = .readyForReview(metrics)
@@ -564,5 +601,8 @@ final class DraftPostFlowViewModel {
     func stop() {
         runTask?.cancel()
         runTask = nil
+        if phase == .running {
+            phase = .failed(DraftPostFlowFailure.cancelled.userMessage, nil)
+        }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -871,7 +871,8 @@ final class DraftPostFlowViewModel {
     }
 
     func run() {
-        guard let source = windows.first(where: { $0.id == sourceID }),
+        guard phase == .ready, runTask == nil,
+              let source = windows.first(where: { $0.id == sourceID }),
               let destination = windows.first(where: { $0.id == destinationID })
         else { return }
         phase = .running

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -101,6 +101,7 @@ enum DraftPostFlowFailure: Error, Equatable, Sendable {
     case permissionMissing
     case cancelled
     case dependencyFailure
+    case accessibilityTreeTooLarge
 
     var isRecoverable: Bool {
         switch self {
@@ -128,6 +129,7 @@ enum DraftPostFlowFailure: Error, Equatable, Sendable {
         case .permissionMissing: "Screen Recording and Accessibility access are required."
         case .cancelled: "The flow was stopped."
         case .dependencyFailure: "The flow stopped because a local system operation failed."
+        case .accessibilityTreeTooLarge: "The selected window is too complex for this preview flow."
         }
     }
 }
@@ -294,7 +296,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         try await focus(selection)
         return try await MainActor.run {
             let window = try Self.exactFocusedWindow(selection)
-            let candidates = Self.editableElements(in: window)
+            let candidates = try Self.editableElements(in: window)
                 .filter {
                     Self.stringAttribute(
                         kAXRoleAttribute as CFString,
@@ -487,7 +489,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             ), running.bundleIdentifier == selection.bundleIdentifier,
                 running.launchDate == selection.processLaunchDate
             else { throw DraftPostFlowFailure.targetUnavailable }
-            let application = AXUIElementCreateApplication(selection.processIdentifier)
+            let application = Self.applicationElement(selection.processIdentifier)
             guard let window = Self.window(matching: selection, in: application),
                   Self.browserDocumentMatches(
                     currentTitle: Self.stringAttribute(
@@ -508,7 +510,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         guard let windowFrame = elementFrame(window) else {
             throw DraftPostFlowFailure.composerAmbiguous
         }
-        let addressFields = allElements(in: window).filter { element in
+        let addressFields = try allElements(in: window).filter { element in
             guard stringAttribute(kAXIdentifierAttribute as CFString, from: element)
                 == "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD",
                 boolAttribute(kAXEnabledAttribute as CFString, from: element) == true,
@@ -534,11 +536,11 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         ), running.bundleIdentifier == selection.bundleIdentifier,
             running.launchDate == selection.processLaunchDate
         else { throw DraftPostFlowFailure.targetUnavailable }
-        let application = AXUIElementCreateApplication(selection.processIdentifier)
+        let application = applicationElement(selection.processIdentifier)
         guard let window = window(matching: selection, in: application) else {
             throw DraftPostFlowFailure.targetUnavailable
         }
-        let candidates = editableElements(in: window)
+        let candidates = try editableElements(in: window)
             .filter {
                 stringAttribute(kAXRoleAttribute as CFString, from: $0)
                     == kAXTextAreaRole as String
@@ -555,7 +557,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                   app.launchDate == selection.processLaunchDate
             else { throw DraftPostFlowFailure.targetUnavailable }
             app.activate()
-            let application = AXUIElementCreateApplication(selection.processIdentifier)
+            let application = Self.applicationElement(selection.processIdentifier)
             guard let window = Self.window(matching: selection, in: application),
                   AXUIElementPerformAction(window, kAXRaiseAction as CFString) == .success
             else { throw DraftPostFlowFailure.targetUnavailable }
@@ -579,7 +581,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             NSWorkspace.shared.frontmostApplication?.processIdentifier
                 == selection.processIdentifier
         else { throw DraftPostFlowFailure.focusChanged }
-        let application = AXUIElementCreateApplication(selection.processIdentifier)
+        let application = applicationElement(selection.processIdentifier)
         guard let selected = window(matching: selection, in: application) else {
             throw DraftPostFlowFailure.targetUnavailable
         }
@@ -594,6 +596,13 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             CFEqual(selected, unsafeDowncast(focusedValue, to: AXUIElement.self))
         else { throw DraftPostFlowFailure.focusChanged }
         return selected
+    }
+
+    @MainActor
+    private static func applicationElement(_ processIdentifier: pid_t) -> AXUIElement {
+        let application = AXUIElementCreateApplication(processIdentifier)
+        AXUIElementSetMessagingTimeout(application, 0.35)
+        return application
     }
 
     @MainActor
@@ -636,7 +645,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     }
 
     @MainActor
-    private static func allElements(in root: AXUIElement) -> [AXUIElement] {
+    private static func allElements(in root: AXUIElement) throws -> [AXUIElement] {
         var queue: [(AXUIElement, Int)] = [(root, 0)]
         var result: [AXUIElement] = []
         var visited = Set<AXUIElement>()
@@ -648,22 +657,30 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             result.append(element)
             guard depth < 32 else { continue }
             var value: CFTypeRef?
-            if AXUIElementCopyAttributeValue(
+            let childrenResult = AXUIElementCopyAttributeValue(
                 element,
                 kAXChildrenAttribute as CFString,
                 &value
-            ) == .success,
+            )
+            if childrenResult == .success,
                 let children = value as? [AXUIElement]
             {
                 queue.append(contentsOf: children.map { ($0, depth + 1) })
+            } else if childrenResult != .noValue,
+                      childrenResult != .attributeUnsupported
+            {
+                throw DraftPostFlowFailure.dependencyFailure
             }
+        }
+        guard cursor >= queue.count else {
+            throw DraftPostFlowFailure.accessibilityTreeTooLarge
         }
         return result
     }
 
     @MainActor
-    private static func editableElements(in root: AXUIElement) -> [AXUIElement] {
-        allElements(in: root).filter { element in
+    private static func editableElements(in root: AXUIElement) throws -> [AXUIElement] {
+        try allElements(in: root).filter { element in
             let role = stringAttribute(kAXRoleAttribute as CFString, from: element)
             let subrole = stringAttribute(kAXSubroleAttribute as CFString, from: element)
             return (role == kAXTextAreaRole as String || role == kAXTextFieldRole as String)
@@ -713,7 +730,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         guard let windowFrame = elementFrame(window) else {
             throw DraftPostFlowFailure.composerMissing
         }
-        let matches = editableElements(in: window).filter {
+        let matches = try editableElements(in: window).filter {
             isExplicitComposer($0, windowFrame: windowFrame)
         }
         guard let match = matches.first else {

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -273,17 +273,10 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         // The destination may now be mutated. Every remaining observation is
         // therefore terminal on failure: recovery must never replay the write.
         do {
-            // Give WebKit and page frameworks a render turn before accepting
-            // the value. A controlled composer that rejects the AX update is
-            // detected by the final re-read instead of producing false success.
-            try await Task.sleep(for: .milliseconds(300))
-            let finalSource = try await readDraft(from: source.selection)
-            guard Self.utf8Matches(finalSource, draft) else {
-                throw DraftPostFlowFailure.verificationFailed
-            }
-            try await verifyComposer(
-                draft,
-                in: destination,
+            try await Self.verifyDefinitivePostMutationState(
+                draft: draft,
+                source: source.selection,
+                destination: destination,
                 documentIdentity: documentIdentity
             )
         } catch {
@@ -425,26 +418,45 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         }
     }
 
-    private func verifyComposer(
-        _ draft: String,
-        in destination: ComputerUseWindowOption,
+    private static func verifyDefinitivePostMutationState(
+        draft: String,
+        source: ComputerUseWindowSelection,
+        destination: ComputerUseWindowOption,
         documentIdentity: String
     ) async throws {
-        let selection = destination.selection
-        try await focus(selection)
-        try await Self.runAXWork {
-            let window = try Self.exactFocusedBrowserWindow(
-                destination,
-                documentIdentity: documentIdentity
-            )
-            let composer = try Self.uniqueComposer(in: window)
-            guard Self.stringAttribute(
-                kAXValueAttribute as CFString,
-                from: composer
-            ).map({ Self.utf8Matches($0, draft) }) == true else {
+        // This detached task is intentionally cancellation-insensitive: after
+        // a possible write, Stop must wait for definitive source/destination
+        // verification rather than misreporting an unknown mutation state.
+        try await Task.detached {
+            try await Task.sleep(for: .milliseconds(300))
+            let finalSource = try readDraftWithoutFocusing(from: source)
+            guard utf8Matches(finalSource, draft) else {
                 throw DraftPostFlowFailure.verificationFailed
             }
-        }
+            let selection = destination.selection
+            guard let running = NSRunningApplication(
+                processIdentifier: selection.processIdentifier
+            ), running.bundleIdentifier == selection.bundleIdentifier,
+                running.launchDate == selection.processLaunchDate
+            else { throw DraftPostFlowFailure.verificationFailed }
+            let application = applicationElement(selection.processIdentifier)
+            guard let window = window(matching: selection, in: application),
+                  browserDocumentMatches(
+                    currentTitle: stringAttribute(
+                        kAXTitleAttribute as CFString,
+                        from: window
+                    ),
+                    selectedTitle: destination.windowTitle
+                  ), try currentBrowserDocumentIdentity(in: window) == documentIdentity
+            else { throw DraftPostFlowFailure.verificationFailed }
+            let composer = try uniqueComposer(in: window)
+            guard stringAttribute(
+                kAXValueAttribute as CFString,
+                from: composer
+            ).map({ utf8Matches($0, draft) }) == true else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
+        }.value
     }
 
     private static func exactFocusedBrowserWindow(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -232,6 +232,17 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             throw DraftPostFlowFailure.draftTooLarge
         }
         try await writeAndVerify(draft, to: destination.selection)
+        // The destination may now be mutated. Every remaining observation is
+        // therefore terminal on failure: recovery must never replay the write.
+        do {
+            let finalSource = try await readDraft(from: source.selection)
+            guard Self.utf8Matches(finalSource, draft) else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
+            try await verifyComposer(draft, in: destination.selection)
+        } catch {
+            throw DraftPostFlowFailure.verificationFailed
+        }
     }
 
     private func readDraft(from selection: ComputerUseWindowSelection) async throws -> String {
@@ -350,6 +361,23 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             }
         } catch {
             throw DraftPostFlowFailure.verificationFailed
+        }
+    }
+
+    private func verifyComposer(
+        _ draft: String,
+        in selection: ComputerUseWindowSelection
+    ) async throws {
+        try await focus(selection)
+        try await MainActor.run {
+            let window = try Self.exactFocusedWindow(selection)
+            let composer = try Self.uniqueComposer(in: window)
+            guard Self.stringAttribute(
+                kAXValueAttribute as CFString,
+                from: composer
+            ).map({ Self.utf8Matches($0, draft) }) == true else {
+                throw DraftPostFlowFailure.verificationFailed
+            }
         }
     }
 
@@ -571,6 +599,7 @@ final class DraftPostFlowViewModel {
         case loading
         case ready
         case running
+        case stopping
         case readyForReview(DraftPostFlowMetrics)
         case failed(String, DraftPostFlowMetrics?)
     }
@@ -613,6 +642,10 @@ final class DraftPostFlowViewModel {
             && destinationOptions.contains(where: { $0.id == destinationID })
     }
 
+    var isActive: Bool {
+        phase == .running || phase == .stopping
+    }
+
     func load() async {
         phase = .loading
         do {
@@ -640,9 +673,11 @@ final class DraftPostFlowViewModel {
         let coordinator = DraftPostFlowCoordinator(driver: driver)
         runTask = Task { [weak self] in
             let outcome = await coordinator.run(source: source, destination: destination)
-            // Dismissing the sheet owns cancellation. Do not let the completed
-            // task race with stop() and overwrite the cancellation state.
-            guard !Task.isCancelled, let self else { return }
+            // A cancellation request may race with the final synchronous write.
+            // Report the driver's definitive outcome instead of claiming that
+            // cancellation prevented a mutation when it did not.
+            guard let self else { return }
+            self.runTask = nil
             switch outcome {
             case .readyForReview(let metrics):
                 self.phase = .readyForReview(metrics)
@@ -654,9 +689,8 @@ final class DraftPostFlowViewModel {
 
     func stop() {
         runTask?.cancel()
-        runTask = nil
         if phase == .running {
-            phase = .failed(DraftPostFlowFailure.cancelled.userMessage, nil)
+            phase = .stopping
         }
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -714,19 +714,15 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private static func isExplicitComposer(
         _ element: AXUIElement,
+        in window: AXUIElement,
         windowFrame: CGRect
     ) -> Bool {
         guard boolAttribute(kAXEnabledAttribute as CFString, from: element) == true,
-              boolAttribute("AXHidden" as CFString, from: element) != true,
               let frame = elementFrame(element), frame.width >= 1, frame.height >= 1,
-              windowFrame.intersects(frame)
+              windowFrame.insetBy(dx: -0.5, dy: -0.5).contains(frame),
+              hasVisibleAncestry(element, through: window)
         else { return false }
-        var settable: DarwinBoolean = false
-        guard AXUIElementIsAttributeSettable(
-            element,
-            kAXValueAttribute as CFString,
-            &settable
-        ) == .success, settable.boolValue else { return false }
+        guard isSettable(kAXValueAttribute as CFString, on: element) else { return false }
         let fields = [
             stringAttribute(kAXTitleAttribute as CFString, from: element),
             stringAttribute(kAXDescriptionAttribute as CFString, from: element),
@@ -734,6 +730,39 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             stringAttribute("AXPlaceholderValue" as CFString, from: element),
         ].compactMap { $0 }
         return fields.contains(where: isExplicitComposerLabel)
+    }
+
+    private static func isSettable(_ attribute: CFString, on element: AXUIElement) -> Bool {
+        var settable: DarwinBoolean = false
+        return AXUIElementIsAttributeSettable(element, attribute, &settable) == .success
+            && settable.boolValue
+    }
+
+    private static func hasVisibleAncestry(
+        _ element: AXUIElement,
+        through window: AXUIElement
+    ) -> Bool {
+        var current = element
+        var visited = Set<AXUIElement>()
+        for _ in 0 ..< 32 {
+            guard visited.insert(current).inserted,
+                  boolAttribute("AXHidden" as CFString, from: current) != true
+            else { return false }
+            if CFEqual(current, window) {
+                return true
+            }
+            var parentValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(
+                current,
+                kAXParentAttribute as CFString,
+                &parentValue
+            ) == .success,
+                let parentValue,
+                CFGetTypeID(parentValue) == AXUIElementGetTypeID()
+            else { return false }
+            current = unsafeDowncast(parentValue, to: AXUIElement.self)
+        }
+        return false
     }
 
     private static func boolAttribute(
@@ -752,7 +781,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             throw DraftPostFlowFailure.composerMissing
         }
         let matches = try editableElements(in: window).filter {
-            isExplicitComposer($0, windowFrame: windowFrame)
+            isExplicitComposer($0, in: window, windowFrame: windowFrame)
         }
         guard let match = matches.first else {
             throw DraftPostFlowFailure.composerMissing

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -194,6 +194,37 @@ actor DraftPostFlowCoordinator {
     }
 }
 
+/// The complete mutation authority granted to the draft flow. Publishing is
+/// structurally impossible because this capability can only focus a composer
+/// and set its draft value.
+@MainActor
+protocol DraftPostComposerActuating: Sendable {
+    func focusComposer(_ composer: AXUIElement) throws
+    func setDraft(_ draft: String, on composer: AXUIElement) throws
+}
+
+struct AXDraftPostComposerActuator: DraftPostComposerActuating {
+    func focusComposer(_ composer: AXUIElement) throws {
+        guard AXUIElementSetAttributeValue(
+            composer,
+            kAXFocusedAttribute as CFString,
+            kCFBooleanTrue
+        ) == .success else {
+            throw DraftPostFlowFailure.writeRejected
+        }
+    }
+
+    func setDraft(_ draft: String, on composer: AXUIElement) throws {
+        guard AXUIElementSetAttributeValue(
+            composer,
+            kAXValueAttribute as CFString,
+            draft as CFString
+        ) == .success else {
+            throw DraftPostFlowFailure.writeRejected
+        }
+    }
+}
+
 /// Accessibility-first implementation for the first bounded starter flow.
 /// The user selects both windows. Rapid reads one TextEdit document, writes an
 /// empty browser composer, verifies the exact value, and stops. No coordinate
@@ -209,6 +240,11 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         "company.thebrowser.Browser",
         "org.mozilla.firefox",
     ]
+    private let actuator: any DraftPostComposerActuating
+
+    init(actuator: any DraftPostComposerActuating = AXDraftPostComposerActuator()) {
+        self.actuator = actuator
+    }
 
     func transferDraft(
         from source: ComputerUseWindowOption,
@@ -231,7 +267,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         guard draft.utf8.count <= Self.maximumDraftBytes else {
             throw DraftPostFlowFailure.draftTooLarge
         }
-        try await writeAndVerify(draft, to: destination.selection)
+        try await writeAndVerify(draft, to: destination)
         // The destination may now be mutated. Every remaining observation is
         // therefore terminal on failure: recovery must never replay the write.
         do {
@@ -239,7 +275,7 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             guard Self.utf8Matches(finalSource, draft) else {
                 throw DraftPostFlowFailure.verificationFailed
             }
-            try await verifyComposer(draft, in: destination.selection)
+            try await verifyComposer(draft, in: destination)
         } catch {
             throw DraftPostFlowFailure.verificationFailed
         }
@@ -263,12 +299,13 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private func writeAndVerify(
         _ draft: String,
-        to selection: ComputerUseWindowSelection
+        to destination: ComputerUseWindowOption
     ) async throws {
+        let selection = destination.selection
         try await focus(selection)
         try Task.checkCancellation()
         try await MainActor.run {
-            let window = try Self.exactFocusedWindow(selection)
+            let window = try Self.exactFocusedBrowserWindow(destination)
             let composer = try Self.uniqueComposer(in: window)
             guard let existing = Self.stringAttribute(
                 kAXValueAttribute as CFString,
@@ -300,17 +337,11 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             ) == .success, settable.boolValue else {
                 throw DraftPostFlowFailure.writeRejected
             }
-            guard AXUIElementSetAttributeValue(
-                composer,
-                kAXFocusedAttribute as CFString,
-                kCFBooleanTrue
-            ) == .success else {
-                throw DraftPostFlowFailure.writeRejected
-            }
+            try actuator.focusComposer(composer)
             // Re-resolve the exact selected window immediately before the
             // value mutation. Focusing the exact bound editor is allowed, but
             // it must not have moved focus into another window.
-            let currentWindow = try Self.exactFocusedWindow(selection)
+            let currentWindow = try Self.exactFocusedBrowserWindow(destination)
             let currentComposer = try Self.uniqueComposer(in: currentWindow)
             guard CFEqual(composer, currentComposer) else {
                 throw DraftPostFlowFailure.verificationFailed
@@ -327,18 +358,12 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             // This is the final cancellation boundary before the only content
             // mutation. No suspension occurs between this check and the write.
             try Task.checkCancellation()
-            guard AXUIElementSetAttributeValue(
-                currentComposer,
-                kAXValueAttribute as CFString,
-                draft as CFString
-            ) == .success else {
-                throw DraftPostFlowFailure.writeRejected
-            }
+            try actuator.setDraft(draft, on: currentComposer)
             // Once content may have changed, no focus/window error is safe to
             // retry. Collapse every post-mutation observation failure into a
             // terminal verification failure.
             try Self.verifyAfterMutation {
-                let verifiedWindow = try Self.exactFocusedWindow(selection)
+                let verifiedWindow = try Self.exactFocusedBrowserWindow(destination)
                 let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
                 return CFEqual(currentComposer, verifiedComposer)
                     && Self.stringAttribute(
@@ -365,11 +390,12 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
 
     private func verifyComposer(
         _ draft: String,
-        in selection: ComputerUseWindowSelection
+        in destination: ComputerUseWindowOption
     ) async throws {
+        let selection = destination.selection
         try await focus(selection)
         try await MainActor.run {
-            let window = try Self.exactFocusedWindow(selection)
+            let window = try Self.exactFocusedBrowserWindow(destination)
             let composer = try Self.uniqueComposer(in: window)
             guard Self.stringAttribute(
                 kAXValueAttribute as CFString,
@@ -378,6 +404,31 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 throw DraftPostFlowFailure.verificationFailed
             }
         }
+    }
+
+    @MainActor
+    private static func exactFocusedBrowserWindow(
+        _ destination: ComputerUseWindowOption
+    ) throws -> AXUIElement {
+        let window = try exactFocusedWindow(destination.selection)
+        guard browserDocumentMatches(
+            currentTitle: stringAttribute(
+            kAXTitleAttribute as CFString,
+            from: window
+            ),
+            selectedTitle: destination.windowTitle
+        ) else {
+            throw DraftPostFlowFailure.focusChanged
+        }
+        return window
+    }
+
+    static func browserDocumentMatches(
+        currentTitle: String?,
+        selectedTitle: String
+    ) -> Bool {
+        guard let currentTitle, !selectedTitle.isEmpty else { return false }
+        return utf8Matches(currentTitle, selectedTitle)
     }
 
     private func focus(_ selection: ComputerUseWindowSelection) async throws {

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -244,13 +244,15 @@ private struct DraftPostFlowSheet: View {
                 title: "1. TextEdit draft",
                 prompt: "Choose a TextEdit window",
                 options: viewModel.sourceOptions,
-                selection: $viewModel.sourceID
+                selection: $viewModel.sourceID,
+                identifier: "ComputerUse.DraftPost.Source"
             )
             picker(
                 title: "2. Signed-in browser composer",
                 prompt: "Choose a browser window",
                 options: viewModel.destinationOptions,
-                selection: $viewModel.destinationID
+                selection: $viewModel.destinationID,
+                identifier: "ComputerUse.DraftPost.Destination"
             )
 
             if viewModel.sourceOptions.isEmpty || viewModel.destinationOptions.isEmpty {
@@ -278,7 +280,8 @@ private struct DraftPostFlowSheet: View {
         title: String,
         prompt: String,
         options: [ComputerUseWindowOption],
-        selection: Binding<String?>
+        selection: Binding<String?>,
+        identifier: String
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(title).font(.headline)
@@ -290,6 +293,7 @@ private struct DraftPostFlowSheet: View {
             }
             .labelsHidden()
             .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityIdentifier(identifier)
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -192,10 +192,10 @@ private struct DraftPostFlowSheet: View {
                     metrics: metrics
                 )
 
-            case .failed(let message, let metrics):
+            case .failed(let failure, let metrics):
                 result(
                     title: "Rapid paused safely",
-                    message: message,
+                    message: failure.userMessage,
                     symbol: "pause.circle.fill",
                     color: .orange,
                     metrics: metrics
@@ -206,18 +206,20 @@ private struct DraftPostFlowSheet: View {
                     }
                     .buttonStyle(.rapidSecondaryCompact)
                     .accessibilityIdentifier("ComputerUse.DraftPost.RefreshAfterFailure")
-                    Button("Allow Screen Recording") {
-                        _ = MacAutomationPermissions.request(.screenRecording)
-                        Task { await viewModel.load() }
+                    if failure == .permissionMissing {
+                        Button("Allow Screen Recording") {
+                            _ = MacAutomationPermissions.request(.screenRecording)
+                            Task { await viewModel.load() }
+                        }
+                        .buttonStyle(.rapidSecondaryCompact)
+                        .accessibilityIdentifier("ComputerUse.DraftPost.AllowScreenRecording")
+                        Button("Allow Accessibility") {
+                            _ = MacAutomationPermissions.request(.accessibility)
+                            Task { await viewModel.load() }
+                        }
+                        .buttonStyle(.rapidSecondaryCompact)
+                        .accessibilityIdentifier("ComputerUse.DraftPost.AllowAccessibility")
                     }
-                    .buttonStyle(.rapidSecondaryCompact)
-                    .accessibilityIdentifier("ComputerUse.DraftPost.AllowScreenRecording")
-                    Button("Allow Accessibility") {
-                        _ = MacAutomationPermissions.request(.accessibility)
-                        Task { await viewModel.load() }
-                    }
-                    .buttonStyle(.rapidSecondaryCompact)
-                    .accessibilityIdentifier("ComputerUse.DraftPost.AllowAccessibility")
                 }
             }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -145,9 +145,9 @@ private struct DraftPostFlowSheet: View {
                 }
                 Spacer()
                 Button("Close") {
-                    viewModel.stop()
                     dismiss()
                 }
+                    .disabled(viewModel.isActive)
                     .buttonStyle(.rapidSecondaryCompact)
                     .accessibilityIdentifier("ComputerUse.DraftPost.Close")
             }
@@ -175,6 +175,12 @@ private struct DraftPostFlowSheet: View {
                     Button("Stop") { viewModel.stop() }
                         .buttonStyle(.rapidSecondaryCompact)
                         .accessibilityIdentifier("ComputerUse.DraftPost.Stop")
+                }
+
+            case .stopping:
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Stopping at a safe boundary…")
                 }
 
             case .readyForReview(let metrics):
@@ -221,6 +227,7 @@ private struct DraftPostFlowSheet: View {
         .frame(width: 620, height: 450)
         .task { await viewModel.load() }
         .onDisappear { viewModel.stop() }
+        .interactiveDismissDisabled(viewModel.isActive)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Draft and post setup")
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -254,7 +254,7 @@ private struct DraftPostFlowSheet: View {
             )
 
             if viewModel.sourceOptions.isEmpty || viewModel.destinationOptions.isEmpty {
-                Text("Open the draft in TextEdit and an empty post composer in Safari, then refresh.")
+                Text("Open the draft in TextEdit and an empty English-language post composer in Safari, then refresh.")
                     .font(.caption)
                     .foregroundStyle(.orange)
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -252,7 +252,7 @@ private struct DraftPostFlowSheet: View {
             )
 
             if viewModel.sourceOptions.isEmpty || viewModel.destinationOptions.isEmpty {
-                Text("Open the draft in TextEdit and an empty post composer in Safari, Chrome, Edge, Arc, or Firefox, then refresh.")
+                Text("Open the draft in TextEdit and an empty post composer in Safari, then refresh.")
                     .font(.caption)
                     .foregroundStyle(.orange)
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -114,6 +114,7 @@ struct ComputerUseView: View {
                 )
         )
         .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("ComputerUse.Starter.\(starter.kind.rawValue)")
         .accessibilityLabel(starter.title)
     }
 
@@ -299,7 +300,6 @@ private struct DraftPostFlowSheet: View {
                 HStack(spacing: 20) {
                     metric("Attempts", metrics.attempts)
                     metric("Auto-recoveries", metrics.automaticRecoveries)
-                    metric("Human corrections", metrics.humanCorrections)
                     metric("Verified steps", metrics.completedSteps)
                 }
                 .padding(12)

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -254,7 +254,7 @@ private struct DraftPostFlowSheet: View {
             )
 
             if viewModel.sourceOptions.isEmpty || viewModel.destinationOptions.isEmpty {
-                Text("Open the draft in TextEdit and an empty English-language post composer in Safari, then refresh.")
+                Text("Open the draft in TextEdit and an empty English-language post composer in Safari, then refresh. Leave both selected windows unchanged until Rapid stops.")
                     .font(.caption)
                     .foregroundStyle(.orange)
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -143,7 +143,10 @@ private struct DraftPostFlowSheet: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                Button("Close") { dismiss() }
+                Button("Close") {
+                    viewModel.stop()
+                    dismiss()
+                }
                     .buttonStyle(.rapidSecondaryCompact)
                     .accessibilityIdentifier("ComputerUse.DraftPost.Close")
             }
@@ -216,6 +219,7 @@ private struct DraftPostFlowSheet: View {
         .padding(24)
         .frame(width: 620, height: 450)
         .task { await viewModel.load() }
+        .onDisappear { viewModel.stop() }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Draft and post setup")
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct ComputerUseView: View {
+    @State private var showingDraftPost = false
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
@@ -64,6 +66,9 @@ struct ComputerUseView: View {
         }
         .background(RapidTheme.surfaceCanvas)
         .accessibilityIdentifier("ComputerUse.Panel")
+        .sheet(isPresented: $showingDraftPost) {
+            DraftPostFlowSheet()
+        }
     }
 
     private func starterCard(_ starter: ComputerUseStarter) -> some View {
@@ -73,7 +78,7 @@ struct ComputerUseView: View {
                     .font(.title2)
                     .foregroundStyle(RapidTheme.brandPrimaryDeep)
                 Spacer()
-                Text(starter.availability == .reserved ? "RESERVED" : "COMING NEXT")
+                Text(availabilityLabel(starter.availability))
                     .font(.caption2.weight(.bold))
                     .foregroundStyle(.secondary)
             }
@@ -87,6 +92,13 @@ struct ComputerUseView: View {
             Label(starter.approvalNote, systemImage: "checkmark.shield")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+            if starter.availability == .available {
+                Button("Start flow") {
+                    showingDraftPost = true
+                }
+                .buttonStyle(.rapidPrimaryCompact)
+                .accessibilityIdentifier("ComputerUse.Starter.DraftAndPost.Start")
+            }
         }
         .frame(maxWidth: .infinity, minHeight: 118, alignment: .topLeading)
         .padding(16)
@@ -101,6 +113,201 @@ struct ComputerUseView: View {
                     )
                 )
         )
-        .accessibilityIdentifier("ComputerUse.Starter.\(starter.kind.rawValue)")
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(starter.title)
+    }
+
+    private func availabilityLabel(
+        _ availability: ComputerUseStarter.Availability
+    ) -> String {
+        switch availability {
+        case .available: "PREVIEW"
+        case .comingSoon: "COMING NEXT"
+        case .reserved: "RESERVED"
+        }
+    }
+}
+
+private struct DraftPostFlowSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel = DraftPostFlowViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Draft and post an update")
+                        .font(.title2.weight(.semibold))
+                    Text("Rapid copies a TextEdit draft into an empty browser composer, verifies it, and stops before publishing.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Close") { dismiss() }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.DraftPost.Close")
+            }
+
+            Divider()
+
+            switch viewModel.phase {
+            case .loading:
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Finding available TextEdit and browser windows…")
+                }
+
+            case .ready:
+                setup
+
+            case .running:
+                VStack(alignment: .leading, spacing: 10) {
+                    ProgressView()
+                    Text("Reading, transferring, and verifying the draft…")
+                        .font(.headline)
+                    Text("Rapid may bring each selected window forward. It will retry a safe step at most twice.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button("Stop") { viewModel.stop() }
+                        .buttonStyle(.rapidSecondaryCompact)
+                        .accessibilityIdentifier("ComputerUse.DraftPost.Stop")
+                }
+
+            case .readyForReview(let metrics):
+                result(
+                    title: "Ready for your review",
+                    message: "The browser composer matches the TextEdit draft. Review it in the browser and publish it yourself when ready.",
+                    symbol: "checkmark.shield.fill",
+                    color: .green,
+                    metrics: metrics
+                )
+
+            case .failed(let message, let metrics):
+                result(
+                    title: "Rapid paused safely",
+                    message: message,
+                    symbol: "pause.circle.fill",
+                    color: .orange,
+                    metrics: metrics
+                )
+                HStack {
+                    Button("Refresh windows") {
+                        Task { await viewModel.load() }
+                    }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.DraftPost.RefreshAfterFailure")
+                    Button("Allow Screen Recording") {
+                        _ = MacAutomationPermissions.request(.screenRecording)
+                        Task { await viewModel.load() }
+                    }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.DraftPost.AllowScreenRecording")
+                    Button("Allow Accessibility") {
+                        _ = MacAutomationPermissions.request(.accessibility)
+                        Task { await viewModel.load() }
+                    }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.DraftPost.AllowAccessibility")
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(24)
+        .frame(width: 620, height: 450)
+        .task { await viewModel.load() }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Draft and post setup")
+    }
+
+    private var setup: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("No screenshots or draft text are stored.", systemImage: "lock.shield")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            picker(
+                title: "1. TextEdit draft",
+                prompt: "Choose a TextEdit window",
+                options: viewModel.sourceOptions,
+                selection: $viewModel.sourceID
+            )
+            picker(
+                title: "2. Signed-in browser composer",
+                prompt: "Choose a browser window",
+                options: viewModel.destinationOptions,
+                selection: $viewModel.destinationID
+            )
+
+            if viewModel.sourceOptions.isEmpty || viewModel.destinationOptions.isEmpty {
+                Text("Open the draft in TextEdit and an empty post composer in Safari, Chrome, Edge, Arc, or Firefox, then refresh.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            HStack {
+                Button("Refresh windows") {
+                    Task { await viewModel.load() }
+                }
+                .buttonStyle(.rapidSecondaryCompact)
+                .accessibilityIdentifier("ComputerUse.DraftPost.Refresh")
+                Spacer()
+                Button("Run locally") { viewModel.run() }
+                    .buttonStyle(.rapidPrimaryCompact)
+                    .disabled(!viewModel.canRun)
+                    .accessibilityIdentifier("ComputerUse.DraftPost.Run")
+            }
+        }
+    }
+
+    private func picker(
+        title: String,
+        prompt: String,
+        options: [ComputerUseWindowOption],
+        selection: Binding<String?>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(.headline)
+            Picker(prompt, selection: selection) {
+                Text(prompt).tag(String?.none)
+                ForEach(options) { option in
+                    Text(option.displayName).tag(Optional(option.id))
+                }
+            }
+            .labelsHidden()
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func result(
+        title: String,
+        message: String,
+        symbol: String,
+        color: Color,
+        metrics: DraftPostFlowMetrics?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: symbol)
+                .font(.headline)
+                .foregroundStyle(color)
+            Text(message).font(.callout)
+            if let metrics {
+                HStack(spacing: 20) {
+                    metric("Attempts", metrics.attempts)
+                    metric("Auto-recoveries", metrics.automaticRecoveries)
+                    metric("Human corrections", metrics.humanCorrections)
+                    metric("Verified steps", metrics.completedSteps)
+                }
+                .padding(12)
+                .background(RapidTheme.surfaceRaised, in: RoundedRectangle(cornerRadius: 10))
+            }
+        }
+    }
+
+    private func metric(_ title: String, _ value: Int) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(value)").font(.headline.monospacedDigit())
+            Text(title).font(.caption2).foregroundStyle(.secondary)
+        }
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ComputerUseFeatureTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ComputerUseFeatureTests.swift
@@ -61,9 +61,11 @@ struct ComputerUseFeatureTests {
             .createDemoVideo,
             .reserved,
         ])
-        #expect(ComputerUseStarter.catalog.dropLast().allSatisfy {
-            $0.availability == .comingSoon
-        })
+        #expect(ComputerUseStarter.catalog.first?.availability == .comingSoon)
+        #expect(ComputerUseStarter.catalog.first(where: { $0.kind == .draftAndPost })?.availability == .available)
+        #expect(ComputerUseStarter.catalog.filter {
+            $0.kind != .draftAndPost && $0.kind != .reserved
+        }.allSatisfy { $0.availability == .comingSoon })
         #expect(ComputerUseStarter.catalog.last?.availability == .reserved)
         #expect(ComputerUseStarter.catalog.allSatisfy {
             !$0.approvalNote.isEmpty

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -179,6 +179,12 @@ struct DraftPostFlowTests {
         }
     }
 
+    @Test("Verification compares exact UTF-8 bytes")
+    func exactUTF8Verification() {
+        #expect(MacOSDraftPostFlowDriver.utf8Matches("draft", "draft"))
+        #expect(!MacOSDraftPostFlowDriver.utf8Matches("é", "e\u{301}"))
+    }
+
     @Test("TextEdit source must expose one document editor")
     func uniqueDraft() throws {
         #expect(try MacOSDraftPostFlowDriver.uniqueDraft(in: ["Draft"]) == "Draft")

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -282,33 +282,24 @@ struct DraftPostFlowTests {
         }
     }
 
-    @Test("The driver contract exposes no publish action")
-    func noPublishSurface() throws {
-        let source = try String(
-            contentsOf: Self.sourceFile("DraftPostFlow.swift"),
-            encoding: .utf8
-        )
-        let protocolSlice = try #require(source.range(
-            of: "protocol DraftPostComposerActuating: Sendable"
-        )).lowerBound ..< #require(source.range(
-            of: "struct AXDraftPostComposerActuator"
-        )).lowerBound
-        let contract = String(source[protocolSlice])
-        #expect(contract.contains("focusComposer"))
-        #expect(contract.contains("setDraft"))
-        #expect(!contract.lowercased().contains("publish"))
-        #expect(!contract.lowercased().contains("send("))
+    @Test("The coordinator can request only a draft transfer")
+    func coordinatorCapabilityIsLimited() async {
+        let driver = ScriptedDraftPostDriver(results: [.success(())])
+        let coordinator = DraftPostFlowCoordinator(driver: driver)
 
-        let driverSlice = try #require(source.range(
-            of: "protocol DraftPostFlowDriving: Sendable"
-        )).lowerBound ..< #require(source.range(
-            of: "/// Runs one idempotent local transfer"
-        )).lowerBound
-        let driverContract = String(source[driverSlice])
-        #expect(driverContract.contains("transferDraft"))
-        #expect(!driverContract.lowercased().contains("publish"))
-        #expect(!driverContract.lowercased().contains("send("))
-        #expect(!driverContract.lowercased().contains("submit"))
+        let outcome = await coordinator.run(
+            source: Self.source,
+            destination: Self.destination
+        )
+
+        #expect(outcome == .readyForReview(DraftPostFlowMetrics(
+            attempts: 1,
+            automaticRecoveries: 0,
+            completedSteps: 3
+        )))
+        #expect(await driver.actions == [
+            .transferDraft(sourceID: Self.source.id, destinationID: Self.destination.id)
+        ])
     }
 
     @MainActor
@@ -376,15 +367,6 @@ struct DraftPostFlowTests {
                 windowID: window
             )
         )
-    }
-
-    private static func sourceFile(_ name: String) -> URL {
-        URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("Sources/Rapid/ComputerUse")
-            .appendingPathComponent(name)
     }
 
     private static func liveOptions() async throws -> (
@@ -507,19 +489,28 @@ private struct NoopDraftPostComposerActuator: DraftPostComposerActuating {
     func setDraft(_: String, on _: AXUIElement) throws {}
 }
 
+private enum ScriptedDraftPostAction: Equatable, Sendable {
+    case transferDraft(sourceID: String, destinationID: String)
+}
+
 private actor ScriptedDraftPostDriver: DraftPostFlowDriving {
     private var results: [Result<Void, DraftPostFlowFailure>]
     private(set) var callCount = 0
+    private(set) var actions: [ScriptedDraftPostAction] = []
 
     init(results: [Result<Void, DraftPostFlowFailure>]) {
         self.results = results
     }
 
     func transferDraft(
-        from _: ComputerUseWindowOption,
-        to _: ComputerUseWindowOption
+        from source: ComputerUseWindowOption,
+        to destination: ComputerUseWindowOption
     ) async throws {
         callCount += 1
+        actions.append(.transferDraft(
+            sourceID: source.id,
+            destinationID: destination.id
+        ))
         guard !results.isEmpty else {
             throw DraftPostFlowFailure.targetUnavailable
         }

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -19,9 +19,9 @@ struct DraftPostFlowTests {
     @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_DOGFOOD"] == "1"))
     func liveFixture() async throws {
         let (source, destination) = try await Self.liveOptions()
-        let actuator = await MainActor.run {
-            RecordingDraftPostComposerActuator(base: AXDraftPostComposerActuator())
-        }
+        let actuator = RecordingDraftPostComposerActuator(
+            base: AXDraftPostComposerActuator()
+        )
         try await Self.clearLiveComposer(
             processIdentifier: destination.selection.processIdentifier
         )
@@ -40,7 +40,7 @@ struct DraftPostFlowTests {
             try await Self.clearLiveComposer(processIdentifier: destination.selection.processIdentifier)
         }
         #expect(successes == 30)
-        let actions = await actuator.actions
+        let actions = actuator.actions
         #expect(actions.count == 60)
         for index in stride(from: 0, to: actions.count, by: 2) {
             #expect(actions[index] == .focusComposer)
@@ -476,22 +476,28 @@ private enum RecordedDraftPostComposerAction: Equatable {
     case setDraft(String)
 }
 
-@MainActor
-private final class RecordingDraftPostComposerActuator: DraftPostComposerActuating {
+private final class RecordingDraftPostComposerActuator: DraftPostComposerActuating,
+    @unchecked Sendable
+{
     private let base: any DraftPostComposerActuating
-    private(set) var actions: [RecordedDraftPostComposerAction] = []
+    private let lock = NSLock()
+    private var recordedActions: [RecordedDraftPostComposerAction] = []
+
+    var actions: [RecordedDraftPostComposerAction] {
+        lock.withLock { recordedActions }
+    }
 
     init(base: any DraftPostComposerActuating) {
         self.base = base
     }
 
     func focusComposer(_ composer: AXUIElement) throws {
-        actions.append(.focusComposer)
+        lock.withLock { recordedActions.append(.focusComposer) }
         try base.focusComposer(composer)
     }
 
     func setDraft(_ draft: String, on composer: AXUIElement) throws {
-        actions.append(.setDraft(draft))
+        lock.withLock { recordedActions.append(.setDraft(draft)) }
         try base.setDraft(draft, on: composer)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -1,0 +1,271 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Computer Use draft-to-post flow")
+struct DraftPostFlowTests {
+    /// Operator-only dogfood. It intentionally requires already-open local
+    /// fixtures and never runs in ordinary CI:
+    ///
+    /// - TextEdit window title contains `rapid-cua-draft.txt`.
+    /// - Browser window title contains `Rapid Computer Use Fixture` and has
+    ///   one empty text area labelled `Post text`.
+    ///
+    /// Run with `RAPID_LIVE_CUA_DOGFOOD=1 swift test --no-parallel --filter
+    /// DraftPostFlowTests/liveFixture` from a trusted GUI session.
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_DOGFOOD"] == "1"))
+    func liveFixture() async throws {
+        let (source, destination) = try await Self.liveOptions()
+        var successes = 0
+        for _ in 0 ..< 30 {
+            let outcome = await DraftPostFlowCoordinator(
+                driver: MacOSDraftPostFlowDriver()
+            ).run(source: source, destination: destination)
+            guard case .readyForReview(let metrics) = outcome else {
+                Issue.record("Live fixture did not reach review: \(outcome)")
+                continue
+            }
+            successes += 1
+            #expect(metrics.attempts <= 3)
+            #expect(metrics.completedSteps == 3)
+        }
+        #expect(successes == 30)
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_DOGFOOD"] == "1"))
+    func liveFocusStealRecovery() async throws {
+        let (source, destination) = try await Self.liveOptions()
+        let driver = FocusStealingDraftPostDriver(base: MacOSDraftPostFlowDriver())
+        let outcome = await DraftPostFlowCoordinator(driver: driver).run(
+            source: source,
+            destination: destination
+        )
+        guard case .readyForReview(let metrics) = outcome else {
+            Issue.record("Focus-steal fixture did not recover: \(outcome)")
+            return
+        }
+        #expect(metrics.attempts == 2)
+        #expect(metrics.automaticRecoveries == 1)
+    }
+
+    @Test("The first runnable starter is draft and post")
+    func catalogAvailability() throws {
+        let available = ComputerUseStarter.catalog.filter {
+            $0.availability == .available
+        }
+        #expect(available.map(\.kind) == [.draftAndPost])
+        #expect(try #require(available.first).approvalNote == "Rapid will stop before publishing.")
+    }
+
+    @Test("A verified transfer finishes without recovery")
+    func happyPath() async {
+        let driver = ScriptedDraftPostDriver(results: [.success(())])
+        let outcome = await DraftPostFlowCoordinator(driver: driver).run(
+            source: Self.source,
+            destination: Self.destination
+        )
+        #expect(outcome == .readyForReview(DraftPostFlowMetrics(
+            attempts: 1,
+            automaticRecoveries: 0,
+            humanCorrections: 0,
+            completedSteps: 3
+        )))
+        #expect(await driver.callCount == 1)
+    }
+
+    @Test("Recoverable focus drift is retried within the fixed budget")
+    func boundedRecovery() async {
+        let driver = ScriptedDraftPostDriver(results: [
+            .failure(.focusChanged),
+            .failure(.targetUnavailable),
+            .success(()),
+        ])
+        let outcome = await DraftPostFlowCoordinator(driver: driver).run(
+            source: Self.source,
+            destination: Self.destination
+        )
+        #expect(outcome == .readyForReview(DraftPostFlowMetrics(
+            attempts: 3,
+            automaticRecoveries: 2,
+            humanCorrections: 0,
+            completedSteps: 3
+        )))
+        #expect(await driver.callCount == 3)
+    }
+
+    @Test("Recovery exhaustion pauses instead of looping")
+    func exhaustedRecovery() async {
+        let driver = ScriptedDraftPostDriver(results: [
+            .failure(.focusChanged),
+            .failure(.focusChanged),
+            .failure(.focusChanged),
+            .success(()),
+        ])
+        let outcome = await DraftPostFlowCoordinator(driver: driver).run(
+            source: Self.source,
+            destination: Self.destination
+        )
+        #expect(outcome == .failed(
+            DraftPostFlowFailure.focusChanged,
+            DraftPostFlowMetrics(
+                attempts: 3,
+                automaticRecoveries: 2,
+                humanCorrections: 0,
+                completedSteps: 0
+            )
+        ))
+        #expect(await driver.callCount == 3)
+    }
+
+    @Test("Unsafe or ambiguous state never retries")
+    func unsafeStateStops() async {
+        for failure in [
+            DraftPostFlowFailure.composerAmbiguous,
+            .composerNotEmpty,
+            .permissionMissing,
+            .writeRejected,
+            .verificationFailed,
+        ] {
+            let driver = ScriptedDraftPostDriver(results: [.failure(failure), .success(())])
+            let outcome = await DraftPostFlowCoordinator(driver: driver).run(
+                source: Self.source,
+                destination: Self.destination
+            )
+            #expect(outcome == .failed(
+                failure,
+                DraftPostFlowMetrics(
+                    attempts: 1,
+                    automaticRecoveries: 0,
+                    humanCorrections: 0,
+                    completedSteps: 0
+                )
+            ))
+            #expect(await driver.callCount == 1)
+        }
+    }
+
+    @Test("The driver contract exposes no publish action")
+    func noPublishSurface() throws {
+        let source = try String(
+            contentsOf: Self.sourceFile("DraftPostFlow.swift"),
+            encoding: .utf8
+        )
+        let protocolSlice = try #require(source.range(
+            of: "protocol DraftPostFlowDriving: Sendable"
+        )).lowerBound ..< #require(source.range(
+            of: "/// Runs one idempotent local transfer"
+        )).lowerBound
+        let contract = String(source[protocolSlice])
+        #expect(contract.contains("transferDraft"))
+        #expect(!contract.lowercased().contains("publish"))
+        #expect(!contract.lowercased().contains("post("))
+    }
+
+    private static let source = option(
+        id: "1:10",
+        application: "TextEdit",
+        bundle: "com.apple.TextEdit",
+        pid: 1,
+        window: 10
+    )
+    private static let destination = option(
+        id: "2:20",
+        application: "Safari",
+        bundle: "com.apple.Safari",
+        pid: 2,
+        window: 20
+    )
+
+    private static func option(
+        id: String,
+        application: String,
+        bundle: String,
+        pid: pid_t,
+        window: CGWindowID
+    ) -> ComputerUseWindowOption {
+        ComputerUseWindowOption(
+            id: id,
+            applicationName: application,
+            windowTitle: "Fixture",
+            selection: ComputerUseWindowSelection(
+                bundleIdentifier: bundle,
+                processIdentifier: pid,
+                processLaunchDate: Date(timeIntervalSince1970: 1),
+                windowID: window
+            )
+        )
+    }
+
+    private static func sourceFile(_ name: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Rapid/ComputerUse")
+            .appendingPathComponent(name)
+    }
+
+    private static func liveOptions() async throws -> (
+        ComputerUseWindowOption,
+        ComputerUseWindowOption
+    ) {
+        let windows = try await MacOSComputerUseWindowCatalog().windows()
+        let source = try #require(windows.first {
+            $0.selection.bundleIdentifier == "com.apple.TextEdit"
+                && $0.windowTitle.contains("rapid-cua-draft.txt")
+        })
+        let destination = try #require(windows.first {
+            MacOSDraftPostFlowDriver.browserBundles.contains(
+                $0.selection.bundleIdentifier
+            ) && $0.windowTitle.contains("Rapid Computer Use Fixture")
+        })
+        return (source, destination)
+    }
+}
+
+private actor ScriptedDraftPostDriver: DraftPostFlowDriving {
+    private var results: [Result<Void, DraftPostFlowFailure>]
+    private(set) var callCount = 0
+
+    init(results: [Result<Void, DraftPostFlowFailure>]) {
+        self.results = results
+    }
+
+    func transferDraft(
+        from _: ComputerUseWindowOption,
+        to _: ComputerUseWindowOption
+    ) async throws {
+        callCount += 1
+        guard !results.isEmpty else {
+            throw DraftPostFlowFailure.targetUnavailable
+        }
+        try results.removeFirst().get()
+    }
+}
+
+private actor FocusStealingDraftPostDriver: DraftPostFlowDriving {
+    private let base: any DraftPostFlowDriving
+    private var shouldSteal = true
+
+    init(base: any DraftPostFlowDriving) {
+        self.base = base
+    }
+
+    func transferDraft(
+        from source: ComputerUseWindowOption,
+        to destination: ComputerUseWindowOption
+    ) async throws {
+        if shouldSteal {
+            shouldSteal = false
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(90))
+                NSRunningApplication.runningApplications(
+                    withBundleIdentifier: "com.apple.finder"
+                ).first?.activate()
+            }
+        }
+        try await base.transferDraft(from: source, to: destination)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -54,6 +54,9 @@ struct DraftPostFlowTests {
     @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_DOGFOOD"] == "1"))
     func liveFocusStealRecovery() async throws {
         let (source, destination) = try await Self.liveOptions()
+        try await Self.clearLiveComposer(
+            processIdentifier: destination.selection.processIdentifier
+        )
         let driver = FocusStealingDraftPostDriver(base: MacOSDraftPostFlowDriver())
         let outcome = await DraftPostFlowCoordinator(driver: driver).run(
             source: source,

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -295,6 +295,17 @@ struct DraftPostFlowTests {
         #expect(contract.contains("setDraft"))
         #expect(!contract.lowercased().contains("publish"))
         #expect(!contract.lowercased().contains("send("))
+
+        let driverSlice = try #require(source.range(
+            of: "protocol DraftPostFlowDriving: Sendable"
+        )).lowerBound ..< #require(source.range(
+            of: "/// Runs one idempotent local transfer"
+        )).lowerBound
+        let driverContract = String(source[driverSlice])
+        #expect(driverContract.contains("transferDraft"))
+        #expect(!driverContract.lowercased().contains("publish"))
+        #expect(!driverContract.lowercased().contains("send("))
+        #expect(!driverContract.lowercased().contains("submit"))
     }
 
     @MainActor
@@ -307,6 +318,26 @@ struct DraftPostFlowTests {
         try actuator.focusComposer(element)
         try actuator.setDraft("Fixture", on: element)
         #expect(actuator.actions == [.focusComposer, .setDraft("Fixture")])
+    }
+
+    @MainActor
+    @Test("Run accepts only one active transfer")
+    func singleActiveTransfer() async {
+        let driver = CancellationIgnoringDraftPostDriver()
+        let viewModel = DraftPostFlowViewModel(
+            catalog: StaticWindowCatalog(windows: [Self.source, Self.destination]),
+            driver: driver
+        )
+        await viewModel.load()
+        viewModel.sourceID = Self.source.id
+        viewModel.destinationID = Self.destination.id
+        viewModel.run()
+        viewModel.run()
+        while !(await driver.didStart) {
+            await Task.yield()
+        }
+        #expect(await driver.callCount == 1)
+        await driver.complete()
     }
 
     private static let source = option(
@@ -526,12 +557,14 @@ private actor UnexpectedDraftPostDriver: DraftPostFlowDriving {
 
 private actor CancellationIgnoringDraftPostDriver: DraftPostFlowDriving {
     private(set) var didStart = false
+    private(set) var callCount = 0
     private var mayComplete = false
 
     func transferDraft(
         from _: ComputerUseWindowOption,
         to _: ComputerUseWindowOption
     ) async throws {
+        callCount += 1
         didStart = true
         while !mayComplete {
             await Task.yield()

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -69,7 +69,6 @@ struct DraftPostFlowTests {
         #expect(outcome == .readyForReview(DraftPostFlowMetrics(
             attempts: 1,
             automaticRecoveries: 0,
-            humanCorrections: 0,
             completedSteps: 3
         )))
         #expect(await driver.callCount == 1)
@@ -89,7 +88,6 @@ struct DraftPostFlowTests {
         #expect(outcome == .readyForReview(DraftPostFlowMetrics(
             attempts: 3,
             automaticRecoveries: 2,
-            humanCorrections: 0,
             completedSteps: 3
         )))
         #expect(await driver.callCount == 3)
@@ -112,7 +110,6 @@ struct DraftPostFlowTests {
             DraftPostFlowMetrics(
                 attempts: 3,
                 automaticRecoveries: 2,
-                humanCorrections: 0,
                 completedSteps: 0
             )
         ))
@@ -138,7 +135,6 @@ struct DraftPostFlowTests {
                 DraftPostFlowMetrics(
                     attempts: 1,
                     automaticRecoveries: 0,
-                    humanCorrections: 0,
                     completedSteps: 0
                 )
             ))
@@ -158,7 +154,6 @@ struct DraftPostFlowTests {
             DraftPostFlowMetrics(
                 attempts: 1,
                 automaticRecoveries: 0,
-                humanCorrections: 0,
                 completedSteps: 0
             )
         ))
@@ -172,6 +167,16 @@ struct DraftPostFlowTests {
         #expect(!MacOSDraftPostFlowDriver.isExplicitComposerLabel("Search posts"))
         #expect(!MacOSDraftPostFlowDriver.isExplicitComposerLabel("Update profile"))
         #expect(!MacOSDraftPostFlowDriver.isExplicitComposerLabel("Post"))
+    }
+
+    @Test("Post-mutation drift is always terminal")
+    func postMutationDriftStops() throws {
+        try MacOSDraftPostFlowDriver.verifyAfterMutation { true }
+        #expect(throws: DraftPostFlowFailure.verificationFailed) {
+            try MacOSDraftPostFlowDriver.verifyAfterMutation {
+                throw DraftPostFlowFailure.focusChanged
+            }
+        }
     }
 
     @Test("TextEdit source must expose one document editor")

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import CoreGraphics
 import Foundation
 import Testing
@@ -18,6 +19,9 @@ struct DraftPostFlowTests {
     @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_DOGFOOD"] == "1"))
     func liveFixture() async throws {
         let (source, destination) = try await Self.liveOptions()
+        try await Self.clearLiveComposer(
+            processIdentifier: destination.selection.processIdentifier
+        )
         var successes = 0
         for _ in 0 ..< 30 {
             let outcome = await DraftPostFlowCoordinator(
@@ -30,6 +34,7 @@ struct DraftPostFlowTests {
             successes += 1
             #expect(metrics.attempts <= 3)
             #expect(metrics.completedSteps == 3)
+            try await Self.clearLiveComposer(processIdentifier: destination.selection.processIdentifier)
         }
         #expect(successes == 30)
     }
@@ -216,6 +221,33 @@ struct DraftPostFlowTests {
         #expect(!viewModel.canRun)
     }
 
+    @MainActor
+    @Test("A late cancellation reports the definitive driver outcome")
+    func lateCancellationIsHonest() async {
+        let driver = CancellationIgnoringDraftPostDriver()
+        let viewModel = DraftPostFlowViewModel(
+            catalog: StaticWindowCatalog(windows: [Self.source, Self.destination]),
+            driver: driver
+        )
+        await viewModel.load()
+        viewModel.sourceID = Self.source.id
+        viewModel.destinationID = Self.destination.id
+        viewModel.run()
+        while !(await driver.didStart) {
+            await Task.yield()
+        }
+        viewModel.stop()
+        #expect(viewModel.phase == .stopping)
+        await driver.complete()
+        for _ in 0 ..< 100 where viewModel.phase == .stopping {
+            await Task.yield()
+        }
+        guard case .readyForReview = viewModel.phase else {
+            Issue.record("A completed mutation was incorrectly reported as cancelled")
+            return
+        }
+    }
+
     @Test("The driver contract exposes no publish action")
     func noPublishSurface() throws {
         let source = try String(
@@ -293,6 +325,72 @@ struct DraftPostFlowTests {
         })
         return (source, destination)
     }
+
+    @MainActor
+    private static func clearLiveComposer(processIdentifier: pid_t) throws {
+        let application = AXUIElementCreateApplication(processIdentifier)
+        var focusedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            application,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedValue
+        ) == .success,
+            let window = focusedValue,
+            CFGetTypeID(window) == AXUIElementGetTypeID()
+        else {
+            throw DraftPostFlowFailure.verificationFailed
+        }
+        var queue = [unsafeDowncast(window, to: AXUIElement.self)]
+        var cursor = 0
+        while cursor < queue.count, cursor < 2_048 {
+            let element = queue[cursor]
+            cursor += 1
+            let labels = [
+                liveStringAttribute(kAXTitleAttribute as CFString, from: element),
+                liveStringAttribute(kAXDescriptionAttribute as CFString, from: element),
+                liveStringAttribute(kAXHelpAttribute as CFString, from: element),
+                liveStringAttribute("AXPlaceholderValue" as CFString, from: element),
+            ].compactMap { $0 }
+            if liveStringAttribute(kAXRoleAttribute as CFString, from: element)
+                == kAXTextAreaRole as String,
+                labels.contains(where: MacOSDraftPostFlowDriver.isExplicitComposerLabel)
+            {
+                guard AXUIElementSetAttributeValue(
+                    element,
+                    kAXValueAttribute as CFString,
+                    "" as CFString
+                ) == .success,
+                    liveStringAttribute(kAXValueAttribute as CFString, from: element) == ""
+                else {
+                    throw DraftPostFlowFailure.verificationFailed
+                }
+                return
+            }
+            var childrenValue: CFTypeRef?
+            if AXUIElementCopyAttributeValue(
+                element,
+                kAXChildrenAttribute as CFString,
+                &childrenValue
+            ) == .success,
+                let children = childrenValue as? [AXUIElement]
+            {
+                queue.append(contentsOf: children)
+            }
+        }
+        throw DraftPostFlowFailure.composerMissing
+    }
+
+    @MainActor
+    private static func liveStringAttribute(
+        _ attribute: CFString,
+        from element: AXUIElement
+    ) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else {
+            return nil
+        }
+        return value as? String
+    }
 }
 
 private actor ScriptedDraftPostDriver: DraftPostFlowDriving {
@@ -349,6 +447,27 @@ private actor UnexpectedDraftPostDriver: DraftPostFlowDriving {
     ) async throws {
         callCount += 1
         throw CocoaError(.fileReadUnknown)
+    }
+}
+
+private actor CancellationIgnoringDraftPostDriver: DraftPostFlowDriving {
+    private(set) var didStart = false
+    private var mayComplete = false
+
+    func transferDraft(
+        from _: ComputerUseWindowOption,
+        to _: ComputerUseWindowOption
+    ) async throws {
+        didStart = true
+        while !mayComplete {
+            await Task.yield()
+        }
+        // Models a cancellation that arrives after the mutation boundary: the
+        // operation has completed and its success must remain observable.
+    }
+
+    func complete() {
+        mayComplete = true
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -196,8 +196,11 @@ struct DraftPostFlowTests {
         #expect(throws: DraftPostFlowFailure.draftMissing) {
             try MacOSDraftPostFlowDriver.uniqueDraft(in: [])
         }
+        #expect(throws: DraftPostFlowFailure.draftMissing) {
+            try MacOSDraftPostFlowDriver.uniqueDraft(in: [nil])
+        }
         #expect(throws: DraftPostFlowFailure.draftAmbiguous) {
-            try MacOSDraftPostFlowDriver.uniqueDraft(in: ["Draft", "Find text"])
+            try MacOSDraftPostFlowDriver.uniqueDraft(in: ["Draft", ""])
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -256,9 +256,9 @@ struct DraftPostFlowTests {
     }
 
     @MainActor
-    @Test("Untitled Safari windows are not offered as destinations")
-    func untitledBrowserIsExcluded() async {
-        let untitled = ComputerUseWindowOption(
+    @Test("Untitled windows are not offered to the flow")
+    func untitledWindowsAreExcluded() async {
+        let untitledBrowser = ComputerUseWindowOption(
             id: "2:21",
             applicationName: "Safari",
             windowTitle: "   ",
@@ -269,14 +269,52 @@ struct DraftPostFlowTests {
                 windowID: 21
             )
         )
+        let untitledSource = ComputerUseWindowOption(
+            id: "1:11",
+            applicationName: "TextEdit",
+            windowTitle: "",
+            selection: ComputerUseWindowSelection(
+                bundleIdentifier: "com.apple.TextEdit",
+                processIdentifier: 1,
+                processLaunchDate: Date(timeIntervalSince1970: 1),
+                windowID: 11
+            )
+        )
         let viewModel = DraftPostFlowViewModel(
-            catalog: StaticWindowCatalog(windows: [Self.destination, untitled]),
+            catalog: StaticWindowCatalog(windows: [
+                Self.source, untitledSource, Self.destination, untitledBrowser,
+            ]),
             driver: ScriptedDraftPostDriver(results: [.success(())])
         )
 
         await viewModel.load()
 
+        #expect(viewModel.sourceOptions.map(\.id) == [Self.source.id])
         #expect(viewModel.destinationOptions.map(\.id) == [Self.destination.id])
+    }
+
+    @MainActor
+    @Test("An older window refresh cannot overwrite a newer result")
+    func staleRefreshIsIgnored() async {
+        let catalog = OutOfOrderWindowCatalog(
+            older: [Self.source],
+            newer: [Self.destination]
+        )
+        let viewModel = DraftPostFlowViewModel(
+            catalog: catalog,
+            driver: ScriptedDraftPostDriver(results: [.success(())])
+        )
+
+        let olderLoad = Task { await viewModel.load() }
+        while await catalog.callCount == 0 {
+            await Task.yield()
+        }
+        let newerLoad = Task { await viewModel.load() }
+        await newerLoad.value
+        await olderLoad.value
+
+        #expect(viewModel.windows == [Self.destination])
+        #expect(viewModel.phase == .ready)
     }
 
     @MainActor
@@ -587,5 +625,25 @@ private actor StaticWindowCatalog: ComputerUseWindowListing {
 
     func replace(with windows: [ComputerUseWindowOption]) {
         storedWindows = windows
+    }
+}
+
+private actor OutOfOrderWindowCatalog: ComputerUseWindowListing {
+    private let older: [ComputerUseWindowOption]
+    private let newer: [ComputerUseWindowOption]
+    private(set) var callCount = 0
+
+    init(older: [ComputerUseWindowOption], newer: [ComputerUseWindowOption]) {
+        self.older = older
+        self.newer = newer
+    }
+
+    func windows() async throws -> [ComputerUseWindowOption] {
+        callCount += 1
+        if callCount == 1 {
+            try await Task.sleep(for: .milliseconds(100))
+            return older
+        }
+        return newer
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -146,6 +146,64 @@ struct DraftPostFlowTests {
         }
     }
 
+    @Test("Unexpected adapter errors fail closed without retry")
+    func unexpectedErrorStops() async {
+        let driver = UnexpectedDraftPostDriver()
+        let outcome = await DraftPostFlowCoordinator(driver: driver).run(
+            source: Self.source,
+            destination: Self.destination
+        )
+        #expect(outcome == .failed(
+            .dependencyFailure,
+            DraftPostFlowMetrics(
+                attempts: 1,
+                automaticRecoveries: 0,
+                humanCorrections: 0,
+                completedSteps: 0
+            )
+        ))
+        #expect(await driver.callCount == 1)
+    }
+
+    @Test("Only exact composer labels are accepted")
+    func exactComposerLabels() {
+        #expect(MacOSDraftPostFlowDriver.isExplicitComposerLabel("Post text"))
+        #expect(MacOSDraftPostFlowDriver.isExplicitComposerLabel("What’s happening?"))
+        #expect(!MacOSDraftPostFlowDriver.isExplicitComposerLabel("Search posts"))
+        #expect(!MacOSDraftPostFlowDriver.isExplicitComposerLabel("Update profile"))
+        #expect(!MacOSDraftPostFlowDriver.isExplicitComposerLabel("Post"))
+    }
+
+    @Test("TextEdit source must expose one document editor")
+    func uniqueDraft() throws {
+        #expect(try MacOSDraftPostFlowDriver.uniqueDraft(in: ["Draft"]) == "Draft")
+        #expect(throws: DraftPostFlowFailure.draftMissing) {
+            try MacOSDraftPostFlowDriver.uniqueDraft(in: [])
+        }
+        #expect(throws: DraftPostFlowFailure.draftAmbiguous) {
+            try MacOSDraftPostFlowDriver.uniqueDraft(in: ["Draft", "Find text"])
+        }
+    }
+
+    @MainActor
+    @Test("Catalog refresh clears stale selections")
+    func refreshClearsSelections() async {
+        let catalog = StaticWindowCatalog(windows: [Self.source, Self.destination])
+        let viewModel = DraftPostFlowViewModel(
+            catalog: catalog,
+            driver: ScriptedDraftPostDriver(results: [.success(())])
+        )
+        await viewModel.load()
+        viewModel.sourceID = Self.source.id
+        viewModel.destinationID = Self.destination.id
+        #expect(viewModel.canRun)
+
+        await catalog.replace(with: [Self.source])
+        await viewModel.load()
+        #expect(viewModel.destinationID == nil)
+        #expect(!viewModel.canRun)
+    }
+
     @Test("The driver contract exposes no publish action")
     func noPublishSurface() throws {
         let source = try String(
@@ -267,5 +325,33 @@ private actor FocusStealingDraftPostDriver: DraftPostFlowDriving {
             }
         }
         try await base.transferDraft(from: source, to: destination)
+    }
+}
+
+private actor UnexpectedDraftPostDriver: DraftPostFlowDriving {
+    private(set) var callCount = 0
+
+    func transferDraft(
+        from _: ComputerUseWindowOption,
+        to _: ComputerUseWindowOption
+    ) async throws {
+        callCount += 1
+        throw CocoaError(.fileReadUnknown)
+    }
+}
+
+private actor StaticWindowCatalog: ComputerUseWindowListing {
+    private var storedWindows: [ComputerUseWindowOption]
+
+    init(windows: [ComputerUseWindowOption]) {
+        storedWindows = windows
+    }
+
+    func windows() async throws -> [ComputerUseWindowOption] {
+        storedWindows
+    }
+
+    func replace(with windows: [ComputerUseWindowOption]) {
+        storedWindows = windows
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -19,13 +19,16 @@ struct DraftPostFlowTests {
     @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_DOGFOOD"] == "1"))
     func liveFixture() async throws {
         let (source, destination) = try await Self.liveOptions()
+        let actuator = await MainActor.run {
+            RecordingDraftPostComposerActuator(base: AXDraftPostComposerActuator())
+        }
         try await Self.clearLiveComposer(
             processIdentifier: destination.selection.processIdentifier
         )
         var successes = 0
         for _ in 0 ..< 30 {
             let outcome = await DraftPostFlowCoordinator(
-                driver: MacOSDraftPostFlowDriver()
+                driver: MacOSDraftPostFlowDriver(actuator: actuator)
             ).run(source: source, destination: destination)
             guard case .readyForReview(let metrics) = outcome else {
                 Issue.record("Live fixture did not reach review: \(outcome)")
@@ -37,6 +40,15 @@ struct DraftPostFlowTests {
             try await Self.clearLiveComposer(processIdentifier: destination.selection.processIdentifier)
         }
         #expect(successes == 30)
+        let actions = await actuator.actions
+        #expect(actions.count == 60)
+        for index in stride(from: 0, to: actions.count, by: 2) {
+            #expect(actions[index] == .focusComposer)
+            guard case .setDraft = actions[index + 1] else {
+                Issue.record("Unexpected composer action sequence")
+                continue
+            }
+        }
     }
 
     @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_DOGFOOD"] == "1"))
@@ -190,6 +202,22 @@ struct DraftPostFlowTests {
         #expect(!MacOSDraftPostFlowDriver.utf8Matches("é", "e\u{301}"))
     }
 
+    @Test("Browser tab identity stays bound to the selected title")
+    func browserTabIdentity() {
+        #expect(MacOSDraftPostFlowDriver.browserDocumentMatches(
+            currentTitle: "Compose — Account A",
+            selectedTitle: "Compose — Account A"
+        ))
+        #expect(!MacOSDraftPostFlowDriver.browserDocumentMatches(
+            currentTitle: "Compose — Account B",
+            selectedTitle: "Compose — Account A"
+        ))
+        #expect(!MacOSDraftPostFlowDriver.browserDocumentMatches(
+            currentTitle: "Compose",
+            selectedTitle: ""
+        ))
+    }
+
     @Test("TextEdit source must expose one document editor")
     func uniqueDraft() throws {
         #expect(try MacOSDraftPostFlowDriver.uniqueDraft(in: ["Draft"]) == "Draft")
@@ -258,14 +286,27 @@ struct DraftPostFlowTests {
             encoding: .utf8
         )
         let protocolSlice = try #require(source.range(
-            of: "protocol DraftPostFlowDriving: Sendable"
+            of: "protocol DraftPostComposerActuating: Sendable"
         )).lowerBound ..< #require(source.range(
-            of: "/// Runs one idempotent local transfer"
+            of: "struct AXDraftPostComposerActuator"
         )).lowerBound
         let contract = String(source[protocolSlice])
-        #expect(contract.contains("transferDraft"))
+        #expect(contract.contains("focusComposer"))
+        #expect(contract.contains("setDraft"))
         #expect(!contract.lowercased().contains("publish"))
-        #expect(!contract.lowercased().contains("post("))
+        #expect(!contract.lowercased().contains("send("))
+    }
+
+    @MainActor
+    @Test("The injected actuator records only focus and draft writes")
+    func actuatorCapabilityIsLimited() throws {
+        let actuator = RecordingDraftPostComposerActuator(
+            base: NoopDraftPostComposerActuator()
+        )
+        let element = AXUIElementCreateSystemWide()
+        try actuator.focusComposer(element)
+        try actuator.setDraft("Fixture", on: element)
+        #expect(actuator.actions == [.focusComposer, .setDraft("Fixture")])
     }
 
     private static let source = option(
@@ -394,6 +435,36 @@ struct DraftPostFlowTests {
         }
         return value as? String
     }
+}
+
+private enum RecordedDraftPostComposerAction: Equatable {
+    case focusComposer
+    case setDraft(String)
+}
+
+@MainActor
+private final class RecordingDraftPostComposerActuator: DraftPostComposerActuating {
+    private let base: any DraftPostComposerActuating
+    private(set) var actions: [RecordedDraftPostComposerAction] = []
+
+    init(base: any DraftPostComposerActuating) {
+        self.base = base
+    }
+
+    func focusComposer(_ composer: AXUIElement) throws {
+        actions.append(.focusComposer)
+        try base.focusComposer(composer)
+    }
+
+    func setDraft(_ draft: String, on composer: AXUIElement) throws {
+        actions.append(.setDraft(draft))
+        try base.setDraft(draft, on: composer)
+    }
+}
+
+private struct NoopDraftPostComposerActuator: DraftPostComposerActuating {
+    func focusComposer(_: AXUIElement) throws {}
+    func setDraft(_: String, on _: AXUIElement) throws {}
 }
 
 private actor ScriptedDraftPostDriver: DraftPostFlowDriving {

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -22,9 +22,6 @@ struct DraftPostFlowTests {
         let actuator = RecordingDraftPostComposerActuator(
             base: AXDraftPostComposerActuator()
         )
-        try await Self.clearLiveComposer(
-            processIdentifier: destination.selection.processIdentifier
-        )
         var successes = 0
         for _ in 0 ..< 30 {
             let outcome = await DraftPostFlowCoordinator(
@@ -37,7 +34,7 @@ struct DraftPostFlowTests {
             successes += 1
             #expect(metrics.attempts <= 3)
             #expect(metrics.completedSteps == 3)
-            try await Self.clearLiveComposer(processIdentifier: destination.selection.processIdentifier)
+            try actuator.clearLastDraftIfUnchanged()
         }
         #expect(successes == 30)
         let actions = actuator.actions
@@ -54,10 +51,12 @@ struct DraftPostFlowTests {
     @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_DOGFOOD"] == "1"))
     func liveFocusStealRecovery() async throws {
         let (source, destination) = try await Self.liveOptions()
-        try await Self.clearLiveComposer(
-            processIdentifier: destination.selection.processIdentifier
+        let actuator = RecordingDraftPostComposerActuator(
+            base: AXDraftPostComposerActuator()
         )
-        let driver = FocusStealingDraftPostDriver(base: MacOSDraftPostFlowDriver())
+        let driver = FocusStealingDraftPostDriver(
+            base: MacOSDraftPostFlowDriver(actuator: actuator)
+        )
         let outcome = await DraftPostFlowCoordinator(driver: driver).run(
             source: source,
             destination: destination
@@ -68,6 +67,7 @@ struct DraftPostFlowTests {
         }
         #expect(metrics.attempts == 2)
         #expect(metrics.automaticRecoveries == 1)
+        try actuator.clearLastDraftIfUnchanged()
     }
 
     @Test("The first runnable starter is draft and post")
@@ -256,6 +256,30 @@ struct DraftPostFlowTests {
     }
 
     @MainActor
+    @Test("Untitled Safari windows are not offered as destinations")
+    func untitledBrowserIsExcluded() async {
+        let untitled = ComputerUseWindowOption(
+            id: "2:21",
+            applicationName: "Safari",
+            windowTitle: "   ",
+            selection: ComputerUseWindowSelection(
+                bundleIdentifier: "com.apple.Safari",
+                processIdentifier: 2,
+                processLaunchDate: Date(timeIntervalSince1970: 1),
+                windowID: 21
+            )
+        )
+        let viewModel = DraftPostFlowViewModel(
+            catalog: StaticWindowCatalog(windows: [Self.destination, untitled]),
+            driver: ScriptedDraftPostDriver(results: [.success(())])
+        )
+
+        await viewModel.load()
+
+        #expect(viewModel.destinationOptions.map(\.id) == [Self.destination.id])
+    }
+
+    @MainActor
     @Test("A late cancellation reports the definitive driver outcome")
     func lateCancellationIsHonest() async {
         let driver = CancellationIgnoringDraftPostDriver()
@@ -386,71 +410,6 @@ struct DraftPostFlowTests {
         return (source, destination)
     }
 
-    @MainActor
-    private static func clearLiveComposer(processIdentifier: pid_t) throws {
-        let application = AXUIElementCreateApplication(processIdentifier)
-        var focusedValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            application,
-            kAXFocusedWindowAttribute as CFString,
-            &focusedValue
-        ) == .success,
-            let window = focusedValue,
-            CFGetTypeID(window) == AXUIElementGetTypeID()
-        else {
-            throw DraftPostFlowFailure.verificationFailed
-        }
-        var queue = [unsafeDowncast(window, to: AXUIElement.self)]
-        var cursor = 0
-        while cursor < queue.count, cursor < 2_048 {
-            let element = queue[cursor]
-            cursor += 1
-            let labels = [
-                liveStringAttribute(kAXTitleAttribute as CFString, from: element),
-                liveStringAttribute(kAXDescriptionAttribute as CFString, from: element),
-                liveStringAttribute(kAXHelpAttribute as CFString, from: element),
-                liveStringAttribute("AXPlaceholderValue" as CFString, from: element),
-            ].compactMap { $0 }
-            if liveStringAttribute(kAXRoleAttribute as CFString, from: element)
-                == kAXTextAreaRole as String,
-                labels.contains(where: MacOSDraftPostFlowDriver.isExplicitComposerLabel)
-            {
-                guard AXUIElementSetAttributeValue(
-                    element,
-                    kAXValueAttribute as CFString,
-                    "" as CFString
-                ) == .success,
-                    liveStringAttribute(kAXValueAttribute as CFString, from: element) == ""
-                else {
-                    throw DraftPostFlowFailure.verificationFailed
-                }
-                return
-            }
-            var childrenValue: CFTypeRef?
-            if AXUIElementCopyAttributeValue(
-                element,
-                kAXChildrenAttribute as CFString,
-                &childrenValue
-            ) == .success,
-                let children = childrenValue as? [AXUIElement]
-            {
-                queue.append(contentsOf: children)
-            }
-        }
-        throw DraftPostFlowFailure.composerMissing
-    }
-
-    @MainActor
-    private static func liveStringAttribute(
-        _ attribute: CFString,
-        from element: AXUIElement
-    ) -> String? {
-        var value: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else {
-            return nil
-        }
-        return value as? String
-    }
 }
 
 private enum RecordedDraftPostComposerAction: Equatable {
@@ -464,6 +423,7 @@ private final class RecordingDraftPostComposerActuator: DraftPostComposerActuati
     private let base: any DraftPostComposerActuating
     private let lock = NSLock()
     private var recordedActions: [RecordedDraftPostComposerAction] = []
+    private var lastWrite: (element: AXUIElement, draft: String)?
 
     var actions: [RecordedDraftPostComposerAction] {
         lock.withLock { recordedActions }
@@ -481,6 +441,42 @@ private final class RecordingDraftPostComposerActuator: DraftPostComposerActuati
     func setDraft(_ draft: String, on composer: AXUIElement) throws {
         lock.withLock { recordedActions.append(.setDraft(draft)) }
         try base.setDraft(draft, on: composer)
+        lock.withLock { lastWrite = (composer, draft) }
+    }
+
+    /// The live test resets only the exact element that this actuator wrote,
+    /// and only while its bytes still match that write. It never searches or
+    /// clears a process's currently focused control.
+    func clearLastDraftIfUnchanged() throws {
+        let write = lock.withLock { lastWrite }
+        guard let write else {
+            throw DraftPostFlowFailure.verificationFailed
+        }
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            write.element,
+            kAXValueAttribute as CFString,
+            &value
+        ) == .success,
+            let current = value as? String,
+            MacOSDraftPostFlowDriver.utf8Matches(current, write.draft),
+            AXUIElementSetAttributeValue(
+                write.element,
+                kAXValueAttribute as CFString,
+                "" as CFString
+            ) == .success
+        else {
+            throw DraftPostFlowFailure.verificationFailed
+        }
+        var clearedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            write.element,
+            kAXValueAttribute as CFString,
+            &clearedValue
+        ) == .success, clearedValue as? String == "" else {
+            throw DraftPostFlowFailure.verificationFailed
+        }
+        lock.withLock { lastWrite = nil }
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -205,6 +205,7 @@ struct DraftPostFlowTests {
             driver: ScriptedDraftPostDriver(results: [.success(())])
         )
         await viewModel.load()
+        #expect(viewModel.sourceID == nil)
         viewModel.sourceID = Self.source.id
         viewModel.destinationID = Self.destination.id
         #expect(viewModel.canRun)


### PR DESCRIPTION
## Why

Part of #3094. The experimental Computer Use workspace and safe macOS adapter exist, but no starter can yet complete useful work. This PR makes one deliberately low-risk starter runnable so we can measure end-to-end success and bounded recovery before expanding the surface.

## Scope

- Make **Draft and post an update** the only available starter; all other starters remain unavailable.
- Let the user explicitly choose one TextEdit source window and one Safari destination window; broader browser support waits for per-browser AX evidence.
- Read the draft through Accessibility, select only an explicitly labelled post composer, require it to be empty, populate it locally, and verify the exact value.
- Retry only pre-mutation focus/window failures, at most twice. Ambiguity, an existing draft, permissions, write rejection, or failed verification pauses immediately.
- Show attempts, automatic recoveries, and verified steps at the end of the run.
- Stop at **Ready for your review**. The runtime driver protocol has no publish/send action.

## Non-goals

- No Teach/recording, scheduling, cloud fallback, or cloud trajectory storage.
- No free-running agent or general desktop task loop.
- No model download or visual-model fallback in this PR; the deterministic Accessibility path is intentionally the first reliability baseline.
- No localized composer vocabulary in this first preview; Safari destinations must expose one of the documented English composer labels.
- No other starter flow becomes runnable.
- No automatic posting, sending, deleting, purchasing, or other consequential action.

## Acceptance

- A local TextEdit draft reaches an empty Safari composer and is verified byte-for-byte against both the unchanged source and the selected page URL/title.
- A focus steal or transient window failure recovers within a maximum of three total attempts.
- Unsafe or ambiguous state pauses without retrying.
- Repeated runs are idempotent when the composer already contains the identical draft.
- The flow cannot publish because no publish operation exists at its action boundary.

## Design precedent

The implementation follows a compiled-automation pattern: deterministic semantic operations own the happy path, the controller owns retry limits and completion, and a verifier—not model narration—decides whether the workflow advanced. Stable operating-system semantics are preferred before visual grounding; ambiguous state fails closed. This keeps the first measured workflow narrow enough to distinguish orchestration reliability from model-grounding reliability.

## Verification

- Focused Swift suite: 20 tests passed (2 live tests skipped by default).
- Release Swift build: passed.
- Complete Swift suite: 3,516 tests across 303 suites passed.
- Operator-only live fixture on Studio: 30/30 independent TextEdit → Safari writes passed, clearing and verifying the local composer between every iteration; no Post action.
- Injected live Finder focus steal: recovered on attempt 2 with one recorded automatic recovery.
- `git diff --check`: passed.
- Exact-head `pr_validate` on `1346ba41c`: **MERGE-SAFE**; Codex review passed with no blocking findings and the dependency-clean full suite passed with 22,941 tests (122 skipped, 22 deselected, 6 xfailed, 1 xpassed).

## AI assistance disclosure

Codex authored and tested the bounded flow, macOS Accessibility driver, setup UI, and regression contracts. Live verification used only a local TextEdit document and a local HTML fixture; no external post was created.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Focused Swift tests and release build pass locally.
- [x] Live local fixture passes 30/30 plus one injected focus-steal recovery.
- [x] Formatting and whitespace checked with `git diff --check`.
- [x] No screenshots, draft text, clipboard contents, or model reasoning are persisted.
- [x] No automatic external side effect is reachable.
