### PR TITLE
perf(image): add M1/M2 precision qualification harness

### DIFF
--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -122,6 +122,11 @@ python3 scripts/benchmark_image_precision.py \
   --hf-cache /path/to/huggingface/hub
 ```
 
+Keep the locally installed candidate wheel at the path recorded by pip for the
+duration of the run. The harness hashes that source artifact itself, compares
+it with `--wheel-sha256`, and starts each server from a neutral directory so a
+nearby source checkout cannot shadow the installed candidate.
+
 The default order is q4, BF16, BF16, q4. Each independent process warms and
 then measures 512-square generation, 1024-square generation, and 1024-square
 editing three times. Keep the JSON as private raw evidence and distill only

--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -77,6 +77,56 @@ its download size, memory demand, and output bytes. The explicit BF16 alias is
 the stable policy until each additional hardware/model combination has
 independent qualification.
 
+## M1/M2 qualification expansion attempt (2026-09-06)
+
+Commit `9c5ff8bdbfd46dab8f2c7c177ba31b09b1ff5dab` adds a fail-closed,
+real-server qualification harness. It requires both immutable checkpoints to be
+complete before starting, accepts only Apple M1/M2 family names with at least
+32 GiB, rejects a non-clean swap baseline, alternates independent q4/BF16
+server processes, validates non-uniform PNG dimensions and deterministic
+per-precision hashes, and records process footprint and system swap. It never
+downloads weights or changes the product's precision default.
+
+No M1 host with enough memory was available for this qualification. The hosted
+Apple runner has 16 GiB and is below the BF16 alias's existing 32 GiB admission
+floor, so it cannot supply a q4/BF16 comparison. **M1 therefore remains
+unqualified**; no M2 number is relabeled as M1 evidence.
+
+On the same M2 Pro 32 GiB mini used above, the exact candidate at
+`96a32e7ef756db3e5326cbb534744e41ac1acf2b` used wheel SHA-256
+`8c4ece191370d74c232f2a921f4e5848bb797927057bd7ba60e3d9fc0f5e7781`,
+Python 3.12.13, Rapid-MLX 0.13.4, mflux 0.19.1, MLX 0.32.2, and Pillow
+12.3.0. Low-power mode was off. A real BF16 512×512, four-step generation
+returned a non-uniform 262,993-byte PNG in 13.651 seconds after a discarded
+17.330-second warm-up. Peak process footprint was 23.0 GiB. The fixed snapshot
+was `4d8e1bae8eb47c7766705de2cda7dabd6cc4ba67`; the response SHA-256 was
+`6360cb555c33b88f669aad1b20f015ecc89907935cff38dba3bec94c3ec6627c`.
+
+That run is correctness evidence, **not an accepted performance row**: system
+swap was already 1,586.19 MiB after restoring the host's resident service and
+grew by another 994.0 MiB during the BF16 session. The harness subsequently
+adopted a 256 MiB maximum starting-swap gate, so the host now fails before model
+launch instead of producing a misleading A/B from a contaminated baseline.
+Fresh zero-swap runs on at least one 32-GiB-or-larger M1 host and an additional
+M2 configuration, plus a clean repeat on this M2 Pro, are still required before
+considering any automatic hardware selection. No reboot was performed as part
+of this work.
+
+Reproduce the intended matrix on an otherwise-idle qualifying host with:
+
+```bash
+python3 scripts/benchmark_image_precision.py \
+  --output /tmp/image-precision.json \
+  --candidate-git-sha "$(git rev-parse HEAD)" \
+  --wheel-sha256 '<sha256-of-installed-candidate-wheel>' \
+  --hf-cache /path/to/huggingface/hub
+```
+
+The default order is q4, BF16, BF16, q4. Each independent process warms and
+then measures 512-square generation, 1024-square generation, and 1024-square
+editing three times. Keep the JSON as private raw evidence and distill only
+reviewed, reproducible results into this report.
+
 ## Completion telemetry
 
 The Images generation route logs one completion line per image. mflux exposes

--- a/docs/engineering/performance/2026-09-04-image-weight-precision.md
+++ b/docs/engineering/performance/2026-09-04-image-weight-precision.md
@@ -79,9 +79,9 @@ independent qualification.
 
 ## M1/M2 qualification expansion attempt (2026-09-06)
 
-Commit `9c5ff8bdbfd46dab8f2c7c177ba31b09b1ff5dab` adds a fail-closed,
-real-server qualification harness. It requires both immutable checkpoints to be
-complete before starting, accepts only Apple M1/M2 family names with at least
+This change adds a fail-closed, real-server qualification harness. It requires
+both immutable checkpoints to be complete before starting, accepts only Apple
+M1/M2 family names with at least
 32 GiB, rejects a non-clean swap baseline, alternates independent q4/BF16
 server processes, validates non-uniform PNG dimensions and deterministic
 per-precision hashes, and records process footprint and system swap. It never

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -7,6 +7,7 @@ summary statistics, and limitations.
 ## Reports
 
 - [Qwen4 fp32-input fast RMSNorm qualification](2026-09-06-qwen4-fast-rmsnorm.md)
+- [FLUX.2 Klein q4/BF16 image precision qualification](2026-09-04-image-weight-precision.md)
 - [Qwen4 block-sparse QSA prefill qualification](2026-09-04-qwen4-qsa-block-sparse-prefill.md)
 - [Qwen4 fused GDN single-token decode](2026-09-01-qwen4-fused-gdn-decode.md)
 - [Gemma 4 12B engine comparison on M2 Pro](2026-08-21-gemma4-12b-engine-comparison.md)

--- a/scripts/benchmark_image_precision.py
+++ b/scripts/benchmark_image_precision.py
@@ -285,6 +285,14 @@ def cache_identity(hf_cache: Path, alias: str) -> dict[str, object]:
     }
 
 
+def server_environment(hf_cache: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["HF_HUB_CACHE"] = str(hf_cache.expanduser())
+    environment["HF_HUB_OFFLINE"] = "1"
+    environment["TRANSFORMERS_OFFLINE"] = "1"
+    return environment
+
+
 def run_session(
     precision: str,
     session_index: int,
@@ -294,8 +302,7 @@ def run_session(
     alias = ALIASES[precision]
     log_path = Path(args.log_dir) / f"{session_index:02d}-{precision}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    environment = os.environ.copy()
-    environment["HF_HUB_CACHE"] = str(Path(args.hf_cache).expanduser())
+    environment = server_environment(Path(args.hf_cache))
     swap_before = swap_used_mb()
     ensure_port_free(args.port)
     with log_path.open("w") as log:
@@ -462,6 +469,8 @@ def main() -> int:
 
     hf_cache = Path(args.hf_cache).expanduser()
     os.environ["HF_HUB_CACHE"] = str(hf_cache)
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
     identities = {
         precision: cache_identity(hf_cache, alias)
         for precision, alias in ALIASES.items()

--- a/scripts/benchmark_image_precision.py
+++ b/scripts/benchmark_image_precision.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Qualify FLUX.2 Klein q4 and BF16 on real Apple M1/M2 hardware.
+
+The harness runs the real server and OpenAI-compatible image routes. It is
+fail-closed: both immutable checkpoints must already be cached, the host must
+identify as Apple M1/M2 with at least 32 GiB, every response must be a
+non-uniform PNG of the requested size, and output hashes must be stable within
+each precision/workload pair. It never downloads weights or changes Rapid's
+default precision policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import platform
+import re
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+from PIL import Image, ImageOps
+
+GIB = 1 << 30
+ALIASES = {
+    "q4": "flux2-klein-4b",
+    "bf16": "flux2-klein-4b-bf16",
+}
+DEFAULT_SEQUENCE = ("q4", "bf16", "bf16", "q4")
+DEFAULT_WORKLOADS = ("generate:512x512:4", "generate:1024x1024:4", "edit:1024x1024:4")
+
+
+def command(*args: str, timeout: float = 30, check: bool = True) -> str:
+    return subprocess.run(
+        args, check=check, capture_output=True, text=True, timeout=timeout
+    ).stdout.strip()
+
+
+def package_version(name: str) -> str:
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def parse_workload(value: str) -> dict[str, object]:
+    try:
+        operation, size, steps_text = value.split(":", 2)
+        width_text, height_text = size.lower().split("x", 1)
+        width, height, steps = int(width_text), int(height_text), int(steps_text)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(
+            "workload must be OPERATION:WIDTHxHEIGHT:STEPS"
+        ) from exc
+    if operation not in {"generate", "edit"}:
+        raise argparse.ArgumentTypeError("operation must be generate or edit")
+    if width < 256 or height < 256 or width % 64 or height % 64:
+        raise argparse.ArgumentTypeError("dimensions must be >=256 and divisible by 64")
+    if not 1 <= steps <= 100:
+        raise argparse.ArgumentTypeError("steps must be between 1 and 100")
+    return {
+        "id": f"{operation}-{width}x{height}-{steps}",
+        "operation": operation,
+        "width": width,
+        "height": height,
+        "steps": steps,
+    }
+
+
+def parse_sequence(value: str) -> tuple[str, ...]:
+    sequence = tuple(part.strip().lower() for part in value.split(",") if part.strip())
+    if not sequence or any(item not in ALIASES for item in sequence):
+        raise argparse.ArgumentTypeError("sequence may contain only q4 and bf16")
+    if sequence.count("q4") != sequence.count("bf16"):
+        raise argparse.ArgumentTypeError("sequence must balance q4 and bf16 sessions")
+    return sequence
+
+
+def json_request(url: str, payload: dict | None = None, timeout: float = 900) -> dict:
+    data = None if payload is None else json.dumps(payload).encode()
+    request = urllib.request.Request(url, data=data)
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.load(response)
+
+
+def multipart_request(
+    url: str, fields: dict[str, str], image_bytes: bytes, timeout: float = 900
+) -> dict:
+    boundary = f"rapid-image-precision-{uuid.uuid4().hex}"
+    body = bytearray()
+    for name, value in fields.items():
+        body.extend(f"--{boundary}\r\n".encode())
+        body.extend(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode())
+        body.extend(value.encode())
+        body.extend(b"\r\n")
+    body.extend(f"--{boundary}\r\n".encode())
+    body.extend(
+        b'Content-Disposition: form-data; name="image"; filename="source.png"\r\n'
+        b"Content-Type: image/png\r\n\r\n"
+    )
+    body.extend(image_bytes)
+    body.extend(f"\r\n--{boundary}--\r\n".encode())
+    request = urllib.request.Request(url, data=bytes(body))
+    request.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.load(response)
+
+
+def validate_png(response: dict, width: int, height: int) -> tuple[str, int]:
+    try:
+        raw = base64.b64decode(response["data"][0]["b64_json"], validate=True)
+        image = Image.open(io.BytesIO(raw))
+        image.load()
+    except (KeyError, IndexError, TypeError, ValueError, OSError) as exc:
+        raise RuntimeError("response did not contain a decodable PNG") from exc
+    if image.format != "PNG" or image.size != (width, height):
+        raise RuntimeError(
+            f"unexpected image format/size: {image.format} {image.size}; "
+            f"expected PNG {(width, height)}"
+        )
+    extrema = image.convert("RGB").getextrema()
+    if all(low == high for low, high in extrema):
+        raise RuntimeError("response PNG is uniform")
+    return hashlib.sha256(raw).hexdigest(), len(raw)
+
+
+def edit_source(width: int, height: int) -> bytes:
+    gradient = Image.linear_gradient("L").resize((width, height))
+    image = ImageOps.colorize(gradient, black="#173c70", white="#f4a261")
+    with io.BytesIO() as buffer:
+        image.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+
+def footprint(pid: int) -> tuple[float, float]:
+    text = command("footprint", "-p", str(pid), timeout=30)
+    current = re.search(r"Footprint:\s+([0-9.]+)\s+(MB|GB)", text)
+    peak = re.search(r"phys_footprint_peak:\s+([0-9.]+)\s+(MB|GB)", text)
+    if not current or not peak:
+        raise RuntimeError("could not parse macOS footprint output")
+
+    def gib(match: re.Match[str]) -> float:
+        value = float(match.group(1))
+        return value if match.group(2) == "GB" else value / 1024
+
+    return round(gib(current), 3), round(gib(peak), 3)
+
+
+def low_power_mode() -> int:
+    text = command("pmset", "-g", "custom")
+    ac_power = text.split("AC Power:", 1)[-1].split("Battery Power:", 1)[0]
+    match = re.search(r"^\s*lowpowermode\s+(\d+)\s*$", ac_power, re.MULTILINE)
+    if not match:
+        raise RuntimeError("could not parse AC lowpowermode")
+    return int(match.group(1))
+
+
+def swap_used_mb() -> float:
+    text = command("sysctl", "-n", "vm.swapusage")
+    match = re.search(r"used = ([0-9.]+)([MG])", text)
+    if not match:
+        raise RuntimeError("could not parse vm.swapusage")
+    value = float(match.group(1))
+    return value * 1024 if match.group(2) == "G" else value
+
+
+def wait_ready(proc: subprocess.Popen[str], port: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"server exited with status {proc.returncode}")
+        try:
+            json_request(f"http://127.0.0.1:{port}/healthz", timeout=2)
+            return
+        except (OSError, urllib.error.URLError, json.JSONDecodeError):
+            time.sleep(1)
+    raise TimeoutError(f"server was not ready after {timeout:.0f}s")
+
+
+def ensure_port_free(port: int) -> None:
+    # Binding can fail for a recently stopped server whose connections remain
+    # in TIME_WAIT even though no process is listening. A real connect probes
+    # the condition that would make the next server unsafe to start.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.25)
+        if probe.connect_ex(("127.0.0.1", port)) == 0:
+            raise RuntimeError(f"benchmark port {port} is already in use")
+
+
+def stop(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        proc.wait(timeout=10)
+        return
+    try:
+        proc.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=10)
+
+
+def request_image(
+    port: int, alias: str, workload: dict[str, object], seed: int
+) -> dict:
+    width, height = int(workload["width"]), int(workload["height"])
+    started = time.monotonic()
+    if workload["operation"] == "generate":
+        response = json_request(
+            f"http://127.0.0.1:{port}/v1/images/generations",
+            {
+                "model": alias,
+                "prompt": "A folded paper crane on a walnut desk, soft window light",
+                "size": f"{width}x{height}",
+                "steps": workload["steps"],
+                "seed": seed,
+            },
+        )
+    else:
+        response = multipart_request(
+            f"http://127.0.0.1:{port}/v1/images/edits",
+            {
+                "model": alias,
+                "prompt": "Turn the scene into a warm sunset while preserving the composition",
+                "steps": str(workload["steps"]),
+                "seed": str(seed),
+            },
+            edit_source(width, height),
+        )
+    elapsed = time.monotonic() - started
+    digest, byte_count = validate_png(response, width, height)
+    return {"wall_s": round(elapsed, 3), "sha256": digest, "png_bytes": byte_count}
+
+
+def cache_identity(hf_cache: Path, alias: str) -> dict[str, object]:
+    from vllm_mlx._download_gate import IMAGE_MODEL_REVISIONS, mflux_missing_weights
+    from vllm_mlx.model_aliases import resolve_model
+
+    repo = resolve_model(alias)
+    revision = IMAGE_MODEL_REVISIONS[repo]
+    snapshot = (
+        hf_cache / ("models--" + repo.replace("/", "--")) / "snapshots" / revision
+    )
+    if not snapshot.is_dir():
+        raise RuntimeError(f"pinned snapshot is not cached: {repo}@{revision}")
+    missing = mflux_missing_weights(repo)
+    if missing != []:
+        raise RuntimeError(f"checkpoint is incomplete: {repo}@{revision}: {missing!r}")
+    return {
+        "alias": alias,
+        "repo": repo,
+        "revision": revision,
+        "snapshot_present": True,
+    }
+
+
+def run_session(
+    precision: str,
+    session_index: int,
+    workloads: list[dict[str, object]],
+    args: argparse.Namespace,
+) -> dict[str, object]:
+    alias = ALIASES[precision]
+    log_path = Path(args.log_dir) / f"{session_index:02d}-{precision}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    environment = os.environ.copy()
+    environment["HF_HUB_CACHE"] = str(Path(args.hf_cache).expanduser())
+    swap_before = swap_used_mb()
+    ensure_port_free(args.port)
+    with log_path.open("w") as log:
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-P",
+                "-u",
+                "-s",
+                "-m",
+                "vllm_mlx.cli",
+                "--no-telemetry",
+                "--no-banner",
+                "serve",
+                alias,
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(args.port),
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=environment,
+            start_new_session=True,
+        )
+        try:
+            wait_ready(proc, args.port, args.load_timeout)
+            samples: list[dict[str, object]] = []
+            for workload in workloads:
+                warmup = request_image(args.port, alias, workload, args.seed)
+                for repeat in range(args.repeats):
+                    sample = request_image(args.port, alias, workload, args.seed)
+                    current_gib, peak_gib = footprint(proc.pid)
+                    samples.append(
+                        {
+                            "workload": workload["id"],
+                            "repeat": repeat + 1,
+                            **sample,
+                            "current_footprint_gib": current_gib,
+                            "peak_footprint_gib": peak_gib,
+                        }
+                    )
+                print(
+                    f"session {session_index} {precision} {workload['id']}: "
+                    f"warmup={warmup['wall_s']}s",
+                    flush=True,
+                )
+            swap_after = swap_used_mb()
+            return {
+                "session": session_index,
+                "precision": precision,
+                "alias": alias,
+                "status": "ok",
+                "swap_before_mb": round(swap_before, 2),
+                "swap_after_mb": round(swap_after, 2),
+                "swap_delta_mb": round(max(0.0, swap_after - swap_before), 2),
+                "samples": samples,
+                "log": str(log_path),
+            }
+        finally:
+            stop(proc)
+            time.sleep(args.cooldown)
+
+
+def summarize(sessions: list[dict[str, object]]) -> list[dict[str, object]]:
+    grouped: dict[tuple[str, str], list[dict[str, object]]] = {}
+    for session in sessions:
+        for sample in session["samples"]:  # type: ignore[index]
+            key = (str(session["precision"]), str(sample["workload"]))
+            grouped.setdefault(key, []).append(sample)
+    rows = []
+    for (precision, workload), samples in sorted(grouped.items()):
+        hashes = {str(sample["sha256"]) for sample in samples}
+        if len(hashes) != 1:
+            raise RuntimeError(f"non-deterministic output for {precision}/{workload}")
+        times = [float(sample["wall_s"]) for sample in samples]
+        rows.append(
+            {
+                "precision": precision,
+                "workload": workload,
+                "samples": len(times),
+                "median_wall_s": round(statistics.median(times), 3),
+                "p95_wall_s_nearest_rank": sorted(times)[
+                    max(0, int(0.95 * len(times) + 0.999) - 1)
+                ],
+                "peak_footprint_gib": max(
+                    float(sample["peak_footprint_gib"]) for sample in samples
+                ),
+                "sha256": hashes.pop(),
+            }
+        )
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--candidate-git-sha", required=True)
+    parser.add_argument("--wheel-sha256", required=True)
+    parser.add_argument(
+        "--hf-cache", required=True, help="concrete HF Hub cache directory"
+    )
+    parser.add_argument("--workload", action="append", type=parse_workload)
+    parser.add_argument("--sequence", type=parse_sequence, default=DEFAULT_SEQUENCE)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=1001)
+    parser.add_argument("--port", type=int, default=18792)
+    parser.add_argument("--load-timeout", type=float, default=300)
+    parser.add_argument("--cooldown", type=float, default=15)
+    parser.add_argument("--max-start-swap-mb", type=float, default=256)
+    parser.add_argument("--log-dir", default="/tmp/rapid-image-precision-logs")
+    args = parser.parse_args()
+    if platform.system() != "Darwin":
+        parser.error("this qualification harness requires macOS")
+    if args.repeats < 1:
+        parser.error("--repeats must be positive")
+
+    chip = command("sysctl", "-n", "machdep.cpu.brand_string")
+    ram_gib = int(command("sysctl", "-n", "hw.memsize")) / GIB
+    if not re.fullmatch(r"Apple M[12](?: Pro| Max| Ultra)?", chip):
+        parser.error(f"host is not an Apple M1/M2 family system: {chip}")
+    if ram_gib < 32:
+        parser.error(
+            f"BF16 qualification requires at least 32 GiB; host has {ram_gib:.1f}"
+        )
+    start_swap_mb = swap_used_mb()
+    if start_swap_mb > args.max_start_swap_mb:
+        parser.error(
+            f"qualification requires a clean swap baseline; host already uses "
+            f"{start_swap_mb:.1f} MiB (limit {args.max_start_swap_mb:.1f} MiB)"
+        )
+
+    hf_cache = Path(args.hf_cache).expanduser()
+    os.environ["HF_HUB_CACHE"] = str(hf_cache)
+    identities = {
+        precision: cache_identity(hf_cache, alias)
+        for precision, alias in ALIASES.items()
+    }
+    workloads = args.workload or [parse_workload(value) for value in DEFAULT_WORKLOADS]
+    result: dict[str, object] = {
+        "schema_version": 1,
+        "environment": {
+            "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "chip": chip,
+            "physical_ram_gib": round(ram_gib, 2),
+            "macos": platform.mac_ver()[0],
+            "low_power_mode": low_power_mode(),
+            "start_swap_mb": round(start_swap_mb, 2),
+            "python": platform.python_version(),
+            "rapid_mlx": package_version("rapid-mlx"),
+            "mflux": package_version("mflux"),
+            "mlx": package_version("mlx"),
+            "pillow": package_version("Pillow"),
+            "candidate_git_sha": args.candidate_git_sha,
+            "wheel_sha256": args.wheel_sha256,
+        },
+        "method": {
+            "sequence": list(args.sequence),
+            "repeats_per_session": args.repeats,
+            "warmup_per_workload_per_session": 1,
+            "seed": args.seed,
+            "workloads": workloads,
+            "models_are_sequential": True,
+            "downloads_allowed": False,
+            "max_start_swap_mb": args.max_start_swap_mb,
+        },
+        "artifacts": identities,
+        "sessions": [],
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        for session_index, precision in enumerate(args.sequence, start=1):
+            session = run_session(precision, session_index, workloads, args)
+            result["sessions"].append(session)  # type: ignore[union-attr]
+            output.write_text(json.dumps(result, indent=2) + "\n")
+        result["summary"] = summarize(result["sessions"])  # type: ignore[arg-type]
+        result["status"] = "pass"
+        output.write_text(json.dumps(result, indent=2) + "\n")
+        return 0
+    except Exception as exc:
+        result["status"] = "error"
+        result["error"] = str(exc)
+        output.write_text(json.dumps(result, indent=2) + "\n")
+        raise
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_image_precision.py
+++ b/scripts/benchmark_image_precision.py
@@ -169,6 +169,18 @@ def low_power_mode() -> int:
     return int(match.group(1))
 
 
+def running_rapid_servers() -> list[int]:
+    rows = command("ps", "-axo", "pid=,command=")
+    matches = []
+    for row in rows.splitlines():
+        pid_text, _, process_command = row.strip().partition(" ")
+        if not pid_text.isdigit() or int(pid_text) == os.getpid():
+            continue
+        if re.search(r"(?:rapid-mlx|vllm_mlx\.cli).*\bserve\b", process_command):
+            matches.append(int(pid_text))
+    return matches
+
+
 def swap_used_mb() -> float:
     text = command("sysctl", "-n", "vm.swapusage")
     match = re.search(r"used = ([0-9.]+)([MG])", text)
@@ -313,8 +325,36 @@ def run_session(
         try:
             wait_ready(proc, args.port, args.load_timeout)
             samples: list[dict[str, object]] = []
+            warmups: list[dict[str, object]] = []
+
+            def session_record(status: str, swap_after: float) -> dict[str, object]:
+                return {
+                    "session": session_index,
+                    "precision": precision,
+                    "alias": alias,
+                    "status": status,
+                    "swap_before_mb": round(swap_before, 2),
+                    "swap_after_mb": round(swap_after, 2),
+                    "swap_delta_mb": round(max(0.0, swap_after - swap_before), 2),
+                    "warmups": warmups,
+                    "samples": samples,
+                    "log": str(log_path),
+                }
+
             for workload in workloads:
                 warmup = request_image(args.port, alias, workload, args.seed)
+                current_gib, peak_gib = footprint(proc.pid)
+                warmups.append(
+                    {
+                        "workload": workload["id"],
+                        **warmup,
+                        "current_footprint_gib": current_gib,
+                        "peak_footprint_gib": peak_gib,
+                    }
+                )
+                swap_now = swap_used_mb()
+                if swap_now - swap_before > args.abort_swap_mb:
+                    return session_record("aborted_swap", swap_now)
                 for repeat in range(args.repeats):
                     sample = request_image(args.port, alias, workload, args.seed)
                     current_gib, peak_gib = footprint(proc.pid)
@@ -327,23 +367,16 @@ def run_session(
                             "peak_footprint_gib": peak_gib,
                         }
                     )
+                    swap_now = swap_used_mb()
+                    if swap_now - swap_before > args.abort_swap_mb:
+                        return session_record("aborted_swap", swap_now)
                 print(
                     f"session {session_index} {precision} {workload['id']}: "
                     f"warmup={warmup['wall_s']}s",
                     flush=True,
                 )
             swap_after = swap_used_mb()
-            return {
-                "session": session_index,
-                "precision": precision,
-                "alias": alias,
-                "status": "ok",
-                "swap_before_mb": round(swap_before, 2),
-                "swap_after_mb": round(swap_after, 2),
-                "swap_delta_mb": round(max(0.0, swap_after - swap_before), 2),
-                "samples": samples,
-                "log": str(log_path),
-            }
+            return session_record("ok", swap_after)
         finally:
             stop(proc)
             time.sleep(args.cooldown)
@@ -395,6 +428,7 @@ def main() -> int:
     parser.add_argument("--load-timeout", type=float, default=300)
     parser.add_argument("--cooldown", type=float, default=15)
     parser.add_argument("--max-start-swap-mb", type=float, default=256)
+    parser.add_argument("--abort-swap-mb", type=float, default=256)
     parser.add_argument("--log-dir", default="/tmp/rapid-image-precision-logs")
     args = parser.parse_args()
     if platform.system() != "Darwin":
@@ -409,6 +443,15 @@ def main() -> int:
     if ram_gib < 32:
         parser.error(
             f"BF16 qualification requires at least 32 GiB; host has {ram_gib:.1f}"
+        )
+    power_mode = low_power_mode()
+    if power_mode != 0:
+        parser.error("qualification requires AC low-power mode to be off")
+    active_servers = running_rapid_servers()
+    if active_servers:
+        parser.error(
+            "qualification requires an otherwise-idle host; active Rapid server PID: "
+            f"{active_servers[0]}"
         )
     start_swap_mb = swap_used_mb()
     if start_swap_mb > args.max_start_swap_mb:
@@ -431,7 +474,7 @@ def main() -> int:
             "chip": chip,
             "physical_ram_gib": round(ram_gib, 2),
             "macos": platform.mac_ver()[0],
-            "low_power_mode": low_power_mode(),
+            "low_power_mode": power_mode,
             "start_swap_mb": round(start_swap_mb, 2),
             "python": platform.python_version(),
             "rapid_mlx": package_version("rapid-mlx"),
@@ -450,6 +493,7 @@ def main() -> int:
             "models_are_sequential": True,
             "downloads_allowed": False,
             "max_start_swap_mb": args.max_start_swap_mb,
+            "abort_swap_mb": args.abort_swap_mb,
         },
         "artifacts": identities,
         "sessions": [],
@@ -461,6 +505,11 @@ def main() -> int:
             session = run_session(precision, session_index, workloads, args)
             result["sessions"].append(session)  # type: ignore[union-attr]
             output.write_text(json.dumps(result, indent=2) + "\n")
+            if session["status"] != "ok":
+                raise RuntimeError(
+                    f"session {session_index} {precision} aborted after "
+                    f"{session['swap_delta_mb']} MiB new swap"
+                )
         result["summary"] = summarize(result["sessions"])  # type: ignore[arg-type]
         result["status"] = "pass"
         output.write_text(json.dumps(result, indent=2) + "\n")

--- a/scripts/benchmark_image_precision.py
+++ b/scripts/benchmark_image_precision.py
@@ -26,9 +26,10 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import uuid
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, distribution, version
 from pathlib import Path
 
 from PIL import Image, ImageOps
@@ -53,6 +54,34 @@ def package_version(name: str) -> str:
         return version(name)
     except PackageNotFoundError:
         return "unknown"
+
+
+def installed_wheel_sha256() -> str:
+    try:
+        raw = distribution("rapid-mlx").read_text("direct_url.json")
+        direct_url = json.loads(raw) if raw else {}
+        parsed = urllib.parse.urlparse(direct_url.get("url", ""))
+        if parsed.scheme != "file":
+            raise ValueError
+        wheel = Path(urllib.request.url2pathname(parsed.path))
+        if wheel.suffix != ".whl" or not wheel.is_file():
+            raise ValueError
+        digest = hashlib.sha256()
+        with wheel.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1 << 20), b""):
+                digest.update(chunk)
+    except (
+        PackageNotFoundError,
+        json.JSONDecodeError,
+        TypeError,
+        AttributeError,
+        OSError,
+        ValueError,
+    ) as exc:
+        raise RuntimeError(
+            "Rapid-MLX must be installed from an available local wheel artifact"
+        ) from exc
+    return digest.hexdigest()
 
 
 def parse_workload(value: str) -> dict[str, object]:
@@ -327,6 +356,7 @@ def run_session(
             stderr=subprocess.STDOUT,
             text=True,
             env=environment,
+            cwd=log_path.parent.resolve(),
             start_new_session=True,
         )
         try:
@@ -438,6 +468,10 @@ def main() -> int:
     parser.add_argument("--abort-swap-mb", type=float, default=256)
     parser.add_argument("--log-dir", default="/tmp/rapid-image-precision-logs")
     args = parser.parse_args()
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", args.candidate_git_sha):
+        parser.error("--candidate-git-sha must be a full 40-character Git SHA")
+    if not re.fullmatch(r"[0-9a-fA-F]{64}", args.wheel_sha256):
+        parser.error("--wheel-sha256 must be a 64-character SHA-256")
     if platform.system() != "Darwin":
         parser.error("this qualification harness requires macOS")
     if args.repeats < 1:
@@ -466,6 +500,12 @@ def main() -> int:
             f"qualification requires a clean swap baseline; host already uses "
             f"{start_swap_mb:.1f} MiB (limit {args.max_start_swap_mb:.1f} MiB)"
         )
+    installed_sha256 = installed_wheel_sha256()
+    if installed_sha256 != args.wheel_sha256.lower():
+        parser.error(
+            "installed Rapid-MLX wheel SHA-256 does not match --wheel-sha256: "
+            f"{installed_sha256}"
+        )
 
     hf_cache = Path(args.hf_cache).expanduser()
     os.environ["HF_HUB_CACHE"] = str(hf_cache)
@@ -490,8 +530,8 @@ def main() -> int:
             "mflux": package_version("mflux"),
             "mlx": package_version("mlx"),
             "pillow": package_version("Pillow"),
-            "candidate_git_sha": args.candidate_git_sha,
-            "wheel_sha256": args.wheel_sha256,
+            "candidate_git_sha": args.candidate_git_sha.lower(),
+            "wheel_sha256": installed_sha256,
         },
         "method": {
             "sequence": list(args.sequence),

--- a/tests/test_benchmark_image_precision.py
+++ b/tests/test_benchmark_image_precision.py
@@ -73,6 +73,20 @@ def test_port_probe_rejects_listener_but_not_released_port():
     bench.ensure_port_free(port)
 
 
+def test_running_rapid_servers_ignores_unrelated_processes(monkeypatch):
+    monkeypatch.setattr(bench.os, "getpid", lambda: 20)
+    monkeypatch.setattr(
+        bench,
+        "command",
+        lambda *args, **kwargs: (
+            "10 /usr/bin/node portal_server.py\n"
+            "20 python benchmark_image_precision.py\n"
+            "30 /usr/bin/rapid-mlx --no-banner serve model --port 8000\n"
+        ),
+    )
+    assert bench.running_rapid_servers() == [30]
+
+
 def test_validate_png_checks_format_dimensions_and_nonuniformity():
     raw = _png()
     response = {"data": [{"b64_json": base64.b64encode(raw).decode()}]}

--- a/tests/test_benchmark_image_precision.py
+++ b/tests/test_benchmark_image_precision.py
@@ -97,6 +97,34 @@ def test_server_environment_forces_pinned_cache_offline(monkeypatch):
     assert environment["TRANSFORMERS_OFFLINE"] == "1"
 
 
+def test_installed_wheel_sha256_hashes_pip_source_artifact(monkeypatch, tmp_path):
+    wheel = tmp_path / "rapid_mlx-0.13.4-py3-none-any.whl"
+    wheel.write_bytes(b"exact candidate")
+
+    class Dist:
+        @staticmethod
+        def read_text(name):
+            assert name == "direct_url.json"
+            return '{"url": "' + wheel.as_uri() + '"}'
+
+    monkeypatch.setattr(bench, "distribution", lambda name: Dist())
+    assert (
+        bench.installed_wheel_sha256()
+        == bench.hashlib.sha256(b"exact candidate").hexdigest()
+    )
+
+
+def test_installed_wheel_sha256_rejects_editable_install(monkeypatch):
+    class Dist:
+        @staticmethod
+        def read_text(name):
+            return '{"dir_info": {}}'
+
+    monkeypatch.setattr(bench, "distribution", lambda name: Dist())
+    with pytest.raises(RuntimeError, match="available local wheel"):
+        bench.installed_wheel_sha256()
+
+
 def test_validate_png_checks_format_dimensions_and_nonuniformity():
     raw = _png()
     response = {"data": [{"b64_json": base64.b64encode(raw).decode()}]}

--- a/tests/test_benchmark_image_precision.py
+++ b/tests/test_benchmark_image_precision.py
@@ -4,6 +4,7 @@ import argparse
 import base64
 import io
 import socket
+from pathlib import Path
 
 import pytest
 from PIL import Image
@@ -85,6 +86,15 @@ def test_running_rapid_servers_ignores_unrelated_processes(monkeypatch):
         ),
     )
     assert bench.running_rapid_servers() == [30]
+
+
+def test_server_environment_forces_pinned_cache_offline(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "0")
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+    environment = bench.server_environment(Path("/tmp/qualification-cache"))
+    assert environment["HF_HUB_CACHE"] == "/tmp/qualification-cache"
+    assert environment["HF_HUB_OFFLINE"] == "1"
+    assert environment["TRANSFORMERS_OFFLINE"] == "1"
 
 
 def test_validate_png_checks_format_dimensions_and_nonuniformity():

--- a/tests/test_benchmark_image_precision.py
+++ b/tests/test_benchmark_image_precision.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import socket
+
+import pytest
+from PIL import Image
+
+from scripts import benchmark_image_precision as bench
+
+
+def _png(size=(512, 512), *, uniform=False) -> bytes:
+    image = Image.new("RGB", size, "red")
+    if not uniform:
+        image.putpixel((0, 0), (0, 0, 255))
+    with io.BytesIO() as buffer:
+        image.save(buffer, format="PNG")
+        return buffer.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("generate:512x512:4", ("generate", 512, 512, 4)),
+        ("edit:1024x768:20", ("edit", 1024, 768, 20)),
+    ],
+)
+def test_parse_workload(value, expected):
+    parsed = bench.parse_workload(value)
+    assert (
+        parsed["operation"],
+        parsed["width"],
+        parsed["height"],
+        parsed["steps"],
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["chat:512x512:4", "generate:500x512:4", "edit:512x512:0", "broken"],
+)
+def test_parse_workload_rejects_invalid_contract(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        bench.parse_workload(value)
+
+
+def test_parse_sequence_requires_balanced_precisions():
+    assert bench.parse_sequence("q4,bf16,bf16,q4") == ("q4", "bf16", "bf16", "q4")
+    with pytest.raises(argparse.ArgumentTypeError):
+        bench.parse_sequence("q4,bf16,bf16")
+
+
+def test_low_power_mode_reads_ac_power_only(monkeypatch):
+    monkeypatch.setattr(
+        bench,
+        "command",
+        lambda *args, **kwargs: (
+            "Battery Power:\n lowpowermode 1\nAC Power:\n lowpowermode 0"
+        ),
+    )
+    assert bench.low_power_mode() == 0
+
+
+def test_port_probe_rejects_listener_but_not_released_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen()
+        port = listener.getsockname()[1]
+        with pytest.raises(RuntimeError, match="already in use"):
+            bench.ensure_port_free(port)
+    bench.ensure_port_free(port)
+
+
+def test_validate_png_checks_format_dimensions_and_nonuniformity():
+    raw = _png()
+    response = {"data": [{"b64_json": base64.b64encode(raw).decode()}]}
+    digest, byte_count = bench.validate_png(response, 512, 512)
+    assert len(digest) == 64
+    assert byte_count == len(raw)
+
+    with pytest.raises(RuntimeError, match="format/size"):
+        bench.validate_png(response, 1024, 1024)
+
+    uniform = _png(uniform=True)
+    with pytest.raises(RuntimeError, match="uniform"):
+        bench.validate_png(
+            {"data": [{"b64_json": base64.b64encode(uniform).decode()}]}, 512, 512
+        )
+
+
+def test_summarize_requires_stable_hashes_and_reports_median():
+    sessions = [
+        {
+            "precision": "q4",
+            "samples": [
+                {
+                    "workload": "generate-512x512-4",
+                    "wall_s": 2.0,
+                    "sha256": "a",
+                    "peak_footprint_gib": 4.0,
+                },
+                {
+                    "workload": "generate-512x512-4",
+                    "wall_s": 1.0,
+                    "sha256": "a",
+                    "peak_footprint_gib": 5.0,
+                },
+            ],
+        }
+    ]
+    row = bench.summarize(sessions)[0]
+    assert row["median_wall_s"] == 1.5
+    assert row["peak_footprint_gib"] == 5.0
+
+    sessions[0]["samples"][1]["sha256"] = "b"
+    with pytest.raises(RuntimeError, match="non-deterministic"):
+        bench.summarize(sessions)


### PR DESCRIPTION
## Why

The explicit Klein BF16 path has one accepted M2 Pro timing receipt, but that is not enough to infer a safe M1/M2 hardware policy. We need a repeatable gate that refuses incompatible, busy, or memory-contaminated hosts instead of turning partial measurements into product defaults.

## Intention and scope

Add a maintainer-only real-server q4/BF16 qualification harness and record the 2026-09-06 expansion attempt. The harness validates immutable cached artifacts, hardware/RAM, low-power and idle state, clean starting swap, PNG correctness, deterministic hashes, per-session swap, process footprint, and alternating independent server order.

The qualification attempt found and split out the existing BF16 real-layout cache defect; #3168 is now merged. This PR targets `main` and its diff is only the harness, tests, performance report, and report index.

Non-goals: automatic precision selection, changing q4 defaults, downloading model weights, adding formats/models/kernels, Desktop behavior, rebooting hardware, release, or deployment.

## Acceptance criteria

- Non-M1/M2, <32 GiB, low-power, active-server, dirty-swap, missing-artifact, bad-PNG, non-deterministic, and swap-growth conditions fail closed.
- Default matrix alternates q4/BF16 independent processes over 512 generation, 1024 generation, and 1024 editing.
- No M1 or M2 performance number is published unless the full acceptance contract passes.
- Existing explicit q4/BF16 product behavior remains unchanged.

## Verification

- 15 harness contract tests pass; Ruff and formatting are clean.
- M3 Ultra reverse gate exits 2 before artifact/model access.
- M2 Pro dirty-baseline reverse gate exits 2 before model launch at 2,564.2 MiB starting swap; the resident service stayed healthy.
- One final-head BF16 correctness smoke from #3168 returned a valid non-uniform 512×512 PNG, but was explicitly rejected as a performance row because starting swap was nonzero and the session added 994.0 MiB.





## Final validation and quantitative outcome

- Exact merged head `9d5153e9c32e606acc2191da4a210ca02040c2eb`: 15 focused harness tests passed.
- Full local suite: **22,858 passed / 122 skipped / 22 deselected / 6 xfailed / 1 xpassed**; Ruff and formatting passed.
- Hosted exact-head validation and the final Mergify macOS candidate passed before merge.
- The M3 Ultra reverse gate exited before artifact/model access, as designed.
- The M2 Pro qualification attempt was rejected before model launch because starting swap was 2,564.2 MiB. A later BF16 correctness smoke produced a valid PNG but was also rejected as a performance row because starting swap was nonzero and the session added 994.0 MiB.
- Therefore this PR publishes **no new M1/M2 speed claim and no automatic precision policy**. The accepted existing Klein receipt remains #3065: q4 median 52.703 seconds versus BF16 41.820 seconds at 1024x1024/four steps on M2 Pro, a 1.26x throughput improvement and 20.6% median wall-time reduction.
