### PR TITLE
fix(desktop): preserve port 8000 for upgrades

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -154,6 +154,14 @@ struct RapidApp: App {
         TelemetryConsent.synchronizeExistingDecision()
         let consentCoordinator = DeferredTelemetryConsentCoordinator()
         let starPromptCoordinator = GitHubStarPromptCoordinator()
+        // #2878 changed the Desktop default from 8000 to 7659. Preserve the
+        // old endpoint for upgrades before InstallTracker records this launch;
+        // otherwise existing OpenAI-compatible clients silently disconnect.
+        PortAllocator.migrateLegacyDefaultIfNeeded(
+            hadPreviousLaunch: UserDefaults.standard.string(
+                forKey: InstallTracker.lastSeenVersionKey
+            ) != nil
+        )
         // Sweep orphan rapid-mlx processes from previous sessions BEFORE
         // anything else looks at our serve port.
         //

--- a/apps/rapid-mac/Sources/Rapid/Server/PortAllocator.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/PortAllocator.swift
@@ -34,8 +34,9 @@ enum PortAllocator {
     /// 10-port window. 7659-7668 is R M L X on a phone keypad — a
     /// port almost nothing else wants, unlike 8000 which every
     /// gateway and FastAPI dev server claims. 8000…8009 is kept as
-    /// a legacy fallback after the 7659 window so existing
-    /// `http://127.0.0.1:8000` clients keep working without a rebind.
+    /// a legacy recovery window after the 7659 window. Existing installs are
+    /// pinned to 8000 by ``migrateLegacyDefaultIfNeeded`` so their clients do
+    /// not silently disconnect on upgrade.
     static let defaultCandidatePorts: [Int] = Array(7659...7668)
     static let legacyFallbackPorts: [Int] = Array(8000...8009)
 
@@ -60,15 +61,40 @@ enum PortAllocator {
     /// UserDefaults key for the GUI-persisted port. Nil means
     /// "use the default window" (fresh install, or user cleared it).
     static let storedPortKey = "rapid.desktop.port"
+    /// One-shot marker for the 8000 -> 7659 default-port migration. Existing
+    /// installs keep their historical endpoint; new installs take the new
+    /// default. Once recorded, clearing the port field means "use 7659".
+    static let legacyDefaultMigrationKey = "rapid.desktop.port.defaultMigration.v1"
 
-    static func storedPort() -> Int? {
+    static func storedPort(defaults: UserDefaults = .standard) -> Int? {
         // GUI stores as string via AppStorage; legacy/env may have stored int.
-        if let s = UserDefaults.standard.string(forKey: storedPortKey),
+        if let s = defaults.string(forKey: storedPortKey),
            let p = Int(s.trimmingCharacters(in: .whitespaces)),
            (1...65_535).contains(p) { return p }
-        let v = UserDefaults.standard.integer(forKey: storedPortKey)
+        let v = defaults.integer(forKey: storedPortKey)
         guard v != 0, (1...65_535).contains(v) else { return nil }
         return v
+    }
+
+    /// Preserve the pre-7659 endpoint for upgrades without pinning fresh
+    /// installs to 8000. This must run before ``InstallTracker`` records the
+    /// current launch, while an absent last-seen version still means a genuine
+    /// first launch.
+    @discardableResult
+    static func migrateLegacyDefaultIfNeeded(
+        hadPreviousLaunch: Bool,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        guard defaults.object(forKey: legacyDefaultMigrationKey) == nil else { return false }
+        let shouldPreserveLegacyDefault = defaults.object(forKey: storedPortKey) == nil
+            && hadPreviousLaunch
+        if shouldPreserveLegacyDefault {
+            // Write the compatibility value first. A crash between these two
+            // writes merely retries the idempotent migration next launch.
+            defaults.set(8_000, forKey: storedPortKey)
+        }
+        defaults.set(true, forKey: legacyDefaultMigrationKey)
+        return shouldPreserveLegacyDefault
     }
 
     /// Test seam — resolve the candidate window from an injected
@@ -77,13 +103,16 @@ enum PortAllocator {
     /// environment. Priority: env var > GUI-stored port > default
     /// window (7659…7668 plus 8000…8009 legacy fallback). A bad value
     /// is ignored rather than crashing the spawn.
-    static func resolveCandidatePorts(environment: [String: String]) -> [Int] {
+    static func resolveCandidatePorts(
+        environment: [String: String],
+        defaults: UserDefaults = .standard
+    ) -> [Int] {
         if let raw = environment["RAPID_DESKTOP_PORT"],
            let port = Int(raw.trimmingCharacters(in: .whitespaces)),
            (1...65_535).contains(port) {
              return [port]
         }
-        if let s = storedPort() {
+        if let s = storedPort(defaults: defaults) {
             return [s]
         }
         return defaultCandidatePorts + legacyFallbackPorts

--- a/apps/rapid-mac/Tests/RapidTests/PortAllocatorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/PortAllocatorTests.swift
@@ -13,8 +13,19 @@ import Darwin
 /// host is actually doing, each case picks its own port window in
 /// the ephemeral high range (60000+) so a developer running rapid-mlx
 /// in another terminal can't false-fail us.
-@Suite("PortAllocator — v0.5.6 fallback contract")
-struct PortAllocatorTests {
+@Suite("PortAllocator — v0.5.6 fallback contract", .serialized)
+final class PortAllocatorTests {
+
+    nonisolated(unsafe) private var createdSuiteNames: [String] = []
+    deinit { TestDefaultsScope.cleanup(suiteNames: createdSuiteNames) }
+
+    private func scratchDefaults() -> UserDefaults {
+        let suite = TestDefaultsScope.mintSuiteName(prefix: "rapid-port-allocator-test-")
+        createdSuiteNames.append(suite)
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
 
     /// Pin a port by holding a real LISTEN socket on it. Returned
     /// closure releases. Tests use this to make a candidate port
@@ -112,10 +123,14 @@ struct PortAllocatorTests {
 
     @Test("Default candidate window is 7659..7668 plus 8000..8009 legacy fallback")
     func defaultWindow() {
-        // Primary window is the RMLX phone-keypad range; 8000…8009 is
-        // probed after it so existing 127.0.0.1:8000 clients keep working.
-        #expect(PortAllocator.candidatePorts == Array(7659...7668) + Array(8000...8009))
-        #expect(PortAllocator.candidatePorts.count == 20)
+        // Primary window is the RMLX phone-keypad range; 8000…8009 remains a
+        // recovery window. Upgrade compatibility is tested separately below.
+        let ports = PortAllocator.resolveCandidatePorts(
+            environment: [:],
+            defaults: scratchDefaults()
+        )
+        #expect(ports == Array(7659...7668) + Array(8000...8009))
+        #expect(ports.count == 20)
     }
 
     // MARK: - #455 RAPID_DESKTOP_PORT override (test-harness isolation)
@@ -123,7 +138,8 @@ struct PortAllocatorTests {
     @Test("RAPID_DESKTOP_PORT pins the candidate window to a single port")
     func envOverridePinsSinglePort() {
         let ports = PortAllocator.resolveCandidatePorts(
-            environment: ["RAPID_DESKTOP_PORT": "8505"]
+            environment: ["RAPID_DESKTOP_PORT": "8505"],
+            defaults: scratchDefaults()
         )
         #expect(ports == [8505])
     }
@@ -132,7 +148,8 @@ struct PortAllocatorTests {
     func envOverrideTrimsWhitespace() {
         #expect(
             PortAllocator.resolveCandidatePorts(
-                environment: ["RAPID_DESKTOP_PORT": "  9123 "]
+                environment: ["RAPID_DESKTOP_PORT": "  9123 "],
+                defaults: scratchDefaults()
             ) == [9123]
         )
     }
@@ -149,10 +166,48 @@ struct PortAllocatorTests {
         ]
         for env in fallbacks {
             #expect(
-                PortAllocator.resolveCandidatePorts(environment: env) == Array(7659...7668) + Array(8000...8009),
+                PortAllocator.resolveCandidatePorts(
+                    environment: env,
+                    defaults: scratchDefaults()
+                ) == Array(7659...7668) + Array(8000...8009),
                 "invalid override \(env) must fall back to the default window"
             )
         }
+    }
+
+    @Test("Existing installs without an override keep the historical port once")
+    func existingInstallMigratesTo8000() {
+        let defaults = scratchDefaults()
+
+        #expect(PortAllocator.migrateLegacyDefaultIfNeeded(hadPreviousLaunch: true, defaults: defaults))
+        #expect(PortAllocator.storedPort(defaults: defaults) == 8_000)
+        #expect(defaults.bool(forKey: PortAllocator.legacyDefaultMigrationKey))
+        #expect(!PortAllocator.migrateLegacyDefaultIfNeeded(hadPreviousLaunch: true, defaults: defaults))
+    }
+
+    @Test("Fresh installs use 7659 and clearing an override does not remigrate")
+    func freshInstallAndClearedOverrideUseNewDefault() {
+        let defaults = scratchDefaults()
+
+        #expect(!PortAllocator.migrateLegacyDefaultIfNeeded(hadPreviousLaunch: false, defaults: defaults))
+        #expect(PortAllocator.storedPort(defaults: defaults) == nil)
+        defaults.set(9_123, forKey: PortAllocator.storedPortKey)
+        defaults.removeObject(forKey: PortAllocator.storedPortKey)
+
+        #expect(!PortAllocator.migrateLegacyDefaultIfNeeded(hadPreviousLaunch: true, defaults: defaults))
+        #expect(
+            PortAllocator.resolveCandidatePorts(environment: [:], defaults: defaults)
+                == Array(7659...7668) + Array(8000...8009)
+        )
+    }
+
+    @Test("An existing explicit port is never overwritten")
+    func explicitPortSurvivesMigration() {
+        let defaults = scratchDefaults()
+        defaults.set(9_001, forKey: PortAllocator.storedPortKey)
+
+        #expect(!PortAllocator.migrateLegacyDefaultIfNeeded(hadPreviousLaunch: true, defaults: defaults))
+        #expect(PortAllocator.storedPort(defaults: defaults) == 9_001)
     }
 
     @Test("Invalid port and host inputs return false instead of trapping")


### PR DESCRIPTION
## Summary

Preserve Desktop's historical `127.0.0.1:8000` endpoint for existing installations when upgrading across #2878, while keeping `7659` as the default for genuinely new installs.

## Release-blocking regression

#2878 changed the primary candidate window to `7659...7668` and placed `8000...8009` after it. That fallback does **not** preserve compatibility: an upgraded installation with no explicit port always selects free port 7659 first, so OpenAI-compatible clients still configured for port 8000 silently disconnect.

## Fix

- run a one-shot migration before `InstallTracker` records the current launch;
- if a previous launch exists and no explicit port exists, persist port 8000;
- leave fresh installs on 7659;
- never overwrite an explicit port;
- record a migration marker so clearing the field later means "use the new default" rather than migrating back;
- inject `UserDefaults` into the resolver so tests do not depend on or mutate the developer's real setting.

The compatibility value is written before the marker, making an interrupted migration safely retryable.

## Verification

- `swift test --filter PortAllocatorTests`
  - 15 tests / 2 suites passed
  - covers existing upgrade, fresh install, explicit override, clear-after-migration, env override, occupied ports, and invalid inputs
- `git diff --check`

## Risk / rollback

Scope is Desktop startup port selection only. Rollback is the single commit; no stored value is destructive, and users can still change or clear the port in the existing UI.
