### PR TITLE
fix(service): enforce loopback-only persistent binds

### DIFF
--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -56,6 +56,10 @@ def test_service_config_round_trip_and_digest(tmp_path):
         ({"schema_version": 999}, "unsupported"),
         ({"port": 0}, "port"),
         ({"executable": "rapid-mlx"}, "absolute"),
+        ({"host": "0.0.0.0"}, "loopback"),
+        ({"host": "::"}, "loopback"),
+        ({"host": "192.168.1.20"}, "loopback"),
+        ({"host": "inference.example.com"}, "loopback"),
         ({"serve_args": ("--api-key=leak",)}, "API key"),
         ({"log_retention_days": 0}, "at least 1"),
     ],
@@ -63,6 +67,13 @@ def test_service_config_round_trip_and_digest(tmp_path):
 def test_service_config_rejects_unsafe_values(updates, message):
     with pytest.raises(ServiceConfigError, match=message):
         _config(**updates)
+
+
+@pytest.mark.parametrize(
+    "host", ["127.0.0.1", "127.42.0.9", "::1", "localhost", "LOCALHOST"]
+)
+def test_service_config_accepts_only_explicit_loopback_hosts(host):
+    assert _config(host=host).host == host
 
 
 def test_service_config_rejects_unknown_fields():
@@ -872,12 +883,12 @@ def test_restart_reads_config_backed_bind(monkeypatch, tmp_path):
     from vllm_mlx.headless_service import restart
 
     path = tmp_path / "service.json"
-    atomic_write(path, config_bytes(_config(host="0.0.0.0", port=9000)))
+    atomic_write(path, config_bytes(_config(host="127.0.0.2", port=9000)))
     monkeypatch.setattr(
         "vllm_mlx.headless_service.definition.installed_identity",
         lambda _label: ("runner", tmp_path, path),
     )
-    assert restart._declared_bind("com.rapidmlx.server") == ("0.0.0.0", 9000)
+    assert restart._declared_bind("com.rapidmlx.server") == ("127.0.0.2", 9000)
 
 
 def test_configure_remaining_error_paths(monkeypatch, tmp_path):

--- a/vllm_mlx/headless_service/common.py
+++ b/vllm_mlx/headless_service/common.py
@@ -11,6 +11,7 @@ diagnostic surface from drifting.
 
 from __future__ import annotations
 
+import ipaddress
 import re
 from pathlib import Path
 
@@ -46,6 +47,23 @@ MIN_USER_UID = 501
 # LaunchDaemons dir requires root to write; also used to gate dry-run vs
 # real mutation (a non-root caller cannot actually install).
 LAUNCH_DAEMONS_DIR_REQUIRES_ROOT = True
+
+
+def is_loopback_host(host: str) -> bool:
+    """Whether a persistent service bind stays on the local machine.
+
+    The service runbook requires a separately managed authenticating reverse
+    proxy for LAN/internet access. Keep that boundary enforceable in persisted
+    configuration rather than relying on help text while accepting wildcard
+    or remote-interface binds.
+    """
+
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def home_for_user(user: str) -> Path | None:

--- a/vllm_mlx/headless_service/config.py
+++ b/vllm_mlx/headless_service/config.py
@@ -48,7 +48,7 @@ class ServiceConfig:
     log_backup_count: int = DEFAULT_LOG_BACKUP_COUNT
 
     def validated(self) -> ServiceConfig:
-        from .common import validate_label
+        from .common import is_loopback_host, validate_label
         from .install import refuse_secret_flags
 
         if self.schema_version != SCHEMA_VERSION:
@@ -67,6 +67,11 @@ class ServiceConfig:
         if not self.host or "\0" in self.host or any(ch.isspace() for ch in self.host):
             raise ServiceConfigError(
                 "host must be a non-empty address without whitespace"
+            )
+        if not is_loopback_host(self.host):
+            raise ServiceConfigError(
+                "host must be a loopback address; expose persistent services "
+                "through the documented TLS-terminating, authenticating reverse proxy"
             )
         if not 1 <= self.port <= 65535:
             raise ServiceConfigError("port must be in [1, 65535]")


### PR DESCRIPTION
## Summary

Make the Always-on Rapid Engine's documented loopback-only network boundary an enforced persisted-config invariant.

## Release-blocking security regression

The service guide and `--host` help both say the persistent LaunchDaemon binds only to loopback and that LAN/internet access must use a separately managed TLS-terminating, authenticating reverse proxy. However, `ServiceConfig.validated()` accepted wildcard, LAN, and arbitrary DNS binds.

Because a credential file is optional at runtime, this command could start a boot-persistent unauthenticated API on every interface:

```bash
sudo rapid-mlx service install --service-user serveuser --host 0.0.0.0
```

## Fix

- accept `localhost`, IPv4 loopback (`127.0.0.0/8`), and IPv6 loopback (`::1`);
- reject wildcard, LAN, and arbitrary hostname binds at the persisted configuration trust boundary;
- keep ordinary `rapid-mlx serve --host ...` behavior unchanged;
- retain the documented reverse-proxy/SSH-tunnel route for remote access.

The validation also applies when loading an existing or hand-edited config, so unsafe persisted definitions fail closed before spawning the server.

## Verification

- `python3.12 -m pytest tests/test_service_config.py tests/test_cli_service.py -q` — 195 passed
- `python3.12 -m ruff check ...` — passed
- `python3.12 -m ruff format --check ...` — passed
- `git diff --check` — passed

## Risk / rollback

Scope is only `rapid-mlx service` persisted LaunchDaemon configuration. Existing non-loopback service definitions will refuse to start and print an actionable config error; loopback installations are unchanged. Rollback is the single commit.
