### PR TITLE
fix(service): block credential-directory symlink escalation

### DIFF
--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -206,6 +206,7 @@ def _installed_config(monkeypatch, tmp_path):
     from vllm_mlx.headless_service import configure
 
     home = tmp_path / "home"
+    home.mkdir(parents=True)
     monkeypatch.setattr(
         config_module, "SERVICE_CONFIG_ROOT", tmp_path / "system-config"
     )
@@ -469,16 +470,25 @@ def test_definition_and_secret_directory_helpers(monkeypatch, tmp_path):
     monkeypatch.setattr(config_module, "SERVICE_CONFIG_ROOT", tmp_path / "definitions")
     monkeypatch.setattr(config_module.os, "geteuid", lambda: 0)
     chowns = []
+    fchowns = []
     monkeypatch.setattr(
         config_module.os,
         "chown",
         lambda path, uid, gid: chowns.append((path, uid, gid)),
     )
+    monkeypatch.setattr(
+        config_module.os,
+        "fchown",
+        lambda fd, uid, gid: fchowns.append((fd, uid, gid)),
+    )
     target = config_module.ensure_config_dir(tmp_path, uid=501, gid=20)
     assert target.is_dir() and stat.S_IMODE(target.stat().st_mode) == 0o755
-    secret_dir = config_module.ensure_credential_dir(tmp_path, uid=501, gid=20)
+    secret_dir = config_module.ensure_credential_dir(
+        tmp_path, uid=os.getuid(), gid=os.getgid()
+    )
     assert secret_dir.is_dir() and stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
-    assert chowns == [(target, 0, 0), (secret_dir, 501, 20)]
+    assert chowns == [(target, 0, 0)]
+    assert [(uid, gid) for _, uid, gid in fchowns] == [(os.getuid(), os.getgid())]
 
     calls = []
     monkeypatch.setattr(
@@ -486,6 +496,76 @@ def test_definition_and_secret_directory_helpers(monkeypatch, tmp_path):
     )
     config_module.atomic_write_definition(tmp_path / "x", b"data")
     assert calls[0][1]["uid"] == calls[0][1]["gid"] == 0
+
+
+def test_credential_directory_symlink_is_refused_without_touching_target(tmp_path):
+    from vllm_mlx.headless_service import config as config_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    victim = tmp_path / "victim"
+    victim.mkdir(mode=0o755)
+    (home / ".rapid-mlx-secrets").symlink_to(victim, target_is_directory=True)
+    before = stat.S_IMODE(victim.stat().st_mode)
+
+    with pytest.raises(OSError):
+        config_module.ensure_credential_dir(home, uid=os.getuid() + 1, gid=os.getgid())
+
+    assert stat.S_IMODE(victim.stat().st_mode) == before
+    assert victim.stat().st_uid == os.getuid()
+
+
+def test_credential_write_detects_directory_swap_and_never_writes_victim(
+    monkeypatch, tmp_path
+):
+    from vllm_mlx.headless_service import config as config_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    credential_dir = home / ".rapid-mlx-secrets"
+    moved = home / ".rapid-mlx-secrets.moved"
+    real_replace = config_module.os.replace
+
+    def swap_then_replace(src, dst, **kwargs):
+        credential_dir.rename(moved)
+        credential_dir.symlink_to(victim, target_is_directory=True)
+        return real_replace(src, dst, **kwargs)
+
+    monkeypatch.setattr(config_module.os, "replace", swap_then_replace)
+    with pytest.raises(ServiceConfigError, match="changed during update"):
+        config_module.atomic_write_credential(
+            home,
+            "com.rapidmlx.server",
+            b"secret\n",
+            uid=os.getuid(),
+            gid=os.getgid(),
+        )
+
+    assert not (victim / "com.rapidmlx.server.credential").exists()
+    assert not (moved / "com.rapidmlx.server.credential").exists()
+
+
+def test_credential_unset_refuses_symlinked_directory(tmp_path):
+    from vllm_mlx.headless_service import config as config_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    victim_file = victim / "com.rapidmlx.server.credential"
+    victim_file.write_text("do-not-delete")
+    (home / ".rapid-mlx-secrets").symlink_to(victim, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        config_module.remove_credential(
+            home,
+            "com.rapidmlx.server",
+            uid=os.getuid(),
+            gid=os.getgid(),
+        )
+    assert victim_file.read_text() == "do-not-delete"
 
 
 def test_private_file_guards_and_presence(monkeypatch, tmp_path):
@@ -668,7 +748,7 @@ def test_credential_rejects_tty_and_write_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(configure.sys, "stdin", stream)
     monkeypatch.setattr(
         configure,
-        "ensure_credential_dir",
+        "atomic_write_credential",
         lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk")),
     )
     assert (
@@ -957,7 +1037,9 @@ def test_credential_unset_oserror(monkeypatch, tmp_path):
     configure, _, _, _ = _installed_config(monkeypatch, tmp_path)
     monkeypatch.setattr(configure, "is_root", lambda: True)
     monkeypatch.setattr(
-        Path, "unlink", lambda *_a, **_k: (_ for _ in ()).throw(OSError("busy"))
+        configure,
+        "remove_credential",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("busy")),
     )
     assert (
         configure.credential_command(

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -610,6 +610,34 @@ def test_credential_write_detects_directory_swap_and_never_writes_victim(
     assert not (moved / "com.rapidmlx.server.credential").exists()
 
 
+def test_credential_write_cleans_up_when_directory_name_disappears(
+    monkeypatch, tmp_path
+):
+    from vllm_mlx.headless_service import config as config_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    credential_dir = home / ".rapid-mlx-secrets"
+    moved = home / ".rapid-mlx-secrets.moved"
+    real_replace = config_module.os.replace
+
+    def replace_then_rename(src, dst, **kwargs):
+        real_replace(src, dst, **kwargs)
+        credential_dir.rename(moved)
+
+    monkeypatch.setattr(config_module.os, "replace", replace_then_rename)
+    with pytest.raises(ServiceConfigError, match="changed during update"):
+        config_module.atomic_write_credential(
+            home,
+            "com.rapidmlx.server",
+            b"secret\n",
+            uid=os.getuid(),
+            gid=os.getgid(),
+        )
+
+    assert not (moved / "com.rapidmlx.server.credential").exists()
+
+
 def test_remove_credential_covers_present_and_missing_file(tmp_path):
     from vllm_mlx.headless_service import config as config_module
 

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -515,6 +515,69 @@ def test_credential_directory_symlink_is_refused_without_touching_target(tmp_pat
     assert victim.stat().st_uid == os.getuid()
 
 
+@pytest.mark.parametrize(
+    ("fake_mode", "fake_uid", "message"),
+    [
+        (stat.S_IFREG | 0o600, os.getuid(), "real directory"),
+        (stat.S_IFDIR | 0o700, os.getuid() + 1, "owned by uid"),
+    ],
+)
+def test_credential_directory_fd_validation_closes_rejected_fd(
+    monkeypatch, tmp_path, fake_mode, fake_uid, message
+):
+    from vllm_mlx.headless_service import config as config_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".rapid-mlx-secrets").mkdir()
+    real_fstat = config_module.os.fstat
+    inspected = []
+
+    def fake_fstat(fd):
+        inspected.append(fd)
+        return types.SimpleNamespace(st_mode=fake_mode, st_uid=fake_uid)
+
+    monkeypatch.setattr(config_module.os, "fstat", fake_fstat)
+    with pytest.raises(ServiceConfigError, match=message):
+        config_module.ensure_credential_dir(home, uid=os.getuid(), gid=os.getgid())
+
+    assert len(inspected) == 1
+    with pytest.raises(OSError):
+        real_fstat(inspected[0])
+
+
+def test_credential_write_closes_temp_fd_and_cleans_up_on_setup_failure(
+    monkeypatch, tmp_path
+):
+    from vllm_mlx.headless_service import config as config_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    real_fchmod = config_module.os.fchmod
+    calls = []
+
+    def fail_second_fchmod(fd, mode):
+        calls.append(fd)
+        if len(calls) == 2:
+            raise OSError("simulated temp-file setup failure")
+        real_fchmod(fd, mode)
+
+    monkeypatch.setattr(config_module.os, "fchmod", fail_second_fchmod)
+    with pytest.raises(OSError, match="setup failure"):
+        config_module.atomic_write_credential(
+            home,
+            "com.rapidmlx.server",
+            b"secret\n",
+            uid=os.getuid(),
+            gid=os.getgid(),
+        )
+
+    assert len(calls) == 2
+    with pytest.raises(OSError):
+        os.fstat(calls[1])
+    assert list((home / ".rapid-mlx-secrets").iterdir()) == []
+
+
 def test_credential_write_detects_directory_swap_and_never_writes_victim(
     monkeypatch, tmp_path
 ):
@@ -545,6 +608,28 @@ def test_credential_write_detects_directory_swap_and_never_writes_victim(
 
     assert not (victim / "com.rapidmlx.server.credential").exists()
     assert not (moved / "com.rapidmlx.server.credential").exists()
+
+
+def test_remove_credential_covers_present_and_missing_file(tmp_path):
+    from vllm_mlx.headless_service import config as config_module
+
+    home = tmp_path / "home"
+    home.mkdir()
+    path = config_module.atomic_write_credential(
+        home,
+        "com.rapidmlx.server",
+        b"secret\n",
+        uid=os.getuid(),
+        gid=os.getgid(),
+    )
+    assert path.is_file()
+    assert config_module.remove_credential(
+        home, "com.rapidmlx.server", uid=os.getuid(), gid=os.getgid()
+    )
+    assert not path.exists()
+    assert not config_module.remove_credential(
+        home, "com.rapidmlx.server", uid=os.getuid(), gid=os.getgid()
+    )
 
 
 def test_credential_unset_refuses_symlinked_directory(tmp_path):
@@ -1047,6 +1132,26 @@ def test_credential_unset_oserror(monkeypatch, tmp_path):
         )
         == 2
     )
+
+
+def test_credential_mutation_reports_disappeared_service_account(
+    monkeypatch, tmp_path, capsys
+):
+    configure, _, _, _ = _installed_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(configure, "is_root", lambda: True)
+    monkeypatch.setattr(
+        configure,
+        "_account",
+        lambda _user: (_ for _ in ()).throw(ServiceConfigError("account disappeared")),
+    )
+
+    assert (
+        configure.credential_command(
+            types.SimpleNamespace(label=None, credential_command="unset")
+        )
+        == 1
+    )
+    assert "account disappeared" in capsys.readouterr().err
 
 
 def test_install_service_config_helper(monkeypatch, tmp_path):

--- a/vllm_mlx/headless_service/config.py
+++ b/vllm_mlx/headless_service/config.py
@@ -345,14 +345,25 @@ def atomic_write_credential(
         # Detect a rename/symlink swap of the directory name while the fd was
         # pinned. The root operation remained contained either way, but a
         # detached secret must not be reported as successfully installed.
-        named = target.stat(follow_symlinks=False)
+        try:
+            named = target.stat(follow_symlinks=False)
+        except OSError as exc:
+            try:
+                os.unlink(filename, dir_fd=dir_fd)
+            finally:
+                installed = False
+            raise ServiceConfigError(
+                "credential directory changed during update"
+            ) from exc
         opened = os.fstat(dir_fd)
         if not stat.S_ISDIR(named.st_mode) or (named.st_dev, named.st_ino) != (
             opened.st_dev,
             opened.st_ino,
         ):
-            os.unlink(filename, dir_fd=dir_fd)
-            installed = False
+            try:
+                os.unlink(filename, dir_fd=dir_fd)
+            finally:
+                installed = False
             raise ServiceConfigError("credential directory changed during update")
         return target / filename
     finally:

--- a/vllm_mlx/headless_service/config.py
+++ b/vllm_mlx/headless_service/config.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import secrets
 import stat
 import tempfile
 from dataclasses import dataclass, replace
@@ -263,12 +264,127 @@ def ensure_config_dir(home: Path, *, uid: int, gid: int) -> Path:
 
 
 def ensure_credential_dir(home: Path, *, uid: int, gid: int) -> Path:
-    """Create the private secret directory traversable by the service only."""
-    target = credential_path(home).parent
-    target.mkdir(mode=0o700, parents=True, exist_ok=True)
-    os.chmod(target, 0o700)
-    os.chown(target, uid, gid)
+    """Create/open the private secret directory without following symlinks."""
+
+    target, dir_fd = _open_credential_dir(home, uid=uid, gid=gid, create=True)
+    os.close(dir_fd)
     return target
+
+
+def _open_credential_dir(
+    home: Path, *, uid: int, gid: int, create: bool
+) -> tuple[Path, int]:
+    """Return an fd for the real credential directory, never a symlink target."""
+
+    target = credential_path(home).parent
+    if create:
+        try:
+            os.mkdir(target, mode=0o700)
+        except FileExistsError:
+            pass
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    dir_fd = os.open(target, flags)
+    try:
+        info = os.fstat(dir_fd)
+        if not stat.S_ISDIR(info.st_mode):
+            raise ServiceConfigError("credential directory must be a real directory")
+        if info.st_uid not in {0, uid}:
+            raise ServiceConfigError(
+                f"credential directory is owned by uid {info.st_uid}, expected {uid}"
+            )
+        os.fchmod(dir_fd, 0o700)
+        os.fchown(dir_fd, uid, gid)
+        return target, dir_fd
+    except BaseException:
+        os.close(dir_fd)
+        raise
+
+
+def atomic_write_credential(
+    home: Path,
+    label: str,
+    data: bytes,
+    *,
+    uid: int,
+    gid: int,
+) -> Path:
+    """Replace a credential through a pinned directory fd.
+
+    The service account owns its home and can race a root-run credential
+    command. All file creation/replacement therefore stays relative to an
+    ``O_NOFOLLOW`` directory fd; path-based chmod/chown/write operations are
+    forbidden at this boundary.
+    """
+
+    from .common import validate_label
+
+    validate_label(label)
+    target, dir_fd = _open_credential_dir(home, uid=uid, gid=gid, create=True)
+    filename = f"{label}.credential"
+    tmp_name = f".{filename}.{secrets.token_hex(12)}"
+    file_fd = -1
+    installed = False
+    try:
+        file_fd = os.open(
+            tmp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=dir_fd,
+        )
+        os.fchmod(file_fd, 0o600)
+        os.fchown(file_fd, uid, gid)
+        with os.fdopen(file_fd, "wb") as handle:
+            file_fd = -1
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, filename, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        installed = True
+        os.fsync(dir_fd)
+
+        # Detect a rename/symlink swap of the directory name while the fd was
+        # pinned. The root operation remained contained either way, but a
+        # detached secret must not be reported as successfully installed.
+        named = target.stat(follow_symlinks=False)
+        opened = os.fstat(dir_fd)
+        if not stat.S_ISDIR(named.st_mode) or (named.st_dev, named.st_ino) != (
+            opened.st_dev,
+            opened.st_ino,
+        ):
+            os.unlink(filename, dir_fd=dir_fd)
+            installed = False
+            raise ServiceConfigError("credential directory changed during update")
+        return target / filename
+    finally:
+        if file_fd >= 0:
+            os.close(file_fd)
+        if not installed:
+            try:
+                os.unlink(tmp_name, dir_fd=dir_fd)
+            except OSError:
+                pass
+        os.close(dir_fd)
+
+
+def remove_credential(home: Path, label: str, *, uid: int, gid: int) -> bool:
+    """Remove a credential relative to a no-follow directory fd."""
+
+    from .common import validate_label
+
+    validate_label(label)
+    try:
+        _, dir_fd = _open_credential_dir(home, uid=uid, gid=gid, create=False)
+    except FileNotFoundError:
+        return False
+    try:
+        try:
+            os.unlink(f"{label}.credential", dir_fd=dir_fd)
+        except FileNotFoundError:
+            return False
+        os.fsync(dir_fd)
+        return True
+    finally:
+        os.close(dir_fd)
 
 
 def assert_private_file(path: Path, *, expected_uid: int | None = None) -> None:

--- a/vllm_mlx/headless_service/configure.py
+++ b/vllm_mlx/headless_service/configure.py
@@ -12,16 +12,16 @@ from pathlib import Path
 from .common import DEFAULT_DOMAIN, DEFAULT_LABEL
 from .config import (
     ServiceConfigError,
-    atomic_write,
+    atomic_write_credential,
     atomic_write_definition,
     backup_config_path,
     config_bytes,
     config_digest,
     credential_path,
-    ensure_credential_dir,
     load_config,
     pending_config_path,
     private_file_present,
+    remove_credential,
 )
 from .definition import installed_identity
 from .install import _plist_path, _port_busy, _wait_ready, is_root
@@ -242,10 +242,20 @@ def credential_command(args) -> int:
             file=sys.stderr,
         )
         return 1
+    try:
+        account = _account(user)
+    except ServiceConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     if action == "unset":
         try:
-            path.unlink(missing_ok=True)
-        except OSError as exc:
+            remove_credential(
+                home,
+                label,
+                uid=account.pw_uid,
+                gid=account.pw_gid,
+            )
+        except (OSError, ServiceConfigError) as exc:
             print(f"error: could not remove credential: {exc}", file=sys.stderr)
             return 2
         print("service API credential removed; restart the service to disable auth.")
@@ -266,10 +276,9 @@ def credential_command(args) -> int:
         print("error: credential must be exactly one non-empty line", file=sys.stderr)
         return 1
     try:
-        account = _account(user)
-        ensure_credential_dir(home, uid=account.pw_uid, gid=account.pw_gid)
-        atomic_write(
-            path,
+        atomic_write_credential(
+            home,
+            label,
             (secret + "\n").encode(),
             uid=account.pw_uid,
             gid=account.pw_gid,


### PR DESCRIPTION
## Summary

Close a local privilege-escalation path in the new root-run Always-on Rapid Engine credential commands.

## P0 security issue

The configured service account owns its home. It can pre-create:

```text
~/.rapid-mlx-secrets -> /etc
```

An administrator then running `sudo rapid-mlx service credential set` caused the old implementation to follow that symlink and execute path-based `chmod(0700)` plus `chown(service_uid, service_gid)` on the target directory before writing. The service account could therefore gain ownership of a root-managed directory. The old `credential unset` path also followed the parent symlink and could unlink a same-named file in an attacker-selected directory.

The existing leaf-file symlink check did not protect either root mutation because the vulnerable object was the parent directory.

## Fix

- open the credential directory with `O_DIRECTORY | O_NOFOLLOW`;
- validate its type and owner using `fstat`;
- use only fd-relative create, replace, unlink, chmod, chown, and fsync operations;
- create temporary credentials with `O_CREAT | O_EXCL | O_NOFOLLOW` and mode 0600;
- compare the still-named directory inode with the pinned fd after replacement, removing the detached credential and failing if an attacker raced a rename/symlink swap;
- route both `credential set` and `credential unset` through the hardened helpers.

## Verification

- `python3.12 -m pytest tests/test_service_config.py tests/test_cli_service.py -q` — 189 passed
- regression tests prove:
  - a pre-existing parent symlink is refused without changing the victim's mode/owner;
  - a mid-write directory swap is detected and writes no credential into the victim;
  - unset refuses a symlinked parent and does not delete the victim file;
- `python3.12 -m ruff check ...` — passed
- `python3.12 -m ruff format --check ...` — passed
- `git diff --check` — passed

## Risk / rollback

Scope is only root-run persistent-service credential set/unset. Normal real-directory behavior and mode/ownership contracts are preserved. Unsafe or raced directory layouts now fail closed with the existing actionable credential error. Rollback is the single commit, but would reopen the escalation path.
