### PR TITLE
fix(ci): recover transient macOS AX preflight failures

### DIFF
--- a/.github/workflows/rapid-mac-ci.yml
+++ b/.github/workflows/rapid-mac-ci.yml
@@ -400,21 +400,16 @@ jobs:
       # nothing, `dump` yields a tree containing only the application root,
       # and the flows would die on "main window did not appear" — blaming the
       # app for a permission problem. This step makes that failure say what it
-      # actually is, in 30 s, instead of after a five-minute build.
+      # actually is, in under a minute, instead of after a five-minute build.
       #
-      # It is deliberately fail-closed: no Dock means no GUI session, which
-      # means the app could not have opened a window either.
+      # It is deliberately fail-closed. The wrapper retries only a Dock that is
+      # still starting and AX's cannotComplete messaging error; missing grants,
+      # locked screens, malformed output, and every other error fail at once.
       - name: Accessibility + GUI session preflight
         run: |
           set -euo pipefail
           swiftc scripts/rapid-ax.swift -o "$RUNNER_TEMP/rapid-ax"
-          dock_pid="$(pgrep -x Dock | head -1 || true)"
-          if [[ -z "$dock_pid" ]]; then
-            echo "::error::No Dock process: this runner has no logged-in GUI (Aqua) session, so the app cannot open a window."
-            exit 1
-          fi
-          echo "Dock pid: $dock_pid"
-          "$RUNNER_TEMP/rapid-ax" trust "$dock_pid"
+          scripts/mac-ci-ax-preflight.sh "$RUNNER_TEMP/rapid-ax"
 
       - name: Download commit-bound GUI app
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5

--- a/apps/rapid-mac/scripts/mac-ci-ax-preflight.sh
+++ b/apps/rapid-mac/scripts/mac-ci-ax-preflight.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Fail-closed Accessibility/Aqua preflight for unattended macOS GUI CI.
+
+set -euo pipefail
+
+if [[ "$#" -ne 1 || ! -x "$1" ]]; then
+  echo "usage: mac-ci-ax-preflight.sh /path/to/rapid-ax" >&2
+  exit 2
+fi
+
+AX_DRIVER="$1"
+MAX_ATTEMPTS=5
+attempt=1
+delay_seconds=1
+scratch="$(mktemp "${RUNNER_TEMP:-/tmp}/rapid-ax-preflight.XXXXXX")"
+trap 'rm -f "$scratch" "$scratch.stderr"' EXIT
+
+retryable_cannot_complete() {
+  python3 - "$scratch" "$dock_pid" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, ValueError, TypeError):
+    raise SystemExit(1)
+
+raise SystemExit(
+    0
+    if payload.get("target_pid") == int(sys.argv[2])
+    and payload.get("trusted") is True
+    and payload.get("screen_locked") is False
+    and payload.get("target_read") is False
+    and payload.get("target_read_error") == -25204
+    and payload.get("success") is False
+    else 1
+)
+PY
+}
+
+successful_payload() {
+  python3 - "$scratch" "$dock_pid" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, ValueError, TypeError):
+    raise SystemExit(1)
+
+raise SystemExit(
+    0
+    if payload.get("target_pid") == int(sys.argv[2])
+    and payload.get("target_timeout_error") == 0
+    and payload.get("trusted") is True
+    and payload.get("screen_locked") is False
+    and payload.get("target_read") is True
+    and payload.get("success") is True
+    else 1
+)
+PY
+}
+
+while [[ "$attempt" -le "$MAX_ATTEMPTS" ]]; do
+  : >"$scratch"
+  : >"$scratch.stderr"
+  console_user="$(stat -f '%Su' /dev/console 2>/dev/null || true)"
+  console_uid=""
+  if [[ -n "$console_user" && "$console_user" != "root" && "$console_user" != "loginwindow" ]]; then
+    console_uid="$(id -u "$console_user" 2>/dev/null || true)"
+  fi
+  dock_pid=""
+  if [[ -n "$console_uid" ]]; then
+    dock_pid="$(pgrep -U "$console_uid" -x Dock | head -1 || true)"
+  fi
+
+  if [[ -z "$dock_pid" ]]; then
+    reason="no Dock for console user ${console_user:-unknown}"
+    retryable=1
+  else
+    echo "AX preflight attempt $attempt/$MAX_ATTEMPTS: console_user=$console_user Dock pid=$dock_pid"
+    set +e
+    "$AX_DRIVER" trust "$dock_pid" >"$scratch" 2>"$scratch.stderr"
+    status=$?
+    set -e
+    cat "$scratch"
+    if [[ "$status" -eq 0 ]] && successful_payload; then
+      if [[ "$attempt" -gt 1 ]]; then
+        echo "::notice::Accessibility preflight recovered on attempt $attempt/$MAX_ATTEMPTS."
+      fi
+      exit 0
+    fi
+    if [[ "$status" -eq 0 ]]; then
+      cat "$scratch.stderr" >&2
+      echo "::error::Accessibility preflight driver exited successfully without a valid success payload."
+      exit 1
+    fi
+    if retryable_cannot_complete; then
+      reason="Dock AX messaging returned transient cannotComplete (-25204)"
+      retryable=1
+    else
+      cat "$scratch.stderr" >&2
+      echo "::error::Accessibility preflight failed with a non-retryable permission or session result."
+      exit "$status"
+    fi
+  fi
+
+  if [[ "$retryable" -eq 1 && "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+    echo "::warning::AX preflight attempt $attempt/$MAX_ATTEMPTS: $reason; retrying in ${delay_seconds}s."
+    sleep "$delay_seconds"
+    if [[ "$delay_seconds" -lt 2 ]]; then
+      delay_seconds=$((delay_seconds * 2))
+    fi
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  if [[ -s "$scratch.stderr" ]]; then
+    cat "$scratch.stderr" >&2
+  fi
+  echo "::error::Accessibility preflight failed after $attempt/$MAX_ATTEMPTS attempts: $reason."
+  exit 1
+done

--- a/apps/rapid-mac/scripts/rapid-ax.swift
+++ b/apps/rapid-mac/scripts/rapid-ax.swift
@@ -61,18 +61,23 @@ if CommandLine.arguments.count >= 2, CommandLine.arguments[1] == "trust" {
         guard let target = pid_t(CommandLine.arguments[2]) else {
             fail("trust: target must be a pid")
         }
+        let targetElement = AXUIElementCreateApplication(target)
+        // Keep the CI preflight's retry budget genuinely bounded when AX's
+        // inter-process messaging service is unhealthy. This timeout applies
+        // only to this target element in this short-lived trust process.
+        let timeoutResult = AXUIElementSetMessagingTimeout(targetElement, 2.0)
         var value: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(
-            AXUIElementCreateApplication(target),
-            kAXChildrenAttribute as CFString,
-            &value
-        )
+        let result = timeoutResult == .success
+            ? AXUIElementCopyAttributeValue(
+                targetElement, kAXChildrenAttribute as CFString, &value)
+            : timeoutResult
         // `.noValue` / `.attributeUnsupported` mean the read itself WORKED and
         // the target simply publishes no children. Only an outright failure is
         // evidence that we were refused.
         readSucceeded =
             result == .success || result == .noValue || result == .attributeUnsupported
         payload["target_pid"] = Int(target)
+        payload["target_timeout_error"] = Int(timeoutResult.rawValue)
         payload["target_read"] = readSucceeded
         payload["target_read_error"] = Int(result.rawValue)
     }

--- a/scripts/select_gui_flows.py
+++ b/scripts/select_gui_flows.py
@@ -34,6 +34,7 @@ FULL_SUITE_PREFIXES = (
     "apps/rapid-mac/scripts/build",
     "apps/rapid-mac/scripts/fake-rapid-mlx.sh",
     "apps/rapid-mac/scripts/gui-golden-flows.sh",
+    "apps/rapid-mac/scripts/mac-ci-ax-preflight.sh",
     "apps/rapid-mac/scripts/rapid-ax.swift",
     "scripts/select_gui_flows.py",
     "tests/test_gui_flow_routing.py",

--- a/tests/test_gui_flow_routing.py
+++ b/tests/test_gui_flow_routing.py
@@ -98,6 +98,8 @@ def test_harness_manifest_and_workflow_changes_fail_closed():
     for path in (
         "apps/rapid-mac/Tests/GUIGoldenFlows/journeys.yaml",
         "apps/rapid-mac/scripts/gui-golden-flows.sh",
+        "apps/rapid-mac/scripts/mac-ci-ax-preflight.sh",
+        "apps/rapid-mac/scripts/rapid-ax.swift",
         ".github/workflows/rapid-mac-ci.yml",
         "scripts/select_gui_flows.py",
     ):

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -19,6 +19,7 @@ machine — it would only quietly restore the misdiagnosis on an unhealthy one.
 from __future__ import annotations
 
 import json
+import os
 import signal
 import subprocess
 import sys
@@ -26,11 +27,147 @@ import textwrap
 import time
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parent.parent
 DRIVER = ROOT / "apps/rapid-mac/scripts/rapid-ax.swift"
+PREFLIGHT = ROOT / "apps/rapid-mac/scripts/mac-ci-ax-preflight.sh"
 HARNESS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
 DOGFOOD = ROOT / "apps/rapid-mac/scripts/dogfood-isolate.sh"
 FAKE_SIDECAR = ROOT / "apps/rapid-mac/scripts/fake-rapid-mlx.sh"
+
+
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(textwrap.dedent(source))
+    path.chmod(0o755)
+
+
+def _run_ax_preflight(tmp_path: Path, mode: str, *, dock: str = "present"):
+    commands = tmp_path / "bin"
+    commands.mkdir()
+    _write_executable(commands / "stat", "#!/bin/bash\necho admin\n")
+    _write_executable(commands / "id", "#!/bin/bash\necho 501\n")
+    _write_executable(commands / "sleep", "#!/bin/bash\nexit 0\n")
+    _write_executable(
+        commands / "pgrep",
+        """
+        #!/bin/bash
+        count=0
+        [[ -f "$FAKE_DOCK_COUNTER" ]] && count="$(cat "$FAKE_DOCK_COUNTER")"
+        count=$((count + 1))
+        echo "$count" >"$FAKE_DOCK_COUNTER"
+        [[ "$FAKE_DOCK_MODE" == "present" ]] && echo 4242
+        """,
+    )
+    driver = tmp_path / "rapid-ax"
+    _write_executable(
+        driver,
+        """
+        #!/bin/bash
+        count=0
+        [[ -f "$FAKE_AX_COUNTER" ]] && count="$(cat "$FAKE_AX_COUNTER")"
+        count=$((count + 1))
+        echo "$count" >"$FAKE_AX_COUNTER"
+        case "$FAKE_AX_MODE" in
+          transient)
+            if [[ "$count" -lt 3 ]]; then
+              echo '{"success":false,"target_pid":4242,"trusted":true,"screen_locked":false,"target_read":false,"target_read_error":-25204}'
+              echo 'rapid-ax: transient cannotComplete' >&2
+              exit 1
+            fi
+            ;;
+          persistent)
+            echo '{"success":false,"target_pid":4242,"trusted":true,"screen_locked":false,"target_read":false,"target_read_error":-25204}'
+            echo 'rapid-ax: persistent cannotComplete' >&2
+            exit 1
+            ;;
+          untrusted)
+            echo '{"success":false,"target_pid":4242,"trusted":false,"screen_locked":false,"target_read":false,"target_read_error":-25211}'
+            echo 'rapid-ax: not trusted' >&2
+            exit 1
+            ;;
+          locked)
+            echo '{"success":false,"target_pid":4242,"trusted":true,"screen_locked":true,"target_read":true,"target_read_error":0}'
+            echo 'rapid-ax: screen locked' >&2
+            exit 1
+            ;;
+          malformed-success)
+            echo 'not-json'
+            exit 0
+            ;;
+          wrong-target)
+            echo '{"success":true,"target_pid":9999,"target_timeout_error":0,"trusted":true,"screen_locked":false,"target_read":true,"target_read_error":0}'
+            exit 0
+            ;;
+        esac
+        echo '{"success":true,"target_pid":4242,"target_timeout_error":0,"trusted":true,"screen_locked":false,"target_read":true,"target_read_error":0}'
+        """,
+    )
+    environment = {
+        **os.environ,
+        "PATH": f"{commands}:{os.environ['PATH']}",
+        "RUNNER_TEMP": str(tmp_path),
+        "FAKE_AX_MODE": mode,
+        "FAKE_AX_COUNTER": str(tmp_path / "ax-count"),
+        "FAKE_DOCK_MODE": dock,
+        "FAKE_DOCK_COUNTER": str(tmp_path / "dock-count"),
+    }
+    return subprocess.run(
+        [str(PREFLIGHT), str(driver)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_ax_preflight_recovers_only_transient_cannot_complete(tmp_path):
+    result = _run_ax_preflight(tmp_path, "transient")
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "ax-count").read_text().strip() == "3"
+    assert "recovered on attempt 3/5" in result.stdout
+    assert result.stdout.count("retrying") == 2
+
+
+def test_ax_preflight_bounds_persistent_cannot_complete(tmp_path):
+    result = _run_ax_preflight(tmp_path, "persistent")
+    assert result.returncode == 1
+    assert (tmp_path / "ax-count").read_text().strip() == "5"
+    assert "failed after 5/5 attempts" in result.stdout
+    assert "persistent cannotComplete" in result.stderr
+
+
+@pytest.mark.parametrize("mode", ["malformed-success", "wrong-target"])
+def test_ax_preflight_rejects_unattested_success_payload(tmp_path, mode):
+    result = _run_ax_preflight(tmp_path, mode)
+    assert result.returncode == 1
+    assert (tmp_path / "ax-count").read_text().strip() == "1"
+    assert "without a valid success payload" in result.stdout
+
+
+@pytest.mark.parametrize("mode", ["untrusted", "locked"])
+def test_ax_preflight_does_not_retry_nonretryable_session_faults(tmp_path, mode):
+    result = _run_ax_preflight(tmp_path, mode)
+    assert result.returncode == 1
+    assert (tmp_path / "ax-count").read_text().strip() == "1"
+    assert "non-retryable permission or session result" in result.stdout
+
+
+def test_ax_preflight_bounds_missing_console_dock(tmp_path):
+    result = _run_ax_preflight(tmp_path, "success", dock="missing")
+    assert result.returncode == 1
+    assert not (tmp_path / "ax-count").exists()
+    assert (tmp_path / "dock-count").read_text().strip() == "5"
+    assert "no Dock for console user admin" in result.stdout
+
+
+def test_gui_workflow_runs_the_bounded_preflight_wrapper():
+    workflow = (ROOT / ".github/workflows/rapid-mac-ci.yml").read_text()
+    step = workflow.split("- name: Accessibility + GUI session preflight", 1)[1]
+    step = step.split("- name: Download commit-bound GUI app", 1)[0]
+    assert 'swiftc scripts/rapid-ax.swift -o "$RUNNER_TEMP/rapid-ax"' in step
+    assert 'scripts/mac-ci-ax-preflight.sh "$RUNNER_TEMP/rapid-ax"' in step
+    assert '"$RUNNER_TEMP/rapid-ax" trust' not in step
 
 
 def test_trust_command_checks_permission_reach_and_lock():
@@ -45,6 +182,7 @@ def test_trust_command_checks_permission_reach_and_lock():
     # ...and the one signal neither of those can carry.
     assert "CGSessionCopyCurrentDictionary()" in trust
     assert "CGSSessionScreenIsLocked" in trust
+    assert "AXUIElementSetMessagingTimeout(targetElement, 2.0)" in trust
 
 
 def test_trust_success_requires_all_three_signals():


### PR DESCRIPTION
## Why

A logged-in, unlocked Mac runner can report `AXIsProcessTrusted=true` while the first real cross-process Dock read returns AX `cannotComplete` (`-25204`). The current one-shot preflight treats that transient messaging failure as a permanent permission defect, producing zero GUI results and failing an otherwise unrelated merge batch.

## Intention and scope

Make the Mac GUI preflight bounded, target-specific, and recoverable for the two startup conditions that can legitimately settle: the console user's Dock is not present yet, or the Dock AX read returns `cannotComplete`. Each attempt re-resolves the console user and Dock PID. Every AX call has a two-second target messaging timeout, and success JSON must attest the same PID, effective trust, unlocked screen, working target read, and timeout setup.

Non-goals: changing product UI, golden-flow assertions, model/server code, broad retry of product failures, fixing unrelated sidecar startup failures, release, or deployment.

## Acceptance criteria

- Transient `-25204` can recover within five attempts.
- Persistent `-25204` and missing Dock fail after exactly five attempts.
- Missing trust, locked screen, malformed output, wrong target PID, and every other error fail immediately.
- Preflight implementation changes select the full GUI journey set whenever the managed full gate runs; ordinary PRs retain the existing path-aware skip and the merge queue supplies the real-runner proof.
- Existing healthy hosts pass on the first attempt.

## Verification

- 103 focused preflight, routing, workflow, and GUI contract tests pass.
- ShellCheck and Ruff pass; the Swift AX driver compiles.
- A real logged-in Mac probe passed on attempt 1 with console-user Dock PID attestation, target read success, and messaging-timeout setup success.
- Three scope-locked adversarial self-review rounds covered fail-open success parsing, bounded AX calls, persistent faults, locked/untrusted sessions, malformed JSON, and wrong/stale target PID.
