### PR TITLE
fix(desktop): ignore signed Dock backdrop for CUA occlusion

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/MacOSComputerUseWindowIdentity.swift
@@ -1,30 +1,63 @@
 import ApplicationServices
 import CoreGraphics
+import Security
 
 /// Accessibility is the public macOS boundary that identifies the focused
 /// window inside an otherwise-frontmost process. It does not expose a public
 /// CGWindow number, so Computer Use binds its frame to exactly one CGWindow;
 /// ambiguous same-frame windows fail closed.
 enum MacOSComputerUseWindowIdentity {
+    struct WindowRecord: Equatable {
+        let identifier: String
+        let ownerPID: pid_t
+        let ownerName: String?
+        let name: String?
+        let layer: Int
+        let frame: CGRect
+        let alpha: Double
+    }
+
     /// Returns the first visible window in Core Graphics front-to-back order
     /// whose bounds contain the global point. Conservatively treating any
     /// visible overlay as an occluder prevents a global click from reaching a
     /// window other than the one the user selected.
     static func topmostWindowIdentifier(at point: CGPoint) -> String? {
-        guard let records = CGWindowListCopyWindowInfo(
+        guard let dictionaries = CGWindowListCopyWindowInfo(
             [.optionOnScreenOnly, .excludeDesktopElements],
             kCGNullWindowID
         ) as? [[CFString: Any]]
         else { return nil }
+        let records = dictionaries.compactMap(windowRecord)
+        let trustedDockPIDs = Set(records.compactMap { record -> pid_t? in
+            guard record.ownerName == "Dock",
+                  isTrustedDockProcess(record.ownerPID)
+            else { return nil }
+            return record.ownerPID
+        })
+        return topmostWindowIdentifier(
+            at: point,
+            records: records,
+            activeDisplayFrames: activeDisplayFrames(),
+            trustedDockPIDs: trustedDockPIDs
+        )
+    }
 
+    static func topmostWindowIdentifier(
+        at point: CGPoint,
+        records: [WindowRecord],
+        activeDisplayFrames: [CGRect],
+        trustedDockPIDs: Set<pid_t>
+    ) -> String? {
         for record in records {
-            guard let number = record[kCGWindowNumber] as? NSNumber,
-                  let bounds = record[kCGWindowBounds] as? [String: NSNumber],
-                  let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary),
-                  frame.contains(point),
-                  ((record[kCGWindowAlpha] as? NSNumber)?.doubleValue ?? 1) > 0
-            else { continue }
-            return String(number.uint32Value)
+            guard record.frame.contains(point), record.alpha > 0 else { continue }
+            if isNonInteractiveDockBackdrop(
+                record,
+                activeDisplayFrames: activeDisplayFrames,
+                trustedDockPIDs: trustedDockPIDs
+            ) {
+                continue
+            }
+            return record.identifier
         }
         return nil
     }
@@ -95,6 +128,70 @@ enum MacOSComputerUseWindowIdentity {
               lhs.windowIdentifier == rhs.windowIdentifier
         else { return false }
         return framesMatch(lhs.windowFrame.cgRect, rhs.windowFrame.cgRect)
+    }
+
+    private static func windowRecord(
+        _ dictionary: [CFString: Any]
+    ) -> WindowRecord? {
+        guard let number = dictionary[kCGWindowNumber] as? NSNumber,
+              let ownerPID = dictionary[kCGWindowOwnerPID] as? NSNumber,
+              let bounds = dictionary[kCGWindowBounds] as? [String: NSNumber],
+              let frame = CGRect(dictionaryRepresentation: bounds as CFDictionary),
+              let layer = dictionary[kCGWindowLayer] as? NSNumber
+        else { return nil }
+        return WindowRecord(
+            identifier: String(number.uint32Value),
+            ownerPID: ownerPID.int32Value,
+            ownerName: dictionary[kCGWindowOwnerName] as? String,
+            name: dictionary[kCGWindowName] as? String,
+            layer: layer.intValue,
+            frame: frame,
+            alpha: (dictionary[kCGWindowAlpha] as? NSNumber)?.doubleValue ?? 1
+        )
+    }
+
+    private static func activeDisplayFrames() -> [CGRect] {
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else {
+            return []
+        }
+        var identifiers = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetActiveDisplayList(count, &identifiers, &count) == .success else {
+            return []
+        }
+        return identifiers.prefix(Int(count)).map(CGDisplayBounds)
+    }
+
+    private static func isTrustedDockProcess(_ processIdentifier: pid_t) -> Bool {
+        let attributes = [kSecGuestAttributePid: NSNumber(value: processIdentifier)]
+            as CFDictionary
+        var code: SecCode?
+        guard SecCodeCopyGuestWithAttributes(nil, attributes, [], &code) == errSecSuccess,
+              let code
+        else { return false }
+
+        var requirement: SecRequirement?
+        guard SecRequirementCreateWithString(
+            "anchor apple and identifier \"com.apple.dock\"" as CFString,
+            [],
+            &requirement
+        ) == errSecSuccess,
+            let requirement
+        else { return false }
+        return SecCodeCheckValidity(code, [], requirement) == errSecSuccess
+    }
+
+    private static func isNonInteractiveDockBackdrop(
+        _ record: WindowRecord,
+        activeDisplayFrames: [CGRect],
+        trustedDockPIDs: Set<pid_t>
+    ) -> Bool {
+        guard trustedDockPIDs.contains(record.ownerPID),
+              record.ownerName == "Dock",
+              record.name == "Dock",
+              record.layer == 20
+        else { return false }
+        return activeDisplayFrames.contains { framesMatch($0, record.frame) }
     }
 }
 

--- a/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseWindowIdentityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MacOSComputerUseWindowIdentityTests.swift
@@ -1,0 +1,172 @@
+import CoreGraphics
+import Testing
+@testable import Rapid
+
+@Suite("Computer Use window identity")
+struct MacOSComputerUseWindowIdentityTests {
+    private let display = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+    private let point = CGPoint(x: 1493, y: 782)
+    private let dockPID: pid_t = 744
+
+    @Test("A trusted display-sized Dock management window is not an occluder")
+    func skipsDockBackdrop() {
+        #expect(topmost([
+            dock(frame: display),
+            app(),
+        ]) == "calculator")
+    }
+
+    @Test("A process merely named Dock remains an occluder")
+    func namedDockIsNotTrusted() {
+        #expect(topmost([
+            dock(frame: display),
+            app(),
+        ], trustedDockPIDs: []) == "dock")
+    }
+
+    @Test("Visible Dock UI smaller than a display remains an occluder")
+    func visibleDockRemainsOccluder() {
+        #expect(topmost([
+            dock(frame: CGRect(x: 1400, y: 740, width: 500, height: 100)),
+            app(),
+        ]) == "dock")
+    }
+
+    @Test("A display lookup failure preserves fail-closed occlusion")
+    func missingDisplayIdentityRemainsOccluder() {
+        #expect(MacOSComputerUseWindowIdentity.topmostWindowIdentifier(
+            at: point,
+            records: [dock(frame: display), app()],
+            activeDisplayFrames: [],
+            trustedDockPIDs: [dockPID]
+        ) == "dock")
+    }
+
+    @Test("A Dock backdrop may match any active display")
+    func matchesSecondaryDisplay() {
+        let secondaryDisplay = CGRect(x: 1920, y: 0, width: 1920, height: 1080)
+        let secondaryPoint = CGPoint(x: 2000, y: 500)
+        let secondaryApp = record(
+            identifier: "secondary-app",
+            ownerPID: 200,
+            ownerName: "Calculator",
+            name: "Calculator",
+            layer: 0,
+            frame: CGRect(x: 1950, y: 400, width: 300, height: 300)
+        )
+        #expect(MacOSComputerUseWindowIdentity.topmostWindowIdentifier(
+            at: secondaryPoint,
+            records: [dock(frame: secondaryDisplay), secondaryApp],
+            activeDisplayFrames: [display, secondaryDisplay],
+            trustedDockPIDs: [dockPID]
+        ) == "secondary-app")
+    }
+
+    @Test("Wrong-name and wrong-layer Dock windows remain occluders")
+    func onlyExactBackdropShapeIsSkipped() {
+        let wrongName = record(
+            identifier: "wrong-name",
+            ownerPID: dockPID,
+            ownerName: "Dock",
+            name: "Item-0",
+            layer: 20,
+            frame: display
+        )
+        let wrongLayer = record(
+            identifier: "wrong-layer",
+            ownerPID: dockPID,
+            ownerName: "Dock",
+            name: "Dock",
+            layer: 21,
+            frame: display
+        )
+        #expect(topmost([wrongName, app()]) == "wrong-name")
+        #expect(topmost([wrongLayer, app()]) == "wrong-layer")
+    }
+
+    @Test("An ordinary overlay still blocks the selected window")
+    func ordinaryOverlayRemainsOccluder() {
+        #expect(topmost([
+            dock(frame: display),
+            record(
+                identifier: "menu",
+                ownerPID: 100,
+                ownerName: "Other",
+                name: "Menu",
+                layer: 25,
+                frame: CGRect(x: 1480, y: 770, width: 60, height: 60)
+            ),
+            app(),
+        ]) == "menu")
+    }
+
+    @Test("Transparent records are ignored without weakening later occlusion")
+    func transparentRecordIsIgnored() {
+        #expect(topmost([
+            record(
+                identifier: "transparent",
+                ownerPID: 100,
+                ownerName: "Other",
+                name: nil,
+                layer: 30,
+                frame: display,
+                alpha: 0
+            ),
+            app(),
+        ]) == "calculator")
+    }
+
+    private func topmost(
+        _ records: [MacOSComputerUseWindowIdentity.WindowRecord],
+        trustedDockPIDs: Set<pid_t>? = nil
+    ) -> String? {
+        MacOSComputerUseWindowIdentity.topmostWindowIdentifier(
+            at: point,
+            records: records,
+            activeDisplayFrames: [display],
+            trustedDockPIDs: trustedDockPIDs ?? [dockPID]
+        )
+    }
+
+    private func dock(frame: CGRect) -> MacOSComputerUseWindowIdentity.WindowRecord {
+        record(
+            identifier: "dock",
+            ownerPID: dockPID,
+            ownerName: "Dock",
+            name: "Dock",
+            layer: 20,
+            frame: frame
+        )
+    }
+
+    private func app() -> MacOSComputerUseWindowIdentity.WindowRecord {
+        record(
+            identifier: "calculator",
+            ownerPID: 200,
+            ownerName: "Calculator",
+            name: "Calculator",
+            layer: 0,
+            frame: CGRect(x: 1462, y: 580, width: 230, height: 408)
+        )
+    }
+
+    private func record(
+        identifier: String,
+        ownerPID: pid_t,
+        ownerName: String?,
+        name: String?,
+        layer: Int,
+        frame: CGRect,
+        alpha: Double = 1
+    ) -> MacOSComputerUseWindowIdentity.WindowRecord {
+        MacOSComputerUseWindowIdentity.WindowRecord(
+            identifier: identifier,
+            ownerPID: ownerPID,
+            ownerName: ownerName,
+            name: name,
+            layer: layer,
+            frame: frame,
+            alpha: alpha
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Keep Computer Use occlusion checks fail-closed while ignoring one non-interactive macOS window-management record that otherwise covers the entire display.
- Authenticate the exception with the process's Apple code signature and `com.apple.dock` signing identifier, then require the exact observed owner/name, layer, and active-display-sized frame.
- Preserve blocking behavior for the visible Dock, menus, overlays, spoofed process names, malformed display discovery, and every other window record.

## Intention and scope

The user-visible goal is to let an explicitly approved, model-grounded click reach the selected frontmost window when macOS reports its non-interactive full-display management backdrop above that window. This PR is limited to the macOS window-identity/occlusion boundary and focused regression coverage.

Non-goals: no autonomous loop, keyboard or text fallback, new model/catalog/download support, workflow sequencing changes, approval changes, broader window allowlists, or consequential actions.

Acceptance criteria:

- Only an Apple-signed Dock process with the exact full-display management-window shape is skipped.
- Any lookup ambiguity or mismatch continues to fail closed.
- Ordinary Dock UI and unrelated overlays continue to win the front-to-back occlusion check.
- The harmless Calculator fixture can complete through the production actuator and an independent accessibility verifier after one explicit approval.

## Quantitative evidence

Hardware/session: Mac Studio (Apple M3 Ultra, 28 CPU cores, 256 GB unified memory), local GUI session, loopback-only EvoCUA 8B 4-bit model.

- Before: **0/1** valid model-grounded Calculator clicks reached actuation. The model returned `click(0.1331, 0.4945)`, resolving to `(1492.6, 781.8)` inside the 48×48 digit-7 button, but the actuator stopped with `targetOccluded` because a Dock-owned layer-20 record covered `(0, 0, 1920, 1080)`.
- After: **12/12** runs that returned a valid grounding completed the real production click and independent verification that Calculator displayed exactly `7`; **0** post-grounding actuation or verification failures.
- Across all **16** live attempts, 4 stopped before approval/action with the model endpoint's bounded `invalidResponse` path (a separate model-output reliability signal); those attempts performed **0** clicks.
- Successful grounding latency: **1.684 s min / 2.584 s median / 3.535 s max**.
- Successful end-to-end latency: **2.234 s min / 3.153 s median / 4.071 s max**.

These numbers demonstrate capability/reliability coverage at the native actuation boundary, not a raw inference-speed improvement.

## Verification

- `swift test --no-parallel --filter MacOSComputerUseWindowIdentityTests` — 8/8 passed
- `swift test --no-parallel --filter MacOSComputerUseActuationTests` — 17/17 passed
- `swift test --no-parallel` — 3,539/3,539 passed across 305 suites
- Operator-gated real Calculator fixture — 16 independent processes; 12 valid groundings, 12 verified actions, 4 fail-closed invalid responses, 0 unintended actions

## Risk and rollback

Risk is concentrated in classifying the system backdrop. The exception requires a trusted system signature plus exact metadata and display geometry; missing display enumeration preserves the original occluding behavior. Reverting this commit restores the prior conservative behavior.

## Test plan

- [x] Focused window-identity tests
- [x] Existing macOS actuation safety tests
- [x] Full Desktop Swift suite
- [x] Real loopback-only model + Calculator dogfood with explicit one-use approval
- [x] CI / PR validation
