### PR TITLE
docs(release): extend P0/P1 audit through CUA delta

### DIFF
--- a/.agents/handoffs/vector-release-p0p1-audit.md
+++ b/.agents/handoffs/vector-release-p0p1-audit.md
@@ -1,21 +1,16 @@
 # Vector -> Atlas: v0.13.4-to-main release audit
 
 - Owner/host: Vector, Studio
-- Audit branch: `audit/release-p0p1-20260906`
-- Audit range: `v0.13.4..28244f4f6` (68 first-parent merged PRs)
+- Audit branch: `vector/release-delta-audit-20260906`
+- Audit range: `v0.13.4..caafd08df` (80 first-parent merged PRs)
 - Durable report: `docs/engineering/operations/2026-09-06-v0.13.4-to-main-release-audit.md`
 
 ## Verified facts
 
-- P0 credential-directory symlink escalation is fixed in #3179; 195 focused
-  tests, 100% statement coverage for both changed production modules, and local
-  lint/diff checks pass. Hosted exact-head checks remain the merge gate.
-- P1 unauthenticated non-loopback persistent bind is fixed in #3178; 195
-  focused tests and local lint/diff checks pass. Hosted exact-head checks remain
-  the merge gate.
-- P1 Desktop upgrade port compatibility is fixed in #3177; local focused tests
-  and all hosted exact-head checks pass, and the PR is queued.
-- Image qualification #3173 and Qwen3.5 4B MTP default-off #3144 are queued.
+- P0 credential-directory symlink escalation is fixed on main by #3179.
+- P1 unauthenticated non-loopback persistent bind is fixed on main by #3178.
+- P1 Desktop upgrade port compatibility is fixed on main by #3177.
+- Image qualification #3173 and Qwen3.5 4B MTP default-off #3144 are on main.
 - #3169, #3150, #3158, and #3110 landed together after their full combined
   Python, Apple Silicon, Desktop, GUI, L1-smoke, coverage, and contract gates
   passed. Their production diffs were included in the final audit; no new
@@ -25,11 +20,20 @@
 - The M3 G0 gate passed four families and hit two honest capacity-skips. The
   Qwen3.5 35B cache is on a nearly-full, pathologically slow external ExFAT
   volume; this is a host-storage blocker, not evidence of a model regression.
+- The 12-merge delta after the original cutoff was rereviewed through #3193.
+  The executable draft flow, dormant local visual grounder, and signed Dock
+  backdrop exception preserve their opt-in, observation, approval, bounded
+  actuation, and fail-closed boundaries. #3193 is test-only and keeps its live
+  Calculator action behind three explicit operator values. No new P0/P1
+  finding survived.
+- Combined-main validation passes 204 service tests, Python 3.12 compileall,
+  release-range diff checks, and 3,542 Swift tests across 306 suites at the
+  exact #3193 head.
 
 ## Risks and next action
 
-Atlas should hold release integration until #3178/#3179 merge and arrange a
-healthy cache volume for a complete `make release-check-m3` rerun. Harbor should
-rerun the exact source/artifact image dogfood receipt on the final signed and
-notarized candidate. Do not delete shared model caches without explicit human
-authorization and a recovery plan.
+Atlas should arrange a healthy cache volume for a complete
+`make release-check-m3` rerun. Harbor should rerun the exact source/artifact
+image dogfood receipt on the final signed and notarized candidate. Do not
+delete shared model caches without explicit human authorization and a recovery
+plan.

--- a/docs/engineering/operations/2026-09-06-v0.13.4-to-main-release-audit.md
+++ b/docs/engineering/operations/2026-09-06-v0.13.4-to-main-release-audit.md
@@ -3,16 +3,16 @@
 ## Scope
 
 Vector reviewed the complete first-parent release range from tag `v0.13.4`
-through `28244f4f6` (`perf(mla): add opt-in absorbed verify path (#3110)`).
-The range contains 68 merged pull requests, 326 changed files, and 57,585
-additions / 1,478 deletions.
+through `caafd08df` (`test(desktop): dogfood visual grounding through workflow
+(#3193)`). The range contains 80 merged pull requests, 353 changed files, and
+65,684 additions / 1,512 deletions.
 
 The inventory is reproducible with:
 
 ```bash
 git fetch --tags --prune origin
-git log --first-parent --pretty='%h %s' v0.13.4..28244f4f6
-git diff --stat v0.13.4..28244f4f6
+git log --first-parent --pretty='%h %s' v0.13.4..caafd08df
+git diff --stat v0.13.4..caafd08df
 ```
 
 Review emphasis followed release risk rather than diff size:
@@ -45,6 +45,28 @@ all six GUI shards, five L1 model smokes, engine and accessibility contracts,
 changed-lines coverage, and PR validation before merge. No additional P0/P1
 finding survived that review.
 
+The release-delta pass then reviewed the 12 merges from `28244f4f6` through
+`caafd08df`, with line-by-line emphasis on the newly executable Computer Use
+path and its network, observation, approval, actuation, cancellation, and
+occlusion boundaries. #3170 remains explicit experimental opt-in, selects one
+TextEdit and one Safari window, can only set and verify a draft, and has no
+publish/send capability. #3190 is compiled but not wired into a product flow;
+it accepts one bounded click from a literal-loopback, redirect-free endpoint
+and cannot bypass the executor's fresh-observation, approval, actuator, or
+verifier gates. #3192 authenticates the sole Dock-backdrop exception with an
+Apple code-signing requirement and exact owner, window name, layer, and active
+display geometry; every mismatch remains an occluder. No new P0/P1 finding
+survived this delta review. #3193 adds test code only: its default hermetic
+path proves the grounder remains subordinate to approval, actuation,
+verification, and the audit ledger; its real Calculator click requires three
+explicit operator environment values and is skipped by default.
+
+Post-merge validation through this delta passed 204 service configuration/CLI
+tests, Python 3.12 compileall, release-range `git diff --check`, and the full
+Desktop Swift suite. The exact #3193 head reports 3,542 tests across 306 suites;
+the preceding `c9ce865cc` combined-main rerun passed all 3,539 tests across 305
+suites in 88.969 seconds.
+
 ## Release-blocking findings and fixes
 
 Three P0/P1 findings survived adversarial review. Each fix is isolated in its
@@ -52,9 +74,9 @@ own PR and is fail-closed.
 
 | Severity | Finding | Fix | Verification |
 | --- | --- | --- | --- |
-| P0 | A service account could pre-create `~/.rapid-mlx-secrets` as a symlink. Root-run `service credential set` followed it and could chmod/chown the target; `unset` could unlink a target file. | [#3179](https://github.com/raullenchai/Rapid-MLX/pull/3179) pins an `O_DIRECTORY|O_NOFOLLOW` directory fd and uses fd-relative create, replace, unlink, chmod, chown, fsync, and inode race checks. | 195 focused service tests; regressions cover pre-existing parent symlinks, mid-write directory swaps (including rename-only disappearance), cleanup of detached credentials, safe unset, rejected-fd closure, and setup-failure cleanup. Both changed production modules reach 100% statement coverage in the focused suite; Ruff and diff checks pass. Exact-head hosted matrices are required before queueing. |
-| P1 | Persistent `rapid-mlx service` configuration accepted wildcard, LAN, and DNS binds while authentication is optional, contradicting its loopback-only deployment contract. | [#3178](https://github.com/raullenchai/Rapid-MLX/pull/3178) accepts only `localhost`, IPv4 loopback (`127/8`), and IPv6 loopback (`::1`) for the persistent service. Ordinary foreground `rapid-mlx serve` remains unchanged. | 195 service tests plus Ruff and diff checks pass. Exact-head hosted matrices are required before queueing. |
-| P1 | The Desktop default moved from port 8000 to 7659 without a one-shot upgrade migration. Existing installations with no explicit stored port silently moved and disconnected clients configured for 8000. | [#3177](https://github.com/raullenchai/Rapid-MLX/pull/3177) preserves 8000 exactly once for existing installs, leaves fresh installs on 7659, and never overwrites an explicit port. | 15 focused Swift tests in two suites, full hosted Desktop build/tests, PR validation, and exact-head CI pass. The PR is queued. |
+| P0 | A service account could pre-create `~/.rapid-mlx-secrets` as a symlink. Root-run `service credential set` followed it and could chmod/chown the target; `unset` could unlink a target file. | [#3179](https://github.com/raullenchai/Rapid-MLX/pull/3179) pins an `O_DIRECTORY|O_NOFOLLOW` directory fd and uses fd-relative create, replace, unlink, chmod, chown, fsync, and inode race checks. | Merged in `637bdc719`; 195 focused tests and exact-head hosted matrices passed before merge. The combined main service suite now passes 204/204. |
+| P1 | Persistent `rapid-mlx service` configuration accepted wildcard, LAN, and DNS binds while authentication is optional, contradicting its loopback-only deployment contract. | [#3178](https://github.com/raullenchai/Rapid-MLX/pull/3178) accepts only `localhost`, IPv4 loopback (`127/8`), and IPv6 loopback (`::1`) for the persistent service. Ordinary foreground `rapid-mlx serve` remains unchanged. | Merged in `cbfc4c2cb`; 195 focused tests and exact-head hosted matrices passed before merge. The combined main service suite now passes 204/204. |
+| P1 | The Desktop default moved from port 8000 to 7659 without a one-shot upgrade migration. Existing installations with no explicit stored port silently moved and disconnected clients configured for 8000. | [#3177](https://github.com/raullenchai/Rapid-MLX/pull/3177) preserves 8000 exactly once for existing installs, leaves fresh installs on 7659, and never overwrites an explicit port. | Merged in `d817e6538`; 15 focused Swift tests, full hosted Desktop build/tests, PR validation, and exact-head CI passed. |
 
 A suspected service-definition parent-symlink issue was rejected after tracing
 the real path: definitions ignore the service user's home and live under the
@@ -75,7 +97,7 @@ that document.
 The image precision qualification harness in
 [#3173](https://github.com/raullenchai/Rapid-MLX/pull/3173) passed 22,858 tests
 (122 skipped, 22 deselected, 6 xfailed, 1 xpassed) locally and all exact-head
-hosted checks; it is queued. Qwen3.5 4B MTP default-off dogfood in #3144 and
+hosted checks; it is on main. Qwen3.5 4B MTP default-off dogfood in #3144 and
 the other opt-in performance work preserve stock behavior unless explicitly
 selected.
 
@@ -110,8 +132,9 @@ the remaining gates did not run after G0 failed.
 
 ## Release decision
 
-Do not cut the release until #3178 and #3179 are exact-head green and queued or
-merged, and the final release candidate has rerun the artifact-level image
-receipt. #3177 is already exact-head green and queued. The external 35B cache
-must be repaired or moved before rerunning `release-check-m3`; deleting shared
+The three P0/P1 fixes found by this audit (#3177, #3178, and #3179) are now on
+main, and the 12-PR delta through `caafd08df` introduced no new surviving
+P0/P1 finding. Do not cut the release until the final release candidate has
+rerun the artifact-level image receipt. The external 35B cache must be repaired
+or moved before rerunning the complete `release-check-m3`; deleting shared
 model caches is outside this audit's authority.


### PR DESCRIPTION
## Summary

Extend the v0.13.4-to-main release audit from the original 68-PR cutoff (`28244f4f6`) through current main `caafd08df`:

- 80 merged PRs, 353 changed files, +65,684/-1,512;
- re-review the 12-merge delta, especially #3170, #3190, #3192, and the test-only #3193 at the Computer Use observation/network/approval/actuation/occlusion boundaries;
- record that the previously found P0/P1 fixes #3177, #3178, and #3179 are now merged;
- preserve the two remaining release gates: final signed/notarized artifact image dogfood and a complete M3 gate after the unhealthy external cache volume is repaired or moved.

No new P0/P1 finding survived the delta review.

## Combined-main verification

On Mac Studio:

- `python3.12 -m pytest tests/test_service_config.py tests/test_cli_service.py -q` — 204 passed
- `python3.12 -m compileall -q vllm_mlx scripts` — passed
- `swift test --no-parallel` at `c9ce865cc` — 3,539 tests across 305 suites passed in 88.969s
- exact #3193 head full Swift suite — 3,542 tests across 306 suites passed
- `git diff --check v0.13.4..main` — passed

The local default Python environment had stale mflux 0.18.1, below the repository's pinned `mflux>=0.19.0,<0.20`; this produced seven Bonsai-only false failures after 23,000 other tests passed. An isolated mflux 0.19.0 overlay passed `tests/test_bonsai_image_alias.py` 27/27 without changing the shared environment. Hosted exact-head matrices remain authoritative.

## Risk

Documentation and role handoff only. No product, release, deployment, or workflow behavior changes.
