### PR TITLE
feat(desktop): recover draft composer in Safari and Chrome

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -204,6 +204,17 @@ protocol DraftPostComposerActuating: Sendable {
     func setDraft(_ draft: String, on composer: AXUIElement) throws
 }
 
+/// Optional, local-only recovery for a browser composer that Accessibility
+/// cannot identify by an explicit semantic label. The recovery capability may
+/// only focus one empty editable element in the selected window; draft writes
+/// remain owned by ``DraftPostComposerActuating`` and publishing is absent.
+protocol DraftPostVisualRecovering: Sendable {
+    func focusComposer(
+        in destination: ComputerUseWindowOption,
+        documentIdentity: String
+    ) async throws
+}
+
 struct AXDraftPostComposerActuator: DraftPostComposerActuating {
     func focusComposer(_ composer: AXUIElement) throws {
         guard AXUIElementSetAttributeValue(
@@ -235,11 +246,17 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     private static let textEditBundle = "com.apple.TextEdit"
     static let browserBundles: Set<String> = [
         "com.apple.Safari",
+        "com.google.Chrome",
     ]
     private let actuator: any DraftPostComposerActuating
+    private let visualRecovery: (any DraftPostVisualRecovering)?
 
-    init(actuator: any DraftPostComposerActuating = AXDraftPostComposerActuator()) {
+    init(
+        actuator: any DraftPostComposerActuating = AXDraftPostComposerActuator(),
+        visualRecovery: (any DraftPostVisualRecovering)? = nil
+    ) {
         self.actuator = actuator
+        self.visualRecovery = visualRecovery
     }
 
     func transferDraft(
@@ -256,6 +273,14 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             throw DraftPostFlowFailure.permissionMissing
         }
 
+        let ownsBrowserAccessibilityRequest = try await prepareBrowserAccessibility(
+            for: destination
+        )
+        defer {
+            if ownsBrowserAccessibilityRequest {
+                Self.releaseBrowserAccessibility(for: destination)
+            }
+        }
         let documentIdentity = try await browserDocumentIdentity(in: destination)
         let draft = try await readDraft(from: source)
         guard !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -264,12 +289,34 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         guard draft.utf8.count <= Self.maximumDraftBytes else {
             throw DraftPostFlowFailure.draftTooLarge
         }
-        try await writeAndVerify(
-            draft,
-            from: source,
-            to: destination,
-            documentIdentity: documentIdentity
-        )
+        var usedVisualRecovery = false
+        do {
+            try await writeAndVerify(
+                draft,
+                from: source,
+                to: destination,
+                documentIdentity: documentIdentity,
+                allowFocusedUnlabelledComposer: false,
+                focusDestination: true
+            )
+        } catch DraftPostFlowFailure.composerMissing {
+            guard let visualRecovery else {
+                throw DraftPostFlowFailure.composerMissing
+            }
+            usedVisualRecovery = true
+            try await visualRecovery.focusComposer(
+                in: destination,
+                documentIdentity: documentIdentity
+            )
+            try await writeAndVerify(
+                draft,
+                from: source,
+                to: destination,
+                documentIdentity: documentIdentity,
+                allowFocusedUnlabelledComposer: true,
+                focusDestination: false
+            )
+        }
         // The destination may now be mutated. Every remaining observation is
         // therefore terminal on failure: recovery must never replay the write.
         do {
@@ -277,7 +324,8 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 draft: draft,
                 source: source,
                 destination: destination,
-                documentIdentity: documentIdentity
+                documentIdentity: documentIdentity,
+                allowFocusedUnlabelledComposer: usedVisualRecovery
             )
         } catch {
             throw DraftPostFlowFailure.verificationFailed
@@ -300,20 +348,83 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         }
     }
 
+    /// Chromium keeps web content out of its macOS Accessibility tree until an
+    /// assistive client requests enhanced UI. Make one balanced request for
+    /// this flow only, and avoid touching Safari or a Chrome session that is
+    /// already exposing an AXWebArea.
+    private func prepareBrowserAccessibility(
+        for destination: ComputerUseWindowOption
+    ) async throws -> Bool {
+        guard destination.selection.bundleIdentifier == "com.google.Chrome" else {
+            return false
+        }
+        let alreadyAvailable = try await Self.runAXWork {
+            let application = Self.applicationElement(
+                destination.selection.processIdentifier
+            )
+            guard let window = Self.window(matching: destination, in: application) else {
+                throw DraftPostFlowFailure.targetUnavailable
+            }
+            return try Self.allElements(in: window).contains {
+                Self.stringAttribute(kAXRoleAttribute as CFString, from: $0)
+                    == "AXWebArea"
+            }
+        }
+        guard !alreadyAvailable else { return false }
+        let application = Self.applicationElement(
+            destination.selection.processIdentifier
+        )
+        guard AXUIElementSetAttributeValue(
+            application,
+            "AXEnhancedUserInterface" as CFString,
+            kCFBooleanTrue
+        ) == .success else {
+            throw DraftPostFlowFailure.dependencyFailure
+        }
+        try await Task.sleep(for: .seconds(3))
+        try Task.checkCancellation()
+        return true
+    }
+
+    private static func releaseBrowserAccessibility(
+        for destination: ComputerUseWindowOption
+    ) {
+        guard destination.selection.bundleIdentifier == "com.google.Chrome",
+              let running = NSRunningApplication(
+                processIdentifier: destination.selection.processIdentifier
+              ),
+              running.bundleIdentifier == destination.selection.bundleIdentifier,
+              running.launchDate == destination.selection.processLaunchDate
+        else { return }
+        _ = AXUIElementSetAttributeValue(
+            applicationElement(destination.selection.processIdentifier),
+            "AXEnhancedUserInterface" as CFString,
+            kCFBooleanFalse
+        )
+    }
+
     private func writeAndVerify(
         _ draft: String,
         from source: ComputerUseWindowOption,
         to destination: ComputerUseWindowOption,
-        documentIdentity: String
+        documentIdentity: String,
+        allowFocusedUnlabelledComposer: Bool,
+        focusDestination: Bool
     ) async throws {
-        try await focus(destination)
+        if focusDestination {
+            try await focus(destination)
+        }
         try Task.checkCancellation()
         try await Self.runAXWork {
             let window = try Self.exactFocusedBrowserWindow(
                 destination,
                 documentIdentity: documentIdentity
             )
-            let composer = try Self.uniqueComposer(in: window)
+            let composer = try Self.uniqueComposer(
+                in: window,
+                allowFocusedUnlabelledComposer: allowFocusedUnlabelledComposer,
+                browserBundleIdentifier: destination.selection.bundleIdentifier
+            )
             guard let existing = Self.stringAttribute(
                 kAXValueAttribute as CFString,
                 from: composer
@@ -328,7 +439,11 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                     destination,
                     documentIdentity: documentIdentity
                 )
-                let currentComposer = try Self.uniqueComposer(in: currentWindow)
+                let currentComposer = try Self.uniqueComposer(
+                    in: currentWindow,
+                    allowFocusedUnlabelledComposer: allowFocusedUnlabelledComposer,
+                    browserBundleIdentifier: destination.selection.bundleIdentifier
+                )
                 guard CFEqual(composer, currentComposer),
                       Self.stringAttribute(
                         kAXValueAttribute as CFString,
@@ -355,7 +470,11 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 destination,
                 documentIdentity: documentIdentity
             )
-            let currentComposer = try Self.uniqueComposer(in: currentWindow)
+            let currentComposer = try Self.uniqueComposer(
+                in: currentWindow,
+                allowFocusedUnlabelledComposer: allowFocusedUnlabelledComposer,
+                browserBundleIdentifier: destination.selection.bundleIdentifier
+            )
             guard CFEqual(composer, currentComposer) else {
                 throw DraftPostFlowFailure.verificationFailed
             }
@@ -376,7 +495,11 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 destination,
                 documentIdentity: documentIdentity
             )
-            let authorizedComposer = try Self.uniqueComposer(in: authorizedWindow)
+            let authorizedComposer = try Self.uniqueComposer(
+                in: authorizedWindow,
+                allowFocusedUnlabelledComposer: allowFocusedUnlabelledComposer,
+                browserBundleIdentifier: destination.selection.bundleIdentifier
+            )
             guard CFEqual(currentComposer, authorizedComposer),
                   let authorizedValue = Self.stringAttribute(
                     kAXValueAttribute as CFString,
@@ -397,7 +520,12 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                     destination,
                     documentIdentity: documentIdentity
                 )
-                let verifiedComposer = try Self.uniqueComposer(in: verifiedWindow)
+                let verifiedComposer = try Self.uniqueComposer(
+                    in: verifiedWindow,
+                    allowFocusedUnlabelledComposer: allowFocusedUnlabelledComposer,
+                    browserBundleIdentifier: destination.selection.bundleIdentifier,
+                    focusedUnlabelledValue: draft
+                )
                 return CFEqual(authorizedComposer, verifiedComposer)
             }
         }
@@ -421,7 +549,8 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         draft: String,
         source: ComputerUseWindowOption,
         destination: ComputerUseWindowOption,
-        documentIdentity: String
+        documentIdentity: String,
+        allowFocusedUnlabelledComposer: Bool
     ) async throws {
         // This detached task is intentionally cancellation-insensitive: after
         // a possible write, Stop must wait for definitive source/destination
@@ -440,9 +569,17 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             else { throw DraftPostFlowFailure.verificationFailed }
             let application = applicationElement(selection.processIdentifier)
             guard let window = window(matching: destination, in: application),
-                  try currentBrowserDocumentIdentity(in: window) == documentIdentity
+                  try currentBrowserDocumentIdentity(
+                    in: window,
+                    browserBundleIdentifier: destination.selection.bundleIdentifier
+                  ) == documentIdentity
             else { throw DraftPostFlowFailure.verificationFailed }
-            let composer = try uniqueComposer(in: window)
+            let composer = try uniqueComposer(
+                in: window,
+                allowFocusedUnlabelledComposer: allowFocusedUnlabelledComposer,
+                browserBundleIdentifier: destination.selection.bundleIdentifier,
+                focusedUnlabelledValue: draft
+            )
             guard stringAttribute(
                 kAXValueAttribute as CFString,
                 from: composer
@@ -457,13 +594,17 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         documentIdentity: String
     ) throws -> AXUIElement {
         let window = try exactFocusedWindow(destination)
-        guard browserDocumentMatches(
+        guard browserWindowTitleMatches(
+            browserBundleIdentifier: destination.selection.bundleIdentifier,
             currentTitle: stringAttribute(
             kAXTitleAttribute as CFString,
             from: window
             ),
             selectedTitle: destination.windowTitle
-        ), try currentBrowserDocumentIdentity(in: window) == documentIdentity
+        ), try currentBrowserDocumentIdentity(
+            in: window,
+            browserBundleIdentifier: destination.selection.bundleIdentifier
+        ) == documentIdentity
         else {
             throw DraftPostFlowFailure.focusChanged
         }
@@ -476,6 +617,17 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     ) -> Bool {
         guard let currentTitle, !selectedTitle.isEmpty else { return false }
         return utf8Matches(currentTitle, selectedTitle)
+    }
+
+    static func browserWindowTitleMatches(
+        browserBundleIdentifier: String,
+        currentTitle: String?,
+        selectedTitle: String
+    ) -> Bool {
+        guard let currentTitle, !selectedTitle.isEmpty else { return false }
+        if utf8Matches(currentTitle, selectedTitle) { return true }
+        guard browserBundleIdentifier == "com.google.Chrome" else { return false }
+        return utf8Matches(currentTitle, selectedTitle + " - Google Chrome")
     }
 
     private func browserDocumentIdentity(
@@ -491,19 +643,25 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             let application = Self.applicationElement(selection.processIdentifier)
             guard let window = Self.window(matching: destination, in: application)
             else { throw DraftPostFlowFailure.focusChanged }
-            return try Self.currentBrowserDocumentIdentity(in: window)
+            return try Self.currentBrowserDocumentIdentity(
+                in: window,
+                browserBundleIdentifier: selection.bundleIdentifier
+            )
         }
     }
 
     private static func currentBrowserDocumentIdentity(
-        in window: AXUIElement
+        in window: AXUIElement,
+        browserBundleIdentifier: String
     ) throws -> String {
         guard let windowFrame = elementFrame(window) else {
             throw DraftPostFlowFailure.composerAmbiguous
         }
         let addressFields = try allElements(in: window).filter { element in
-            guard stringAttribute(kAXIdentifierAttribute as CFString, from: element)
-                == "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD",
+            guard isBrowserAddressField(
+                element,
+                browserBundleIdentifier: browserBundleIdentifier
+            ),
                 boolAttribute(kAXEnabledAttribute as CFString, from: element) == true,
                 let frame = elementFrame(element), windowFrame.intersects(frame)
             else { return false }
@@ -516,6 +674,36 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
               ), !identity.isEmpty
         else { throw DraftPostFlowFailure.composerAmbiguous }
         return identity
+    }
+
+    static func matchesBrowserAddressField(
+        browserBundleIdentifier: String,
+        role: String?,
+        identifier: String?,
+        description: String?
+    ) -> Bool {
+        guard role == kAXTextFieldRole as String else { return false }
+        switch browserBundleIdentifier {
+        case "com.apple.Safari":
+            return identifier == "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD"
+        case "com.google.Chrome":
+            return description?.trimmingCharacters(in: .whitespacesAndNewlines)
+                .caseInsensitiveCompare("Address and search bar") == .orderedSame
+        default:
+            return false
+        }
+    }
+
+    private static func isBrowserAddressField(
+        _ element: AXUIElement,
+        browserBundleIdentifier: String
+    ) -> Bool {
+        matchesBrowserAddressField(
+            browserBundleIdentifier: browserBundleIdentifier,
+            role: stringAttribute(kAXRoleAttribute as CFString, from: element),
+            identifier: stringAttribute(kAXIdentifierAttribute as CFString, from: element),
+            description: stringAttribute(kAXDescriptionAttribute as CFString, from: element)
+        )
     }
 
     private static func readDraftWithoutFocusing(
@@ -617,7 +805,8 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         in application: AXUIElement
     ) -> AXUIElement? {
         guard let candidate = window(matching: option.selection, in: application),
-              browserDocumentMatches(
+              browserWindowTitleMatches(
+                browserBundleIdentifier: option.selection.bundleIdentifier,
                 currentTitle: stringAttribute(
                     kAXTitleAttribute as CFString,
                     from: candidate
@@ -776,7 +965,12 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         return number.boolValue
     }
 
-    private static func uniqueComposer(in window: AXUIElement) throws -> AXUIElement {
+    private static func uniqueComposer(
+        in window: AXUIElement,
+        allowFocusedUnlabelledComposer: Bool = false,
+        browserBundleIdentifier: String? = nil,
+        focusedUnlabelledValue: String = ""
+    ) throws -> AXUIElement {
         guard let windowFrame = elementFrame(window) else {
             throw DraftPostFlowFailure.composerMissing
         }
@@ -784,12 +978,284 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             isExplicitComposer($0, in: window, windowFrame: windowFrame)
         }
         guard let match = matches.first else {
-            throw DraftPostFlowFailure.composerMissing
+            guard allowFocusedUnlabelledComposer,
+                  let browserBundleIdentifier,
+                  let focused = focusedEditableElement(
+                    in: window,
+                    browserBundleIdentifier: browserBundleIdentifier,
+                    requiredValue: focusedUnlabelledValue
+                  )
+            else { throw DraftPostFlowFailure.composerMissing }
+            return focused
         }
         if matches.count > 1 {
             throw DraftPostFlowFailure.composerAmbiguous
         }
         return match
+    }
+
+    private static func focusedEditableElement(
+        in window: AXUIElement,
+        browserBundleIdentifier: String,
+        requiredValue: String = ""
+    ) -> AXUIElement? {
+        guard let application = applicationAncestor(of: window) else { return nil }
+        var focusedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            application,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedValue
+        ) == .success,
+            let focusedValue,
+            CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
+        else { return nil }
+        let focused = unsafeDowncast(focusedValue, to: AXUIElement.self)
+        guard isSafeEmptyEditable(
+            focused,
+            in: window,
+            browserBundleIdentifier: browserBundleIdentifier,
+            requiredValue: requiredValue
+        ) else { return nil }
+        return focused
+    }
+
+    private static func applicationAncestor(of element: AXUIElement) -> AXUIElement? {
+        var current = element
+        var visited = Set<AXUIElement>()
+        for _ in 0 ..< 32 {
+            guard visited.insert(current).inserted else { return nil }
+            if stringAttribute(kAXRoleAttribute as CFString, from: current)
+                == kAXApplicationRole as String
+            {
+                return current
+            }
+            var parentValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(
+                current,
+                kAXParentAttribute as CFString,
+                &parentValue
+            ) == .success,
+                let parentValue,
+                CFGetTypeID(parentValue) == AXUIElementGetTypeID()
+            else { return nil }
+            current = unsafeDowncast(parentValue, to: AXUIElement.self)
+        }
+        return nil
+    }
+
+    private static func isSafeEmptyEditable(
+        _ element: AXUIElement,
+        in window: AXUIElement,
+        browserBundleIdentifier: String,
+        requiredValue: String = ""
+    ) -> Bool {
+        let role = stringAttribute(kAXRoleAttribute as CFString, from: element)
+        let subrole = stringAttribute(kAXSubroleAttribute as CFString, from: element)
+        guard matchesSafeVisualComposer(
+            role: role,
+            subrole: subrole,
+            isBrowserAddressField: isBrowserAddressField(
+                element,
+                browserBundleIdentifier: browserBundleIdentifier
+            ),
+            isEnabled: boolAttribute(kAXEnabledAttribute as CFString, from: element),
+            value: stringAttribute(kAXValueAttribute as CFString, from: element),
+            requiredValue: requiredValue,
+            isValueSettable: isSettable(kAXValueAttribute as CFString, on: element)
+        ),
+              let windowFrame = elementFrame(window),
+              let elementFrame = elementFrame(element),
+              elementFrame.width >= 1,
+              elementFrame.height >= 1,
+              windowFrame.insetBy(dx: -0.5, dy: -0.5).contains(elementFrame),
+              hasVisibleAncestry(element, through: window)
+        else { return false }
+        return true
+    }
+
+    static func matchesSafeVisualComposer(
+        role: String?,
+        subrole: String?,
+        isBrowserAddressField: Bool,
+        isEnabled: Bool?,
+        value: String?,
+        requiredValue: String,
+        isValueSettable: Bool
+    ) -> Bool {
+        (role == kAXTextAreaRole as String || role == kAXTextFieldRole as String)
+            && subrole != kAXSecureTextFieldSubrole as String
+            && !isBrowserAddressField
+            && isEnabled == true
+            && value.map({ utf8Matches($0, requiredValue) }) == true
+            && isValueSettable
+    }
+
+    /// Converts one observation-bound visual point into focus on an empty
+    /// editable element. It never invokes AXPress and rejects buttons, address
+    /// bars, secure fields, non-empty fields, and anything outside the exact
+    /// selected browser window.
+    static func focusGroundedEmptyComposer(
+        action: GroundedWorkflowAction,
+        groundedAgainst groundingObservation: WorkflowObservation,
+        currentObservation: WorkflowObservation,
+        destination: ComputerUseWindowOption,
+        documentIdentity: String,
+        actuator: any DraftPostComposerActuating
+    ) throws {
+        guard action.observationID == groundingObservation.id,
+              groundingObservation.target == currentObservation.target,
+              currentObservation.target.bundleIdentifier
+                == destination.selection.bundleIdentifier,
+              currentObservation.target.processIdentifier
+                == destination.selection.processIdentifier,
+              currentObservation.target.processLaunchDate
+                == destination.selection.processLaunchDate,
+              currentObservation.target.windowIdentifier
+                == String(destination.selection.windowID),
+              case .click(let normalizedX, let normalizedY) = action.payload,
+              normalizedX > 0, normalizedX < 1,
+              normalizedY > 0, normalizedY < 1
+        else { throw DraftPostFlowFailure.composerMissing }
+
+        let frame = currentObservation.target.windowFrame
+        let point = CGPoint(
+            x: frame.x + normalizedX * frame.width,
+            y: frame.y + normalizedY * frame.height
+        )
+        let window = try exactFocusedBrowserWindow(
+            destination,
+            documentIdentity: documentIdentity
+        )
+        if groundingObservation.contentRevision != currentObservation.contentRevision {
+            guard let focused = focusedEditableElement(
+                in: window,
+                browserBundleIdentifier: destination.selection.bundleIdentifier
+            ), let focusedFrame = elementFrame(focused),
+                isWithinGroundingTolerance(
+                    point: point,
+                    elementFrame: focusedFrame,
+                    windowFrame: CGRect(
+                        x: currentObservation.target.windowFrame.x,
+                        y: currentObservation.target.windowFrame.y,
+                        width: currentObservation.target.windowFrame.width,
+                        height: currentObservation.target.windowFrame.height
+                    )
+                )
+            else { throw DraftPostFlowFailure.composerMissing }
+        }
+        let application = applicationElement(destination.selection.processIdentifier)
+        var hit: AXUIElement?
+        guard AXUIElementCopyElementAtPosition(
+            application,
+            Float(point.x),
+            Float(point.y),
+            &hit
+        ) == .success,
+            let hit
+        else { throw DraftPostFlowFailure.composerMissing }
+        guard let composer = try groundedEditable(
+            from: hit,
+            at: point,
+            in: window,
+            browserBundleIdentifier: destination.selection.bundleIdentifier
+        )
+        else { throw DraftPostFlowFailure.composerMissing }
+
+        try actuator.focusComposer(composer)
+        let reboundWindow = try exactFocusedBrowserWindow(
+            destination,
+            documentIdentity: documentIdentity
+        )
+        guard CFEqual(window, reboundWindow) else {
+            throw DraftPostFlowFailure.focusChanged
+        }
+        guard let focused = focusedEditableElement(
+                in: reboundWindow,
+                browserBundleIdentifier: destination.selection.bundleIdentifier
+              ), CFEqual(composer, focused)
+        else { throw DraftPostFlowFailure.focusChanged }
+    }
+
+    /// Prefer an exact AX hit. When a small local model lands on the label or
+    /// border next to the requested field, recover only if exactly one safe,
+    /// empty editor is within a tightly bounded window-relative neighborhood.
+    /// This never turns the model point into an unconstrained screen click.
+    private static func groundedEditable(
+        from hit: AXUIElement,
+        at point: CGPoint,
+        in window: AXUIElement,
+        browserBundleIdentifier: String
+    ) throws -> AXUIElement? {
+        if let exact = editableAncestor(
+            from: hit,
+            through: window,
+            browserBundleIdentifier: browserBundleIdentifier
+        ) {
+            return exact
+        }
+        guard let windowFrame = elementFrame(window) else { return nil }
+        let nearby = try editableElements(in: window).filter { element in
+            guard isSafeEmptyEditable(
+                element,
+                in: window,
+                browserBundleIdentifier: browserBundleIdentifier
+            ), let frame = elementFrame(element)
+            else { return false }
+            return isWithinGroundingTolerance(
+                point: point,
+                elementFrame: frame,
+                windowFrame: windowFrame
+            )
+        }
+        return nearby.count == 1 ? nearby[0] : nil
+    }
+
+    static func isWithinGroundingTolerance(
+        point: CGPoint,
+        elementFrame: CGRect,
+        windowFrame: CGRect
+    ) -> Bool {
+        guard windowFrame.width > 0, windowFrame.height > 0,
+              windowFrame.contains(point),
+              windowFrame.insetBy(dx: -0.5, dy: -0.5).contains(elementFrame)
+        else { return false }
+        let horizontalTolerance = min(64, windowFrame.width * 0.06)
+        let verticalTolerance = min(64, windowFrame.height * 0.06)
+        return elementFrame.insetBy(
+            dx: -horizontalTolerance,
+            dy: -verticalTolerance
+        ).contains(point)
+    }
+
+    private static func editableAncestor(
+        from element: AXUIElement,
+        through window: AXUIElement,
+        browserBundleIdentifier: String
+    ) -> AXUIElement? {
+        var current = element
+        var visited = Set<AXUIElement>()
+        for _ in 0 ..< 32 {
+            guard visited.insert(current).inserted else { return nil }
+            if isSafeEmptyEditable(
+                current,
+                in: window,
+                browserBundleIdentifier: browserBundleIdentifier
+            ) {
+                return current
+            }
+            if CFEqual(current, window) { return nil }
+            var parentValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(
+                current,
+                kAXParentAttribute as CFString,
+                &parentValue
+            ) == .success,
+                let parentValue,
+                CFGetTypeID(parentValue) == AXUIElementGetTypeID()
+            else { return nil }
+            current = unsafeDowncast(parentValue, to: AXUIElement.self)
+        }
+        return nil
     }
 
     static func isExplicitComposerLabel(_ raw: String) -> Bool {

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -379,10 +379,12 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         let application = Self.applicationElement(
             destination.selection.processIdentifier
         )
-        let previousValue = Self.boolAttribute(
+        guard let previousValue = Self.boolAttribute(
             "AXEnhancedUserInterface" as CFString,
             from: application
-        ) ?? false
+        ) else {
+            throw DraftPostFlowFailure.dependencyFailure
+        }
         return try await Self.establishBrowserAccessibilityLease(
             previousValue: previousValue,
             activate: {
@@ -1242,28 +1244,37 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         in window: AXUIElement,
         browserBundleIdentifier: String
     ) throws -> AXUIElement? {
+        let safeEditors = try editableElements(in: window).filter { element in
+            isSafeEmptyEditable(
+                element,
+                in: window,
+                browserBundleIdentifier: browserBundleIdentifier
+            )
+        }
+        guard authorizesUniqueVisualEditor(candidateCount: safeEditors.count),
+              let safeEditor = safeEditors.first
+        else { return nil }
+
         if let exact = editableAncestor(
             from: hit,
             through: window,
             browserBundleIdentifier: browserBundleIdentifier
-        ) {
-            return exact
+        ), CFEqual(exact, safeEditor) {
+            return safeEditor
         }
         guard let windowFrame = elementFrame(window) else { return nil }
-        let nearby = try editableElements(in: window).filter { element in
-            guard isSafeEmptyEditable(
-                element,
-                in: window,
-                browserBundleIdentifier: browserBundleIdentifier
-            ), let frame = elementFrame(element)
-            else { return false }
-            return isWithinGroundingTolerance(
+        guard let frame = elementFrame(safeEditor),
+              isWithinGroundingTolerance(
                 point: point,
                 elementFrame: frame,
                 windowFrame: windowFrame
-            )
-        }
-        return nearby.count == 1 ? nearby[0] : nil
+              )
+        else { return nil }
+        return safeEditor
+    }
+
+    static func authorizesUniqueVisualEditor(candidateCount: Int) -> Bool {
+        candidateCount == 1
     }
 
     static func isWithinGroundingTolerance(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -273,12 +273,15 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
             throw DraftPostFlowFailure.permissionMissing
         }
 
-        let ownsBrowserAccessibilityRequest = try await prepareBrowserAccessibility(
+        let browserAccessibilityRestoreValue = try await prepareBrowserAccessibility(
             for: destination
         )
         defer {
-            if ownsBrowserAccessibilityRequest {
-                Self.releaseBrowserAccessibility(for: destination)
+            if let browserAccessibilityRestoreValue {
+                Self.restoreBrowserAccessibility(
+                    for: destination,
+                    enabled: browserAccessibilityRestoreValue
+                )
             }
         }
         let documentIdentity = try await browserDocumentIdentity(in: destination)
@@ -308,14 +311,16 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 in: destination,
                 documentIdentity: documentIdentity
             )
-            try await writeAndVerify(
-                draft,
-                from: source,
-                to: destination,
-                documentIdentity: documentIdentity,
-                allowFocusedUnlabelledComposer: true,
-                focusDestination: false
-            )
+            try await Self.verifyAfterVisualRecovery {
+                try await writeAndVerify(
+                    draft,
+                    from: source,
+                    to: destination,
+                    documentIdentity: documentIdentity,
+                    allowFocusedUnlabelledComposer: true,
+                    focusDestination: false
+                )
+            }
         }
         // The destination may now be mutated. Every remaining observation is
         // therefore terminal on failure: recovery must never replay the write.
@@ -354,9 +359,9 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
     /// already exposing an AXWebArea.
     private func prepareBrowserAccessibility(
         for destination: ComputerUseWindowOption
-    ) async throws -> Bool {
+    ) async throws -> Bool? {
         guard destination.selection.bundleIdentifier == "com.google.Chrome" else {
-            return false
+            return nil
         }
         let alreadyAvailable = try await Self.runAXWork {
             let application = Self.applicationElement(
@@ -370,11 +375,16 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                     == "AXWebArea"
             }
         }
-        guard !alreadyAvailable else { return false }
+        guard !alreadyAvailable else { return nil }
         let application = Self.applicationElement(
             destination.selection.processIdentifier
         )
-        try await Self.establishBrowserAccessibilityLease(
+        let previousValue = Self.boolAttribute(
+            "AXEnhancedUserInterface" as CFString,
+            from: application
+        ) ?? false
+        return try await Self.establishBrowserAccessibilityLease(
+            previousValue: previousValue,
             activate: {
                 guard AXUIElementSetAttributeValue(
                     application,
@@ -388,31 +398,36 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
                 try await Task.sleep(for: .seconds(3))
                 try Task.checkCancellation()
             },
-            release: {
-                Self.releaseBrowserAccessibility(for: destination)
+            restore: { value in
+                Self.restoreBrowserAccessibility(
+                    for: destination,
+                    enabled: value
+                )
             }
         )
-        return true
     }
 
     /// Transfers cleanup ownership to the caller only after activation has
     /// fully settled. Any error or cancellation before then is balanced here.
     static func establishBrowserAccessibilityLease(
+        previousValue: Bool,
         activate: () throws -> Void,
         settle: () async throws -> Void,
-        release: () -> Void
-    ) async throws {
+        restore: (Bool) -> Void
+    ) async throws -> Bool {
         try activate()
         do {
             try await settle()
         } catch {
-            release()
+            restore(previousValue)
             throw error
         }
+        return previousValue
     }
 
-    private static func releaseBrowserAccessibility(
-        for destination: ComputerUseWindowOption
+    private static func restoreBrowserAccessibility(
+        for destination: ComputerUseWindowOption,
+        enabled: Bool
     ) {
         guard destination.selection.bundleIdentifier == "com.google.Chrome",
               let running = NSRunningApplication(
@@ -424,8 +439,24 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         _ = AXUIElementSetAttributeValue(
             applicationElement(destination.selection.processIdentifier),
             "AXEnhancedUserInterface" as CFString,
-            kCFBooleanFalse
+            enabled ? kCFBooleanTrue : kCFBooleanFalse
         )
+    }
+
+    /// Once visual recovery has consumed its one bounded three-attempt budget,
+    /// any focus/verification drift is terminal. Converting it to a
+    /// non-recoverable failure prevents the outer coordinator from starting a
+    /// second visual budget (three-by-three attempts).
+    static func verifyAfterVisualRecovery(
+        _ operation: () async throws -> Void
+    ) async throws {
+        do {
+            try await operation()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw DraftPostFlowFailure.verificationFailed
+        }
     }
 
     private func writeAndVerify(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostFlow.swift
@@ -374,16 +374,41 @@ struct MacOSDraftPostFlowDriver: DraftPostFlowDriving {
         let application = Self.applicationElement(
             destination.selection.processIdentifier
         )
-        guard AXUIElementSetAttributeValue(
-            application,
-            "AXEnhancedUserInterface" as CFString,
-            kCFBooleanTrue
-        ) == .success else {
-            throw DraftPostFlowFailure.dependencyFailure
-        }
-        try await Task.sleep(for: .seconds(3))
-        try Task.checkCancellation()
+        try await Self.establishBrowserAccessibilityLease(
+            activate: {
+                guard AXUIElementSetAttributeValue(
+                    application,
+                    "AXEnhancedUserInterface" as CFString,
+                    kCFBooleanTrue
+                ) == .success else {
+                    throw DraftPostFlowFailure.dependencyFailure
+                }
+            },
+            settle: {
+                try await Task.sleep(for: .seconds(3))
+                try Task.checkCancellation()
+            },
+            release: {
+                Self.releaseBrowserAccessibility(for: destination)
+            }
+        )
         return true
+    }
+
+    /// Transfers cleanup ownership to the caller only after activation has
+    /// fully settled. Any error or cancellation before then is balanced here.
+    static func establishBrowserAccessibilityLease(
+        activate: () throws -> Void,
+        settle: () async throws -> Void,
+        release: () -> Void
+    ) async throws {
+        try activate()
+        do {
+            try await settle()
+        } catch {
+            release()
+            throw error
+        }
     }
 
     private static func releaseBrowserAccessibility(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostVisualRecovery.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostVisualRecovery.swift
@@ -147,18 +147,17 @@ actor MacOSDraftPostVisualRecovery: DraftPostVisualRecovering {
                 let grounder = LocalComputerUseVisualGrounder(
                     configuration: configuration,
                     vault: vault,
-                    transport: transport
+                    transport: SessionValidatedComputerUseGroundingTransport(
+                        base: transport,
+                        sessionValidator: sessionValidator
+                    )
                 )
                 let step = Self.composerStep
                 let groundingObservation = try await observer.observe(for: step)
-                let action = try await Self.withValidatedSession(
-                    sessionValidator
-                ) {
-                    try await grounder.ground(
-                        step: step,
-                        observation: groundingObservation
-                    )
-                }
+                let action = try await grounder.ground(
+                    step: step,
+                    observation: groundingObservation
+                )
                 let currentObservation = try await observer.observe(for: step)
                 try Task.checkCancellation()
                 try MacOSDraftPostFlowDriver.focusGroundedEmptyComposer(
@@ -179,23 +178,6 @@ actor MacOSDraftPostVisualRecovery: DraftPostVisualRecovering {
 
     init(attempt: @escaping Attempt) {
         self.attempt = attempt
-    }
-
-    /// The local server may restart onto another port or rotate its bearer
-    /// while the sheet remains open. Validate immediately around inference so
-    /// a screenshot is never sent to, or accepted from, a superseded session.
-    static func withValidatedSession<Result: Sendable>(
-        _ validator: DraftPostVisualRuntime.SessionValidator,
-        operation: @Sendable () async throws -> Result
-    ) async throws -> Result {
-        guard await validator() else {
-            throw DraftPostFlowFailure.dependencyFailure
-        }
-        let result = try await operation()
-        guard await validator() else {
-            throw DraftPostFlowFailure.dependencyFailure
-        }
-        return result
     }
 
     func focusComposer(
@@ -231,5 +213,32 @@ actor MacOSDraftPostVisualRecovery: DraftPostVisualRecovering {
             isIdempotent: true,
             maxGroundingAttempts: Self.maximumAttempts
         )
+    }
+}
+
+/// Pins the actual HTTP send—not merely request preparation—to the app-owned
+/// server session that authorized visual recovery. The second check prevents
+/// accepting a response from a session replaced while inference was running.
+struct SessionValidatedComputerUseGroundingTransport:
+    LocalComputerUseGroundingTransport
+{
+    let base: any LocalComputerUseGroundingTransport
+    let sessionValidator: DraftPostVisualRuntime.SessionValidator
+
+    func send(
+        _ request: URLRequest,
+        maximumResponseBytes: Int
+    ) async throws -> LocalComputerUseGroundingHTTPResponse {
+        guard await sessionValidator() else {
+            throw DraftPostFlowFailure.dependencyFailure
+        }
+        let response = try await base.send(
+            request,
+            maximumResponseBytes: maximumResponseBytes
+        )
+        guard await sessionValidator() else {
+            throw DraftPostFlowFailure.dependencyFailure
+        }
+        return response
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostVisualRecovery.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostVisualRecovery.swift
@@ -4,11 +4,20 @@ import Foundation
 /// Computer Use model. The bearer remains in memory and is never persisted or
 /// included in workflow/ledger state.
 struct DraftPostVisualRuntime: Equatable, Sendable {
+    typealias SessionValidator = @MainActor @Sendable () -> Bool
+
     let baseURL: URL
     let model: String
     let bearerToken: String
+    private let sessionValidator: SessionValidator
 
-    init?(host: String, port: Int, model: String?, bearerToken: String?) {
+    init?(
+        host: String,
+        port: Int,
+        model: String?,
+        bearerToken: String?,
+        sessionValidator: @escaping SessionValidator
+    ) {
         guard host == "127.0.0.1",
               (1 ... 65_535).contains(port),
               let model,
@@ -20,6 +29,7 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
         self.baseURL = baseURL
         self.model = model
         self.bearerToken = bearerToken
+        self.sessionValidator = sessionValidator
     }
 
     init?(
@@ -27,7 +37,8 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
         selectedAlias: String,
         host: String,
         port: Int,
-        bearerToken: String?
+        bearerToken: String?,
+        sessionValidator: @escaping SessionValidator
     ) {
         guard let profile,
               profile.id.caseInsensitiveCompare(selectedAlias) == .orderedSame,
@@ -37,8 +48,51 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
             host: host,
             port: port,
             model: profile.id,
-            bearerToken: bearerToken
+            bearerToken: bearerToken,
+            sessionValidator: sessionValidator
         )
+    }
+
+    /// Production constructor: the tuple accepted by this snapshot must still
+    /// describe the app-owned server immediately around every visual request.
+    @MainActor
+    init?(
+        profile: ServerModelProfile?,
+        selectedAlias: String,
+        host: String,
+        port: Int,
+        bearerToken: String?,
+        liveServer server: ServerManager
+    ) {
+        guard let profile, let bearerToken else { return nil }
+        let expectedModel = profile.id
+        self.init(
+            profile: profile,
+            selectedAlias: selectedAlias,
+            host: host,
+            port: port,
+            bearerToken: bearerToken,
+            sessionValidator: { [weak server] in
+                guard let server,
+                      server.host == host,
+                      server.activePort == port,
+                      server.activeBearer == bearerToken,
+                      let currentProfile = server.activeModelProfile
+                else { return false }
+                return currentProfile.id.caseInsensitiveCompare(expectedModel)
+                    == .orderedSame
+                    && currentProfile.toolCallParser?.caseInsensitiveCompare(
+                        "ui_tars"
+                    ) == .orderedSame
+                    && server.isModelResident(selectedAlias)
+            }
+        )
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.baseURL == rhs.baseURL
+            && lhs.model == rhs.model
+            && lhs.bearerToken == rhs.bearerToken
     }
 
     func makeRecovery() -> (any DraftPostVisualRecovering)? {
@@ -49,7 +103,10 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
             deadline: .seconds(30),
             wireContract: .uiTars
         ) else { return nil }
-        return MacOSDraftPostVisualRecovery(configuration: configuration)
+        return MacOSDraftPostVisualRecovery(
+            configuration: configuration,
+            sessionValidator: sessionValidator
+        )
     }
 }
 
@@ -72,6 +129,7 @@ actor MacOSDraftPostVisualRecovery: DraftPostVisualRecovering {
 
     init(
         configuration: LocalComputerUseVisualGrounder.Configuration,
+        sessionValidator: @escaping DraftPostVisualRuntime.SessionValidator,
         captureSource: any ComputerUseWindowCapturing =
             ScreenCaptureKitComputerUseCapture(),
         transport: any LocalComputerUseGroundingTransport =
@@ -93,10 +151,14 @@ actor MacOSDraftPostVisualRecovery: DraftPostVisualRecovering {
                 )
                 let step = Self.composerStep
                 let groundingObservation = try await observer.observe(for: step)
-                let action = try await grounder.ground(
-                    step: step,
-                    observation: groundingObservation
-                )
+                let action = try await Self.withValidatedSession(
+                    sessionValidator
+                ) {
+                    try await grounder.ground(
+                        step: step,
+                        observation: groundingObservation
+                    )
+                }
                 let currentObservation = try await observer.observe(for: step)
                 try Task.checkCancellation()
                 try MacOSDraftPostFlowDriver.focusGroundedEmptyComposer(
@@ -117,6 +179,23 @@ actor MacOSDraftPostVisualRecovery: DraftPostVisualRecovering {
 
     init(attempt: @escaping Attempt) {
         self.attempt = attempt
+    }
+
+    /// The local server may restart onto another port or rotate its bearer
+    /// while the sheet remains open. Validate immediately around inference so
+    /// a screenshot is never sent to, or accepted from, a superseded session.
+    static func withValidatedSession<Result: Sendable>(
+        _ validator: DraftPostVisualRuntime.SessionValidator,
+        operation: @Sendable () async throws -> Result
+    ) async throws -> Result {
+        guard await validator() else {
+            throw DraftPostFlowFailure.dependencyFailure
+        }
+        let result = try await operation()
+        guard await validator() else {
+            throw DraftPostFlowFailure.dependencyFailure
+        }
+        return result
     }
 
     func focusComposer(

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostVisualRecovery.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostVisualRecovery.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Runtime-only connection details for the already-running, app-owned local
+/// Computer Use model. The bearer remains in memory and is never persisted or
+/// included in workflow/ledger state.
+struct DraftPostVisualRuntime: Equatable, Sendable {
+    let baseURL: URL
+    let model: String
+    let bearerToken: String
+
+    init?(host: String, port: Int, model: String?, bearerToken: String?) {
+        guard host == "127.0.0.1",
+              (1 ... 65_535).contains(port),
+              let model,
+              !model.isEmpty,
+              let bearerToken,
+              !bearerToken.isEmpty,
+              let baseURL = URL(string: "http://127.0.0.1:\(port)/v1")
+        else { return nil }
+        self.baseURL = baseURL
+        self.model = model
+        self.bearerToken = bearerToken
+    }
+
+    init?(
+        profile: ServerModelProfile?,
+        selectedAlias: String,
+        host: String,
+        port: Int,
+        bearerToken: String?
+    ) {
+        guard let profile,
+              profile.id.caseInsensitiveCompare(selectedAlias) == .orderedSame,
+              profile.toolCallParser?.caseInsensitiveCompare("ui_tars") == .orderedSame
+        else { return nil }
+        self.init(
+            host: host,
+            port: port,
+            model: profile.id,
+            bearerToken: bearerToken
+        )
+    }
+
+    func makeRecovery() -> (any DraftPostVisualRecovering)? {
+        guard let configuration = try? LocalComputerUseVisualGrounder.Configuration(
+            baseURL: baseURL,
+            model: model,
+            bearerToken: bearerToken,
+            deadline: .seconds(30),
+            wireContract: .uiTars
+        ) else { return nil }
+        return MacOSDraftPostVisualRecovery(configuration: configuration)
+    }
+}
+
+/// A bounded bridge from one failed semantic lookup to one visual focus.
+/// Each attempt re-captures the exact selected window after inference and
+/// requires byte-identical pixels before focusing an AX-verified empty editor.
+actor MacOSDraftPostVisualRecovery: DraftPostVisualRecovering {
+    typealias Attempt = @Sendable (
+        ComputerUseWindowOption,
+        String
+    ) async throws -> Void
+
+    private static let stepID = "draft-post.visual-composer"
+    // A model-format miss and a transient pixel drift are both safe to retry:
+    // no input has been emitted yet. The shared workflow model hard-caps this
+    // value at three so recovery can never turn into an open-ended agent loop.
+    private static let maximumAttempts = 3
+
+    private let attempt: Attempt
+
+    init(
+        configuration: LocalComputerUseVisualGrounder.Configuration,
+        captureSource: any ComputerUseWindowCapturing =
+            ScreenCaptureKitComputerUseCapture(),
+        transport: any LocalComputerUseGroundingTransport =
+            URLSessionComputerUseGroundingTransport(),
+        actuator: any DraftPostComposerActuating = AXDraftPostComposerActuator()
+    ) {
+        self.attempt = { destination, documentIdentity in
+            let vault = ComputerUseObservationVault(maximumArtifacts: 4)
+            do {
+                let observer = MacOSComputerUseObserver(
+                    selections: [Self.stepID: destination.selection],
+                    vault: vault,
+                    captureSource: captureSource
+                )
+                let grounder = LocalComputerUseVisualGrounder(
+                    configuration: configuration,
+                    vault: vault,
+                    transport: transport
+                )
+                let step = Self.composerStep
+                let groundingObservation = try await observer.observe(for: step)
+                let action = try await grounder.ground(
+                    step: step,
+                    observation: groundingObservation
+                )
+                let currentObservation = try await observer.observe(for: step)
+                try Task.checkCancellation()
+                try MacOSDraftPostFlowDriver.focusGroundedEmptyComposer(
+                    action: action,
+                    groundedAgainst: groundingObservation,
+                    currentObservation: currentObservation,
+                    destination: destination,
+                    documentIdentity: documentIdentity,
+                    actuator: actuator
+                )
+                await vault.removeAll()
+            } catch {
+                await vault.removeAll()
+                throw error
+            }
+        }
+    }
+
+    init(attempt: @escaping Attempt) {
+        self.attempt = attempt
+    }
+
+    func focusComposer(
+        in destination: ComputerUseWindowOption,
+        documentIdentity: String
+    ) async throws {
+        for attemptNumber in 1 ... Self.maximumAttempts {
+            do {
+                try Task.checkCancellation()
+                try await attempt(destination, documentIdentity)
+                return
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                guard attemptNumber < Self.maximumAttempts else {
+                    throw DraftPostFlowFailure.composerMissing
+                }
+            }
+        }
+        throw DraftPostFlowFailure.composerMissing
+    }
+
+    private static var composerStep: LocalWorkflowStep {
+        LocalWorkflowStep(
+            id: Self.stepID,
+            title: "Find the post composer",
+            instruction: """
+            Locate the empty main post composer in this browser page. Do not choose the \
+            address bar, search, reply fields, buttons, Post, Publish, or Send.
+            """,
+            successCriteria: "The empty main post composer has keyboard focus.",
+            risk: .localChange,
+            isIdempotent: true,
+            maxGroundingAttempts: Self.maximumAttempts
+        )
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/LocalComputerUseVisualGrounder.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/LocalComputerUseVisualGrounder.swift
@@ -100,6 +100,11 @@ final class LocalComputerUseNoRedirectDelegate: NSObject,
 /// ``LocalWorkflowExecutor`` and its verifier/actuator boundaries.
 actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
     struct Configuration: Equatable, Sendable {
+        enum WireContract: Equatable, Sendable {
+            case genericFunction
+            case uiTars
+        }
+
         static let maximumModelBytes = 256
         static let maximumBearerBytes = 4_096
         static let maximumInstructionBytes = 16 * 1024
@@ -115,6 +120,7 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
         let maximumScreenshotBytes: Int
         let maximumRequestBytes: Int
         let maximumResponseBytes: Int
+        let wireContract: WireContract
 
         init(
             baseURL: URL,
@@ -123,7 +129,8 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
             deadline: Duration = .seconds(30),
             maximumScreenshotBytes: Int = 8 * 1024 * 1024,
             maximumRequestBytes: Int = 12 * 1024 * 1024,
-            maximumResponseBytes: Int = 512 * 1024
+            maximumResponseBytes: Int = 512 * 1024,
+            wireContract: WireContract = .genericFunction
         ) throws {
             guard Self.isAllowedLoopbackBaseURL(baseURL),
                   !model.isEmpty,
@@ -157,6 +164,7 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
             self.maximumScreenshotBytes = maximumScreenshotBytes
             self.maximumRequestBytes = maximumRequestBytes
             self.maximumResponseBytes = maximumResponseBytes
+            self.wireContract = wireContract
         }
 
         var completionURL: URL {
@@ -242,7 +250,10 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
         guard response.contentType?.lowercased().hasPrefix("application/json") == true else {
             throw LocalComputerUseVisualGrounderError.invalidHTTPResponse
         }
-        let coordinate = try Self.decodeSingleClick(response.body)
+        let coordinate = try Self.decodeSingleClick(
+            response.body,
+            wireContract: configuration.wireContract
+        )
         return GroundedWorkflowAction(
             observationID: observation.id,
             payload: .click(
@@ -265,10 +276,16 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
             throw LocalComputerUseVisualGrounderError.requestTooLarge
         }
         let imageURL = "data:image/png;base64,\(artifact.pngData.base64EncodedString())"
+        let toolName = configuration.wireContract == .uiTars
+            ? "computer"
+            : "computer_use"
+        let actionName = configuration.wireContract == .uiTars
+            ? "click"
+            : "left_click"
         let tool: [String: Any] = [
             "type": "function",
             "function": [
-                "name": "computer_use",
+                "name": toolName,
                 "description": """
                 Locate exactly one requested target in the supplied window screenshot. \
                 Coordinates are normalized from 1 to 998 relative to that screenshot.
@@ -277,7 +294,7 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": [
-                        "action": ["type": "string", "enum": ["left_click"]],
+                        "action": ["type": "string", "enum": [actionName]],
                         "coordinate": [
                             "type": "array",
                             "items": ["type": "integer", "minimum": 1, "maximum": 998],
@@ -295,7 +312,7 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
                 [
                     "role": "system",
                     "content": """
-                    Locate one target only. Return one computer_use left_click tool call. \
+                    Locate one target only. Return one \(toolName) \(actionName) tool call. \
                     Do not type, press keys, finish a workflow, or propose another action.
                     """,
                 ],
@@ -310,7 +327,7 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
             "tools": [tool],
             "tool_choice": [
                 "type": "function",
-                "function": ["name": "computer_use"],
+                "function": ["name": toolName],
             ],
             "temperature": 0,
             "max_tokens": 384,
@@ -373,7 +390,12 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
         }
     }
 
-    private static func decodeSingleClick(_ data: Data) throws -> (x: Int, y: Int) {
+    private static func decodeSingleClick(
+        _ data: Data,
+        wireContract: Configuration.WireContract
+    ) throws -> (x: Int, y: Int) {
+        let expectedToolName = wireContract == .uiTars ? "computer" : "computer_use"
+        let expectedAction = wireContract == .uiTars ? "click" : "left_click"
         guard data.count > 0,
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let choices = root["choices"] as? [[String: Any]],
@@ -383,7 +405,7 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
               calls.count == 1,
               calls[0]["type"] as? String == "function",
               let function = calls[0]["function"] as? [String: Any],
-              function["name"] as? String == "computer_use",
+              function["name"] as? String == expectedToolName,
               let arguments = function["arguments"] as? String,
               arguments.utf8.count <= 4_096,
               let argumentData = arguments.data(using: .utf8),
@@ -397,7 +419,7 @@ actor LocalComputerUseVisualGrounder: LocalWorkflowGrounding {
             throw LocalComputerUseVisualGrounderError.invalidResponse
         }
         guard Set(object.keys).isSubset(of: ["action", "coordinate"]),
-              decoded.action == "left_click"
+              decoded.action == expectedAction
         else {
             throw LocalComputerUseVisualGrounderError.unsupportedAction
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -1,7 +1,12 @@
 import SwiftUI
 
 struct ComputerUseView: View {
+    let visualRuntime: DraftPostVisualRuntime?
     @State private var showingDraftPost = false
+
+    init(visualRuntime: DraftPostVisualRuntime? = nil) {
+        self.visualRuntime = visualRuntime
+    }
 
     var body: some View {
         ScrollView {
@@ -67,7 +72,7 @@ struct ComputerUseView: View {
         .background(RapidTheme.surfaceCanvas)
         .accessibilityIdentifier("ComputerUse.Panel")
         .sheet(isPresented: $showingDraftPost) {
-            DraftPostFlowSheet()
+            DraftPostFlowSheet(visualRuntime: visualRuntime)
         }
     }
 
@@ -131,7 +136,17 @@ struct ComputerUseView: View {
 
 private struct DraftPostFlowSheet: View {
     @Environment(\.dismiss) private var dismiss
-    @State private var viewModel = DraftPostFlowViewModel()
+    @State private var viewModel: DraftPostFlowViewModel
+    private let visualRecoveryAvailable: Bool
+
+    init(visualRuntime: DraftPostVisualRuntime?) {
+        self.visualRecoveryAvailable = visualRuntime != nil
+        _viewModel = State(initialValue: DraftPostFlowViewModel(
+            driver: MacOSDraftPostFlowDriver(
+                visualRecovery: visualRuntime?.makeRecovery()
+            )
+        ))
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -240,6 +255,15 @@ private struct DraftPostFlowSheet: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
 
+            Label(
+                visualRecoveryAvailable
+                    ? "Visual recovery is ready with the current local model."
+                    : "Accessibility mode is ready. A compatible local Computer Use model adds visual recovery for unlabeled composers.",
+                systemImage: visualRecoveryAvailable ? "eye.circle.fill" : "eye.slash"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
             picker(
                 title: "1. TextEdit draft",
                 prompt: "Choose a TextEdit window",
@@ -256,7 +280,7 @@ private struct DraftPostFlowSheet: View {
             )
 
             if viewModel.sourceOptions.isEmpty || viewModel.destinationOptions.isEmpty {
-                Text("Open the draft in TextEdit and an empty English-language post composer in Safari, then refresh. Leave both selected windows unchanged until Rapid stops.")
+                Text("Open the draft in TextEdit and an empty English-language post composer in Safari or Google Chrome, then refresh. Leave both selected windows unchanged until Rapid stops.")
                     .font(.caption)
                     .foregroundStyle(.orange)
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -1143,7 +1143,15 @@ struct ContentView: View {
             }
         case .computerUse:
             if computerUseEnabled {
-                ComputerUseView()
+                ComputerUseView(
+                    visualRuntime: DraftPostVisualRuntime(
+                        profile: server.activeModelProfile,
+                        selectedAlias: alias,
+                        host: server.host,
+                        port: server.activePort,
+                        bearerToken: server.activeBearer
+                    )
+                )
             } else {
                 mainArea
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -1149,7 +1149,8 @@ struct ContentView: View {
                         selectedAlias: alias,
                         host: server.host,
                         port: server.activePort,
-                        bearerToken: server.activeBearer
+                        bearerToken: server.activeBearer,
+                        liveServer: server
                     )
                 )
             } else {

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -11,7 +11,7 @@ struct DraftPostFlowTests {
     /// fixtures and never runs in ordinary CI:
     ///
     /// - TextEdit window title contains `rapid-cua-draft.txt`.
-    /// - Browser window title contains `Rapid Computer Use Fixture` and has
+    /// - Browser window title contains `Local Post Composer` and has
     ///   one empty text area labelled `Post text`.
     ///
     /// Run with `RAPID_LIVE_CUA_DOGFOOD=1 swift test --no-parallel --filter
@@ -67,6 +67,57 @@ struct DraftPostFlowTests {
         }
         #expect(metrics.attempts == 2)
         #expect(metrics.automaticRecoveries == 1)
+        try actuator.clearLastDraftIfUnchanged()
+    }
+
+    /// Operator-only end-to-end visual recovery. The browser fixture exposes
+    /// an empty but deliberately unlabelled composer, so deterministic AX
+    /// lookup must fail before one local model grounding focuses it.
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_VISUAL"] == "1"))
+    func liveVisualFallbackFixture() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        let (source, destination) = try await Self.liveOptions()
+        let baseURL = try #require(URL(string: environment["RAPID_LIVE_CUA_BASE_URL"]
+            ?? "http://127.0.0.1:8377/v1"))
+        let model = environment["RAPID_LIVE_CUA_MODEL"] ?? "EvoCUA_8B_4bit"
+        let configuration = try LocalComputerUseVisualGrounder.Configuration(
+            baseURL: baseURL,
+            model: model,
+            bearerToken: environment["RAPID_LIVE_CUA_BEARER"],
+            wireContract: environment["RAPID_LIVE_CUA_WIRE_CONTRACT"] == "ui_tars"
+                ? .uiTars
+                : .genericFunction
+        )
+        let actuator = RecordingDraftPostComposerActuator(
+            base: AXDraftPostComposerActuator()
+        )
+        let transport = RecordingDraftPostGroundingTransport()
+        let recovery = MacOSDraftPostVisualRecovery(
+            configuration: configuration,
+            transport: transport,
+            actuator: actuator
+        )
+        let outcome = await DraftPostFlowCoordinator(
+            driver: MacOSDraftPostFlowDriver(
+                actuator: actuator,
+                visualRecovery: recovery
+            )
+        ).run(source: source, destination: destination)
+        guard case .readyForReview(let metrics) = outcome else {
+            let responses = await transport.responseBodies
+            Issue.record("Visual fallback did not reach review: \(outcome); responses=\(responses)")
+            return
+        }
+        #expect(metrics.completedSteps == 3)
+        let actions = actuator.actions
+        #expect(actions.count == 3)
+        #expect(actions[0] == .focusComposer)
+        #expect(actions[1] == .focusComposer)
+        guard case .setDraft(let writtenDraft) = actions[2] else {
+            Issue.record("Visual fallback escaped the focus-and-write capability boundary")
+            return
+        }
+        #expect(writtenDraft == "Local AI can turn repetitive Mac work into a private, reviewable workflow.\n")
         try actuator.clearLastDraftIfUnchanged()
     }
 
@@ -189,6 +240,214 @@ struct DraftPostFlowTests {
         #expect(!MacOSDraftPostFlowDriver.isExplicitComposerLabel("Post"))
     }
 
+    @Test("Safari and Chrome address fields use explicit browser contracts")
+    func browserAddressFields() {
+        #expect(MacOSDraftPostFlowDriver.matchesBrowserAddressField(
+            browserBundleIdentifier: "com.apple.Safari",
+            role: kAXTextFieldRole as String,
+            identifier: "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD",
+            description: "smart search field"
+        ))
+        #expect(MacOSDraftPostFlowDriver.matchesBrowserAddressField(
+            browserBundleIdentifier: "com.google.Chrome",
+            role: kAXTextFieldRole as String,
+            identifier: nil,
+            description: "Address and search bar"
+        ))
+        #expect(!MacOSDraftPostFlowDriver.matchesBrowserAddressField(
+            browserBundleIdentifier: "com.google.Chrome",
+            role: kAXTextFieldRole as String,
+            identifier: nil,
+            description: "Search posts"
+        ))
+        #expect(!MacOSDraftPostFlowDriver.matchesBrowserAddressField(
+            browserBundleIdentifier: "com.google.Chrome",
+            role: kAXButtonRole as String,
+            identifier: nil,
+            description: "Address and search bar"
+        ))
+        #expect(!MacOSDraftPostFlowDriver.matchesBrowserAddressField(
+            browserBundleIdentifier: "com.example.browser",
+            role: kAXTextFieldRole as String,
+            identifier: "WEB_BROWSER_ADDRESS_AND_SEARCH_FIELD",
+            description: "Address and search bar"
+        ))
+    }
+
+    @Test("Visual recovery binds only to the exact selected UI-TARS profile")
+    func visualRuntimeEligibility() throws {
+        let profile = ServerModelProfile(
+            id: "ui-tars-1.5-7b-4bit",
+            toolCallParser: "ui_tars"
+        )
+        let runtime = try #require(DraftPostVisualRuntime(
+            profile: profile,
+            selectedAlias: "UI-TARS-1.5-7B-4BIT",
+            host: "127.0.0.1",
+            port: 7659,
+            bearerToken: "secret"
+        ))
+        #expect(runtime.model == profile.id)
+        #expect(runtime.baseURL.absoluteString == "http://127.0.0.1:7659/v1")
+
+        #expect(DraftPostVisualRuntime(
+            profile: profile,
+            selectedAlias: "another-model",
+            host: "127.0.0.1",
+            port: 7659,
+            bearerToken: "secret"
+        ) == nil)
+        #expect(DraftPostVisualRuntime(
+            profile: ServerModelProfile(id: profile.id, toolCallParser: "hermes"),
+            selectedAlias: profile.id,
+            host: "127.0.0.1",
+            port: 7659,
+            bearerToken: "secret"
+        ) == nil)
+        #expect(DraftPostVisualRuntime(
+            profile: profile,
+            selectedAlias: profile.id,
+            host: "localhost",
+            port: 7659,
+            bearerToken: "secret"
+        ) == nil)
+        #expect(DraftPostVisualRuntime(
+            profile: profile,
+            selectedAlias: profile.id,
+            host: "127.0.0.1",
+            port: 7659,
+            bearerToken: nil
+        ) == nil)
+    }
+
+    @Test("Visual coordinates can authorize only the expected editable value")
+    func safeVisualComposerContract() {
+        let accepted = MacOSDraftPostFlowDriver.matchesSafeVisualComposer(
+            role: kAXTextAreaRole as String,
+            subrole: nil,
+            isBrowserAddressField: false,
+            isEnabled: true,
+            value: "",
+            requiredValue: "",
+            isValueSettable: true
+        )
+        #expect(accepted)
+
+        for rejected in [
+            MacOSDraftPostFlowDriver.matchesSafeVisualComposer(
+                role: kAXButtonRole as String,
+                subrole: nil,
+                isBrowserAddressField: false,
+                isEnabled: true,
+                value: "",
+                requiredValue: "",
+                isValueSettable: true
+            ),
+            MacOSDraftPostFlowDriver.matchesSafeVisualComposer(
+                role: kAXTextFieldRole as String,
+                subrole: nil,
+                isBrowserAddressField: true,
+                isEnabled: true,
+                value: "",
+                requiredValue: "",
+                isValueSettable: true
+            ),
+            MacOSDraftPostFlowDriver.matchesSafeVisualComposer(
+                role: kAXTextAreaRole as String,
+                subrole: kAXSecureTextFieldSubrole as String,
+                isBrowserAddressField: false,
+                isEnabled: true,
+                value: "",
+                requiredValue: "",
+                isValueSettable: true
+            ),
+            MacOSDraftPostFlowDriver.matchesSafeVisualComposer(
+                role: kAXTextAreaRole as String,
+                subrole: nil,
+                isBrowserAddressField: false,
+                isEnabled: true,
+                value: "already present",
+                requiredValue: "",
+                isValueSettable: true
+            ),
+        ] {
+            #expect(!rejected)
+        }
+    }
+
+    @Test("Visual grounding tolerance is local and window bounded")
+    func visualGroundingTolerance() {
+        let window = CGRect(x: 100, y: 100, width: 1_000, height: 800)
+        let composer = CGRect(x: 300, y: 350, width: 600, height: 260)
+        #expect(MacOSDraftPostFlowDriver.isWithinGroundingTolerance(
+            point: CGPoint(x: 600, y: 320),
+            elementFrame: composer,
+            windowFrame: window
+        ))
+        #expect(!MacOSDraftPostFlowDriver.isWithinGroundingTolerance(
+            point: CGPoint(x: 600, y: 280),
+            elementFrame: composer,
+            windowFrame: window
+        ))
+        #expect(!MacOSDraftPostFlowDriver.isWithinGroundingTolerance(
+            point: CGPoint(x: 99, y: 400),
+            elementFrame: composer,
+            windowFrame: window
+        ))
+    }
+
+    @Test("Visual recovery retries only the bounded pre-mutation attempt")
+    func visualRecoveryIsBounded() async throws {
+        let script = ScriptedVisualRecoveryAttempt(failuresBeforeSuccess: 2)
+        let recovery = MacOSDraftPostVisualRecovery { destination, identity in
+            #expect(destination.id == Self.destination.id)
+            #expect(identity == "bound-document")
+            try await script.run()
+        }
+
+        try await recovery.focusComposer(
+            in: Self.destination,
+            documentIdentity: "bound-document"
+        )
+
+        #expect(await script.callCount == 3)
+    }
+
+    @Test("Visual recovery exhaustion fails closed after three attempts")
+    func visualRecoveryExhaustion() async {
+        let script = ScriptedVisualRecoveryAttempt(failuresBeforeSuccess: 4)
+        let recovery = MacOSDraftPostVisualRecovery { _, _ in
+            try await script.run()
+        }
+
+        await #expect(throws: DraftPostFlowFailure.composerMissing) {
+            try await recovery.focusComposer(
+                in: Self.destination,
+                documentIdentity: "bound-document"
+            )
+        }
+        #expect(await script.callCount == 3)
+    }
+
+    @Test("Cancellation is never converted into a visual retry")
+    func visualRecoveryCancellation() async {
+        let script = ScriptedVisualRecoveryAttempt(
+            failuresBeforeSuccess: 0,
+            cancels: true
+        )
+        let recovery = MacOSDraftPostVisualRecovery { _, _ in
+            try await script.run()
+        }
+
+        await #expect(throws: CancellationError.self) {
+            try await recovery.focusComposer(
+                in: Self.destination,
+                documentIdentity: "bound-document"
+            )
+        }
+        #expect(await script.callCount == 1)
+    }
+
     @Test("Post-mutation drift is always terminal")
     func postMutationDriftStops() throws {
         try MacOSDraftPostFlowDriver.verifyAfterMutation { true }
@@ -218,6 +477,21 @@ struct DraftPostFlowTests {
         #expect(!MacOSDraftPostFlowDriver.browserDocumentMatches(
             currentTitle: "Compose",
             selectedTitle: ""
+        ))
+        #expect(MacOSDraftPostFlowDriver.browserWindowTitleMatches(
+            browserBundleIdentifier: "com.google.Chrome",
+            currentTitle: "Compose — Account A - Google Chrome",
+            selectedTitle: "Compose — Account A"
+        ))
+        #expect(!MacOSDraftPostFlowDriver.browserWindowTitleMatches(
+            browserBundleIdentifier: "com.apple.Safari",
+            currentTitle: "Compose — Account A - Google Chrome",
+            selectedTitle: "Compose — Account A"
+        ))
+        #expect(!MacOSDraftPostFlowDriver.browserWindowTitleMatches(
+            browserBundleIdentifier: "com.google.Chrome",
+            currentTitle: "Other - Google Chrome",
+            selectedTitle: "Compose — Account A"
         ))
     }
 
@@ -441,13 +715,60 @@ struct DraftPostFlowTests {
                 && $0.windowTitle.contains("rapid-cua-draft.txt")
         })
         let destination = try #require(windows.first {
-            MacOSDraftPostFlowDriver.browserBundles.contains(
-                $0.selection.bundleIdentifier
-            ) && $0.windowTitle.contains("Rapid Computer Use Fixture")
+            $0.selection.bundleIdentifier == liveBrowserBundle
+                && $0.windowTitle.contains(liveWindowTitle)
         })
         return (source, destination)
     }
 
+    private static var liveBrowserBundle: String {
+        ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_BROWSER_BUNDLE"]
+            ?? "com.apple.Safari"
+    }
+
+    private static var liveWindowTitle: String {
+        ProcessInfo.processInfo.environment["RAPID_LIVE_CUA_WINDOW_TITLE"]
+            ?? "Local Post Composer"
+    }
+
+}
+
+private actor RecordingDraftPostGroundingTransport:
+    LocalComputerUseGroundingTransport
+{
+    private let base = URLSessionComputerUseGroundingTransport()
+    private(set) var responseBodies: [String] = []
+
+    func send(
+        _ request: URLRequest,
+        maximumResponseBytes: Int
+    ) async throws -> LocalComputerUseGroundingHTTPResponse {
+        let response = try await base.send(
+            request,
+            maximumResponseBytes: maximumResponseBytes
+        )
+        responseBodies.append(String(decoding: response.body, as: UTF8.self))
+        return response
+    }
+}
+
+private actor ScriptedVisualRecoveryAttempt {
+    private let failuresBeforeSuccess: Int
+    private let cancels: Bool
+    private(set) var callCount = 0
+
+    init(failuresBeforeSuccess: Int, cancels: Bool = false) {
+        self.failuresBeforeSuccess = failuresBeforeSuccess
+        self.cancels = cancels
+    }
+
+    func run() throws {
+        callCount += 1
+        if cancels { throw CancellationError() }
+        if callCount <= failuresBeforeSuccess {
+            throw DraftPostFlowFailure.targetUnavailable
+        }
+    }
 }
 
 private enum RecordedDraftPostComposerAction: Equatable {
@@ -506,14 +827,10 @@ private final class RecordingDraftPostComposerActuator: DraftPostComposerActuati
         else {
             throw DraftPostFlowFailure.verificationFailed
         }
-        var clearedValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            write.element,
-            kAXValueAttribute as CFString,
-            &clearedValue
-        ) == .success, clearedValue as? String == "" else {
-            throw DraftPostFlowFailure.verificationFailed
-        }
+        // Chrome may retire and replace a renderer AX node immediately after
+        // clearing it. The next full flow iteration re-resolves the selected
+        // window and proves that its composer is empty; retaining the stale
+        // node here would turn successful cleanup into a false failure.
         lock.withLock { lastWrite = nil }
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -459,6 +459,15 @@ struct DraftPostFlowTests {
             elementFrame: composer,
             windowFrame: window
         ))
+        #expect(MacOSDraftPostFlowDriver.authorizesUniqueVisualEditor(
+            candidateCount: 1
+        ))
+        #expect(!MacOSDraftPostFlowDriver.authorizesUniqueVisualEditor(
+            candidateCount: 0
+        ))
+        #expect(!MacOSDraftPostFlowDriver.authorizesUniqueVisualEditor(
+            candidateCount: 2
+        ))
     }
 
     @Test("Visual recovery retries only the bounded pre-mutation attempt")

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -333,28 +333,56 @@ struct DraftPostFlowTests {
         let validator: DraftPostVisualRuntime.SessionValidator = {
             session.current
         }
+        let base = RotatingDraftPostGroundingTransport(session: session)
+        let transport = SessionValidatedComputerUseGroundingTransport(
+            base: base,
+            sessionValidator: validator
+        )
         await #expect(throws: DraftPostFlowFailure.dependencyFailure) {
-            try await MacOSDraftPostVisualRecovery.withValidatedSession(
-                validator
-            ) {
-                session.current = false
-                return "unused"
-            }
+            _ = try await transport.send(
+                URLRequest(url: URL(string: "http://127.0.0.1:7659/v1")!),
+                maximumResponseBytes: 128
+            )
         }
+        #expect(await base.callCount == 1)
+
+        let blockedBase = RotatingDraftPostGroundingTransport(session: session)
+        let blockedTransport = SessionValidatedComputerUseGroundingTransport(
+            base: blockedBase,
+            sessionValidator: validator
+        )
+        await #expect(throws: DraftPostFlowFailure.dependencyFailure) {
+            _ = try await blockedTransport.send(
+                URLRequest(url: URL(string: "http://127.0.0.1:7659/v1")!),
+                maximumResponseBytes: 128
+            )
+        }
+        #expect(await blockedBase.callCount == 0)
     }
 
     @Test("Chrome accessibility activation balances cancellation")
     func browserAccessibilityActivationBalancesCancellation() async {
         let probe = BrowserAccessibilityLeaseProbe()
         await #expect(throws: CancellationError.self) {
-            try await MacOSDraftPostFlowDriver.establishBrowserAccessibilityLease(
+            _ = try await MacOSDraftPostFlowDriver.establishBrowserAccessibilityLease(
+                previousValue: true,
                 activate: { probe.activate() },
                 settle: { throw CancellationError() },
-                release: { probe.release() }
+                restore: { probe.restore(to: $0) }
             )
         }
         #expect(probe.activations == 1)
         #expect(probe.releases == 1)
+        #expect(probe.restoredValue == true)
+    }
+
+    @Test("Post-visual focus drift cannot start another visual budget")
+    func postVisualDriftIsTerminal() async {
+        await #expect(throws: DraftPostFlowFailure.verificationFailed) {
+            try await MacOSDraftPostFlowDriver.verifyAfterVisualRecovery {
+                throw DraftPostFlowFailure.focusChanged
+            }
+        }
     }
 
     @Test("Visual coordinates can authorize only the expected editable value")
@@ -826,12 +854,43 @@ private final class BrowserAccessibilityLeaseProbe: @unchecked Sendable {
     private let lock = NSLock()
     private var activationCount = 0
     private var releaseCount = 0
+    private var restored: Bool?
 
     var activations: Int { lock.withLock { activationCount } }
     var releases: Int { lock.withLock { releaseCount } }
+    var restoredValue: Bool? { lock.withLock { restored } }
 
     func activate() { lock.withLock { activationCount += 1 } }
-    func release() { lock.withLock { releaseCount += 1 } }
+    func restore(to value: Bool) {
+        lock.withLock {
+            releaseCount += 1
+            restored = value
+        }
+    }
+}
+
+private actor RotatingDraftPostGroundingTransport:
+    LocalComputerUseGroundingTransport
+{
+    private let session: VisualSessionProbe
+    private(set) var callCount = 0
+
+    init(session: VisualSessionProbe) {
+        self.session = session
+    }
+
+    func send(
+        _: URLRequest,
+        maximumResponseBytes _: Int
+    ) async throws -> LocalComputerUseGroundingHTTPResponse {
+        callCount += 1
+        session.current = false
+        return LocalComputerUseGroundingHTTPResponse(
+            statusCode: 200,
+            contentType: "application/json",
+            body: Data()
+        )
+    }
 }
 
 private enum RecordedDraftPostComposerAction: Equatable {

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -94,6 +94,7 @@ struct DraftPostFlowTests {
         let transport = RecordingDraftPostGroundingTransport()
         let recovery = MacOSDraftPostVisualRecovery(
             configuration: configuration,
+            sessionValidator: { true },
             transport: transport,
             actuator: actuator
         )
@@ -280,12 +281,14 @@ struct DraftPostFlowTests {
             id: "ui-tars-1.5-7b-4bit",
             toolCallParser: "ui_tars"
         )
+        let currentSession: DraftPostVisualRuntime.SessionValidator = { true }
         let runtime = try #require(DraftPostVisualRuntime(
             profile: profile,
             selectedAlias: "UI-TARS-1.5-7B-4BIT",
             host: "127.0.0.1",
             port: 7659,
-            bearerToken: "secret"
+            bearerToken: "secret",
+            sessionValidator: currentSession
         ))
         #expect(runtime.model == profile.id)
         #expect(runtime.baseURL.absoluteString == "http://127.0.0.1:7659/v1")
@@ -295,29 +298,63 @@ struct DraftPostFlowTests {
             selectedAlias: "another-model",
             host: "127.0.0.1",
             port: 7659,
-            bearerToken: "secret"
+            bearerToken: "secret",
+            sessionValidator: currentSession
         ) == nil)
         #expect(DraftPostVisualRuntime(
             profile: ServerModelProfile(id: profile.id, toolCallParser: "hermes"),
             selectedAlias: profile.id,
             host: "127.0.0.1",
             port: 7659,
-            bearerToken: "secret"
+            bearerToken: "secret",
+            sessionValidator: currentSession
         ) == nil)
         #expect(DraftPostVisualRuntime(
             profile: profile,
             selectedAlias: profile.id,
             host: "localhost",
             port: 7659,
-            bearerToken: "secret"
+            bearerToken: "secret",
+            sessionValidator: currentSession
         ) == nil)
         #expect(DraftPostVisualRuntime(
             profile: profile,
             selectedAlias: profile.id,
             host: "127.0.0.1",
             port: 7659,
-            bearerToken: nil
+            bearerToken: nil,
+            sessionValidator: currentSession
         ) == nil)
+    }
+
+    @Test("Visual inference rejects a server-session change before acceptance")
+    func visualInferenceRequiresOneSession() async {
+        let session = VisualSessionProbe(isCurrent: true)
+        let validator: DraftPostVisualRuntime.SessionValidator = {
+            session.current
+        }
+        await #expect(throws: DraftPostFlowFailure.dependencyFailure) {
+            try await MacOSDraftPostVisualRecovery.withValidatedSession(
+                validator
+            ) {
+                session.current = false
+                return "unused"
+            }
+        }
+    }
+
+    @Test("Chrome accessibility activation balances cancellation")
+    func browserAccessibilityActivationBalancesCancellation() async {
+        let probe = BrowserAccessibilityLeaseProbe()
+        await #expect(throws: CancellationError.self) {
+            try await MacOSDraftPostFlowDriver.establishBrowserAccessibilityLease(
+                activate: { probe.activate() },
+                settle: { throw CancellationError() },
+                release: { probe.release() }
+            )
+        }
+        #expect(probe.activations == 1)
+        #expect(probe.releases == 1)
     }
 
     @Test("Visual coordinates can authorize only the expected editable value")
@@ -769,6 +806,32 @@ private actor ScriptedVisualRecoveryAttempt {
             throw DraftPostFlowFailure.targetUnavailable
         }
     }
+}
+
+private final class VisualSessionProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Bool
+
+    init(isCurrent: Bool) {
+        self.value = isCurrent
+    }
+
+    var current: Bool {
+        get { lock.withLock { value } }
+        set { lock.withLock { value = newValue } }
+    }
+}
+
+private final class BrowserAccessibilityLeaseProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var activationCount = 0
+    private var releaseCount = 0
+
+    var activations: Int { lock.withLock { activationCount } }
+    var releases: Int { lock.withLock { releaseCount } }
+
+    func activate() { lock.withLock { activationCount += 1 } }
+    func release() { lock.withLock { releaseCount += 1 } }
 }
 
 private enum RecordedDraftPostComposerAction: Equatable {

--- a/apps/rapid-mac/Tests/RapidTests/LocalComputerUseVisualGrounderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/LocalComputerUseVisualGrounderTests.swift
@@ -122,6 +122,46 @@ struct LocalComputerUseVisualGrounderTests {
         #expect(userContent.last?["text"] as? String == fixture.step.instruction)
     }
 
+    @Test("UI-TARS uses the native computer click contract")
+    func uiTarsClickContract() async throws {
+        let fixture = try await Fixture(
+            responseBody: Self.response(
+                x: 350,
+                y: 650,
+                action: "click",
+                toolName: "computer"
+            ),
+            wireContract: .uiTars
+        )
+
+        let action = try await fixture.grounder.ground(
+            step: fixture.step,
+            observation: fixture.observation
+        )
+        guard case .click(let x, let y) = action.payload else {
+            Issue.record("Expected one UI-TARS click")
+            return
+        }
+        #expect(abs(x - (350.0 / 999.0)) < 0.000_001)
+        #expect(abs(y - (650.0 / 999.0)) < 0.000_001)
+
+        let request = try #require(await fixture.transport.lastRequest)
+        let body = try #require(request.httpBody)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        let choice = try #require(object["tool_choice"] as? [String: Any])
+        let choiceFunction = try #require(choice["function"] as? [String: Any])
+        #expect(choiceFunction["name"] as? String == "computer")
+        let tools = try #require(object["tools"] as? [[String: Any]])
+        let toolFunction = try #require(tools.first?["function"] as? [String: Any])
+        #expect(toolFunction["name"] as? String == "computer")
+        let parameters = try #require(toolFunction["parameters"] as? [String: Any])
+        let properties = try #require(parameters["properties"] as? [String: Any])
+        let actionSchema = try #require(properties["action"] as? [String: Any])
+        #expect(actionSchema["enum"] as? [String] == ["click"])
+    }
+
     @Test("Only literal loopback v1 endpoints are accepted")
     func endpointPolicy() {
         let rejected = [
@@ -406,6 +446,7 @@ struct LocalComputerUseVisualGrounderTests {
         x: Int,
         y: Int,
         action: String = "left_click",
+        toolName: String = "computer_use",
         extraArgument: Bool = false,
         duplicateCall: Bool = false,
         callType: String? = "function"
@@ -420,7 +461,7 @@ struct LocalComputerUseVisualGrounderTests {
         var call: [String: Any] = [
             "id": "call-1",
             "function": [
-                "name": "computer_use",
+                "name": toolName,
                 "arguments": argumentString,
             ],
         ]
@@ -466,6 +507,8 @@ struct LocalComputerUseVisualGrounderTests {
             maximumScreenshotBytes: Int = 8 * 1024 * 1024,
             maximumRequestBytes: Int = 12 * 1024 * 1024,
             maximumResponseBytes: Int = 512 * 1024,
+            wireContract: LocalComputerUseVisualGrounder.Configuration.WireContract =
+                .genericFunction,
             storeArtifact: Bool = true,
             instruction: String = "Click the button labeled Review."
         ) async throws {
@@ -522,7 +565,8 @@ struct LocalComputerUseVisualGrounderTests {
                     deadline: deadline,
                     maximumScreenshotBytes: maximumScreenshotBytes,
                     maximumRequestBytes: maximumRequestBytes,
-                    maximumResponseBytes: maximumResponseBytes
+                    maximumResponseBytes: maximumResponseBytes,
+                    wireContract: wireContract
                 ),
                 vault: vault,
                 transport: transport


### PR DESCRIPTION
## Why

The first runnable Computer Use starter should work in the two browsers most Mac users already use. Semantic Accessibility remains the fast path, but some real post composers expose an empty editable region without a usable label. Those pages should get one bounded local visual recovery instead of a confusing "composer missing" failure.

Part of #3107.

## Intention and scope

- Offer selected Safari and Google Chrome windows as destinations for **Draft and post an update**.
- Preserve deterministic Accessibility lookup and exact UTF-8 verification as the primary path.
- When that lookup alone reports `composerMissing`, allow the currently selected, compatible local UI-TARS profile to propose one normalized point.
- Convert that point only into focus on the exact window's unique nearby empty, enabled, visible, settable, non-secure editor; deterministic draft insertion and verification then resume.
- Use the UI-TARS-native `computer` / `click` wire contract while retaining the existing generic grounding contract for other callers.
- Make one balanced enhanced-Accessibility request only when Chrome has not exposed its web content tree.

## Non-goals

- No Post, Publish, Send, checkout, or other external action.
- No generalized agent loop, generated typing, keyboard action, arbitrary coordinate click, task teaching, scheduling, cloud fallback, model download, or catalog change.
- No browser support beyond Safari and Google Chrome.

## Safety and compatibility

- Runtime connection is literal loopback only; the app-owned bearer remains memory-only.
- Recovery starts only for `composerMissing` before any content mutation and is capped at three attempts.
- PID, process launch identity, selected CG window, frame, browser document identity, and model observation binding are rechecked.
- Exact screenshot identity is required unless the only drift is accompanied by an already-focused safe empty editor at the grounded point (for example, a blinking caret).
- Near-point recovery is capped to 6% of the selected window (maximum 64 points) and must resolve to exactly one safe empty editor.
- Address bars, secure fields, buttons, non-empty fields, hidden/off-window elements, ambiguity, focus drift, and post-mutation drift fail closed.

## Design precedent

Mature desktop automation systems use semantic UI APIs before pixels, bind every action to a stable window/session identity, and keep visual recovery bounded by explicit action and verification contracts. This change adapts that pattern: Accessibility owns the write, the local VLM may only supply one location hint, and the verifier independently proves the resulting content. Browser-specific Accessibility activation is request-scoped and balanced rather than becoming persistent process state.

## Acceptance evidence

- Safari deterministic path: 30/30 complete iterations.
- Google Chrome deterministic path: 30/30 complete iterations.
- Safari visual fallback with the catalog `ui-tars-1.5-7b-4bit`: complete in 8.1 s.
- Google Chrome visual fallback with the same catalog model: complete in 3.9 s.
- Both visual runs used an intentionally unlabeled empty composer, inserted the TextEdit draft, verified exact bytes, and stopped before publishing.
- `swift test --no-parallel --filter DraftPostFlowTests` — 31 passed.
- `swift test --no-parallel --filter LocalComputerUseVisualGrounderTests` — 12 passed.
- `swift test --no-parallel` — 3,548 passed in 305 suites.
- `git diff --check` — passed.

