### PR TITLE
fix(cli): keep model inventory responsive on unhealthy relocated caches

### DIFF
--- a/.agents/handoffs/vector-server-gui-release-dogfood.md
+++ b/.agents/handoffs/vector-server-gui-release-dogfood.md
@@ -23,7 +23,7 @@
 - The isolated release-mode GUI passed onboarding, model inventory, GUI model
   start, exact `GUI_RELEASE_OK` chat, shutdown, relaunch, and conversation
   persistence. The production app and its state were untouched.
-- Focused Python tests (123), Ruff, diff check, the supported serialized
+- Focused Python tests (124), Ruff, diff check, the supported serialized
   Desktop gate (3,542 tests), full release-mode app/sidecar build, and packaged
   inventory regression passed. The 23,225-test Python collection had only two
   environment-path failures: optional mflux absence (passed after installing

--- a/.agents/handoffs/vector-server-gui-release-dogfood.md
+++ b/.agents/handoffs/vector-server-gui-release-dogfood.md
@@ -2,8 +2,8 @@
 
 - Owner/host: Vector, Studio (Apple M3 Ultra, 256 GiB, macOS 26.5.2)
 - Branch: `vector/release-dogfood-20260906`
-- Latest tested upstream base: `cc7d849821643706da15a9cdc52545ea28a05ace`
-- Exact tested branch head: `f09a761a26de553f0e87f66c30bd733759f6f4b2`
+- Latest tested upstream base: `2eac979c66fedee5cd9767b416b4fabdc9cf8d00`
+- Exact tested branch head: `444eb395400b57516765f81536125d02387eb9c4`
 - Durable report:
   `docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md`
 
@@ -40,6 +40,17 @@
   recomputed medians matched: 171.0 tok/s + 266 ms TTFT for `pp512-tg128`,
   169.6 tok/s + 947 ms TTFT for `pp2048-tg512`. No P0/P1 was found in that
   newly merged surface.
+- After the final rebase, `candidate-444eb395` passed a complete release app
+  and sidecar build. Its sidecar tarball SHA-256 is
+  `bd4cfe48f4a74a71a4d9565353578b66f549acf14439282b67f02706b0bfbcaf`.
+  Focused latest-base verification passed 321 Python tests and 72 Swift tests
+  covering cache inventory, Community Benchmark, draft-post, and bounded
+  visual recovery.
+- The latest packaged Qwen 3.5 4B benchmark completed all ten rounds at 170.5
+  tok/s + 264 ms TTFT (`pp512-tg128`) and 168.6 tok/s + 944 ms TTFT
+  (`pp2048-tg512`). Its stored identity was read from the actual cached model:
+  affine four-bit weights, group size 64, resolved revision
+  `32f3e8ecf65426fc3306969496342d504bfa13f3`.
 
 ## Risk and next action
 

--- a/.agents/handoffs/vector-server-gui-release-dogfood.md
+++ b/.agents/handoffs/vector-server-gui-release-dogfood.md
@@ -2,7 +2,8 @@
 
 - Owner/host: Vector, Studio (Apple M3 Ultra, 256 GiB, macOS 26.5.2)
 - Branch: `vector/release-dogfood-20260906`
-- Base: `caafd08df9e8d7242b081a3fc9fb7c9f6807eca0`
+- Latest tested upstream base: `cc7d849821643706da15a9cdc52545ea28a05ace`
+- Exact tested branch head: `f09a761a26de553f0e87f66c30bd733759f6f4b2`
 - Durable report:
   `docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md`
 
@@ -29,6 +30,16 @@
   the release-pinned version) and a Transformers 5.15 wrapped offline miss.
   The latter test-harness compatibility fix and its narrow fail-closed guard
   pass. Hosted exact-head results must still be read from the PR.
+- After rebasing onto the Community Benchmark UI changes in `cc7d84982`, a
+  second exact-head release build passed. Its packaged inventory returned 43
+  healthy rows in 4.19 seconds and its sidecar tarball SHA-256 is
+  `108556bdbea7550296863dd72a855dbddb682781401bdefbec19e2ae38cd80ba`.
+- Exact-head isolated GUI dogfood verified the Recommended / Downloaded / All
+  models grouping, live run scope and elapsed status, cancellation/reaping,
+  and a complete real Qwen 3.5 4B benchmark. The GUI and independently
+  recomputed medians matched: 171.0 tok/s + 266 ms TTFT for `pp512-tg128`,
+  169.6 tok/s + 947 ms TTFT for `pp2048-tg512`. No P0/P1 was found in that
+  newly merged surface.
 
 ## Risk and next action
 

--- a/.agents/handoffs/vector-server-gui-release-dogfood.md
+++ b/.agents/handoffs/vector-server-gui-release-dogfood.md
@@ -1,0 +1,39 @@
+# Vector -> Atlas: server + GUI release dogfood P1
+
+- Owner/host: Vector, Studio (Apple M3 Ultra, 256 GiB, macOS 26.5.2)
+- Branch: `vector/release-dogfood-20260906`
+- Base: `caafd08df9e8d7242b081a3fc9fb7c9f6807eca0`
+- Durable report:
+  `docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md`
+
+## Verified facts
+
+- A real external-cache failure made `models --cached --json` hang for more
+  than two minutes; an installed-sidecar instance had remained blocked for
+  more than 42 minutes. This also blocks Desktop model inventory.
+- The candidate bounds all relocated symlink scans under one shared two-second
+  deadline while preserving exact local and healthy-relocated sizing.
+- With three unresponsive external entries still present, source inventory
+  finishes in 3.05 seconds and the packaged sidecar finishes in 4.17 seconds;
+  both return 43 healthy rows and skip only the three named bad entries.
+- Source server real-weight Chat, Responses, Anthropic, both SSE paths,
+  function calling, eight-way concurrency, disconnect abort/recovery, and
+  graceful shutdown passed on `qwen3.5-4b-4bit`.
+- The isolated release-mode GUI passed onboarding, model inventory, GUI model
+  start, exact `GUI_RELEASE_OK` chat, shutdown, relaunch, and conversation
+  persistence. The production app and its state were untouched.
+- Focused Python tests (123), Ruff, diff check, the supported serialized
+  Desktop gate (3,542 tests), full release-mode app/sidecar build, and packaged
+  inventory regression passed. The 23,225-test Python collection had only two
+  environment-path failures: optional mflux absence (passed after installing
+  the release-pinned version) and a Transformers 5.15 wrapped offline miss.
+  The latter test-harness compatibility fix and its narrow fail-closed guard
+  pass. Hosted exact-head results must still be read from the PR.
+
+## Risk and next action
+
+Atlas should treat this as a release P1 and merge it before building the final
+candidate. The external ExFAT cache is still 99.8% full and too unhealthy for
+the large-model fleet gate; no cache data was deleted or moved. After merge,
+Harbor should rebuild and repeat exact-artifact smoke on the signed/notarized
+candidate. Publishing still requires explicit human authorization.

--- a/docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md
+++ b/docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md
@@ -1,0 +1,170 @@
+# Server and GUI release-candidate dogfood — 2026-09-06
+
+## Verdict
+
+The release-mode Desktop build and a source-tree server both completed their
+real-weight acceptance walks on an Apple M3 Ultra. Dogfood found one P1 release
+blocker: a single unresponsive external-volume symlink in the Hugging Face
+cache could hang `rapid-mlx models --cached --json` indefinitely. That command
+is also the Desktop model inventory probe, so the same condition could leave
+the GUI picker waiting forever.
+
+The candidate fix bounds all relocated cache probes under one two-second
+deadline, preserves exact sizing for responsive relocated entries, and omits
+only entries whose backing volume does not respond. With three unresponsive
+entries present, the source command went from **more than two minutes without
+returning** to **3.05 seconds**, and the packaged sidecar completed in **4.17
+seconds**. Server and isolated-GUI dogfood passed after the fix.
+
+This is a commit-bound local qualification receipt, not authorization to
+publish a release. The source base was `caafd08df9e8d7242b081a3fc9fb7c9f6807eca0`;
+the P1 fix was tested as an uncommitted candidate on top and must pass the PR
+merge gates before Atlas uses it for release integration.
+
+## Candidate and host
+
+- Rapid-MLX: 0.13.4, base `caafd08df9e8d7242b081a3fc9fb7c9f6807eca0`
+- Branch: `vector/release-dogfood-20260906`
+- Host: Apple M3 Ultra, 256 GiB unified memory, macOS 26.5.2
+- Source runtime: Python 3.11.16, MLX 0.32.2
+- Desktop sidecar: Python 3.12, MLX 0.32.2, mlx-lm 0.31.3,
+  mlx-vlm 0.6.17, mlx-audio 0.4.3, mflux 0.19.0
+- Release-mode sidecar: 482 MiB raw, 160 MiB compressed, 173 Mach-O files
+- Sidecar tarball SHA-256:
+  `22dd46425296d6d3644c5b4eab2fd11220e4301a2afb0ef45b451b24b33fb44d`
+- Desktop signing: deep ad-hoc signing for local dogfood only
+
+The production app at `/Applications/Rapid-MLX Desktop.app` remained running
+and untouched. GUI work used a copied app with bundle ID
+`com.rapidmlx.rapid.dogfood-8dbdee13`, a throwaway HOME, and port 59381.
+
+## P1 reproduced and fixed
+
+The default HF cache contained three model-entry symlinks into an external
+ExFAT volume that was mounted but pathologically slow and 99.8% full:
+
+- `mlx-community/Qwen3.5-9B-4bit`
+- `mlx-community/Qwen3.5-35B-A3B-4bit`
+- `mlx-community/Qwen3.6-35B-A3B-4bit`
+
+Before the fix, `uv run rapid-mlx models --cached --json` remained blocked for
+more than two minutes in `_dir_size_bytes -> os.scandir -> __opendir2`. A
+sampled installed-sidecar process showed the same stack after more than 42
+minutes. The CLI had no filesystem deadline, and Desktop's `ModelCatalog`
+waited on that child without its own timeout.
+
+The fix keeps local cache directories on the existing exact synchronous path.
+It detects only relocated root symlinks, scans them concurrently in daemon
+workers, and applies one shared two-second deadline to the whole relocated set.
+Responsive links retain their true size and modification time. Timed-out links
+are excluded from the inventory pass so later runnability checks cannot block
+on them again; stderr names every skipped repo.
+
+Measured with the real unhealthy cache still mounted:
+
+| Probe | Before | Fixed source | Fixed packaged sidecar |
+| --- | ---: | ---: | ---: |
+| `models --cached --json` | >120 s, manually interrupted | 3.05 s | 4.17 s |
+| Exit status | none | 0 | 0 |
+| Healthy rows returned | none | 43 | 43 |
+| Unresponsive rows skipped | none | 3 | 3 |
+
+No cache was deleted, migrated, or unmounted. The external-volume capacity
+problem remains a host-operations issue; the product fix prevents it from
+freezing unrelated healthy inventory.
+
+## Source server dogfood
+
+`qwen3.5-4b-4bit` loaded from the local cache on loopback port 8000. Warmup
+completed, health reported `ready=true`, and the following real inference
+paths passed:
+
+- `/health` and `/v1/models`
+- OpenAI Chat, non-streaming: exact `RAPID_RELEASE_OK`
+- OpenAI Chat SSE: exact `STREAM_OK` followed by `[DONE]`
+- Responses API, non-streaming: completed output item with exact
+  `RESPONSES_OK`
+- Responses API SSE: ordered events through `response.completed`, exact
+  `RESPONSE_STREAM_OK`
+- Anthropic Messages: exact `ANTHROPIC_OK`
+- Named no-argument function call: `finish_reason=tool_calls`, function
+  `ping`, arguments `{}`
+- Eight simultaneous Chat requests: all eight returned their distinct exact
+  `CONCURRENT_<n>_OK` values
+- Client disconnect after 200 ms: scheduler aborted the orphaned request;
+  immediate health stayed ready and the next request returned exact
+  `AFTER_CANCEL_OK`
+- Graceful Ctrl-C: prefix cache saved and the engine, scheduler, and server
+  stopped without a remaining listener
+
+One deliberately strict forced-tool request requiring a `city` object made the
+4B model emit malformed scalar/XML arguments. The server returned HTTP 400
+under the existing fail-closed schema contract. A named no-argument tool call
+passed immediately afterward. This is a small-model output-quality limitation,
+not justification to weaken validation before release.
+
+## Desktop GUI dogfood
+
+The fixed source was rebuilt into the full release-mode sidecar before GUI
+testing. The isolated app completed these user-visible paths:
+
+- Fresh-persona onboarding appeared with stable AX selectors and correctly
+  reported Apple M3 Ultra / 256 GB hardware.
+- Skipping onboarding entered the main chat surface without mutating the
+  production bundle's preferences or Application Support.
+- Model inventory completed despite the three unhealthy external symlinks.
+  Model Management displayed 184 available models and a completed storage
+  summary of 30 models on disk; controls and rows exposed stable AX identifiers.
+- `qwen3.5-4b-4bit` started from the GUI. The owned packaged sidecar listened
+  only on isolated port 59381 and reported `ready=true`.
+- A message entered and sent through the GUI returned exact `GUI_RELEASE_OK`.
+  Captured stats were 2.17 s time-to-first-token and 2.23 s total for three
+  completion tokens on the first GUI request.
+- After app termination and relaunch with the same isolated persona,
+  onboarding did not repeat. The conversation and both persisted messages
+  reappeared after selecting its sidebar row.
+- Both shutdowns reaped the owned sidecar and released port 59381. The
+  throwaway run was marked finished for host hygiene.
+
+## Automated verification
+
+- `uv run pytest -q tests/test_cli_models.py`: 85 passed
+- `uv run pytest -q tests/test_cli_models.py tests/test_cli_models_json.py tests/test_first_run_guide.py`:
+  123 passed
+- Expanded post-fix selection including cache inventory, first-run, the
+  Transformers 5.15 offline-wrapper regression, and packaged BF16 image
+  construction: 125 passed, 1 sanctioned offline skip
+- `uv run ruff check vllm_mlx/cli.py tests/test_cli_models.py tests/integrations/test_default_on_deep.py`:
+  passed
+- `git diff --check`: passed
+- `apps/rapid-mac/scripts/desktop-test-timeout.sh`: 3,542 tests in 306
+  suites passed in 90.61 seconds
+- `RAPID_CANDIDATE_IDENTITY=candidate-caafd08e bash scripts/build.sh`:
+  passed
+- Packaged `rapid-mlx models --cached --json` under a ten-second outer guard:
+  passed in 4.17 seconds
+
+An initial direct `swift test` invocation produced timing failures because it
+allowed Swift Testing to parallelize suites. The repository and hosted CI
+explicitly require `desktop-test-timeout.sh` / `--no-parallel`: synchronous
+child-process waits can starve the cooperative pool otherwise. The exact same
+built test bundle passed completely through the supported serial gate above.
+The first complete Python collection selected 23,225 tests and finished with
+22,963 passed, 256 skipped, 6 expected failures, 1 expected pass, and two
+environment-path failures. The packaged BF16 construction test required the
+optional `mflux` dependency and passed once the release-pinned mflux 0.19.0 was
+installed. The constrained-tool negative control exposed a real test-harness
+compatibility gap: Transformers 5.15 wraps a typed Hub offline cache miss in
+`OSError`, so the intended sanctioned skip did not fire. The test now walks
+the exception chain for the typed cause while continuing to fail on unrelated
+disk `OSError`s; its positive and negative guards pass. Hosted exact-head
+checks remain mandatory.
+
+## Release boundary and remaining risk
+
+Atlas should merge the P1 fix before cutting the candidate, then rebuild and
+run artifact-bound smoke on the final signed/notarized output. This run did not
+create a tag, GitHub Release, notarized artifact, deployment, or updater
+mutation. The nearly-full external ExFAT volume is still unsuitable for the
+large-model fleet gate, so a healthy cache volume remains necessary for a
+complete multi-family `release-check-m3` receipt.

--- a/docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md
+++ b/docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md
@@ -17,26 +17,34 @@ returning** to **3.05 seconds**, and the packaged sidecar completed in **4.17
 seconds**. Server and isolated-GUI dogfood passed after the fix.
 
 This is a commit-bound local qualification receipt, not authorization to
-publish a release. The source base was `caafd08df9e8d7242b081a3fc9fb7c9f6807eca0`;
-the P1 fix was tested as an uncommitted candidate on top and must pass the PR
-merge gates before Atlas uses it for release integration.
+publish a release. The initial qualification base was
+`caafd08df9e8d7242b081a3fc9fb7c9f6807eca0`. The branch was then rebased onto
+`cc7d849821643706da15a9cdc52545ea28a05ace` and the complete release app plus
+the newly merged Community Benchmark surface were requalified at
+`f09a761a26de553f0e87f66c30bd733759f6f4b2`. PR merge gates remain mandatory
+before Atlas uses the fix for release integration.
 
 ## Candidate and host
 
-- Rapid-MLX: 0.13.4, base `caafd08df9e8d7242b081a3fc9fb7c9f6807eca0`
+- Rapid-MLX: 0.13.4, latest tested head
+  `f09a761a26de553f0e87f66c30bd733759f6f4b2`
+- Latest tested upstream base:
+  `cc7d849821643706da15a9cdc52545ea28a05ace`
 - Branch: `vector/release-dogfood-20260906`
 - Host: Apple M3 Ultra, 256 GiB unified memory, macOS 26.5.2
 - Source runtime: Python 3.11.16, MLX 0.32.2
 - Desktop sidecar: Python 3.12, MLX 0.32.2, mlx-lm 0.31.3,
   mlx-vlm 0.6.17, mlx-audio 0.4.3, mflux 0.19.0
 - Release-mode sidecar: 482 MiB raw, 160 MiB compressed, 173 Mach-O files
-- Sidecar tarball SHA-256:
-  `22dd46425296d6d3644c5b4eab2fd11220e4301a2afb0ef45b451b24b33fb44d`
+- Exact-head sidecar tarball SHA-256:
+  `108556bdbea7550296863dd72a855dbddb682781401bdefbec19e2ae38cd80ba`
 - Desktop signing: deep ad-hoc signing for local dogfood only
 
 The production app at `/Applications/Rapid-MLX Desktop.app` remained running
-and untouched. GUI work used a copied app with bundle ID
-`com.rapidmlx.rapid.dogfood-8dbdee13`, a throwaway HOME, and port 59381.
+and untouched. Initial GUI work used bundle ID
+`com.rapidmlx.rapid.dogfood-8dbdee13` and port 59381. Exact-head Community
+Benchmark qualification used `com.rapidmlx.rapid.dogfood-2ec525f1`, another
+throwaway HOME, and port 59382.
 
 ## P1 reproduced and fixed
 
@@ -126,6 +134,35 @@ testing. The isolated app completed these user-visible paths:
 - Both shutdowns reaped the owned sidecar and released port 59381. The
   throwaway run was marked finished for host hygiene.
 
+### Exact-head Community Benchmark dogfood
+
+After rebasing onto upstream `cc7d84982` (Desktop Community Benchmark result,
+model-grouping, and run-progress changes), the full release app was rebuilt and
+launched as a second isolated persona. The model menu rendered the three new
+sections in order: Recommended for this Mac, Downloaded, and All models. The
+recommended group included the fitting Flux 2 Klein, Gemma 4, and Qwen focus
+models; the cached Qwen 3.5 4B model appeared under Downloaded.
+
+A first real run was stopped after the UI showed the model, workload scope,
+expected duration, and advancing elapsed timer. The benchmark process group
+was gone within the five-second observation window, the control returned to
+Run locally, and the UI reported that no incomplete result was shared.
+
+A second real `qwen3.5-4b-4bit` run completed all ten measured rounds and
+flowed from the packaged CLI's JSON record into the GUI:
+
+| Case | Measured rounds | GUI / independently recomputed result |
+| --- | ---: | ---: |
+| `pp512-tg128` | 5 | 171.0 tok/s, TTFT 266 ms |
+| `pp2048-tg512` | 5 | 169.6 tok/s, TTFT 947 ms |
+
+The independent calculation used the leaderboard formula
+`(output_tokens - 1) / decode_duration`. It matched both GUI rows exactly.
+The completion stamp `2026-09-07T05:29:39.745233Z` rendered in the local time
+zone as `Today 10:29 PM`. The exact-head app then terminated cleanly, released
+its host lock, and was marked finished. No P0 or P1 issue was found in the new
+Community Benchmark surface.
+
 ## Automated verification
 
 - `uv run pytest -q tests/test_cli_models.py`: 85 passed
@@ -139,10 +176,12 @@ testing. The isolated app completed these user-visible paths:
 - `git diff --check`: passed
 - `apps/rapid-mac/scripts/desktop-test-timeout.sh`: 3,542 tests in 306
   suites passed in 90.61 seconds
-- `RAPID_CANDIDATE_IDENTITY=candidate-caafd08e bash scripts/build.sh`:
-  passed
+- Exact-head Community Benchmark Swift selection: 29 passed
+- Exact-head cache/first-run/offline Python selection: 27 passed
+- Initial release build (`candidate-caafd08e`): passed
+- Exact-head release build (`candidate-f09a761a`): passed
 - Packaged `rapid-mlx models --cached --json` under a ten-second outer guard:
-  passed in 4.17 seconds
+  passed in 4.17 seconds initially and 4.19 seconds at exact head
 
 An initial direct `swift test` invocation produced timing failures because it
 allowed Swift Testing to parallelize suites. The repository and hosted CI

--- a/docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md
+++ b/docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md
@@ -14,22 +14,27 @@ deadline, preserves exact sizing for responsive relocated entries, and omits
 only entries whose backing volume does not respond. With three unresponsive
 entries present, the source command went from **more than two minutes without
 returning** to **3.05 seconds**, and the packaged sidecar completed in **4.17
-seconds**. Server and isolated-GUI dogfood passed after the fix.
+seconds** on both the original and latest upstream bases. Server and
+isolated-GUI dogfood passed after the fix.
 
 This is a commit-bound local qualification receipt, not authorization to
 publish a release. The initial qualification base was
 `caafd08df9e8d7242b081a3fc9fb7c9f6807eca0`. The branch was then rebased onto
 `cc7d849821643706da15a9cdc52545ea28a05ace` and the complete release app plus
 the newly merged Community Benchmark surface were requalified at
-`f09a761a26de553f0e87f66c30bd733759f6f4b2`. PR merge gates remain mandatory
-before Atlas uses the fix for release integration.
+`f09a761a26de553f0e87f66c30bd733759f6f4b2`. A final release audit rebased onto
+`2eac979c66fedee5cd9767b416b4fabdc9cf8d00`; its exact candidate
+`444eb395400b57516765f81536125d02387eb9c4` passed a fresh release build,
+packaged inventory, Community Benchmark identity run, and the focused tests
+for the newly merged benchmark and Desktop visual-recovery changes. PR merge
+gates remain mandatory before Atlas uses the fix for release integration.
 
 ## Candidate and host
 
 - Rapid-MLX: 0.13.4, latest tested head
-  `f09a761a26de553f0e87f66c30bd733759f6f4b2`
+  `444eb395400b57516765f81536125d02387eb9c4`
 - Latest tested upstream base:
-  `cc7d849821643706da15a9cdc52545ea28a05ace`
+  `2eac979c66fedee5cd9767b416b4fabdc9cf8d00`
 - Branch: `vector/release-dogfood-20260906`
 - Host: Apple M3 Ultra, 256 GiB unified memory, macOS 26.5.2
 - Source runtime: Python 3.11.16, MLX 0.32.2
@@ -37,7 +42,7 @@ before Atlas uses the fix for release integration.
   mlx-vlm 0.6.17, mlx-audio 0.4.3, mflux 0.19.0
 - Release-mode sidecar: 482 MiB raw, 160 MiB compressed, 173 Mach-O files
 - Exact-head sidecar tarball SHA-256:
-  `108556bdbea7550296863dd72a855dbddb682781401bdefbec19e2ae38cd80ba`
+  `bd4cfe48f4a74a71a4d9565353578b66f549acf14439282b67f02706b0bfbcaf`
 - Desktop signing: deep ad-hoc signing for local dogfood only
 
 The production app at `/Applications/Rapid-MLX Desktop.app` remained running
@@ -163,6 +168,16 @@ zone as `Today 10:29 PM`. The exact-head app then terminated cleanly, released
 its host lock, and was marked finished. No P0 or P1 issue was found in the new
 Community Benchmark surface.
 
+After the subsequent upstream benchmark-identity hardening, the newly rebuilt
+packaged CLI ran the same registered protocol against the real cached
+`qwen3.5-4b-4bit` snapshot. All ten measured rounds completed. The stored model
+record now reflects the artifact actually loaded: affine weights, four bits
+(`weight_bits_x2=8`), group size 64, and resolved Hugging Face revision
+`32f3e8ecf65426fc3306969496342d504bfa13f3`. Its measured medians were 170.5
+tok/s with 264 ms TTFT for `pp512-tg128`, and 168.6 tok/s with 944 ms TTFT for
+`pp2048-tg512`. This validates both the packaged inference path and the new
+quantization/revision provenance rather than trusting catalog metadata.
+
 ## Automated verification
 
 - `uv run pytest -q tests/test_cli_models.py`: 86 passed
@@ -177,12 +192,18 @@ Community Benchmark surface.
 - `apps/rapid-mac/scripts/desktop-test-timeout.sh`: 3,542 tests in 306
   suites passed in 90.61 seconds
 - Exact-head Community Benchmark Swift selection: 29 passed
+- Latest-base Python cache and Community Benchmark selection: 321 passed
+- Latest-base Swift Community Benchmark, draft-post, and visual-grounder
+  selection: 72 tests in 3 suites passed; live-only fixtures skipped
 - Exact-head cache/first-run/offline Python selection: 27 passed
 - Changed production lines under targeted coverage: 100% (40/40)
 - Initial release build (`candidate-caafd08e`): passed
 - Exact-head release build (`candidate-f09a761a`): passed
+- Latest-base release build (`candidate-444eb395`): passed
 - Packaged `rapid-mlx models --cached --json` under a ten-second outer guard:
-  passed in 4.17 seconds initially and 4.19 seconds at exact head
+  passed in 4.17 seconds initially, 4.19 seconds at the first exact head, and
+  4.17 seconds at the latest base; every run returned 43 healthy rows and
+  skipped the same three unresponsive entries
 
 An initial direct `swift test` invocation produced timing failures because it
 allowed Swift Testing to parallelize suites. The repository and hosted CI

--- a/docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md
+++ b/docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md
@@ -165,9 +165,9 @@ Community Benchmark surface.
 
 ## Automated verification
 
-- `uv run pytest -q tests/test_cli_models.py`: 85 passed
+- `uv run pytest -q tests/test_cli_models.py`: 86 passed
 - `uv run pytest -q tests/test_cli_models.py tests/test_cli_models_json.py tests/test_first_run_guide.py`:
-  123 passed
+  124 passed
 - Expanded post-fix selection including cache inventory, first-run, the
   Transformers 5.15 offline-wrapper regression, and packaged BF16 image
   construction: 125 passed, 1 sanctioned offline skip
@@ -178,6 +178,7 @@ Community Benchmark surface.
   suites passed in 90.61 seconds
 - Exact-head Community Benchmark Swift selection: 29 passed
 - Exact-head cache/first-run/offline Python selection: 27 passed
+- Changed production lines under targeted coverage: 100% (40/40)
 - Initial release build (`candidate-caafd08e`): passed
 - Exact-head release build (`candidate-f09a761a`): passed
 - Packaged `rapid-mlx models --cached --json` under a ten-second outer guard:

--- a/tests/integrations/test_default_on_deep.py
+++ b/tests/integrations/test_default_on_deep.py
@@ -478,7 +478,35 @@ def _negctrl_offline_skip_types() -> tuple[type[BaseException], ...]:
         types.append(_ReqConnErr)
     except Exception:  # pragma: no cover - requests not present
         pass
-    return tuple(types) or (OSError,)
+    return tuple(types)
+
+
+def _is_negctrl_offline_cache_miss(exc: BaseException) -> bool:
+    """Recognize a genuine HF offline miss through transformers wrappers.
+
+    Transformers 5.15 wraps ``LocalEntryNotFoundError`` in a generic
+    ``OSError``. Match the typed cause anywhere in the exception chain rather
+    than treating every disk-related ``OSError`` as skippable; corrupt local
+    tokenizer artifacts must remain real failures.
+    """
+    offline_types = _negctrl_offline_skip_types()
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, offline_types):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def test_negctrl_offline_cache_miss_detection_is_narrow():
+    """Wrapped HF misses skip, but unrelated OSErrors still fail closed."""
+    assert not _is_negctrl_offline_cache_miss(OSError("corrupt tokenizer.json"))
+    hub_errors = pytest.importorskip("huggingface_hub.errors")
+    wrapped = OSError("transformers could not resolve the tokenizer")
+    wrapped.__cause__ = hub_errors.LocalEntryNotFoundError("not cached")
+    assert _is_negctrl_offline_cache_miss(wrapped)
 
 
 def _load_negctrl_tokenizers():
@@ -497,7 +525,9 @@ def _load_negctrl_tokenizers():
         tok = transformers.AutoTokenizer.from_pretrained(
             _NEGCTRL_TOKENIZER, revision=_NEGCTRL_REVISION
         )
-    except _negctrl_offline_skip_types():  # pragma: no cover - offline & uncached
+    except Exception as exc:  # noqa: BLE001 - re-raised unless typed offline miss
+        if not _is_negctrl_offline_cache_miss(exc):
+            raise
         pytest.skip(
             f"tokenizer {_NEGCTRL_TOKENIZER}@{_NEGCTRL_REVISION[:8]} not cached "
             "and no network — negative control requires it"

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1040,6 +1040,31 @@ def test_scan_hf_cache_models_keeps_healthy_relocated_entry(tmp_path, monkeypatc
     assert [(repo, size) for repo, size, _mtime in rows] == [("acme/Widget-4bit", 4096)]
 
 
+def test_scan_hf_cache_models_keeps_relocated_entry_when_mtime_is_unreadable(
+    tmp_path, monkeypatch
+):
+    """A metadata error must not discard an otherwise readable relocation."""
+    cache_root = tmp_path / "hub"
+    real = tmp_path / "external" / "Widget-4bit"
+    _make_hf_cache_repo(real, {"sha_weights": 4096})
+    cache_root.mkdir()
+    relocated = cache_root / "models--acme--Widget-4bit"
+    relocated.symlink_to(real, target_is_directory=True)
+    real_getmtime = cli.os.path.getmtime
+
+    def getmtime(path):
+        if os.fspath(path) == os.fspath(relocated):
+            raise OSError("metadata temporarily unavailable")
+        return real_getmtime(path)
+
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_CACHE", str(cache_root), raising=False
+    )
+    monkeypatch.setattr(cli.os.path, "getmtime", getmtime)
+
+    assert cli._scan_hf_cache_models() == [("acme/Widget-4bit", 4096, 0.0)]
+
+
 # ---------------------------------------------------------------------------
 # External model discovery (#1718)
 #

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import io
 import os
 import sys
+import threading
+import time
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
@@ -981,6 +983,63 @@ def test_scan_hf_cache_models_reports_blob_bytes_not_double(tmp_path, monkeypatc
     rows = cli._scan_hf_cache_models()
     sizes = {repo_id: size for repo_id, size, _mtime in rows}
     assert sizes["acme/Widget-4bit"] == 8192
+
+
+def test_scan_hf_cache_models_skips_unresponsive_relocated_entry(
+    tmp_path, monkeypatch, caplog
+):
+    """One stalled external cache link must not hang CLI or GUI inventory."""
+    cache_root = tmp_path / "hub"
+    local = cache_root / "models--acme--Local-4bit"
+    _make_hf_cache_repo(local, {"sha_weights": 1024})
+    external = tmp_path / "external" / "Stalled-4bit"
+    external.mkdir(parents=True)
+    relocated = cache_root / "models--acme--Stalled-4bit"
+    relocated.symlink_to(external, target_is_directory=True)
+
+    release_worker = threading.Event()
+    real_dir_size = cli._dir_size_bytes
+
+    def blocking_dir_size(path):
+        if os.path.islink(path):
+            release_worker.wait(1.0)
+            return 2048
+        return real_dir_size(path)
+
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_CACHE", str(cache_root), raising=False
+    )
+    monkeypatch.setattr(cli, "_dir_size_bytes", blocking_dir_size)
+    monkeypatch.setattr(cli, "_RELOCATED_CACHE_SCAN_TIMEOUT_SECONDS", 0.02)
+
+    started = time.monotonic()
+    rows = cli._scan_hf_cache_models()
+    elapsed = time.monotonic() - started
+    release_worker.set()
+
+    assert elapsed < 0.25
+    assert [repo for repo, _size, _mtime in rows] == ["acme/Local-4bit"]
+    assert "Skipped 1 relocated cache entry" in caplog.text
+
+
+def test_scan_hf_cache_models_keeps_healthy_relocated_entry(tmp_path, monkeypatch):
+    """The deadline must not regress supported, responsive cache relocation."""
+    cache_root = tmp_path / "hub"
+    real = tmp_path / "external" / "Widget-4bit"
+    _make_hf_cache_repo(real, {"sha_weights": 4096})
+    cache_root.mkdir()
+    (cache_root / "models--acme--Widget-4bit").symlink_to(
+        real, target_is_directory=True
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.constants.HF_HUB_CACHE", str(cache_root), raising=False
+    )
+
+    rows = cli._scan_hf_cache_models()
+
+    assert [(repo, size) for repo, size, _mtime in rows] == [
+        ("acme/Widget-4bit", 4096)
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_models.py
+++ b/tests/test_cli_models.py
@@ -1037,9 +1037,7 @@ def test_scan_hf_cache_models_keeps_healthy_relocated_entry(tmp_path, monkeypatc
 
     rows = cli._scan_hf_cache_models()
 
-    assert [(repo, size) for repo, size, _mtime in rows] == [
-        ("acme/Widget-4bit", 4096)
-    ]
+    assert [(repo, size) for repo, size, _mtime in rows] == [("acme/Widget-4bit", 4096)]
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -6227,6 +6227,81 @@ def _dir_size_bytes(path: str) -> int:
     return total
 
 
+_RELOCATED_CACHE_SCAN_TIMEOUT_SECONDS = 2.0
+
+
+def _scan_relocated_hf_cache_entries(
+    entries: list[tuple[int, str, str]],
+) -> dict[int, tuple[str, int, float]]:
+    """Inspect relocated HF cache entries without letting a bad mount hang ``ls``.
+
+    A cache root symlink is a supported way to keep large models on an external
+    volume, so healthy links must still report their real size.  ``stat`` and
+    ``scandir`` have no useful Python-level timeout, though: an unavailable USB,
+    network, or FUSE mount can otherwise block ``rapid-mlx models --cached`` and
+    the desktop app's model inventory forever.
+
+    Run all relocated roots concurrently under one shared deadline.  Workers are
+    daemon threads because a kernel-blocked filesystem call cannot be cancelled;
+    this matches the bounded-call strategy used by ``_download_gate``.  Entries
+    that miss the deadline are omitted from this inventory pass, rather than
+    retained with a fake zero-byte size (or probed again by the runnability
+    check).  Plain local cache directories stay on the exact synchronous path.
+    """
+    import logging
+    import threading
+    import time
+
+    jobs: list[tuple[int, str, threading.Event, list[tuple[str, int, float]]]] = []
+
+    def inspect(
+        repo: str,
+        full: str,
+        done: threading.Event,
+        result: list[tuple[str, int, float]],
+    ) -> None:
+        try:
+            try:
+                mtime = os.path.getmtime(full)
+            except OSError:
+                mtime = 0.0
+            result.append((repo, _dir_size_bytes(full), mtime))
+        finally:
+            done.set()
+
+    for index, repo, full in entries:
+        done = threading.Event()
+        result: list[tuple[str, int, float]] = []
+        jobs.append((index, repo, done, result))
+        threading.Thread(
+            target=inspect,
+            args=(repo, full, done, result),
+            name=f"rapid-mlx-cache-scan-{index}",
+            daemon=True,
+        ).start()
+
+    deadline = time.monotonic() + _RELOCATED_CACHE_SCAN_TIMEOUT_SECONDS
+    for _index, _repo, done, _result in jobs:
+        done.wait(max(0.0, deadline - time.monotonic()))
+
+    completed: dict[int, tuple[str, int, float]] = {}
+    skipped: list[str] = []
+    for index, repo, done, result in jobs:
+        if done.is_set() and result:
+            completed[index] = result[0]
+        else:
+            skipped.append(repo)
+    if skipped:
+        logging.getLogger(__name__).warning(
+            "Skipped %d relocated cache entr%s that did not respond within %.1fs: %s",
+            len(skipped),
+            "y" if len(skipped) == 1 else "ies",
+            _RELOCATED_CACHE_SCAN_TIMEOUT_SECONDS,
+            ", ".join(skipped),
+        )
+    return completed
+
+
 def _scan_hf_cache_models() -> list[tuple[str, int, float]]:
     """Return ``[(hf_repo, size_bytes, last_modified_epoch), ...]`` for every
     ``models--<org>--<name>`` directory in the HF cache.
@@ -6241,7 +6316,8 @@ def _scan_hf_cache_models() -> list[tuple[str, int, float]]:
         HF_HUB_CACHE = os.path.expanduser("~/.cache/huggingface/hub")
     if not os.path.isdir(HF_HUB_CACHE):
         return []
-    out: list[tuple[str, int, float]] = []
+    rows_by_index: dict[int, tuple[str, int, float]] = {}
+    relocated: list[tuple[int, str, str]] = []
     for name in os.listdir(HF_HUB_CACHE):
         if not name.startswith("models--"):
             continue
@@ -6251,13 +6327,18 @@ def _scan_hf_cache_models() -> list[tuple[str, int, float]]:
         parts = name[len("models--") :].split("--", 1)
         repo = "/".join(parts) if len(parts) == 2 else parts[0]
         full = os.path.join(HF_HUB_CACHE, name)
+        index = len(rows_by_index) + len(relocated)
+        if os.path.islink(full):
+            relocated.append((index, repo, full))
+            continue
         try:
             mtime = os.path.getmtime(full)
         except OSError:
             mtime = 0.0
         size = _dir_size_bytes(full)
-        out.append((repo, size, mtime))
-    return out
+        rows_by_index[index] = (repo, size, mtime)
+    rows_by_index.update(_scan_relocated_hf_cache_entries(relocated))
+    return [rows_by_index[index] for index in sorted(rows_by_index)]
 
 
 def _external_model_roots() -> list[str]:


### PR DESCRIPTION
## Why

A real release-candidate dogfood run found that `rapid-mlx models --cached --json` could block forever when a Hugging Face model-entry symlink points at a mounted but unresponsive external volume. The same command backs Desktop model inventory, so one unhealthy relocated model could freeze model discovery for every healthy model. On the affected M3 Ultra it remained blocked for more than 120 seconds; an older packaged process had been stuck for more than 42 minutes.

## Scope

- Keep ordinary local HF cache directories on the existing exact synchronous scan.
- Scan root-level relocated model symlinks concurrently under one shared two-second deadline.
- Preserve exact size/mtime for responsive links; omit and name only timed-out links so they cannot block the later runnability probe.
- Add regressions for a blocked external entry, a healthy relocated entry, and unreadable relocated-entry metadata.
- Make the constrained-tool negative-control test recognize Transformers 5.15's generic `OSError` wrapper only when its exception chain contains a typed Hub/network offline miss.
- Record the server + GUI release-candidate receipt and Atlas handoff, including exact quantitative results.

## Non-goals

- No cache entry is deleted, moved, unmounted, or assigned a fake size.
- This does not make a genuinely unhealthy external volume usable for loading a model.
- This does not weaken production tokenizer/model errors or tool-schema validation.
- This does not publish, tag, notarize, or deploy a release.

## Acceptance

- One kernel-blocked relocated entry cannot hold up healthy model inventory indefinitely.
- Healthy local and relocated entries retain exact byte accounting.
- Skipped repos are visible on stderr and absent from downstream runnability probes.
- Desktop inventory, packaged server/chat, benchmark start/stop, and a full benchmark result remain functional from the release app.

## Verification

- Real unhealthy cache, before: no return after >120 s (manually interrupted); older packaged process sampled in `os.scandir` after >42 min.
- Fixed source: 43 healthy rows, 3 named skipped entries, exit 0 in 3.05 s.
- Initial packaged sidecar: same 43/3 result in 4.17 s.
- Latest-base packaged sidecar: same 43/3 result in 4.17 s; 482 MiB raw, 160 MiB tarball, 173 Mach-O files; SHA-256 `bd4cfe48f4a74a71a4d9565353578b66f549acf14439282b67f02706b0bfbcaf`.
- Full release builds passed at the initial candidate, after rebasing onto `cc7d84982`, and at `candidate-444eb395` on latest base `2eac979c6`.
- Hosted exact-head gates are green with zero failures: Apple Silicon 5m31s; Python 3.10/3.11/3.12 matrices 16m50s/16m21s/10m43s; Desktop build 4m09s; changed-lines coverage, PR validation, lint/type/engine/GUI contracts all passed.
- `tests/test_cli_models.py`: 86 passed; related model/first-run selection: 124 passed.
- Exact-head cache/first-run/offline selection: 27 passed; Ruff and `git diff --check` passed.
- Exact-head targeted production diff coverage: 40/40 changed lines (100%).
- Supported serialized Desktop gate: 3,542 tests / 306 suites passed in 90.61 s.
- Exact-head Community Benchmark selection: 29 passed. Latest-base cache/benchmark Python selection: 321 passed; latest-base Community Benchmark, draft-post, and visual-grounder Swift selection: 72 tests / 3 suites passed.
- Local pr_validate in the declared project environment: MERGE-SAFE; full unit 22,954 passed, 129 skipped, 22 deselected, 6 xfailed, 1 xpassed in 12:05; advisory full-suite patch coverage before the final fallback regression was 95%, and the targeted exact-head replay is 100%.
- Source server with real `qwen3.5-4b-4bit`: health/models; OpenAI Chat + SSE; Responses + SSE; Anthropic; no-arg function call; 8 concurrent exact replies; disconnect abort/recovery; graceful shutdown all passed.
- Isolated packaged GUI: onboarding, inventory, GUI chat (`GUI_RELEASE_OK`), persistence/relaunch, sidecar cleanup passed.
- Exact-head isolated Community Benchmark: grouped picker and elapsed state passed; Stop reaped its process group. A complete 10-round Qwen 3.5 4B run rendered values matching independent JSON recomputation: `pp512-tg128` 171.0 tok/s + 266 ms TTFT; `pp2048-tg512` 169.6 tok/s + 947 ms TTFT. After the latest rebase, the rebuilt packaged CLI completed another ten rounds at 170.5/168.6 tok/s and 264/944 ms TTFT, and recorded the actual cached artifact as affine 4-bit/group-64 with resolved revision `32f3e8ecf65426fc3306969496342d504bfa13f3`.
- An initial full Python collection used two missing/older optional environment paths. The packaged BF16 test passed with release-pinned mflux 0.19.0, and the Transformers 5.15 wrapped-offline case passed after the narrow test-harness fix. A first pr_validate invocation accidentally used host mflux 0.18.1 and failed the seven Bonsai tests that require declared mflux >=0.19.0; the correctly isolated project-environment run passed all 22,954 unit tests.
- Durable receipt: `docs/engineering/operations/2026-09-06-server-gui-release-candidate-dogfood.md`.

## Behaviour delta

`models --cached --json` with an unresponsive relocated model: unbounded wait for all inventory → one shared two-second relocated-entry budget, returning healthy rows while warning about timed-out repos. Normal local-cache behavior is unchanged.

## AI assistance disclosure

Codex wrote and repeatedly self-reviewed the Python implementation, regressions, test compatibility update, operations receipt, and handoff. Verification included real blocked filesystem behavior, packaged release builds, real-weight server/API exercises, isolated GUI interaction, independent benchmark-metric recomputation, targeted and full test suites, and diff review. No external Spark reviewer was used.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally (see the exact full-suite qualification and environment A/B above)
- [x] Lint and format checks pass
- [x] Self-validated with `uv run python -m scripts.pr_validate 3199`
- [x] New critical-path tests were spot-checked against the blocking production line
- [x] Updated durable operations docs and cross-role handoff
- [x] No breaking changes to existing API

## Author

X handle (optional, external contributors):
