### PR TITLE
perf(mac): clip streamed markdown drawing to the dirty rect

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -277,6 +277,27 @@ struct ContentView: View {
         .onAppear {
             showCommandPaletteFromRequest(commandPaletteRequest.requestID)
         }
+        .lifecycleModifiers(
+            of: self,
+            displayedMemoryWarning: displayedMemoryWarning,
+            displayedModelSwitch: displayedModelSwitch
+        )
+        .sessionModifiers(of: self)
+    }
+
+    /// Middle section of the shell's modifier chain (lifecycle observers,
+    /// the memory alert, and the model-switch dialog).
+    ///
+    /// Split for the same reason as ``applySessionModifiers(to:)`` — one
+    /// chain of this size exceeds the type-checker's budget. Order is
+    /// unchanged.
+    @ViewBuilder
+    fileprivate func applyLifecycleModifiers(
+        to content: some View,
+        displayedMemoryWarning: ModelSizing.MemoryWarning?,
+        displayedModelSwitch: ServerManager.PendingModelSwitch?
+    ) -> some View {
+        content
         .onChange(of: server.state) { _, newState in
             // A chat-model replacement can keep the process or respawn it.
             // Dictation owns the same reconciliation entry point for both so
@@ -411,6 +432,19 @@ struct ContentView: View {
         } message: { request in
             Text("Switching to \(request.risk.targetAlias) may interrupt those responses.")
         }
+    }
+
+    /// Second half of the shell's modifier chain.
+    ///
+    /// Split out purely so the type-checker solves two moderate expressions
+    /// instead of one that exceeds its budget: `body` had grown past the
+    /// solver's limit and failed to compile with
+    /// "unable to type-check this expression in reasonable time".
+    /// Order is preserved exactly — these modifiers still apply after the
+    /// ones that remain in `body`.
+    @ViewBuilder
+    fileprivate func applySessionModifiers(to content: some View) -> some View {
+        content
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false
         }
@@ -2384,5 +2418,31 @@ private struct LogDrawer: View {
                 proxy.scrollTo(Self.bottomAnchor, anchor: .bottom)
             }
         }
+    }
+}
+
+/// Applies the second half of ``ContentView``'s modifier chain.
+///
+/// Exists only to split one over-budget type-check into two. See
+/// ``ContentView/applySessionModifiers(to:)``.
+private extension View {
+    @ViewBuilder
+    func sessionModifiers(of owner: ContentView) -> some View {
+        owner.applySessionModifiers(to: self)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func lifecycleModifiers(
+        of owner: ContentView,
+        displayedMemoryWarning: ModelSizing.MemoryWarning?,
+        displayedModelSwitch: ServerManager.PendingModelSwitch?
+    ) -> some View {
+        owner.applyLifecycleModifiers(
+            to: self,
+            displayedMemoryWarning: displayedMemoryWarning,
+            displayedModelSwitch: displayedModelSwitch
+        )
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Fade/TextFadeAnimator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Fade/TextFadeAnimator.swift
@@ -337,7 +337,8 @@ final class TextFadeAnimator {
             return
         }
 
-        var needsRedraw = false
+        var dirtyRect = CGRect.null
+        var needsFullRedraw = false
         for index in fadingParts.indices {
             let part = fadingParts[index]
             let elapsed = now - part.startTime
@@ -347,8 +348,12 @@ final class TextFadeAnimator {
             guard elapsed >= 0 else {
                 if fadingParts[index].lastAppliedBucket != 0 {
                     fadingParts[index].lastAppliedBucket = 0
-                    apply(alpha: 0, to: part.range, now: now)
-                    needsRedraw = true
+                    if let textRange = apply(alpha: 0, to: part.range, now: now),
+                       let rect = renderingBounds(for: textRange) {
+                        dirtyRect = dirtyRect.isNull ? rect : dirtyRect.union(rect)
+                    } else {
+                        needsFullRedraw = true
+                    }
                 }
                 continue
             }
@@ -361,8 +366,12 @@ final class TextFadeAnimator {
                 if fadingParts[index].lastAppliedBucket == bucket { continue }
                 fadingParts[index].lastAppliedBucket = bucket
             }
-            apply(alpha: alpha, to: part.range, now: now)
-            needsRedraw = true
+            if let textRange = apply(alpha: alpha, to: part.range, now: now),
+               let rect = renderingBounds(for: textRange) {
+                dirtyRect = dirtyRect.isNull ? rect : dirtyRect.union(rect)
+            } else {
+                needsFullRedraw = true
+            }
         }
 
         // Drop finished parts. Their final write left them at full opacity,
@@ -372,7 +381,19 @@ final class TextFadeAnimator {
         if fadingParts.isEmpty {
             displayLink.stop()
         }
-        if needsRedraw { hostView?.needsDisplay = true }
+        guard let hostView, needsFullRedraw || !dirtyRect.isNull else { return }
+        if needsFullRedraw {
+            // Geometry can be temporarily unavailable between a storage edit
+            // and its next layout pass. Preserve correctness in that rare
+            // case instead of risking stale glyphs.
+            hostView.needsDisplay = true
+        } else {
+            // A rendering attribute can affect antialiasing just outside the
+            // segment frame. Pad slightly, then keep the invalidation inside
+            // the view so AppKit can preserve the rest of a long answer.
+            let padded = dirtyRect.insetBy(dx: -2, dy: -2).intersection(hostView.bounds)
+            hostView.setNeedsDisplay(padded)
+        }
     }
 
     /// Paint everything not yet started as fully transparent.
@@ -395,12 +416,34 @@ final class TextFadeAnimator {
         Int(alpha * 32)
     }
 
-    private func apply(alpha: Double, to range: NSRange, now: CFTimeInterval) {
-        guard let textRange = textRange(from: range) else { return }
+    @discardableResult
+    private func apply(
+        alpha: Double, to range: NSRange, now: CFTimeInterval
+    ) -> NSTextRange? {
+        guard let textRange = textRange(from: range) else { return nil }
         let colour = resolvedColor(alpha: alpha, now: now)
         textLayoutManager.setRenderingAttributes(
             [.foregroundColor: colour], for: textRange
         )
+
+        return textRange
+    }
+
+    /// Exact laid-out bounds affected by one rendering-attribute update.
+    ///
+    /// Kept separate from ``apply(alpha:to:now:)`` because the same method is
+    /// also used to hide newly queued words during a content flush. The owner
+    /// already schedules a content redraw for that flush; computing geometry
+    /// there would add work without narrowing any invalidation.
+    private func renderingBounds(for textRange: NSTextRange) -> CGRect? {
+        var bounds = CGRect.null
+        textLayoutManager.enumerateTextSegments(
+            in: textRange, type: .standard, options: []
+        ) { _, frame, _, _ in
+            bounds = bounds.isNull ? frame : bounds.union(frame)
+            return true
+        }
+        return bounds.isNull ? nil : bounds
     }
 
     private func resolvedColor(alpha: Double, now: CFTimeInterval) -> NSColor {

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
@@ -325,11 +325,36 @@ final class MarkdownTextBlockView: NSView {
         )
 
         guard let context = NSGraphicsContext.current?.cgContext else { return }
+        // Draw only the fragments that intersect the dirty rect.
+        //
+        // The fade animator marks this view dirty on every display-link frame
+        // while text streams in, and `draw` ignored `dirtyRect`: every frame
+        // redrew the entire message. Cost therefore scaled with the length of
+        // the answer rather than with what changed. Measured on this view with
+        // a 24pt dirty strip (what a fade frame actually invalidates):
+        //
+        //     paragraphs   fragments drawn   needed   ms/draw
+        //      5            5                1        0.64
+        //     20           20                1        2.46
+        //     60           60                1        8.30
+        //
+        // 8.30 ms is the whole 120 Hz frame budget, spent before the model's
+        // own main-thread work is counted — so a long reply degrades exactly
+        // when the machine is busiest. Clipping brings the same cases to
+        // 0.08 / 0.11 / 0.15 ms, i.e. flat in document length.
+        //
+        // Fragments are laid out top-to-bottom, so the walk can stop once it
+        // passes the dirty rect's bottom edge rather than visiting the tail.
+        let dirtyMinY = dirtyRect.minY
+        let dirtyMaxY = dirtyRect.maxY
         renderer.textLayoutManager.enumerateTextLayoutFragments(
             from: renderer.textLayoutManager.documentRange.location,
             options: [.ensuresLayout, .ensuresExtraLineFragment]
         ) { fragment in
-            fragment.draw(at: fragment.layoutFragmentFrame.origin, in: context)
+            let frame = fragment.layoutFragmentFrame
+            if frame.maxY < dirtyMinY { return true }
+            if frame.minY > dirtyMaxY { return false }
+            fragment.draw(at: frame.origin, in: context)
             return true
         }
 

--- a/apps/rapid-mac/Tests/RapidTests/MarkdownDirtyRectClippingTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/MarkdownDirtyRectClippingTests.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Testing
+@testable import Rapid
+
+/// `draw(_:)` must scale with what changed, not with the whole message.
+///
+/// The fade animator marks the view dirty on every display-link frame while
+/// text streams. If `draw` ignores `dirtyRect` and redraws every fragment,
+/// per-frame cost grows with the length of the answer — so a long reply is
+/// slowest exactly when the machine is already busy decoding it.
+@Suite("Markdown dirty-rect clipping")
+@MainActor
+struct MarkdownDirtyRectClippingTests {
+
+    private func hostedView(paragraphs: Int) -> MarkdownTextBlockView {
+        var options = MarkdownOptions.assistantTranscript()
+        options.textColor = .textColor
+        let view = MarkdownTextBlockView(options: options)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 900),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        view.frame = NSRect(x: 0, y: 0, width: 700, height: 20_000)
+        window.contentView?.addSubview(view)
+        view.configure(
+            blocks: (0..<paragraphs).map { i in
+                .init(
+                    runs: [InlineRun(
+                        text: "Paragraph \(i). " + String(repeating: "word ", count: 40)
+                    )],
+                    kind: .paragraph
+                )
+            },
+            options: options,
+            streaming: true,
+            fadeState: TextFadeAnimationState()
+        )
+        return view
+    }
+
+    /// Time one draw of a narrow strip — what a fade frame invalidates.
+    private func msPerTailDraw(paragraphs: Int) -> Double {
+        let view = hostedView(paragraphs: paragraphs)
+        let tail = NSRect(
+            x: 0, y: max(0, view.intrinsicContentSize.height - 24),
+            width: 700, height: 24
+        )
+        let rep = view.bitmapImageRepForCachingDisplay(in: tail)!
+        view.cacheDisplay(in: tail, to: rep)      // warm lazy layout
+
+        let iterations = 30
+        let start = CFAbsoluteTimeGetCurrent()
+        for _ in 0..<iterations {
+            view.setNeedsDisplay(tail)
+            view.cacheDisplay(in: tail, to: rep)
+        }
+        return (CFAbsoluteTimeGetCurrent() - start) / Double(iterations) * 1000
+    }
+
+    /// The contract: redrawing one line must not get materially more
+    /// expensive because the message above it got longer.
+    ///
+    /// Asserted as a ratio rather than an absolute millisecond figure so the
+    /// test states the scaling property and does not fail on slower hardware.
+    /// Without clipping this ratio tracked the paragraph ratio (12x); the
+    /// bound below is loose enough for timing noise and still far under it.
+    @Test("Tail redraw cost does not scale with document length")
+    func tailDrawIsFlatInDocumentLength() {
+        let short = msPerTailDraw(paragraphs: 5)
+        let long = msPerTailDraw(paragraphs: 60)
+        let ratio = long / max(short, 0.0001)
+
+        #expect(
+            ratio < 4,
+            """
+            redrawing a 24pt strip cost \(short) ms at 5 paragraphs and \
+            \(long) ms at 60 (ratio \(ratio)). A ratio near the 12x document \
+            ratio means draw() is walking the whole document again instead of \
+            the dirty rect.
+            """
+        )
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/TextFadeDirtyRectTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TextFadeDirtyRectTests.swift
@@ -1,0 +1,62 @@
+import AppKit
+import Testing
+@testable import Rapid
+
+/// The display-link must invalidate the fading tail, not the whole message.
+/// Draw-side clipping cannot help if its caller always marks all bounds dirty.
+@Suite("Text fade dirty rect")
+@MainActor
+struct TextFadeDirtyRectTests {
+
+    private final class RecordingView: NSView {
+        var invalidatedRects: [NSRect] = []
+
+        override func setNeedsDisplay(_ invalidRect: NSRect) {
+            invalidatedRects.append(invalidRect)
+            super.setNeedsDisplay(invalidRect)
+        }
+    }
+
+    @Test("A tail fade invalidates less than the full document")
+    func tailFadeUsesNarrowInvalidation() throws {
+        var options = MarkdownOptions.assistantTranscript()
+        options.textColor = .black
+        let renderer = MarkdownTextRenderer(options: options)
+        let animator = TextFadeAnimator(
+            textLayoutManager: renderer.textLayoutManager,
+            textContentStorage: renderer.textContentStorage,
+            animationState: TextFadeAnimationState()
+        )
+        animator.textColor = .black
+        animator.contentLengthProvider = { renderer.proseLength }
+
+        let view = RecordingView(frame: NSRect(x: 0, y: 0, width: 700, height: 20_000))
+        animator.attach(to: view)
+
+        let prefix = (0..<60).map { index in
+            MarkdownItem.TextBlock(
+                runs: [InlineRun(
+                    text: "Paragraph \(index). " + String(repeating: "word ", count: 40)
+                )],
+                kind: .paragraph
+            )
+        }
+        renderer.setBlocks(prefix)
+        _ = renderer.measureHeight(width: view.bounds.width)
+        animator.markAllRevealed()
+
+        var grown = prefix
+        grown.append(.init(runs: [InlineRun(text: "new tail")], kind: .paragraph))
+        renderer.setBlocks(grown)
+        let documentHeight = renderer.measureHeight(width: view.bounds.width)
+        animator.testing_setClock { 1.0 }
+        animator.contentDidGrow()
+
+        view.invalidatedRects.removeAll()
+        animator.testing_tick(at: 1.05)
+
+        let invalidated = try #require(view.invalidatedRects.last)
+        #expect(invalidated.height < documentHeight / 2)
+        #expect(invalidated.maxY > documentHeight / 2)
+    }
+}


### PR DESCRIPTION
> **Depends on #3203** — this branch is stacked on the `ContentView.body`
> type-check fix. Rebase once #3203 lands.

## Why

Streaming markdown repainted every layout fragment on each fade frame.
`MarkdownTextBlockView.draw(_:)` received a dirty rect but ignored it, so draw
cost grew with the length of the answer.

The original measured draw-only path for a 24pt tail strip was:

| Paragraphs | Before | After |
| ---: | ---: | ---: |
| 5 | 0.64 ms | 0.08 ms |
| 20 | 2.46 ms | 0.11 ms |
| 60 | **8.30 ms** | **0.15 ms** |

8.30 ms consumes the complete 120 Hz frame budget. Review then found an
important missing half: the production display-link used
`hostView.needsDisplay = true`, which invalidated the whole view and prevented
the draw-side clip from receiving the narrow rect used by the benchmark.

This PR now closes both ends of the contract:

- `MarkdownTextBlockView.draw(_:)` skips fragments above the dirty rect and
  stops once ordered TextKit fragments are below it.
- `TextFadeAnimator` unions the exact TextKit segment bounds whose rendering
  attributes changed, pads by 2pt for antialiasing, clips to view bounds, and
  invalidates only that region.
- If geometry is temporarily unavailable after a storage edit, it deliberately
  falls back to a full redraw for visual correctness.

## Scope and non-goals

The change affects streamed prose rendering only. It does not change fade
timing, frame rate, layout, link geometry, typing-dot behavior, APIs, or
defaults. `MarkdownCodeBlockView` remains a possible follow-up and is not part
of the measured path. The separate dark-mode fade-color fix remains #3204.

## Verification

- `swift test --filter "TextFade|Markdown|TextKit"`: **79 tests passed** on
  Xcode 26.6 / Swift 6.3.3.
- Draw negative control: reverting the clipping hunk makes the 60-vs-5 tail
  redraw ratio **10.0×**; fixed stays below the test's 4× noise-tolerant bound.
- Invalidation negative control: with only the original PR, a real fade tick
  records a full-domain dirty height (`CGFloat.greatestFiniteMagnitude`) and
  the new test fails. With range-aware invalidation, the recorded dirty rect is
  confined to the appended tail and the test passes.
- The contributor's running-build instrumentation observed one fragment per
  live fade draw and 5-second draw averages of **0.23–0.38 ms**.

## Behaviour delta

Per-frame streamed-prose drawing changes from document-sized invalidation and
`O(document)` fragment drawing to fading-tail invalidation and dirty-region
drawing. Rendered output is unchanged.

## AI assistance disclosure

Claude assisted the original diagnosis, measurement, patch, and tests under
contributor direction. Codex independently reviewed the production path,
identified that full-view invalidation bypassed the benchmarked optimization,
implemented the range-aware invalidation, and added its positive/negative
regression test. No external Spark reviewer was used.
