### PR TITLE
fix(mac): split ContentView.body so it type-checks again

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -277,6 +277,27 @@ struct ContentView: View {
         .onAppear {
             showCommandPaletteFromRequest(commandPaletteRequest.requestID)
         }
+        .lifecycleModifiers(
+            of: self,
+            displayedMemoryWarning: displayedMemoryWarning,
+            displayedModelSwitch: displayedModelSwitch
+        )
+        .sessionModifiers(of: self)
+    }
+
+    /// Middle section of the shell's modifier chain (lifecycle observers,
+    /// the memory alert, and the model-switch dialog).
+    ///
+    /// Split for the same reason as ``applySessionModifiers(to:)`` — one
+    /// chain of this size exceeds the type-checker's budget. Order is
+    /// unchanged.
+    @ViewBuilder
+    fileprivate func applyLifecycleModifiers(
+        to content: some View,
+        displayedMemoryWarning: ModelSizing.MemoryWarning?,
+        displayedModelSwitch: ServerManager.PendingModelSwitch?
+    ) -> some View {
+        content
         .onChange(of: server.state) { _, newState in
             // A chat-model replacement can keep the process or respawn it.
             // Dictation owns the same reconciliation entry point for both so
@@ -411,6 +432,19 @@ struct ContentView: View {
         } message: { request in
             Text("Switching to \(request.risk.targetAlias) may interrupt those responses.")
         }
+    }
+
+    /// Second half of the shell's modifier chain.
+    ///
+    /// Split out purely so the type-checker solves two moderate expressions
+    /// instead of one that exceeds its budget: `body` had grown past the
+    /// solver's limit and failed to compile with
+    /// "unable to type-check this expression in reasonable time".
+    /// Order is preserved exactly — these modifiers still apply after the
+    /// ones that remain in `body`.
+    @ViewBuilder
+    fileprivate func applySessionModifiers(to content: some View) -> some View {
+        content
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false
         }
@@ -2384,5 +2418,31 @@ private struct LogDrawer: View {
                 proxy.scrollTo(Self.bottomAnchor, anchor: .bottom)
             }
         }
+    }
+}
+
+/// Applies the second half of ``ContentView``'s modifier chain.
+///
+/// Exists only to split one over-budget type-check into two. See
+/// ``ContentView/applySessionModifiers(to:)``.
+private extension View {
+    @ViewBuilder
+    func sessionModifiers(of owner: ContentView) -> some View {
+        owner.applySessionModifiers(to: self)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func lifecycleModifiers(
+        of owner: ContentView,
+        displayedMemoryWarning: ModelSizing.MemoryWarning?,
+        displayedModelSwitch: ServerManager.PendingModelSwitch?
+    ) -> some View {
+        owner.applyLifecycleModifiers(
+            to: self,
+            displayedMemoryWarning: displayedMemoryWarning,
+            displayedModelSwitch: displayedModelSwitch
+        )
     }
 }


### PR DESCRIPTION
Queue-compatible maintainer import of #3203. The repository merge queue intentionally rejects fork heads, so this same-repository PR carries the reviewed exact head `55880a028a6107d3376793c8923541d55994ba04`. Original author attribution remains on the commit.

Supersedes #3203 for landing only.

## Why

`swift build` fails outright on Swift 6.2.1 (Xcode 26):

```
apps/rapid-mac/Sources/Rapid/UI/ContentView.swift:210:25: error: the compiler
is unable to type-check this expression in reasonable time; try breaking up
the expression into distinct sub-expressions
```

On the affected Swift 6.2.1 toolchain, nobody can build the desktop app at all —
not to test a change, not to reproduce a bug report. A maintainer recheck on
Xcode 26.6 / Swift 6.3.3 builds both the unpatched base and this branch, so the
hard failure is specifically reproduced on Swift 6.2.1 rather than every newer
26.x toolchain.

CI does not catch it: `rapid-mac-ci.yml` pins Xcode 16.4 / Swift 6.1.2, and the
solver's budget is toolchain-dependent. The eleven commits that grew `body`
between `8631acc5` and `cbfc4c2c` each passed on the CI image; the ceiling is
only crossed on a newer compiler.

## Scope

`apps/rapid-mac/Sources/Rapid/UI/ContentView.swift` only.

Splits `ContentView.body` — 278 lines carrying ~30 chained modifiers — into
three contiguous runs:

- `body` — the shell, frame, background, overlays, and the animation/alert chain
- `applyLifecycleModifiers(to:…)` — lifecycle observers, memory alert, model-switch dialog
- `applySessionModifiers(to:)` — approval dialogs, star prompt, session `task`s

Two `private extension View` helpers thread them together.

## Non-goals

- No behaviour change, no visual change, no modifier reordering.
- Does not touch the other `body` implementations in the file.
- Does not raise `-solver-expression-time-threshold`; that was tried at 600s and
  does not help, because this is the solver's complexity ceiling rather than a
  timeout.
- Does not address the streaming-render defects found while getting a build to
  test with — those are separate PRs.

## Acceptance

- `swift build -c release` succeeds on Swift 6.2.1, where it previously failed.
- Still builds on the CI toolchain.
- The modifier chain applies in exactly the order it did before, including
  `.alert` before `.confirmationDialog` before the `.task`s.
- No new test failures.

## Verification

- `swift build -c release` on Swift 6.2.1 / Xcode 26.1.1: **Build complete**
  (hard failure before this change).
- `git show 8631acc5` (pre-growth commit) builds on the same toolchain, which is
  what identifies this as accumulated `body` size rather than a toolchain
  regression.
- `swift test` on this branch vs the same commit without the patch: no new
  failures. Both runs share pre-existing environment-dependent failures in the
  Mermaid/WebKit and subprocess-probe suites; those flap run to run on this
  machine (13 then 15 failures across two baseline runs of identical code), so
  the totals differ slightly between runs in both directions.
- Diff reviewed with whitespace normalised to confirm the only changes are the
  extraction points and the two parameters described below.

## Behaviour delta

None intended. The diff is a re-association of the same modifiers in the same
order.

One detail worth a reviewer's eye: `displayedMemoryWarning` and
`displayedModelSwitch` are captured in `body` and **passed as parameters** into
`applyLifecycleModifiers` rather than re-read from `server` inside it. They
capture the identity owned by a single render pass (#1463) — re-reading
`server.pending*` in the extracted method would reintroduce the race that fix
removed, where a delayed dismiss callback cancels a newer warning.

## AI assistance disclosure

Claude (via an agent harness) performed the investigation and wrote this patch;
I directed the work and reviewed the result.

- **Diagnosis** — AI. The bisect between `8631acc5` and `cbfc4c2c`, the
  `body`-size measurement (213 → 278 lines), and the
  `-solver-expression-time-threshold=600` experiment that ruled out a plain
  timeout were all run as commands with output inspected, not asserted.
- **The split** — AI-written, chosen to preserve modifier order exactly.
- **Verification** — the build result is the primary evidence and is
  reproducible in one command. The "no new test failures" claim was established
  by running the suite on both this branch and the unpatched base commit and
  diffing the failure lists, then re-running the differing suites on the base
  twice to confirm they flap.

The one judgement call a reviewer should check independently is the parameter
threading described under Behaviour delta — the rest is mechanical.