### PR TITLE
fix(mac): streamed text is invisible in dark mode while it fades in

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -277,6 +277,27 @@ struct ContentView: View {
         .onAppear {
             showCommandPaletteFromRequest(commandPaletteRequest.requestID)
         }
+        .lifecycleModifiers(
+            of: self,
+            displayedMemoryWarning: displayedMemoryWarning,
+            displayedModelSwitch: displayedModelSwitch
+        )
+        .sessionModifiers(of: self)
+    }
+
+    /// Middle section of the shell's modifier chain (lifecycle observers,
+    /// the memory alert, and the model-switch dialog).
+    ///
+    /// Split for the same reason as ``applySessionModifiers(to:)`` — one
+    /// chain of this size exceeds the type-checker's budget. Order is
+    /// unchanged.
+    @ViewBuilder
+    fileprivate func applyLifecycleModifiers(
+        to content: some View,
+        displayedMemoryWarning: ModelSizing.MemoryWarning?,
+        displayedModelSwitch: ServerManager.PendingModelSwitch?
+    ) -> some View {
+        content
         .onChange(of: server.state) { _, newState in
             // A chat-model replacement can keep the process or respawn it.
             // Dictation owns the same reconciliation entry point for both so
@@ -411,6 +432,19 @@ struct ContentView: View {
         } message: { request in
             Text("Switching to \(request.risk.targetAlias) may interrupt those responses.")
         }
+    }
+
+    /// Second half of the shell's modifier chain.
+    ///
+    /// Split out purely so the type-checker solves two moderate expressions
+    /// instead of one that exceeds its budget: `body` had grown past the
+    /// solver's limit and failed to compile with
+    /// "unable to type-check this expression in reasonable time".
+    /// Order is preserved exactly — these modifiers still apply after the
+    /// ones that remain in `body`.
+    @ViewBuilder
+    fileprivate func applySessionModifiers(to content: some View) -> some View {
+        content
         .onChange(of: settingsRouter.quickstartReturnGeneration) { _, _ in
             quickstartDismissedThisSession = false
         }
@@ -2384,5 +2418,31 @@ private struct LogDrawer: View {
                 proxy.scrollTo(Self.bottomAnchor, anchor: .bottom)
             }
         }
+    }
+}
+
+/// Applies the second half of ``ContentView``'s modifier chain.
+///
+/// Exists only to split one over-budget type-check into two. See
+/// ``ContentView/applySessionModifiers(to:)``.
+private extension View {
+    @ViewBuilder
+    func sessionModifiers(of owner: ContentView) -> some View {
+        owner.applySessionModifiers(to: self)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func lifecycleModifiers(
+        of owner: ContentView,
+        displayedMemoryWarning: ModelSizing.MemoryWarning?,
+        displayedModelSwitch: ServerManager.PendingModelSwitch?
+    ) -> some View {
+        owner.applyLifecycleModifiers(
+            to: self,
+            displayedMemoryWarning: displayedMemoryWarning,
+            displayedModelSwitch: displayedModelSwitch
+        )
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Fade/TextFadeAnimator.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Fade/TextFadeAnimator.swift
@@ -397,7 +397,31 @@ final class TextFadeAnimator {
 
     private func apply(alpha: Double, to range: NSRange, now: CFTimeInterval) {
         guard let textRange = textRange(from: range) else { return }
-        let colour = resolvedColor(alpha: alpha, now: now)
+        // Resolve the colour under the host view's appearance.
+        //
+        // `withAlphaComponent` and `blended(withFraction:of:)` both FLATTEN a
+        // dynamic `NSColor`: they read components, which resolves the colour
+        // against the drawing appearance current on the calling thread. A
+        // display-link callback has none, so `NSColor.textColor` resolved to
+        // its light-mode value in BOTH appearances — measured (0, 0, 0) under
+        // `.aqua` and under `.darkAqua`.
+        //
+        // Light mode wanted near-black anyway, so the fade looked correct
+        // there. Dark mode painted black text on the dark transcript
+        // background: a streaming reply stayed invisible for the whole fade,
+        // then appeared all at once when `clearRenderingAttributes` dropped
+        // the override at the end. Resolving inside the view's appearance is
+        // what keeps the two modes equivalent.
+        let colour: NSColor
+        if let appearance = hostView?.effectiveAppearance {
+            var resolved = textColor
+            appearance.performAsCurrentDrawingAppearance {
+                resolved = resolvedColor(alpha: alpha, now: now)
+            }
+            colour = resolved
+        } else {
+            colour = resolvedColor(alpha: alpha, now: now)
+        }
         textLayoutManager.setRenderingAttributes(
             [.foregroundColor: colour], for: textRange
         )

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
@@ -555,4 +555,26 @@ final class MarkdownTextBlockView: NSView {
         }
     }
 
+    // MARK: - Test hooks
+
+    /// Hand back the first `.foregroundColor` rendering attribute the fade
+    /// animator has written. Rendering attributes live on the layout manager
+    /// rather than the text storage, so a test cannot read them off the
+    /// attributed string.
+    func testing_renderingForegroundColor(_ receive: (NSColor) -> Void) {
+        var found = false
+        renderer.textLayoutManager.enumerateRenderingAttributes(
+            from: renderer.textLayoutManager.documentRange.location,
+            reverse: false
+        ) { _, attributes, _ in
+            guard let colour = attributes[.foregroundColor] as? NSColor else {
+                return true
+            }
+            found = true
+            receive(colour)
+            return false
+        }
+        _ = found
+    }
+
 }

--- a/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/Markdown/TextKit/Render/MarkdownTextBlockView.swift
@@ -561,8 +561,8 @@ final class MarkdownTextBlockView: NSView {
     /// animator has written. Rendering attributes live on the layout manager
     /// rather than the text storage, so a test cannot read them off the
     /// attributed string.
-    func testing_renderingForegroundColor(_ receive: (NSColor) -> Void) {
-        var found = false
+    func testing_renderingForegroundColor() -> NSColor? {
+        var found: NSColor?
         renderer.textLayoutManager.enumerateRenderingAttributes(
             from: renderer.textLayoutManager.documentRange.location,
             reverse: false
@@ -570,11 +570,10 @@ final class MarkdownTextBlockView: NSView {
             guard let colour = attributes[.foregroundColor] as? NSColor else {
                 return true
             }
-            found = true
-            receive(colour)
+            found = colour
             return false
         }
-        _ = found
+        return found
     }
 
 }

--- a/apps/rapid-mac/Tests/RapidTests/TextFadeAppearanceTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TextFadeAppearanceTests.swift
@@ -1,0 +1,86 @@
+import AppKit
+import Testing
+@testable import Rapid
+
+/// The fade must not paint dark-mode text with the light-mode colour.
+///
+/// `withAlphaComponent` and `blended(withFraction:of:)` flatten a dynamic
+/// `NSColor`: both read components, which resolves the colour against the
+/// drawing appearance current on the calling thread. A display-link callback
+/// has none, so `NSColor.textColor` resolved to its light-mode value in *both*
+/// appearances. Light mode wanted near-black anyway and looked correct; dark
+/// mode painted black-on-dark, so a streaming reply stayed invisible for the
+/// whole fade and then appeared all at once when the animator cleared its
+/// rendering attributes.
+///
+/// The asymmetry is why this needs a test: the bug is invisible in light mode,
+/// which is where it was written and reviewed.
+@Suite("Text fade appearance")
+@MainActor
+struct TextFadeAppearanceTests {
+
+    /// Relative luminance of `color` as resolved under `appearance`.
+    private func luminance(_ color: NSColor, under appearance: NSAppearance.Name) -> CGFloat {
+        var out: CGFloat = 0
+        NSAppearance(named: appearance)!.performAsCurrentDrawingAppearance {
+            let c = color.usingColorSpace(.sRGB) ?? .black
+            out = 0.2126 * c.redComponent
+                + 0.7152 * c.greenComponent
+                + 0.0722 * c.blueComponent
+        }
+        return out
+    }
+
+    /// The colour the animator writes for a half-faded word, for a view whose
+    /// window is pinned to `appearance`.
+    private func fadedColor(under appearance: NSAppearance.Name) -> NSColor {
+        var options = MarkdownOptions.assistantTranscript()
+        options.textColor = .textColor
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.appearance = NSAppearance(named: appearance)
+
+        let view = MarkdownTextBlockView(options: options)
+        view.appearance = NSAppearance(named: appearance)
+        view.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
+        window.contentView?.addSubview(view)
+
+        view.configure(
+            blocks: [.init(runs: [InlineRun(text: "alpha beta gamma delta")],
+                           kind: .paragraph)],
+            options: options,
+            streaming: true,
+            fadeState: TextFadeAnimationState()
+        )
+
+        // Draw once so the animator writes its rendering attributes.
+        let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds)!
+        view.cacheDisplay(in: view.bounds, to: rep)
+
+        var found: NSColor?
+        view.testing_renderingForegroundColor { found = $0 }
+        return found ?? options.textColor
+    }
+
+    @Test("Dark mode fades toward a light colour")
+    func darkModeFadeIsVisible() {
+        let lum = luminance(fadedColor(under: .darkAqua), under: .darkAqua)
+        #expect(
+            lum > 0.5,
+            """
+            the dark-mode fade resolved to luminance \(lum); text painted this \
+            way is invisible against the dark transcript background until the \
+            fade clears its rendering attributes
+            """
+        )
+    }
+
+    @Test("Light mode still fades toward a dark colour")
+    func lightModeFadeStaysDark() {
+        let lum = luminance(fadedColor(under: .aqua), under: .aqua)
+        #expect(lum < 0.5, "light mode must keep dark text; got luminance \(lum)")
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/TextFadeAppearanceTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/TextFadeAppearanceTests.swift
@@ -33,7 +33,7 @@ struct TextFadeAppearanceTests {
 
     /// The colour the animator writes for a half-faded word, for a view whose
     /// window is pinned to `appearance`.
-    private func fadedColor(under appearance: NSAppearance.Name) -> NSColor {
+    private func fadedColor(under appearance: NSAppearance.Name) -> NSColor? {
         var options = MarkdownOptions.assistantTranscript()
         options.textColor = .textColor
 
@@ -60,14 +60,13 @@ struct TextFadeAppearanceTests {
         let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds)!
         view.cacheDisplay(in: view.bounds, to: rep)
 
-        var found: NSColor?
-        view.testing_renderingForegroundColor { found = $0 }
-        return found ?? options.textColor
+        return view.testing_renderingForegroundColor()
     }
 
     @Test("Dark mode fades toward a light colour")
-    func darkModeFadeIsVisible() {
-        let lum = luminance(fadedColor(under: .darkAqua), under: .darkAqua)
+    func darkModeFadeIsVisible() throws {
+        let color = try #require(fadedColor(under: .darkAqua))
+        let lum = luminance(color, under: .darkAqua)
         #expect(
             lum > 0.5,
             """
@@ -79,8 +78,9 @@ struct TextFadeAppearanceTests {
     }
 
     @Test("Light mode still fades toward a dark colour")
-    func lightModeFadeStaysDark() {
-        let lum = luminance(fadedColor(under: .aqua), under: .aqua)
+    func lightModeFadeStaysDark() throws {
+        let color = try #require(fadedColor(under: .aqua))
+        let lum = luminance(color, under: .aqua)
         #expect(lum < 0.5, "light mode must keep dark text; got luminance \(lum)")
     }
 }


### PR DESCRIPTION
Queue-compatible maintainer import of #3204. The repository merge queue intentionally rejects fork heads, so this same-repository PR carries the reviewed exact head `55f01fd4c0ad66a70b168bb24651d05c92f4ab53`, including maintainer regression-test hardening. Original author attribution remains on the implementation commit.

Supersedes #3204 for landing only.

> **Depends on #3203** — this branch is stacked on the `ContentView.body`
> type-check fix. Rebase once #3203 lands.

## Why

In dark mode a streaming reply can show an empty bubble while generation is
active, then flash the completed text in at the end. Light mode is unaffected.

`TextFadeAnimator.apply` derives a temporary `.foregroundColor` from dynamic
`NSColor.textColor` on a display-link callback. `withAlphaComponent` and
`blended(withFraction:of:)` flatten that dynamic color against the current
drawing appearance. The callback has no drawing appearance, so both modes were
measured as `(0, 0, 0)`; dark mode therefore painted black text on a dark
background until the temporary rendering attribute was cleared.

The fix resolves the fade color inside `hostView.effectiveAppearance` using
`performAsCurrentDrawingAppearance`. This affects Desktop releases since
`rapid-mac-v0.12.12`; Reduce Motion disables the fade and avoids the bug.

## Scope

- Resolve fade colors under the host view's effective appearance.
- Add a test-only accessor for the first temporary foreground rendering
  attribute.
- Assert that a rendering attribute was actually written before checking its
  luminance, so a missing animator write cannot pass by falling back to the
  normal dynamic text color.

No timing, easing, accent-tint, API, or default changes.

## Verification

- `swift test --filter "TextFade|Markdown|TextKit"`: **79 tests passed** on
  Xcode 26.6 / Swift 6.3.3.
- Negative control: restoring the old `apply` body fails only the dark test at
  luminance **0.0837778802**; the light test still passes.
- The strengthened test uses `#require` on the rendering attribute before
  measuring it, preventing a false green if setup stops exercising the fade.
- Manually verified by the contributor in a running light/dark build.

## Behaviour delta

Dark-mode streamed text now fades in as it arrives instead of remaining
invisible until the temporary rendering attributes clear. Light mode is
unchanged.

## AI assistance disclosure

Claude assisted the original diagnosis, patch, and tests under contributor
direction. Codex independently reviewed the diff, reproduced the negative
control, and hardened the test against a missing-rendering-attribute false
positive. No external Spark reviewer was used.