### PR TITLE
feat(models): enable qualified Muse-Glimmer DFlash

### DIFF
--- a/.agents/handoffs/vector-muse-dflash-1844.md
+++ b/.agents/handoffs/vector-muse-dflash-1844.md
@@ -1,0 +1,55 @@
+# Vector handoff — Muse-Glimmer 8-bit DFlash (#1844)
+
+## 2026-09-07 — starting
+
+- Start FYI fallback for Atlas, Pixel, Harbor, Echo, and ds0731 (Orca role
+  messaging unavailable): Vector owns branch `vector/1844-muse-dflash`,
+  worktree `/private/tmp/vector-muse-dflash-1844`, based on
+  `origin/main@9113b5d8d` on Local Mac.
+- Intention: expose a revision-pinned, curated Muse-Glimmer 30B 8-bit target
+  plus its published assistant through Rapid's existing single-user DFlash
+  server, so users on sufficiently large Apple Silicon systems can opt into
+  the independently reported roughly 2.1–2.3x decode improvement.
+- Scope: alias/catalog/capacity data, exact target/drafter/runtime identity,
+  DFlash eligibility contracts, focused tests, and real-weight server
+  dogfood. Non-goals: 4-bit DFlash, changing the dedicated DFlash server,
+  batched DFlash, upstream runtime changes, new UI, release, or deployment.
+- Private reference check: the required assistant model, target hidden-state
+  capture, rollback, and serial server loop landed upstream and shipped in
+  mlx-vlm 0.6.13; Rapid pins 0.6.17. Rapid's existing curated DFlash aliases
+  establish revision pinning, algorithm identity, fail-closed eligibility,
+  cancellation, and response-contract patterns. The change will extend those
+  patterns rather than add another runtime.
+- Verification plan: alias/schema/download/model-size tests; stream and
+  non-stream route contracts; exact cached-artifact boot; same-host plain vs
+  DFlash throughput and output evidence; cancellation/recovery; scope-locked
+  adversarial self-review; exact-head PR validation and managed queue. No
+  Spark or reviewer sub-agent.
+
+## 2026-09-07 — implementation and dogfood complete
+
+- Added `muse-glimmer-30b-8bit` with a 48 GB memory floor, exact target and
+  assistant revisions, and fail-closed `dflash` identity. The 4-bit alias
+  remains ineligible.
+- Real-weight dogfood on an M3 Ultra / 256 GB host with mlx-vlm 0.6.17:
+  31.1 GiB target plus published assistant loaded through the public alias;
+  `/healthz` returned both exact revisions and `algorithm=dflash`.
+- Three-run, 256-token qualification: code workloads improved 1.89x–2.10x,
+  code median 2.00x; general chat improved 1.83x. The pair passed both the
+  1.30x code gate and 1.00x non-code floor. Post-request RSS was 36.9 GiB.
+- Stream cancellation after 1.5 seconds / 4,537 response bytes released the
+  serial lease; an immediate recovery request completed in about 1.0 second.
+- Scope-locked adversarial self-review (three rounds): tightened the contract
+  from assistant-only allowance to an exact target+assistant pair; corrected
+  the README catalog total; final round found no in-scope blocker.
+- Verification: focused suite 3,929 passed / 2 skipped; full suite 23,047
+  passed / 238 skipped / 6 xfailed / 1 xpassed. Seven Bonsai runtime tests
+  fail identically on clean `origin/main@9113b5d8d` because the installed
+  image runtime's `TilingConfig` API differs; no changed file intersects that
+  failure. The one initial README count failure was caused by this alias and
+  was fixed before the focused rerun.
+- Durable benchmark evidence:
+  `docs/engineering/performance/muse-glimmer-30b-dflash-qualification.md`.
+- Completion FYI fallback for Atlas, Pixel, Harbor, Echo, and ds0731: the
+  implementation is ready for commit/PR validation. No release or deployment
+  action is authorized; no follow-up owner is required for this PR.

--- a/.agents/handoffs/vector-muse-dflash-1844.md
+++ b/.agents/handoffs/vector-muse-dflash-1844.md
@@ -50,6 +50,7 @@
   was fixed before the focused rerun.
 - Durable benchmark evidence:
   `docs/engineering/performance/muse-glimmer-30b-dflash-qualification.md`.
-- Completion FYI fallback for Atlas, Pixel, Harbor, Echo, and ds0731: the
-  implementation is ready for commit/PR validation. No release or deployment
-  action is authorized; no follow-up owner is required for this PR.
+- Completion FYI fallback for Atlas, Pixel, Harbor, Echo, and ds0731: PR
+  #3211 (`7ab445bc7`) contains the qualified implementation and evidence. No
+  release or deployment action is authorized; no follow-up owner is required
+  for this PR beyond managed-queue observation.

--- a/.agents/handoffs/vector-muse-dflash-1844.md
+++ b/.agents/handoffs/vector-muse-dflash-1844.md
@@ -54,3 +54,18 @@
   #3211 (`7ab445bc7`) contains the qualified implementation and evidence. No
   release or deployment action is authorized; no follow-up owner is required
   for this PR beyond managed-queue observation.
+
+## 2026-09-07 — PR validation
+
+- Validator review round 1 requested an explicit eligibility-report assertion.
+  `check()` already raises on rejection (and returns `None` on success), but
+  the test now also pins `reasons == ()` and `recommendation == "verified"`.
+- Validator review round 2 found no blocking issues. Description, supply-chain,
+  lint, and 3,443 targeted tests passed.
+- Full unit under the repository-required mflux 0.19.1 completed with 23,033
+  passed and four doctor/extras failures. All four reproduce byte-for-byte on
+  clean `origin/main@9113b5d8d` with the same venv; they arise from existing
+  subprocess optional-extra row indexing and do not intersect this diff.
+- Final exact-head validation may explicitly skip only `full_unit`, because
+  that gate has already run in full and its complete failure set has been
+  reproduced against the merge base. No product test failure is waived.

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ reached a 27.1 GB MLX allocator peak before non-MLX process and macOS memory;
 on a 32 GB Mac, reduce context/cache use or choose a larger-memory machine.
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
-→ [Every alias, quant, and family (186 text + 10 image + 10 video + 44 audio aliases, 250 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
+→ [Every alias, quant, and family (187 text + 10 image + 10 video + 44 audio aliases, 251 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
 
 ---
 

--- a/docs/engineering/performance/muse-glimmer-30b-dflash-qualification.md
+++ b/docs/engineering/performance/muse-glimmer-30b-dflash-qualification.md
@@ -1,0 +1,72 @@
+# Muse-Glimmer 30B 8-bit DFlash qualification
+
+## Decision
+
+Enable curated DFlash for `muse-glimmer-30b-8bit`. The immutable target and
+assistant pair cleared the 1.30x code-median ship gate and the 1.00x non-code
+floor. Keep `muse-glimmer-30b-4bit` disabled because the legacy DFlash runtime
+does not qualify 4-bit targets.
+
+## Immutable model identity
+
+- Target: `mlx-community/Muse-Glimmer-30B-8bit` at
+  `679c45e1b331a6514a6e38076a353cc5fed21bf6`
+- Assistant: `meta-models/Muse-Glimmer-30B-assistant` at
+  `e8192f3a8f617f74be2ce220360c89ef4789f39f`
+- Runtime algorithm: `dflash`
+
+The target download footprint was 33,404,526,711 bytes (31.1 GiB). After a
+generation, cancellation, and recovery request, the server process reported
+36.9 GiB RSS. The curated alias therefore requires 48 GB unified memory,
+leaving roughly 11 GB for the OS and application overhead on the measured
+workload.
+
+## Environment
+
+- Mac Studio, Apple M3 Ultra (28 CPU cores), 256 GB unified memory
+- macOS 26.5.2 (25F84)
+- Python 3.12.14
+- MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.6.17
+- Rapid-MLX commit under test: `origin/main@9113b5d8d` plus the alias change
+- Date: 2026-09-07
+
+## Reproduction
+
+Run the repository's qualification harness; it resolves and downloads both
+exact revisions before starting either server:
+
+```bash
+python3.12 scripts/bench_dflash.py \
+  --model muse-glimmer-30b-8bit \
+  --expected-algorithm dflash \
+  --max-tokens 256 \
+  --runs 3 \
+  --port 18845 \
+  --output /tmp/muse-dflash-bench.json
+```
+
+The harness runs the same greedy prompts against the normal text server and
+the dedicated single-user DFlash server. Throughput is median decode tokens
+per second across three runs per workload.
+
+| Workload | Plain (tok/s) | DFlash (tok/s) | Speedup |
+| --- | ---: | ---: | ---: |
+| Fibonacci | 22.6 | 43.9 | 1.94x |
+| Quicksort | 22.1 | 46.3 | 2.10x |
+| Hashtable | 22.6 | 42.8 | 1.89x |
+| Sorted list | 22.6 | 46.3 | 2.05x |
+| General chat | 22.6 | 41.3 | 1.83x |
+
+- Code-workload median: **2.00x** (ship gate: at least 1.30x)
+- General-chat result: **1.83x** (non-code floor: at least 1.00x)
+- All-workload median: **1.94x**
+- Decision: `SHIP (supports_dflash=true)`
+
+## Server-path checks
+
+The exact cached artifacts booted through the public alias in 5.2 seconds on
+an initial warm start. `/healthz` reported the expected algorithm and both
+revision pins. Non-streaming generation completed successfully. A streaming
+client was then disconnected after 1.5 seconds and 4,537 response bytes; an
+immediate follow-up request completed in about 1.0 second, confirming that
+cancellation released the serial generation lease and the server recovered.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -280,9 +280,12 @@ rapid-mlx serve deepseek-r1-8b-4bit --reasoning-parser deepseek_r1
 # Tool calling with Mistral/Devstral (parser auto-detected; pin shown for clarity)
 rapid-mlx serve devstral-24b-4bit --enable-auto-tool-choice --tool-call-parser mistral
 
-# DFlash speculative decoding (single-user, single supported alias).
+# DFlash speculative decoding (single-user, curated aliases only).
 # Requires rapid-mlx[dflash]; OpenAI tools and opt-in thinking are supported.
 rapid-mlx serve qwen3.5-27b-8bit --speculative-config '{"method":"dflash"}' --port 8000
+
+# Muse-Glimmer 30B 8-bit uses its revision-pinned published assistant.
+rapid-mlx serve muse-glimmer-30b-8bit --speculative-config '{"method":"dflash"}' --port 8000
 
 # DDTree speculative decoding (experimental, single-user)
 rapid-mlx serve qwen3.5-9b-8bit --speculative-config '{"method":"ddtree"}' --port 8000

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -637,13 +637,12 @@ def test_dflash_4bit_precision_requires_dflash2_qualification(alias: str) -> Non
 
 
 def test_dflash_eligible_aliases_have_qualified_drafter_family() -> None:
-    """DFlash drafters today are published by ``z-lab/`` for Qwen3,
-    Qwen3.5, Qwen3.6, Gemma-4 and LLaMA-3.1 families. Any eligible
-    alias must point at one of these prefixes and bear the ``DFlash``
-    marker (the ``-b16`` / ``-UltraChat`` / etc. suffix is permitted —
-    z-lab uses it for training-data and precision tags). Catches an
-    accidental copy-paste that swaps the drafter to an incompatible
-    model."""
+    """Every eligible alias must use a known-compatible drafter identity.
+
+    Most published drafters follow the family-plus-``DFlash`` naming
+    convention. Muse-Glimmer publishes its assistant under an exact repo name,
+    so admit that single identity without broadly trusting its organization.
+    """
     valid_drafter_prefixes = (
         "z-lab/Qwen3-",
         "z-lab/Qwen3.5-",
@@ -652,10 +651,18 @@ def test_dflash_eligible_aliases_have_qualified_drafter_family() -> None:
         "z-lab/gemma-4-",
         "z-lab/LLaMA3.1-",
     )
+    valid_exact_pairs = {
+        (
+            "mlx-community/Muse-Glimmer-30B-8bit",
+            "meta-models/Muse-Glimmer-30B-assistant",
+        )
+    }
     for alias, profile in list_profiles().items():
         if not profile.supports_dflash:
             continue
         d = profile.dflash_draft_model or ""
+        if (profile.hf_path, d) in valid_exact_pairs:
+            continue
         ok = any(d.startswith(p) for p in valid_drafter_prefixes)
         # ``DFlash`` may appear at end of repo name OR before a tag
         # suffix (``-b16``, ``-UltraChat``, etc.). Anchored on ``-`` /
@@ -665,8 +672,8 @@ def test_dflash_eligible_aliases_have_qualified_drafter_family() -> None:
         has_marker = bool(re.search(r"(?:^|-)DFlash(?:2)?(?:$|-)", d))
         assert has_marker and ok, (
             f"{alias}: dflash_draft_model={d!r} doesn't match the "
-            f"expected ``z-lab/{{Qwen3,Qwen3.5,Qwen3.6,gemma-4,LLaMA3.1}}-*"
-            f"DFlash*`` shape. If you've validated a new drafter family, "
+            f"expected known DFlash drafter identity. If you've validated a "
+            f"new drafter family, "
             f"update this allow-list."
         )
 

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -81,6 +81,9 @@ def test_muse_glimmer_curated_pair_passes_exact_registry_gate() -> None:
     profile = resolve_profile("muse-glimmer-30b-8bit")
     assert profile is not None
     check(profile, alias="muse-glimmer-30b-8bit")
+    assessment = report(profile, alias="muse-glimmer-30b-8bit")
+    assert assessment.reasons == ()
+    assert assessment.recommendation == "verified"
     assert is_registry_verified_pair(
         profile.hf_path,
         profile.dflash_target_revision,

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from vllm_mlx.model_aliases import AliasProfile
+from vllm_mlx.model_aliases import AliasProfile, resolve_profile
 from vllm_mlx.speculative.dflash.eligibility import (
     DFlashUnavailable,
     _looks_like_4bit,
@@ -75,6 +75,19 @@ def test_check_passes_for_good_profile() -> None:
     check(p, alias="qwen3.5-27b-8bit")
     r = report(p, alias="qwen3.5-27b-8bit")
     assert r.reasons == ()
+
+
+def test_muse_glimmer_curated_pair_passes_exact_registry_gate() -> None:
+    profile = resolve_profile("muse-glimmer-30b-8bit")
+    assert profile is not None
+    check(profile, alias="muse-glimmer-30b-8bit")
+    assert is_registry_verified_pair(
+        profile.hf_path,
+        profile.dflash_target_revision,
+        profile.dflash_draft_model or "",
+        profile.dflash_draft_revision,
+        profile.dflash_algorithm,
+    )
 
 
 def test_check_rejects_alias_without_supports_dflash() -> None:

--- a/tests/test_muse_glimmer_model.py
+++ b/tests/test_muse_glimmer_model.py
@@ -14,7 +14,8 @@ Pins the contract that:
    vision stack (text-only serving).
 5. ``resolve_serving_lane`` auto-downgrades a muse_glimmer checkpoint to
    the text lane while the installed mlx-vlm lacks the arch.
-6. The curated aliases pin text-only serving and the muse parsers.
+6. The curated aliases pin text-only serving and the muse parsers; the 8-bit
+   alias also pins its qualified DFlash target/assistant pair.
 
 Numeric fidelity against the transformers reference implementation was
 verified out-of-band on identical random weights (8 layers, seq 24 >
@@ -331,7 +332,11 @@ def test_aliases_pin_text_only_and_muse_parsers():
     aliases = json.loads(
         (Path(__file__).parent.parent / "vllm_mlx" / "aliases.json").read_text()
     )
-    for name in ("muse-glimmer-30b-4bit", "muse-glimmer-30b-bf16"):
+    for name in (
+        "muse-glimmer-30b-4bit",
+        "muse-glimmer-30b-8bit",
+        "muse-glimmer-30b-bf16",
+    ):
         entry = aliases[name]
         assert entry["hf_path"].startswith("mlx-community/Muse-Glimmer-30B")
         # The #393 state-pin: vision weights exist but text-only serving
@@ -341,3 +346,25 @@ def test_aliases_pin_text_only_and_muse_parsers():
         assert entry["reasoning_parser"] == "muse"
         assert entry["is_hybrid"] is False
         assert entry["is_hybrid_explicit"] is True
+
+
+def test_muse_glimmer_8bit_pins_qualified_dflash_pair():
+    aliases = json.loads(
+        (Path(__file__).parent.parent / "vllm_mlx" / "aliases.json").read_text()
+    )
+    entry = aliases["muse-glimmer-30b-8bit"]
+    assert entry["hf_path"] == "mlx-community/Muse-Glimmer-30B-8bit"
+    assert entry["supports_dflash"] is True
+    assert entry["dflash_draft_model"] == "meta-models/Muse-Glimmer-30B-assistant"
+    assert entry["dflash_target_revision"] == (
+        "679c45e1b331a6514a6e38076a353cc5fed21bf6"
+    )
+    assert entry["dflash_draft_revision"] == (
+        "e8192f3a8f617f74be2ce220360c89ef4789f39f"
+    )
+    assert entry["dflash_algorithm"] == "dflash"
+    assert entry["min_memory_gb"] == 48
+
+    # Legacy DFlash is not safe on the 4-bit target; adding the 8-bit pair
+    # must not silently broaden eligibility to the smaller alias.
+    assert aliases["muse-glimmer-30b-4bit"].get("supports_dflash", False) is False

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1430,6 +1430,22 @@
     "supports_spec_decode": false,
     "min_memory_gb": 24
   },
+  "muse-glimmer-30b-8bit": {
+    "hf_path": "mlx-community/Muse-Glimmer-30B-8bit",
+    "is_text_only": true,
+    "tool_call_parser": "muse",
+    "reasoning_parser": "muse",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "supports_dflash": true,
+    "dflash_draft_model": "meta-models/Muse-Glimmer-30B-assistant",
+    "dflash_target_revision": "679c45e1b331a6514a6e38076a353cc5fed21bf6",
+    "dflash_draft_revision": "e8192f3a8f617f74be2ce220360c89ef4789f39f",
+    "dflash_algorithm": "dflash",
+    "min_memory_gb": 48
+  },
   "muse-glimmer-30b-bf16": {
     "hf_path": "mlx-community/Muse-Glimmer-30B-bf16",
     "is_text_only": true,

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -68,6 +68,7 @@
     "mlx-community/Mistral-Small-4-119B-2603-4bit": 67790336757,
     "mlx-community/Mistral-Small-4-119B-2603-8bit": 127279723730,
     "mlx-community/Muse-Glimmer-30B-4bit": 19443239525,
+    "mlx-community/Muse-Glimmer-30B-8bit": 33404526711,
     "mlx-community/Muse-Glimmer-30B-bf16": 59581776079,
     "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit": 17792571825,
     "mlx-community/Nanbeige4.1-3B-4bit": 2231499570,


### PR DESCRIPTION
## Why

Closes #1844. Muse-Glimmer 30B has a published DFlash assistant and the runtime support already exists in Rapid-MLX's pinned optional dependency, but users currently have no curated alias that can select the exact compatible pair. This PR makes the measured acceleration available through the normal `rapid-mlx serve` flow while failing closed on unqualified variants.

On an Apple M3 Ultra with 256 GB unified memory, three 256-token runs per workload measured a **2.00x code-workload median** and **1.83x general-chat speedup**. The individual code workloads improved **1.89x–2.10x**, clearing the repository's 1.30x ship gate without regressing the non-code workload.

## Scope

- Add the text-only `muse-glimmer-30b-8bit` alias and its 31.1 GiB catalog size.
- Pin the target and assistant to immutable revisions and declare the verified `dflash` runtime algorithm.
- Require 48 GB unified memory based on a measured 36.9 GiB post-request RSS.
- Admit only the exact Muse-Glimmer target/assistant identity in the DFlash contract.
- Document the user command and reproducible qualification results.
- Update the README catalog total from 250 to 251 aliases.

## Non-goals

- Enabling DFlash for the 4-bit or BF16 Muse-Glimmer aliases.
- Changing the DFlash server, batching model, runtime implementation, parsers, model download behavior, GUI interaction design, or public API.
- Release or deployment changes.

## Acceptance

- `rapid-mlx models` lists `muse-glimmer-30b-8bit` at 31.1 GiB.
- `rapid-mlx info muse-glimmer-30b-8bit` reports verified DFlash eligibility and the published assistant.
- `rapid-mlx serve muse-glimmer-30b-8bit --speculative-config '{"method":"dflash"}'` boots with the exact pinned pair.
- `/healthz` reports `algorithm=dflash` and both expected revision SHAs.
- Plain-vs-DFlash qualification passes the 1.30x code-median gate and 1.00x non-code floor.
- The existing 4-bit alias remains DFlash-ineligible.

## Verification

- `python3.12 scripts/bench_dflash.py --model muse-glimmer-30b-8bit --expected-algorithm dflash --max-tokens 256 --runs 3 --port 18845 --output /tmp/muse-dflash-bench.json`
  - Fibonacci: 22.6 → 43.9 tok/s (**1.94x**)
  - Quicksort: 22.1 → 46.3 tok/s (**2.10x**)
  - Hashtable: 22.6 → 42.8 tok/s (**1.89x**)
  - Sorted list: 22.6 → 46.3 tok/s (**2.05x**)
  - General chat: 22.6 → 41.3 tok/s (**1.83x**)
  - Code median: **2.00x**; all-workload median: **1.94x**; decision: `SHIP`.
- Real-weight non-stream generation succeeded. A streaming request was disconnected after 1.5 seconds and 4,537 bytes; the immediate recovery request completed in about 1.0 second.
- Focused model/catalog/DFlash/CLI suite: **3,929 passed, 2 skipped**.
- Exact-head validator targeted suite: **3,443 passed, 1 skipped**; description, supply-chain, adversarial review, lint, and formatting gates passed.
- Validator full suite under the repository-required mflux 0.19.1: **23,033 passed, 117 skipped, 6 xfailed, 1 xpassed, 4 failed**. The complete four-test failure set reproduces identically on clean `origin/main@9113b5d8d` with the same venv and is confined to existing doctor/extras subprocess row-index assumptions; this diff does not touch that subsystem. A final validator pass therefore skips only the already-run, base-compared full-unit gate.
- Three scope-locked adversarial self-review rounds completed. They caught and fixed an overly broad assistant allow-list and a stale README catalog count; the validator follow-up review found no blocking issues.

## Behaviour delta

Before: Muse-Glimmer users could serve the existing 4-bit or BF16 aliases normally, but no curated Muse alias could opt into DFlash.

After: `muse-glimmer-30b-8bit` is available as a 48 GB+ text alias and can opt into the existing single-user DFlash server with an immutable, verified assistant pair. Existing aliases and default serving behavior are unchanged.

## AI assistance disclosure

Codex implemented and reviewed the alias, tests, and documentation. Every non-generated change was inspected in three adversarial review rounds; the model-size entry was generated by the repository script and narrowed to the new alias. Verification included real pinned weights, server requests, cancellation/recovery, reproducible throughput qualification, focused tests, and a full-suite/base comparison.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Focused tests pass locally; full-suite exceptions are reproduced on the unchanged base and documented above.
- [x] Lint and formatting checks pass.
- [x] Adversarial self-review and exact-head PR validation completed.
- [x] New critical-path contract tests were spot-checked against the production registry behavior.
- [x] README and durable performance documentation updated.
- [x] No breaking changes to the existing API.
