### PR TITLE
feat(serve): add primary standby lifecycle

### DIFF
--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -80,9 +80,11 @@ sudo rapid-mlx service apply
 
 `/readyz` remains successful in `standby` because the endpoint can accept and
 coalesce a demand load; `/health` and `/health/ready` expose the lifecycle state
-and whether weights are currently loaded. A request can only wake the model
-configured by the service definition—it cannot select an arbitrary repository
-or trigger a new download.
+and whether weights are currently loaded. Chat Completions, legacy Completions,
+Responses, and Anthropic Messages/counting wake the configured primary. The
+independent `--embedding-model` lane is unaffected. A request can only wake the
+primary configured by the service definition—it cannot select an arbitrary
+repository or trigger a new download.
 
 For API authentication, send the key over stdin to a private credential file.
 It never appears in argv, the plist, shell history, `service config`, or status:

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -69,6 +69,21 @@ To clear advanced serve flags, use `service configure --clear-serve-args`.
 Changing the service account or executable still requires uninstall/install,
 because those are security boundaries rather than runtime preferences.
 
+For an endpoint that survives reboot without permanently reserving model
+memory, pass the primary standby policy through to `serve`:
+
+```bash
+sudo rapid-mlx service configure --model qwen3.5-9b-4bit -- \
+  --lazy-load --idle-unload-seconds 1800
+sudo rapid-mlx service apply
+```
+
+`/readyz` remains successful in `standby` because the endpoint can accept and
+coalesce a demand load; `/health` and `/health/ready` expose the lifecycle state
+and whether weights are currently loaded. A request can only wake the model
+configured by the service definition—it cannot select an arbitrary repository
+or trigger a new download.
+
 For API authentication, send the key over stdin to a private credential file.
 It never appears in argv, the plist, shell history, `service config`, or status:
 

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -84,6 +84,8 @@ flag visible in `rapid-mlx serve --help`, grouped by category — lives in the
 | `--enable-audio` | Mount `/v1/audio/*` routes on a text-only server (audio-capable models auto-mount them) | False |
 | `--disk-stream` | Stream MoE routed-expert weights from disk instead of holding them resident (opt-in; budget via `--disk-stream-cache-gb`) | False |
 | `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB (multi-model serving); LRU idle unpinned models are evicted first; 0 disables (companion: `--resident-model-idle-ttl`) | 0 |
+| `--lazy-load` | Keep the endpoint online in `standby` until the configured primary receives its first inference request | False |
+| `--idle-unload-seconds` | Unload the configured primary after an idle interval, preserving its route and reloading on demand; 0 disables | 0 |
 | `--pflash` | PFlash long-prompt prefill compression (`off`, `auto`, `always`); tuning knobs in the [CLI reference](../reference/cli.md#pflash-long-prompt-compression) | `always` for verified aliases, `off` otherwise |
 
 ## API Endpoints

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -84,9 +84,13 @@ flag visible in `rapid-mlx serve --help`, grouped by category — lives in the
 | `--enable-audio` | Mount `/v1/audio/*` routes on a text-only server (audio-capable models auto-mount them) | False |
 | `--disk-stream` | Stream MoE routed-expert weights from disk instead of holding them resident (opt-in; budget via `--disk-stream-cache-gb`) | False |
 | `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB (multi-model serving); LRU idle unpinned models are evicted first; 0 disables (companion: `--resident-model-idle-ttl`) | 0 |
-| `--lazy-load` | Keep the endpoint online in `standby` until the configured primary receives its first inference request | False |
+| `--lazy-load` | Keep the endpoint online in `standby` until the configured primary receives its first text-generation request | False |
 | `--idle-unload-seconds` | Unload the configured primary after an idle interval, preserving its route and reloading on demand; 0 disables | 0 |
 | `--pflash` | PFlash long-prompt prefill compression (`off`, `auto`, `always`); tuning knobs in the [CLI reference](../reference/cli.md#pflash-long-prompt-compression) | `always` for verified aliases, `off` otherwise |
+
+Primary standby applies to Chat Completions, legacy Completions, Responses,
+and Anthropic Messages/counting. `/v1/embeddings` has an independent engine
+selected by `--embedding-model`; it neither wakes nor uses the primary model.
 
 ## API Endpoints
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,7 +146,7 @@ are the argparse defaults from `vllm_mlx/cli.py`.
 | `--disk-stream-cache-gb` | Byte budget (GB) for the disk-stream expert LRU cache; only used with `--disk-stream` | 1.0 |
 | `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB; loading another model evicts the least-recently-used idle unpinned model first. 0 disables. | 0 (disabled) |
 | `--resident-model-idle-ttl` | Evict idle unpinned secondary models after this many seconds. 0 disables. | 0 (disabled) |
-| `--lazy-load` | Start the endpoint with the configured primary in standby; its first inference request loads and warms the weights. | off |
+| `--lazy-load` | Start the endpoint with the configured primary in standby; its first text-generation request loads and warms the weights. The independently configured `--embedding-model` lane is unaffected. | off |
 | `--idle-unload-seconds` | Release the configured primary after this many idle seconds without stopping the endpoint; the next request reloads it. | 0 (disabled) |
 | `--mllm` | Force-load as multimodal (vision) even if the name doesn't match auto-detection, and hard-fail instead of silently auto-degrading to text-only when the checkpoint ships no usable vision tower | off |
 | `--no-mllm` / `--text-only` | Force-load as text-only even when auto-detection would route to the multimodal path (escape hatch for incomplete vision-tower checkpoints) | off |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,6 +146,8 @@ are the argparse defaults from `vllm_mlx/cli.py`.
 | `--disk-stream-cache-gb` | Byte budget (GB) for the disk-stream expert LRU cache; only used with `--disk-stream` | 1.0 |
 | `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB; loading another model evicts the least-recently-used idle unpinned model first. 0 disables. | 0 (disabled) |
 | `--resident-model-idle-ttl` | Evict idle unpinned secondary models after this many seconds. 0 disables. | 0 (disabled) |
+| `--lazy-load` | Start the endpoint with the configured primary in standby; its first inference request loads and warms the weights. | off |
+| `--idle-unload-seconds` | Release the configured primary after this many idle seconds without stopping the endpoint; the next request reloads it. | 0 (disabled) |
 | `--mllm` | Force-load as multimodal (vision) even if the name doesn't match auto-detection, and hard-fail instead of silently auto-degrading to text-only when the checkpoint ships no usable vision tower | off |
 | `--no-mllm` / `--text-only` | Force-load as text-only even when auto-detection would route to the multimodal path (escape hatch for incomplete vision-tower checkpoints) | off |
 | `--vision-min-pixels` | Minimum pixels for dynamic-resolution VLM image processors; 0 keeps the model default | 0 |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -113,7 +113,7 @@ needed by the application; leave it unset for URL/base64-only deployments.
 | `--disk-stream-cache-gb` | Byte budget (GB) for the disk-stream expert LRU cache | `1.0` |
 | `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB; LRU idle unpinned models are evicted first. `0` disables. | `0` |
 | `--resident-model-idle-ttl` | Evict idle unpinned secondary models after this many seconds. `0` disables. | `0` |
-| `--lazy-load` | Bind the stable API endpoint with the configured primary in `standby`; load and warm its weights on the first inference request. | `false` |
+| `--lazy-load` | Bind the stable API endpoint with the configured primary in `standby`; load and warm its weights on the first text-generation request. The separate `--embedding-model` lane is unaffected. | `false` |
 | `--idle-unload-seconds` | Release the configured primary model after this many idle seconds while keeping the endpoint online; the next request reloads it. `0` disables. | `0` |
 | `--mllm` / `--no-mllm` | Force multimodal (vision) loading / force text-only loading, overriding auto-detection | auto-detect |
 | `--enable-audio` | Mount `/v1/audio/*` routes on a text-only server (audio-capable models auto-mount them) | `false` |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -113,6 +113,8 @@ needed by the application; leave it unset for URL/base64-only deployments.
 | `--disk-stream-cache-gb` | Byte budget (GB) for the disk-stream expert LRU cache | `1.0` |
 | `--resident-memory-limit-gb` | Process-wide resident model ceiling in GiB; LRU idle unpinned models are evicted first. `0` disables. | `0` |
 | `--resident-model-idle-ttl` | Evict idle unpinned secondary models after this many seconds. `0` disables. | `0` |
+| `--lazy-load` | Bind the stable API endpoint with the configured primary in `standby`; load and warm its weights on the first inference request. | `false` |
+| `--idle-unload-seconds` | Release the configured primary model after this many idle seconds while keeping the endpoint online; the next request reloads it. `0` disables. | `0` |
 | `--mllm` / `--no-mllm` | Force multimodal (vision) loading / force text-only loading, overriding auto-detection | auto-detect |
 | `--enable-audio` | Mount `/v1/audio/*` routes on a text-only server (audio-capable models auto-mount them) | `false` |
 

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -216,6 +216,19 @@ async def test_shutdown_drains_cancellation_isolated_load():
     assert engine._loaded is True
     with pytest.raises(RuntimeError, match="closed"):
         await lifecycle.ensure_loaded()
+
+
+@pytest.mark.asyncio
+async def test_demand_warmup_runs_off_the_event_loop(monkeypatch):
+    from vllm_mlx import server
+
+    engine = FakeEngine(loaded=True)
+    engine.generate_warmup = Mock()
+    to_thread = AsyncMock()
+    monkeypatch.setattr(server.asyncio, "to_thread", to_thread)
+
+    await server._warmup_primary_engine(engine)
+    to_thread.assert_awaited_once_with(engine.generate_warmup)
 
 
 @pytest.mark.asyncio

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -15,6 +15,8 @@ class FakeEngine:
         self.active_requests = 0
         self.start_gate: asyncio.Event | None = None
         self.fail_start = False
+        self.fail_resume = False
+        self.partial_start_failure = False
         self.paused = False
 
     async def start(self) -> None:
@@ -22,6 +24,8 @@ class FakeEngine:
         if self.start_gate is not None:
             await self.start_gate.wait()
         if self.fail_start:
+            if self.partial_start_failure:
+                self._loaded = True
             raise RuntimeError("load failed")
         self._loaded = True
 
@@ -44,6 +48,8 @@ class FakeEngine:
         return self.lifecycle_status()
 
     async def resume_generation(self):
+        if self.fail_resume:
+            raise RuntimeError("resume failed")
         self.paused = False
         return self.lifecycle_status()
 
@@ -130,6 +136,27 @@ async def test_pre_unload_failure_keeps_loaded_engine_ready():
 
 
 @pytest.mark.asyncio
+async def test_resume_failure_never_publishes_false_standby():
+    now = [100.0]
+    engine = FakeEngine(loaded=True)
+    engine.fail_resume = True
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=5, clock=lambda: now[0]
+    )
+    now[0] += 6
+
+    with pytest.raises(RuntimeError, match="resume failed"):
+        await lifecycle.evict_if_idle()
+    assert lifecycle.snapshot()["state"] == "error"
+    assert lifecycle.snapshot()["error"] == "AdmissionResumeError"
+
+    engine.fail_resume = False
+    await lifecycle.ensure_loaded()
+    assert lifecycle.snapshot()["state"] == "ready"
+    assert engine.paused is False
+
+
+@pytest.mark.asyncio
 async def test_detach_refuses_in_flight_load_then_suppresses_callbacks():
     engine = FakeEngine()
     engine.start_gate = asyncio.Event()
@@ -208,6 +235,64 @@ async def test_failed_load_is_retryable_and_reports_only_error_type():
     await lifecycle.ensure_loaded()
     assert engine.start_calls == 2
     assert lifecycle.snapshot()["state"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_partial_failed_load_is_cleaned_and_retryable():
+    engine = FakeEngine()
+    engine.fail_start = True
+    engine.partial_start_failure = True
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        await lifecycle.ensure_loaded()
+    assert engine._loaded is False
+    assert engine.stop_calls == 1
+
+    engine.fail_start = False
+    await lifecycle.ensure_loaded()
+    assert engine.start_calls == 2
+    assert lifecycle.snapshot()["state"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_streaming_release_starts_idle_window_after_final_chunk():
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.service.helpers import _disconnect_guard
+
+    class ConnectedRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def stream():
+        yield "data: done\n\n"
+
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=5, clock=lambda: now[0]
+    )
+    cfg = reset_config()
+    cfg.primary_model_lifecycle = lifecycle
+    now[0] += 20
+
+    chunks = [
+        chunk
+        async for chunk in _disconnect_guard(
+            stream(),
+            ConnectedRequest(),
+            poll_interval=0.01,
+            engine=engine,
+            keepalive_seconds=0,
+        )
+    ]
+    assert chunks == ["data: done\n\n"]
+    assert engine.release_calls == 1
+    now[0] += 4
+    assert await lifecycle.evict_if_idle() is False
+    now[0] += 2
+    assert await lifecycle.evict_if_idle() is True
+    reset_config()
 
 
 @pytest.mark.asyncio

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -250,6 +250,29 @@ async def test_shutdown_drains_cancellation_isolated_load():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_load_drain_has_a_deadline():
+    engine = FakeEngine()
+    engine.start_gate = asyncio.Event()
+    lifecycle = PrimaryModelLifecycle(
+        engine, lazy_load=True, shutdown_load_timeout_seconds=0.01
+    )
+    waiter = asyncio.create_task(lifecycle.ensure_loaded())
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    with pytest.raises(TimeoutError, match="timed out waiting"):
+        await lifecycle.shutdown()
+    assert lifecycle.snapshot()["state"] == "error"
+    assert lifecycle.snapshot()["error"] == "ShutdownLoadDrainTimeout"
+
+    engine.start_gate.set()
+    assert lifecycle._load_task is not None
+    await lifecycle._load_task
+
+
+@pytest.mark.asyncio
 async def test_demand_warmup_runs_off_the_event_loop(monkeypatch):
     from vllm_mlx import server
 
@@ -379,6 +402,27 @@ async def test_streaming_release_starts_idle_window_after_final_chunk():
     assert await lifecycle.evict_if_idle() is False
     now[0] += 2
     assert await lifecycle.evict_if_idle() is True
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_non_generation_route_decorator_releases_primary_owner():
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.anthropic import _release_primary_request_after_route
+
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine, idle_unload_seconds=5)
+    cfg = reset_config()
+    cfg.primary_model_lifecycle = lifecycle
+
+    @_release_primary_request_after_route
+    async def route():
+        lifecycle.acquire_request()
+        assert lifecycle.snapshot()["active_request_owners"] == 1
+        return "done"
+
+    assert await route() == "done"
+    assert lifecycle.snapshot()["active_request_owners"] == 0
     reset_config()
 
 

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -1055,6 +1055,8 @@ def test_configure_primary_lifecycle_resets_existing_state(monkeypatch):
     cfg = reset_config()
     cfg.primary_model_lifecycle = object()
     monkeypatch.setattr(server, "_primary_model_lifecycle", object())
+    monkeypatch.setattr(server, "_primary_lazy_load", False)
+    monkeypatch.setattr(server, "_primary_idle_unload_seconds", 0.0)
     server.configure_primary_model_lifecycle(lazy_load=True, idle_unload_seconds=12)
     assert server._primary_lazy_load is True
     assert server._primary_idle_unload_seconds == 12
@@ -1075,6 +1077,8 @@ async def test_resident_primary_handoff_detaches_or_rejects(monkeypatch):
     old = FakeEngine(loaded=True)
     lifecycle = PrimaryModelLifecycle(old, idle_unload_seconds=3)
     monkeypatch.setattr(server, "_primary_model_lifecycle", lifecycle)
+    monkeypatch.setattr(server, "_primary_lazy_load", True)
+    monkeypatch.setattr(server, "_primary_idle_unload_seconds", 3.0)
     replacement = ModelEntry(FakeEngine(loaded=True), "new", "new")
     server._set_resident_primary(replacement)
     assert lifecycle._detached is True

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -14,6 +14,7 @@ class FakeEngine:
         self.release_calls = 0
         self.active_requests = 0
         self.start_gate: asyncio.Event | None = None
+        self.pause_gate: asyncio.Event | None = None
         self.fail_start = False
         self.fail_resume = False
         self.partial_start_failure = False
@@ -45,6 +46,8 @@ class FakeEngine:
         if self.active_requests:
             raise TimeoutError
         self.paused = True
+        if self.pause_gate is not None:
+            await self.pause_gate.wait()
         return self.lifecycle_status()
 
     async def resume_generation(self):
@@ -195,6 +198,34 @@ async def test_request_owner_closes_post_load_pre_admission_race():
     assert await lifecycle.evict_if_idle() is False
     now[0] += 0.6
     assert await lifecycle.evict_if_idle() is True
+
+
+@pytest.mark.asyncio
+async def test_request_arriving_during_pause_aborts_idle_unload():
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+    engine.pause_gate = asyncio.Event()
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=1, clock=lambda: now[0]
+    )
+    now[0] += 2
+
+    eviction = asyncio.create_task(lifecycle.evict_if_idle())
+    await asyncio.sleep(0)
+    assert lifecycle.snapshot()["state"] == "unloading"
+
+    lifecycle.acquire_request()
+    ready = asyncio.create_task(lifecycle.ensure_loaded())
+    await asyncio.sleep(0)
+    assert ready.done() is False
+
+    engine.pause_gate.set()
+    assert await eviction is False
+    await ready
+    assert engine.stop_calls == 0
+    assert engine.paused is False
+    assert lifecycle.snapshot()["state"] == "ready"
+    lifecycle.release_request()
 
 
 @pytest.mark.asyncio

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -105,6 +105,52 @@ async def test_idle_unload_keeps_engine_reloadable_and_runs_cache_hooks():
 
 
 @pytest.mark.asyncio
+async def test_pre_unload_failure_keeps_loaded_engine_ready():
+    now = [100.0]
+    engine = FakeEngine(loaded=True)
+
+    async def fail_save() -> None:
+        raise OSError("disk full")
+
+    lifecycle = PrimaryModelLifecycle(
+        engine,
+        idle_unload_seconds=5,
+        before_unload=fail_save,
+        clock=lambda: now[0],
+    )
+    now[0] += 6
+
+    assert await lifecycle.evict_if_idle() is False
+    assert engine._loaded is True
+    assert engine.stop_calls == 0
+    assert engine.paused is False
+    assert lifecycle.snapshot()["state"] == "ready"
+    await lifecycle.ensure_loaded()
+    assert engine.start_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_detach_refuses_in_flight_load_then_suppresses_callbacks():
+    engine = FakeEngine()
+    engine.start_gate = asyncio.Event()
+    states: list[str] = []
+    lifecycle = PrimaryModelLifecycle(
+        engine, lazy_load=True, on_state_change=states.append
+    )
+    load = asyncio.create_task(lifecycle.ensure_loaded())
+    await asyncio.sleep(0)
+
+    with pytest.raises(RuntimeError, match="transition is in progress"):
+        lifecycle.detach()
+
+    engine.start_gate.set()
+    await load
+    lifecycle.detach()
+    lifecycle._set_state("standby")
+    assert states == ["loading", "ready"]
+
+
+@pytest.mark.asyncio
 async def test_active_request_restarts_idle_window():
     now = [10.0]
     engine = FakeEngine(loaded=True)
@@ -190,6 +236,26 @@ async def test_ready_engine_wakes_only_the_configured_primary():
     assert await get_ready_engine("primary-alias") is primary
     lifecycle.ensure_loaded.assert_awaited_once()
     reset_config()
+
+
+def test_residency_state_callback_is_bound_to_engine_identity():
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.runtime.resident_models import ResidentModelManager
+
+    old_engine = FakeEngine(loaded=True)
+    new_engine = FakeEngine(loaded=True)
+    registry = ModelRegistry()
+    registry.add(ModelEntry(old_engine, "old", "old"), is_default=True)
+    manager = ResidentModelManager(registry, AsyncMock())
+    old_record = manager.register_primary(registry.get_entry("old"))
+    old_record.primary = False
+    registry.add(ModelEntry(new_engine, "new", "new"), is_default=True)
+    new_record = manager.register_primary(registry.get_entry("new"))
+
+    manager.set_primary_lifecycle_state(old_engine, "standby")
+    assert new_record.state == "resident"
+    manager.set_primary_lifecycle_state(new_engine, "standby")
+    assert new_record.state == "standby"
 
 
 @pytest.mark.asyncio

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -178,6 +178,47 @@ async def test_detach_refuses_in_flight_load_then_suppresses_callbacks():
 
 
 @pytest.mark.asyncio
+async def test_request_owner_closes_post_load_pre_admission_race():
+    now = [10.0]
+    engine = FakeEngine()
+    lifecycle = PrimaryModelLifecycle(
+        engine, lazy_load=True, idle_unload_seconds=1, clock=lambda: now[0]
+    )
+
+    lifecycle.acquire_request()
+    await lifecycle.ensure_loaded()
+    now[0] += 10
+    assert await lifecycle.evict_if_idle() is False
+
+    lifecycle.release_request()
+    now[0] += 0.5
+    assert await lifecycle.evict_if_idle() is False
+    now[0] += 0.6
+    assert await lifecycle.evict_if_idle() is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_cancellation_isolated_load():
+    engine = FakeEngine()
+    engine.start_gate = asyncio.Event()
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+    waiter = asyncio.create_task(lifecycle.ensure_loaded())
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    shutdown = asyncio.create_task(lifecycle.shutdown())
+    await asyncio.sleep(0)
+    assert shutdown.done() is False
+    engine.start_gate.set()
+    await shutdown
+    assert engine._loaded is True
+    with pytest.raises(RuntimeError, match="closed"):
+        await lifecycle.ensure_loaded()
+
+
+@pytest.mark.asyncio
 async def test_active_request_restarts_idle_window():
     now = [10.0]
     engine = FakeEngine(loaded=True)
@@ -211,6 +252,7 @@ async def test_route_release_starts_full_idle_window():
     cfg.primary_model_lifecycle = lifecycle
 
     now[0] += 20
+    lifecycle.acquire_request()
     _release_admission_unless_committed(engine, False)
     assert engine.release_calls == 1
     now[0] += 4
@@ -275,6 +317,7 @@ async def test_streaming_release_starts_idle_window_after_final_chunk():
     cfg = reset_config()
     cfg.primary_model_lifecycle = lifecycle
     now[0] += 20
+    lifecycle.acquire_request()
 
     chunks = [
         chunk

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -1,0 +1,230 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from vllm_mlx.runtime.primary_lifecycle import PrimaryModelLifecycle
+
+
+class FakeEngine:
+    def __init__(self, *, loaded: bool = False) -> None:
+        self._loaded = loaded
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.release_calls = 0
+        self.active_requests = 0
+        self.start_gate: asyncio.Event | None = None
+        self.fail_start = False
+        self.paused = False
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        if self.start_gate is not None:
+            await self.start_gate.wait()
+        if self.fail_start:
+            raise RuntimeError("load failed")
+        self._loaded = True
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        self._loaded = False
+
+    def release_admission_reservation(self) -> None:
+        self.release_calls += 1
+
+    def lifecycle_status(self) -> dict[str, int]:
+        return {"active_requests": self.active_requests}
+
+    async def pause_generation(self, mode: str, *, timeout: float | None = None):
+        assert mode == "wait"
+        assert timeout == 0
+        if self.active_requests:
+            raise TimeoutError
+        self.paused = True
+        return self.lifecycle_status()
+
+    async def resume_generation(self):
+        self.paused = False
+        return self.lifecycle_status()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_requests_share_load_and_cancellation_isolated():
+    engine = FakeEngine()
+    engine.start_gate = asyncio.Event()
+    loaded_hooks = 0
+
+    async def on_loaded() -> None:
+        nonlocal loaded_hooks
+        loaded_hooks += 1
+
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True, on_loaded=on_loaded)
+    first = asyncio.create_task(lifecycle.ensure_loaded())
+    second = asyncio.create_task(lifecycle.ensure_loaded())
+    await asyncio.sleep(0)
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    engine.start_gate.set()
+    await second
+
+    assert engine.start_calls == 1
+    assert loaded_hooks == 1
+    assert lifecycle.snapshot()["state"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_idle_unload_keeps_engine_reloadable_and_runs_cache_hooks():
+    now = [100.0]
+    engine = FakeEngine(loaded=True)
+    events: list[str] = []
+    states: list[str] = []
+
+    lifecycle = PrimaryModelLifecycle(
+        engine,
+        idle_unload_seconds=30,
+        before_unload=lambda: events.append("save"),
+        release_allocator_cache=lambda: events.append("release"),
+        on_loaded=lambda: events.append("restore"),
+        on_state_change=states.append,
+        clock=lambda: now[0],
+    )
+
+    now[0] += 31
+    assert await lifecycle.evict_if_idle() is True
+    assert engine.stop_calls == 1
+    assert events == ["save", "release"]
+    assert lifecycle.snapshot()["state"] == "standby"
+    assert engine.paused is False
+
+    await lifecycle.ensure_loaded()
+    assert engine.start_calls == 1
+    assert events == ["save", "release", "restore"]
+    assert states == ["unloading", "standby", "loading", "ready"]
+
+
+@pytest.mark.asyncio
+async def test_active_request_restarts_idle_window():
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=5, clock=lambda: now[0]
+    )
+    engine.active_requests = 1
+    now[0] += 6
+
+    assert await lifecycle.evict_if_idle() is False
+    assert engine.stop_calls == 0
+
+    engine.active_requests = 0
+    now[0] += 4
+    assert await lifecycle.evict_if_idle() is False
+    now[0] += 2
+    assert await lifecycle.evict_if_idle() is True
+
+
+@pytest.mark.asyncio
+async def test_route_release_starts_full_idle_window():
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.service.helpers import _release_admission_unless_committed
+
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=5, clock=lambda: now[0]
+    )
+    cfg = reset_config()
+    cfg.primary_model_lifecycle = lifecycle
+
+    now[0] += 20
+    _release_admission_unless_committed(engine, False)
+    assert engine.release_calls == 1
+    now[0] += 4
+    assert await lifecycle.evict_if_idle() is False
+    now[0] += 2
+    assert await lifecycle.evict_if_idle() is True
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_failed_load_is_retryable_and_reports_only_error_type():
+    engine = FakeEngine()
+    engine.fail_start = True
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        await lifecycle.ensure_loaded()
+    assert lifecycle.snapshot()["state"] == "error"
+    assert lifecycle.snapshot()["error"] == "RuntimeError"
+
+    engine.fail_start = False
+    await lifecycle.ensure_loaded()
+    assert engine.start_calls == 2
+    assert lifecycle.snapshot()["state"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_ready_engine_wakes_only_the_configured_primary():
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.runtime.model_registry import ModelEntry, ModelRegistry
+    from vllm_mlx.service.helpers import get_ready_engine
+
+    primary = FakeEngine()
+    secondary = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(primary, lazy_load=True)
+    lifecycle.ensure_loaded = AsyncMock(wraps=lifecycle.ensure_loaded)
+    registry = ModelRegistry()
+    registry.add(
+        ModelEntry(primary, "primary", "primary", aliases={"primary-alias"}),
+        is_default=True,
+    )
+    registry.add(ModelEntry(secondary, "secondary", "secondary"))
+    cfg = reset_config()
+    cfg.engine = primary
+    cfg.model_registry = registry
+    cfg.primary_model_lifecycle = lifecycle
+
+    assert await get_ready_engine("secondary") is secondary
+    lifecycle.ensure_loaded.assert_not_awaited()
+    assert await get_ready_engine("primary-alias") is primary
+    lifecycle.ensure_loaded.assert_awaited_once()
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_ready_probe_reports_standby_as_available():
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.health import health_ready
+
+    engine = FakeEngine()
+    cfg = reset_config()
+    cfg.ready = True
+    cfg.engine = engine
+    cfg.model_name = "configured-model"
+    cfg.primary_model_lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+
+    result = await health_ready()
+    assert result == {
+        "ready": True,
+        "model": "configured-model",
+        "state": "standby",
+        "model_loaded": False,
+    }
+    reset_config()
+
+
+def test_serve_parser_exposes_primary_standby_options():
+    from vllm_mlx.cli import build_parser
+
+    args = build_parser().parse_args(
+        [
+            "serve",
+            "some/model",
+            "--lazy-load",
+            "--idle-unload-seconds",
+            "300",
+        ]
+    )
+    assert args.lazy_load is True
+    assert args.idle_unload_seconds == 300

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -114,7 +114,7 @@ async def test_idle_unload_keeps_engine_reloadable_and_runs_cache_hooks():
 
 
 @pytest.mark.asyncio
-async def test_pre_unload_failure_keeps_loaded_engine_ready():
+async def test_pre_unload_failure_still_honors_memory_policy():
     now = [100.0]
     engine = FakeEngine(loaded=True)
 
@@ -129,13 +129,13 @@ async def test_pre_unload_failure_keeps_loaded_engine_ready():
     )
     now[0] += 6
 
-    assert await lifecycle.evict_if_idle() is False
-    assert engine._loaded is True
-    assert engine.stop_calls == 0
+    assert await lifecycle.evict_if_idle() is True
+    assert engine._loaded is False
+    assert engine.stop_calls == 1
     assert engine.paused is False
-    assert lifecycle.snapshot()["state"] == "ready"
+    assert lifecycle.snapshot()["state"] == "standby"
     await lifecycle.ensure_loaded()
-    assert engine.start_calls == 0
+    assert engine.start_calls == 1
 
 
 @pytest.mark.asyncio
@@ -250,25 +250,25 @@ async def test_shutdown_drains_cancellation_isolated_load():
 
 
 @pytest.mark.asyncio
-async def test_shutdown_load_drain_has_a_deadline():
+async def test_shutdown_load_drain_propagates_external_cancellation():
     engine = FakeEngine()
     engine.start_gate = asyncio.Event()
-    lifecycle = PrimaryModelLifecycle(
-        engine, lazy_load=True, shutdown_load_timeout_seconds=0.01
-    )
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
     waiter = asyncio.create_task(lifecycle.ensure_loaded())
     await asyncio.sleep(0)
     waiter.cancel()
     with pytest.raises(asyncio.CancelledError):
         await waiter
 
-    with pytest.raises(TimeoutError, match="timed out waiting"):
-        await lifecycle.shutdown()
-    assert lifecycle.snapshot()["state"] == "error"
-    assert lifecycle.snapshot()["error"] == "ShutdownLoadDrainTimeout"
+    shutdown = asyncio.create_task(lifecycle.shutdown())
+    await asyncio.sleep(0)
+    shutdown.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await shutdown
+    assert lifecycle._load_task is not None
+    assert lifecycle._load_task.done() is False
 
     engine.start_gate.set()
-    assert lifecycle._load_task is not None
     await lifecycle._load_task
 
 

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -496,6 +496,668 @@ async def test_ready_probe_reports_standby_as_available():
     reset_config()
 
 
+@pytest.mark.asyncio
+async def test_lifecycle_properties_and_request_token_edges():
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine)
+
+    assert lifecycle.enabled is False
+    assert lifecycle.last_error is None
+    assert lifecycle.model_loaded is True
+    lifecycle.release_request()  # no request in this context
+
+    lifecycle.acquire_request()
+    lifecycle.acquire_request()  # acquisition is idempotent within one route
+    assert lifecycle.snapshot()["active_request_owners"] == 1
+    lifecycle.transfer_request_to_stream()
+    assert list(lifecycle._request_tokens.values()) == [True]
+    lifecycle.release_request()
+    assert lifecycle.snapshot()["active_request_owners"] == 0
+
+
+@pytest.mark.asyncio
+async def test_start_shutdown_and_detach_monitor_paths(monkeypatch):
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine, idle_unload_seconds=10)
+    await lifecycle.start()
+    monitor = lifecycle._monitor_task
+    assert monitor is not None
+    await lifecycle.start()  # does not install a duplicate monitor
+    await lifecycle.shutdown()
+    assert monitor.cancelled()
+
+    detached = PrimaryModelLifecycle(engine, idle_unload_seconds=10)
+    await detached.start()
+    monitor = detached._monitor_task
+    detached.detach()
+    assert monitor is not None and monitor.cancelled() is False
+    await asyncio.sleep(0)
+    assert monitor.cancelled()
+    await detached.start()  # detached coordinators stay retired
+    assert detached._monitor_task is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_logs_failed_detached_load(caplog):
+    engine = FakeEngine()
+    engine.start_gate = asyncio.Event()
+    engine.fail_start = True
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+    load = asyncio.create_task(lifecycle.ensure_loaded())
+    await asyncio.sleep(0)
+    load.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await load
+
+    shutdown = asyncio.create_task(lifecycle.shutdown())
+    await asyncio.sleep(0)
+    engine.start_gate.set()
+    await shutdown
+    assert "load failed during shutdown drain" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_loaded_fast_paths_and_closed_acquisition():
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine)
+    lifecycle._last_error = "old"
+    await lifecycle.ensure_loaded()
+    assert lifecycle.last_error is None
+
+    # Force the first fast-path check to miss, then become ready while waiting
+    # for the transition lock so the in-lock fast path owns the decision.
+    await lifecycle._transition_lock.acquire()
+    lifecycle.state = "standby"
+    waiter = asyncio.create_task(lifecycle.ensure_loaded())
+    await asyncio.sleep(0)
+    lifecycle.state = "ready"
+    lifecycle._transition_lock.release()
+    await waiter
+    assert engine.start_calls == 0
+
+    await lifecycle.shutdown()
+    with pytest.raises(RuntimeError, match="closed"):
+        lifecycle.acquire_request()
+
+
+@pytest.mark.asyncio
+async def test_error_state_loaded_retry_resets_before_loading():
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine)
+    lifecycle.state = "error"
+    await lifecycle.ensure_loaded()
+    assert engine.stop_calls == 1
+    assert engine.start_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_or_ineffective_engine_lifecycle_methods():
+    class NoStop:
+        _loaded = True
+
+    lifecycle = PrimaryModelLifecycle(NoStop())
+    with pytest.raises(RuntimeError, match="cannot be reset"):
+        await lifecycle._reset_partial_load()
+
+    class IneffectiveStop:
+        _loaded = True
+
+        def stop(self):
+            return None
+
+    lifecycle = PrimaryModelLifecycle(IneffectiveStop())
+    with pytest.raises(RuntimeError, match="did not stop"):
+        await lifecycle._reset_partial_load()
+
+    class NoResume:
+        _loaded = False
+
+    lifecycle = PrimaryModelLifecycle(NoResume())
+    with pytest.raises(RuntimeError, match="resume_generation"):
+        await lifecycle._resume_admission()
+
+    class NoStart:
+        _loaded = False
+
+    lifecycle = PrimaryModelLifecycle(NoStart(), lazy_load=True)
+    with pytest.raises(RuntimeError, match=r"support start\(\)"):
+        await lifecycle.ensure_loaded()
+
+
+@pytest.mark.asyncio
+async def test_load_task_ready_shortcut_and_failed_cleanup_logging(caplog):
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine)
+    lifecycle.state = "standby"
+    await lifecycle._load()
+    assert lifecycle.state == "ready"
+
+    engine = FakeEngine()
+    engine.fail_start = True
+    engine.partial_start_failure = True
+
+    async def broken_stop():
+        raise RuntimeError("cleanup failed")
+
+    engine.stop = broken_stop
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+    with pytest.raises(RuntimeError, match="load failed"):
+        await lifecycle.ensure_loaded()
+    assert "Failed to reset partially loaded primary engine" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_idle_rechecks_state_and_clock_after_lock_wait():
+    now = [20.0]
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=1, clock=lambda: now[0]
+    )
+    now[0] = 22.0
+    await lifecycle._transition_lock.acquire()
+    eviction = asyncio.create_task(lifecycle.evict_if_idle())
+    await asyncio.sleep(0)
+    lifecycle.state = "standby"
+    lifecycle._transition_lock.release()
+    assert await eviction is False
+
+    lifecycle.state = "ready"
+    lifecycle._last_activity = 20.0
+    await lifecycle._transition_lock.acquire()
+    eviction = asyncio.create_task(lifecycle.evict_if_idle())
+    await asyncio.sleep(0)
+    lifecycle.touch()
+    lifecycle._transition_lock.release()
+    assert await eviction is False
+
+
+@pytest.mark.asyncio
+async def test_pause_timeout_recovers_or_reports_resume_failure():
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+    engine.active_requests = 1
+
+    # Hide the activity from the pre-pause status check so pause_generation
+    # remains the final authority and raises its TimeoutError.
+    engine.lifecycle_status = lambda: {"active_requests": 0}
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=1, clock=lambda: now[0]
+    )
+    now[0] = 12.0
+    assert await lifecycle.evict_if_idle() is False
+    assert lifecycle.state == "ready"
+
+    engine.fail_resume = True
+    now[0] = 14.0
+    with pytest.raises(RuntimeError, match="resume failed"):
+        await lifecycle.evict_if_idle()
+    assert lifecycle.state == "error"
+
+
+@pytest.mark.asyncio
+async def test_pause_exception_recovers_or_reports_resume_failure():
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+
+    async def broken_pause(*_args, **_kwargs):
+        raise RuntimeError("pause failed")
+
+    engine.pause_generation = broken_pause
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=1, clock=lambda: now[0]
+    )
+    now[0] = 12.0
+    with pytest.raises(RuntimeError, match="pause failed"):
+        await lifecycle.evict_if_idle()
+    assert lifecycle.state == "ready"
+
+    engine.fail_resume = True
+    now[0] = 14.0
+    with pytest.raises(RuntimeError, match="resume failed"):
+        await lifecycle.evict_if_idle()
+    assert lifecycle.state == "error"
+
+
+@pytest.mark.asyncio
+async def test_request_during_pause_resume_failure_is_terminal():
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+    engine.pause_gate = asyncio.Event()
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=1, clock=lambda: now[0]
+    )
+    now[0] = 12.0
+    eviction = asyncio.create_task(lifecycle.evict_if_idle())
+    await asyncio.sleep(0)
+    lifecycle.acquire_request()
+    engine.fail_resume = True
+    engine.pause_gate.set()
+    with pytest.raises(RuntimeError, match="resume failed"):
+        await eviction
+    assert lifecycle.state == "error"
+    lifecycle.release_request()
+
+
+@pytest.mark.asyncio
+async def test_unload_cancellation_and_stop_contract_failures():
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+
+    async def cancelled_save():
+        raise asyncio.CancelledError
+
+    lifecycle = PrimaryModelLifecycle(
+        engine,
+        idle_unload_seconds=1,
+        before_unload=cancelled_save,
+        clock=lambda: now[0],
+    )
+    now[0] = 12.0
+    with pytest.raises(asyncio.CancelledError):
+        await lifecycle.evict_if_idle()
+    assert lifecycle.state == "ready"
+
+    class NoStop(FakeEngine):
+        stop = None
+
+    no_stop = NoStop(loaded=True)
+    lifecycle = PrimaryModelLifecycle(
+        no_stop, idle_unload_seconds=1, clock=lambda: now[0]
+    )
+    lifecycle._last_activity = 10.0
+    with pytest.raises(RuntimeError, match=r"support stop\(\)"):
+        await lifecycle.evict_if_idle()
+    assert lifecycle.state == "ready"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("remains_loaded", [True, False])
+async def test_stop_failure_publishes_truthful_state(remains_loaded):
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+
+    async def broken_stop():
+        engine._loaded = remains_loaded
+        raise RuntimeError("stop failed")
+
+    engine.stop = broken_stop
+    lifecycle = PrimaryModelLifecycle(
+        engine, idle_unload_seconds=1, clock=lambda: now[0]
+    )
+    now[0] = 12.0
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await lifecycle.evict_if_idle()
+    assert lifecycle.state == ("ready" if remains_loaded else "error")
+
+
+@pytest.mark.asyncio
+async def test_allocator_release_failure_is_best_effort(caplog):
+    now = [10.0]
+    engine = FakeEngine(loaded=True)
+
+    async def broken_release():
+        raise RuntimeError("allocator failed")
+
+    lifecycle = PrimaryModelLifecycle(
+        engine,
+        idle_unload_seconds=1,
+        release_allocator_cache=broken_release,
+        clock=lambda: now[0],
+    )
+    now[0] = 12.0
+    assert await lifecycle.evict_if_idle() is True
+    assert lifecycle.state == "standby"
+    assert "allocator cache release failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_monitor_logs_failures_and_propagates_cancellation(monkeypatch, caplog):
+    from vllm_mlx.runtime import primary_lifecycle as lifecycle_module
+
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine, idle_unload_seconds=4)
+    lifecycle.evict_if_idle = AsyncMock(side_effect=RuntimeError("evict failed"))
+    sleeps = 0
+
+    async def fake_sleep(_interval):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(lifecycle_module.asyncio, "sleep", fake_sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await lifecycle._monitor_idle()
+    assert "idle unload failed" in caplog.text
+
+    lifecycle = PrimaryModelLifecycle(engine, idle_unload_seconds=4)
+    lifecycle.evict_if_idle = AsyncMock(side_effect=asyncio.CancelledError)
+
+    async def one_sleep(_interval):
+        return None
+
+    monkeypatch.setattr(lifecycle_module.asyncio, "sleep", one_sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await lifecycle._monitor_idle()
+
+
+@pytest.mark.asyncio
+async def test_ensure_engine_ready_releases_on_cancel_and_failure():
+    from fastapi import HTTPException
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.service.helpers import ensure_engine_ready
+
+    engine = FakeEngine()
+    cfg = reset_config()
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+    cfg.primary_model_lifecycle = lifecycle
+    lifecycle.ensure_loaded = AsyncMock(side_effect=asyncio.CancelledError)
+    with pytest.raises(asyncio.CancelledError):
+        await ensure_engine_ready(engine)
+    assert lifecycle.snapshot()["active_request_owners"] == 0
+
+    lifecycle.ensure_loaded = AsyncMock(side_effect=RuntimeError("bad load"))
+    with pytest.raises(HTTPException) as raised:
+        await ensure_engine_ready(engine)
+    assert raised.value.status_code == 503
+    assert raised.value.headers == {"Retry-After": "5"}
+    assert lifecycle.snapshot()["active_request_owners"] == 0
+
+    other = FakeEngine(loaded=True)
+    assert await ensure_engine_ready(other) is other
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_route_ownership_helpers_cover_all_lease_shapes():
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.service.helpers import _release_route_ownership
+
+    engine = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine, idle_unload_seconds=5)
+    cfg = reset_config()
+    cfg.primary_model_lifecycle = lifecycle
+
+    lifecycle.acquire_request()
+    _release_route_ownership(engine, admission_acquired=True, committed=True)
+    assert list(lifecycle._request_tokens.values()) == [True]
+    lifecycle.release_request()
+
+    lifecycle.acquire_request()
+    _release_route_ownership(engine, admission_acquired=False, committed=True)
+    assert list(lifecycle._request_tokens.values()) == [True]
+    lifecycle.release_request()
+
+    lifecycle.acquire_request()
+    _release_route_ownership(engine, admission_acquired=False, committed=False)
+    assert lifecycle.snapshot()["active_request_owners"] == 0
+
+    lifecycle.acquire_request()
+    _release_route_ownership(engine, admission_acquired=True, committed=False)
+    assert lifecycle.snapshot()["active_request_owners"] == 0
+    assert engine.release_calls == 1
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_stream_cleanup_releases_lifecycle_when_admission_release_raises():
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.service import helpers
+
+    class ConnectedRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    class BrokenReleaseEngine(FakeEngine):
+        def release_admission_reservation(self) -> None:
+            raise RuntimeError("release failed")
+
+    async def stream():
+        yield "done"
+
+    engine = BrokenReleaseEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(engine, idle_unload_seconds=5)
+    cfg = reset_config()
+    cfg.primary_model_lifecycle = lifecycle
+    lifecycle.acquire_request()
+
+    assert [
+        chunk
+        async for chunk in helpers._disconnect_guard(
+            stream(),
+            ConnectedRequest(),
+            poll_interval=0.01,
+            engine=engine,
+            keepalive_seconds=0,
+        )
+    ] == ["done"]
+    assert lifecycle.snapshot()["active_request_owners"] == 0
+
+    aborted = Mock()
+    original_abort = helpers._force_abort_request
+    helpers._force_abort_request = aborted
+
+    async def failed_stream():
+        raise RuntimeError("stream failed")
+        yield  # pragma: no cover - makes this an async generator
+
+    try:
+        chunks = [
+            chunk
+            async for chunk in helpers._disconnect_guard(
+                failed_stream(),
+                ConnectedRequest(),
+                poll_interval=0.01,
+                engine=None,
+                keepalive_seconds=0,
+            )
+        ]
+        assert chunks
+        aborted.assert_called_once()
+    finally:
+        helpers._force_abort_request = original_abort
+
+    cfg.engine = engine
+    cfg.model_registry = None
+    assert helpers.get_engine() is engine
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_health_probe_rejects_lifecycle_error():
+    from fastapi import HTTPException
+
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes.health import health_ready
+
+    engine = FakeEngine()
+    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+    lifecycle.state = "error"
+    cfg = reset_config()
+    cfg.ready = True
+    cfg.engine = engine
+    cfg.primary_model_lifecycle = lifecycle
+    with pytest.raises(HTTPException) as raised:
+        await health_ready()
+    assert raised.value.status_code == 503
+    reset_config()
+
+
+@pytest.mark.asyncio
+async def test_primary_server_lifecycle_helpers(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+
+    class HybridEngine(FakeEngine):
+        async def stream_chat(self, **_kwargs):
+            yield "token"
+
+    hybrid = HybridEngine(loaded=True)
+    monkeypatch.setattr(server, "_detect_hybrid_for_warmup", lambda _engine: True)
+    await server._warmup_primary_engine(hybrid)
+
+    async def broken_stream(**_kwargs):
+        raise RuntimeError("warmup failed")
+        yield  # pragma: no cover - makes this an async generator
+
+    hybrid.stream_chat = broken_stream
+    await server._warmup_primary_engine(hybrid)
+
+    monkeypatch.setattr(
+        server, "_detect_hybrid_for_warmup", Mock(side_effect=RuntimeError("detect"))
+    )
+    await server._warmup_primary_engine(hybrid)
+
+    monkeypatch.setattr(server, "_engine", None)
+    await server._finish_primary_demand_load()
+
+    engine = FakeEngine(loaded=True)
+    engine.load_cache_from_disk = Mock()
+    monkeypatch.setattr(server, "_engine", engine)
+    warmup = AsyncMock()
+    grammar = AsyncMock(side_effect=RuntimeError("grammar"))
+    cache_load = AsyncMock()
+    monkeypatch.setattr(server, "_warmup_primary_engine", warmup)
+    monkeypatch.setattr(server, "_warmup_tool_grammar", grammar)
+    monkeypatch.setattr(server, "_deferred_load_prefix_cache", cache_load)
+    await server._finish_primary_demand_load()
+    assert server._prefix_cache_load_task is not None
+    await server._prefix_cache_load_task
+
+    drain = AsyncMock()
+    save = AsyncMock()
+    monkeypatch.setattr(server, "_drain_deferred_prefix_cache_load", drain)
+    monkeypatch.setattr(server, "_shutdown_save_prefix_cache", save)
+    await server._prepare_primary_idle_unload()
+    drain.assert_awaited_once()
+    save.assert_awaited_once()
+
+    manager = SimpleNamespace(set_primary_lifecycle_state=Mock())
+    monkeypatch.setattr(server, "_residency_manager", None)
+    server._mirror_primary_lifecycle_state(engine, "standby")
+    monkeypatch.setattr(server, "_residency_manager", manager)
+    server._mirror_primary_lifecycle_state(engine, "ready")
+    manager.set_primary_lifecycle_state.assert_called_once_with(engine, "ready")
+
+    monkeypatch.setattr(server, "_primary_lazy_load", True)
+    monkeypatch.setattr(server, "_primary_idle_unload_seconds", 9.0)
+    lifecycle = server._build_primary_model_lifecycle(engine)
+    assert lifecycle.lazy_load is True
+    assert lifecycle.idle_unload_seconds == 9.0
+
+
+def test_configure_primary_lifecycle_resets_existing_state(monkeypatch):
+    from vllm_mlx import server
+    from vllm_mlx.config import reset_config
+
+    cfg = reset_config()
+    cfg.primary_model_lifecycle = object()
+    monkeypatch.setattr(server, "_primary_model_lifecycle", object())
+    server.configure_primary_model_lifecycle(lazy_load=True, idle_unload_seconds=12)
+    assert server._primary_lazy_load is True
+    assert server._primary_idle_unload_seconds == 12
+    assert server._primary_model_lifecycle is None
+    assert cfg.primary_model_lifecycle is None
+
+
+@pytest.mark.asyncio
+async def test_resident_primary_handoff_detaches_or_rejects(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.runtime.model_registry import ModelEntry
+    from vllm_mlx.runtime.resident_models import ResidentModelBusyError
+
+    cfg = reset_config()
+    old = FakeEngine(loaded=True)
+    lifecycle = PrimaryModelLifecycle(old, idle_unload_seconds=3)
+    monkeypatch.setattr(server, "_primary_model_lifecycle", lifecycle)
+    replacement = ModelEntry(FakeEngine(loaded=True), "new", "new")
+    server._set_resident_primary(replacement)
+    assert lifecycle._detached is True
+    assert server._primary_model_lifecycle is not None
+    assert server._primary_model_lifecycle.engine is replacement.engine
+    assert cfg.primary_model_lifecycle is server._primary_model_lifecycle
+    await server._primary_model_lifecycle.shutdown()
+
+    busy = SimpleNamespace(engine=old, detach=Mock(side_effect=RuntimeError("busy")))
+    monkeypatch.setattr(server, "_primary_model_lifecycle", busy)
+    with pytest.raises(ResidentModelBusyError, match="transition"):
+        server._set_resident_primary(None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("lazy_load", "idle_seconds", "expected_start_calls"),
+    [(True, 0.0, 0), (False, 10.0, 1), (False, 0.0, 1)],
+)
+async def test_lifespan_primary_lifecycle_modes(
+    monkeypatch, lazy_load, idle_seconds, expected_start_calls
+):
+    from types import SimpleNamespace
+
+    from vllm_mlx import server
+    from vllm_mlx.config import reset_config
+    from vllm_mlx.routes import audio, video
+    from vllm_mlx.runtime import audio_worker
+
+    engine = FakeEngine()
+    manager = SimpleNamespace(
+        start=AsyncMock(),
+        shutdown=AsyncMock(),
+        contains=Mock(return_value=False),
+        register_primary=Mock(),
+        set_primary_lifecycle_state=Mock(),
+    )
+    registry = SimpleNamespace(list_entries=Mock(return_value=[]))
+    cfg = reset_config()
+    cfg.bind_host = None
+    cfg.bind_port = None
+    monkeypatch.setattr(server, "_engine", engine)
+    monkeypatch.setattr(server, "_model_registry", registry)
+    monkeypatch.setattr(server, "_residency_manager", manager)
+    monkeypatch.setattr(server, "_primary_model_lifecycle", None)
+    monkeypatch.setattr(server, "_primary_lazy_load", lazy_load)
+    monkeypatch.setattr(server, "_primary_idle_unload_seconds", idle_seconds)
+    monkeypatch.setattr(server, "_warmup_primary_engine", AsyncMock())
+    monkeypatch.setattr(server, "_warmup_tool_grammar", AsyncMock())
+    monkeypatch.setattr(server, "_drain_deferred_prefix_cache_load", AsyncMock())
+    monkeypatch.setattr(server, "_shutdown_save_prefix_cache", AsyncMock())
+    monkeypatch.setattr(audio, "audio_routes_should_register", Mock(return_value=False))
+    monkeypatch.setattr(audio, "shutdown_audio_lanes", AsyncMock())
+    monkeypatch.setattr(video, "start_video_jobs", Mock())
+    monkeypatch.setattr(video, "shutdown_video_jobs", AsyncMock())
+    monkeypatch.setattr(audio_worker, "bind_audio_worker", Mock())
+
+    lifespan = server.lifespan(server.app)
+    await lifespan.__anext__()
+    assert engine.start_calls == expected_start_calls
+    assert (server._primary_model_lifecycle is not None) is (
+        lazy_load or idle_seconds > 0
+    )
+    with pytest.raises(StopAsyncIteration):
+        await lifespan.__anext__()
+    assert cfg.ready is False
+
+
+@pytest.mark.asyncio
+async def test_lifespan_rejects_unsupported_lazy_engine(monkeypatch):
+    from vllm_mlx import server
+    from vllm_mlx.config import reset_config
+
+    reset_config()
+    monkeypatch.setattr(server, "_engine", object())
+    monkeypatch.setattr(server, "_primary_lazy_load", True)
+    monkeypatch.setattr(server, "_primary_idle_unload_seconds", 0.0)
+    monkeypatch.setattr(server, "_primary_model_lifecycle", None)
+    lifespan = server.lifespan(server.app)
+    with pytest.raises(RuntimeError, match="text and vision-language"):
+        await lifespan.__anext__()
+
+
 def test_serve_parser_exposes_primary_standby_options():
     from vllm_mlx.cli import build_parser
 

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -359,6 +359,46 @@ def test_serve_command_dispatches_uvicorn_with_fd_when_listen_fd_set(
     assert cfg.bind_port is None
 
 
+def test_serve_command_lazy_fd_banner_and_lifecycle_wiring(
+    stub_heavy_serve_deps, monkeypatch, capsys
+):
+    """The always-on path advertises standby and forwards both lifecycle knobs."""
+    from vllm_mlx import server as server_mod
+
+    configured: list[dict] = []
+    monkeypatch.setattr(
+        server_mod,
+        "configure_primary_model_lifecycle",
+        lambda **kwargs: configured.append(kwargs),
+    )
+    _capture_uvicorn_run(monkeypatch)
+    ns = _minimal_serve_ns(listen_fd=9)
+    ns.lazy_load = True
+    ns.idle_unload_seconds = 42.0
+
+    cli.serve_command(ns)
+
+    assert configured == [{"lazy_load": True, "idle_unload_seconds": 42.0}]
+    assert (
+        "inherited fd 9 (standby — model loads on first request)"
+        in capsys.readouterr().out
+    )
+
+
+@pytest.mark.parametrize("invalid", [-1.0, float("nan"), float("inf")])
+def test_serve_command_rejects_invalid_idle_unload_seconds(
+    invalid, capsys, stub_heavy_serve_deps
+):
+    ns = _minimal_serve_ns()
+    ns.idle_unload_seconds = invalid
+
+    with pytest.raises(SystemExit) as raised:
+        cli.serve_command(ns)
+
+    assert raised.value.code == 1
+    assert "--idle-unload-seconds must be finite and >= 0" in capsys.readouterr().out
+
+
 def test_dflash_memory_check_receives_original_alias(
     stub_heavy_serve_deps, monkeypatch, scheduler_config_stub
 ):

--- a/tests/test_serve_listen_fd.py
+++ b/tests/test_serve_listen_fd.py
@@ -359,41 +359,22 @@ def test_serve_command_dispatches_uvicorn_with_fd_when_listen_fd_set(
     assert cfg.bind_port is None
 
 
-def test_serve_command_lazy_fd_banner_and_lifecycle_wiring(
-    stub_heavy_serve_deps, monkeypatch, capsys
-):
-    """The always-on path advertises standby and forwards both lifecycle knobs."""
-    from vllm_mlx import server as server_mod
-
-    configured: list[dict] = []
-    monkeypatch.setattr(
-        server_mod,
-        "configure_primary_model_lifecycle",
-        lambda **kwargs: configured.append(kwargs),
-    )
-    _capture_uvicorn_run(monkeypatch)
+def test_lazy_fd_startup_message_is_pure_and_reports_standby():
     ns = _minimal_serve_ns(listen_fd=9)
     ns.lazy_load = True
-    ns.idle_unload_seconds = 42.0
-
-    cli.serve_command(ns)
-
-    assert configured == [{"lazy_load": True, "idle_unload_seconds": 42.0}]
     assert (
         "inherited fd 9 (standby — model loads on first request)"
-        in capsys.readouterr().out
+        in cli._serve_startup_message(ns)
     )
 
 
 @pytest.mark.parametrize("invalid", [-1.0, float("nan"), float("inf")])
-def test_serve_command_rejects_invalid_idle_unload_seconds(
-    invalid, capsys, stub_heavy_serve_deps
-):
+def test_serve_command_rejects_invalid_idle_unload_seconds(invalid, capsys):
     ns = _minimal_serve_ns()
     ns.idle_unload_seconds = invalid
 
     with pytest.raises(SystemExit) as raised:
-        cli.serve_command(ns)
+        cli._validate_primary_lifecycle_args(ns)
 
     assert raised.value.code == 1
     assert "--idle-unload-seconds must be finite and >= 0" in capsys.readouterr().out

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3833,6 +3833,9 @@ def serve_command(args):
     if getattr(args, "resident_model_idle_ttl", 0.0) < 0:
         print("Error: --resident-model-idle-ttl must be >= 0")
         sys.exit(1)
+    if getattr(args, "idle_unload_seconds", 0.0) < 0:
+        print("Error: --idle-unload-seconds must be >= 0")
+        sys.exit(1)
     idle_cache_clear_seconds = getattr(args, "idle_cache_clear_seconds", None)
     if idle_cache_clear_seconds is not None:
         import math
@@ -5084,6 +5087,10 @@ def serve_command(args):
         idle_ttl_seconds=getattr(args, "resident_model_idle_ttl", 0.0),
         gpu_memory_utilization=args.gpu_memory_utilization,
     )
+    server.configure_primary_model_lifecycle(
+        lazy_load=bool(getattr(args, "lazy_load", False)),
+        idle_unload_seconds=getattr(args, "idle_unload_seconds", 0.0),
+    )
     try:
         load_model(
             args.model,
@@ -5165,18 +5172,20 @@ def serve_command(args):
     print()
     host_display = "localhost" if args.host == "0.0.0.0" else args.host
     listen_fd = getattr(args, "listen_fd", None)
+    startup_status = (
+        "standby — model loads on first request"
+        if getattr(args, "lazy_load", False)
+        else "warming up — this can take a few seconds"
+    )
     if listen_fd is not None:
         # Socket activation path — supervisor pre-bound the listening
         # socket. We don't know the actual address from the fd without a
         # ``getsockname`` lookup; surfacing fd=<N> in the banner is the
         # honest thing to print here.
-        print(
-            f"  Starting server on inherited fd {listen_fd} "
-            "(warming up — this can take a few seconds)"
-        )
+        print(f"  Starting server on inherited fd {listen_fd} ({startup_status})")
     else:
         print(
-            f"  Starting server on http://{host_display}:{args.port} (warming up — this can take a few seconds)"
+            f"  Starting server on http://{host_display}:{args.port} ({startup_status})"
         )
     from vllm_mlx._version_check import print_staleness_warning_if_any
 
@@ -11694,6 +11703,24 @@ Examples:
         help=(
             "Evict idle unpinned secondary models after this many seconds. "
             "0 disables idle eviction (default: 0)."
+        ),
+    )
+    serve_parser.add_argument(
+        "--lazy-load",
+        action="store_true",
+        help=(
+            "Bind the API endpoint without loading the configured model's "
+            "weights; the first inference request loads and warms it."
+        ),
+    )
+    serve_parser.add_argument(
+        "--idle-unload-seconds",
+        type=float,
+        default=0.0,
+        help=(
+            "Release the configured primary model after this many idle "
+            "seconds while keeping the API endpoint online. A later request "
+            "reloads it. 0 disables primary idle unload (default: 0)."
         ),
     )
     # Paged cache options (experimental)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -3833,13 +3833,14 @@ def serve_command(args):
     if getattr(args, "resident_model_idle_ttl", 0.0) < 0:
         print("Error: --resident-model-idle-ttl must be >= 0")
         sys.exit(1)
-    if getattr(args, "idle_unload_seconds", 0.0) < 0:
-        print("Error: --idle-unload-seconds must be >= 0")
+    import math
+
+    idle_unload_seconds = getattr(args, "idle_unload_seconds", 0.0)
+    if not math.isfinite(idle_unload_seconds) or idle_unload_seconds < 0:
+        print("Error: --idle-unload-seconds must be finite and >= 0")
         sys.exit(1)
     idle_cache_clear_seconds = getattr(args, "idle_cache_clear_seconds", None)
     if idle_cache_clear_seconds is not None:
-        import math
-
         if not math.isfinite(idle_cache_clear_seconds) or idle_cache_clear_seconds < 0:
             print("Error: --idle-cache-clear-seconds must be finite and >= 0")
             sys.exit(1)

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -501,6 +501,32 @@ def _run_uvicorn(app, args, log_level: str) -> None:
         raise
 
 
+def _serve_startup_message(args) -> str:
+    """Render the pre-bind status without importing the inference stack."""
+
+    startup_status = (
+        "standby — model loads on first request"
+        if getattr(args, "lazy_load", False)
+        else "warming up — this can take a few seconds"
+    )
+    listen_fd = getattr(args, "listen_fd", None)
+    if listen_fd is not None:
+        return f"  Starting server on inherited fd {listen_fd} ({startup_status})"
+    host_display = "localhost" if args.host == "0.0.0.0" else args.host
+    return f"  Starting server on http://{host_display}:{args.port} ({startup_status})"
+
+
+def _validate_primary_lifecycle_args(args) -> None:
+    """Reject invalid standby policy before model discovery or MLX imports."""
+
+    import math
+
+    idle_unload_seconds = getattr(args, "idle_unload_seconds", 0.0)
+    if not math.isfinite(idle_unload_seconds) or idle_unload_seconds < 0:
+        print("Error: --idle-unload-seconds must be finite and >= 0")
+        raise SystemExit(1)
+
+
 def _port_is_busy(host: str, port: int) -> bool:
     """Best-effort probe: is ``(host, port)`` already bound by another
     process? Used by ``_run_uvicorn`` to disambiguate an uvicorn
@@ -3441,6 +3467,8 @@ def serve_command(args):
     import os
     import sys
 
+    _validate_primary_lifecycle_args(args)
+
     if bounds_error := _vision_pixel_bounds_error(
         getattr(args, "vision_min_pixels", 0),
         getattr(args, "vision_max_pixels", 0),
@@ -3835,10 +3863,6 @@ def serve_command(args):
         sys.exit(1)
     import math
 
-    idle_unload_seconds = getattr(args, "idle_unload_seconds", 0.0)
-    if not math.isfinite(idle_unload_seconds) or idle_unload_seconds < 0:
-        print("Error: --idle-unload-seconds must be finite and >= 0")
-        sys.exit(1)
     idle_cache_clear_seconds = getattr(args, "idle_cache_clear_seconds", None)
     if idle_cache_clear_seconds is not None:
         if not math.isfinite(idle_cache_clear_seconds) or idle_cache_clear_seconds < 0:
@@ -5173,21 +5197,7 @@ def serve_command(args):
     print()
     host_display = "localhost" if args.host == "0.0.0.0" else args.host
     listen_fd = getattr(args, "listen_fd", None)
-    startup_status = (
-        "standby — model loads on first request"
-        if getattr(args, "lazy_load", False)
-        else "warming up — this can take a few seconds"
-    )
-    if listen_fd is not None:
-        # Socket activation path — supervisor pre-bound the listening
-        # socket. We don't know the actual address from the fd without a
-        # ``getsockname`` lookup; surfacing fd=<N> in the banner is the
-        # honest thing to print here.
-        print(f"  Starting server on inherited fd {listen_fd} ({startup_status})")
-    else:
-        print(
-            f"  Starting server on http://{host_display}:{args.port} ({startup_status})"
-        )
+    print(_serve_startup_message(args))
     from vllm_mlx._version_check import print_staleness_warning_if_any
 
     # Long-lived launchd/daemon servers have no interactive prompt. Preserve

--- a/vllm_mlx/config/server_config.py
+++ b/vllm_mlx/config/server_config.py
@@ -45,6 +45,9 @@ class ServerConfig:
     # legacy ``engine`` fields remain the protected startup/default model;
     # request routes consult this manager for residency, eviction, and status.
     residency_manager: Any = None
+    # Optional demand-driven lifecycle for the configured startup model.
+    # Its registry entry remains published while the weights are in standby.
+    primary_model_lifecycle: Any = None
     # True only after lifespan has finished engine.start(), warmup,
     # prefix-cache load_from_disk, and MCP init. Used by /health/ready
     # so callers (e.g. validation pipelines) can wait for a real

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -7,6 +7,7 @@ import logging
 import time
 import uuid
 from collections.abc import AsyncIterator
+from functools import wraps
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
@@ -136,6 +137,21 @@ async def _attach_mllm_schema_processor(engine, openai_request, chat_kwargs) -> 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _release_primary_request_after_route(func):
+    """Ensure non-generation primary users cannot leak a standby lease."""
+
+    @wraps(func)
+    async def wrapped(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            lifecycle = get_config().primary_model_lifecycle
+            if lifecycle is not None:
+                lifecycle.release_request()
+
+    return wrapped
 
 
 def _should_start_in_thinking(
@@ -1219,6 +1235,7 @@ async def create_anthropic_message(
         Depends(check_rate_limit_or_x_api_key),
     ],
 )
+@_release_primary_request_after_route
 async def count_anthropic_tokens(request: Request):
     """Count tokens for an Anthropic Messages API request.
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -55,6 +55,7 @@ from ..service.helpers import (
     _finalize_content_and_reasoning,
     _parse_tool_calls_with_parser,
     _raise_lifecycle_cancel_or_reraise,
+    _release_admission_unless_committed,
     _release_route_ownership,
     _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
@@ -1225,6 +1226,7 @@ async def create_anthropic_message(
             engine,
             admission_acquired=_admission_acquired,
             committed=_admission_committed,
+            release_admission=_release_admission_unless_committed,
         )
 
 

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -55,6 +55,7 @@ from ..service.helpers import (
     _parse_tool_calls_with_parser,
     _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
+    _release_primary_request_unless_committed,
     _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
     _resolve_max_tokens,
@@ -633,9 +634,11 @@ async def create_anthropic_message(
     # ``_disconnect_guard`` owns the release once the SSE generator
     # closes. Closes the codex R3 leak (validation errors between the
     # reservation and the helper used to pin the slot until restart).
-    _check_admission_or_503(engine)
     _admission_committed = False
+    _admission_acquired = False
     try:
+        _check_admission_or_503(engine)
+        _admission_acquired = True
         # --- Detailed request logging ---
         n_msgs = len(anthropic_request.messages)
         total_chars = 0
@@ -1203,7 +1206,10 @@ async def create_anthropic_message(
     except asyncio.CancelledError as exc:
         _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
-        _release_admission_unless_committed(engine, _admission_committed)
+        if _admission_acquired:
+            _release_admission_unless_committed(engine, _admission_committed)
+        else:
+            _release_primary_request_unless_committed(engine, _admission_committed)
 
 
 @router.post(

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -69,6 +69,7 @@ from ..service.helpers import (
     build_extended_sampling_kwargs,
     count_prompt_tokens,
     enforce_context_length_for_messages,
+    ensure_engine_ready,
     get_engine,
     maybe_auto_disable_thinking_for_casual_chat,
     maybe_auto_disable_thinking_for_tools,
@@ -624,6 +625,7 @@ async def create_anthropic_message(
     if not (anthropic_request.model or "").startswith(("claude-", "gpt-")):
         _validate_model_name(anthropic_request.model)
     engine = get_engine(anthropic_request.model)
+    await ensure_engine_ready(engine)
 
     # Pre-flight admission gate (C4) — see routes/chat.py for rationale.
     # Reservation released by the route-level ``finally`` below; on the
@@ -1319,6 +1321,7 @@ async def count_anthropic_tokens(request: Request):
             _validate_model_name(requested_model)
 
     engine = get_engine()
+    await ensure_engine_ready(engine)
 
     # F12: count_tokens must apply the SAME chat template + tools
     # rendering that ``/v1/messages`` applies before tokenizing,

--- a/vllm_mlx/routes/anthropic.py
+++ b/vllm_mlx/routes/anthropic.py
@@ -55,8 +55,7 @@ from ..service.helpers import (
     _finalize_content_and_reasoning,
     _parse_tool_calls_with_parser,
     _raise_lifecycle_cancel_or_reraise,
-    _release_admission_unless_committed,
-    _release_primary_request_unless_committed,
+    _release_route_ownership,
     _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
     _resolve_max_tokens,
@@ -1222,10 +1221,11 @@ async def create_anthropic_message(
     except asyncio.CancelledError as exc:
         _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
-        if _admission_acquired:
-            _release_admission_unless_committed(engine, _admission_committed)
-        else:
-            _release_primary_request_unless_committed(engine, _admission_committed)
+        _release_route_ownership(
+            engine,
+            admission_acquired=_admission_acquired,
+            committed=_admission_committed,
+        )
 
 
 @router.post(

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -115,6 +115,7 @@ from ..service.helpers import (
     build_extended_sampling_kwargs,
     enable_thinking_warning_header,
     enforce_context_length_for_messages,
+    ensure_engine_ready,
     get_engine,
     get_model_max_context,
     maybe_apply_reasoning_effort,
@@ -3444,6 +3445,7 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     """
     _validate_model_name(request.model)
     engine = get_engine(request.model)
+    await ensure_engine_ready(engine)
 
     # Admission reservation is acquired LATER — after cheap validation
     # that may raise HTTPException (codex R3: validation errors used to

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -98,6 +98,7 @@ from ..service.helpers import (
     _parse_tool_calls_with_parser,
     _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
+    _release_primary_request_unless_committed,
     _rescue_silent_drop_from_reasoning,
     _resolve_enable_thinking,
     _resolve_max_tokens,
@@ -3465,6 +3466,8 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     finally:
         if _admission_acquired[0]:
             _release_admission_unless_committed(engine, _commit_state[0])
+        else:
+            _release_primary_request_unless_committed(engine, _commit_state[0])
 
 
 def _effective_posthoc_reasoning_cap(sampling_kwargs: dict, request) -> int | None:

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -30,8 +30,7 @@ from ..service.helpers import (
     _disconnect_guard,
     _extract_streaming_token_logprobs,
     _raise_lifecycle_cancel_or_reraise,
-    _release_admission_unless_committed,
-    _release_primary_request_unless_committed,
+    _release_route_ownership,
     _resolve_max_tokens,
     _resolve_model_name,
     _resolve_temperature,
@@ -702,10 +701,11 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     except asyncio.CancelledError as exc:
         _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
-        if _admission_acquired:
-            _release_admission_unless_committed(engine, _admission_committed)
-        else:
-            _release_primary_request_unless_committed(engine, _admission_committed)
+        _release_route_ownership(
+            engine,
+            admission_acquired=_admission_acquired,
+            committed=_admission_committed,
+        )
 
 
 async def stream_completion(

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -31,6 +31,7 @@ from ..service.helpers import (
     _extract_streaming_token_logprobs,
     _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
+    _release_primary_request_unless_committed,
     _resolve_max_tokens,
     _resolve_model_name,
     _resolve_temperature,
@@ -313,9 +314,11 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     # the release once the SSE generator closes. Closes the codex R3
     # leak where any HTTPException between this call and the
     # streaming/non-streaming helper pinned the slot until restart.
-    _check_admission_or_503(engine)
     _admission_committed = False
+    _admission_acquired = False
     try:
+        _check_admission_or_503(engine)
+        _admission_acquired = True
         # Handle single prompt or list of prompts
         prompts = (
             request.prompt if isinstance(request.prompt, list) else [request.prompt]
@@ -699,7 +702,10 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     except asyncio.CancelledError as exc:
         _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
-        _release_admission_unless_committed(engine, _admission_committed)
+        if _admission_acquired:
+            _release_admission_unless_committed(engine, _admission_committed)
+        else:
+            _release_primary_request_unless_committed(engine, _admission_committed)
 
 
 async def stream_completion(

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -39,6 +39,7 @@ from ..service.helpers import (
     _wait_with_disconnect,
     build_extended_sampling_kwargs,
     enforce_context_length_for_prompt,
+    ensure_engine_ready,
     get_engine,
     get_usage,
 )
@@ -304,6 +305,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             },
         )
     engine = get_engine(request.model)
+    await ensure_engine_ready(engine)
 
     # Pre-flight admission gate (C4). Reservation is released by the
     # ``finally`` block below; on the streaming path we flip

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -30,6 +30,7 @@ from ..service.helpers import (
     _disconnect_guard,
     _extract_streaming_token_logprobs,
     _raise_lifecycle_cancel_or_reraise,
+    _release_admission_unless_committed,
     _release_route_ownership,
     _resolve_max_tokens,
     _resolve_model_name,
@@ -705,6 +706,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             engine,
             admission_acquired=_admission_acquired,
             committed=_admission_committed,
+            release_admission=_release_admission_unless_committed,
         )
 
 

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -91,6 +91,15 @@ async def health():
     # any future lane from tripping the handler.
     engine = cfg.engine
     engine_stats = engine.get_stats() if engine is not None else {}
+    primary_lifecycle = cfg.primary_model_lifecycle
+    primary_status = (
+        primary_lifecycle.snapshot() if primary_lifecycle is not None else None
+    )
+    model_loaded = (
+        bool(primary_status["model_loaded"])
+        if primary_status is not None
+        else engine is not None
+    )
 
     if getattr(engine, "is_image_gen", False):
         model_type = "image-gen"
@@ -104,11 +113,12 @@ async def health():
     return {
         "status": "healthy",
         "ready": cfg.ready,
-        "model_loaded": engine is not None,
+        "model_loaded": model_loaded,
         "model_name": cfg.model_name,
         "model_type": model_type,
         "engine_type": engine_stats.get("engine_type", "unknown"),
         "mcp": mcp_info,
+        "model_lifecycle": primary_status,
     }
 
 
@@ -126,7 +136,20 @@ async def health_ready():
     cfg = get_config()
     if not cfg.ready:
         raise HTTPException(status_code=503, detail="model loading")
-    return {"ready": True, "model": cfg.model_name}
+    lifecycle = cfg.primary_model_lifecycle
+    status = lifecycle.snapshot() if lifecycle is not None else None
+    if status is not None and status["state"] == "error":
+        raise HTTPException(status_code=503, detail="model lifecycle error")
+    return {
+        "ready": True,
+        "model": cfg.model_name,
+        "state": status["state"] if status is not None else "ready",
+        "model_loaded": (
+            bool(status["model_loaded"])
+            if status is not None
+            else cfg.engine is not None
+        ),
+    }
 
 
 @probe_router.get("/healthz")
@@ -166,6 +189,13 @@ async def healthz():
     close.
     """
     cfg = get_config()
+    lifecycle = cfg.primary_model_lifecycle
+    lifecycle_status = lifecycle.snapshot() if lifecycle is not None else None
+    model_loaded = (
+        bool(lifecycle_status["model_loaded"])
+        if lifecycle_status is not None
+        else cfg.engine is not None
+    )
     if cfg.draining:
         # Mirror the JSON shape the healthy path emits so operators /
         # dashboards parsing the body get a structured ``status`` field
@@ -176,14 +206,14 @@ async def healthz():
             content={
                 "status": "draining",
                 "ready": False,
-                "model_loaded": cfg.engine is not None,
+                "model_loaded": model_loaded,
                 "model_name": cfg.model_name,
             },
         )
     return {
         "status": "healthy",
         "ready": cfg.ready,
-        "model_loaded": cfg.engine is not None,
+        "model_loaded": model_loaded,
         "model_name": cfg.model_name,
     }
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -110,6 +110,7 @@ from ..service.helpers import (
     build_extended_sampling_kwargs,
     enforce_context_length,
     enforce_context_length_for_messages,
+    ensure_engine_ready,
     get_engine,
     get_model_max_context,
     maybe_apply_reasoning_effort,
@@ -971,6 +972,7 @@ async def create_response(request: Request):
     if not (responses_request.model or "").startswith(("claude-", "gpt-")):
         _validate_model_name(responses_request.model)
     engine = get_engine(responses_request.model)
+    await ensure_engine_ready(engine)
 
     # Pre-flight admission — same C4 reservation shape the other two
     # routes use. ``_admission_committed`` flips to True when the

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -98,8 +98,7 @@ from ..service.helpers import (
     _is_structured_output_requested,
     _parse_tool_calls_with_parser,
     _raise_lifecycle_cancel_or_reraise,
-    _release_admission_unless_committed,
-    _release_primary_request_unless_committed,
+    _release_route_ownership,
     _resolve_enable_thinking,
     _resolve_max_tokens,
     _resolve_temperature,
@@ -1451,10 +1450,11 @@ async def create_response(request: Request):
     except asyncio.CancelledError as exc:
         _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
-        if _admission_acquired:
-            _release_admission_unless_committed(engine, _admission_committed)
-        else:
-            _release_primary_request_unless_committed(engine, _admission_committed)
+        _release_route_ownership(
+            engine,
+            admission_acquired=_admission_acquired,
+            committed=_admission_committed,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -98,6 +98,7 @@ from ..service.helpers import (
     _is_structured_output_requested,
     _parse_tool_calls_with_parser,
     _raise_lifecycle_cancel_or_reraise,
+    _release_admission_unless_committed,
     _release_route_ownership,
     _resolve_enable_thinking,
     _resolve_max_tokens,
@@ -1454,6 +1455,7 @@ async def create_response(request: Request):
             engine,
             admission_acquired=_admission_acquired,
             committed=_admission_committed,
+            release_admission=_release_admission_unless_committed,
         )
 
 

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -99,6 +99,7 @@ from ..service.helpers import (
     _parse_tool_calls_with_parser,
     _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
+    _release_primary_request_unless_committed,
     _resolve_enable_thinking,
     _resolve_max_tokens,
     _resolve_temperature,
@@ -977,9 +978,11 @@ async def create_response(request: Request):
     # Pre-flight admission — same C4 reservation shape the other two
     # routes use. ``_admission_committed`` flips to True when the
     # streaming path takes over so ``_disconnect_guard`` owns release.
-    _check_admission_or_503(engine)
     _admission_committed = False
+    _admission_acquired = False
     try:
+        _check_admission_or_503(engine)
+        _admission_acquired = True
         _log_request(responses_request)
 
         cfg_for_log = get_config()
@@ -1448,7 +1451,10 @@ async def create_response(request: Request):
     except asyncio.CancelledError as exc:
         _raise_lifecycle_cancel_or_reraise(engine, exc)
     finally:
-        _release_admission_unless_committed(engine, _admission_committed)
+        if _admission_acquired:
+            _release_admission_unless_committed(engine, _admission_committed)
+        else:
+            _release_primary_request_unless_committed(engine, _admission_committed)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -61,6 +61,7 @@ class PrimaryModelLifecycle:
         self._last_activity = self._clock()
         self._last_error: str | None = None
         self._detached = False
+        self._resume_required = False
         self.state = "ready" if self._is_loaded() else "standby"
 
     def _set_state(self, state: str) -> None:
@@ -157,10 +158,10 @@ class PrimaryModelLifecycle:
                 self._last_error = None
                 return
             if self._is_loaded() and self.state == "error":
-                raise RuntimeError(
-                    "configured engine is still resident after a failed "
-                    "lifecycle transition"
-                )
+                # start() can fail after publishing part of the engine. Retry
+                # the cleanup on every later request so a transient stop
+                # failure cannot wedge the endpoint forever.
+                await self._reset_partial_load()
             task = self._load_task
             if task is None or task.done():
                 task = asyncio.create_task(
@@ -171,6 +172,26 @@ class PrimaryModelLifecycle:
         # One disconnected client must not cancel a load shared by another
         # request.  The task remains the single transition authority.
         await asyncio.shield(task)
+
+    async def _reset_partial_load(self) -> None:
+        stop = getattr(self.engine, "stop", None)
+        if not callable(stop):
+            raise RuntimeError("partially loaded engine cannot be reset")
+        result = stop()
+        if inspect.isawaitable(result):
+            await result
+        await _run_hook(self._release_allocator_cache)
+        if self._is_loaded():
+            raise RuntimeError("partially loaded engine did not stop cleanly")
+
+    async def _resume_admission(self) -> None:
+        resume = getattr(self.engine, "resume_generation", None)
+        if not callable(resume):
+            raise RuntimeError("configured engine does not support resume_generation()")
+        result = resume()
+        if inspect.isawaitable(result):
+            await result
+        self._resume_required = False
 
     async def _load(self) -> None:
         async with self._transition_lock:
@@ -187,10 +208,19 @@ class PrimaryModelLifecycle:
                 result = start()
                 if inspect.isawaitable(result):
                     await result
+                if self._resume_required:
+                    await self._resume_admission()
                 await _run_hook(self._on_loaded)
             except BaseException as exc:
                 self._set_state("error")
                 self._last_error = type(exc).__name__
+                if self._is_loaded():
+                    try:
+                        await self._reset_partial_load()
+                    except BaseException:
+                        logger.exception(
+                            "Failed to reset partially loaded primary engine"
+                        )
                 raise
             self._set_state("ready")
             self.touch()
@@ -226,13 +256,11 @@ class PrimaryModelLifecycle:
                     if inspect.isawaitable(result):
                         await result
                     paused = True
+                    self._resume_required = True
                 except TimeoutError:
                     self.touch()
-                    resume = getattr(self.engine, "resume_generation", None)
-                    if callable(resume):
-                        result = resume()
-                        if inspect.isawaitable(result):
-                            await result
+                    self._resume_required = True
+                    await self._resume_admission()
                     return False
                 except BaseException:
                     # Cancellation can arrive after the engine closed
@@ -240,11 +268,8 @@ class PrimaryModelLifecycle:
                     # defensively even though our local `paused` flag was not
                     # assigned yet.
                     self.touch()
-                    resume = getattr(self.engine, "resume_generation", None)
-                    if callable(resume):
-                        result = resume()
-                        if inspect.isawaitable(result):
-                            await result
+                    self._resume_required = True
+                    await self._resume_admission()
                     raise
 
             self._set_state("unloading")
@@ -294,16 +319,15 @@ class PrimaryModelLifecycle:
                     logger.exception("Primary allocator cache release failed")
             finally:
                 if paused:
-                    resume = getattr(self.engine, "resume_generation", None)
-                    if callable(resume):
-                        try:
-                            result = resume()
-                            if inspect.isawaitable(result):
-                                await result
-                        except BaseException:
-                            logger.exception(
-                                "Failed to reopen primary admission after idle unload"
-                            )
+                    try:
+                        await self._resume_admission()
+                    except BaseException:
+                        self._set_state("error")
+                        self._last_error = "AdmissionResumeError"
+                        logger.exception(
+                            "Failed to reopen primary admission after idle unload"
+                        )
+                        raise
 
             self._set_state("standby")
             self._last_error = None

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -1,0 +1,259 @@
+"""Demand-driven lifecycle for the configured primary model.
+
+The resident-model manager owns routing and memory policy for additional
+models.  This small coordinator handles the one model whose fully configured
+``BatchedEngine`` is constructed by ``rapid-mlx serve``: it may start in
+standby, load on the first request, and return to standby after an idle TTL.
+
+The engine object and registry entry deliberately survive standby.  That keeps
+the configured model identity, tokenizer/parser settings, and every serve-time
+engine option intact without accepting arbitrary request-triggered downloads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+LifecycleHook = Callable[[], object | Awaitable[object]]
+StateHook = Callable[[str], object]
+
+
+async def _run_hook(hook: LifecycleHook | None) -> None:
+    if hook is None:
+        return
+    result = hook()
+    if inspect.isawaitable(result):
+        await result
+
+
+class PrimaryModelLifecycle:
+    """Serialize primary load/unload transitions and monitor idle time."""
+
+    def __init__(
+        self,
+        engine: object,
+        *,
+        lazy_load: bool = False,
+        idle_unload_seconds: float = 0,
+        on_loaded: LifecycleHook | None = None,
+        before_unload: LifecycleHook | None = None,
+        release_allocator_cache: LifecycleHook | None = None,
+        on_state_change: StateHook | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.engine = engine
+        self.lazy_load = bool(lazy_load)
+        self.idle_unload_seconds = max(0.0, float(idle_unload_seconds))
+        self._on_loaded = on_loaded
+        self._before_unload = before_unload
+        self._release_allocator_cache = release_allocator_cache
+        self._on_state_change = on_state_change
+        self._clock = clock
+        self._transition_lock = asyncio.Lock()
+        self._load_task: asyncio.Task | None = None
+        self._monitor_task: asyncio.Task | None = None
+        self._last_activity = self._clock()
+        self._last_error: str | None = None
+        self.state = "ready" if self._is_loaded() else "standby"
+
+    def _set_state(self, state: str) -> None:
+        self.state = state
+        if self._on_state_change is not None:
+            self._on_state_change(state)
+
+    @property
+    def enabled(self) -> bool:
+        return self.lazy_load or self.idle_unload_seconds > 0
+
+    @property
+    def last_error(self) -> str | None:
+        return self._last_error
+
+    @property
+    def model_loaded(self) -> bool:
+        return self._is_loaded()
+
+    def _is_loaded(self) -> bool:
+        loaded = getattr(self.engine, "_loaded", None)
+        return bool(loaded) if loaded is not None else True
+
+    def touch(self) -> None:
+        self._last_activity = self._clock()
+
+    def snapshot(self) -> dict[str, object]:
+        return {
+            "state": self.state,
+            "model_loaded": self.model_loaded,
+            "idle_seconds": max(0.0, self._clock() - self._last_activity),
+            "idle_unload_seconds": self.idle_unload_seconds,
+            "lazy_load": self.lazy_load,
+            "error": self._last_error,
+        }
+
+    async def start(self) -> None:
+        if self.idle_unload_seconds <= 0 or self._monitor_task is not None:
+            return
+        self._monitor_task = asyncio.create_task(
+            self._monitor_idle(), name="primary-model-idle-unload"
+        )
+
+    async def shutdown(self) -> None:
+        task = self._monitor_task
+        self._monitor_task = None
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    def detach(self) -> None:
+        """Synchronously retire this coordinator during a primary handoff."""
+
+        task = self._monitor_task
+        self._monitor_task = None
+        if task is not None:
+            task.cancel()
+        self.idle_unload_seconds = 0
+
+    async def ensure_loaded(self) -> None:
+        """Load once and let concurrent/cancelled callers share the attempt."""
+
+        self.touch()
+        if self._is_loaded() and self.state == "ready":
+            self._set_state("ready")
+            self._last_error = None
+            return
+
+        async with self._transition_lock:
+            if self._is_loaded() and self.state == "ready":
+                self._set_state("ready")
+                self._last_error = None
+                return
+            if self._is_loaded() and self.state == "error":
+                raise RuntimeError(
+                    "configured engine is still resident after a failed "
+                    "lifecycle transition"
+                )
+            task = self._load_task
+            if task is None or task.done():
+                task = asyncio.create_task(
+                    self._load(), name="primary-model-demand-load"
+                )
+                self._load_task = task
+
+        # One disconnected client must not cancel a load shared by another
+        # request.  The task remains the single transition authority.
+        await asyncio.shield(task)
+
+    async def _load(self) -> None:
+        async with self._transition_lock:
+            if self._is_loaded():
+                self._set_state("ready")
+                self._last_error = None
+                return
+            self._set_state("loading")
+            self._last_error = None
+            try:
+                start = getattr(self.engine, "start", None)
+                if not callable(start):
+                    raise RuntimeError("configured engine does not support start()")
+                result = start()
+                if inspect.isawaitable(result):
+                    await result
+                await _run_hook(self._on_loaded)
+            except BaseException as exc:
+                self._set_state("error")
+                self._last_error = type(exc).__name__
+                raise
+            self._set_state("ready")
+            self.touch()
+
+    async def evict_if_idle(self) -> bool:
+        """Move an idle loaded primary to standby without removing its route."""
+
+        if self.idle_unload_seconds <= 0 or self.state != "ready":
+            return False
+        if self._clock() - self._last_activity < self.idle_unload_seconds:
+            return False
+
+        async with self._transition_lock:
+            if not self._is_loaded() or self.state != "ready":
+                return False
+            if self._clock() - self._last_activity < self.idle_unload_seconds:
+                return False
+
+            status = getattr(self.engine, "lifecycle_status", None)
+            if callable(status):
+                activity = status()
+                if int(activity.get("active_requests", 0) or 0) > 0:
+                    # Start the idle window after the most recent observation
+                    # of real work, not after request admission.
+                    self.touch()
+                    return False
+
+            pause = getattr(self.engine, "pause_generation", None)
+            paused = False
+            if callable(pause):
+                try:
+                    result = pause("wait", timeout=0)
+                    if inspect.isawaitable(result):
+                        await result
+                    paused = True
+                except TimeoutError:
+                    self.touch()
+                    resume = getattr(self.engine, "resume_generation", None)
+                    if callable(resume):
+                        result = resume()
+                        if inspect.isawaitable(result):
+                            await result
+                    return False
+
+            self._set_state("unloading")
+            try:
+                await _run_hook(self._before_unload)
+                stop = getattr(self.engine, "stop", None)
+                if not callable(stop):
+                    raise RuntimeError("configured engine does not support stop()")
+                result = stop()
+                if inspect.isawaitable(result):
+                    await result
+                await _run_hook(self._release_allocator_cache)
+            except BaseException as exc:
+                self._set_state("error")
+                self._last_error = type(exc).__name__
+                raise
+            finally:
+                if paused:
+                    resume = getattr(self.engine, "resume_generation", None)
+                    if callable(resume):
+                        try:
+                            result = resume()
+                            if inspect.isawaitable(result):
+                                await result
+                        except BaseException:
+                            logger.exception(
+                                "Failed to reopen primary admission after idle unload"
+                            )
+
+            self._set_state("standby")
+            self._last_error = None
+            return True
+
+    async def _monitor_idle(self) -> None:
+        interval = min(60.0, max(1.0, self.idle_unload_seconds / 4.0))
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await self.evict_if_idle()
+            except asyncio.CancelledError:
+                raise
+            except BaseException:
+                logger.exception("Primary model idle unload failed")

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -60,11 +60,12 @@ class PrimaryModelLifecycle:
         self._monitor_task: asyncio.Task | None = None
         self._last_activity = self._clock()
         self._last_error: str | None = None
+        self._detached = False
         self.state = "ready" if self._is_loaded() else "standby"
 
     def _set_state(self, state: str) -> None:
         self.state = state
-        if self._on_state_change is not None:
+        if not self._detached and self._on_state_change is not None:
             self._on_state_change(state)
 
     @property
@@ -78,6 +79,15 @@ class PrimaryModelLifecycle:
     @property
     def model_loaded(self) -> bool:
         return self._is_loaded()
+
+    @property
+    def transitioning(self) -> bool:
+        task = self._load_task
+        return (
+            self._transition_lock.locked()
+            or self.state in {"loading", "unloading"}
+            or (task is not None and not task.done())
+        )
 
     def _is_loaded(self) -> bool:
         loaded = getattr(self.engine, "_loaded", None)
@@ -97,7 +107,11 @@ class PrimaryModelLifecycle:
         }
 
     async def start(self) -> None:
-        if self.idle_unload_seconds <= 0 or self._monitor_task is not None:
+        if (
+            self._detached
+            or self.idle_unload_seconds <= 0
+            or self._monitor_task is not None
+        ):
             return
         self._monitor_task = asyncio.create_task(
             self._monitor_idle(), name="primary-model-idle-unload"
@@ -117,6 +131,9 @@ class PrimaryModelLifecycle:
     def detach(self) -> None:
         """Synchronously retire this coordinator during a primary handoff."""
 
+        if self.transitioning:
+            raise RuntimeError("primary model lifecycle transition is in progress")
+        self._detached = True
         task = self._monitor_task
         self._monitor_task = None
         if task is not None:
@@ -126,6 +143,8 @@ class PrimaryModelLifecycle:
     async def ensure_loaded(self) -> None:
         """Load once and let concurrent/cancelled callers share the attempt."""
 
+        if self._detached:
+            raise RuntimeError("primary model lifecycle is detached")
         self.touch()
         if self._is_loaded() and self.state == "ready":
             self._set_state("ready")
@@ -179,7 +198,7 @@ class PrimaryModelLifecycle:
     async def evict_if_idle(self) -> bool:
         """Move an idle loaded primary to standby without removing its route."""
 
-        if self.idle_unload_seconds <= 0 or self.state != "ready":
+        if self._detached or self.idle_unload_seconds <= 0 or self.state != "ready":
             return False
         if self._clock() - self._last_activity < self.idle_unload_seconds:
             return False
@@ -215,21 +234,64 @@ class PrimaryModelLifecycle:
                         if inspect.isawaitable(result):
                             await result
                     return False
+                except BaseException:
+                    # Cancellation can arrive after the engine closed
+                    # admission but before pause_generation returned. Reopen
+                    # defensively even though our local `paused` flag was not
+                    # assigned yet.
+                    self.touch()
+                    resume = getattr(self.engine, "resume_generation", None)
+                    if callable(resume):
+                        result = resume()
+                        if inspect.isawaitable(result):
+                            await result
+                    raise
 
             self._set_state("unloading")
             try:
-                await _run_hook(self._before_unload)
+                try:
+                    await _run_hook(self._before_unload)
+                except asyncio.CancelledError:
+                    self._set_state("ready")
+                    self.touch()
+                    raise
+                except Exception as exc:
+                    # Cache persistence is best-effort. A failure before stop
+                    # leaves a perfectly usable resident engine and must not
+                    # turn the stable endpoint into a permanent 503.
+                    self._last_error = type(exc).__name__
+                    self._set_state("ready")
+                    self.touch()
+                    logger.exception(
+                        "Primary model pre-unload hook failed; keeping it resident"
+                    )
+                    return False
+
                 stop = getattr(self.engine, "stop", None)
                 if not callable(stop):
+                    self._set_state("ready")
+                    self.touch()
                     raise RuntimeError("configured engine does not support stop()")
-                result = stop()
-                if inspect.isawaitable(result):
-                    await result
-                await _run_hook(self._release_allocator_cache)
-            except BaseException as exc:
-                self._set_state("error")
-                self._last_error = type(exc).__name__
-                raise
+                try:
+                    result = stop()
+                    if inspect.isawaitable(result):
+                        await result
+                except BaseException as exc:
+                    self._last_error = type(exc).__name__
+                    if self._is_loaded():
+                        self._set_state("ready")
+                        self.touch()
+                    else:
+                        self._set_state("error")
+                    raise
+
+                try:
+                    await _run_hook(self._release_allocator_cache)
+                except Exception:
+                    # The engine and its model references are already gone.
+                    # Allocator cleanup can reduce RSS but is not required for
+                    # correctness, so remain reloadable in standby.
+                    logger.exception("Primary allocator cache release failed")
             finally:
                 if paused:
                     resume = getattr(self.engine, "resume_generation", None)

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -334,6 +334,10 @@ class PrimaryModelLifecycle:
 
             pause = getattr(self.engine, "pause_generation", None)
             paused = False
+            # Close ensure_loaded()'s ready fast path before the first await.
+            # A request arriving while pause_generation is in flight will take
+            # a lifecycle lease and wait on this transition lock.
+            self._set_state("unloading")
             if callable(pause):
                 try:
                     result = pause("wait", timeout=0)
@@ -344,7 +348,13 @@ class PrimaryModelLifecycle:
                 except TimeoutError:
                     self.touch()
                     self._resume_required = True
-                    await self._resume_admission()
+                    try:
+                        await self._resume_admission()
+                    except BaseException:
+                        self._set_state("error")
+                        self._last_error = "AdmissionResumeError"
+                        raise
+                    self._set_state("ready")
                     return False
                 except BaseException:
                     # Cancellation can arrive after the engine closed
@@ -353,10 +363,27 @@ class PrimaryModelLifecycle:
                     # assigned yet.
                     self.touch()
                     self._resume_required = True
-                    await self._resume_admission()
+                    try:
+                        await self._resume_admission()
+                    except BaseException:
+                        self._set_state("error")
+                        self._last_error = "AdmissionResumeError"
+                        raise
+                    self._set_state("ready")
                     raise
 
-            self._set_state("unloading")
+            if self._request_tokens:
+                try:
+                    await self._resume_admission()
+                except BaseException:
+                    self._set_state("error")
+                    self._last_error = "AdmissionResumeError"
+                    raise
+                paused = False
+                self._set_state("ready")
+                self.touch()
+                return False
+
             try:
                 try:
                     await _run_hook(self._before_unload)

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -50,7 +50,6 @@ class PrimaryModelLifecycle:
         release_allocator_cache: LifecycleHook | None = None,
         on_state_change: StateHook | None = None,
         clock: Callable[[], float] = time.monotonic,
-        shutdown_load_timeout_seconds: float = 25.0,
     ) -> None:
         self.engine = engine
         self.lazy_load = bool(lazy_load)
@@ -60,9 +59,6 @@ class PrimaryModelLifecycle:
         self._release_allocator_cache = release_allocator_cache
         self._on_state_change = on_state_change
         self._clock = clock
-        self._shutdown_load_timeout_seconds = max(
-            0.01, float(shutdown_load_timeout_seconds)
-        )
         self._transition_lock = asyncio.Lock()
         self._load_task: asyncio.Task | None = None
         self._monitor_task: asyncio.Task | None = None
@@ -148,16 +144,7 @@ class PrimaryModelLifecycle:
         load_task = self._load_task
         if load_task is not None and not load_task.done():
             try:
-                await asyncio.wait_for(
-                    asyncio.shield(load_task),
-                    timeout=self._shutdown_load_timeout_seconds,
-                )
-            except TimeoutError:
-                self._set_state("error")
-                self._last_error = "ShutdownLoadDrainTimeout"
-                raise TimeoutError(
-                    "timed out waiting for primary model load during shutdown"
-                ) from None
+                await asyncio.shield(load_task)
             except asyncio.CancelledError:
                 # Propagate process-teardown cancellation. The caller must not
                 # proceed to stop the engine concurrently with the shielded
@@ -399,16 +386,12 @@ class PrimaryModelLifecycle:
                     self.touch()
                     raise
                 except Exception as exc:
-                    # Cache persistence is best-effort. A failure before stop
-                    # leaves a perfectly usable resident engine and must not
-                    # turn the stable endpoint into a permanent 503.
-                    self._last_error = type(exc).__name__
-                    self._set_state("ready")
-                    self.touch()
+                    # Cache persistence is best-effort: losing this cache is
+                    # preferable to silently defeating the operator's memory
+                    # policy and retaining the full model indefinitely.
                     logger.exception(
-                        "Primary model pre-unload hook failed; keeping it resident"
+                        "Primary model pre-unload hook failed; continuing unload"
                     )
-                    return False
 
                 stop = getattr(self.engine, "stop", None)
                 if not callable(stop):

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -17,11 +17,15 @@ import inspect
 import logging
 import time
 from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
 
 logger = logging.getLogger(__name__)
 
 LifecycleHook = Callable[[], object | Awaitable[object]]
 StateHook = Callable[[str], object]
+_request_token_context: ContextVar[tuple[int, object] | None] = ContextVar(
+    "primary_model_request_token", default=None
+)
 
 
 async def _run_hook(hook: LifecycleHook | None) -> None:
@@ -61,7 +65,9 @@ class PrimaryModelLifecycle:
         self._last_activity = self._clock()
         self._last_error: str | None = None
         self._detached = False
+        self._closed = False
         self._resume_required = False
+        self._request_tokens: dict[object, bool] = {}
         self.state = "ready" if self._is_loaded() else "standby"
 
     def _set_state(self, state: str) -> None:
@@ -86,6 +92,7 @@ class PrimaryModelLifecycle:
         task = self._load_task
         return (
             self._transition_lock.locked()
+            or bool(self._request_tokens)
             or self.state in {"loading", "unloading"}
             or (task is not None and not task.done())
         )
@@ -104,6 +111,7 @@ class PrimaryModelLifecycle:
             "idle_seconds": max(0.0, self._clock() - self._last_activity),
             "idle_unload_seconds": self.idle_unload_seconds,
             "lazy_load": self.lazy_load,
+            "active_request_owners": len(self._request_tokens),
             "error": self._last_error,
         }
 
@@ -119,15 +127,37 @@ class PrimaryModelLifecycle:
         )
 
     async def shutdown(self) -> None:
+        self._closed = True
         task = self._monitor_task
         self._monitor_task = None
-        if task is None:
-            return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # A request waiter is cancellation-isolated from the shared model
+        # load. Drain that task before lifespan teardown stops/frees the same
+        # engine; cancelling an executor-backed MLX load cannot stop its worker
+        # safely and would create a start/stop race.
+        load_task = self._load_task
+        if load_task is not None and not load_task.done():
+            while not load_task.done():
+                try:
+                    await asyncio.shield(load_task)
+                except asyncio.CancelledError:
+                    # Teardown owns the engine and must not race its executor-
+                    # backed load. Re-arm the shield until the worker reaches
+                    # a terminal state, matching resident-model retirement.
+                    continue
+                except Exception:
+                    break
+            if load_task.done() and not load_task.cancelled():
+                try:
+                    load_task.result()
+                except Exception:
+                    logger.exception("Primary model load failed during shutdown drain")
 
     def detach(self) -> None:
         """Synchronously retire this coordinator during a primary handoff."""
@@ -135,6 +165,7 @@ class PrimaryModelLifecycle:
         if self.transitioning:
             raise RuntimeError("primary model lifecycle transition is in progress")
         self._detached = True
+        self._closed = True
         task = self._monitor_task
         self._monitor_task = None
         if task is not None:
@@ -144,8 +175,8 @@ class PrimaryModelLifecycle:
     async def ensure_loaded(self) -> None:
         """Load once and let concurrent/cancelled callers share the attempt."""
 
-        if self._detached:
-            raise RuntimeError("primary model lifecycle is detached")
+        if self._closed:
+            raise RuntimeError("primary model lifecycle is closed")
         self.touch()
         if self._is_loaded() and self.state == "ready":
             self._set_state("ready")
@@ -172,6 +203,50 @@ class PrimaryModelLifecycle:
         # One disconnected client must not cancel a load shared by another
         # request.  The task remains the single transition authority.
         await asyncio.shield(task)
+
+    def acquire_request(self) -> None:
+        """Protect one accepted route from idle unload through completion."""
+
+        if self._closed:
+            raise RuntimeError("primary model lifecycle is closed")
+        current = _request_token_context.get()
+        if current is not None and current[0] == id(self):
+            return
+        token = object()
+        self._request_tokens[token] = False
+        _request_token_context.set((id(self), token))
+        task = asyncio.current_task()
+        if task is not None:
+            task.add_done_callback(
+                lambda _task, request_token=token: self._release_abandoned_request(
+                    request_token
+                )
+            )
+        self.touch()
+
+    def release_request(self) -> None:
+        current = _request_token_context.get()
+        if current is None or current[0] != id(self):
+            return
+        self._release_request_token(current[1])
+        _request_token_context.set(None)
+
+    def transfer_request_to_stream(self) -> None:
+        """Keep the route token alive after its handler returns an SSE body."""
+
+        current = _request_token_context.get()
+        if current is not None and current[0] == id(self):
+            token = current[1]
+            if token in self._request_tokens:
+                self._request_tokens[token] = True
+
+    def _release_abandoned_request(self, token: object) -> None:
+        if self._request_tokens.get(token) is False:
+            self._release_request_token(token)
+
+    def _release_request_token(self, token: object) -> None:
+        if self._request_tokens.pop(token, None) is not None:
+            self.touch()
 
     async def _reset_partial_load(self) -> None:
         stop = getattr(self.engine, "stop", None)
@@ -228,13 +303,22 @@ class PrimaryModelLifecycle:
     async def evict_if_idle(self) -> bool:
         """Move an idle loaded primary to standby without removing its route."""
 
-        if self._detached or self.idle_unload_seconds <= 0 or self.state != "ready":
+        if (
+            self._closed
+            or bool(self._request_tokens)
+            or self.idle_unload_seconds <= 0
+            or self.state != "ready"
+        ):
             return False
         if self._clock() - self._last_activity < self.idle_unload_seconds:
             return False
 
         async with self._transition_lock:
-            if not self._is_loaded() or self.state != "ready":
+            if (
+                bool(self._request_tokens)
+                or not self._is_loaded()
+                or self.state != "ready"
+            ):
                 return False
             if self._clock() - self._last_activity < self.idle_unload_seconds:
                 return False

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -211,11 +211,11 @@ class PrimaryModelLifecycle:
         _request_token_context.set((id(self), token))
         task = asyncio.current_task()
         if task is not None:
-            task.add_done_callback(
-                lambda _task, request_token=token: self._release_abandoned_request(
-                    request_token
-                )
-            )
+
+            def release_when_done(_task: asyncio.Task) -> None:
+                self._release_abandoned_request(token)
+
+            task.add_done_callback(release_when_done)
         self.touch()
 
     def release_request(self) -> None:

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -50,6 +50,7 @@ class PrimaryModelLifecycle:
         release_allocator_cache: LifecycleHook | None = None,
         on_state_change: StateHook | None = None,
         clock: Callable[[], float] = time.monotonic,
+        shutdown_load_timeout_seconds: float = 25.0,
     ) -> None:
         self.engine = engine
         self.lazy_load = bool(lazy_load)
@@ -59,6 +60,9 @@ class PrimaryModelLifecycle:
         self._release_allocator_cache = release_allocator_cache
         self._on_state_change = on_state_change
         self._clock = clock
+        self._shutdown_load_timeout_seconds = max(
+            0.01, float(shutdown_load_timeout_seconds)
+        )
         self._transition_lock = asyncio.Lock()
         self._load_task: asyncio.Task | None = None
         self._monitor_task: asyncio.Task | None = None
@@ -143,21 +147,24 @@ class PrimaryModelLifecycle:
         # safely and would create a start/stop race.
         load_task = self._load_task
         if load_task is not None and not load_task.done():
-            while not load_task.done():
-                try:
-                    await asyncio.shield(load_task)
-                except asyncio.CancelledError:
-                    # Teardown owns the engine and must not race its executor-
-                    # backed load. Re-arm the shield until the worker reaches
-                    # a terminal state, matching resident-model retirement.
-                    continue
-                except Exception:
-                    break
-            if load_task.done() and not load_task.cancelled():
-                try:
-                    load_task.result()
-                except Exception:
-                    logger.exception("Primary model load failed during shutdown drain")
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(load_task),
+                    timeout=self._shutdown_load_timeout_seconds,
+                )
+            except TimeoutError:
+                self._set_state("error")
+                self._last_error = "ShutdownLoadDrainTimeout"
+                raise TimeoutError(
+                    "timed out waiting for primary model load during shutdown"
+                ) from None
+            except asyncio.CancelledError:
+                # Propagate process-teardown cancellation. The caller must not
+                # proceed to stop the engine concurrently with the shielded
+                # load; lifespan cancellation terminates that teardown path.
+                raise
+            except Exception:
+                logger.exception("Primary model load failed during shutdown drain")
 
     def detach(self) -> None:
         """Synchronously retire this coordinator during a primary handoff."""

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -800,11 +800,15 @@ class ResidentModelManager:
         self._index_record(record)
         return record
 
-    def set_primary_lifecycle_state(self, state: str) -> None:
+    def set_primary_lifecycle_state(self, engine: object, state: str) -> None:
         """Mirror the configured primary's standby lifecycle into accounting."""
 
         record = next(
-            (candidate for candidate in self._records.values() if candidate.primary),
+            (
+                candidate
+                for candidate in self._records.values()
+                if candidate.primary and candidate.entry.engine is engine
+            ),
             None,
         )
         if record is None:

--- a/vllm_mlx/runtime/resident_models.py
+++ b/vllm_mlx/runtime/resident_models.py
@@ -791,9 +791,25 @@ class ResidentModelManager:
             last_used_at=now,
             pinned=True,
             primary=True,
+            state=(
+                "resident"
+                if bool(getattr(entry.engine, "_loaded", True))
+                else "standby"
+            ),
         )
         self._index_record(record)
         return record
+
+    def set_primary_lifecycle_state(self, state: str) -> None:
+        """Mirror the configured primary's standby lifecycle into accounting."""
+
+        record = next(
+            (candidate for candidate in self._records.values() if candidate.primary),
+            None,
+        )
+        if record is None:
+            return
+        record.state = "resident" if state == "ready" else state
 
     def _read_memory(self) -> int:
         try:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -131,9 +131,11 @@ from .engine import (
     BatchedEngine,
 )
 from .runtime.model_registry import ModelEntry, ModelRegistry
+from .runtime.primary_lifecycle import PrimaryModelLifecycle
 from .runtime.resident_models import (
     ResidentModelBusyError,
     ResidentModelManager,
+    _release_allocator_cache,
     estimate_model_bytes,
 )
 from .service.helpers import (  # noqa: F401 — re-export for backward compat
@@ -205,6 +207,9 @@ _resident_idle_ttl_seconds: float = 0.0
 # ``None`` = per-model auto budgeting (#2858); a float is the operator's
 # explicit --gpu-memory-utilization, applied to every resident model.
 _resident_gpu_memory_utilization: float | None = None
+_primary_lazy_load: bool = False
+_primary_idle_unload_seconds: float = 0.0
+_primary_model_lifecycle: PrimaryModelLifecycle | None = None
 
 # Global engine instance (single-model legacy path, also primary model in multi-model)
 _engine: BaseEngine | None = None
@@ -616,9 +621,81 @@ def _detect_hybrid_for_warmup(engine) -> bool:
     return False
 
 
+async def _warmup_primary_engine(engine: object) -> None:
+    """Compile the configured engine on its model-owning worker."""
+
+    import time as _time
+
+    logger.info("Warming up (compiling Metal shaders)...")
+    warmup_start = _time.monotonic()
+    try:
+        is_hybrid = _detect_hybrid_for_warmup(engine)
+        if not is_hybrid:
+            engine.generate_warmup()
+        else:
+            logger.info(
+                "Hybrid model: running full request warmup "
+                "(compiling GatedDeltaNet kernels)"
+            )
+            try:
+                async for _ in engine.stream_chat(
+                    messages=[{"role": "user", "content": "Hi"}],
+                    max_tokens=2,
+                    temperature=0.0,
+                ):
+                    pass
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Hybrid warmup error (non-fatal): %s", exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Warmup failed (non-fatal): %s", exc)
+    logger.info("Warmup complete (%.1fs)", _time.monotonic() - warmup_start)
+
+
+async def _finish_primary_demand_load() -> None:
+    """Run the same post-load work used by eager startup."""
+
+    global _prefix_cache_load_task
+    if _engine is None:
+        return
+    await _warmup_primary_engine(_engine)
+    try:
+        await _warmup_tool_grammar(_engine)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Tool-grammar warmup failed (non-fatal): %s", exc)
+    if hasattr(_engine, "load_cache_from_disk"):
+        _prefix_cache_load_task = asyncio.create_task(
+            _deferred_load_prefix_cache(),
+            name="primary-prefix-cache-load",
+        )
+
+
+async def _prepare_primary_idle_unload() -> None:
+    """Finish cache restore and persist it before releasing model weights."""
+
+    await _drain_deferred_prefix_cache_load()
+    await _shutdown_save_prefix_cache()
+
+
+def _mirror_primary_lifecycle_state(state: str) -> None:
+    if _residency_manager is not None:
+        _residency_manager.set_primary_lifecycle_state(state)
+
+
+def _build_primary_model_lifecycle(engine: object) -> PrimaryModelLifecycle:
+    return PrimaryModelLifecycle(
+        engine,
+        lazy_load=_primary_lazy_load,
+        idle_unload_seconds=_primary_idle_unload_seconds,
+        on_loaded=_finish_primary_demand_load,
+        before_unload=_prepare_primary_idle_unload,
+        release_allocator_cache=_release_allocator_cache,
+        on_state_change=_mirror_primary_lifecycle_state,
+    )
+
+
 async def lifespan(app: FastAPI):
     """FastAPI lifespan for startup/shutdown events."""
-    global _engine, _mcp_manager
+    global _engine, _mcp_manager, _primary_model_lifecycle
 
     # Install process-death observability BEFORE any executor is created.
     # Two complementary mechanisms (codex r3 NIT clarification):
@@ -660,10 +737,39 @@ async def lifespan(app: FastAPI):
         gc.set_threshold(100_000, 50, 50)
         logger.info("GC control enabled: thresholds set to (100000, 50, 50)")
 
-    # Startup: Start engine if loaded (needed for BatchedEngine in uvicorn's event loop)
-    if _engine is not None and hasattr(_engine, "_loaded") and not _engine._loaded:
+    # The configured engine object is built before uvicorn starts, but its
+    # weights may remain absent until the first request.  Keeping that exact
+    # object preserves every serve-time option and avoids request-controlled
+    # model discovery/downloads.
+    _primary_post_load_done = False
+    if _engine is not None and (_primary_lazy_load or _primary_idle_unload_seconds > 0):
+        if not (
+            hasattr(_engine, "_loaded")
+            and callable(getattr(_engine, "start", None))
+            and callable(getattr(_engine, "stop", None))
+        ):
+            raise RuntimeError(
+                "--lazy-load and --idle-unload-seconds currently support "
+                "text and vision-language serving engines only"
+            )
+        _primary_model_lifecycle = _build_primary_model_lifecycle(_engine)
+        get_config().primary_model_lifecycle = _primary_model_lifecycle
+
+    # Normal mode keeps the established eager-load contract.  An idle-unload
+    # deployment also loads eagerly unless --lazy-load was requested, but does
+    # so through the same coordinator later requests use to wake from standby.
+    if (
+        _engine is not None
+        and hasattr(_engine, "_loaded")
+        and not _engine._loaded
+        and not _primary_lazy_load
+    ):
         try:
-            await _engine.start()
+            if _primary_model_lifecycle is not None:
+                await _primary_model_lifecycle.ensure_loaded()
+                _primary_post_load_done = True
+            else:
+                await _engine.start()
         except Exception as _start_exc:
             # Opt-in telemetry (Phase 2.2 error wiring): serve's real weight
             # load happens HERE in the async lifespan, not in the CLI's
@@ -684,43 +790,8 @@ async def lifespan(app: FastAPI):
 
     # Warmup: generate one token to trigger Metal shader compilation.
     # Runs here (not in CLI) so all engine types are fully started first.
-    if _engine is not None:
-        import time as _time
-
-        logger.info("Warming up (compiling Metal shaders)...")
-        _warmup_start = _time.monotonic()
-        try:
-            _is_hybrid = _detect_hybrid_for_warmup(_engine)
-            if not _is_hybrid:
-                _engine.generate_warmup()
-                # NOTE: do NOT call `mx.eval(mx.zeros(1))` here — that
-                # allocates on the main (asyncio loop) thread which lazily
-                # creates Stream(gpu, 1), and any subsequent eval of arrays
-                # whose graph touches that stream from the mlx-step worker
-                # raises "There is no Stream(gpu, 1) in current thread"
-                # (#170). `generate_warmup()` already routes its own forward
-                # + eval through the step thread, which is what we want.
-            else:
-                # Hybrid models need a full request warmup to compile
-                # Metal shaders and prime the BatchGenerator, preventing
-                # corruption on the first concurrent batch.
-                logger.info(
-                    "Hybrid model: running full request warmup "
-                    "(compiling GatedDeltaNet kernels)"
-                )
-                try:
-                    async for _ in _engine.stream_chat(
-                        messages=[{"role": "user", "content": "Hi"}],
-                        max_tokens=2,
-                        temperature=0.0,
-                    ):
-                        pass
-                except Exception as _e:
-                    logger.debug(f"Hybrid warmup error (non-fatal): {_e}")
-        except Exception as e:
-            logger.debug(f"Warmup failed (non-fatal): {e}")
-        _warmup_secs = _time.monotonic() - _warmup_start
-        logger.info(f"Warmup complete ({_warmup_secs:.1f}s)")
+    if _engine is not None and not _primary_lazy_load and not _primary_post_load_done:
+        await _warmup_primary_engine(_engine)
 
     # Publish the startup engine into the resident-model lifecycle after it is
     # fully started. Legacy routes still expose this engine through cfg.engine,
@@ -760,6 +831,8 @@ async def lifespan(app: FastAPI):
                 ),
             )
     await _residency_manager.start()
+    if _primary_model_lifecycle is not None:
+        await _primary_model_lifecycle.start()
 
     # Tool-grammar warmup (#558): the FIRST grammar-constrained tool call
     # otherwise pays a one-time ~1s llguidance ``LLTokenizer`` build on the
@@ -768,7 +841,7 @@ async def lifespan(app: FastAPI):
     # cost is the shared tokenizer build, not per-schema compile). Pre-build it
     # at startup, off the event loop, so no user request eats the cold-start.
     # Self-gates to grammar-capable tool deployments and is non-fatal.
-    if _engine is not None:
+    if _engine is not None and not _primary_lazy_load and not _primary_post_load_done:
         try:
             await _warmup_tool_grammar(_engine)
         except Exception as _e:
@@ -854,7 +927,12 @@ async def lifespan(app: FastAPI):
     # arrives mid-load either misses (recompute — always correct) or hits the
     # fully-installed cache, never a partially-populated one. Worst case a few
     # early requests recompute their prefix; they never see a wedged server.
-    if _engine is not None and hasattr(_engine, "load_cache_from_disk"):
+    if (
+        _engine is not None
+        and not _primary_lazy_load
+        and not _primary_post_load_done
+        and hasattr(_engine, "load_cache_from_disk")
+    ):
         global _prefix_cache_load_task
         _prefix_cache_load_task = asyncio.create_task(_deferred_load_prefix_cache())
 
@@ -921,6 +999,9 @@ async def lifespan(app: FastAPI):
         from .routes.video import shutdown_video_jobs
 
         await shutdown_video_jobs()
+
+        if _primary_model_lifecycle is not None:
+            await _primary_model_lifecycle.shutdown()
 
         # Let the deferred prefix-cache load (#1350) finish before we save or
         # tear down the engine — see the helper's docstring for why we await
@@ -2423,7 +2504,10 @@ def load_model(
         _engine._load_blocking()  # noqa: SLF001 — internal helper
         logger.info(f"Model loaded: {model_name}")
     else:
-        logger.info(f"Loading model with BatchedEngine: {model_name}")
+        if _primary_lazy_load:
+            logger.info(f"Preparing lazy BatchedEngine: {model_name}")
+        else:
+            logger.info(f"Loading model with BatchedEngine: {model_name}")
         _engine = BatchedEngine(
             model_name=_engine_model_path,
             chat_template_id=(
@@ -2444,7 +2528,14 @@ def load_model(
             enable_disk_stream=enable_disk_stream,
             disk_stream_cache_gb=disk_stream_cache_gb,
         )
-        logger.info(f"Model loaded: {model_name}")
+        if _primary_lazy_load:
+            logger.info(
+                "Model configured in standby; weights will load on the first "
+                "inference request: %s",
+                model_name,
+            )
+        else:
+            logger.info(f"Model loaded: {model_name}")
 
     # Sync globals into ServerConfig BEFORE _detect_native_tool_support reads
     # them via get_config(). Detection short-circuits when cfg.tool_call_parser
@@ -2735,6 +2826,21 @@ def configure_model_residency(
     return _residency_manager
 
 
+def configure_primary_model_lifecycle(
+    *, lazy_load: bool = False, idle_unload_seconds: float = 0
+) -> None:
+    """Configure standby/wake behavior before the server lifespan starts."""
+
+    global _primary_lazy_load
+    global _primary_idle_unload_seconds
+    global _primary_model_lifecycle
+
+    _primary_lazy_load = bool(lazy_load)
+    _primary_idle_unload_seconds = max(0.0, float(idle_unload_seconds))
+    _primary_model_lifecycle = None
+    get_config().primary_model_lifecycle = None
+
+
 class _ResidentPrimaryAudioHandoff:
     """Adapt the audio dispatcher's lease to residency model entries."""
 
@@ -2774,6 +2880,14 @@ def _set_resident_primary(entry: ModelEntry | None) -> None:
     global _engine, _model_name, _model_alias, _model_path, _served_model_name_set
     global _enable_auto_tool_choice, _tool_call_parser, _tool_parser_instance
     global _reasoning_parser, _reasoning_parser_name
+    global _primary_model_lifecycle
+
+    if _primary_model_lifecycle is not None and (
+        entry is None or entry.engine is not _primary_model_lifecycle.engine
+    ):
+        _primary_model_lifecycle.detach()
+        _primary_model_lifecycle = None
+        get_config().primary_model_lifecycle = None
 
     if entry is None:
         _engine = None
@@ -2828,6 +2942,10 @@ def _set_resident_primary(entry: ModelEntry | None) -> None:
     cfg.reasoning_parser = _reasoning_parser
     cfg.reasoning_parser_name = entry.reasoning_parser
     cfg.ready = True
+    if _primary_lazy_load or _primary_idle_unload_seconds > 0:
+        _primary_model_lifecycle = _build_primary_model_lifecycle(entry.engine)
+        cfg.primary_model_lifecycle = _primary_model_lifecycle
+        asyncio.create_task(_primary_model_lifecycle.start())
 
 
 def _sync_config() -> None:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2508,10 +2508,11 @@ def load_model(
         _engine._load_blocking()  # noqa: SLF001 — internal helper
         logger.info(f"Model loaded: {model_name}")
     else:
-        if _primary_lazy_load:
-            logger.info(f"Preparing lazy BatchedEngine: {model_name}")
-        else:
-            logger.info(f"Loading model with BatchedEngine: {model_name}")
+        logger.info(
+            "%s BatchedEngine: %s",
+            "Preparing lazy" if _primary_lazy_load else "Loading model with",
+            model_name,
+        )
         _engine = BatchedEngine(
             model_name=_engine_model_path,
             chat_template_id=(
@@ -2532,14 +2533,15 @@ def load_model(
             enable_disk_stream=enable_disk_stream,
             disk_stream_cache_gb=disk_stream_cache_gb,
         )
-        if _primary_lazy_load:
-            logger.info(
+        logger.info(
+            (
                 "Model configured in standby; weights will load on the first "
-                "inference request: %s",
-                model_name,
-            )
-        else:
-            logger.info(f"Model loaded: {model_name}")
+                "inference request: %s"
+                if _primary_lazy_load
+                else "Model loaded: %s"
+            ),
+            model_name,
+        )
 
     # Sync globals into ServerConfig BEFORE _detect_native_tool_support reads
     # them via get_config(). Detection short-circuits when cfg.tool_call_parser

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -676,9 +676,9 @@ async def _prepare_primary_idle_unload() -> None:
     await _shutdown_save_prefix_cache()
 
 
-def _mirror_primary_lifecycle_state(state: str) -> None:
+def _mirror_primary_lifecycle_state(engine: object, state: str) -> None:
     if _residency_manager is not None:
-        _residency_manager.set_primary_lifecycle_state(state)
+        _residency_manager.set_primary_lifecycle_state(engine, state)
 
 
 def _build_primary_model_lifecycle(engine: object) -> PrimaryModelLifecycle:
@@ -689,7 +689,7 @@ def _build_primary_model_lifecycle(engine: object) -> PrimaryModelLifecycle:
         on_loaded=_finish_primary_demand_load,
         before_unload=_prepare_primary_idle_unload,
         release_allocator_cache=_release_allocator_cache,
-        on_state_change=_mirror_primary_lifecycle_state,
+        on_state_change=lambda state: _mirror_primary_lifecycle_state(engine, state),
     )
 
 
@@ -2885,7 +2885,12 @@ def _set_resident_primary(entry: ModelEntry | None) -> None:
     if _primary_model_lifecycle is not None and (
         entry is None or entry.engine is not _primary_model_lifecycle.engine
     ):
-        _primary_model_lifecycle.detach()
+        try:
+            _primary_model_lifecycle.detach()
+        except RuntimeError as exc:
+            raise ResidentModelBusyError(
+                "primary model lifecycle transition is in progress"
+            ) from exc
         _primary_model_lifecycle = None
         get_config().primary_model_lifecycle = None
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -621,7 +621,7 @@ def _detect_hybrid_for_warmup(engine) -> bool:
     return False
 
 
-async def _warmup_primary_engine(engine: object) -> None:
+async def _warmup_primary_engine(engine: BaseEngine) -> None:
     """Compile the configured engine on its model-owning worker."""
 
     import time as _time

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -631,7 +631,11 @@ async def _warmup_primary_engine(engine: object) -> None:
     try:
         is_hybrid = _detect_hybrid_for_warmup(engine)
         if not is_hybrid:
-            engine.generate_warmup()
+            # `generate_warmup()` synchronously waits for the model-owning MLX
+            # executor. During eager boot there is no traffic yet, but on a
+            # demand load that wait must leave the event loop free for health
+            # probes and other coalesced requests.
+            await asyncio.to_thread(engine.generate_warmup)
         else:
             logger.info(
                 "Hybrid model: running full request warmup "

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -181,6 +181,17 @@ def _release_primary_request_unless_committed(engine, committed: bool) -> None:
         _release_primary_request(engine)
 
 
+def _release_route_ownership(
+    engine, *, admission_acquired: bool, committed: bool
+) -> None:
+    """Release whichever lease a generation route successfully acquired."""
+
+    if admission_acquired:
+        _release_admission_unless_committed(engine, committed)
+    else:
+        _release_primary_request_unless_committed(engine, committed)
+
+
 def _transfer_primary_request_to_stream(engine) -> None:
     lifecycle = get_config().primary_model_lifecycle
     if lifecycle is not None and lifecycle.engine is engine:

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -149,26 +149,42 @@ def _release_admission_unless_committed(engine, committed: bool) -> None:
         # terminal finally both releases the reservation and touches the
         # lifecycle after the final chunk/disconnect. Touching here would
         # incorrectly start the idle clock while the SSE response is active.
+        _transfer_primary_request_to_stream(engine)
         return
     release = getattr(engine, "release_admission_reservation", None)
-    if release is None:
-        return
     try:
-        release()
-        _touch_primary_lifecycle(engine)
+        if release is not None:
+            release()
     except Exception:
         logger.warning(
             "release_admission_reservation raised on route finally",
             exc_info=True,
         )
+    finally:
+        _release_primary_request(engine)
 
 
-def _touch_primary_lifecycle(engine) -> None:
-    """Start the primary idle window after request ownership ends."""
+def _release_primary_request(engine) -> None:
+    """Release route ownership and start the primary's idle window."""
 
     lifecycle = get_config().primary_model_lifecycle
     if lifecycle is not None and lifecycle.engine is engine:
-        lifecycle.touch()
+        lifecycle.release_request()
+
+
+def _release_primary_request_unless_committed(engine, committed: bool) -> None:
+    """Keep streaming ownership until `_disconnect_guard` reaches terminal."""
+
+    if committed:
+        _transfer_primary_request_to_stream(engine)
+    else:
+        _release_primary_request(engine)
+
+
+def _transfer_primary_request_to_stream(engine) -> None:
+    lifecycle = get_config().primary_model_lifecycle
+    if lifecycle is not None and lifecycle.engine is engine:
+        lifecycle.transfer_request_to_stream()
 
 
 def _raise_lifecycle_cancel_or_reraise(engine, exc: asyncio.CancelledError) -> None:
@@ -2775,11 +2791,14 @@ async def ensure_engine_ready(engine: BaseEngine) -> BaseEngine:
 
     lifecycle = get_config().primary_model_lifecycle
     if lifecycle is not None and engine is lifecycle.engine:
+        lifecycle.acquire_request()
         try:
             await lifecycle.ensure_loaded()
         except asyncio.CancelledError:
+            lifecycle.release_request()
             raise
         except BaseException as exc:
+            lifecycle.release_request()
             logger.exception("Configured primary model failed to load on demand")
             raise HTTPException(
                 status_code=503,
@@ -4357,15 +4376,16 @@ async def _disconnect_guard(
             _force_abort_request(engine, request_id_holder)
         if engine is not None:
             release = getattr(engine, "release_admission_reservation", None)
-            if release is not None:
-                try:
+            try:
+                if release is not None:
                     release()
-                    _touch_primary_lifecycle(engine)
-                except Exception:
-                    logger.warning(
-                        "[disconnect_guard] release_admission_reservation raised",
-                        exc_info=True,
-                    )
+            except Exception:
+                logger.warning(
+                    "[disconnect_guard] release_admission_reservation raised",
+                    exc_info=True,
+                )
+            finally:
+                _release_primary_request(engine)
         logger.info(
             f"[disconnect_guard] CLEANUP done, {chunk_count} chunks total, elapsed={_elapsed()}"
         )

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -182,12 +182,16 @@ def _release_primary_request_unless_committed(engine, committed: bool) -> None:
 
 
 def _release_route_ownership(
-    engine, *, admission_acquired: bool, committed: bool
+    engine,
+    *,
+    admission_acquired: bool,
+    committed: bool,
+    release_admission=None,
 ) -> None:
     """Release whichever lease a generation route successfully acquired."""
 
     if admission_acquired:
-        _release_admission_unless_committed(engine, committed)
+        (release_admission or _release_admission_unless_committed)(engine, committed)
     else:
         _release_primary_request_unless_committed(engine, committed)
 

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -151,11 +151,20 @@ def _release_admission_unless_committed(engine, committed: bool) -> None:
         return
     try:
         release()
+        _touch_primary_lifecycle(engine)
     except Exception:
         logger.warning(
             "release_admission_reservation raised on route finally",
             exc_info=True,
         )
+
+
+def _touch_primary_lifecycle(engine) -> None:
+    """Start the primary idle window after request ownership ends."""
+
+    lifecycle = get_config().primary_model_lifecycle
+    if lifecycle is not None and lifecycle.engine is engine:
+        lifecycle.touch()
 
 
 def _raise_lifecycle_cancel_or_reraise(engine, exc: asyncio.CancelledError) -> None:
@@ -2757,6 +2766,31 @@ def get_engine(model_name: str | None = None) -> BaseEngine:
     return cfg.engine
 
 
+async def ensure_engine_ready(engine: BaseEngine) -> BaseEngine:
+    """Demand-load ``engine`` when it is the configured standby primary."""
+
+    lifecycle = get_config().primary_model_lifecycle
+    if lifecycle is not None and engine is lifecycle.engine:
+        try:
+            await lifecycle.ensure_loaded()
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            logger.exception("Configured primary model failed to load on demand")
+            raise HTTPException(
+                status_code=503,
+                headers={"Retry-After": "5"},
+                detail="Configured model failed to load; retry after the delay.",
+            ) from exc
+    return engine
+
+
+async def get_ready_engine(model_name: str | None = None) -> BaseEngine:
+    """Resolve an engine and demand-load the configured primary if needed."""
+
+    return await ensure_engine_ready(get_engine(model_name))
+
+
 def _resolve_reasoning_enabled(model_name: str | None) -> bool:
     """Return whether the selected alias is reasoning-capable.
 
@@ -4322,6 +4356,7 @@ async def _disconnect_guard(
             if release is not None:
                 try:
                     release()
+                    _touch_primary_lifecycle(engine)
                 except Exception:
                     logger.warning(
                         "[disconnect_guard] release_admission_reservation raised",

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -145,6 +145,10 @@ def _release_admission_unless_committed(engine, committed: bool) -> None:
     the route handler also releases) cannot corrupt the accounting.
     """
     if committed:
+        # Streaming ownership was transferred to `_disconnect_guard`; its
+        # terminal finally both releases the reservation and touches the
+        # lifecycle after the final chunk/disconnect. Touching here would
+        # incorrectly start the idle clock while the SSE response is active.
         return
     release = getattr(engine, "release_admission_reservation", None)
     if release is None:
@@ -3934,9 +3938,9 @@ async def _disconnect_guard(
     the ``finally`` clause so the slot acquired by
     ``_check_admission_or_503`` is returned to the pool once the
     streaming response finishes (or the client disconnects, or the
-    generator raises). The release is the safety net for the
-    streaming path; non-streaming routes mirror it via
-    ``_wait_with_disconnect``.
+    generator raises). The same terminal block resets the primary lifecycle's
+    idle clock. Non-streaming routes mirror both actions in their route-level
+    finalizers.
 
     SSE keepalive (F-070): when ``keepalive_seconds > 0`` (default
     falls through to ``ServerConfig.sse_keepalive_seconds``), emit a


### PR DESCRIPTION
## Why

Closes #319 and completes the Tier 2 portion of #265.

The Always-on Rapid Engine can already survive reboot as a reliable launchd service, and the residency manager already supports LRU/TTL eviction for dynamically loaded secondary models. The remaining user-visible gap was the configured primary model: it was always loaded at process startup and remained pinned for the lifetime of the service. That forced an always-on endpoint to reserve the full model working set even when it had not served a request for hours.

This PR adds a deliberately narrow standby/wake lifecycle for the startup-configured primary. It does not turn the request model field into a model downloader or introduce current/candidate worker orchestration.

## Scope

### Operator surface

```bash
rapid-mlx serve MODEL --lazy-load --idle-unload-seconds 1800
```

- `--lazy-load` binds the stable HTTP endpoint with the configured model in `standby`; weights load and warm on the first text-generation request.
- `--idle-unload-seconds N` saves the prefix cache, drains/stops the primary engine, releases allocator cache, and returns to `standby` after a full idle interval. `0` preserves the existing resident behavior.
- The two flags are independent: idle unload can follow the normal eager startup, while lazy load can be used without later unloading.
- Negative, NaN, and infinite idle values fail CLI validation.
- Startup messaging now says `standby — model loads on first request` instead of falsely claiming the model is loaded/warming.

### Lifecycle and request behavior

- Adds `PrimaryModelLifecycle` with `standby`, `loading`, `ready`, `unloading`, and `error` states.
- Reuses the exact `BatchedEngine` constructed from the serve configuration, preserving scheduler, cache, MLLM, speculative-decode, routing, and memory flags across reloads.
- Chat Completions, legacy Completions, Responses, Anthropic Messages, and Anthropic token counting all pass through the same demand-load gate.
- Concurrent cold requests share one load task. A disconnected/cancelled waiter is shielded from cancelling the load needed by other requests.
- Every primary-backed route holds an identity-tokenized lifecycle lease from demand load through admission and final response cleanup; streaming transfers the lease through the last SSE chunk, and abandoned route tasks release it automatically.
- Idle eviction uses both those leases and the existing engine admission counters, publishes `unloading` before awaiting admission pause, rechecks for arrivals after the pause, and starts a fresh full idle window when request ownership is released.
- Load failures expose a retryable HTTP 503 with `Retry-After: 5`; health reports only the exception type, not model paths or exception text.
- Dynamic resident-model primary handoff detaches the old monitor and transfers lifecycle ownership to the new primary.

### Cache, health, and service integration

- Demand loading runs the same Metal and tool-grammar warmups as eager startup; blocking warmup work stays off the HTTP event loop so health probes remain responsive.
- Idle unload waits for deferred prefix-cache restoration, attempts a best-effort cache save, stops the engine even if persistence fails, then clears Python/MLX allocator caches. Reload schedules prefix-cache restore again.
- Shutdown drains a cancellation-isolated in-flight load before normal teardown; external shutdown cancellation propagates instead of starting a concurrent engine stop.
- `/health` includes `model_lifecycle`; `/health/ready` reports lifecycle state and `model_loaded`.
- `standby` remains ready because the stable endpoint can accept and coalesce a demand load. `error` returns 503.
- `/healthz` stays a cheap non-blocking probe and reports real model residency.
- The resident-model manager mirrors primary standby state so its accounting does not claim unloaded weights are resident.
- Headless launchd documentation includes a `service configure ... -- --lazy-load --idle-unload-seconds 1800` example.

## Non-goals

- No arbitrary request-triggered Hugging Face repository discovery or download. Only the model selected and validated at service startup can wake.
- No multi-worker current/candidate swap architecture and no zero-downtime model replacement.
- No change to existing defaults; operators must opt in.
- The standby process keeps one-time Metal runtime / compiled-shader overhead after the first load. It releases the model engine and weight references, but does not promise a return to pristine pre-Metal RSS.
- The independent `--embedding-model` engine is not the primary and is unaffected. Image-generation, video, audio, and text-diffusion lanes are not enabled for this lifecycle in this PR; unsupported engines fail clearly at lifespan startup.

## Acceptance

- [x] Lazy mode binds the configured port with `state=standby` and `model_loaded=false` before loading weights.
- [x] The first request loads the configured model and returns a valid response.
- [x] Concurrent first requests share one load operation; cancellation of one waiter does not cancel the shared load.
- [x] Active/admitted requests prevent idle unload.
- [x] A full idle interval after request release persists cache, stops the engine, clears allocator cache, and returns to standby.
- [x] A later request reloads and succeeds through the same PID/port.
- [x] Prefix-cache save/restore works across the unload/reload boundary.
- [x] Health endpoints expose standby/loading/ready/unloading/error without waking the model.
- [x] Existing behavior is unchanged when both new flags are omitted.

## Verification

- Final GitHub CI on `e0c904dd`: Linux Python 3.10/3.11/3.12, Apple Silicon, macOS/desktop build, type-check, lint, engine contracts, and the 100% changed-lines coverage gate all passed. PR entered the managed macOS merge queue with `merge-ready-mac` + `queued`.
- Changed-lines gate follow-up: added exhaustive transition/error-path coverage after CI exposed a 69% changed-line gap. The lifecycle module now measures 100% locally; the focused route/server suite reports `255 passed, 2 skipped, 3 deselected`, and the reconstructed Linux + Apple + focused coverage union leaves no lifecycle, route, health, CLI, or server wiring lines uncovered.
- `416 passed` across lifecycle, API validation/model routing, cancellation, completions parity, sampling validation, health perf budget, startup banner, docs defaults, and stop matching.
- Earlier compatibility sweep after route integration: `619 passed` across the initially affected route/mock suites.
- Broad suite: `11,373 passed, 53 skipped, 6 xfailed, 1 xpassed` before stopping on an environmental port conflict: the existing Rapid-MLX Desktop `qwen3-asr` service has owned `127.0.0.1:8000` for two days, while `test_legacy_prefix_cache_flag_warnings` hard-codes port 8000. The process was intentionally left running.
- A separate broad-suite attempt reached `10,978 passed` before an unrelated missing optional `mflux` dependency.
- Latest post-review targeted groups: `368 passed`, `234 passed`, `164 passed`, and `112 passed`, covering route leases, pause races, cancellation-isolated shutdown, cache failures, Anthropic token counting, resident handoff identity, embeddings isolation, and warmup responsiveness.
- Final `pr_validate` review convergence run: `MERGE-SAFE`; description, supply chain, environment, vocabulary, Codex adversarial review, and lint passed with zero blocking findings. Full-unit, stress, and advisory diff-coverage steps were skipped in this convergence run because the broader local evidence and environmental blockers are documented above.
- Ruff lint and format checks pass for every touched Python file; `git diff --check` passes.
- Real Apple Silicon dogfood with cached `mlx-community/Qwen3-0.6B-4bit`, same PID and port:
  - cold boot: `/health/ready` → `standby`, `model_loaded=false`, RSS 132.4 MiB;
  - first Chat Completions request → HTTP 200 / `Loaded.`, `ready`, RSS 632.2 MiB;
  - 5-second idle expiry → prefix cache saved, engine stopped, `standby`, RSS settled at 435.5–447.9 MiB;
  - second request → HTTP 200 / `reloaded`, cache restored, then returned to standby again.

## Behaviour delta

Default: no change.

Opt-in before → after:

- `--lazy-load`: model eagerly loaded before Ready → endpoint becomes Ready in standby and loads on first text-generation request.
- `--idle-unload-seconds N`: configured primary pinned for process lifetime → primary unloads after N idle seconds and transparently reloads on the next request.

## Website documentation handoff

Everything below is part of the public product contract and must be carried into the Rapid-MLX website docs. This section is intentionally structured as the source material for that follow-up rather than leaving the behavior implicit in implementation notes.

### Recommended docs placement

1. Add an **Always-on Rapid Engine** guide under server/deployment documentation.
2. Add both flags to the `rapid-mlx serve` CLI reference.
3. Extend the launchd/service guide with an always-on, memory-reclaiming example.
4. Document lifecycle fields in the health/readiness API reference.
5. Add cold-start and post-first-load memory behavior to troubleshooting/operations.

### Canonical setup examples

Lazy-load while keeping the endpoint online:

```bash
rapid-mlx serve mlx-community/Qwen3-0.6B-4bit --lazy-load
```

Lazy-load and return the primary model to standby after 30 idle minutes:

```bash
rapid-mlx serve mlx-community/Qwen3-0.6B-4bit \
  --lazy-load \
  --idle-unload-seconds 1800
```

Persist the same policy through the existing launchd service:

```bash
sudo rapid-mlx service configure \
  --model mlx-community/Qwen3-0.6B-4bit \
  -- \
  --lazy-load \
  --idle-unload-seconds 1800
```

`--idle-unload-seconds 0` disables idle unload and remains the default. Both flags are opt-in; existing eager-start behavior is unchanged when they are omitted. Negative, NaN, and infinite idle values are rejected before model discovery or MLX initialization.

### User-visible lifecycle

| State | Meaning | Endpoint behavior |
| --- | --- | --- |
| `standby` | Service is healthy; configured primary weights are not resident. | Health and discovery remain available. The next supported inference request wakes the model. |
| `loading` | One shared demand-load is in progress. | Concurrent requests coalesce onto the same load rather than starting duplicate loads. |
| `ready` | Primary model is resident and can serve inference. | Requests run normally; request completion starts/restarts the idle window. |
| `unloading` | Admission is paused and the engine is being safely drained/unloaded. | A newly accepted request aborts the idle eviction, reopens admission, and keeps/reloads the configured primary. |
| `error` | A load, stop, or admission-resume transition failed. | Readiness returns 503; a later inference request may retry a recoverable load failure. |

The API URL, port, configured model identity, tokenizer/parser settings, and process remain stable across standby → ready → standby transitions. This is lifecycle management for the model chosen at server startup, not request-controlled model discovery.

### Request and cache semantics

- The first supported inference request loads and warms the configured primary model.
- Concurrent cold requests share one load operation. Cancelling one client does not cancel the shared engine load needed by other clients.
- Non-streaming requests hold a lifecycle lease through their route finalizer. Streaming requests transfer that lease to the SSE cleanup path and release it only after the final chunk, disconnect, or generator failure.
- Active/admitted requests prevent idle unload. The full idle interval begins after the latest request ownership is released.
- Idle unload pauses admission, rechecks for newly arrived work, waits for active generation to drain, finishes any prefix-cache restore, saves the prefix cache on a best-effort basis, stops the engine, clears allocator cache, and returns to standby.
- Prefix-cache save failure is logged but does not silently defeat the operator's requested memory policy. Allocator cleanup failure is also non-fatal after weights have been released.
- Process shutdown drains a cancellation-isolated in-flight demand load before normal engine teardown, preventing concurrent start/stop corruption.

### Health and readiness contract

`/health`, `/health/ready`, and `/healthz` report lifecycle state without waking the model. Public examples should show at least:

```json
{
  "ready": true,
  "model": "mlx-community/Qwen3-0.6B-4bit",
  "state": "standby",
  "model_loaded": false
}
```

`standby` is a healthy/ready service state because the stable endpoint can accept a request and wake its configured model. `error` returns readiness 503. The full health response also exposes `model_lifecycle`, including `idle_seconds`, configured idle timeout, lazy-load status, active request-owner count, and sanitized error type.

### Supported request surface and explicit limits

- OpenAI-compatible Chat Completions, Completions, and Responses routes wake the configured primary.
- Anthropic Messages and token-counting routes wake the configured primary.
- Model discovery and health routes never wake it.
- `/v1/embeddings` uses the independent `--embedding-model` engine. It neither wakes nor inherits the primary lifecycle.
- This release enables the lifecycle for text and vision-language serving engines. Image generation, video, audio, and text-diffusion primary lanes are not supported by these flags and fail clearly during lifespan startup.
- This is not arbitrary request-triggered Hugging Face downloading, multi-model pinning, or a current/candidate zero-downtime switching system. Only the startup-configured primary can be demand-loaded.

### Memory and latency expectations

- Lazy startup substantially lowers pre-request residency and makes the endpoint available before model weights and Metal shaders are loaded.
- The first request pays model load and warmup latency. Operators should choose the idle timeout based on the tradeoff between cold-start frequency and reclaimed memory.
- Unloading releases model engine/weight references, but macOS/Metal may retain one-time runtime state and compiled shader overhead after the first load. Documentation must not promise a return to pristine pre-Metal RSS.
- Reference dogfood measurement for `mlx-community/Qwen3-0.6B-4bit`: 132.4 MiB before first load, 632.2 MiB resident, and approximately 435.5–447.9 MiB after idle unload. Treat these as an example, not a universal memory guarantee.

### Troubleshooting entries

- Long first request: expected when starting from standby; inspect `state=loading` and server logs.
- Repeated cold starts: raise `--idle-unload-seconds` or disable idle unload with `0`.
- Readiness 503 with `state=error`: inspect the sanitized lifecycle error type and model-load logs, then retry after correcting model/configuration problems.
- Memory does not return to cold-boot RSS: expected Metal runtime/shader retention; verify that `model_loaded=false` and `state=standby` rather than using process RSS alone.
- Embeddings still consume memory: the embedding engine is independent and requires separate lifecycle/operational decisions.

### Docs follow-up acceptance

- The website examples above are executable and use the current CLI spelling.
- Website state definitions match the health endpoint exactly.
- Default behavior, supported routes, independent embeddings behavior, unsupported modalities, and the Metal RSS caveat are all stated explicitly.
- The launchd page links to the Always-on guide, and the Always-on guide links to health/readiness and CLI reference pages.

## Release notes draft

Always-on Rapid Engine can now keep a stable macOS service endpoint without permanently reserving model memory. Start `rapid-mlx serve` with `--lazy-load` to load the configured model on the first request, and add `--idle-unload-seconds N` to save its prefix cache and return to standby after inactivity. The next OpenAI- or Anthropic-compatible request wakes the same configured model through the same URL; requests cannot trigger arbitrary model downloads.

## AI assistance disclosure

Codex inspected the existing launchd service, resident-model lifecycle, prior #340/#1788 work, and issue #319; implemented the lifecycle, route integration, health/CLI/docs changes, and tests; reviewed the complete diff; ran targeted and broad test suites; and dogfooded the full lifecycle with a locally cached model. All AI-touched files are the files in this PR.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally (`python3 -m pytest tests/ -x`) — broad suite is blocked only by the documented occupied Desktop port / missing optional integration dependencies; affected suites pass
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated against PR #3214 — final convergence run is `MERGE-SAFE` with zero blocking findings (full-unit/stress/diff-coverage skips explicitly documented above)
- [x] New lifecycle tests were mutation-spot-checked through load/unload state and hook assertions
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API

## Author

X handle (optional, external contributors):


