### PR TITLE
feat(scheduler): reduce short-request TTFT under prompt contention

### DIFF
--- a/.agents/handoffs/vector-scheduler-admission-1950.md
+++ b/.agents/handoffs/vector-scheduler-admission-1950.md
@@ -81,3 +81,8 @@
   The legacy-runtime regression now feeds a flat response through real
   `Scheduler.step()`. Post-fix cache/scheduler regression run: 226 passed,
   2 deselected.
+- PR validation round 3 was MERGE-SAFE with two nits. Both were resolved:
+  unusable/negative observable cache offsets now force cold-cost ranking, and
+  scheduler stats expose both configured and effective policy so a legacy
+  runtime fallback reports effective `fcfs`. Post-fix focused run: 178 passed,
+  2 deselected.

--- a/.agents/handoffs/vector-scheduler-admission-1950.md
+++ b/.agents/handoffs/vector-scheduler-admission-1950.md
@@ -1,0 +1,66 @@
+# Vector handoff — contention-aware prompt admission (#1950)
+
+## 2026-09-07 — starting
+
+- Start FYI fallback for Atlas, Pixel, Harbor, Echo, and ds0731 (Orca role
+  messaging unavailable): Vector owns branch
+  `vector/1950-contention-admission`, worktree
+  `/private/tmp/vector-scheduler-admission-1950`, based on
+  `origin/main@dcad4aa90` on Local Mac.
+- Intention: add an opt-in scheduler admission policy that selects the
+  shortest validated uncached prompt tail when prompt slots are contended,
+  reducing interactive TTFT without changing the default FCFS behavior.
+- Scope: scheduler config/CLI plumbing, prompt-slot admission, non-mutating
+  validated-tail ranking, live-generator compatibility filtering,
+  selection-count anti-starvation, metrics/tests, reproducible contention
+  benchmark, and durable performance evidence.
+- Non-goals: changing the default policy, preempting running requests,
+  chunk-boundary yielding, modifying mlx-lm, activating the dormant external
+  priority API, multimodal scheduling changes, release, or deployment.
+- Private reference check: vLLM keeps FCFS as the default and isolates policy
+  selection in its request queue; SGLang separates policy ranking from token /
+  cache admission, computes prefix matches at selection time, and documents
+  starvation risk for cache-locality ordering. Rapid will adapt the narrow
+  principles: opt-in policy, validate current cost at grant time, keep
+  execution/correctness gates authoritative, and bound displacement. It will
+  not copy their GPU-specific token-budget or preemption machinery.
+- Verification plan: unit/property tests for estimator purity and grant order;
+  stop/sampler compatibility; cache invalidation fallback; max-deferrals;
+  cancellation/capacity/default parity; matched-shape greedy output parity;
+  real same-host contended TTFT and no-contention overhead; three rounds of
+  scope-locked adversarial self-review; exact-head PR validation and managed
+  queue. No Spark or reviewer sub-agent.
+
+## 2026-09-07 — implementation and dogfood
+
+- Implemented the opt-in `shortest_validated_tail` policy while leaving the
+  default FCFS admission branch unchanged. The policy grants only real prompt
+  and completion headroom, ranks a non-mutating cache-validated tail estimate,
+  skips incompatible live-generator stop groups, and forces the oldest
+  compatible request after eight pass-overs by default.
+- Added both server-entrypoint flags, config validation, status counters,
+  focused tests, and CLI documentation. No MLLM, request priority, running
+  preemption, or prompt-chunk-yield behavior was added.
+- Local M3 Ultra / 256 GB dogfood with cached Qwen3-0.6B-4bit, prefix cache
+  disabled, prefill B=1, three 8,000-word prompts ahead of one short prompt:
+  short-request TTFT median fell from 3.067 s to 1.206 s (2.54x faster, 60.7%
+  lower; five waves per arm). Client cancellation after first SSE content also
+  recovered all slots between waves. Reproduction and raw samples are in
+  `docs/engineering/performance/scheduler-admission-1950.md`.
+- Review round 1 found compatibility risk for lightweight downstream config /
+  scheduler test doubles; non-critical reads now use FCFS/zero fallbacks while
+  real `SchedulerConfig` remains strict. Targeted regression suite after the
+  fix: 205 passed, 2 deselected.
+- Review rounds 2-3 verified prompt-slot cleanup across cancellation, normal
+  completion, cache recovery and fatal generation errors; stop-token cohort
+  isolation; MTP width; CLI fidelity; default FCFS order; and byte-identical
+  B=1 greedy output (`black, white, gray`) across both policies.
+- Full non-external suite: 22,973 passed, 138 skipped, 25 deselected, 6 xfailed,
+  1 xpassed, and one unrelated missing-optional-`mflux` failure in
+  `test_packaged_bf16_uses_model_path_without_onload_quantization`. The exact
+  same test fails at clean base `dcad4aa90` with the same
+  `ModuleNotFoundError: mflux`; the temporary comparison worktree was removed.
+- Repository-wide Ruff lint and format checks pass. The local mypy-budget
+  runner is operationally blocked because the repository targets Python 3.10
+  while the installed NumPy stub uses Python 3.12 `type` syntax; this produced
+  no project diagnostic and will be rechecked by the PR validation environment.

--- a/.agents/handoffs/vector-scheduler-admission-1950.md
+++ b/.agents/handoffs/vector-scheduler-admission-1950.md
@@ -72,3 +72,12 @@
   94 passed, 2 deselected. The obsolete-head full-unit portion of validation
   was stopped after recording the blocker because the broader suite had already
   completed locally and exact-head validation must be rerun after this fix.
+- PR validation round 2 found two in-scope correctness gaps and one test nit.
+  The cost probe now validates cache shape, cached-token bounds, the exact
+  current prompt suffix, and every observable cache-layer offset before using
+  a warm-tail cost. Selection is now read-only; queue removal, deferral updates,
+  and forced-grant accounting commit only after `BatchGenerator.insert*`
+  returns a UID, so every failure preserves position and starvation history.
+  The legacy-runtime regression now feeds a flat response through real
+  `Scheduler.step()`. Post-fix cache/scheduler regression run: 226 passed,
+  2 deselected.

--- a/.agents/handoffs/vector-scheduler-admission-1950.md
+++ b/.agents/handoffs/vector-scheduler-admission-1950.md
@@ -86,3 +86,7 @@
   scheduler stats expose both configured and effective policy so a legacy
   runtime fallback reports effective `fcfs`. Post-fix focused run: 178 passed,
   2 deselected.
+- PR validation round 4 remained MERGE-SAFE with one final nit: permissive
+  integer coercion could accept malformed boolean/float/string cache offsets.
+  Offset validation now requires a non-boolean Python integer and tests each
+  rejected shape.

--- a/.agents/handoffs/vector-scheduler-admission-1950.md
+++ b/.agents/handoffs/vector-scheduler-admission-1950.md
@@ -90,3 +90,8 @@
   integer coercion could accept malformed boolean/float/string cache offsets.
   Offset validation now requires a non-boolean Python integer and tests each
   rejected shape.
+- PR validation round 5 found the reversed batch-size edge: upstream currently
+  coerces completion capacity up to prefill capacity, but the opt-in Rapid
+  admission contract must honor the operator-configured completion limit.
+  Effective capacity now caps directly at `completion_batch_size`, with a
+  regression where prefill B=4 and completion B=2.

--- a/.agents/handoffs/vector-scheduler-admission-1950.md
+++ b/.agents/handoffs/vector-scheduler-admission-1950.md
@@ -95,3 +95,7 @@
   admission contract must honor the operator-configured completion limit.
   Effective capacity now caps directly at `completion_batch_size`, with a
   regression where prefill B=4 and completion B=2.
+- GitHub type-check exposed two new dynamic-attribute diagnostics for admission
+  deferrals (the local Python 3.12 environment could not run the repository
+  Python 3.10-targeted mypy surface). Deferral state is now an explicit typed
+  `Request` field with `init=False`, preserving constructor compatibility.

--- a/.agents/handoffs/vector-scheduler-admission-1950.md
+++ b/.agents/handoffs/vector-scheduler-admission-1950.md
@@ -64,3 +64,11 @@
   runner is operationally blocked because the repository targets Python 3.10
   while the installed NumPy stub uses Python 3.12 `type` syntax; this produced
   no project diagnostic and will be rechecked by the PR validation environment.
+- PR #3216 validation round 1 found one legitimate blocker: older mlx-lm flat
+  response shapes do not expose prompt-promotion events, so the mirror could
+  stay occupied. Fixed with a one-time, warning-backed fallback to historical
+  FCFS when that legacy shape is observed; the configured policy remains
+  visible but unsafe ranking is disabled. Focused post-fix regression run:
+  94 passed, 2 deselected. The obsolete-head full-unit portion of validation
+  was stopped after recording the blocker because the broader suite had already
+  completed locally and exact-head validation must be rerun after this fix.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,7 @@ jobs:
             tests/test_speculative_request_policy.py \
             tests/test_deepseek_v4_vendored.py \
             tests/test_dspark_scheduler.py \
+            tests/test_scheduler_admission_policy.py \
             tests/test_scheduler_recurrent_cache_materialization.py \
             tests/test_prefix_cache_persistence.py \
             tests/test_prefix_boundary_path_parity.py \

--- a/docs/engineering/performance/scheduler-admission-1950.md
+++ b/docs/engineering/performance/scheduler-admission-1950.md
@@ -1,0 +1,64 @@
+# Contention-aware prompt admission benchmark
+
+Date: 2026-09-07
+
+This benchmark measures the interactive request most exposed to prompt-slot
+head-of-line blocking: one short request arriving behind three long requests.
+It compares the historical `fcfs` default with the opt-in
+`shortest_validated_tail` policy. It does not measure or claim preemption of a
+prompt that is already running.
+
+## Environment
+
+- Mac Studio, Apple M3 Ultra (28 CPU cores), 256 GB unified memory
+- macOS 26.5.2 (25F84)
+- Python 3.12.13, MLX 0.32.2, mlx-lm 0.31.3, Rapid-MLX 0.13.4
+- Model: `mlx-community/Qwen3-0.6B-4bit`, already present in the local HF cache
+- Base revision: `dcad4aa900f1711d850f9a27c7477a0a417cd411`
+- Prefix cache disabled so prompt-tail ordering, not reuse, drives the result
+
+## Server commands
+
+Run each arm in a freshly started process:
+
+```bash
+uv run rapid-mlx serve mlx-community/Qwen3-0.6B-4bit \
+  --host 127.0.0.1 --port 18124 \
+  --prefill-batch-size 1 --completion-batch-size 4 --max-num-seqs 4 \
+  --scheduling-policy fcfs --disable-prefix-cache --log-level WARNING
+```
+
+For the experimental arm, replace `fcfs` with
+`shortest_validated_tail --scheduling-max-deferrals 8`.
+
+Each of five measured waves sent one 8,000-word `contention` prompt, waited
+50 ms, then sent two more identical long prompts at 0/10 ms and `Say OK.` at
+20 ms. Every request used streaming, `temperature=0`, and `max_tokens=8`.
+TTFT was measured from the short request's HTTP dispatch to its first non-empty
+SSE content delta. The client closed each stream after that first delta, which
+also exercised cancellation cleanup between waves.
+
+## Results
+
+| Policy | Short-request TTFT samples (s) | Median | Change |
+| --- | --- | ---: | ---: |
+| `fcfs` | 3.166, 3.041, 3.124, 3.043, 3.067 | 3.067 s | baseline |
+| `shortest_validated_tail` | 0.262, 1.214, 1.208, 1.206, 1.206 | 1.206 s | 2.54x faster / 60.7% lower |
+
+The first experimental sample selected the short request before the initial
+long prompt acquired the sole prefill slot; the other four show the intended
+non-preemptive case, where the short request waits for the active prompt and
+then bypasses the two unstarted long prompts. The median therefore remains a
+conservative non-preemptive result.
+
+## Interpretation
+
+The improvement comes from retaining excess requests in Rapid-MLX's queue
+until a real prompt slot is available. That preserves the opportunity to rank
+the currently grantable requests by cache-validated remaining prompt work.
+Default `fcfs` behavior remains unchanged, and the opt-in policy forces an old
+compatible request after eight pass-overs to bound starvation.
+
+A separate matched-shape greedy check used a fresh B=1 server per policy,
+`temperature=0`, `seed=42`, and the prompt “Reply with exactly three lowercase
+color words.” Both arms returned byte-identical content: `black, white, gray`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -97,6 +97,8 @@ are the argparse defaults from `vllm_mlx/cli.py`.
 | `--max-concurrent-requests` | Admission cap on in-flight requests (queued + running); when exceeded, new requests get HTTP 503 with `Retry-After` | 256 |
 | `--prefill-batch-size` | Max prompts prefilled together in one cold wave; lower it to cut first-token latency under concurrent cold load, at an aggregate-throughput cost on large MoE models | 8 |
 | `--completion-batch-size` | Completion batch size | 32 |
+| `--scheduling-policy` | Prompt-slot admission order: `fcfs`, or opt-in `shortest_validated_tail` to favor cache-hot/short prompts under contention | `fcfs` |
+| `--scheduling-max-deferrals` | Compatible grants that may pass over one request before `shortest_validated_tail` forces it through in FIFO order | 8 |
 | `--prefill-step-size` | Chunk size for prompt prefill processing; larger values use more memory but can improve prefill throughput | 2048 |
 | `--stream-interval` | Tokens to batch before streaming (1 = smooth, higher = throughput) | 1 |
 | `--gpu-memory-utilization` | Fraction of device memory for the Metal allocation limit and admission cap (0.0-1.0). Advanced override — by default the budget is sized automatically to the loaded model (measured weights + headroom, 0.90–0.97 of the device working-set budget) | auto |

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -121,6 +121,10 @@ def test_cost_probe_rejects_stale_tail_and_accepts_current_prompt_suffix():
     request.remaining_tokens = [98, 99]
     request.prompt_cache = SimpleNamespace(offset=97)
     assert scheduler._validated_prompt_tail_cost(request) == 100
+    request.prompt_cache = SimpleNamespace(offset=-1)
+    assert scheduler._validated_prompt_tail_cost(request) == 100
+    request.prompt_cache = SimpleNamespace(offset="corrupt")
+    assert scheduler._validated_prompt_tail_cost(request) == 100
 
 
 def test_selection_is_read_only_until_admission_commit():
@@ -232,6 +236,9 @@ def test_legacy_flat_response_runtime_falls_back_to_fcfs_without_sticking_slots(
 
     assert scheduler._shortest_tail_runtime_supported is False
     assert not scheduler._admission_prefill_uids
+    stats = scheduler.get_stats()
+    assert stats["configured_scheduling_policy"] == "shortest_validated_tail"
+    assert stats["scheduling_policy"] == "fcfs"
 
 
 def test_serve_cli_exposes_policy_and_starvation_bound():

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -276,6 +276,31 @@ def test_opt_in_keeps_excess_prompts_out_of_generator_but_fcfs_is_unchanged():
     assert not fcfs.waiting
 
 
+def test_empty_uid_insert_preserves_opt_in_request_without_spinning():
+    scheduler = Scheduler(
+        model=object(),
+        tokenizer=SimpleNamespace(
+            encode=lambda value: value,
+            decode=lambda value: str(value),
+            eos_token_id=0,
+            eos_token_ids={0},
+        ),
+        config=SchedulerConfig(
+            enable_prefix_cache=False,
+            scheduling_policy="shortest_validated_tail",
+        ),
+    )
+    scheduler.batch_generator = SimpleNamespace(insert=lambda *args, **kwargs: [])
+    scheduler._current_sampler_params = (frozenset(), False)
+    request = _request("retry-empty-uid", 1)
+    scheduler.requests[request.request_id] = request
+    scheduler.waiting.append(request)
+
+    assert scheduler._schedule_waiting() == []
+    assert list(scheduler.waiting) == [request]
+    assert request._admission_deferrals == 0
+
+
 def test_legacy_flat_response_runtime_falls_back_to_fcfs_without_sticking_slots():
     scheduler = Scheduler(
         MagicMock(),

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scope-locked tests for contention-aware prompt-slot admission."""
+
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+from vllm_mlx.cli import build_parser
+from vllm_mlx.request import Request, SamplingParams
+from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+
+
+def _request(request_id: str, tail: int, *, stop_ids=()) -> Request:
+    request = Request(
+        request_id=request_id,
+        prompt=request_id,
+        sampling_params=SamplingParams(stop_token_ids=list(stop_ids)),
+    )
+    request.prompt_token_ids = list(range(max(tail, 1)))
+    request.remaining_tokens = list(range(tail))
+    return request
+
+
+def _selector(*requests: Request, max_deferrals: int = 8) -> Scheduler:
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.config = SchedulerConfig(
+        scheduling_policy="shortest_validated_tail",
+        scheduling_max_deferrals=max_deferrals,
+    )
+    scheduler.waiting = deque(requests)
+    scheduler.running = {}
+    scheduler.batch_generator = None
+    scheduler._current_sampler_params = None
+    scheduler._admission_prefill_uids = set()
+    scheduler.num_admission_deferrals = 0
+    scheduler.num_admission_forced_grants = 0
+    return scheduler
+
+
+def test_default_policy_preserves_fcfs_and_validates_opt_in():
+    assert SchedulerConfig().scheduling_policy == "fcfs"
+    assert SchedulerConfig().scheduling_max_deferrals == 8
+    with pytest.raises(ValueError, match="scheduling_policy"):
+        SchedulerConfig(scheduling_policy="shortest_prompt")
+    for invalid in (0, -1, True, 1.5):
+        with pytest.raises(ValueError, match="scheduling_max_deferrals"):
+            SchedulerConfig(scheduling_max_deferrals=invalid)
+
+
+def test_shortest_validated_tail_wins_and_ties_remain_fifo():
+    long = _request("long", 4096)
+    short_first = _request("short-first", 8)
+    short_second = _request("short-second", 8)
+    scheduler = _selector(long, short_first, short_second)
+
+    assert scheduler._select_waiting_request() is short_first
+    assert list(scheduler.waiting) == [long, short_second]
+    assert long._admission_deferrals == 1
+    assert short_second._admission_deferrals == 1
+
+
+def test_incompatible_head_does_not_block_or_accrue_deferrals():
+    incompatible = _request("incompatible", 1, stop_ids=(9,))
+    compatible = _request("compatible", 20, stop_ids=(7,))
+    scheduler = _selector(incompatible, compatible)
+    scheduler.batch_generator = object()
+    scheduler.running = {"live": object()}
+    scheduler._current_sampler_params = (frozenset({7}), False)
+
+    assert scheduler._select_waiting_request() is compatible
+    assert list(scheduler.waiting) == [incompatible]
+    assert not hasattr(incompatible, "_admission_deferrals")
+
+
+def test_max_deferrals_forces_oldest_compatible_request():
+    old_long = _request("old-long", 4096)
+    old_long._admission_deferrals = 2
+    new_short = _request("new-short", 1)
+    scheduler = _selector(old_long, new_short, max_deferrals=2)
+
+    assert scheduler._select_waiting_request() is old_long
+    assert scheduler.num_admission_forced_grants == 1
+    assert list(scheduler.waiting) == [new_short]
+
+
+def test_cost_probe_does_not_mutate_invalid_cache_fallback():
+    request = _request("invalid-cache", 0)
+    request.prompt_token_ids = list(range(12))
+    request.prompt_cache = []
+    scheduler = _selector(request)
+
+    assert scheduler._validated_prompt_tail_cost(request) == 12
+    assert request.prompt_cache == []
+    assert request.remaining_tokens == []
+
+
+def test_policy_grants_only_real_prompt_and_completion_headroom():
+    scheduler = _selector()
+    scheduler.config.prefill_batch_size = 2
+    scheduler.config.completion_batch_size = 4
+    scheduler.config.max_num_seqs = 9
+    scheduler.running = {"a": object(), "b": object(), "c": object()}
+    scheduler._admission_prefill_uids = {11}
+
+    assert scheduler._shortest_tail_admission_capacity() == 1
+    scheduler._admission_prefill_uids.add(12)
+    assert scheduler._shortest_tail_admission_capacity() == 0
+
+
+def test_prompt_promotion_reopens_exactly_one_slot():
+    scheduler = _selector()
+    scheduler._admission_prefill_uids = {11, 12}
+    scheduler._record_prompt_promotions(
+        [
+            SimpleNamespace(uid=11, end_of_prompt=True),
+            SimpleNamespace(uid=12, end_of_prompt=False),
+        ]
+    )
+    assert scheduler._admission_prefill_uids == {12}
+
+
+def test_opt_in_keeps_excess_prompts_out_of_generator_but_fcfs_is_unchanged():
+    def run(policy: str):
+        scheduler = Scheduler(
+            model=object(),
+            tokenizer=SimpleNamespace(
+                encode=lambda value: value,
+                decode=lambda value: str(value),
+                eos_token_id=0,
+                eos_token_ids={0},
+            ),
+            config=SchedulerConfig(
+                max_num_seqs=3,
+                prefill_batch_size=1,
+                completion_batch_size=3,
+                enable_prefix_cache=False,
+                scheduling_policy=policy,
+            ),
+        )
+        scheduler.batch_generator = SimpleNamespace(
+            insert=lambda *args, **kwargs: [100 + len(scheduler.running)]
+        )
+        scheduler._current_sampler_params = (frozenset(), False)
+        for request in (
+            _request("long", 100),
+            _request("short", 2),
+            _request("medium", 20),
+        ):
+            scheduler.requests[request.request_id] = request
+            scheduler.waiting.append(request)
+        return scheduler, scheduler._schedule_waiting()
+
+    shortest, scheduled = run("shortest_validated_tail")
+    assert [request.request_id for request in scheduled] == ["short"]
+    assert [request.request_id for request in shortest.waiting] == ["long", "medium"]
+
+    fcfs, scheduled = run("fcfs")
+    assert [request.request_id for request in scheduled] == ["long", "short", "medium"]
+    assert not fcfs.waiting
+
+
+def test_serve_cli_exposes_policy_and_starvation_bound():
+    args = build_parser().parse_args(
+        [
+            "serve",
+            "model",
+            "--scheduling-policy",
+            "shortest_validated_tail",
+            "--scheduling-max-deferrals",
+            "3",
+        ]
+    )
+    assert args.scheduling_policy == "shortest_validated_tail"
+    assert args.scheduling_max_deferrals == 3

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -163,6 +163,17 @@ def test_opt_in_keeps_excess_prompts_out_of_generator_but_fcfs_is_unchanged():
     assert not fcfs.waiting
 
 
+def test_legacy_flat_response_runtime_falls_back_to_fcfs_without_sticking_slots():
+    scheduler = _selector(_request("long", 100), _request("short", 2))
+    scheduler._shortest_tail_runtime_supported = None
+    scheduler._admission_prefill_uids = {11}
+
+    scheduler._fallback_from_unobservable_prompt_runtime()
+
+    assert scheduler._shortest_tail_runtime_supported is False
+    assert not scheduler._admission_prefill_uids
+
+
 def test_serve_cli_exposes_policy_and_starvation_bound():
     args = build_parser().parse_args(
         [

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -125,6 +125,10 @@ def test_cost_probe_rejects_stale_tail_and_accepts_current_prompt_suffix():
     assert scheduler._validated_prompt_tail_cost(request) == 100
     request.prompt_cache = SimpleNamespace(offset="corrupt")
     assert scheduler._validated_prompt_tail_cost(request) == 100
+    request.prompt_cache = SimpleNamespace(offset=True)
+    assert scheduler._validated_prompt_tail_cost(request) == 100
+    request.prompt_cache = SimpleNamespace(offset=98.9)
+    assert scheduler._validated_prompt_tail_cost(request) == 100
 
 
 def test_selection_is_read_only_until_admission_commit():

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Scope-locked tests for contention-aware prompt-slot admission."""
 
+import sys
 from collections import deque
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -10,6 +11,7 @@ import pytest
 pytest.importorskip("mlx")
 pytestmark = pytest.mark.requires_mlx
 
+from vllm_mlx import server
 from vllm_mlx.cli import build_parser
 from vllm_mlx.request import Request, RequestStatus, SamplingParams
 from vllm_mlx.scheduler import Scheduler, SchedulerConfig
@@ -131,6 +133,37 @@ def test_cost_probe_rejects_stale_tail_and_accepts_current_prompt_suffix():
     assert scheduler._validated_prompt_tail_cost(request) == 100
 
 
+def test_cost_probe_observes_nested_cache_offsets_without_mutation():
+    cache = SimpleNamespace(
+        caches=[SimpleNamespace(offset=2), [SimpleNamespace(offset=2)]]
+    )
+
+    assert Scheduler._observable_prompt_cache_offsets(cache) == ((2, 2), True)
+
+
+def test_exact_cache_match_uses_trim_probe_and_safely_falls_back(monkeypatch):
+    request = _request("exact-cache", 0)
+    request.prompt_token_ids = [0, 1, 2]
+    request.cached_tokens = 3
+    request.prompt_cache = SimpleNamespace(offset=3)
+    scheduler = _selector(request)
+    scheduler._validate_cache = lambda _cache: True
+
+    import mlx_lm.models.cache as cache_module
+
+    monkeypatch.setattr(cache_module, "can_trim_prompt_cache", lambda _cache: True)
+    assert scheduler._validated_prompt_tail_cost(request) == 1
+
+    monkeypatch.setattr(cache_module, "can_trim_prompt_cache", lambda _cache: False)
+    assert scheduler._validated_prompt_tail_cost(request) == 3
+
+    def fail_trim(_cache):
+        raise RuntimeError("unsupported cache")
+
+    monkeypatch.setattr(cache_module, "can_trim_prompt_cache", fail_trim)
+    assert scheduler._validated_prompt_tail_cost(request) == 3
+
+
 def test_selection_is_read_only_until_admission_commit():
     old = _request("old", 100)
     old._admission_deferrals = 3
@@ -142,6 +175,34 @@ def test_selection_is_read_only_until_admission_commit():
     assert selected is short and not forced
     assert list(scheduler.waiting) == [old, short]
     assert old._admission_deferrals == 3
+
+
+def test_selection_returns_none_when_live_generator_is_incompatible():
+    request = _request("incompatible", 1, stop_ids=(9,))
+    scheduler = _selector(request)
+    scheduler.batch_generator = object()
+    scheduler.running = {"live": object()}
+    scheduler._current_sampler_params = (frozenset({7}), False)
+
+    assert scheduler._select_waiting_request() is None
+    assert scheduler._schedule_waiting() == []
+    assert list(scheduler.waiting) == [request]
+
+
+@pytest.mark.parametrize("generator_ready", [False, True])
+@pytest.mark.parametrize("policy", ["shortest_validated_tail", "fcfs"])
+def test_admission_failure_preserves_queue_and_deferrals(generator_ready, policy):
+    request = _request("retry", 1)
+    request._admission_deferrals = 2
+    scheduler = _selector(request)
+    scheduler.config.scheduling_policy = policy
+    scheduler._ensure_batch_generator = lambda _params: generator_ready
+    if generator_ready:
+        scheduler.batch_generator = None
+
+    assert scheduler._schedule_waiting() == []
+    assert list(scheduler.waiting) == [request]
+    assert request._admission_deferrals == 2
 
 
 def test_policy_grants_only_real_prompt_and_completion_headroom():
@@ -251,6 +312,66 @@ def test_legacy_flat_response_runtime_falls_back_to_fcfs_without_sticking_slots(
     assert stats["scheduling_policy"] == "fcfs"
 
 
+def test_tuple_response_records_prompt_promotion_and_runtime_support():
+    scheduler = Scheduler(
+        MagicMock(),
+        SimpleNamespace(
+            encode=lambda value: value,
+            decode=lambda value: str(value),
+            eos_token_id=0,
+            eos_token_ids={0},
+        ),
+        SchedulerConfig(
+            enable_prefix_cache=False,
+            scheduling_policy="shortest_validated_tail",
+        ),
+    )
+    request = _request("live", 1)
+    request.status = RequestStatus.RUNNING
+    scheduler.requests = {request.request_id: request}
+    scheduler.running = {request.request_id: request}
+    scheduler.batch_generator = SimpleNamespace(
+        next=lambda: ([SimpleNamespace(uid=11, end_of_prompt=True)], []),
+        _generation_batch=None,
+        _prompt_batch=None,
+        _currently_processing=(),
+        _unprocessed_sequences=(),
+    )
+    scheduler._admission_prefill_uids = {11}
+
+    scheduler.step()
+
+    assert scheduler._shortest_tail_runtime_supported is True
+    assert not scheduler._admission_prefill_uids
+
+
+def test_admission_mirror_is_cleared_on_generator_close_and_uid_forget():
+    scheduler = Scheduler(
+        MagicMock(),
+        SimpleNamespace(eos_token_id=0, eos_token_ids={0}),
+        SchedulerConfig(enable_prefix_cache=False),
+    )
+    scheduler._admission_prefill_uids = {7, 8}
+    scheduler._close_batch_generator()
+    assert not scheduler._admission_prefill_uids
+
+    scheduler._admission_prefill_uids = {7}
+    scheduler._forget_uid_grammar(7)
+    assert not scheduler._admission_prefill_uids
+
+
+def test_runtime_fallback_is_idempotent_and_ignored_for_fcfs():
+    scheduler = _selector()
+    scheduler._shortest_tail_runtime_supported = False
+    scheduler._fallback_from_unobservable_prompt_runtime()
+    assert scheduler._shortest_tail_runtime_supported is False
+
+    scheduler.config.scheduling_policy = "fcfs"
+    scheduler._shortest_tail_runtime_supported = None
+    scheduler._fallback_from_unobservable_prompt_runtime()
+    assert scheduler._shortest_tail_runtime_supported is None
+
+
 def test_serve_cli_exposes_policy_and_starvation_bound():
     args = build_parser().parse_args(
         [
@@ -264,3 +385,17 @@ def test_serve_cli_exposes_policy_and_starvation_bound():
     )
     assert args.scheduling_policy == "shortest_validated_tail"
     assert args.scheduling_max_deferrals == 3
+
+
+def test_standalone_server_parser_registers_admission_flags(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["vllm_mlx.server", "--scheduling-policy", "invalid"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        server.main()
+
+    assert exc.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -156,6 +156,12 @@ def test_policy_grants_only_real_prompt_and_completion_headroom():
     scheduler._admission_prefill_uids.add(12)
     assert scheduler._shortest_tail_admission_capacity() == 0
 
+    scheduler.running = {"a": object()}
+    scheduler._admission_prefill_uids.clear()
+    scheduler.config.prefill_batch_size = 4
+    scheduler.config.completion_batch_size = 2
+    assert scheduler._shortest_tail_admission_capacity() == 1
+
 
 def test_prompt_promotion_reopens_exactly_one_slot():
     scheduler = _selector()

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -80,7 +80,7 @@ def test_incompatible_head_does_not_block_or_accrue_deferrals():
     assert selected is compatible
     scheduler._commit_waiting_selection(selected, forced)
     assert list(scheduler.waiting) == [incompatible]
-    assert not hasattr(incompatible, "_admission_deferrals")
+    assert incompatible._admission_deferrals == 0
 
 
 def test_max_deferrals_forces_oldest_compatible_request():

--- a/tests/test_scheduler_admission_policy.py
+++ b/tests/test_scheduler_admission_policy.py
@@ -3,6 +3,7 @@
 
 from collections import deque
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -10,7 +11,7 @@ pytest.importorskip("mlx")
 pytestmark = pytest.mark.requires_mlx
 
 from vllm_mlx.cli import build_parser
-from vllm_mlx.request import Request, SamplingParams
+from vllm_mlx.request import Request, RequestStatus, SamplingParams
 from vllm_mlx.scheduler import Scheduler, SchedulerConfig
 
 
@@ -57,7 +58,11 @@ def test_shortest_validated_tail_wins_and_ties_remain_fifo():
     short_second = _request("short-second", 8)
     scheduler = _selector(long, short_first, short_second)
 
-    assert scheduler._select_waiting_request() is short_first
+    selected, forced = scheduler._select_waiting_request()
+    assert selected is short_first
+    assert not forced
+    assert list(scheduler.waiting) == [long, short_first, short_second]
+    scheduler._commit_waiting_selection(selected, forced)
     assert list(scheduler.waiting) == [long, short_second]
     assert long._admission_deferrals == 1
     assert short_second._admission_deferrals == 1
@@ -71,7 +76,9 @@ def test_incompatible_head_does_not_block_or_accrue_deferrals():
     scheduler.running = {"live": object()}
     scheduler._current_sampler_params = (frozenset({7}), False)
 
-    assert scheduler._select_waiting_request() is compatible
+    selected, forced = scheduler._select_waiting_request()
+    assert selected is compatible
+    scheduler._commit_waiting_selection(selected, forced)
     assert list(scheduler.waiting) == [incompatible]
     assert not hasattr(incompatible, "_admission_deferrals")
 
@@ -82,7 +89,10 @@ def test_max_deferrals_forces_oldest_compatible_request():
     new_short = _request("new-short", 1)
     scheduler = _selector(old_long, new_short, max_deferrals=2)
 
-    assert scheduler._select_waiting_request() is old_long
+    selected, forced = scheduler._select_waiting_request()
+    assert selected is old_long
+    assert forced
+    scheduler._commit_waiting_selection(selected, forced)
     assert scheduler.num_admission_forced_grants == 1
     assert list(scheduler.waiting) == [new_short]
 
@@ -96,6 +106,34 @@ def test_cost_probe_does_not_mutate_invalid_cache_fallback():
     assert scheduler._validated_prompt_tail_cost(request) == 12
     assert request.prompt_cache == []
     assert request.remaining_tokens == []
+
+
+def test_cost_probe_rejects_stale_tail_and_accepts_current_prompt_suffix():
+    request = _request("cache-hit", 100)
+    request.prompt_cache = object()
+    request.cached_tokens = 98
+    request.remaining_tokens = [98, 99]
+    scheduler = _selector(request)
+
+    assert scheduler._validated_prompt_tail_cost(request) == 2
+    request.remaining_tokens = [7, 8]
+    assert scheduler._validated_prompt_tail_cost(request) == 100
+    request.remaining_tokens = [98, 99]
+    request.prompt_cache = SimpleNamespace(offset=97)
+    assert scheduler._validated_prompt_tail_cost(request) == 100
+
+
+def test_selection_is_read_only_until_admission_commit():
+    old = _request("old", 100)
+    old._admission_deferrals = 3
+    short = _request("short", 1)
+    scheduler = _selector(old, short)
+
+    selected, forced = scheduler._select_waiting_request()
+
+    assert selected is short and not forced
+    assert list(scheduler.waiting) == [old, short]
+    assert old._admission_deferrals == 3
 
 
 def test_policy_grants_only_real_prompt_and_completion_headroom():
@@ -164,11 +202,33 @@ def test_opt_in_keeps_excess_prompts_out_of_generator_but_fcfs_is_unchanged():
 
 
 def test_legacy_flat_response_runtime_falls_back_to_fcfs_without_sticking_slots():
-    scheduler = _selector(_request("long", 100), _request("short", 2))
-    scheduler._shortest_tail_runtime_supported = None
+    scheduler = Scheduler(
+        MagicMock(),
+        SimpleNamespace(
+            encode=lambda value: value,
+            decode=lambda value: str(value),
+            eos_token_id=0,
+            eos_token_ids={0},
+        ),
+        SchedulerConfig(
+            enable_prefix_cache=False,
+            scheduling_policy="shortest_validated_tail",
+        ),
+    )
+    request = _request("live", 1)
+    request.status = RequestStatus.RUNNING
+    scheduler.requests = {request.request_id: request}
+    scheduler.running = {request.request_id: request}
+    scheduler.batch_generator = SimpleNamespace(
+        next=lambda: [],
+        _generation_batch=None,
+        _prompt_batch=None,
+        _currently_processing=(),
+        _unprocessed_sequences=(),
+    )
     scheduler._admission_prefill_uids = {11}
 
-    scheduler._fallback_from_unobservable_prompt_runtime()
+    scheduler.step()
 
     assert scheduler._shortest_tail_runtime_supported is False
     assert not scheduler._admission_prefill_uids

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -4712,6 +4712,8 @@ def serve_command(args):
         max_concurrent_requests=args.max_concurrent_requests,
         prefill_batch_size=args.prefill_batch_size,
         completion_batch_size=args.completion_batch_size,
+        scheduling_policy=args.scheduling_policy,
+        scheduling_max_deferrals=args.scheduling_max_deferrals,
         enable_prefix_cache=enable_prefix_cache,
         prefix_cache_size=args.prefix_cache_size,
         # R15-P1 (task #303): radix-tree prefix-cache index.
@@ -11195,6 +11197,26 @@ Examples:
     )
     serve_parser.add_argument(
         "--completion-batch-size", type=int, default=32, help="Completion batch size"
+    )
+    serve_parser.add_argument(
+        "--scheduling-policy",
+        choices=("fcfs", "shortest_validated_tail"),
+        default="fcfs",
+        help=(
+            "Prompt-slot admission order (default: fcfs). "
+            "shortest_validated_tail favors cache-hot and short prompts while "
+            "bounding how often an older compatible request may be deferred."
+        ),
+    )
+    serve_parser.add_argument(
+        "--scheduling-max-deferrals",
+        type=int,
+        default=8,
+        metavar="N",
+        help=(
+            "Maximum compatible prompt-slot grants that may pass over a request "
+            "under shortest_validated_tail before it is forced FIFO (default: 8)."
+        ),
     )
     serve_parser.add_argument(
         "--enable-prefix-cache",

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -245,6 +245,10 @@ class Request:
         None  # Type of cache hit: exact/prefix/supersequence/lcp/miss
     )
 
+    # Opt-in scheduler-local starvation accounting. ``init=False`` keeps the
+    # public and positional Request constructor unchanged.
+    _admission_deferrals: int = field(default=0, init=False, repr=False)
+
     @property
     def num_output_tokens(self) -> int:
         """Number of output tokens generated so far."""

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -3776,6 +3776,11 @@ class Scheduler:
         # driven mirror to avoid filling mlx-lm's private FIFO ahead of its
         # actual prefill slots. Default FCFS never reads this set.
         self._admission_prefill_uids: set[int] = set()
+        # None until the first BatchGenerator response establishes whether the
+        # public prompt-promotion stream is available. Older mlx-lm versions
+        # return a flat generation list; the opt-in policy then fails safe to
+        # historical FCFS because it cannot observe prompt-slot release.
+        self._shortest_tail_runtime_supported: bool | None = None
 
         # #558 PR-3: authoritative per-uid logits-processor state. mlx-lm's
         # ``GenerationBatch`` keys ``logits_processors`` positionally by uid
@@ -5294,6 +5299,22 @@ class Scheduler:
         for response in prompt_responses or ():
             if getattr(response, "end_of_prompt", False):
                 self._admission_prefill_uids.discard(response.uid)
+
+    def _fallback_from_unobservable_prompt_runtime(self) -> None:
+        """Disable opt-in ranking when an old runtime hides promotions."""
+        if (
+            getattr(self.config, "scheduling_policy", "fcfs")
+            != "shortest_validated_tail"
+            or getattr(self, "_shortest_tail_runtime_supported", None) is False
+        ):
+            return
+        self._shortest_tail_runtime_supported = False
+        self._admission_prefill_uids.clear()
+        logger.warning(
+            "shortest_validated_tail requires prompt-promotion responses; "
+            "this mlx-lm runtime returns the legacy flat response shape, "
+            "falling back to FCFS"
+        )
 
     def _validate_cache(self, cache: Any) -> bool:
         """
@@ -8032,6 +8053,7 @@ class Scheduler:
         shortest_tail = (
             getattr(self.config, "scheduling_policy", "fcfs")
             == "shortest_validated_tail"
+            and getattr(self, "_shortest_tail_runtime_supported", None) is not False
         )
         while self.waiting and len(self.running) < self._max_running_sequences():
             if shortest_tail:
@@ -9344,6 +9366,7 @@ class Scheduler:
                             getattr(self.config, "scheduling_policy", "fcfs")
                             == "shortest_validated_tail"
                         ):
+                            self._shortest_tail_runtime_supported = True
                             self._record_prompt_promotions(prompt_responses)
                         self._snapshot_promoted_prompts(prompt_responses)
                         # issue #427: per-message boundary snapshot for
@@ -9351,6 +9374,7 @@ class Scheduler:
                         # but prompt still has tail to process).
                         self._snapshot_boundary_segments(prompt_responses)
                     else:
+                        self._fallback_from_unobservable_prompt_runtime()
                         responses = raw_next
 
                     if responses:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5237,15 +5237,13 @@ class Scheduler:
             offset = getattr(value, "offset", None)
             if offset is None:
                 return
-            try:
-                parsed = int(offset)
-            except (TypeError, ValueError):
+            if isinstance(offset, bool) or not isinstance(offset, int):
                 valid = False
                 return
-            if parsed < 0:
+            if offset < 0:
                 valid = False
                 return
-            values.append(parsed)
+            values.append(offset)
 
         visit(cache)
         return tuple(values), valid

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5303,9 +5303,7 @@ class Scheduler:
             return None
         max_deferrals = self.config.scheduling_max_deferrals
         forced = [
-            pair
-            for pair in candidates
-            if int(getattr(pair[1], "_admission_deferrals", 0)) >= max_deferrals
+            pair for pair in candidates if pair[1]._admission_deferrals >= max_deferrals
         ]
         if forced:
             _selected_index, selected = forced[0]
@@ -5330,9 +5328,7 @@ class Scheduler:
         for request in candidates:
             if request is selected:
                 continue
-            request._admission_deferrals = (
-                int(getattr(request, "_admission_deferrals", 0)) + 1
-            )
+            request._admission_deferrals += 1
             self.num_admission_deferrals += 1
         selected._admission_deferrals = 0
         self.waiting.remove(selected)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5345,10 +5345,7 @@ class Scheduler:
         )
         completion_capacity = min(
             self._max_running_sequences(),
-            max(
-                int(self.config.prefill_batch_size),
-                int(self.config.completion_batch_size),
-            ),
+            int(self.config.completion_batch_size),
         )
         completion_headroom = max(0, completion_capacity - len(self.running))
         return min(prompt_headroom, completion_headroom)

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5218,11 +5218,13 @@ class Scheduler:
         return self._current_sampler_params == self._request_generator_key(request)
 
     @staticmethod
-    def _observable_prompt_cache_offsets(cache: Any) -> tuple[int, ...]:
+    def _observable_prompt_cache_offsets(cache: Any) -> tuple[tuple[int, ...], bool]:
         """Read logical cache offsets without modifying cache objects."""
         values: list[int] = []
+        valid = True
 
         def visit(value: Any) -> None:
+            nonlocal valid
             children = getattr(value, "caches", None)
             if isinstance(children, (list, tuple)):
                 for child in children:
@@ -5238,12 +5240,15 @@ class Scheduler:
             try:
                 parsed = int(offset)
             except (TypeError, ValueError):
+                valid = False
                 return
-            if parsed >= 0:
-                values.append(parsed)
+            if parsed < 0:
+                valid = False
+                return
+            values.append(parsed)
 
         visit(cache)
-        return tuple(values)
+        return tuple(values), valid
 
     def _validated_prompt_tail_cost(self, request: Request) -> int:
         """Estimate committed prompt work without mutating cache/request state."""
@@ -5265,9 +5270,11 @@ class Scheduler:
             or remaining != prompt_tokens[cached_tokens:]
         ):
             return len(prompt_tokens)
-        observed_offsets = self._observable_prompt_cache_offsets(cache)
-        if observed_offsets and any(
-            offset != cached_tokens for offset in observed_offsets
+        observed_offsets, offsets_valid = self._observable_prompt_cache_offsets(cache)
+        if (
+            not offsets_valid
+            or observed_offsets
+            and any(offset != cached_tokens for offset in observed_offsets)
         ):
             return len(prompt_tokens)
         if remaining:
@@ -10006,7 +10013,14 @@ class Scheduler:
             "num_repetition_loop_breaks": self.num_repetition_loop_breaks,
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
-            "scheduling_policy": getattr(self.config, "scheduling_policy", "fcfs"),
+            "configured_scheduling_policy": getattr(
+                self.config, "scheduling_policy", "fcfs"
+            ),
+            "scheduling_policy": (
+                "fcfs"
+                if getattr(self, "_shortest_tail_runtime_supported", None) is False
+                else getattr(self.config, "scheduling_policy", "fcfs")
+            ),
             "num_admission_deferrals": getattr(self, "num_admission_deferrals", 0),
             "num_admission_forced_grants": getattr(
                 self, "num_admission_forced_grants", 0

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -5217,19 +5217,61 @@ class Scheduler:
             return True
         return self._current_sampler_params == self._request_generator_key(request)
 
+    @staticmethod
+    def _observable_prompt_cache_offsets(cache: Any) -> tuple[int, ...]:
+        """Read logical cache offsets without modifying cache objects."""
+        values: list[int] = []
+
+        def visit(value: Any) -> None:
+            children = getattr(value, "caches", None)
+            if isinstance(children, (list, tuple)):
+                for child in children:
+                    visit(child)
+                return
+            if isinstance(value, (list, tuple)):
+                for child in value:
+                    visit(child)
+                return
+            offset = getattr(value, "offset", None)
+            if offset is None:
+                return
+            try:
+                parsed = int(offset)
+            except (TypeError, ValueError):
+                return
+            if parsed >= 0:
+                values.append(parsed)
+
+        visit(cache)
+        return tuple(values)
+
     def _validated_prompt_tail_cost(self, request: Request) -> int:
         """Estimate committed prompt work without mutating cache/request state."""
         prompt_tokens = request.prompt_token_ids or []
         cache = request.prompt_cache
-        if cache is not None and not self._validate_cache(cache):
+        if cache is None:
+            return len(prompt_tokens)
+        if not self._validate_cache(cache):
             return len(prompt_tokens)
         remaining = request.remaining_tokens
-        if remaining is None:
+        cached_tokens = request.cached_tokens
+        if (
+            remaining is None
+            or isinstance(cached_tokens, bool)
+            or not isinstance(cached_tokens, int)
+            or cached_tokens < 0
+            or cached_tokens > len(prompt_tokens)
+            or len(remaining) != len(prompt_tokens) - cached_tokens
+            or remaining != prompt_tokens[cached_tokens:]
+        ):
+            return len(prompt_tokens)
+        observed_offsets = self._observable_prompt_cache_offsets(cache)
+        if observed_offsets and any(
+            offset != cached_tokens for offset in observed_offsets
+        ):
             return len(prompt_tokens)
         if remaining:
             return len(remaining)
-        if cache is None:
-            return max(1, len(prompt_tokens))
         try:
             from mlx_lm.models.cache import can_trim_prompt_cache
 
@@ -5239,8 +5281,8 @@ class Scheduler:
             pass
         return len(prompt_tokens)
 
-    def _select_waiting_request(self) -> Request | None:
-        """Remove and return the next opt-in admission candidate.
+    def _select_waiting_request(self) -> tuple[Request, bool] | None:
+        """Choose, but do not remove, the next opt-in admission candidate.
 
         Incompatible requests remain in place and do not accrue deferrals:
         they cannot legally join the live generator. Compatible candidates
@@ -5261,14 +5303,26 @@ class Scheduler:
             if int(getattr(pair[1], "_admission_deferrals", 0)) >= max_deferrals
         ]
         if forced:
-            selected_index, selected = forced[0]
-            self.num_admission_forced_grants += 1
+            _selected_index, selected = forced[0]
+            forced_selection = True
         else:
-            selected_index, selected = min(
+            _selected_index, selected = min(
                 candidates,
                 key=lambda pair: (self._validated_prompt_tail_cost(pair[1]), pair[0]),
             )
-        for _index, request in candidates:
+            forced_selection = False
+        return selected, forced_selection
+
+    def _commit_waiting_selection(self, selected: Request, forced: bool) -> None:
+        """Commit queue/fairness state only after generator insertion succeeds."""
+        candidates = [
+            request
+            for request in self.waiting
+            if self._request_is_generator_compatible(request)
+        ]
+        if forced:
+            self.num_admission_forced_grants += 1
+        for request in candidates:
             if request is selected:
                 continue
             request._admission_deferrals = (
@@ -5276,8 +5330,7 @@ class Scheduler:
             )
             self.num_admission_deferrals += 1
         selected._admission_deferrals = 0
-        del self.waiting[selected_index]
-        return selected
+        self.waiting.remove(selected)
 
     def _shortest_tail_admission_capacity(self) -> int:
         """Return grants available without creating an internal prompt FIFO."""
@@ -8059,11 +8112,13 @@ class Scheduler:
             if shortest_tail:
                 if self._shortest_tail_admission_capacity() <= 0:
                     break
-                request = self._select_waiting_request()
-                if request is None:
+                selection = self._select_waiting_request()
+                if selection is None:
                     break
+                request, selection_forced = selection
             else:
                 request = self.waiting.popleft()
+                selection_forced = False
 
             # Ensure we have a batch generator. The False return means
             # the live generator has incompatible stop_tokens / sampler
@@ -8072,12 +8127,14 @@ class Scheduler:
             # PR #612). Requeue and break so the next ``step`` retries
             # once the running batch completes.
             if not self._ensure_batch_generator(request.sampling_params):
-                self.waiting.appendleft(request)
+                if not shortest_tail:
+                    self.waiting.appendleft(request)
                 break
 
             if self.batch_generator is None:
                 # Put back and try again later
-                self.waiting.appendleft(request)
+                if not shortest_tail:
+                    self.waiting.appendleft(request)
                 break
 
             # Determine tokens to process and cache to use
@@ -8368,6 +8425,8 @@ class Scheduler:
 
             if uids:
                 uid = uids[0]
+                if shortest_tail:
+                    self._commit_waiting_selection(request, selection_forced)
                 self.request_id_to_uid[request.request_id] = uid
                 self.uid_to_request_id[uid] = request.request_id
                 if shortest_tail:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -561,7 +561,26 @@ class SchedulerConfig:
     # positional_prefix``.
     kv_cache_dtype_explicit: bool = False
 
+    # Opt-in queue discipline for prompt-slot admission. ``fcfs`` preserves
+    # the historical zero-scan path. ``shortest_validated_tail`` keeps excess
+    # requests in Rapid's queue and grants an open prompt slot to the request
+    # with the least cache-validated work. Appended for positional callers.
+    scheduling_policy: str = "fcfs"
+    # Bound how many compatible grants may pass over one request before it is
+    # forced into the next available slot. Only used by the opt-in policy.
+    scheduling_max_deferrals: int = 8
+
     def __post_init__(self) -> None:
+        if self.scheduling_policy not in ("fcfs", "shortest_validated_tail"):
+            raise ValueError(
+                "scheduling_policy must be 'fcfs' or 'shortest_validated_tail'"
+            )
+        if (
+            isinstance(self.scheduling_max_deferrals, bool)
+            or not isinstance(self.scheduling_max_deferrals, int)
+            or self.scheduling_max_deferrals < 1
+        ):
+            raise ValueError("scheduling_max_deferrals must be a positive integer")
         if not isinstance(self.mtp_continuous_batching, bool):
             raise ValueError("mtp_continuous_batching must be a boolean")
         if not isinstance(self.mtp_allow_dynamic_membership, bool):
@@ -3752,6 +3771,11 @@ class Scheduler:
         # Mapping between our request IDs and BatchGenerator UIDs
         self.request_id_to_uid: dict[str, int] = {}
         self.uid_to_request_id: dict[int, str] = {}
+        # Uids admitted to mlx-lm but not yet promoted out of prompt
+        # processing. The opt-in admission policy uses this public-response-
+        # driven mirror to avoid filling mlx-lm's private FIFO ahead of its
+        # actual prefill slots. Default FCFS never reads this set.
+        self._admission_prefill_uids: set[int] = set()
 
         # #558 PR-3: authoritative per-uid logits-processor state. mlx-lm's
         # ``GenerationBatch`` keys ``logits_processors`` positionally by uid
@@ -4021,6 +4045,9 @@ class Scheduler:
         self.num_requests_processed = 0
         self.total_prompt_tokens = 0
         self.total_completion_tokens = 0
+        # Opt-in admission-policy observability. Counters stay zero on FCFS.
+        self.num_admission_deferrals = 0
+        self.num_admission_forced_grants = 0
         # Last observed text-path throughput. The upstream BatchGenerator has
         # no stats object, so derive rates from request timing in our wrapper.
         self._last_prompt_tps = 0.0
@@ -5082,6 +5109,7 @@ class Scheduler:
             except Exception as e:
                 logger.debug(f"Error closing BatchGenerator: {e}")
             self.batch_generator = None
+        getattr(self, "_admission_prefill_uids", set()).clear()
         # The hook lives on the closed generator. Clear its published runtime
         # state even when close() raised; a replacement will republish only
         # after its own installer succeeds.
@@ -5169,6 +5197,103 @@ class Scheduler:
             self._current_sampler_params = sampler_params
 
         return True
+
+    @staticmethod
+    def _request_generator_key(request: Request) -> tuple[frozenset[int], bool]:
+        params = request.sampling_params
+        return (
+            frozenset(params.stop_token_ids or ()),
+            bool(params.ignore_eos),
+        )
+
+    def _request_is_generator_compatible(self, request: Request) -> bool:
+        """Pure compatibility probe used while ranking waiting requests."""
+        if self.batch_generator is None or not self.running:
+            return True
+        return self._current_sampler_params == self._request_generator_key(request)
+
+    def _validated_prompt_tail_cost(self, request: Request) -> int:
+        """Estimate committed prompt work without mutating cache/request state."""
+        prompt_tokens = request.prompt_token_ids or []
+        cache = request.prompt_cache
+        if cache is not None and not self._validate_cache(cache):
+            return len(prompt_tokens)
+        remaining = request.remaining_tokens
+        if remaining is None:
+            return len(prompt_tokens)
+        if remaining:
+            return len(remaining)
+        if cache is None:
+            return max(1, len(prompt_tokens))
+        try:
+            from mlx_lm.models.cache import can_trim_prompt_cache
+
+            if can_trim_prompt_cache(cache):
+                return 1
+        except Exception:  # noqa: BLE001 - commit path safely cold-prefills
+            pass
+        return len(prompt_tokens)
+
+    def _select_waiting_request(self) -> Request | None:
+        """Remove and return the next opt-in admission candidate.
+
+        Incompatible requests remain in place and do not accrue deferrals:
+        they cannot legally join the live generator. Compatible candidates
+        passed over by a grant accrue one deferral. Once the configured bound
+        is reached, the oldest forced candidate outranks the cost metric.
+        """
+        candidates = [
+            (index, request)
+            for index, request in enumerate(self.waiting)
+            if self._request_is_generator_compatible(request)
+        ]
+        if not candidates:
+            return None
+        max_deferrals = self.config.scheduling_max_deferrals
+        forced = [
+            pair
+            for pair in candidates
+            if int(getattr(pair[1], "_admission_deferrals", 0)) >= max_deferrals
+        ]
+        if forced:
+            selected_index, selected = forced[0]
+            self.num_admission_forced_grants += 1
+        else:
+            selected_index, selected = min(
+                candidates,
+                key=lambda pair: (self._validated_prompt_tail_cost(pair[1]), pair[0]),
+            )
+        for _index, request in candidates:
+            if request is selected:
+                continue
+            request._admission_deferrals = (
+                int(getattr(request, "_admission_deferrals", 0)) + 1
+            )
+            self.num_admission_deferrals += 1
+        selected._admission_deferrals = 0
+        del self.waiting[selected_index]
+        return selected
+
+    def _shortest_tail_admission_capacity(self) -> int:
+        """Return grants available without creating an internal prompt FIFO."""
+        prompt_headroom = max(
+            0,
+            int(self.config.prefill_batch_size) - len(self._admission_prefill_uids),
+        )
+        completion_capacity = min(
+            self._max_running_sequences(),
+            max(
+                int(self.config.prefill_batch_size),
+                int(self.config.completion_batch_size),
+            ),
+        )
+        completion_headroom = max(0, completion_capacity - len(self.running))
+        return min(prompt_headroom, completion_headroom)
+
+    def _record_prompt_promotions(self, prompt_responses: Any) -> None:
+        for response in prompt_responses or ():
+            if getattr(response, "end_of_prompt", False):
+                self._admission_prefill_uids.discard(response.uid)
 
     def _validate_cache(self, cache: Any) -> bool:
         """
@@ -7386,6 +7511,7 @@ class Scheduler:
         disarms the guard (codex). Penalty-only uids carry no stateful processor
         and are simply dropped.
         """
+        getattr(self, "_admission_prefill_uids", set()).discard(uid)
         self._uids_with_grammar.discard(uid)
         self._uids_with_reasoning_budget.pop(uid, None)
         self._uids_with_suppressed_tokens.pop(uid, None)
@@ -7903,8 +8029,19 @@ class Scheduler:
         # and explicitly supports B=1. Keep later requests in the ordinary
         # scheduler queue until that request departs; this preserves liveness
         # without ever attempting a lossy MTP-to-plain handoff mid-stream.
+        shortest_tail = (
+            getattr(self.config, "scheduling_policy", "fcfs")
+            == "shortest_validated_tail"
+        )
         while self.waiting and len(self.running) < self._max_running_sequences():
-            request = self.waiting.popleft()
+            if shortest_tail:
+                if self._shortest_tail_admission_capacity() <= 0:
+                    break
+                request = self._select_waiting_request()
+                if request is None:
+                    break
+            else:
+                request = self.waiting.popleft()
 
             # Ensure we have a batch generator. The False return means
             # the live generator has incompatible stop_tokens / sampler
@@ -8211,6 +8348,8 @@ class Scheduler:
                 uid = uids[0]
                 self.request_id_to_uid[request.request_id] = uid
                 self.uid_to_request_id[uid] = request.request_id
+                if shortest_tail:
+                    self._admission_prefill_uids.add(uid)
                 request.batch_uid = uid
                 request.status = RequestStatus.RUNNING
                 request._prefill_started_at = time.time()
@@ -9201,6 +9340,11 @@ class Scheduler:
                     # older versions return a flat list of responses
                     if isinstance(raw_next, tuple):
                         prompt_responses, responses = raw_next
+                        if (
+                            getattr(self.config, "scheduling_policy", "fcfs")
+                            == "shortest_validated_tail"
+                        ):
+                            self._record_prompt_promotions(prompt_responses)
                         self._snapshot_promoted_prompts(prompt_responses)
                         # issue #427: per-message boundary snapshot for
                         # multi-turn hybrid workloads (segment finished
@@ -9779,6 +9923,11 @@ class Scheduler:
             "num_repetition_loop_breaks": self.num_repetition_loop_breaks,
             "total_prompt_tokens": self.total_prompt_tokens,
             "total_completion_tokens": self.total_completion_tokens,
+            "scheduling_policy": getattr(self.config, "scheduling_policy", "fcfs"),
+            "num_admission_deferrals": getattr(self, "num_admission_deferrals", 0),
+            "num_admission_forced_grants": getattr(
+                self, "num_admission_forced_grants", 0
+            ),
             "batch_generator": {
                 "prompt_tps": round(self._last_prompt_tps, 2),
                 "generation_tps": round(self._last_generation_tps, 2),

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -8421,6 +8421,13 @@ class Scheduler:
                 else:
                     raise
 
+            # Opt-in selection is deliberately transactional: an empty insert
+            # result has not committed queue or fairness state. Leave the
+            # request in place and retry on a later scheduler tick instead of
+            # spinning forever in this unchanged loop.
+            if not uids and shortest_tail:
+                break
+
             if uids:
                 uid = uids[0]
                 if shortest_tail:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -3404,6 +3404,19 @@ Examples:
         "Larger values may improve TTFT on Apple Silicon with sufficient memory.",
     )
     parser.add_argument(
+        "--scheduling-policy",
+        choices=("fcfs", "shortest_validated_tail"),
+        default="fcfs",
+        help="Prompt-slot admission order (default: fcfs).",
+    )
+    parser.add_argument(
+        "--scheduling-max-deferrals",
+        type=int,
+        default=8,
+        metavar="N",
+        help="Starvation bound for shortest_validated_tail (default: 8 grants).",
+    )
+    parser.add_argument(
         "--vision-prefill-token-budget",
         type=int,
         default=None,
@@ -3800,6 +3813,8 @@ Examples:
 
     scheduler_config = SchedulerConfig(
         prefill_step_size=args.prefill_step_size,
+        scheduling_policy=args.scheduling_policy,
+        scheduling_max_deferrals=args.scheduling_max_deferrals,
         vision_prefill_token_budget=vision_prefill_token_budget,
         vision_min_pixels=args.vision_min_pixels,
         vision_max_pixels=args.vision_max_pixels,


### PR DESCRIPTION
## User impact

Adds an opt-in `shortest_validated_tail` prompt-slot admission policy so short and cache-hot interactive requests do not sit behind unstarted long prompts. On an M3 Ultra with Qwen3-0.6B-4bit, three 8,000-word prompts contending with one short prompt at prefill B=1, short-request TTFT median fell from **3.067s to 1.206s: 2.54x faster and 60.7% lower** across five waves per arm.

The historical `fcfs` policy remains the default and keeps its direct dequeue path. The new policy does not preempt a running prompt. It retains excess work in the Rapid-MLX queue, ranks only cache-validated remaining prompt work, respects live stop-token compatibility, and forces the oldest compatible request after a configurable number of pass-overs to prevent starvation.

Closes #1950.

## Scope

- append-only scheduler config fields and validation
- `rapid-mlx serve` and standalone server CLI flags
- prompt/completion-slot-aware admission and promotion tracking
- non-mutating cache-tail cost estimation
- compatibility-aware selection and bounded deferral counters
- focused tests, CLI documentation, and reproducible performance evidence

## Non-goals

- no default scheduling change
- no running-request preemption or prompt-chunk yielding
- no request-priority API activation
- no multimodal scheduler or dependency changes

## Validation

- Real-server contention dogfood: 3.067s -> 1.206s median short TTFT, five waves per arm
- Real-server B=1 greedy parity: byte-identical `black, white, gray` output under both policies
- Full non-external suite: 22,973 passed, 138 skipped, 25 deselected, 6 xfailed, 1 xpassed
- Post-review focused scheduler/cache/request regressions: 229 passed, 2 deselected
- Exact-head PR validation: MERGE-SAFE with no blocking findings
- Ruff lint and format: pass
- CLI/config fidelity audit: pass
- Pinned Python 3.11 mypy error budget: pass, zero growth
- One full-suite image precision test lacks the optional `mflux` package in this local environment; the exact same failure reproduces on clean base `dcad4aa90`

Detailed environment, commands, raw TTFT samples, interpretation, and parity evidence are recorded in `docs/engineering/performance/scheduler-admission-1950.md`.