### PR TITLE
fix(mac): keep short follow-up replies pinned to latest

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -288,6 +288,10 @@ struct ChatView: View {
     /// preference arrives after the scroll event, which leaves a window
     /// where the next streamed token can still yank the reader downward.
     @State private var isPinnedToBottom = true
+    /// Measured from the live assistant row itself. Whole-document growth is
+    /// not a safe proxy in a multi-turn transcript because older Markdown can
+    /// finish layout after the next request starts.
+    @State private var streamingAnswerHeight: CGFloat = 0
     /// Incremented to ask the probe for an explicit scroll — see
     /// ``TranscriptScrollPositionProbe/scrollToBottomRequest``.
     @State private var scrollToBottomRequest = 0
@@ -442,6 +446,9 @@ struct ChatView: View {
                             isPinnedToBottom: $isPinnedToBottom,
                             bottomResumeSlack: bottomResumeSlack,
                             isStreaming: viewModel.isStreaming,
+                            streamingMessageID: viewModel.streamingBody?.id,
+                            streamingContentLength: viewModel.streamingBody?.text.utf8.count ?? 0,
+                            streamingAnswerHeight: streamingAnswerHeight,
                             scrollToBottomRequest: scrollToBottomRequest
                         )
                     )
@@ -457,7 +464,16 @@ struct ChatView: View {
             // A new message is deliberate navigation to the conversation
             // tip; streamed frame changes then keep following from there.
             .onAppear { isPinnedToBottom = true }
-            .onChange(of: messages.count) { _, _ in isPinnedToBottom = true }
+            .onChange(of: messages.count) { _, _ in
+                isPinnedToBottom = true
+                // Re-pinning is only policy. If the previous long answer
+                // deliberately released following, the already-attached
+                // AppKit scroll view is still physically above the tip and
+                // has no new-attachment event to move it. A new message is an
+                // explicit navigation to the tip, so send the same concrete
+                // request used by the Jump to latest button.
+                scrollToBottomRequest += 1
+            }
             // Switching conversations is navigation to a DIFFERENT tip, but it
             // need not change `messages.count` — two conversations can have the
             // same number of turns, and then the count-keyed reset above never
@@ -597,6 +613,17 @@ struct ChatView: View {
                     )
                     .frame(maxWidth: contentMaxWidth, alignment: .leading)
                     .frame(maxWidth: .infinity, alignment: .center)
+                    .background {
+                        if message.role == .assistant,
+                           message.status == .streaming {
+                            GeometryReader { proxy in
+                                Color.clear.preference(
+                                    key: StreamingAnswerHeightKey.self,
+                                    value: proxy.size.height
+                                )
+                            }
+                        }
+                    }
                     .id(message.id)
                 }
             }
@@ -620,6 +647,9 @@ struct ChatView: View {
         }
         .padding(.horizontal, RapidTheme.Space.xl)
         .padding(.vertical, RapidTheme.Space.xl)
+        .onPreferenceChange(StreamingAnswerHeightKey.self) { height in
+            streamingAnswerHeight = height
+        }
     }
 
     /// Index every ``role: .tool`` row by the ``toolCallID`` it answers, so an
@@ -3104,6 +3134,16 @@ extension MarkdownUI.Theme {
                 )
         }
 }
+/// Carries the live assistant row's post-layout height to the AppKit scroll
+/// coordinator, which uses it for the one-viewport follow threshold.
+private struct StreamingAnswerHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 /// Carries the code block's scrollable content span up to
 /// ``CodeBlockWithCopy``. Measured inside the scroll view, so the
 /// value tracks the scroll offset as well as the content width.

--- a/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/TranscriptScrollPositionProbe.swift
@@ -12,6 +12,13 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
     /// releases once the new answer grows beyond one viewport, so the reader
     /// can start at its beginning without fighting continuous auto-scroll.
     var isStreaming: Bool = false
+    /// Identity and accumulated size distinguish a genuinely growing answer
+    /// from layout work still landing for the preceding turn.
+    var streamingMessageID: UUID? = nil
+    var streamingContentLength: Int = 0
+    /// Height of the current assistant row, measured by SwiftUI after layout.
+    /// This is authoritative when a message identity is available.
+    var streamingAnswerHeight: CGFloat = 0
     /// Bumped by anything outside that wants the transcript moved to the
     /// bottom right now, ``JumpToBottomButton`` being the only caller today.
     ///
@@ -45,7 +52,12 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
             isPinnedToBottom: $isPinnedToBottom,
             bottomResumeSlack: bottomResumeSlack
         )
-        context.coordinator.setStreaming(isStreaming)
+        context.coordinator.setStreaming(
+            isStreaming,
+            messageID: streamingMessageID,
+            contentLength: streamingContentLength,
+            answerHeight: streamingAnswerHeight
+        )
         context.coordinator.attach(to: probe)
         // After ``attach``: a first render arrives with the token already at
         // its initial value, and attaching is what anchors that one.
@@ -102,7 +114,16 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
                 attachmentChanged = true
             }
             attachmentChanged = observeDocumentViewIfNeeded() || attachmentChanged
-            if isStreaming, documentHeightAtStreamStart == nil {
+            // Only a newly attached document has a trustworthy synchronous
+            // stream baseline. On an already-mounted SwiftUI transcript,
+            // `setStreaming(true)` can run before the just-appended user row
+            // (and deferred markdown from the previous turn) has laid out.
+            // Capturing that stale height here makes old layout work look like
+            // one viewport of new answer and spuriously releases following.
+            // Let the first document-frame notification establish the settled
+            // baseline in that case.
+            if attachmentChanged, isStreaming, hasSeenStreamingContent,
+               documentHeightAtStreamStart == nil {
                 documentHeightAtStreamStart = documentView?.bounds.height
             }
             // updateNSView runs for every streamed mutation. Document-frame
@@ -156,6 +177,26 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
         @objc private func boundsDidChange(_ notification: Notification) {
             // Our frame-driven movement emits this too; it is not user intent.
             guard !isProgrammaticScroll else { return }
+            // SwiftUI/AppKit can also adjust the clip bounds while an older
+            // Markdown row finishes layout. Those notifications have no
+            // input event and must not silently disable following. Legacy
+            // mouse wheels are the reason this path cannot rely only on the
+            // live-scroll bracket, so keep the actual input event types as a
+            // second source of user intent.
+            let currentEvent = NSApplication.shared.currentEvent
+            let eventType = currentEvent?.type
+            let hasUnbracketedUserIntent = eventType == .scrollWheel
+                || eventType == .leftMouseDragged
+                || (eventType == .keyDown
+                    && Self.isTranscriptScrollKey(currentEvent?.keyCode))
+            // Outside a stream, no document growth is competing with the
+            // gesture. Treat an off-bottom bounds change as navigation even
+            // when AppKit exposes no originating event (VoiceOver and AX
+            // scroll actions take this path).
+            guard !isStreaming || isLiveScrolling || hasUnbracketedUserIntent else {
+                if isAtBottom { setPinned(true) }
+                return
+            }
             if !isAtBottom {
                 // Any move away from the bottom releases the pin — whether or
                 // not AppKit bracketed it. A legacy mouse wheel can post bounds
@@ -199,29 +240,81 @@ struct TranscriptScrollPositionProbe: NSViewRepresentable {
 
         private var didReleaseForCurrentStream = false
         private var isStreaming = false
+        private var streamingMessageID: UUID?
+        private var hasSeenStreamingContent = false
+        private var streamingAnswerHeight: CGFloat = 0
         private var documentHeightAtStreamStart: CGFloat?
 
-        func setStreaming(_ streaming: Bool) {
-            guard streaming != isStreaming else { return }
+        /// AppKit key codes for Home, Page Up, End, Page Down, Down, and Up.
+        /// Ordinary typing/navigation in the composer must not look like a
+        /// transcript scroll merely because layout happened in the same event.
+        static func isTranscriptScrollKey(_ keyCode: UInt16?) -> Bool {
+            guard let keyCode else { return false }
+            return [115, 116, 119, 121, 125, 126].contains(keyCode)
+        }
+
+        func setStreaming(
+            _ streaming: Bool,
+            messageID: UUID? = nil,
+            contentLength: Int = 0,
+            answerHeight: CGFloat = 0
+        ) {
+            let startedNewMessage = streaming && messageID != streamingMessageID
+            let changedStreamingState = streaming != isStreaming
             isStreaming = streaming
-            if streaming {
+
+            if streaming && (changedStreamingState || startedNewMessage) {
                 didReleaseForCurrentStream = false
-                documentHeightAtStreamStart = documentView?.bounds.height
-            } else {
+                // The representable update that reports `streaming` can
+                // precede SwiftUI's layout for the newly appended user row.
+                // A newly attached document is captured in `attach`; an
+                // existing one takes its baseline from its next frame change.
+                documentHeightAtStreamStart = nil
+                hasSeenStreamingContent = false
+            } else if !streaming {
+                documentHeightAtStreamStart = nil
+                hasSeenStreamingContent = false
+            }
+            streamingMessageID = streaming ? messageID : nil
+            streamingAnswerHeight = streaming ? answerHeight : 0
+
+            // Begin measuring only once this answer has real content. Before
+            // that, frame changes can only belong to the new user bubble,
+            // placeholder row, or deferred layout from the previous turn.
+            if streaming, contentLength > 0, !hasSeenStreamingContent {
+                hasSeenStreamingContent = true
                 documentHeightAtStreamStart = nil
             }
+            _ = releaseIfAnswerOutgrewViewport()
         }
 
         private func releaseIfAnswerOutgrewViewport() -> Bool {
-            guard isStreaming, !didReleaseForCurrentStream else { return false }
-            guard let scrollView, let documentView,
-                  let startingHeight = documentHeightAtStreamStart else { return false }
+            guard isStreaming, hasSeenStreamingContent,
+                  !didReleaseForCurrentStream else { return false }
+            guard let scrollView, let documentView else { return false }
+            if streamingMessageID != nil {
+                guard streamingAnswerHeight > scrollView.contentView.bounds.height else {
+                    return false
+                }
+                return releaseFollowing()
+            }
+            guard let startingHeight = documentHeightAtStreamStart else {
+                // The first frame after a new turn also absorbs layout that
+                // was queued before streaming began. It is the first reliable
+                // point from which to measure this answer's own growth.
+                documentHeightAtStreamStart = documentView.bounds.height
+                return false
+            }
             let viewportHeight = scrollView.contentView.bounds.height
             guard Self.answerOutgrewViewport(
                 documentHeight: documentView.bounds.height,
                 documentHeightAtStreamStart: startingHeight,
                 viewportHeight: viewportHeight
             ) else { return false }
+            return releaseFollowing()
+        }
+
+        private func releaseFollowing() -> Bool {
             didReleaseForCurrentStream = true
             cancelScrollTarget()
             if isPinnedToBottom.wrappedValue {

--- a/apps/rapid-mac/Tests/RapidTests/JumpToBottomScrollTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/JumpToBottomScrollTests.swift
@@ -196,7 +196,7 @@ struct JumpToBottomScrollTests {
         let (scrollView, document, probe) = makeScrollView()
         let coordinator = makeCoordinator(pinned: binding)
 
-        coordinator.setStreaming(true)
+        coordinator.setStreaming(true, contentLength: 1)
         coordinator.attach(to: probe)
         await settle()
         #expect(abs(scrollView.contentView.bounds.minY - 1_800) < 1)
@@ -207,6 +207,34 @@ struct JumpToBottomScrollTests {
 
         #expect(!pinned)
         #expect(abs(scrollView.contentView.bounds.minY - 1_800) < 1)
+    }
+
+    @Test("A measured assistant row, not older document layout, controls release")
+    func measuredAssistantRowControlsRelease() async {
+        var pinned = true
+        let binding = Binding(get: { pinned }, set: { pinned = $0 })
+        let (scrollView, _, probe) = makeScrollView()
+        defer { withExtendedLifetime(scrollView) {} }
+        let coordinator = makeCoordinator(pinned: binding)
+        let messageID = UUID()
+
+        coordinator.attach(to: probe)
+        await settle()
+        coordinator.setStreaming(
+            true,
+            messageID: messageID,
+            contentLength: 20,
+            answerHeight: 200
+        )
+        #expect(pinned, "an answer exactly one viewport tall should keep following")
+
+        coordinator.setStreaming(
+            true,
+            messageID: messageID,
+            contentLength: 21,
+            answerHeight: 201
+        )
+        #expect(!pinned, "a measured answer taller than the viewport should release following")
     }
 
     @Test("Answer growth threshold is one viewport")
@@ -221,6 +249,15 @@ struct JumpToBottomScrollTests {
             documentHeightAtStreamStart: 2_000,
             viewportHeight: 200
         ))
+    }
+
+    @Test("Only transcript navigation keys count as scroll intent")
+    func transcriptScrollKeys() {
+        for keyCode: UInt16 in [115, 116, 119, 121, 125, 126] {
+            #expect(TranscriptScrollPositionProbe.Coordinator.isTranscriptScrollKey(keyCode))
+        }
+        #expect(!TranscriptScrollPositionProbe.Coordinator.isTranscriptScrollKey(0))
+        #expect(!TranscriptScrollPositionProbe.Coordinator.isTranscriptScrollKey(nil))
     }
 }
 


### PR DESCRIPTION
## Summary

- keep each new follow-up turn anchored to the conversation tip, even after a preceding long answer deliberately released follow mode
- use the live streaming assistant row's measured height for the one-viewport release threshold, instead of whole-document growth polluted by delayed layout from older Markdown
- ignore layout-originated clip-bound changes while streaming, while preserving wheel, scrollbar, navigation-key, VoiceOver, and AX scroll intent

## User impact

During pre-release dogfood, a long second answer left follow mode released. Every later short turn then remained above the newest content: from turn 2 onward `Jump to latest` stayed visible, and the five-turn journey ended at scrollbar fraction `~0.857` instead of the tail. Users had to click Jump after each ordinary follow-up.

This was reproduced twice on unmodified `bdf9d302`. With this change, a long answer still releases after one viewport so it can be read from the beginning, but the next deliberate turn returns to and follows the tip.

## Root cause

Three effects combined:

1. whole-document height was treated as current-answer growth, although older Markdown and user-row layout can land after the next request starts;
2. changing the policy flag back to pinned did not physically scroll an already-attached `NSScrollView`;
3. AppKit bounds notifications caused by SwiftUI layout, with no input event, were interpreted as user scrolling.

## Validation

- Final base/head: `1373012f6` / `54e8e42b9`
- Release build with complete bundled sidecar: PASS
  - candidate identity: `candidate-54e8e42b`
  - sidecar: Rapid-MLX `0.13.4`, 482 MB raw / 161 MB compressed, 173 Mach-O files
  - sidecar tar SHA-256: `3a6535d32a836d0d17795d8335b3eb97c89bde4572924e145562ba45fa97da2d`
- Desktop serial gate: **3570 tests / 309 suites**, PASS in **88.807s**
- Focused scroll + settled Jump tests: **11 tests / 2 suites**, PASS
- `make lint`: PASS
- Local `pr_validate` (Python 3.12 + declared `mflux 0.19.0`): **MERGE-SAFE** — 23,038 passed, 117 skipped, 22 deselected, 6 xfailed, 1 xpassed
- Hosted `pr_validate`: **MERGE-SAFE**
- Packaged resource verification: PASS (PNG dimensions, 80 English/zh-Hans localization keys, SwiftMath fonts/licenses, Mermaid digest)
- Exact final `chat-depth` GUI journey: PASS
  - five turns covering prose, code, table, list, CJK/emoji/RTL
  - correct message ownership, rendered Markdown, and relaunch restoration
  - no lingering Jump button after the final short reply
- Broader pre-release GUI pass: onboarding, consent, cached Quickstart, hardware-fit chooser, quantized sibling collapse, download progress, settings persistence/MTP, chat restore/search/session actions, model switch confirmation, lifecycle/crash recovery, low-memory escape, update states, campaign dismissal, window-close prompt, no-dead-controls, web-search status, external-model read-only handling, Browse All navigation, Images, Audio, resident-load rejection, and all 14 launch integrations passed.
- Real-weight GUI (`qwen3.5-4b-4bit`, packaged sidecar, existing local cache): PASS
  - `/health`: ready, model loaded, MLX batched engine
  - long answer released at scrollbar fraction `0.0975`
  - next short answer settled at `1.0000`, with no Jump button
  - AX scroll to `0.0000` exposed Jump; pressing it returned to `1.0000`
  - observed first/second turn decode: ~85 / ~34 tok/s (functional dogfood, not a throughput benchmark)

## Review notes

- Streaming content uses UTF-8 byte count to avoid a potentially linear `String.count` on every streamed update.
- Only Home/Page Up/End/Page Down/Up/Down count as keyboard transcript scroll intent; typing in the composer cannot accidentally disable following.
- The standalone `verify-chat-scroll-runtime.sh` fixed-count burst assertion is red on both this branch (5–10 adjustments) and clean `origin/main` (7 adjustments) on this 120Hz Studio. The functional runtime behavior is covered by the passing focused tests and exact GUI journeys; the refresh-rate-dependent harness threshold is pre-existing and intentionally not changed in this scoped P1 fix.

## Safety

- Dogfood used an isolated bundle ID, preferences, application support, and port; the production `/Applications/Rapid-MLX Desktop.app` process remained PID `34466` throughout.
- The real model was already present in `~/.cache/huggingface/hub`; no model download, deletion, cache redirect, or migration occurred.
