### PR TITLE
feat(service): qualify lazy configurations before commit

### DIFF
--- a/.agents/handoffs/atlas-service-qualify-lazy.md
+++ b/.agents/handoffs/atlas-service-qualify-lazy.md
@@ -3,7 +3,7 @@
 - **Owner:** Atlas
 - **Branch:** `atlas/service-qualify-lazy`
 - **PR:** #3222
-- **Base/dependency:** `atlas/319-lazy-idle`, PR #3214
+- **Base:** `main` at #3214 merge commit `3d50f5eb`
 - **Host:** local Apple silicon Mac
 - **Scope:** require configured-primary activation before service install,
   configuration apply, or runtime upgrade commits
@@ -38,10 +38,9 @@
 
 ## Remaining work / next action
 
-1. Wait for #3214 to merge from the managed mac queue.
-2. Retarget/rebase #3222 onto `main` without changing the service behavior.
-3. Re-run the final CI/Apple Silicon service qualification on the rebased head.
-4. Only after those gates pass, add the repository's merge-ready/mac-queue
+1. #3214 has merged; #3222 was retargeted/rebased onto its `main` merge commit.
+2. Re-run the final CI/Apple Silicon service qualification on the rebased head.
+3. Only after those gates pass, add the repository's merge-ready/mac-queue
    labels to #3222.
 
 ## Risks and rollback

--- a/.agents/handoffs/atlas-service-qualify-lazy.md
+++ b/.agents/handoffs/atlas-service-qualify-lazy.md
@@ -1,0 +1,53 @@
+# Atlas handoff: lazy service model qualification
+
+- **Owner:** Atlas
+- **Branch:** `atlas/service-qualify-lazy`
+- **PR:** #3222
+- **Base/dependency:** `atlas/319-lazy-idle`, PR #3214
+- **Host:** local Apple silicon Mac
+- **Scope:** require configured-primary activation before service install,
+  configuration apply, or runtime upgrade commits
+
+## Verified facts
+
+- Lazy `standby` is intentionally endpoint-ready and does not load weights.
+- `POST /v1/models/activate` is an auth-gated, model-selector-free operation
+  that loads only the configured primary through `PrimaryModelLifecycle`.
+- Install, apply, and upgrade now require `/readyz` followed by activation with
+  `state=ready` and `model_loaded=true`; existing rollback paths remain intact.
+- Rollback checks only endpoint readiness so restoration remains compatible
+  with an older runtime that does not expose the activation operation.
+- The root-run client reads a credential through `O_NOFOLLOW`, validates the
+  opened inode's type, mode, and service-account uid, and sends it only in an
+  in-memory loopback Authorization header.
+- Product docs, API reference, architecture decision, website handoff, and
+  release-notes source copy are recorded in the PR description and docs diff.
+
+## Verification
+
+- Diff-aware targeted suite: 548 passed.
+- Focused service/route/lifecycle suite: 345 passed.
+- Patch coverage: 85/85 executable changed lines, 100%.
+- Ruff lint/format and diff check: pass.
+- Independent Codex review: no blocking findings.
+- Full unit: 23,069 passed; three environment-only failures from missing
+  optional `mflux` and the running Desktop service owning hard-coded port 8000.
+- Real `Qwen3-0.6B-4bit` dogfood: authenticated activation moved one lazy PID
+  from 48,816 KiB standby to 795,728 KiB ready; five-second idle unload returned
+  it to 52,864 KiB standby, then the test server shut down cleanly.
+
+## Remaining work / next action
+
+1. Wait for #3214 to merge from the managed mac queue.
+2. Retarget/rebase #3222 onto `main` without changing the service behavior.
+3. Re-run the final CI/Apple Silicon service qualification on the rebased head.
+4. Only after those gates pass, add the repository's merge-ready/mac-queue
+   labels to #3222.
+
+## Risks and rollback
+
+- Model activation can add up to one cold-load interval to maintenance actions;
+  the client timeout is bounded at ten minutes.
+- Qualification verifies load/lifecycle readiness, not semantic answer quality.
+- Reverting #3222 restores endpoint-only gating; no persisted schema migration
+  or user data rollback is required.

--- a/docs/engineering/decisions/2026-09-05-always-on-service-configuration.md
+++ b/docs/engineering/decisions/2026-09-05-always-on-service-configuration.md
@@ -31,8 +31,17 @@ Configuration changes use two phases:
 
 1. `service configure` validates and writes a pending candidate.
 2. `service apply` saves the active definition, stops the job, promotes the
-   candidate, bootstraps it, and gates success on `/readyz`. Any failure restores
-   and starts the previous definition.
+   candidate, bootstraps it, and first gates endpoint availability on `/readyz`.
+3. Because a lazy model can correctly report endpoint readiness in `standby`,
+   the transaction then calls the authenticated `POST /v1/models/activate`
+   control-plane operation and requires `state=ready` plus `model_loaded=true`
+   before committing. Any failure restores and starts the previous definition.
+
+The same qualification gate protects first install and runtime upgrade. The
+activation request never accepts a model identifier; it can only load and warm
+the primary already fixed in the validated service definition. When an API key
+is configured, the root-run service command reads its private credential file
+and sends it only as an in-memory Authorization header.
 
 An optional API key lives in a separate mode-0600 non-symlink credential file.
 The runtime launcher reads it immediately before `execve` and exposes it only as

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -50,8 +50,11 @@ also lets a venv rebuild leave service configuration untouched.
 
 Change an installed definition as a two-step transaction. `configure` validates
 and stages a candidate but does not disturb the running server. `apply` swaps
-the candidate into place, restarts, and requires `/readyz`; if bootstrap or
-readiness fails it restores the previous config and service.
+the candidate into place, restarts, requires `/readyz`, and activates the
+configured primary model before committing. If bootstrap, endpoint readiness,
+or model activation fails, it restores the previous config and service.
+This prevents a lazy service from appearing successfully deployed in
+`standby` only to fail hours later on its first real request.
 
 An installation created by the original argv-in-plist service release has no
 versioned config yet. Migrate it once with `service uninstall` followed by
@@ -86,6 +89,14 @@ independent `--embedding-model` lane is unaffected. A request can only wake the
 primary configured by the service definition—it cannot select an arbitrary
 repository or trigger a new download.
 
+The service transaction uses the authenticated `POST /v1/models/activate`
+control-plane operation after the endpoint becomes ready. It loads and warms
+only the model fixed in the service definition, never a model supplied by the
+request. If service authentication is enabled, the CLI reads the existing
+mode-0600 credential into an in-memory Authorization header; the key is not
+placed in argv, command output, or logs. Successful qualification may leave the
+model resident until its configured idle timeout returns it to `standby`.
+
 For API authentication, send the key over stdin to a private credential file.
 It never appears in argv, the plist, shell history, `service config`, or status:
 
@@ -118,8 +129,9 @@ retention. Stage different limits with `service configure --log-max-mb`,
 Upgrade the service with the same health gate and rollback behavior. The
 command freezes the working environment before stopping the server, runs the
 package upgrade as the service account, diagnoses it with `doctor`, and only
-accepts it after launchd `/readyz` succeeds. On failure it restores the frozen
-environment and starts the previous service.
+accepts it after launchd `/readyz` succeeds and the configured primary model
+loads and completes its standard warmup path. On activation failure it restores
+the frozen environment and starts the previous service.
 
 ```bash
 sudo rapid-mlx service upgrade --dry-run

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -132,6 +132,7 @@ are marked; multimodal and MCP surfaces link to their own guides.
 | `/v1/mcp/execute` | POST | Execute an MCP tool by name |
 | `/v1/mcp/reload` | POST | Re-read the MCP config file without a server restart |
 | `/v1/status` | GET | Real-time server statistics (detailed below) |
+| `/v1/models/activate` | POST | Authenticated pre-warm/qualification of the configured primary model |
 | `/v1/cache/stats` | GET | Cache statistics |
 | `/v1/cache/clear` | POST | Clear reusable prompt KV state without unloading model weights |
 | `/v1/cache/export` | POST | Export the prefix cache to a disk snapshot |
@@ -139,7 +140,7 @@ are marked; multimodal and MCP surfaces link to their own guides.
 | `/v1/cache/info` | GET | Read the manifest of an exported cache snapshot |
 | `/v1/requests/{id}/cancel` | POST | Cancel an active or queued request by its `chatcmpl-...` id (`DELETE /v1/requests/{id}` is an alias) |
 | `/health` | GET | Full health view (queries engine stats on every hit) |
-| `/health/ready` | GET | Readiness — 503 until model load and warmup complete |
+| `/health/ready` | GET | Endpoint readiness; lazy `standby` is ready, lifecycle `error` is 503 |
 | `/healthz` | GET | Constant-cost liveness probe (k8s convention; 503 while draining) |
 | `/readyz` | GET | Alias for `/health/ready` |
 | `/livez` | GET | Process liveness only (does not check model readiness) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -548,6 +548,8 @@ rapid-mlx service uninstall [--dry-run]
   deterministic root-owned plist to `/Library/LaunchDaemons/`, and
   bootstraps the daemon. It refuses an administrator/system account, a
   secret in the definition, and a target port that already has a server.
+  Before reporting success it activates and warms the configured model, so a
+  lazy endpoint cannot pass installation while its weights are unusable.
   `--dry-run` prints every step without changing anything.
 - Additional `serve` options must follow a `--` separator, for example
   `-- --max-num-seqs 4`. Bind overrides and secret-bearing options are
@@ -557,6 +559,9 @@ rapid-mlx service uninstall [--dry-run]
 - `logs` tails the daemon's stdout/stderr logs (`--follow` streams across
   KeepAlive restarts).
 - `restart` kickstarts the daemon and waits for readiness.
+- `apply` and `upgrade` require both endpoint readiness and authenticated model
+  activation before committing; a model-load failure restores the previous
+  configuration or runtime.
 - `uninstall` removes the launchd registration and plist only — models,
   cache, and logs are never deleted.
 

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -390,6 +390,7 @@ class _HttpResponder:
         self.port = self.sock.getsockname()[1]
         self.status_line = status_line
         self.body = body
+        self.request = b""
         self.thread = threading.Thread(target=self._serve, daemon=True)
         self.thread.start()
 
@@ -397,7 +398,7 @@ class _HttpResponder:
         conn, _ = self.sock.accept()
         conn.settimeout(2)
         try:
-            conn.recv(4096)
+            self.request = conn.recv(4096)
             conn.sendall(
                 self.status_line
                 + b"\r\nContent-Length: "
@@ -432,6 +433,159 @@ def test_readyz_ready_semantics(monkeypatch, status, body, expected):
         assert _readyz_ready("127.0.0.1", srv.port) is expected
     finally:
         srv.sock.close()
+
+
+def test_activate_model_sends_credential_only_in_header(tmp_path):
+    credential = tmp_path / "credential"
+    credential.write_text("top-secret\n")
+    credential.chmod(0o600)
+    srv = _HttpResponder(
+        b"HTTP/1.1 200 OK",
+        b'{"status":"ready","state":"ready","model_loaded":true}',
+    )
+    try:
+        assert ins_mod._activate_model(
+            "127.0.0.1",
+            srv.port,
+            credential_file=str(credential),
+            credential_uid=credential.stat().st_uid,
+            timeout_s=2,
+        )
+        assert b"POST /v1/models/activate HTTP/1.1" in srv.request
+        assert b"Authorization: Bearer top-secret" in srv.request
+    finally:
+        srv.sock.close()
+
+
+def test_activate_model_rejects_endpoint_only_readiness():
+    srv = _HttpResponder(
+        b"HTTP/1.1 200 OK",
+        b'{"status":"ready","state":"standby","model_loaded":false}',
+    )
+    try:
+        assert not ins_mod._activate_model(
+            "127.0.0.1",
+            srv.port,
+            credential_file=None,
+            credential_uid=0,
+            timeout_s=2,
+        )
+    finally:
+        srv.sock.close()
+
+
+def test_read_service_credential_rejects_symlink_and_foreign_owner(tmp_path):
+    credential = tmp_path / "credential"
+    credential.write_text("secret\n")
+    credential.chmod(0o600)
+    link = tmp_path / "link"
+    link.symlink_to(credential)
+    with pytest.raises(ValueError, match="cannot open credential"):
+        ins_mod._read_service_credential(link, expected_uid=credential.stat().st_uid)
+    with pytest.raises(ValueError, match="owned by uid"):
+        ins_mod._read_service_credential(
+            credential, expected_uid=credential.stat().st_uid + 1
+        )
+
+
+def test_read_service_credential_missing_is_unconfigured(tmp_path):
+    assert (
+        ins_mod._read_service_credential(
+            tmp_path / "missing", expected_uid=tmp_path.stat().st_uid
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "message"),
+    [
+        ("directory", "regular file"),
+        ("public", "group or others"),
+        ("large", "unexpectedly large"),
+        ("empty", "one non-empty line"),
+        ("multiline", "one non-empty line"),
+    ],
+)
+def test_read_service_credential_rejects_unsafe_contents(tmp_path, kind, message):
+    credential = tmp_path / "credential"
+    if kind == "directory":
+        credential.mkdir()
+    else:
+        contents = {
+            "public": "secret\n",
+            "large": "x" * 65_537,
+            "empty": "\n",
+            "multiline": "one\ntwo\n",
+        }[kind]
+        credential.write_text(contents)
+        credential.chmod(0o644 if kind == "public" else 0o600)
+    with pytest.raises(ValueError, match=message):
+        ins_mod._read_service_credential(
+            credential, expected_uid=credential.stat().st_uid
+        )
+
+
+def test_activate_model_rejects_malformed_response():
+    srv = _HttpResponder(b"HTTP/1.1 200 OK", b"not-json")
+    try:
+        assert not ins_mod._activate_model(
+            "127.0.0.1",
+            srv.port,
+            credential_file=None,
+            credential_uid=0,
+            timeout_s=2,
+        )
+    finally:
+        srv.sock.close()
+
+
+def test_wait_qualified_requires_endpoint_then_model_activation(monkeypatch):
+    config = types.SimpleNamespace(
+        host="127.0.0.1",
+        port=8000,
+        credential_file="/private/key",
+        service_user="serveuser",
+    )
+    calls = []
+    monkeypatch.setattr(
+        ins_mod,
+        "_wait_ready",
+        lambda host, port, **kwargs: calls.append(("ready", host, port)) or True,
+    )
+    monkeypatch.setattr(
+        ins_mod,
+        "_activate_model",
+        lambda host, port, **kwargs: (
+            calls.append(("activate", host, port, kwargs["credential_file"])) or True
+        ),
+    )
+    monkeypatch.setattr(ins_mod, "user_uid", lambda _user: 501)
+    assert ins_mod._wait_qualified(config)
+    assert calls == [
+        ("ready", "127.0.0.1", 8000),
+        ("activate", "127.0.0.1", 8000, "/private/key"),
+    ]
+
+
+def test_wait_qualified_short_circuits_unready_or_missing_account(monkeypatch):
+    config = types.SimpleNamespace(
+        host="127.0.0.1",
+        port=8000,
+        credential_file=None,
+        service_user="gone",
+    )
+    monkeypatch.setattr(ins_mod, "_wait_ready", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        ins_mod,
+        "_activate_model",
+        lambda *_a, **_k: pytest.fail("activation must not run"),
+    )
+    assert not ins_mod._wait_qualified(config)
+
+    monkeypatch.setattr(ins_mod, "_wait_ready", lambda *_a, **_k: True)
+    monkeypatch.setattr(ins_mod, "user_uid", lambda _user: None)
+    assert not ins_mod._wait_qualified(config)
 
 
 # ---------------------------------------------------------------------------
@@ -1675,7 +1829,7 @@ def test_install_success_cleans_secure_staging_file(monkeypatch, tmp_path, capsy
     monkeypatch.setattr(ins, "_port_busy", lambda _h, _p: False)
     monkeypatch.setattr(ins, "is_root", lambda: True)
     monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
-    monkeypatch.setattr(ins, "_wait_ready", lambda _h, _p, **_k: True)
+    monkeypatch.setattr(ins, "_wait_qualified", lambda _config: True)
     monkeypatch.setattr(ins.tempfile, "tempdir", str(tmp_path))
 
     def _fake_run(argv, check=True):
@@ -1699,7 +1853,7 @@ def test_install_success_tolerates_staging_cleanup_failure(monkeypatch, tmp_path
     monkeypatch.setattr(ins, "_port_busy", lambda _h, _p: False)
     monkeypatch.setattr(ins, "is_root", lambda: True)
     monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
-    monkeypatch.setattr(ins, "_wait_ready", lambda _h, _p, **_k: True)
+    monkeypatch.setattr(ins, "_wait_qualified", lambda _config: True)
     monkeypatch.setattr(ins, "_run", lambda *_a, **_k: _FakeResult())
     staged = tmp_path / "private-stage.plist"
     staged.write_bytes(b"plist")

--- a/tests/test_model_activation_route.py
+++ b/tests/test_model_activation_route.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""No-MLX contracts for explicit configured-primary activation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm_mlx.config import get_config
+from vllm_mlx.routes.health import admin_router
+
+
+@pytest.fixture(autouse=True)
+def restore_server_config() -> Iterator[None]:
+    cfg = get_config()
+    fields = (
+        "api_key",
+        "draining",
+        "engine",
+        "model_name",
+        "primary_model_lifecycle",
+        "ready",
+    )
+    original = {field: getattr(cfg, field) for field in fields}
+    yield
+    for field, value in original.items():
+        setattr(cfg, field, value)
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(admin_router)
+    return TestClient(app)
+
+
+def _configure(**updates) -> None:
+    cfg = get_config()
+    defaults = {
+        "api_key": None,
+        "draining": False,
+        "engine": object(),
+        "model_name": "test-model",
+        "primary_model_lifecycle": None,
+        "ready": True,
+    }
+    defaults.update(updates)
+    for field, value in defaults.items():
+        setattr(cfg, field, value)
+
+
+class _Lifecycle:
+    def __init__(self, *, state: str = "ready", loaded: bool = False) -> None:
+        self.state = state
+        self.loaded = loaded
+        self.owners = 0
+
+    def acquire_request(self) -> None:
+        self.owners += 1
+
+    async def ensure_loaded(self) -> None:
+        self.loaded = True
+
+    def snapshot(self) -> dict[str, object]:
+        return {"state": self.state, "model_loaded": self.loaded}
+
+    def release_request(self) -> None:
+        self.owners -= 1
+
+
+def test_activate_loads_lazy_primary_and_requires_authentication():
+    lifecycle = _Lifecycle()
+    _configure(api_key="test-secret", primary_model_lifecycle=lifecycle)
+    client = _client()
+
+    assert client.post("/v1/models/activate").status_code == 401
+    response = client.post(
+        "/v1/models/activate",
+        headers={"Authorization": "Bearer test-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ready",
+        "model": "test-model",
+        "state": "ready",
+        "model_loaded": True,
+    }
+    assert lifecycle.owners == 0
+
+
+def test_activate_eager_primary_returns_ready_without_lifecycle():
+    _configure()
+    response = _client().post("/v1/models/activate")
+    assert response.status_code == 200
+    assert response.json()["model_loaded"] is True
+
+
+class _FailingLifecycle(_Lifecycle):
+    async def ensure_loaded(self) -> None:
+        raise RuntimeError("/private/model/path must not leak")
+
+
+def test_activate_sanitizes_load_failure_and_releases_owner():
+    lifecycle = _FailingLifecycle()
+    _configure(primary_model_lifecycle=lifecycle)
+    response = _client().post("/v1/models/activate")
+    assert response.status_code == 503
+    assert "/private/model/path" not in response.text
+    assert lifecycle.owners == 0
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected_detail"),
+    [
+        ({"ready": False}, "Service is not accepting work"),
+        ({"draining": True}, "Service is not accepting work"),
+        ({"engine": None}, "Primary model unavailable"),
+    ],
+)
+def test_activate_rejects_unavailable_service(updates, expected_detail):
+    _configure(**updates)
+    response = _client().post("/v1/models/activate")
+    assert response.status_code == 503
+    assert response.json()["detail"] == expected_detail
+
+
+def test_activate_requires_loaded_ready_snapshot():
+    lifecycle = _Lifecycle(state="standby")
+    _configure(primary_model_lifecycle=lifecycle)
+    response = _client().post("/v1/models/activate")
+    assert response.status_code == 503
+    assert "ready state" in response.json()["detail"]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -275,6 +275,131 @@ class TestHealthRoutes:
         finally:
             self._restore_config(orig)
 
+    def test_activate_primary_model_loads_lazy_engine(self, mock_engine):
+        class _Lifecycle:
+            def __init__(self):
+                self.loaded = False
+                self.acquired = 0
+
+            def acquire_request(self):
+                self.acquired += 1
+
+            async def ensure_loaded(self):
+                self.loaded = True
+
+            def release_request(self):
+                self.acquired -= 1
+
+            def snapshot(self):
+                return {"state": "ready", "model_loaded": self.loaded}
+
+        lifecycle = _Lifecycle()
+        orig = self._patch_config(
+            api_key="test-secret",
+            engine=mock_engine,
+            model_name="test-model",
+            ready=True,
+            draining=False,
+            primary_model_lifecycle=lifecycle,
+        )
+        try:
+            client = TestClient(self._make_app())
+            unauthorized = client.post("/v1/models/activate")
+            assert unauthorized.status_code == 401
+            response = client.post(
+                "/v1/models/activate",
+                headers={"Authorization": "Bearer test-secret"},
+            )
+            assert response.status_code == 200
+            assert response.json() == {
+                "status": "ready",
+                "model": "test-model",
+                "state": "ready",
+                "model_loaded": True,
+            }
+            assert lifecycle.acquired == 0
+        finally:
+            self._restore_config(orig)
+
+    def test_activate_primary_model_sanitizes_load_failure(self, mock_engine):
+        class _FailingLifecycle:
+            def acquire_request(self):
+                pass
+
+            async def ensure_loaded(self):
+                raise RuntimeError("/private/model/path must not leak")
+
+            def release_request(self):
+                pass
+
+        orig = self._patch_config(
+            api_key=None,
+            engine=mock_engine,
+            model_name="test-model",
+            ready=True,
+            draining=False,
+            primary_model_lifecycle=_FailingLifecycle(),
+        )
+        try:
+            response = TestClient(self._make_app()).post("/v1/models/activate")
+            assert response.status_code == 503
+            assert "/private/model/path" not in response.text
+        finally:
+            self._restore_config(orig)
+
+    @pytest.mark.parametrize(
+        ("ready", "draining", "engine", "expected_detail"),
+        [
+            (False, False, object(), "Service is not accepting work"),
+            (True, True, object(), "Service is not accepting work"),
+            (True, False, None, "Primary model unavailable"),
+        ],
+    )
+    def test_activate_primary_model_rejects_unavailable_service(
+        self, ready, draining, engine, expected_detail
+    ):
+        orig = self._patch_config(
+            api_key=None,
+            engine=engine,
+            ready=ready,
+            draining=draining,
+            primary_model_lifecycle=None,
+        )
+        try:
+            response = TestClient(self._make_app()).post("/v1/models/activate")
+            assert response.status_code == 503
+            assert response.json()["detail"] == expected_detail
+        finally:
+            self._restore_config(orig)
+
+    def test_activate_primary_model_requires_loaded_ready_snapshot(self, mock_engine):
+        class _Lifecycle:
+            def acquire_request(self):
+                pass
+
+            async def ensure_loaded(self):
+                pass
+
+            def snapshot(self):
+                return {"state": "standby", "model_loaded": False}
+
+            def release_request(self):
+                pass
+
+        orig = self._patch_config(
+            api_key=None,
+            engine=mock_engine,
+            ready=True,
+            draining=False,
+            primary_model_lifecycle=_Lifecycle(),
+        )
+        try:
+            response = TestClient(self._make_app()).post("/v1/models/activate")
+            assert response.status_code == 503
+            assert "ready state" in response.json()["detail"]
+        finally:
+            self._restore_config(orig)
+
     def test_health_with_mcp(self, mock_engine):
         """Health endpoint includes MCP info."""
         mcp = MagicMock()
@@ -341,6 +466,7 @@ class TestHealthRoutes:
     @pytest.mark.parametrize(
         ("method", "path"),
         [
+            ("post", "/v1/models/activate"),
             ("post", "/v1/cache/clear"),
             ("get", "/v1/status"),
             ("get", "/v1/cache/stats"),
@@ -435,6 +561,7 @@ class TestHealthRoutes:
         [
             ("get", "/health", 200),
             ("get", "/health/ready", 200),
+            ("post", "/v1/models/activate", 200),
             ("post", "/v1/cache/clear", 200),
             ("get", "/v1/status", 200),
             ("get", "/v1/cache/stats", 200),

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -275,131 +275,6 @@ class TestHealthRoutes:
         finally:
             self._restore_config(orig)
 
-    def test_activate_primary_model_loads_lazy_engine(self, mock_engine):
-        class _Lifecycle:
-            def __init__(self):
-                self.loaded = False
-                self.acquired = 0
-
-            def acquire_request(self):
-                self.acquired += 1
-
-            async def ensure_loaded(self):
-                self.loaded = True
-
-            def release_request(self):
-                self.acquired -= 1
-
-            def snapshot(self):
-                return {"state": "ready", "model_loaded": self.loaded}
-
-        lifecycle = _Lifecycle()
-        orig = self._patch_config(
-            api_key="test-secret",
-            engine=mock_engine,
-            model_name="test-model",
-            ready=True,
-            draining=False,
-            primary_model_lifecycle=lifecycle,
-        )
-        try:
-            client = TestClient(self._make_app())
-            unauthorized = client.post("/v1/models/activate")
-            assert unauthorized.status_code == 401
-            response = client.post(
-                "/v1/models/activate",
-                headers={"Authorization": "Bearer test-secret"},
-            )
-            assert response.status_code == 200
-            assert response.json() == {
-                "status": "ready",
-                "model": "test-model",
-                "state": "ready",
-                "model_loaded": True,
-            }
-            assert lifecycle.acquired == 0
-        finally:
-            self._restore_config(orig)
-
-    def test_activate_primary_model_sanitizes_load_failure(self, mock_engine):
-        class _FailingLifecycle:
-            def acquire_request(self):
-                pass
-
-            async def ensure_loaded(self):
-                raise RuntimeError("/private/model/path must not leak")
-
-            def release_request(self):
-                pass
-
-        orig = self._patch_config(
-            api_key=None,
-            engine=mock_engine,
-            model_name="test-model",
-            ready=True,
-            draining=False,
-            primary_model_lifecycle=_FailingLifecycle(),
-        )
-        try:
-            response = TestClient(self._make_app()).post("/v1/models/activate")
-            assert response.status_code == 503
-            assert "/private/model/path" not in response.text
-        finally:
-            self._restore_config(orig)
-
-    @pytest.mark.parametrize(
-        ("ready", "draining", "engine", "expected_detail"),
-        [
-            (False, False, object(), "Service is not accepting work"),
-            (True, True, object(), "Service is not accepting work"),
-            (True, False, None, "Primary model unavailable"),
-        ],
-    )
-    def test_activate_primary_model_rejects_unavailable_service(
-        self, ready, draining, engine, expected_detail
-    ):
-        orig = self._patch_config(
-            api_key=None,
-            engine=engine,
-            ready=ready,
-            draining=draining,
-            primary_model_lifecycle=None,
-        )
-        try:
-            response = TestClient(self._make_app()).post("/v1/models/activate")
-            assert response.status_code == 503
-            assert response.json()["detail"] == expected_detail
-        finally:
-            self._restore_config(orig)
-
-    def test_activate_primary_model_requires_loaded_ready_snapshot(self, mock_engine):
-        class _Lifecycle:
-            def acquire_request(self):
-                pass
-
-            async def ensure_loaded(self):
-                pass
-
-            def snapshot(self):
-                return {"state": "standby", "model_loaded": False}
-
-            def release_request(self):
-                pass
-
-        orig = self._patch_config(
-            api_key=None,
-            engine=mock_engine,
-            ready=True,
-            draining=False,
-            primary_model_lifecycle=_Lifecycle(),
-        )
-        try:
-            response = TestClient(self._make_app()).post("/v1/models/activate")
-            assert response.status_code == 503
-            assert "ready state" in response.json()["detail"]
-        finally:
-            self._restore_config(orig)
-
     def test_health_with_mcp(self, mock_engine):
         """Health endpoint includes MCP info."""
         mcp = MagicMock()
@@ -466,7 +341,6 @@ class TestHealthRoutes:
     @pytest.mark.parametrize(
         ("method", "path"),
         [
-            ("post", "/v1/models/activate"),
             ("post", "/v1/cache/clear"),
             ("get", "/v1/status"),
             ("get", "/v1/cache/stats"),
@@ -561,7 +435,6 @@ class TestHealthRoutes:
         [
             ("get", "/health", 200),
             ("get", "/health/ready", 200),
-            ("post", "/v1/models/activate", 200),
             ("post", "/v1/cache/clear", 200),
             ("get", "/v1/status", 200),
             ("get", "/v1/cache/stats", 200),

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -273,12 +273,18 @@ def test_apply_promotes_healthy_candidate(monkeypatch, tmp_path):
         "_bootstrap",
         lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
-    monkeypatch.setattr(configure, "_wait_ready", lambda _host, _port: True)
+    qualified = []
+    monkeypatch.setattr(
+        configure,
+        "_wait_qualified",
+        lambda config: qualified.append(config) or True,
+    )
     assert (
         configure.apply_command(types.SimpleNamespace(label=None, dry_run=False)) == 0
     )
     assert load_config(current_path) == candidate
     assert not pending.exists()
+    assert qualified == [candidate]
 
 
 def test_apply_restores_previous_config_when_candidate_is_unhealthy(
@@ -303,6 +309,7 @@ def test_apply_restores_previous_config_when_candidate_is_unhealthy(
         "_wait_ready",
         lambda _host, port: port == current.port,
     )
+    monkeypatch.setattr(configure, "_wait_qualified", lambda _config: False)
     assert (
         configure.apply_command(types.SimpleNamespace(label=None, dry_run=False)) == 2
     )
@@ -371,7 +378,10 @@ def test_upgrade_success_snapshots_before_mutation(monkeypatch, tmp_path):
         "_bootstrap",
         lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
-    monkeypatch.setattr(upgrade, "_wait_ready", lambda _host, _port: True)
+    qualified = []
+    monkeypatch.setattr(
+        upgrade, "_wait_qualified", lambda config: qualified.append(config) or True
+    )
     args = types.SimpleNamespace(
         label=None,
         dry_run=False,
@@ -383,6 +393,7 @@ def test_upgrade_success_snapshots_before_mutation(monkeypatch, tmp_path):
     assert events[0][-2:] == ("pip", "freeze")
     assert events[1] == ("bootout",)
     assert any("rapid-mlx[vision]==0.13.5" in event for event in events)
+    assert len(qualified) == 1
     snapshot = (
         tmp_path / "system-config" / "com.rapidmlx.server.previous-requirements.txt"
     )
@@ -412,7 +423,7 @@ def test_upgrade_rolls_back_after_readiness_failure(monkeypatch, tmp_path, capsy
         "_bootstrap",
         lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
-    monkeypatch.setattr(upgrade, "_wait_ready", lambda _host, _port: False)
+    monkeypatch.setattr(upgrade, "_wait_qualified", lambda _config: False)
     monkeypatch.setattr(upgrade, "_restore", lambda **_kwargs: True)
     args = types.SimpleNamespace(
         label=None,
@@ -1148,7 +1159,7 @@ def test_apply_restore_and_pending_unlink_oserrors(monkeypatch, tmp_path):
         "_bootstrap",
         lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
     )
-    monkeypatch.setattr(configure, "_wait_ready", lambda *_a: True)
+    monkeypatch.setattr(configure, "_wait_qualified", lambda _config: True)
     real_unlink = Path.unlink
     monkeypatch.setattr(
         Path, "unlink", lambda *_a, **_k: (_ for _ in ()).throw(OSError("busy"))
@@ -1406,7 +1417,7 @@ def test_upgrade_snapshot_write_and_doctor_warning(monkeypatch, tmp_path, capsys
     monkeypatch.setattr(
         upgrade, "_bootstrap", lambda _label: types.SimpleNamespace(returncode=0)
     )
-    monkeypatch.setattr(upgrade, "_wait_ready", lambda *_a: True)
+    monkeypatch.setattr(upgrade, "_wait_qualified", lambda _config: True)
     assert upgrade.upgrade_command(args) == 0
     assert "doctor" in capsys.readouterr().err
 

--- a/vllm_mlx/headless_service/configure.py
+++ b/vllm_mlx/headless_service/configure.py
@@ -24,7 +24,7 @@ from .config import (
     remove_credential,
 )
 from .definition import installed_identity
-from .install import _plist_path, _port_busy, _wait_ready, is_root
+from .install import _plist_path, _port_busy, _wait_qualified, _wait_ready, is_root
 
 
 def _identity_or_error(label: str) -> tuple[str, Path, Path]:
@@ -150,6 +150,7 @@ def apply_command(args) -> int:
             f"[DRY-RUN] bootout {DEFAULT_DOMAIN}/{label}\n"
             f"[DRY-RUN] promote candidate {config_digest(candidate)[:12]}\n"
             f"[DRY-RUN] bootstrap {_plist_path(label)} and require /readyz\n"
+            "[DRY-RUN] activate and qualify the configured primary model\n"
             "[DRY-RUN] restore previous config and service on any failure"
         )
         return 0
@@ -177,9 +178,10 @@ def apply_command(args) -> int:
             raise ServiceConfigError(
                 f"launchctl bootstrap failed: {boot.stderr.strip() or boot.stdout.strip()}"
             )
-        if not _wait_ready(candidate.host, candidate.port):
+        if not _wait_qualified(candidate):
             raise ServiceConfigError(
-                f"candidate did not become ready on {candidate.host}:{candidate.port} within 120s"
+                "candidate endpoint or configured model did not qualify on "
+                f"{candidate.host}:{candidate.port}"
             )
     except (OSError, ServiceConfigError) as exc:
         _bootout(label)

--- a/vllm_mlx/headless_service/install.py
+++ b/vllm_mlx/headless_service/install.py
@@ -21,12 +21,18 @@ already documented — this command just makes it safe and one-shot.
 
 from __future__ import annotations
 
+import json
 import os
+import stat
 import subprocess
 import sys
 import tempfile
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .config import ServiceConfig
 
 from .common import (
     DEFAULT_DOMAIN,
@@ -242,7 +248,8 @@ def _mutation_list(
         "validate temporary plist with plutil -lint",
         f"install -o root -g wheel -m 644 temporary plist -> {plist_path}",
         f"launchctl bootstrap {DEFAULT_DOMAIN} {plist_path}",
-        f"poll {host}:{port}/readyz until ready (max 120s)",
+        f"poll {host}:{port}/readyz until endpoint-ready (max 120s)",
+        "activate and qualify the configured primary model before commit",
     ]
 
 
@@ -282,10 +289,10 @@ def _readyz_ready(host: str, port: int) -> bool:
     """True when ``/readyz`` reports ready.
 
     rapid-mlx ``/readyz`` returns HTTP 200 once the process is able to serve
-    (sets ``"ready": true`` in the body once the model is loaded; it returns
-    503 while draining). Matching the smoke script's contract, we require
-    BOTH an HTTP 200 status line AND a ``"ready": true`` in the body — a bare
-    200 during early boot (model still loading) does NOT count.
+    (including a lazy primary in ``standby``; it returns 503 during early boot,
+    lifecycle error, or drain). Matching the smoke script's contract, we
+    require BOTH an HTTP 200 status line AND a ``"ready": true`` in the body.
+    Model residency is qualified separately by ``_wait_qualified``.
     """
     import socket
 
@@ -316,6 +323,102 @@ def _wait_ready(host: str, port: int, timeout_s: int = 120) -> bool:
             return True
         time.sleep(1.0)
     return False
+
+
+def _read_service_credential(
+    credential_file: str | None, *, expected_uid: int
+) -> str | None:
+    """Securely read the daemon credential into memory as root.
+
+    Open with ``O_NOFOLLOW`` first, then validate the opened inode.  This
+    avoids a check/read replacement race in the service-user-owned home and
+    prevents the privileged CLI from reading a foreign file through a link.
+    """
+    if not credential_file:
+        return None
+    path = Path(credential_file)
+    from .config import ServiceConfigError
+
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ServiceConfigError(f"cannot open credential file: {exc}") from None
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise ServiceConfigError("credential file must be a regular file")
+        if stat.S_IMODE(info.st_mode) & 0o077:
+            raise ServiceConfigError(
+                "credential file must not be accessible by group or others"
+            )
+        if info.st_uid != expected_uid:
+            raise ServiceConfigError(
+                f"credential file is owned by uid {info.st_uid}, expected {expected_uid}"
+            )
+        with os.fdopen(fd, encoding="utf-8") as handle:
+            fd = -1
+            secret = handle.read(65_537)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    if len(secret) > 65_536:
+        raise ServiceConfigError("credential file is unexpectedly large")
+    secret = secret.strip()
+    if not secret or "\n" in secret or "\r" in secret:
+        raise ServiceConfigError("credential file must contain one non-empty line")
+    return secret
+
+
+def _activate_model(
+    host: str,
+    port: int,
+    *,
+    credential_file: str | None,
+    credential_uid: int,
+    timeout_s: int = 600,
+) -> bool:
+    """Ask the local service to load/warm its configured primary model."""
+    import http.client
+
+    try:
+        secret = _read_service_credential(credential_file, expected_uid=credential_uid)
+        headers = {"Content-Length": "0"}
+        if secret is not None:
+            headers["Authorization"] = f"Bearer {secret}"
+        connection = http.client.HTTPConnection(
+            _probe_host(host), port, timeout=timeout_s
+        )
+        try:
+            connection.request("POST", "/v1/models/activate", headers=headers)
+            response = connection.getresponse()
+            payload = json.loads(response.read())
+        finally:
+            connection.close()
+    except (OSError, ValueError, http.client.HTTPException):
+        return False
+    return bool(
+        response.status == 200
+        and isinstance(payload, dict)
+        and payload.get("state") == "ready"
+        and payload.get("model_loaded") is True
+    )
+
+
+def _wait_qualified(config: ServiceConfig, *, ready_timeout_s: int = 120) -> bool:
+    """Require both an accepting endpoint and a loadable configured model."""
+    if not _wait_ready(config.host, config.port, timeout_s=ready_timeout_s):
+        return False
+    credential_uid = user_uid(config.service_user)
+    if credential_uid is None:
+        return False
+    return _activate_model(
+        config.host,
+        config.port,
+        credential_file=config.credential_file,
+        credential_uid=credential_uid,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -578,9 +681,9 @@ def install_command(args) -> int:
             raise ServiceInstallError(f"launchctl bootstrap failed: {boot_err}")
         # Wait for readiness; on failure roll back the load AND the plist so
         # nothing persists to auto-start on the next boot.
-        if not _wait_ready(host, port):
+        if not _wait_qualified(service_config):
             raise ServiceInstallError(
-                f"service did not become ready on {host}:{port} within 120s; "
+                f"service endpoint or configured model did not qualify on {host}:{port}; "
                 f"rolled back. Check {home}/Library/Logs/Rapid-MLX/"
                 "server.stderr.log"
             )

--- a/vllm_mlx/headless_service/status.py
+++ b/vllm_mlx/headless_service/status.py
@@ -100,11 +100,12 @@ def _read_installed_plist(label: str) -> dict | None:
 def _endpoint_health(host: str, port: int) -> tuple[bool, bool]:
     """``(live, ready)`` for ``/livez`` and ``/readyz`` over HTTP.
 
-    ``live`` = the process is alive (``/livez`` returns 200 — it never means
-    "model ready"). ``ready`` = the model is loaded (``/readyz`` returns 200
-    AND ``"ready": true``), sharing the corrected ``install._readyz_ready``
-    so status, install, and restart all agree on "healthy". Best-effort via
-    a raw socket GET — no external HTTP client dependency.
+    ``live`` = the process is alive (``/livez`` returns 200). ``ready`` = the
+    endpoint can accept work (``/readyz`` returns 200 AND ``"ready": true``).
+    A lazy service can therefore be ready in ``standby`` without resident
+    weights; install/apply/upgrade separately use the authenticated activation
+    gate to qualify the configured model. Best-effort via a raw socket GET —
+    no external HTTP client dependency.
     """
     import socket
 

--- a/vllm_mlx/headless_service/upgrade.py
+++ b/vllm_mlx/headless_service/upgrade.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from .common import DEFAULT_LABEL
 from .config import ServiceConfigError, atomic_write, load_config
 from .configure import _account, _bootout, _bootstrap, _identity_or_error
-from .install import _wait_ready, is_root
+from .install import _wait_qualified, _wait_ready, is_root
 
 
 def _target(version: str | None, extras: str | None) -> str:
@@ -97,6 +97,7 @@ def upgrade_command(args) -> int:
         f"install {target} as {user}",
         "run rapid-mlx doctor (diagnostic)",
         f"bootstrap and require {config.host}:{config.port}/readyz",
+        "activate and qualify the configured primary model",
         "restore frozen environment and old service on any failure",
     ]
     if dry_run:
@@ -144,7 +145,7 @@ def upgrade_command(args) -> int:
                 file=sys.stderr,
             )
         boot = _bootstrap(label)
-        healthy = boot.returncode == 0 and _wait_ready(config.host, config.port)
+        healthy = boot.returncode == 0 and _wait_qualified(config)
     else:
         healthy = False
 

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -231,6 +231,60 @@ async def livez():
     return {"status": "alive"}
 
 
+@admin_router.post("/v1/models/activate")
+async def activate_primary_model():
+    """Load and warm the configured primary without running user inference.
+
+    Probe endpoints deliberately leave a lazy service in ``standby``.  This
+    authenticated control-plane operation is the explicit opt-in used by the
+    transactional launchd installer/apply/upgrade gates (and by operators who
+    want to pre-warm an always-on endpoint).  It never selects or downloads a
+    request-supplied model: only the primary fixed in the server configuration
+    can be activated.
+    """
+    cfg = get_config()
+    if not cfg.ready or cfg.draining:
+        raise HTTPException(status_code=503, detail="Service is not accepting work")
+    lifecycle = cfg.primary_model_lifecycle
+    if lifecycle is None:
+        if cfg.engine is None:
+            raise HTTPException(status_code=503, detail="Primary model unavailable")
+        return {
+            "status": "ready",
+            "model": cfg.model_name,
+            "state": "ready",
+            "model_loaded": True,
+        }
+
+    acquired = False
+    try:
+        lifecycle.acquire_request()
+        acquired = True
+        await lifecycle.ensure_loaded()
+        status = lifecycle.snapshot()
+    except Exception as exc:
+        # Keep model paths / loader messages out of the wire response.  The
+        # full traceback remains in the service log for the local operator.
+        logger.exception("Primary model activation failed")
+        raise HTTPException(
+            status_code=503, detail="Primary model activation failed"
+        ) from exc
+    finally:
+        if acquired:
+            lifecycle.release_request()
+
+    if status["state"] != "ready" or not status["model_loaded"]:
+        raise HTTPException(
+            status_code=503, detail="Primary model did not reach ready state"
+        )
+    return {
+        "status": "ready",
+        "model": cfg.model_name,
+        "state": status["state"],
+        "model_loaded": True,
+    }
+
+
 @admin_router.post("/v1/requests/{request_id}/cancel")
 async def cancel_request(request_id: str):
     """Cancel an active or queued request.


### PR DESCRIPTION
## Why

Depends on #3214.

#3129 made `rapid-mlx service install/apply/upgrade` transactional and gated candidate acceptance on `/readyz`. #3214 correctly changes readiness for an Always-on Rapid Engine: a lazy service in `standby` returns ready because its stable endpoint can accept and coalesce a demand load without probes waking the model.

Those two correct behaviors create a deployment gap when combined. A candidate can pass `/readyz` while its configured weights have never loaded. A bad model path, incompatible weights, or a load-time runtime failure would then surface on the first real request—possibly hours after `apply` or `upgrade` had already committed and released its rollback boundary.

This PR separates endpoint readiness from model qualification. A successful service transaction now means both:

1. the endpoint is accepting work; and
2. the configured primary has actually reached `state=ready` with `model_loaded=true`.

## User outcome

- `service install` does not report success for a lazy configuration whose primary cannot load.
- `service apply` restores the prior definition when the candidate model cannot activate.
- `service upgrade` restores the frozen runtime when the upgraded server cannot activate its configured primary.
- Failures appear during the operator's maintenance action instead of on the first user request.
- `/readyz` remains a cheap, non-waking endpoint probe, so ordinary health checks preserve standby memory savings.
- After successful qualification, the existing idle timeout may return the model to `standby`; the URL, PID, and configured model identity remain stable.

## Behavior

The transaction is now:

```text
bootstrap candidate
  -> /readyz: endpoint can accept work
  -> POST /v1/models/activate
  -> require state=ready and model_loaded=true
  -> commit
```

On any failure, the existing rollback path boots out the candidate and restores the prior definition/runtime.

The rollback service itself is checked with the existing endpoint readiness gate only. This is intentional: the previous installed version may predate the new activation endpoint, and rollback must remain available across version boundaries.

## Server API

Adds authenticated:

```http
POST /v1/models/activate
```

The operation:

- accepts no model identifier;
- can only load the primary fixed in the validated server configuration;
- uses the existing `PrimaryModelLifecycle.ensure_loaded()` path;
- therefore shares/coalesces an in-flight cold load and runs the same post-load warmup/cache path as a first inference request;
- holds a lifecycle request lease through activation so idle unload cannot race qualification;
- returns only after the lifecycle snapshot is `ready` and resident;
- returns a sanitized 503 on load failure while retaining the full traceback in local service logs;
- rejects activation while the server is starting or draining;
- returns immediately for an already eager/resident primary.

This is also a useful explicit pre-warm operation for operators, but service transactions are its first consumer.

## Credential safety

When service authentication is enabled, the root-run service command must authenticate its local activation request without leaking the key.

- The key is never placed in argv, the plist, command output, a URL, or logs.
- It is sent only in an in-memory `Authorization: Bearer` header to the validated loopback endpoint.
- The credential is opened with `O_NOFOLLOW`.
- The already-open inode is required to be a regular file, mode-private, and owned by the configured service uid.
- Reads are bounded to 64 KiB and the existing one-non-empty-line contract is enforced.
- Missing credentials remain equivalent to authentication being unconfigured; if a running authenticated daemon and the on-disk credential disagree, qualification fails closed.

## Scope and non-goals

- No current/candidate worker pair.
- No zero-downtime model switching.
- No arbitrary request-triggered model discovery or download.
- No change to `/readyz` standby semantics.
- No change to normal inference requests.
- `service restart` keeps its existing endpoint-health behavior; it is not a configuration/runtime commit boundary.
- Qualification proves the configured primary can load and reach the server's ready lifecycle. It is not a semantic model-quality evaluation.

## Acceptance

- [x] Lazy standby alone cannot satisfy the model qualification gate.
- [x] First install activates the configured primary before reporting success.
- [x] Apply commits only after candidate activation succeeds.
- [x] Apply restores the previous configuration when activation fails.
- [x] Upgrade commits only after activation succeeds.
- [x] Upgrade restores the previous environment when activation fails.
- [x] Authenticated services qualify without exposing credentials.
- [x] Activation cannot select a different model.
- [x] Health probes do not wake a standby model.
- [x] Activation failures do not expose model paths or loader exception text.
- [x] Existing eager service behavior remains compatible.

## Verification

- `345 passed` across service configuration, service CLI, health/control routes, and primary lifecycle suites.
- Changed-lines coverage against #3214: **100%** (85 executable changed lines, 0 missing).
- Ruff lint: passed for every touched Python file.
- Ruff format check: passed.
- `git diff --check`: passed.
- Targeted mypy traversal reported no errors in the modified files; the command still exits non-zero on pre-existing repository-wide type errors in unrelated imported modules.

## Website documentation handoff

The website's Always-on Rapid Engine and headless macOS service pages should carry these product distinctions:

### Endpoint ready vs model qualified

- `/readyz` answers: "Can this stable endpoint accept a request?"
- A lazy `standby` endpoint is ready and health probes do not load weights.
- Service install/apply/upgrade additionally activate the configured primary before committing.
- Therefore a successful service transaction means the configured model has loaded at least once, even if idle policy later unloads it.

### Operator wording

Recommended copy:

> Rapid-MLX validates more than the daemon process during installation, configuration changes, and upgrades. It starts the candidate endpoint, activates the configured model, and commits only after the model becomes resident and ready. If activation fails, Rapid-MLX automatically restores the previous configuration or runtime. Lazy services may return to standby afterward according to their idle policy.

### API reference

Document `POST /v1/models/activate` as an authenticated pre-warm/qualification operation:

- no request body or model selector;
- activates only the configured primary;
- `200`: `status=ready`, `state=ready`, `model_loaded=true`;
- `401`: configured API credential missing/invalid;
- `503`: server not accepting work, primary unavailable, or activation failed;
- may take model cold-start time;
- does not run a user-visible completion.

### Troubleshooting

- If apply/upgrade reports model qualification failure, inspect `rapid-mlx service logs`.
- Correct the model/configuration and stage/apply again; the previous service remains the rollback target.
- A successful transaction followed later by `state=standby` is expected when idle unload is enabled; it does not mean qualification was skipped.
- Repeated qualification timeout can mean the model exceeds available unified memory or cold load exceeds the bounded activation window.

## Release notes draft

Always-on Rapid Engine deployments now verify the configured model before committing an install, configuration change, or runtime upgrade. Lazy services still keep their endpoint online in low-memory standby, but Rapid-MLX performs one authenticated activation during the maintenance transaction and automatically restores the previous configuration or runtime if the model cannot load.

## Dependency / merge plan

#3214 merged first as required. This PR is now rebased directly onto its `main` merge commit and contains only the service-qualification changes. The final main-based CI and Apple Silicon gates passed before queue admission.

## AI assistance disclosure

Codex identified the cross-feature readiness gap between #3129 and #3214, implemented the activation gate, credential hardening, transaction integration, tests, architecture/docs updates, and reviewed the final diff. All AI-touched files are listed in this PR.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For generated or boilerplate sections, I have identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally
- [x] Lint and format checks pass
- [x] Changed-lines coverage is 100%
- [x] Product and architecture docs updated
- [x] Website documentation handoff included
- [x] Release notes draft included
- [x] No credentials or machine-specific secrets committed
- [x] No breaking change to the OpenAI-compatible inference API



## Final self-validation scorecard

Repository validator run on commit `bb7e5724`:

- Independent Codex adversarial review: passed with no blocking findings.
- Diff-aware targeted suite: `548 passed`.
- Instrumented patch coverage: `85/85` changed executable lines, **100%**.
- Full unit suite: `23,069 passed`, `101 skipped`, `22 deselected`, `6 xfailed`, `1 xpassed`, with three environment-dependent failures:
  - `test_packaged_bf16_uses_model_path_without_onload_quantization`: optional `mflux` package is not installed in this development environment.
  - two `test_legacy_prefix_cache_flag_warnings` cases: the existing Rapid-MLX Desktop service owns their hard-coded `127.0.0.1:8000` test port.
- Stress/E2E was intentionally skipped for this stacked validation run.

That pre-rebase local aggregate verdict was `DO NOT MERGE` because any full-unit failure is gating. The three failures were unrelated to this diff. After #3214 merged, the PR was rebased onto `main`; the repository CI reran the supported matrix in its declared environments and passed completely.



## Apple Silicon dogfood

Real local run on commit `bb7e5724` with cached `mlx-community/Qwen3-0.6B-4bit`, API authentication enabled, `--lazy-load --idle-unload-seconds 5`, and one stable PID/port:

- Cold endpoint: `/readyz` returned `state=standby`, `model_loaded=false`; RSS 48,816 KiB.
- Unauthenticated `POST /v1/models/activate`: HTTP 401.
- Authenticated activation: HTTP 200 with `state=ready`, `model_loaded=true`; RSS 795,728 KiB.
- After the five-second idle window: the same PID returned to `state=standby`, `model_loaded=false`; RSS 52,864 KiB.
- Server logs confirmed model load, Metal warmup, tool-grammar warmup, prefix-cache restore/save, engine stop, and clean process shutdown.

This directly verifies that endpoint probes do not wake weights, the activation gate honors authentication, activation reaches real residency, and existing idle unload reclaims the primary afterward.



## Final main-based CI

Final GitHub CI on head `a314456a` passed every required job:

- Linux unit matrices: Python 3.10, 3.11, and 3.12.
- Apple Silicon test suite.
- Changed-lines coverage: 100%.
- PR validation, lint, type-check, engine contracts, and MLX bound guard.
- macOS build, Desktop tests, GUI harness contracts, and accessibility checks.

The first main-based CI run exposed that route tests placed in an existing whole-file `requires_mlx` module were absent from both merged coverage artifacts. The activation contracts were moved into a dedicated no-MLX FastAPI test module; the supported Linux roster now executes them, and the unchanged 85/85 implementation-line coverage passes in CI.
