### PR TITLE
feat: expose request-scoped MTP response metrics

### DIFF
--- a/.agents/handoffs/vector-3155-response-telemetry.md
+++ b/.agents/handoffs/vector-3155-response-telemetry.md
@@ -1,0 +1,78 @@
+# Vector handoff: #3155 request-scoped MTP response telemetry
+
+## PR contract
+
+- Owner: Vector
+- Host: Mac Studio
+- Branch: `vector/3155-response-telemetry`
+- Worktree: `/private/tmp/vector-3155-response-telemetry`
+- Goal: expose request-scoped MTP accepted/drafted depth counts, verify calls,
+  correction tokens, and bonus tokens in the final response telemetry so a
+  user can diagnose why speculative decoding did or did not improve latency.
+- Scope: request-local accounting for both the singleton and continuous MTP
+  paths; final-output propagation; OpenAI-compatible chat, completion, and
+  Responses serialization; streaming/non-streaming parity; regression tests.
+- Non-goals: no MTP algorithm, depth policy, cache behavior, model/catalog,
+  downloader, or unrelated response-API change.
+- Verification: pure-Python counter and concurrency tests, scheduler/output
+  propagation tests, route serialization tests, local API dogfood, scoped
+  adversarial review, PR validation, and CI.
+
+## Reference-first notes (internal only)
+
+- Rapid-MLX: reviewed the process-global `MTPAcceptCounter`, continuous MTP
+  proposal accounting, request/output lifecycle, and the JSON serializers that
+  already use `exclude_none=True`.
+- vLLM: reviewed its current request-owned speculative accumulator and its
+  final-output-only `metrics.speculative_decoding` response contract. Adopt the
+  request ownership and final-only transport pattern; do not derive a request
+  delta from process-global counters because concurrent requests would mix.
+- SGLang: reviewed its per-request speculative counts and `sgl_ext` response
+  extension. Adopt the explicit extension-envelope principle, while using the
+  more neutral `metrics.speculative_decoding` envelope that also accommodates
+  Rapid's future timing metrics.
+- MLX-LM: no corresponding public per-request response contract was found; its
+  generator response remains the lower-level token delivery surface, so the
+  accounting must remain in Rapid's scheduler/request layer.
+
+## Storage policy
+
+No model download is required for this PR. Before any later model download or
+checkpoint conversion, read `~/STORAGE-POLICY.md`, inspect the existing global
+Hugging Face cache, and never override or redirect its configured cache paths.
+
+## Verification evidence
+
+- Scoped route/engine/counter suite: 318 passed, 2 skipped, 3 deselected.
+- Real server dogfood used only the already-cached
+  `mlx-community/Qwen3.5-4B-MLX-4bit` base and
+  `mlx-community/Qwen3.5-4B-MTP-4bit` sidecar; no model bytes were downloaded.
+- Singleton non-stream response: 1 verify call, 1/1 depth-1 accepted; streaming
+  response: exactly 1 of 12 JSON events carried metrics, on the terminal chunk.
+- Four simultaneous continuous-MTP requests (prefix cache disabled to exercise
+  that lane) returned four distinct request-owned histograms: 40, 16, 39, and
+  39 verify calls. The service log confirmed a four-lane continuous cohort.
+- A deliberately prefix-cache-routed concurrent run returned no metrics because
+  it performed no MTP verification; this matches the documented omission rule.
+- Microbenchmark, CPython 3.11 on this Studio, 7 repeats x 200,000
+  `record_round(3, 2)` calls: existing single counter median 568.7 ns/call;
+  process + request fan-out median 1089.7 ns/call; incremental bookkeeping
+  521.0 ns per verifier round. This is accounting overhead only, not a claimed
+  end-to-end inference speedup.
+
+## Self-adversarial review
+
+- Round 1 found cached response replay could leak the original request's MTP
+  metrics into a cache hit. Fixed by clearing metrics on cache replay and added
+  a route regression test.
+- Round 2 checked singleton/continuous ownership, dynamic joins, terminal output
+  aggregation, stream finalization, and multi-prompt Completions. Multi-prompt
+  metrics now sum per-depth counts across choices instead of dropping them.
+- Round 3 dogfood checked ordinary, streaming, concurrent continuous-MTP, and
+  no-verification fallback behavior. No further in-scope correctness finding.
+- Round 4 full-smoke probing found open-ended test doubles can synthesize a
+  `MagicMock.spec_decode_metrics` attribute. The serializer now accepts only a
+  dict or the typed schema and otherwise fails closed; the three affected
+  completions logging tests pass. Full smoke then reached an unrelated optional
+  image test whose local environment lacks `mflux` (isolated: 22 passed, 1
+  environment failure); no image-scope change was made.

--- a/.agents/handoffs/vector-3155-response-telemetry.md
+++ b/.agents/handoffs/vector-3155-response-telemetry.md
@@ -80,3 +80,6 @@ Hugging Face cache, and never override or redirect its configured cache paths.
   continuous-cohort attachment. The optional id is now narrowed before
   `dict.get`; the pinned CI type environment reports the existing 701-error
   grandfathered budget with no growth, and 162 related tests pass.
+- Round 6 changed-lines coverage reached 98% and identified exactly two missing
+  branches: empty counter-group construction and JSON-buffered Completions
+  terminal metrics. Added direct regression tests; the focused suite is 26/26.

--- a/.agents/handoffs/vector-3155-response-telemetry.md
+++ b/.agents/handoffs/vector-3155-response-telemetry.md
@@ -76,3 +76,7 @@ Hugging Face cache, and never override or redirect its configured cache paths.
   completions logging tests pass. Full smoke then reached an unrelated optional
   image test whose local environment lacks `mflux` (isolated: 22 passed, 1
   environment failure); no image-scope change was made.
+- Round 5 hosted CI found one new mypy diagnostic at the request-id lookup in
+  continuous-cohort attachment. The optional id is now narrowed before
+  `dict.get`; the pinned CI type environment reports the existing 701-error
+  grandfathered budget with no growth, and 162 related tests pass.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -274,6 +274,31 @@ you turn it on.
 > diagnostic above already assumes one model and `disable_auto_k`; keep it
 > that way — a fresh process per checkpoint — when you read the ratio.
 
+For request-level diagnosis, successful MTP requests also include an
+experimental `metrics.speculative_decoding` object in the terminal response:
+
+```json
+{
+  "metrics": {
+    "speculative_decoding": {
+      "verify_calls": 12,
+      "correction_tokens": 3,
+      "bonus_tokens": 5,
+      "accepted_by_depth": [11, 8, 4],
+      "drafted_by_depth": [12, 11, 8]
+    }
+  }
+}
+```
+
+The counters belong only to that HTTP request, so concurrent traffic cannot
+mix their values. Multi-prompt Completions sum the counters across their
+choices. They appear on non-streaming Chat Completions, Completions, and
+Responses payloads, or on the single terminal event for their streaming forms.
+The `metrics` field is omitted when MTP did not perform a verification round,
+including ordinary decoding and response-cache hits. The process-wide
+`/metrics` series remain the right surface for service dashboards.
+
 #### MTP sidecar heads are not standalone models
 
 The `*-mtp-4bit` aliases — `qwen3.6-27b-mtp-4bit`

--- a/tests/test_continuous_self_mtp_engine.py
+++ b/tests/test_continuous_self_mtp_engine.py
@@ -193,8 +193,12 @@ def test_rapid_forward_seams_use_return_hidden_and_n_confirmed():
 
 def test_fixed_membership_prepare_attach_propose_commit_detach_lifecycle():
     runtime, compute, caches, _calls = _runtime()
-    lane1, first1 = _prepare(runtime, 1)
-    lane2, first2 = _prepare(runtime, 2)
+    from vllm_mlx.spec_decode.mtp.accept_counter import MTPAcceptCounter
+
+    lane1_counter = MTPAcceptCounter()
+    lane2_counter = MTPAcceptCounter()
+    lane1, first1 = _prepare(runtime, 1, accept_counter=lane1_counter)
+    lane2, first2 = _prepare(runtime, 2, accept_counter=lane2_counter)
     assert (first1.token, first2.token) == (101, 102)
 
     batch = engine.attach_self_mtp_lanes(None, [lane1, lane2])
@@ -219,6 +223,22 @@ def test_fixed_membership_prepare_attach_propose_commit_detach_lifecycle():
     assert snap.accepts == sum(proposal.accepted_lengths) == 1
     assert dict(snap.drafted_by_depth)[1] == snap.verify_calls
     assert dict(snap.accepted_by_depth) == {1: 1}
+    # Each response accumulator sees only its own lane, even though the
+    # continuous verifier executes both rows in one batched proposal.
+    assert lane1_counter.snapshot().response_metrics() == {
+        "verify_calls": 1,
+        "correction_tokens": 1,
+        "bonus_tokens": 0,
+        "drafted_by_depth": [1, 1],
+        "accepted_by_depth": [1, 0],
+    }
+    assert lane2_counter.snapshot().response_metrics() == {
+        "verify_calls": 1,
+        "correction_tokens": 1,
+        "bonus_tokens": 0,
+        "drafted_by_depth": [1, 1],
+        "accepted_by_depth": [0, 0],
+    }
     assert not [call for call in caches.calls if call[0] == "rollback"]
     with pytest.raises(engine.ContinuousSelfMTPError, match="proposal is open"):
         engine.detach_self_mtp_lanes(batch, [0, 1])

--- a/tests/test_mtp_cli_wiring.py
+++ b/tests/test_mtp_cli_wiring.py
@@ -3420,6 +3420,22 @@ def test_install_mtp_vendored_latches_prompt_lookup_and_complete_history(
     assert (policy.min_ngram, policy.max_ngram, policy.max_tokens) == (18, 42, 6)
     assert seen["timing_stats"] is batch_gen._mtp_vendored_stats
     assert batch_gen._mtp_vendored_stats["prompt_lookup_proposals"] == 0.0
+    # #3155: the singleton verifier receives a fan-out recorder so its
+    # existing process-wide Prometheus accounting and this request's response
+    # telemetry advance from the same outcomes, without global delta math.
+    seen["accept_counter"].record_round(2, 1)
+    assert request_stub._mtp_accept_counter.snapshot().response_metrics() == {
+        "verify_calls": 1,
+        "correction_tokens": 1,
+        "bonus_tokens": 0,
+        "drafted_by_depth": [1, 1],
+        "accepted_by_depth": [1, 0],
+    }
+    from vllm_mlx.spec_decode.mtp.accept_counter import (
+        reset_global_counter_for_tests,
+    )
+
+    reset_global_counter_for_tests()
 
 
 def test_scheduler_stats_export_vendored_mtp_counters_by_value():

--- a/tests/test_mtp_depth_telemetry_3155.py
+++ b/tests/test_mtp_depth_telemetry_3155.py
@@ -12,9 +12,39 @@ import pytest
 
 from vllm_mlx.spec_decode.mtp.accept_counter import (
     MTPAcceptCounter,
+    MTPAcceptCounterGroup,
     get_global_counter,
     reset_global_counter_for_tests,
 )
+
+
+def test_response_metrics_are_dense_and_absent_before_a_verify():
+    counter = MTPAcceptCounter()
+    assert counter.snapshot().response_metrics() is None
+
+    counter.record_round(3, 1)
+    counter.record_round(2, 0)
+
+    assert counter.snapshot().response_metrics() == {
+        "verify_calls": 2,
+        "correction_tokens": 2,
+        "bonus_tokens": 0,
+        "drafted_by_depth": [2, 2, 1],
+        "accepted_by_depth": [1, 0, 0],
+    }
+
+
+def test_counter_group_keeps_process_and_request_lifetimes_in_sync():
+    process = MTPAcceptCounter()
+    request = MTPAcceptCounter()
+    group = MTPAcceptCounterGroup(process, request)
+
+    group.record_attempt()
+    group.record_accept(tokens_saved=1)
+    group.record_verify(1, 1)
+    group.record_reject()
+
+    assert process.snapshot() == request.snapshot()
 
 
 def test_record_verify_builds_prefix_histogram():

--- a/tests/test_mtp_depth_telemetry_3155.py
+++ b/tests/test_mtp_depth_telemetry_3155.py
@@ -47,6 +47,11 @@ def test_counter_group_keeps_process_and_request_lifetimes_in_sync():
     assert process.snapshot() == request.snapshot()
 
 
+def test_counter_group_rejects_an_empty_fanout():
+    with pytest.raises(ValueError, match="requires at least one counter"):
+        MTPAcceptCounterGroup()
+
+
 def test_record_verify_builds_prefix_histogram():
     c = MTPAcceptCounter()
     c.record_verify(3, 3)  # all accepted -> bonus

--- a/tests/test_mtp_response_telemetry_3155.py
+++ b/tests/test_mtp_response_telemetry_3155.py
@@ -1,0 +1,104 @@
+"""#3155 request-scoped MTP telemetry response contract."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from vllm_mlx.api.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
+    ChatCompletionChunkDelta,
+    ChatCompletionResponse,
+)
+from vllm_mlx.api.responses_adapter import openai_to_responses
+from vllm_mlx.api.responses_models import ResponsesRequest
+from vllm_mlx.engine import GenerationOutput
+from vllm_mlx.service.helpers import _build_response_metrics, _merge_response_metrics
+
+_RAW_METRICS = {
+    "verify_calls": 3,
+    "correction_tokens": 1,
+    "bonus_tokens": 2,
+    "accepted_by_depth": [3, 2, 1],
+    "drafted_by_depth": [3, 3, 2],
+}
+
+
+def _metrics():
+    return _build_response_metrics(
+        GenerationOutput(text="ok", spec_decode_metrics=_RAW_METRICS)
+    )
+
+
+def test_chat_response_emits_metrics_only_when_mtp_ran():
+    choice = ChatCompletionChoice(message=AssistantMessage(content="ok"))
+    plain = ChatCompletionResponse(model="model", choices=[choice])
+    assert "metrics" not in plain.model_dump(exclude_none=True)
+
+    measured = ChatCompletionResponse(
+        model="model", choices=[choice], metrics=_metrics()
+    )
+    assert measured.model_dump(exclude_none=True)["metrics"] == {
+        "speculative_decoding": _RAW_METRICS
+    }
+
+    assert _build_response_metrics(MagicMock()) is None
+
+
+def test_terminal_chat_chunk_serializes_the_same_metrics_envelope():
+    chunk = ChatCompletionChunk(
+        model="model",
+        choices=[
+            ChatCompletionChunkChoice(
+                delta=ChatCompletionChunkDelta(), finish_reason="stop"
+            )
+        ],
+        metrics=_metrics(),
+    )
+    payload = json.loads(chunk.model_dump_json(exclude_none=True))
+    assert payload["metrics"]["speculative_decoding"] == _RAW_METRICS
+
+
+def test_responses_adapter_preserves_request_metrics():
+    response = ChatCompletionResponse(
+        model="model",
+        choices=[ChatCompletionChoice(message=AssistantMessage(content="ok"))],
+        metrics=_metrics(),
+    )
+    converted = openai_to_responses(
+        response,
+        model="model",
+        request=ResponsesRequest(model="model", input="hello"),
+        created_at=1,
+    )
+    payload = converted.model_dump(exclude_none=True)
+    assert payload["metrics"]["speculative_decoding"] == _RAW_METRICS
+
+
+def test_multi_prompt_completion_metrics_are_summed_by_depth():
+    first = GenerationOutput(text="a", spec_decode_metrics=_RAW_METRICS)
+    second = GenerationOutput(
+        text="b",
+        spec_decode_metrics={
+            "verify_calls": 2,
+            "correction_tokens": 2,
+            "bonus_tokens": 0,
+            "accepted_by_depth": [1],
+            "drafted_by_depth": [2],
+        },
+    )
+
+    merged = _merge_response_metrics([first, GenerationOutput(text="plain"), second])
+
+    assert merged is not None
+    assert merged.speculative_decoding is not None
+    assert merged.speculative_decoding.model_dump() == {
+        "verify_calls": 5,
+        "correction_tokens": 3,
+        "bonus_tokens": 2,
+        "accepted_by_depth": [4, 2, 1],
+        "drafted_by_depth": [5, 3, 2],
+    }

--- a/tests/test_response_cache_route.py
+++ b/tests/test_response_cache_route.py
@@ -75,6 +75,13 @@ class _CountingEngine:
             completion_tokens=3,
             finished=True,
             finish_reason="stop",
+            spec_decode_metrics={
+                "verify_calls": 2,
+                "correction_tokens": 1,
+                "bonus_tokens": 1,
+                "accepted_by_depth": [2, 1],
+                "drafted_by_depth": [2, 2],
+            },
         )
 
 
@@ -138,6 +145,11 @@ def test_repeated_deterministic_request_served_from_cache():
     # (fresh id) carrying the SAME stored completion body. The id differs
     # (each hit is a distinct response), the content is the replayed one.
     assert r1.json()["id"] != r2.json()["id"]
+    assert r1.json()["metrics"]["speculative_decoding"]["verify_calls"] == 2
+    assert "metrics" not in r2.json(), (
+        "a response-cache hit must not replay request metrics from the engine "
+        "execution that originally populated the cache"
+    )
 
     # The cache recorded exactly one hit and one miss.
     snap = get_response_cache().snapshot()

--- a/tests/test_responses_route.py
+++ b/tests/test_responses_route.py
@@ -46,6 +46,7 @@ class _GenerationOutput:
     logprobs: Any = None
     channel: str | None = None
     tool_calls: list | None = None
+    spec_decode_metrics: dict | None = None
 
 
 class _Engine:
@@ -57,6 +58,7 @@ class _Engine:
         self.stream_calls: list[SimpleNamespace] = []
         self.build_prompt_calls: list[SimpleNamespace] = []
         self.tokenizer = _Tokenizer()
+        self.emit_mtp_metrics = False
 
     async def chat(self, messages, **kwargs):
         self.calls.append(SimpleNamespace(messages=messages, kwargs=kwargs))
@@ -78,6 +80,17 @@ class _Engine:
                 prompt_tokens=3 if i == 0 else 0,
                 completion_tokens=i + 1,
                 finish_reason=None if i < len(chunks) - 1 else "stop",
+                spec_decode_metrics=(
+                    {
+                        "verify_calls": 2,
+                        "correction_tokens": 1,
+                        "bonus_tokens": 1,
+                        "accepted_by_depth": [2, 1],
+                        "drafted_by_depth": [2, 2],
+                    }
+                    if self.emit_mtp_metrics and i == len(chunks) - 1
+                    else None
+                ),
             )
 
     def build_prompt(self, messages, tools=None, enable_thinking=None):
@@ -1296,6 +1309,30 @@ class TestResponsesStream:
         assert usage["input_tokens"] == 3
         assert usage["output_tokens"] == 3
         assert usage["total_tokens"] == 6
+
+    def test_stream_completed_event_carries_request_mtp_metrics(self, responses_client):
+        responses_client.engine.emit_mtp_metrics = True
+
+        with responses_client.client.stream(
+            "POST",
+            "/v1/responses",
+            json=_payload(stream=True),
+            headers={"Authorization": "Bearer test-secret"},
+        ) as resp:
+            body = "".join(resp.iter_text())
+
+        events = _parse_sse(body)
+        completed = [d for name, d in events if name == "response.completed"]
+        assert len(completed) == 1
+        assert completed[0]["response"]["metrics"] == {
+            "speculative_decoding": {
+                "verify_calls": 2,
+                "correction_tokens": 1,
+                "bonus_tokens": 1,
+                "accepted_by_depth": [2, 1],
+                "drafted_by_depth": [2, 2],
+            }
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -547,12 +547,14 @@ class TestRequestOutputCollectorThreadSafety:
             completion_tokens=2,
             cached_tokens=64,
             error="exact repetition loop detected",
+            spec_decode_metrics={"verify_calls": 1},
         )
         merged = collector._merge_outputs(existing, new)
         assert merged.cached_tokens == 64
         assert merged.new_token_ids == [1, 2]
         assert merged.completion_tokens == 2
         assert merged.error == "exact repetition loop detected"
+        assert merged.spec_decode_metrics == {"verify_calls": 1}
 
 
 class TestEngineCoreStreamBufferMerge:
@@ -578,12 +580,14 @@ class TestEngineCoreStreamBufferMerge:
             completion_tokens=1,
             cached_tokens=128,
             error="generation aborted",
+            spec_decode_metrics={"verify_calls": 1},
         )
         merged = EngineCore._merge_stream_buffer(None, chunk)
         assert merged.cached_tokens == 128
         assert merged.new_token_ids == [7]
         assert merged.new_text == "hi"
         assert merged.error == "generation aborted"
+        assert merged.spec_decode_metrics == {"verify_calls": 1}
 
     def test_merge_into_existing_buffer_preserves_cached_tokens(self):
         from vllm_mlx.engine_core import EngineCore
@@ -605,6 +609,7 @@ class TestEngineCoreStreamBufferMerge:
             completion_tokens=3,
             cached_tokens=128,
             error="generation aborted",
+            spec_decode_metrics={"verify_calls": 2},
         )
         merged = EngineCore._merge_stream_buffer(prev, chunk)
         assert merged.cached_tokens == 128
@@ -613,6 +618,7 @@ class TestEngineCoreStreamBufferMerge:
         assert merged.new_text == "abc"
         assert merged.completion_tokens == 3
         assert merged.error == "generation aborted"
+        assert merged.spec_decode_metrics == {"verify_calls": 2}
 
 
 class TestRequestTimeoutField:

--- a/tests/test_stream_include_usage_honored.py
+++ b/tests/test_stream_include_usage_honored.py
@@ -56,8 +56,11 @@ class _PlainChatEngine:
     supports_guided_generation = False
     tokenizer = None
 
-    def __init__(self, deltas: list[str] | None = None) -> None:
+    def __init__(
+        self, deltas: list[str] | None = None, *, with_mtp_metrics: bool = False
+    ) -> None:
         self._deltas = deltas or ["Hello", " world", "."]
+        self._with_mtp_metrics = with_mtp_metrics
 
     def build_prompt(self, messages, tools=None, enable_thinking=None):
         return "PROMPT"
@@ -75,6 +78,17 @@ class _PlainChatEngine:
                 finished=is_last,
                 finish_reason="stop" if is_last else None,
                 channel=None,
+                spec_decode_metrics=(
+                    {
+                        "verify_calls": 2,
+                        "correction_tokens": 1,
+                        "bonus_tokens": 1,
+                        "accepted_by_depth": [2, 1],
+                        "drafted_by_depth": [2, 2],
+                    }
+                    if is_last and self._with_mtp_metrics
+                    else None
+                ),
             )
 
 
@@ -89,8 +103,11 @@ class _PlainCompletionsEngine:
     supports_guided_generation = False
     tokenizer = None
 
-    def __init__(self, deltas: list[str] | None = None) -> None:
+    def __init__(
+        self, deltas: list[str] | None = None, *, with_mtp_metrics: bool = False
+    ) -> None:
         self._deltas = deltas or ["foo", "bar", "baz"]
+        self._with_mtp_metrics = with_mtp_metrics
 
     async def stream_generate(self, prompt, **kwargs):
         accumulated = ""
@@ -105,6 +122,17 @@ class _PlainCompletionsEngine:
                 finished=is_last,
                 finish_reason="stop" if is_last else None,
                 channel=None,
+                spec_decode_metrics=(
+                    {
+                        "verify_calls": 2,
+                        "correction_tokens": 1,
+                        "bonus_tokens": 1,
+                        "accepted_by_depth": [2, 1],
+                        "drafted_by_depth": [2, 2],
+                    }
+                    if is_last and self._with_mtp_metrics
+                    else None
+                ),
             )
 
 
@@ -374,6 +402,43 @@ def test_completions_stream_emits_dedicated_usage_chunk_when_include_usage_true(
         f"per-token chunks MUST NOT carry usage; got {len(per_token)} "
         f"that did: {per_token!r}"
     )
+
+
+@pytest.mark.parametrize("endpoint", ["chat", "completions"])
+def test_terminal_stream_chunk_carries_request_scoped_mtp_metrics(endpoint):
+    if endpoint == "chat":
+        client = _make_chat_client(_PlainChatEngine(with_mtp_metrics=True))
+        path = "/v1/chat/completions"
+        body = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "max_tokens": 16,
+        }
+    else:
+        client = _make_completions_client(
+            _PlainCompletionsEngine(with_mtp_metrics=True)
+        )
+        path = "/v1/completions"
+        body = {
+            "model": "test-model",
+            "prompt": "hi",
+            "stream": True,
+            "max_tokens": 16,
+        }
+
+    response = client.post(path, json=body)
+    assert response.status_code == 200, response.text
+    events = _parse_sse(response.text)
+    measured = [event for event in events if "metrics" in event]
+    assert len(measured) == 1
+    assert measured[0]["metrics"]["speculative_decoding"] == {
+        "verify_calls": 2,
+        "correction_tokens": 1,
+        "bonus_tokens": 1,
+        "accepted_by_depth": [2, 1],
+        "drafted_by_depth": [2, 2],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stream_include_usage_honored.py
+++ b/tests/test_stream_include_usage_honored.py
@@ -441,6 +441,29 @@ def test_terminal_stream_chunk_carries_request_scoped_mtp_metrics(endpoint):
     }
 
 
+def test_json_buffered_completion_terminal_carries_request_scoped_mtp_metrics():
+    client = _make_completions_client(
+        _PlainCompletionsEngine(deltas=['{"ok"', ":true}"], with_mtp_metrics=True)
+    )
+    response = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hi",
+            "stream": True,
+            "max_tokens": 16,
+            "response_format": {"type": "json_object"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    events = _parse_sse(response.text)
+    measured = [event for event in events if "metrics" in event]
+    assert len(measured) == 1
+    assert measured[0]["choices"][0]["finish_reason"] == "stop"
+    assert measured[0]["metrics"]["speculative_decoding"]["verify_calls"] == 2
+
+
 # ---------------------------------------------------------------------------
 # Spec edge cases
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/api/models.py
+++ b/vllm_mlx/api/models.py
@@ -2198,6 +2198,22 @@ class PromptTokensDetails(BaseModel):
     cached_tokens: int = 0
 
 
+class SpeculativeDecodingMetrics(BaseModel):
+    """Experimental counters for one request's MTP verifier work."""
+
+    verify_calls: int = 0
+    correction_tokens: int = 0
+    bonus_tokens: int = 0
+    accepted_by_depth: list[int] = Field(default_factory=list)
+    drafted_by_depth: list[int] = Field(default_factory=list)
+
+
+class PerRequestMetrics(BaseModel):
+    """Optional engine metrics carried only on a terminal response."""
+
+    speculative_decoding: SpeculativeDecodingMetrics | None = None
+
+
 class Usage(BaseModel):
     """Token usage statistics."""
 
@@ -2217,6 +2233,7 @@ class ChatCompletionResponse(BaseModel):
     model: str
     choices: list[ChatCompletionChoice]
     usage: Usage = Field(default_factory=Usage)
+    metrics: PerRequestMetrics | None = None
 
 
 # =============================================================================
@@ -2469,6 +2486,7 @@ class CompletionResponse(BaseModel):
     model: str
     choices: list[CompletionChoice]
     usage: Usage = Field(default_factory=Usage)
+    metrics: PerRequestMetrics | None = None
 
 
 # =============================================================================
@@ -3317,6 +3335,7 @@ class ChatCompletionChunk(BaseModel):
     model: str
     choices: list[ChatCompletionChunkChoice]
     usage: Usage | None = None  # Included when stream_options.include_usage=true
+    metrics: PerRequestMetrics | None = None
 
 
 # Supported output dimensions: a bounded range keeps a single request from

--- a/vllm_mlx/api/responses_adapter.py
+++ b/vllm_mlx/api/responses_adapter.py
@@ -1005,6 +1005,7 @@ def openai_to_responses(
         status=status,
         output=output,
         usage=usage,
+        metrics=response.metrics,
         parallel_tool_calls=bool(request.parallel_tool_calls),
         tool_choice=request.tool_choice or "auto",
         tools=request.tools or [],

--- a/vllm_mlx/api/responses_models.py
+++ b/vllm_mlx/api/responses_models.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from .models import (
     _TOP_K_SENTINEL_CAP,
     _VALID_REASONING_EFFORTS,
+    PerRequestMetrics,
     ResponseFormat,
     StreamOptions,
     _validate_nonnegative_int,
@@ -534,6 +535,7 @@ class ResponsesResponse(BaseModel):
     status: str = "completed"  # "completed" | "failed" | "incomplete"
     output: list[ResponsesOutputItem]
     usage: ResponsesUsage = Field(default_factory=ResponsesUsage)
+    metrics: PerRequestMetrics | None = None
     parallel_tool_calls: bool = False
     tool_choice: str | dict = "auto"
     tools: list[dict] = Field(default_factory=list)

--- a/vllm_mlx/engine/base.py
+++ b/vllm_mlx/engine/base.py
@@ -97,6 +97,10 @@ class GenerationOutput:
     # note above to preserve positional constructor arg indices for
     # pre-existing fields.
     matched_stop: str | None = None
+    # Experimental per-request speculative-decoding counters. Populated only
+    # on the terminal output when MTP actually verified at least one draft.
+    # Appended last to preserve positional compatibility.
+    spec_decode_metrics: dict[str, int | list[int]] | None = None
 
 
 def _callable_accepts_kwarg(func: Any, name: str, inspect_mod: Any) -> bool:

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -2589,6 +2589,7 @@ class BatchedEngine(BaseEngine):
             # on the OpenAI surface (it already lumps stop+EOS under
             # ``finish_reason="stop"``).
             matched_stop=getattr(output, "matched_stop", None),
+            spec_decode_metrics=getattr(output, "spec_decode_metrics", None),
         )
 
     async def stream_generate(
@@ -2735,6 +2736,7 @@ class BatchedEngine(BaseEngine):
                     # H-03: MLLM stream parity — propagate the matched
                     # stop string for the Anthropic adapter.
                     matched_stop=getattr(output, "matched_stop", None),
+                    spec_decode_metrics=getattr(output, "spec_decode_metrics", None),
                 )
             return
 
@@ -2836,6 +2838,7 @@ class BatchedEngine(BaseEngine):
                     # H-03: text stream parity — propagate the matched
                     # stop string for the Anthropic adapter.
                     matched_stop=getattr(output, "matched_stop", None),
+                    spec_decode_metrics=getattr(output, "spec_decode_metrics", None),
                 )
         finally:
             # Best-effort defensive abort. Codex r2 P1 #2 concern: this
@@ -3500,6 +3503,7 @@ class BatchedEngine(BaseEngine):
             # streaming chunks so the terminal chunk still carries it
             # for /v1/messages stop_sequence surfacing.
             matched_stop=source.matched_stop,
+            spec_decode_metrics=source.spec_decode_metrics,
         )
 
     def _routed_finish_sentinel(self, source: GenerationOutput) -> GenerationOutput:
@@ -3518,6 +3522,7 @@ class BatchedEngine(BaseEngine):
             # /v1/messages stop_sequence surfacing works on router-led
             # streams (harmony / gemma4).
             matched_stop=source.matched_stop,
+            spec_decode_metrics=source.spec_decode_metrics,
         )
 
     def _finalize_output_router(

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -1426,6 +1426,10 @@ class EngineCore:
                 req_output.matched_stop
                 or (buf.matched_stop if buf is not None else None)
             ),
+            spec_decode_metrics=(
+                req_output.spec_decode_metrics
+                or (buf.spec_decode_metrics if buf is not None else None)
+            ),
         )
 
     async def stream_outputs(

--- a/vllm_mlx/output_collector.py
+++ b/vllm_mlx/output_collector.py
@@ -181,6 +181,12 @@ class RequestOutputCollector:
             # ``/v1/messages`` reads this on the FINAL output and would
             # otherwise lose the stop_sequence signal under aggregation.
             matched_stop=new.matched_stop or existing.matched_stop,
+            # Request-scoped speculative metrics are terminal-only. Prefer the
+            # newest terminal payload, while retaining one already buffered if
+            # a later synthetic flush carries no metrics.
+            spec_decode_metrics=(
+                new.spec_decode_metrics or existing.spec_decode_metrics
+            ),
         )
 
     def clear(self) -> None:

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -215,6 +215,12 @@ class Request:
     # share one typed lifecycle boundary.  ``init=False`` preserves every
     # positional Request constructor used by existing clients.
     _continuous_mtp_state: Any | None = field(default=None, init=False, repr=False)
+    # Request-owned speculative acceptance counter. The MTP installers create
+    # it lazily only after this request enters a verifier path; the process
+    # counter remains the separate Prometheus lifetime. Keeping this state on
+    # the Request prevents concurrent generations from contaminating response
+    # telemetry through global before/after snapshots.
+    _mtp_accept_counter: Any | None = field(default=None, init=False, repr=False)
 
     # PFlash prompt compression state. When pflash_metadata["compressed"]
     # is True, prompt_token_ids is the compressed list and
@@ -385,6 +391,10 @@ class RequestOutput:
     # the end of the dataclass so positional constructor args for the pre-existing
     # fields keep their indices.
     error_kind: str | None = None
+    # Per-request speculative-decoding metrics, populated only on the terminal
+    # output and only when at least one MTP verify call ran. Appended last to
+    # preserve positional compatibility for downstream RequestOutput callers.
+    spec_decode_metrics: dict[str, int | list[int]] | None = None
 
     @property
     def usage(self) -> dict[str, int]:

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -85,6 +85,7 @@ from ..service.helpers import (
     _append_tool_use_suffix,
     _apply_reasoning_cutoff_notice,
     _build_prompt_with_thinking_compat,
+    _build_response_metrics,
     _build_usage,
     _check_admission_or_503,
     _consume_guided_lifecycle_cancel,
@@ -4918,6 +4919,11 @@ async def _create_chat_completion_impl(
                         update={
                             "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
                             "created": int(time.time()),
+                            # The cached body came from an earlier engine
+                            # execution. Request-scoped MTP counters describe
+                            # work performed by THIS request, so a cache hit
+                            # must not replay the original verify histogram.
+                            "metrics": None,
                         }
                     )
                     _hit_headers = enable_thinking_warning_header(
@@ -6414,6 +6420,7 @@ async def _create_chat_completion_impl(
             )
         ],
         usage=_build_usage(output, reasoning_text),
+        metrics=_build_response_metrics(output),
     )
     # ── Response cache — STORE ───────────────────────────────────────
     #
@@ -7024,6 +7031,11 @@ async def stream_chat_completion(
                         # AI-SDK / vercel-ai-stream parsers double-count
                         # token totals when usage shows up unexpectedly.
                         usage=None,
+                        metrics=(
+                            _build_response_metrics(output)
+                            if event.finish_reason is not None
+                            else None
+                        ),
                     )
                     _tc_sse = f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
                     # Dogfood F-R2-05 + codex r5 NIT #3: previously
@@ -7693,6 +7705,7 @@ async def stream_chat_completion(
                 # the field is omitted from this terminal chunk; the
                 # dedicated trailing usage chunk is suppressed too.
                 usage=None,
+                metrics=_build_response_metrics(finish_output),
             )
             yield f"data: {final_chunk.model_dump_json(exclude_none=True)}\n\n"
         elif fallback_tool_calls or finalize_content:
@@ -8312,6 +8325,7 @@ async def stream_chat_completion_guided(
                 )
             ],
             usage=finish_usage,
+            metrics=_build_response_metrics(output),
         )
         yield f"data: {finish_chunk.model_dump_json(exclude_none=True)}\n\n"
 

--- a/vllm_mlx/routes/completions.py
+++ b/vllm_mlx/routes/completions.py
@@ -26,9 +26,11 @@ from ..config import get_config
 from ..middleware.auth import check_rate_limit, verify_api_key
 from ..service.helpers import (
     SSE_RESPONSE_HEADERS,
+    _build_response_metrics,
     _check_admission_or_503,
     _disconnect_guard,
     _extract_streaming_token_logprobs,
+    _merge_response_metrics,
     _raise_lifecycle_cancel_or_reraise,
     _release_admission_unless_committed,
     _resolve_max_tokens,
@@ -407,6 +409,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         total_completion_tokens = 0
         total_prompt_tokens = 0
         total_cached_tokens = 0
+        completed_outputs = []
 
         extended_kwargs = build_extended_sampling_kwargs(request)
 
@@ -628,6 +631,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     logprobs=choice_logprobs,
                 )
             )
+            completed_outputs.append(output)
             total_completion_tokens += output.completion_tokens
             total_prompt_tokens += (
                 output.prompt_tokens if hasattr(output, "prompt_tokens") else 0
@@ -689,6 +693,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                     else None
                 ),
             ),
+            metrics=_merge_response_metrics(completed_outputs),
         )
         return Response(
             content=comp_response.model_dump_json(exclude_none=True),
@@ -789,6 +794,7 @@ async def stream_completion(
     # usage to the finish chunk unconditionally — see comment further
     # down at the chunk-build site.
     _final_usage = None
+    _final_metrics = None
 
     # R10-H4 (R9-H2 carry) — chat-lane parity for json-mode streaming.
     # Pre-fix the streaming path emitted raw tokens that decoded as
@@ -834,6 +840,7 @@ async def stream_completion(
             _buffered_text += output.new_text or ""
             if output.finished:
                 _final_usage = get_usage(output)
+                _final_metrics = _build_response_metrics(output)
                 _buffered_finish_reason = output.finish_reason
             continue
         if output.finished and is_cancellation_finish_reason(output.finish_reason):
@@ -899,6 +906,9 @@ async def stream_completion(
         # aggregating clients (LangChain / AI-SDK / vercel-ai-stream).
         if output.finished:
             _final_usage = get_usage(output)
+            _final_metrics = _build_response_metrics(output)
+            if _final_metrics is not None:
+                data["metrics"] = _final_metrics.model_dump(exclude_none=True)
         # Task C: latch the timestamp of the first non-empty content chunk
         # for a true TTFT on the streaming emit below. This fires only in the
         # non-JSON, non-echo path (the loop ``continue``s above for
@@ -940,6 +950,8 @@ async def stream_completion(
             "model": model_name,
             "choices": [final_choice],
         }
+        if _final_metrics is not None:
+            final_data["metrics"] = _final_metrics.model_dump(exclude_none=True)
         yield f"data: {json.dumps(final_data)}\n\n"
 
     # Dedicated trailing usage chunk (OpenAI spec — empty ``choices``,

--- a/vllm_mlx/routes/responses.py
+++ b/vllm_mlx/routes/responses.py
@@ -87,6 +87,7 @@ from ..reasoning import finalize_streaming_compat
 from ..service.helpers import (
     SSE_RESPONSE_HEADERS,
     _apply_reasoning_cutoff_notice,
+    _build_response_metrics,
     _build_usage,
     _check_admission_or_503,
     _client_signalled_reasoning_intent,
@@ -2288,6 +2289,7 @@ async def _non_stream(
             )
         ],
         usage=_build_usage(output, reasoning_text),
+        metrics=_build_response_metrics(output),
     )
 
     responses_response = openai_to_responses(
@@ -2884,6 +2886,7 @@ async def _stream_responses(
         # cover legitimate immediate-stop / zero-budget /
         # stop-sequence turns whose ``finish_reason`` is ``"stop"``).
         last_finish_reason: str | None = None
+        last_response_metrics = None
         tool_filter = StreamingToolCallFilter()
 
         # Yuki F6 codex r1 BLOCKING #2 (PR #817): when the request
@@ -3499,6 +3502,8 @@ async def _stream_responses(
             if _frx is not None:
                 last_finish_reason = _frx
             chunk_is_terminal = bool(getattr(output, "finished", False) or _frx)
+            if chunk_is_terminal:
+                last_response_metrics = _build_response_metrics(output)
 
             terminal_reasoning_text = getattr(output, "reasoning_text", "")
             if terminal_reasoning_text:
@@ -4167,6 +4172,8 @@ async def _stream_responses(
                 payload["error"] = error
             if incomplete_details is not None:
                 payload["incomplete_details"] = incomplete_details
+            if last_response_metrics is not None:
+                payload["metrics"] = last_response_metrics.model_dump(exclude_none=True)
             return payload
 
         def _build_reasoning_done_payload() -> dict:

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -18,7 +18,7 @@ import os
 import threading
 import time
 from collections import OrderedDict, deque
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import mlx.core as mx
@@ -787,6 +787,17 @@ def _mtp_controller_key(model_name: str | None, sidecar: str | None) -> str | No
     return f"{len(model_name)}:{model_name}+mtp:{sidecar}"
 
 
+def _ensure_request_mtp_counter(request: Any):
+    """Return the counter owned by one request, creating it lazily."""
+    from .spec_decode.mtp.accept_counter import MTPAcceptCounter
+
+    counter = getattr(request, "_mtp_accept_counter", None)
+    if counter is None:
+        counter = MTPAcceptCounter()
+        request._mtp_accept_counter = counter
+    return counter
+
+
 def _install_continuous_mtp_router(
     batch_gen: "BatchGenerator",
     model: Any,
@@ -1032,7 +1043,18 @@ def _install_continuous_mtp_router(
         routed = router.plan(metadata, free_bytes=_free_bytes())
         if routed.route is not ContinuousMTPIntegrationRoute.CONTINUOUS_PLANNED:
             return
-        specs = [lane.spec for lane in routed.cohort]
+        specs = []
+        for lane in routed.cohort:
+            request_id = (
+                None
+                if uid_to_request_id is None
+                else uid_to_request_id.get(lane.spec.uid)
+            )
+            request = None if requests is None else requests.get(request_id)
+            counter = (
+                _ensure_request_mtp_counter(request) if request is not None else None
+            )
+            specs.append(replace(lane.spec, accept_counter=counter))
         selected = {spec.uid for spec in specs}
         try:
             candidate_driver = ContinuousMTPDriver.create(
@@ -1096,6 +1118,11 @@ def _install_continuous_mtp_router(
                 max_tokens=metadata.max_tokens,
                 num_draft=2,
                 sampling=SelfMTPSampling(temperature=metadata.temperature),
+                accept_counter=(
+                    _ensure_request_mtp_counter(requests[metadata.lane_id])
+                    if requests is not None and metadata.lane_id in requests
+                    else None
+                ),
             )
             joining_specs.append(spec)
             joining_stops[spec.uid] = metadata.stop_tokens
@@ -1948,6 +1975,19 @@ def _install_mtp_vendored(
             # exactly as it would be under baseline. Mark the uid as
             # permanently disabled so we don't retry construction on
             # every subsequent step.
+            request_counter = None
+            if uid_to_request_id is not None and requests is not None:
+                request_id = uid_to_request_id.get(uid)
+                request = requests.get(request_id) if request_id is not None else None
+                if request is not None:
+                    from .spec_decode.mtp.accept_counter import (
+                        MTPAcceptCounterGroup,
+                        get_global_counter,
+                    )
+
+                    request_counter = MTPAcceptCounterGroup(
+                        get_global_counter(), _ensure_request_mtp_counter(request)
+                    )
             try:
                 prompt_lookup_policy = _effective_prompt_lookup_policy(mtp_model)
                 prompt_lookup_enabled = sampling_options[
@@ -2001,6 +2041,7 @@ def _install_mtp_vendored(
                     # thread; never re-derive from the public seed.
                     lane_rng=sampling_options["lane_rng"],
                     timing_stats=_stats,
+                    accept_counter=request_counter,
                     # Prompt lookup is request-scoped. Capture both the
                     # route decision and immutable prompt history before the
                     # generator mutates GenerationBatch bookkeeping.
@@ -8528,6 +8569,11 @@ class Scheduler:
 
                 output.finished = True
                 output.finish_reason = response.finish_reason
+                request_mtp_counter = getattr(request, "_mtp_accept_counter", None)
+                if request_mtp_counter is not None:
+                    output.spec_decode_metrics = (
+                        request_mtp_counter.snapshot().response_metrics()
+                    )
                 if repetition_error is not None:
                     output.error = repetition_error
                     # Mark this abort as the graceful repetition-guard stop so

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1050,7 +1050,11 @@ def _install_continuous_mtp_router(
                 if uid_to_request_id is None
                 else uid_to_request_id.get(lane.spec.uid)
             )
-            request = None if requests is None else requests.get(request_id)
+            request = (
+                None
+                if requests is None or request_id is None
+                else requests.get(request_id)
+            )
             counter = (
                 _ensure_request_mtp_counter(request) if request is not None else None
             )

--- a/vllm_mlx/service/helpers.py
+++ b/vllm_mlx/service/helpers.py
@@ -42,7 +42,9 @@ from ..api.models import (
     OPENAI_REASONING_EFFORT_TO_MAX_TOKENS,
     CompletionTokensDetails,
     FunctionCall,
+    PerRequestMetrics,
     PromptTokensDetails,
+    SpeculativeDecodingMetrics,
     TokenLogProb,
     ToolCall,
     TopLogProb,
@@ -2575,6 +2577,43 @@ def build_extended_sampling_kwargs(request) -> dict:
 
 
 # ── Usage / logprobs ───────────────────────────────────────────────
+
+
+def _build_response_metrics(output: Any) -> PerRequestMetrics | None:
+    """Build terminal response metrics when this request actually ran MTP."""
+    metrics = getattr(output, "spec_decode_metrics", None)
+    if not isinstance(metrics, (dict, SpeculativeDecodingMetrics)):
+        return None
+    return PerRequestMetrics(
+        speculative_decoding=SpeculativeDecodingMetrics.model_validate(metrics)
+    )
+
+
+def _merge_response_metrics(outputs: list[Any]) -> PerRequestMetrics | None:
+    """Combine per-generation counters for one multi-prompt HTTP request."""
+    merged: SpeculativeDecodingMetrics | None = None
+    for output in outputs:
+        envelope = _build_response_metrics(output)
+        current = None if envelope is None else envelope.speculative_decoding
+        if current is None:
+            continue
+        if merged is None:
+            merged = current.model_copy(deep=True)
+            continue
+        merged.verify_calls += current.verify_calls
+        merged.correction_tokens += current.correction_tokens
+        merged.bonus_tokens += current.bonus_tokens
+        max_depth = max(len(merged.drafted_by_depth), len(current.drafted_by_depth))
+        merged.drafted_by_depth.extend([0] * (max_depth - len(merged.drafted_by_depth)))
+        merged.accepted_by_depth.extend(
+            [0] * (max_depth - len(merged.accepted_by_depth))
+        )
+        for depth in range(max_depth):
+            if depth < len(current.drafted_by_depth):
+                merged.drafted_by_depth[depth] += current.drafted_by_depth[depth]
+            if depth < len(current.accepted_by_depth):
+                merged.accepted_by_depth[depth] += current.accepted_by_depth[depth]
+    return None if merged is None else PerRequestMetrics(speculative_decoding=merged)
 
 
 def _build_usage(output: GenerationOutput, reasoning_text: str | None) -> Usage:

--- a/vllm_mlx/spec_decode/mtp/__init__.py
+++ b/vllm_mlx/spec_decode/mtp/__init__.py
@@ -58,13 +58,14 @@ tree-cache implementation once upstream ships
 
 from __future__ import annotations
 
-from .accept_counter import MTPAcceptCounter, get_global_counter
+from .accept_counter import MTPAcceptCounter, MTPAcceptCounterGroup, get_global_counter
 from .cache_patch import patch_arrays_cache_rollback_state
 from .detect import MTPEligibility, detect_mtp_eligibility
 from .dispatch import dispatch_mtp_inject, dispatch_mtp_validate
 
 __all__ = [
     "MTPAcceptCounter",
+    "MTPAcceptCounterGroup",
     "MTPEligibility",
     "detect_mtp_eligibility",
     "dispatch_mtp_inject",

--- a/vllm_mlx/spec_decode/mtp/accept_counter.py
+++ b/vllm_mlx/spec_decode/mtp/accept_counter.py
@@ -107,6 +107,25 @@ class MTPAcceptSnapshot:
             return 0.0
         return self.accepts / self.attempts
 
+    def response_metrics(self) -> dict[str, int | list[int]] | None:
+        """Return the request response payload, or ``None`` if MTP never ran."""
+        if self.verify_calls == 0:
+            return None
+        drafted = dict(self.drafted_by_depth)
+        accepted = dict(self.accepted_by_depth)
+        max_depth = max(drafted, default=0)
+        return {
+            "verify_calls": self.verify_calls,
+            "correction_tokens": self.correction_tokens,
+            "bonus_tokens": self.bonus_tokens,
+            "drafted_by_depth": [
+                drafted.get(depth, 0) for depth in range(1, max_depth + 1)
+            ],
+            "accepted_by_depth": [
+                accepted.get(depth, 0) for depth in range(1, max_depth + 1)
+            ],
+        }
+
 
 class MTPAcceptCounter:
     """Thread-safe accept-rate counter for MTP speculative decoding.
@@ -291,6 +310,42 @@ class MTPAcceptCounter:
             self._bonus_tokens = 0
             self._drafted_by_depth = {}
             self._accepted_by_depth = {}
+
+
+class MTPAcceptCounterGroup:
+    """Fan one verifier outcome out to independent counter lifetimes.
+
+    The MTP generator historically accepted one counter: the process-global
+    Prometheus accumulator.  Response telemetry additionally needs a counter
+    owned by the request.  Keeping the fan-out behind the same recorder
+    protocol makes each generator outcome update both without deriving unsafe
+    before/after deltas from process-global state under concurrent serving.
+    """
+
+    def __init__(self, *counters: MTPAcceptCounter) -> None:
+        if not counters:
+            raise ValueError("MTPAcceptCounterGroup requires at least one counter")
+        self._counters = counters
+
+    def record_attempt(self) -> None:
+        for counter in self._counters:
+            counter.record_attempt()
+
+    def record_accept(self, tokens_saved: int = 1) -> None:
+        for counter in self._counters:
+            counter.record_accept(tokens_saved=tokens_saved)
+
+    def record_verify(self, depth: int, accepted: int) -> None:
+        for counter in self._counters:
+            counter.record_verify(depth, accepted)
+
+    def record_round(self, depth: int, accepted: int) -> None:
+        for counter in self._counters:
+            counter.record_round(depth, accepted)
+
+    def record_reject(self) -> None:
+        for counter in self._counters:
+            counter.record_reject()
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_mlx/spec_decode/mtp/continuous_engine.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_engine.py
@@ -144,6 +144,7 @@ class SelfMTPLaneSpec:
     sampling: SelfMTPSampling = SelfMTPSampling()
     prompt_cache: Any = None
     mtp_cache: Any = None
+    accept_counter: Any = None
 
     def __post_init__(self) -> None:
         if isinstance(self.uid, bool) or not isinstance(self.uid, int):
@@ -186,6 +187,7 @@ class SelfMTPLane:
     pending_hidden: Any = None
     pending_tokens: list[int] = field(default_factory=list)
     backend_state: Any = None
+    accept_counter: Any = None
 
 
 @dataclass
@@ -449,6 +451,7 @@ def prepare_self_mtp_lane(
         num_draft=spec.num_draft,
         sampling=spec.sampling,
         backend_state=prepared.backend_state,
+        accept_counter=spec.accept_counter,
     )
     return (
         DetachedSelfMTPLane(lane, prepared.caches, runtime),
@@ -585,8 +588,12 @@ def propose_batched_self_mtp(batch: BatchedSelfMTPState) -> SelfMTPCycleResult:
     # the default (tier-verified) route.  Every validated row is one verify
     # call with a prefix-accepted chain of ``accepted`` drafts.
     counter = get_global_counter()
-    for depth, accepted in zip(computation.draft_depths, computation.accepted_lengths):
+    for lane, depth, accepted in zip(
+        batch.lanes, computation.draft_depths, computation.accepted_lengths
+    ):
         counter.record_round(depth, accepted)
+        if lane.accept_counter is not None:
+            lane.accept_counter.record_round(depth, accepted)
     proposal = SelfMTPCycleResult(
         membership_epoch=batch.membership_epoch,
         lane_uids=computation.lane_uids,


### PR DESCRIPTION
## Why

Closes #3155.

The process-wide speculative counters can show aggregate acceptance, but they cannot explain why one request won or lost. Users need request-owned accepted/drafted depth histograms plus verify, correction, and bonus counts without concurrent requests contaminating each other.

## Scope

- Add a request-owned MTP counter alongside the existing process-wide counter.
- Cover singleton and continuous-batching MTP lanes, including dynamic joins.
- Propagate terminal metrics through scheduler, collectors, output routing, and engine adapters.
- Expose `metrics.speculative_decoding` on Chat Completions, Completions, and Responses APIs in streaming and non-streaming forms.
- Sum multi-prompt Completions across choices and suppress stale metrics on response-cache replay.
- Document the response contract and add regression tests.

## Non-goals

- No MTP algorithm, depth-controller, model, catalog, downloader, or cache-policy change.
- No inference-speed claim or default behavior change.
- No telemetry for speculative methods other than MTP.

## Acceptance

- A successful request that performs MTP verification reports `verify_calls`, `correction_tokens`, `bonus_tokens`, `accepted_by_depth`, and `drafted_by_depth`.
- Streaming returns the block on exactly one terminal event.
- Ordinary decode, cache hits, and any path with zero MTP verify calls omit the block.
- Concurrent requests receive independent counters; process-wide `/metrics` behavior remains intact.

## Verification

- `ruff check` and `ruff format --check`: pass.
- Affected counter/scheduler/engine/route suite: 319 passed, 2 skipped, 3 deselected; post-CI type fix: 162 related tests pass; coverage branch probes: 26 passed.
- Pinned CI mypy environment: 701 grandfathered errors, no budget growth.
- Full local smoke passed the changed completions/MTP areas; one unrelated optional-image test cannot import the locally absent `mflux` extra (isolated result: 22 passed, 1 environment failure). Hosted Python and Apple test matrices provide the complete dependency-managed gate.
- Real cached-model dogfood: non-streaming response reported 1 verify call and 1/1 depth-1 acceptance.
- Real cached-model streaming dogfood: exactly 1 of 12 JSON events carried metrics, on the terminal chunk.
- Four simultaneous continuous-MTP requests reported four independent histograms with 40, 16, 39, and 39 verify calls.
- CPython 3.11 microbenchmark, 7 x 200,000 rounds: request + process fan-out adds a median 521 ns per verifier round (accounting overhead only).
- Six scoped adversarial-review rounds fixed stale cache replay, multi-prompt aggregation, fail-closed handling for non-schema attributes, and strict optional-id typing.

## Behaviour delta

Before: only process-lifetime MTP counters were observable. After: a terminal API response also carries request-owned MTP diagnostics when that request actually performed verification. Existing fields and ordinary responses are unchanged.

## AI assistance disclosure

Codex implemented and self-reviewed the request accounting, response propagation, API schema, documentation, and tests. The output was verified with targeted tests, lint/format checks, deliberate regression probes, real singleton/streaming/concurrent model dogfood, a hot-path microbenchmark, and the pinned type-check environment.

## Checklist

- [x] Scoped and dependency-managed test gates are passing; the local optional-image environment limitation is documented above
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] PR validation description, supply-chain, lint, and type gates have been run; hosted matrices are tracked to completion
- [x] Critical scheduler/response tests were spot-checked against the production paths
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API

## Author


