### PR TITLE
feat(service): expose model lifecycle in status and metrics

### DIFF
--- a/.agents/handoffs/atlas-service-lifecycle-observability.md
+++ b/.agents/handoffs/atlas-service-lifecycle-observability.md
@@ -1,0 +1,51 @@
+# Atlas handoff: lifecycle-aware service observability
+
+- **Owner:** Atlas
+- **Branch:** `atlas/service-lifecycle-observability`
+- **Base/dependency:** stacked on `atlas/service-qualify-lazy` at `a314456a`
+  while PR #3222 is in the mac-batch merge queue
+- **Goal:** make an always-on endpoint's availability, primary-model residency,
+  and recent lifecycle behavior visible without issuing inference traffic
+
+## Implemented contract
+
+- `PrimaryModelLifecycle.snapshot()` retains process-local load attempts,
+  failures, latest completed load duration, successful unload counts, and last
+  unload reason. Error output remains the sanitized exception type.
+- `rapid-mlx service status` reads the existing public `/health` response and
+  renders lifecycle state, residency, idle policy, load/unload summary, and last
+  error. `--json` exposes stable flattened keys.
+- A running older server or malformed/unavailable `/health` detail response is
+  non-fatal: existing launchd, liveness, readiness, and exit-code behavior is
+  unchanged and lifecycle keys are `null`.
+- `/metrics` exposes primary residency, a fixed one-hot lifecycle state family,
+  load attempt/failure counters, latest load duration, and successful idle
+  unloads. Lifecycle metrics render before engine-dependent statistics, so
+  standby and partial-engine scrapes remain useful.
+- User and server guides, CLI reference, and the Always-on service decision
+  record document the contract for later website/release-note reuse.
+
+## Deliberate non-goals
+
+- No current/candidate workers, multi-model concurrency, or GUI state machine.
+- No manual or memory-pressure unload behavior. The unload reason label is
+  currently the one implemented policy, `idle`; future policies can add their
+  own bounded reason values when their behavior lands.
+- Metrics are process-local and reset on restart, matching Prometheus counter
+  semantics for other Rapid-MLX runtime metrics.
+
+## Verification
+
+- `ruff check` and `ruff format --check` on all touched Python files
+- 290 targeted tests passed on Python 3.12 after error/fallback coverage
+- changed-lines coverage: 77/77 lines, 100%
+- Python 3.11 pinned mypy budget passed: 701 grandfathered errors, zero growth
+- Apple Silicon dogfood with cached `mlx-community/Qwen3-0.6B-4bit`, API auth,
+  lazy load, and a 3-second idle timeout passed. The same PID stayed ready from
+  cold standby through activation (2.163s load) and back to standby; load and
+  idle-unload metrics advanced from 0 to 1 as expected.
+
+## Remaining action
+
+Commit, push, open a stacked PR with a detailed docs/release-note-ready
+description, and rebase onto `main` after #3222 merges.

--- a/docs/engineering/decisions/2026-09-05-always-on-service-configuration.md
+++ b/docs/engineering/decisions/2026-09-05-always-on-service-configuration.md
@@ -61,6 +61,13 @@ only whether a credential exists.
 - The stable runtime supervises the server process and bounds stdout/stderr by
   size, backup count, and age. Release-directory upgrades remain separate
   operational work and should not be hidden inside this config transaction.
+- Availability and residency are separate operator signals. A lazy endpoint in
+  `standby` remains ready to accept and coalesce a demand load, so
+  `service status`, `/health`, and `/metrics` expose lifecycle state and
+  `model_loaded` independently. Process-local counters record load
+  attempts/failures, the latest load duration, and successful unload reasons.
+  Metrics use fixed low-cardinality state/reason labels; error messages are not
+  exported.
 
 ## Rollback
 

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -122,6 +122,37 @@ rapid-mlx service logs --follow          # stream, across KeepAlive restarts
 sudo rapid-mlx service restart           # kickstart + wait until healthy
 ```
 
+`service status` separates endpoint availability from model residency. A lazy
+service can correctly report `readyz=ok` while its model lifecycle is
+`state=standby loaded=no`. When lifecycle management is enabled, the human view
+also shows the idle-unload policy, most recent load duration, process-local load
+attempt/failure counts, the last successful unload reason, and the sanitized
+last error type. The same fields are available as stable keys in `--json` for
+automation; older running servers that do not expose lifecycle details leave
+those keys `null` rather than making status fail.
+
+Prometheus scrapes can distinguish a healthy cold endpoint from a resident
+model using:
+
+```text
+rapid_mlx_model_loaded
+rapid_mlx_model_lifecycle_state{state="STATE"}
+rapid_mlx_model_load_total
+rapid_mlx_model_load_failures_total
+rapid_mlx_model_load_duration_seconds
+rapid_mlx_model_unload_total{reason="idle"}
+```
+
+The lifecycle state family is a fixed one-hot gauge, and errors are never used
+as labels. `STATE` is one of `standby`, `loading`, `ready`, `unloading`,
+`error`, or `unknown`. Counters reset when the server process restarts,
+following standard Prometheus process semantics.
+If the lifecycle snapshot cannot be read, `unknown` is one and the numeric
+lifecycle samples are `NaN`; this preserves the series without claiming the
+model is unloaded or resetting counters.
+`model_load_duration_seconds` is the duration of the most recently completed
+load attempt, including its warmup hooks.
+
 The stable runtime captures server stdout and stderr through bounded rotating
 logs. Defaults are 100 MiB per active stream, five backups, and seven-day
 retention. Stage different limits with `service configure --log-max-mb`,

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -146,6 +146,17 @@ are marked; multimodal and MCP surfaces link to their own guides.
 | `/livez` | GET | Process liveness only (does not check model readiness) |
 | `/metrics` | GET | Prometheus metrics |
 
+For lazy or idle-unload deployments, `/metrics` always exposes primary-model
+residency and lifecycle series even while the engine is in standby:
+`rapid_mlx_model_loaded`, the one-hot `rapid_mlx_model_lifecycle_state`, load
+attempt/failure counters, the most recent load duration, and successful unloads
+by reason. These process-local series make `ready but cold` distinguishable from
+`loaded and ready` without probing an inference route. See the
+[headless macOS service guide](headless-macos-service.md) for the complete metric
+names and status output contract. If the lifecycle snapshot itself is
+temporarily unavailable, the state is `unknown` and its numeric samples are
+`NaN` rather than false zeroes.
+
 The `/v1/audio/*` routes are mounted when the loaded model is audio-capable
 or `--enable-audio` is passed; on a plain text-only server they return 404.
 Image and video routes are always mounted and answer with a structured 409

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -691,7 +691,9 @@ rapid-mlx service uninstall [--dry-run]
   `-- --max-num-seqs 4`. Bind overrides and secret-bearing options are
   rejected; use the service command's own `--host` and `--port` flags.
 - `status` reports launchd registration, PID and owner, the declared model
-  and bind, endpoint (`/livez`/`/readyz`) health, and log paths.
+  and bind, endpoint (`/livez`/`/readyz`) health, model lifecycle/residency,
+  idle policy, recent load/unload outcome, and log paths. `--json` keeps the
+  lifecycle keys present with `null` values when querying an older server.
 - `logs` tails the daemon's stdout/stderr logs (`--follow` streams across
   KeepAlive restarts).
 - `restart` kickstarts the daemon and waits for readiness.

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -982,6 +982,27 @@ def test_collect_status_full_branch(monkeypatch, plist_kwargs, tmp_path):
     monkeypatch.setattr(st, "_plist_path", staticmethod(lambda _l: plist))
     monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
     monkeypatch.setattr(st, "_pid_listens_on_port", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        st,
+        "_endpoint_model_status",
+        staticmethod(
+            lambda h, p, **_kwargs: {
+                "model_loaded": False,
+                "model_lifecycle": {
+                    "state": "standby",
+                    "idle_seconds": 4.0,
+                    "idle_unload_seconds": 1800.0,
+                    "lazy_load": True,
+                    "load_total": 2,
+                    "load_failures_total": 1,
+                    "last_load_duration_seconds": 8.4,
+                    "unload_total": 1,
+                    "last_unload_reason": "idle",
+                    "error": None,
+                },
+            }
+        ),
+    )
     monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: True))
     # Stub `ps -o user=` so the owner lookup is hermetic.
     monkeypatch.setattr(
@@ -1011,6 +1032,10 @@ def test_collect_status_full_branch(monkeypatch, plist_kwargs, tmp_path):
     assert data["host"] == "127.0.0.1"
     assert data["port"] == 8000
     assert data["log_dir"]
+    assert data["model_state"] == "standby"
+    assert data["model_loaded"] is False
+    assert data["model_last_load_duration_seconds"] == 8.4
+    assert data["model_last_unload_reason"] == "idle"
 
 
 def test_status_command_json_and_exit_codes(monkeypatch, capsys):
@@ -1033,6 +1058,9 @@ def test_status_command_json_and_exit_codes(monkeypatch, capsys):
     )
     monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
     monkeypatch.setattr(st, "_pid_listens_on_port", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        st, "_endpoint_model_status", staticmethod(lambda h, p, **_kwargs: None)
+    )
     monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: True))
     ns = _ns(json=True)
     assert st.status_command(ns) == 0
@@ -1131,6 +1159,13 @@ def test_collect_status_does_not_probe_unattributed_endpoint(monkeypatch):
         "_endpoint_health",
         lambda *_a, **_k: (_ for _ in ()).throw(
             AssertionError("unattributed endpoint was probed")
+        ),
+    )
+    monkeypatch.setattr(
+        st,
+        "_endpoint_model_status",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("unattributed lifecycle endpoint was probed")
         ),
     )
     monkeypatch.setattr(
@@ -1268,6 +1303,37 @@ def test_render_human_lines():
     assert "registered" in text
     assert "pid:                   42 (as serveuser)" in text
     assert "healthy" not in text
+
+    lifecycle_status = dict(
+        s,
+        model_state="standby",
+        model_loaded=False,
+        model_idle_unload_seconds=1800.0,
+        model_last_load_duration_seconds=8.4,
+        model_load_total=2,
+        model_load_failures_total=1,
+        model_last_unload_reason="idle",
+        model_unload_total=1,
+        model_last_error=None,
+    )
+    lifecycle_text = st._render_human(lifecycle_status)
+    assert "state=standby loaded=no" in lifecycle_text
+    assert "unload after 1800s" in lifecycle_text
+    assert "8.400s (attempts=2 failures=1)" in lifecycle_text
+    assert "idle (successful=1)" in lifecycle_text
+    assert "last model error:      none" in lifecycle_text
+
+    never_loaded = dict(
+        lifecycle_status,
+        model_last_load_duration_seconds=None,
+        model_load_total=0,
+        model_load_failures_total=0,
+        model_last_unload_reason=None,
+        model_unload_total=0,
+    )
+    never_loaded_text = st._render_human(never_loaded)
+    assert "never (attempts=0 failures=0)" in never_loaded_text
+    assert "none (successful=0)" in never_loaded_text
 
     # Down + no pid + hint.
     s2 = dict(
@@ -1551,6 +1617,295 @@ def test_listener_pid_probe_missing_tool_and_execution_error(monkeypatch):
     assert st._pid_listens_on_port(42, "127.0.0.1", 8000) is None
 
 
+def test_endpoint_model_status_reads_bounded_health_json(monkeypatch):
+    import http.client
+
+    import vllm_mlx.headless_service.status as st
+
+    class _Response:
+        status = 200
+
+        def read(self, _limit):
+            return b'{"model_loaded":false,"model_lifecycle":{"state":"standby"}}'
+
+    class _Connection:
+        def __init__(self, host, port, timeout):
+            assert (host, port) == ("127.0.0.1", 8123)
+            assert 0 < timeout <= 2.0
+            self.timeout = timeout
+            self.sock = None
+
+        def connect(self):
+            class _Socket:
+                def settimeout(self, _timeout):
+                    pass
+
+            self.sock = _Socket()
+
+        def request(self, method, path, headers):
+            assert (method, path, headers) == (
+                "GET",
+                "/health",
+                {"Connection": "close"},
+            )
+
+        def getresponse(self):
+            return _Response()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(http.client, "HTTPConnection", _Connection)
+    payload = st._endpoint_model_status("localhost", 8123)
+    assert payload == {
+        "model_loaded": False,
+        "model_lifecycle": {"state": "standby"},
+    }
+
+
+def test_endpoint_model_status_uses_one_deadline_and_suppresses_close_error(
+    monkeypatch,
+):
+    import http.client
+
+    import vllm_mlx.headless_service.status as st
+
+    now = iter((10.0, 10.1, 10.2, 10.3, 10.4, 10.45, 10.475, 10.49))
+    socket_timeouts = []
+    timer_intervals = []
+
+    class _Timer:
+        daemon = False
+
+        def __init__(self, interval, _callback):
+            timer_intervals.append(interval)
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            pass
+
+    class _Socket:
+        def settimeout(self, timeout):
+            socket_timeouts.append(timeout)
+
+    class _Response:
+        status = 200
+
+        def read(self, _limit):
+            return b'{"model_loaded":true}'
+
+    class _Connection:
+        def __init__(self, _host, _port, timeout):
+            assert timeout == pytest.approx(0.4)
+            self.timeout = timeout
+            self.sock = None
+
+        def connect(self):
+            assert self.timeout == pytest.approx(0.3)
+            self.sock = _Socket()
+
+        def request(self, *_args, **_kwargs):
+            pass
+
+        def getresponse(self):
+            return _Response()
+
+        def close(self):
+            raise OSError("late socket close")
+
+    monkeypatch.setattr(st.time, "monotonic", lambda: next(now))
+    monkeypatch.setattr(st.threading, "Timer", _Timer)
+    monkeypatch.setattr(http.client, "HTTPConnection", _Connection)
+
+    assert st._endpoint_model_status("127.0.0.1", 8123, timeout_s=0.5) == {
+        "model_loaded": True
+    }
+    assert timer_intervals == pytest.approx([0.2])
+    assert socket_timeouts == pytest.approx([0.1, 0.025, 0.01])
+
+
+def test_endpoint_model_status_hard_deadline_aborts_live_socket(monkeypatch):
+    import http.client
+    import socket
+
+    import vllm_mlx.headless_service.status as st
+
+    shutdowns = []
+    closes = []
+    timer_cancels = []
+
+    class _Socket:
+        def settimeout(self, _timeout):
+            pass
+
+        def shutdown(self, how):
+            shutdowns.append(how)
+
+    class _Connection:
+        def __init__(self, _host, _port, timeout):
+            self.timeout = timeout
+            self.sock = None
+            self.closed = False
+
+        def connect(self):
+            self.sock = _Socket()
+
+        def request(self, *_args, **_kwargs):
+            _Timer.current.callback()
+
+        def close(self):
+            self.closed = True
+            closes.append(True)
+
+    class _Timer:
+        daemon = False
+        current = None
+
+        def __init__(self, _interval, callback):
+            self.callback = callback
+            type(self).current = self
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            timer_cancels.append(True)
+
+    monkeypatch.setattr(st.threading, "Timer", _Timer)
+    monkeypatch.setattr(http.client, "HTTPConnection", _Connection)
+
+    assert st._endpoint_model_status("127.0.0.1", 8123, timeout_s=0.5) is None
+    assert shutdowns == [socket.SHUT_RDWR]
+    assert len(closes) == 2
+    assert timer_cancels == [True]
+
+
+def test_endpoint_model_status_stops_after_total_deadline(monkeypatch):
+    import http.client
+
+    import vllm_mlx.headless_service.status as st
+
+    now = iter((10.0, 10.6))
+    monkeypatch.setattr(st.time, "monotonic", lambda: next(now))
+    monkeypatch.setattr(
+        http.client,
+        "HTTPConnection",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("expired probe opened a connection")
+        ),
+    )
+
+    assert st._endpoint_model_status("127.0.0.1", 8123, timeout_s=0.5) is None
+
+
+def test_endpoint_model_status_refuses_unbounded_dns(monkeypatch):
+    import http.client
+
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        http.client,
+        "HTTPConnection",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("same-host lifecycle probe attempted DNS")
+        ),
+    )
+
+    assert st._endpoint_model_status("service.example", 8123) is None
+
+
+def test_collect_status_bounds_lifecycle_probe_to_shared_deadline(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    observed_timeouts = []
+    monkeypatch.setattr(
+        st,
+        "_launchctl_probe",
+        lambda *_a, **_k: (_fake_launchctl_print(pid=42), None),
+    )
+    monkeypatch.setattr(
+        st,
+        "_read_installed_plist",
+        lambda _label: {"ProgramArguments": ["/bin/rapid-mlx", "serve", "model"]},
+    )
+    monkeypatch.setattr(
+        st,
+        "_parse_legacy_serve",
+        lambda _argv: ("/bin/rapid-mlx", "model", "127.0.0.1", 8000),
+    )
+    monkeypatch.setattr(st, "_pid_listens_on_port", lambda *_a, **_k: True)
+    monkeypatch.setattr(st, "_endpoint_health", lambda *_a, **_k: (True, True))
+
+    def model_status(_host, _port, *, timeout_s):
+        observed_timeouts.append(timeout_s)
+        return {"model_loaded": True, "model_lifecycle": {"state": "ready"}}
+
+    monkeypatch.setattr(st, "_endpoint_model_status", model_status)
+    monkeypatch.setattr(st, "_port_busy", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        st.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(returncode=0, stdout="serveuser\n"),
+    )
+    monkeypatch.setattr(st, "_plist_path", lambda _label: Path("/missing.plist"))
+
+    status = st.collect_status(probe_timeout_s=0.5)
+
+    assert status["model_state"] == "ready"
+    assert len(observed_timeouts) == 1
+    assert 0 < observed_timeouts[0] <= 0.5
+
+
+def test_endpoint_model_status_rejects_unusable_responses(monkeypatch):
+    import http.client
+
+    import vllm_mlx.headless_service.status as st
+
+    class _Response:
+        def __init__(self, status, body):
+            self.status = status
+            self._body = body
+
+        def read(self, _limit):
+            return self._body
+
+    class _Connection:
+        response = _Response(503, b"")
+        request_error = False
+
+        def __init__(self, *_args, timeout, **_kwargs):
+            self.timeout = timeout
+            self.sock = None
+
+        def connect(self):
+            class _Socket:
+                def settimeout(self, _timeout):
+                    pass
+
+            self.sock = _Socket()
+
+        def request(self, *_args, **_kwargs):
+            if self.request_error:
+                raise OSError("endpoint disappeared")
+
+        def getresponse(self):
+            return self.response
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(http.client, "HTTPConnection", _Connection)
+    assert st._endpoint_model_status("127.0.0.1", 8123) is None
+
+    _Connection.response = _Response(200, b"x" * 65_537)
+    assert st._endpoint_model_status("127.0.0.1", 8123) is None
+
+    _Connection.request_error = True
+    assert st._endpoint_model_status("127.0.0.1", 8123) is None
+
+
 def test_status_owner_ps_error(monkeypatch, plist_kwargs, tmp_path):
     """A failing `ps` owner lookup degrades to owner=None, not a crash."""
     import vllm_mlx.headless_service.status as st
@@ -1561,6 +1916,9 @@ def test_status_owner_ps_error(monkeypatch, plist_kwargs, tmp_path):
         lambda *_a, **_k: (_fake_launchctl_print(pid=7), None),
     )
     monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
+    monkeypatch.setattr(
+        st, "_endpoint_model_status", staticmethod(lambda h, p, **_kwargs: None)
+    )
     monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: False))
     plist = tmp_path / "com.rapidmlx.server.plist"
     plist.write_bytes(serialize_plist(build_plist_dict(**plist_kwargs)))

--- a/tests/test_metrics_route.py
+++ b/tests/test_metrics_route.py
@@ -76,6 +76,67 @@ def test_metrics_engine_not_loaded_still_returns_200(metrics_client):
     # Engine-dependent metrics must be absent (no fake zeros that imply
     # a running engine).
     assert "rapid_mlx_requests_processed_total" not in body
+    assert "rapid_mlx_model_loaded 0" in body
+    assert 'rapid_mlx_model_lifecycle_state{state="standby"} 1' in body
+
+
+def test_metrics_exposes_primary_model_lifecycle(metrics_client):
+    metrics_client.cfg.primary_model_lifecycle = SimpleNamespace(
+        snapshot=lambda: {
+            "state": "ready",
+            "model_loaded": True,
+            "load_total": 3,
+            "load_failures_total": 1,
+            "last_load_duration_seconds": 8.4,
+            "unload_total_by_reason": {"idle": 2},
+        }
+    )
+
+    body = metrics_client.client.get("/metrics").text
+
+    assert "rapid_mlx_model_loaded 1" in body
+    assert 'rapid_mlx_model_lifecycle_state{state="ready"} 1' in body
+    assert 'rapid_mlx_model_lifecycle_state{state="standby"} 0' in body
+    assert "rapid_mlx_model_load_total 3" in body
+    assert "rapid_mlx_model_load_failures_total 1" in body
+    assert "rapid_mlx_model_load_duration_seconds 8.4" in body
+    assert 'rapid_mlx_model_unload_total{reason="idle"} 2' in body
+
+
+def test_metrics_lifecycle_snapshot_failure_and_unknown_state_are_safe(
+    metrics_client,
+):
+    def _explode():
+        raise RuntimeError("snapshot unavailable")
+
+    metrics_client.cfg.primary_model_lifecycle = SimpleNamespace(snapshot=_explode)
+    body = metrics_client.client.get("/metrics").text
+    assert 'rapid_mlx_model_lifecycle_state{state="unknown"} 1' in body
+    assert "rapid_mlx_model_loaded nan" in body
+    assert "rapid_mlx_model_load_total nan" in body
+    assert "rapid_mlx_model_load_failures_total nan" in body
+    assert "rapid_mlx_model_load_duration_seconds nan" in body
+    assert 'rapid_mlx_model_unload_total{reason="idle"} nan' in body
+
+    metrics_client.cfg.primary_model_lifecycle = SimpleNamespace(
+        snapshot=lambda: {"state": "future-state", "model_loaded": True}
+    )
+    body = metrics_client.client.get("/metrics").text
+    assert 'rapid_mlx_model_lifecycle_state{state="unknown"} 1' in body
+    assert "rapid_mlx_model_loaded 1" in body
+
+    metrics_client.cfg.primary_model_lifecycle = SimpleNamespace(
+        snapshot=lambda: {
+            "state": "standby",
+            "model_loaded": False,
+            "load_total": 0,
+            "load_failures_total": 0,
+            "last_load_duration_seconds": None,
+            "unload_total_by_reason": {},
+        }
+    )
+    body = metrics_client.client.get("/metrics").text
+    assert "rapid_mlx_model_load_duration_seconds nan" in body
 
 
 def test_metrics_engine_get_stats_raises_falls_back_to_build_info(metrics_client):

--- a/tests/test_primary_model_lifecycle.py
+++ b/tests/test_primary_model_lifecycle.py
@@ -105,12 +105,18 @@ async def test_idle_unload_keeps_engine_reloadable_and_runs_cache_hooks():
     assert engine.stop_calls == 1
     assert events == ["save", "release"]
     assert lifecycle.snapshot()["state"] == "standby"
+    assert lifecycle.snapshot()["unload_total"] == 1
+    assert lifecycle.snapshot()["unload_total_by_reason"] == {"idle": 1}
+    assert lifecycle.snapshot()["last_unload_reason"] == "idle"
     assert engine.paused is False
 
     await lifecycle.ensure_loaded()
     assert engine.start_calls == 1
     assert events == ["save", "release", "restore"]
     assert states == ["unloading", "standby", "loading", "ready"]
+    assert lifecycle.snapshot()["load_total"] == 1
+    assert lifecycle.snapshot()["load_failures_total"] == 0
+    assert lifecycle.snapshot()["last_load_duration_seconds"] == 0.0
 
 
 @pytest.mark.asyncio
@@ -339,24 +345,59 @@ async def test_failed_load_is_retryable_and_reports_only_error_type():
         await lifecycle.ensure_loaded()
     assert lifecycle.snapshot()["state"] == "error"
     assert lifecycle.snapshot()["error"] == "RuntimeError"
+    assert lifecycle.snapshot()["load_total"] == 1
+    assert lifecycle.snapshot()["load_failures_total"] == 1
 
     engine.fail_start = False
     await lifecycle.ensure_loaded()
     assert engine.start_calls == 2
     assert lifecycle.snapshot()["state"] == "ready"
+    assert lifecycle.snapshot()["load_total"] == 2
+    assert lifecycle.snapshot()["load_failures_total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_load_duration_includes_post_load_hooks():
+    now = [10.0]
+    engine = FakeEngine()
+
+    def finish_load() -> None:
+        now[0] += 2.5
+
+    lifecycle = PrimaryModelLifecycle(
+        engine,
+        lazy_load=True,
+        on_loaded=finish_load,
+        clock=lambda: now[0],
+    )
+
+    await lifecycle.ensure_loaded()
+
+    assert lifecycle.snapshot()["last_load_duration_seconds"] == 2.5
 
 
 @pytest.mark.asyncio
 async def test_partial_failed_load_is_cleaned_and_retryable():
+    now = [10.0]
     engine = FakeEngine()
     engine.fail_start = True
     engine.partial_start_failure = True
-    lifecycle = PrimaryModelLifecycle(engine, lazy_load=True)
+
+    async def release_allocator_cache():
+        now[0] += 2.5
+
+    lifecycle = PrimaryModelLifecycle(
+        engine,
+        lazy_load=True,
+        release_allocator_cache=release_allocator_cache,
+        clock=lambda: now[0],
+    )
 
     with pytest.raises(RuntimeError, match="load failed"):
         await lifecycle.ensure_loaded()
     assert engine._loaded is False
     assert engine.stop_calls == 1
+    assert lifecycle.snapshot()["last_load_duration_seconds"] == 2.5
 
     engine.fail_start = False
     await lifecycle.ensure_loaded()

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -1310,6 +1310,7 @@ def test_status_config_and_human_diagnostics(monkeypatch, tmp_path):
         lambda _label: ("runner", tmp_path, config_file),
     )
     monkeypatch.setattr(status, "_endpoint_health", lambda *_a: (True, True))
+    monkeypatch.setattr(status, "_endpoint_model_status", lambda *_a: None)
     monkeypatch.setattr(status, "_port_busy", lambda *_a: True)
     data = status.collect_status()
     assert data["config_sha256"] == config_digest(effective)

--- a/vllm_mlx/headless_service/status.py
+++ b/vllm_mlx/headless_service/status.py
@@ -25,6 +25,7 @@ import re
 import socket
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -416,6 +417,87 @@ def _pid_listens_on_port(
     return None
 
 
+def _endpoint_model_status(
+    host: str, port: int, *, timeout_s: float = 2.0
+) -> dict | None:
+    """Best-effort lifecycle snapshot from the public ``/health`` view."""
+    import http.client
+
+    from .install import _probe_host
+
+    connection: http.client.HTTPConnection | None = None
+    deadline_timer: threading.Timer | None = None
+    deadline_expired = threading.Event()
+    deadline = time.monotonic() + max(0.0, timeout_s)
+
+    def remaining() -> float:
+        if deadline_expired.is_set():
+            raise TimeoutError("lifecycle status probe deadline exceeded")
+        left = deadline - time.monotonic()
+        if left <= 0:
+            raise TimeoutError("lifecycle status probe deadline exceeded")
+        return max(0.001, left)
+
+    def bound_socket() -> None:
+        # ``HTTPConnection.timeout`` is otherwise reused independently for
+        # connect, headers and body. Reset the live socket before each phase
+        # so all of them share one wall-clock budget.
+        sock = getattr(connection, "sock", None)
+        if sock is not None:
+            sock.settimeout(remaining())
+
+    def abort_connection() -> None:
+        # Socket timeouts are inactivity timeouts, so a peer that trickles
+        # bytes can otherwise outlive the absolute Doctor budget. A one-shot
+        # deadline closes the live socket and interrupts any blocking phase.
+        deadline_expired.set()
+        assert connection is not None  # timer is created only after assignment
+        sock = getattr(connection, "sock", None)
+        if sock is not None:
+            with contextlib.suppress(OSError):
+                sock.shutdown(socket.SHUT_RDWR)
+        with contextlib.suppress(OSError):
+            connection.close()
+
+    try:
+        probe_host = _probe_host(host)
+        if probe_host.lower() == "localhost":
+            probe_host = "127.0.0.1"
+        try:
+            ipaddress.ip_address(probe_host.strip("[]"))
+        except ValueError:
+            # This is a same-host diagnostic. Refuse DNS here rather than let
+            # resolver latency escape Doctor's shared wall-clock budget.
+            return None
+        connection = http.client.HTTPConnection(probe_host, port, timeout=remaining())
+        connection.timeout = remaining()
+        deadline_timer = threading.Timer(remaining(), abort_connection)
+        deadline_timer.daemon = True
+        deadline_timer.start()
+        connection.connect()
+        bound_socket()
+        remaining()
+        connection.request("GET", "/health", headers={"Connection": "close"})
+        bound_socket()
+        response = connection.getresponse()
+        bound_socket()
+        if response.status != 200:
+            return None
+        body = response.read(65_537)
+        if len(body) > 65_536:
+            return None
+        payload = json.loads(body)
+        return payload if isinstance(payload, dict) else None
+    except (http.client.HTTPException, OSError, ValueError, RecursionError):
+        return None
+    finally:
+        if deadline_timer is not None:
+            deadline_timer.cancel()
+        if connection is not None:
+            with contextlib.suppress(OSError):
+                connection.close()
+
+
 def collect_status(
     *,
     label: str = DEFAULT_LABEL,
@@ -549,6 +631,31 @@ def collect_status(
     else:
         live, ready = None, None
 
+    # Read lifecycle detail only from the endpoint already proven to belong to
+    # this launchd PID. This avoids attributing an unrelated process on the
+    # configured port and preserves Doctor's shared deadline.
+    endpoint_status = (
+        _endpoint_model_status(
+            effective_host,
+            effective_port,
+            timeout_s=2.0 if probe_timeout_s is None else remaining(probe_timeout_s),
+        )
+        if endpoint_attributable and live is True
+        else None
+    )
+    lifecycle = (
+        endpoint_status.get("model_lifecycle")
+        if isinstance(endpoint_status, dict)
+        and isinstance(endpoint_status.get("model_lifecycle"), dict)
+        else None
+    )
+    endpoint_model_loaded = (
+        endpoint_status.get("model_loaded")
+        if isinstance(endpoint_status, dict)
+        and isinstance(endpoint_status.get("model_loaded"), bool)
+        else None
+    )
+
     effective_user = user or (declared_user if isinstance(declared_user, str) else None)
     log_dir = log_dir_for(effective_user) if effective_user else None
     return {
@@ -583,6 +690,41 @@ def collect_status(
         "endpoint_attributable": endpoint_attributable,
         "pending_config": pending_config,
         "credential_configured": credential_configured,
+        "model_state": (
+            lifecycle.get("state")
+            if lifecycle is not None
+            else "ready"
+            if endpoint_model_loaded is True
+            else None
+        ),
+        "model_loaded": endpoint_model_loaded,
+        "model_idle_seconds": (
+            lifecycle.get("idle_seconds") if lifecycle is not None else None
+        ),
+        "model_idle_unload_seconds": (
+            lifecycle.get("idle_unload_seconds") if lifecycle is not None else None
+        ),
+        "model_lazy_load": (
+            lifecycle.get("lazy_load") if lifecycle is not None else None
+        ),
+        "model_load_total": (
+            lifecycle.get("load_total") if lifecycle is not None else None
+        ),
+        "model_load_failures_total": (
+            lifecycle.get("load_failures_total") if lifecycle is not None else None
+        ),
+        "model_last_load_duration_seconds": (
+            lifecycle.get("last_load_duration_seconds")
+            if lifecycle is not None
+            else None
+        ),
+        "model_unload_total": (
+            lifecycle.get("unload_total") if lifecycle is not None else None
+        ),
+        "model_last_unload_reason": (
+            lifecycle.get("last_unload_reason") if lifecycle is not None else None
+        ),
+        "model_last_error": (lifecycle.get("error") if lifecycle is not None else None),
     }
 
 
@@ -632,6 +774,44 @@ def _render_human(s: dict) -> str:
         f"readyz={'unknown' if s['readyz'] is None else 'ok' if s['readyz'] else 'down'} "
         f"port={'open' if s['port_open'] else 'closed'}"
     )
+    if s.get("model_state") is not None:
+        loaded = s.get("model_loaded")
+        loaded_label = (
+            "yes" if loaded is True else "no" if loaded is False else "unknown"
+        )
+        lines.append(
+            f"  model lifecycle:       state={s['model_state']} loaded={loaded_label}"
+        )
+    idle_timeout = s.get("model_idle_unload_seconds")
+    if isinstance(idle_timeout, (int, float)):
+        idle_policy = (
+            f"unload after {idle_timeout:g}s"
+            if idle_timeout > 0
+            else "resident (idle unload disabled)"
+        )
+        lines.append(f"  idle policy:           {idle_policy}")
+    load_duration = s.get("model_last_load_duration_seconds")
+    if isinstance(load_duration, (int, float)):
+        attempts = s.get("model_load_total")
+        failures = s.get("model_load_failures_total")
+        lines.append(
+            f"  last load:             {load_duration:.3f}s "
+            f"(attempts={attempts} failures={failures})"
+        )
+    elif s.get("model_load_total") is not None:
+        lines.append(
+            "  last load:             never "
+            f"(attempts={s.get('model_load_total')} "
+            f"failures={s.get('model_load_failures_total')})"
+        )
+    if s.get("model_unload_total") is not None:
+        unload_reason = s.get("model_last_unload_reason") or "none"
+        lines.append(
+            f"  last unload:           {unload_reason} "
+            f"(successful={s.get('model_unload_total')})"
+        )
+    if s.get("model_load_total") is not None:
+        lines.append(f"  last model error:      {s.get('model_last_error') or 'none'}")
     lines.append(f"  plist:                 {s['plist']}")
     if s["log_dir"]:
         lines.append(f"  logs:                  {s['log_dir']}/server.stdout.log")

--- a/vllm_mlx/routes/metrics.py
+++ b/vllm_mlx/routes/metrics.py
@@ -208,6 +208,116 @@ def _coerce_number(value: Any, default: float = 0.0) -> float:
         return default
 
 
+def _render_primary_lifecycle(cfg: Any) -> list[str]:
+    """Render bounded-cardinality primary residency and transition metrics."""
+    lifecycle = getattr(cfg, "primary_model_lifecycle", None)
+    snapshot_available = True
+    if lifecycle is None:
+        snapshot: dict[str, Any] = {
+            "state": "ready" if getattr(cfg, "engine", None) is not None else "standby",
+            "model_loaded": getattr(cfg, "engine", None) is not None,
+            "load_total": 0,
+            "load_failures_total": 0,
+            "last_load_duration_seconds": 0.0,
+            "unload_total_by_reason": {},
+        }
+    else:
+        try:
+            snapshot = lifecycle.snapshot()
+        except Exception:
+            # Observability must never turn a healthy scrape into a 500.
+            snapshot_available = False
+            snapshot = {
+                "state": "unknown",
+            }
+
+    known_states = (
+        "standby",
+        "loading",
+        "ready",
+        "unloading",
+        "error",
+        "unknown",
+    )
+    state = str(snapshot.get("state") or "unknown")
+    if state not in known_states:
+        state = "unknown"
+    lines: list[str] = []
+    if snapshot_available:
+        model_loaded: float | int = int(bool(snapshot.get("model_loaded")))
+    else:
+        model_loaded = float("nan")
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_model_loaded",
+            "gauge",
+            "Whether the configured primary model weights are resident.",
+            model_loaded,
+        )
+    )
+    lines.extend(
+        _fmt_metric_family(
+            "rapid_mlx_model_lifecycle_state",
+            "gauge",
+            "Current primary model lifecycle state as a one-hot gauge.",
+            [
+                (int(candidate == state), {"state": candidate})
+                for candidate in known_states
+            ],
+        )
+    )
+    unknown_value = float("nan")
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_model_load_total",
+            "counter",
+            "Primary model load attempts since process start.",
+            (
+                int(_coerce_number(snapshot.get("load_total")))
+                if snapshot_available
+                else unknown_value
+            ),
+        )
+    )
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_model_load_failures_total",
+            "counter",
+            "Primary model load attempts that failed since process start.",
+            (
+                int(_coerce_number(snapshot.get("load_failures_total")))
+                if snapshot_available
+                else unknown_value
+            ),
+        )
+    )
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_model_load_duration_seconds",
+            "gauge",
+            "Duration of the most recently completed primary model load attempt.",
+            (
+                _coerce_number(snapshot.get("last_load_duration_seconds"))
+                if snapshot_available
+                and snapshot.get("last_load_duration_seconds") is not None
+                else unknown_value
+            ),
+        )
+    )
+    unloads = snapshot.get("unload_total_by_reason")
+    idle_unloads = unloads.get("idle", 0) if isinstance(unloads, dict) else 0
+    lines.extend(
+        _fmt_metric(
+            "rapid_mlx_model_unload_total",
+            "counter",
+            "Successful primary model unloads since process start by reason.",
+            int(_coerce_number(idle_unloads)) if snapshot_available else unknown_value,
+            labels={"reason": "idle"},
+        )
+    )
+    return lines
+
+
 def _render_model_performance(stats: dict[str, Any]) -> list[str]:
     """Render model-labelled request outcomes and latency distributions."""
     performance = stats.get("model_performance")
@@ -1370,6 +1480,10 @@ def _render_prometheus(cfg: Any) -> str:
             },
         )
     )
+
+    # Primary lifecycle metrics are process-owned and remain meaningful while
+    # the weights are in standby, so render them before engine-dependent stats.
+    lines.extend(_render_primary_lifecycle(cfg))
 
     # Embedding truncations (issue #1381). Non-silent signal: how many
     # inputs had their tail discarded for exceeding the effective max input

--- a/vllm_mlx/runtime/primary_lifecycle.py
+++ b/vllm_mlx/runtime/primary_lifecycle.py
@@ -64,6 +64,11 @@ class PrimaryModelLifecycle:
         self._monitor_task: asyncio.Task | None = None
         self._last_activity = self._clock()
         self._last_error: str | None = None
+        self._load_total = 0
+        self._load_failures_total = 0
+        self._last_load_duration_seconds: float | None = None
+        self._unload_total_by_reason: dict[str, int] = {}
+        self._last_unload_reason: str | None = None
         self._detached = False
         self._closed = False
         self._resume_required = False
@@ -113,6 +118,12 @@ class PrimaryModelLifecycle:
             "lazy_load": self.lazy_load,
             "active_request_owners": len(self._request_tokens),
             "error": self._last_error,
+            "load_total": self._load_total,
+            "load_failures_total": self._load_failures_total,
+            "last_load_duration_seconds": self._last_load_duration_seconds,
+            "unload_total": sum(self._unload_total_by_reason.values()),
+            "unload_total_by_reason": dict(self._unload_total_by_reason),
+            "last_unload_reason": self._last_unload_reason,
         }
 
     async def start(self) -> None:
@@ -270,6 +281,8 @@ class PrimaryModelLifecycle:
                 return
             self._set_state("loading")
             self._last_error = None
+            self._load_total += 1
+            started_at = self._clock()
             try:
                 start = getattr(self.engine, "start", None)
                 if not callable(start):
@@ -281,6 +294,7 @@ class PrimaryModelLifecycle:
                     await self._resume_admission()
                 await _run_hook(self._on_loaded)
             except BaseException as exc:
+                self._load_failures_total += 1
                 self._set_state("error")
                 self._last_error = type(exc).__name__
                 if self._is_loaded():
@@ -290,7 +304,9 @@ class PrimaryModelLifecycle:
                         logger.exception(
                             "Failed to reset partially loaded primary engine"
                         )
+                self._last_load_duration_seconds = max(0.0, self._clock() - started_at)
                 raise
+            self._last_load_duration_seconds = max(0.0, self._clock() - started_at)
             self._set_state("ready")
             self.touch()
 
@@ -432,6 +448,10 @@ class PrimaryModelLifecycle:
 
             self._set_state("standby")
             self._last_error = None
+            self._last_unload_reason = "idle"
+            self._unload_total_by_reason["idle"] = (
+                self._unload_total_by_reason.get("idle", 0) + 1
+            )
             return True
 
     async def _monitor_idle(self) -> None:


### PR DESCRIPTION
## Outcome

Always-on Rapid-MLX operators can now tell the difference between an endpoint
that is available and a primary model whose weights are actually resident.
This closes the observability gap created intentionally by lazy loading:
`/readyz` remains healthy in standby, while `service status` and `/metrics`
show whether the next inference will pay a cold-load cost and whether recent
loads have been failing.

## Why this matters to users

Before this change, `rapid-mlx service status` could say `readyz=ok` for both a
warm service and a lazy service in standby. That readiness behavior is correct
because standby can accept and coalesce a demand load, but it left an operator
unable to answer basic appliance questions without sending inference traffic:

- Is the configured model currently occupying unified memory?
- Is this endpoint healthy-but-cold or loaded-and-ready?
- How long did the last load take?
- Have demand loads failed since this process started?
- Did the model return to standby under the configured idle policy?

The new surface answers those questions without changing request routing,
launchd behavior, or GUI state.

## User-visible behavior

### `rapid-mlx service status`

The human-readable status view now adds lifecycle detail when the running
server supports it:

```text
health:                livez=ok readyz=ok port=open
model lifecycle:       state=standby loaded=no
idle policy:           unload after 1800s
last load:             8.400s (attempts=2 failures=1)
last unload:           idle (successful=1)
last model error:      none
```

`service status --json` exposes stable flattened keys:

- `model_state`
- `model_loaded`
- `model_idle_seconds`
- `model_idle_unload_seconds`
- `model_lazy_load`
- `model_load_total`
- `model_load_failures_total`
- `model_last_load_duration_seconds`
- `model_unload_total`
- `model_last_unload_reason`
- `model_last_error`

Status reads the existing unauthenticated `/health` view with a two-second
timeout and a 64 KiB response bound. An older server, malformed response, or
unavailable rich health view is non-fatal: existing launchd/livez/readyz output
and exit-code behavior stay intact, and unsupported lifecycle keys remain
`null`.

### Prometheus `/metrics`

The following process-local series are always emitted before engine-dependent
statistics, including while weights are absent:

```text
rapid_mlx_model_loaded
rapid_mlx_model_lifecycle_state{state="STATE"}
rapid_mlx_model_load_total
rapid_mlx_model_load_failures_total
rapid_mlx_model_load_duration_seconds
rapid_mlx_model_unload_total{reason="idle"}
```

- `model_loaded` is a 0/1 residency gauge.
- Lifecycle state is a fixed one-hot family for `standby`, `loading`, `ready`,
  `unloading`, `error`, and `unknown`.
- Load total counts attempts; failures are a subset.
- Load duration is the most recently completed attempt, including post-load
  warmup/cache hooks.
- Unload total counts successful idle-policy unloads.
- Counters reset with the server process, matching the existing metrics model.

The metrics renderer degrades to an `unknown` lifecycle snapshot if the
coordinator snapshot itself fails, so observability can never poison the whole
Prometheus scrape.

## Runtime implementation

`PrimaryModelLifecycle` now retains a bounded process-local ledger:

- load attempts and failures;
- duration of the latest completed load attempt;
- successful unload count by bounded reason;
- last successful unload reason.

The existing lifecycle `error` remains a sanitized exception type, never the
exception message. Successful recovery clears the active error exactly as
before. Idle-unload counters advance only after the engine has stopped,
allocator cleanup has completed/best-effort degraded, admission has reopened,
and standby is published.

## Compatibility and security

- No API route is added; status reuses the public `/health` contract.
- No authentication secret is read or rendered by status.
- No error message, path, model name, or user input is used as a Prometheus
  lifecycle label.
- State labels are fixed and unknown future states fold into `unknown`, keeping
  cardinality bounded.
- Existing eager servers without a lifecycle coordinator report ready/loaded
  gauges with zero transition counters.
- Existing `service status` success criteria remain registration + PID +
  `/readyz`; standby remains a successful service state.

## Deliberate non-goals

- No current/candidate worker pair or zero-downtime model switching.
- No multi-model concurrency or per-user QoS.
- No GUI state machine or GUI dependency.
- No manual or memory-pressure unload behavior in this PR. `idle` is the only
  reason exported because it is the only primary-lifecycle unload policy that
  exists today; future policies can add bounded reason values when implemented.

## Documentation / website handoff

Updated source-of-truth documentation:

- `docs/guides/headless-macos-service.md`: operator interpretation, JSON
  compatibility, complete metric list and semantics.
- `docs/guides/server.md`: lifecycle metrics at the server endpoint level.
- `docs/reference/cli.md`: expanded `service status` contract.
- `docs/engineering/decisions/2026-09-05-always-on-service-configuration.md`:
  durable decision separating availability from residency.
- `.agents/handoffs/atlas-service-lifecycle-observability.md`: implementation,
  evidence, dependency, and next-action record.

Suggested website/release-note copy:

> Always-on Rapid-MLX now reports primary-model residency separately from
> endpoint readiness. `rapid-mlx service status` shows standby/load/unload
> details, while new Prometheus lifecycle metrics reveal cold endpoints, load
> latency and failures, and successful idle unloads without issuing inference
> traffic.

## Design precedent

This follows the established operational pattern of separating process readiness from model residency: readiness stays stable while a bounded, process-local lifecycle ledger exposes cold/warm state and transition outcomes. Metrics use fixed-cardinality one-hot state gauges plus monotonic process counters; CLI status treats richer data as best-effort and preserves compatibility with older servers. During the post-parent restack, the status probe was further constrained to run only after PID/listener attribution and within the caller shared deadline.

## Verification

- Ruff check: passed on all touched Python files.
- Ruff format check: passed on all touched Python files.
- Targeted tests: **290 passed** on Python 3.12.
- Changed-lines coverage: **77/77 lines, 100%** against stacked base
  `a314456a`.
- Pinned Python 3.11 mypy budget: passed with **701 grandfathered errors across
  143 files and zero growth**.
- `git diff --check`: passed.

### Real Apple Silicon dogfood

Ran cached `mlx-community/Qwen3-0.6B-4bit` with API authentication,
`--lazy-load`, and `--idle-unload-seconds 3` on port 18023:

1. Cold endpoint: `ready=true`, `state=standby`, `model_loaded=false`, load and
   unload counters both 0.
2. Authenticated `POST /v1/models/activate`: 200, `state=ready`,
   `model_loaded=true`, `load_total=1`, `load_failures_total=0`, measured load
   duration **2.163s**.
3. After the idle window: same PID 30153 and endpoint still ready,
   `state=standby`, `model_loaded=false`,
   `model_unload_total{reason="idle"}=1`.
4. Temporary server shut down cleanly; nothing remained listening on port
   18023.

## Merge plan

The parent service-qualification layer has landed. This PR is now restacked as one scoped commit on current `main`; the conflict resolution preserves PID/listener attribution before lifecycle network I/O and bounds that extra probe by the shared Doctor deadline. Queue only after the rewritten exact head passes review, validation, and required checks.