### PR TITLE
Add Qwen3.8 27B MTP FP16 sibling for M1/M2

### DIFF
--- a/.agents/handoffs/vector-3154-qwen38-mtp-fp16.md
+++ b/.agents/handoffs/vector-3154-qwen38-mtp-fp16.md
@@ -57,11 +57,11 @@ extensionless blob layout used by the local Hugging Face cache.
    and deliberately did not copy DFlash revision pins because they bind the
    original target revision.
 
-## Remaining action
+## M2 Pro follow-up
 
-Finish the isolated M2 Pro paired measurement if the shared resident service
-becomes available without stopping another owner's process. Then update the
-performance report and model card, run final tests and PR validation, create
-and queue the PR, and send completion FYIs. If the machine remains occupied,
-publish the PR with the supplied M2 Max result clearly attributed and record
-the M2 Pro run as pending rather than producing a contaminated benchmark.
+The mini had another managed inference model resident and 1,914 MiB swap in
+use, so this task declined to load Qwen or publish a contaminated A/B. Both
+fixed checkpoints are being placed in the policy-mandated default Hugging Face
+cache for later #3156 work; no other cache or model was removed. A future
+paired measurement requires an owner-provided idle, low-swap window. The PR
+uses the supplied M2 Max result with explicit attribution in the meantime.

--- a/.agents/handoffs/vector-3154-qwen38-mtp-fp16.md
+++ b/.agents/handoffs/vector-3154-qwen38-mtp-fp16.md
@@ -1,0 +1,67 @@
+# Vector handoff: Qwen3.8 27B MTP FP16 sibling
+
+- Owner: Vector
+- Issue: #3154
+- Branch: `vector/3154-qwen38-mtp-fp16`
+- Worktree: `/private/tmp/vector-3154-qwen38-mtp-fp16`
+- Published model: `rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX`
+- Published revision: `53542c8c8c41261bfde18871197daac4e4fdb74f`
+
+## Goal and scope
+
+Give M1/M2 users an explicit FP16-storage sibling of the existing Qwen3.8 27B
+4-bit MTP checkpoint. Preserve the regular alias and all engine behavior. No
+automatic hardware routing, engine math change, default switch, or unrelated
+model/catalog work belongs in this PR.
+
+## Verified facts
+
+- Converted 1,705 BF16 tensors to FP16 and preserved 506 non-BF16 tensors
+  value-for-value across three target shards and the MTP sidecar.
+- Read-back verification covered tensor names, shapes, dtypes, values, and
+  safetensors metadata. The sidecar checksum was regenerated.
+- The public artifact is 16.3 GB and contains 18 expected repository files.
+- Rapid-MLX loaded all 31/31 MTP tensors from the sibling on M3 Ultra.
+- Two of three fixed greedy FP16/BF16 prompts were byte-identical; the third
+  differed by one semantically equivalent phrase, so no universal identity
+  claim is made.
+- FP16 MTP output was byte-identical to FP16 autoregressive output for the
+  paired smoke prompt. Four simultaneous HTTP requests completed.
+- Reporter evidence on M2 Max: a 2,726-token cold prefill improved from 133 to
+  178 tok/s (+33.8%, 1.34x) when only non-quantized storage changed BF16→FP16.
+
+## Reference-first check (private)
+
+Reviewed vLLM and SGLang checkpoint conversion/loading precedents first, then
+MLX-LM's dtype conversion and atomic shard-save path, and the repository's
+existing Qwen3.8 streaming converter. Adopted a deterministic offline artifact
+conversion with explicit source revision, per-shard read-back, a success
+manifest written last, and publication kept outside the converter. Rapid-MLX
+diverges only by preserving its colocated MTP sidecar and validating the
+extensionless blob layout used by the local Hugging Face cache.
+
+## Adversarial review record
+
+1. Artifact input review found that cache snapshot symlinks resolve to
+   extensionless blobs. Fixed loading by explicitly selecting safetensors and
+   added a regression test.
+2. Integrity review found that copying the source sidecar checksum left stale
+   metadata. Fixed by regenerating SHA-256 after conversion and asserting it.
+3. Numerical review rejected the original byte-identity assumption after one
+   of three M3 prompts diverged at a normal FP16/BF16 boundary. Model card,
+   performance report, and PR evidence state the measured 2/3 result.
+4. Boundary review added fail-closed existing/nested output checks, indexed
+   path-escape rejection, required-sidecar enforcement, and preflight disk
+   capacity validation. The converter has no upload path.
+5. Alias review kept the BF16 alias unchanged, declined silent chip routing,
+   and deliberately did not copy DFlash revision pins because they bind the
+   original target revision.
+
+## Remaining action
+
+Finish the isolated M2 Pro paired measurement if the shared resident service
+becomes available without stopping another owner's process. Then update the
+performance report and model card, run final tests and PR validation, create
+and queue the PR, and send completion FYIs. If the machine remains occupied,
+publish the PR with the supplied M2 Max result clearly attributed and record
+the M2 Pro run as pending rather than producing a contaminated benchmark.

--- a/.agents/handoffs/vector-3154-qwen38-mtp-fp16.md
+++ b/.agents/handoffs/vector-3154-qwen38-mtp-fp16.md
@@ -56,6 +56,11 @@ extensionless blob layout used by the local Hugging Face cache.
 5. Alias review kept the BF16 alias unchanged, declined silent chip routing,
    and deliberately did not copy DFlash revision pins because they bind the
    original target revision.
+6. Full-unit review caught the new repository missing from the checked-in size
+   manifest. Added the exact Hub `used_storage` value (16,313,463,520 bytes)
+   and passed the size-manifest and adjacent image-precision suites. The other
+   initial full-unit failure was a local validation environment missing the
+   declared image extra; installing that extra made the unchanged test pass.
 
 ## M2 Pro follow-up
 

--- a/README.md
+++ b/README.md
@@ -430,8 +430,14 @@ qualification (about 20 GB for the complete process tree). The 32K Studio run
 reached a 27.1 GB MLX allocator peak before non-MLX process and macOS memory;
 on a 32 GB Mac, reduce context/cache use or choose a larger-memory machine.
 
+M1 and M2 Macs can explicitly select `qwen3.8-27b-4bit-fp16`. It carries the
+same 4-bit target and native MTP layout, but stores the checkpoint's
+non-quantized tensors as FP16 for chips without accelerated BF16 matrix
+multiplication. The regular `qwen3.8-27b-4bit` alias remains unchanged for M3
+and newer Macs; Rapid does not silently swap checkpoint precision.
+
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
-→ [Every alias, quant, and family (187 text + 10 image + 10 video + 44 audio aliases, 251 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
+→ [Every alias, quant, and family (188 text + 10 image + 10 video + 44 audio aliases, 252 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
 
 ---
 

--- a/docs/engineering/performance/2026-09-07-qwen38-mtp-fp16.md
+++ b/docs/engineering/performance/2026-09-07-qwen38-mtp-fp16.md
@@ -42,10 +42,13 @@ non-quantized tensors from BF16 to FP16 increased prefill from 133 to 178
 tokens/s: **+33.8%, or 1.34x throughput**. This is supplied evidence rather
 than a run performed by this change.
 
-A paired M2 Pro qualification is recorded below once the fixed source and
-published sibling have both completed on an otherwise-idle host. Until that
-row exists, the M2 Max result is the quantitative performance evidence and the
-local runs below are correctness evidence.
+A paired run was prepared on an Apple M2 Pro Mac mini with 32 GB unified
+memory, but the host had another managed inference model resident and already
+reported 1,914 MiB of swap. That attempt was declined before loading either
+Qwen checkpoint: stopping another owner's service or reporting a
+memory-contaminated A/B would not be valid qualification. Until a clean rerun
+is available, the M2 Max result above is the quantitative performance evidence
+and the local runs below are correctness evidence.
 
 ## Rapid-MLX correctness dogfood
 

--- a/docs/engineering/performance/2026-09-07-qwen38-mtp-fp16.md
+++ b/docs/engineering/performance/2026-09-07-qwen38-mtp-fp16.md
@@ -1,0 +1,83 @@
+# Qwen3.8 27B MTP FP16 checkpoint qualification
+
+## Decision
+
+Ship an explicit `qwen3.8-27b-4bit-fp16` alias for M1 and M2 Macs. Keep
+`qwen3.8-27b-4bit` unchanged for M3 and newer chips. The new artifact changes
+only non-quantized BF16 tensors to FP16; it preserves the packed 4-bit target
+weights and the colocated native MTP drafter.
+
+This is deliberately opt-in. Automatic precision substitution would change a
+checkpoint's identity and output numerics, and this qualification does not
+cover every M1/M2 memory configuration.
+
+## Artifact contract
+
+Source:
+`rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX@aa985c29ff5b334cbfdcbbc787d47e66e9d9e456`
+
+Published sibling:
+`rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX@53542c8c8c41261bfde18871197daac4e4fdb74f`
+
+The conversion was produced by `scripts/qwen38_mtp_fp16_sibling.py`. It read
+back and checked every tensor after writing:
+
+- 1,705 BF16 tensors converted to FP16;
+- 506 non-BF16 tensors preserved value-for-value, including packed U32
+  quantized weights;
+- names, shapes, dtypes, safetensors metadata, and values verified across all
+  three target shards and `mtp/model.safetensors`;
+- all 31/31 expected MTP tensors loaded through the real Rapid-MLX engine;
+- the MTP sidecar SHA-256 regenerated after conversion.
+
+The sibling occupies 16.3 GB in Hugging Face storage and has the same shard
+layout as the source. `fp16-conversion.json` in the artifact records the
+machine-readable conversion counts and source revision.
+
+## M1/M2 performance motivation
+
+The issue reporter measured one engine on a 32 GB M2 Max using a cold
+2,726-token prompt with MTP disabled. Changing only the same checkpoint's
+non-quantized tensors from BF16 to FP16 increased prefill from 133 to 178
+tokens/s: **+33.8%, or 1.34x throughput**. This is supplied evidence rather
+than a run performed by this change.
+
+A paired M2 Pro qualification is recorded below once the fixed source and
+published sibling have both completed on an otherwise-idle host. Until that
+row exists, the M2 Max result is the quantitative performance evidence and the
+local runs below are correctness evidence.
+
+## Rapid-MLX correctness dogfood
+
+The published artifact was served on an Apple M3 Ultra with 256 GB unified
+memory and macOS 26.5.2. Both checkpoints used their exact revisions, greedy
+sampling, no prefix cache, no multimodal lane, and no speculative decoding for
+the paired target comparison:
+
+```bash
+rapid-mlx serve SNAPSHOT \
+  --host 127.0.0.1 --port 18465 \
+  --no-mllm --no-spec-decode --no-thinking \
+  --disable-prefix-cache --force-hybrid
+```
+
+Across three fixed prompts, two FP16 outputs were byte-identical to BF16. The
+third changed one Polish phrase while preserving its meaning. FP16 and BF16
+are therefore not advertised as universally byte-identical.
+
+The FP16 sibling was then served with its native MTP sidecar. It loaded 31/31
+expected sidecar tensors, returned a byte-identical greedy answer to the FP16
+autoregressive target for the paired prompt, and completed four simultaneous
+HTTP requests without an error. The target and drafter both retained 4-bit,
+group-size-64 quantization. This confirms artifact compatibility; MTP speed is
+qualified separately because draft acceptance can vary by workload.
+
+## Reproduction requirements
+
+For an M1/M2 performance row, use an otherwise-idle host with low-power mode
+off and no resident model. Pin both revisions above, disable MTP and the prefix
+cache, and alternate fresh server processes. Use the same 2,726-token prompt,
+four output tokens, temperature zero, and at least three measured runs per
+checkpoint after one discarded warm-up. Record median prompt throughput,
+package versions, hardware, macOS version, memory pressure, and swap. Do not
+present a run with another inference service resident as an isolated A/B.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -6,6 +6,7 @@ summary statistics, and limitations.
 
 ## Reports
 
+- [Qwen3.8 27B MTP FP16 checkpoint qualification](2026-09-07-qwen38-mtp-fp16.md)
 - [Qwen4 fp32-input fast RMSNorm qualification](2026-09-06-qwen4-fast-rmsnorm.md)
 - [FLUX.2 Klein q4/BF16 image precision qualification](2026-09-04-image-weight-precision.md)
 - [Qwen4 block-sparse QSA prefill qualification](2026-09-04-qwen4-qsa-block-sparse-prefill.md)

--- a/scripts/qwen38_mtp_fp16_sibling.py
+++ b/scripts/qwen38_mtp_fp16_sibling.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Create and verify an FP16 sibling of an MLX safetensors checkpoint.
+
+The converter is intentionally narrow: every BF16 tensor becomes FP16 and
+every other tensor is copied value-for-value.  Tensor names, shapes, shard
+membership, safetensors metadata, and the model's colocated MTP sidecar are
+preserved.  Publication is deliberately a separate operator action.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+SOURCE_REPOSITORY = "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX"
+SOURCE_REVISION = "aa985c29ff5b334cbfdcbbc787d47e66e9d9e456"
+TARGET_REPOSITORY = "rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX"
+SUCCESS_MANIFEST = "fp16-conversion.json"
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _validate_paths(source: Path, output: Path) -> tuple[Path, Path]:
+    source = source.expanduser().resolve()
+    output = output.expanduser().resolve()
+    if not source.is_dir():
+        raise ValueError(f"source is not a directory: {source}")
+    if output.exists():
+        raise ValueError(f"output already exists: {output}")
+    if _is_relative_to(output, source) or _is_relative_to(source, output):
+        raise ValueError("source and output must not contain one another")
+    return source, output
+
+
+def _load_index(source: Path) -> dict[str, Any]:
+    path = source / "model.safetensors.index.json"
+    try:
+        index = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid or missing safetensors index: {path}") from exc
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError("safetensors index has no non-empty weight_map")
+    return index
+
+
+def _safe_relative_file(source: Path, relative: Path) -> Path:
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"unsafe checkpoint path: {relative}")
+    candidate = source / relative
+    if not candidate.is_file():
+        raise ValueError(f"checkpoint file is missing: {relative}")
+    resolved = candidate.resolve()
+    allowed = [source]
+    if source.parent.name == "snapshots":
+        blobs = source.parent.parent / "blobs"
+        if blobs.is_dir():
+            allowed.append(blobs.resolve())
+    if not any(_is_relative_to(resolved, root) for root in allowed):
+        raise ValueError(f"checkpoint file escapes its repository cache: {relative}")
+    return resolved
+
+
+def checkpoint_shards(source: Path) -> list[Path]:
+    """Return every indexed target shard plus the required MTP sidecar."""
+
+    index = _load_index(source)
+    raw_shards = set(index["weight_map"].values())
+    if not all(isinstance(name, str) and name for name in raw_shards):
+        raise ValueError("safetensors index contains an invalid shard name")
+    relative = {Path(name) for name in raw_shards}
+    mtp = Path("mtp/model.safetensors")
+    if not (source / mtp).is_file():
+        raise ValueError("checkpoint is missing the colocated MTP sidecar")
+    relative.add(mtp)
+    for path in relative:
+        _safe_relative_file(source, path)
+    return sorted(relative)
+
+
+def _iter_auxiliary_files(source: Path) -> Iterator[Path]:
+    for path in sorted(source.rglob("*")):
+        if not path.is_file() or path.suffix == ".safetensors":
+            continue
+        relative = path.relative_to(source)
+        _safe_relative_file(source, relative)
+        yield relative
+
+
+def _copy_auxiliary_files(source: Path, output: Path) -> None:
+    for relative in _iter_auxiliary_files(source):
+        destination = output / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(_safe_relative_file(source, relative), destination)
+
+
+def _rewrite_declared_dtype(config: Any) -> int:
+    changed = 0
+    if isinstance(config, dict):
+        for key, value in config.items():
+            if key in {"dtype", "torch_dtype"} and value == "bfloat16":
+                config[key] = "float16"
+                changed += 1
+            else:
+                changed += _rewrite_declared_dtype(value)
+    elif isinstance(config, list):
+        for value in config:
+            changed += _rewrite_declared_dtype(value)
+    return changed
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", dir=path.parent, delete=False) as handle:
+        temporary = Path(handle.name)
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _write_sidecar_checksum(output: Path) -> None:
+    sidecar = output / "mtp/model.safetensors"
+    digest = hashlib.sha256()
+    with sidecar.open("rb") as handle:
+        for block in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+    checksum = output / "mtp/model.safetensors.sha256"
+    checksum.write_text(f"{digest.hexdigest()}  model.safetensors\n")
+
+
+def _free_bytes(path: Path) -> int:
+    existing = path
+    while not existing.exists():
+        if existing.parent == existing:
+            raise ValueError(f"cannot find an existing output parent for {path}")
+        existing = existing.parent
+    return shutil.disk_usage(existing).free
+
+
+def _required_output_bytes(source: Path, shards: list[Path]) -> int:
+    source_bytes = sum(
+        _safe_relative_file(source, shard).stat().st_size for shard in shards
+    )
+    # Safetensors headers and copied metadata are small, but retain a useful
+    # safety margin so a run fails before producing a partial checkpoint.
+    return max(source_bytes + (1 << 30), int(source_bytes * 1.10))
+
+
+def _array_equal(left: Any, right: Any) -> bool:
+    import mlx.core as mx
+
+    return bool(mx.array_equal(left, right).item())
+
+
+def _convert_shard(source_file: Path, output_file: Path) -> tuple[int, int]:
+    import mlx.core as mx
+
+    arrays, metadata = mx.load(source_file, format="safetensors", return_metadata=True)
+    converted: dict[str, Any] = {}
+    bf16_count = 0
+    preserved_count = 0
+    for name, value in arrays.items():
+        if value.dtype == mx.bfloat16:
+            converted[name] = value.astype(mx.float16)
+            bf16_count += 1
+        else:
+            converted[name] = value
+            preserved_count += 1
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output_file.with_name(f".{output_file.stem}.partial.safetensors")
+    mx.save_safetensors(temporary, converted, metadata=metadata)
+    os.replace(temporary, output_file)
+
+    written, written_metadata = mx.load(output_file, return_metadata=True)
+    if metadata != written_metadata or set(arrays) != set(written):
+        raise RuntimeError(f"metadata or tensor-name mismatch in {output_file.name}")
+    for name, source_value in arrays.items():
+        target_value = written[name]
+        if source_value.shape != target_value.shape:
+            raise RuntimeError(f"shape mismatch for {name}")
+        if source_value.dtype == mx.bfloat16:
+            if target_value.dtype != mx.float16 or not _array_equal(
+                source_value.astype(mx.float16), target_value
+            ):
+                raise RuntimeError(f"BF16 to FP16 mismatch for {name}")
+        elif source_value.dtype != target_value.dtype or not _array_equal(
+            source_value, target_value
+        ):
+            raise RuntimeError(f"preserved tensor mismatch for {name}")
+    return bf16_count, preserved_count
+
+
+def convert_snapshot(
+    source: Path,
+    output: Path,
+    *,
+    source_repository: str = SOURCE_REPOSITORY,
+    source_revision: str = SOURCE_REVISION,
+) -> dict[str, Any]:
+    """Convert a self-contained Qwen3.8 MTP snapshot and verify every tensor."""
+
+    source, output = _validate_paths(source, output)
+    shards = checkpoint_shards(source)
+    required = _required_output_bytes(source, shards)
+    available = _free_bytes(output)
+    if available < required:
+        raise ValueError(
+            f"insufficient output space: need {required} bytes, have {available} bytes"
+        )
+
+    output.mkdir(parents=True)
+    _copy_auxiliary_files(source, output)
+
+    config_path = output / "config.json"
+    config = json.loads(config_path.read_text())
+    changed_dtype_fields = _rewrite_declared_dtype(config)
+    if changed_dtype_fields == 0:
+        raise RuntimeError("config declares no bfloat16 model dtype")
+    _write_json_atomic(config_path, config)
+
+    bf16_count = 0
+    preserved_count = 0
+    for relative in shards:
+        converted, preserved = _convert_shard(
+            _safe_relative_file(source, relative), output / relative
+        )
+        bf16_count += converted
+        preserved_count += preserved
+
+    _write_sidecar_checksum(output)
+
+    if bf16_count == 0 or preserved_count == 0:
+        raise RuntimeError("checkpoint did not contain both BF16 and preserved tensors")
+
+    manifest: dict[str, Any] = {
+        "format": "rapid-mlx-fp16-sibling-v1",
+        "source_repository": source_repository,
+        "source_revision": source_revision,
+        "target_repository": TARGET_REPOSITORY,
+        "shards": [path.as_posix() for path in shards],
+        "converted_bf16_tensors": bf16_count,
+        "preserved_non_bf16_tensors": preserved_count,
+        "changed_config_dtype_fields": changed_dtype_fields,
+        "verification": "all tensor names, shapes, dtypes, metadata, and values",
+    }
+    _write_json_atomic(output / SUCCESS_MANIFEST, manifest)
+    return manifest
+
+
+def configure_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--source-repository", default=SOURCE_REPOSITORY)
+    parser.add_argument("--source-revision", default=SOURCE_REVISION)
+    return parser
+
+
+def main() -> None:
+    args = configure_parser().parse_args()
+    manifest = convert_snapshot(
+        args.source,
+        args.output,
+        source_repository=args.source_repository,
+        source_revision=args.source_revision,
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -135,10 +135,14 @@ def test_qwen38_flash_next_alias_is_experimental_and_memory_gated() -> None:
 
 
 def test_qwen38_27b_aliases_pin_the_native_named_xml_tool_contract() -> None:
-    """Both shipped 27B quants use the same native XML tool template."""
+    """Every shipped 27B checkpoint uses the same native XML tool template."""
 
     profiles = list_profiles()
-    for alias in ("qwen3.8-27b-4bit", "qwen3.8-27b-mixed-3.5bpw"):
+    for alias in (
+        "qwen3.8-27b-4bit",
+        "qwen3.8-27b-4bit-fp16",
+        "qwen3.8-27b-mixed-3.5bpw",
+    ):
         profile = profiles[alias]
         assert profile.tool_call_parser == "qwen3_coder_xml"
         assert detect_model_config(alias) == profile
@@ -2056,6 +2060,7 @@ def test_image_input_capability_is_strict_and_explicit() -> None:
 
     profiles = list_profiles()
     assert profiles["qwen3.8-27b-4bit"].supports_image_input is True
+    assert profiles["qwen3.8-27b-4bit-fp16"].supports_image_input is True
     assert profiles["qwen3-vl-4b-4bit"].supports_image_input is True
     assert profiles["qwen3.5-122b-mxfp4"].supports_image_input is False
 

--- a/tests/test_mtp_alias_declared_sidecar_1998.py
+++ b/tests/test_mtp_alias_declared_sidecar_1998.py
@@ -52,6 +52,7 @@ EXPERIMENTAL_MTP_ALIASES = {
     "qwen3.6-35b-ud": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
     "qwen3.6-35b": "mlx-community/Qwen3.6-35B-A3B-MTP-4bit",
     "qwen3.8-27b-4bit": "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX",
+    "qwen3.8-27b-4bit-fp16": "rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX",
     "qwen3.8-27b-mixed-3.5bpw": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",
 }
 

--- a/tests/test_qwen38_mtp_fp16_sibling.py
+++ b/tests/test_qwen38_mtp_fp16_sibling.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from scripts.qwen38_mtp_fp16_sibling import (  # noqa: E402
+    SUCCESS_MANIFEST,
+    checkpoint_shards,
+    convert_snapshot,
+)
+
+
+def _write_checkpoint(root: Path) -> None:
+    root.mkdir()
+    target = {
+        "model.layers.0.weight": mx.array([[1.0, -2.0]], dtype=mx.uint32),
+        "model.layers.0.scales": mx.array([[0.5, 1.5]], dtype=mx.bfloat16),
+        "model.norm.weight": mx.array([0.25, -0.75], dtype=mx.bfloat16),
+    }
+    mtp = {
+        "mtp.layers.0.weight": mx.array([[3, 4]], dtype=mx.uint32),
+        "mtp.layers.0.scales": mx.array([[0.125, 0.25]], dtype=mx.bfloat16),
+    }
+    mx.save_safetensors(
+        root / "model-00001-of-00001.safetensors", target, {"format": "mlx"}
+    )
+    (root / "mtp").mkdir()
+    mx.save_safetensors(root / "mtp/model.safetensors", mtp, {"format": "mlx"})
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "total_size": sum(value.nbytes for value in target.values())
+                },
+                "weight_map": {
+                    name: "model-00001-of-00001.safetensors" for name in target
+                },
+            }
+        )
+    )
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                "text_config": {
+                    "dtype": "bfloat16",
+                    "mamba_ssm_dtype": "float32",
+                    "mtp_num_hidden_layers": 1,
+                },
+                "quantization": {"bits": 4, "group_size": 64},
+            }
+        )
+    )
+    (root / "tokenizer_config.json").write_text('{"kind":"synthetic"}\n')
+
+
+def test_converts_bf16_and_preserves_quantized_and_mtp_tensors(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    output = tmp_path / "output"
+    _write_checkpoint(source)
+
+    manifest = convert_snapshot(source, output)
+
+    assert manifest["converted_bf16_tensors"] == 3
+    assert manifest["preserved_non_bf16_tensors"] == 2
+    assert manifest["shards"] == [
+        "model-00001-of-00001.safetensors",
+        "mtp/model.safetensors",
+    ]
+    assert json.loads((output / SUCCESS_MANIFEST).read_text()) == manifest
+
+    source_target = mx.load(source / "model-00001-of-00001.safetensors")
+    target = mx.load(output / "model-00001-of-00001.safetensors")
+    assert target["model.layers.0.scales"].dtype == mx.float16
+    assert target["model.norm.weight"].dtype == mx.float16
+    assert target["model.layers.0.weight"].dtype == mx.uint32
+    assert mx.array_equal(
+        source_target["model.layers.0.weight"], target["model.layers.0.weight"]
+    ).item()
+
+    source_mtp = mx.load(source / "mtp/model.safetensors")
+    target_mtp = mx.load(output / "mtp/model.safetensors")
+    assert target_mtp["mtp.layers.0.scales"].dtype == mx.float16
+    assert target_mtp["mtp.layers.0.weight"].dtype == mx.uint32
+    assert mx.array_equal(
+        source_mtp["mtp.layers.0.weight"], target_mtp["mtp.layers.0.weight"]
+    ).item()
+    digest = hashlib.sha256((output / "mtp/model.safetensors").read_bytes()).hexdigest()
+    assert (output / "mtp/model.safetensors.sha256").read_text() == (
+        f"{digest}  model.safetensors\n"
+    )
+
+    config = json.loads((output / "config.json").read_text())
+    assert config["text_config"]["dtype"] == "float16"
+    assert config["text_config"]["mamba_ssm_dtype"] == "float32"
+    assert config["text_config"]["mtp_num_hidden_layers"] == 1
+    assert (output / "tokenizer_config.json").read_text() == '{"kind":"synthetic"}\n'
+
+
+def test_requires_colocated_mtp_sidecar(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    _write_checkpoint(source)
+    (source / "mtp/model.safetensors").unlink()
+
+    with pytest.raises(ValueError, match="MTP sidecar"):
+        checkpoint_shards(source)
+
+
+def test_refuses_existing_or_nested_output(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    _write_checkpoint(source)
+    existing = tmp_path / "existing"
+    existing.mkdir()
+
+    with pytest.raises(ValueError, match="already exists"):
+        convert_snapshot(source, existing)
+    with pytest.raises(ValueError, match="must not contain"):
+        convert_snapshot(source, source / "output")
+
+
+def test_rejects_index_path_escape(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    _write_checkpoint(source)
+    index_path = source / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text())
+    index["weight_map"]["model.norm.weight"] = "../outside.safetensors"
+    index_path.write_text(json.dumps(index))
+
+    with pytest.raises(ValueError, match="unsafe checkpoint path"):
+        checkpoint_shards(source)
+
+
+def test_reads_extensionless_hf_cache_blob_symlink(tmp_path: Path) -> None:
+    repository = tmp_path / "models--rapid-mlx--synthetic"
+    source = repository / "snapshots/revision"
+    source.parent.mkdir(parents=True)
+    _write_checkpoint(source)
+    blobs = repository / "blobs"
+    blobs.mkdir()
+    shard = source / "model-00001-of-00001.safetensors"
+    blob = blobs / "0123456789abcdef"
+    shard.replace(blob)
+    shard.symlink_to(Path("../../blobs") / blob.name)
+
+    output = tmp_path / "output"
+    convert_snapshot(source, output)
+
+    converted = mx.load(output / shard.name)
+    assert converted["model.norm.weight"].dtype == mx.float16

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -427,6 +427,17 @@
     "dflash_draft_revision": "50307d4c4cde6860d4eee73e2547cd786fe8e8a4",
     "dflash_algorithm": "dflash2"
   },
+  "qwen3.8-27b-4bit-fp16": {
+    "supports_image_input": true,
+    "hf_path": "rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false,
+    "mtp_draft_model": "rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX",
+    "mtp_speculative_tokens": 3,
+    "mtp_continuous_batching_tier": "verified"
+  },
   "qwen3.8-27b-mixed-3.5bpw": {
     "supports_image_input": true,
     "hf_path": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -219,6 +219,7 @@
     "prism-ml/Ternary-Bonsai-27B-mlx-2bit": 8521052337,
     "prism-ml/bonsai-image-ternary-4B-mlx-2bit": 3888262196,
     "rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529,
+    "rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX": 16313463520,
     "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX": 16320413916,
     "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX": 14788605437,
     "rapid-mlx/Qwen3.8-Flash-Next-4bit": 104695605424,


### PR DESCRIPTION
## Why

Closes #3154. M1/M2 users currently receive a checkpoint whose non-quantized tensors use BF16 even though those chips do not accelerate BF16 matrix multiplication. In the reported controlled M2 Max comparison, changing only those tensors to FP16 raised cold prefill for a 2,726-token prompt from 133 to 178 tok/s: **+33.8%, or 1.34x throughput**. The existing checkpoint also contains native MTP heads, so users need a matching sibling rather than a generic target-only conversion.

## Scope

- Publish and register `rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX` behind the explicit `qwen3.8-27b-4bit-fp16` alias.
- Add a fail-closed, reproducible BF16-to-FP16 converter that preserves packed quantized tensors and the colocated MTP sidecar.
- Document the M1/M2 selection, artifact contract, quantitative evidence, and reproduction method.
- Extend alias, image-input, catalog, parser, and declared-MTP-sidecar contracts.

## Non-goals

No engine math changes, silent chip-based routing, default alias change, DFlash enablement, or unrelated catalog work. The regular `qwen3.8-27b-4bit` alias remains unchanged for M3 and newer Macs.

## Acceptance

- `rapid-mlx serve qwen3.8-27b-4bit-fp16` resolves to the published sibling with the existing Qwen parser, vision, hybrid, and native MTP contracts.
- All BF16 tensors become FP16; packed U32 and other non-BF16 tensors remain value-identical.
- The MTP sidecar remains complete, loadable, and checksum-consistent.
- Existing Qwen3.8 aliases and defaults do not change.

## Verification

- Converted and read back every tensor: **1,705 BF16 tensors converted; 506 non-BF16 tensors preserved** across three target shards plus the MTP sidecar.
- Real M3 Ultra dogfood loaded **31/31 MTP tensors**. Two of three fixed BF16/FP16 greedy prompts were byte-identical; the third differed by one semantically equivalent phrase, so this PR does not claim universal byte identity.
- FP16 MTP output was byte-identical to FP16 autoregressive output for the paired greedy smoke prompt; four simultaneous HTTP requests completed without error.
- A local M2 Pro A/B was declined before model load because another managed inference service was resident and swap was already 1,914 MiB; the PR does not relabel that contaminated host as performance evidence.
- `uv run pytest -q tests/test_qwen38_mtp_fp16_sibling.py tests/test_aliases_contract.py tests/test_mtp_alias_declared_sidecar_1998.py tests/test_model_aliases.py tests/test_model_auto_config.py tests/test_cli_models.py tests/test_atomic_model_catalog.py` — **3,920 passed**.
- `uv run pytest -q tests/test_model_sizes.py tests/test_image_weight_precision.py tests/test_qwen38_mtp_fp16_sibling.py` — **42 passed** after the size-manifest fix.
- `uv run ruff check ...` and `uv run ruff format --check ...` — passed.
- Five scope-locked adversarial self-review rounds found and fixed extensionless HF-cache blob loading and stale MTP checksum handling, narrowed numerical claims, and verified output-path and alias boundaries.

## Behaviour delta

Before: M1/M2 users had no Rapid alias for the MTP-preserving FP16 sibling. After: they can opt into `qwen3.8-27b-4bit-fp16`; no default changes.

## AI assistance disclosure

Codex implemented and adversarially reviewed the converter, tests, alias, and documentation. Every artifact claim was checked against the fixed published revision, the real engine dogfood above, and the listed local tests.

## Checklist

- [x] Full local unit gate: 23,063 passed, 131 skipped, 22 deselected, 6 xfailed, 1 xpassed
- [x] Self-validated with `PR_VALIDATE_NO_CODEX=1 PR_VALIDATE_NO_STRESS=1 uv run python -m scripts.pr_validate 3228` — MERGE-SAFE
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] New tests were mutation-spot-checked against the corresponding converter guards
- [x] Updated README/docs if applicable
- [x] No breaking changes to existing API

## Author

