### PR TITLE
fix(doctor): distinguish inconclusive import probes

### DIFF
--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -168,6 +168,36 @@ Do not disable disk encryption merely to follow this guide. An authenticated
 restart used by some managed updates is not a substitute for testing the cold
 boot behavior of your own machine.
 
+### Verify the default route on multi-interface Macs
+
+An appliance with Wi-Fi plus a private Ethernet or Thunderbolt link can remain
+reachable over SSH while losing its internet default route. macOS may rank the
+private link first; `install.sh`, pip, Hugging Face downloads, and DNS then fail
+even though the machine does not look offline from the other Mac.
+
+Before the first install and before booting out a working service for upgrade,
+inspect the configured service order and default route:
+
+```bash
+networksetup -listnetworkserviceorder
+route -n get default
+```
+
+For a point-to-point private link, prefer leaving its router/default-gateway
+field empty. If both interfaces provide a default route, put the intended
+internet service first. Use the exact service names printed on your Mac and
+include every enabled network service; for example:
+
+```bash
+sudo networksetup -ordernetworkservices \
+  "Wi-Fi" "Ethernet" "Thunderbolt Bridge"
+```
+
+Do not copy that order blindly: remote-only machines can lose their management
+path when network settings change. Recheck the default route, DNS, SSH access,
+and `curl -fsSIL https://rapidmlx.com/install.sh` before stopping the running
+daemon.
+
 ## 1. Prepare the service account
 
 Log in as the service account while the machine still has a display. Run every
@@ -352,9 +382,14 @@ sudo launchctl bootstrap system \
 ./scripts/headless_service_smoke.sh
 ```
 
-Investigate every Doctor issue, but do not use Doctor alone to accept or reject
-the update. Some 0.13.3 runtime layouts can produce false import failures. The
-API smoke test is the actionable gate: it proves that the daemon can load the
+Investigate every Doctor ✗, but distinguish it from an inconclusive ⚠. A row
+that says an import probe timed out, did not complete, was skipped because the
+time budget expired, or could not be verified is not evidence of a broken
+package and is not a rollback signal. Freshly installed vision dependencies can
+have slow first imports; rerun Doctor once after those cold imports settle and
+use `doctor --verbose` for the exact interpreter-bound verification command.
+Do not reinstall merely because a probe was inconclusive. The API smoke test is
+the actionable acceptance gate: it proves that the daemon can load the
 configured model and serve a request in its real launchd environment.
 
 The installer upgrades a compatible `~/.rapid-mlx` environment in place, so

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,7 +21,7 @@
 | `rapid-mlx connect` | Show the server's connection info and wire up a tool |
 | `rapid-mlx agents` | List, configure, and test agent integrations |
 | `rapid-mlx start` | Start an AI agent with a local model in one command |
-| `rapid-mlx doctor` | Run self-diagnostic / regression harness |
+| `rapid-mlx doctor` | Diagnose the selected runtime; timeout/unverified checks are warnings, not broken-package failures |
 | `rapid-mlx telemetry` | Manage anonymous usage telemetry (opt-in) |
 | `rapid-mlx upgrade` | Upgrade rapid-mlx with its detected manager (brew / uv / pipx / pip / install.sh) |
 | `rapid-mlx version` | Show version number |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -601,7 +601,9 @@ def clean_doctor_runtime_state(monkeypatch):
     env_health._RUNTIME_CONTEXTS.clear()
     env_health._RUNTIME_DISTRIBUTION_CACHE.clear()
     env_health._RUNTIME_PROBE_CACHE.clear()
+    env_health._RUNTIME_PROBE_TIMEOUTS.clear()
     env_health._RUNTIME_IMPORT_CACHE.clear()
+    env_health._RUNTIME_IMPORT_OUTCOMES.clear()
     env_health._RUNTIME_IMPORT_TIMEOUTS.clear()
 
     yield
@@ -609,5 +611,7 @@ def clean_doctor_runtime_state(monkeypatch):
     env_health._RUNTIME_CONTEXTS.clear()
     env_health._RUNTIME_DISTRIBUTION_CACHE.clear()
     env_health._RUNTIME_PROBE_CACHE.clear()
+    env_health._RUNTIME_PROBE_TIMEOUTS.clear()
     env_health._RUNTIME_IMPORT_CACHE.clear()
+    env_health._RUNTIME_IMPORT_OUTCOMES.clear()
     env_health._RUNTIME_IMPORT_TIMEOUTS.clear()

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -1812,8 +1812,45 @@ def test_runtime_probes_stop_after_deadline(tmp_path, monkeypatch):
     monkeypatch.setattr(eh, "_RUNTIME_IMPORT_CACHE", {})
 
     assert eh._probe_runtime(runtime) is None
+    assert eh._runtime_probe_timed_out(runtime)
     assert not eh._runtime_module_importable(runtime, "transformers", None)
     assert eh._import_probe_was_interrupted(runtime, "transformers", None)
+
+
+def test_runtime_probe_timeout_is_warning_not_environment_failure(
+    tmp_path,
+    monkeypatch,
+):
+    doctor_exe = tmp_path / "doctor" / "bin" / "python"
+    doctor_exe.parent.mkdir(parents=True)
+    doctor_exe.write_text("")
+    runtime = Path(sys.executable)
+    monkeypatch.setattr(eh.sys, "executable", str(doctor_exe))
+    monkeypatch.setattr(eh, "_runtime_python_path", lambda: runtime)
+    monkeypatch.setattr(eh, "_DOCTOR_DEADLINE", 0.0)
+
+    section = eh.section_required_packages()
+    report = eh.Report(sections=[section])
+
+    assert len(section.checks) == 1
+    assert section.checks[0].status is eh.CheckStatus.WARN
+    assert "inspection timed out" in section.checks[0].label
+    assert "does not indicate" in section.checks[0].detail
+    assert report.exit_code == 0
+
+
+def test_runtime_probe_records_subprocess_timeout(tmp_path, monkeypatch):
+    runtime = tmp_path / "server-runtime" / "bin" / "python"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("")
+    monkeypatch.setattr(
+        eh.subprocess,
+        "run",
+        mock.Mock(side_effect=subprocess.TimeoutExpired([str(runtime)], 1.0)),
+    )
+
+    assert eh._probe_runtime(runtime) is None
+    assert eh._runtime_probe_timed_out(runtime)
 
 
 def test_timed_out_required_import_is_unknown_not_failed(
@@ -1886,6 +1923,32 @@ def test_timeout_during_visibility_is_unknown_not_failed(
     row = next(check for check in section.checks if "transformers" in check.label)
     assert row.status is eh.CheckStatus.WARN
     assert "importability unknown" in row.label
+
+
+def test_unverified_required_import_is_warning_without_reinstall_instruction(
+    tmp_path,
+    monkeypatch,
+):
+    doctor_exe = tmp_path / "doctor" / "bin" / "python"
+    doctor_exe.parent.mkdir(parents=True)
+    doctor_exe.write_text("")
+    runtime = tmp_path / "server-runtime" / "bin" / "python"
+    runtime.parent.mkdir(parents=True)
+    monkeypatch.setattr(eh.sys, "executable", str(doctor_exe))
+    monkeypatch.setattr(eh, "_runtime_python_path", lambda: runtime)
+    monkeypatch.setattr(eh, "_probe_runtime", lambda *args, **kwargs: {"packages": {}})
+    monkeypatch.setattr(eh, "_safe_version", lambda dist, runtime=None: "5.12.1")
+    eh._RUNTIME_IMPORT_OUTCOMES[
+        eh._import_probe_cache_key(runtime, "transformers", None)
+    ] = eh._ImportProbeOutcome.UNVERIFIED
+
+    section = eh.section_required_packages()
+    row = next(check for check in section.checks if "transformers" in check.label)
+
+    assert row.status is eh.CheckStatus.WARN
+    assert "probe did not complete" in row.label
+    assert "does not indicate that reinstall" in row.detail
+    assert "pip install" not in row.label
 
 
 def test_unrelated_vllm_mlx_module_server_is_not_selected(
@@ -3075,6 +3138,32 @@ def test_incomplete_audio_dependency_import_stack_marks_warning():
     assert broken.status is eh.CheckStatus.WARN
 
 
+def test_audio_dependency_timeout_is_inconclusive_not_incomplete(monkeypatch):
+    runtime = Path(sys.executable)
+
+    def fake_ver(dist: str, runtime=None) -> str | None:
+        return "0.4.3" if dist == "mlx-audio" else None
+
+    def module_available(module, _runtime=None, *, real_import=False):
+        if module == "f5_tts_mlx":
+            key = eh._import_probe_cache_key(runtime, module, None)
+            eh._RUNTIME_IMPORT_OUTCOMES[key] = eh._ImportProbeOutcome.TIMED_OUT
+            return False
+        return True
+
+    monkeypatch.setattr(eh, "_safe_version", fake_ver)
+    monkeypatch.setattr(eh, "_module_available", module_available)
+
+    section = eh.section_optional_packages()
+    audio_row = next(c for c in section.checks if c.label.startswith("mlx-audio"))
+
+    assert audio_row.status is eh.CheckStatus.WARN
+    assert "importability unknown" in audio_row.label
+    assert "not verify: f5-tts-mlx" in audio_row.label
+    assert "incomplete" not in audio_row.label
+    assert "does not indicate" in audio_row.detail
+
+
 def _stage_sidecar_bundle(tmp_path: Path, *, slot: str = "embedded") -> Path:
     """Build the on-disk shape ``build-sidecar.sh`` produces and return the
     interpreter.
@@ -4180,6 +4269,10 @@ def test_runtime_import_probe_rejects_non_object_and_timeout(tmp_path):
     result = SimpleNamespace(stdout=f"{eh._PROBE_RESULT_PREFIX}{json.dumps([])}\n")
     with mock.patch.object(eh.subprocess, "run", return_value=result):
         assert not eh._runtime_module_importable(runtime, "transformers", None)
+        assert (
+            eh._import_probe_outcome(runtime, "transformers", None)
+            is eh._ImportProbeOutcome.UNVERIFIED
+        )
 
     with mock.patch.object(
         eh.subprocess,
@@ -4190,6 +4283,10 @@ def test_runtime_import_probe_rejects_non_object_and_timeout(tmp_path):
         assert not eh._import_probe_was_interrupted(runtime, "transformers", None)
         assert not eh._runtime_module_importable(runtime, "mlx_vlm", None)
         assert eh._import_probe_was_interrupted(runtime.absolute(), "mlx_vlm", None)
+        assert (
+            eh._import_probe_outcome(runtime.absolute(), "mlx_vlm", None)
+            is eh._ImportProbeOutcome.TIMED_OUT
+        )
 
 
 def test_python_section_warns_when_selected_runtime_cannot_be_probed(
@@ -4854,6 +4951,98 @@ def test_optional_package_probe_can_interrupt_after_visibility(tmp_path, monkeyp
     assert all(check.status is eh.CheckStatus.WARN for check in timeout_rows)
 
 
+def test_installed_vision_import_timeout_is_explicit_and_non_failing(
+    tmp_path,
+    monkeypatch,
+):
+    doctor_exe = tmp_path / "doctor" / "bin" / "python"
+    doctor_exe.parent.mkdir(parents=True)
+    doctor_exe.write_text("")
+    runtime = tmp_path / "server" / "bin" / "python"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("")
+    probe = {"packages": {}}
+
+    def safe_version(dist, runtime=None):
+        return "0.6.17" if dist == "mlx-vlm" else None
+
+    def visibility(dist, runtime=None):
+        module = eh._DISTRIBUTION_MODULES[dist]
+        if dist == "mlx-vlm":
+            key = eh._import_probe_cache_key(runtime, module, None)
+            eh._RUNTIME_IMPORT_OUTCOMES[key] = eh._ImportProbeOutcome.TIMED_OUT
+            return True, False
+        return False, False
+
+    monkeypatch.setattr(eh.sys, "executable", str(doctor_exe))
+    monkeypatch.setattr(eh, "_runtime_python_path", lambda: runtime)
+    monkeypatch.setattr(eh, "_probe_runtime", lambda *args, **kwargs: probe)
+    monkeypatch.setattr(eh, "_safe_version", safe_version)
+    monkeypatch.setattr(eh, "_pil_importable", lambda runtime=None: True)
+    monkeypatch.setattr(eh, "_module_visibility", visibility)
+
+    section = eh.section_optional_packages()
+    vision_rows = [row for row in section.checks if row.label.startswith("mlx-vlm")]
+
+    assert vision_rows
+    assert all(row.status is eh.CheckStatus.WARN for row in vision_rows)
+    assert all("importability unknown" in row.label for row in vision_rows)
+    assert all("broken or unverified" not in row.label for row in vision_rows)
+    assert all("does not indicate" in row.detail for row in vision_rows)
+    assert eh.Report(sections=[section]).exit_code == 0
+
+
+def test_installed_vision_pillow_timeout_is_inconclusive(tmp_path, monkeypatch):
+    runtime = Path(sys.executable)
+    key = eh._import_probe_cache_key(
+        runtime,
+        "PIL.Image",
+        None,
+        exercise=True,
+    )
+    eh._RUNTIME_IMPORT_OUTCOMES[key] = eh._ImportProbeOutcome.TIMED_OUT
+
+    monkeypatch.setattr(
+        eh,
+        "_safe_version",
+        lambda dist, runtime=None: "0.6.17" if dist == "mlx-vlm" else None,
+    )
+    monkeypatch.setattr(eh, "_pil_importable", lambda runtime=None: False)
+
+    section = eh.section_optional_packages()
+    row = next(c for c in section.checks if c.label.startswith("mlx-vlm"))
+
+    assert row.status is eh.CheckStatus.WARN
+    assert "probe timed out" in row.label
+    assert "Pillow (PIL) missing or broken" not in row.label
+
+
+def test_confirmed_vision_import_failure_is_explicit(tmp_path, monkeypatch):
+    runtime = Path(sys.executable)
+
+    def visibility(dist, runtime=None):
+        module = eh._DISTRIBUTION_MODULES[dist]
+        key = eh._import_probe_cache_key(Path(sys.executable), module, None)
+        eh._RUNTIME_IMPORT_OUTCOMES[key] = eh._ImportProbeOutcome.BROKEN
+        return True, False
+
+    monkeypatch.setattr(
+        eh,
+        "_safe_version",
+        lambda dist, runtime=None: "0.6.17" if dist == "mlx-vlm" else None,
+    )
+    monkeypatch.setattr(eh, "_pil_importable", lambda runtime=None: True)
+    monkeypatch.setattr(eh, "_module_visibility", visibility)
+
+    section = eh.section_optional_packages()
+    rows = [c for c in section.checks if c.label.startswith("mlx-vlm")]
+
+    assert len(rows) == 2
+    assert all(row.status is eh.CheckStatus.WARN for row in rows)
+    assert all("import failed" in row.label for row in rows)
+    assert all(str(runtime) in row.label for row in rows)
+
+
 def test_dflash_reports_supported_vlm_with_unverified_import(tmp_path, monkeypatch):
     doctor_exe = tmp_path / "doctor" / "bin" / "python"
     doctor_exe.parent.mkdir(parents=True)
@@ -4885,5 +5074,5 @@ def test_dflash_reports_supported_vlm_with_unverified_import(tmp_path, monkeypat
     row = next(c for c in section.checks if c.label.startswith("mlx-vlm 0.5.0+"))
 
     assert row.status is eh.CheckStatus.WARN
-    assert "broken or unverified" in row.label
+    assert "cannot be verified safely" in row.label
     assert str(runtime) in row.detail

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -54,6 +54,13 @@ class CheckStatus(str, Enum):
     FAIL = "fail"
 
 
+class _ImportProbeOutcome(str, Enum):
+    VERIFIED = "verified"
+    BROKEN = "broken"
+    TIMED_OUT = "timed_out"
+    UNVERIFIED = "unverified"
+
+
 @dataclass
 class Check:
     """One row in a section. ``detail`` is shown under ``--verbose``."""
@@ -823,6 +830,7 @@ for _audio_dist, _audio_module in (*_AUDIO_IMPORTS, *_AUDIO_DESKTOP_IMPORTS):
 _RUNTIME_PROBE_CACHE: dict[
     tuple[Path, Path | None, tuple[Path, ...]], dict[str, object] | None
 ] = {}
+_RUNTIME_PROBE_TIMEOUTS: set[tuple[Path, Path | None, tuple[Path, ...]]] = set()
 _PROBE_RESULT_PREFIX = "__RAPID_MLX_IMPORT_RESULT__"
 _RUNTIME_IMPORT_SCRIPT = """\
 import importlib
@@ -863,9 +871,13 @@ if spec is None or not _module_path_is_trusted(spec):
     _emit_import_result({"importable": False, "trusted_origin": False})
 else:
     if exercise:
-        import PIL.Image as Image
+        try:
+            import PIL.Image as Image
 
-        Image.new("RGB", (1, 1))
+            Image.new("RGB", (1, 1))
+        except (Exception, SystemExit):
+            _emit_import_result({"importable": False, "trusted_origin": True})
+            sys.exit(0)
         _emit_import_result({"importable": True, "trusted_origin": True})
     else:
         try:
@@ -878,6 +890,10 @@ else:
 _RUNTIME_IMPORT_CACHE: dict[
     tuple[Path, str, str, bool, bool, tuple[str, ...]],
     bool,
+] = {}
+_RUNTIME_IMPORT_OUTCOMES: dict[
+    tuple[Path, str, str, bool, bool, tuple[str, ...]],
+    _ImportProbeOutcome,
 ] = {}
 _RUNTIME_IMPORT_TIMEOUTS: set[tuple[Path, str, str, bool, bool, tuple[str, ...]]] = (
     set()
@@ -930,6 +946,95 @@ def _import_probe_was_interrupted(
     return cache_key in _RUNTIME_IMPORT_TIMEOUTS
 
 
+def _import_probe_outcome(
+    runtime: Path,
+    module: str,
+    sidecar_root: Path | None,
+    *,
+    trusted_roots: tuple[Path, ...] = (),
+    exercise: bool = False,
+    isolated: bool = True,
+) -> _ImportProbeOutcome | None:
+    cache_key = _import_probe_cache_key(
+        runtime,
+        module,
+        sidecar_root,
+        trusted_roots=trusted_roots,
+        exercise=exercise,
+        isolated=isolated,
+    )
+    outcome = _RUNTIME_IMPORT_OUTCOMES.get(cache_key)
+    if outcome is None and cache_key in _RUNTIME_IMPORT_TIMEOUTS:
+        return _ImportProbeOutcome.TIMED_OUT
+    if outcome is None and not trusted_roots:
+        # Local-runtime callers add the trusted sys.path roots internally.
+        # Sections should not need to reconstruct that private cache-key
+        # detail merely to classify the probe result.
+        prefix = cache_key[:5]
+        for recorded_key, recorded_outcome in reversed(
+            _RUNTIME_IMPORT_OUTCOMES.items()
+        ):
+            if recorded_key[:5] == prefix:
+                return recorded_outcome
+    return outcome
+
+
+def _runtime_import_command(runtime: Path, module: str) -> str:
+    statement = f"import {module}"
+    return f"{shlex.quote(str(runtime))} -I -c {shlex.quote(statement)}"
+
+
+def _add_inconclusive_import(
+    section: Section,
+    *,
+    label: str,
+    version: str | None,
+    runtime: Path,
+    module: str,
+    sidecar_root: Path | None,
+    exercise: bool = False,
+) -> bool:
+    """Render an inconclusive import as a warning, never a false failure."""
+    outcome = _import_probe_outcome(
+        runtime,
+        module,
+        sidecar_root,
+        exercise=exercise,
+    )
+    interrupted = (
+        _import_probe_was_interrupted(
+            runtime,
+            module,
+            sidecar_root,
+            exercise=True,
+        )
+        if exercise
+        else _import_probe_was_interrupted(runtime, module, sidecar_root)
+    )
+    if outcome is None and interrupted:
+        outcome = _ImportProbeOutcome.TIMED_OUT
+    if outcome not in {
+        _ImportProbeOutcome.TIMED_OUT,
+        _ImportProbeOutcome.UNVERIFIED,
+    }:
+        return False
+    reason = (
+        "timed out" if outcome is _ImportProbeOutcome.TIMED_OUT else "did not complete"
+    )
+    version_text = f" {version}" if version else ""
+    verify = _runtime_import_command(runtime, module)
+    section.add(
+        f"{label}{version_text} importability unknown — doctor probe {reason}",
+        CheckStatus.WARN,
+        detail=(
+            f"distribution={label} module={module} outcome={outcome.value}; "
+            f"rerun doctor after cold imports settle or verify with `{verify}`; "
+            "this result does not indicate that reinstall or rollback is needed"
+        ),
+    )
+    return True
+
+
 def _probe_package(
     probe: dict[str, object],
     distribution: str,
@@ -975,11 +1080,19 @@ def _runtime_module_importable(
         isolated=isolated,
     )
     if cache_key in _RUNTIME_IMPORT_CACHE:
+        _RUNTIME_IMPORT_OUTCOMES.setdefault(
+            cache_key,
+            _ImportProbeOutcome.VERIFIED
+            if _RUNTIME_IMPORT_CACHE[cache_key]
+            else _ImportProbeOutcome.UNVERIFIED,
+        )
         return _RUNTIME_IMPORT_CACHE[cache_key]
     _RUNTIME_IMPORT_TIMEOUTS.discard(cache_key)
+    _RUNTIME_IMPORT_OUTCOMES.pop(cache_key, None)
     if _DOCTOR_DEADLINE is not None and time.monotonic() >= _DOCTOR_DEADLINE:
         _RUNTIME_IMPORT_CACHE[cache_key] = False
         _RUNTIME_IMPORT_TIMEOUTS.add(cache_key)
+        _RUNTIME_IMPORT_OUTCOMES[cache_key] = _ImportProbeOutcome.TIMED_OUT
         return False
     importable = False
     try:
@@ -1020,17 +1133,26 @@ def _runtime_module_importable(
         if not probe_lines:
             importable = False
             _RUNTIME_IMPORT_CACHE[cache_key] = importable
+            _RUNTIME_IMPORT_OUTCOMES[cache_key] = _ImportProbeOutcome.UNVERIFIED
             return importable
         result_json = json.loads(probe_lines[-1].removeprefix(_PROBE_RESULT_PREFIX))
         if not isinstance(result_json, dict):
             importable = False
+            _RUNTIME_IMPORT_OUTCOMES[cache_key] = _ImportProbeOutcome.UNVERIFIED
         else:
             importable = bool(result_json.get("importable"))
+            _RUNTIME_IMPORT_OUTCOMES[cache_key] = (
+                _ImportProbeOutcome.VERIFIED
+                if importable
+                else _ImportProbeOutcome.BROKEN
+            )
     except subprocess.TimeoutExpired:
         importable = False
         _RUNTIME_IMPORT_TIMEOUTS.add(cache_key)
+        _RUNTIME_IMPORT_OUTCOMES[cache_key] = _ImportProbeOutcome.TIMED_OUT
     except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
         importable = False
+        _RUNTIME_IMPORT_OUTCOMES[cache_key] = _ImportProbeOutcome.UNVERIFIED
     _RUNTIME_IMPORT_CACHE[cache_key] = importable
     return importable
 
@@ -1049,9 +1171,11 @@ def _probe_runtime(
     cache = _RUNTIME_PROBE_CACHE
     if cache_key in cache:
         return cache[cache_key]
+    _RUNTIME_PROBE_TIMEOUTS.discard(cache_key)
     try:
         if _DOCTOR_DEADLINE is not None and time.monotonic() >= _DOCTOR_DEADLINE:
             cache[cache_key] = None
+            _RUNTIME_PROBE_TIMEOUTS.add(cache_key)
             return None
         env = {
             "HOME": os.environ.get("HOME", str(Path.home())),
@@ -1089,9 +1213,51 @@ def _probe_runtime(
         typed_probe = cast("dict[str, object]", probe)
         cache[cache_key] = typed_probe
         return typed_probe
+    except subprocess.TimeoutExpired:
+        cache[cache_key] = None
+        _RUNTIME_PROBE_TIMEOUTS.add(cache_key)
+        return None
     except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
         cache[cache_key] = None
         return None
+
+
+def _runtime_probe_timed_out(
+    runtime: Path,
+    sidecar_root: Path | None = None,
+) -> bool:
+    cache_key = (
+        runtime,
+        sidecar_root.resolve() if sidecar_root else None,
+        tuple(_server_import_paths(runtime)),
+    )
+    return cache_key in _RUNTIME_PROBE_TIMEOUTS
+
+
+def _add_runtime_probe_unavailable(
+    section: Section,
+    runtime: Path,
+    sidecar_root: Path | None,
+) -> None:
+    if _runtime_probe_timed_out(runtime, sidecar_root):
+        section.add(
+            "Active server runtime inspection timed out — package checks skipped",
+            CheckStatus.WARN,
+            detail=(
+                f"runtime={runtime}; rerun doctor after cold imports settle; "
+                "this result does not indicate that reinstall or rollback is needed"
+            ),
+        )
+        return
+    section.add(
+        "Could not inspect the active server runtime",
+        CheckStatus.FAIL,
+        detail=(
+            f"runtime={runtime}; set RAPID_MLX_RUNTIME_PYTHON to its "
+            "Python executable, ensure that interpreter is readable and "
+            "runnable, then run doctor again"
+        ),
+    )
 
 
 def _server_import_paths(runtime: Path) -> list[Path]:
@@ -1764,15 +1930,7 @@ def section_required_packages() -> Section:
         else None
     )
     if _runtime_uses_context(runtime) and runtime_probe is None:
-        s.add(
-            "Could not inspect the active server runtime",
-            CheckStatus.FAIL,
-            detail=(
-                f"runtime={runtime}; set RAPID_MLX_RUNTIME_PYTHON to its "
-                "Python executable, ensure that interpreter is readable and "
-                "runnable, then run doctor again"
-            ),
-        )
+        _add_runtime_probe_unavailable(s, runtime, sidecar_root)
         return s
     for dist, label in REQUIRED_PACKAGES:
         ver = (
@@ -1808,32 +1966,34 @@ def section_required_packages() -> Section:
         elif ver:
             repair = sidecar_hint or _runtime_pip_command("rapid-mlx", runtime=runtime)
             module = _DISTRIBUTION_MODULES[dist]
-            if _import_probe_was_interrupted(
-                runtime,
-                module,
-                sidecar_root,
+            if _add_inconclusive_import(
+                s,
+                label=label,
+                version=ver,
+                runtime=runtime,
+                module=module,
+                sidecar_root=sidecar_root,
             ):
-                s.add(
-                    f"{label} {ver} importability unknown — doctor probe timed out",
-                    CheckStatus.WARN,
-                    detail=f"distribution={dist} module={module} timeout=true",
-                )
                 continue
             visible, import_verified = _module_visibility(
                 dist,
                 runtime if _runtime_uses_context(runtime) else None,
             )
-            if _import_probe_was_interrupted(runtime, module, sidecar_root):
-                s.add(
-                    f"{label} {ver} importability unknown — doctor probe timed out",
-                    CheckStatus.WARN,
-                    detail=f"distribution={dist} module={module} timeout=true",
-                )
+            if _add_inconclusive_import(
+                s,
+                label=label,
+                version=ver,
+                runtime=runtime,
+                module=module,
+                sidecar_root=sidecar_root,
+            ):
                 continue
             if not visible:
+                verify = _runtime_import_command(runtime, module)
                 s.add(
                     f"{label} {ver} has broken metadata or cannot import in "
-                    f"{runtime} — run `{repair}`",
+                    f"{runtime} — verify with `{verify}`; if it fails, run "
+                    f"`{repair}`",
                     CheckStatus.FAIL,
                     detail=(
                         f"distribution={dist} version={ver} "
@@ -1862,27 +2022,27 @@ def section_required_packages() -> Section:
             )
         else:
             module = _DISTRIBUTION_MODULES[dist]
-            if _import_probe_was_interrupted(
-                runtime,
-                module,
-                sidecar_root,
+            if _add_inconclusive_import(
+                s,
+                label=label,
+                version=None,
+                runtime=runtime,
+                module=module,
+                sidecar_root=sidecar_root,
             ):
-                s.add(
-                    f"{label} importability unknown — doctor probe timed out",
-                    CheckStatus.WARN,
-                    detail=f"distribution={dist} module={module} timeout=true",
-                )
                 continue
             visible, import_verified = _module_visibility(
                 dist,
                 runtime if _runtime_uses_context(runtime) else None,
             )
-            if _import_probe_was_interrupted(runtime, module, sidecar_root):
-                s.add(
-                    f"{label} importability unknown — doctor probe timed out",
-                    CheckStatus.WARN,
-                    detail=f"distribution={dist} module={module} timeout=true",
-                )
+            if _add_inconclusive_import(
+                s,
+                label=label,
+                version=None,
+                runtime=runtime,
+                module=module,
+                sidecar_root=sidecar_root,
+            ):
                 continue
             if not visible:
                 repair = sidecar_hint or _runtime_pip_command(
@@ -2010,15 +2170,7 @@ def section_optional_packages() -> Section:
         else None
     )
     if _runtime_uses_context(runtime) and runtime_probe is None:
-        s.add(
-            "Could not inspect the active server runtime",
-            CheckStatus.FAIL,
-            detail=(
-                f"runtime={runtime}; set RAPID_MLX_RUNTIME_PYTHON to its "
-                "Python executable, ensure that interpreter is readable and "
-                "runnable, then run doctor again"
-            ),
-        )
+        _add_runtime_probe_unavailable(s, runtime, sidecar_root)
         return s
     for dist, label, install_hint in OPTIONAL_PACKAGES:
         # ``pip`` on PATH may belong to ~/.rapid-mlx-python or Homebrew while
@@ -2083,14 +2235,36 @@ def section_optional_packages() -> Section:
                 )
                 continue
             if dist == "mlx-audio":
-                missing = [
-                    distribution
-                    for distribution, module in audio_contract
-                    if not _module_available(
+                missing: list[str] = []
+                inconclusive: list[str] = []
+                for distribution, module in audio_contract:
+                    if _module_available(
                         module,
                         runtime if _runtime_uses_context(runtime) else None,
+                    ):
+                        continue
+                    outcome = _import_probe_outcome(runtime, module, sidecar_root)
+                    if outcome in {
+                        _ImportProbeOutcome.TIMED_OUT,
+                        _ImportProbeOutcome.UNVERIFIED,
+                    }:
+                        inconclusive.append(distribution)
+                    else:
+                        missing.append(distribution)
+                if inconclusive:
+                    inconclusive_text = ", ".join(inconclusive)
+                    s.add(
+                        f"{label} {ver} importability unknown — doctor could "
+                        f"not verify: {inconclusive_text}",
+                        CheckStatus.WARN,
+                        detail=(
+                            f"distribution={dist} version={ver} "
+                            f"inconclusive={inconclusive_text}; rerun doctor "
+                            "after cold imports settle; this result does not "
+                            "indicate that reinstall or rollback is needed"
+                        ),
                     )
-                ]
+                    continue
                 if missing:
                     missing_text = ", ".join(missing)
                     s.add(
@@ -2113,6 +2287,16 @@ def section_optional_packages() -> Section:
             if dist == "mlx-vlm" and not _pil_importable(
                 runtime if _runtime_uses_context(runtime) else None,
             ):
+                if _add_inconclusive_import(
+                    s,
+                    label=label,
+                    version=ver,
+                    runtime=runtime,
+                    module="PIL.Image",
+                    sidecar_root=sidecar_root,
+                    exercise=True,
+                ):
+                    continue
                 s.add(
                     f"{label} {ver} present but Pillow (PIL) missing or "
                     f"broken — vision paths will fail (`{hint}`)",
@@ -2127,14 +2311,49 @@ def section_optional_packages() -> Section:
                 dist,
                 runtime if _runtime_uses_context(runtime) else None,
             )
-            if not visible or not import_verified:
+            module = _DISTRIBUTION_MODULES[dist]
+            if _add_inconclusive_import(
+                s,
+                label=label,
+                version=ver,
+                runtime=runtime,
+                module=module,
+                sidecar_root=sidecar_root,
+            ):
+                continue
+            outcome = _import_probe_outcome(runtime, module, sidecar_root)
+            if outcome is _ImportProbeOutcome.BROKEN:
+                verify = _runtime_import_command(runtime, module)
                 s.add(
-                    f"{label} {ver} present but importability is broken or unverified",
+                    f"{label} {ver} import failed in {runtime} — verify with "
+                    f"`{verify}`; if it fails, run `{hint}`",
+                    CheckStatus.WARN,
+                    detail=(
+                        f"distribution={dist} version={ver} module={module} "
+                        f"outcome=broken runtime={runtime}"
+                    ),
+                )
+                continue
+            if not visible:
+                s.add(
+                    f"{label} {ver} metadata is present but its module is not "
+                    f"discoverable (`{hint}`)",
                     CheckStatus.WARN,
                     detail=(
                         f"distribution={dist} version={ver} "
-                        f"module={_DISTRIBUTION_MODULES[dist]} "
+                        f"module={module} "
                         f"visible={visible} verified={import_verified} "
+                        f"runtime={runtime}"
+                    ),
+                )
+                continue
+            if not import_verified:
+                s.add(
+                    f"{label} {ver} is visible but importability cannot be "
+                    "verified safely",
+                    CheckStatus.WARN,
+                    detail=(
+                        f"distribution={dist} version={ver} module={module} "
                         f"runtime={runtime}"
                     ),
                 )
@@ -2146,27 +2365,27 @@ def section_optional_packages() -> Section:
             )
         else:
             module = _DISTRIBUTION_MODULES[dist]
-            if _import_probe_was_interrupted(
-                runtime,
-                module,
-                sidecar_root,
+            if _add_inconclusive_import(
+                s,
+                label=label,
+                version=None,
+                runtime=runtime,
+                module=module,
+                sidecar_root=sidecar_root,
             ):
-                s.add(
-                    f"{label} importability unknown — doctor probe timed out",
-                    CheckStatus.WARN,
-                    detail=f"distribution={dist} module={module} timeout=true",
-                )
                 continue
             visible, import_verified = _module_visibility(
                 dist,
                 runtime if _runtime_uses_context(runtime) else None,
             )
-            if _import_probe_was_interrupted(runtime, module, sidecar_root):
-                s.add(
-                    f"{label} importability unknown — doctor probe timed out",
-                    CheckStatus.WARN,
-                    detail=f"distribution={dist} module={module} timeout=true",
-                )
+            if _add_inconclusive_import(
+                s,
+                label=label,
+                version=None,
+                runtime=runtime,
+                module=module,
+                sidecar_root=sidecar_root,
+            ):
                 continue
             if not visible:
                 s.add(
@@ -2232,24 +2451,62 @@ def section_optional_packages() -> Section:
         if not _pil_importable(
             runtime if _runtime_uses_context(runtime) else None,
         ):
-            s.add(
-                "mlx-vlm 0.5.0+ (dflash extras) present but Pillow (PIL) "
-                "missing or broken — dflash/vision paths will fail",
-                CheckStatus.WARN,
-                detail=(
-                    f"distribution=mlx-vlm version={vlm_ver} "
-                    f"pil=missing-or-broken hint={vision_hint}"
-                ),
-            )
+            if not _add_inconclusive_import(
+                s,
+                label="mlx-vlm 0.5.0+ (dflash extras)",
+                version=None,
+                runtime=runtime,
+                module="PIL.Image",
+                sidecar_root=sidecar_root,
+                exercise=True,
+            ):
+                s.add(
+                    "mlx-vlm 0.5.0+ (dflash extras) present but Pillow (PIL) "
+                    "missing or broken — dflash/vision paths will fail",
+                    CheckStatus.WARN,
+                    detail=(
+                        f"distribution=mlx-vlm version={vlm_ver} "
+                        f"pil=missing-or-broken hint={vision_hint}"
+                    ),
+                )
         else:
             _, vlm_verified = _module_visibility(
                 "mlx-vlm",
                 runtime if _runtime_uses_context(runtime) else None,
             )
-            if not vlm_verified:
+            if _add_inconclusive_import(
+                s,
+                label="mlx-vlm 0.5.0+ (dflash extras)",
+                version=None,
+                runtime=runtime,
+                module=_DISTRIBUTION_MODULES["mlx-vlm"],
+                sidecar_root=sidecar_root,
+            ):
+                pass
+            elif (
+                _import_probe_outcome(
+                    runtime,
+                    _DISTRIBUTION_MODULES["mlx-vlm"],
+                    sidecar_root,
+                )
+                is _ImportProbeOutcome.BROKEN
+            ):
+                verify = _runtime_import_command(
+                    runtime, _DISTRIBUTION_MODULES["mlx-vlm"]
+                )
                 s.add(
-                    "mlx-vlm 0.5.0+ (dflash extras) present but importability "
-                    "is broken or unverified",
+                    "mlx-vlm 0.5.0+ (dflash extras) import failed — verify "
+                    f"with `{verify}`; if it fails, run `{vision_hint}`",
+                    CheckStatus.WARN,
+                    detail=(
+                        f"distribution=mlx-vlm version={vlm_ver} "
+                        f"outcome=broken runtime={runtime}"
+                    ),
+                )
+            elif not vlm_verified:
+                s.add(
+                    "mlx-vlm 0.5.0+ (dflash extras) is visible but "
+                    "importability cannot be verified safely",
                     CheckStatus.WARN,
                     detail=(
                         f"distribution=mlx-vlm version={vlm_ver} "
@@ -2884,7 +3141,9 @@ def _run_all_serialized(caller_deadline: float) -> Report:
         _DOCTOR_DEADLINE = caller_deadline
         _RUNTIME_SELECTION_DONE = False
         _RUNTIME_PROBE_CACHE.clear()
+        _RUNTIME_PROBE_TIMEOUTS.clear()
         _RUNTIME_IMPORT_CACHE.clear()
+        _RUNTIME_IMPORT_OUTCOMES.clear()
         _RUNTIME_IMPORT_TIMEOUTS.clear()
         _RUNTIME_DISTRIBUTION_CACHE.clear()
         _RUNTIME_CONTEXTS.clear()


### PR DESCRIPTION
## Why this is a hotfix

A real headless 16 GB M4 mini upgrade from 0.13.1 to 0.13.4 completed successfully: launchd serving, strict JSON Schema enum output, prompt-injection resistance, and vision all passed. Immediately after installing `rapid-mlx[vision]`, however, `rapid-mlx doctor` reported six issues, including five hard failures claiming that packages such as transformers 5.15.1 had broken metadata or could not import.

The packages were healthy in the exact interpreter Doctor named. A later Doctor run returned 0 issues while marking those same checks skipped because its time budget was exhausted. That puts a false rollback signal at the most sensitive point in the documented upgrade flow.

## Root cause

Doctor reduced every import probe to a boolean. A confirmed import failure, a subprocess timeout, a malformed or missing probe result, and a probe infrastructure error all became `False`. Downstream required-package checks could therefore promote an inconclusive cold-import probe to a hard environment failure. Optional-package checks similarly combined distinct states into “broken or unverified.”

The runtime metadata probe also did not preserve whether its failure was a timeout. Pillow exercise imports could exit outside the structured probe protocol, making classification less reliable.

## What changes

### Explicit probe outcomes

Import probes now retain one of four internal outcomes:

- `verified`: the module imported from a trusted runtime path
- `broken`: the probe completed and explicitly reported import failure
- `timed_out`: the probe or global Doctor budget expired
- `unverified`: Doctor could not obtain a trustworthy structured result

Required-package checks only emit a hard failure for actionable evidence. `timed_out` and `unverified` are warnings and keep Doctor exit code 0.

### Honest operator guidance

Inconclusive checks now say exactly that importability is unknown because the probe timed out or did not complete. The verbose detail:

- recommends rerunning Doctor after cold imports settle;
- includes an exact interpreter-bound import command where appropriate;
- explicitly says the result does not indicate that reinstall or rollback is needed.

Confirmed import failures remain visible and provide a two-step instruction: verify with the selected runtime first, then repair only if that command actually fails. This removes the circular “upgrade Rapid-MLX” instruction immediately after an upgrade.

The same distinction is applied to required packages, vision, Pillow, dflash, and audio dependency-contract checks. The old “broken or unverified” wording is removed.

### Runtime inspection timeout

A timeout while inspecting the active server runtime is now a warning with package checks skipped, rather than “Could not inspect runtime” as a hard failure. A genuinely unreadable or unrunnable selected interpreter remains a hard failure.

### Structured Pillow failure

The Pillow exercise probe now catches import/exercise exceptions and emits a structured `broken` result. This preserves a real missing/broken Pillow warning while keeping timeout/infrastructure failures inconclusive.

### Headless networking guidance

The headless macOS service guide now documents a real multi-interface appliance failure mode: a private Ethernet or Thunderbolt link can outrank Wi-Fi, leave SSH reachable, and silently remove working internet/DNS for the installer.

The guide adds:

- service-order and default-route preflight commands;
- guidance to omit a router/default gateway on a point-to-point private link;
- a concrete `networksetup -ordernetworkservices` example;
- a warning not to copy service order blindly on remote-only machines;
- route, DNS, SSH, and installer URL checks before booting out a working daemon.

## User-visible result

After a fresh install or upgrade, slow first imports no longer make a healthy deployment look broken. Operators can distinguish:

- a real package problem that needs verification and possibly repair;
- a cold-start timeout that should be retried;
- an unverified diagnostic result that is not a rollback signal.

The launchd/API smoke test remains the acceptance gate for the actual deployed runtime.

## Verification

- `225 passed`: Doctor environment and extras suites
- `30 passed`: runtime routing and vision runtime-detection suites
- `255 passed`: combined coverage run
- changed-lines coverage: `100%` (101/101 executable changed lines)
- Ruff format/check: pass
- Python 3.11 mypy error budget: pass, no growth
- Real local Desktop sidecar `rapid-mlx doctor --verbose`: 20 OK, 5 warnings, 0 issues; mlx-vlm 0.6.17 and mlx-audio 0.4.3 verified

## Release notes draft

Fixed a `rapid-mlx doctor` false failure immediately after fresh vision installs or upgrades. Cold import timeouts and inconclusive probes are now reported as warnings instead of broken-package errors, with clear retry and interpreter verification guidance. Confirmed import failures remain actionable. The headless macOS guide also adds a multi-NIC default-route preflight for appliances using Wi-Fi plus private Ethernet or Thunderbolt links.
