### PR TITLE
feat(desktop): add supervised Downloads cleanup flow

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/ComputerUseStarter.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/ComputerUseStarter.swift
@@ -37,7 +37,7 @@ struct ComputerUseStarter: Identifiable, Equatable, Sendable {
             systemImage: "externaldrive.badge.minus",
             applications: "Finder",
             approvalNote: "Nothing moves until you review and approve it.",
-            availability: .comingSoon
+            availability: .available
         ),
         ComputerUseStarter(
             kind: .tidyInbox,

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/FreeUpSpaceFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/FreeUpSpaceFlow.swift
@@ -1,0 +1,266 @@
+import Darwin
+import Foundation
+
+struct FreeUpSpaceFileIdentity: Equatable, Hashable, Sendable {
+    let device: UInt64
+    let inode: UInt64
+    let size: Int64
+    let modifiedSeconds: Int64
+    let modifiedNanoseconds: Int64
+}
+
+struct FreeUpSpaceCandidate: Identifiable, Equatable, Hashable, Sendable {
+    let url: URL
+    let identity: FreeUpSpaceFileIdentity
+    let modifiedAt: Date
+
+    var id: String {
+        "\(identity.device):\(identity.inode):\(url.lastPathComponent)"
+    }
+
+    var name: String { url.lastPathComponent }
+    var byteCount: Int64 { identity.size }
+
+    func ageInDays(relativeTo now: Date) -> Int {
+        max(0, Calendar.current.dateComponents(
+            [.day],
+            from: modifiedAt,
+            to: now
+        ).day ?? 0)
+    }
+}
+
+enum FreeUpSpaceScanError: Error, Equatable, Sendable {
+    case downloadsUnavailable
+    case permissionDenied
+    case enumerationFailed
+    case cancelled
+}
+
+enum FreeUpSpaceMoveFailureReason: Equatable, Sendable {
+    case changedSinceReview
+    case permissionDenied
+    case moveRejected
+    case verificationFailed
+}
+
+struct FreeUpSpaceMoveFailure: Equatable, Sendable {
+    let candidate: FreeUpSpaceCandidate
+    let reason: FreeUpSpaceMoveFailureReason
+}
+
+struct FreeUpSpaceMoveOutcome: Equatable, Sendable {
+    var moved: [FreeUpSpaceCandidate] = []
+    var failures: [FreeUpSpaceMoveFailure] = []
+    var wasCancelled = false
+
+    var movedByteCount: Int64 {
+        moved.reduce(0) { $0 + $1.byteCount }
+    }
+}
+
+protocol FreeUpSpaceServicing: Sendable {
+    func scan(now: Date) async throws -> [FreeUpSpaceCandidate]
+    func moveToTrash(_ candidates: [FreeUpSpaceCandidate]) async -> FreeUpSpaceMoveOutcome
+}
+
+/// A deliberately narrow filesystem adapter for the first cleanup flow.
+///
+/// The service only inventories direct, old, regular files in one canonical
+/// Downloads root. Moving is a second operation and repeats every safety check
+/// against the reviewed inode immediately before asking macOS to move it to
+/// Trash. Folders, hidden entries, symlinks, recently changed files, and any
+/// path outside the root never become candidates.
+actor MacOSDownloadsCleanupService: FreeUpSpaceServicing {
+    static let defaultMinimumAge: TimeInterval = 30 * 24 * 60 * 60
+    static let defaultMaximumCandidates = 200
+
+    typealias TrashOperation = @Sendable (URL) throws -> Void
+
+    private let root: URL
+    private let minimumAge: TimeInterval
+    private let maximumCandidates: Int
+    private let trashOperation: TrashOperation
+
+    init?(
+        root: URL? = FileManager.default.urls(
+            for: .downloadsDirectory,
+            in: .userDomainMask
+        ).first,
+        minimumAge: TimeInterval = defaultMinimumAge,
+        maximumCandidates: Int = defaultMaximumCandidates,
+        trashOperation: @escaping TrashOperation = { url in
+            var resultingURL: NSURL?
+            try FileManager.default.trashItem(
+                at: url,
+                resultingItemURL: &resultingURL
+            )
+        }
+    ) {
+        guard let root, minimumAge >= 0, maximumCandidates > 0 else { return nil }
+        self.root = root.resolvingSymlinksInPath().standardizedFileURL
+        self.minimumAge = minimumAge
+        self.maximumCandidates = maximumCandidates
+        self.trashOperation = trashOperation
+    }
+
+    func scan(now: Date) async throws -> [FreeUpSpaceCandidate] {
+        guard Self.isDirectory(root) else {
+            throw FreeUpSpaceScanError.downloadsUnavailable
+        }
+        let entries: [URL]
+        do {
+            entries = try FileManager.default.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+            )
+        } catch {
+            throw Self.scanError(for: error)
+        }
+
+        let cutoff = now.addingTimeInterval(-minimumAge)
+        var candidates: [FreeUpSpaceCandidate] = []
+        candidates.reserveCapacity(min(entries.count, maximumCandidates))
+        for entry in entries {
+            guard !Task.isCancelled else { throw FreeUpSpaceScanError.cancelled }
+            guard let candidate = Self.candidate(
+                at: entry,
+                root: root,
+                modifiedBefore: cutoff
+            ) else { continue }
+            candidates.append(candidate)
+        }
+        candidates.sort {
+            if $0.byteCount != $1.byteCount { return $0.byteCount > $1.byteCount }
+            if $0.modifiedAt != $1.modifiedAt { return $0.modifiedAt < $1.modifiedAt }
+            return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+        return Array(candidates.prefix(maximumCandidates))
+    }
+
+    func moveToTrash(
+        _ candidates: [FreeUpSpaceCandidate]
+    ) async -> FreeUpSpaceMoveOutcome {
+        var outcome = FreeUpSpaceMoveOutcome()
+        for candidate in candidates {
+            if Task.isCancelled {
+                outcome.wasCancelled = true
+                break
+            }
+            guard let current = Self.candidate(
+                at: candidate.url,
+                root: root,
+                modifiedBefore: .distantFuture
+            ), current.identity == candidate.identity else {
+                outcome.failures.append(FreeUpSpaceMoveFailure(
+                    candidate: candidate,
+                    reason: .changedSinceReview
+                ))
+                continue
+            }
+            do {
+                try trashOperation(candidate.url)
+            } catch let error as CocoaError where error.code == .fileWriteNoPermission {
+                outcome.failures.append(FreeUpSpaceMoveFailure(
+                    candidate: candidate,
+                    reason: .permissionDenied
+                ))
+                continue
+            } catch {
+                outcome.failures.append(FreeUpSpaceMoveFailure(
+                    candidate: candidate,
+                    reason: .moveRejected
+                ))
+                continue
+            }
+            if Self.pathIsAbsent(candidate.url) {
+                outcome.moved.append(candidate)
+            } else {
+                outcome.failures.append(FreeUpSpaceMoveFailure(
+                    candidate: candidate,
+                    reason: .verificationFailed
+                ))
+            }
+        }
+        return outcome
+    }
+
+    private static func candidate(
+        at input: URL,
+        root: URL,
+        modifiedBefore cutoff: Date
+    ) -> FreeUpSpaceCandidate? {
+        let url = input.standardizedFileURL
+        guard url.deletingLastPathComponent() == root,
+              !url.lastPathComponent.hasPrefix("."),
+              let identity = fileIdentity(at: url),
+              !isTransientDownload(url.lastPathComponent)
+        else { return nil }
+
+        let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+        guard resolved == url,
+              resolved.deletingLastPathComponent() == root
+        else { return nil }
+
+        let modifiedAt = Date(
+            timeIntervalSince1970: TimeInterval(identity.modifiedSeconds)
+                + TimeInterval(identity.modifiedNanoseconds) / 1_000_000_000
+        )
+        guard modifiedAt <= cutoff else { return nil }
+        return FreeUpSpaceCandidate(
+            url: url,
+            identity: identity,
+            modifiedAt: modifiedAt
+        )
+    }
+
+    private static func fileIdentity(at url: URL) -> FreeUpSpaceFileIdentity? {
+        var value = stat()
+        guard lstat(url.path, &value) == 0,
+              (value.st_mode & S_IFMT) == S_IFREG
+        else { return nil }
+        return FreeUpSpaceFileIdentity(
+            device: UInt64(value.st_dev),
+            inode: UInt64(value.st_ino),
+            size: max(0, Int64(value.st_size)),
+            modifiedSeconds: Int64(value.st_mtimespec.tv_sec),
+            modifiedNanoseconds: Int64(value.st_mtimespec.tv_nsec)
+        )
+    }
+
+    private static func isDirectory(_ url: URL) -> Bool {
+        var value = stat()
+        guard lstat(url.path, &value) == 0 else { return false }
+        return (value.st_mode & S_IFMT) == S_IFDIR
+    }
+
+    private static func pathIsAbsent(_ url: URL) -> Bool {
+        var value = stat()
+        guard lstat(url.path, &value) != 0 else { return false }
+        return errno == ENOENT || errno == ENOTDIR
+    }
+
+    private static func isTransientDownload(_ name: String) -> Bool {
+        let lowered = name.lowercased()
+        return lowered.hasSuffix(".crdownload")
+            || lowered.hasSuffix(".download")
+            || lowered.hasSuffix(".part")
+    }
+
+    static func scanError(for error: Error) -> FreeUpSpaceScanError {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain,
+           nsError.code == CocoaError.fileReadNoPermission.rawValue {
+            return .permissionDenied
+        }
+        if nsError.domain == NSPOSIXErrorDomain,
+           (nsError.code == Int(EACCES) || nsError.code == Int(EPERM)) {
+            return .permissionDenied
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return scanError(for: underlying)
+        }
+        return .enumerationFailed
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/FreeUpSpaceFlow.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/FreeUpSpaceFlow.swift
@@ -161,16 +161,12 @@ actor MacOSDownloadsCleanupService: FreeUpSpaceServicing {
             }
             do {
                 try trashOperation(candidate.url)
-            } catch let error as CocoaError where error.code == .fileWriteNoPermission {
-                outcome.failures.append(FreeUpSpaceMoveFailure(
-                    candidate: candidate,
-                    reason: .permissionDenied
-                ))
-                continue
             } catch {
                 outcome.failures.append(FreeUpSpaceMoveFailure(
                     candidate: candidate,
-                    reason: .moveRejected
+                    reason: Self.isPermissionError(error)
+                        ? .permissionDenied
+                        : .moveRejected
                 ))
                 continue
             }
@@ -249,18 +245,30 @@ actor MacOSDownloadsCleanupService: FreeUpSpaceServicing {
     }
 
     static func scanError(for error: Error) -> FreeUpSpaceScanError {
+        isPermissionError(error) ? .permissionDenied : .enumerationFailed
+    }
+
+    private static func isPermissionError(
+        _ error: Error,
+        remainingUnderlyingErrors: Int = 4
+    ) -> Bool {
         let nsError = error as NSError
         if nsError.domain == NSCocoaErrorDomain,
-           nsError.code == CocoaError.fileReadNoPermission.rawValue {
-            return .permissionDenied
+           (nsError.code == CocoaError.fileReadNoPermission.rawValue
+               || nsError.code == CocoaError.fileWriteNoPermission.rawValue) {
+            return true
         }
         if nsError.domain == NSPOSIXErrorDomain,
            (nsError.code == Int(EACCES) || nsError.code == Int(EPERM)) {
-            return .permissionDenied
+            return true
         }
-        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
-            return scanError(for: underlying)
+        if remainingUnderlyingErrors > 0,
+           let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return isPermissionError(
+                underlying,
+                remainingUnderlyingErrors: remainingUnderlyingErrors - 1
+            )
         }
-        return .enumerationFailed
+        return false
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/FreeUpSpaceFlowViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/FreeUpSpaceFlowViewModel.swift
@@ -61,11 +61,11 @@ final class FreeUpSpaceFlowViewModel {
             } catch let error as FreeUpSpaceScanError {
                 guard requestedGeneration == generation else { return }
                 task = nil
-                phase = error == .cancelled ? .reviewing : .failed(error)
+                phase = .failed(error)
             } catch is CancellationError {
                 guard requestedGeneration == generation else { return }
                 task = nil
-                phase = .reviewing
+                phase = .failed(.cancelled)
             } catch {
                 guard requestedGeneration == generation else { return }
                 task = nil

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/FreeUpSpaceFlowViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/FreeUpSpaceFlowViewModel.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class FreeUpSpaceFlowViewModel {
+    enum Phase: Equatable {
+        case scanning
+        case reviewing
+        case confirming
+        case moving
+        case finished(FreeUpSpaceMoveOutcome)
+        case failed(FreeUpSpaceScanError)
+    }
+
+    var phase: Phase = .scanning
+    var candidates: [FreeUpSpaceCandidate] = []
+    var selectedIDs: Set<String> = []
+    var scanDate = Date()
+
+    private let service: any FreeUpSpaceServicing
+    private let now: @Sendable () -> Date
+    private var task: Task<Void, Never>?
+    private var generation = 0
+
+    init(
+        service: any FreeUpSpaceServicing,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.service = service
+        self.now = now
+    }
+
+    var selectedCandidates: [FreeUpSpaceCandidate] {
+        candidates.filter { selectedIDs.contains($0.id) }
+    }
+
+    var selectedByteCount: Int64 {
+        selectedCandidates.reduce(0) { $0 + $1.byteCount }
+    }
+
+    var isActive: Bool { phase == .scanning || phase == .moving }
+
+    func scan() {
+        cancelTask()
+        generation += 1
+        let requestedGeneration = generation
+        phase = .scanning
+        candidates = []
+        selectedIDs = []
+        scanDate = now()
+        let requestedScanDate = scanDate
+        task = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let result = try await service.scan(now: requestedScanDate)
+                guard requestedGeneration == generation else { return }
+                task = nil
+                candidates = result
+                phase = .reviewing
+            } catch let error as FreeUpSpaceScanError {
+                guard requestedGeneration == generation else { return }
+                task = nil
+                phase = error == .cancelled ? .reviewing : .failed(error)
+            } catch is CancellationError {
+                guard requestedGeneration == generation else { return }
+                task = nil
+                phase = .reviewing
+            } catch {
+                guard requestedGeneration == generation else { return }
+                task = nil
+                phase = .failed(.enumerationFailed)
+            }
+        }
+    }
+
+    func toggle(_ candidate: FreeUpSpaceCandidate) {
+        guard phase == .reviewing else { return }
+        if selectedIDs.contains(candidate.id) {
+            selectedIDs.remove(candidate.id)
+        } else {
+            selectedIDs.insert(candidate.id)
+        }
+    }
+
+    func selectAll() {
+        guard phase == .reviewing else { return }
+        selectedIDs = Set(candidates.map(\.id))
+    }
+
+    func clearSelection() {
+        guard phase == .reviewing else { return }
+        selectedIDs = []
+    }
+
+    func reviewMove() {
+        guard phase == .reviewing, !selectedCandidates.isEmpty else { return }
+        phase = .confirming
+    }
+
+    func returnToSelection() {
+        guard phase == .confirming else { return }
+        phase = .reviewing
+    }
+
+    func moveSelectedToTrash() {
+        guard phase == .confirming, task == nil else { return }
+        let selected = selectedCandidates
+        guard !selected.isEmpty else {
+            phase = .reviewing
+            return
+        }
+        generation += 1
+        let requestedGeneration = generation
+        phase = .moving
+        task = Task { [weak self] in
+            guard let self else { return }
+            let outcome = await service.moveToTrash(selected)
+            guard requestedGeneration == generation else { return }
+            task = nil
+            phase = .finished(outcome)
+        }
+    }
+
+    func stop() {
+        guard isActive else { return }
+        task?.cancel()
+    }
+
+    func cancelTask() {
+        generation += 1
+        task?.cancel()
+        task = nil
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -4,6 +4,7 @@ struct ComputerUseView: View {
     let languageRuntime: DraftPostLanguageRuntime?
     let visualRuntime: DraftPostVisualRuntime?
     @State private var showingDraftPost = false
+    @State private var showingFreeUpSpace = false
 
     init(
         languageRuntime: DraftPostLanguageRuntime? = nil,
@@ -82,6 +83,9 @@ struct ComputerUseView: View {
                 visualRuntime: visualRuntime
             )
         }
+        .sheet(isPresented: $showingFreeUpSpace) {
+            FreeUpSpaceFlowSheet()
+        }
     }
 
     private func starterCard(_ starter: ComputerUseStarter) -> some View {
@@ -107,10 +111,10 @@ struct ComputerUseView: View {
                 .foregroundStyle(.secondary)
             if starter.availability == .available {
                 Button("Start flow") {
-                    showingDraftPost = true
+                    start(starter.kind)
                 }
                 .buttonStyle(.rapidPrimaryCompact)
-                .accessibilityIdentifier("ComputerUse.Starter.DraftAndPost.Start")
+                .accessibilityIdentifier(startIdentifier(starter.kind))
             }
         }
         .frame(maxWidth: .infinity, minHeight: 118, alignment: .topLeading)
@@ -129,6 +133,28 @@ struct ComputerUseView: View {
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("ComputerUse.Starter.\(starter.kind.rawValue)")
         .accessibilityLabel(starter.title)
+    }
+
+    private func start(_ kind: ComputerUseStarter.Kind) {
+        switch kind {
+        case .freeUpSpace:
+            showingFreeUpSpace = true
+        case .draftAndPost:
+            showingDraftPost = true
+        case .tidyInbox, .prospectCustomers, .createDemoVideo, .reserved:
+            break
+        }
+    }
+
+    private func startIdentifier(_ kind: ComputerUseStarter.Kind) -> String {
+        switch kind {
+        case .freeUpSpace:
+            "ComputerUse.Starter.FreeUpSpace.Start"
+        case .draftAndPost:
+            "ComputerUse.Starter.DraftAndPost.Start"
+        case .tidyInbox, .prospectCustomers, .createDemoVideo, .reserved:
+            "ComputerUse.Starter.Unavailable.Start"
+        }
     }
 
     private func availabilityLabel(

--- a/apps/rapid-mac/Sources/Rapid/UI/FreeUpSpaceFlowView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/FreeUpSpaceFlowView.swift
@@ -1,0 +1,318 @@
+import SwiftUI
+
+struct FreeUpSpaceFlowSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var viewModel: FreeUpSpaceFlowViewModel
+
+    init(
+        service: (any FreeUpSpaceServicing)? = MacOSDownloadsCleanupService(),
+        now: Date = Date()
+    ) {
+        let resolvedService = service ?? UnavailableFreeUpSpaceService()
+        _viewModel = State(initialValue: FreeUpSpaceFlowViewModel(
+            service: resolvedService,
+            now: { now }
+        ))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Free up space")
+                        .font(.title2.weight(.semibold))
+                    Text("Review old files in Downloads. Rapid moves only the files you approve to Trash.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Close") { dismiss() }
+                    .disabled(viewModel.isActive)
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.Close")
+            }
+
+            Divider()
+
+            switch viewModel.phase {
+            case .scanning:
+                progress(
+                    title: "Reviewing Downloads…",
+                    detail: "Rapid is checking file names, sizes, and last-modified dates. Nothing is moving."
+                )
+                Button("Stop") { viewModel.stop() }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.StopScan")
+
+            case .reviewing:
+                review
+
+            case .confirming:
+                confirmation
+
+            case .moving:
+                progress(
+                    title: "Moving approved files to Trash…",
+                    detail: "Rapid verifies every file again before moving it and stops between files if you cancel."
+                )
+                Button("Stop after current file") { viewModel.stop() }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.StopMove")
+
+            case .finished(let outcome):
+                result(outcome)
+
+            case .failed(let error):
+                failure(error)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(24)
+        .frame(width: 720, height: 680)
+        .task { viewModel.scan() }
+        .onDisappear { viewModel.cancelTask() }
+        .interactiveDismissDisabled(viewModel.isActive)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Free up space flow")
+    }
+
+    private var review: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if viewModel.candidates.isEmpty {
+                Label("No old files to review", systemImage: "checkmark.circle.fill")
+                    .font(.headline)
+                    .foregroundStyle(.green)
+                Text("Downloads has no top-level files that have been unchanged for at least 30 days.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Button("Scan again") { viewModel.scan() }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.ScanAgain")
+            } else {
+                HStack {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Choose files to move")
+                            .font(.headline)
+                        Text("Nothing is selected by default. Folders, hidden files, active downloads, and symbolic links are excluded.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if viewModel.selectedIDs.count == viewModel.candidates.count {
+                        Button("Clear") { viewModel.clearSelection() }
+                            .buttonStyle(.rapidSecondaryCompact)
+                            .accessibilityIdentifier("ComputerUse.FreeSpace.Clear")
+                    } else {
+                        Button("Select all") { viewModel.selectAll() }
+                            .buttonStyle(.rapidSecondaryCompact)
+                            .accessibilityIdentifier("ComputerUse.FreeSpace.SelectAll")
+                    }
+                }
+
+                ScrollView {
+                    LazyVStack(spacing: 8) {
+                        ForEach(viewModel.candidates) { candidate in
+                            candidateRow(candidate)
+                        }
+                    }
+                }
+                .frame(maxHeight: 390)
+                .accessibilityIdentifier("ComputerUse.FreeSpace.Candidates")
+
+                HStack {
+                    Text(selectionSummary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Review move") { viewModel.reviewMove() }
+                        .buttonStyle(.rapidPrimaryCompact)
+                        .disabled(viewModel.selectedCandidates.isEmpty)
+                        .accessibilityIdentifier("ComputerUse.FreeSpace.ReviewMove")
+                }
+            }
+        }
+    }
+
+    private var confirmation: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("Confirm what moves to Trash", systemImage: "checkmark.shield.fill")
+                .font(.headline)
+                .foregroundStyle(.orange)
+            Text("Rapid will move \(viewModel.selectedCandidates.count) selected \(fileWord(viewModel.selectedCandidates.count)) (\(bytes(viewModel.selectedByteCount))) from Downloads to Trash.")
+                .font(.callout)
+            VStack(alignment: .leading, spacing: 7) {
+                ForEach(viewModel.selectedCandidates.prefix(8)) { candidate in
+                    HStack {
+                        Image(systemName: "doc")
+                            .foregroundStyle(.secondary)
+                        Text(candidate.name)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(bytes(candidate.byteCount))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if viewModel.selectedCandidates.count > 8 {
+                    Text("and \(viewModel.selectedCandidates.count - 8) more…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(12)
+            .background(RapidTheme.surfaceRaised, in: RoundedRectangle(cornerRadius: 10))
+
+            Text("This is recoverable from Trash. Disk space is not reclaimed until you empty Trash yourself.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Button("Back") { viewModel.returnToSelection() }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.Back")
+                Spacer()
+                Button("Move to Trash") { viewModel.moveSelectedToTrash() }
+                    .buttonStyle(.rapidPrimaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.ConfirmMove")
+            }
+        }
+        .accessibilityIdentifier("ComputerUse.FreeSpace.Confirmation")
+    }
+
+    private func result(_ outcome: FreeUpSpaceMoveOutcome) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label(
+                outcome.failures.isEmpty && !outcome.wasCancelled
+                    ? "Approved files moved to Trash"
+                    : "Cleanup stopped safely",
+                systemImage: outcome.failures.isEmpty && !outcome.wasCancelled
+                    ? "checkmark.circle.fill"
+                    : "exclamationmark.circle.fill"
+            )
+            .font(.headline)
+            .foregroundStyle(outcome.failures.isEmpty && !outcome.wasCancelled ? .green : .orange)
+
+            Text("Moved \(outcome.moved.count) \(fileWord(outcome.moved.count)) totaling \(bytes(outcome.movedByteCount)).")
+                .font(.callout)
+            if !outcome.failures.isEmpty {
+                Text("\(outcome.failures.count) \(fileWord(outcome.failures.count)) stayed in Downloads because they changed, could not be moved, or could not be verified.")
+                    .font(.callout)
+            }
+            if outcome.wasCancelled {
+                Text("You stopped the run. Files already moved remain in Trash; unprocessed files stayed in Downloads.")
+                    .font(.callout)
+            }
+            Text("Empty Trash yourself when you are ready to reclaim the disk space.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack {
+                Button("Scan again") { viewModel.scan() }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.ScanAfterResult")
+                Spacer()
+                Button("Done") { dismiss() }
+                    .buttonStyle(.rapidPrimaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.Done")
+            }
+        }
+        .accessibilityIdentifier("ComputerUse.FreeSpace.Result")
+    }
+
+    private func failure(_ error: FreeUpSpaceScanError) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Rapid could not review Downloads", systemImage: "folder.badge.questionmark")
+                .font(.headline)
+                .foregroundStyle(.orange)
+            Text(errorMessage(error))
+                .font(.callout)
+            HStack {
+                Button("Try again") { viewModel.scan() }
+                    .buttonStyle(.rapidSecondaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.Retry")
+                Spacer()
+                Button("Close") { dismiss() }
+                    .buttonStyle(.rapidPrimaryCompact)
+                    .accessibilityIdentifier("ComputerUse.FreeSpace.CloseAfterFailure")
+            }
+        }
+        .accessibilityIdentifier("ComputerUse.FreeSpace.Failure")
+    }
+
+    private func candidateRow(_ candidate: FreeUpSpaceCandidate) -> some View {
+        let selected = viewModel.selectedIDs.contains(candidate.id)
+        return Button { viewModel.toggle(candidate) } label: {
+            HStack(spacing: 12) {
+                Image(systemName: selected ? "checkmark.square.fill" : "square")
+                    .font(.title3)
+                    .foregroundStyle(selected ? RapidTheme.brandPrimaryDeep : .secondary)
+                Image(systemName: "doc")
+                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(candidate.name)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text("Last changed \(candidate.ageInDays(relativeTo: viewModel.scanDate)) days ago")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(bytes(candidate.byteCount))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            .padding(10)
+            .background(
+                selected ? RapidTheme.brandPrimaryDeep.opacity(0.08) : RapidTheme.surfaceRaised,
+                in: RoundedRectangle(cornerRadius: 10)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(selected ? "Selected" : "Not selected"), \(candidate.name), \(bytes(candidate.byteCount))")
+        .accessibilityIdentifier("ComputerUse.FreeSpace.Candidate.\(candidate.id)")
+    }
+
+    private func progress(title: String, detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ProgressView()
+            Text(title).font(.headline)
+            Text(detail).font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    private var selectionSummary: String {
+        guard !viewModel.selectedCandidates.isEmpty else { return "No files selected" }
+        return "\(viewModel.selectedCandidates.count) selected · \(bytes(viewModel.selectedByteCount))"
+    }
+
+    private func bytes(_ count: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: count, countStyle: .file)
+    }
+
+    private func fileWord(_ count: Int) -> String { count == 1 ? "file" : "files" }
+
+    private func errorMessage(_ error: FreeUpSpaceScanError) -> String {
+        switch error {
+        case .downloadsUnavailable:
+            "The Downloads folder is not available on this Mac."
+        case .permissionDenied:
+            "macOS did not allow Rapid to read Downloads. Review Files & Folders access in System Settings, then try again."
+        case .enumerationFailed:
+            "Downloads could not be read. No files were changed."
+        case .cancelled:
+            "The scan was stopped. No files were changed."
+        }
+    }
+}
+
+private actor UnavailableFreeUpSpaceService: FreeUpSpaceServicing {
+    func scan(now: Date) async throws -> [FreeUpSpaceCandidate] {
+        throw FreeUpSpaceScanError.downloadsUnavailable
+    }
+
+    func moveToTrash(
+        _ candidates: [FreeUpSpaceCandidate]
+    ) async -> FreeUpSpaceMoveOutcome {
+        FreeUpSpaceMoveOutcome()
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ComputerUseFeatureTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ComputerUseFeatureTests.swift
@@ -61,10 +61,10 @@ struct ComputerUseFeatureTests {
             .createDemoVideo,
             .reserved,
         ])
-        #expect(ComputerUseStarter.catalog.first?.availability == .comingSoon)
+        #expect(ComputerUseStarter.catalog.first?.availability == .available)
         #expect(ComputerUseStarter.catalog.first(where: { $0.kind == .draftAndPost })?.availability == .available)
         #expect(ComputerUseStarter.catalog.filter {
-            $0.kind != .draftAndPost && $0.kind != .reserved
+            $0.kind != .freeUpSpace && $0.kind != .draftAndPost && $0.kind != .reserved
         }.allSatisfy { $0.availability == .comingSoon })
         #expect(ComputerUseStarter.catalog.last?.availability == .reserved)
         #expect(ComputerUseStarter.catalog.allSatisfy {

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -122,13 +122,13 @@ struct DraftPostFlowTests {
         try actuator.clearLastDraftIfUnchanged()
     }
 
-    @Test("The first runnable starter is draft and post")
+    @Test("Draft and post remains runnable with its publish boundary")
     func catalogAvailability() throws {
-        let available = ComputerUseStarter.catalog.filter {
-            $0.availability == .available
-        }
-        #expect(available.map(\.kind) == [.draftAndPost])
-        #expect(try #require(available.first).approvalNote == "Rapid will stop before publishing.")
+        let starter = try #require(ComputerUseStarter.catalog.first {
+            $0.kind == .draftAndPost
+        })
+        #expect(starter.availability == .available)
+        #expect(starter.approvalNote == "Rapid will stop before publishing.")
     }
 
     @Test("A verified transfer finishes without recovery")

--- a/apps/rapid-mac/Tests/RapidTests/FreeUpSpaceFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreeUpSpaceFlowTests.swift
@@ -161,6 +161,44 @@ struct FreeUpSpaceFlowTests {
         #expect(FileManager.default.fileExists(atPath: reviewed.url.path))
     }
 
+    @Test("Trash permission failures are reported without claiming a move")
+    func trashPermissionFailureIsClassified() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        try fixture.file(
+            "protected.txt",
+            bytes: 20,
+            modifiedAt: now.addingTimeInterval(-40 * 24 * 60 * 60)
+        )
+        let denied: MacOSDownloadsCleanupService.TrashOperation = { _ in
+            throw NSError(
+                domain: NSCocoaErrorDomain,
+                code: CocoaError.fileWriteUnknown.rawValue,
+                userInfo: [
+                    NSUnderlyingErrorKey: NSError(
+                        domain: NSPOSIXErrorDomain,
+                        code: Int(EACCES)
+                    )
+                ]
+            )
+        }
+        let service = try #require(MacOSDownloadsCleanupService(
+            root: fixture.root,
+            trashOperation: denied
+        ))
+        let reviewed = try #require(try await service.scan(now: now).first)
+
+        let outcome = await service.moveToTrash([reviewed])
+
+        #expect(outcome.moved.isEmpty)
+        #expect(outcome.failures == [FreeUpSpaceMoveFailure(
+            candidate: reviewed,
+            reason: .permissionDenied
+        )])
+        #expect(FileManager.default.fileExists(atPath: reviewed.url.path))
+    }
+
     @Test("a crafted candidate outside the reviewed root fails closed")
     func candidateOutsideRootIsRejected() async throws {
         let fixture = try Fixture()

--- a/apps/rapid-mac/Tests/RapidTests/FreeUpSpaceFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreeUpSpaceFlowTests.swift
@@ -210,12 +210,8 @@ struct FreeUpSpaceFlowTests {
         try fixture.file("inside.txt", bytes: 20, modifiedAt: old)
         let outsideURL = try outside.file("outside.txt", bytes: 20, modifiedAt: old)
         let service = try #require(MacOSDownloadsCleanupService(root: fixture.root))
-        let reviewed = try #require(try await service.scan(now: now).first)
-        let crafted = FreeUpSpaceCandidate(
-            url: outsideURL,
-            identity: reviewed.identity,
-            modifiedAt: reviewed.modifiedAt
-        )
+        let outsideService = try #require(MacOSDownloadsCleanupService(root: outside.root))
+        let crafted = try #require(try await outsideService.scan(now: now).first)
 
         let outcome = await service.moveToTrash([crafted])
 

--- a/apps/rapid-mac/Tests/RapidTests/FreeUpSpaceFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreeUpSpaceFlowTests.swift
@@ -1,0 +1,297 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Computer Use free-up-space flow", .serialized)
+struct FreeUpSpaceFlowTests {
+    @Test("scan includes only old top-level regular files and orders by size")
+    func scanIsNarrowAndDeterministic() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let old = now.addingTimeInterval(-40 * 24 * 60 * 60)
+
+        try fixture.file("large.zip", bytes: 200, modifiedAt: old)
+        try fixture.file("small.txt", bytes: 20, modifiedAt: old)
+        try fixture.file("recent.bin", bytes: 1_000, modifiedAt: now)
+        try fixture.file(".hidden.log", bytes: 2_000, modifiedAt: old)
+        try fixture.file("unfinished.crdownload", bytes: 3_000, modifiedAt: old)
+        try fixture.directory("old-folder", modifiedAt: old)
+        try fixture.symlink("old-link", destination: fixture.root.appendingPathComponent("large.zip"))
+
+        let service = try #require(MacOSDownloadsCleanupService(root: fixture.root))
+        let candidates = try await service.scan(now: now)
+
+        #expect(candidates.map(\.name) == ["large.zip", "small.txt"])
+        #expect(candidates.map(\.byteCount) == [200, 20])
+        #expect(candidates.allSatisfy { $0.ageInDays(relativeTo: now) >= 39 })
+    }
+
+    @Test("candidate count is bounded after deterministic ordering")
+    func scanCapKeepsLargestCandidates() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let old = now.addingTimeInterval(-40 * 24 * 60 * 60)
+        try fixture.file("one", bytes: 1, modifiedAt: old)
+        try fixture.file("two", bytes: 2, modifiedAt: old)
+        try fixture.file("three", bytes: 3, modifiedAt: old)
+
+        let service = try #require(MacOSDownloadsCleanupService(
+            root: fixture.root,
+            maximumCandidates: 2
+        ))
+        let candidates = try await service.scan(now: now)
+
+        #expect(candidates.map(\.name) == ["three", "two"])
+    }
+
+    @Test("Cocoa and wrapped POSIX access failures become permission guidance")
+    func permissionErrorsAreClassified() {
+        let cocoa = CocoaError(.fileReadNoPermission)
+        #expect(MacOSDownloadsCleanupService.scanError(for: cocoa) == .permissionDenied)
+
+        let wrapped = NSError(
+            domain: NSCocoaErrorDomain,
+            code: CocoaError.fileReadUnknown.rawValue,
+            userInfo: [
+                NSUnderlyingErrorKey: NSError(
+                    domain: NSPOSIXErrorDomain,
+                    code: Int(EPERM)
+                )
+            ]
+        )
+        #expect(MacOSDownloadsCleanupService.scanError(for: wrapped) == .permissionDenied)
+        #expect(MacOSDownloadsCleanupService.scanError(
+            for: CocoaError(.fileReadCorruptFile)
+        ) == .enumerationFailed)
+    }
+
+    @Test("approved file moves through Trash adapter and original path disappears")
+    func approvedMoveIsVerified() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let quarantine = fixture.root.deletingLastPathComponent()
+            .appendingPathComponent("quarantine-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: quarantine, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: quarantine) }
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        try fixture.file(
+            "approved.zip",
+            bytes: 64,
+            modifiedAt: now.addingTimeInterval(-40 * 24 * 60 * 60)
+        )
+        let trash: MacOSDownloadsCleanupService.TrashOperation = { url in
+            try FileManager.default.moveItem(
+                at: url,
+                to: quarantine.appendingPathComponent(url.lastPathComponent)
+            )
+        }
+        let candidateService = MacOSDownloadsCleanupService(
+            root: fixture.root,
+            trashOperation: trash
+        )
+        let service = try #require(candidateService)
+        let candidate = try #require(try await service.scan(now: now).first)
+
+        let outcome = await service.moveToTrash([candidate])
+
+        #expect(outcome.moved == [candidate])
+        #expect(outcome.failures.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: candidate.url.path))
+        #expect(FileManager.default.fileExists(
+            atPath: quarantine.appendingPathComponent(candidate.name).path
+        ))
+    }
+
+    @Test("a file replaced after review is left in Downloads")
+    func replacedFileFailsClosed() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let old = now.addingTimeInterval(-40 * 24 * 60 * 60)
+        let url = try fixture.file("changed.txt", bytes: 20, modifiedAt: old)
+        let trash: MacOSDownloadsCleanupService.TrashOperation = { _ in
+            Issue.record("trash must not run for changed identity")
+        }
+        let candidateService = MacOSDownloadsCleanupService(
+            root: fixture.root,
+            trashOperation: trash
+        )
+        let service = try #require(candidateService)
+        let reviewed = try #require(try await service.scan(now: now).first)
+        try FileManager.default.removeItem(at: url)
+        try fixture.file("changed.txt", bytes: 21, modifiedAt: old)
+
+        let outcome = await service.moveToTrash([reviewed])
+
+        #expect(outcome.moved.isEmpty)
+        #expect(outcome.failures == [FreeUpSpaceMoveFailure(
+            candidate: reviewed,
+            reason: .changedSinceReview
+        )])
+        #expect(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("a successful adapter return is not accepted without the move postcondition")
+    func noOpTrashAdapterFailsVerification() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        try fixture.file(
+            "still-here.txt",
+            bytes: 20,
+            modifiedAt: now.addingTimeInterval(-40 * 24 * 60 * 60)
+        )
+        let noOp: MacOSDownloadsCleanupService.TrashOperation = { _ in }
+        let candidateService = MacOSDownloadsCleanupService(
+            root: fixture.root,
+            trashOperation: noOp
+        )
+        let service = try #require(candidateService)
+        let reviewed = try #require(try await service.scan(now: now).first)
+
+        let outcome = await service.moveToTrash([reviewed])
+
+        #expect(outcome.moved.isEmpty)
+        #expect(outcome.failures == [FreeUpSpaceMoveFailure(
+            candidate: reviewed,
+            reason: .verificationFailed
+        )])
+        #expect(FileManager.default.fileExists(atPath: reviewed.url.path))
+    }
+
+    @Test("a crafted candidate outside the reviewed root fails closed")
+    func candidateOutsideRootIsRejected() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let outside = try Fixture()
+        defer { outside.remove() }
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let old = now.addingTimeInterval(-40 * 24 * 60 * 60)
+        try fixture.file("inside.txt", bytes: 20, modifiedAt: old)
+        let outsideURL = try outside.file("outside.txt", bytes: 20, modifiedAt: old)
+        let service = try #require(MacOSDownloadsCleanupService(root: fixture.root))
+        let reviewed = try #require(try await service.scan(now: now).first)
+        let crafted = FreeUpSpaceCandidate(
+            url: outsideURL,
+            identity: reviewed.identity,
+            modifiedAt: reviewed.modifiedAt
+        )
+
+        let outcome = await service.moveToTrash([crafted])
+
+        #expect(outcome.moved.isEmpty)
+        #expect(outcome.failures.first?.reason == .changedSinceReview)
+        #expect(FileManager.default.fileExists(atPath: outsideURL.path))
+    }
+
+    @MainActor
+    @Test("review requires selection and confirmation before move")
+    func viewModelRequiresTwoExplicitSteps() async throws {
+        let candidate = sampleCandidate()
+        let expected = FreeUpSpaceMoveOutcome(moved: [candidate])
+        let model = FreeUpSpaceFlowViewModel(
+            service: ImmediateFreeUpSpaceService(
+                candidates: [candidate],
+                outcome: expected
+            ),
+            now: { Date(timeIntervalSince1970: 2_000_000_000) }
+        )
+
+        model.scan()
+        try await waitUntil { model.phase == .reviewing }
+        #expect(model.selectedCandidates.isEmpty)
+        model.reviewMove()
+        #expect(model.phase == .reviewing)
+
+        model.toggle(candidate)
+        model.reviewMove()
+        #expect(model.phase == .confirming)
+        model.returnToSelection()
+        #expect(model.phase == .reviewing)
+
+        model.reviewMove()
+        model.moveSelectedToTrash()
+        try await waitUntil { model.phase == .finished(expected) }
+        #expect(model.phase == .finished(expected))
+    }
+
+    private func sampleCandidate() -> FreeUpSpaceCandidate {
+        FreeUpSpaceCandidate(
+            url: URL(fileURLWithPath: "/tmp/old.zip"),
+            identity: FreeUpSpaceFileIdentity(
+                device: 1,
+                inode: 2,
+                size: 100,
+                modifiedSeconds: 1_000,
+                modifiedNanoseconds: 0
+            ),
+            modifiedAt: Date(timeIntervalSince1970: 1_000)
+        )
+    }
+
+    @MainActor
+    private func waitUntil(
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + .seconds(2)
+        while !condition(), clock.now < deadline { await Task.yield() }
+        guard condition() else { throw TestWaitError.timedOut }
+    }
+}
+
+private enum TestWaitError: Error { case timedOut }
+
+private struct ImmediateFreeUpSpaceService: FreeUpSpaceServicing {
+    let candidates: [FreeUpSpaceCandidate]
+    let outcome: FreeUpSpaceMoveOutcome
+
+    func scan(now: Date) async throws -> [FreeUpSpaceCandidate] { candidates }
+
+    func moveToTrash(
+        _ candidates: [FreeUpSpaceCandidate]
+    ) async -> FreeUpSpaceMoveOutcome { outcome }
+}
+
+private struct Fixture {
+    let root: URL
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rapid-free-space-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    @discardableResult
+    func file(_ name: String, bytes: Int, modifiedAt: Date) throws -> URL {
+        let url = root.appendingPathComponent(name)
+        try Data(repeating: 0x41, count: bytes).write(to: url)
+        try FileManager.default.setAttributes(
+            [.modificationDate: modifiedAt],
+            ofItemAtPath: url.path
+        )
+        return url
+    }
+
+    func directory(_ name: String, modifiedAt: Date) throws {
+        let url = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.modificationDate: modifiedAt],
+            ofItemAtPath: url.path
+        )
+    }
+
+    func symlink(_ name: String, destination: URL) throws {
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent(name),
+            withDestinationURL: destination
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/FreeUpSpaceFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/FreeUpSpaceFlowTests.swift
@@ -251,6 +251,19 @@ struct FreeUpSpaceFlowTests {
         #expect(model.phase == .finished(expected))
     }
 
+    @MainActor
+    @Test("stopping a scan reports cancellation instead of an empty result")
+    func stoppingScanIsNotReportedAsEmpty() async throws {
+        let model = FreeUpSpaceFlowViewModel(service: CancellableScanService())
+
+        model.scan()
+        await Task.yield()
+        model.stop()
+
+        try await waitUntil { model.phase == .failed(.cancelled) }
+        #expect(model.candidates.isEmpty)
+    }
+
     private func sampleCandidate() -> FreeUpSpaceCandidate {
         FreeUpSpaceCandidate(
             url: URL(fileURLWithPath: "/tmp/old.zip"),
@@ -287,6 +300,19 @@ private struct ImmediateFreeUpSpaceService: FreeUpSpaceServicing {
     func moveToTrash(
         _ candidates: [FreeUpSpaceCandidate]
     ) async -> FreeUpSpaceMoveOutcome { outcome }
+}
+
+private struct CancellableScanService: FreeUpSpaceServicing {
+    func scan(now: Date) async throws -> [FreeUpSpaceCandidate] {
+        try await Task.sleep(for: .seconds(10))
+        return []
+    }
+
+    func moveToTrash(
+        _ candidates: [FreeUpSpaceCandidate]
+    ) async -> FreeUpSpaceMoveOutcome {
+        FreeUpSpaceMoveOutcome()
+    }
 }
 
 private struct Fixture {


### PR DESCRIPTION
## Why

Computer Use currently offers a safe local Draft-and-Post preview, but its “Free up space” starter is still a non-functional card. Users should be able to get immediate value from a second workflow without trusting a model to decide what to delete: review old Downloads, select exact files, confirm the bounded action, and retain recovery through macOS Trash.

Part of #3107.

## Scope

- Make “Free up space” an available Computer Use preview flow.
- Inventory only direct, non-hidden, non-symlink regular files in Downloads that have been unchanged for at least 30 days.
- Sort candidates by size, cap the result set at 200, and select nothing by default.
- Present exact file names, ages, sizes, selection totals, and a separate in-app confirmation state.
- Revalidate canonical root containment, regular-file type, inode, size, and modification identity immediately before each move.
- Move approved files through the native macOS Trash API and verify the original path disappeared before reporting success.
- Preserve honest partial-success and cancellation results, including the distinction between “moved to Trash” and “disk space reclaimed.”

## Non-goals

- No permanent deletion, Empty Trash, automatic selection, recursive directory traversal, or background scheduling.
- No scanning of model caches, app data, hidden files, folders, system locations, external disks, or any path outside Downloads.
- No cloud fallback, local-model call, visual grounding, Finder coordinate automation, Teach mode, or implementation of other starter cards.
- No change to host storage policy or release/disk-hygiene automation.

## Acceptance

- Opening the flow performs a read-only scan and never selects a file automatically.
- A move is impossible until the user explicitly selects files and advances through a separate confirmation state.
- A file replaced or modified after review, a symlink, a directory, an incomplete download, or an out-of-root candidate fails closed.
- A successful Trash API return is not treated as success unless the original path is independently absent.
- Cancellation stops between files and reports any already moved files honestly.
- Users are told that Trash is recoverable and that disk space is reclaimed only after they empty it themselves.

## Design precedent

Mature storage-management and local-automation systems separate read-only recommendations from mutation, require action-scoped approval, re-check target identity immediately before a consequential write, and verify the effect independently afterward. This change adapts that pattern into scan, select, confirm, move, and verified-result phases. The healthy path is deterministic filesystem logic; no model output can choose a file or produce an executable action.

## Verification

- `swift test --no-parallel --filter FreeUpSpaceFlowTests` — 10 passed on the exact head.
- `swift test --no-parallel --filter 'FreeUpSpaceFlowTests|ComputerUseFeatureTests|DraftPostFlowTests'` — 44 integration-adjacent tests passed.
- `swift test --no-parallel --skip-build` — 3,607 tests passed in 311 suites on the exact head.
- Exact-head rapid-mac CI `build` and `desktop-tests` — passed.
- Read-only Desktop dogfood — flow opened from the real Computer Use card; an ad-hoc-build Downloads TCC denial rendered a safe “no files changed” failure state. No user file was selected or moved.
- `git diff --check` — passed.

## Behaviour delta

“Free up space”: coming-next card → runnable local Downloads review with explicit selection, confirmation, Trash recovery, cancellation, and verified outcome.

## AI assistance disclosure

Codex implemented and tested this Swift vertical slice under the human-approved Computer Use contract. The review is scope-locked to Downloads cleanup safety, state handling, and UI clarity; unrelated cleanup or general-purpose automation work is out of scope.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Focused and full Swift tests pass locally
- [x] Negative safety cases cover replacement, out-of-root input, permission denial, symlinks, transient downloads, and false-success verification
- [x] User-facing availability and recovery copy is updated
- [x] No breaking public API change

## Author
