### PR TITLE
feat(doctor): add structured report and bounded check runner

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,50 @@
 
 Run `rapid-mlx <cmd> --help` for the full flag list of any subcommand.
 
+## `rapid-mlx doctor`
+
+Run the fast, read-only environment diagnostic without loading a model or
+starting a server:
+
+```bash
+rapid-mlx doctor                 # complete human-readable report
+rapid-mlx doctor --verbose       # include evidence and remediation detail
+rapid-mlx doctor --summary       # one line for logs and shell scripts
+rapid-mlx doctor --json          # versioned report for automation/support
+```
+
+The built-in filesystem, network, and subprocess operations carry explicit
+timeouts. A shared five-second scheduling budget prevents later sections from
+starting after earlier checks consume the target runtime; it is not a process
+watchdog for arbitrary third-party Python code.
+
+To isolate a slow or suspect area, select sections by their stable IDs. Both
+flags are repeatable, and `--skip` wins when the same ID appears in both:
+
+```bash
+rapid-mlx doctor --only packages.required --only packages.optional
+rapid-mlx doctor --skip updates --skip network
+```
+
+Available IDs are `system`, `python`, `packages.required`, `updates`,
+`packages.optional`, `cache.huggingface`, `network`, `shell`,
+`tools.optional`, and `agents`.
+
+JSON output uses `schemaVersion: 1` and includes the Rapid-MLX version,
+overall status (`ok`, `warn`, `fail`, or `skipped`), exit code, total and per-section durations, counts, stable
+section IDs, optional semantic check IDs, and redacted summaries/details.
+Legacy checks that do not yet declare a semantic identity return `id: null`;
+consumers must not derive identity from their position or English prose. It
+writes JSON only to stdout. Exit code `0` means no confirmed failure (warnings
+and skipped checks remain visible); exit code `1` means at least one confirmed
+failure. A report containing both successful and skipped checks has root status
+`warn` (partially complete); `skipped` means no check produced a result.
+For JSON mode, the CLI starts a fresh isolated Python executable and receives
+only its atomically written structured result. Python, native-library,
+subprocess, and delayed thread output from probes therefore cannot corrupt the
+JSON stream, and the worker does not inherit initialized native-library locks
+from the caller. A parent deadline cleans up the worker's entire process group.
+
 `rapid-mlx models --cached --json` is the stable machine-readable cache
 inventory used by the Desktop app. Each row includes `repo`, `alias`,
 `subfolder`, `size_bytes`, `state`, and `external`; `subfolder: null` means the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -598,6 +598,7 @@ def clean_doctor_runtime_state(monkeypatch):
     monkeypatch.setattr(env_health, "_SELECTED_RUNTIME", None)
     monkeypatch.setattr(env_health, "_SELECTED_SERVER_RUNTIME", False)
     monkeypatch.setattr(env_health, "_RUNTIME_SELECTION_DONE", False)
+    monkeypatch.setattr(env_health, "_DOCTOR_DEADLINE", None)
     env_health._RUNTIME_CONTEXTS.clear()
     env_health._RUNTIME_DISTRIBUTION_CACHE.clear()
     env_health._RUNTIME_PROBE_CACHE.clear()

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -1438,12 +1438,15 @@ def test_doctor_uses_one_cached_runtime_selection(monkeypatch, tmp_path):
         return runtime
 
     def section():
+        assert eh._selected_runtime()[0] == runtime
+        assert eh._selected_runtime()[0] == runtime
         section_section = eh.Section("Cached")
         section_section.add("cached", eh.CheckStatus.OK)
         return section_section
 
     monkeypatch.setattr(eh, "_runtime_python_path", select_runtime)
     monkeypatch.setattr(eh, "_SECTION_BUILDERS", (section,))
+    monkeypatch.setattr(eh, "_RUNTIME_SECTION_BUILDERS", frozenset({section}))
     monkeypatch.setattr(eh, "_DOCTOR_DEADLINE", None)
     eh._RUNTIME_SELECTION_DONE = False
     try:
@@ -2918,7 +2921,7 @@ def test_run_all_skips_remaining_sections_after_shared_deadline(monkeypatch):
     report = eh.run_all()
 
     assert [section.title for section in report.sections] == ["First", "Must_Not_Run"]
-    assert report.sections[1].checks[0].status is eh.CheckStatus.WARN
+    assert report.sections[1].checks[0].status is eh.CheckStatus.SKIPPED
     assert "budget exhausted" in report.sections[1].checks[0].label
     assert eh._DOCTOR_DEADLINE is None
 
@@ -2939,6 +2942,101 @@ def test_expired_caller_does_not_start_runtime_discovery(monkeypatch):
     )
     eh._selected_runtime.assert_not_called()
     assert eh._DOCTOR_DEADLINE is None
+
+
+def test_runtime_discovery_budget_overrun_skips_selected_sections(monkeypatch):
+    clock = [100.0]
+
+    def consume_budget():
+        clock[0] = 105.0
+        return Path(sys.executable), False
+
+    monkeypatch.setattr(eh.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(eh, "_selected_runtime", consume_budget)
+    monkeypatch.setattr(eh, "_SECTION_BUILDERS", (eh.section_python,))
+    monkeypatch.setattr(eh, "_RUNTIME_SECTION_BUILDERS", frozenset({eh.section_python}))
+
+    report = eh.run_all()
+
+    assert [section.id for section in report.sections] == ["python"]
+    assert report.sections[0].checks[0].status is eh.CheckStatus.SKIPPED
+    assert "budget exhausted" in report.sections[0].checks[0].label
+
+
+def test_runtime_discovery_runs_after_preceding_independent_sections(monkeypatch):
+    clock = [100.0]
+    calls = []
+
+    def independent_section():
+        calls.append("independent")
+        section = eh.Section("Independent")
+        section.add("ran", eh.CheckStatus.OK)
+        return section
+
+    def runtime_section():
+        raise AssertionError("runtime section started after discovery exhausted budget")
+
+    def consume_budget():
+        calls.append("runtime discovery")
+        clock[0] = 105.0
+        return Path(sys.executable), False
+
+    monkeypatch.setattr(eh.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(eh, "_selected_runtime", consume_budget)
+    monkeypatch.setattr(eh, "_SECTION_BUILDERS", (independent_section, runtime_section))
+    monkeypatch.setattr(eh, "_RUNTIME_SECTION_BUILDERS", frozenset({runtime_section}))
+
+    report = eh.run_all()
+
+    assert calls == ["independent", "runtime discovery"]
+    assert [section.id for section in report.sections] == [
+        "independent.section",
+        "runtime.section",
+    ]
+    assert report.sections[0].checks[0].status is eh.CheckStatus.OK
+    assert report.sections[1].checks[0].status is eh.CheckStatus.SKIPPED
+
+
+def test_runtime_discovery_crash_is_reported_without_aborting_independent_checks(
+    monkeypatch,
+):
+    calls = []
+
+    def runtime_one():
+        raise AssertionError("runtime builder must not run without discovery")
+
+    def independent():
+        calls.append("independent")
+        section = eh.Section("Independent")
+        section.add("ran", eh.CheckStatus.OK)
+        return section
+
+    def runtime_two():
+        raise AssertionError("dependent runtime builder must be skipped")
+
+    monkeypatch.setattr(
+        eh, "_selected_runtime", mock.Mock(side_effect=RuntimeError("bad plist"))
+    )
+    monkeypatch.setattr(
+        eh, "_SECTION_BUILDERS", (runtime_one, independent, runtime_two)
+    )
+    monkeypatch.setattr(
+        eh, "_RUNTIME_SECTION_BUILDERS", frozenset({runtime_one, runtime_two})
+    )
+
+    report = eh.run_all()
+
+    assert calls == ["independent"]
+    assert [section.id for section in report.sections] == [
+        "runtime.one",
+        "independent",
+        "runtime.two",
+    ]
+    assert report.sections[0].checks[0].status is eh.CheckStatus.FAIL
+    assert "bad plist" in report.sections[0].checks[0].detail
+    assert report.sections[1].checks[0].status is eh.CheckStatus.OK
+    assert report.sections[2].checks[0].status is eh.CheckStatus.SKIPPED
+    eh._selected_runtime.assert_called_once_with()
 
 
 def test_bounded_timeout_uses_only_one_millisecond_after_deadline(monkeypatch):
@@ -3879,19 +3977,23 @@ def test_run_all_crashing_probe_does_not_abort_report(monkeypatch):
     """If a section builder crashes, run_all() records it as a single ✗
     row but keeps going. A buggy probe must not blank the whole report."""
 
+    clock = [100.0]
+
     def boom() -> eh.Section:
+        clock[0] += 0.002
         raise RuntimeError("synthetic")
 
-    # Patch the second builder so we can confirm earlier sections still rendered.
-    builders = list(eh._SECTION_BUILDERS)
-    builders[1] = boom
-    monkeypatch.setattr(eh, "_SECTION_BUILDERS", tuple(builders))
+    monkeypatch.setattr(eh.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(eh, "_SECTION_BUILDERS", (boom,))
+    monkeypatch.setattr(eh, "_RUNTIME_SECTION_BUILDERS", frozenset())
 
     report = eh.run_all()
-    assert len(report.sections) == len(builders)
-    crashed = report.sections[1]
+    assert len(report.sections) == 1
+    crashed = report.sections[0]
     assert any("probe crashed" in c.label for c in crashed.checks)
     assert any(c.status is eh.CheckStatus.FAIL for c in crashed.checks)
+    assert crashed.id == "boom"
+    assert crashed.duration_ms == 2
 
 
 def test_render_outputs_section_headers(capsys):

--- a/tests/test_doctor_report_contract.py
+++ b/tests/test_doctor_report_contract.py
@@ -1,0 +1,954 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Machine-readable and selective execution contracts for Doctor v2."""
+
+from __future__ import annotations
+
+import copy
+import io
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.doctor import cli as doctor_cli
+from vllm_mlx.doctor import env_health as eh
+from vllm_mlx.doctor import json_worker
+from vllm_mlx.doctor.cli import (
+    _collect_report_isolated,
+    _open_collector_pipes,
+    _report_from_document,
+    doctor_command,
+    render,
+    render_json,
+    render_summary,
+    report_document,
+)
+
+
+def _report() -> eh.Report:
+    section = eh.Section("Network", id="network", duration_ms=12)
+    section.add(
+        "API token=secret-value under /Users/tester/project",
+        eh.CheckStatus.WARN,
+        detail="password=hunter2",
+        check_id="network.credentials",
+    )
+    return eh.Report(sections=[section], duration_ms=14)
+
+
+def test_json_report_has_versioned_stable_shape(monkeypatch):
+    monkeypatch.setenv("HOME", "/Users/tester")
+    output = io.StringIO()
+
+    render_json(_report(), stream=output)
+    document = json.loads(output.getvalue())
+
+    assert document["schemaVersion"] == 1
+    assert document["status"] == "warn"
+    assert document["exitCode"] == 0
+    assert document["durationMs"] == 14
+    assert document["sections"][0]["id"] == "network"
+    check = document["sections"][0]["checks"][0]
+    assert check["id"] == "network.credentials"
+    assert "secret-value" not in check["summary"]
+    assert "/Users/tester" not in check["summary"]
+    assert "hunter2" not in check["detail"]
+
+
+def test_json_redacts_complete_authorization_header():
+    section = eh.Section("Auth", id="auth")
+    section.add(
+        "Authorization: Bearer abc123",
+        eh.CheckStatus.WARN,
+        detail="Authorization=Basic dXNlcjpwYXNz\nnext=safe",
+    )
+    output = io.StringIO()
+    render_json(eh.Report(sections=[section]), stream=output)
+    rendered = output.getvalue()
+    assert "abc123" not in rendered
+    assert "dXNlcjpwYXNz" not in rendered
+    assert "next=safe" in rendered
+
+
+@pytest.mark.parametrize(
+    "detail,secret",
+    [
+        ("Bearer sk-secret", "sk-secret"),
+        ("bearer eyJhbGciOiJIUzI1NiJ9.payload", "eyJhbGciOiJIUzI1NiJ9"),
+        ("Basic dXNlcjpwYXNz", "dXNlcjpwYXNz"),
+    ],
+)
+def test_json_redacts_standalone_authentication_schemes(detail, secret):
+    section = eh.Section("Auth", id="auth")
+    section.add("probe failed", eh.CheckStatus.FAIL, detail=detail)
+
+    rendered = json.dumps(report_document(eh.Report(sections=[section])))
+
+    assert secret not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_json_redacts_quoted_secrets_with_spaces_and_escapes():
+    section = eh.Section("Secrets", id="secrets")
+    section.add(
+        'password="correct horse \\"battery\\" staple"',
+        eh.CheckStatus.WARN,
+        detail="api_key='single quoted value' next=safe",
+    )
+    output = io.StringIO()
+    render_json(eh.Report(sections=[section]), stream=output)
+    rendered = output.getvalue()
+    assert "correct horse" not in rendered
+    assert "single quoted value" not in rendered
+    # Once a sensitive assignment starts, redact the rest of that line: an
+    # unquoted secret may itself contain spaces, commas, or semicolons.
+    assert "next=safe" not in rendered
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "access_token",
+        "refresh-token",
+        "client_secret",
+        "OPENAI_API_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+        "signing_private_key",
+        "service_credential",
+        "passwd",
+        "pwd",
+        "ssh_passphrase",
+        "cookie",
+        "session_id",
+        "auth",
+        "connection_string",
+        "access_token_value",
+        "client_secret_value",
+        "password_hash",
+        "accessTokenValue",
+        "AWSSecretAccessKey",
+        "apikey",
+        "privatekey",
+        "connectionstring",
+    ],
+)
+def test_json_redacts_compound_credential_keys(key):
+    section = eh.Section("Secrets", id="secrets")
+    section.add(f"{key}=top-secret-value", eh.CheckStatus.WARN)
+    output = io.StringIO()
+    render_json(eh.Report(sections=[section]), stream=output)
+    assert "top-secret-value" not in output.getvalue()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:password@example.com/path",
+        "http://user:p%40ss@127.0.0.1:8000/v1",
+        "https://ghp_secret@github.com/repo",
+        "postgresql://user:password@database.internal/app",
+        "ssh://deployment-token@server.internal",
+        "redis+sentinel://user:password@cache.internal/0",
+        "https://user:p@ss@example.com/private",
+    ],
+)
+def test_json_redacts_url_userinfo(url):
+    section = eh.Section("Network", id="network")
+    section.add(f"endpoint={url}", eh.CheckStatus.WARN)
+    output = io.StringIO()
+    render_json(eh.Report(sections=[section]), stream=output)
+    rendered = output.getvalue()
+    assert "user:" not in rendered
+    assert "[REDACTED]@" in rendered
+
+
+@pytest.mark.parametrize("secret", ["abc,def", "abc;def", "abc def"])
+def test_json_redacts_complete_unquoted_secret_line(secret):
+    section = eh.Section("Secrets", id="secrets")
+    section.add(f"password={secret}", eh.CheckStatus.WARN)
+    output = io.StringIO()
+    render_json(eh.Report(sections=[section]), stream=output)
+    assert secret not in output.getvalue()
+
+
+def test_json_finds_sensitive_assignment_after_safe_assignment():
+    section = eh.Section("Secrets", id="secrets")
+    section.add("context=diagnostic password=hunter2", eh.CheckStatus.WARN)
+    output = io.StringIO()
+    render_json(eh.Report(sections=[section]), stream=output)
+    rendered = output.getvalue()
+    assert "context=diagnostic" in rendered
+    assert "hunter2" not in rendered
+
+
+@pytest.mark.parametrize(
+    "detail,secret",
+    [
+        ('{"password": "hunter2"}', "hunter2"),
+        ("{'api_key': 'top-secret'}", "top-secret"),
+    ],
+)
+def test_json_redacts_quoted_mapping_keys(detail, secret):
+    section = eh.Section("Secrets", id="secrets")
+    section.add("mapping", eh.CheckStatus.WARN, detail=detail)
+
+    rendered = json.dumps(report_document(eh.Report(sections=[section])))
+
+    assert secret not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_json_redacts_multiline_secret_continuations():
+    section = eh.Section("Auth")
+    section.add(
+        "credentials inspected",
+        eh.CheckStatus.WARN,
+        detail='mode=local\npassword="first line\nsecret-second"\npublic=visible',
+    )
+
+    rendered = json.dumps(report_document(eh.Report(sections=[section])))
+
+    assert "first line" not in rendered
+    assert "secret-second" not in rendered
+    assert "public=visible" in rendered
+    assert "mode=local" in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_json_redacts_authorization_through_end_of_line():
+    section = eh.Section("Auth", id="auth")
+    section.add("Authorization: Bearer abc,def;ghi", eh.CheckStatus.WARN)
+    output = io.StringIO()
+    render_json(eh.Report(sections=[section]), stream=output)
+    rendered = output.getvalue()
+    assert "abc" not in rendered
+    assert "def" not in rendered
+    assert "ghi" not in rendered
+
+
+def test_summary_is_one_line():
+    output = io.StringIO()
+    render_summary(_report(), stream=output)
+    assert output.getvalue().count("\n") == 1
+    assert "warn" in output.getvalue()
+
+
+def test_legacy_human_summary_omits_zero_skipped():
+    from vllm_mlx.doctor.cli import render
+
+    output = io.StringIO()
+    render(_report(), stream=output)
+    assert "skipped" not in output.getvalue()
+
+
+def test_overall_status_covers_ok_and_fail():
+    ok_section = eh.Section("OK")
+    ok_section.add("healthy", eh.CheckStatus.OK)
+    assert eh.Report(sections=[ok_section]).overall_status == "ok"
+
+    failed_section = eh.Section("Failed")
+    failed_section.add("broken", eh.CheckStatus.FAIL)
+    assert eh.Report(sections=[failed_section]).overall_status == "fail"
+
+    skipped_section = eh.Section("Skipped")
+    skipped_section.add("not run", eh.CheckStatus.SKIPPED)
+    assert eh.Report(sections=[skipped_section]).overall_status == "skipped"
+
+
+def test_run_all_only_and_skip_use_stable_section_ids(monkeypatch):
+    def alpha() -> eh.Section:
+        section = eh.Section("Alpha")
+        section.add("a", eh.CheckStatus.OK)
+        return section
+
+    def beta() -> eh.Section:
+        section = eh.Section("Beta")
+        section.add("b", eh.CheckStatus.OK)
+        return section
+
+    monkeypatch.setattr(eh, "_SECTION_BUILDERS", (alpha, beta))
+    monkeypatch.setattr(eh, "_selected_runtime", lambda: None)
+
+    report = eh.run_all(only={"alpha", "beta"}, skip={"beta"})
+
+    assert [section.id for section in report.sections] == ["alpha"]
+    assert report.sections[0].checks[0].id is None
+
+
+def test_empty_selection_does_not_discover_runtime(monkeypatch):
+    def must_not_run():
+        raise AssertionError("runtime discovery must not run")
+
+    monkeypatch.setattr(eh, "_selected_runtime", must_not_run)
+    assert eh.run_all(only={"unknown.section"}).sections == []
+
+
+def test_explicit_empty_only_set_runs_no_sections(monkeypatch):
+    def must_not_run():
+        raise AssertionError("an explicit empty selection must run nothing")
+
+    monkeypatch.setattr(eh, "_SECTION_BUILDERS", (must_not_run,))
+    assert eh.run_all(only=set()).sections == []
+
+
+def test_cli_preserves_explicit_empty_only_selection(monkeypatch):
+    calls = []
+
+    def capture_run_all(**kwargs):
+        calls.append(kwargs)
+        return eh.Report()
+
+    monkeypatch.setattr("vllm_mlx.doctor.cli.run_all", capture_run_all)
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=False,
+        summary=True,
+        only=[],
+        skip=None,
+    )
+
+    with pytest.raises(SystemExit):
+        doctor_command(args)
+
+    assert calls == [{"only": set(), "skip": None}]
+
+
+def test_redaction_respects_home_boundaries_and_benign_tokenizer_keys(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_mlx.doctor.cli.os.path.expanduser", lambda _: "/Users/tester"
+    )
+    section = eh.Section("Paths", id="paths")
+    section.add(
+        "paths",
+        eh.CheckStatus.OK,
+        detail=(
+            "home=/Users/tester/cache bracket=[/Users/tester] "
+            "object={/Users/tester} other=/Users/tester2 tokenizer=Qwen2"
+        ),
+    )
+
+    document = report_document(eh.Report(sections=[section]))
+    detail = document["sections"][0]["checks"][0]["detail"]
+
+    assert "home=~/cache" in detail
+    assert "bracket=[~]" in detail
+    assert "object={~}" in detail
+    assert "/Users/tester2" in detail
+    assert "tokenizer=Qwen2" in detail
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        "Authorization Bearer abc123",
+        "Authorization Basic dXNlcjpwYXNz",
+        "token abc",
+        "token abc123",
+        "token abcdefghijklmnop",
+        "api_key abc123",
+        "api_key abcdefgh",
+        "client_secret abc123",
+        "AWS_SECRET_ACCESS_KEY abc123",
+        "ssh_passphrase abc123",
+        "cookie abc123",
+        "session_id abc123",
+        "auth abc123",
+        "connection_string abc123",
+    ],
+)
+def test_json_redacts_whitespace_delimited_credentials(detail):
+    section = eh.Section("Auth", id="auth")
+    section.add("credential", eh.CheckStatus.WARN, detail=detail)
+
+    rendered = json.dumps(report_document(eh.Report(sections=[section])))
+
+    assert "abc123" not in rendered
+    assert "dXNlcjpwYXNz" not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_system_only_does_not_discover_runtime(monkeypatch):
+    def must_not_run():
+        raise AssertionError("unselected runtime checks must not run")
+
+    monkeypatch.setattr(eh, "_selected_runtime", must_not_run)
+    report = eh.run_all(only={"system"})
+    assert [section.id for section in report.sections] == ["system"]
+
+
+def test_budget_exhaustion_is_skipped_not_warning(monkeypatch):
+    monkeypatch.setattr(eh.time, "monotonic", lambda: 100.0)
+    report = eh._run_all_serialized(99.0)
+    assert report.n_warn == 0
+    assert report.n_skipped == len(report.sections)
+    assert all(
+        section.checks[0].status is eh.CheckStatus.SKIPPED
+        for section in report.sections
+    )
+
+
+def test_expired_budget_preserves_only_and_skip_selection(monkeypatch):
+    monkeypatch.setattr(eh.time, "monotonic", lambda: 100.0)
+    report = eh._run_all_serialized(99.0, only={"network", "python"}, skip={"python"})
+    assert [section.id for section in report.sections] == ["network"]
+
+
+def test_lock_timeout_preserves_only_selection(monkeypatch):
+    class BusyLock:
+        def acquire(self, **_kwargs):
+            return False
+
+    monkeypatch.setattr(eh, "_DOCTOR_RUN_LOCK", BusyLock())
+    report = eh.run_all(only={"network"})
+    assert [section.id for section in report.sections] == ["network"]
+
+
+def test_doctor_json_does_not_mix_human_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "vllm_mlx.doctor.cli._collect_report_isolated", lambda **_: _report()
+    )
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=True,
+        summary=False,
+        only=["network"],
+        skip=None,
+    )
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+    assert exc.value.code == 0
+    stdout = capsys.readouterr().out
+    parsed = json.loads(stdout)
+    assert parsed["sections"][0]["id"] == "network"
+
+
+def test_doctor_json_collector_failure_is_schema_valid(monkeypatch, capsys):
+    def fail_collection(*_args, **_kwargs):
+        raise OSError("collector unavailable")
+
+    monkeypatch.setattr("vllm_mlx.doctor.cli._collect_report_isolated", fail_collection)
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=True,
+        summary=False,
+        only=None,
+        skip=None,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+
+    assert exc.value.code == 1
+    document = json.loads(capsys.readouterr().out)
+    assert document["status"] == "fail"
+    assert document["sections"][0]["checks"][0]["id"] == "doctor.json.collection"
+
+
+@pytest.mark.parametrize(
+    "document",
+    [None, {}, {"sections": "invalid"}, {"sections": [{}]}],
+)
+def test_isolated_report_payload_is_strictly_validated(document):
+    with pytest.raises(RuntimeError, match="invalid"):
+        _report_from_document(document)
+
+
+def test_isolated_report_rejects_schema_and_field_contract_violations():
+    valid = report_document(_report())
+    invalid_documents = []
+
+    wrong_schema = copy.deepcopy(valid)
+    wrong_schema["schemaVersion"] = 2
+    invalid_documents.append(wrong_schema)
+
+    float_schema = copy.deepcopy(valid)
+    float_schema["schemaVersion"] = 1.0
+    invalid_documents.append(float_schema)
+
+    float_exit_code = copy.deepcopy(valid)
+    float_exit_code["exitCode"] = 0.0
+    invalid_documents.append(float_exit_code)
+
+    extra_root = copy.deepcopy(valid)
+    extra_root["unexpected"] = True
+    invalid_documents.append(extra_root)
+
+    negative_duration = copy.deepcopy(valid)
+    negative_duration["durationMs"] = -1
+    invalid_documents.append(negative_duration)
+
+    invalid_version = copy.deepcopy(valid)
+    invalid_version["rapidMlxVersion"] = 1
+    invalid_documents.append(invalid_version)
+
+    invalid_status = copy.deepcopy(valid)
+    invalid_status["status"] = "unknown"
+    invalid_documents.append(invalid_status)
+
+    invalid_exit_code = copy.deepcopy(valid)
+    invalid_exit_code["exitCode"] = True
+    invalid_documents.append(invalid_exit_code)
+
+    invalid_summary = copy.deepcopy(valid)
+    invalid_summary["summary"] = []
+    invalid_documents.append(invalid_summary)
+
+    invalid_summary_count = copy.deepcopy(valid)
+    invalid_summary_count["summary"]["warnings"] = True
+    invalid_documents.append(invalid_summary_count)
+
+    invalid_sections = copy.deepcopy(valid)
+    invalid_sections["sections"] = {}
+    invalid_documents.append(invalid_sections)
+
+    invalid_section = copy.deepcopy(valid)
+    invalid_section["sections"][0]["extra"] = True
+    invalid_documents.append(invalid_section)
+
+    invalid_section_id = copy.deepcopy(valid)
+    invalid_section_id["sections"][0]["id"] = ""
+    invalid_documents.append(invalid_section_id)
+
+    invalid_section_title = copy.deepcopy(valid)
+    invalid_section_title["sections"][0]["title"] = 1
+    invalid_documents.append(invalid_section_title)
+
+    invalid_section_checks = copy.deepcopy(valid)
+    invalid_section_checks["sections"][0]["checks"] = {}
+    invalid_documents.append(invalid_section_checks)
+
+    invalid_check = copy.deepcopy(valid)
+    invalid_check["sections"][0]["checks"][0]["extra"] = True
+    invalid_documents.append(invalid_check)
+
+    invalid_check_id = copy.deepcopy(valid)
+    invalid_check_id["sections"][0]["checks"][0]["id"] = 1
+    invalid_documents.append(invalid_check_id)
+
+    invalid_check_text = copy.deepcopy(valid)
+    invalid_check_text["sections"][0]["checks"][0]["detail"] = None
+    invalid_documents.append(invalid_check_text)
+
+    mismatched_summary = copy.deepcopy(valid)
+    mismatched_summary["summary"]["warnings"] = 0
+    invalid_documents.append(mismatched_summary)
+
+    mismatched_status = copy.deepcopy(valid)
+    mismatched_status["status"] = "ok"
+    invalid_documents.append(mismatched_status)
+
+    mismatched_exit_code = copy.deepcopy(valid)
+    mismatched_exit_code["exitCode"] = 1
+    invalid_documents.append(mismatched_exit_code)
+
+    missing_title = copy.deepcopy(valid)
+    del missing_title["sections"][0]["title"]
+    invalid_documents.append(missing_title)
+
+    for document in invalid_documents:
+        with pytest.raises(RuntimeError, match="invalid|schemaVersion"):
+            _report_from_document(document)
+
+
+def test_mixed_ok_and_skipped_report_is_partial_warning():
+    section = eh.Section("Mixed", id="mixed")
+    section.add("healthy", eh.CheckStatus.OK)
+    section.add("not run", eh.CheckStatus.SKIPPED)
+    report = eh.Report(sections=[section])
+
+    assert report.overall_status == "warn"
+    assert report.exit_code == 0
+
+
+def test_empty_report_is_skipped():
+    report = eh.run_all(only={"network"}, skip={"network"})
+
+    assert report.sections == []
+    assert report.overall_status == "skipped"
+    assert report.exit_code == 0
+
+
+def test_ambiguous_token_text_prefers_redaction_safety():
+    section = eh.Section("Usage", id="usage")
+    section.add("metrics", eh.CheckStatus.OK, detail="token count 42")
+
+    detail = report_document(eh.Report(sections=[section]))["sections"][0]["checks"][0][
+        "detail"
+    ]
+
+    assert detail == "token [REDACTED]"
+
+
+def test_json_process_isolation_collects_in_fresh_executable(monkeypatch):
+    child_pids = []
+    popen_options = []
+    real_popen = subprocess.Popen
+
+    def tracked_popen(*args, **kwargs):
+        process = real_popen(*args, **kwargs)
+        child_pids.append(process.pid)
+        popen_options.append(kwargs)
+        return process
+
+    monkeypatch.setattr(doctor_cli.subprocess, "Popen", tracked_popen)
+    report = _collect_report_isolated(only={"system"}, skip=None)
+
+    assert child_pids and child_pids[0] != os.getpid()
+    assert len(popen_options) == 1
+    assert popen_options[0]["stdin"] == subprocess.DEVNULL
+    assert popen_options[0]["stdout"] == subprocess.DEVNULL
+    assert popen_options[0]["stderr"] == subprocess.DEVNULL
+    assert popen_options[0]["pass_fds"]
+    assert popen_options[0]["start_new_session"] is True
+    assert [section.id for section in report.sections] == ["system"]
+
+
+def _run_json_worker(tmp_path, monkeypatch, request, *, result_parent=True):
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(request))
+    result_root = tmp_path if result_parent else tmp_path / "missing"
+    result_path = result_root / "report.json"
+    keepalive_read, keepalive_write = os.pipe()
+    status_read, status_write = os.pipe()
+    os.close(keepalive_write)
+    monkeypatch.setattr(json_worker, "run_all", lambda **_kwargs: _report())
+    try:
+        exit_code = json_worker.main(
+            [
+                str(request_path),
+                str(result_path),
+                str(keepalive_read),
+                str(status_write),
+            ]
+        )
+    finally:
+        os.close(status_read)
+    return exit_code, result_path
+
+
+def test_json_worker_publishes_atomic_report(tmp_path, monkeypatch):
+    exit_code, result_path = _run_json_worker(
+        tmp_path,
+        monkeypatch,
+        {"only": ["network"], "skip": None},
+    )
+
+    assert exit_code == 0
+    message = json.loads(result_path.read_text())
+    assert message["ok"] is True
+    assert message["report"]["sections"][0]["id"] == "network"
+    assert not result_path.with_suffix(".json.tmp").exists()
+
+
+def test_json_worker_serializes_invalid_request_as_error(tmp_path, monkeypatch):
+    exit_code, result_path = _run_json_worker(
+        tmp_path,
+        monkeypatch,
+        {"only": "network", "skip": None},
+    )
+
+    assert exit_code == 0
+    message = json.loads(result_path.read_text())
+    assert message["ok"] is False
+    assert "TypeError" in message["error"]
+
+
+def test_json_worker_serializes_invalid_request_fields_as_error(tmp_path, monkeypatch):
+    exit_code, result_path = _run_json_worker(
+        tmp_path,
+        monkeypatch,
+        {"only": None, "skip": None, "unexpected": True},
+    )
+
+    assert exit_code == 0
+    message = json.loads(result_path.read_text())
+    assert message["ok"] is False
+    assert "request fields are invalid" in message["error"]
+
+
+def test_json_worker_argument_and_write_failures(tmp_path, monkeypatch):
+    assert json_worker.main([]) == 2
+    assert json_worker.main(["request", "result", "not-an-fd", "also-bad"]) == 2
+
+    exit_code, result_path = _run_json_worker(
+        tmp_path,
+        monkeypatch,
+        {"only": None, "skip": []},
+        result_parent=False,
+    )
+    assert exit_code == 1
+    assert not result_path.exists()
+
+    # Invalid lifecycle descriptors also exercise the best-effort close path.
+    request_path = tmp_path / "request-invalid-fds.json"
+    request_path.write_text(json.dumps({"only": None, "skip": None}))
+    assert (
+        json_worker.main([str(request_path), str(result_path), "999999", "999998"]) == 1
+    )
+
+
+def test_json_worker_tolerates_keepalive_read_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        json_worker.os, "read", lambda *_args: (_ for _ in ()).throw(OSError("closed"))
+    )
+    exit_code, result_path = _run_json_worker(
+        tmp_path,
+        monkeypatch,
+        {"only": None, "skip": None},
+    )
+
+    assert exit_code == 0
+    assert result_path.exists()
+
+
+class _CollectorProcess:
+    pid = 424242
+
+    def __init__(self, *, waits=None, kill_error=None):
+        self.waits = list(waits or [None])
+        self.kill_error = kill_error
+        self.killed = False
+
+    def wait(self, *, timeout):
+        outcome = self.waits.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def kill(self):
+        self.killed = True
+        if self.kill_error is not None:
+            raise self.kill_error
+
+
+def _install_collector_result(monkeypatch, message, *, process=None):
+    process = process or _CollectorProcess()
+
+    def fake_popen(args, **_kwargs):
+        Path(args[-3]).write_text(message)
+        return process
+
+    monkeypatch.setattr(doctor_cli.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(doctor_cli, "_terminate_collector_group", lambda _pid: None)
+    return process
+
+
+@pytest.mark.parametrize(
+    "message,match",
+    [
+        ("not-json", "result is unreadable"),
+        (json.dumps([]), "invalid message"),
+        (json.dumps({"ok": "yes"}), "invalid message"),
+        (json.dumps({"ok": False, "error": "boom"}), "collection failed: boom"),
+    ],
+)
+def test_json_collector_rejects_invalid_child_messages(monkeypatch, message, match):
+    _install_collector_result(monkeypatch, message)
+
+    with pytest.raises(RuntimeError, match=match):
+        _collect_report_isolated(only=None, skip=None)
+
+
+def test_json_collector_closes_pipes_when_spawn_fails(monkeypatch):
+    monkeypatch.setattr(
+        doctor_cli.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("spawn failed")),
+    )
+
+    with pytest.raises(OSError, match="spawn failed"):
+        _collect_report_isolated(only=None, skip=None)
+
+
+def test_json_collector_reports_process_group_cleanup_failure(monkeypatch):
+    _install_collector_result(monkeypatch, json.dumps({"ok": False}))
+    monkeypatch.setattr(
+        doctor_cli,
+        "_terminate_collector_group",
+        lambda _pid: (_ for _ in ()).throw(OSError("killpg denied")),
+    )
+
+    with pytest.raises(RuntimeError, match="group cleanup failed"):
+        _collect_report_isolated(only=None, skip=None)
+
+
+def test_json_collector_falls_back_to_direct_kill(monkeypatch):
+    process = _CollectorProcess(
+        waits=[subprocess.TimeoutExpired("collector", 0.5), None]
+    )
+    _install_collector_result(monkeypatch, json.dumps({"ok": False}), process=process)
+
+    with pytest.raises(RuntimeError, match="collection failed"):
+        _collect_report_isolated(only=None, skip=None)
+
+    assert process.killed is True
+
+
+def test_json_collector_tolerates_already_exited_direct_kill(monkeypatch):
+    process = _CollectorProcess(
+        waits=[subprocess.TimeoutExpired("collector", 0.5), None],
+        kill_error=ProcessLookupError(),
+    )
+    _install_collector_result(monkeypatch, json.dumps({"ok": False}), process=process)
+
+    with pytest.raises(RuntimeError, match="collection failed"):
+        _collect_report_isolated(only=None, skip=None)
+
+
+def test_json_collector_reports_direct_kill_failure(monkeypatch):
+    process = _CollectorProcess(
+        waits=[subprocess.TimeoutExpired("collector", 0.5), None],
+        kill_error=OSError("kill denied"),
+    )
+    _install_collector_result(monkeypatch, json.dumps({"ok": False}), process=process)
+
+    with pytest.raises(RuntimeError, match="could not be killed"):
+        _collect_report_isolated(only=None, skip=None)
+
+
+def test_json_collector_reports_unreaped_process(monkeypatch):
+    process = _CollectorProcess(
+        waits=[
+            subprocess.TimeoutExpired("collector", 0.5),
+            subprocess.TimeoutExpired("collector", 0.5),
+        ]
+    )
+    _install_collector_result(monkeypatch, json.dumps({"ok": False}), process=process)
+
+    with pytest.raises(RuntimeError, match="could not be reaped"):
+        _collect_report_isolated(only=None, skip=None)
+
+
+def test_terminate_collector_group_ignores_missing_process(monkeypatch):
+    monkeypatch.setattr(
+        doctor_cli.os,
+        "killpg",
+        lambda *_args: (_ for _ in ()).throw(ProcessLookupError()),
+    )
+
+    doctor_cli._terminate_collector_group(123)
+
+
+def test_json_timeout_terminates_collector_leader_and_descendant(monkeypatch, tmp_path):
+    descendant_path = tmp_path / "descendant.pid"
+    processes = []
+    real_popen = subprocess.Popen
+    script = (
+        "import pathlib,subprocess,sys,time; "
+        "child=subprocess.Popen([sys.executable,'-c','import time;time.sleep(60)']); "
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid)); time.sleep(60)"
+    )
+
+    def blocking_popen(_args, **kwargs):
+        process = real_popen(
+            [sys.executable, "-c", script, str(descendant_path)], **kwargs
+        )
+        processes.append(process)
+        ready_deadline = time.monotonic() + 1.0
+        while not descendant_path.exists() and time.monotonic() < ready_deadline:
+            time.sleep(0.01)
+        assert descendant_path.exists()
+        return process
+
+    monkeypatch.setattr(doctor_cli.subprocess, "Popen", blocking_popen)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        _collect_report_isolated(only={"system"}, skip=None, timeout_s=0.3)
+
+    assert processes[0].returncode == -signal.SIGKILL
+    descendant_pid = int(descendant_path.read_text())
+    ps = real_popen(
+        ["/bin/ps", "-o", "stat=", "-p", str(descendant_pid)],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    descendant_state = ps.communicate(timeout=1.0)[0].strip()
+    assert ps.returncode in {0, 1}
+    if descendant_state and not descendant_state.startswith("Z"):
+        os.kill(descendant_pid, signal.SIGKILL)
+    assert not descendant_state or descendant_state.startswith("Z")
+
+
+def test_json_process_isolation_detects_child_exit_without_waiting_for_timeout(
+    monkeypatch,
+):
+    monkeypatch.setattr(doctor_cli.sys, "executable", "/usr/bin/false")
+    started_at = time.monotonic()
+
+    with pytest.raises(RuntimeError, match="exited without a report"):
+        _collect_report_isolated(only={"system"}, skip=None, timeout_s=2.0)
+
+    assert time.monotonic() - started_at < 1.0
+
+
+def test_json_collector_pipe_setup_closes_partial_allocation(monkeypatch):
+    real_pipe = os.pipe
+    opened_fds = []
+    calls = 0
+
+    def fail_second_pipe():
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("descriptor limit")
+        opened_fds.extend(real_pipe())
+        return tuple(opened_fds)
+
+    monkeypatch.setattr(doctor_cli.os, "pipe", fail_second_pipe)
+
+    with pytest.raises(OSError, match="descriptor limit"):
+        _open_collector_pipes()
+
+    for fd in opened_fds:
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+
+@pytest.mark.parametrize(
+    "summary,expected",
+    [
+        (True, "Rapid-MLX Doctor: warn"),
+        (False, "◆ Network"),
+    ],
+)
+def test_doctor_human_output_modes(monkeypatch, capsys, summary, expected):
+    monkeypatch.setattr("vllm_mlx.doctor.cli.run_all", lambda **_: _report())
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=False,
+        summary=summary,
+        only=None,
+        skip=None,
+    )
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+    assert exc.value.code == 0
+    assert expected in capsys.readouterr().out
+
+
+def test_human_summary_includes_skipped_count():
+    section = eh.Section("Optional", id="optional")
+    section.add("not selected", eh.CheckStatus.SKIPPED)
+
+    output = io.StringIO()
+    render(eh.Report(sections=[section]), stream=output)
+
+    assert "1 skipped" in output.getvalue()
+
+
+def test_output_modes_are_mutually_exclusive():
+    from vllm_mlx.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc:
+        build_parser().parse_args(["doctor", "--json", "--verbose"])
+    assert exc.value.code == 2

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -13018,11 +13018,48 @@ Examples:
         choices=["smoke", "check", "full", "benchmark"],
         help=argparse.SUPPRESS,
     )
-    doctor_parser.add_argument(
+    doctor_output = doctor_parser.add_mutually_exclusive_group()
+    doctor_output.add_argument(
         "--verbose",
         "-v",
         action="store_true",
         help="Print the underlying probe detail for each check",
+    )
+    doctor_output.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the versioned machine-readable report as JSON",
+    )
+    doctor_output.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print only the one-line result summary",
+    )
+    doctor_section_ids = (
+        "system",
+        "python",
+        "packages.required",
+        "updates",
+        "packages.optional",
+        "cache.huggingface",
+        "network",
+        "shell",
+        "tools.optional",
+        "agents",
+    )
+    doctor_parser.add_argument(
+        "--only",
+        action="append",
+        choices=doctor_section_ids,
+        metavar="SECTION",
+        help="Run only this section ID (repeatable)",
+    )
+    doctor_parser.add_argument(
+        "--skip",
+        action="append",
+        choices=doctor_section_ids,
+        metavar="SECTION",
+        help="Skip this section ID (repeatable)",
     )
     # Legacy compatibility shims — accepted-but-ignored so the redirect
     # message in ``doctor_command`` can fire (see comment above).

--- a/vllm_mlx/doctor/__init__.py
+++ b/vllm_mlx/doctor/__init__.py
@@ -2,7 +2,7 @@
 """
 Rapid-MLX Doctor — environment-health check.
 
-``rapid-mlx doctor`` is a fast (≤ 5 s) self-diagnostic that answers one
+``rapid-mlx doctor`` is a fast, cooperatively budgeted self-diagnostic that answers one
 question: *is my install/env broken?*  It probes hardware, Python, packages,
 HuggingFace cache, network, shell integration, and optional tooling.  It
 never loads a model, boots a server, or runs benchmarks.
@@ -10,10 +10,10 @@ never loads a model, boots a server, or runs benchmarks.
 Model-validation tiers that used to live here (``smoke / check / full /
 benchmark``) moved to ``rapid-mlx bench --tier ...`` as of v0.7.22.
 
-Entry point: ``rapid-mlx doctor [--verbose]``.
+Entry point: ``rapid-mlx doctor [--verbose|--json|--summary]``.
 
 Exit codes:
-  0 — everything ok or only warnings
+  0 — everything ok, skipped, or only warnings
   1 — one or more ✗ issues
 """
 

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -7,13 +7,24 @@ Model-validation tiers (smoke / check / full / benchmark) moved to
 this PR rips out the dispatch and leaves only the env-health surface.
 
 Output is modelled on ``hermes doctor``: sections of one-line ✓/⚠/✗ probes,
-a summary, an exit code (0 unless any ✗). Runtime budget: ≤ 5 s end-to-end.
+a summary, and an exit code (0 unless any ✗). Built-in I/O is timeout-bounded,
+and the runner targets a five-second scheduling budget.
 """
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import signal
+import subprocess
 import sys
+import tempfile
+import time
+from pathlib import Path
 from typing import Any
+
+from vllm_mlx import __version__
 
 from .env_health import CheckStatus, Report, Section, run_all
 
@@ -30,7 +41,340 @@ _GLYPHS = {
     CheckStatus.OK: "✓",  # ✓
     CheckStatus.WARN: "⚠",  # ⚠
     CheckStatus.FAIL: "✗",  # ✗
+    CheckStatus.SKIPPED: "○",
 }
+
+_ASSIGNMENT_RE = re.compile(
+    r"(?i)(?:[\"'])?\b([a-z][a-z0-9_.-]*)\b(?:[\"'])?\s*[=:]\s*"
+)
+_AUTHORIZATION_RE = re.compile(
+    r"(?i)\b(?P<authorization>authorization\s+(?:bearer|basic)\s+)"
+)
+_AUTH_SCHEME_RE = re.compile(
+    r"(?i)(?<![\w-])(?P<authorization>(?:bearer|basic)\s+)(?=\S+)"
+)
+_SPACE_KEY_VALUE_RE = re.compile(
+    r"(?i)(?=\b(?P<key>[a-z][a-z0-9_.-]*)\s+(?P<value>\S+))"
+)
+_URL_USERINFO_RE = re.compile(r"(?i)\b([a-z][a-z0-9+.-]*://)[^\s/?#]*@")
+_SECRET_KEY_COMPONENTS = {
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "pwd",
+    "passphrase",
+    "credential",
+    "authorization",
+    "auth",
+    "cookie",
+    "privatekey",
+    "accesskey",
+    "apikey",
+    "secretkey",
+    "authorizationheader",
+    "sessionid",
+    "connectionstring",
+}
+_SECRET_KEY_PAIRS = {
+    ("private", "key"),
+    ("access", "key"),
+    ("api", "key"),
+    ("secret", "key"),
+    ("authorization", "header"),
+    ("session", "id"),
+    ("connection", "string"),
+}
+
+
+def _is_secret_key(key: str) -> bool:
+    """Recognize sensitive components in snake, kebab, dotted, or camel keys."""
+    words = [
+        word.lower()
+        for word in re.findall(
+            r"[A-Z]+(?=[A-Z][a-z]|\d|\b)|[A-Z]?[a-z]+|\d+",
+            re.sub(r"[_.-]+", " ", key),
+        )
+    ]
+    if any(word in _SECRET_KEY_COMPONENTS for word in words):
+        return True
+    return any(pair in _SECRET_KEY_PAIRS for pair in zip(words, words[1:]))
+
+
+def _open_collector_pipes() -> tuple[int, int, int, int]:
+    """Allocate collector lifecycle pipes without leaking on partial setup."""
+    allocated: list[int] = []
+    try:
+        keepalive_read_fd, keepalive_write_fd = os.pipe()
+        allocated.extend((keepalive_read_fd, keepalive_write_fd))
+        status_read_fd, status_write_fd = os.pipe()
+        allocated.extend((status_read_fd, status_write_fd))
+        os.set_blocking(status_read_fd, False)
+        return (
+            keepalive_read_fd,
+            keepalive_write_fd,
+            status_read_fd,
+            status_write_fd,
+        )
+    except Exception:
+        for fd in allocated:
+            os.close(fd)
+        raise
+
+
+def _collect_report_isolated(
+    *, only: set[str] | None, skip: set[str] | None, timeout_s: float = 8.0
+) -> Report:
+    """Collect a report in a fresh executable whose stdout is discarded."""
+    with tempfile.TemporaryDirectory(prefix="rapid-mlx-doctor-") as result_dir:
+        request_path = Path(result_dir) / "request.json"
+        result_path = Path(result_dir) / "report.json"
+        request_path.write_text(
+            json.dumps(
+                {
+                    "only": None if only is None else sorted(only),
+                    "skip": None if skip is None else sorted(skip),
+                }
+            ),
+            encoding="utf-8",
+        )
+        (
+            keepalive_read_fd,
+            keepalive_write_fd,
+            status_read_fd,
+            status_write_fd,
+        ) = _open_collector_pipes()
+        process: subprocess.Popen | None = None
+        try:
+            process = subprocess.Popen(  # noqa: S603
+                [
+                    sys.executable,
+                    "-I",
+                    "-c",
+                    (
+                        "import runpy,sys; sys.path.insert(0,sys.argv.pop(1)); "
+                        "runpy.run_module('vllm_mlx.doctor.json_worker',"
+                        "run_name='__main__')"
+                    ),
+                    str(Path(__file__).resolve().parents[2]),
+                    str(request_path),
+                    str(result_path),
+                    str(keepalive_read_fd),
+                    str(status_write_fd),
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                pass_fds=(keepalive_read_fd, status_write_fd),
+                start_new_session=True,
+            )
+        except Exception:
+            os.close(keepalive_write_fd)
+            os.close(status_read_fd)
+            raise
+        finally:
+            os.close(keepalive_read_fd)
+            os.close(status_write_fd)
+        assert process is not None
+        deadline = time.monotonic() + timeout_s
+        result_ready = False
+        child_exited = False
+        try:
+            # The worker stays alive on the keepalive pipe after publishing
+            # the atomic result, so its process-group ID cannot be reused.
+            while time.monotonic() < deadline:
+                if result_path.exists():
+                    result_ready = True
+                    break
+                try:
+                    if os.read(status_read_fd, 1) == b"":
+                        child_exited = True
+                        break
+                except BlockingIOError:
+                    pass
+                time.sleep(0.01)
+        finally:
+            # Kill the disposable group before closing the keepalive or
+            # reaping its leader. SIGKILL also covers stuck descendants.
+            group_cleanup_error: OSError | None = None
+            try:
+                _terminate_collector_group(process.pid)
+            except OSError as exc:
+                # A child that exited before publishing may already have no
+                # live process group on macOS; the unreaped leader still
+                # protects the PID until the wait below.
+                if not child_exited:
+                    group_cleanup_error = exc
+            finally:
+                os.close(keepalive_write_fd)
+                os.close(status_read_fd)
+            try:
+                process.wait(timeout=0.5)
+            except subprocess.TimeoutExpired:
+                direct_kill_error: OSError | None = None
+                try:
+                    process.kill()
+                except ProcessLookupError:
+                    pass
+                except OSError as exc:
+                    direct_kill_error = exc
+                try:
+                    process.wait(timeout=0.5)
+                except (OSError, subprocess.TimeoutExpired) as exc:
+                    raise RuntimeError("JSON collector could not be reaped") from exc
+                if direct_kill_error is not None:
+                    raise RuntimeError("JSON collector could not be killed") from (
+                        direct_kill_error
+                    )
+            if group_cleanup_error is not None:
+                raise RuntimeError("JSON collector group cleanup failed") from (
+                    group_cleanup_error
+                )
+        if child_exited:
+            raise RuntimeError("JSON report child exited without a report")
+        if not result_ready:
+            raise RuntimeError("JSON report collection timed out")
+        try:
+            message = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"JSON report result is unreadable: {exc}") from exc
+
+    if not isinstance(message, dict) or not isinstance(message.get("ok"), bool):
+        raise RuntimeError("JSON report child returned an invalid message")
+    if not message["ok"]:
+        raise RuntimeError(
+            f"JSON report collection failed: {message.get('error', '?')}"
+        )
+    return _report_from_document(message.get("report"))
+
+
+def _report_from_document(document: object) -> Report:
+    """Strictly validate and reconstruct a schema-v1 collector report."""
+    try:
+        root_keys = {
+            "schemaVersion",
+            "rapidMlxVersion",
+            "status",
+            "exitCode",
+            "durationMs",
+            "summary",
+            "sections",
+        }
+        if not isinstance(document, dict) or set(document) != root_keys:
+            raise TypeError("report root fields are invalid")
+        if (
+            isinstance(document["schemaVersion"], bool)
+            or not isinstance(document["schemaVersion"], int)
+            or document["schemaVersion"] != 1
+        ):
+            raise ValueError("schemaVersion must be 1")
+        if not isinstance(document["rapidMlxVersion"], str):
+            raise TypeError("rapidMlxVersion is invalid")
+        if document["status"] not in {"ok", "warn", "fail", "skipped"}:
+            raise ValueError("status is invalid")
+        if (
+            isinstance(document["exitCode"], bool)
+            or not isinstance(document["exitCode"], int)
+            or document["exitCode"] not in {0, 1}
+        ):
+            raise ValueError("exitCode is invalid")
+        _require_nonnegative_int(document["durationMs"], "durationMs")
+        summary = document["summary"]
+        if not isinstance(summary, dict) or set(summary) != {
+            "ok",
+            "warnings",
+            "failures",
+            "skipped",
+        }:
+            raise TypeError("summary is invalid")
+        for key, value in summary.items():
+            _require_nonnegative_int(value, f"summary.{key}")
+        if not isinstance(document["sections"], list):
+            raise TypeError("sections is invalid")
+        report = Report(duration_ms=document["durationMs"])
+        for raw_section in document["sections"]:
+            if not isinstance(raw_section, dict) or set(raw_section) != {
+                "id",
+                "title",
+                "durationMs",
+                "checks",
+            }:
+                raise TypeError("section is invalid")
+            if not isinstance(raw_section["id"], str) or not raw_section["id"]:
+                raise TypeError("section id is invalid")
+            if not isinstance(raw_section["title"], str) or not raw_section["title"]:
+                raise TypeError("section title is invalid")
+            _require_nonnegative_int(raw_section["durationMs"], "section duration")
+            if not isinstance(raw_section["checks"], list):
+                raise TypeError("section checks are invalid")
+            section = Section(
+                raw_section["title"],
+                id=raw_section["id"],
+                duration_ms=raw_section["durationMs"],
+            )
+            for raw_check in raw_section["checks"]:
+                if not isinstance(raw_check, dict) or set(raw_check) != {
+                    "id",
+                    "status",
+                    "summary",
+                    "detail",
+                }:
+                    raise TypeError("check is invalid")
+                raw_id = raw_check["id"]
+                if raw_id is not None and not isinstance(raw_id, str):
+                    raise TypeError("check id is invalid")
+                if not isinstance(raw_check["summary"], str) or not isinstance(
+                    raw_check["detail"], str
+                ):
+                    raise TypeError("check text is invalid")
+                section.add(
+                    raw_check["summary"],
+                    CheckStatus(str(raw_check["status"])),
+                    detail=raw_check["detail"],
+                    check_id=raw_id,
+                )
+            report.sections.append(section)
+        expected_summary = {
+            "ok": report.n_ok,
+            "warnings": report.n_warn,
+            "failures": report.n_fail,
+            "skipped": report.n_skipped,
+        }
+        if summary != expected_summary:
+            raise ValueError("summary counts do not match checks")
+        if document["status"] != report.overall_status:
+            raise ValueError("root status does not match checks")
+        if document["exitCode"] != report.exit_code:
+            raise ValueError("exitCode does not match checks")
+        return report
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"JSON report child returned an invalid report: {exc}"
+        ) from exc
+
+
+def _require_nonnegative_int(value: object, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise TypeError(f"{field_name} is invalid")
+
+
+def _terminate_collector_group(pid: int) -> None:
+    """Kill a disposable collector group while its leader is still owned."""
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+
+
+def _collection_failure_report(exc: Exception) -> Report:
+    section = Section("Doctor", id="doctor")
+    section.add(
+        "JSON report collection failed",
+        CheckStatus.FAIL,
+        detail=f"{type(exc).__name__}: {exc}",
+        check_id="doctor.json.collection",
+    )
+    return Report(sections=[section])
 
 
 def doctor_command(args: Any) -> None:
@@ -55,9 +399,28 @@ def doctor_command(args: Any) -> None:
         sys.exit(2)
 
     verbose = bool(getattr(args, "verbose", False))
+    json_output = bool(getattr(args, "json", False))
+    summary_only = bool(getattr(args, "summary", False))
+    raw_only = getattr(args, "only", None)
+    raw_skip = getattr(args, "skip", None)
+    only = None if raw_only is None else set(raw_only)
+    skip = None if raw_skip is None else set(raw_skip)
 
-    report = run_all()
-    render(report, verbose=verbose)
+    if json_output:
+        # A disposable child contains Python/native/subprocess chatter and any
+        # writer threads a dependency may start. Only the Report crosses back.
+        try:
+            report = _collect_report_isolated(only=only, skip=skip)
+        except Exception as exc:  # noqa: BLE001 - preserve JSON output contract
+            report = _collection_failure_report(exc)
+    else:
+        report = run_all(only=only, skip=skip)
+    if json_output:
+        render_json(report)
+    elif summary_only:
+        render_summary(report)
+    else:
+        render(report, verbose=verbose)
     sys.exit(report.exit_code)
 
 
@@ -84,6 +447,143 @@ def render(report: Report, *, verbose: bool = False, stream=None) -> None:
     _render_summary(report, write=write, verbose=verbose)
 
 
+def _redact(value: str) -> str:
+    """Remove common local identifiers and inline credentials from JSON."""
+    home = os.path.expanduser("~")
+    if home and home != "/":
+        value = re.sub(
+            rf"{re.escape(home)}(?![\w.-])",
+            "~",
+            value,
+        )
+    value = _URL_USERINFO_RE.sub(r"\1[REDACTED]@", value)
+
+    redacted_lines: list[str] = []
+    continuation_quote: str | None = None
+    for line in value.splitlines(keepends=True):
+        if continuation_quote is not None:
+            if _contains_unescaped_quote(line, continuation_quote):
+                continuation_quote = None
+            redacted_lines.append(_line_ending(line))
+            continue
+        sensitive_assignment = None
+        for match in _ASSIGNMENT_RE.finditer(line):
+            if _is_secret_key(match.group(1)):
+                sensitive_assignment = match
+                break
+        spaced_secret = None
+        for match in _SPACE_KEY_VALUE_RE.finditer(line):
+            if not _is_secret_key(match.group("key")):
+                continue
+            spaced_secret = match
+            break
+        authorization = _AUTHORIZATION_RE.search(line)
+        auth_scheme = _AUTH_SCHEME_RE.search(line)
+        candidates = [
+            (sensitive_assignment.start(), sensitive_assignment.group(0))
+            if sensitive_assignment
+            else None,
+            (
+                spaced_secret.start("key"),
+                line[spaced_secret.start("key") : spaced_secret.start("value")],
+            )
+            if spaced_secret
+            else None,
+            (authorization.start(), authorization.group("authorization"))
+            if authorization
+            else None,
+            (auth_scheme.start(), auth_scheme.group("authorization"))
+            if auth_scheme
+            else None,
+        ]
+        matches = [candidate for candidate in candidates if candidate is not None]
+        if matches:
+            start, prefix = min(matches, key=lambda candidate: candidate[0])
+            tail = line[start + len(prefix) :]
+            stripped_tail = tail.lstrip()
+            if stripped_tail[:1] in {'"', "'"}:
+                quote = stripped_tail[0]
+                if not _contains_unescaped_quote(stripped_tail[1:], quote):
+                    continuation_quote = quote
+            # An unquoted value may contain spaces or delimiters, so redact
+            # through this line. A subsequent line is independent unless a
+            # quoted value was genuinely left open above.
+            redacted_lines.append(
+                f"{line[:start]}{prefix}[REDACTED]{_line_ending(line)}"
+            )
+            continue
+        redacted_lines.append(line)
+    return "".join(redacted_lines)
+
+
+def _line_ending(line: str) -> str:
+    return line[len(line.rstrip("\r\n")) :]
+
+
+def _contains_unescaped_quote(value: str, quote: str) -> bool:
+    escaped = False
+    for character in value:
+        if escaped:
+            escaped = False
+        elif character == "\\":
+            escaped = True
+        elif character == quote:
+            return True
+    return False
+
+
+def report_document(report: Report) -> dict[str, Any]:
+    """Return the versioned, redacted machine-readable Doctor contract."""
+    return {
+        "schemaVersion": 1,
+        "rapidMlxVersion": __version__,
+        "status": report.overall_status,
+        "exitCode": report.exit_code,
+        "durationMs": report.duration_ms,
+        "summary": {
+            "ok": report.n_ok,
+            "warnings": report.n_warn,
+            "failures": report.n_fail,
+            "skipped": report.n_skipped,
+        },
+        "sections": [
+            {
+                "id": section.id,
+                "title": section.title,
+                "durationMs": section.duration_ms,
+                "checks": [
+                    {
+                        "id": check.id,
+                        "status": check.status.value,
+                        "summary": _redact(check.label),
+                        "detail": _redact(check.detail),
+                    }
+                    for check in section.checks
+                ],
+            }
+            for section in report.sections
+        ],
+    }
+
+
+def render_json(report: Report, *, stream=None) -> None:
+    """Write only JSON to stdout so callers can parse it safely."""
+    stream = stream or sys.stdout
+    json.dump(report_document(report), stream, indent=2, sort_keys=True)
+    stream.write("\n")
+
+
+def render_summary(report: Report, *, stream=None) -> None:
+    """Write a single-line status suitable for logs and shell scripts."""
+    stream = stream or sys.stdout
+    stream.write(
+        f"Rapid-MLX Doctor: {report.overall_status} — "
+        f"{report.n_ok} ok, {report.n_warn} warnings, "
+        f"{report.n_fail} issues, {report.n_skipped} skipped "
+        f"({report.duration_ms} ms)\n"
+    )
+
+
 def _render_section(section: Section, *, write, verbose: bool) -> None:
     write(f"◆ {section.title}\n")
     for check in section.checks:
@@ -99,7 +599,10 @@ def _render_summary(report: Report, *, write, verbose: bool) -> None:
         f"Summary: {report.n_ok} ok, "
         f"{report.n_warn} warnings, "
         f"{report.n_fail} issue"
-        f"{'s' if report.n_fail != 1 else ''}\n"
+        f"{'s' if report.n_fail != 1 else ''}"
     )
+    if report.n_skipped:
+        write(f", {report.n_skipped} skipped")
+    write("\n")
     if not verbose and (report.n_warn or report.n_fail):
         write("Run with `--verbose` for details on each check.\n")

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -10,9 +10,10 @@ optional dev tools. The user runs ``rapid-mlx doctor`` to answer one question
 * never escalate to sudo or read user data outside ``~/.cache/huggingface``;
 * report a deterministic status (✓ / ⚠ / ✗) with a one-line label.
 
-Total wall-clock for ``rapid-mlx doctor`` ≤ 5 s on a warm cache, dominated by
-the single 2-second network HEAD against ``huggingface.co`` (which downgrades
-to ⚠ on timeout — never ✗).
+On a warm cache, ``rapid-mlx doctor`` targets five seconds, dominated by the
+single two-second network HEAD against ``huggingface.co``. Built-in I/O and
+subprocess probes have explicit timeouts, and timeout results downgrade to ⚠
+or skipped — never ✗.
 
 The CLI in ``doctor/cli.py`` consumes ``run_all()`` and renders the report.
 Tests in ``tests/test_doctor_env_health.py`` cover each section's probe.
@@ -34,7 +35,7 @@ import sys
 import threading
 import time
 import urllib.parse
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -52,6 +53,7 @@ class CheckStatus(str, Enum):
     OK = "ok"
     WARN = "warn"
     FAIL = "fail"
+    SKIPPED = "skipped"
 
 
 class _ImportProbeOutcome(str, Enum):
@@ -68,20 +70,33 @@ class Check:
     label: str
     status: CheckStatus
     detail: str = ""
+    id: str | None = None
 
 
 @dataclass
 class Section:
     title: str
     checks: list[Check] = field(default_factory=list)
+    id: str = ""
+    duration_ms: int = 0
 
-    def add(self, label: str, status: CheckStatus, detail: str = "") -> None:
-        self.checks.append(Check(label=label, status=status, detail=detail))
+    def add(
+        self,
+        label: str,
+        status: CheckStatus,
+        detail: str = "",
+        *,
+        check_id: str | None = None,
+    ) -> None:
+        self.checks.append(
+            Check(label=label, status=status, detail=detail, id=check_id)
+        )
 
 
 @dataclass
 class Report:
     sections: list[Section] = field(default_factory=list)
+    duration_ms: int = 0
 
     def all_checks(self) -> list[Check]:
         return [c for s in self.sections for c in s.checks]
@@ -97,6 +112,22 @@ class Report:
     @property
     def n_fail(self) -> int:
         return sum(1 for c in self.all_checks() if c.status is CheckStatus.FAIL)
+
+    @property
+    def n_skipped(self) -> int:
+        return sum(1 for c in self.all_checks() if c.status is CheckStatus.SKIPPED)
+
+    @property
+    def overall_status(self) -> str:
+        if not self.all_checks():
+            return "skipped"
+        if self.n_fail:
+            return "fail"
+        if self.n_warn:
+            return "warn"
+        if self.n_skipped:
+            return "warn" if self.n_ok else "skipped"
+        return "ok"
 
     @property
     def exit_code(self) -> int:
@@ -245,11 +276,11 @@ _RUNTIME_OVERRIDE_REPAIR_HINT_TEMPLATE = (
     "sidecar), then remove {root} and relaunch so the bundled sidecar is used"
 )
 _DOCTOR_BUDGET_S = 5.0
-# Leave enough wall-clock headroom for subprocess timeout cleanup, report
+# Leave enough scheduling-budget headroom for subprocess timeout cleanup, report
 # assembly, and CLI rendering.  ``subprocess.run(timeout=...)`` only starts
 # terminating the child at its timeout and can return a few milliseconds
-# later; consuming the full user-facing budget inside probes therefore makes
-# the end-to-end command exceed its own contract.
+# later; consuming the full target budget inside probes would leave no room
+# for rendering and cleanup.
 _DOCTOR_COMPLETION_HEADROOM_S = 0.1
 _DOCTOR_DEADLINE: float | None = None
 _DOCTOR_RUN_LOCK = threading.Lock()
@@ -1449,7 +1480,7 @@ def _hf_cache_dir() -> Path:
 
 
 # Wall-clock budget for the recursive HF-cache size walk. The whole doctor
-# run is contracted at ≤ 5 s and the network probe alone can spend 2 s, so
+# run targets 5 s and the network probe alone can spend 2 s, so
 # the cache walk must finish in ~1 s on a hot FS / abort cleanly on a cold
 # or network-mounted cache. Codex-review round 1 flagged the previous
 # unbounded walk as a contract violation on TB-scale caches.
@@ -1855,7 +1886,7 @@ def _pil_importable(
     without relying on the version-specific moment Pillow first touches
     ``_imaging``. ``PIL.Image`` + a 1×1 allocation is microsecond-cheap and
     does NOT pull torch the way a real ``import mlx_vlm`` would, so it stays
-    well within doctor's ≤5 s budget. ANY failure (missing, shadowed, broken
+    well within Doctor's five-second target. ANY failure (missing, shadowed, broken
     native ext) ⇒ not importable."""
     if runtime is not None and _runtime_uses_context(runtime):
         probe = _probe_runtime(
@@ -2629,7 +2660,7 @@ def section_hf_cache() -> Section:
 # Single, time-boxed network probe. The whole point is to catch "user is
 # behind a proxy / offline / DNS broken" early — not to audit reachability
 # of every endpoint we ever talk to. A 2 s budget keeps the worst-case
-# doctor runtime under the 5 s contract even when the resolver hangs.
+# typical Doctor runtime under the five-second target when the resolver hangs.
 _HF_PROBE_URL = "https://huggingface.co"
 _HF_PROBE_TIMEOUT_S = 2.0
 _HF_PROBE_SCRIPT = r"""
@@ -3096,6 +3127,17 @@ _SECTION_BUILDERS = (
     section_agent_integrations,
 )
 
+# Select the diagnostic runtime once before any section that consumes it so
+# every runtime-aware probe observes one coherent environment. Lightweight
+# selections such as ``--only system`` deliberately avoid runtime discovery.
+_RUNTIME_SECTION_BUILDERS = frozenset(
+    {
+        section_python,
+        section_required_packages,
+        section_optional_packages,
+    }
+)
+
 _SECTION_TITLES = {
     section_system: "System",
     section_python: "Python",
@@ -3109,10 +3151,66 @@ _SECTION_TITLES = {
     section_agent_integrations: "Agent Integrations",
 }
 
+_SECTION_IDS = {
+    section_system: "system",
+    section_python: "python",
+    section_required_packages: "packages.required",
+    section_updates: "updates",
+    section_optional_packages: "packages.optional",
+    section_hf_cache: "cache.huggingface",
+    section_network: "network",
+    section_shell_integration: "shell",
+    section_optional_tools: "tools.optional",
+    section_agent_integrations: "agents",
+}
 
-def _budget_exhausted_report() -> Report:
+
+def _builder_id(builder: Callable[[], Section]) -> str:
+    return _SECTION_IDS.get(
+        builder,
+        builder.__name__.removeprefix("section_").replace("_", "."),
+    )
+
+
+def _finish_section(
+    section: Section,
+    *,
+    builder: Callable[[], Section],
+    started_at: float,
+) -> Section:
+    """Attach the machine-readable identity and timing contract."""
+    section.id = section.id or _builder_id(builder)
+    section.duration_ms = max(0, round((time.monotonic() - started_at) * 1000))
+    return section
+
+
+def _selected_section_builders(
+    *, only: set[str] | None = None, skip: set[str] | None = None
+) -> tuple[Callable[[], Section], ...]:
+    skipped_ids = skip or set()
+    return tuple(
+        builder
+        for builder in _SECTION_BUILDERS
+        if (only is None or _builder_id(builder) in only)
+        and _builder_id(builder) not in skipped_ids
+    )
+
+
+def _budget_exhausted_report(
+    *, only: set[str] | None = None, skip: set[str] | None = None
+) -> Report:
     report = Report()
-    for builder in _SECTION_BUILDERS:
+    _append_budget_exhausted_sections(
+        report, _selected_section_builders(only=only, skip=skip)
+    )
+    return report
+
+
+def _append_budget_exhausted_sections(
+    report: Report, builders: Sequence[Callable[[], Section]]
+) -> None:
+    """Record selected sections that could not start before the deadline."""
+    for builder in builders:
         skipped = Section(
             _SECTION_TITLES.get(
                 builder, builder.__name__.replace("section_", "").title()
@@ -3120,14 +3218,20 @@ def _budget_exhausted_report() -> Report:
         )
         skipped.add(
             "Skipped: doctor time budget exhausted",
-            CheckStatus.WARN,
+            CheckStatus.SKIPPED,
             detail="probe did not start before the shared deadline",
+            check_id=f"{_builder_id(builder)}.budget",
         )
+        skipped.id = _builder_id(builder)
         report.sections.append(skipped)
-    return report
 
 
-def _run_all_serialized(caller_deadline: float) -> Report:
+def _run_all_serialized(
+    caller_deadline: float,
+    *,
+    only: set[str] | None = None,
+    skip: set[str] | None = None,
+) -> Report:
     """Run every section and return the aggregate report.
 
     Each section builder is wrapped in a try/except so a single buggy probe
@@ -3147,49 +3251,119 @@ def _run_all_serialized(caller_deadline: float) -> Report:
         _RUNTIME_IMPORT_TIMEOUTS.clear()
         _RUNTIME_DISTRIBUTION_CACHE.clear()
         _RUNTIME_CONTEXTS.clear()
+        selected_builders = _selected_section_builders(only=only, skip=skip)
         if time.monotonic() >= _DOCTOR_DEADLINE:
-            return _budget_exhausted_report()
-        _selected_runtime()
-        for index, builder in enumerate(_SECTION_BUILDERS):
+            return _budget_exhausted_report(only=only, skip=skip)
+        if not selected_builders:
+            return report
+        runtime_selected = False
+        runtime_discovery_error: Exception | None = None
+        for index, builder in enumerate(selected_builders):
             if time.monotonic() >= _DOCTOR_DEADLINE:
-                for skipped_builder in _SECTION_BUILDERS[index:]:
+                _append_budget_exhausted_sections(report, selected_builders[index:])
+                break
+            if builder in _RUNTIME_SECTION_BUILDERS and not runtime_selected:
+                started_at = time.monotonic()
+                try:
+                    _selected_runtime()
+                except Exception as exc:  # noqa: BLE001 — diagnostic boundary
+                    runtime_discovery_error = exc
+                runtime_selected = True
+                if runtime_discovery_error is not None:
+                    crashed = Section(
+                        _SECTION_TITLES.get(
+                            builder,
+                            builder.__name__.replace("section_", "").title(),
+                        )
+                    )
+                    crashed.add(
+                        "runtime discovery crashed",
+                        CheckStatus.FAIL,
+                        detail=(
+                            f"{type(runtime_discovery_error).__module__}."
+                            f"{type(runtime_discovery_error).__name__}: "
+                            f"{runtime_discovery_error}"
+                        ),
+                        check_id=f"{_builder_id(builder)}.runtime.discovery",
+                    )
+                    report.sections.append(
+                        _finish_section(crashed, builder=builder, started_at=started_at)
+                    )
+                    continue
+                if time.monotonic() >= _DOCTOR_DEADLINE:
+                    _append_budget_exhausted_sections(report, selected_builders[index:])
+                    break
+            elif builder in _RUNTIME_SECTION_BUILDERS:
+                if runtime_discovery_error is not None:
                     skipped = Section(
                         _SECTION_TITLES.get(
-                            skipped_builder,
-                            skipped_builder.__name__.replace("section_", "").title(),
+                            builder,
+                            builder.__name__.replace("section_", "").title(),
                         )
                     )
                     skipped.add(
-                        "Skipped: doctor time budget exhausted",
-                        CheckStatus.WARN,
-                        detail="probe did not start before the shared deadline",
+                        "Skipped: runtime discovery failed",
+                        CheckStatus.SKIPPED,
+                        detail="a prerequisite runtime probe crashed",
+                        check_id=f"{_builder_id(builder)}.runtime.dependency",
                     )
-                    report.sections.append(skipped)
-                break
+                    report.sections.append(
+                        _finish_section(
+                            skipped,
+                            builder=builder,
+                            started_at=time.monotonic(),
+                        )
+                    )
+                    continue
             try:
-                report.sections.append(builder())
+                started_at = time.monotonic()
+                report.sections.append(
+                    _finish_section(builder(), builder=builder, started_at=started_at)
+                )
             except Exception as e:  # noqa: BLE001 — see docstring above
                 crashed = Section(builder.__name__.replace("section_", "").title())
                 crashed.add(
                     f"probe crashed: {type(e).__name__}: {e}",
                     CheckStatus.FAIL,
                     detail=f"{type(e).__module__}.{type(e).__name__}: {e}",
+                    check_id=f"{_builder_id(builder)}.crash",
                 )
-                report.sections.append(crashed)
+                report.sections.append(
+                    _finish_section(crashed, builder=builder, started_at=started_at)
+                )
     finally:
         _DOCTOR_DEADLINE = None
     return report
 
 
-def run_all() -> Report:
-    """Run one coherent probe set; serialize access to process-global caches."""
+def run_all(
+    *,
+    only: set[str] | None = None,
+    skip: set[str] | None = None,
+) -> Report:
+    """Run a cooperatively budgeted probe set; serialize shared probe caches.
+
+    ``only`` and ``skip`` contain stable section IDs such as ``network`` or
+    ``packages.required``. Unknown IDs are rejected by the CLI before this
+    layer; library callers simply receive an empty report for no matches.
+    """
+    started_at = time.monotonic()
     caller_deadline = time.monotonic() + (
         _DOCTOR_BUDGET_S - _DOCTOR_COMPLETION_HEADROOM_S
     )
     remaining = max(0.0, caller_deadline - time.monotonic())
     if not _DOCTOR_RUN_LOCK.acquire(timeout=remaining):
-        return _budget_exhausted_report()
+        report = _budget_exhausted_report(only=only, skip=skip)
+        report.duration_ms = max(0, round((time.monotonic() - started_at) * 1000))
+        return report
     try:
-        return _run_all_serialized(caller_deadline)
+        if only is not None or skip:
+            report = _run_all_serialized(caller_deadline, only=only, skip=skip)
+        else:
+            # Preserve the one-argument internal seam used by downstream
+            # embedders and older test doubles.
+            report = _run_all_serialized(caller_deadline)
+        report.duration_ms = max(0, round((time.monotonic() - started_at) * 1000))
+        return report
     finally:
         _DOCTOR_RUN_LOCK.release()

--- a/vllm_mlx/doctor/json_worker.py
+++ b/vllm_mlx/doctor/json_worker.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fresh-process report collector for ``rapid-mlx doctor --json``."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from .cli import report_document
+from .env_health import run_all
+
+
+def _selection(request: dict[str, object], key: str) -> set[str] | None:
+    value = request.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise TypeError(f"{key} selection is invalid")
+    return set(value)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 4:
+        return 2
+    request_path, result_path = map(Path, args[:2])
+    try:
+        keepalive_fd = int(args[2])
+        status_fd = int(args[3])
+    except ValueError:
+        return 2
+    staging_path = result_path.with_suffix(".json.tmp")
+    try:
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+        if not isinstance(request, dict) or set(request) != {"only", "skip"}:
+            raise TypeError("request fields are invalid")
+        report = run_all(
+            only=_selection(request, "only"),
+            skip=_selection(request, "skip"),
+        )
+        message: dict[str, object] = {"ok": True, "report": report_document(report)}
+    except Exception as exc:  # noqa: BLE001 - parent renders schema-valid failure
+        message = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+    try:
+        with staging_path.open("w", encoding="utf-8") as stream:
+            json.dump(message, stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        staging_path.replace(result_path)
+    except OSError:
+        for fd in (keepalive_fd, status_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        return 1
+    # Retain the process-group leader until the parent has consumed the
+    # result. If the parent dies, its pipe closes and this read returns EOF.
+    try:
+        os.read(keepalive_fd, 1)
+    except OSError:
+        pass
+    finally:
+        os.close(keepalive_fd)
+        os.close(status_fd)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by subprocess tests
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

`rapid-mlx doctor` already gives operators a useful human report, but automation has had to scrape glyphs and English labels. It also represented a probe that never ran as a warning, which loses the distinction between a negative finding and missing evidence.

This PR establishes the Doctor v2 output/execution contract before service-specific probes are added. #3229 has merged, so the cold-import timeout hotfix is part of `main` and of the behavior being formalized here.

## User value

- CI, appliance management, and support agents can consume a versioned JSON document instead of scraping terminal output.
- Operators can isolate expensive or suspect diagnostic families with stable section IDs.
- Logs can use a compact one-line result.
- A check that does not run is explicitly `skipped`; it is never confused with a warning or a confirmed failure.
- JSON output is collected in a disposable child process, so probe/native/subprocess/thread stdout cannot corrupt the document; an absolute parent deadline terminates the collector process group, collector failures still produce schema-valid failure JSON, and home paths/common inline credentials are redacted before output.

## Scope

- Add `--json`, `--summary`, repeatable `--only SECTION`, and repeatable `--skip SECTION`.
- Collect JSON diagnostics in a fresh `-I` Python executable with atomic request/result files, strict schema validation, a parent deadline, and process-group cleanup.
- Define `schemaVersion: 1` with Rapid-MLX version, overall status, exit code, total/per-section durations, counts, section/check IDs, summaries, and details.
- Add `skipped` to the status model and keep exit semantics compatible: only a confirmed `fail` exits 1.
- Preserve the existing default and `--verbose` output.
- Preserve the read-only, no-model-load contract and the five-second scheduling target; every built-in I/O/subprocess probe remains individually timeout-bounded.
- Add contract/redaction/selection tests and CLI reference documentation.

## How to use (website-ready)

Run the complete human-readable diagnostic:

```bash
rapid-mlx doctor
```

Show the evidence/details behind each row:

```bash
rapid-mlx doctor --verbose
```

Print one line for an operator log or shell script:

```bash
rapid-mlx doctor --summary
```

Emit parseable JSON (and no human banner) for CI, fleet tooling, or a support bundle:

```bash
rapid-mlx doctor --json
rapid-mlx doctor --json > doctor.json
```

Limit a run to one or more diagnostic areas:

```bash
rapid-mlx doctor --only packages.required --only packages.optional
rapid-mlx doctor --only network --json
```

Skip checks that intentionally require network access:

```bash
rapid-mlx doctor --skip updates --skip network
```

`--only` and `--skip` are repeatable; `--skip` wins for an ID present in both. Section IDs are:

- `system`
- `python`
- `packages.required`
- `updates`
- `packages.optional`
- `cache.huggingface`
- `network`
- `shell`
- `tools.optional`
- `agents`

The JSON root contains:

```json
{
  "schemaVersion": 1,
  "rapidMlxVersion": "...",
  "status": "ok | warn | fail | skipped",
  "exitCode": 0,
  "durationMs": 123,
  "summary": {"ok": 1, "warnings": 0, "failures": 0, "skipped": 0},
  "sections": []
}
```

Each section has a stable `id`, `title`, `durationMs`, and `checks`. Each check has a nullable `id`, `status`, `summary`, and `detail`. New checks with a semantic identity expose it; legacy checks return `id: null` rather than a misleading ordinal that changes when conditional rows appear. Consumers should branch on `schemaVersion` and non-null semantic IDs, never array position or English prose.

Exit codes remain shell-friendly:

- `0`: no confirmed breakage; warnings and skipped checks may still be present.
- `1`: at least one confirmed failure.
- `2`: invalid CLI usage, including removed legacy Doctor tiers.

At the report root, all-skipped output is `skipped`; a mix of successful and skipped checks is `warn` to signal a partially complete diagnosis without changing the exit code.

## Compatibility

- Existing `rapid-mlx doctor` and `rapid-mlx doctor --verbose` output remains available.
- No model is downloaded or loaded, no engine/server is started, and no listening socket is opened.
- Default execution uses a shared five-second scheduling budget: later sections become `skipped` once it is consumed. This is deliberately not advertised as a process watchdog for arbitrary third-party Python code.
- Stable section IDs are available across the whole report. Legacy checks return `id: null`; new service/deep checks declare explicit semantic IDs.

## Verification

```bash
python -m pytest -q \
  tests/test_doctor_report_contract.py \
  tests/test_doctor_no_model_load.py \
  tests/test_doctor_env_health.py
# 325 passed

ruff check vllm_mlx/doctor vllm_mlx/cli.py \
  tests/test_doctor_report_contract.py tests/test_doctor_env_health.py
# All checks passed
```

## Docs / release-note seed

Document Doctor as a read-only, cooperatively budgeted diagnostic with three output modes: normal, one-line summary, and schema-versioned JSON. Recommend `--json` for automation and support collection, and `--only`/`--skip` for targeted troubleshooting. Make clear that built-in I/O has explicit timeouts, the shared budget prevents later work from starting, and warnings/skipped probes do not fail the command; only verified breakage does.

## Stack

- Base: `main` (#3229 merged)
- This PR: Doctor v2 structured report and bounded/selective runner contract
- Follow-up 1: Always-on service end-to-end diagnostics
- Follow-up 2: deep probes and verified repairs
