### PR TITLE
feat(doctor): diagnose always-on service end to end

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -56,7 +56,32 @@ rapid-mlx doctor --skip updates --skip network
 
 Available IDs are `system`, `python`, `packages.required`, `updates`,
 `packages.optional`, `cache.huggingface`, `network`, `shell`,
-`tools.optional`, and `agents`.
+`tools.optional`, `agents`, and `service`.
+
+On macOS, the default report also diagnoses an installed Always-on service
+from end to end: LaunchDaemon definition, launchd registration, process and
+service-account ownership, active/pending configuration, service runtime
+version, `/livez`, and `/readyz`. An absent service is healthy because the
+feature is optional. Once either its plist or launchd registration exists,
+inconsistencies are actionable failures. A live endpoint that is not ready is
+a warning rather than a hard failure because it may still be loading a model
+or waiting in lazy mode.
+
+Before making an HTTP request, Doctor requires `/usr/sbin/lsof` to prove that
+the launchd PID owns a listener covering the configured host and port. A
+different PID/address, a permission error, timeout, truncated response, or
+invalid response is reported as skipped/unverified (`unknown` in `service
+status`), never as healthy or as a confirmed outage. Runtime version evidence
+is read without executing the service binary and is accepted only when its
+wheel `RECORD` size/SHA-256 authenticates that executable in the interpreter's
+matching `pythonX.Y/site-packages` directory.
+
+Run only these checks with:
+
+```bash
+rapid-mlx doctor --only service --verbose
+rapid-mlx doctor --only service --json
+```
 
 JSON output uses `schemaVersion: 1` and includes the Rapid-MLX version,
 overall status (`ok`, `warn`, `fail`, or `skipped`), exit code, total and per-section durations, counts, stable

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -335,7 +335,7 @@ def test_uninstall_dry_run_prints_removal_and_touches_nothing(monkeypatch, capsy
 def test_status_json_shape(monkeypatch, capsys):
     from vllm_mlx.headless_service import status as st
 
-    monkeypatch.setattr(st, "_launchctl_print", staticmethod(lambda _label: None))
+    monkeypatch.setattr(st, "_launchctl_probe", lambda *_a, **_k: (None, None))
     monkeypatch.setattr(st, "_read_installed_plist", staticmethod(lambda _label: None))
     monkeypatch.setattr(
         st, "_endpoint_health", staticmethod(lambda h, p: (False, False))
@@ -974,13 +974,14 @@ def test_collect_status_full_branch(monkeypatch, plist_kwargs, tmp_path):
 
     monkeypatch.setattr(
         st,
-        "_launchctl_print",
-        staticmethod(lambda _l: _fake_launchctl_print(pid=4242, last_exit=0)),
+        "_launchctl_probe",
+        lambda *_a, **_k: (_fake_launchctl_print(pid=4242, last_exit=0), None),
     )
     plist = tmp_path / "com.rapidmlx.server.plist"
     plist.write_bytes(serialize_plist(build_plist_dict(**plist_kwargs)))
     monkeypatch.setattr(st, "_plist_path", staticmethod(lambda _l: plist))
     monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
+    monkeypatch.setattr(st, "_pid_listens_on_port", lambda *_a, **_k: True)
     monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: True))
     # Stub `ps -o user=` so the owner lookup is hermetic.
     monkeypatch.setattr(
@@ -1016,10 +1017,22 @@ def test_status_command_json_and_exit_codes(monkeypatch, capsys):
     import vllm_mlx.headless_service.status as st
 
     monkeypatch.setattr(
-        st, "_launchctl_print", staticmethod(lambda _l: _fake_launchctl_print(pid=9))
+        st,
+        "_launchctl_probe",
+        lambda *_a, **_k: (_fake_launchctl_print(pid=9), None),
     )
-    monkeypatch.setattr(st, "_read_installed_plist", staticmethod(lambda _l: None))
+    monkeypatch.setattr(
+        st,
+        "_read_installed_plist",
+        lambda _label: {"ProgramArguments": ["/bin/rapid-mlx", "serve", "model"]},
+    )
+    monkeypatch.setattr(
+        st,
+        "_parse_legacy_serve",
+        lambda _argv: ("/bin/rapid-mlx", "model", "127.0.0.1", 8000),
+    )
     monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
+    monkeypatch.setattr(st, "_pid_listens_on_port", lambda *_a, **_k: True)
     monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: True))
     ns = _ns(json=True)
     assert st.status_command(ns) == 0
@@ -1028,9 +1041,207 @@ def test_status_command_json_and_exit_codes(monkeypatch, capsys):
 
     # Ready but no PID → not "up" → exit 1.
     monkeypatch.setattr(
-        st, "_launchctl_print", staticmethod(lambda _l: _fake_launchctl_print(pid=None))
+        st,
+        "_launchctl_probe",
+        lambda *_a, **_k: (_fake_launchctl_print(pid=None), None),
     )
     assert st.status_command(_ns(json=True)) == 1
+
+
+def test_listener_pid_probe_distinguishes_owner_mismatch_and_errors(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(st.Path, "is_file", lambda _self: True)
+    monkeypatch.setattr(
+        st.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(
+            returncode=0, stdout="p42\nn127.0.0.1:8000\n"
+        ),
+    )
+    assert st._pid_listens_on_port(42, "127.0.0.1", 8000) is True
+    assert st._pid_listens_on_port(42, "127.0.0.2", 8000) is False
+    assert st._pid_listens_on_port(41, "127.0.0.1", 8000) is False
+
+    monkeypatch.setattr(
+        st.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    assert st._pid_listens_on_port(42, "127.0.0.1", 8000) is False
+
+    monkeypatch.setattr(
+        st.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(
+            returncode=1, stdout="", stderr="permission denied"
+        ),
+    )
+    assert st._pid_listens_on_port(42, "127.0.0.1", 8000) is None
+
+
+def test_listener_pid_probe_resolves_legacy_hostname_only_when_enabled(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(st.Path, "is_file", lambda _self: True)
+    monkeypatch.setattr(
+        st.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(
+            returncode=0, stdout="p42\nn192.0.2.10:8000\n"
+        ),
+    )
+    monkeypatch.setattr(
+        st.socket,
+        "getaddrinfo",
+        lambda *_a, **_k: [
+            (st.socket.AF_INET, st.socket.SOCK_STREAM, 6, "", ("192.0.2.10", 0))
+        ],
+    )
+
+    assert st._pid_listens_on_port(42, "my-mac.local", 8000) is False
+    assert (
+        st._pid_listens_on_port(42, "my-mac.local", 8000, resolve_hostnames=True)
+        is True
+    )
+
+
+def test_collect_status_does_not_probe_unattributed_endpoint(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        st,
+        "_launchctl_probe",
+        lambda *_a, **_k: (_fake_launchctl_print(pid=42), None),
+    )
+    monkeypatch.setattr(
+        st,
+        "_read_installed_plist",
+        lambda _label: {"ProgramArguments": ["/bin/rapid-mlx", "serve", "model"]},
+    )
+    monkeypatch.setattr(
+        st,
+        "_parse_legacy_serve",
+        lambda _argv: ("/bin/rapid-mlx", "model", "127.0.0.1", 8000),
+    )
+    monkeypatch.setattr(st, "_pid_listens_on_port", lambda *_a, **_k: False)
+    monkeypatch.setattr(st, "_port_busy", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        st,
+        "_endpoint_health",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("unattributed endpoint was probed")
+        ),
+    )
+    monkeypatch.setattr(
+        st.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(returncode=0, stdout="serveuser\n"),
+    )
+
+    status = st.collect_status()
+    assert status["endpoint_attributable"] is False
+    assert status["livez"] is None
+    assert status["readyz"] is None
+
+
+def test_collect_status_records_invalid_legacy_definition(monkeypatch):
+    import vllm_mlx.headless_service.definition as definition
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(st, "_launchctl_probe", lambda *_a, **_k: (None, None))
+    monkeypatch.setattr(
+        st,
+        "_read_installed_plist",
+        lambda _label: {"ProgramArguments": ["invalid"]},
+    )
+    monkeypatch.setattr(definition, "installed_identity", lambda _label: None)
+    monkeypatch.setattr(st, "_port_busy", lambda *_a, **_k: False)
+    monkeypatch.setattr(st, "_plist_path", lambda _label: Path("/missing.plist"))
+
+    status = st.collect_status()
+    assert status["config_valid"] is False
+    assert "unrecognized legacy" in status["config_error"]
+
+
+def test_collect_status_prefers_valid_config_backed_identity(monkeypatch, tmp_path):
+    import vllm_mlx.headless_service.config as config
+    import vllm_mlx.headless_service.definition as definition
+    import vllm_mlx.headless_service.status as st
+
+    config_file = tmp_path / "active.json"
+    pending = tmp_path / "pending.json"
+    pending.write_text("{}")
+    effective = types.SimpleNamespace(
+        executable="/opt/rapid/bin/rapid-mlx",
+        model="model-from-config",
+        host="127.0.0.1",
+        port=8123,
+        credential_file=None,
+    )
+    monkeypatch.setattr(st, "_launchctl_probe", lambda *_a, **_k: (None, None))
+    monkeypatch.setattr(
+        st,
+        "_read_installed_plist",
+        lambda _label: {"ProgramArguments": ["invalid"], "UserName": "serveuser"},
+    )
+    monkeypatch.setattr(
+        definition,
+        "installed_identity",
+        lambda _label: ("serveuser", tmp_path, config_file),
+    )
+    monkeypatch.setattr(config, "pending_config_path", lambda *_a, **_k: pending)
+    monkeypatch.setattr(config, "load_config", lambda _path: effective)
+    monkeypatch.setattr(config, "config_digest", lambda _config: "digest")
+    monkeypatch.setattr(st, "_port_busy", lambda *_a, **_k: False)
+    monkeypatch.setattr(st, "_plist_path", lambda _label: Path("/missing.plist"))
+
+    status = st.collect_status()
+    assert status["config_valid"] is True
+    assert status["pending_config"] is True
+    assert status["model"] == "model-from-config"
+    assert status["port"] == 8123
+    assert status["config_sha256"] == "digest"
+
+
+def test_collect_status_bounded_probe_rejects_legacy_hostname(monkeypatch):
+    import vllm_mlx.headless_service.definition as definition
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        st,
+        "_launchctl_probe",
+        lambda *_a, **_k: (_fake_launchctl_print(pid=42), None),
+    )
+    monkeypatch.setattr(
+        st,
+        "_read_installed_plist",
+        lambda _label: {"ProgramArguments": ["legacy"], "UserName": "serveuser"},
+    )
+    monkeypatch.setattr(
+        st,
+        "_parse_legacy_serve",
+        lambda _argv: ("/bin/rapid-mlx", "model", "legacy-host.local", 8000),
+    )
+    monkeypatch.setattr(definition, "installed_identity", lambda _label: None)
+    monkeypatch.setattr(st, "_pid_listens_on_port", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        st,
+        "_endpoint_health",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("bounded legacy host must not be probed")
+        ),
+    )
+    monkeypatch.setattr(
+        st.subprocess,
+        "run",
+        lambda *_a, **_k: types.SimpleNamespace(returncode=0, stdout="serveuser\n"),
+    )
+    monkeypatch.setattr(st, "_port_busy", lambda *_a, **_k: False)
+    monkeypatch.setattr(st, "_plist_path", lambda _label: Path("/missing.plist"))
+
+    status = st.collect_status(probe_timeout_s=0.5)
+    assert status["endpoint_attributable"] is False
 
 
 def test_render_human_lines():
@@ -1169,6 +1380,63 @@ def test_launchctl_print_returns_none_on_error(monkeypatch):
     assert st._launchctl_print("com.rapidmlx.server") is None
 
 
+def test_launchctl_probe_preserves_execution_error(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        staticmethod(lambda *_a, **_k: (_ for _ in ()).throw(OSError("denied"))),
+    )
+
+    output, error = st._launchctl_probe("com.rapidmlx.server", timeout_s=0.1)
+    assert output is None
+    assert error == "OSError: denied"
+
+
+def test_launchctl_probe_distinguishes_missing_job_from_permission_failure(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    outcomes = iter(
+        [
+            types.SimpleNamespace(
+                returncode=113, stdout="", stderr='Could not find service "x"'
+            ),
+            types.SimpleNamespace(
+                returncode=113, stdout="", stderr="Operation not permitted"
+            ),
+        ]
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: next(outcomes))
+
+    assert st._launchctl_probe("missing") == (None, None)
+    output, error = st._launchctl_probe("denied")
+    assert output is None
+    assert error == "launchctl exited 113: Operation not permitted"
+
+
+def test_legacy_service_definition_rejects_incomplete_arguments():
+    import vllm_mlx.headless_service.status as st
+
+    with pytest.raises(ValueError, match="invalid legacy serve arguments"):
+        st._parse_legacy_serve(["/bin/rapid-mlx", "serve", "qwen", "--host"])
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (None, "string array"),
+        (["rapid-mlx", "serve", "model"], "unrecognized legacy"),
+        (["/bin/rapid-mlx", "bench", "model"], "not a serve command"),
+    ],
+)
+def test_legacy_service_definition_rejects_wrong_shapes(argv, message):
+    import vllm_mlx.headless_service.status as st
+
+    with pytest.raises(ValueError, match=message):
+        st._parse_legacy_serve(argv)
+
+
 def test_read_installed_plist_none_when_missing(monkeypatch, tmp_path):
     import vllm_mlx.headless_service.status as st
 
@@ -1198,8 +1466,89 @@ def test_endpoint_health_connection_error(monkeypatch):
     monkeypatch.setattr(socket, "create_connection", _boom)
     monkeypatch.setattr(ins_mod, "_readyz_ready", staticmethod(lambda h, p: False))
     live, ready = st._endpoint_health("127.0.0.1", 1)
-    assert live is False
-    assert ready is False
+    assert live is None
+    assert ready is None
+
+
+def test_endpoint_health_deadlines_are_inconclusive(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            raise AssertionError("expired probes must not read")
+
+    ticks = iter(range(0, 100, 10))
+    monkeypatch.setattr(st.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(st.socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000, timeout_s=1) == (None, None)
+
+
+def test_endpoint_health_shared_deadline_normalizes_or_rejects_hosts(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    seen = []
+
+    def refused(address, **_kwargs):
+        seen.append(address)
+        raise OSError("refused")
+
+    monkeypatch.setattr(st.socket, "create_connection", refused)
+    assert st._endpoint_health("localhost", 8000, shared_deadline=True) == (None, None)
+    assert seen[0] == ("127.0.0.1", 8000)
+
+    seen.clear()
+    assert st._endpoint_health("legacy-host.local", 8000, shared_deadline=True) == (
+        None,
+        None,
+    )
+    assert seen == []
+
+
+def test_listener_host_matching_special_cases(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    assert st._listener_covers_host("*", "127.0.0.1") is True
+    assert st._listener_covers_host("[::1]", "localhost") is True
+
+    monkeypatch.setattr(
+        st.socket,
+        "getaddrinfo",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("dns unavailable")),
+    )
+    assert (
+        st._listener_covers_host(
+            "192.0.2.10", "legacy-host.local", resolve_hostnames=True
+        )
+        is False
+    )
+
+
+def test_listener_pid_probe_missing_tool_and_execution_error(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    monkeypatch.setattr(st.Path, "is_file", lambda _self: False)
+    assert st._pid_listens_on_port(42, "127.0.0.1", 8000) is None
+
+    monkeypatch.setattr(st.Path, "is_file", lambda _self: True)
+    monkeypatch.setattr(
+        st.subprocess,
+        "run",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("lsof failed")),
+    )
+    assert st._pid_listens_on_port(42, "127.0.0.1", 8000) is None
 
 
 def test_status_owner_ps_error(monkeypatch, plist_kwargs, tmp_path):
@@ -1207,7 +1556,9 @@ def test_status_owner_ps_error(monkeypatch, plist_kwargs, tmp_path):
     import vllm_mlx.headless_service.status as st
 
     monkeypatch.setattr(
-        st, "_launchctl_print", staticmethod(lambda _l: _fake_launchctl_print(pid=7))
+        st,
+        "_launchctl_probe",
+        lambda *_a, **_k: (_fake_launchctl_print(pid=7), None),
     )
     monkeypatch.setattr(st, "_endpoint_health", staticmethod(lambda h, p: (True, True)))
     monkeypatch.setattr(st, "_port_busy", staticmethod(lambda h, p: False))
@@ -1229,7 +1580,9 @@ def test_status_command_human_branch(monkeypatch, capsys):
     import vllm_mlx.headless_service.status as st
 
     monkeypatch.setattr(
-        st, "_launchctl_print", staticmethod(lambda _l: _fake_launchctl_print())
+        st,
+        "_launchctl_probe",
+        lambda *_a, **_k: (_fake_launchctl_print(), None),
     )
     monkeypatch.setattr(st, "_read_installed_plist", staticmethod(lambda _l: None))
     monkeypatch.setattr(
@@ -1242,7 +1595,7 @@ def test_status_command_human_branch(monkeypatch, capsys):
     assert "launcher registration:" in text
     # Down state surfaces in the human table.
     assert "(no live process)" in text
-    assert "livez=down readyz=down port=closed" in text
+    assert "livez=unknown readyz=unknown port=closed" in text
 
 
 def test_resolve_executable_success(monkeypatch, tmp_path):
@@ -1461,6 +1814,15 @@ def test_endpoint_health_live_200(monkeypatch):
     import vllm_mlx.headless_service.status as st
 
     class _Conn:
+        def __init__(self):
+            self.responses = iter(
+                [
+                    b'HTTP/1.1 200 OK\r\nContent-Length: 15\r\n\r\n{"ready": ',
+                    b"true}",
+                    b"",
+                ]
+            )
+
         def __enter__(self):
             return self
 
@@ -1474,15 +1836,138 @@ def test_endpoint_health_live_200(monkeypatch):
             pass
 
         def recv(self, n):
-            return b"HTTP/1.1 200 OK\r\n\r\n"
+            return next(self.responses, b"")
 
     monkeypatch.setattr(
         socket, "create_connection", staticmethod(lambda *a, **k: _Conn())
     )
-    monkeypatch.setattr(ins_mod, "_readyz_ready", staticmethod(lambda h, p: True))
     live, ready = st._endpoint_health("127.0.0.1", 8000)
     assert live is True
     assert ready is True
+
+
+def test_endpoint_health_rejects_truncated_live_headers(monkeypatch):
+    """A status line alone is not a complete HTTP response."""
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            response, self.response = (
+                getattr(self, "response", b"HTTP/1.1 200 OK\r\n"),
+                b"",
+            )
+            return response
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    live, _ready = st._endpoint_health("127.0.0.1", 8000)
+    assert live is None
+
+
+def test_endpoint_health_treats_recursive_json_as_unverified(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.responses = iter(
+                [b'HTTP/1.1 200 OK\r\nContent-Length: 15\r\n\r\n{"ready": true}']
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            return next(self.responses, b"")
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+    monkeypatch.setattr(
+        st.json,
+        "loads",
+        lambda _body: (_ for _ in ()).throw(RecursionError("too deep")),
+    )
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, None)
+
+
+def test_endpoint_health_accepts_split_status_line(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.responses = iter(
+                [
+                    b"HTTP/1.1 ",
+                    b"200 OK\r\nContent-Length: 15\r\n\r\n",
+                    b'{"ready": true}',
+                ]
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            return next(self.responses, b"")
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, True)
+
+
+def test_endpoint_health_rejects_non_http_status_line(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.responses = iter([b'garbage 200\r\n\r\n{"ready": true}'])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            return next(self.responses, b"")
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (None, None)
 
 
 def test_endpoint_health_probes_wildcard_bind_via_loopback(monkeypatch):
@@ -1491,6 +1976,9 @@ def test_endpoint_health_probes_wildcard_bind_via_loopback(monkeypatch):
     seen = []
 
     class _Conn:
+        def __init__(self):
+            self.responses = iter([b'HTTP/1.1 200 OK\r\n\r\n{"ready": true}', b""])
+
         def __enter__(self):
             return self
 
@@ -1504,20 +1992,296 @@ def test_endpoint_health_probes_wildcard_bind_via_loopback(monkeypatch):
             pass
 
         def recv(self, n):
-            return b"HTTP/1.1 200 OK\r\n\r\n"
+            return next(self.responses, b"")
 
     def _connect(address, **_kwargs):
         seen.append(address)
         return _Conn()
 
     monkeypatch.setattr(socket, "create_connection", _connect)
-    monkeypatch.setattr(
-        ins_mod,
-        "_readyz_ready",
-        lambda host, port: seen.append((host, port)) or True,
-    )
     assert st._endpoint_health("0.0.0.0", 8000) == (True, True)
     assert seen == [("127.0.0.1", 8000), ("127.0.0.1", 8000)]
+
+
+def test_endpoint_health_decodes_chunked_readiness(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.responses = iter(
+                [
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+                    b'f\r\n{"ready": true}\r\n0\r\n\r\n',
+                ]
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            return next(self.responses, b"")
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, True)
+
+
+def test_endpoint_health_parses_transfer_encoding_whitespace(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.responses = iter(
+                [
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding:\tChunked\r\n\r\n",
+                    b'f\r\n{"ready": true}\r\n0\r\n\r\n',
+                ]
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            return next(self.responses, b"")
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, True)
+
+
+def test_endpoint_health_rejects_chunked_readiness_without_terminal_chunk(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.responses = iter(
+                [
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+                    b'f\r\n{"ready": true}\r\n',
+                    b"",
+                ]
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            return next(self.responses, b"")
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, None)
+
+
+def test_endpoint_health_rejects_incomplete_chunk_terminator(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.responses = iter(
+                [
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+                    b'f\r\n{"ready": true}\r\n0\r\n',
+                    b"",
+                ]
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            return next(self.responses, b"")
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, None)
+
+
+def test_endpoint_health_accepts_valid_chunked_trailer(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.response = (
+                b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+                b'f\r\n{"ready": true}\r\n0\r\nX-Trace: done\r\n\r\n'
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            if not self.response:
+                raise AssertionError("complete chunked response was read again")
+            response, self.response = self.response, b""
+            return response
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, True)
+
+
+def test_endpoint_health_rejects_truncated_content_length(monkeypatch):
+    import vllm_mlx.headless_service.status as st
+
+    class _Conn:
+        def __init__(self):
+            self.responses = iter(
+                [
+                    b'HTTP/1.1 200 OK\r\nContent-Length: 99\r\n\r\n{"ready": true}',
+                    b"",
+                ]
+            )
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            return next(self.responses, b"")
+
+    monkeypatch.setattr(socket, "create_connection", lambda *_a, **_k: _Conn())
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, None)
+
+
+@pytest.mark.parametrize(
+    "chunked_body",
+    [
+        b"z\r\ninvalid\r\n0\r\n\r\n",
+        b"f\r\nshortXX",
+        b"missing-size-separator",
+    ],
+)
+def test_endpoint_health_rejects_malformed_chunk_frames(monkeypatch, chunked_body):
+    import vllm_mlx.headless_service.status as st
+
+    responses = iter(
+        [
+            b"HTTP/1.1 200 OK\r\n\r\n",
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" + chunked_body,
+        ]
+    )
+
+    class _Conn:
+        def __init__(self, response):
+            self.response = response
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            response, self.response = self.response, b""
+            return response
+
+    monkeypatch.setattr(
+        st.socket, "create_connection", lambda *_a, **_k: _Conn(next(responses))
+    )
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, None)
+
+
+@pytest.mark.parametrize("payload", [b"[]", b'{"state": "loading"}'])
+def test_endpoint_health_requires_ready_object_field(monkeypatch, payload):
+    import vllm_mlx.headless_service.status as st
+
+    responses = iter(
+        [
+            b"HTTP/1.1 200 OK\r\n\r\n",
+            b"HTTP/1.1 200 OK\r\nContent-Length: "
+            + str(len(payload)).encode()
+            + b"\r\n\r\n"
+            + payload,
+        ]
+    )
+
+    class _Conn:
+        def __init__(self, response):
+            self.response = response
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, *_args):
+            pass
+
+        def sendall(self, *_args):
+            pass
+
+        def recv(self, _size):
+            response, self.response = self.response, b""
+            return response
+
+    monkeypatch.setattr(
+        st.socket, "create_connection", lambda *_a, **_k: _Conn(next(responses))
+    )
+
+    assert st._endpoint_health("127.0.0.1", 8000) == (True, None)
 
 
 def test_logs_follow_keyboard_interrupt(monkeypatch, tmp_path, capsys):

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -3967,6 +3967,7 @@ def test_run_all_returns_all_sections():
         "Shell Integration",
         "Optional Tools",
         "Agent Integrations",
+        "Always-on Service",
     ]
     assert titles == expected, (
         f"sections drifted from spec order. got {titles}, expected {expected}"

--- a/tests/test_doctor_service_health.py
+++ b/tests/test_doctor_service_health.py
@@ -1,0 +1,465 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Always-on service checks exposed through ``rapid-mlx doctor``."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import sys
+from pathlib import Path
+
+from vllm_mlx import __version__
+from vllm_mlx.doctor import env_health as eh
+
+
+def _status(**changes):
+    value = {
+        "plist_present": True,
+        "registered": True,
+        "pid": 42,
+        "owner": "serveuser",
+        "declared_user": "serveuser",
+        "last_exit": 0,
+        "launchd_state": "running",
+        "runs": 1,
+        "crash_loop_suspected": False,
+        "model": "qwen3.5-4b-4bit",
+        "host": "127.0.0.1",
+        "port": 8000,
+        "livez": True,
+        "readyz": True,
+        "plist": "/Library/LaunchDaemons/com.rapidmlx.server.plist",
+        "config_file": "/Library/Application Support/Rapid-MLX/Services/config.json",
+        "config_error": None,
+        "config_valid": True,
+        "endpoint_configured": True,
+        "endpoint_attributable": True,
+        "pending_config": False,
+        "executable": None,
+    }
+    value.update(changes)
+    return value
+
+
+def _runtime_with_metadata(tmp_path, version=__version__):
+    executable = tmp_path / "bin" / "rapid-mlx"
+    executable.parent.mkdir(parents=True, exist_ok=True)
+    interpreter = tmp_path / "bin" / "python3"
+    if not interpreter.exists():
+        interpreter.symlink_to(sys.executable)
+    executable.write_text(
+        f"#!{interpreter}\nimport re\n"
+        "import sys\n"
+        "from vllm_mlx.cli import cli_entrypoint\n"
+        "if __name__ == '__main__':\n"
+        r"    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])"
+        "\n"
+        "    sys.exit(cli_entrypoint())\n"
+    )
+    executable.chmod(0o755)
+    metadata = (
+        tmp_path
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+        / f"rapid_mlx-{version}.dist-info"
+        / "METADATA"
+    )
+    metadata.parent.mkdir(parents=True, exist_ok=True)
+    metadata.write_text(f"Name: rapid-mlx\nVersion: {version}\n")
+    digest = (
+        base64.urlsafe_b64encode(hashlib.sha256(executable.read_bytes()).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    relative_executable = executable.relative_to(tmp_path)
+    (metadata.parent / "RECORD").write_text(
+        f"../../../{relative_executable},sha256={digest},{executable.stat().st_size}\n"
+    )
+    return executable
+
+
+def _refresh_runtime_record(tmp_path, executable):
+    record = next(
+        tmp_path.glob("lib/python*/site-packages/rapid_mlx-*.dist-info/RECORD")
+    )
+    digest = (
+        base64.urlsafe_b64encode(hashlib.sha256(executable.read_bytes()).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    relative_executable = executable.relative_to(tmp_path)
+    record.write_text(
+        f"../../../{relative_executable},sha256={digest},{executable.stat().st_size}\n"
+    )
+
+
+def test_absent_optional_service_is_healthy():
+    section = eh.section_always_on_service(
+        status_data=_status(plist_present=False, registered=False),
+        platform_name="darwin",
+    )
+    assert len(section.checks) == 1
+    assert section.checks[0].status is eh.CheckStatus.OK
+    assert section.checks[0].id == "service.installation"
+
+
+def test_healthy_service_checks_every_layer(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+
+    section = eh.section_always_on_service(
+        status_data=_status(executable=str(executable)),
+        platform_name="darwin",
+    )
+    assert all(check.status is eh.CheckStatus.OK for check in section.checks)
+    assert {check.id for check in section.checks} >= {
+        "service.definition",
+        "service.registration",
+        "service.process",
+        "service.owner",
+        "service.config",
+        "service.runtime",
+        "service.endpoint.liveness",
+        "service.endpoint.readiness",
+    }
+
+
+def test_crash_loop_is_a_confirmed_failure():
+    section = eh.section_always_on_service(
+        status_data=_status(
+            pid=None,
+            owner=None,
+            last_exit=78,
+            crash_loop_suspected=True,
+            livez=False,
+            readyz=False,
+        ),
+        platform_name="darwin",
+    )
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["service.process"].status is eh.CheckStatus.FAIL
+    assert "repeated startup failure" in by_id["service.process"].label
+    assert by_id["service.endpoint.liveness"].status is eh.CheckStatus.SKIPPED
+
+
+def test_owner_mismatch_is_a_confirmed_failure():
+    section = eh.section_always_on_service(
+        status_data=_status(pid=42, owner="root", declared_user="serveuser"),
+        platform_name="darwin",
+    )
+
+    owner = next(check for check in section.checks if check.id == "service.owner")
+    assert owner.status is eh.CheckStatus.FAIL
+    assert "expected serveuser" in owner.label
+
+
+def test_running_service_requires_a_declared_non_root_owner():
+    for declared_user in (None, "", "root"):
+        section = eh.section_always_on_service(
+            status_data=_status(
+                pid=42,
+                owner="root" if declared_user == "root" else "serveuser",
+                declared_user=declared_user,
+            ),
+            platform_name="darwin",
+        )
+        owner = next(check for check in section.checks if check.id == "service.owner")
+        assert owner.status is eh.CheckStatus.FAIL
+
+
+def test_live_but_unready_is_warning_not_broken():
+    section = eh.section_always_on_service(
+        status_data=_status(readyz=False), platform_name="darwin"
+    )
+    readiness = next(
+        check for check in section.checks if check.id == "service.endpoint.readiness"
+    )
+    assert readiness.status is eh.CheckStatus.WARN
+    assert "loading" in readiness.detail
+
+
+def test_endpoint_probe_errors_are_skipped_not_confirmed_failures():
+    section = eh.section_always_on_service(
+        status_data=_status(livez=None, readyz=None), platform_name="darwin"
+    )
+
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["service.endpoint.liveness"].status is eh.CheckStatus.SKIPPED
+    assert by_id["service.endpoint.readiness"].status is eh.CheckStatus.SKIPPED
+
+
+def test_invalid_config_and_pending_change_are_distinct():
+    section = eh.section_always_on_service(
+        status_data=_status(
+            config_error="bad schema", config_valid=False, pending_config=True
+        ),
+        platform_name="darwin",
+    )
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["service.config"].status is eh.CheckStatus.FAIL
+    assert by_id["service.config.pending"].status is eh.CheckStatus.WARN
+
+
+def test_unverified_config_and_missing_runtime_are_failures():
+    section = eh.section_always_on_service(
+        status_data=_status(config_valid=False, executable=None),
+        platform_name="darwin",
+    )
+
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["service.config"].status is eh.CheckStatus.FAIL
+    assert by_id["service.runtime"].status is eh.CheckStatus.FAIL
+
+
+def test_zero_launch_count_is_not_rendered_as_unknown(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+    section = eh.section_always_on_service(
+        status_data=_status(runs=0, executable=str(executable)),
+        platform_name="darwin",
+    )
+
+    process = next(check for check in section.checks if check.id == "service.process")
+    assert "runs=0" in process.detail
+
+
+def test_non_executable_runtime_is_a_confirmed_failure(tmp_path):
+    executable = tmp_path / "rapid-mlx"
+    executable.write_text("")
+    executable.chmod(0o644)
+
+    section = eh.section_always_on_service(
+        status_data=_status(executable=str(executable)),
+        platform_name="darwin",
+    )
+
+    runtime = next(check for check in section.checks if check.id == "service.runtime")
+    assert runtime.status is eh.CheckStatus.FAIL
+    assert "not executable" in runtime.label
+
+
+def test_runtime_metadata_io_error_is_unverified(monkeypatch, tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+
+    def inaccessible(_self, _pattern):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "glob", inaccessible)
+
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_runtime_metadata_rejects_unrelated_launcher_and_stale_versions(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+    executable.write_text("#!/bin/sh\necho impostor\n")
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_runtime_metadata_rejects_extra_top_level_guard(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+    executable.write_text(
+        executable.read_text()
+        + "\nif True:\n"
+        + "    print('unexpected top-level conditional')\n"
+    )
+
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_runtime_metadata_rejects_shadowed_entrypoint(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+    executable.write_text(
+        executable.read_text().replace(
+            "if __name__ == '__main__':",
+            "from impostor import cli_entrypoint\nif __name__ == '__main__':",
+        )
+    )
+
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_runtime_metadata_ignores_other_python_version(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+    stale = tmp_path / "lib/python9.9/site-packages/rapid_mlx-9.9.9.dist-info/METADATA"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("Name: rapid-mlx\nVersion: 9.9.9\n")
+
+    assert eh._service_runtime_version(str(executable)) == __version__
+
+
+def test_runtime_metadata_rejects_multiple_active_versions(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+    active_tag = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    stale = (
+        tmp_path / f"lib/{active_tag}/site-packages/rapid_mlx-9.9.9.dist-info/METADATA"
+    )
+    stale.parent.mkdir(parents=True)
+    stale.write_text("Name: rapid-mlx\nVersion: 9.9.9\n")
+
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_launchctl_probe_error_is_unverified_not_confirmed_absence():
+    section = eh.section_always_on_service(
+        status_data=_status(
+            registered=False,
+            pid=None,
+            launchctl_error="TimeoutExpired: launchctl",
+        ),
+        platform_name="darwin",
+    )
+
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["service.registration"].status is eh.CheckStatus.WARN
+    assert by_id["service.process"].status is eh.CheckStatus.WARN
+
+
+def test_unattributable_endpoint_cannot_make_service_look_healthy():
+    section = eh.section_always_on_service(
+        status_data=_status(
+            pid=None,
+            livez=True,
+            readyz=True,
+            endpoint_configured=False,
+        ),
+        platform_name="darwin",
+    )
+
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["service.endpoint.liveness"].status is eh.CheckStatus.SKIPPED
+    assert by_id["service.endpoint.readiness"].status is eh.CheckStatus.SKIPPED
+
+
+def test_missing_endpoint_attribution_evidence_fails_closed():
+    status = _status()
+    status.pop("endpoint_attributable")
+    section = eh.section_always_on_service(status_data=status, platform_name="darwin")
+
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["service.endpoint.liveness"].status is eh.CheckStatus.SKIPPED
+    assert by_id["service.endpoint.readiness"].status is eh.CheckStatus.SKIPPED
+
+
+def test_runtime_metadata_rejects_oversized_or_headerless_launchers(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+    executable.write_bytes(b"x" * (32 * 1024 + 1))
+    assert eh._service_runtime_version(str(executable)) is None
+
+    executable.write_text("not a console script\n")
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_runtime_metadata_rejects_missing_or_non_executable_interpreter(
+    monkeypatch, tmp_path
+):
+    executable = _runtime_with_metadata(tmp_path)
+    lines = executable.read_text().splitlines()
+    lines[0] = f"#!{tmp_path / 'bin' / 'python-missing'}"
+    executable.write_text("\n".join(lines) + "\n")
+    assert eh._service_runtime_version(str(executable)) is None
+
+    executable = _runtime_with_metadata(tmp_path / "access")
+    monkeypatch.setattr(eh.os, "access", lambda *_a, **_k: False)
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_runtime_metadata_uses_pyvenv_version_for_unversioned_interpreter(tmp_path):
+    interpreter = tmp_path / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n")
+    interpreter.chmod(0o755)
+    executable = _runtime_with_metadata(tmp_path)
+    executable.write_text(executable.read_text().replace("python3", "python", 1))
+    _refresh_runtime_record(tmp_path, executable)
+    (tmp_path / "pyvenv.cfg").write_text(
+        f"version = {sys.version_info.major}.{sys.version_info.minor}.0\n"
+    )
+
+    assert eh._service_runtime_version(str(executable)) == __version__
+
+
+def test_runtime_metadata_rejects_unversioned_environment_without_version(tmp_path):
+    interpreter = tmp_path / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n")
+    interpreter.chmod(0o755)
+    executable = _runtime_with_metadata(tmp_path)
+    executable.write_text(executable.read_text().replace("python3", "python", 1))
+
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_runtime_metadata_skips_wrong_distribution_and_missing_record_entry(tmp_path):
+    executable = _runtime_with_metadata(tmp_path)
+    metadata = next(
+        tmp_path.glob("lib/python*/site-packages/rapid_mlx-*.dist-info/METADATA")
+    )
+    metadata.write_text("Name: another-project\nVersion: 1.0\n")
+    assert eh._service_runtime_version(str(executable)) is None
+
+    executable = _runtime_with_metadata(tmp_path / "record")
+    record = next(
+        (tmp_path / "record").glob(
+            "lib/python*/site-packages/rapid_mlx-*.dist-info/RECORD"
+        )
+    )
+    record.write_text(f"missing-file,sha256=ignored,1\n{record.read_text()}")
+    assert eh._service_runtime_version(str(executable)) == __version__
+
+    executable_row = record.read_text().splitlines()[-1]
+    record.write_text(executable_row.replace("sha256=", "missing=") + "\n")
+    assert eh._service_runtime_version(str(executable)) is None
+
+
+def test_service_section_platform_and_collector_paths(monkeypatch):
+    section = eh.section_always_on_service(platform_name="linux")
+    assert section.checks[0].id == "service.platform"
+
+    import vllm_mlx.headless_service.status as service_status
+
+    monkeypatch.setattr(
+        service_status,
+        "collect_status",
+        lambda **_kwargs: _status(plist_present=False, registered=False),
+    )
+    section = eh.section_always_on_service(platform_name="darwin")
+    assert section.checks[0].id == "service.installation"
+
+
+def test_uninstalled_service_launchctl_error_is_unverified():
+    section = eh.section_always_on_service(
+        status_data=_status(
+            plist_present=False,
+            registered=False,
+            launchctl_error="permission denied",
+        ),
+        platform_name="darwin",
+    )
+    assert section.checks[0].status is eh.CheckStatus.WARN
+
+
+def test_service_section_covers_runtime_and_owner_failure_variants(tmp_path):
+    missing = tmp_path / "missing-rapid-mlx"
+    section = eh.section_always_on_service(
+        status_data=_status(owner=None, executable=str(missing)),
+        platform_name="darwin",
+    )
+    by_id = {check.id: check for check in section.checks}
+    assert "could not be verified" in by_id["service.owner"].label
+    assert by_id["service.runtime"].status is eh.CheckStatus.FAIL
+
+    unverified = tmp_path / "rapid-mlx"
+    unverified.write_text("not a launcher\n")
+    unverified.chmod(0o755)
+    section = eh.section_always_on_service(
+        status_data=_status(executable=str(unverified)), platform_name="darwin"
+    )
+    runtime = next(check for check in section.checks if check.id == "service.runtime")
+    assert runtime.status is eh.CheckStatus.WARN
+
+    different = _runtime_with_metadata(tmp_path / "different", version="9.9.9")
+    section = eh.section_always_on_service(
+        status_data=_status(executable=str(different)), platform_name="darwin"
+    )
+    runtime = next(check for check in section.checks if check.id == "service.runtime")
+    assert runtime.status is eh.CheckStatus.WARN
+    assert "differs from Doctor" in runtime.label

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -1281,7 +1281,10 @@ def test_install_service_config_helper(monkeypatch, tmp_path):
 
 
 def test_status_config_and_human_diagnostics(monkeypatch, tmp_path):
+    from vllm_mlx.headless_service import config as config_module
     from vllm_mlx.headless_service import definition, status
+
+    monkeypatch.setattr(config_module, "SERVICE_CONFIG_ROOT", tmp_path)
 
     config_file = tmp_path / "service.json"
     credential = tmp_path / "credential"
@@ -1326,8 +1329,10 @@ def test_status_config_and_human_diagnostics(monkeypatch, tmp_path):
     assert "unknown (run status with sudo)" in rendered
 
     config_file.write_text("{")
+    atomic_write(pending_config_path(tmp_path), config_bytes(effective))
     broken = status.collect_status()
     assert broken["config_error"]
+    assert broken["pending_config"] is True
 
 
 def _upgrade_fixture(monkeypatch, tmp_path):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -13046,6 +13046,7 @@ Examples:
         "shell",
         "tools.optional",
         "agents",
+        "service",
     )
     doctor_parser.add_argument(
         "--only",

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -21,6 +21,9 @@ Tests in ``tests/test_doctor_env_health.py`` cover each section's probe.
 
 from __future__ import annotations
 
+import base64
+import csv
+import hashlib
 import importlib.metadata as _im
 import importlib.util as _iu
 import json
@@ -37,6 +40,7 @@ import time
 import urllib.parse
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from email.parser import Parser
 from enum import Enum
 from pathlib import Path
 from typing import Any, cast
@@ -3106,6 +3110,357 @@ def section_agent_integrations(
     return section
 
 
+def _service_runtime_version(
+    executable: str,
+) -> str | None:
+    """Read Rapid-MLX package metadata without executing the service runtime."""
+    try:
+        executable_path = Path(executable).resolve(strict=True)
+        environment = executable_path.parent.parent
+        if executable_path.stat().st_size > 32 * 1024:
+            return None
+        launcher = executable_path.read_text(encoding="utf-8")
+        lines = launcher.splitlines()
+        if not lines or not lines[0].startswith("#!"):
+            return None
+        declared_interpreter = Path(lines[0][2:].strip())
+        if (
+            not declared_interpreter.is_absolute()
+            or declared_interpreter.parent.parent != environment
+            or not declared_interpreter.name.startswith("python")
+        ):
+            return None
+        resolved_interpreter = declared_interpreter.resolve(strict=True)
+        if not resolved_interpreter.is_file() or not os.access(
+            resolved_interpreter, os.X_OK
+        ):
+            return None
+    except (OSError, UnicodeError):
+        return None
+    try:
+        python_tag = None
+        for interpreter_name in (declared_interpreter.name, resolved_interpreter.name):
+            match = re.fullmatch(r"python(?:w)?(\d+\.\d+)", interpreter_name)
+            if match:
+                python_tag = match.group(1)
+                break
+        if python_tag is None:
+            config = environment / "pyvenv.cfg"
+            if config.is_file():
+                for line in config.read_text(encoding="utf-8").splitlines():
+                    key, separator, value = line.partition("=")
+                    if separator and key.strip().lower() in {"version", "version_info"}:
+                        match = re.match(r"\s*(\d+\.\d+)", value)
+                        if match:
+                            python_tag = match.group(1)
+                            break
+        if python_tag is None:
+            return None
+        metadata_root = environment / "lib" / f"python{python_tag}" / "site-packages"
+        distributions: list[tuple[str, Path]] = []
+        for metadata_file in metadata_root.glob("rapid_mlx-*.dist-info/METADATA"):
+            metadata = Parser().parsestr(metadata_file.read_text(encoding="utf-8"))
+            name = str(metadata.get("Name") or "").strip().lower().replace("_", "-")
+            version = str(metadata.get("Version") or "").strip()
+            if name != "rapid-mlx":
+                continue
+            Version(version)
+            distributions.append((version, metadata_file.parent))
+        if len(distributions) != 1:
+            return None
+        version, distribution_root = distributions[0]
+        record_path = distribution_root / "RECORD"
+        record_rows = csv.reader(record_path.read_text(encoding="utf-8").splitlines())
+        recorded_hash = recorded_size = None
+        for relative_path, digest, size in record_rows:
+            try:
+                recorded_path = (metadata_root / relative_path).resolve(strict=True)
+            except OSError:
+                continue
+            if recorded_path == executable_path:
+                recorded_hash = digest
+                recorded_size = size
+                break
+        if not recorded_hash or not recorded_hash.startswith("sha256="):
+            return None
+        launcher_bytes = executable_path.read_bytes()
+        actual_hash = (
+            base64.urlsafe_b64encode(hashlib.sha256(launcher_bytes).digest())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        if recorded_hash != f"sha256={actual_hash}" or recorded_size != str(
+            len(launcher_bytes)
+        ):
+            return None
+    except (csv.Error, InvalidVersion, OSError, UnicodeError, ValueError):
+        return None
+    return version
+
+
+def section_always_on_service(
+    *,
+    status_data: dict[str, Any] | None = None,
+    platform_name: str | None = None,
+) -> Section:
+    """Explain the installed LaunchDaemon from definition through readiness."""
+    section = Section("Always-on Service")
+    current_platform = platform_name or sys.platform
+    if current_platform != "darwin":
+        section.add(
+            "Always-on launchd service is macOS-only",
+            CheckStatus.OK,
+            check_id="service.platform",
+        )
+        return section
+
+    if status_data is None:
+        from vllm_mlx.headless_service.status import collect_status
+
+        status_data = collect_status(probe_timeout_s=_bounded_timeout(0.5))
+
+    launchctl_error = status_data.get("launchctl_error")
+    installed = bool(status_data.get("plist_present") or status_data.get("registered"))
+    if not installed and launchctl_error:
+        section.add(
+            "Always-on service installation could not be verified",
+            CheckStatus.WARN,
+            detail=str(launchctl_error),
+            check_id="service.installation",
+        )
+        return section
+    if not installed:
+        section.add(
+            "Always-on service is not installed (optional)",
+            CheckStatus.OK,
+            detail="install with `sudo rapid-mlx service install ...` when needed",
+            check_id="service.installation",
+        )
+        return section
+
+    plist_present = bool(status_data.get("plist_present"))
+    section.add(
+        "LaunchDaemon definition is installed"
+        if plist_present
+        else "LaunchDaemon definition is missing",
+        CheckStatus.OK if plist_present else CheckStatus.FAIL,
+        detail=str(status_data.get("plist") or ""),
+        check_id="service.definition",
+    )
+
+    registered = bool(status_data.get("registered"))
+    if launchctl_error:
+        section.add(
+            "launchd registration could not be verified",
+            CheckStatus.WARN,
+            detail=str(launchctl_error),
+            check_id="service.registration",
+        )
+    else:
+        section.add(
+            "launchd job is registered"
+            if registered
+            else "launchd job is not registered",
+            CheckStatus.OK if registered else CheckStatus.FAIL,
+            detail="repair with `sudo rapid-mlx service restart`; reinstall if registration still fails",
+            check_id="service.registration",
+        )
+
+    pid = status_data.get("pid")
+    crash_loop = bool(status_data.get("crash_loop_suspected"))
+    runs = status_data.get("runs")
+    rendered_runs = runs if runs is not None else "unknown"
+    if pid:
+        section.add(
+            f"service process is running (pid {pid})",
+            CheckStatus.OK,
+            detail=f"launchd state={status_data.get('launchd_state') or 'unknown'}; runs={rendered_runs}",
+            check_id="service.process",
+        )
+    elif launchctl_error:
+        section.add(
+            "service process could not be verified",
+            CheckStatus.WARN,
+            detail=str(launchctl_error),
+            check_id="service.process",
+        )
+    else:
+        label = "service process is not running"
+        if crash_loop:
+            label += "; repeated startup failure suspected"
+        section.add(
+            label,
+            CheckStatus.FAIL,
+            detail=f"last exit={status_data.get('last_exit')}; inspect `rapid-mlx service logs --stderr`",
+            check_id="service.process",
+        )
+
+    owner = status_data.get("owner")
+    declared_user = status_data.get("declared_user")
+    if pid:
+        declared_account = (
+            declared_user
+            if isinstance(declared_user, str) and declared_user.strip()
+            else None
+        )
+        actual_owner = owner if isinstance(owner, str) and owner.strip() else None
+        matches = bool(
+            declared_account
+            and declared_account != "root"
+            and actual_owner
+            and actual_owner == declared_account
+        )
+        if declared_account is None:
+            owner_label = "service account is not declared"
+        elif declared_account == "root":
+            owner_label = "service is configured to run as root"
+        elif actual_owner is None:
+            owner_label = (
+                f"service owner could not be verified; expected {declared_account}"
+            )
+        else:
+            owner_label = f"service owner is {actual_owner}"
+            if not matches:
+                owner_label += f"; expected {declared_account}"
+        section.add(
+            owner_label,
+            CheckStatus.OK if matches else CheckStatus.FAIL,
+            detail="the daemon and model cache must use the configured non-root service account",
+            check_id="service.owner",
+        )
+
+    config_error = status_data.get("config_error")
+    config_valid = status_data.get("config_valid") is True
+    section.add(
+        "service configuration is valid"
+        if config_valid
+        else "service configuration is invalid",
+        CheckStatus.OK if config_valid else CheckStatus.FAIL,
+        detail=str(
+            config_error
+            or status_data.get("config_file")
+            or "no recognizable service configuration was found"
+        ),
+        check_id="service.config",
+    )
+    if status_data.get("pending_config"):
+        section.add(
+            "qualified configuration changes are pending",
+            CheckStatus.WARN,
+            detail="review with `rapid-mlx service config`, then activate with `sudo rapid-mlx service apply`",
+            check_id="service.config.pending",
+        )
+
+    executable = status_data.get("executable")
+    if not isinstance(executable, str) or not executable.strip():
+        section.add(
+            "configured service executable is missing from the definition",
+            CheckStatus.FAIL,
+            detail="reinstall the service to restore a qualified runtime path",
+            check_id="service.runtime",
+        )
+    else:
+        if not Path(executable).is_file():
+            section.add(
+                "configured service executable is missing",
+                CheckStatus.FAIL,
+                detail=executable,
+                check_id="service.runtime",
+            )
+        elif not os.access(executable, os.X_OK):
+            section.add(
+                "configured service executable is not executable",
+                CheckStatus.FAIL,
+                detail=executable,
+                check_id="service.runtime",
+            )
+        else:
+            from vllm_mlx import __version__
+
+            service_version = _service_runtime_version(executable)
+            if service_version is None:
+                section.add(
+                    "service runtime version could not be verified",
+                    CheckStatus.WARN,
+                    detail=executable,
+                    check_id="service.runtime",
+                )
+            elif __version__ != "0.0.0" and Version(service_version) != Version(
+                __version__
+            ):
+                section.add(
+                    f"service runtime {service_version} differs from Doctor {__version__}",
+                    CheckStatus.WARN,
+                    detail=f"service executable={executable}; restart after upgrading the service runtime",
+                    check_id="service.runtime",
+                )
+            else:
+                section.add(
+                    f"service runtime {service_version} matches Doctor",
+                    CheckStatus.OK,
+                    detail=executable,
+                    check_id="service.runtime",
+                )
+
+    endpoint_attributable = bool(
+        pid
+        and config_valid
+        and status_data.get("endpoint_configured") is True
+        and status_data.get("endpoint_attributable", False) is True
+    )
+    if not endpoint_attributable:
+        for endpoint, check_id in (
+            ("/livez", "service.endpoint.liveness"),
+            ("/readyz", "service.endpoint.readiness"),
+        ):
+            section.add(
+                f"endpoint {endpoint} was not attributed to the service",
+                CheckStatus.SKIPPED,
+                detail="requires a live service PID and a validated configured bind",
+                check_id=check_id,
+            )
+    else:
+        live = status_data.get("livez")
+        ready = status_data.get("readyz")
+        if live is None:
+            section.add(
+                "endpoint /livez probe was not verified",
+                CheckStatus.SKIPPED,
+                detail="the attributed endpoint timed out or returned an invalid response",
+                check_id="service.endpoint.liveness",
+            )
+        else:
+            section.add(
+                f"endpoint /livez is {'healthy' if live else 'down'}",
+                CheckStatus.OK if live else CheckStatus.FAIL,
+                detail=f"http://{status_data.get('host')}:{status_data.get('port')}/livez",
+                check_id="service.endpoint.liveness",
+            )
+        if ready is None:
+            section.add(
+                "endpoint /readyz probe was not verified",
+                CheckStatus.SKIPPED,
+                detail="the attributed endpoint timed out or returned an invalid response",
+                check_id="service.endpoint.readiness",
+            )
+        else:
+            section.add(
+                f"endpoint /readyz is {'ready' if ready else 'not ready'}",
+                CheckStatus.OK
+                if ready
+                else CheckStatus.WARN
+                if live is True
+                else CheckStatus.FAIL,
+                detail=(
+                    "a live but unready endpoint may still be loading or waiting in lazy mode; inspect service logs"
+                    if live is True and not ready
+                    else f"model={status_data.get('model') or 'unknown'}"
+                ),
+                check_id="service.endpoint.readiness",
+            )
+    return section
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -3125,6 +3480,7 @@ _SECTION_BUILDERS = (
     section_shell_integration,
     section_optional_tools,
     section_agent_integrations,
+    section_always_on_service,
 )
 
 # Select the diagnostic runtime once before any section that consumes it so
@@ -3149,6 +3505,7 @@ _SECTION_TITLES = {
     section_shell_integration: "Shell Integration",
     section_optional_tools: "Optional Tools",
     section_agent_integrations: "Agent Integrations",
+    section_always_on_service: "Always-on Service",
 }
 
 _SECTION_IDS = {
@@ -3162,6 +3519,7 @@ _SECTION_IDS = {
     section_shell_integration: "shell",
     section_optional_tools: "tools.optional",
     section_agent_integrations: "agents",
+    section_always_on_service: "service",
 }
 
 

--- a/vllm_mlx/headless_service/status.py
+++ b/vllm_mlx/headless_service/status.py
@@ -17,10 +17,15 @@ owner / model / port / healthy / log paths / last launchd exit).
 
 from __future__ import annotations
 
+import contextlib
+import io
+import ipaddress
 import json
 import re
+import socket
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from .common import (
@@ -31,21 +36,58 @@ from .common import (
 from .install import _plist_path, _port_busy
 
 
-def _launchctl_print(label: str) -> str | None:
-    """Raw ``launchctl print <domain>/<label>`` output, or None if the job is
-    not registered."""
+def _launchctl_probe(
+    label: str, *, timeout_s: float = 10
+) -> tuple[str | None, str | None]:
+    """Return launchctl output plus a distinct execution-error description."""
     try:
         result = subprocess.run(
-            ["launchctl", "print", f"{DEFAULT_DOMAIN}/{label}"],
+            ["/bin/launchctl", "print", f"{DEFAULT_DOMAIN}/{label}"],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=timeout_s,
         )
-    except (subprocess.SubprocessError, OSError):
-        return None
-    if result.returncode != 0:
-        return None
-    return result.stdout
+    except (subprocess.SubprocessError, OSError) as exc:
+        return None, f"{type(exc).__name__}: {exc}"
+    if result.returncode == 0:
+        return result.stdout, None
+    stderr = str(getattr(result, "stderr", "") or "").strip()
+    lowered = stderr.lower()
+    if "could not find service" in lowered or "service not found" in lowered:
+        return None, None
+    detail = stderr or "no diagnostic output"
+    return None, f"launchctl exited {result.returncode}: {detail}"
+
+
+def _launchctl_print(label: str, *, timeout_s: float = 10) -> str | None:
+    """Raw ``launchctl print <domain>/<label>`` output, or None if the job is
+    not registered."""
+    return _launchctl_probe(label, timeout_s=timeout_s)[0]
+
+
+def _parse_legacy_serve(argv: object) -> tuple[str, str, str, int]:
+    """Strictly parse a legacy direct-serve definition with the real CLI parser."""
+    if not isinstance(argv, list) or any(not isinstance(item, str) for item in argv):
+        raise ValueError("ProgramArguments must be a string array")
+    if (
+        len(argv) < 3
+        or not Path(argv[0]).is_absolute()
+        or not argv[0].endswith("rapid-mlx")
+    ):
+        raise ValueError("unrecognized legacy service executable")
+    from vllm_mlx.cli import build_parser
+
+    try:
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            parsed = build_parser().parse_args(argv[1:])
+    except SystemExit as exc:
+        raise ValueError("invalid legacy serve arguments") from exc
+    if getattr(parsed, "command", None) != "serve":
+        raise ValueError("legacy definition is not a serve command")
+    return argv[0], parsed.model, parsed.host, parsed.port
 
 
 def _parse_pid(print_out: str | None) -> int | None:
@@ -97,8 +139,14 @@ def _read_installed_plist(label: str) -> dict | None:
         return None
 
 
-def _endpoint_health(host: str, port: int) -> tuple[bool, bool]:
-    """``(live, ready)`` for ``/livez`` and ``/readyz`` over HTTP.
+def _endpoint_health(
+    host: str,
+    port: int,
+    *,
+    timeout_s: float = 2.0,
+    shared_deadline: bool = False,
+) -> tuple[bool | None, bool | None]:
+    """Tri-state ``(live, ready)`` for ``/livez`` and ``/readyz`` over HTTP.
 
     ``live`` = the process is alive (``/livez`` returns 200). ``ready`` = the
     endpoint can accept work (``/readyz`` returns 200 AND ``"ready": true``).
@@ -108,25 +156,264 @@ def _endpoint_health(host: str, port: int) -> tuple[bool, bool]:
     Best-effort via a raw socket GET —
     no external HTTP client dependency.
     """
-    import socket
+    shared_probe_deadline = time.monotonic() + timeout_s
 
-    def _probe_live() -> bool:
+    def probe_deadline() -> float:
+        return (
+            shared_probe_deadline if shared_deadline else time.monotonic() + timeout_s
+        )
+
+    def remaining(deadline: float) -> float:
+        return max(0.001, deadline - time.monotonic())
+
+    def http_status(status_line: bytes) -> int | None:
+        match = re.fullmatch(
+            rb"HTTP/[0-9]+\.[0-9]+ ([0-9]{3})(?: [^\r\n]*)?", status_line
+        )
+        return int(match.group(1)) if match else None
+
+    def chunked_message_complete(body: bytes) -> bool:
+        """Return true once chunk data and the trailer section are complete."""
+        remaining_body = body
+        while True:
+            raw_size, separator, remaining_body = remaining_body.partition(b"\r\n")
+            if not separator:
+                return False
+            try:
+                size = int(raw_size.split(b";", 1)[0], 16)
+            except ValueError:
+                return False
+            if size == 0:
+                return remaining_body == b"\r\n" or b"\r\n\r\n" in remaining_body
+            if (
+                len(remaining_body) < size + 2
+                or remaining_body[size : size + 2] != b"\r\n"
+            ):
+                return False
+            remaining_body = remaining_body[size + 2 :]
+
+    def _probe_live() -> bool | None:
+        deadline = probe_deadline()
         try:
-            with socket.create_connection((host, port), timeout=2.0) as sock:
-                sock.settimeout(2.0)
+            with socket.create_connection(
+                (host, port), timeout=remaining(deadline)
+            ) as sock:
+                sock.settimeout(remaining(deadline))
                 sock.sendall(
                     b"GET /livez HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"
                 )
-                return b"200" in sock.recv(4096).split(b"\r\n", 1)[0]
+                status_data = bytearray()
+                while len(status_data) < 8192 and b"\r\n\r\n" not in status_data:
+                    if time.monotonic() >= deadline:
+                        return None
+                    sock.settimeout(remaining(deadline))
+                    chunk = sock.recv(8192 - len(status_data))
+                    if not chunk:
+                        break
+                    status_data.extend(chunk)
+                status_line = bytes(status_data).split(b"\r\n", 1)[0]
+                status = http_status(status_line)
+                if b"\r\n\r\n" not in status_data or status is None:
+                    return None
+                return status == 200
         except OSError:
-            return False
+            return None
 
-    from .install import _probe_host, _readyz_ready
+    def _probe_ready() -> bool | None:
+        deadline = probe_deadline()
+        try:
+            with socket.create_connection(
+                (host, port), timeout=remaining(deadline)
+            ) as sock:
+                sock.settimeout(remaining(deadline))
+                sock.sendall(
+                    b"GET /readyz HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"
+                )
+                data = bytearray()
+                content_length: int | None = None
+                transfer_codings: list[bytes] = []
+                headers_parsed = False
+                while len(data) < 64 * 1024:
+                    if time.monotonic() >= deadline:
+                        return None
+                    sock.settimeout(remaining(deadline))
+                    chunk = sock.recv(min(4096, 64 * 1024 - len(data)))
+                    if not chunk:
+                        break
+                    data.extend(chunk)
+                    head, separator, body = bytes(data).partition(b"\r\n\r\n")
+                    if separator and not headers_parsed:
+                        headers_parsed = True
+                        for header in head.split(b"\r\n")[1:]:
+                            name, colon, value = header.partition(b":")
+                            header_name = name.strip().lower()
+                            if colon and header_name == b"content-length":
+                                content_length = int(value.strip())
+                            elif colon and header_name == b"transfer-encoding":
+                                transfer_codings.extend(
+                                    coding.strip().lower()
+                                    for coding in value.split(b",")
+                                    if coding.strip()
+                                )
+                    chunked = (
+                        bool(transfer_codings) and transfer_codings[-1] == b"chunked"
+                    )
+                    if (
+                        not chunked
+                        and content_length is not None
+                        and len(body) >= content_length
+                    ):
+                        break
+                    if separator and chunked and chunked_message_complete(body):
+                        break
+        except (OSError, ValueError):
+            return None
+        head, separator, body = bytes(data).partition(b"\r\n\r\n")
+        status = http_status(head.split(b"\r\n", 1)[0])
+        if not separator or status is None:
+            return None
+        if status != 200:
+            return False
+        chunked = bool(transfer_codings) and transfer_codings[-1] == b"chunked"
+        if chunked:
+            decoded = bytearray()
+            terminal_chunk_seen = False
+            try:
+                while body:
+                    raw_size, separator, body = body.partition(b"\r\n")
+                    if not separator:
+                        return None
+                    size = int(raw_size.split(b";", 1)[0], 16)
+                    if size == 0:
+                        if body != b"\r\n":
+                            trailers, trailer_end, remainder = body.partition(
+                                b"\r\n\r\n"
+                            )
+                            if (
+                                not trailer_end
+                                or remainder
+                                or any(
+                                    not name.strip() or not colon
+                                    for line in trailers.split(b"\r\n")
+                                    for name, colon, _value in [line.partition(b":")]
+                                )
+                            ):
+                                return None
+                        terminal_chunk_seen = True
+                        break
+                    if len(body) < size + 2 or body[size : size + 2] != b"\r\n":
+                        return None
+                    decoded.extend(body[:size])
+                    body = body[size + 2 :]
+                if not terminal_chunk_seen:
+                    return None
+                body = bytes(decoded)
+            except ValueError:
+                return None
+        elif content_length is not None:
+            if len(body) < content_length:
+                return None
+            body = body[:content_length]
+        try:
+            payload = json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+            return None
+        if not isinstance(payload, dict) or "ready" not in payload:
+            return None
+        return payload.get("ready") is True
+
+    from .install import _probe_host
 
     probe_host = _probe_host(host)
+    if shared_deadline:
+        if probe_host.lower() == "localhost":
+            probe_host = "127.0.0.1"
+        try:
+            ipaddress.ip_address(probe_host.strip("[]"))
+        except ValueError:
+            return None, None
     if probe_host != host:
         host = probe_host
-    return _probe_live(), _readyz_ready(host, port)
+    return _probe_live(), _probe_ready()
+
+
+def _listener_covers_host(
+    listener: str, configured_host: str, *, resolve_hostnames: bool = False
+) -> bool:
+    listener = listener.strip().removeprefix("[").removesuffix("]")
+    configured = configured_host.strip().removeprefix("[").removesuffix("]")
+    if listener == "*":
+        return True
+    if configured.lower() == "localhost":
+        return listener in {"127.0.0.1", "::1"}
+    try:
+        return ipaddress.ip_address(listener) == ipaddress.ip_address(configured)
+    except ValueError:
+        if not resolve_hostnames:
+            return False
+    try:
+        addresses = {
+            entry[4][0]
+            for entry in socket.getaddrinfo(configured, None, type=socket.SOCK_STREAM)
+        }
+    except OSError:
+        return False
+    return listener in addresses
+
+
+def _pid_listens_on_port(
+    pid: int,
+    host: str,
+    port: int,
+    *,
+    timeout_s: float = 5.0,
+    resolve_hostnames: bool = False,
+) -> bool | None:
+    """Prove that *pid* owns the configured TCP listener; None means unverified."""
+    lsof = Path("/usr/sbin/lsof")
+    if not lsof.is_file():
+        return None
+    try:
+        result = subprocess.run(
+            [
+                str(lsof),
+                "-nP",
+                "-a",
+                "-p",
+                str(pid),
+                f"-iTCP:{port}",
+                "-sTCP:LISTEN",
+                "-Fpn",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode == 0:
+        lines = result.stdout.splitlines()
+        if f"p{pid}" not in lines:
+            return False
+        for line in lines:
+            if not line.startswith("n"):
+                continue
+            endpoint = line[1:].removesuffix(" (LISTEN)")
+            listener, separator, listener_port = endpoint.rpartition(":")
+            if (
+                separator
+                and listener_port == str(port)
+                and _listener_covers_host(
+                    listener, host, resolve_hostnames=resolve_hostnames
+                )
+            ):
+                return True
+        return False
+    stderr = str(getattr(result, "stderr", "") or "").strip()
+    if result.returncode == 1 and not result.stdout.strip() and not stderr:
+        return False
+    return None
 
 
 def collect_status(
@@ -135,9 +422,20 @@ def collect_status(
     user: str | None = None,
     host: str = "127.0.0.1",
     port: int = 8000,
+    probe_timeout_s: float | None = None,
 ) -> dict:
     """Aggregate full service status into a plain dict (JSON-serializable)."""
-    print_out = _launchctl_print(label)
+    deadline = (
+        time.monotonic() + probe_timeout_s if probe_timeout_s is not None else None
+    )
+
+    def remaining(default: float) -> float:
+        return default if deadline is None else max(0.001, deadline - time.monotonic())
+
+    print_out, launchctl_error = _launchctl_probe(
+        label,
+        timeout_s=10 if probe_timeout_s is None else remaining(probe_timeout_s),
+    )
     registered = print_out is not None
     pid = _parse_pid(print_out)
     last_exit = _parse_last_exit(print_out)
@@ -146,20 +444,26 @@ def collect_status(
     runs = int(raw_runs) if raw_runs and raw_runs.isdigit() else None
     plist = _read_installed_plist(label)
 
-    model = port_declared = host_declared = None
+    model = port_declared = host_declared = executable = declared_user = None
     config_file = config_sha256 = config_error = None
+    config_valid = False
+    endpoint_configured = False
     pending_config = False
     credential_configured: bool | None = False
     if plist:
+        declared_user = plist.get("UserName")
         argv = plist.get("ProgramArguments") or []
         # argv shape: [<bin>, "serve", <model>, ...]
-        if len(argv) >= 3 and argv[0].endswith("rapid-mlx") and argv[1] == "serve":
-            model = argv[2] if len(argv) > 2 else None
-            for i, tok in enumerate(argv[:-1]):
-                if tok == "--port" and i + 1 < len(argv):
-                    port_declared = argv[i + 1]
-                if tok == "--host" and i + 1 < len(argv):
-                    host_declared = argv[i + 1]
+        try:
+            legacy_executable, legacy_model, legacy_host, legacy_port = (
+                _parse_legacy_serve(argv)
+            )
+            config_valid = True
+            endpoint_configured = True
+            executable, model = legacy_executable, legacy_model
+            host_declared, port_declared = legacy_host, legacy_port
+        except ValueError as exc:
+            config_error = str(exc)
 
         # New definitions use a stable config-backed launcher. Keep the argv
         # parser above for installations created by the first service release.
@@ -173,14 +477,19 @@ def collect_status(
 
         identity = installed_identity(label)
         if identity is not None:
+            config_valid = False
             config_file = str(identity[2])
+            pending_config = pending_config_path(identity[1], label).is_file()
             try:
                 effective = load_config(identity[2])
+                executable = effective.executable
                 model = effective.model
                 host_declared = effective.host
                 port_declared = effective.port
                 config_sha256 = config_digest(effective)
-                pending_config = pending_config_path(identity[1], label).is_file()
+                config_valid = True
+                endpoint_configured = True
+                config_error = None
                 credential_configured = (
                     private_file_present(Path(effective.credential_file))
                     if effective.credential_file
@@ -189,35 +498,68 @@ def collect_status(
             except Exception as exc:
                 config_error = str(exc)
 
-    # Probe the bind the plist declares (fall back to CLI defaults) — probing
-    # the CLI default while the service actually listens elsewhere would report
-    # a false "down".
-    effective_host = host_declared or host
-    effective_port = int(port_declared) if port_declared else port
-    live, ready = _endpoint_health(effective_host, effective_port)
-
     owner = None
     if pid:
         try:
             out = subprocess.run(
-                ["ps", "-o", "user=", "-p", str(pid)],
+                ["/bin/ps", "-o", "user=", "-p", str(pid)],
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=remaining(5),
             )
             owner = out.stdout.strip() or None
         except (subprocess.SubprocessError, OSError):
             owner = None
 
-    declared_user = plist.get("UserName") if plist else None
+    # Probe ownership before network I/O so a slow endpoint cannot consume the
+    # shared Doctor deadline and make a healthy owner look unverifiable.
+    effective_host = host_declared or host
+    effective_port = int(port_declared) if port_declared else port
+    endpoint_attributable = False
+    if pid and config_valid and endpoint_configured:
+        endpoint_attributable = (
+            _pid_listens_on_port(
+                pid,
+                effective_host,
+                effective_port,
+                timeout_s=remaining(5),
+                resolve_hostnames=probe_timeout_s is None,
+            )
+            is True
+        )
+    if probe_timeout_s is not None and effective_host.lower() != "localhost":
+        try:
+            ipaddress.ip_address(effective_host.strip("[]"))
+        except ValueError:
+            # Persisted configs accept only localhost/numeric loopback binds.
+            # A legacy hostname cannot be resolved inside this synchronous
+            # deadline without risking an unbounded libc DNS call.
+            endpoint_attributable = False
+    if endpoint_attributable:
+        live, ready = (
+            _endpoint_health(effective_host, effective_port)
+            if probe_timeout_s is None
+            else _endpoint_health(
+                effective_host,
+                effective_port,
+                timeout_s=remaining(probe_timeout_s),
+                shared_deadline=True,
+            )
+        )
+    else:
+        live, ready = None, None
+
     effective_user = user or (declared_user if isinstance(declared_user, str) else None)
     log_dir = log_dir_for(effective_user) if effective_user else None
     return {
         "label": label,
         "domain": DEFAULT_DOMAIN,
         "registered": registered,
+        "launchctl_error": launchctl_error,
         "pid": pid,
         "owner": owner,
+        "declared_user": declared_user,
+        "executable": executable,
         "last_exit": last_exit,
         "launchd_state": launchd_state,
         "runs": runs,
@@ -236,6 +578,9 @@ def collect_status(
         "config_file": config_file,
         "config_sha256": config_sha256,
         "config_error": config_error,
+        "config_valid": config_valid,
+        "endpoint_configured": endpoint_configured,
+        "endpoint_attributable": endpoint_attributable,
         "pending_config": pending_config,
         "credential_configured": credential_configured,
     }
@@ -283,8 +628,8 @@ def _render_human(s: dict) -> str:
         lines.append("  authentication:        " + auth_label)
     lines.append(f"  endpoint:              http://{s['host']}:{s['port']}")
     lines.append(
-        f"  health:                livez={'ok' if s['livez'] else 'down'} "
-        f"readyz={'ok' if s['readyz'] else 'down'} "
+        f"  health:                livez={'unknown' if s['livez'] is None else 'ok' if s['livez'] else 'down'} "
+        f"readyz={'unknown' if s['readyz'] is None else 'ok' if s['readyz'] else 'down'} "
         f"port={'open' if s['port_open'] else 'closed'}"
     )
     lines.append(f"  plist:                 {s['plist']}")


### PR DESCRIPTION
## Why

An Always-on Rapid Engine can fail at several independent layers: the plist exists but launchd did not register it; launchd registered it but the child is crash-looping; the child runs as the wrong user; the active config is invalid or differs from a staged candidate; the configured runtime vanished or was upgraded separately; the port is open but the API is not live; or the process is live while its model is still not ready.

`rapid-mlx service status` already collects the underlying facts. This PR makes Doctor reuse that source of truth and translate it into stable, actionable checks instead of building a competing service inspector.

## User value

- One `rapid-mlx doctor` run now follows an installed service from disk definition through launchd, process identity, configuration, runtime, and API readiness.
- A missing optional service does not make an ordinary workstation look unhealthy.
- Crash loops and owner mismatches become confirmed failures with direct log/restart guidance.
- A live but unready endpoint is not mislabeled as a dead service; it remains a warning while a model loads or lazy mode waits.
- CLI/service runtime drift is visible before an operator debugs the wrong Python environment.
- Every service result has a semantic ID for fleet automation and future support bundles.

## Scope

- Add the `service` Doctor section and `--only service` selector.
- Reuse and extend `headless_service.status.collect_status()` rather than duplicate launchd/config/endpoint parsing.
- Diagnose:
  - LaunchDaemon plist presence
  - launchd registration, state, run count, last exit, and suspected crash loop
  - live PID and actual vs declared service account
  - active config validity and pending qualified config
  - configured executable presence and CLI/service Rapid-MLX version drift
  - `/livez` process health and `/readyz` model readiness
- Allow Doctor to request shorter bounded service probe timeouts while retaining existing `service status` defaults.
- Add hermetic service-diagnostic tests and update the CLI reference.

## How to use (website-ready)

The complete Doctor report includes the Always-on section automatically on macOS:

```bash
rapid-mlx doctor
```

For service-only troubleshooting with evidence and remediation hints:

```bash
rapid-mlx doctor --only service --verbose
```

For monitoring, fleet collection, or an agent-managed appliance:

```bash
rapid-mlx doctor --only service --json
```

The service section uses these stable check IDs:

- `service.installation` — optional service absent
- `service.definition` — installed LaunchDaemon plist
- `service.registration` — job registered in the system launchd domain
- `service.process` — live child PID or suspected repeated startup failure
- `service.owner` — process owner matches the configured non-root account
- `service.config` — active configuration parses and validates
- `service.config.pending` — a qualified candidate is staged but not active
- `service.runtime` — configured executable exists and its version matches Doctor
- `service.endpoint.liveness` — `/livez` says the server process can answer
- `service.endpoint.readiness` — `/readyz` says the configured model can serve

Interpretation:

- If neither the plist nor launchd registration exists, Doctor reports the optional service as healthy/not installed.
- Once either exists, a missing counterpart is a failure because the installation is inconsistent.
- No PID with a non-zero prior launchd exit is a confirmed service failure and is labeled as a suspected crash loop.
- A running daemon must declare a non-root service account and `ps` must verify that the live owner matches it; missing, root, unknown, and mismatched owners fail `service.owner`.
- An installed service without a successfully parsed config (qualified config-backed or recognized legacy definition) fails `service.config`; absence of a non-empty executable path independently fails `service.runtime`.
- A launchctl timeout/permission error is `warn`/unverified, not false proof that a job is unregistered or stopped. Legacy direct-serve definitions are accepted only after the complete argv passes the real Rapid-MLX parser.
- A runtime path must be a regular executable file; a present but non-executable binary is confirmed broken. Version comparison reads the runtime venv's validated `rapid-mlx` package metadata and never executes the configured binary.
- Runtime metadata is trusted only when the console script points to the same venv interpreter, exactly one valid Rapid-MLX distribution is installed for that interpreter's Python minor version, and the executable's size/SHA-256 match the wheel `RECORD`; installer wrapper variations remain supported while modified launchers, impostors, and stale active-version metadata remain unverified.
- Pending qualified config is reported even when the active config is malformed, so an operator does not lose sight of a recoverable candidate.
- `/livez` down while a service PID is expected is a failure.
- Endpoint health is attributed only when a live launchd PID, a validated config-sourced bind, and `/usr/sbin/lsof` proof that the same PID owns a listener covering that exact host and port are all present. PID/host/port mismatch or inability to prove ownership leaves both endpoint rows skipped/unverified; Doctor never probes an unrelated process on the configured or fallback address.
- Endpoint results are tri-state: an actual non-200 response or `ready:false` is negative, while timeout, deadline exhaustion, truncated HTTP, invalid JSON, and other probe errors are skipped/unverified rather than false service failures.
- `/livez` healthy but `/readyz` false is a warning: the process is alive, but a model may still be loading or waiting in lazy mode.
- A different service runtime version is a warning. Use the executable path in `--verbose` output to confirm which environment needs upgrade/restart.

Useful follow-ups:

```bash
rapid-mlx service status --json
rapid-mlx service logs --tail 200
rapid-mlx service logs --follow
sudo rapid-mlx service restart
rapid-mlx service config
sudo rapid-mlx service apply
```

Doctor remains read-only: it does not restart launchd, rewrite configuration, load a model, or bind a port.

## Compatibility and risk controls

- macOS only: non-macOS hosts get a neutral row and never call launchd.
- Service status keeps its existing default timeouts; only Doctor requests the shorter budget-aware path.
- The service section is appended after existing sections, preserving their order and IDs.
- Only confirmed inconsistencies exit 1. Pending config, version drift, and live-but-unready remain warnings.
- No credential value is read or emitted; only the existing boolean credential state may be collected.

## Verification

```bash
python -m pytest -q \
  tests/test_doctor_service_health.py \
  tests/test_cli_service.py \
  tests/test_doctor_report_contract.py \
  tests/test_doctor_no_model_load.py \
  tests/test_doctor_env_health.py \
  tests/test_service_config.py
# 594 passed

ruff check vllm_mlx/doctor/env_health.py \
  vllm_mlx/headless_service/status.py vllm_mlx/cli.py \
  tests/test_doctor_service_health.py tests/test_doctor_env_health.py
# All checks passed

python -m coverage run --source=vllm_mlx -m pytest -q \
  tests/test_cli_service.py tests/test_doctor_service_health.py
python -m coverage xml -o /tmp/rapid-pr3235-coverage.xml
python -m diff_cover.diff_cover_tool /tmp/rapid-pr3235-coverage.xml \
  --compare-branch origin/main --show-uncovered --fail-under 100
# 185 passed; 395/395 changed executable lines covered (100%)
```

## Docs / release-note seed

Doctor now understands the Always-on Rapid Engine as one system instead of isolated packages: installed definition → launchd registration → process/user → active config/runtime → liveness/readiness. Use `rapid-mlx doctor --only service --verbose` for interactive troubleshooting and `--json` for automation. Highlight the distinction between liveness and readiness, especially for cold start and lazy loading.

## Stack

Built-On: #3234 (merged)

- #3229 — timeout/unverified import hotfix
- #3234 — structured Doctor report and bounded/selective runner (merged)
- This PR — Always-on service end-to-end diagnosis
- Follow-up — deep probes and verified repairs
