### PR TITLE
test: include speculative metrics in output field order

### DIFF
--- a/.agents/handoffs/vector-generation-output-field-order.md
+++ b/.agents/handoffs/vector-generation-output-field-order.md
@@ -1,0 +1,24 @@
+# Vector handoff: GenerationOutput field-order contract
+
+Owner: Vector
+
+Branch: `fix/generation-output-spec-metrics-order`
+
+Worktree: `/private/tmp/vector-generation-output-field-order`
+
+## Intention
+
+Restore the full-unit baseline after request-scoped MTP telemetry appended
+`spec_decode_metrics` to `GenerationOutput` but the chronological field-order
+test retained the old expected tail.
+
+The runtime/dataclass behavior is already correct. This task changes only the
+test expectation and its diagnostic text. It does not alter the API, telemetry,
+serialization, field order, or MTP behavior.
+
+The failure was reproduced on exact `origin/main` (`42cf53c31`) before the
+change. Planned verification is the focused regression, lint, scoped self
+review, PR validation, and hosted CI.
+
+PR-start FYI delivery to the active Atlas, Harbor, and ds0731 worktrees failed
+with Orca `invalid_argument`; this handoff preserves the same awareness payload.

--- a/tests/test_server_utils.py
+++ b/tests/test_server_utils.py
@@ -1234,7 +1234,8 @@ class TestGenerationOutputFieldOrder:
     def test_field_order_appends_new_fields_at_end(self):
         """Make the rule machine-checkable: new fields added after
         v0.6.65 (``raw_text``, ``reasoning_text``, ``tool_calls``,
-        ``cached_tokens``) must be APPENDED in chronological order at
+        ``cached_tokens``, ``matched_stop``, ``spec_decode_metrics``)
+        must be APPENDED in chronological order at
         the end of the dataclass. If a refactor ever reorders them
         back into the middle, this test fails loud instead of producing
         silent positional-bind regressions for downstream callers that
@@ -1259,10 +1260,15 @@ class TestGenerationOutputFieldOrder:
             # order — anything inserted MID-LIST silently rebinds
             # positional construction for pre-v0.6.65 callers.
             "matched_stop",
+            # Request-scoped speculative telemetry was appended after
+            # ``matched_stop``. Keep it at the tail for the same positional
+            # compatibility guarantee.
+            "spec_decode_metrics",
         ], (
             f"new GenerationOutput fields must be APPENDED in order "
             f"(raw_text → reasoning_text → tool_calls → cached_tokens "
-            f"→ matched_stop) to preserve positional-arg compatibility "
+            f"→ matched_stop → spec_decode_metrics) to preserve "
+            f"positional-arg compatibility "
             f"for the pre-v0.6.65 surface. Current trailing fields "
             f"after ``channel``: {appended}"
         )


### PR DESCRIPTION
## Goal

Restore the full-unit baseline after request-scoped speculative telemetry appended `spec_decode_metrics` to `GenerationOutput` but its chronological positional-compatibility test retained the previous expected tail.

## Change

Update only the test expectation, documentation, and failure message to include `spec_decode_metrics` after `matched_stop`.

## Scope

No runtime, dataclass, field-order, API, serialization, telemetry, or MTP behavior changes.

## Evidence

The focused test failed on exact `origin/main` (`42cf53c31`) before this change because the actual tail correctly ended with `spec_decode_metrics`. After the change:

- `python -m pytest tests/test_server_utils.py::TestGenerationOutputFieldOrder -q` — 3 passed
- Ruff lint and format — passed
- `git diff --check` — passed

This is intentionally separate from #3233 so that performance work does not absorb an unrelated base-test repair.
