### PR TITLE
feat(doctor): add deep probes and verified repairs

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,6 +39,7 @@ rapid-mlx doctor                 # complete human-readable report
 rapid-mlx doctor --verbose       # include evidence and remediation detail
 rapid-mlx doctor --summary       # one line for logs and shell scripts
 rapid-mlx doctor --json          # versioned report for automation/support
+rapid-mlx doctor --deep          # active dependency/DNS/route checks (≤30s)
 ```
 
 The built-in filesystem, network, and subprocess operations carry explicit
@@ -83,9 +84,73 @@ rapid-mlx doctor --only service --verbose
 rapid-mlx doctor --only service --json
 ```
 
-JSON output uses `schemaVersion: 1` and includes the Rapid-MLX version,
+### Deep checks and repairs
+
+The default command remains a five-second, read-only check. Use `--deep` when
+actively troubleshooting an appliance; it allows up to 30 seconds and adds:
+
+- `pip check` in the selected Rapid-MLX runtime, to find incompatible installed
+  dependency versions. Confirmed conflicts are failures; sealed/minimal runtimes
+  without pip are skipped, while operational errors such as permission or
+  interpreter startup failures are warnings rather than false conflicts;
+- DNS resolution for PyPI and Hugging Face, which distinguishes network setup
+  trouble from a broken package;
+- the macOS default-route interface, useful on multi-NIC Mac minis that remain
+  reachable over SSH while their internet route points at a private link.
+
+```bash
+rapid-mlx doctor --deep --verbose
+rapid-mlx doctor --deep --only deep --json
+```
+
+`--fix` implies `--deep` and follows a detect → plan → apply → re-detect flow.
+It only offers repairs that have both a bounded action and an objective health
+verifier. Today, the automated repair is a kickstart of an already-registered
+Always-on service whose process or liveness check failed. Doctor never invokes
+`sudo` itself, never installs packages, and never edits service configuration.
+The read-only deep diagnosis has a 30-second budget. An applied repair has
+separate bounded stages: up to 10 seconds for the command, 20 seconds for
+health verification, and—only after verified recovery—another 30-second deep
+diagnosis. Including the initial diagnosis, the complete successful workflow
+can therefore take up to approximately 90 seconds.
+
+Preview without changing the machine:
+
+```bash
+rapid-mlx doctor --only service --fix --dry-run --verbose
+rapid-mlx doctor --only service --fix --dry-run --json
+```
+
+Apply interactively:
+
+```bash
+sudo rapid-mlx doctor --only service --fix
+```
+
+Answering anything other than `y`/`yes` records the proposal as `not_applied`
+with an operator-declined reason; it does not leave the repair result ambiguous.
+
+Apply explicitly in non-interactive appliance automation:
+
+```bash
+sudo rapid-mlx doctor --only service --fix --yes --json
+```
+
+Without root, Doctor reports the exact `sudo /bin/launchctl ...` command as
+`not_applied`; it does not prompt for or acquire privilege. A zero exit from
+`launchctl` is not enough to claim success: Doctor polls the service again and
+records `verified` only after registration, PID, and `/livez` all recover.
+Otherwise the repair is `failed` or `unverified`, and the original diagnosis
+remains visible. JSON adds a root-level `repairs` array with `id`, `status`,
+`summary`, `command`, and `detail`.
+
+Ordinary JSON output remains `schemaVersion: 1` and includes the Rapid-MLX version,
 overall status (`ok`, `warn`, `fail`, or `skipped`), exit code, total and per-section durations, counts, stable
 section IDs, optional semantic check IDs, and redacted summaries/details.
+Only explicit `--fix --json` output uses schema v2 and adds the root-level
+`repairs` array (empty when no repair was planned or attempted). Existing
+read-only automation can continue consuming schema v1 unchanged; integrations
+that opt into repair mode must support schema v2.
 Legacy checks that do not yet declare a semantic identity return `id: null`;
 consumers must not derive identity from their position or English prose. It
 writes JSON only to stdout. Exit code `0` means no confirmed failure (warnings

--- a/tests/test_doctor_deep_repair.py
+++ b/tests/test_doctor_deep_repair.py
@@ -1,0 +1,578 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in deep probes and detect-plan-repair-verify behavior."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from vllm_mlx.doctor import env_health as eh
+from vllm_mlx.doctor.cli import doctor_command, render, report_document
+from vllm_mlx.doctor.repairs import (
+    RepairAction,
+    RepairResult,
+    apply_repairs,
+    plan_repairs,
+    service_is_live,
+)
+
+
+def test_deep_runtime_reports_dependency_dns_and_route(monkeypatch):
+    monkeypatch.setattr(
+        eh, "_selected_runtime", lambda: (Path("/usr/bin/python3"), False)
+    )
+    monkeypatch.setattr(eh.sys, "platform", "darwin")
+
+    def run(argv, **_kwargs):
+        if argv[-3:] == ["-m", "pip", "check"]:
+            return subprocess.CompletedProcess(
+                argv, 0, "No broken requirements found.\n", ""
+            )
+        if argv[0] == "/sbin/route":
+            return subprocess.CompletedProcess(argv, 0, " interface: en0\n", "")
+        return subprocess.CompletedProcess(argv, 0, "ok\n", "")
+
+    section = eh.section_deep_runtime(run=run)
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["deep.python.pip-check"].status is eh.CheckStatus.OK
+    assert by_id["deep.network.dns"].status is eh.CheckStatus.OK
+    assert "en0" in by_id["deep.network.default-route"].label
+
+
+def test_deep_timeout_is_skipped_not_failure(monkeypatch):
+    monkeypatch.setattr(
+        eh, "_selected_runtime", lambda: (Path("/usr/bin/python3"), False)
+    )
+    monkeypatch.setattr(eh.sys, "platform", "linux")
+
+    def run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(["probe"], 1)
+
+    section = eh.section_deep_runtime(run=run)
+    assert all(check.status is eh.CheckStatus.SKIPPED for check in section.checks)
+
+
+def test_deep_operating_system_errors_are_warnings(monkeypatch):
+    monkeypatch.setattr(
+        eh, "_selected_runtime", lambda: (Path("/usr/bin/python3"), False)
+    )
+    monkeypatch.setattr(eh.sys, "platform", "linux")
+
+    def unavailable(*_args, **_kwargs):
+        raise OSError("operation unavailable")
+
+    section = eh.section_deep_runtime(run=unavailable)
+    by_id = {check.id: check for check in section.checks}
+    assert by_id["deep.python.pip-check"].status is eh.CheckStatus.WARN
+    assert by_id["deep.network.dns"].status is eh.CheckStatus.WARN
+
+
+def test_deep_route_operating_system_error_is_warning(monkeypatch):
+    monkeypatch.setattr(
+        eh, "_selected_runtime", lambda: (Path("/usr/bin/python3"), False)
+    )
+    monkeypatch.setattr(eh.sys, "platform", "darwin")
+
+    def run(argv, **_kwargs):
+        if argv[0] == "/sbin/route":
+            raise OSError("route unavailable")
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    section = eh.section_deep_runtime(run=run)
+    route = next(
+        check for check in section.checks if check.id == "deep.network.default-route"
+    )
+    assert route.status is eh.CheckStatus.WARN
+
+
+def test_only_deep_enables_deep_probe(monkeypatch):
+    calls = []
+
+    def run_all(**kwargs):
+        calls.append(kwargs)
+        return eh.Report()
+
+    monkeypatch.setattr("vllm_mlx.doctor.cli.run_all", run_all)
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=False,
+        summary=True,
+        only=["deep"],
+        skip=None,
+        fix=False,
+        dry_run=False,
+        yes=False,
+        deep=False,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+
+    assert exc.value.code == 0
+    assert calls == [{"only": {"deep"}, "skip": None, "deep": True}]
+
+
+def test_pipless_bundled_runtime_is_skipped_not_dependency_failure(monkeypatch):
+    monkeypatch.setattr(eh, "_selected_runtime", lambda: (Path("/app/python"), True))
+    monkeypatch.setattr(eh, "_bundled_sidecar_root", lambda _runtime: Path("/app"))
+    monkeypatch.setattr(eh, "_runtime_environment", lambda _runtime: "unknown")
+    monkeypatch.setattr(eh.sys, "platform", "linux")
+
+    def run(argv, **_kwargs):
+        if "pip" in argv:
+            return subprocess.CompletedProcess(argv, 1, "", "No module named pip")
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    section = eh.section_deep_runtime(run=run)
+    pip_check = next(c for c in section.checks if c.id == "deep.python.pip-check")
+    assert pip_check.status is eh.CheckStatus.SKIPPED
+
+
+def test_missing_pip_in_normal_runtime_is_warning(monkeypatch):
+    monkeypatch.setattr(
+        eh, "_selected_runtime", lambda: (Path("/usr/local/bin/python3"), False)
+    )
+    monkeypatch.setattr(eh, "_runtime_environment", lambda _runtime: "system")
+    monkeypatch.setattr(eh.sys, "platform", "linux")
+
+    def run(argv, **_kwargs):
+        if "pip" in argv:
+            return subprocess.CompletedProcess(
+                argv, 1, "starting pip", "No module named pip"
+            )
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    pip_check = eh.section_deep_runtime(run=run).checks[0]
+    assert pip_check.status is eh.CheckStatus.WARN
+    assert "starting pip" in pip_check.detail
+    assert "No module named pip" in pip_check.detail
+
+
+def test_pip_check_separates_conflicts_from_operational_failures(monkeypatch):
+    monkeypatch.setattr(
+        eh, "_selected_runtime", lambda: (Path("/usr/bin/python3"), False)
+    )
+    monkeypatch.setattr(eh.sys, "platform", "linux")
+
+    def run_conflict(argv, **_kwargs):
+        if "pip" in argv:
+            return subprocess.CompletedProcess(
+                argv, 1, "demo 1.0 requires missing, which is not installed.\n", ""
+            )
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    conflict = eh.section_deep_runtime(run=run_conflict).checks[0]
+    assert conflict.status is eh.CheckStatus.FAIL
+
+    def run_unsupported(argv, **_kwargs):
+        if "pip" in argv:
+            return subprocess.CompletedProcess(
+                argv, 1, "demo 1.0 is not supported on this platform\n", ""
+            )
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    unsupported = eh.section_deep_runtime(run=run_unsupported).checks[0]
+    assert unsupported.status is eh.CheckStatus.FAIL
+
+    def run_bad_metadata(argv, **_kwargs):
+        if "pip" in argv:
+            return subprocess.CompletedProcess(
+                argv, 1, "", "WARNING: Error parsing dependencies of demo: bad metadata"
+            )
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    bad_metadata = eh.section_deep_runtime(run=run_bad_metadata).checks[0]
+    assert bad_metadata.status is eh.CheckStatus.FAIL
+
+    def run_operational_failure(argv, **_kwargs):
+        if "pip" in argv:
+            return subprocess.CompletedProcess(argv, 1, "", "permission denied")
+        return subprocess.CompletedProcess(argv, 0, "ok", "")
+
+    operational = eh.section_deep_runtime(run=run_operational_failure).checks[0]
+    assert operational.status is eh.CheckStatus.WARN
+
+
+def _service_report(*, process=eh.CheckStatus.FAIL, live=eh.CheckStatus.FAIL):
+    section = eh.Section("Always-on Service", id="service")
+    section.add("registered", eh.CheckStatus.OK, check_id="service.registration")
+    section.add("process", process, check_id="service.process")
+    section.add("live", live, check_id="service.endpoint.liveness")
+    return eh.Report(sections=[section])
+
+
+def test_repair_plan_only_targets_registered_unhealthy_service():
+    actions = plan_repairs(_service_report())
+    assert [action.id for action in actions] == ["repair.service.kickstart"]
+    assert actions[0].command[0] == "/bin/launchctl"
+
+    healthy = _service_report(process=eh.CheckStatus.OK, live=eh.CheckStatus.OK)
+    assert plan_repairs(healthy) == []
+
+
+def test_repair_dry_run_never_executes():
+    action = plan_repairs(_service_report())
+
+    def must_not_run(*_args, **_kwargs):
+        raise AssertionError("dry-run executed a command")
+
+    result = apply_repairs(action, dry_run=True, run=must_not_run)
+    assert result[0].status == "planned"
+
+
+def test_declined_interactive_repair_is_recorded(monkeypatch, capsys):
+    class InteractiveInput(io.StringIO):
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(
+        "vllm_mlx.doctor.cli.run_all", lambda **_kwargs: _service_report()
+    )
+    monkeypatch.setattr("vllm_mlx.doctor.cli.sys.stdin", InteractiveInput("no\n"))
+    monkeypatch.setattr(
+        "vllm_mlx.doctor.repairs.plan_repairs",
+        lambda _report: [
+            RepairAction(
+                id="repair.test",
+                summary="token=secret-value",
+                command=("/bin/launchctl", "password=hunter2"),
+            )
+        ],
+    )
+
+    def must_not_apply(*_args, **_kwargs):
+        raise AssertionError("declined repair was applied")
+
+    monkeypatch.setattr("vllm_mlx.doctor.repairs.apply_repairs", must_not_apply)
+    args = Namespace(
+        tier=None,
+        verbose=True,
+        json=False,
+        summary=False,
+        only=["service"],
+        skip=None,
+        fix=True,
+        dry_run=False,
+        yes=False,
+        deep=False,
+    )
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+
+    assert exc.value.code == 1
+    rendered = capsys.readouterr()
+    assert "not_applied" in rendered.out
+    assert "operator declined" in rendered.out
+    assert "secret-value" not in rendered.out + rendered.err
+    assert "hunter2" not in rendered.out + rendered.err
+
+
+def test_fix_json_uses_schema_v2_even_when_no_action_is_needed(monkeypatch, capsys):
+    healthy = _service_report(process=eh.CheckStatus.OK, live=eh.CheckStatus.OK)
+    monkeypatch.setattr(
+        "vllm_mlx.doctor.cli._collect_report_isolated", lambda **_kwargs: healthy
+    )
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=True,
+        summary=False,
+        only=["service"],
+        skip=None,
+        fix=True,
+        dry_run=False,
+        yes=True,
+        deep=False,
+    )
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+
+    assert exc.value.code == 0
+    document = json.loads(capsys.readouterr().out)
+    assert document["schemaVersion"] == 2
+    assert document["repairs"] == []
+
+
+def test_noninteractive_fix_requires_yes_before_diagnosis(monkeypatch):
+    monkeypatch.setattr("vllm_mlx.doctor.cli.sys.stdin", io.StringIO())
+    monkeypatch.setattr(
+        "vllm_mlx.doctor.cli._collect_report_isolated",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("diagnosis ran before authorization")
+        ),
+    )
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=True,
+        summary=False,
+        only=["service"],
+        skip=None,
+        fix=True,
+        dry_run=False,
+        yes=False,
+        deep=False,
+    )
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("flag", ["dry_run", "yes"])
+def test_repair_only_flags_require_fix(flag, capsys):
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=False,
+        summary=False,
+        only=None,
+        skip=None,
+        fix=False,
+        dry_run=flag == "dry_run",
+        yes=flag == "yes",
+        deep=False,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+
+    assert exc.value.code == 2
+    assert "requires --fix" in capsys.readouterr().err
+
+
+def test_verified_repair_triggers_fresh_deep_report(monkeypatch, capsys):
+    reports = iter([_service_report(), eh.Report()])
+    collections = []
+
+    def collect(**kwargs):
+        collections.append(kwargs)
+        return next(reports)
+
+    monkeypatch.setattr("vllm_mlx.doctor.cli._collect_report_isolated", collect)
+    monkeypatch.setattr(
+        "vllm_mlx.doctor.repairs.plan_repairs",
+        lambda _report: [
+            RepairAction(
+                id="repair.test",
+                summary="restart service",
+                command=("/bin/launchctl", "kickstart", "service"),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.doctor.repairs.apply_repairs",
+        lambda *_args, **_kwargs: [
+            RepairResult(
+                id="repair.test",
+                status="verified",
+                summary="restart service",
+                command=["/bin/launchctl", "kickstart", "service"],
+                detail="verification passed",
+            )
+        ],
+    )
+    args = Namespace(
+        tier=None,
+        verbose=False,
+        json=True,
+        summary=False,
+        only=["service"],
+        skip=None,
+        fix=True,
+        dry_run=False,
+        yes=True,
+        deep=False,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        doctor_command(args)
+
+    assert exc.value.code == 0
+    assert [call["deep"] for call in collections] == [True, True]
+    document = json.loads(capsys.readouterr().out)
+    assert document["schemaVersion"] == 2
+    assert document["repairs"][0]["status"] == "verified"
+
+
+def test_repair_never_invokes_sudo_implicitly():
+    action = plan_repairs(_service_report())
+
+    def must_not_run(*_args, **_kwargs):
+        raise AssertionError("non-root repair executed a command")
+
+    result = apply_repairs(action, run=must_not_run, geteuid=lambda: 501)
+    assert result[0].status == "not_applied"
+    assert result[0].command[0] == "sudo"
+
+
+def test_repair_is_success_only_after_verification():
+    action = plan_repairs(_service_report())
+    probes = iter((False, True))
+
+    def run(argv, **_kwargs):
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    result = apply_repairs(
+        action,
+        run=run,
+        geteuid=lambda: 0,
+        verify_service=lambda: next(probes),
+        sleep=lambda _seconds: None,
+    )
+    assert result[0].status == "verified"
+    assert "passed" in result[0].detail
+
+
+def test_repair_command_success_without_health_is_unverified(monkeypatch):
+    action = plan_repairs(_service_report())
+    clock = iter((0.0, 0.0, 1.0, 1.0))
+    monkeypatch.setattr("vllm_mlx.doctor.repairs.time.monotonic", lambda: next(clock))
+
+    def run(argv, **_kwargs):
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    result = apply_repairs(
+        action,
+        run=run,
+        geteuid=lambda: 0,
+        verify_service=lambda: False,
+        sleep=lambda _seconds: None,
+        verify_timeout_s=1.0,
+    )
+    assert result[0].status == "unverified"
+
+
+def test_repair_without_verifier_or_with_crashing_verifier_is_unverified(monkeypatch):
+    action = plan_repairs(_service_report())
+    run = lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0, "", "")
+
+    missing = apply_repairs(action, run=run, geteuid=lambda: 0)
+    assert missing[0].status == "unverified"
+
+    clock = iter((0.0, 0.0, 1.0, 1.0))
+    monkeypatch.setattr("vllm_mlx.doctor.repairs.time.monotonic", lambda: next(clock))
+    crashing = apply_repairs(
+        action,
+        run=run,
+        geteuid=lambda: 0,
+        verify_service=lambda: (_ for _ in ()).throw(RuntimeError("probe failed")),
+        sleep=lambda _seconds: None,
+        verify_timeout_s=1.0,
+    )
+    assert crashing[0].status == "unverified"
+    assert "RuntimeError: probe failed" in crashing[0].detail
+
+
+def test_repair_nonzero_without_output_has_actionable_detail():
+    action = plan_repairs(_service_report())
+    result = apply_repairs(
+        action,
+        run=lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 7, "", ""),
+        geteuid=lambda: 0,
+    )
+    assert result[0].status == "failed"
+    assert "status 7" in result[0].detail
+
+
+def test_repair_execution_error_is_failed():
+    action = plan_repairs(_service_report())
+
+    def unavailable(*_args, **_kwargs):
+        raise OSError("launchctl unavailable")
+
+    result = apply_repairs(action, run=unavailable, geteuid=lambda: 0)
+    assert result[0].status == "failed"
+    assert "launchctl unavailable" in result[0].detail
+
+
+def test_repair_retries_after_transient_verifier_exception():
+    action = plan_repairs(_service_report())
+    probes = iter((RuntimeError("not ready"), True))
+
+    def verify():
+        result = next(probes)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    result = apply_repairs(
+        action,
+        run=lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0, "", ""),
+        geteuid=lambda: 0,
+        verify_service=verify,
+        sleep=lambda _seconds: None,
+    )
+    assert result[0].status == "verified"
+
+
+def test_service_verifier_requires_registration_pid_and_liveness(monkeypatch):
+    healthy = {"registered": True, "pid": 42, "livez": True}
+    status = dict(healthy)
+    monkeypatch.setattr(
+        "vllm_mlx.headless_service.status.collect_status", lambda **_kwargs: status
+    )
+    assert service_is_live() is True
+
+    for missing in ("registered", "pid", "livez"):
+        value = dict(healthy)
+        value[missing] = None
+        status.clear()
+        status.update(value)
+        assert service_is_live() is False
+
+    for invalid_pid in (True, 0, -1, "42"):
+        status.clear()
+        status.update(healthy, pid=invalid_pid)
+        assert service_is_live() is False
+
+    status.clear()
+    status.update(healthy, livez={"error": "timeout"})
+    assert service_is_live() is False
+
+
+def test_repair_json_redacts_result_strings():
+    report = eh.Report(
+        repairs=[
+            {
+                "id": "repair.test",
+                "status": "failed",
+                "summary": "token=secret-value",
+                "command": ["tool", "password=hunter2"],
+                "detail": "/Users/tester token=another-secret",
+            }
+        ]
+    )
+
+    document = report_document(report)
+    assert document["schemaVersion"] == 2
+    rendered = str(document["repairs"])
+    assert "secret-value" not in rendered
+    assert "hunter2" not in rendered
+    assert "another-secret" not in rendered
+
+
+def test_repair_human_output_redacts_result_strings():
+    report = eh.Report(
+        repairs=[
+            {
+                "id": "repair.test",
+                "status": "failed",
+                "summary": "token=secret-value",
+                "command": ["tool", "password=hunter2"],
+                "detail": "token=another-secret",
+            }
+        ]
+    )
+    output = io.StringIO()
+    render(report, verbose=True, stream=output)
+
+    rendered = output.getvalue()
+    assert "secret-value" not in rendered
+    assert "hunter2" not in rendered
+    assert "another-secret" not in rendered

--- a/tests/test_doctor_report_contract.py
+++ b/tests/test_doctor_report_contract.py
@@ -614,7 +614,7 @@ def test_json_process_isolation_collects_in_fresh_executable(monkeypatch):
 
 def _run_json_worker(tmp_path, monkeypatch, request, *, result_parent=True):
     request_path = tmp_path / "request.json"
-    request_path.write_text(json.dumps(request))
+    request_path.write_text(json.dumps({"deep": False, **request}))
     result_root = tmp_path if result_parent else tmp_path / "missing"
     result_path = result_root / "report.json"
     keepalive_read, keepalive_write = os.pipe()
@@ -673,6 +673,19 @@ def test_json_worker_serializes_invalid_request_fields_as_error(tmp_path, monkey
     message = json.loads(result_path.read_text())
     assert message["ok"] is False
     assert "request fields are invalid" in message["error"]
+
+
+def test_json_worker_rejects_non_boolean_deep_flag(tmp_path, monkeypatch):
+    exit_code, result_path = _run_json_worker(
+        tmp_path,
+        monkeypatch,
+        {"only": None, "skip": None, "deep": "yes"},
+    )
+
+    assert exit_code == 0
+    message = json.loads(result_path.read_text())
+    assert message["ok"] is False
+    assert "deep flag is invalid" in message["error"]
 
 
 def test_json_worker_argument_and_write_failures(tmp_path, monkeypatch):

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -13035,6 +13035,29 @@ Examples:
         action="store_true",
         help="Print only the one-line result summary",
     )
+    doctor_parser.add_argument(
+        "--deep",
+        action="store_true",
+        help="Run opt-in dependency, DNS, and route probes (up to 30 seconds)",
+    )
+    doctor_parser.add_argument(
+        "--fix",
+        action="store_true",
+        help=(
+            "Plan and apply only verified repairs (bounded stages may total "
+            "up to 90 seconds)"
+        ),
+    )
+    doctor_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="With --fix, print the repair plan without making changes",
+    )
+    doctor_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="With --fix, accept the repair plan non-interactively",
+    )
     doctor_section_ids = (
         "system",
         "python",
@@ -13047,6 +13070,7 @@ Examples:
         "tools.optional",
         "agents",
         "service",
+        "deep",
     )
     doctor_parser.add_argument(
         "--only",

--- a/vllm_mlx/doctor/__init__.py
+++ b/vllm_mlx/doctor/__init__.py
@@ -10,7 +10,7 @@ never loads a model, boots a server, or runs benchmarks.
 Model-validation tiers that used to live here (``smoke / check / full /
 benchmark``) moved to ``rapid-mlx bench --tier ...`` as of v0.7.22.
 
-Entry point: ``rapid-mlx doctor [--verbose|--json|--summary]``.
+Entry point: ``rapid-mlx doctor [--verbose|--json|--summary|--deep|--fix]``.
 
 Exit codes:
   0 — everything ok, skipped, or only warnings

--- a/vllm_mlx/doctor/cli.py
+++ b/vllm_mlx/doctor/cli.py
@@ -123,7 +123,11 @@ def _open_collector_pipes() -> tuple[int, int, int, int]:
 
 
 def _collect_report_isolated(
-    *, only: set[str] | None, skip: set[str] | None, timeout_s: float = 8.0
+    *,
+    only: set[str] | None,
+    skip: set[str] | None,
+    deep: bool = False,
+    timeout_s: float = 8.0,
 ) -> Report:
     """Collect a report in a fresh executable whose stdout is discarded."""
     with tempfile.TemporaryDirectory(prefix="rapid-mlx-doctor-") as result_dir:
@@ -134,6 +138,7 @@ def _collect_report_isolated(
                 {
                     "only": None if only is None else sorted(only),
                     "skip": None if skip is None else sorted(skip),
+                    "deep": deep,
                 }
             ),
             encoding="utf-8",
@@ -405,16 +410,91 @@ def doctor_command(args: Any) -> None:
     raw_skip = getattr(args, "skip", None)
     only = None if raw_only is None else set(raw_only)
     skip = None if raw_skip is None else set(raw_skip)
+    fix = bool(getattr(args, "fix", False))
+    dry_run = bool(getattr(args, "dry_run", False))
+    assume_yes = bool(getattr(args, "yes", False))
+    # Selecting the deep section is itself an explicit opt-in. Without this,
+    # ``--only deep`` filters out every normal builder while never registering
+    # the deep builder, producing an empty successful report.
+    deep = bool(getattr(args, "deep", False) or fix or (only and "deep" in only))
 
-    if json_output:
-        # A disposable child contains Python/native/subprocess chatter and any
-        # writer threads a dependency may start. Only the Report crosses back.
-        try:
-            report = _collect_report_isolated(only=only, skip=skip)
-        except Exception as exc:  # noqa: BLE001 - preserve JSON output contract
-            report = _collection_failure_report(exc)
-    else:
-        report = run_all(only=only, skip=skip)
+    if dry_run and not fix:
+        print("error: --dry-run requires --fix", file=sys.stderr)
+        sys.exit(2)
+    if assume_yes and not fix:
+        print("error: --yes requires --fix", file=sys.stderr)
+        sys.exit(2)
+    if fix and not dry_run and not assume_yes and not sys.stdin.isatty():
+        print(
+            "error: --fix needs interactive confirmation or explicit --yes",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    def collect_report(*, force_deep: bool = False) -> Report:
+        use_deep = deep or force_deep
+
+        def operation() -> Report:
+            return (
+                run_all(only=only, skip=skip, deep=True)
+                if use_deep
+                else run_all(only=only, skip=skip)
+            )
+
+        if json_output:
+            try:
+                return _collect_report_isolated(
+                    only=only,
+                    skip=skip,
+                    deep=use_deep,
+                    timeout_s=35.0 if use_deep else 8.0,
+                )
+            except Exception as exc:  # noqa: BLE001 - preserve JSON contract
+                return _collection_failure_report(exc)
+        return operation()
+
+    def execute() -> Report:
+        nonlocal assume_yes
+        report = collect_report()
+        if fix:
+            report.schema_version = 2
+            from .repairs import apply_repairs, plan_repairs, service_is_live
+
+            actions = plan_repairs(report)
+            if actions and not dry_run and not assume_yes:
+                print("Doctor proposes:", file=sys.stderr)
+                for action in actions:
+                    print(f"  - {_redact(action.summary)}", file=sys.stderr)
+                    command = " ".join(_redact(argument) for argument in action.command)
+                    print(f"    {command}", file=sys.stderr)
+                print(
+                    "Apply these repairs? [y/N] ", end="", file=sys.stderr, flush=True
+                )
+                assume_yes = sys.stdin.readline().strip().lower() in {"y", "yes"}
+                if not assume_yes:
+                    report.repairs = [
+                        {
+                            "id": action.id,
+                            "status": "not_applied",
+                            "summary": action.summary,
+                            "command": list(action.command),
+                            "detail": "operator declined the proposed repair",
+                        }
+                        for action in actions
+                    ]
+            if actions and (dry_run or assume_yes):
+                results = apply_repairs(
+                    actions,
+                    dry_run=dry_run,
+                    verify_service=service_is_live,
+                )
+                if any(result.status == "verified" for result in results):
+                    report = collect_report(force_deep=True)
+                    report.schema_version = 2
+                report.repairs = [result.to_dict() for result in results]
+        return report
+
+    report = execute()
     if json_output:
         render_json(report)
     elif summary_only:
@@ -445,6 +525,15 @@ def render(report: Report, *, verbose: bool = False, stream=None) -> None:
         write("\n")
 
     _render_summary(report, write=write, verbose=verbose)
+    if report.repairs:
+        write("\nRepairs:\n")
+        for repair in report.repairs:
+            status = _redact(str(repair["status"]))
+            summary = _redact(str(repair["summary"]))
+            command = " ".join(_redact(str(item)) for item in repair["command"])
+            write(f"  {status}: {summary} ({command})\n")
+            if verbose and repair.get("detail"):
+                write(f"      ↳ {_redact(str(repair['detail']))}\n")
 
 
 def _redact(value: str) -> str:
@@ -534,8 +623,9 @@ def _contains_unescaped_quote(value: str, quote: str) -> bool:
 
 def report_document(report: Report) -> dict[str, Any]:
     """Return the versioned, redacted machine-readable Doctor contract."""
-    return {
-        "schemaVersion": 1,
+    schema_version = 2 if report.repairs else report.schema_version
+    document = {
+        "schemaVersion": schema_version,
         "rapidMlxVersion": __version__,
         "status": report.overall_status,
         "exitCode": report.exit_code,
@@ -564,6 +654,24 @@ def report_document(report: Report) -> dict[str, Any]:
             for section in report.sections
         ],
     }
+    if schema_version >= 2:
+        document["repairs"] = [
+            {
+                key: (
+                    _redact(value)
+                    if isinstance(value, str)
+                    else [
+                        _redact(item) if isinstance(item, str) else item
+                        for item in value
+                    ]
+                    if isinstance(value, list)
+                    else value
+                )
+                for key, value in repair.items()
+            }
+            for repair in report.repairs
+        ]
+    return document
 
 
 def render_json(report: Report, *, stream=None) -> None:

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -101,6 +101,8 @@ class Section:
 class Report:
     sections: list[Section] = field(default_factory=list)
     duration_ms: int = 0
+    repairs: list[dict[str, Any]] = field(default_factory=list)
+    schema_version: int = 1
 
     def all_checks(self) -> list[Check]:
         return [c for s in self.sections for c in s.checks]
@@ -280,6 +282,7 @@ _RUNTIME_OVERRIDE_REPAIR_HINT_TEMPLATE = (
     "sidecar), then remove {root} and relaunch so the bundled sidecar is used"
 )
 _DOCTOR_BUDGET_S = 5.0
+_DOCTOR_DEEP_BUDGET_S = 30.0
 # Leave enough scheduling-budget headroom for subprocess timeout cleanup, report
 # assembly, and CLI rendering.  ``subprocess.run(timeout=...)`` only starts
 # terminating the child at its timeout and can return a few milliseconds
@@ -743,7 +746,7 @@ def _runtime_python_path() -> Path:
 
 
 def _selected_runtime() -> tuple[Path, bool]:
-    """Return the cached runtime selection for one doctor invocation."""
+    """Return ``(runtime, selected_from_running_server)`` for this invocation."""
     global _SELECTED_RUNTIME, _RUNTIME_SELECTION_DONE
     if not _RUNTIME_SELECTION_DONE:
         _SELECTED_RUNTIME = _runtime_python_path()
@@ -3461,6 +3464,153 @@ def section_always_on_service(
     return section
 
 
+def section_deep_runtime(
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> Section:
+    """Opt-in active probes that are too expensive for the default Doctor."""
+    section = Section("Deep Diagnostics")
+    runtime, _selected_from_running_server = _selected_runtime()
+    pip_optional = _bundled_sidecar_root(runtime) is not None or (
+        _runtime_environment(runtime)
+        in {"desktop sidecar", "Rapid-MLX application environment"}
+    )
+    try:
+        result = run(
+            [str(runtime), "-m", "pip", "check"],
+            capture_output=True,
+            text=True,
+            timeout=_bounded_timeout(10.0),
+            check=False,
+        )
+        detail = "\n".join(
+            output.strip()
+            for output in (result.stdout, result.stderr)
+            if output and output.strip()
+        )
+        if result.returncode != 0 and "No module named pip" in detail:
+            section.add(
+                "Python dependency graph check is unavailable in this runtime",
+                CheckStatus.SKIPPED if pip_optional else CheckStatus.WARN,
+                detail=(
+                    f"{runtime} is a sealed application runtime without pip; "
+                    f"output={detail}"
+                    if pip_optional
+                    else f"{runtime} unexpectedly has no pip module; output={detail}"
+                ),
+                check_id="deep.python.pip-check",
+            )
+        else:
+            healthy = result.returncode == 0
+            validation_patterns = (
+                r"(?m)^.+ requires .+, which is not installed\.$",
+                r"(?m)^.+ has requirement .+, but you have .+\.$",
+                r"(?m)^.+ is not supported on this platform$",
+                r"(?im)^.*error parsing dependencies of .+$",
+            )
+            conflict = result.returncode == 1 and any(
+                re.search(pattern, detail) for pattern in validation_patterns
+            )
+            section.add(
+                "Python dependency graph is consistent"
+                if healthy
+                else (
+                    "Python dependency graph has conflicts"
+                    if conflict
+                    else "Python dependency graph check could not complete"
+                ),
+                CheckStatus.OK
+                if healthy
+                else CheckStatus.FAIL
+                if conflict
+                else CheckStatus.WARN,
+                detail=detail or f"runtime={runtime}",
+                check_id="deep.python.pip-check",
+            )
+    except subprocess.TimeoutExpired:
+        section.add(
+            "Python dependency graph check timed out",
+            CheckStatus.SKIPPED,
+            detail=f"runtime={runtime}",
+            check_id="deep.python.pip-check",
+        )
+    except OSError as exc:
+        section.add(
+            "Python dependency graph could not be checked",
+            CheckStatus.WARN,
+            detail=str(exc),
+            check_id="deep.python.pip-check",
+        )
+
+    dns_script = (
+        "import socket; "
+        "[socket.getaddrinfo(h, 443, type=socket.SOCK_STREAM) "
+        "for h in ('pypi.org', 'huggingface.co')]; print('ok')"
+    )
+    try:
+        result = run(
+            [str(runtime), "-I", "-c", dns_script],
+            capture_output=True,
+            text=True,
+            timeout=_bounded_timeout(5.0),
+            check=False,
+        )
+        section.add(
+            "Package and model hosts resolve through DNS"
+            if result.returncode == 0
+            else "DNS resolution failed for a package or model host",
+            CheckStatus.OK if result.returncode == 0 else CheckStatus.WARN,
+            detail=(result.stderr or result.stdout).strip(),
+            check_id="deep.network.dns",
+        )
+    except subprocess.TimeoutExpired:
+        section.add(
+            "DNS resolution check timed out",
+            CheckStatus.SKIPPED,
+            detail="pypi.org and huggingface.co were not classified as broken",
+            check_id="deep.network.dns",
+        )
+    except OSError as exc:
+        section.add(
+            "DNS resolution could not be checked",
+            CheckStatus.WARN,
+            detail=str(exc),
+            check_id="deep.network.dns",
+        )
+
+    if sys.platform == "darwin":
+        try:
+            route = run(
+                ["/sbin/route", "-n", "get", "default"],
+                capture_output=True,
+                text=True,
+                timeout=_bounded_timeout(2.0),
+                check=False,
+            )
+            match = re.search(r"^\s*interface:\s*(\S+)", route.stdout, re.MULTILINE)
+            interface = match.group(1) if match else None
+            section.add(
+                f"default network route uses {interface}"
+                if route.returncode == 0 and interface
+                else "default network route could not be identified",
+                CheckStatus.OK
+                if route.returncode == 0 and interface
+                else CheckStatus.WARN,
+                detail=(
+                    "multi-NIC appliances should keep the internet-facing service first in macOS network service order"
+                ),
+                check_id="deep.network.default-route",
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            section.add(
+                "default network route could not be checked",
+                CheckStatus.WARN,
+                detail=str(exc),
+                check_id="deep.network.default-route",
+            )
+    return section
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -3522,6 +3672,10 @@ _SECTION_IDS = {
     section_always_on_service: "service",
 }
 
+_DEEP_SECTION_BUILDERS = (section_deep_runtime,)
+_SECTION_TITLES[section_deep_runtime] = "Deep Diagnostics"
+_SECTION_IDS[section_deep_runtime] = "deep"
+
 
 def _builder_id(builder: Callable[[], Section]) -> str:
     return _SECTION_IDS.get(
@@ -3543,23 +3697,30 @@ def _finish_section(
 
 
 def _selected_section_builders(
-    *, only: set[str] | None = None, skip: set[str] | None = None
+    *,
+    only: set[str] | None = None,
+    skip: set[str] | None = None,
+    deep: bool = False,
 ) -> tuple[Callable[[], Section], ...]:
     skipped_ids = skip or set()
+    available_builders = _SECTION_BUILDERS + (_DEEP_SECTION_BUILDERS if deep else ())
     return tuple(
         builder
-        for builder in _SECTION_BUILDERS
+        for builder in available_builders
         if (only is None or _builder_id(builder) in only)
         and _builder_id(builder) not in skipped_ids
     )
 
 
 def _budget_exhausted_report(
-    *, only: set[str] | None = None, skip: set[str] | None = None
+    *,
+    only: set[str] | None = None,
+    skip: set[str] | None = None,
+    deep: bool = False,
 ) -> Report:
     report = Report()
     _append_budget_exhausted_sections(
-        report, _selected_section_builders(only=only, skip=skip)
+        report, _selected_section_builders(only=only, skip=skip, deep=deep)
     )
     return report
 
@@ -3589,6 +3750,7 @@ def _run_all_serialized(
     *,
     only: set[str] | None = None,
     skip: set[str] | None = None,
+    deep: bool = False,
 ) -> Report:
     """Run every section and return the aggregate report.
 
@@ -3609,9 +3771,9 @@ def _run_all_serialized(
         _RUNTIME_IMPORT_TIMEOUTS.clear()
         _RUNTIME_DISTRIBUTION_CACHE.clear()
         _RUNTIME_CONTEXTS.clear()
-        selected_builders = _selected_section_builders(only=only, skip=skip)
+        selected_builders = _selected_section_builders(only=only, skip=skip, deep=deep)
         if time.monotonic() >= _DOCTOR_DEADLINE:
-            return _budget_exhausted_report(only=only, skip=skip)
+            return _budget_exhausted_report(only=only, skip=skip, deep=deep)
         if not selected_builders:
             return report
         runtime_selected = False
@@ -3698,6 +3860,7 @@ def run_all(
     *,
     only: set[str] | None = None,
     skip: set[str] | None = None,
+    deep: bool = False,
 ) -> Report:
     """Run a cooperatively budgeted probe set; serialize shared probe caches.
 
@@ -3706,17 +3869,18 @@ def run_all(
     layer; library callers simply receive an empty report for no matches.
     """
     started_at = time.monotonic()
-    caller_deadline = time.monotonic() + (
-        _DOCTOR_BUDGET_S - _DOCTOR_COMPLETION_HEADROOM_S
-    )
+    budget_s = _DOCTOR_DEEP_BUDGET_S if deep else _DOCTOR_BUDGET_S
+    caller_deadline = time.monotonic() + (budget_s - _DOCTOR_COMPLETION_HEADROOM_S)
     remaining = max(0.0, caller_deadline - time.monotonic())
     if not _DOCTOR_RUN_LOCK.acquire(timeout=remaining):
-        report = _budget_exhausted_report(only=only, skip=skip)
+        report = _budget_exhausted_report(only=only, skip=skip, deep=deep)
         report.duration_ms = max(0, round((time.monotonic() - started_at) * 1000))
         return report
     try:
-        if only is not None or skip:
-            report = _run_all_serialized(caller_deadline, only=only, skip=skip)
+        if only is not None or skip or deep:
+            report = _run_all_serialized(
+                caller_deadline, only=only, skip=skip, deep=deep
+            )
         else:
             # Preserve the one-argument internal seam used by downstream
             # embedders and older test doubles.

--- a/vllm_mlx/doctor/json_worker.py
+++ b/vllm_mlx/doctor/json_worker.py
@@ -34,11 +34,14 @@ def main(argv: list[str] | None = None) -> int:
     staging_path = result_path.with_suffix(".json.tmp")
     try:
         request = json.loads(request_path.read_text(encoding="utf-8"))
-        if not isinstance(request, dict) or set(request) != {"only", "skip"}:
+        if not isinstance(request, dict) or set(request) != {"only", "skip", "deep"}:
             raise TypeError("request fields are invalid")
+        if not isinstance(request["deep"], bool):
+            raise TypeError("deep flag is invalid")
         report = run_all(
             only=_selection(request, "only"),
             skip=_selection(request, "skip"),
+            deep=request["deep"],
         )
         message: dict[str, object] = {"ok": True, "report": report_document(report)}
     except Exception as exc:  # noqa: BLE001 - parent renders schema-valid failure

--- a/vllm_mlx/doctor/repairs.py
+++ b/vllm_mlx/doctor/repairs.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Conservative Doctor repair planning and post-action verification."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+
+from .env_health import CheckStatus, Report
+
+
+@dataclass(frozen=True)
+class RepairAction:
+    id: str
+    summary: str
+    command: tuple[str, ...]
+    requires_root: bool = False
+
+
+@dataclass(frozen=True)
+class RepairResult:
+    id: str
+    status: str
+    summary: str
+    command: list[str]
+    detail: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def plan_repairs(report: Report) -> list[RepairAction]:
+    """Return only repairs with a bounded action and objective verifier."""
+    checks = {check.id: check for check in report.all_checks()}
+    registration = checks.get("service.registration")
+    process = checks.get("service.process")
+    liveness = checks.get("service.endpoint.liveness")
+    unhealthy = any(
+        check is not None and check.status is CheckStatus.FAIL
+        for check in (process, liveness)
+    )
+    if unhealthy and registration is not None and registration.status is CheckStatus.OK:
+        return [
+            RepairAction(
+                id="repair.service.kickstart",
+                summary="restart the registered Always-on service",
+                command=(
+                    "/bin/launchctl",
+                    "kickstart",
+                    "-k",
+                    "system/com.rapidmlx.server",
+                ),
+                requires_root=True,
+            )
+        ]
+    return []
+
+
+def apply_repairs(
+    actions: list[RepairAction],
+    *,
+    dry_run: bool = False,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    geteuid: Callable[[], int] = os.geteuid,
+    verify_service: Callable[[], bool] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    verify_timeout_s: float = 20.0,
+) -> list[RepairResult]:
+    """Apply each action, then report success only after re-detection."""
+    results: list[RepairResult] = []
+    for action in actions:
+        command = list(action.command)
+        if dry_run:
+            results.append(
+                RepairResult(
+                    id=action.id,
+                    status="planned",
+                    summary=action.summary,
+                    command=command,
+                    detail="dry run; no changes made",
+                )
+            )
+            continue
+        if action.requires_root and geteuid() != 0:
+            results.append(
+                RepairResult(
+                    id=action.id,
+                    status="not_applied",
+                    summary=action.summary,
+                    command=["sudo", *command],
+                    detail="root is required; Doctor never invokes sudo automatically",
+                )
+            )
+            continue
+        try:
+            completed = run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            results.append(
+                RepairResult(
+                    id=action.id,
+                    status="failed",
+                    summary=action.summary,
+                    command=command,
+                    detail=str(exc),
+                )
+            )
+            continue
+        if completed.returncode != 0:
+            failure_detail = (completed.stderr or completed.stdout).strip()
+            results.append(
+                RepairResult(
+                    id=action.id,
+                    status="failed",
+                    summary=action.summary,
+                    command=command,
+                    detail=failure_detail
+                    or f"repair command exited with status {completed.returncode}",
+                )
+            )
+            continue
+
+        verified = False
+        verification_error: Exception | None = None
+        if verify_service is not None:
+            deadline = time.monotonic() + verify_timeout_s
+            while time.monotonic() < deadline:
+                try:
+                    if verify_service():
+                        verified = True
+                        break
+                except Exception as exc:  # noqa: BLE001 — verifier boundary
+                    verification_error = exc
+                sleep(min(1.0, max(0.0, deadline - time.monotonic())))
+        results.append(
+            RepairResult(
+                id=action.id,
+                status="verified" if verified else "unverified",
+                summary=action.summary,
+                command=command,
+                detail=(
+                    "post-repair liveness check passed"
+                    if verified
+                    else (
+                        f"command succeeded but verification failed: "
+                        f"{type(verification_error).__name__}: {verification_error}"
+                        if verification_error is not None
+                        else "command succeeded but liveness did not recover before timeout"
+                    )
+                ),
+            )
+        )
+    return results
+
+
+def service_is_live() -> bool:
+    """Bounded verifier for the only currently automated repair."""
+    from vllm_mlx.headless_service.status import collect_status
+
+    status = collect_status(probe_timeout_s=0.5)
+    pid = status.get("pid")
+    return (
+        status.get("registered") is True
+        and isinstance(pid, int)
+        and not isinstance(pid, bool)
+        and pid > 0
+        and status.get("livez") is True
+    )


### PR DESCRIPTION
## Why

The default Doctor should remain fast, read-only, and safe to run after every install. Some appliance failures, however, need active checks that are inappropriate for that five-second path: verifying the whole Python dependency graph, separating DNS/routing trouble from package trouble, and recovering a launchd job that is registered but no longer live.

This PR adds an explicit deep posture and a deliberately narrow repair workflow modeled around detect → plan → apply → re-detect. It does not turn Doctor into a package installer or a general mutation framework.

## User value

- Operators can opt into higher-confidence dependency/network evidence without slowing every normal Doctor run.
- Multi-NIC Mac mini failures now show the actual default-route interface alongside DNS reachability—the exact class of failure reported by the 0.13.4 headless upgrader.
- Repair mode previews the exact action, confirms before mutation, never acquires privilege itself, and never claims success from a command exit code alone.
- Automation receives repair plans/results in the same JSON report.
- Sealed or minimal runtimes without `pip` are explicitly `skipped`, not falsely diagnosed as having broken dependencies.

## Scope

- Add `--deep` with a 30-second bounded profile.
- Add a stable `deep` section with:
  - `deep.python.pip-check`
  - `deep.network.dns`
  - `deep.network.default-route` on macOS
- Add `--fix`, `--dry-run`, and `--yes`.
- Add a conservative repair registry and result model.
- Implement one objectively verifiable repair: kickstart an already-registered Always-on service when its process or `/livez` check failed.
- Require root for that action, but never invoke `sudo` automatically.
- Verify registration + PID + `/livez` after the action before recording `verified`; otherwise record `failed` or `unverified`.
- Add a root-level JSON `repairs` array and human repair rendering; only explicit
  `--fix --json` uses schema v2, while ordinary read-only JSON remains v1.
- Add hermetic tests for timeouts, pip-less runtimes, planning, dry-run, privilege boundaries, and verification.

## How to use (website-ready)

### Deep diagnosis

The normal path remains unchanged and bounded to five seconds:

```bash
rapid-mlx doctor
```

Run active probes with a maximum 30-second budget:

```bash
rapid-mlx doctor --deep --verbose
```

Run only the added deep checks and return JSON:

```bash
rapid-mlx doctor --deep --only deep --json
```

Deep checks mean:

- `deep.python.pip-check`: runs `<selected-runtime> -m pip check`. A confirmed dependency conflict is a failure. Timeout is `skipped`. A sealed/minimal Desktop runtime without `pip` is also `skipped`; operational errors such as permission or interpreter startup failures are warnings, not false dependency conflicts.
- `deep.network.dns`: resolves `pypi.org` and `huggingface.co` in the selected runtime. Failure is a warning because offline/air-gapped operation can be intentional; timeout is `skipped`.
- `deep.network.default-route`: on macOS, reports the active default interface. On a multi-NIC appliance, compare it with System Settings → Network service order. If a private Ethernet link outranks the internet-facing service, restore the intended order, for example:

```bash
sudo networksetup -ordernetworkservices "Wi-Fi" "Ethernet" "Thunderbolt Bridge"
```

Use the actual service names from `networksetup -listallnetworkservices`; the example must not be copied blindly when names differ.

### Preview a repair

`--fix` implies `--deep`. Preview mode is non-mutating and does not need confirmation:

```bash
rapid-mlx doctor --only service --fix --dry-run --verbose
rapid-mlx doctor --only service --fix --dry-run --json
```

The read-only deep diagnosis has a 30-second budget. An applied repair then has
separate limits of 10 seconds for the command and 20 seconds for verification;
after verified recovery, one fresh deep diagnosis may use another 30 seconds.
Including the initial diagnosis, the complete successful workflow can take up
to approximately 90 seconds. Dry-run and no-action paths stop after diagnosis.

Doctor currently proposes an automated action only when all of these are true:

1. the Always-on service is registered in launchd;
2. its process or `/livez` check is a confirmed failure;
3. the action has an objective post-repair verifier.

It will not automatically install/reinstall Python packages, change models, apply pending config, edit credentials, create accounts, install a LaunchDaemon, or invoke `sudo`.

### Apply interactively

The one current repair manages a system LaunchDaemon, so run it as root. Doctor prints the plan and waits for confirmation:

```bash
sudo rapid-mlx doctor --only service --fix
```

Answering anything other than `y`/`yes` records each proposal as `not_applied`
with an operator-declined reason; no command is executed.

Without root, Doctor returns the exact manual command with status `not_applied`. It never launches `sudo` or asks for a password itself.

### Apply in automation

Non-interactive mutation requires the explicit `--yes` flag:

```bash
sudo rapid-mlx doctor --only service --fix --yes --json > doctor-repair.json
```

`--fix --json` without `--yes` in a non-interactive session exits 2 instead of hanging or silently mutating the host.

After `launchctl kickstart`, Doctor polls the same service facts again. Result statuses are:

- `planned`: dry-run only; no action executed.
- `not_applied`: prerequisites such as root privilege were absent, or the operator declined the interactive proposal.
- `failed`: the action itself returned non-zero or raised an execution error.
- `unverified`: the action returned zero, but registration + PID + `/livez` did not recover before the bounded verifier timed out.
- `verified`: the action returned zero and post-action detection proved the service live.

Ordinary read-only `doctor --json` remains schema v1. Explicit `--fix --json`
uses schema v2; its root-level `repairs` array contains `id`, `status`,
`summary`, `command`, and `detail`, and is empty when no repair was planned or
attempted. Existing read-only integrations therefore remain compatible, while
repair-mode integrations must support v2. The initial diagnosis remains visible
unless verification succeeds and Doctor completes a fresh report.

### Flag validation

- `--dry-run` requires `--fix`.
- `--yes` requires `--fix`.
- `--fix` implies `--deep`.
- Only a confirmed check failure makes the diagnostic exit 1; invalid CLI use exits 2.

## Safety decisions

- No implicit privilege escalation.
- No package install/upgrade from Doctor; this avoids circular remediation immediately after an upgrade and respects sealed Desktop runtimes.
- No config/model/credential mutation.
- Repair summaries, commands, and subprocess details are redacted in both human and JSON output.
- Repair success requires fresh observed health, not a zero process return code.
- The automated action targets only the fixed supported system-domain label already diagnosed by Doctor.
- Default Doctor remains read-only and five-second bounded; deep behavior is opt-in.

## Verification

```bash
python -m pytest -q \
  tests/test_doctor_deep_repair.py \
  tests/test_doctor_service_health.py \
  tests/test_cli_service.py \
  tests/test_doctor_report_contract.py \
  tests/test_doctor_no_model_load.py \
  tests/test_doctor_env_health.py \
  tests/test_service_config.py
# 621 passed

ruff check vllm_mlx/doctor vllm_mlx/cli.py \
  tests/test_doctor_deep_repair.py tests/test_doctor_report_contract.py \
  tests/test_doctor_service_health.py tests/test_doctor_env_health.py
# All checks passed

python -m coverage run --source=vllm_mlx -m pytest -q \
  tests/test_doctor_deep_repair.py tests/test_doctor_service_health.py \
  tests/test_cli_service.py tests/test_doctor_report_contract.py \
  tests/test_doctor_no_model_load.py tests/test_doctor_env_health.py \
  tests/test_service_config.py
python -m coverage xml -o /tmp/rapid-pr3238-coverage.xml
python -m diff_cover.diff_cover_tool /tmp/rapid-pr3238-coverage.xml \
  --compare-branch origin/main --show-uncovered --fail-under 100
# 621 passed; 180/180 changed executable lines covered (100%)

python scripts/check_mypy_error_budget.py
# mypy error budget OK: 701 grandfathered errors across 143 files; no growth

python -m vllm_mlx.cli doctor --deep --only deep --json \
  > /tmp/doctor-deep-smoke.json
python -m json.tool /tmp/doctor-deep-smoke.json
# Valid schema v1 JSON; pip-less Desktop runtime was skipped; DNS and route passed
```

## Docs / release-note seed

Doctor now has two explicit operating postures: fast/read-only by default, and active/bounded with `--deep`. `--fix` adds a conservative repair loop in which every mutation is planned, confirmed, and re-detected. The first repair safely kickstarts a registered but dead Always-on service, and only reports `verified` after the endpoint is observably live. Ordinary `doctor --json` stays on schema v1; explicit repair-mode JSON uses schema v2 with a root-level `repairs` array.

## Stack

Built-On: #3235 (merged)

- #3229 — timeout/unverified import hotfix
- #3234 — structured report and bounded/selective runner
- #3235 — Always-on service end-to-end diagnosis (merged)
- This PR — deep probes and verified repairs
