### PR TITLE
fix(desktop): bind visual recovery to server session

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostVisualRecovery.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/DraftPostVisualRecovery.swift
@@ -9,6 +9,10 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
     let baseURL: URL
     let model: String
     let bearerToken: String
+    /// Process-local identity for the exact app-owned sidecar launch. A
+    /// persisted bearer can survive a restart, so connection values alone do
+    /// not identify the process that receives the private screenshot.
+    let sessionID: UUID?
     private let sessionValidator: SessionValidator
 
     init?(
@@ -16,6 +20,7 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
         port: Int,
         model: String?,
         bearerToken: String?,
+        sessionID: UUID? = nil,
         sessionValidator: @escaping SessionValidator
     ) {
         guard host == "127.0.0.1",
@@ -29,6 +34,7 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
         self.baseURL = baseURL
         self.model = model
         self.bearerToken = bearerToken
+        self.sessionID = sessionID
         self.sessionValidator = sessionValidator
     }
 
@@ -38,6 +44,7 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
         host: String,
         port: Int,
         bearerToken: String?,
+        sessionID: UUID? = nil,
         sessionValidator: @escaping SessionValidator
     ) {
         guard let profile,
@@ -49,6 +56,7 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
             port: port,
             model: profile.id,
             bearerToken: bearerToken,
+            sessionID: sessionID,
             sessionValidator: sessionValidator
         )
     }
@@ -64,7 +72,13 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
         bearerToken: String?,
         liveServer server: ServerManager
     ) {
-        guard let profile, let bearerToken else { return nil }
+        guard let profile,
+              let bearerToken,
+              let expectedSessionID = server.activeServerSessionID,
+              // A private screenshot must never be authorized by a bearer
+              // that is intentionally reusable by a replacement process.
+              server.embeddedBearerLifetime == .perLaunch
+        else { return nil }
         let expectedModel = profile.id
         self.init(
             profile: profile,
@@ -72,11 +86,13 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
             host: host,
             port: port,
             bearerToken: bearerToken,
+            sessionID: expectedSessionID,
             sessionValidator: { [weak server] in
                 guard let server,
                       server.host == host,
                       server.activePort == port,
                       server.activeBearer == bearerToken,
+                      server.activeServerSessionID == expectedSessionID,
                       let currentProfile = server.activeModelProfile
                 else { return false }
                 return currentProfile.id.caseInsensitiveCompare(expectedModel)
@@ -93,6 +109,13 @@ struct DraftPostVisualRuntime: Equatable, Sendable {
         lhs.baseURL == rhs.baseURL
             && lhs.model == rhs.model
             && lhs.bearerToken == rhs.bearerToken
+            && lhs.sessionID == rhs.sessionID
+    }
+
+    /// Shared by recovery construction and focused lifecycle tests so the
+    /// production session predicate is exercised without sending pixels.
+    func isCurrentSession() async -> Bool {
+        await sessionValidator()
     }
 
     func makeRecovery() -> (any DraftPostVisualRecovering)? {

--- a/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DraftPostFlowTests.swift
@@ -360,6 +360,59 @@ struct DraftPostFlowTests {
         #expect(await blockedBase.callCount == 0)
     }
 
+    @MainActor
+    @Test("A retained visual runtime rejects a restarted server with reused connection values")
+    func visualRuntimeRejectsRestartedServerSession() async throws {
+        let alias = "ui-tars-1.5-7b-4bit"
+        let bearer = "persisted-secret"
+        let profile = ServerModelProfile(id: alias, toolCallParser: "ui_tars")
+        let server = ServerManager(
+            testingState: .ready(alias: alias),
+            activePort: 7659,
+            activeBearer: bearer
+        )
+        server.applyActiveModelProfile(profile, forAlias: alias)
+        let runtime = try #require(DraftPostVisualRuntime(
+            profile: profile,
+            selectedAlias: alias,
+            host: server.host,
+            port: server.activePort,
+            bearerToken: bearer,
+            liveServer: server
+        ))
+        let originalSessionID = try #require(runtime.sessionID)
+        #expect(await runtime.isCurrentSession())
+
+        server._testReplaceActiveServerSession(bearer: bearer)
+        #expect(server.activeServerSessionID != originalSessionID)
+        server.applyActiveModelProfile(profile, forAlias: alias)
+
+        #expect(!(await runtime.isCurrentSession()))
+    }
+
+    @MainActor
+    @Test("A long-lived embedded credential cannot authorize visual recovery")
+    func persistentCredentialIsIneligibleForVisualRecovery() throws {
+        let alias = "ui-tars-1.5-7b-4bit"
+        let profile = ServerModelProfile(id: alias, toolCallParser: "ui_tars")
+        let server = ServerManager(
+            testingState: .ready(alias: alias),
+            activePort: 7659,
+            activeBearer: "persisted-secret"
+        )
+        server.applyActiveModelProfile(profile, forAlias: alias)
+        server.setEmbeddedBearerLifetime(.daily)
+
+        #expect(DraftPostVisualRuntime(
+            profile: profile,
+            selectedAlias: alias,
+            host: server.host,
+            port: server.activePort,
+            bearerToken: server.activeBearer,
+            liveServer: server
+        ) == nil)
+    }
+
     @Test("Chrome accessibility activation balances cancellation")
     func browserAccessibilityActivationBalancesCancellation() async {
         let probe = BrowserAccessibilityLeaseProbe()


### PR DESCRIPTION
## Why

Draft and Post visual recovery handles a private window screenshot. Its retained runtime validated host, port, bearer, model, parser, and residency, but a persistent bearer could survive an embedded-server restart with all of those values unchanged. The old runtime could therefore accept a replacement process as the session that authorized the screenshot.

## What

- bind the production visual runtime to `activeServerSessionID`
- require the per-launch embedded credential policy for private visual recovery
- include the session identity in runtime equality
- add focused regressions for same-connection-value restart and persistent-credential rejection

## Design precedent

This applies the existing in-app private-planning boundary: sensitive local-model clients capture one process-local launch identity, validate it immediately around inference, and reject credentials designed to survive process replacement. Connection coordinates remain necessary but are not treated as process identity.

## Scope

Allowed: visual-runtime eligibility and session validation, plus focused tests.

Non-goals: browser automation semantics, visual prompts, retry budgets, credential settings, or broader Computer Use behavior.

## Validation

- `swift test --no-parallel --filter DraftPostFlowTests` (33 passed, 3 explicit live-fixture skips)
- `git diff --check`
- adversarial self-review: no unresolved correctness, security, compatibility, or scope findings

Fixes #3241