### PR TITLE
fix(service): qualify startup without credential exposure

### DIFF
--- a/docs/engineering/decisions/2026-09-05-always-on-service-configuration.md
+++ b/docs/engineering/decisions/2026-09-05-always-on-service-configuration.md
@@ -33,15 +33,15 @@ Configuration changes use two phases:
 2. `service apply` saves the active definition, stops the job, promotes the
    candidate, bootstraps it, and first gates endpoint availability on `/readyz`.
 3. Because a lazy model can correctly report endpoint readiness in `standby`,
-   the transaction then calls the authenticated `POST /v1/models/activate`
-   control-plane operation and requires `state=ready` plus `model_loaded=true`
-   before committing. Any failure restores and starts the previous definition.
+   the transaction temporarily removes `--lazy-load`, boots the candidate, and
+   requires `/readyz` to report `ready=true` plus `model_loaded=true`. Only then
+   does it persist the operator's requested lazy policy. Any failure restores
+   and starts the previous definition.
 
-The same qualification gate protects first install and runtime upgrade. The
-activation request never accepts a model identifier; it can only load and warm
-the primary already fixed in the validated service definition. When an API key
-is configured, the root-run service command reads its private credential file
-and sends it only as an in-memory Authorization header.
+The same qualification gate protects first install and runtime upgrade. It
+never reads or transmits the persistent API credential across TCP: the model is
+selected solely by the validated service definition and loaded by normal
+startup before the listener is trusted.
 
 An optional API key lives in a separate mode-0600 non-symlink credential file.
 The runtime launcher reads it immediately before `execve` and exposes it only as

--- a/docs/guides/headless-macos-service.md
+++ b/docs/guides/headless-macos-service.md
@@ -49,10 +49,11 @@ strictly validated to exclude secrets. Keeping it outside the Python runtime
 also lets a venv rebuild leave service configuration untouched.
 
 Change an installed definition as a two-step transaction. `configure` validates
-and stages a candidate but does not disturb the running server. `apply` swaps
-the candidate into place, restarts, requires `/readyz`, and activates the
-configured primary model before committing. If bootstrap, endpoint readiness,
-or model activation fails, it restores the previous config and service.
+and stages a candidate but does not disturb the running server. `apply` starts
+the candidate once without `--lazy-load` and requires `/readyz` to report the
+configured primary model resident before committing the requested lazy policy.
+If bootstrap, endpoint readiness, or model loading fails, it restores the
+previous config and service.
 This prevents a lazy service from appearing successfully deployed in
 `standby` only to fail hours later on its first real request.
 
@@ -129,8 +130,8 @@ retention. Stage different limits with `service configure --log-max-mb`,
 Upgrade the service with the same health gate and rollback behavior. The
 command freezes the working environment before stopping the server, runs the
 package upgrade as the service account, diagnoses it with `doctor`, and only
-accepts it after launchd `/readyz` succeeds and the configured primary model
-loads and completes its standard warmup path. On activation failure it restores
+accepts it after launchd `/readyz` succeeds with the configured primary model
+resident after its standard warmup path. On qualification failure it restores
 the frozen environment and starts the previous service.
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -548,8 +548,10 @@ rapid-mlx service uninstall [--dry-run]
   deterministic root-owned plist to `/Library/LaunchDaemons/`, and
   bootstraps the daemon. It refuses an administrator/system account, a
   secret in the definition, and a target port that already has a server.
-  Before reporting success it activates and warms the configured model, so a
-  lazy endpoint cannot pass installation while its weights are unusable.
+  Before reporting success it starts once without lazy loading and requires the
+  configured model to be resident, so a standby endpoint cannot pass
+  installation while its weights are unusable. The requested lazy policy is
+  persisted only after that qualification succeeds.
   `--dry-run` prints every step without changing anything.
 - Additional `serve` options must follow a `--` separator, for example
   `-- --max-num-seqs 4`. Bind overrides and secret-bearing options are
@@ -559,9 +561,10 @@ rapid-mlx service uninstall [--dry-run]
 - `logs` tails the daemon's stdout/stderr logs (`--follow` streams across
   KeepAlive restarts).
 - `restart` kickstarts the daemon and waits for readiness.
-- `apply` and `upgrade` require both endpoint readiness and authenticated model
-  activation before committing; a model-load failure restores the previous
-  configuration or runtime.
+- `apply` and `upgrade` transiently disable lazy loading and require both
+  endpoint readiness and model residency before committing; a model-load
+  failure restores the previous configuration or runtime. Qualification never
+  transmits the persistent API credential to an unverified listener.
 - `uninstall` removes the launchd registration and plist only — models,
   cache, and logs are never deleted.
 

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -21,6 +21,7 @@ import pytest
 from vllm_mlx.cli import build_parser
 from vllm_mlx.headless_service import common
 from vllm_mlx.headless_service import install as ins_mod
+from vllm_mlx.headless_service.config import SCHEMA_VERSION, ServiceConfig
 from vllm_mlx.headless_service.plist import (
     build_plist_dict,
     parse_plist,
@@ -435,112 +436,61 @@ def test_readyz_ready_semantics(monkeypatch, status, body, expected):
         srv.sock.close()
 
 
-def test_activate_model_sends_credential_only_in_header(tmp_path):
-    credential = tmp_path / "credential"
-    credential.write_text("top-secret\n")
-    credential.chmod(0o600)
+def test_qualification_never_sends_the_persistent_credential():
     srv = _HttpResponder(
         b"HTTP/1.1 200 OK",
-        b'{"status":"ready","state":"ready","model_loaded":true}',
+        b'{"ready":true,"state":"ready","model_loaded":true}',
     )
     try:
-        assert ins_mod._activate_model(
-            "127.0.0.1",
-            srv.port,
-            credential_file=str(credential),
-            credential_uid=credential.stat().st_uid,
-            timeout_s=2,
+        config = types.SimpleNamespace(
+            host="127.0.0.1",
+            port=srv.port,
+            credential_file="/private/persistent-key",
         )
-        assert b"POST /v1/models/activate HTTP/1.1" in srv.request
-        assert b"Authorization: Bearer top-secret" in srv.request
+        assert ins_mod._wait_qualified(config, ready_timeout_s=2)
+        assert b"GET /readyz HTTP/1.1" in srv.request
+        assert b"Authorization:" not in srv.request
+        assert b"persistent-key" not in srv.request
     finally:
         srv.sock.close()
 
 
-def test_activate_model_rejects_endpoint_only_readiness():
+def test_qualification_rejects_endpoint_only_readiness():
     srv = _HttpResponder(
         b"HTTP/1.1 200 OK",
-        b'{"status":"ready","state":"standby","model_loaded":false}',
+        b'{"ready":true,"state":"standby","model_loaded":false}',
     )
     try:
-        assert not ins_mod._activate_model(
-            "127.0.0.1",
-            srv.port,
-            credential_file=None,
-            credential_uid=0,
-            timeout_s=2,
+        assert not ins_mod._readyz_ready(
+            "127.0.0.1", srv.port, require_model_loaded=True
         )
     finally:
         srv.sock.close()
 
 
-def test_read_service_credential_rejects_symlink_and_foreign_owner(tmp_path):
-    credential = tmp_path / "credential"
-    credential.write_text("secret\n")
-    credential.chmod(0o600)
-    link = tmp_path / "link"
-    link.symlink_to(credential)
-    with pytest.raises(ValueError, match="cannot open credential"):
-        ins_mod._read_service_credential(link, expected_uid=credential.stat().st_uid)
-    with pytest.raises(ValueError, match="owned by uid"):
-        ins_mod._read_service_credential(
-            credential, expected_uid=credential.stat().st_uid + 1
-        )
+def test_startup_qualification_removes_only_lazy_load():
+    config = ServiceConfig(
+        schema_version=SCHEMA_VERSION,
+        label="com.rapidmlx.server",
+        service_user="serveuser",
+        executable="/Users/serveuser/.local/bin/rapid-mlx",
+        model="qwen3.5-4b-4bit",
+        serve_args=("--lazy-load", "--idle-unload-seconds", "300", "--lazy-load"),
+    ).validated()
 
+    qualified = ins_mod._startup_qualification_config(config)
 
-def test_read_service_credential_missing_is_unconfigured(tmp_path):
-    assert (
-        ins_mod._read_service_credential(
-            tmp_path / "missing", expected_uid=tmp_path.stat().st_uid
-        )
-        is None
+    assert qualified.serve_args == ("--idle-unload-seconds", "300")
+    assert config.serve_args == (
+        "--lazy-load",
+        "--idle-unload-seconds",
+        "300",
+        "--lazy-load",
     )
+    assert ins_mod._startup_qualification_config(qualified) is qualified
 
 
-@pytest.mark.parametrize(
-    ("kind", "message"),
-    [
-        ("directory", "regular file"),
-        ("public", "group or others"),
-        ("large", "unexpectedly large"),
-        ("empty", "one non-empty line"),
-        ("multiline", "one non-empty line"),
-    ],
-)
-def test_read_service_credential_rejects_unsafe_contents(tmp_path, kind, message):
-    credential = tmp_path / "credential"
-    if kind == "directory":
-        credential.mkdir()
-    else:
-        contents = {
-            "public": "secret\n",
-            "large": "x" * 65_537,
-            "empty": "\n",
-            "multiline": "one\ntwo\n",
-        }[kind]
-        credential.write_text(contents)
-        credential.chmod(0o644 if kind == "public" else 0o600)
-    with pytest.raises(ValueError, match=message):
-        ins_mod._read_service_credential(
-            credential, expected_uid=credential.stat().st_uid
-        )
-
-
-def test_activate_model_rejects_malformed_response():
-    srv = _HttpResponder(b"HTTP/1.1 200 OK", b"not-json")
-    try:
-        assert not ins_mod._activate_model(
-            "127.0.0.1",
-            srv.port,
-            credential_file=None,
-            credential_uid=0,
-            timeout_s=2,
-        )
-    finally:
-        srv.sock.close()
-
-
-def test_wait_qualified_requires_endpoint_then_model_activation(monkeypatch):
+def test_wait_qualified_requires_resident_startup_readiness(monkeypatch):
     config = types.SimpleNamespace(
         host="127.0.0.1",
         port=8000,
@@ -548,27 +498,17 @@ def test_wait_qualified_requires_endpoint_then_model_activation(monkeypatch):
         service_user="serveuser",
     )
     calls = []
-    monkeypatch.setattr(
-        ins_mod,
-        "_wait_ready",
-        lambda host, port, **kwargs: calls.append(("ready", host, port)) or True,
-    )
-    monkeypatch.setattr(
-        ins_mod,
-        "_activate_model",
-        lambda host, port, **kwargs: (
-            calls.append(("activate", host, port, kwargs["credential_file"])) or True
-        ),
-    )
-    monkeypatch.setattr(ins_mod, "user_uid", lambda _user: 501)
+
+    def wait_ready(host, port, **kwargs):
+        calls.append(("ready", host, port, kwargs["require_model_loaded"]))
+        return True
+
+    monkeypatch.setattr(ins_mod, "_wait_ready", wait_ready)
     assert ins_mod._wait_qualified(config)
-    assert calls == [
-        ("ready", "127.0.0.1", 8000),
-        ("activate", "127.0.0.1", 8000, "/private/key"),
-    ]
+    assert calls == [("ready", "127.0.0.1", 8000, True)]
 
 
-def test_wait_qualified_short_circuits_unready_or_missing_account(monkeypatch):
+def test_wait_qualified_returns_false_when_model_is_not_ready(monkeypatch):
     config = types.SimpleNamespace(
         host="127.0.0.1",
         port=8000,
@@ -576,15 +516,6 @@ def test_wait_qualified_short_circuits_unready_or_missing_account(monkeypatch):
         service_user="gone",
     )
     monkeypatch.setattr(ins_mod, "_wait_ready", lambda *_a, **_k: False)
-    monkeypatch.setattr(
-        ins_mod,
-        "_activate_model",
-        lambda *_a, **_k: pytest.fail("activation must not run"),
-    )
-    assert not ins_mod._wait_qualified(config)
-
-    monkeypatch.setattr(ins_mod, "_wait_ready", lambda *_a, **_k: True)
-    monkeypatch.setattr(ins_mod, "user_uid", lambda _user: None)
     assert not ins_mod._wait_qualified(config)
 
 
@@ -1382,12 +1313,16 @@ def test_port_busy_false_on_connect_error(monkeypatch):
 
 
 def test_wait_ready_immediate(monkeypatch):
-    monkeypatch.setattr(ins_mod, "_readyz_ready", staticmethod(lambda h, p: True))
+    monkeypatch.setattr(
+        ins_mod, "_readyz_ready", staticmethod(lambda h, p, **kwargs: True)
+    )
     assert ins_mod._wait_ready("127.0.0.1", 1, timeout_s=5) is True
 
 
 def test_wait_ready_timeout(monkeypatch):
-    monkeypatch.setattr(ins_mod, "_readyz_ready", staticmethod(lambda h, p: False))
+    monkeypatch.setattr(
+        ins_mod, "_readyz_ready", staticmethod(lambda h, p, **kwargs: False)
+    )
     state = {"t": 0.0}
 
     def _tick():
@@ -1831,6 +1766,12 @@ def test_install_success_cleans_secure_staging_file(monkeypatch, tmp_path, capsy
     monkeypatch.setattr(ins, "LAUNCH_DAEMONS_DIR", tmp_path)
     monkeypatch.setattr(ins, "_wait_qualified", lambda _config: True)
     monkeypatch.setattr(ins.tempfile, "tempdir", str(tmp_path))
+    config_writes = []
+    monkeypatch.setattr(
+        ins,
+        "_install_service_config",
+        lambda **kwargs: config_writes.append(json.loads(kwargs["data"])),
+    )
 
     def _fake_run(argv, check=True):
         if argv[0] == "install":
@@ -1839,11 +1780,20 @@ def test_install_success_cleans_secure_staging_file(monkeypatch, tmp_path, capsy
 
     monkeypatch.setattr(ins, "_run", _fake_run)
     code = ins.install_command(
-        _ns(dry_run=False, serve_args=["--", "--max-num-seqs", "4"])
+        _ns(
+            dry_run=False,
+            serve_args=["--", "--lazy-load", "--max-num-seqs", "4"],
+        )
     )
     assert code == 0
     assert "Installed and running" in capsys.readouterr().out
     assert not list(tmp_path.glob("rapid-mlx-service-*.plist"))
+    assert config_writes[0]["serve_args"] == ["--max-num-seqs", "4"]
+    assert config_writes[1]["serve_args"] == [
+        "--lazy-load",
+        "--max-num-seqs",
+        "4",
+    ]
 
 
 def test_install_success_tolerates_staging_cleanup_failure(monkeypatch, tmp_path):

--- a/tests/test_service_config.py
+++ b/tests/test_service_config.py
@@ -263,16 +263,23 @@ def test_configure_stages_without_touching_active(monkeypatch, tmp_path):
 def test_apply_promotes_healthy_candidate(monkeypatch, tmp_path):
     configure, home, current_path, _ = _installed_config(monkeypatch, tmp_path)
     pending = pending_config_path(home)
-    candidate = _config(service_user="runner", model="new-model", port=9000)
+    candidate = _config(
+        service_user="runner",
+        model="new-model",
+        port=9000,
+        serve_args=("--lazy-load", "--idle-unload-seconds", "300"),
+    )
     atomic_write(pending, config_bytes(candidate))
     monkeypatch.setattr(configure, "is_root", lambda: True)
     monkeypatch.setattr(configure, "_port_busy", lambda _host, _port: False)
     monkeypatch.setattr(configure, "_bootout", lambda _label: None)
-    monkeypatch.setattr(
-        configure,
-        "_bootstrap",
-        lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
-    )
+    boot_configs = []
+
+    def bootstrap(_label):
+        boot_configs.append(load_config(current_path))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(configure, "_bootstrap", bootstrap)
     qualified = []
     monkeypatch.setattr(
         configure,
@@ -283,6 +290,7 @@ def test_apply_promotes_healthy_candidate(monkeypatch, tmp_path):
         configure.apply_command(types.SimpleNamespace(label=None, dry_run=False)) == 0
     )
     assert load_config(current_path) == candidate
+    assert boot_configs[0].serve_args == ("--idle-unload-seconds", "300")
     assert not pending.exists()
     assert qualified == [candidate]
 
@@ -353,7 +361,9 @@ def test_upgrade_target_is_constrained(version, extras, expected):
 def test_upgrade_success_snapshots_before_mutation(monkeypatch, tmp_path):
     from vllm_mlx.headless_service import upgrade
 
-    configure, home, _, _ = _installed_config(monkeypatch, tmp_path)
+    configure, home, current_path, current = _installed_config(monkeypatch, tmp_path)
+    current = current.updated(serve_args=("--lazy-load", "--max-num-seqs", "4"))
+    atomic_write(current_path, config_bytes(current))
     python = home / ".rapid-mlx" / "bin" / "python"
     python.parent.mkdir(parents=True)
     python.write_text("#!/bin/sh\n")
@@ -373,11 +383,13 @@ def test_upgrade_success_snapshots_before_mutation(monkeypatch, tmp_path):
 
     monkeypatch.setattr(upgrade, "_as_user", as_user)
     monkeypatch.setattr(upgrade, "_bootout", lambda _label: events.append(("bootout",)))
-    monkeypatch.setattr(
-        upgrade,
-        "_bootstrap",
-        lambda _label: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
-    )
+    boot_configs = []
+
+    def bootstrap(_label):
+        boot_configs.append(load_config(current_path))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(upgrade, "_bootstrap", bootstrap)
     qualified = []
     monkeypatch.setattr(
         upgrade, "_wait_qualified", lambda config: qualified.append(config) or True
@@ -394,6 +406,8 @@ def test_upgrade_success_snapshots_before_mutation(monkeypatch, tmp_path):
     assert events[1] == ("bootout",)
     assert any("rapid-mlx[vision]==0.13.5" in event for event in events)
     assert len(qualified) == 1
+    assert boot_configs[0].serve_args == ("--max-num-seqs", "4")
+    assert load_config(current_path) == current
     snapshot = (
         tmp_path / "system-config" / "com.rapidmlx.server.previous-requirements.txt"
     )
@@ -434,6 +448,54 @@ def test_upgrade_rolls_back_after_readiness_failure(monkeypatch, tmp_path, capsy
     )
     assert upgrade.upgrade_command(args) == 2
     assert "previous environment restored" in capsys.readouterr().err
+
+
+def test_upgrade_never_restores_from_transient_config_when_definition_writes_fail(
+    monkeypatch, tmp_path, capsys
+):
+    from vllm_mlx.headless_service import upgrade
+
+    configure, home, _, _ = _installed_config(monkeypatch, tmp_path)
+    python = home / ".rapid-mlx" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\n")
+    python.chmod(0o700)
+    monkeypatch.setattr(upgrade, "is_root", lambda: True)
+    monkeypatch.setattr(upgrade, "_account", configure._account)
+
+    responses = iter(
+        [
+            types.SimpleNamespace(
+                returncode=0, stdout="rapid-mlx==0.13.4\n", stderr=""
+            ),
+            types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+            types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+        ]
+    )
+    monkeypatch.setattr(upgrade, "_as_user", lambda *_a, **_k: next(responses))
+    monkeypatch.setattr(upgrade, "_bootout", lambda _label: None)
+    monkeypatch.setattr(
+        upgrade,
+        "atomic_write_definition",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("read-only config")),
+    )
+    monkeypatch.setattr(
+        upgrade,
+        "_restore",
+        lambda **_kwargs: pytest.fail(
+            "must not restart while the transient definition may remain"
+        ),
+    )
+
+    args = types.SimpleNamespace(
+        label=None,
+        dry_run=False,
+        version=None,
+        extras=None,
+        pre=False,
+    )
+    assert upgrade.upgrade_command(args) == 2
+    assert "ROLLBACK FAILED" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/vllm_mlx/headless_service/configure.py
+++ b/vllm_mlx/headless_service/configure.py
@@ -24,7 +24,14 @@ from .config import (
     remove_credential,
 )
 from .definition import installed_identity
-from .install import _plist_path, _port_busy, _wait_qualified, _wait_ready, is_root
+from .install import (
+    _plist_path,
+    _port_busy,
+    _startup_qualification_config,
+    _wait_qualified,
+    _wait_ready,
+    is_root,
+)
 
 
 def _identity_or_error(label: str) -> tuple[str, Path, Path]:
@@ -150,7 +157,9 @@ def apply_command(args) -> int:
             f"[DRY-RUN] bootout {DEFAULT_DOMAIN}/{label}\n"
             f"[DRY-RUN] promote candidate {config_digest(candidate)[:12]}\n"
             f"[DRY-RUN] bootstrap {_plist_path(label)} and require /readyz\n"
-            "[DRY-RUN] activate and qualify the configured primary model\n"
+            "[DRY-RUN] start transiently without --lazy-load and require "
+            "resident model readiness\n"
+            "[DRY-RUN] commit the requested lazy-load policy after qualification\n"
             "[DRY-RUN] restore previous config and service on any failure"
         )
         return 0
@@ -172,7 +181,10 @@ def apply_command(args) -> int:
     try:
         atomic_write_definition(backup, previous)
         _bootout(label)
-        atomic_write_definition(current_path, candidate_bytes)
+        atomic_write_definition(
+            current_path,
+            config_bytes(_startup_qualification_config(candidate)),
+        )
         boot = _bootstrap(label)
         if boot.returncode != 0:
             raise ServiceConfigError(
@@ -183,6 +195,7 @@ def apply_command(args) -> int:
                 "candidate endpoint or configured model did not qualify on "
                 f"{candidate.host}:{candidate.port}"
             )
+        atomic_write_definition(current_path, candidate_bytes)
     except (OSError, ServiceConfigError) as exc:
         _bootout(label)
         try:

--- a/vllm_mlx/headless_service/install.py
+++ b/vllm_mlx/headless_service/install.py
@@ -21,9 +21,7 @@ already documented — this command just makes it safe and one-shot.
 
 from __future__ import annotations
 
-import json
 import os
-import stat
 import subprocess
 import sys
 import tempfile
@@ -248,8 +246,11 @@ def _mutation_list(
         "validate temporary plist with plutil -lint",
         f"install -o root -g wheel -m 644 temporary plist -> {plist_path}",
         f"launchctl bootstrap {DEFAULT_DOMAIN} {plist_path}",
-        f"poll {host}:{port}/readyz until endpoint-ready (max 120s)",
-        "activate and qualify the configured primary model before commit",
+        (
+            f"start transiently without --lazy-load and poll {host}:{port}/readyz "
+            "until the configured model is resident (max 600s)"
+        ),
+        "commit the requested lazy-load policy only after qualification",
     ]
 
 
@@ -285,7 +286,12 @@ def _install_service_config(*, user: str, home: Path, path: Path, data: bytes) -
     atomic_write_definition(path, data)
 
 
-def _readyz_ready(host: str, port: int) -> bool:
+def _readyz_ready(
+    host: str,
+    port: int,
+    *,
+    require_model_loaded: bool = False,
+) -> bool:
     """True when ``/readyz`` reports ready.
 
     rapid-mlx ``/readyz`` returns HTTP 200 once the process is able to serve
@@ -308,10 +314,18 @@ def _readyz_ready(host: str, port: int) -> bool:
         return False
     # Compact JSON separators or pretty-printed — compare whitespace-free.
     body = b"".join(rest.split()).lower()
-    return b'"ready":true' in body
+    if b'"ready":true' not in body:
+        return False
+    return not require_model_loaded or b'"model_loaded":true' in body
 
 
-def _wait_ready(host: str, port: int, timeout_s: int = 120) -> bool:
+def _wait_ready(
+    host: str,
+    port: int,
+    timeout_s: int = 120,
+    *,
+    require_model_loaded: bool = False,
+) -> bool:
     """Poll ``/readyz`` until it reports ready or ``timeout_s`` elapses.
 
     Mirrors the readiness loop in ``scripts/headless_service_smoke.sh`` so
@@ -319,105 +333,38 @@ def _wait_ready(host: str, port: int, timeout_s: int = 120) -> bool:
     """
     deadline = time.time() + timeout_s
     while time.time() < deadline:
-        if _readyz_ready(host, port):
+        if _readyz_ready(
+            host,
+            port,
+            require_model_loaded=require_model_loaded,
+        ):
             return True
         time.sleep(1.0)
     return False
 
 
-def _read_service_credential(
-    credential_file: str | None, *, expected_uid: int
-) -> str | None:
-    """Securely read the daemon credential into memory as root.
+def _startup_qualification_config(config: ServiceConfig) -> ServiceConfig:
+    """Return a transient definition that proves weights load at startup.
 
-    Open with ``O_NOFOLLOW`` first, then validate the opened inode.  This
-    avoids a check/read replacement race in the service-user-owned home and
-    prevents the privileged CLI from reading a foreign file through a link.
+    The desired on-disk definition may use ``--lazy-load``.  Qualification
+    deliberately boots the same model and options without that one flag, then
+    commits the original definition after readiness reports resident weights.
+    This avoids sending a reusable API credential to an unverified TCP peer.
     """
-    if not credential_file:
-        return None
-    path = Path(credential_file)
-    from .config import ServiceConfigError
-
-    try:
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
-    except FileNotFoundError:
-        return None
-    except OSError as exc:
-        raise ServiceConfigError(f"cannot open credential file: {exc}") from None
-    try:
-        info = os.fstat(fd)
-        if not stat.S_ISREG(info.st_mode):
-            raise ServiceConfigError("credential file must be a regular file")
-        if stat.S_IMODE(info.st_mode) & 0o077:
-            raise ServiceConfigError(
-                "credential file must not be accessible by group or others"
-            )
-        if info.st_uid != expected_uid:
-            raise ServiceConfigError(
-                f"credential file is owned by uid {info.st_uid}, expected {expected_uid}"
-            )
-        with os.fdopen(fd, encoding="utf-8") as handle:
-            fd = -1
-            secret = handle.read(65_537)
-    finally:
-        if fd >= 0:
-            os.close(fd)
-    if len(secret) > 65_536:
-        raise ServiceConfigError("credential file is unexpectedly large")
-    secret = secret.strip()
-    if not secret or "\n" in secret or "\r" in secret:
-        raise ServiceConfigError("credential file must contain one non-empty line")
-    return secret
-
-
-def _activate_model(
-    host: str,
-    port: int,
-    *,
-    credential_file: str | None,
-    credential_uid: int,
-    timeout_s: int = 600,
-) -> bool:
-    """Ask the local service to load/warm its configured primary model."""
-    import http.client
-
-    try:
-        secret = _read_service_credential(credential_file, expected_uid=credential_uid)
-        headers = {"Content-Length": "0"}
-        if secret is not None:
-            headers["Authorization"] = f"Bearer {secret}"
-        connection = http.client.HTTPConnection(
-            _probe_host(host), port, timeout=timeout_s
-        )
-        try:
-            connection.request("POST", "/v1/models/activate", headers=headers)
-            response = connection.getresponse()
-            payload = json.loads(response.read())
-        finally:
-            connection.close()
-    except (OSError, ValueError, http.client.HTTPException):
-        return False
-    return bool(
-        response.status == 200
-        and isinstance(payload, dict)
-        and payload.get("state") == "ready"
-        and payload.get("model_loaded") is True
+    if "--lazy-load" not in config.serve_args:
+        return config
+    return config.updated(
+        serve_args=tuple(arg for arg in config.serve_args if arg != "--lazy-load")
     )
 
 
-def _wait_qualified(config: ServiceConfig, *, ready_timeout_s: int = 120) -> bool:
-    """Require both an accepting endpoint and a loadable configured model."""
-    if not _wait_ready(config.host, config.port, timeout_s=ready_timeout_s):
-        return False
-    credential_uid = user_uid(config.service_user)
-    if credential_uid is None:
-        return False
-    return _activate_model(
+def _wait_qualified(config: ServiceConfig, *, ready_timeout_s: int = 600) -> bool:
+    """Require startup readiness with the configured model resident."""
+    return _wait_ready(
         config.host,
         config.port,
-        credential_file=config.credential_file,
-        credential_uid=credential_uid,
+        timeout_s=ready_timeout_s,
+        require_model_loaded=True,
     )
 
 
@@ -646,7 +593,7 @@ def install_command(args) -> int:
             user=user,
             home=home,
             path=service_config_path,
-            data=config_bytes(service_config),
+            data=config_bytes(_startup_qualification_config(service_config)),
         )
         # Stage + lint. check=False so a lint failure surfaces its specific
         # message instead of a generic "install step failed" traceback.
@@ -687,6 +634,15 @@ def install_command(args) -> int:
                 f"rolled back. Check {home}/Library/Logs/Rapid-MLX/"
                 "server.stderr.log"
             )
+        # The running process has already loaded the model from the transient
+        # eager definition. Persist the operator's original lazy policy for
+        # every later launch only after qualification succeeds.
+        _install_service_config(
+            user=user,
+            home=home,
+            path=service_config_path,
+            data=config_bytes(service_config),
+        )
     except Exception as exc:
         # Best-effort rollback: remove the staged file AND the persistent
         # plist (never the models/data/logs), so a failed install cannot

--- a/vllm_mlx/headless_service/status.py
+++ b/vllm_mlx/headless_service/status.py
@@ -103,8 +103,9 @@ def _endpoint_health(host: str, port: int) -> tuple[bool, bool]:
     ``live`` = the process is alive (``/livez`` returns 200). ``ready`` = the
     endpoint can accept work (``/readyz`` returns 200 AND ``"ready": true``).
     A lazy service can therefore be ready in ``standby`` without resident
-    weights; install/apply/upgrade separately use the authenticated activation
-    gate to qualify the configured model. Best-effort via a raw socket GET —
+    weights; install/apply/upgrade separately start with eager loading and
+    require model-resident readiness before restoring the requested lazy policy.
+    Best-effort via a raw socket GET —
     no external HTTP client dependency.
     """
     import socket

--- a/vllm_mlx/headless_service/upgrade.py
+++ b/vllm_mlx/headless_service/upgrade.py
@@ -10,9 +10,20 @@ import sys
 from pathlib import Path
 
 from .common import DEFAULT_LABEL
-from .config import ServiceConfigError, atomic_write, load_config
+from .config import (
+    ServiceConfigError,
+    atomic_write,
+    atomic_write_definition,
+    config_bytes,
+    load_config,
+)
 from .configure import _account, _bootout, _bootstrap, _identity_or_error
-from .install import _wait_qualified, _wait_ready, is_root
+from .install import (
+    _startup_qualification_config,
+    _wait_qualified,
+    _wait_ready,
+    is_root,
+)
 
 
 def _target(version: str | None, extras: str | None) -> str:
@@ -97,7 +108,8 @@ def upgrade_command(args) -> int:
         f"install {target} as {user}",
         "run rapid-mlx doctor (diagnostic)",
         f"bootstrap and require {config.host}:{config.port}/readyz",
-        "activate and qualify the configured primary model",
+        "start transiently without --lazy-load and require resident model readiness",
+        "restore the requested lazy-load policy after qualification",
         "restore frozen environment and old service on any failure",
     ]
     if dry_run:
@@ -144,8 +156,17 @@ def upgrade_command(args) -> int:
                 "the real launchd readiness gate will decide acceptance.",
                 file=sys.stderr,
             )
-        boot = _bootstrap(label)
-        healthy = boot.returncode == 0 and _wait_qualified(config)
+        try:
+            atomic_write_definition(
+                current_path,
+                config_bytes(_startup_qualification_config(config)),
+            )
+            boot = _bootstrap(label)
+            healthy = boot.returncode == 0 and _wait_qualified(config)
+            if healthy:
+                atomic_write_definition(current_path, config_bytes(config))
+        except OSError:
+            healthy = False
     else:
         healthy = False
 
@@ -157,7 +178,13 @@ def upgrade_command(args) -> int:
         return 0
 
     reason = upgraded.stderr.strip() if upgraded.returncode else "readiness gate failed"
-    rollback_ok = _restore(
+    try:
+        # Rollback must never reboot from the transient eager definition.
+        atomic_write_definition(current_path, config_bytes(config))
+        definition_restored = True
+    except OSError:
+        definition_restored = False
+    rollback_ok = definition_restored and _restore(
         user=user,
         python=python,
         requirements=requirements,

--- a/vllm_mlx/routes/health.py
+++ b/vllm_mlx/routes/health.py
@@ -236,11 +236,12 @@ async def activate_primary_model():
     """Load and warm the configured primary without running user inference.
 
     Probe endpoints deliberately leave a lazy service in ``standby``.  This
-    authenticated control-plane operation is the explicit opt-in used by the
-    transactional launchd installer/apply/upgrade gates (and by operators who
-    want to pre-warm an always-on endpoint).  It never selects or downloads a
-    request-supplied model: only the primary fixed in the server configuration
-    can be activated.
+    authenticated control-plane operation lets an operator pre-warm an
+    already-trusted endpoint. Transactional service installation qualifies the
+    model through eager startup instead, so it never sends a persistent
+    credential to a listener whose identity has not yet been established. The
+    operation never selects or downloads a request-supplied model: only the
+    primary fixed in the server configuration can be activated.
     """
     cfg = get_config()
     if not cfg.ready or cfg.draining:


### PR DESCRIPTION
## Why

The root-run headless service installer, config apply, and upgrader qualified a lazy model by reading the persistent API credential and sending it to whichever loopback process answered on the configured port. A bind race could therefore disclose a reusable service credential to an unrelated local listener.

## What

- qualify install/apply/upgrade with a transient copy of the validated config that removes only `--lazy-load`
- require `/readyz` to report both readiness and resident model weights before accepting the transaction
- persist the operator's requested lazy-load policy only after qualification succeeds
- remove the privileged credential-read and TCP activation path
- preserve rollback behavior and the 600-second model-load allowance
- document the updated transaction and add lifecycle tests for all three mutation paths

## Design precedent

Production serving systems distinguish process liveness from model readiness and make startup admission depend on the configured model becoming loadable. This adapts that startup-readiness boundary to the launchd transaction: the selected model remains fixed by the validated definition, while qualification no longer needs a reusable control-plane secret.

## Scope

Allowed: headless macOS service install/configure/upgrade qualification, its status wording, tests, and operator documentation.

Non-goals: changing the explicit authenticated activation API, server authentication policy, bind policy, model selection, or timeout values.

## Validation

- `python3.12 -m pytest -q tests/test_cli_service.py tests/test_service_config.py tests/test_model_activation_route.py` — 216 passed
- `python3.12 -m ruff check ...` on changed Python files — passed
- `python scripts/check_mypy_error_budget.py` in the pinned mypy environment — passed, no budget growth
- `git diff --check` — passed

Fixes #3243
