### PR TITLE
fix(desktop): tidy Computer Use grid + make Benchmark an Experimental opt-in

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/ComputerUseStarter.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/ComputerUseStarter.swift
@@ -29,10 +29,13 @@ struct ComputerUseStarter: Identifiable, Equatable, Sendable {
 
     var id: Kind { kind }
 
-    /// The catalog ordered for display: usable starters (`.available`) first
-    /// — so the one flow a user can actually run leads the grid — then the
-    /// rest in catalog order. A stable sort over the whole catalog: it never
-    /// drops an entry, even one carrying an availability tier added later.
+    /// The catalog ordered for display, by availability tier: usable
+    /// starters (`.available`) first — so the one flow a user can actually
+    /// run leads the grid — then `.comingSoon`, then the `.reserved`
+    /// placeholder last (it is the "more flows are coming" filler and belongs
+    /// at the end). The sort is stable, so entries keep their catalog order
+    /// within a tier, and it never drops an entry — a new tier added later
+    /// still appears, ranked after the ones below.
     static var ordered: [ComputerUseStarter] {
         func rank(_ availability: Availability) -> Int {
             switch availability {

--- a/apps/rapid-mac/Sources/Rapid/ComputerUse/ComputerUseStarter.swift
+++ b/apps/rapid-mac/Sources/Rapid/ComputerUse/ComputerUseStarter.swift
@@ -29,6 +29,28 @@ struct ComputerUseStarter: Identifiable, Equatable, Sendable {
 
     var id: Kind { kind }
 
+    /// The catalog ordered for display: usable starters (`.available`) first
+    /// — so the one flow a user can actually run leads the grid — then the
+    /// rest in catalog order. A stable sort over the whole catalog: it never
+    /// drops an entry, even one carrying an availability tier added later.
+    static var ordered: [ComputerUseStarter] {
+        func rank(_ availability: Availability) -> Int {
+            switch availability {
+            case .available: 0
+            case .comingSoon: 1
+            case .reserved: 2
+            }
+        }
+        return catalog
+            .enumerated()
+            .sorted { lhs, rhs in
+                let l = rank(lhs.element.availability)
+                let r = rank(rhs.element.availability)
+                return l == r ? lhs.offset < rhs.offset : l < r
+            }
+            .map(\.element)
+    }
+
     static let catalog: [ComputerUseStarter] = [
         ComputerUseStarter(
             kind: .freeUpSpace,

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkFeatureConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkFeatureConfig.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Explicit opt-in for the Benchmark workspace (the local community-benchmark
+/// runner).
+///
+/// Like the Video and Computer Use previews, the sidebar tab stays hidden until
+/// the user enables it in Settings → Experimental. Reading or writing this
+/// preference only controls discoverability: it never starts the server,
+/// downloads a benchmark model, or runs a measurement. Those remain explicit
+/// actions inside the Benchmark surface itself.
+enum CommunityBenchmarkFeatureConfig {
+    static let enabledKey = "Rapid.experimental.communityBenchmarkEnabled"
+    static let defaultEnabled = false
+
+    static func isEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enabledKey) as? Bool ?? defaultEnabled
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -5,6 +5,13 @@ struct ComputerUseView: View {
     let visualRuntime: DraftPostVisualRuntime?
     @State private var showingDraftPost = false
     @State private var showingFreeUpSpace = false
+    /// A shared minimum keeps the flow grid even at the common text size;
+    /// cards still grow past it rather than clip when the summary wraps under
+    /// larger Dynamic Type. Scaled so the floor tracks the viewer's text size.
+    @ScaledMetric(relativeTo: .body) private var starterCardMinHeight: CGFloat = 210
+    /// Space reserved at the bottom of every card for the (bottom-anchored)
+    /// action, so content never collides with it. Scaled with Dynamic Type.
+    @ScaledMetric(relativeTo: .body) private var starterActionReserve: CGFloat = 44
 
     init(
         languageRuntime: DraftPostLanguageRuntime? = nil,
@@ -38,7 +45,7 @@ struct ComputerUseView: View {
                         columns: [GridItem(.adaptive(minimum: 260, maximum: 320), spacing: 12)],
                         spacing: 12
                     ) {
-                        ForEach(ComputerUseStarter.catalog) { starter in
+                        ForEach(ComputerUseStarter.ordered) { starter in
                             starterCard(starter)
                         }
                     }
@@ -89,11 +96,14 @@ struct ComputerUseView: View {
     }
 
     private func starterCard(_ starter: ComputerUseStarter) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
+        let isAvailable = starter.availability == .available
+        return VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Image(systemName: starter.systemImage)
                     .font(.title2)
-                    .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                    .foregroundStyle(
+                        isAvailable ? RapidTheme.brandPrimaryDeep : RapidTheme.textSecondary
+                    )
                 Spacer()
                 Text(availabilityLabel(starter.availability))
                     .font(.caption2.weight(.bold))
@@ -103,22 +113,40 @@ struct ComputerUseView: View {
             Text(starter.summary)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             Text(starter.applications)
                 .font(.caption2.weight(.medium))
                 .foregroundStyle(.secondary)
             Label(starter.approvalNote, systemImage: "checkmark.shield")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
-            if starter.availability == .available {
-                Button("Start flow") {
-                    start(starter.kind)
-                }
-                .buttonStyle(.rapidPrimaryCompact)
-                .accessibilityIdentifier(startIdentifier(starter.kind))
+        }
+        // Dim only the content of not-yet-available cards; the card fill,
+        // border, and action below stay full strength so the tile still
+        // reads as present.
+        .opacity(isAvailable ? 1 : 0.6)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(16)
+        // Reserve the action row on every card so text never runs under the
+        // bottom-anchored button and the tiles line up whether or not they
+        // carry one. Scales with Dynamic Type.
+        .padding(.bottom, starterActionReserve)
+        // A shared *minimum* height keeps the grid even at the common text
+        // size; using a minimum (not a fixed height) lets a card grow rather
+        // than clip when the summary wraps to more lines under larger
+        // Dynamic Type. Scales so the floor tracks the text size.
+        .frame(minHeight: starterCardMinHeight, alignment: .topLeading)
+        // Anchor the action to the card's true bottom edge with an overlay,
+        // so it stays pinned regardless of how the height is proposed and
+        // follows the card as it grows.
+        .overlay(alignment: .bottomLeading) {
+            if isAvailable {
+                Button("Start flow") { start(starter.kind) }
+                    .buttonStyle(.rapidPrimaryCompact)
+                    .accessibilityIdentifier(startIdentifier(starter.kind))
+                    .padding(16)
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 118, alignment: .topLeading)
-        .padding(16)
         .background(RapidTheme.surfaceRaised, in: RoundedRectangle(cornerRadius: 14))
         .overlay(
             RoundedRectangle(cornerRadius: 14)

--- a/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ComputerUseView.swift
@@ -1,5 +1,15 @@
 import SwiftUI
 
+/// Collects the tallest starter-card height so every card can adopt it and
+/// the flow grid stays equal-height. Max-reducing: the largest reported
+/// height wins.
+private struct StarterCardHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 struct ComputerUseView: View {
     let languageRuntime: DraftPostLanguageRuntime?
     let visualRuntime: DraftPostVisualRuntime?
@@ -12,6 +22,14 @@ struct ComputerUseView: View {
     /// Space reserved at the bottom of every card for the (bottom-anchored)
     /// action, so content never collides with it. Scaled with Dynamic Type.
     @ScaledMetric(relativeTo: .body) private var starterActionReserve: CGFloat = 44
+    /// The tallest card's measured height, shared back to every card so the
+    /// whole grid is equal-height. A `LazyVGrid` does not stretch a short
+    /// cell to its row's tallest sibling, so without this a card whose
+    /// content grows (e.g. a wrapped summary at a large Dynamic Type size)
+    /// would leave the others short and the grid ragged. Measuring the real
+    /// rendered height (rather than a fixed guess) means it also tracks
+    /// Dynamic Type instead of clipping.
+    @State private var measuredStarterHeight: CGFloat = 0
 
     init(
         languageRuntime: DraftPostLanguageRuntime? = nil,
@@ -52,6 +70,9 @@ struct ComputerUseView: View {
                     // Three cards at their maximum width plus two gaps. The
                     // adaptive grid can still collapse to two or one column.
                     .frame(maxWidth: 984, alignment: .leading)
+                    .onPreferenceChange(StarterCardHeightKey.self) { height in
+                        measuredStarterHeight = height
+                    }
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
@@ -64,19 +85,25 @@ struct ComputerUseView: View {
                             .foregroundStyle(.secondary)
                         VStack(alignment: .leading, spacing: 3) {
                             Text("Teach Rapid a new task").font(.headline)
-                            Text("Show Rapid how you work when no starter fits. Planned for the next Computer Use preview.")
+                            Text("Show Rapid how you work when no starter fits.")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
                         Spacer()
-                        Button("Coming next") {}
-                            .buttonStyle(.rapidSecondaryCompact)
-                            .disabled(true)
+                        // A plain status label, not a disabled button: there is
+                        // nothing to press yet, so a button-shaped control only
+                        // invites a dead click.
+                        Text("Coming next")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(.secondary)
                             .accessibilityIdentifier("ComputerUse.Teach.ComingNext")
                     }
                     .padding(16)
                     .background(RapidTheme.surfaceRaised, in: RoundedRectangle(cornerRadius: 14))
                     .overlay(RoundedRectangle(cornerRadius: 14).stroke(.secondary.opacity(0.2)))
+                    // Share the grid's trailing edge so the page reads as one
+                    // column of content rather than a grid plus a wider band.
+                    .frame(maxWidth: 984, alignment: .leading)
                 }
             }
             .padding(RapidTheme.Space.xl)
@@ -97,6 +124,10 @@ struct ComputerUseView: View {
 
     private func starterCard(_ starter: ComputerUseStarter) -> some View {
         let isAvailable = starter.availability == .available
+        // Quiet the supporting content of a not-yet-available card, but keep
+        // its title and status legible so the tile reads as a real, named
+        // capability rather than a greyed-out blur.
+        let supportOpacity = isAvailable ? 1.0 : 0.6
         return VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Image(systemName: starter.systemImage)
@@ -104,44 +135,59 @@ struct ComputerUseView: View {
                     .foregroundStyle(
                         isAvailable ? RapidTheme.brandPrimaryDeep : RapidTheme.textSecondary
                     )
+                    .opacity(supportOpacity)
                 Spacer()
                 Text(availabilityLabel(starter.availability))
                     .font(.caption2.weight(.bold))
                     .foregroundStyle(.secondary)
             }
-            Text(starter.title).font(.headline)
+            Text(starter.title)
+                .font(.headline)
+                .foregroundStyle(isAvailable ? Color.primary : Color.secondary)
             Text(starter.summary)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+                .opacity(supportOpacity)
             Text(starter.applications)
                 .font(.caption2.weight(.medium))
                 .foregroundStyle(.secondary)
+                .opacity(supportOpacity)
             Label(starter.approvalNote, systemImage: "checkmark.shield")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+                .opacity(supportOpacity)
         }
-        // Dim only the content of not-yet-available cards; the card fill,
-        // border, and action below stay full strength so the tile still
-        // reads as present.
-        .opacity(isAvailable ? 1 : 0.6)
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .padding(16)
         // Reserve the action row on every card so text never runs under the
         // bottom-anchored button and the tiles line up whether or not they
         // carry one. Scales with Dynamic Type.
         .padding(.bottom, starterActionReserve)
-        // A shared *minimum* height keeps the grid even at the common text
-        // size; using a minimum (not a fixed height) lets a card grow rather
-        // than clip when the summary wraps to more lines under larger
-        // Dynamic Type. Scales so the floor tracks the text size.
-        .frame(minHeight: starterCardMinHeight, alignment: .topLeading)
+        // Equal-height across the grid: at least the scaled floor, and at
+        // least the tallest measured card (so a card that grows under large
+        // Dynamic Type pulls every sibling up to match instead of leaving
+        // them short). A minimum — never a fixed height — so growth never
+        // clips. The measurement below reports each card's real height back
+        // up through StarterCardHeightKey.
+        .frame(
+            minHeight: max(starterCardMinHeight, measuredStarterHeight),
+            alignment: .topLeading
+        )
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: StarterCardHeightKey.self,
+                    value: proxy.size.height
+                )
+            }
+        )
         // Anchor the action to the card's true bottom edge with an overlay,
         // so it stays pinned regardless of how the height is proposed and
         // follows the card as it grows.
         .overlay(alignment: .bottomLeading) {
             if isAvailable {
-                Button("Start flow") { start(starter.kind) }
+                Button(actionLabel(starter.kind)) { start(starter.kind) }
                     .buttonStyle(.rapidPrimaryCompact)
                     .accessibilityIdentifier(startIdentifier(starter.kind))
                     .padding(16)
@@ -171,6 +217,16 @@ struct ComputerUseView: View {
             showingDraftPost = true
         case .tidyInbox, .prospectCustomers, .createDemoVideo, .reserved:
             break
+        }
+    }
+
+    /// A concrete verb for each live flow's button, so the primary action
+    /// says what it will do instead of a generic "Start flow".
+    private func actionLabel(_ kind: ComputerUseStarter.Kind) -> String {
+        switch kind {
+        case .freeUpSpace: "Review files"
+        case .draftAndPost: "Draft update"
+        case .tidyInbox, .prospectCustomers, .createDemoVideo, .reserved: "Start flow"
         }
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -102,6 +102,8 @@ struct ContentView: View {
     private var videoGenerationEnabled = VideoFeatureConfig.defaultEnabled
     @AppStorage(ComputerUseFeatureConfig.enabledKey)
     private var computerUseEnabled = ComputerUseFeatureConfig.defaultEnabled
+    @AppStorage(CommunityBenchmarkFeatureConfig.enabledKey)
+    private var communityBenchmarkEnabled = CommunityBenchmarkFeatureConfig.defaultEnabled
     /// Window-level conversation search, opened from the toolbar.
     @State private var showConversationSearch = false
     // Was @SceneStorage. Moved to @AppStorage so the View menu command in
@@ -325,11 +327,14 @@ struct ContentView: View {
                 mcpCatalog.clear()
             }
         }
-        .onChange(of: experimentalDestinationState) { _, state in
+        .onChange(of: experimentalDestinationState, initial: true) { _, state in
             // Removing an experimental destination while it is active must
-            // never leave an unreachable detail pane on screen. Keep both
+            // never leave an unreachable detail pane on screen. Keep the
             // gates in one observation node so the already-large shell body
-            // remains tractable for Swift's type checker.
+            // remains tractable for Swift's type checker. `initial: true`
+            // also sanitises the selection on first appearance, so an app
+            // launched with a now-disabled experimental tab still selected
+            // (e.g. a persisted or deep-linked section) lands on Chat.
             section = Self.sectionAfterVideoGateChange(
                 current: section,
                 enabled: state.videoEnabled
@@ -337,6 +342,10 @@ struct ContentView: View {
             section = Self.sectionAfterComputerUseGateChange(
                 current: section,
                 enabled: state.computerUseEnabled
+            )
+            section = Self.sectionAfterBenchmarkGateChange(
+                current: section,
+                enabled: state.benchmarkEnabled
             )
         }
         .onChange(of: server.state) { _, newState in
@@ -611,6 +620,7 @@ struct ContentView: View {
                     selection: $section,
                     videoGenerationEnabled: videoGenerationEnabled,
                     computerUseEnabled: computerUseEnabled,
+                    benchmarkEnabled: communityBenchmarkEnabled,
                     chat: chat,
                 onNewChat: {
                     chat.newConversation()
@@ -1208,15 +1218,24 @@ struct ContentView: View {
                 onReadinessAction: performReadinessAction
             )
         case .benchmark:
-            CommunityBenchmarkView(
-                catalog: catalogEntries,
-                binary: server.binaryPath,
-                prepareServer: { try await server.prepareForCommunityBenchmark() },
-                releaseServer: { server.finishCommunityBenchmark($0) },
-                retainServerDuringDeferredReap: {
-                    server.retainCommunityBenchmarkDuringDeferredReap($0)
-                }
-            )
+            if communityBenchmarkEnabled {
+                CommunityBenchmarkView(
+                    catalog: catalogEntries,
+                    binary: server.binaryPath,
+                    prepareServer: { try await server.prepareForCommunityBenchmark() },
+                    releaseServer: { server.finishCommunityBenchmark($0) },
+                    retainServerDuringDeferredReap: {
+                        server.retainCommunityBenchmarkDuringDeferredReap($0)
+                    }
+                )
+            } else {
+                // Flag flipped off while this tab was selected. Show the
+                // default surface until the experimentalDestinationState
+                // onChange routes back to Chat — same fallback the Video and
+                // Computer Use branches use. Not recursive: `mainArea`
+                // switches on `server.state`, not `section`.
+                mainArea
+            }
         }
     }
 
@@ -1429,15 +1448,24 @@ struct ContentView: View {
         !enabled && current == .computerUse ? .chat : current
     }
 
+    static func sectionAfterBenchmarkGateChange(
+        current: SidebarSection,
+        enabled: Bool
+    ) -> SidebarSection {
+        !enabled && current == .benchmark ? .chat : current
+    }
+
     private struct ExperimentalDestinationState: Equatable {
         let videoEnabled: Bool
         let computerUseEnabled: Bool
+        let benchmarkEnabled: Bool
     }
 
     private var experimentalDestinationState: ExperimentalDestinationState {
         ExperimentalDestinationState(
             videoEnabled: videoGenerationEnabled,
-            computerUseEnabled: computerUseEnabled
+            computerUseEnabled: computerUseEnabled,
+            benchmarkEnabled: communityBenchmarkEnabled
         )
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -49,6 +49,8 @@ struct SettingsView: View {
     private var videoGenerationEnabled = VideoFeatureConfig.defaultEnabled
     @AppStorage(ComputerUseFeatureConfig.enabledKey)
     private var computerUseEnabled = ComputerUseFeatureConfig.defaultEnabled
+    @AppStorage(CommunityBenchmarkFeatureConfig.enabledKey)
+    private var communityBenchmarkEnabled = CommunityBenchmarkFeatureConfig.defaultEnabled
 
     /// Stable reference shared by the sidebar and detail canvas. Keeping the
     /// frequently-mutated category outside this large view's value state means
@@ -542,6 +544,15 @@ struct SettingsView: View {
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
                 .accessibilityIdentifier("Settings.Experimental.ComputerUseToggle")
+                SettingsRowDivider()
+                Toggle(isOn: $communityBenchmarkEnabled) {
+                    SettingsRowLabel(
+                        title: "Enable Benchmark",
+                        description: "Adds the Benchmark tab for measuring models on this Mac. Nothing runs until you start a benchmark."
+                    )
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityIdentifier("Settings.Experimental.BenchmarkToggle")
             }
         }
         .accessibilityIdentifier("Settings.Experimental.Panel")

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -118,7 +118,7 @@ struct SettingsView: View {
             case .tools: return "Tools"
             case .connectors: return "Connectors"
             case .performance: return "Performance"
-            case .experimentalFeatures: return "Experimental Features"
+            case .experimentalFeatures: return "Experimental"
             case .appearance: return "Appearance"
             case .privacy: return "Privacy"
             case .app: return "App"
@@ -520,7 +520,7 @@ struct SettingsView: View {
     private var experimentalFeaturesPanel: some View {
         VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
             SectionHeader(
-                "Experimental Features",
+                "Experimental",
                 subtitle: "Opt in to features that are still being validated across supported Macs.",
                 emphasis: .page
             )
@@ -528,16 +528,16 @@ struct SettingsView: View {
                 Toggle(isOn: $videoGenerationEnabled) {
                     SettingsRowLabel(
                         title: "Enable Video Generation",
-                        description: "Shows the Video tab. Video models need Apple silicon, large downloads, and typically 24 GB or more of unified memory. Nothing downloads or starts until you choose a model."
+                        description: "Adds the Video tab; requires Apple silicon and typically 24 GB+ of unified memory, with no downloads or activity until you choose a model."
                     )
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
                 .accessibilityIdentifier("Settings.Experimental.VideoGenerationToggle")
-                Divider()
+                SettingsRowDivider()
                 Toggle(isOn: $computerUseEnabled) {
                     SettingsRowLabel(
                         title: "Enable Computer Use",
-                        description: "Shows the Computer Use tab with local starter tasks. Nothing observes your screen, downloads a model, or acts until you choose a task. Rapid previews consequential actions for your approval."
+                        description: "Adds the Computer Use tab; Rapid acts only on a task you choose and previews consequential actions for your approval."
                     )
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -40,6 +40,9 @@ struct SidebarView: View {
     /// Computer Use is a deliberately opt-in preview. Enabling discoverability
     /// does not start observation, request permissions, or load a model.
     var computerUseEnabled: Bool = false
+    /// The Benchmark tab is an opt-in experimental surface. Enabling
+    /// discoverability does not start the server or run any measurement.
+    var benchmarkEnabled: Bool = false
     /// The chat model — source of the conversation history list + the
     /// active conversation id (for highlighting).
     @Bindable var chat: ChatViewModel
@@ -183,24 +186,6 @@ struct SidebarView: View {
                 action: { selection = .audio }
             )
             .accessibilityIdentifier("Sidebar.Audio")
-            if videoGenerationEnabled {
-                row(
-                    title: "Video",
-                    systemImage: "film",
-                    isSelected: selection == .video,
-                    action: { selection = .video }
-                )
-                .accessibilityIdentifier("Sidebar.Video")
-            }
-            if computerUseEnabled {
-                row(
-                    title: "Computer Use",
-                    systemImage: "macwindow.on.rectangle",
-                    isSelected: selection == .computerUse,
-                    action: { selection = .computerUse }
-                )
-                .accessibilityIdentifier("Sidebar.ComputerUse")
-            }
             row(
                 title: "Launch",
                 systemImage: "paperplane",
@@ -208,13 +193,45 @@ struct SidebarView: View {
                 action: { selection = .launch }
             )
             .accessibilityIdentifier("Sidebar.Launch")
-            row(
-                title: "Community Benchmark",
-                systemImage: "gauge.with.dots.needle.50percent",
-                isSelected: selection == .benchmark,
-                action: { selection = .benchmark }
-            )
-            .accessibilityIdentifier("Sidebar.CommunityBenchmark")
+
+            // Experimental workspaces live in their own labelled group below
+            // the everyday tabs (rather than interleaved with them), so the
+            // opt-in previews read as a distinct, still-being-validated set.
+            // The header appears only when at least one is enabled.
+            if videoGenerationEnabled || computerUseEnabled || benchmarkEnabled {
+                SectionHeader("Experimental")
+                    .padding(.horizontal, RapidTheme.Space.sm)
+                    .padding(.top, RapidTheme.Space.lg)
+                    .padding(.bottom, RapidTheme.Space.xs)
+                    .accessibilityIdentifier("Sidebar.ExperimentalHeader")
+                if videoGenerationEnabled {
+                    row(
+                        title: "Video",
+                        systemImage: "film",
+                        isSelected: selection == .video,
+                        action: { selection = .video }
+                    )
+                    .accessibilityIdentifier("Sidebar.Video")
+                }
+                if computerUseEnabled {
+                    row(
+                        title: "Computer Use",
+                        systemImage: "macwindow.on.rectangle",
+                        isSelected: selection == .computerUse,
+                        action: { selection = .computerUse }
+                    )
+                    .accessibilityIdentifier("Sidebar.ComputerUse")
+                }
+                if benchmarkEnabled {
+                    row(
+                        title: "Benchmark",
+                        systemImage: "gauge.with.dots.needle.50percent",
+                        isSelected: selection == .benchmark,
+                        action: { selection = .benchmark }
+                    )
+                    .accessibilityIdentifier("Sidebar.CommunityBenchmark")
+                }
+            }
 
             // Folders can exist before any conversation does (create one, then
             // file into it), so an empty history no longer means an empty rail.

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.speech.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/audio-readiness.speech.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXGroup id="Audio.Mode" desc="Audio mode" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/campaign-banner.visible.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/campaign-banner.visible.txt
@@ -14,7 +14,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.five-turns.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-depth.restored.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.answered.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.conversation-instructions.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.search-results.txt
@@ -17,7 +17,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.<uuid>" desc="golden restore marker" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/chat-restore.transcript-restored.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXScrollArea
             AXButton id="Sidebar.Folder.Toggle.Golden-Work" desc="Golden Work (1)" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.post-value-consent.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.post-value-consent.txt
@@ -15,7 +15,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/fresh-install.steady.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.empty.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText id="Images.EmptyState" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.finalizing.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.generated.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/image-generation.inflight.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXImage id="Sidebar.Residency" desc="memorychip" enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true
           AXStaticText id="Sidebar.Residency" value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/launch-integrations.complete.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXHeading desc="Connect your agents, Connect any agent or editor that supports a local base URL. It's free and stays on your Mac." enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/model-crash-recovery.recovered.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
           AXScrollArea
             AXHeading desc="<relative-day>" enabled=true
             AXButton id="Sidebar.Conversation.Pin.<uuid>" desc="Pin conversation" help="Pin conversation" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
@@ -65,7 +65,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
@@ -65,7 +65,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -66,7 +66,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -66,7 +66,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -66,7 +66,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -66,7 +66,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -66,7 +66,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -66,7 +66,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -66,7 +66,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -72,7 +72,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -8,7 +8,6 @@ AXApplication title="Rapid-MLX"
           AXButton id="Sidebar.Images" desc="Images" enabled=true
           AXButton id="Sidebar.Audio" desc="Audio" enabled=true
           AXButton id="Sidebar.Launch" desc="Launch" enabled=true
-          AXButton id="Sidebar.CommunityBenchmark" desc="Community Benchmark" enabled=true
         AXSplitter value=number enabled=false
         AXGroup subrole=AXHostingView
           AXStaticText value=text enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -65,7 +65,7 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental Features" enabled=true
+              AXButton id="Settings.Category.experimentalFeatures" desc="Experimental" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
               AXButton id="Settings.Category.appearance" desc="Appearance" enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkFeatureGateTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkFeatureGateTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Experimental Benchmark gate", .serialized)
+struct CommunityBenchmarkFeatureGateTests {
+    @Test("Benchmark is opt-in when no preference exists")
+    func defaultsOff() throws {
+        let suite = "rapid.benchmark-gate-tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(!CommunityBenchmarkFeatureConfig.isEnabled(in: defaults))
+        defaults.set(true, forKey: CommunityBenchmarkFeatureConfig.enabledKey)
+        #expect(CommunityBenchmarkFeatureConfig.isEnabled(in: defaults))
+    }
+
+    @MainActor
+    @Test("Disabling while Benchmark is active returns to Chat")
+    func disablingRecoversNavigation() {
+        #expect(ContentView.sectionAfterBenchmarkGateChange(current: .benchmark, enabled: false) == .chat)
+        #expect(ContentView.sectionAfterBenchmarkGateChange(current: .benchmark, enabled: true) == .benchmark)
+        #expect(ContentView.sectionAfterBenchmarkGateChange(current: .images, enabled: false) == .images)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ComputerUseFeatureTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ComputerUseFeatureTests.swift
@@ -47,7 +47,7 @@ struct ComputerUseFeatureTests {
         let canonical = SourceGuardSupport.canonicalSource(source, literals: .preserve)
 
         #expect(canonical.contains("@AppStorage(ComputerUseFeatureConfig.enabledKey)privatevarcomputerUseEnabled"))
-        #expect(canonical.contains(".onChange(of:experimentalDestinationState){_,statein"))
+        #expect(canonical.contains(".onChange(of:experimentalDestinationState,initial:true){_,statein"))
         #expect(canonical.contains("section=Self.sectionAfterComputerUseGateChange(current:section,enabled:state.computerUseEnabled)"))
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/ComputerUseStarterOrderTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ComputerUseStarterOrderTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// The Computer Use "Start with a flow" grid leads with the flow a user can
+/// actually run. That ordering is product behavior, not view chrome, so it is
+/// asserted against the catalog model rather than a rendered grid (#3254).
+@Suite("Computer Use starter order")
+struct ComputerUseStarterOrderTests {
+    @Test("available starters come first")
+    func availableStartersLead() {
+        let ranks = ComputerUseStarter.ordered.map { starter -> Int in
+            switch starter.availability {
+            case .available: 0
+            case .comingSoon: 1
+            case .reserved: 2
+            }
+        }
+        // Non-decreasing: every available starter precedes every coming-soon
+        // one, which precedes every reserved one.
+        #expect(ranks == ranks.sorted())
+        #expect(ComputerUseStarter.ordered.first?.availability == .available)
+    }
+
+    @Test("ordering preserves every catalog entry exactly once")
+    func orderingDropsNothing() {
+        let orderedKinds = Set(ComputerUseStarter.ordered.map(\.kind))
+        let catalogKinds = Set(ComputerUseStarter.catalog.map(\.kind))
+        #expect(ComputerUseStarter.ordered.count == ComputerUseStarter.catalog.count)
+        #expect(orderedKinds == catalogKinds)
+    }
+
+    @Test("ordering is stable within every availability tier")
+    func orderingIsStableWithinEveryTier() {
+        // Within a tier, entries keep their catalog order. Verify the ordered
+        // subsequence equals the catalog subsequence for EACH tier, so a
+        // reversal in any tier — not just the leading one — fails the test.
+        for availability: ComputerUseStarter.Availability in [.available, .comingSoon, .reserved] {
+            let catalogTier = ComputerUseStarter.catalog
+                .filter { $0.availability == availability }
+                .map(\.kind)
+            let orderedTier = ComputerUseStarter.ordered
+                .filter { $0.availability == availability }
+                .map(\.kind)
+            #expect(catalogTier == orderedTier, "tier \(availability) reordered")
+        }
+    }
+}


### PR DESCRIPTION
## Why

Dogfooding the latest `main` build surfaced rough edges on the experimental surfaces a new user meets first. The Computer Use "Start with a flow" grid rendered ragged and the usable flow wasn't first. Settings → Experimental crowded the sidebar with a long label and verbose copy. The community-benchmark runner sat permanently in the sidebar even though it's still experimental. And the sidebar interleaved the opt-in experimental tabs with the everyday ones. A follow-up visual design pass (screenshots run through an image model on a spare Mac) then suggested small refinements to the Computer Use cards.

## What

### Computer Use — "Start with a flow" grid
- **Available-first ordering** via a testable `ComputerUseStarter.ordered` (stable, reserved placeholder last, never drops an entry) so the usable flow leads top-left.
- **Equal-height cards**: every card adopts the tallest measured height (a max-reducing PreferenceKey applied as a minimum), so the grid stays even and grows — never clips — under larger Dynamic Type. Actions are bottom-anchored via an overlay.
- **Legible dimming**: not-yet-available cards keep their title and status crisp; only the icon and supporting text quiet down.
- **Design-review polish**: live flows get concrete button labels ("Review files", "Draft update"); the "Teach Rapid a new task" row is a plain "Coming next" label (no dead-click button) that shares the grid's trailing edge.

### Settings → Experimental
- Renamed **"Experimental Features" → "Experimental"**; toggles separated with `SettingsRowDivider`; descriptions shortened. All three experimental workspaces have a toggle here (Video, Computer Use, Benchmark).

### Benchmark → an Experimental opt-in
- New `CommunityBenchmarkFeatureConfig` (default **off**): the tab is hidden until enabled, mirroring Video / Computer Use. Sidebar tab renamed **"Community Benchmark" → "Benchmark"**; row and detail render gated on the flag; navigation routes back to Chat if the flag is turned off while active (sanitised on launch via `onChange(initial: true)`).

### Sidebar — a dedicated Experimental group
- Everyday tabs stay in their original order at the top (New Chat, Images, Audio, Launch); the opt-in previews (Video, Computer Use, Benchmark, and future ones) live under a labelled **"Experimental"** group header, shown only when at least one is enabled.

## Testing
- `swift build` succeeds (debug + release); built and visually verified on a spare Mac (each surface screenshotted).
- New unit tests: `ComputerUseStarterOrderTests` (3) and `CommunityBenchmarkFeatureGateTests` (2) pass.
- GUI golden snapshots updated: experimental rows hidden by default; the Settings category reads "Experimental".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019A88kUrTwWXNnbhhXbSPcx