### PR TITLE
feat(models): add experimental NeoHorse 1 9B

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ multiplication. The regular `qwen3.8-27b-4bit` alias remains unchanged for M3
 and newer Macs; Rapid does not silently swap checkpoint precision.
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
-→ [Every alias, quant, and family (188 text + 10 image + 10 video + 44 audio aliases, 252 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
+→ [Every alias, quant, and family (189 text + 10 image + 10 video + 44 audio aliases, 253 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
 
 ---
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -307,6 +307,15 @@ final class QuickstartCoordinator {
             tier: .tradeUp
         ),
         QuickstartModelChoice(
+            alias: "neohorse-9b-4bit",
+            displayName: "NeoHorse 1 · 9B",
+            hfRepo: "rapid-mlx/NeoHorse-1-9B-MLX-4bit",
+            downloadBytes: 5_058_235_254,
+            blurb: "Experimental 9B chat and tools for comparing model behavior.",
+            tier: .tradeUp,
+            minRAMGB: 18
+        ),
+        QuickstartModelChoice(
             alias: "qwen3.8-27b-4bit",
             displayName: "Qwen 3.8 · 27B",
             hfRepo: nil,

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -333,6 +333,12 @@ final class QuickstartCoordinator {
         ),
     ]
 
+    /// Experimental choices that onboarding may offer explicitly but must
+    /// never promote merely because their weights happen to be cached. This
+    /// keeps the first-run recommendation stable while still letting an
+    /// informed user select and compare the model.
+    static let optionalOnlyAliases: Set<String> = ["neohorse-9b-4bit"]
+
     /// Hardware-aware first-run policy. The existing cache-aware policy is the
     /// eligibility SSOT for cached choices; onboarding adds only its explicit
     /// 16 GB baseline. The 1.2B choice is automatic only when it is already
@@ -344,6 +350,7 @@ final class QuickstartCoordinator {
         let baseline = baselineChoice(hardware: hardware)
         let eligibleCatalog = catalog.filter { $0.supports(.chat) }
         var excluded = CacheAwareDefault.retiredAutomaticAliases
+            .union(optionalOnlyAliases)
         if baseline.alias != lowMemoryChoice.alias {
             excluded.insert(lowMemoryChoice.alias)
         } else {

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -2322,17 +2322,30 @@ struct QuickstartView: View {
         tradeUps: [QuickstartModelChoice],
         hardware: MacHardware
     ) -> [OnboardingComparisonTable.Column] {
-        tradeUps.map { choice in
+        let titles = comparisonColumnTitles(for: tradeUps)
+        return tradeUps.enumerated().map { index, choice in
             let footprint = ModelSizing.estimate(alias: choice.alias)
             let fit = ModelSizing.classify(footprint, on: hardware)
             return OnboardingComparisonTable.Column(
-                title: comparisonColumnTitle(for: choice),
+                title: titles[index],
                 isPicked: choice.alias == selection,
                 download: sizeText(for: choice),
                 memory: footprint.totalGB > 0 ? "≈ \(preciseGB(footprint.totalGB))" : "Unknown",
                 fit: fitText(fit),
                 fitIsWarning: fit != .recommended
             )
+        }
+    }
+
+    /// Prefer the compact parameter-count header, but disambiguate models of
+    /// the same size with their authored display names. A comparison can offer
+    /// multiple 9B choices; two identical "9B" columns would make the picked
+    /// state and the sourced cost figures impossible to attribute.
+    static func comparisonColumnTitles(for choices: [QuickstartModelChoice]) -> [String] {
+        let compact = choices.map(comparisonColumnTitle(for:))
+        let frequencies = Dictionary(compact.map { ($0, 1) }, uniquingKeysWith: +)
+        return zip(choices, compact).map { choice, title in
+            frequencies[title, default: 0] > 1 ? choice.displayName : title
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/OnboardingDirectionDTests.swift
@@ -537,8 +537,11 @@ struct OnboardingDirectionDTests {
             let title = QuickstartView.comparisonColumnTitle(for: choice)
             #expect(title.hasSuffix("B"), "\(choice.alias) header was \(title)")
         }
-        #expect(Set(Self.tradeUps.map(QuickstartView.comparisonColumnTitle(for:))).count
-                == Self.tradeUps.count, "columns must be distinguishable")
+        let titles = QuickstartView.comparisonColumnTitles(for: Self.tradeUps)
+        #expect(Set(titles).count == Self.tradeUps.count,
+                "same-size choices must be disambiguated by model name")
+        #expect(titles.contains("Qwen 3.5 · 9B"))
+        #expect(titles.contains("NeoHorse 1 · 9B"))
     }
 
     // MARK: - The click contract (unchanged by this visual pass)

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartStarterPolicyTests.swift
@@ -141,6 +141,20 @@ struct QuickstartStarterPolicyTests {
         #expect(pick.alias == "qwen3.5-9b-4bit")
     }
 
+    @Test("A cached experimental trade-up never becomes the automatic first model")
+    func cachedExperimentalTradeUpIsNeverAutomatic() {
+        let pick = QuickstartCoordinator.defaultChoice(
+            hardware: hardware(24),
+            catalog: [
+                entry("qwen3.5-4b-4bit"),
+                entry("neohorse-9b-4bit", cached: true),
+            ]
+        )
+
+        #expect(pick.alias == "qwen3.5-4b-4bit")
+        #expect(QuickstartCoordinator.optionalOnlyAliases.contains("neohorse-9b-4bit"))
+    }
+
     @Test("A cached standard starter stays visible when it wins below 16 GB")
     func cachedStandardStarterRemainsVisible() {
         let catalog = [

--- a/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/Step2ModelSelectionBehaviorTests.swift
@@ -462,6 +462,22 @@ struct Step2ModelSelectionBehaviorTests {
         #expect(visible.map(\.alias) == ["chat-a", "chat-b"])
     }
 
+    @Test("NeoHorse is an optional memory-gated first-run trade-up")
+    func neoHorseIsOptionalFirstRunTradeUp() throws {
+        let choice = try #require(
+            QuickstartCoordinator.onboardingChoices.first {
+                $0.alias == "neohorse-9b-4bit"
+            }
+        )
+        #expect(choice.tier == .tradeUp)
+        #expect(choice.hfRepo == "rapid-mlx/NeoHorse-1-9B-MLX-4bit")
+        #expect(choice.downloadBytes == 5_058_235_254)
+        #expect(choice.blurb.localizedCaseInsensitiveContains("experimental"))
+        #expect(!choice.isVisible(onRAMGB: 16))
+        #expect(choice.isVisible(onRAMGB: 24))
+        #expect(QuickstartCoordinator.defaultChoice.alias == "qwen3.5-4b-4bit")
+    }
+
     @Test("Search matches alias and Hugging Face repo through the shared primitive")
     func searchUsesTheSharedFilter() {
         let catalog = [Self.entry("qwen3.5-9b-4bit"), Self.entry("gemma3-1b")]

--- a/docs/engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md
+++ b/docs/engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md
@@ -9,7 +9,7 @@ experimental model. It is not evidence for changing the default model.
 
 - Machine: Apple M3 Ultra, 256 GB unified memory
 - macOS: 26.5.2 (25F84)
-- Python: 3.11
+- Python: 3.12.13
 - MLX: 0.32.2
 - mlx-lm: 0.31.3
 - NeoHorse source: `TokenRhythm/NeoHorse-1-9B` at
@@ -19,25 +19,61 @@ experimental model. It is not evidence for changing the default model.
 - Baseline: `mlx-community/Qwen3.5-9B-4bit` at
   `8b2b98c00a6b4d291155e4890773ca8f769aee53`
 - Quantization: affine 4-bit, group size 64
+- Rapid-MLX revision under test: `525b62ac3`
 
 ## Results
 
-The fixed local prompt set scored reasoning, general Chat, coding, and
-first-action tool selection separately:
+The checked-in product-path evaluator produced these results:
 
-| Model | Reasoning | General Chat | Coding | Tool first action |
-|---|---:|---:|---:|---:|
-| Qwen3.5 9B 4-bit | 8/10 | 6/10 | 8/10 | 25/30 |
-| NeoHorse 1 9B 4-bit | 8/10 | 7/10 | 8/10 | 28/30 |
+| Suite | Result |
+|---|---:|
+| Tool calling, including parallel, sequential, and recovery cases | 24/31 (77%) |
+| Executable coding tasks | 6/10 (60%) |
+| Deterministically graded reasoning | 6/10 (60%) |
+| General knowledge and instruction following | 7/10 (70%) |
 
-NeoHorse was better at parallel tool selection and clarifying an ambiguous
-request. It also invented specific project names in one factuality probe.
-That regression is why the model remains experimental.
+The failures include incomplete parallel tool batches, missed later steps in
+sequential tool workflows, one failed recovery case, four coding tasks with
+runtime failures, and four incorrect reasoning answers. These results support
+an experimental listing, but do not support replacing the default 9B model.
 
-A single 256-token speed smoke on the same machine measured 115.2 tokens/s
-for NeoHorse and 112.4 tokens/s for the baseline, with reported peak memory
-of 5.25 GB and 6.75 GB respectively. This is a smoke result, not a general
-performance claim: it is one prompt, one run, and one machine.
+The same run measured 165 ms cold TTFT, 96 ms warm TTFT, 44.5 tokens/s for its
+short decode probe, 113.9 tokens/s for its 500-token decode probe, 5.5 GB active
+RAM, and 5.7 GB peak RAM. These are single-machine qualification measurements,
+not cross-hardware performance claims.
+
+## Reproduction
+
+The prompts and graders are versioned in `evals/prompts/{tool_calling,coding,
+reasoning,general}.json` and `evals/run_eval.py`. Tool and reasoning suites use
+deterministic structural/answer graders; coding outputs are executed against
+the checked-in task tests; general answers use the task-specific deterministic
+checks. All requests use temperature 0. Tool calls use at most 512 output
+tokens, coding 4,096, reasoning 1,024, and general 2,048.
+
+With the published artifact available in the standard Hugging Face cache:
+
+```bash
+rapid-mlx serve neohorse-9b-4bit --host 127.0.0.1 --port 8327
+
+python evals/run_eval.py \
+  --model NeoHorse-1-9B-MLX-4bit \
+  --host 127.0.0.1 --port 8327 \
+  --parser hermes --quantization 4bit \
+  --suite speed tool_calling coding reasoning general \
+  --output /private/tmp/rapid-mlx-neohorse9-standard-eval.json \
+  --hardware 'Apple M3 Ultra (256 GB)' \
+  --server-flags \
+    'rapid-mlx serve neohorse-9b-4bit --host 127.0.0.1 --port 8327' \
+  --model-path \
+    'rapid-mlx/NeoHorse-1-9B-MLX-4bit@9fe3cd3f69e2d653e82ec094e1c4d0caa9564897' \
+  --engine batched
+```
+
+An earlier direct-loader screen suggested promising behavior relative to the
+current 9B default, but used a separate prompt harness and is intentionally not
+used as promotion evidence here. A default decision requires both candidates
+to be compared with this checked-in evaluator and broader user journeys.
 
 ## Artifact checks
 

--- a/docs/engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md
+++ b/docs/engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md
@@ -1,0 +1,58 @@
+# NeoHorse 1 9B Chat qualification
+
+Date: 2026-09-08
+
+This note records the evidence used to introduce `neohorse-9b-4bit` as an
+experimental model. It is not evidence for changing the default model.
+
+## Artifacts and environment
+
+- Machine: Apple M3 Ultra, 256 GB unified memory
+- macOS: 26.5.2 (25F84)
+- Python: 3.11
+- MLX: 0.32.2
+- mlx-lm: 0.31.3
+- NeoHorse source: `TokenRhythm/NeoHorse-1-9B` at
+  `6cd9248d8070d8a0ad8d20aa19e2fe6848419e93`
+- Published MLX artifact: `rapid-mlx/NeoHorse-1-9B-MLX-4bit` at
+  `9fe3cd3f69e2d653e82ec094e1c4d0caa9564897`
+- Baseline: `mlx-community/Qwen3.5-9B-4bit` at
+  `8b2b98c00a6b4d291155e4890773ca8f769aee53`
+- Quantization: affine 4-bit, group size 64
+
+## Results
+
+The fixed local prompt set scored reasoning, general Chat, coding, and
+first-action tool selection separately:
+
+| Model | Reasoning | General Chat | Coding | Tool first action |
+|---|---:|---:|---:|---:|
+| Qwen3.5 9B 4-bit | 8/10 | 6/10 | 8/10 | 25/30 |
+| NeoHorse 1 9B 4-bit | 8/10 | 7/10 | 8/10 | 28/30 |
+
+NeoHorse was better at parallel tool selection and clarifying an ambiguous
+request. It also invented specific project names in one factuality probe.
+That regression is why the model remains experimental.
+
+A single 256-token speed smoke on the same machine measured 115.2 tokens/s
+for NeoHorse and 112.4 tokens/s for the baseline, with reported peak memory
+of 5.25 GB and 6.75 GB respectively. This is a smoke result, not a general
+performance claim: it is one prompt, one run, and one machine.
+
+## Artifact checks
+
+- The published artifact was downloaded again at its exact commit and loaded
+  through the standard `qwen3_5` MLX loader.
+- A stop-token smoke returned `REMOTE READY` without leaking `<|im_end|>`.
+- `model.safetensors` SHA-256:
+  `19defa62f104fc4dcea1c2352d5dfa1ce259a4f6868eeab39f5d98f3886e9a26`
+- The Rapid-MLX server exposed the alias as text-only and experimental, and
+  completed non-streaming Chat, SSE streaming through `[DONE]`, a Hermes tool
+  call, tool-result replay, and separated Qwen-style reasoning/content without
+  leaking `<|im_end|>`.
+
+## Promotion gate
+
+Before considering a default change, run broader multi-turn factuality,
+streaming, tool-result replay, long-context, and Desktop journeys on the
+published artifact. A default change must be a separate reviewable change.

--- a/docs/engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md
+++ b/docs/engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md
@@ -16,8 +16,6 @@ experimental model. It is not evidence for changing the default model.
   `6cd9248d8070d8a0ad8d20aa19e2fe6848419e93`
 - Published MLX artifact: `rapid-mlx/NeoHorse-1-9B-MLX-4bit` at
   `9fe3cd3f69e2d653e82ec094e1c4d0caa9564897`
-- Baseline: `mlx-community/Qwen3.5-9B-4bit` at
-  `8b2b98c00a6b4d291155e4890773ca8f769aee53`
 - Quantization: affine 4-bit, group size 64
 - Rapid-MLX revision under test: `525b62ac3`
 
@@ -51,10 +49,16 @@ the checked-in task tests; general answers use the task-specific deterministic
 checks. All requests use temperature 0. Tool calls use at most 512 output
 tokens, coding 4,096, reasoning 1,024, and general 2,048.
 
-With the published artifact available in the standard Hugging Face cache:
+Resolve the immutable Hub revision into the standard Hugging Face cache, then
+serve that resolved snapshot path. The `--model-path` evaluator argument is
+provenance metadata; pinning the server input is what guarantees identical
+weights:
 
 ```bash
-rapid-mlx serve neohorse-9b-4bit --host 127.0.0.1 --port 8327
+NEOHORSE_SNAPSHOT="$(python -c \
+  'from huggingface_hub import snapshot_download; print(snapshot_download("rapid-mlx/NeoHorse-1-9B-MLX-4bit", revision="9fe3cd3f69e2d653e82ec094e1c4d0caa9564897"))')"
+
+rapid-mlx serve "$NEOHORSE_SNAPSHOT" --host 127.0.0.1 --port 8327
 
 python evals/run_eval.py \
   --model NeoHorse-1-9B-MLX-4bit \
@@ -64,16 +68,16 @@ python evals/run_eval.py \
   --output /private/tmp/rapid-mlx-neohorse9-standard-eval.json \
   --hardware 'Apple M3 Ultra (256 GB)' \
   --server-flags \
-    'rapid-mlx serve neohorse-9b-4bit --host 127.0.0.1 --port 8327' \
+    'rapid-mlx serve <resolved pinned snapshot> --host 127.0.0.1 --port 8327' \
   --model-path \
     'rapid-mlx/NeoHorse-1-9B-MLX-4bit@9fe3cd3f69e2d653e82ec094e1c4d0caa9564897' \
   --engine batched
 ```
 
-An earlier direct-loader screen suggested promising behavior relative to the
-current 9B default, but used a separate prompt harness and is intentionally not
-used as promotion evidence here. A default decision requires both candidates
-to be compared with this checked-in evaluator and broader user journeys.
+An earlier direct-loader screen motivated this experimental integration, but it
+used a separate prompt harness and is intentionally not used as promotion
+evidence here. A default decision requires both candidates to be compared with
+this checked-in evaluator and broader user journeys.
 
 ## Artifact checks
 

--- a/docs/engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md
+++ b/docs/engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md
@@ -58,7 +58,10 @@ weights:
 NEOHORSE_SNAPSHOT="$(python -c \
   'from huggingface_hub import snapshot_download; print(snapshot_download("rapid-mlx/NeoHorse-1-9B-MLX-4bit", revision="9fe3cd3f69e2d653e82ec094e1c4d0caa9564897"))')"
 
-rapid-mlx serve "$NEOHORSE_SNAPSHOT" --host 127.0.0.1 --port 8327
+rapid-mlx serve "$NEOHORSE_SNAPSHOT" \
+  --host 127.0.0.1 --port 8327 \
+  --enable-auto-tool-choice --tool-call-parser hermes \
+  --reasoning-parser qwen3
 
 python evals/run_eval.py \
   --model NeoHorse-1-9B-MLX-4bit \
@@ -68,7 +71,7 @@ python evals/run_eval.py \
   --output /private/tmp/rapid-mlx-neohorse9-standard-eval.json \
   --hardware 'Apple M3 Ultra (256 GB)' \
   --server-flags \
-    'rapid-mlx serve <resolved pinned snapshot> --host 127.0.0.1 --port 8327' \
+    'rapid-mlx serve <resolved pinned snapshot> --host 127.0.0.1 --port 8327 --enable-auto-tool-choice --tool-call-parser hermes --reasoning-parser qwen3' \
   --model-path \
     'rapid-mlx/NeoHorse-1-9B-MLX-4bit@9fe3cd3f69e2d653e82ec094e1c4d0caa9564897' \
   --engine batched

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -22,6 +22,7 @@ Families with registered aliases (run `rapid-mlx models` for the full, current l
 | GPT-OSS | 20B, 120B | 4/8-bit, mxfp4 |
 | Ternary Bonsai | 1.7B, 27B | 2-bit (ternary) |
 | Hunyuan 3 (Hy3) | 295B MoE (21B active) — **Ultra-only** | 4-bit |
+| NeoHorse 1 | 9B (experimental Chat candidate) | 4-bit |
 
 ### Recommended Models
 
@@ -34,6 +35,25 @@ Recommendations live in one catalog (`vllm_mlx/model_recommendations.json`) shar
 | 18–23 GB | `qwen3.5-9b-4bit` | 8.7 GB |
 | 24–31 GB | `bonsai-27b-2bit` | 13.0 GB |
 | 32 GB+ | `qwen3.8-27b-4bit` | 20.0 GB |
+
+### Experimental Chat candidate: NeoHorse 1 9B
+
+`neohorse-9b-4bit` is an opt-in, text-only Chat model for Macs with at
+least 18 GB of unified memory. It is not a Smart/Fast recommendation and does
+not change any default. The initial qualification found stronger tool
+selection and ambiguity handling than the current 9B default, while also
+finding a factuality regression that requires broader dogfood before any
+default change.
+
+```bash
+rapid-mlx serve neohorse-9b-4bit
+```
+
+The alias deliberately enables none of the Qwen-specific speculative or
+cache optimizations until that exact checkpoint has separate compatibility
+evidence. See the
+[reproducible qualification note](../engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md)
+for the current evidence and limitations.
 
 ### Ultra-only: Hunyuan 3 (Hy3)
 

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -40,10 +40,9 @@ Recommendations live in one catalog (`vllm_mlx/model_recommendations.json`) shar
 
 `neohorse-9b-4bit` is an opt-in, text-only Chat model for Macs with at
 least 18 GB of unified memory. It is not a Smart/Fast recommendation and does
-not change any default. The initial qualification found stronger tool
-selection and ambiguity handling than the current 9B default, while also
-finding a factuality regression that requires broader dogfood before any
-default change.
+not change any default. Product-path qualification found unresolved gaps in
+multi-step tool use, executable coding, reasoning, and instruction following,
+so broader comparative dogfood is required before any default change.
 
 ```bash
 rapid-mlx serve neohorse-9b-4bit

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -134,6 +134,33 @@ def test_qwen38_flash_next_alias_is_experimental_and_memory_gated() -> None:
     assert detect_model_config(profile.hf_path) == profile
 
 
+def test_neohorse_9b_alias_is_experimental_text_only_and_conservative() -> None:
+    """NeoHorse ships as an opt-in Chat candidate without borrowed speedups."""
+
+    alias = "neohorse-9b-4bit"
+    profile = list_profiles()[alias]
+
+    assert profile.hf_path == "rapid-mlx/NeoHorse-1-9B-MLX-4bit"
+    assert profile.modality == "text"
+    assert profile.is_text_only is True
+    assert profile.experimental is True
+    assert profile.min_memory_gb == 18.0
+    assert profile.tool_call_parser == "hermes"
+    assert profile.reasoning_parser == "qwen3"
+    assert profile.is_hybrid is False
+    assert profile.is_hybrid_explicit is True
+    assert profile.is_moe is False
+    assert profile.supports_spec_decode is False
+    assert profile.supports_native_mtp is False
+    assert profile.mtp_draft_model is None
+    assert profile.mtp_default_enabled is False
+    assert profile.pflash_tier == "unknown"
+    assert profile.turboquant_tier == "unknown"
+    assert detect_model_config(alias) == profile
+    assert detect_model_config(profile.hf_path) == profile
+    assert alias not in POPULAR_ALIASES
+
+
 def test_qwen38_27b_aliases_pin_the_native_named_xml_tool_contract() -> None:
     """Every shipped 27B checkpoint uses the same native XML tool template."""
 

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -1,4 +1,18 @@
 {
+  "neohorse-9b-4bit": {
+    "hf_path": "rapid-mlx/NeoHorse-1-9B-MLX-4bit",
+    "modality": "text",
+    "is_text_only": true,
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_hybrid_explicit": true,
+    "is_moe": false,
+    "supports_spec_decode": false,
+    "mtp_default_enabled": false,
+    "min_memory_gb": 18,
+    "experimental": true
+  },
   "north-mini-code-4bit": {
     "hf_path": "mlx-community/North-Mini-Code-1.0-4bit",
     "reasoning_parser": "cohere_command4",

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -219,6 +219,7 @@
     "prism-ml/Ternary-Bonsai-27B-mlx-2bit": 8521052337,
     "prism-ml/bonsai-image-ternary-4B-mlx-2bit": 3888262196,
     "rapid-mlx/Ling-3.0-tiny-MLX-4bit": 4459772529,
+    "rapid-mlx/NeoHorse-1-9B-MLX-4bit": 5058235254,
     "rapid-mlx/Qwen3.8-27B-4bit-MTP-fp16-MLX": 16313463520,
     "rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX": 16320413916,
     "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX": 14788605437,


### PR DESCRIPTION
## Why

NeoHorse 1 9B is a promising local Chat candidate with efficient memory use,
but full product-path evaluation still exposes quality gaps. This PR therefore
adds it as an explicit experimental option without changing any recommendation
or default.

Fixes #3259.

## Intention and scope

- Add `neohorse-9b-4bit` for the published
  `rapid-mlx/NeoHorse-1-9B-MLX-4bit` artifact.
- Route it through the text-only MLX lane with the existing Hermes tool and
  Qwen reasoning parsers.
- Mark it experimental and require 18 GB of unified memory.
- Publish its resolved download size and reproducible qualification evidence.
- Make it discoverable through CLI and Server, the Desktop Chat catalog, and
  the first-run model chooser on Macs meeting the memory floor.

## Non-goals

- No Smart/Fast recommendation or default-model change.
- No MTP, PFlash, TurboQuant, DFlash, DDTree, or speculative-decoding claim.
- No model-loader or inference-engine change.
- No claim that this single-machine qualification is a general benchmark.

## Design precedent

The integration follows the established declarative model-profile pattern:
normalize upstream checkpoint identity at the artifact boundary, register a
short product alias, pin routing and parsers explicitly, and keep every
unqualified optimization fail-closed. A new candidate remains opt-in until
artifact-specific compatibility and user-journey evidence justify promotion.

## Acceptance criteria

- Alias and direct HF path resolve to the same conservative profile.
- `rapid-mlx models --json` and `rapid-mlx info` expose the model, size, and
  experimental state without changing recommendations.
- Normal Chat, SSE completion, Qwen reasoning separation, Hermes tool calls,
  and tool-result replay finish cleanly without special-token leakage.
- Desktop's atomic catalog exposes the model to Chat.
- First-run Browse/choice can select it on an eligible Mac, calls it
  experimental, uses the exact artifact and download size, and leaves Qwen 3.5
  4B selected as the default.

## Verification

- `python -m pytest -q tests/test_aliases_contract.py tests/test_model_aliases.py tests/test_models_command_layout.py tests/test_model_sizes.py`
  - 3,488 passed.
- `python -m pytest -q tests/test_readme_image_matrix.py tests/test_aliases_contract.py`
  - 3,429 passed.
- `swift test --filter QuickstartStarterPolicyTests --filter Step2ModelSelectionBehaviorTests --filter AtomicModelCatalogTests`
  - 95 passed, including a cached-model regression proving the experimental
    choice cannot displace Qwen from the automatic onboarding default.
- `swift test --filter OnboardingDirectionDTests --filter Step2ModelSelectionBehaviorTests --filter QuickstartStarterPolicyTests`
  - 124 passed after adding the second 9B option, including distinct comparison
    headers for same-size models.
- Checked-in product-path evaluator at `525b62ac3`, temperature 0:
  - tool calling: 24/31 (77%);
  - executable coding: 6/10 (60%);
  - deterministic reasoning: 6/10 (60%);
  - general/instruction following: 7/10 (70%);
  - 165 ms cold and 96 ms warm TTFT;
  - 113.9 tok/s on the 500-token decode probe;
  - 5.5 GB active and 5.7 GB peak RAM.
- Real Server smoke using the published HF artifact:
  - model list: text-only, tools, experimental, 262,144-token context;
  - non-streaming Chat and SSE through `[DONE]`;
  - Hermes tool call and grounded tool-result replay;
  - separated reasoning content and no `<|im_end|>` leakage.
- Final `python -m scripts.pr_validate 3260`: `MERGE-SAFE`; Codex review,
  supply-chain checks, lint, 3,427 targeted tests, and the full 23,479-test
  suite passed after installing the declared local `image` extra.

The exact evaluator command, pinned artifact revisions, checked-in prompt files,
sampling limits, grading procedure, and limitations are recorded in the
qualification note included in this PR.

## Rollout and rollback

The alias is opt-in and defaults remain unchanged. Rollback is removal of the
single alias, first-run choice, size entry, and documentation; the
already-published model artifact does not affect existing users unless
explicitly selected.
