### PR TITLE
docs(audit): extend v0.13.4 release review to current main

### DIFF
--- a/docs/engineering/operations/2026-09-06-v0.13.4-to-main-release-audit.md
+++ b/docs/engineering/operations/2026-09-06-v0.13.4-to-main-release-audit.md
@@ -2,18 +2,19 @@
 
 ## Scope
 
-Vector and Harbor reviewed the complete first-parent release range from tag
-`v0.13.4` through the request-time `origin/main` at `18d488664`
-(`feat(desktop): add supervised Downloads cleanup flow (#3231)`). The range
-contains 103 merged pull requests, 428 changed files, and 79,447 additions /
-1,943 deletions.
+Vector and Harbor initially reviewed the complete first-parent release range
+from tag `v0.13.4` through `18d488664` (`feat(desktop): add supervised
+Downloads cleanup flow (#3231)`). Vector extended that review on 2026-09-08
+through request-time `origin/main` at `e6f3d8896` (`feat(share): --quicksilver
+compute-pool provider mode (#3251)`). The extended range contains 111 merged
+pull requests, 439 changed files, and 89,573 additions / 2,039 deletions.
 
 The inventory is reproducible with:
 
 ```bash
 git fetch --tags --prune origin
-git log --first-parent --pretty='%h %s' v0.13.4..18d488664
-git diff --stat v0.13.4..18d488664
+git log --first-parent --pretty='%h %s' v0.13.4..e6f3d8896
+git diff --stat v0.13.4..e6f3d8896
 ```
 
 Review emphasis followed release risk rather than diff size:
@@ -82,6 +83,33 @@ No P0/P1 issue survived in those paths except the two findings below.
 The exact `18d488664` Desktop package then passed 3,610 tests across 311
 suites in 91.727 seconds.
 
+Vector reviewed the five production PRs after the previous source-clean
+cutoff at `463ecd39e`: #3249 (DMG support-icon placement), #3234 (structured
+Doctor reports), #3235 (Always-on service diagnosis), #3238 (deep Doctor
+probes and verified repair), and #3251 (QuickSilver compute-pool provider).
+The Doctor path was traced from CLI selection through probe attribution,
+repair planning, privilege checks, the fixed launchd action, and post-action
+liveness verification. Default Doctor remains read-only; mutation requires
+explicit `--fix`, non-interactive mutation additionally requires `--yes`, and
+Doctor never invokes `sudo`. The only repair targets the fixed supported
+system launchd label and cannot claim success without fresh registration, PID,
+listener attribution, and `/livez` evidence. The QuickSilver merge was checked
+against its credential isolation, registration/readiness, cancellation,
+reconnect-backoff, per-machine identity, and child-process lifetime contracts.
+The DMG change affects only Finder layout metadata and its verifier.
+
+On the exact extended head, 795 focused Doctor, service, DMG, and QuickSilver
+tests passed in Python 3.12. Compileall, release-range `git diff --check`, Ruff
+lint, and Ruff format checks also passed. Exact-head hosted CI then passed the
+Python 3.10/3.11/3.12 matrices, Apple Silicon tests, type check, lint, engine
+contracts, five model L1 smokes, Desktop build/unit tests, accessibility gates,
+and all six GUI shards. The first Desktop run had one isolated native chat
+attachment XCUITest failure after relaunch; its other five native tests and all
+three matching accessibility-driven flows passed. A failed-job rerun reused the
+same commit-bound app artifact and passed all six native tests plus every GUI
+shard, so this audit found no source regression to fix. No additional P0/P1
+finding survived the extended source review.
+
 ## Release-blocking findings and fixes
 
 Five P0/P1 findings survived adversarial review. Each fix is isolated in its
@@ -138,21 +166,21 @@ Studio host:
 - Qwen3.5 35B-A3B 4-bit: infrastructure failure after 180 seconds without
   startup progress
 
-The 35B failure is attributable to the host cache volume, not an alias mismatch
-or a demonstrated code regression. The alias correctly resolves to
-`mlx-community/Qwen3.5-35B-A3B-4bit`; its cache is symlinked to the external
-ExFAT volume `/Volumes/Extreme SSD`, which had only 4.6 GB free (0.2%). A
-bounded probe returned from `exists()` immediately but timed out after five
-seconds in a single top-level `listdir()`. No model cache was deleted. The full
-gate should be rerun only after the storage owner restores a healthy volume;
-the remaining gates did not run after G0 failed.
+The 35B failure was attributable to the cache storage available during that
+historical run, not an alias mismatch or a demonstrated code regression. The
+alias correctly resolves to `mlx-community/Qwen3.5-35B-A3B-4bit`. No model
+cache was deleted. Studio storage policy changed on 2026-09-07: release checks
+must now use only the configured Hugging Face cache, including its managed
+warm-tier symlinks; they must not redirect downloads or access personal archive
+volumes. The full gate remains pending under that policy, and a quota failure
+must be reported rather than worked around.
 
 ## Release decision
 
 All five P0/P1 fixes found by this audit (#3177, #3178, #3179, #3242, and
-#3244) are on main. The reviewed source range is P0/P1-clean at `463ecd39e`.
+#3244) are on main. The reviewed source range is P0/P1-clean at `e6f3d8896`.
 This source conclusion does not replace release acceptance: the final signed
 and notarized candidate must rerun the artifact-level image receipt, and the
-external 35B cache must be repaired or moved before rerunning the complete
-`release-check-m3`. Deleting shared model caches is outside this audit's
-authority.
+complete `release-check-m3` must finish under the current Studio storage
+policy. Deleting shared model caches or redirecting model downloads is outside
+this audit's authority.


### PR DESCRIPTION
## Why

Extend the existing v0.13.4-to-main release audit from its prior source-clean cutoff through the current main head, so release coordination uses the actual candidate boundary and current storage constraints.

## User-visible goal

Prevent a release decision from relying on a stale source cutoff or obsolete model-cache instructions.

## Scope

- Extend the audited boundary to `e6f3d8896` / #3251.
- Record the five newly reviewed production PRs and their risk boundaries.
- Record exact-head local and hosted validation, including the isolated Desktop retry and successful same-artifact rerun.
- Replace superseded cache guidance with the currently enforced Studio policy.

## Non-goals

- No product, runtime, CI, catalog, version, release, or deployment changes.
- No P2 cleanup or speculative fix for the non-reproducing GUI failure.
- Does not claim artifact-level or full M3 release acceptance.

## Acceptance criteria

- The report inventory matches `v0.13.4..e6f3d8896`: 111 first-parent merges, 439 files, +89,573/-2,039.
- The source conclusion and remaining gates distinguish source review from release acceptance.
- No machine-private path, credential, or obsolete cache workaround is published.

## Verification

- Self-adversarial review of #3249, #3234, #3235, #3238, and #3251.
- 795 focused Doctor, service, DMG, and QuickSilver tests passed on Python 3.12.
- Python 3.12 compileall passed.
- Release-range `git diff --check` passed.
- Ruff lint and format checks passed.
- Exact-head backend CI passed, including Python 3.10/3.11/3.12, Apple Silicon, five L1 smokes, type check, lint, and engine contracts.
- Exact-head Desktop CI passed on failed-job rerun with the same commit-bound artifact, including all six GUI shards and all six native attachment tests.