### PR TITLE
feat(benchmark): live run progress + ETA, and guide users to share

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -580,11 +580,19 @@ enum CommunityBenchmarkRunStatus {
         return body.split(whereSeparator: \.isWhitespace).joined(separator: " ")
     }
 
-    /// True when a (stripped) progress line marks one completed unit of work
-    /// — a warmup pass or a measured round — so the view can count steps.
+    /// True when a (stripped) progress line marks one COMPLETED unit of work.
+    /// Completion lines are always `<case-id> warmup …` or
+    /// `<case-id> round N/M …`, i.e. the phase is the SECOND token. Matching
+    /// the token position (not a bare "warmup"/"round" substring) is what
+    /// keeps plan/status lines — "Benchmarking … 1 warmup + 5 measured
+    /// rounds", "Estimated time remaining … from the warmup rate" — from
+    /// wrongly advancing the bar.
     static func isStepLine(_ stripped: String) -> Bool {
-        stripped.range(of: #"\bround \d+/\d+\b"#, options: .regularExpression) != nil
-            || stripped.range(of: #"\bwarmup\b"#, options: .regularExpression) != nil
+        let tokens = stripped.split(separator: " ")
+        guard tokens.count >= 2 else { return false }
+        if tokens[1] == "warmup" { return true }
+        return tokens[1] == "round" && tokens.count >= 3
+            && tokens[2].range(of: #"^\d+/\d+$"#, options: .regularExpression) != nil
     }
 
     /// Total warmup + measured passes for a task, i.e. how many step lines to
@@ -616,9 +624,12 @@ enum CommunityBenchmarkRunStatus {
         let perStep = max(0, lastStepAt.timeIntervalSince(firstStepAt))
             / Double(stepsDone - 1)
         let projected = perStep * Double(totalSteps - stepsDone)
-        let sinceLast = max(0, now.timeIntervalSince(lastStepAt))
-        let remaining = Int(max(0, projected - sinceLast).rounded())
-        return String(format: "~%d:%02d left", remaining / 60, remaining % 60)
+        let remaining = projected - max(0, now.timeIntervalSince(lastStepAt))
+        // Past the projection with no new step: don't sit on a stale
+        // "~0:00 left" — say we're finishing the last pass(es).
+        guard remaining > 0 else { return "wrapping up…" }
+        let secs = Int(remaining.rounded())
+        return String(format: "~%d:%02d left", secs / 60, secs % 60)
     }
 
     /// `m:ss` elapsed clock, clamped at zero so a clock adjustment mid-run

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -598,21 +598,26 @@ enum CommunityBenchmarkRunStatus {
         }
     }
 
-    /// A `~m:ss left` estimate from the average interval BETWEEN completed
-    /// steps. `firstStepAt` is the first step's completion, so the elapsed
-    /// span covers `stepsDone - 1` intervals — dividing by that (not by
-    /// `stepsDone`) is what keeps the estimate honest and excludes the
-    /// one-off model-load + first-step time. Suppressed until two steps have
+    /// A `~m:ss left` estimate. The average step time comes only from
+    /// COMPLETION timestamps — the span `lastStepAt - firstStepAt` over
+    /// `stepsDone - 1` intervals — so it is stable between steps (dividing by
+    /// intervals, not steps, excludes the one-off model-load + first-step
+    /// time). `now` is used only to count the projection DOWN as time passes,
+    /// never to inflate the per-step average. Suppressed until two steps have
     /// completed (one interval), and once none remain.
     static func eta(
         stepsDone: Int,
         totalSteps: Int,
-        since firstStepAt: Date,
+        firstStepAt: Date,
+        lastStepAt: Date,
         now: Date
     ) -> String? {
         guard stepsDone >= 2, stepsDone < totalSteps else { return nil }
-        let perStep = max(0, now.timeIntervalSince(firstStepAt)) / Double(stepsDone - 1)
-        let remaining = Int((perStep * Double(totalSteps - stepsDone)).rounded())
+        let perStep = max(0, lastStepAt.timeIntervalSince(firstStepAt))
+            / Double(stepsDone - 1)
+        let projected = perStep * Double(totalSteps - stepsDone)
+        let sinceLast = max(0, now.timeIntervalSince(lastStepAt))
+        let remaining = Int(max(0, projected - sinceLast).rounded())
         return String(format: "~%d:%02d left", remaining / 60, remaining % 60)
     }
 
@@ -1051,6 +1056,9 @@ struct CommunityBenchmarkView: View {
     /// the determinate progress bar and the live ETA.
     @State private var stepsDone = 0
     @State private var firstStepAt: Date?
+    /// The most recent step completion, so the ETA divides by real
+    /// inter-step time and stays stable between steps.
+    @State private var lastStepAt: Date?
     @State private var errorMessage: String?
     /// The result id of the run that just finished, so a prominent CTA can
     /// invite the user to share it (instead of relying on the small per-row
@@ -1362,11 +1370,12 @@ struct CommunityBenchmarkView: View {
                         HStack(spacing: 8) {
                             Text("Elapsed \(CommunityBenchmarkRunStatus.elapsed(from: runStartedAt, to: context.date))")
                                 .monospacedDigit()
-                            if let totalSteps, let firstStepAt,
+                            if let totalSteps, let firstStepAt, let lastStepAt,
                                let eta = CommunityBenchmarkRunStatus.eta(
                                    stepsDone: stepsDone,
                                    totalSteps: totalSteps,
-                                   since: firstStepAt,
+                                   firstStepAt: firstStepAt,
+                                   lastStepAt: lastStepAt,
                                    now: context.date
                                ) {
                                 Text(eta)
@@ -1549,6 +1558,7 @@ struct CommunityBenchmarkView: View {
         appliedProgressSequence = 0
         stepsDone = 0
         firstStepAt = nil
+        lastStepAt = nil
         pendingShareResultID = nil
         let activeRunID = UUID()
         currentRunID = activeRunID
@@ -1599,6 +1609,7 @@ struct CommunityBenchmarkView: View {
                             // timestamp (step 1) regardless of hop order.
                             if stepIndex > 0, let stepAt {
                                 firstStepAt = min(firstStepAt ?? stepAt, stepAt)
+                                lastStepAt = max(lastStepAt ?? stepAt, stepAt)
                                 stepsDone = max(stepsDone, stepIndex)
                             }
                         }
@@ -1624,6 +1635,7 @@ struct CommunityBenchmarkView: View {
             runProgressLine = nil
             stepsDone = 0
             firstStepAt = nil
+            lastStepAt = nil
             runTask = nil
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -555,10 +555,62 @@ enum CommunityBenchmarkRunStatus {
 
     static func expectedDuration(for task: ModelTask) -> String {
         switch task {
-        case .imageGeneration: return "usually 1–3 minutes"
+        // Image time is dominated by the model: a small SD-class model lands
+        // in a couple of minutes, a flux-class one can take ten. Keep the
+        // up-front hint wide and honest; the live ETA below carries accuracy.
+        case .imageGeneration: return "usually 2–10 minutes"
         case .videoGeneration: return "usually 5–15 minutes"
         default: return "usually 2–5 minutes"
         }
+    }
+
+    /// Record-separator prefix the CLI puts on machine-readable progress
+    /// lines under `--json --progress`. Mirrors `PROGRESS_TAG` in
+    /// `vllm_mlx/community_bench/cli.py`.
+    static let progressTag = "\u{1e}"
+
+    /// A tagged progress line with its marker removed and whitespace
+    /// collapsed, or nil for any other stderr (the untagged failure
+    /// document, warnings, tracebacks) so the view never mirrors it.
+    static func strippedProgress(from line: String) -> String? {
+        guard line.hasPrefix(progressTag) else { return nil }
+        let body = line.dropFirst(progressTag.count)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty, body.count <= 200 else { return nil }
+        return body.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    }
+
+    /// True when a (stripped) progress line marks one completed unit of work
+    /// — a warmup pass or a measured round — so the view can count steps.
+    static func isStepLine(_ stripped: String) -> Bool {
+        stripped.range(of: #"\bround \d+/\d+\b"#, options: .regularExpression) != nil
+            || stripped.range(of: #"\bwarmup\b"#, options: .regularExpression) != nil
+    }
+
+    /// Total warmup + measured passes for a task, i.e. how many step lines to
+    /// expect. Returns nil for shapes too coarse for a determinate bar (a
+    /// single measured pass), where the spinner + elapsed clock read better.
+    static func totalSteps(for task: ModelTask) -> Int? {
+        switch task {
+        case .imageGeneration: return 2   // 1 warmup + 1 measured
+        case .videoGeneration: return nil // 1 measured render — no useful bar
+        default: return 12                // 2 buckets × (1 warmup + 5 measured)
+        }
+    }
+
+    /// A `~m:ss left` estimate from the average time per completed step,
+    /// measured from the first step so model-load time does not skew it.
+    /// nil until at least one step has completed and while none remain.
+    static func eta(
+        stepsDone: Int,
+        totalSteps: Int,
+        since firstStepAt: Date,
+        now: Date
+    ) -> String? {
+        guard stepsDone >= 1, stepsDone < totalSteps else { return nil }
+        let perStep = max(0, now.timeIntervalSince(firstStepAt)) / Double(stepsDone)
+        let remaining = Int((perStep * Double(totalSteps - stepsDone)).rounded())
+        return String(format: "~%d:%02d left", remaining / 60, remaining % 60)
     }
 
     /// `m:ss` elapsed clock, clamped at zero so a clock adjustment mid-run
@@ -708,6 +760,9 @@ enum CommunityBenchmarkCommand {
     static func benchmarkRunArguments(alias: String) -> [String] {
         [
             "benchmark", "run", alias, "--json",
+            // Stream RS-tagged live progress so the run shows a determinate
+            // bar + ETA; the untagged failure document stays clean.
+            "--progress",
             "--inherit-process-group",
         ]
     }
@@ -813,7 +868,14 @@ enum CommunityBenchmarkCommand {
                     let output = await outputTask.value
                     let errorCapture = await errorTask.value
                     guard child.terminationStatus == 0 else {
+                        // Drop RS-tagged live-progress lines so the failure
+                        // document the user sees stays clean.
                         let detail = String(data: errorCapture.data, encoding: .utf8)?
+                            .split(separator: "\n", omittingEmptySubsequences: false)
+                            .filter {
+                                !$0.hasPrefix(CommunityBenchmarkRunStatus.progressTag)
+                            }
+                            .joined(separator: "\n")
                             .trimmingCharacters(in: .whitespacesAndNewlines)
                         let message = detail.flatMap { $0.isEmpty ? nil : $0 }
                             ?? "Benchmark exited with code \(child.terminationStatus)."
@@ -971,6 +1033,10 @@ struct CommunityBenchmarkView: View {
     /// arrival order off the main actor and applied only if newer, so the
     /// unordered main-actor hops can never show an older round.
     @State private var appliedProgressSequence = 0
+    /// Completed warmup + measured passes, and when the first one landed, for
+    /// the determinate progress bar and the live ETA.
+    @State private var stepsDone = 0
+    @State private var firstStepAt: Date?
     @State private var errorMessage: String?
     @State private var runTask: Task<Void, Never>?
     @State private var shareTask: Task<Void, Never>?
@@ -1192,17 +1258,44 @@ struct CommunityBenchmarkView: View {
     /// live elapsed clock — the only feedback the user gets for several
     /// minutes while the CLI owns the machine.
     private var runningStatus: some View {
-        VStack(alignment: .leading, spacing: 3) {
+        // A determinate bar is only honest when we know how many passes to
+        // expect (text, image); other shapes keep the spinner + clock.
+        let totalSteps = runningModel.flatMap {
+            CommunityBenchmarkRunStatus.totalSteps(for: $0.task)
+        }
+        return VStack(alignment: .leading, spacing: 6) {
             if let runningModel {
                 Text(CommunityBenchmarkRunStatus.description(for: runningModel))
                     .font(.callout)
                     .accessibilityIdentifier("CommunityBenchmark.RunStatus")
             }
+            if let totalSteps {
+                ProgressView(
+                    value: Double(min(stepsDone, totalSteps)),
+                    total: Double(totalSteps)
+                )
+                .progressViewStyle(.linear)
+                .frame(maxWidth: 360)
+                .accessibilityIdentifier("CommunityBenchmark.RunProgressBar")
+            }
             HStack(spacing: 8) {
                 if let runStartedAt {
                     TimelineView(.periodic(from: runStartedAt, by: 1)) { context in
-                        Text("Elapsed \(CommunityBenchmarkRunStatus.elapsed(from: runStartedAt, to: context.date))")
-                            .monospacedDigit()
+                        HStack(spacing: 8) {
+                            Text("Elapsed \(CommunityBenchmarkRunStatus.elapsed(from: runStartedAt, to: context.date))")
+                                .monospacedDigit()
+                            if let totalSteps, let firstStepAt,
+                               let eta = CommunityBenchmarkRunStatus.eta(
+                                   stepsDone: stepsDone,
+                                   totalSteps: totalSteps,
+                                   since: firstStepAt,
+                                   now: context.date
+                               ) {
+                                Text(eta)
+                                    .monospacedDigit()
+                                    .accessibilityIdentifier("CommunityBenchmark.RunETA")
+                            }
+                        }
                     }
                     .accessibilityIdentifier("CommunityBenchmark.RunElapsed")
                 }
@@ -1325,6 +1418,8 @@ struct CommunityBenchmarkView: View {
         runStartedAt = Date()
         runProgressLine = nil
         appliedProgressSequence = 0
+        stepsDone = 0
+        firstStepAt = nil
         let activeRunID = UUID()
         currentRunID = activeRunID
         let sequencer = ProgressSequencer()
@@ -1342,10 +1437,11 @@ struct CommunityBenchmarkView: View {
                     ),
                     onDeferredReap: retainServerDuringDeferredReap,
                     onStandardErrorLine: { line in
-                        guard let progress = CommunityBenchmarkRunStatus.progressLine(
+                        guard let progress = CommunityBenchmarkRunStatus.strippedProgress(
                             from: line
                         ) else { return }
                         let sequence = sequencer.next()
+                        let isStep = CommunityBenchmarkRunStatus.isStepLine(progress)
                         Task { @MainActor in
                             // A line that arrives after Stop / a new run must
                             // not resurrect stale progress, and an older line
@@ -1357,6 +1453,10 @@ struct CommunityBenchmarkView: View {
                             else { return }
                             appliedProgressSequence = sequence
                             runProgressLine = progress
+                            if isStep {
+                                stepsDone += 1
+                                if firstStepAt == nil { firstStepAt = Date() }
+                            }
                         }
                     }
                 )
@@ -1373,6 +1473,8 @@ struct CommunityBenchmarkView: View {
             runningModel = nil
             runStartedAt = nil
             runProgressLine = nil
+            stepsDone = 0
+            firstStepAt = nil
             runTask = nil
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -1038,6 +1038,10 @@ struct CommunityBenchmarkView: View {
     @State private var stepsDone = 0
     @State private var firstStepAt: Date?
     @State private var errorMessage: String?
+    /// The result id of the run that just finished, so a prominent CTA can
+    /// invite the user to share it (instead of relying on the small per-row
+    /// link). Cleared when the row is shared, dismissed, or a new run starts.
+    @State private var pendingShareResultID: String?
     @State private var runTask: Task<Void, Never>?
     @State private var shareTask: Task<Void, Never>?
     @State private var shareCandidate: CommunityBenchmarkUploadPreview?
@@ -1071,6 +1075,7 @@ struct CommunityBenchmarkView: View {
             VStack(alignment: .leading, spacing: 24) {
                 header
                 setupCard
+                postRunShareCTA
                 recentResults
             }
             .frame(maxWidth: 760, alignment: .leading)
@@ -1096,6 +1101,20 @@ struct CommunityBenchmarkView: View {
             VStack(alignment: .leading, spacing: 16) {
                 Text("Share benchmark result?")
                     .font(.title2.weight(.semibold))
+                Label(
+                    "Every shared result makes the community leaderboard more "
+                        + "complete — helping everyone compare models across real "
+                        + "Macs and find faster local AI for their machine.",
+                    systemImage: "mappin.and.ellipse"
+                )
+                .font(.callout)
+                .foregroundStyle(RapidTheme.textSecondary)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RapidTheme.brandPrimaryDeep.opacity(0.08),
+                    in: RoundedRectangle(cornerRadius: 10)
+                )
                 Text("Everything in the JSON below will be sent to \(preview.target).")
                     .foregroundStyle(.secondary)
                 ScrollView {
@@ -1131,47 +1150,92 @@ struct CommunityBenchmarkView: View {
     }
 
     private func shareSuccessSheet(_ receipt: CommunityBenchmarkReceipt) -> some View {
-        VStack(spacing: 18) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 44))
-                .foregroundStyle(.green)
-                .accessibilityHidden(true)
-            Text(receipt.alreadyExists ? "Already on the map" : "You added a point to the map")
-                .font(.title2.weight(.semibold))
-            if let contributor = receipt.contributor {
-                VStack(spacing: 6) {
-                    Text("Your Community Benchmark identity")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text(contributor.displayName)
-                        .font(.system(.headline, design: .monospaced))
-                        .textSelection(.enabled)
-                        .accessibilityIdentifier("CommunityBenchmark.Share.Identity")
+        VStack(spacing: 0) {
+            VStack(spacing: 24) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 32, weight: .medium))
+                    .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                    .frame(width: 72, height: 72)
+                    .background(RapidTheme.brandPrimaryDeep.opacity(0.10), in: Circle())
+                    .overlay(alignment: .bottomTrailing) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 22, weight: .semibold))
+                            .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                            .padding(3)
+                            .background(RapidTheme.surfaceRaised, in: Circle())
+                    }
+                    .accessibilityHidden(true)
+
+                VStack(spacing: 10) {
+                    Text(receipt.alreadyExists ? "Already on the map" : "You added a point to the map")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(RapidTheme.textPrimary)
+                    Text(receipt.alreadyExists
+                         ? "This result is already part of the community leaderboard. Thanks for contributing."
+                         : "Your model’s performance on this Mac now has a place on the community leaderboard.")
+                        .font(.body)
+                        .foregroundStyle(RapidTheme.textSecondary)
                 }
-                if let url = contributor.profileURL {
-                    Link("View my contributions", destination: url)
-                        .buttonStyle(.borderedProminent)
-                        .accessibilityIdentifier("CommunityBenchmark.Share.Profile")
+
+                if let contributor = receipt.contributor {
+                    VStack(spacing: 10) {
+                        Text("Your community identity")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(RapidTheme.textSecondary)
+                        Text(contributor.displayName)
+                            .font(.system(.callout, design: .monospaced).weight(.medium))
+                            .foregroundStyle(RapidTheme.textPrimary)
+                            .textSelection(.enabled)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 10)
+                            .background(RapidTheme.surfaceCanvas, in: Capsule())
+                            .overlay {
+                                Capsule().strokeBorder(RapidTheme.hairline, lineWidth: 1)
+                            }
+                            .accessibilityIdentifier("CommunityBenchmark.Share.Identity")
+                    }
                 }
-            } else {
-                Link(
-                    "View Community Benchmark",
-                    destination: communityBenchmarkLeaderboardURL
-                )
-                    .buttonStyle(.borderedProminent)
-                    .accessibilityIdentifier("CommunityBenchmark.Share.Leaderboard")
+
+                Text("Together, we’re building a clearer picture of local AI performance—so everyone can find faster models for their Mac.")
+                    .font(.callout)
+                    .foregroundStyle(RapidTheme.textSecondary)
             }
-            Text("Thanks for helping other Mac users choose models with real-world evidence.")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-            Button("Done") { shareSuccess = nil }
-                .keyboardShortcut(.defaultAction)
-                .accessibilityIdentifier("CommunityBenchmark.Share.Done")
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(32)
+
+            Rectangle()
+                .fill(RapidTheme.hairline)
+                .frame(height: 1)
+
+            HStack(spacing: 12) {
+                if let contributor = receipt.contributor {
+                    if let url = contributor.profileURL {
+                        Link("View my contributions", destination: url)
+                            .buttonStyle(.bordered)
+                            .accessibilityIdentifier("CommunityBenchmark.Share.Profile")
+                    }
+                } else {
+                    Link(
+                        "View Community Benchmark",
+                        destination: communityBenchmarkLeaderboardURL
+                    )
+                        .buttonStyle(.bordered)
+                        .accessibilityIdentifier("CommunityBenchmark.Share.Leaderboard")
+                }
+                Spacer(minLength: 0)
+                Button("Done") { shareSuccess = nil }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("CommunityBenchmark.Share.Done")
+            }
+            .controlSize(.large)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 18)
+            .background(RapidTheme.surfaceCanvas)
         }
-        .padding(32)
-        .frame(width: 440)
-        .frame(minHeight: 330)
+        .frame(width: 480)
+        .background(RapidTheme.surfaceRaised)
         .accessibilityIdentifier("CommunityBenchmark.Share.Success")
     }
 
@@ -1313,6 +1377,57 @@ struct CommunityBenchmarkView: View {
         }
     }
 
+    /// A prominent invitation to contribute the run that just finished — the
+    /// per-row "Share" link is easy to miss, and a result is only useful to
+    /// the community once it is shared. Hidden once the run is shared (a
+    /// receipt appears), dismissed, or superseded by a new run.
+    @ViewBuilder
+    private var postRunShareCTA: some View {
+        if let id = pendingShareResultID,
+           receipts[id] == nil,
+           !isRunning,
+           let result = results.first(where: { $0.id == id }) {
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.title2)
+                    .foregroundStyle(RapidTheme.brandPrimaryDeep)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Put your Mac on the map").font(.headline)
+                    Text(
+                        "Share this \(alias(for: result.repoID)) result to help the "
+                            + "community compare models and find faster local AI."
+                    )
+                    .font(.callout)
+                    .foregroundStyle(RapidTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    HStack(spacing: 12) {
+                        Button(sharingRunID == result.id ? "Sharing…" : "Share benchmark result") {
+                            prepareShare(result)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(sharingRunID != nil || binary == nil)
+                        .accessibilityIdentifier("CommunityBenchmark.ShareCTA.Confirm")
+                        Button("Not now") { pendingShareResultID = nil }
+                            .buttonStyle(.link)
+                            .accessibilityIdentifier("CommunityBenchmark.ShareCTA.Dismiss")
+                    }
+                    .padding(.top, 2)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(16)
+            .background(
+                RapidTheme.brandPrimaryDeep.opacity(0.06),
+                in: RoundedRectangle(cornerRadius: 14)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .strokeBorder(RapidTheme.brandPrimaryDeep.opacity(0.25))
+            )
+            .accessibilityIdentifier("CommunityBenchmark.ShareCTA")
+        }
+    }
+
     private var recentResults: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Recent local results").font(.headline)
@@ -1420,6 +1535,7 @@ struct CommunityBenchmarkView: View {
         appliedProgressSequence = 0
         stepsDone = 0
         firstStepAt = nil
+        pendingShareResultID = nil
         let activeRunID = UUID()
         currentRunID = activeRunID
         let sequencer = ProgressSequencer()
@@ -1462,6 +1578,8 @@ struct CommunityBenchmarkView: View {
                 )
                 await refreshProductCatalog()
                 await refreshResults()
+                // Invite the user to contribute the run that just finished.
+                pendingShareResultID = results.first?.id
             } catch is CancellationError {
                 errorMessage = acquiredReservation
                     ? "Benchmark stopped. No incomplete result was shared."

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -774,6 +774,17 @@ enum CommunityBenchmarkCommand {
         ["benchmark", "results", "--limit", String(limit), "--json"]
     }
 
+    /// The `run_id` from a `benchmark run --json` payload, so the caller can
+    /// act on the exact run that finished rather than inferring it from list
+    /// order. nil for any payload without one (e.g. a deferred-reap result).
+    static func runID(from data: Data) -> String? {
+        struct RunID: Decodable {
+            let runID: String
+            enum CodingKeys: String, CodingKey { case runID = "run_id" }
+        }
+        return try? JSONDecoder().decode(RunID.self, from: data).runID
+    }
+
     static func benchmarkSharePreviewArguments(runID: String) -> [String] {
         ["benchmark", "share", runID, "--preview", "--json"]
     }
@@ -1553,7 +1564,7 @@ struct CommunityBenchmarkView: View {
                 acquiredReservation = true
                 defer { releaseServer(reservation) }
                 try Task.checkCancellation()
-                _ = try await CommunityBenchmarkCommand.run(
+                let runOutput = try await CommunityBenchmarkCommand.run(
                     binary: binary,
                     arguments: CommunityBenchmarkCommand.benchmarkRunArguments(
                         alias: selected.entry.alias
@@ -1566,9 +1577,12 @@ struct CommunityBenchmarkView: View {
                         let sequence = sequencer.next()
                         // Cumulative step index (0 for non-step lines), assigned
                         // in arrival order so the count survives unordered hops.
-                        let stepIndex = CommunityBenchmarkRunStatus.isStepLine(progress)
-                            ? stepCounter.next()
-                            : 0
+                        let isStep = CommunityBenchmarkRunStatus.isStepLine(progress)
+                        let stepIndex = isStep ? stepCounter.next() : 0
+                        // Timestamp the step at emission (arrival order), not
+                        // when its main-actor hop lands, so the ETA baseline is
+                        // the first step's real completion time.
+                        let stepAt = isStep ? Date() : nil
                         Task { @MainActor in
                             guard isRunning, runStartedAt != nil,
                                   currentRunID == activeRunID
@@ -1581,9 +1595,10 @@ struct CommunityBenchmarkView: View {
                             }
                             // Count: monotonic max, so an out-of-order hop can
                             // never discard a completed step (undercounting the
-                            // bar/ETA).
-                            if stepIndex > 0 {
-                                if firstStepAt == nil { firstStepAt = Date() }
+                            // bar/ETA). The baseline keeps the earliest step
+                            // timestamp (step 1) regardless of hop order.
+                            if stepIndex > 0, let stepAt {
+                                firstStepAt = min(firstStepAt ?? stepAt, stepAt)
                                 stepsDone = max(stepsDone, stepIndex)
                             }
                         }
@@ -1591,8 +1606,11 @@ struct CommunityBenchmarkView: View {
                 )
                 await refreshProductCatalog()
                 await refreshResults()
-                // Invite the user to contribute the run that just finished.
-                pendingShareResultID = results.first?.id
+                // Invite the user to contribute the run that just finished —
+                // by the exact run id the CLI reported, not "whatever sorts
+                // first" (guards against sort/ordering surprises).
+                pendingShareResultID = CommunityBenchmarkCommand.runID(from: runOutput)
+                    ?? results.first?.id
             } catch is CancellationError {
                 errorMessage = acquiredReservation
                     ? "Benchmark stopped. No incomplete result was shared."

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -1607,10 +1607,10 @@ struct CommunityBenchmarkView: View {
                 await refreshProductCatalog()
                 await refreshResults()
                 // Invite the user to contribute the run that just finished —
-                // by the exact run id the CLI reported, not "whatever sorts
-                // first" (guards against sort/ordering surprises).
+                // only when the CLI payload names it. No fallback to "whatever
+                // sorts first": a payload without a run_id (e.g. deferred reap)
+                // must not surface the CTA for an unrelated historical run.
                 pendingShareResultID = CommunityBenchmarkCommand.runID(from: runOutput)
-                    ?? results.first?.id
             } catch is CancellationError {
                 errorMessage = acquiredReservation
                     ? "Benchmark stopped. No incomplete result was shared."

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -611,18 +611,26 @@ enum CommunityBenchmarkRunStatus {
     /// `stepsDone - 1` intervals — so it is stable between steps (dividing by
     /// intervals, not steps, excludes the one-off model-load + first-step
     /// time). `now` is used only to count the projection DOWN as time passes,
-    /// never to inflate the per-step average. Suppressed until two steps have
-    /// completed (one interval), and once none remain.
+    /// never to inflate the per-step average. Text estimates wait for two
+    /// completions. A two-step image run uses its warmup duration from run
+    /// start; otherwise its ETA would first become available at completion.
     static func eta(
         stepsDone: Int,
         totalSteps: Int,
+        runStartedAt: Date,
         firstStepAt: Date,
         lastStepAt: Date,
         now: Date
     ) -> String? {
-        guard stepsDone >= 2, stepsDone < totalSteps else { return nil }
-        let perStep = max(0, lastStepAt.timeIntervalSince(firstStepAt))
-            / Double(stepsDone - 1)
+        guard stepsDone >= 1, stepsDone < totalSteps else { return nil }
+        let perStep: TimeInterval
+        if stepsDone == 1, totalSteps == 2 {
+            perStep = max(0, lastStepAt.timeIntervalSince(runStartedAt))
+        } else {
+            guard stepsDone >= 2 else { return nil }
+            perStep = max(0, lastStepAt.timeIntervalSince(firstStepAt))
+                / Double(stepsDone - 1)
+        }
         let projected = perStep * Double(totalSteps - stepsDone)
         let remaining = projected - max(0, now.timeIntervalSince(lastStepAt))
         // Past the projection with no new step: don't sit on a stale
@@ -1407,6 +1415,7 @@ struct CommunityBenchmarkView: View {
                                let eta = CommunityBenchmarkRunStatus.eta(
                                    stepsDone: stepsDone,
                                    totalSteps: totalSteps,
+                                   runStartedAt: runStartedAt,
                                    firstStepAt: firstStepAt,
                                    lastStepAt: lastStepAt,
                                    now: context.date

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -801,6 +801,26 @@ enum CommunityBenchmarkCommand {
         return try? JSONDecoder().decode(RunID.self, from: data).runID
     }
 
+    /// A human sentence for a failed run. Under `--json` the CLI prints a
+    /// `{"error": …, "run": {…}}` failure document; surface just its `error`
+    /// so the user sees one clear line instead of a wall of raw JSON. Falls
+    /// back to the raw text for any non-JSON failure (a crash, a traceback).
+    static func failureSummary(from detail: String) -> String {
+        struct Doc: Decodable { let error: String }
+        // The document is one JSON line, but tracebacks/warnings may precede
+        // it — try the whole string, then each line newest-first.
+        let candidates = [detail]
+            + detail.split(separator: "\n").reversed().map(String.init)
+        for candidate in candidates {
+            if let data = candidate.data(using: .utf8),
+               let doc = try? JSONDecoder().decode(Doc.self, from: data),
+               !doc.error.isEmpty {
+                return doc.error
+            }
+        }
+        return detail
+    }
+
     static func benchmarkSharePreviewArguments(runID: String) -> [String] {
         ["benchmark", "share", runID, "--preview", "--json"]
     }
@@ -907,7 +927,8 @@ enum CommunityBenchmarkCommand {
                             }
                             .joined(separator: "\n")
                             .trimmingCharacters(in: .whitespacesAndNewlines)
-                        let message = detail.flatMap { $0.isEmpty ? nil : $0 }
+                        let message = detail
+                            .flatMap { $0.isEmpty ? nil : Self.failureSummary(from: $0) }
                             ?? "Benchmark exited with code \(child.terminationStatus)."
                         throw Failure(message: message)
                     }

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -598,17 +598,20 @@ enum CommunityBenchmarkRunStatus {
         }
     }
 
-    /// A `~m:ss left` estimate from the average time per completed step,
-    /// measured from the first step so model-load time does not skew it.
-    /// nil until at least one step has completed and while none remain.
+    /// A `~m:ss left` estimate from the average interval BETWEEN completed
+    /// steps. `firstStepAt` is the first step's completion, so the elapsed
+    /// span covers `stepsDone - 1` intervals — dividing by that (not by
+    /// `stepsDone`) is what keeps the estimate honest and excludes the
+    /// one-off model-load + first-step time. Suppressed until two steps have
+    /// completed (one interval), and once none remain.
     static func eta(
         stepsDone: Int,
         totalSteps: Int,
         since firstStepAt: Date,
         now: Date
     ) -> String? {
-        guard stepsDone >= 1, stepsDone < totalSteps else { return nil }
-        let perStep = max(0, now.timeIntervalSince(firstStepAt)) / Double(stepsDone)
+        guard stepsDone >= 2, stepsDone < totalSteps else { return nil }
+        let perStep = max(0, now.timeIntervalSince(firstStepAt)) / Double(stepsDone - 1)
         let remaining = Int((perStep * Double(totalSteps - stepsDone)).rounded())
         return String(format: "~%d:%02d left", remaining / 60, remaining % 60)
     }
@@ -1539,6 +1542,10 @@ struct CommunityBenchmarkView: View {
         let activeRunID = UUID()
         currentRunID = activeRunID
         let sequencer = ProgressSequencer()
+        // Cumulative step index, stamped off the main actor in arrival order
+        // (LineSplitter delivers lines sequentially). The view applies it as
+        // a monotonic max, so a late/out-of-order hop can never drop a step.
+        let stepCounter = ProgressSequencer()
         runTask = Task {
             var acquiredReservation = false
             do {
@@ -1557,21 +1564,27 @@ struct CommunityBenchmarkView: View {
                             from: line
                         ) else { return }
                         let sequence = sequencer.next()
-                        let isStep = CommunityBenchmarkRunStatus.isStepLine(progress)
+                        // Cumulative step index (0 for non-step lines), assigned
+                        // in arrival order so the count survives unordered hops.
+                        let stepIndex = CommunityBenchmarkRunStatus.isStepLine(progress)
+                            ? stepCounter.next()
+                            : 0
                         Task { @MainActor in
-                            // A line that arrives after Stop / a new run must
-                            // not resurrect stale progress, and an older line
-                            // whose hop landed late must not overwrite a
-                            // newer one.
                             guard isRunning, runStartedAt != nil,
-                                  currentRunID == activeRunID,
-                                  sequence > appliedProgressSequence
+                                  currentRunID == activeRunID
                             else { return }
-                            appliedProgressSequence = sequence
-                            runProgressLine = progress
-                            if isStep {
-                                stepsDone += 1
+                            // Display: show only the newest line — a hop that
+                            // lands late must not overwrite a newer status.
+                            if sequence > appliedProgressSequence {
+                                appliedProgressSequence = sequence
+                                runProgressLine = progress
+                            }
+                            // Count: monotonic max, so an out-of-order hop can
+                            // never discard a completed step (undercounting the
+                            // bar/ETA).
+                            if stepIndex > 0 {
                                 if firstStepAt == nil { firstStepAt = Date() }
+                                stepsDone = max(stepsDone, stepIndex)
                             }
                         }
                     }

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -1295,10 +1295,11 @@ struct CommunityBenchmarkView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Community Benchmark")
+            Text("Benchmark")
                 .font(.system(size: 28, weight: .semibold))
-            Text("Measure any supported model on this Mac. Results stay local unless you choose to share them later.")
+            Text("How fast is local AI on this Mac? Find out in minutes — then share your result to help build an open leaderboard of real models on real Macs, so everyone can pick the fastest local AI for their machine.")
                 .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -206,7 +206,7 @@ struct CommunityBenchmarkModelTests {
     func benchmarkRunTopologyFlag() {
         #expect(
             CommunityBenchmarkCommand.benchmarkRunArguments(alias: "flux2-klein-4b") == [
-                "benchmark", "run", "flux2-klein-4b", "--json",
+                "benchmark", "run", "flux2-klein-4b", "--json", "--progress",
                 "--inherit-process-group",
             ]
         )
@@ -725,7 +725,7 @@ struct CommunityBenchmarkModelTests {
         )
         #expect(
             CommunityBenchmarkRunStatus.description(for: image)
-                == "Measuring flux2-klein-4b · 1 warmup + 1 measured render · usually 1–3 minutes · plus the download"
+                == "Measuring flux2-klein-4b · 1 warmup + 1 measured render · usually 2–10 minutes · plus the download"
         )
         let start = Date(timeIntervalSince1970: 1_000)
         #expect(CommunityBenchmarkRunStatus.elapsed(from: start, to: start.addingTimeInterval(0)) == "0:00")

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
@@ -42,30 +42,39 @@ struct CommunityBenchmarkProgressTests {
         #expect(CommunityBenchmarkRunStatus.totalSteps(for: .videoGeneration) == nil)
     }
 
-    @Test("ETA needs two completions and divides by intervals, not steps")
+    @Test("ETA divides by real inter-step time and counts down, not up")
     func etaBoundaries() {
         let start = Date(timeIntervalSince1970: 1_000)
         // One completion: no interval yet → no estimate (never "~0:00 left").
         #expect(
             CommunityBenchmarkRunStatus.eta(
-                stepsDone: 1, totalSteps: 12, since: start, now: start
+                stepsDone: 1, totalSteps: 12, firstStepAt: start,
+                lastStepAt: start, now: start
             ) == nil
         )
-        // Two completions, 10 s apart → 10 s/interval × 10 remaining = 100 s.
+        // Two completions 10 s apart → 10 s/step × 10 remaining = 100 s, at
+        // the instant of the second completion.
         #expect(
             CommunityBenchmarkRunStatus.eta(
-                stepsDone: 2,
-                totalSteps: 12,
-                since: start,
+                stepsDone: 2, totalSteps: 12,
+                firstStepAt: start, lastStepAt: start.addingTimeInterval(10),
                 now: start.addingTimeInterval(10)
             ) == "~1:40 left"
+        )
+        // 4 s later with no new step, the estimate COUNTS DOWN (100 - 4), it
+        // does not inflate — the per-step average is fixed by completions.
+        #expect(
+            CommunityBenchmarkRunStatus.eta(
+                stepsDone: 2, totalSteps: 12,
+                firstStepAt: start, lastStepAt: start.addingTimeInterval(10),
+                now: start.addingTimeInterval(14)
+            ) == "~1:36 left"
         )
         // All steps done → nothing left to estimate.
         #expect(
             CommunityBenchmarkRunStatus.eta(
-                stepsDone: 12,
-                totalSteps: 12,
-                since: start,
+                stepsDone: 12, totalSteps: 12,
+                firstStepAt: start, lastStepAt: start.addingTimeInterval(60),
                 now: start.addingTimeInterval(60)
             ) == nil
         )

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// The live-progress parsing/estimation that drives the run's determinate bar
+/// and ETA. Pure helpers, so they are pinned here without standing up a view.
+@Suite("Community Benchmark run progress")
+struct CommunityBenchmarkProgressTests {
+    private let tag = CommunityBenchmarkRunStatus.progressTag
+
+    @Test("Only RS-tagged lines are treated as progress")
+    func strippedProgressGating() {
+        // Tagged → stripped and whitespace-collapsed.
+        #expect(
+            CommunityBenchmarkRunStatus.strippedProgress(
+                from: "\(tag)pp512-tg128      round 1/5    46.1 tok/s"
+            ) == "pp512-tg128 round 1/5 46.1 tok/s"
+        )
+        // Untagged (the failure document, warnings) → ignored.
+        #expect(
+            CommunityBenchmarkRunStatus.strippedProgress(
+                from: "pp512-tg128 round 1/5 46.1 tok/s"
+            ) == nil
+        )
+        #expect(CommunityBenchmarkRunStatus.strippedProgress(from: "\(tag)   ") == nil)
+        #expect(CommunityBenchmarkRunStatus.strippedProgress(from: "Traceback…") == nil)
+    }
+
+    @Test("A step line is a completed warmup or measured round")
+    func stepDetection() {
+        #expect(CommunityBenchmarkRunStatus.isStepLine("pp512-tg128 round 3/5 46 tok/s"))
+        #expect(CommunityBenchmarkRunStatus.isStepLine("pp512-tg128 warmup"))
+        #expect(!CommunityBenchmarkRunStatus.isStepLine("Loading mlx-community/x (hf)..."))
+        #expect(!CommunityBenchmarkRunStatus.isStepLine("Server ready in 4.2 s"))
+    }
+
+    @Test("Determinate-bar totals per task")
+    func totals() {
+        #expect(CommunityBenchmarkRunStatus.totalSteps(for: .textGeneration) == 12)
+        #expect(CommunityBenchmarkRunStatus.totalSteps(for: .imageGeneration) == 2)
+        // A single measured render has no useful bar.
+        #expect(CommunityBenchmarkRunStatus.totalSteps(for: .videoGeneration) == nil)
+    }
+
+    @Test("ETA needs two completions and divides by intervals, not steps")
+    func etaBoundaries() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        // One completion: no interval yet → no estimate (never "~0:00 left").
+        #expect(
+            CommunityBenchmarkRunStatus.eta(
+                stepsDone: 1, totalSteps: 12, since: start, now: start
+            ) == nil
+        )
+        // Two completions, 10 s apart → 10 s/interval × 10 remaining = 100 s.
+        #expect(
+            CommunityBenchmarkRunStatus.eta(
+                stepsDone: 2,
+                totalSteps: 12,
+                since: start,
+                now: start.addingTimeInterval(10)
+            ) == "~1:40 left"
+        )
+        // All steps done → nothing left to estimate.
+        #expect(
+            CommunityBenchmarkRunStatus.eta(
+                stepsDone: 12,
+                totalSteps: 12,
+                since: start,
+                now: start.addingTimeInterval(60)
+            ) == nil
+        )
+    }
+
+    @Test("run_id is read from the CLI payload")
+    func runIDDecoding() {
+        let data = Data(#"{"run_id":"abc-123","measurements":[]}"#.utf8)
+        #expect(CommunityBenchmarkCommand.runID(from: data) == "abc-123")
+        #expect(CommunityBenchmarkCommand.runID(from: Data("not json".utf8)) == nil)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
@@ -26,10 +26,22 @@ struct CommunityBenchmarkProgressTests {
         #expect(CommunityBenchmarkRunStatus.strippedProgress(from: "Traceback…") == nil)
     }
 
-    @Test("A step line is a completed warmup or measured round")
+    @Test("Only a completion line (phase as 2nd token) counts as a step")
     func stepDetection() {
+        // Completions: "<case-id> warmup …" / "<case-id> round N/M …".
         #expect(CommunityBenchmarkRunStatus.isStepLine("pp512-tg128 round 3/5 46 tok/s"))
         #expect(CommunityBenchmarkRunStatus.isStepLine("pp512-tg128 warmup"))
+        #expect(CommunityBenchmarkRunStatus.isStepLine("t2i-1024-square warmup 12 s"))
+        // Plan / status lines that merely mention warmup/rounds must NOT count.
+        #expect(!CommunityBenchmarkRunStatus.isStepLine(
+            "Benchmarking gemma-4-e4b-4bit (text_generation): 2 warmup + 10 measured rounds in total"
+        ))
+        #expect(!CommunityBenchmarkRunStatus.isStepLine(
+            "Estimated time remaining: ~0:42 (from the warmup rate)"
+        ))
+        #expect(!CommunityBenchmarkRunStatus.isStepLine(
+            "pp512-tg128 512 prompt tokens -> 128 output tokens"
+        ))
         #expect(!CommunityBenchmarkRunStatus.isStepLine("Loading mlx-community/x (hf)..."))
         #expect(!CommunityBenchmarkRunStatus.isStepLine("Server ready in 4.2 s"))
     }
@@ -69,6 +81,15 @@ struct CommunityBenchmarkProgressTests {
                 firstStepAt: start, lastStepAt: start.addingTimeInterval(10),
                 now: start.addingTimeInterval(14)
             ) == "~1:36 left"
+        )
+        // Overdue (past the projection, no new step) → a finishing state, not
+        // a stale "~0:00 left".
+        #expect(
+            CommunityBenchmarkRunStatus.eta(
+                stepsDone: 2, totalSteps: 12,
+                firstStepAt: start, lastStepAt: start.addingTimeInterval(10),
+                now: start.addingTimeInterval(200)
+            ) == "wrapping up…"
         )
         // All steps done → nothing left to estimate.
         #expect(

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
@@ -107,4 +107,24 @@ struct CommunityBenchmarkProgressTests {
         #expect(CommunityBenchmarkCommand.runID(from: data) == "abc-123")
         #expect(CommunityBenchmarkCommand.runID(from: Data("not json".utf8)) == nil)
     }
+
+    @Test("A failed run shows the error line, not the raw JSON document")
+    func failureSummaryExtraction() {
+        // The CLI's --json failure document → just the human error line.
+        let doc = #"{"error":"image benchmark request failed with HTTP 500","run":{"run_id":"x"},"saved":true}"#
+        #expect(
+            CommunityBenchmarkCommand.failureSummary(from: doc)
+                == "image benchmark request failed with HTTP 500"
+        )
+        // A warning/traceback preceding the JSON still resolves to the error.
+        #expect(
+            CommunityBenchmarkCommand.failureSummary(from: "warning: noisy\n\(doc)")
+                == "image benchmark request failed with HTTP 500"
+        )
+        // Non-JSON failure (a crash) falls back to the raw text.
+        #expect(
+            CommunityBenchmarkCommand.failureSummary(from: "Segmentation fault: 11")
+                == "Segmentation fault: 11"
+        )
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkProgressTests.swift
@@ -60,15 +60,28 @@ struct CommunityBenchmarkProgressTests {
         // One completion: no interval yet → no estimate (never "~0:00 left").
         #expect(
             CommunityBenchmarkRunStatus.eta(
-                stepsDone: 1, totalSteps: 12, firstStepAt: start,
+                stepsDone: 1, totalSteps: 12,
+                runStartedAt: start, firstStepAt: start,
                 lastStepAt: start, now: start
             ) == nil
+        )
+        // A two-step image run shows an estimate after its warmup; waiting
+        // for two completions would make the ETA first appear at completion.
+        #expect(
+            CommunityBenchmarkRunStatus.eta(
+                stepsDone: 1, totalSteps: 2,
+                runStartedAt: start,
+                firstStepAt: start.addingTimeInterval(20),
+                lastStepAt: start.addingTimeInterval(20),
+                now: start.addingTimeInterval(20)
+            ) == "~0:20 left"
         )
         // Two completions 10 s apart → 10 s/step × 10 remaining = 100 s, at
         // the instant of the second completion.
         #expect(
             CommunityBenchmarkRunStatus.eta(
                 stepsDone: 2, totalSteps: 12,
+                runStartedAt: start,
                 firstStepAt: start, lastStepAt: start.addingTimeInterval(10),
                 now: start.addingTimeInterval(10)
             ) == "~1:40 left"
@@ -78,6 +91,7 @@ struct CommunityBenchmarkProgressTests {
         #expect(
             CommunityBenchmarkRunStatus.eta(
                 stepsDone: 2, totalSteps: 12,
+                runStartedAt: start,
                 firstStepAt: start, lastStepAt: start.addingTimeInterval(10),
                 now: start.addingTimeInterval(14)
             ) == "~1:36 left"
@@ -87,6 +101,7 @@ struct CommunityBenchmarkProgressTests {
         #expect(
             CommunityBenchmarkRunStatus.eta(
                 stepsDone: 2, totalSteps: 12,
+                runStartedAt: start,
                 firstStepAt: start, lastStepAt: start.addingTimeInterval(10),
                 now: start.addingTimeInterval(200)
             ) == "wrapping up…"
@@ -95,6 +110,7 @@ struct CommunityBenchmarkProgressTests {
         #expect(
             CommunityBenchmarkRunStatus.eta(
                 stepsDone: 12, totalSteps: 12,
+                runStartedAt: start,
                 firstStepAt: start, lastStepAt: start.addingTimeInterval(60),
                 now: start.addingTimeInterval(60)
             ) == nil

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -5277,6 +5277,7 @@ def test_progress_sink_never_aborts_the_benchmark(
 
     monkeypatch.setattr(sys, "stderr", BrokenStream())
     community_cli._progress_to_stderr("pp512-tg128      round 1/5")
+    community_cli._tagged_progress_to_stderr("pp512-tg128      round 1/5")
 
     class ClosedStream(io.StringIO):
         def write(self, text: str) -> int:
@@ -5284,6 +5285,7 @@ def test_progress_sink_never_aborts_the_benchmark(
 
     monkeypatch.setattr(sys, "stderr", ClosedStream())
     community_cli._progress_to_stderr("pp512-tg128      round 2/5")
+    community_cli._tagged_progress_to_stderr("pp512-tg128      round 2/5")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -4945,6 +4945,23 @@ def test_cli_run_streams_progress_to_stderr_only_in_text_mode(
     assert json.loads(captured.out) == {"run_id": "abc-123", "measurements": []}
     assert captured.err == ""
 
+    # --json --progress: the Desktop opts in, so progress DOES stream to
+    # stderr — but every line is RS-tagged so it can be told apart from the
+    # (untagged) failure document, and stdout stays exactly one JSON document.
+    args.progress = True
+    assert community_cli.benchmark_command(args) == 0
+    captured = capsys.readouterr()
+    assert callable(seen[-1])
+    tag = community_cli.PROGRESS_TAG
+    assert f"{tag}pp512-tg128      round 1/5    46.1 tok/s" in captured.err
+    # Untagged lines (the failure document) would have no RS prefix; here
+    # every emitted line carries one. Split on newline only — str.splitlines()
+    # would also break on the RS tag itself.
+    for line in captured.err.split("\n"):
+        if line:
+            assert line.startswith(tag), repr(line)
+    assert json.loads(captured.out) == {"run_id": "abc-123", "measurements": []}
+
 
 def test_run_local_announces_plan_and_forwards_progress(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -12533,6 +12533,11 @@ Examples:
         help="Print machine-readable JSON instead of the text summary",
     )
     community_run.add_argument(
+        "--progress",
+        action="store_true",
+        help=argparse.SUPPRESS,  # emit machine-readable progress under --json
+    )
+    community_run.add_argument(
         "--inherit-process-group",
         action="store_true",
         help=argparse.SUPPRESS,

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -54,6 +54,25 @@ def _progress_to_stderr(line: str) -> None:
         pass
 
 
+#: Record-separator prefix for machine-readable progress lines under ``--json``.
+#: A caller that opts in with ``--progress`` (the Desktop app) can then tell
+#: progress from the failure document, which is emitted UNtagged on stderr and
+#: surfaced verbatim on a non-zero exit — so the plain ``--json`` contract
+#: (nothing on stderr) is preserved for callers that do not pass ``--progress``.
+PROGRESS_TAG = "\x1e"
+
+
+def _tagged_progress_to_stderr(line: str) -> None:
+    """Like :func:`_progress_to_stderr` but prefixes each line with
+    :data:`PROGRESS_TAG` so a ``--json`` consumer can separate live progress
+    from the untagged failure document."""
+
+    try:
+        print(f"{PROGRESS_TAG}{line}", file=sys.stderr, flush=True)
+    except (OSError, ValueError):
+        pass
+
+
 def _local_time(timestamp: Any) -> str:
     """Render an archived UTC timestamp in the user's local clock.
 
@@ -315,14 +334,22 @@ def benchmark_command(args) -> int:
                 check_cache=True,
             )
         elif action == "run":
+            # Progress is for a human watching a terminal. Under --json stderr
+            # stays reserved for the failure document the Desktop app surfaces
+            # verbatim on a non-zero exit — UNLESS the caller opts in with
+            # --progress, which streams RS-tagged progress the Desktop can tell
+            # apart from that document and render as a live bar + ETA.
+            if not args.json:
+                progress_sink = _progress_to_stderr
+            elif getattr(args, "progress", False):
+                progress_sink = _tagged_progress_to_stderr
+            else:
+                progress_sink = None
             value = run_local(
                 args.benchmark_model,
                 archive=archive,
                 inherit_process_group=getattr(args, "inherit_process_group", False),
-                # Progress is for a human watching a terminal. Under --json
-                # stderr stays reserved for the failure document the Desktop
-                # app surfaces verbatim on a non-zero exit.
-                progress=None if args.json else _progress_to_stderr,
+                progress=progress_sink,
             )
         elif action == "results":
             runs = archive.list(limit=getattr(args, "limit", None))


### PR DESCRIPTION
## Why

Dogfooding the Community Benchmark surfaced two gaps:
1. **A run gave no sense of how long it takes** — just a spinner, an elapsed clock, and a static "usually N minutes" hint that is unreliable across models (a flux image run took ~10 min, not the "1–3 minutes" shown).
2. **Finished results rarely get shared** — the only prompt was a tiny per-row "Share" link, and the share sheets never explained *why* contributing matters. A benchmark is only useful to the community once it is shared.

## What

### Live progress bar + ETA
- The engine already emits per-round progress, but `benchmark run --json` suppressed it (stderr is reserved for the failure document). Added an opt-in **`--progress`** flag that streams the same progress **RS-tagged**, so the Desktop can tell live progress from that document. Plain `--json` stays byte-for-byte clean (existing contract + test unchanged).
- Desktop: parse the tagged lines, count completed warmup+measured passes into a **determinate bar** (text: 12 steps, image: 2), and show a **`~m:ss left` ETA** from average time per completed step (measured from the first step, so model-load time doesn't skew it). Tagged lines are excluded from the failure message.
- Widened the image time hint (2–10 min); the live ETA carries accuracy.

### Guide users to share, with the "why"
- **Post-run CTA** — after a run completes, a prominent card ("Put your Mac on the map") invites sharing and explains the payoff: the community leaderboard lets everyone compare models across real Macs and find faster local AI. Dismissable; hides once shared or superseded.
- **Confirmation sheet** now leads with that collective-value "why" (privacy note unchanged).
- **Success sheet** redesigned (image-model design pass) into a warm, map-themed acknowledgement with a clean identity pill and community-value copy; all states, links, and accessibility identifiers preserved.

## Testing
- `swift build` succeeds; `CommunityBenchmarkView` recompiled and verified.
- New engine test: `--json --progress` streams RS-tagged progress while stdout stays one JSON document; the existing plain-`--json` clean-stderr test is unchanged and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019A88kUrTwWXNnbhhXbSPcx