### PR TITLE
fix(doctor/info): sync spec-decode copy and metadata probes with runtime reality

### DIFF
--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -5179,3 +5179,86 @@ def test_dflash_reports_supported_vlm_with_unverified_import(tmp_path, monkeypat
     assert row.status is eh.CheckStatus.WARN
     assert "cannot be verified safely" in row.label
     assert str(runtime) in row.detail
+
+
+# ---------------------------------------------------------------------------
+# 0.13.4 dogfood P2 fixes
+# ---------------------------------------------------------------------------
+
+
+def test_install_location_reports_unresolved_venv_interpreter(
+    tmp_path, monkeypatch
+):
+    """A virtualenv must display its own interpreter, not the resolved base.
+
+    ``_install_location()`` used to ``.resolve()`` the venv python symlink
+    first, so the display path landed in Homebrew's Cellar / a uv-managed
+    CPython while the label read ``virtualenv`` — two semantics on one
+    line (0.13.4 dogfood). The label classification may keep inspecting
+    the resolved path; the displayed path must stay the configured one.
+    """
+    base_bin = tmp_path / "base" / "bin"
+    base_bin.mkdir(parents=True)
+    base_python = base_bin / "python3.14"
+    base_python.write_text("#!/bin/sh\n")
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_python = venv_bin / "python3.14"
+    venv_python.symlink_to(base_python)
+
+    monkeypatch.setattr(eh.sys, "prefix", str(tmp_path / "venv"))
+    monkeypatch.setattr(eh.sys, "base_prefix", str(tmp_path / "base"))
+
+    label, path = eh._install_location(venv_python)
+    assert label == "virtualenv"
+    assert path == venv_python
+    assert "base" not in path.parts
+
+
+def test_install_location_row_details_base_interpreter(tmp_path, monkeypatch):
+    """The verbose detail carries the base interpreter prefix so venv
+    users can still see which interpreter the venv was seeded from."""
+    monkeypatch.setattr(eh.sys, "prefix", str(tmp_path / "venv"))
+    monkeypatch.setattr(eh.sys, "base_prefix", str(tmp_path / "base"))
+
+    section = eh.section_python()
+    row = next(c for c in section.checks if "Install location" in c.label)
+    assert "base interpreter prefix=" in row.detail
+    assert str(tmp_path / "base") in row.detail
+
+
+def test_probe_reports_namespace_package_version(tmp_path):
+    """Namespace packages must not lose their distribution version.
+
+    ``mlx`` is a namespace package: ``find_spec("mlx").origin`` is None
+    while ``submodule_search_locations`` points at the real
+    ``site-packages/mlx`` directory. The probe used to pass the None
+    origin into distribution-ownership matching, which failed, and
+    doctor warned "version metadata is unavailable" for a perfectly
+    readable distribution (0.13.4 dogfood).
+    """
+    site = tmp_path / "sidecar" / "site-packages"
+    ns_pkg = site / "dogfoodns"
+    ns_pkg.mkdir(parents=True)
+    (ns_pkg / "bridge.py").write_text("x = 1\n")
+    dist_info = site / "dogfoodns-stub-1.2.3.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: dogfoodns-stub\nVersion: 1.2.3\n"
+    )
+    (dist_info / "RECORD").write_text(
+        "dogfoodns/bridge.py,,\ndogfoodns-stub-1.2.3.dist-info/METADATA,,\n"
+    )
+
+    monkey_packages = {"dogfoodns-stub": "dogfoodns"}
+    eh._RUNTIME_PROBE_CACHE.clear()
+    try:
+        with mock.patch.object(eh, "_RUNTIME_PACKAGES", monkey_packages):
+            probe = eh._probe_runtime(Path(sys.executable), tmp_path / "sidecar")
+    finally:
+        eh._RUNTIME_PROBE_CACHE.clear()
+
+    assert probe is not None
+    entry = probe["packages"]["dogfoodns-stub"]
+    assert entry["discoverable"] is True
+    assert entry["version"] == "1.2.3"

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -5186,9 +5186,7 @@ def test_dflash_reports_supported_vlm_with_unverified_import(tmp_path, monkeypat
 # ---------------------------------------------------------------------------
 
 
-def test_install_location_reports_unresolved_venv_interpreter(
-    tmp_path, monkeypatch
-):
+def test_install_location_reports_unresolved_venv_interpreter(tmp_path, monkeypatch):
     """A virtualenv must display its own interpreter, not the resolved base.
 
     ``_install_location()`` used to ``.resolve()`` the venv python symlink

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -5213,6 +5213,35 @@ def test_install_location_reports_unresolved_venv_interpreter(tmp_path, monkeypa
     assert "base" not in path.parts
 
 
+@pytest.mark.parametrize(
+    ("resolved_parent", "expected_label"),
+    [
+        (Path("uv/tools/runtime/bin"), "uv tool"),
+        (Path("pipx/venvs/rapid-mlx/bin"), "pipx"),
+        (Path("Cellar/python@3.14/bin"), "Homebrew"),
+        (Path("usr/bin"), "system"),
+    ],
+)
+def test_install_location_classifies_resolved_runtime_layouts(
+    tmp_path, monkeypatch, resolved_parent, expected_label
+):
+    """Classification follows the resolved runtime while display stays raw."""
+    runtime = tmp_path / resolved_parent / "python3.14"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("#!/bin/sh\n")
+    configured = tmp_path / "configured" / "python"
+    configured.parent.mkdir()
+    configured.symlink_to(runtime)
+
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(eh.sys, "prefix", str(tmp_path / "system"))
+    monkeypatch.setattr(eh.sys, "base_prefix", str(tmp_path / "system"))
+
+    label, path = eh._install_location(configured)
+    assert label == expected_label
+    assert path == configured
+
+
 def test_install_location_row_details_base_interpreter(tmp_path, monkeypatch):
     """The verbose detail carries the base interpreter prefix so venv
     users can still see which interpreter the venv was seeded from."""

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -5260,3 +5260,106 @@ def test_probe_reports_namespace_package_version(tmp_path):
     entry = probe["packages"]["dogfoodns-stub"]
     assert entry["discoverable"] is True
     assert entry["version"] == "1.2.3"
+
+
+def test_probe_namespace_anchor_requires_trusted_portion(tmp_path):
+    """A shadow dist-info in an untrusted context path must not spoof the
+    version of a namespace-packaged distribution.
+
+    Namespace portions merge across sys.path and the server's cwd sits at
+    sys.path[0] (context root). Anchoring ownership on portion[0] let a
+    crafted same-named package dir + dist-info in the context path claim
+    any version while ``trusted_origin`` still reported True (adversarial
+    security review #3266). The anchor must be the first TRUSTED portion;
+    the spoof dist-info's RECORD only covers files under the context root,
+    so it fails ownership matching against the trusted anchor.
+    """
+    site = tmp_path / "sidecar" / "site-packages"
+    ns_pkg = site / "dogfoodns"
+    ns_pkg.mkdir(parents=True)
+    (ns_pkg / "bridge.py").write_text("x = 1\n")
+    real_dist = site / "dogfoodns-stub-1.2.3.dist-info"
+    real_dist.mkdir()
+    (real_dist / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: dogfoodns-stub\nVersion: 1.2.3\n"
+    )
+    (real_dist / "RECORD").write_text(
+        "dogfoodns/bridge.py,,\ndogfoodns-stub-1.2.3.dist-info/METADATA,,\n"
+    )
+
+    # Server-context shadow: unowned same-named namespace portion plus a
+    # spoof dist-info whose RECORD claims a file that exists in the shadow
+    # (Python 3.12+ drops nonexistent RECORD entries, so the file must be
+    # real for the spoof to even reach ownership matching).
+    ctx = tmp_path / "ctx"
+    shadow = ctx / "dogfoodns"
+    shadow.mkdir(parents=True)
+    (shadow / "shadow_impl.py").write_text("x = 2\n")
+    spoof_dist = ctx / "dogfoodns-stub-9.9.9.dist-info"
+    spoof_dist.mkdir()
+    (spoof_dist / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: dogfoodns-stub\nVersion: 9.9.9\n"
+    )
+    (spoof_dist / "RECORD").write_text(
+        "dogfoodns/shadow_impl.py,,\ndogfoodns-stub-9.9.9.dist-info/METADATA,,\n"
+    )
+
+    runtime = Path(sys.executable)
+    monkey_packages = {"dogfoodns-stub": "dogfoodns"}
+    saved_contexts = dict(eh._RUNTIME_CONTEXTS)
+    eh._RUNTIME_PROBE_CACHE.clear()
+    try:
+        eh._RUNTIME_CONTEXTS[runtime] = (ctx, {})
+        with mock.patch.object(eh, "_RUNTIME_PACKAGES", monkey_packages):
+            probe = eh._probe_runtime(runtime, tmp_path / "sidecar")
+    finally:
+        eh._RUNTIME_CONTEXTS.clear()
+        eh._RUNTIME_CONTEXTS.update(saved_contexts)
+        eh._RUNTIME_PROBE_CACHE.clear()
+
+    assert probe is not None
+    entry = probe["packages"]["dogfoodns-stub"]
+    assert entry["trusted_origin"] is True
+    assert entry["version"] == "1.2.3", entry
+
+
+def test_safe_version_gates_on_trusted_origin(monkeypatch):
+    """``_safe_version`` must not surface probe versions from untrusted
+    origins: version feeds supported-range checks and repair hints
+    (adversarial security review #3266 — previously only importability
+    was gated)."""
+    runtime = Path(sys.executable)
+    monkeypatch.setattr(eh, "_runtime_uses_context", lambda _rt: True)
+    monkeypatch.setattr(
+        eh,
+        "_probe_runtime",
+        lambda _rt, _root=None: {
+            "packages": {
+                "stub": {
+                    "version": "0.0.1",
+                    "trusted_origin": False,
+                    "discoverable": True,
+                    "module": "stub",
+                    "importable": None,
+                }
+            }
+        },
+    )
+    assert eh._safe_version("stub", runtime) is None
+
+    monkeypatch.setattr(
+        eh,
+        "_probe_runtime",
+        lambda _rt, _root=None: {
+            "packages": {
+                "stub": {
+                    "version": "1.2.3",
+                    "trusted_origin": True,
+                    "discoverable": True,
+                    "module": "stub",
+                    "importable": None,
+                }
+            }
+        },
+    )
+    assert eh._safe_version("stub", runtime) == "1.2.3"

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -5363,3 +5363,54 @@ def test_safe_version_gates_on_trusted_origin(monkeypatch):
         },
     )
     assert eh._safe_version("stub", runtime) == "1.2.3"
+
+
+@pytest.mark.parametrize("escape_shape", ["dotdot", "absolute"])
+def test_probe_record_escape_cannot_claim_trusted_anchor(
+    tmp_path, monkeypatch, escape_shape
+):
+    """A dist-info in an untrusted context root must not claim ownership
+    of the trusted sidecar's namespace portion via RECORD tricks.
+
+    ``Distribution.locate_file`` joins RECORD entries verbatim, so a
+    crafted dist-info can reference files OUTSIDE its own install root
+    (``..`` or absolute entries). Round 2 on #3266 verified both shapes
+    spoof the version whenever no trusted dist-info claims the anchor
+    first (the exact 'visible without metadata' residue this probe
+    diagnoses). Ownership entries must stay inside their own root."""
+    site = tmp_path / "sidecar" / "site-packages"
+    ns_pkg = site / "dogfoodns"
+    ns_pkg.mkdir(parents=True)
+    (ns_pkg / "bridge.py").write_text("x = 1\n")
+    # Deliberately NO dist-info in the trusted root: the anchor is the
+    # visible-but-unclaimed namespace portion.
+
+    ctx = tmp_path / "ctx"
+    spoof_dist = ctx / "dogfoodns-stub-9.9.9.dist-info"
+    spoof_dist.mkdir(parents=True)
+    (spoof_dist / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: dogfoodns-stub\nVersion: 9.9.9\n"
+    )
+    if escape_shape == "dotdot":
+        record_entry = "../sidecar/site-packages/dogfoodns/bridge.py,,\n"
+    else:
+        record_entry = f"{ns_pkg / 'bridge.py'},,\n"
+    (spoof_dist / "RECORD").write_text(record_entry)
+
+    runtime = Path(sys.executable)
+    monkey_packages = {"dogfoodns-stub": "dogfoodns"}
+    saved_contexts = dict(eh._RUNTIME_CONTEXTS)
+    eh._RUNTIME_PROBE_CACHE.clear()
+    try:
+        eh._RUNTIME_CONTEXTS[runtime] = (ctx, {})
+        with mock.patch.object(eh, "_RUNTIME_PACKAGES", monkey_packages):
+            probe = eh._probe_runtime(runtime, tmp_path / "sidecar")
+    finally:
+        eh._RUNTIME_CONTEXTS.clear()
+        eh._RUNTIME_CONTEXTS.update(saved_contexts)
+        eh._RUNTIME_PROBE_CACHE.clear()
+
+    assert probe is not None
+    entry = probe["packages"]["dogfoodns-stub"]
+    assert entry["trusted_origin"] is True
+    assert entry["version"] != "9.9.9", entry

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -3040,7 +3040,9 @@ class TestCheckpointMetadataFallback:
         assert detect_model_config("publisher/unknown-model") is None
 
 
-def test_registry_invariant_default_on_implies_declared_mechanism():
+def test_registry_invariant_default_on_implies_declared_mechanism(
+    tmp_path, monkeypatch
+):
     """Pins the seam round-2 review on #3266 flagged: `_mtp_path_label`
     only consults the serve-side default-on helpers when the DETECTED cfg
     declares a mechanism (``supports_native_mtp`` or ``mtp_draft_model``).
@@ -3051,6 +3053,14 @@ def test_registry_invariant_default_on_implies_declared_mechanism():
     alias must keep the two views consistent."""
     from vllm_mlx.model_aliases import list_profiles
     from vllm_mlx.model_auto_config import detect_model_config
+
+    # Hermeticity (round-3 review on #3266): list_profiles() merges the
+    # host's user-alias file, which is outside the conftest env
+    # allowlist — point it at an empty tmp file so a corrupt/dev-machine
+    # alias config can't fail this suite.
+    empty_aliases = tmp_path / "user-aliases.json"
+    empty_aliases.write_text('{"version": 1, "aliases": {}}\n')
+    monkeypatch.setenv("RAPID_MLX_USER_ALIASES_FILE", str(empty_aliases))
 
     offenders: list[str] = []
     for alias, profile in list_profiles().items():

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -985,6 +985,8 @@ class TestVisibility:
         assert "MTP path         : sidecar (default; --no-spec-decode off)" in table
         assert "✗ disabled (hybrid arch)" not in table
         assert "sidecar (opt-in: --speculative-config)" not in table
+        assert "Suffix tier      : n/a (hybrid arch — suffix unsupported)" in table
+        assert "spec decode off" not in table
 
     def test_table_matches_serve_default_on_mtp_sidecar_dense(self):
         # Same contract on a non-hybrid alias: ``qwen3.5-9b-4bit`` is

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from vllm_mlx import model_auto_config as auto_config_mod
+from vllm_mlx import model_aliases, model_auto_config as auto_config_mod
 from vllm_mlx.model_auto_config import (
     ModelConfig,
     _deepseek_template_family,
@@ -959,10 +959,62 @@ class TestVisibility:
     def test_table_for_hybrid_shows_disabled_spec(self):
         # r6-A R6-C1: use the A3B MoE Qwen3.5 path — see
         # ``test_summary_for_hybrid`` for the dense-vs-MoE rationale.
+        # This alias is mtp_continuous_batching_tier=unknown, so serve
+        # does NOT default-enable MTP and the honest reason for the
+        # standard lane stays ``disabled (hybrid arch)``.
         cfg = detect_model_config("mlx-community/Qwen3.5-35B-A3B-4bit")
         table = format_profile_table("mlx-community/Qwen3.5-35B-A3B-4bit", cfg)
         assert "✗ disabled (hybrid arch)" in table
         assert "✓ 200ms gap" in table
+
+    def test_table_matches_serve_default_on_mtp_sidecar_hybrid(self):
+        # 0.13.4 dogfood P1: ``qwen3.8-27b-4bit`` is hybrid
+        # (``supports_spec_decode=False``) yet serve boots it with MTP
+        # by default — the alias is
+        # ``mtp_continuous_batching_tier=verified`` +
+        # ``mtp_default_enabled=True`` with a declared sidecar drafter.
+        # The info table used to claim ``✗ disabled (hybrid arch)`` +
+        # ``sidecar (opt-in: --speculative-config)``, the exact
+        # registry-vs-reality mismatch this row must never ship again.
+        cfg = detect_model_config("qwen3.8-27b-4bit")
+        assert cfg is not None and cfg.is_hybrid is True
+        table = format_profile_table("qwen3.8-27b-4bit", cfg)
+        assert "✓ default-on (MTP)" in table
+        assert "MTP path         : sidecar (default; --no-spec-decode off)" in table
+        assert "✗ disabled (hybrid arch)" not in table
+        assert "sidecar (opt-in: --speculative-config)" not in table
+
+    def test_table_matches_serve_default_on_mtp_sidecar_dense(self):
+        # Same contract on a non-hybrid alias: ``qwen3.5-9b-4bit`` is
+        # verified + default-enabled with a declared sidecar, so the
+        # generic lane copy ``✓ supported`` understates what serve does.
+        cfg = detect_model_config("qwen3.5-9b-4bit")
+        table = format_profile_table("qwen3.5-9b-4bit", cfg)
+        assert "✓ default-on (MTP)" in table
+        assert "MTP path         : sidecar (default; --no-spec-decode off)" in table
+
+    def test_table_keeps_opt_in_label_for_default_off_alias(self):
+        # #3115 contract: ``qwen3.5-4b-4bit`` is verified but shipped
+        # ``mtp_default_enabled=False`` (measured regression on M2 Pro /
+        # M3 Ultra), so serve leaves it off unasked and the table must
+        # keep naming the explicit opt-in.
+        cfg = detect_model_config("qwen3.5-4b-4bit")
+        table = format_profile_table("qwen3.5-4b-4bit", cfg)
+        assert "sidecar (opt-in: --speculative-config)" in table
+        assert "✓ default-on (MTP)" not in table
+
+    def test_table_fails_closed_when_registry_unavailable(self, monkeypatch):
+        # Registry failure must not fabricate a default-on claim — the
+        # table degrades to the pre-existing capability copy, mirroring
+        # serve's fail-closed plain-decode path.
+        def _raise(_name: str):
+            raise RuntimeError("broken alias registry")
+
+        monkeypatch.setattr(model_aliases, "resolve_profile", _raise)
+        cfg = detect_model_config("qwen3.8-27b-4bit")
+        table = format_profile_table("qwen3.8-27b-4bit", cfg)
+        assert "✓ default-on (MTP)" not in table
+        assert "sidecar (default" not in table
 
     def test_qwen4_exp_alias_surfaces_experimental_status(self):
         cfg = detect_model_config("qwen3.8-flash-next-4bit")

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -5,7 +5,8 @@ from unittest import mock
 
 import pytest
 
-from vllm_mlx import model_aliases, model_auto_config as auto_config_mod
+from vllm_mlx import model_aliases
+from vllm_mlx import model_auto_config as auto_config_mod
 from vllm_mlx.model_auto_config import (
     ModelConfig,
     _deepseek_template_family,

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1,6 +1,7 @@
 """Tests for model auto-config detection."""
 
 import logging
+import sys
 from unittest import mock
 
 import pytest
@@ -1105,6 +1106,21 @@ class TestVisibility:
         table = format_profile_table("qwen3.8-27b-4bit", cfg)
         assert "✓ default-on (MTP)" not in table
         assert "sidecar (default" not in table
+
+    def test_mtp_default_probe_fails_closed_when_cli_import_is_unavailable(
+        self, monkeypatch
+    ):
+        monkeypatch.setitem(sys.modules, "vllm_mlx.cli", None)
+        assert auto_config_mod._serve_mtp_default_on("qwen3.8-27b-4bit") is False
+
+    def test_native_mtp_default_on_label(self, monkeypatch):
+        monkeypatch.setattr(
+            auto_config_mod, "_serve_mtp_default_on", lambda _name: True
+        )
+        cfg = ModelConfig(supports_native_mtp=True)
+        assert auto_config_mod._mtp_path_label("native-model", cfg) == (
+            "native (default; --no-spec-decode off)"
+        )
 
     def test_qwen4_exp_alias_surfaces_experimental_status(self):
         cfg = detect_model_config("qwen3.8-flash-next-4bit")

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1035,22 +1035,33 @@ class TestVisibility:
         assert "✗ not needed" in table
 
     def test_table_for_dense_no_drafter_shows_honest_reason(self):
-        # 0.9.0 dogfood regression guard. ``qwen3.5-4b-4bit`` has
-        # ``supports_spec_decode=False`` (no MTP head trained) but is
-        # NOT hybrid. Before 0.9.1 the Spec-decode row claimed
-        # ``(hybrid arch)`` as the reason, contradicting the
-        # ``Architecture: pure attention`` row two lines above. Now we
-        # surface the actual reason — no MTP/drafter trained for this
-        # alias — so the user can act on it (or stop expecting a flag
-        # to flip).
-        cfg = detect_model_config("mlx-community/Qwen3.5-4B-MLX-4bit")
+        # 0.9.0 dogfood regression guard, re-pointed at a TRUE
+        # no-drafter alias (``qwen3.5-4b-4bit`` grew a declared MTP
+        # sidecar + default-off in #3115, so it now belongs to the
+        # opt-in test below). Non-hybrid + spec-off must render the
+        # actual reason — no MTP/drafter trained for this alias — not
+        # the ``(hybrid arch)`` misnomer pre-0.9.1 shipped.
+        cfg = detect_model_config("qwen3.5-27b-4bit")
         assert cfg is not None
         assert cfg.is_hybrid is False
         assert cfg.supports_spec_decode is False
-        table = format_profile_table("mlx-community/Qwen3.5-4B-MLX-4bit", cfg)
+        table = format_profile_table("qwen3.5-27b-4bit", cfg)
         assert "✗ disabled (no MTP/drafter trained)" in table
         assert "✗ disabled (hybrid arch)" not in table
         assert "pure attention" in table
+
+    def test_table_default_off_sidecar_names_opt_in_not_no_drafter(self):
+        # 0.13.4 dogfood round 2: ``qwen3.5-4b-4bit`` declares an MTP
+        # sidecar drafter but ships ``mtp_default_enabled=False``
+        # (#3115). The Spec decode row must not claim
+        # ``(no MTP/drafter trained)`` two lines above
+        # ``MTP path: sidecar (opt-in: …)`` — same row-vs-row honesty
+        # contract as the default-on fix.
+        cfg = detect_model_config("qwen3.5-4b-4bit")
+        table = format_profile_table("qwen3.5-4b-4bit", cfg)
+        assert "✗ off (MTP opt-in: --speculative-config)" in table
+        assert "MTP path         : sidecar (opt-in: --speculative-config)" in table
+        assert "✗ disabled (no MTP/drafter trained)" not in table
 
     def test_table_for_dflash_alias_surfaces_opt_in_flag(self):
         # 0.9.1 dogfood follow-up. ``qwen3.5-27b-8bit`` is the operator-

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -921,14 +921,14 @@ class TestVisibility:
         assert "throttle ON" in line
         assert "spec decode OFF" in line
 
-    def test_summary_shows_explicit_runtime_spec_decode(self):
+    def test_summary_shows_active_runtime_spec_decode(self):
         cfg = detect_model_config("mlx-community/Qwen3.5-35B-A3B-4bit")
         line = format_profile_summary(
             "mlx-community/Qwen3.5-35B-A3B-4bit",
             cfg,
             runtime_spec_decode="mtp",
         )
-        assert "spec decode MTP (explicit)" in line
+        assert "spec decode MTP (active)" in line
         assert "spec decode OFF" not in line
 
     def test_summary_for_unknown(self):
@@ -936,12 +936,12 @@ class TestVisibility:
         assert "unknown family" in line
         assert "brand-new-model" in line
 
-    def test_unknown_summary_shows_explicit_runtime_spec_decode(self):
+    def test_unknown_summary_shows_active_runtime_spec_decode(self):
         line = format_profile_summary(
             "brand-new-model", None, runtime_spec_decode="mtp"
         )
         assert "unknown family" in line
-        assert "spec decode MTP (explicit)" in line
+        assert "spec decode MTP (active)" in line
 
     # --- Level 2 / Level 3: ASCII table ---
 
@@ -1003,6 +1003,61 @@ class TestVisibility:
         table = format_profile_table("qwen3.5-4b-4bit", cfg)
         assert "sidecar (opt-in: --speculative-config)" in table
         assert "✓ default-on (MTP)" not in table
+
+    def test_table_no_spec_decode_runtime_overrides_default_on(self):
+        # Adversarial review round 1 (#3266): the registry view is
+        # runtime-blind. ``serve qwen3.8-27b-4bit --no-spec-decode`` with
+        # RAPID_MLX_PROFILE_VERBOSE=1 used to render ``✓ default-on
+        # (MTP)`` + ``sidecar (default; …)`` in the same box as
+        # ``Suffix tier: … spec decode off`` while the server ran plain
+        # decode. The engine now passes runtime_spec_decode="off" and the
+        # default-on claims must yield.
+        cfg = detect_model_config("qwen3.8-27b-4bit")
+        table = format_profile_table("qwen3.8-27b-4bit", cfg, runtime_spec_decode="off")
+        assert "✗ off (--no-spec-decode)" in table
+        assert "MTP path         : off (--no-spec-decode)" in table
+        assert "✓ default-on (MTP)" not in table
+        assert "sidecar (default; --no-spec-decode off)" not in table
+
+    def test_table_no_spec_decode_keeps_capability_rows(self):
+        # Only default-on ACTIVITY claims are overridden. A default-off
+        # alias under --no-spec-decode keeps its opt-in rows: the
+        # mechanism exists, it is simply not running — same truth the
+        # #3115 contract requires flag-less.
+        cfg = detect_model_config("qwen3.5-4b-4bit")
+        table = format_profile_table("qwen3.5-4b-4bit", cfg, runtime_spec_decode="off")
+        assert "✗ off (MTP opt-in: --speculative-config)" in table
+        assert "sidecar (opt-in: --speculative-config)" in table
+
+    def test_table_active_runtime_method_overrides_off_rows(self):
+        # Explicit opt-in boot on a default-off alias: the runtime IS
+        # decoding with MTP, so the registry's ``✗ off (MTP opt-in …)``
+        # row would deny reality. Same for non-MTP lanes (dflash) on a
+        # default-on alias.
+        cfg = detect_model_config("qwen3.5-4b-4bit")
+        table = format_profile_table("qwen3.5-4b-4bit", cfg, runtime_spec_decode="mtp")
+        assert "✓ active (MTP)" in table
+        assert "✗ off (MTP opt-in" not in table
+
+        hybrid = detect_model_config("qwen3.8-27b-4bit")
+        table = format_profile_table(
+            "qwen3.8-27b-4bit", hybrid, runtime_spec_decode="dflash"
+        )
+        assert "✓ active (DFLASH)" in table
+
+    def test_table_runtime_mtp_keeps_default_on_copy(self):
+        # Flag-less default-on boot: runtime method "mtp" agrees with the
+        # registry view, which is the more informative copy — keep it.
+        cfg = detect_model_config("qwen3.8-27b-4bit")
+        table = format_profile_table("qwen3.8-27b-4bit", cfg, runtime_spec_decode="mtp")
+        assert "✓ default-on (MTP)" in table
+
+    def test_table_unmatched_profile_runtime_off(self):
+        # The unmatched-profile branch hardcodes a generic ``✓
+        # default-on``; under --no-spec-decode that is false regardless
+        # of what loads.
+        table = format_profile_table("brand-new-model", None, runtime_spec_decode="off")
+        assert "✗ off (--no-spec-decode)" in table
 
     def test_table_fails_closed_when_registry_unavailable(self, monkeypatch):
         # Registry failure must not fabricate a default-on claim — the

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1052,6 +1052,40 @@ class TestVisibility:
         table = format_profile_table("qwen3.8-27b-4bit", cfg, runtime_spec_decode="mtp")
         assert "✓ default-on (MTP)" in table
 
+    def test_table_suffix_lane_overrides_default_on_mtp(self):
+        # Round 2 on #3266: the SuffixDecoding lane leaves scheduler
+        # spec_decode "none" while decoding speculatively. The table must
+        # not claim default-on MTP for a server that is actively decoding
+        # via Suffix — and the MTP-path row must stop advertising the
+        # "(default; --no-spec-decode off)" disposition that isn't loaded.
+        cfg = detect_model_config("qwen3.8-27b-4bit")
+        table = format_profile_table(
+            "qwen3.8-27b-4bit", cfg, runtime_spec_decode="suffix"
+        )
+        assert "✓ active (SUFFIX)" in table
+        assert "MTP path         : off (decoding via SUFFIX)" in table
+        assert "✓ default-on (MTP)" not in table
+        assert "sidecar (default; --no-spec-decode off)" not in table
+
+    def test_table_dflash_lane_marks_mtp_off(self):
+        # Same contract for DFlash (dedicated single-user engine): MTP is
+        # not loaded while DFlash decodes.
+        cfg = detect_model_config("qwen3.8-27b-4bit")
+        table = format_profile_table(
+            "qwen3.8-27b-4bit", cfg, runtime_spec_decode="dflash"
+        )
+        assert "✓ active (DFLASH)" in table
+        assert "MTP path         : off (decoding via DFLASH)" in table
+
+    def test_table_unmatched_profile_active_lane(self):
+        # The unmatched-profile branch must also reconcile an active lane,
+        # not just the --no-spec-decode override.
+        table = format_profile_table(
+            "brand-new-model", None, runtime_spec_decode="suffix"
+        )
+        assert "✓ active (SUFFIX)" in table
+        assert "✓ default-on" not in table
+
     def test_table_unmatched_profile_runtime_off(self):
         # The unmatched-profile branch hardcodes a generic ``✓
         # default-on``; under --no-spec-decode that is false regardless
@@ -3004,3 +3038,33 @@ class TestCheckpointMetadataFallback:
         monkeypatch.setattr(auto_config_mod, "read_model_metadata", lambda name: None)
 
         assert detect_model_config("publisher/unknown-model") is None
+
+
+def test_registry_invariant_default_on_implies_declared_mechanism():
+    """Pins the seam round-2 review on #3266 flagged: `_mtp_path_label`
+    only consults the serve-side default-on helpers when the DETECTED cfg
+    declares a mechanism (``supports_native_mtp`` or ``mtp_draft_model``).
+    If an alias ever ships ``mtp_continuous_batching_tier=verified`` +
+    ``mtp_default_enabled`` truthy WITHOUT declaring a mechanism, serve
+    would boot MTP by default while the info table claims opt-in/disabled
+    — the exact registry-vs-reality split this PR closes. Every shipped
+    alias must keep the two views consistent."""
+    from vllm_mlx.model_aliases import list_profiles
+    from vllm_mlx.model_auto_config import detect_model_config
+
+    offenders: list[str] = []
+    for alias, profile in list_profiles().items():
+        if profile.mtp_continuous_batching_tier != "verified":
+            continue
+        if not profile.mtp_default_enabled:
+            continue
+        cfg = detect_model_config(alias)
+        declares = bool(getattr(cfg, "supports_native_mtp", False)) or bool(
+            (getattr(cfg, "mtp_draft_model", None) or "").strip()
+        )
+        if not declares:
+            offenders.append(alias)
+    assert not offenders, (
+        "verified+default-on aliases must declare a native MTP head or a "
+        f"sidecar drafter so the info table can see it: {offenders}"
+    )

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2821,6 +2821,7 @@ def test_engine_core_suffix_lane_reconciles_profile_log(monkeypatch, caplog):
     (adversarial review round 2, #3266)."""
     try:
         from vllm_mlx.engine_core import EngineConfig
+        from vllm_mlx.model_auto_config import ModelConfig
         from vllm_mlx.scheduler import SchedulerConfig
     except (ImportError, RuntimeError) as exc:
         pytest.skip(f"MLX runtime unavailable ({exc})")
@@ -2832,12 +2833,45 @@ def test_engine_core_suffix_lane_reconciles_profile_log(monkeypatch, caplog):
         ),
     )
     monkeypatch.setenv("RAPID_MLX_PROFILE_VERBOSE", "1")
+    # Suffix is installable only for supports_spec_decode=True profiles —
+    # represent a suffix-capable model, not the harness's hybrid default.
     with caplog.at_level("INFO", logger="vllm_mlx.engine_core"):
-        _make_engine_core_for_override_test(monkeypatch, cfg)
+        _make_engine_core_for_override_test(
+            monkeypatch,
+            cfg,
+            base=ModelConfig(is_hybrid=False, supports_spec_decode=True),
+        )
 
     assert "spec decode SUFFIX (active)" in caplog.text
     assert "✓ active (SUFFIX)" in caplog.text
     assert "✓ default-on (MTP)" not in caplog.text
+
+
+def test_engine_core_suffix_flag_without_install_gate_stays_honest(monkeypatch, caplog):
+    """Programmatic-only combo (CLI exits 2): the suffix flag is set but
+    the profile cannot install it (supports_spec_decode forced False via
+    no_spec_decode). The lane claim must stay silent — 'active' would be
+    its own registry-vs-reality lie (round 3, #3266)."""
+    try:
+        from vllm_mlx.engine_core import EngineConfig
+        from vllm_mlx.scheduler import SchedulerConfig
+    except (ImportError, RuntimeError) as exc:
+        pytest.skip(f"MLX runtime unavailable ({exc})")
+
+    cfg = EngineConfig(
+        model_name="fake/model",
+        no_spec_decode=True,
+        scheduler_config=SchedulerConfig(
+            spec_decode="none", enable_suffix_decoding=True
+        ),
+    )
+    monkeypatch.setenv("RAPID_MLX_PROFILE_VERBOSE", "1")
+    with caplog.at_level("INFO", logger="vllm_mlx.engine_core"):
+        _make_engine_core_for_override_test(monkeypatch, cfg)
+
+    assert "spec decode SUFFIX" not in caplog.text
+    assert "✓ active (SUFFIX)" not in caplog.text
+    assert "spec decode OFF" in caplog.text
 
 
 def _engine_core_mutex_cases() -> list[dict[str, bool]]:

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2814,6 +2814,32 @@ def test_engine_core_profile_log_shows_explicit_mtp(monkeypatch, caplog):
     assert "spec decode OFF" not in caplog.text
 
 
+def test_engine_core_suffix_lane_reconciles_profile_log(monkeypatch, caplog):
+    """SuffixDecoding leaves scheduler ``spec_decode="none"`` while the
+    server decodes speculatively — summary AND verbose table must name
+    the active lane instead of the registry's default-on MTP claim
+    (adversarial review round 2, #3266)."""
+    try:
+        from vllm_mlx.engine_core import EngineConfig
+        from vllm_mlx.scheduler import SchedulerConfig
+    except (ImportError, RuntimeError) as exc:
+        pytest.skip(f"MLX runtime unavailable ({exc})")
+
+    cfg = EngineConfig(
+        model_name="fake/model",
+        scheduler_config=SchedulerConfig(
+            spec_decode="none", enable_suffix_decoding=True
+        ),
+    )
+    monkeypatch.setenv("RAPID_MLX_PROFILE_VERBOSE", "1")
+    with caplog.at_level("INFO", logger="vllm_mlx.engine_core"):
+        _make_engine_core_for_override_test(monkeypatch, cfg)
+
+    assert "spec decode SUFFIX (active)" in caplog.text
+    assert "✓ active (SUFFIX)" in caplog.text
+    assert "✓ default-on (MTP)" not in caplog.text
+
+
 def _engine_core_mutex_cases() -> list[dict[str, bool]]:
     """Build mutex-conflict parametrize cases from the registry. For
     every pair with ``model_config_field`` not None, generate one

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2874,6 +2874,31 @@ def test_engine_core_suffix_flag_without_install_gate_stays_honest(monkeypatch, 
     assert "spec decode OFF" in caplog.text
 
 
+def test_engine_core_verbose_plain_registry_view_uses_no_runtime_override(
+    monkeypatch, caplog
+):
+    """A normal boot leaves the verbose table on its registry capability view."""
+    try:
+        from vllm_mlx.engine_core import EngineConfig
+        from vllm_mlx.scheduler import SchedulerConfig
+    except (ImportError, RuntimeError) as exc:
+        pytest.skip(f"MLX runtime unavailable ({exc})")
+
+    cfg = EngineConfig(
+        model_name="fake/model",
+        scheduler_config=SchedulerConfig(
+            spec_decode="none", enable_suffix_decoding=False
+        ),
+    )
+    monkeypatch.setenv("RAPID_MLX_PROFILE_VERBOSE", "1")
+    with caplog.at_level("INFO", logger="vllm_mlx.engine_core"):
+        _make_engine_core_for_override_test(monkeypatch, cfg)
+
+    assert "Spec decode" in caplog.text
+    assert "spec decode MTP (active)" not in caplog.text
+    assert "spec decode SUFFIX (active)" not in caplog.text
+
+
 def _engine_core_mutex_cases() -> list[dict[str, bool]]:
     """Build mutex-conflict parametrize cases from the registry. For
     every pair with ``model_config_field`` not None, generate one

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2810,7 +2810,7 @@ def test_engine_core_profile_log_shows_explicit_mtp(monkeypatch, caplog):
     with caplog.at_level("INFO", logger="vllm_mlx.engine_core"):
         _make_engine_core_for_override_test(monkeypatch, cfg)
 
-    assert "spec decode MTP (explicit)" in caplog.text
+    assert "spec decode MTP (active)" in caplog.text
     assert "spec decode OFF" not in caplog.text
 
 

--- a/tests/test_suffix_decoding_tier.py
+++ b/tests/test_suffix_decoding_tier.py
@@ -211,7 +211,7 @@ class TestProfileTableCell:
         the truncator should be a no-op on the common case."""
         cfg = ModelConfig(supports_spec_decode=False, is_hybrid=True)
         cell = _suffix_tier_cell(cfg, max_width=41)
-        assert cell == "n/a (hybrid arch — spec decode off)"
+        assert cell == "n/a (hybrid arch — suffix unsupported)"
         assert "…" not in cell
 
     def test_dense_no_drafter_tier_cell_does_not_lie_about_hybrid(self):

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -831,9 +831,24 @@ for distribution, module_name in distributions.items():
     spec = None
     try:
         spec = importlib.util.find_spec(module_name)
+        # Namespace packages (mlx is one) have ``origin is None`` but a
+        # real ``submodule_search_locations`` directory. Ownership
+        # matching needs an existing path, so fall back to the package
+        # directory — otherwise a perfectly readable distribution
+        # (mlx 0.32.2) was reported as "version metadata unavailable"
+        # (0.13.4 dogfood P2). The path-trust check is unchanged:
+        # ``_module_path_is_trusted`` already accepts
+        # ``submodule_search_locations``.
+        probe_path = spec.origin if spec is not None else None
+        if (
+            probe_path is None
+            and spec is not None
+            and spec.submodule_search_locations
+        ):
+            probe_path = next(iter(spec.submodule_search_locations), None)
         version = None if spec is None else distribution_version(
             distribution,
-            spec.origin,
+            probe_path,
         )
     except importlib.metadata.PackageNotFoundError:
         version = None
@@ -1659,23 +1674,36 @@ def section_system() -> Section:
 def _install_location(exe: Path | None = None) -> tuple[str, Path]:
     """Classify where ``rapid-mlx`` is installed: ``uv tool``, ``pipx``,
     ``virtualenv``, ``system``. Returned label is for display; the path
-    is shown in --verbose."""
-    exe = (exe or Path(sys.executable)).resolve()
+    is shown in --verbose.
+
+    The returned path is the interpreter as configured — symlinks are
+    NOT dereferenced — so a virtualenv reports its own ``bin/python``
+    instead of the base interpreter its symlink points at. Resolving
+    first used to land the display path in Homebrew's Cellar (or a uv-
+    managed CPython) while the label read ``virtualenv``, mixing two
+    semantics on one line (0.13.4 dogfood P2). The label classification
+    below still inspects the resolved path, because uv/pipx layouts are
+    only recognizable through the real location; the base interpreter
+    remains reachable via ``sys.base_prefix`` for verbose detail.
+    """
+    raw = exe or Path(sys.executable)
+    exe = raw.resolve()
+    display = raw.absolute()
     parts = exe.parts
     lower = str(exe).lower()
     if "uv/tools" in lower or "/uv/tools/" in lower:
-        return "uv tool", exe
+        return "uv tool", display
     if "pipx" in lower:
-        return "pipx", exe
+        return "pipx", display
     # site-packages under a venv-style structure
     if (
         sys.prefix != getattr(sys, "base_prefix", sys.prefix)
         or "VIRTUAL_ENV" in os.environ
     ):
-        return "virtualenv", exe
+        return "virtualenv", display
     if "Cellar" in parts or "/homebrew/" in lower:
-        return "Homebrew", exe
-    return "system", exe
+        return "Homebrew", display
+    return "system", display
 
 
 def section_python() -> Section:
@@ -1760,7 +1788,8 @@ def section_python() -> Section:
         f"Install location: {install_label} ({path})",
         CheckStatus.OK,
         detail=(
-            f"sys.executable={path}; all package checks use this runtime's "
+            f"sys.executable={path}; base interpreter prefix="
+            f"{Path(sys.base_prefix)}; all package checks use this runtime's "
             "sys.path (or the running server's equivalent runtime)"
         ),
     )

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -812,9 +812,29 @@ def _distribution_owns_module(distribution, module_path):
     owned_paths = [module_path]
     if module_path.name == "__init__.py":
         owned_paths.append(module_path.parent)
+    # RECORD is attacker-controlled when the dist-info comes from an
+    # untrusted root: ``locate_file`` joins entries verbatim, so absolute
+    # entries (and "../" entries that escape the dist-info's install
+    # root) could otherwise claim a module in a DIFFERENT root — e.g. a
+    # context dist-info asserting ownership of the trusted sidecar's
+    # namespace portion (adversarial review round 2 on #3266). Entries
+    # that stay inside their own install root are matched as before;
+    # out-of-root entries (legitimately: console scripts like
+    # ../../../bin/foo) are simply not eligible for ownership.
+    try:
+        dist_root = Path(distribution.locate_file("")).resolve()
+    except (Exception, SystemExit):
+        dist_root = None
     for installed_file in distribution.files or []:
         try:
-            installed_path = Path(distribution.locate_file(installed_file)).resolve()
+            entry = Path(installed_file)
+            if entry.is_absolute():
+                continue
+            installed_path = Path(distribution.locate_file(entry)).resolve()
+            if dist_root is not None and not installed_path.is_relative_to(
+                dist_root
+            ):
+                continue
         except (Exception, SystemExit):
             continue
         for owned_path in owned_paths:

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -836,16 +836,29 @@ for distribution, module_name in distributions.items():
         # matching needs an existing path, so fall back to the package
         # directory — otherwise a perfectly readable distribution
         # (mlx 0.32.2) was reported as "version metadata unavailable"
-        # (0.13.4 dogfood P2). The path-trust check is unchanged:
-        # ``_module_path_is_trusted`` already accepts
-        # ``submodule_search_locations``.
+        # (0.13.4 dogfood P2).
+        # Anchor on the first portion that is ITSELF trusted, not portion
+        # [0]: namespace portions merge across sys.path, context roots sit
+        # at sys.path[0], and ``_module_path_is_trusted`` is any-portion —
+        # so anchoring blindly on portion [0] let a shadow dist-info in an
+        # untrusted server-context directory claim a spoofed version while
+        # trusted_origin still reported True (adversarial security review
+        # #3266). No trusted portion → no anchor → version stays None
+        # (fail-closed), matching the pre-fallback behavior.
         probe_path = spec.origin if spec is not None else None
         if (
             probe_path is None
             and spec is not None
             and spec.submodule_search_locations
         ):
-            probe_path = next(iter(spec.submodule_search_locations), None)
+            probe_path = next(
+                (
+                    location
+                    for location in spec.submodule_search_locations
+                    if _path_is_trusted(location)
+                ),
+                None,
+            )
         version = None if spec is None else distribution_version(
             distribution,
             probe_path,
@@ -1814,8 +1827,19 @@ def _safe_version(
         )
         package = _probe_package(probe, dist) if probe else None
         if package is not None:
+            # Version consumers (repair-hint comparisons, supported-range
+            # checks) must only see probed metadata from trusted origins:
+            # a dist-info shadowing the module from a server-context path
+            # can claim any version (adversarial security review #3266 —
+            # previously only *importability* was gated on trusted_origin).
+            # The probe emits trusted_origin unconditionally; treat an
+            # ABSENT key as trusted (older fixture/probe formats) and gate
+            # only on an explicit False.
+            trusted = package.get("trusted_origin")
             version = package.get("version")
-            return str(version) if version else None
+            if trusted is not False and version:
+                return str(version)
+            return None
         return None
     try:
         return _im.version(dist)

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -416,8 +416,14 @@ class EngineCore:
         # SuffixDecoding lane leaves it "none" while decoding speculatively
         # (adversarial review round 2 on #3266). DDTree/DFlash run dedicated
         # single-user servers that never construct EngineCore, so Suffix is
-        # the only such lane reachable here.
-        suffix_active = bool(getattr(scheduler_config, "enable_suffix_decoding", False))
+        # the only such lane reachable here. Keyed on supports_spec_decode
+        # too because that is the install gate (scheduler refuses to install
+        # suffix for profiles with it False — including the --no-spec-decode
+        # forced False above): claiming an active lane that nothing installs
+        # would be its own registry-vs-reality lie (round 3 on #3266).
+        suffix_active = bool(
+            getattr(scheduler_config, "enable_suffix_decoding", False)
+        ) and bool(self.model_config.supports_spec_decode)
         lane_active = (
             runtime_spec_decode
             if runtime_spec_decode != "none"

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -424,8 +424,20 @@ class EngineCore:
         if os.environ.get("RAPID_MLX_PROFILE_VERBOSE") == "1" or getattr(
             self.config, "verbose_profile", False
         ):
+            # Reconcile the table with the runtime (adversarial review
+            # round 1 on #3266): spec_decode == "none" alone is not proof
+            # of plain decode — the Suffix/DDTree lanes leave it "none" —
+            # so "off" is only claimed for the explicit --no-spec-decode
+            # override; otherwise an active method name, or None to keep
+            # the registry view.
+            if self.config.no_spec_decode:
+                table_runtime_spec = "off"
+            elif runtime_spec_decode != "none":
+                table_runtime_spec = runtime_spec_decode
+            else:
+                table_runtime_spec = None
             for line in format_profile_table(
-                display_path, self.model_config
+                display_path, self.model_config, runtime_spec_decode=table_runtime_spec
             ).splitlines():
                 logger.info(line)
 

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -412,28 +412,44 @@ class EngineCore:
         # via env var ``RAPID_MLX_PROFILE_VERBOSE=1`` (or set on EngineConfig).
         display_path = model_path or "(unknown)"
         runtime_spec_decode = getattr(scheduler_config, "spec_decode", "none")
+        # spec_decode == "none" is not proof of plain decode: the
+        # SuffixDecoding lane leaves it "none" while decoding speculatively
+        # (adversarial review round 2 on #3266). DDTree/DFlash run dedicated
+        # single-user servers that never construct EngineCore, so Suffix is
+        # the only such lane reachable here.
+        suffix_active = bool(getattr(scheduler_config, "enable_suffix_decoding", False))
+        lane_active = (
+            runtime_spec_decode
+            if runtime_spec_decode != "none"
+            else ("suffix" if suffix_active else None)
+        )
         logger.info(
             format_profile_summary(
                 display_path,
                 self.model_config,
-                runtime_spec_decode=(
-                    runtime_spec_decode if runtime_spec_decode != "none" else None
-                ),
+                runtime_spec_decode=lane_active,
             )
         )
         if os.environ.get("RAPID_MLX_PROFILE_VERBOSE") == "1" or getattr(
             self.config, "verbose_profile", False
         ):
             # Reconcile the table with the runtime (adversarial review
-            # round 1 on #3266): spec_decode == "none" alone is not proof
-            # of plain decode — the Suffix/DDTree lanes leave it "none" —
-            # so "off" is only claimed for the explicit --no-spec-decode
-            # override; otherwise an active method name, or None to keep
-            # the registry view.
-            if self.config.no_spec_decode:
+            # rounds 1-2 on #3266): "off" is only claimed for the explicit
+            # --no-spec-decode override with no other lane active;
+            # otherwise an active method/lane name, or None to keep the
+            # registry view.
+            if (
+                self.config.no_spec_decode
+                and runtime_spec_decode == "none"
+                and not suffix_active
+            ):
+                # Keyed on "no lane actually active" too: no_spec_decode
+                # coexisting with an active scheduler lane is only
+                # constructible programmatically (the CLI exits 2), and
+                # the active lane is the truth then (round 2, #3266).
                 table_runtime_spec = "off"
-            elif runtime_spec_decode != "none":
-                table_runtime_spec = runtime_spec_decode
+            elif lane_active is not None:
+                table_runtime_spec = lane_active
             else:
                 table_runtime_spec = None
             for line in format_profile_table(

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2347,8 +2347,11 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
     Derivation is from the resolved profile only (no ``config.json``
     read), keeping the ``rapid-mlx info`` path weight-free. The
     default-on vs opt-in split consults the same registry helpers serve
-    consults, so this label can never again report opt-in for a model
-    the server decodes with MTP by default (0.13.4 dogfood P1).
+    consults, so a flag-less serve never reports opt-in for a model it
+    decodes with MTP by default (0.13.4 dogfood P1). The registry view
+    is runtime-blind, though: callers that KNOW the runtime state pass
+    ``runtime_spec_decode`` (below) so the rows can't contradict what
+    the server is actually doing.
     """
     if getattr(cfg, "supports_native_mtp", False):
         # Method-specific capability metadata is authoritative here. A hybrid
@@ -2424,8 +2427,12 @@ def format_profile_summary(
     Empty/no-match models return a generic line so the log is consistent
     across known and unknown models.
     """
+    # "(active)" not "(explicit)": the engine can't tell a user-passed
+    # --speculative-config from the alias default-on path — cli normalizes
+    # both to the same scheduler spec_decode — so claiming provenance here
+    # would be wrong for default-on boots.
     runtime_status = (
-        f"spec decode {runtime_spec_decode.upper()} (explicit)"
+        f"spec decode {runtime_spec_decode.upper()} (active)"
         if runtime_spec_decode
         else None
     )
@@ -2447,9 +2454,23 @@ def format_profile_summary(
     return f"Model profile: {model_path} → " + ", ".join(parts)
 
 
-def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
+def format_profile_table(
+    model_path: str,
+    cfg: "ModelConfig | None",
+    *,
+    runtime_spec_decode: str | None = None,
+) -> str:
     """Multi-line ASCII capability table for verbose startup output and
     the ``rapid-mlx info`` CLI command (Level 2 + Level 3).
+
+    ``runtime_spec_decode`` reconciles the registry view with what the
+    server is actually doing (adversarial review round 1 on #3266): the
+    engine passes ``"off"`` when ``--no-spec-decode`` forced plain decode,
+    or the active method name (``"mtp"`` / ``"dflash"`` / ``"dspark"``);
+    ``None`` — the ``rapid-mlx info`` default — keeps the pure registry
+    view. Without this, ``serve … --no-spec-decode RAPID_MLX_PROFILE_VERBOSE=1``
+    rendered ``✓ default-on (MTP)`` next to ``Suffix tier: … spec decode
+    off`` in one box.
 
     Width is fixed at 64 cols so it renders cleanly in terminal logs.
     Note: Unicode check/cross marks count as 1 char each (no double-width).
@@ -2475,7 +2496,15 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ("Tool format", "(none)"),
             ("Reasoning parser", "(none)"),
             ("Architecture", "unknown"),
-            ("Spec decode", "✓ default-on"),
+            # Runtime reconciliation: an unmatched profile defaults to the
+            # generic "✓ default-on" line, but under an explicit
+            # --no-spec-decode the server runs plain decode regardless.
+            (
+                "Spec decode",
+                "✗ off (--no-spec-decode)"
+                if runtime_spec_decode == "off"
+                else "✓ default-on",
+            ),
             # Truth-in-labeling: no regex/alias matched, so the
             # architecture is genuinely UNKNOWN here — an opaquely named
             # Qwen3.5 or Gemma 4 checkpoint would land in this branch too.
@@ -2532,6 +2561,24 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             # 0.9.0 dogfood: non-hybrid + spec-off was rendering
             # ``hybrid arch`` next to ``Architecture: pure attention``.
             spec = "✗ disabled (no MTP/drafter trained)"
+        # Runtime reconciliation (adversarial review round 1 on #3266).
+        # ``spec_decode == "none"`` at the scheduler is NOT proof of plain
+        # decode — the Suffix/DDTree lanes leave it "none" — so the engine
+        # passes "off" only for the explicit --no-spec-decode override and
+        # None otherwise. Only default-on claims are overridden: capability
+        # rows ("supported", "opt-in") stay truthful under plain decode.
+        if runtime_spec_decode == "off":
+            if spec == "✓ default-on (MTP)":
+                spec = "✗ off (--no-spec-decode)"
+                mtp_label = "off (--no-spec-decode)"
+        elif runtime_spec_decode and not (
+            runtime_spec_decode == "mtp" and spec == "✓ default-on (MTP)"
+        ):
+            # An active lane that disagrees with the registry copy:
+            # explicit --speculative-config mtp on a default-off alias,
+            # or dflash/dspark on any alias (including one whose MTP
+            # would be default-on — the server is doing DFlash, not MTP).
+            spec = f"✓ active ({runtime_spec_decode.upper()})"
         rows = [
             ("Tool format", cfg.tool_call_parser or "(none)"),
             ("Reasoning parser", cfg.reasoning_parser or "(none)"),

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2498,7 +2498,17 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             ),
         ]
     else:
-        if cfg.supports_spec_decode:
+        throttle = "✓ 200ms gap" if cfg.is_hybrid else "✗ not needed"
+        mtp_label = _mtp_path_label(model_path, cfg)
+        if mtp_label.endswith("(default; --no-spec-decode off)"):
+            # Serve enables MTP for this alias unasked (verified tier +
+            # catalog default-on) — say so instead of the generic
+            # ``supported``/``disabled (hybrid arch)`` copy, which read
+            # as the opposite of what the server does (0.13.4 dogfood
+            # P1). Derived FROM the MTP-path label so the two rows can
+            # never disagree.
+            spec = "✓ default-on (MTP)"
+        elif cfg.supports_spec_decode:
             spec = "✓ supported"
         elif cfg.is_hybrid:
             spec = "✗ disabled (hybrid arch)"
@@ -2511,20 +2521,17 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             # misleading because the DFlash drafter IS registered.
             # Surface the actionable opt-in instead.
             spec = '✗ try --speculative-config {"method":"dflash"}'
+        elif mtp_label.startswith(("sidecar (opt-in", "native (opt-in")):
+            # Same row-vs-row honesty contract, default-off flavour
+            # (0.13.4 dogfood round 2): a declared MTP drafter/head with
+            # ``mtp_default_enabled=False`` (#3115) must not have the
+            # Spec decode row claim ``no MTP/drafter trained`` two lines
+            # above the ``MTP path: … (opt-in)`` row. Name the opt-in.
+            spec = "✗ off (MTP opt-in: --speculative-config)"
         else:
             # 0.9.0 dogfood: non-hybrid + spec-off was rendering
             # ``hybrid arch`` next to ``Architecture: pure attention``.
             spec = "✗ disabled (no MTP/drafter trained)"
-        throttle = "✓ 200ms gap" if cfg.is_hybrid else "✗ not needed"
-        mtp_label = _mtp_path_label(model_path, cfg)
-        if mtp_label.endswith("(default; --no-spec-decode off)"):
-            # Serve enables MTP for this alias unasked (verified tier +
-            # catalog default-on) — say so instead of the generic
-            # ``supported``/``disabled (hybrid arch)`` copy, which read
-            # as the opposite of what the server does (0.13.4 dogfood
-            # P1). Derived FROM the MTP-path label so the two rows can
-            # never disagree.
-            spec = "✓ default-on (MTP)"
         rows = [
             ("Tool format", cfg.tool_call_parser or "(none)"),
             ("Reasoning parser", cfg.reasoning_parser or "(none)"),

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2282,25 +2282,60 @@ def _resolve_family(model_path: str, cfg: "ModelConfig") -> str:
     return "other"
 
 
+def _serve_mtp_default_on(model_path: str) -> bool:
+    """Whether ``vllm_mlx serve`` enables MTP for this alias unasked.
+
+    Mirrors the serve-side decision (``cli._alias_continuous_mtp_tier``
+    + ``cli._alias_mtp_default_enabled``, the same helpers behind the
+    ``raw_config = '{"method":"mtp"}'`` default in
+    ``_normalize_speculative_config_or_exit``): verified-qualified
+    artifacts whose catalog entry ships ``mtp_default_enabled`` boot
+    with their declared MTP preset without any flag. The cli helpers
+    are imported lazily (cli already sits upstream of this module in
+    every real entry point) so the info path cannot drift from serve
+    again — one decision, one source. Registry or import failure fails
+    closed to *off*, same as serve.
+    """
+    try:
+        from .cli import (
+            _alias_continuous_mtp_tier,
+            _alias_mtp_default_enabled,
+        )
+    except Exception:  # noqa: BLE001 - degraded import must fail closed
+        return False
+    if _alias_continuous_mtp_tier(model_path) != "verified":
+        return False
+    return _alias_mtp_default_enabled(model_path)
+
+
 def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
     """Truth-in-labeling for the MTP spec-decode path of a model.
 
     Returns one of ``native`` /
-    ``native (opt-in: --speculative-config)`` / ``sidecar`` /
-    ``sidecar (opt-in: --speculative-config)`` / ``disabled``:
+    ``native (opt-in: --speculative-config)`` /
+    ``native (default; --no-spec-decode off)`` / ``sidecar`` /
+    ``sidecar (opt-in: --speculative-config)`` /
+    ``sidecar (default; --no-spec-decode off)`` / ``disabled``:
 
     * ``native``   — the family ships a native MTP head in the checkpoint
       (Qwen3.5 / Qwen3.6 / HY3) AND the resolved profile enables spec
       decode (``supports_spec_decode=True``). This is the path
       ``vllm_mlx.spec_decode.mtp`` drives directly.
     * ``native (opt-in: --speculative-config)`` — method-specific profile
-      metadata declares a validated native head while the generic speculative
-      lane remains disabled (for example, a coupled hybrid verifier).
+      metadata declares a validated native head while serve leaves MTP
+      off until the user opts in.
+    * ``native (default; --no-spec-decode off)`` — validated native head
+      whose alias is ``mtp_continuous_batching_tier=verified`` +
+      ``mtp_default_enabled=True``: serve enables it unasked, and
+      ``--no-spec-decode`` is the escape hatch.
     * ``sidecar``  — Gemma 4: MTP is provided by an assistant drafter
       loaded alongside the base weights (no head baked in), and the
       profile enables spec decode.
     * ``sidecar (opt-in: --speculative-config)`` — the alias declares an MTP
       sidecar, but Rapid leaves it disabled until the user explicitly opts in.
+    * ``sidecar (default; --no-spec-decode off)`` — the alias declares an
+      MTP sidecar AND serve enables it unasked (verified + default-on);
+      ``--no-spec-decode`` is the escape hatch.
     * ``disabled`` — no native/sidecar MTP capability is declared and spec
       decode is off for this profile
       (``supports_spec_decode=False`` — hybrid arch, or no MTP head /
@@ -2310,13 +2345,17 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
       (see ``_resolve_family``).
 
     Derivation is from the resolved profile only (no ``config.json``
-    read), keeping the ``rapid-mlx info`` path weight-free.
+    read), keeping the ``rapid-mlx info`` path weight-free. The
+    default-on vs opt-in split consults the same registry helpers serve
+    consults, so this label can never again report opt-in for a model
+    the server decodes with MTP by default (0.13.4 dogfood P1).
     """
     if getattr(cfg, "supports_native_mtp", False):
         # Method-specific capability metadata is authoritative here. A hybrid
         # checkpoint can disable the generic speculative lane while its
-        # native MTP injector remains verified. The feature is still
-        # explicit opt-in; this reports capability, never default-on state.
+        # native MTP injector remains verified.
+        if _serve_mtp_default_on(model_path):
+            return "native (default; --no-spec-decode off)"
         return "native (opt-in: --speculative-config)"
     if (getattr(cfg, "mtp_draft_model", None) or "").strip():
         # #1998: the alias DECLARES its own MTP sidecar, and that declaration
@@ -2326,7 +2365,10 @@ def _mtp_path_label(model_path: str, cfg: "ModelConfig") -> str:
         # it); the MTP sidecar lane is separate and was verified end-to-end on
         # Qwen3.8-27B. Checked BEFORE the flag, because reporting "disabled"
         # for a model that decodes with MTP is exactly the registry-vs-reality
-        # mismatch #1998 was about. Names the opt-in, mirroring the DFlash row.
+        # mismatch #1998 was about. Report default-on vs opt-in from the same
+        # helpers serve consults (0.13.4 dogfood P1), mirroring the DFlash row.
+        if _serve_mtp_default_on(model_path):
+            return "sidecar (default; --no-spec-decode off)"
         return "sidecar (opt-in: --speculative-config)"
     if not cfg.supports_spec_decode:
         # Honest: the profile has spec decode gated off (hybrid arch, or
@@ -2474,6 +2516,15 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             # ``hybrid arch`` next to ``Architecture: pure attention``.
             spec = "✗ disabled (no MTP/drafter trained)"
         throttle = "✓ 200ms gap" if cfg.is_hybrid else "✗ not needed"
+        mtp_label = _mtp_path_label(model_path, cfg)
+        if mtp_label.endswith("(default; --no-spec-decode off)"):
+            # Serve enables MTP for this alias unasked (verified tier +
+            # catalog default-on) — say so instead of the generic
+            # ``supported``/``disabled (hybrid arch)`` copy, which read
+            # as the opposite of what the server does (0.13.4 dogfood
+            # P1). Derived FROM the MTP-path label so the two rows can
+            # never disagree.
+            spec = "✓ default-on (MTP)"
         rows = [
             ("Tool format", cfg.tool_call_parser or "(none)"),
             ("Reasoning parser", cfg.reasoning_parser or "(none)"),
@@ -2487,7 +2538,7 @@ def format_profile_table(model_path: str, cfg: "ModelConfig | None") -> str:
             # Gemma 4 family default, not a per-checkpoint config.json
             # read). The unmatched-profile (``cfg is None``) branch above
             # reports ``unknown`` for both instead of a definite value.
-            ("MTP path", _mtp_path_label(model_path, cfg)),
+            ("MTP path", mtp_label),
             ("KV-share", _kv_share_label(model_path, cfg)),
             ("Throttle", throttle),
             ("Suffix tier", _suffix_tier_cell(cfg, max_width=value_width)),

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2095,7 +2095,11 @@ def _suffix_tier_cell(cfg: "ModelConfig", max_width: int | None = None) -> str:
         # pure-attention Qwen3.5/3.6 dense aliases, which contradicts the
         # ``Architecture: pure attention`` row two lines above.
         if cfg.is_hybrid:
-            text = "n/a (hybrid arch — spec decode off)"
+            # This row describes SuffixDecoding eligibility, not every
+            # speculative method. Hybrid aliases may still run MTP through a
+            # native head or sidecar, so saying "spec decode off" here can
+            # directly contradict the active/default-on MTP rows above.
+            text = "n/a (hybrid arch — suffix unsupported)"
         else:
             # Tight enough to fit the 41-char ``info`` value column
             # (``inner=60 − 17-char key − 2-char ": "``) so the row

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2491,20 +2491,21 @@ def format_profile_table(
         header = header[: inner - 1] + "…"
 
     if cfg is None:
+        # Runtime reconciliation for the unmatched-profile branch too:
+        # the generic "✓ default-on" line must yield to what the server
+        # is actually doing (round 2 on #3266).
+        if runtime_spec_decode == "off":
+            unknown_spec = "✗ off (--no-spec-decode)"
+        elif runtime_spec_decode:
+            unknown_spec = f"✓ active ({runtime_spec_decode.upper()})"
+        else:
+            unknown_spec = "✓ default-on"
         rows = [
             ("Profile", "(no pattern matched — using defaults)"),
             ("Tool format", "(none)"),
             ("Reasoning parser", "(none)"),
             ("Architecture", "unknown"),
-            # Runtime reconciliation: an unmatched profile defaults to the
-            # generic "✓ default-on" line, but under an explicit
-            # --no-spec-decode the server runs plain decode regardless.
-            (
-                "Spec decode",
-                "✗ off (--no-spec-decode)"
-                if runtime_spec_decode == "off"
-                else "✓ default-on",
-            ),
+            ("Spec decode", unknown_spec),
             # Truth-in-labeling: no regex/alias matched, so the
             # architecture is genuinely UNKNOWN here — an opaquely named
             # Qwen3.5 or Gemma 4 checkpoint would land in this branch too.
@@ -2576,9 +2577,14 @@ def format_profile_table(
         ):
             # An active lane that disagrees with the registry copy:
             # explicit --speculative-config mtp on a default-off alias,
-            # or dflash/dspark on any alias (including one whose MTP
-            # would be default-on — the server is doing DFlash, not MTP).
+            # or dflash/dspark/suffix on any alias (including one whose
+            # MTP would be default-on — the server is decoding via that
+            # lane, and MTP is not loaded; round 2 on #3266 caught the
+            # Suffix variant rendering "✓ default-on (MTP)" under an
+            # active SuffixDecoding boot).
             spec = f"✓ active ({runtime_spec_decode.upper()})"
+            if runtime_spec_decode != "mtp":
+                mtp_label = f"off (decoding via {runtime_spec_decode.upper()})"
         rows = [
             ("Tool format", cfg.tool_call_parser or "(none)"),
             ("Reasoning parser", cfg.reasoning_parser or "(none)"),


### PR DESCRIPTION
## Summary

0.13.4 dogfood (fresh-venv CLI + GUI pass) surfaced three registry-vs-reality mismatches, all reproduced and verified on latest main:

### P1 — `rapid-mlx info` contradicts serve's default-on MTP

`info qwen3.8-27b-4bit` reported:

```
Spec decode      : ✗ disabled (hybrid arch)
MTP path         : sidecar (opt-in: --speculative-config)
```

while `serve` boots the same alias with MTP active (`/v1/models` → `speculative_decoding.runtime_state: active`). Root cause: verified-artifact default enablement (`cli.py` `_alias_mtp_default_enabled` + tier check) landed after the static copy in `_mtp_path_label` / the `Spec decode` row and the two never synced.

**Fix:** the info table now consults the *same* cli helpers serve consults (`_alias_continuous_mtp_tier` + `_alias_mtp_default_enabled`, lazily imported — one decision, one source) and renders:

```
Spec decode      : ✓ default-on (MTP)
MTP path         : sidecar (default; --no-spec-decode off)
```

The `Spec decode` row is derived FROM the MTP-path label so the two rows structurally cannot disagree. Verified-tier aliases shipped `mtp_default_enabled=False` (qwen3.5-4b-4bit, the #3115 measured regression) keep the honest `opt-in` copy; registry failure fails closed to the old capability copy, mirroring serve's plain-decode fallback.

### P2 — doctor false "mlx version metadata is unavailable"

Doctor's distribution probe passed `spec.origin` into distribution-ownership matching. `mlx` is a **namespace package** (`find_spec("mlx").origin is None`), so the ownership check failed and a perfectly readable `mlx 0.32.2` was reported as "importable but version metadata is unavailable".

**Fix:** when origin is None, anchor ownership matching on the first **trusted** `submodule_search_locations` portion (fail-closed to `None` when no portion is trusted — the pre-fix behavior for unreadable installs). Round-1 adversarial review hardened this: naive `portion[0]` anchoring is exploitable, because namespace portions merge across `sys.path` with server-context roots at `sys.path[0]` while `_module_path_is_trusted` is any-portion — a shadow dist-info in an untrusted context path could spoof the reported version with `trusted_origin: true`. Additionally `_safe_version` now gates version consumption on `trusted_origin` (previously only importability was gated; absent key = legacy probe format → trusted). Verified with a shadow-spoof fixture: post-fix reports the real dist's version, pre-fix reports the spoofed one.

### P2 — install-location label/path semantics mismatch

`_install_location()` resolved the venv python symlink before display, landing the path in Homebrew's Cellar / uv-managed CPython, while the label came from `sys.prefix != sys.base_prefix` → `virtualenv`. Two semantics on one line.

**Fix:** display the configured interpreter **unresolved** (`virtualenv (/path/to/venv/bin/python3.14)`); label classification still inspects the resolved path (uv/pipx layouts are only recognizable there); the base interpreter prefix moves into the verbose detail.

## Adversarial review round 1 (two independent reviewers, every finding verified by execution)

- **[MAJOR] Runtime-blind verbose table (fixed):** `serve … --no-spec-decode RAPID_MLX_PROFILE_VERBOSE=1` rendered `✓ default-on (MTP)` + `sidecar (default; …)` in the same box as `Suffix tier: … spec decode off` while the server ran plain decode. `format_profile_table` now takes `runtime_spec_decode` — the engine passes `"off"` only for the explicit `--no-spec-decode` override (scheduler `spec_decode == "none"` alone is *not* proof of plain decode: the Suffix/DDTree lanes leave it `"none"`) or the active method name; capability rows (`supported` / `opt-in`) stay truthful under plain decode; active non-default lanes override the `✗ off …` rows.
- **[MAJOR] Namespace version spoofing (fixed):** anchor + consumer trust fixes described above.
- **[MINOR, fixed] `spec decode MTP (explicit)` → `(active)`:** the engine cannot distinguish an explicit `--speculative-config` from the alias default-on path (cli normalizes both), so claiming provenance was wrong for default-on boots.
- **[MINOR, fixed] Default-off MTP sidecar rows:** qwen3.5-4b-4bit (declared sidecar, `mtp_default_enabled=False` per #3115) rendered `✗ disabled (no MTP/drafter trained)` two rows above `sidecar (opt-in)` — contradictory; now `✗ off (MTP opt-in: --speculative-config)`, and the no-drafter test was repointed to a genuinely drafterless alias (qwen3.5-27b-4bit).
- **[MINOR, accepted]:** a broken regular package (deleted `__init__.py`) can gain an optimistic version via the namespace fallback. `importable` is tracked separately; Python 3.12+ `skip_missing_files` drops nonexistent RECORD entries, so ownership matching usually fails anyway. Direction is optimistic, not fail-closed.

## Adversarial review round 2 (all findings verified by execution; commit 1127c34d3)

- **[MAJOR] Suffix-lane table contradiction (fixed):** the SuffixDecoding lane leaves scheduler `spec_decode == "none"` while decoding speculatively, so `--suffix-decoding` boots rendered `✓ default-on (MTP)` in the verbose table while the summary in the same log said `spec decode OFF`. The engine now detects the active lane and names it (`✓ active (SUFFIX)` / `spec decode SUFFIX (active)`); DDTree/DFlash run dedicated servers that never construct EngineCore, so Suffix is the only such lane. An active non-MTP lane also stops the `MTP path` row from advertising `(default; --no-spec-decode off)` — it renders `off (decoding via …)` instead.
- **[MAJOR] RECORD-escape ownership bypass (fixed):** RECORD is attacker-controlled in untrusted dist-infos and `Distribution.locate_file` joins entries verbatim — `../` or absolute entries claimed ownership of the trusted sidecar's namespace anchor, defeating the round-1 anchor fix (verified spoof). Ownership entries must now stay inside their own install root; legit out-of-root entries (console scripts) are simply not eligible for module ownership.
- **[MINOR] Duplicate-dist-info ambiguity:** two same-named dist-infos in ONE root both covering the anchor resolve arbitrarily (alphabetical). After the root-scoping fix this is no longer exploitable across trust boundaries; dual installs with well-scoped RECORDs resolve sys.path-first correctly.
- **[MINOR] Registry seam pinned by test:** `verified + mtp_default_enabled ⇒ declares native head or sidecar drafter` is now an invariant test across all shipped aliases (holds today; nothing could previously stop serve booting default-on MTP while info claims opt-in).

## Adversarial review round 3 (scope: the round-2 commit itself; no BLOCKING findings)

- **[MAJOR, test-only, fixed]** the new registry-invariant test read the host's user-alias file (outside the conftest hermeticity allowlist) — now points `RAPID_MLX_USER_ALIASES_FILE` at an empty tmp file.
- **[MINOR, fixed, programmatic-only]** the suffix lane claim was keyed on `enable_suffix_decoding` alone; the scheduler's install gate is `supports_spec_decode` (forced False by `--no-spec-decode`), so a programmatic flag combo could log `✓ active (SUFFIX)` while nothing installs. Lane claim now respects the install gate; engine test pins the honest rendering.
- **Checked clean with executed evidence:** the RECORD guard does not regress real-venv version reporting (mlx 0.32.2 / mlx-lm / transformers / scipy resolve identically pre/post guard; legit `../../../bin/…` console-script entries skipped harmlessly — ownership only matches module paths); `enable_suffix_decoding` has no post-init writers so the reconciled log cannot go stale; no MTP/other-lane coexistence path exists (`off (decoding via …)` is accurate).

## Validation

pr_validate (local, full pipeline): **codex review "No blocking issues found."**, lint ✓, test-plan/CL-quality/supply-chain/review-vocab ✓, targeted 609 ✓, full_unit 23503 passed (+1 env failure verified pre-existing on clean b2264d61b), diff_coverage 100% (required changed production lines covered after Harbor review), stress_e2e_bench: all 4 golden models boot + bench clean, every finding NOT-THIS-PR (warm deltas ≤ ±0.4%). First run's single BLOCKING (unsloth Qwen3.6-27B not ready in 360s) was verified from the server log to be a cold-cache model download (33.8/34.7 GB at timeout) — environmental, not the diff; the cached rerun boots it cleanly.

## Follow-up findings (out of scope here, discovered during serve-boot E2E verification)

1. **MLLM-lane boots emit no profile summary/table.** The MLLM lane never constructs `EngineCore` (`batched.py`: "AsyncEngineCore for LLM" / "The MLLM lane has no text EngineCore"), so the Level-1 `Model profile:` line and the Level-2 verbose table are silent on **all Qwen3.x models — i.e. every default-on MTP alias**. Pre-exists on main. `rapid-mlx info` covers the registry view; serve-side spec-decode state is only visible via `/v1/models`.
2. **EngineCore resolves the profile from the HF snapshot path**, which loses the alias's `mtp_draft_model` metadata — a verbose text-lane (`--no-mllm`) boot renders a default-on sidecar alias as `✗ disabled (hybrid arch)` / `MTP path: disabled`. Pre-exists on main.

Fix shape for both: thread the original alias (`args._original_alias`) into `EngineConfig` and emit the summary/table from the MLLM lane start path too.

## Test plan

- [x] New regression tests fail on clean main, pass with the fix:
  - `test_table_matches_serve_default_on_mtp_sidecar_hybrid` / `_dense` (P1: qwen3.8-27b-4bit hybrid + qwen3.5-9b-4bit dense both default-on)
  - `test_table_keeps_opt_in_label_for_default_off_alias` (P1 negative: qwen3.5-4b-4bit stays opt-in)
  - `test_table_fails_closed_when_registry_unavailable` (P1 fail-closed)
  - `test_probe_reports_namespace_package_version` (P2: synthetic namespace pkg + dist-info → version 1.2.3 recovered)
  - `test_install_location_reports_unresolved_venv_interpreter` / `test_install_location_row_details_base_interpreter` (P2)
  - `test_probe_namespace_anchor_requires_trusted_portion` (round-1 security: shadow dist-info in a server-context path must not spoof the version)
  - `test_safe_version_gates_on_trusted_origin` (round-1 security: version consumption gated on trusted_origin)
  - 6 × `test_table_*runtime*` (round-1: `--no-spec-decode` overrides default-on rows, active lanes override off rows, capability rows preserved)
- [x] `tests/test_model_auto_config.py` + `tests/test_mtp_default_off_3115.py` + `tests/test_continuous_mtp_qualification.py` + `tests/test_suffix_decoding_tier.py`: 407 passed
- [x] `tests/test_doctor_env_health.py` + extras + report-contract: 663 passed (3 failures pre-exist on clean main in this env — `test_remote_pillow_probe_accepts_a_successful_image_exercise`, `test_dflash_row_ok_when_mlx_vlm_is_validated_version`, `test_packaged_bf16_uses_model_path_without_onload_quantization` (verified failing on a clean b2264d61b worktree) — unrelated to this diff)
- [x] Empirical on M3 Ultra, fresh venv `pip install --no-deps --force-reinstall .`:
  - `rapid-mlx info qwen3.8-27b-4bit` → `✓ default-on (MTP)` + `sidecar (default; --no-spec-decode off)`
  - `rapid-mlx doctor` → `✓ mlx 0.32.2` (warning gone)
  - `rapid-mlx doctor --verbose` → `Install location: virtualenv (/private/tmp/.../bin/python3.14)` + `base interpreter prefix=/opt/homebrew/...` in detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)






