### PR TITLE
feat(benchmark): App Attest client + engine relay for the ranked leaderboard

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkAttest.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkAttest.swift
@@ -43,6 +43,9 @@ protocol AttestHTTP: Sendable {
 
 enum AppAttestError: Error, Equatable {
     case unsupported
+    /// The cached key is gone (App Attest keys do not survive reinstall,
+    /// migration, or a backup restore). The client drops it and re-registers.
+    case invalidKey
     case badChallengeResponse
     case registrationRejected(status: Int, body: String)
 }
@@ -88,9 +91,18 @@ final class AppAttestClient: Sendable {
         guard service.isSupported else { throw AppAttestError.unsupported }
         let challengeURL = target.appendingPathComponent("challenge")
         let attestURL = target.appendingPathComponent("attest")
+        do {
+            return try await sign(body: body, challengeURL: challengeURL, attestURL: attestURL)
+        } catch AppAttestError.invalidKey {
+            // The cached key is dead (reinstall / migration). Drop it and
+            // register a fresh one exactly once, then sign again.
+            keychain.delete(account: keyAccount)
+            return try await sign(body: body, challengeURL: challengeURL, attestURL: attestURL)
+        }
+    }
 
+    private func sign(body: Data, challengeURL: URL, attestURL: URL) async throws -> AttestMaterial {
         let keyID = try await ensureRegisteredKey(challengeURL: challengeURL, attestURL: attestURL)
-
         // Fresh challenge per assertion; sign SHA256(challenge ‖ body).
         let challenge = try await http.fetchChallenge(challengeURL)
         var signed = Data(challenge.utf8)
@@ -130,11 +142,18 @@ struct DeviceCheckAttestService: AttestService {
 
     var isSupported: Bool { DCAppAttestService.shared.isSupported }
 
+    /// Normalise a DeviceCheck "key no longer valid" error so the client can
+    /// recover (drop the cached id + re-register) regardless of framework type.
+    private func mapped(_ error: Error?) -> Error {
+        if let error, (error as? DCError)?.code == .invalidKey { return AppAttestError.invalidKey }
+        return error ?? AppAttestError.unsupported
+    }
+
     func generateKey() async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
             shared.generateKey { keyID, error in
                 if let keyID { continuation.resume(returning: keyID) }
-                else { continuation.resume(throwing: error ?? AppAttestError.unsupported) }
+                else { continuation.resume(throwing: self.mapped(error)) }
             }
         }
     }
@@ -143,7 +162,7 @@ struct DeviceCheckAttestService: AttestService {
         try await withCheckedThrowingContinuation { continuation in
             shared.attestKey(keyID, clientDataHash: clientDataHash) { attestation, error in
                 if let attestation { continuation.resume(returning: attestation) }
-                else { continuation.resume(throwing: error ?? AppAttestError.unsupported) }
+                else { continuation.resume(throwing: self.mapped(error)) }
             }
         }
     }
@@ -152,7 +171,7 @@ struct DeviceCheckAttestService: AttestService {
         try await withCheckedThrowingContinuation { continuation in
             shared.generateAssertion(keyID, clientDataHash: clientDataHash) { assertion, error in
                 if let assertion { continuation.resume(returning: assertion) }
-                else { continuation.resume(throwing: error ?? AppAttestError.unsupported) }
+                else { continuation.resume(throwing: self.mapped(error)) }
             }
         }
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkAttest.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkAttest.swift
@@ -1,0 +1,194 @@
+import CryptoKit
+import DeviceCheck
+import Foundation
+
+// App Attest for the Community Benchmark ranked leaderboard.
+//
+// The leaderboard is a contest (race to #1) with anonymous, account-less
+// uploads, so a well-formed fake could take the top spot. App Attest proves a
+// submission comes from a genuine, unmodified instance of THIS notarized app
+// on real Apple hardware — with no user prompt and no account. DCAppAttestService
+// only works inside the signed app, so the assertion is produced here and
+// relayed by the bundled engine as X-Rapid-Attest-* headers (see
+// `benchmark share --attest-*`). The server verifies against the pinned Apple
+// App Attest Root CA; design + server live in rapidmlx.com
+// (docs/benchmark-authenticity.md).
+//
+// Attestation (device-key registration) happens once per install; every later
+// upload is just a cheap assertion. All of it is silent.
+
+/// The material the engine relays as request headers on the atomic upload.
+struct AttestMaterial: Equatable, Sendable {
+    let keyID: String
+    let assertionBase64: String
+    let challenge: String
+}
+
+// MARK: - Seams (so the orchestration is testable without a device/network)
+
+/// DCAppAttestService, behind a protocol. The real calls can only run on a
+/// genuine Apple device in a signed app; tests inject a fake.
+protocol AttestService: Sendable {
+    var isSupported: Bool { get }
+    func generateKey() async throws -> String
+    func attestKey(_ keyID: String, clientDataHash: Data) async throws -> Data
+    func generateAssertion(_ keyID: String, clientDataHash: Data) async throws -> Data
+}
+
+/// The two server calls App Attest needs beyond the (engine-run) upload.
+protocol AttestHTTP: Sendable {
+    func fetchChallenge(_ url: URL) async throws -> String
+    func register(_ url: URL, attestation: Data, challenge: String) async throws
+}
+
+enum AppAttestError: Error, Equatable {
+    case unsupported
+    case badChallengeResponse
+    case registrationRejected(status: Int, body: String)
+}
+
+// MARK: - Client
+
+/// Produces `AttestMaterial` for one upload, or `nil` when this device/build
+/// cannot attest (old build, unsupported device, or a transient failure) — in
+/// which case the caller uploads un-attested, which simply will not rank.
+final class AppAttestClient: Sendable {
+    private let service: AttestService
+    private let http: AttestHTTP
+    private let keychain: any KeychainStoring
+    private let keyAccount: String
+
+    init(
+        service: AttestService = DeviceCheckAttestService(),
+        http: AttestHTTP = URLSessionAttestHTTP(),
+        keychain: any KeychainStoring = SystemKeychain(),
+        keyAccount: String = "Rapid.communityBenchmark.attestKeyId"
+    ) {
+        self.service = service
+        self.http = http
+        self.keychain = keychain
+        self.keyAccount = keyAccount
+    }
+
+    /// `body` is the exact wire bytes the engine will POST (the preview's
+    /// `payload_json`); the assertion signs SHA256(challenge ‖ body) so it
+    /// covers precisely what is sent. `target` is the atomic upload URL;
+    /// `/challenge` and `/attest` are derived from it.
+    func attestMaterial(forBody body: Data, target: URL) async -> AttestMaterial? {
+        do {
+            return try await make(forBody: body, target: target)
+        } catch {
+            // Fail soft: an un-attested upload is better than a failed one.
+            // (When the server gate is on it will 426; the caller surfaces that.)
+            return nil
+        }
+    }
+
+    private func make(forBody body: Data, target: URL) async throws -> AttestMaterial {
+        guard service.isSupported else { throw AppAttestError.unsupported }
+        let challengeURL = target.appendingPathComponent("challenge")
+        let attestURL = target.appendingPathComponent("attest")
+
+        let keyID = try await ensureRegisteredKey(challengeURL: challengeURL, attestURL: attestURL)
+
+        // Fresh challenge per assertion; sign SHA256(challenge ‖ body).
+        let challenge = try await http.fetchChallenge(challengeURL)
+        var signed = Data(challenge.utf8)
+        signed.append(body)
+        let clientDataHash = Data(SHA256.hash(data: signed))
+        let assertion = try await service.generateAssertion(keyID, clientDataHash: clientDataHash)
+        return AttestMaterial(
+            keyID: keyID,
+            assertionBase64: assertion.base64EncodedString(),
+            challenge: challenge
+        )
+    }
+
+    /// The device key is minted + attested once and cached in the Keychain.
+    private func ensureRegisteredKey(challengeURL: URL, attestURL: URL) async throws -> String {
+        if let existing = keychain.read(account: keyAccount), !existing.isEmpty {
+            return existing
+        }
+        let challenge = try await http.fetchChallenge(challengeURL)
+        let keyID = try await service.generateKey()
+        // attestKey binds the key to SHA256(challenge), matching the server.
+        let attestation = try await service.attestKey(
+            keyID, clientDataHash: Data(SHA256.hash(data: Data(challenge.utf8)))
+        )
+        try await http.register(attestURL, attestation: attestation, challenge: challenge)
+        // Only persist after the server accepts the registration; a failed
+        // attest leaves no key, so the next attempt starts clean.
+        keychain.write(account: keyAccount, secret: keyID)
+        return keyID
+    }
+}
+
+// MARK: - Real implementations
+
+struct DeviceCheckAttestService: AttestService {
+    private var shared: DCAppAttestService { .shared }
+
+    var isSupported: Bool { DCAppAttestService.shared.isSupported }
+
+    func generateKey() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            shared.generateKey { keyID, error in
+                if let keyID { continuation.resume(returning: keyID) }
+                else { continuation.resume(throwing: error ?? AppAttestError.unsupported) }
+            }
+        }
+    }
+
+    func attestKey(_ keyID: String, clientDataHash: Data) async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            shared.attestKey(keyID, clientDataHash: clientDataHash) { attestation, error in
+                if let attestation { continuation.resume(returning: attestation) }
+                else { continuation.resume(throwing: error ?? AppAttestError.unsupported) }
+            }
+        }
+    }
+
+    func generateAssertion(_ keyID: String, clientDataHash: Data) async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            shared.generateAssertion(keyID, clientDataHash: clientDataHash) { assertion, error in
+                if let assertion { continuation.resume(returning: assertion) }
+                else { continuation.resume(throwing: error ?? AppAttestError.unsupported) }
+            }
+        }
+    }
+}
+
+struct URLSessionAttestHTTP: AttestHTTP {
+    private let session: URLSession
+    init(session: URLSession = .shared) { self.session = session }
+
+    func fetchChallenge(_ url: URL) async throws -> String {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        let (data, _) = try await session.data(for: request)
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let challenge = object["challenge"] as? String,
+            !challenge.isEmpty
+        else { throw AppAttestError.badChallengeResponse }
+        return challenge
+    }
+
+    func register(_ url: URL, attestation: Data, challenge: String) async throws {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "attestation": attestation.base64EncodedString(),
+            "challenge": challenge,
+        ])
+        let (data, response) = try await session.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard (200...299).contains(status) else {
+            throw AppAttestError.registrationRejected(
+                status: status,
+                body: String(data: data, encoding: .utf8) ?? ""
+            )
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -722,13 +722,24 @@ enum CommunityBenchmarkCommand {
 
     static func benchmarkShareArguments(
         runID: String, installID: String, payloadDigest: String,
-        bodyDigest: String, target: String
+        bodyDigest: String, target: String, attest: AttestMaterial? = nil
     ) -> [String] {
-        [
+        var arguments = [
             "benchmark", "share", runID, "--yes", "--install-id", installID,
             "--payload-digest", payloadDigest, "--body-digest", bodyDigest,
-            "--target", target, "--json",
+            "--target", target,
         ]
+        // App Attest material (computed in-app) is relayed by the engine as
+        // X-Rapid-Attest-* headers so the run can rank. Absent → un-attested.
+        if let attest {
+            arguments += [
+                "--attest-key-id", attest.keyID,
+                "--attest-assertion", attest.assertionBase64,
+                "--attest-challenge", attest.challenge,
+            ]
+        }
+        arguments.append("--json")
+        return arguments
     }
 
     static func decodeSharePreview(_ data: Data, runID: String) throws
@@ -1409,6 +1420,15 @@ struct CommunityBenchmarkView: View {
         errorMessage = nil
         shareTask = Task {
             do {
+                // Attest in-app over the exact bytes the engine will POST, so
+                // this run can rank. nil (unsupported device / older build /
+                // transient failure) → un-attested upload, which will not rank.
+                var attest: AttestMaterial?
+                if let target = URL(string: preview.target) {
+                    attest = await AppAttestClient().attestMaterial(
+                        forBody: Data(preview.payloadJSON.utf8), target: target
+                    )
+                }
                 let data = try await CommunityBenchmarkCommand.run(
                     binary: binary,
                     arguments: CommunityBenchmarkCommand.benchmarkShareArguments(
@@ -1416,7 +1436,8 @@ struct CommunityBenchmarkView: View {
                         installID: preview.installID,
                         payloadDigest: preview.payloadDigest,
                         bodyDigest: preview.bodyDigest,
-                        target: preview.target
+                        target: preview.target,
+                        attest: attest
                     )
                 )
                 let response = try JSONDecoder().decode(

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkAttestTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkAttestTests.swift
@@ -34,6 +34,7 @@ private struct FakeService: AttestService {
         var generatedKeys = 0
         var attestCalls: [(keyID: String, clientDataHash: Data)] = []
         var assertionCalls: [(keyID: String, clientDataHash: Data)] = []
+        var invalidKeyOnce = false  // throw .invalidKey on the first assertion
         init(supported: Bool) { self.supported = supported }
     }
     var isSupported: Bool { box.supported }
@@ -47,6 +48,10 @@ private struct FakeService: AttestService {
     }
     func generateAssertion(_ keyID: String, clientDataHash: Data) async throws -> Data {
         box.assertionCalls.append((keyID, clientDataHash))
+        if box.invalidKeyOnce {
+            box.invalidKeyOnce = false
+            throw AppAttestError.invalidKey
+        }
         return Data("assertion".utf8)
     }
 }
@@ -129,6 +134,26 @@ struct CommunityBenchmarkAttestTests {
 
         #expect(await client.attestMaterial(forBody: Data("b".utf8), target: target) == nil)
         #expect(keychain.read(account: "Rapid.communityBenchmark.attestKeyId") == nil)
+    }
+
+    @Test("A dead cached key is dropped and re-registered once, then the upload attests")
+    func invalidKeyClearsCacheAndReRegisters() async throws {
+        // Recovery consumes three challenges: the first (failed) assertion,
+        // then re-register + the successful assertion. The stale key triggers
+        // .invalidKey on the first assertion.
+        let http = FakeHTTP(box: .init(challenges: ["chal-1", "chal-register", "chal-assert"]))
+        let service = FakeService(box: .init(supported: true))
+        service.box.invalidKeyOnce = true
+        let keychain = InMemoryKeychain()
+        keychain.write(account: "Rapid.communityBenchmark.attestKeyId", secret: "stale-key")
+        let client = AppAttestClient(service: service, http: http, keychain: keychain)
+
+        let material = try #require(await client.attestMaterial(forBody: Data("b".utf8), target: target))
+        // Recovered: stale key dropped, a fresh one minted + attested + cached.
+        #expect(material.keyID == "key-1")
+        #expect(service.box.generatedKeys == 1)
+        #expect(http.box.registerCalls.count == 1)
+        #expect(keychain.read(account: "Rapid.communityBenchmark.attestKeyId") == "key-1")
     }
 
     @Test("Share arguments relay the attest triple only when present")

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkAttestTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkAttestTests.swift
@@ -1,0 +1,153 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import Rapid
+
+// The App Attest orchestration (challenge → attest-once → assertion) driven
+// through injected fakes. The DCAppAttestService calls themselves only run on
+// a real device in a signed app; these pin everything around them: the
+// register-once flow, the Keychain caching, the exact bytes the assertion
+// signs, and graceful failure. Plus the CLI-argument relay.
+
+private struct FakeHTTP: AttestHTTP {
+    let box: Box
+    final class Box: @unchecked Sendable {
+        var challenges: [String]
+        var registerCalls: [(url: URL, attestation: Data, challenge: String)] = []
+        var registerError: Error?
+        init(challenges: [String]) { self.challenges = challenges }
+    }
+    func fetchChallenge(_ url: URL) async throws -> String {
+        if box.challenges.isEmpty { throw AppAttestError.badChallengeResponse }
+        return box.challenges.removeFirst()
+    }
+    func register(_ url: URL, attestation: Data, challenge: String) async throws {
+        if let error = box.registerError { throw error }
+        box.registerCalls.append((url, attestation, challenge))
+    }
+}
+
+private struct FakeService: AttestService {
+    let box: Box
+    final class Box: @unchecked Sendable {
+        var supported: Bool
+        var generatedKeys = 0
+        var attestCalls: [(keyID: String, clientDataHash: Data)] = []
+        var assertionCalls: [(keyID: String, clientDataHash: Data)] = []
+        init(supported: Bool) { self.supported = supported }
+    }
+    var isSupported: Bool { box.supported }
+    func generateKey() async throws -> String {
+        box.generatedKeys += 1
+        return "key-\(box.generatedKeys)"
+    }
+    func attestKey(_ keyID: String, clientDataHash: Data) async throws -> Data {
+        box.attestCalls.append((keyID, clientDataHash))
+        return Data("attestation-for-\(keyID)".utf8)
+    }
+    func generateAssertion(_ keyID: String, clientDataHash: Data) async throws -> Data {
+        box.assertionCalls.append((keyID, clientDataHash))
+        return Data("assertion".utf8)
+    }
+}
+
+private final class InMemoryKeychain: KeychainStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var store: [String: String] = [:]
+    func read(account: String) -> String? { lock.lock(); defer { lock.unlock() }; return store[account] }
+    @discardableResult func write(account: String, secret: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }; store[account] = secret; return true
+    }
+    @discardableResult func delete(account: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }; store[account] = nil; return true
+    }
+}
+
+private let target = URL(string: "https://rapidmlx.com/api/benchmarks/atomic")!
+
+@Suite("Community Benchmark App Attest")
+struct CommunityBenchmarkAttestTests {
+    @Test("First upload mints + attests a key, then signs the body with a fresh challenge")
+    func firstUploadRegistersThenAsserts() async throws {
+        let http = FakeHTTP(box: .init(challenges: ["chal-register", "chal-assert"]))
+        let service = FakeService(box: .init(supported: true))
+        let keychain = InMemoryKeychain()
+        let client = AppAttestClient(service: service, http: http, keychain: keychain)
+
+        let body = Data("the-exact-wire-body".utf8)
+        let material = try #require(await client.attestMaterial(forBody: body, target: target))
+
+        // Registered once, key cached.
+        #expect(service.box.generatedKeys == 1)
+        #expect(service.box.attestCalls.count == 1)
+        #expect(http.box.registerCalls.count == 1)
+        #expect(keychain.read(account: "Rapid.communityBenchmark.attestKeyId") == "key-1")
+
+        // attestKey binds SHA256(register challenge); the derived URLs are right.
+        #expect(service.box.attestCalls[0].clientDataHash == Data(SHA256.hash(data: Data("chal-register".utf8))))
+        #expect(http.box.registerCalls[0].url.absoluteString == target.absoluteString + "/attest")
+
+        // The assertion signs SHA256(assertion-challenge ‖ body), and the
+        // material carries that second challenge — not the registration one.
+        #expect(material.keyID == "key-1")
+        #expect(material.challenge == "chal-assert")
+        var signed = Data("chal-assert".utf8); signed.append(body)
+        #expect(service.box.assertionCalls[0].clientDataHash == Data(SHA256.hash(data: signed)))
+        #expect(material.assertionBase64 == Data("assertion".utf8).base64EncodedString())
+    }
+
+    @Test("A cached key skips registration and only asserts")
+    func cachedKeySkipsRegistration() async throws {
+        let http = FakeHTTP(box: .init(challenges: ["chal-assert"]))
+        let service = FakeService(box: .init(supported: true))
+        let keychain = InMemoryKeychain()
+        keychain.write(account: "Rapid.communityBenchmark.attestKeyId", secret: "existing-key")
+        let client = AppAttestClient(service: service, http: http, keychain: keychain)
+
+        let material = try #require(await client.attestMaterial(forBody: Data("b".utf8), target: target))
+        #expect(service.box.generatedKeys == 0)
+        #expect(service.box.attestCalls.isEmpty)
+        #expect(http.box.registerCalls.isEmpty)
+        #expect(material.keyID == "existing-key")
+    }
+
+    @Test("An unsupported device yields no material (upload proceeds un-attested)")
+    func unsupportedDeviceReturnsNil() async {
+        let http = FakeHTTP(box: .init(challenges: ["c"]))
+        let service = FakeService(box: .init(supported: false))
+        let client = AppAttestClient(service: service, http: http, keychain: InMemoryKeychain())
+        #expect(await client.attestMaterial(forBody: Data(), target: target) == nil)
+    }
+
+    @Test("A rejected registration yields nil and caches no key")
+    func rejectedRegistrationDoesNotCache() async {
+        let http = FakeHTTP(box: .init(challenges: ["chal-register", "chal-assert"]))
+        http.box.registerError = AppAttestError.registrationRejected(status: 400, body: "nope")
+        let service = FakeService(box: .init(supported: true))
+        let keychain = InMemoryKeychain()
+        let client = AppAttestClient(service: service, http: http, keychain: keychain)
+
+        #expect(await client.attestMaterial(forBody: Data("b".utf8), target: target) == nil)
+        #expect(keychain.read(account: "Rapid.communityBenchmark.attestKeyId") == nil)
+    }
+
+    @Test("Share arguments relay the attest triple only when present")
+    func shareArgumentsRelayAttest() {
+        let base = CommunityBenchmarkCommand.benchmarkShareArguments(
+            runID: "r", installID: "i", payloadDigest: "pd", bodyDigest: "bd", target: "t"
+        )
+        #expect(!base.contains("--attest-key-id"))
+        #expect(base.last == "--json")
+
+        let attested = CommunityBenchmarkCommand.benchmarkShareArguments(
+            runID: "r", installID: "i", payloadDigest: "pd", bodyDigest: "bd", target: "t",
+            attest: AttestMaterial(keyID: "kid", assertionBase64: "sig", challenge: "chal")
+        )
+        #expect(attested.contains("--attest-key-id"))
+        for (flag, value) in [("--attest-key-id", "kid"), ("--attest-assertion", "sig"), ("--attest-challenge", "chal")] {
+            let index = try! #require(attested.firstIndex(of: flag))
+            #expect(attested[index + 1] == value)
+        }
+        #expect(attested.last == "--json")
+    }
+}

--- a/tests/test_community_bench_upload.py
+++ b/tests/test_community_bench_upload.py
@@ -594,3 +594,38 @@ def test_transport_errors_do_not_claim_a_local_copy_exists(monkeypatch) -> None:
     with pytest.raises(upload.SubmitError) as exc:
         upload.post_submission({"a": 1}, url="https://x/api")
     assert "saved" not in str(exc.value).lower()
+
+
+def test_post_submission_relays_attest_headers(monkeypatch) -> None:
+    """App Attest headers computed in the signed app are relayed verbatim."""
+    seen = {}
+
+    def fake_open(req, timeout=None):
+        seen["headers"] = {k.lower(): v for k, v in req.header_items()}
+        return _Resp(b'{"ok":true,"submission_id":"abcdef012345"}')
+
+    monkeypatch.setattr(upload.urllib.request, "urlopen", fake_open)
+    upload.post_submission(
+        {"submission_id": "abcdef012345"},
+        url="https://x/api",
+        attest_headers={
+            "X-Rapid-Attest-Key-Id": "kid",
+            "X-Rapid-Attest-Assertion": "sig",
+            "X-Rapid-Attest-Challenge": "chal",
+        },
+    )
+    assert seen["headers"]["x-rapid-attest-key-id"] == "kid"
+    assert seen["headers"]["x-rapid-attest-assertion"] == "sig"
+    assert seen["headers"]["x-rapid-attest-challenge"] == "chal"
+
+
+def test_post_submission_omits_attest_headers_when_absent(monkeypatch) -> None:
+    seen = {}
+
+    def fake_open(req, timeout=None):
+        seen["headers"] = {k.lower(): v for k, v in req.header_items()}
+        return _Resp(b'{"ok":true,"submission_id":"abcdef012345"}')
+
+    monkeypatch.setattr(upload.urllib.request, "urlopen", fake_open)
+    upload.post_submission({"submission_id": "abcdef012345"}, url="https://x/api")
+    assert not any(k.startswith("x-rapid-attest") for k in seen["headers"])

--- a/tests/test_community_bench_upload.py
+++ b/tests/test_community_bench_upload.py
@@ -629,3 +629,29 @@ def test_post_submission_omits_attest_headers_when_absent(monkeypatch) -> None:
     monkeypatch.setattr(upload.urllib.request, "urlopen", fake_open)
     upload.post_submission({"submission_id": "abcdef012345"}, url="https://x/api")
     assert not any(k.startswith("x-rapid-attest") for k in seen["headers"])
+
+
+def test_attested_post_is_not_retried(monkeypatch) -> None:
+    """A one-use assertion must not be replayed: attested POST tries once."""
+    monkeypatch.setattr(upload.time, "sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    def fake_open(req, timeout=None):
+        calls["n"] += 1
+        raise upload.urllib.error.HTTPError(req.full_url, 500, "server error", {}, None)
+
+    monkeypatch.setattr(upload.urllib.request, "urlopen", fake_open)
+
+    with pytest.raises(upload.SubmitError):
+        upload.post_submission(
+            {"submission_id": "abcdef012345"},
+            url="https://x/api",
+            attest_headers={"X-Rapid-Attest-Key-Id": "k"},
+        )
+    assert calls["n"] == 1  # no replay of the single-use assertion
+
+    # An un-attested POST keeps the normal 3-attempt retry budget.
+    calls["n"] = 0
+    with pytest.raises(upload.SubmitError):
+        upload.post_submission({"submission_id": "abcdef012345"}, url="https://x/api")
+    assert calls["n"] == 3

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -12593,6 +12593,12 @@ Examples:
         "--target",
         help=argparse.SUPPRESS,
     )
+    # App Attest material computed in the signed app (Rapid Desktop), relayed
+    # as X-Rapid-Attest-* headers so the submission can rank. Not for CLI users
+    # — DCAppAttestService only runs inside the notarized app.
+    community_share.add_argument("--attest-key-id", help=argparse.SUPPRESS)
+    community_share.add_argument("--attest-assertion", help=argparse.SUPPRESS)
+    community_share.add_argument("--attest-challenge", help=argparse.SUPPRESS)
     community_share.add_argument(
         "--json",
         action="store_true",

--- a/vllm_mlx/community_bench/atomic_upload.py
+++ b/vllm_mlx/community_bench/atomic_upload.py
@@ -180,11 +180,17 @@ def upload_run(
     approved_payload_digest: str | None = None,
     approved_body_digest: str | None = None,
     approved_target: str | None = None,
+    attest: dict[str, str] | None = None,
 ) -> AtomicUploadAcceptance | None:
     """Upload one validated run, returning its server receipt.
 
     ``None`` means an interactive user declined. ``assume_yes`` exists for a
     caller such as Rapid Desktop that presents its own native confirmation.
+
+    ``attest`` optionally carries App Attest material (``key_id``,
+    ``assertion``, ``challenge``) that Rapid Desktop computes in-app over the
+    exact wire body; when present it is relayed as ``X-Rapid-Attest-*`` request
+    headers so the submission can rank on the leaderboard.
     """
 
     preview = preview_run(run, install_id=approved_install_id, url=url)
@@ -216,7 +222,14 @@ def upload_run(
         raise SubmitError(
             "the install id changed before upload; review the payload and try again"
         )
-    response = post_submission(wire, url=target)
+    attest_headers: dict[str, str] | None = None
+    if attest and attest.get("key_id") and attest.get("assertion") and attest.get("challenge"):
+        attest_headers = {
+            "X-Rapid-Attest-Key-Id": attest["key_id"],
+            "X-Rapid-Attest-Assertion": attest["assertion"],
+            "X-Rapid-Attest-Challenge": attest["challenge"],
+        }
+    response = post_submission(wire, url=target, attest_headers=attest_headers)
     receipt = _validated_receipt(response, run["run_id"], wire_digest)
     return AtomicUploadAcceptance(receipt, candidate, wire_digest)
 

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -353,6 +353,11 @@ def benchmark_command(args) -> int:
                     approved_payload_digest=getattr(args, "payload_digest", None),
                     approved_body_digest=getattr(args, "body_digest", None),
                     approved_target=getattr(args, "target", None),
+                    attest={
+                        "key_id": getattr(args, "attest_key_id", None),
+                        "assertion": getattr(args, "attest_assertion", None),
+                        "challenge": getattr(args, "attest_challenge", None),
+                    },
                 )
                 if acceptance is None:
                     value = {"schema_version": 1, "uploaded": False, "cancelled": True}

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -268,8 +268,13 @@ def post_submission(
     if attest_headers:
         headers.update(attest_headers)
     last: Exception | None = None
+    # An App Attest assertion is one-use (its signature counter must strictly
+    # increase and the server records it), so a retry would replay identical
+    # headers and be rejected as stale. Do not auto-retry attested requests —
+    # the app acquires a fresh challenge + assertion and calls again instead.
+    max_attempts = 1 if attest_headers else _MAX_ATTEMPTS
 
-    for attempt in range(1, _MAX_ATTEMPTS + 1):
+    for attempt in range(1, max_attempts + 1):
         req = urllib.request.Request(
             target,
             data=body,
@@ -314,14 +319,14 @@ def post_submission(
                 detail = exc.read().decode("utf-8", "replace")[:500]
             except Exception:  # noqa: BLE001 - diagnostic only
                 pass
-            if exc.code < 500 or attempt == _MAX_ATTEMPTS:
+            if exc.code < 500 or attempt == max_attempts:
                 raise SubmitError(
                     f"the board rejected this submission (HTTP {exc.code}). {detail}"
                 ) from exc
             last = exc
             _sleep_before_retry(attempt, getattr(exc, "headers", None))
         except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            if attempt == _MAX_ATTEMPTS:
+            if attempt == max_attempts:
                 # No persistence claim here: whether a local copy exists is
                 # something only the caller knows, and asserting it from this
                 # layer told users their run was safe when archiving had

--- a/vllm_mlx/community_bench/upload.py
+++ b/vllm_mlx/community_bench/upload.py
@@ -241,16 +241,32 @@ def _sleep_before_retry(attempt: int, headers) -> None:
     time.sleep(min(delay, 10.0))
 
 
-def post_submission(payload: dict, *, url: str | None = None) -> dict:
+def post_submission(
+    payload: dict,
+    *,
+    url: str | None = None,
+    attest_headers: dict[str, str] | None = None,
+) -> dict:
     """POST one submission. Returns the decoded server response.
 
     Retries only on transport errors and 5xx — a 4xx means the payload is
     wrong and retrying would just replay the same rejection. ``429`` is not
     retried either: the caller is over a documented cap, and hammering it is
     the opposite of what the response is asking for.
+
+    ``attest_headers`` carries the App Attest ``X-Rapid-Attest-*`` values that
+    Rapid Desktop computes in-app (DCAppAttestService lives in the signed app,
+    not this bundled engine). The engine only relays them; ``body`` is the
+    exact bytes the app signed, so the assertion covers what is sent.
     """
     target = url or board_url()
     body = submission_body(payload)
+    headers = {
+        "content-type": "application/json",
+        "user-agent": "rapid-mlx-bench",
+    }
+    if attest_headers:
+        headers.update(attest_headers)
     last: Exception | None = None
 
     for attempt in range(1, _MAX_ATTEMPTS + 1):
@@ -258,10 +274,7 @@ def post_submission(payload: dict, *, url: str | None = None) -> dict:
             target,
             data=body,
             method="POST",
-            headers={
-                "content-type": "application/json",
-                "user-agent": "rapid-mlx-bench",
-            },
+            headers=headers,
         )
         try:
             with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:


### PR DESCRIPTION
Companion to rapidmlx.com **[PR #132](https://github.com/raullenchai/rapidmlx.com/pull/132)** (design + server verifier). Makes the Community Benchmark leaderboard rankable as a **race-to-#1 contest** without accounts: only runs proven to come from a genuine, unmodified instance of this notarized app on real Apple hardware can rank. Zero user friction — App Attest never prompts.

## What this PR does

**Engine relay** (`upload.py`, `atomic_upload.py`, `cli.py`) — `benchmark share` gains hidden `--attest-key-id/--attest-assertion/--attest-challenge`; `upload_run()` relays them as `X-Rapid-Attest-*` headers on the existing POST. The wire body is unchanged, so the assertion the app signed covers exactly what is sent. No behaviour change when absent (CLI / un-attested).

**Desktop client** (`CommunityBenchmarkAttest.swift`) — `AppAttestClient` mints + attests a device key **once** (cached in the Keychain), then per upload fetches a fresh challenge and signs `SHA256(challenge ‖ payload_json)`. The share path computes this in-app and passes it to `benchmark share`. `DCAppAttestService` lives in the signed app, so the crypto is here and the engine only relays.

## Why the split

`DCAppAttestService` only runs inside the signed/notarized app. Keeping the POST + receipt/install-id/consent in the engine (unchanged) and adding only the crypto + two small HTTP calls (`/challenge`, `/attest`) in Swift is the smallest, lowest-risk seam.

## Testing

- Engine: header relay + omission (`test_community_bench_upload.py`, full file 26/26 on the repo venv).
- Desktop: register-once flow, Keychain caching, exact body-binding, unsupported/rejected fail-soft, CLI-arg relay — 5 tests via injected fakes (device crypto only runs signed-on-hardware). Package compiles.
- **End-to-end needs a notarized build on a real device.** The server (PR #132) already verifies the real Apple App Attest Root CA chain, proven against the root's own signature.

## Fail-soft & rollout

Unsupported device / older build / transient error → un-attested upload (won't rank; server returns 426 once `ATOMIC_REQUIRE_ATTESTATION` is on, surfaced to the user). No entitlement change (App Attest keys off the Team ID + bundle id; production is the default environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)