### PR TITLE
feat(mac): add experimental Share Compute workspace

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/RapidApp.swift
+++ b/apps/rapid-mac/Sources/Rapid/RapidApp.swift
@@ -111,6 +111,9 @@ struct RapidApp: App {
     @State private var githubStarPrompt: GitHubStarPromptCoordinator
     /// Side-car downloader — spawns ``rapid-mlx pull <alias>`` jobs.
     @State private var downloads: DownloadManager
+    /// Owns the opt-in QuickSilver provider process independently of the tab,
+    /// so window closure cannot orphan shared compute.
+    @State private var shareCompute: ShareComputeManager
     /// Detects the "Finder Replace into /Applications silently failed
     /// because Rapid-MLX was still running" footgun (issue #251).
     @State private var installTracker: InstallTracker
@@ -312,6 +315,7 @@ struct RapidApp: App {
             fixtureState: updateBusyFixture ? .busy : nil
         )
         let downloadsInstance = DownloadManager(binaryPath: manager.binaryPath)
+        let shareComputeManager = ShareComputeManager(server: manager)
         // TCC cannot be granted hermetically on an unattended runner. This
         // two-key fixture exercises the real model/server warmup lifecycle
         // while replacing only the OS permission and event-tap boundaries.
@@ -340,6 +344,7 @@ struct RapidApp: App {
         manager.attachDownloads(downloadsInstance)
         _server = State(initialValue: manager)
         _downloads = State(initialValue: downloadsInstance)
+        _shareCompute = State(initialValue: shareComputeManager)
         _installTracker = State(initialValue: InstallTracker())
         _quickstart = State(initialValue: QuickstartCoordinator())
         let dockPrompt = DockVisibilityPromptStore()
@@ -369,6 +374,7 @@ struct RapidApp: App {
         // the SwiftUI environment.
         AppDelegate.shared.server = manager
         AppDelegate.shared.downloads = downloadsInstance
+        AppDelegate.shared.shareCompute = shareComputeManager
         AppDelegate.shared.updater = updateChecker
         AppDelegate.shared.sparkleUpdater = sparkleUpdateController
         AppDelegate.shared.chat = chat
@@ -385,6 +391,7 @@ struct RapidApp: App {
                 .tint(RapidTheme.brandAmber)
                 .environment(server)
                 .environment(downloads)
+                .environment(shareCompute)
                 .environment(chatViewModel)
                 .environment(imageGen)
                 .environment(audio)
@@ -561,6 +568,7 @@ struct RapidApp: App {
                 .environment(appearance)
                 .environment(settingsRouter)
                 .environment(server)
+                .environment(shareCompute)
                 // Settings → Developer resets the wizard, and SwiftUI traps
                 // rather than warns when an @Environment observable is
                 // missing — so the Settings scene needs this even though the
@@ -614,6 +622,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     weak var server: ServerManager?
     weak var downloads: DownloadManager?
+    weak var shareCompute: ShareComputeManager?
     /// Hand from ``RapidApp.init`` so ``applicationWillTerminate`` can
     /// cancel the in-flight chat stream task before shutting the child
     /// down, and the menu-bar tray's "New Chat" can reach it.
@@ -1031,8 +1040,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     static func runTerminationSequence(
         stopDictation: () -> Void,
         stopStream: () -> Void,
+        signalShareCompute: () -> Void,
         signalServer: () -> Void,
         signalDownloads: () -> Void,
+        reapShareCompute: () -> Void,
         reapServer: () -> Void,
         reapDownloads: () -> Void,
         flushConversations: () -> Void,
@@ -1048,12 +1059,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         stopStream()
         // Signal phase — non-blocking. Both subsystems get their
         // SIGTERM before anyone waits, so the graces overlap.
+        signalShareCompute()
         signalServer()
         signalDownloads()
         // Reap phase — blocking. Server first: its grace is the long
         // one, and by the time it returns the download children have
         // had that entire window to exit.
         reapServer()
+        reapShareCompute()
         reapDownloads()
         // Drain any queued conversation-history write so the last turn /
         // edit / deletion isn't lost when the process exits before the
@@ -1083,8 +1096,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 AppDelegate.shared.dictation = nil
             },
             stopStream: { AppDelegate.shared.chat?.stopAndPersist() },
+            signalShareCompute: { AppDelegate.shared.shareCompute?.beginShutdown() },
             signalServer: { AppDelegate.shared.server?.beginShutdown() },
             signalDownloads: { AppDelegate.shared.downloads?.beginShutdown() },
+            reapShareCompute: { AppDelegate.shared.shareCompute?.finishShutdown() },
             reapServer: { AppDelegate.shared.server?.shutdownSync() },
             reapDownloads: { AppDelegate.shared.downloads?.finishShutdown() },
             flushConversations: { ConversationStore.flush() },

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeFeatureConfig.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeFeatureConfig.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Explicit opt-in for lending this Mac to a third-party compute pool.
+/// The preference controls discoverability only; enabling it never downloads
+/// weights, starts a model, or contacts QuickSilver.
+enum ShareComputeFeatureConfig {
+    static let enabledKey = "Rapid.experimental.shareComputeEnabled"
+    static let defaultEnabled = false
+
+    static func isEnabled(in defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enabledKey) as? Bool ?? defaultEnabled
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -43,6 +43,8 @@ final class ShareComputeManager {
     private var stderrPipe: Pipe?
     private var expectedStop = false
     private var restoreAlias: String?
+    private var restoreTask: Task<Void, Never>?
+    private var restoreAttemptID: UUID?
     private var shuttingDown = false
     private var shutdownSignalledAt: Date?
     private var currentStatusURL: URL?
@@ -118,6 +120,13 @@ final class ShareComputeManager {
             return
         }
 
+        // A replacement join owns the pending restore alias. Cancel an
+        // in-flight restore attempt, but keep the alias so the last session in
+        // the chain can still restore it.
+        restoreAttemptID = nil
+        restoreTask?.cancel()
+        restoreTask = nil
+
         state = .preparing
         activeModel = model
         snapshot = nil
@@ -154,13 +163,13 @@ final class ShareComputeManager {
             return
         }
         guard operationID == operation, !shuttingDown else {
+            restoreIfPreparationHasNoSuccessor()
             server.finishCommunityBenchmark(lease)
             // This operation no longer owns manager state. A subsequent join
             // may already have replaced activeModel and restoreAlias, so only
             // release the lease acquired by this stale operation. The pending
             // restore is inherited by a successor, or performed now if the
             // user simply cancelled and no successor exists.
-            restoreIfPreparationHasNoSuccessor()
             return
         }
         reservation = lease
@@ -226,11 +235,11 @@ final class ShareComputeManager {
             inputPipe.fileHandleForWriting.closeFile()
             detachPipes(out, err)
             removeCurrentStatusFile()
-            releaseReservation()
             activeModel = nil
             state = .failed("Rapid couldn't start Share Compute.")
             operationID = nil
             restorePreviousModelIfNeeded()
+            releaseReservation()
         }
     }
 
@@ -253,6 +262,9 @@ final class ShareComputeManager {
         shuttingDown = true
         operationID = nil
         restoreAlias = nil
+        restoreAttemptID = nil
+        restoreTask?.cancel()
+        restoreTask = nil
         statusTask?.cancel()
         stopEscalationTask?.cancel()
         expectedStop = true
@@ -417,8 +429,8 @@ final class ShareComputeManager {
         child = nil
         activeModel = nil
         if expectedStop, !shuttingDown { state = .idle }
-        releaseReservation()
         restorePreviousModelIfNeeded()
+        releaseReservation()
     }
 
     private func scheduleStopEscalation(for child: ProcessGroupChild) {
@@ -449,8 +461,19 @@ final class ShareComputeManager {
             restoreAlias = nil
             return
         }
-        restoreAlias = nil
-        Task { await server.start(alias: alias) }
+        restoreTask?.cancel()
+        let attempt = UUID()
+        restoreAttemptID = attempt
+        restoreTask = Task { @MainActor [weak self, weak server] in
+            guard let server else { return }
+            await server.start(alias: alias)
+            guard let self, self.restoreAttemptID == attempt else { return }
+            self.restoreAttemptID = nil
+            self.restoreTask = nil
+            if self.operationID == nil, self.child == nil {
+                self.restoreAlias = nil
+            }
+        }
     }
 
     private func restoreIfPreparationHasNoSuccessor() {

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -48,6 +48,7 @@ final class ShareComputeManager {
     private var shuttingDown = false
     private var shutdownSignalledAt: Date?
     private var currentStatusURL: URL?
+    private var currentSession: String?
     /// Invalidates a join that is still waiting for the shared residency
     /// lease. Without this, disabling the experiment during preparation could
     /// let the suspended task wake later and start a now-hidden provider.
@@ -77,6 +78,14 @@ final class ShareComputeManager {
         )
     }
 
+    nonisolated static func credentialCacheURL(
+        catalogID: String,
+        home: URL? = nil
+    ) -> URL {
+        let home = home ?? runtimeHomeURL()
+        return home.appendingPathComponent(".rapid-mlx/quicksilver/\(catalogID).json")
+    }
+
     func hasRegistration(for model: ShareComputeModel, worker: String) -> Bool {
         Self.registrationMatches(model: model, worker: worker)
     }
@@ -87,6 +96,12 @@ final class ShareComputeManager {
         home: URL? = nil
     ) -> Bool {
         let url = registrationURL(catalogID: model.catalogID, home: home)
+        let credentialURL = credentialCacheURL(catalogID: model.catalogID, home: home)
+        let credentialValues = try? credentialURL.resourceValues(forKeys: [.isRegularFileKey])
+        guard credentialValues?.isRegularFile == true,
+              FileManager.default.isReadableFile(atPath: credentialURL.path) else {
+            return false
+        }
         guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
         defer { try? handle.close() }
         guard let data = try? handle.read(upToCount: 4_097), data.count <= 4_096,
@@ -177,6 +192,7 @@ final class ShareComputeManager {
         let session = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
         let statusURL = Self.statusURL(session: session)
         currentStatusURL = statusURL
+        currentSession = session
         try? FileManager.default.removeItem(at: statusURL)
         let inputPipe = Pipe()
         let out = Pipe()
@@ -384,7 +400,14 @@ final class ShareComputeManager {
         // between two 250 ms polls. Read once at process-exit before removing
         // the snapshot so a revoked credential does not degrade into the
         // generic "stopped unexpectedly" message.
-        let finalSnapshot = currentStatusURL.flatMap(Self.loadStatus(at:)) ?? snapshot
+        let diskSnapshot = currentStatusURL.flatMap(Self.loadStatus(at:))
+        let finalSnapshot = if let diskSnapshot, let currentSession,
+                               diskSnapshot.schemaVersion == 1,
+                               diskSnapshot.session == currentSession {
+            diskSnapshot
+        } else {
+            snapshot
+        }
         if let finalSnapshot { snapshot = finalSnapshot }
         statusTask?.cancel()
         removeCurrentStatusFile()
@@ -498,8 +521,10 @@ final class ShareComputeManager {
     }
 
     private func removeCurrentStatusFile() {
-        guard let currentStatusURL else { return }
-        try? FileManager.default.removeItem(at: currentStatusURL)
+        if let currentStatusURL {
+            try? FileManager.default.removeItem(at: currentStatusURL)
+        }
         self.currentStatusURL = nil
+        currentSession = nil
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -101,19 +101,32 @@ final class ShareComputeManager {
         state = .preparing
         activeModel = model
         snapshot = nil
-        restoreAlias = server.servingAlias
+        // Preserve the model captured by the first join in a cancel/rejoin
+        // chain. The first preparation may already have stopped it by the
+        // time the replacement join reads `servingAlias`.
+        restoreAlias = Self.restoreAliasForJoin(
+            pending: restoreAlias,
+            currentlyServing: server.servingAlias
+        )
         let operation = UUID()
         operationID = operation
         let lease: UUID
         do {
             lease = try await server.prepareForCommunityBenchmark()
         } catch is CancellationError {
-            guard operationID == operation else { return }
+            guard operationID == operation else {
+                restoreIfPreparationHasNoSuccessor()
+                return
+            }
             operationID = nil
             resetToIdle()
+            restorePreviousModelIfNeeded()
             return
         } catch {
-            guard operationID == operation else { return }
+            guard operationID == operation else {
+                restoreIfPreparationHasNoSuccessor()
+                return
+            }
             operationID = nil
             state = .failed("Rapid couldn't pause the current model safely.")
             activeModel = nil
@@ -124,7 +137,10 @@ final class ShareComputeManager {
             server.finishCommunityBenchmark(lease)
             // This operation no longer owns manager state. A subsequent join
             // may already have replaced activeModel and restoreAlias, so only
-            // release the lease acquired by this stale operation.
+            // release the lease acquired by this stale operation. The pending
+            // restore is inherited by a successor, or performed now if the
+            // user simply cancelled and no successor exists.
+            restoreIfPreparationHasNoSuccessor()
             return
         }
         reservation = lease
@@ -292,6 +308,13 @@ final class ShareComputeManager {
         }
     }
 
+    nonisolated static func restoreAliasForJoin(
+        pending: String?,
+        currentlyServing: String?
+    ) -> String? {
+        pending ?? currentlyServing
+    }
+
     /// Pure representation of every caller-controlled value handed to the
     /// process boundary. Keeping stdin beside argv and environment makes the
     /// credential transport invariant directly testable.
@@ -386,6 +409,11 @@ final class ShareComputeManager {
         }
         restoreAlias = nil
         Task { await server.start(alias: alias) }
+    }
+
+    private func restoreIfPreparationHasNoSuccessor() {
+        guard operationID == nil else { return }
+        restorePreviousModelIfNeeded()
     }
 
     private func installDiscardingDrainer(on pipe: Pipe) {

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -116,8 +116,11 @@ final class ShareComputeManager {
     }
 
     func join(model: ShareComputeModel, worker: String, providerKey: String? = nil) async {
-        guard child == nil, operationID == nil,
-              let server, let binary = server.binaryPath else {
+        // Connect is idempotent while a preparation or provider is already
+        // live. A second button event must not replace truthful session state
+        // with an unrelated engine-availability error.
+        guard child == nil, operationID == nil else { return }
+        guard let server, let binary = server.binaryPath else {
             state = .failed("Rapid-MLX's local engine is not available.")
             return
         }
@@ -344,7 +347,10 @@ final class ShareComputeManager {
         case "connecting": .connecting
         case "online": .online
         case "reconnecting": .reconnecting
-        case "stopped": .idle
+        // The provider publishes this before its process group is necessarily
+        // gone. Keep controls locked until childExited/finishDeferredExit has
+        // confirmed teardown and released unified-memory residency.
+        case "stopped": .stopping
         case "error": .failed(snapshot.message ?? "Share Compute stopped unexpectedly.")
         default: .failed("Share Compute reported an unsupported status.")
         }

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -70,11 +70,32 @@ final class ShareComputeManager {
 
     nonisolated static func registrationURL(catalogID: String, home: URL? = nil) -> URL {
         let home = home ?? runtimeHomeURL()
-        return home.appendingPathComponent(".rapid-mlx/quicksilver/\(catalogID).json")
+        return home.appendingPathComponent(
+            ".rapid-mlx/quicksilver/\(catalogID).registration.json"
+        )
     }
 
-    func hasRegistration(for model: ShareComputeModel) -> Bool {
-        FileManager.default.fileExists(atPath: Self.registrationURL(catalogID: model.catalogID).path)
+    func hasRegistration(for model: ShareComputeModel, worker: String) -> Bool {
+        Self.registrationMatches(model: model, worker: worker)
+    }
+
+    nonisolated static func registrationMatches(
+        model: ShareComputeModel,
+        worker: String,
+        home: URL? = nil
+    ) -> Bool {
+        let url = registrationURL(catalogID: model.catalogID, home: home)
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: 4_097), data.count <= 4_096,
+              let marker = try? JSONDecoder().decode(
+                  ShareComputeRegistrationSnapshot.self,
+                  from: data
+              ) else { return false }
+        return marker.schemaVersion == 1
+            && marker.model == model.catalogID
+            && marker.alias == model.alias
+            && marker.worker == ShareComputeModel.sanitizedWorker(worker)
     }
 
     func join(model: ShareComputeModel, worker: String, providerKey: String? = nil) async {
@@ -93,7 +114,7 @@ final class ShareComputeManager {
             state = .failed("That provider key is not valid.")
             return
         }
-        if !hasRegistration(for: model), trimmedKey?.isEmpty != false {
+        if !hasRegistration(for: model, worker: worker), trimmedKey?.isEmpty != false {
             state = .failed("Connect QuickSilver with a provider key first.")
             return
         }
@@ -347,6 +368,7 @@ final class ShareComputeManager {
     private func childExited(_ process: ProcessGroupChild) {
         guard child === process else { return }
         let wasExpected = expectedStop
+        let groupIsAlive = process.isProcessGroupAlive
         // The provider can publish its actionable terminal status and exit
         // between two 250 ms polls. Read once at process-exit before removing
         // the snapshot so a revoked credential does not degrade into the
@@ -357,10 +379,8 @@ final class ShareComputeManager {
         stopEscalationTask?.cancel()
         removeCurrentStatusFile()
         cleanupPipes()
-        child = nil
-        activeModel = nil
         if wasExpected || shuttingDown {
-            state = .idle
+            state = groupIsAlive ? .stopping : .idle
         } else if let finalSnapshot, finalSnapshot.phase == "error" {
             state = Self.state(for: finalSnapshot)
         } else if case .failed = state {
@@ -368,23 +388,28 @@ final class ShareComputeManager {
         } else {
             state = .failed(finalSnapshot?.message ?? "Share Compute stopped unexpectedly.")
         }
-        if process.isProcessGroupAlive, !shuttingDown {
+        if groupIsAlive, !shuttingDown {
             // The supervisor may exit a beat before its nested serve child.
             // Keep exclusive residency until the kernel confirms the whole
-            // group is gone; otherwise restoration could overlap its weights.
+            // group is gone; retain `child` too so leave/app shutdown can
+            // still signal that surviving process group.
             ProcessGroupChild.monitorProcessGroupUntilExit(
                 processGroupID: process.processGroupID
             ) { [weak self] in
                 Task { @MainActor [weak self] in
-                    self?.finishDeferredExit()
+                    self?.finishDeferredExit(process)
                 }
             }
         } else {
-            finishDeferredExit()
+            finishDeferredExit(process)
         }
     }
 
-    private func finishDeferredExit() {
+    private func finishDeferredExit(_ process: ProcessGroupChild) {
+        guard child === process else { return }
+        child = nil
+        activeModel = nil
+        if expectedStop, !shuttingDown { state = .idle }
         releaseReservation()
         restorePreviousModelIfNeeded()
     }

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -1,0 +1,377 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ShareComputeManager {
+    enum State: Equatable {
+        case idle
+        case preparing
+        case registering
+        case starting
+        case warming
+        case connecting
+        case online
+        case reconnecting
+        case stopping
+        case failed(String)
+
+        var isActive: Bool {
+            switch self {
+            case .idle, .failed: false
+            default: true
+            }
+        }
+    }
+
+    private(set) var state: State = .idle
+    private(set) var snapshot: ShareComputeStatusSnapshot?
+    private(set) var activeModel: ShareComputeModel?
+
+    private weak var server: ServerManager?
+    private var child: ProcessGroupChild?
+    private var reservation: UUID?
+    private var statusTask: Task<Void, Never>?
+    private var stopEscalationTask: Task<Void, Never>?
+    private var stdoutPipe: Pipe?
+    private var stderrPipe: Pipe?
+    private var expectedStop = false
+    private var restoreAlias: String?
+    private var shuttingDown = false
+    private var currentStatusURL: URL?
+    /// Invalidates a join that is still waiting for the shared residency
+    /// lease. Without this, disabling the experiment during preparation could
+    /// let the suspended task wake later and start a now-hidden provider.
+    private var operationID: UUID?
+
+    init(server: ServerManager) {
+        self.server = server
+    }
+
+    nonisolated static func runtimeHomeURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fallback: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        guard let raw = environment["HOME"], raw.hasPrefix("/") else { return fallback }
+        return URL(fileURLWithPath: raw, isDirectory: true).standardizedFileURL
+    }
+
+    nonisolated static func statusURL(session: String, home: URL? = nil) -> URL {
+        let home = home ?? runtimeHomeURL()
+        return home.appendingPathComponent(".rapid-mlx/quicksilver/desktop-status-\(session).json")
+    }
+
+    nonisolated static func registrationURL(catalogID: String, home: URL? = nil) -> URL {
+        let home = home ?? runtimeHomeURL()
+        return home.appendingPathComponent(".rapid-mlx/quicksilver/\(catalogID).json")
+    }
+
+    func hasRegistration(for model: ShareComputeModel) -> Bool {
+        FileManager.default.fileExists(atPath: Self.registrationURL(catalogID: model.catalogID).path)
+    }
+
+    func join(model: ShareComputeModel, worker: String, providerKey: String? = nil) async {
+        guard child == nil, operationID == nil,
+              let server, let binary = server.binaryPath else {
+            state = .failed("Rapid-MLX's local engine is not available.")
+            return
+        }
+        guard ShareComputeModel.supported.contains(model) else {
+            state = .failed("That model is not available in the QuickSilver pool.")
+            return
+        }
+        let trimmedKey = providerKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedKey,
+           (trimmedKey.count > 4095 || trimmedKey.contains("\n") || trimmedKey.contains("\r")) {
+            state = .failed("That provider key is not valid.")
+            return
+        }
+        if !hasRegistration(for: model), trimmedKey?.isEmpty != false {
+            state = .failed("Connect QuickSilver with a provider key first.")
+            return
+        }
+
+        state = .preparing
+        activeModel = model
+        restoreAlias = server.servingAlias
+        let operation = UUID()
+        operationID = operation
+        let lease: UUID
+        do {
+            lease = try await server.prepareForCommunityBenchmark()
+        } catch is CancellationError {
+            operationID = nil
+            resetToIdle()
+            return
+        } catch {
+            operationID = nil
+            state = .failed("Rapid couldn't pause the current model safely.")
+            activeModel = nil
+            restorePreviousModelIfNeeded()
+            return
+        }
+        guard operationID == operation, !shuttingDown else {
+            server.finishCommunityBenchmark(lease)
+            resetToIdle()
+            restorePreviousModelIfNeeded()
+            return
+        }
+        reservation = lease
+
+        let session = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+        let statusURL = Self.statusURL(session: session)
+        currentStatusURL = statusURL
+        try? FileManager.default.removeItem(at: statusURL)
+        let arguments = Self.arguments(
+            model: model,
+            worker: worker,
+            session: session,
+            hasProviderKey: trimmedKey?.isEmpty == false
+        )
+
+        let inputPipe = Pipe()
+        let out = Pipe()
+        let err = Pipe()
+        installDiscardingDrainer(on: out)
+        installDiscardingDrainer(on: err)
+        let environment = ServerManager.serveEnvironmentAdditions(
+            bearer: "",
+            ambient: ProcessInfo.processInfo.environment,
+            physicalRAMBytes: MacHardware.detect().physicalRAMBytes,
+            availableRAMBytes: MemoryProbe.snapshot()?.freeBytes ?? 0,
+            supervisorPID: ProcessInfo.processInfo.processIdentifier,
+            modelsFolderOverride: ModelsFolderPreference.validatedOverrideURL()?.path
+        )
+
+        do {
+            // Fill the bounded pipe while its read end is unquestionably open.
+            // Writing after spawn creates a narrow SIGPIPE race if the child
+            // fails before Swift gets scheduled again.
+            if let trimmedKey, !trimmedKey.isEmpty {
+                inputPipe.fileHandleForWriting.write(Data((trimmedKey + "\n").utf8))
+            }
+            let spawned = try ProcessGroupChild.spawn(
+                executableURL: binary,
+                arguments: arguments,
+                standardInput: inputPipe.fileHandleForReading,
+                standardOutput: out,
+                standardError: err,
+                environmentAdditions: environment,
+                replaceEnvironment: true,
+                startMonitorImmediately: false
+            ) { [weak self] process in
+                Task { @MainActor [weak self] in self?.childExited(process) }
+            }
+            child = spawned
+            operationID = nil
+            stdoutPipe = out
+            stderrPipe = err
+            expectedStop = false
+            spawned.startMonitor()
+            inputPipe.fileHandleForReading.closeFile()
+            inputPipe.fileHandleForWriting.closeFile()
+            state = .starting
+            statusTask = Task { [weak self] in
+                await self?.pollStatus(at: statusURL, session: session)
+            }
+        } catch {
+            inputPipe.fileHandleForReading.closeFile()
+            inputPipe.fileHandleForWriting.closeFile()
+            detachPipes(out, err)
+            removeCurrentStatusFile()
+            releaseReservation()
+            activeModel = nil
+            state = .failed("Rapid couldn't start Share Compute.")
+            operationID = nil
+            restorePreviousModelIfNeeded()
+        }
+    }
+
+    func leave() {
+        operationID = nil
+        guard let child else {
+            releaseReservation()
+            resetToIdle()
+            return
+        }
+        expectedStop = true
+        state = .stopping
+        statusTask?.cancel()
+        child.signalProcessGroup(SIGTERM)
+        stopEscalationTask?.cancel()
+        stopEscalationTask = Task { [weak self, weak child] in
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, let self, let child,
+                  self.child === child, child.isProcessGroupAlive else { return }
+            child.signalProcessGroup(SIGKILL)
+        }
+    }
+
+    func beginShutdown() {
+        shuttingDown = true
+        operationID = nil
+        restoreAlias = nil
+        statusTask?.cancel()
+        stopEscalationTask?.cancel()
+        expectedStop = true
+        child?.signalProcessGroup(SIGTERM)
+    }
+
+    func finishShutdown() {
+        beginShutdown()
+        guard let child else { return }
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline && child.isProcessGroupAlive {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        if child.isProcessGroupAlive { child.signalProcessGroup(SIGKILL) }
+        removeCurrentStatusFile()
+        cleanupPipes()
+        self.child = nil
+        releaseReservation()
+    }
+
+    private func pollStatus(at url: URL, session: String) async {
+        while !Task.isCancelled, child != nil {
+            if let value = Self.loadStatus(at: url),
+               value.schemaVersion == 1, value.session == session {
+                snapshot = value
+                state = Self.state(for: value)
+            }
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+    }
+
+    nonisolated static func loadStatus(at url: URL) -> ShareComputeStatusSnapshot? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: 65_537),
+              data.count <= 65_536 else { return nil }
+        return try? JSONDecoder().decode(ShareComputeStatusSnapshot.self, from: data)
+    }
+
+    nonisolated static func state(for snapshot: ShareComputeStatusSnapshot) -> State {
+        switch snapshot.phase {
+        case "preparing": .preparing
+        case "registering": .registering
+        case "starting": .starting
+        case "warming": .warming
+        case "connecting": .connecting
+        case "online": .online
+        case "reconnecting": .reconnecting
+        case "stopped": .idle
+        case "error": .failed(snapshot.message ?? "Share Compute stopped unexpectedly.")
+        default: .failed("Share Compute reported an unsupported status.")
+        }
+    }
+
+    /// Pure spawn contract. The provider key is represented only by the
+    /// transport flag; its bytes must never be interpolated into argv.
+    nonisolated static func arguments(
+        model: ShareComputeModel,
+        worker: String,
+        session: String,
+        hasProviderKey: Bool
+    ) -> [String] {
+        var result = [
+            "share", model.alias,
+            "--quicksilver",
+            "--quicksilver-model", model.catalogID,
+            "--worker", ShareComputeModel.sanitizedWorker(worker),
+            "--desktop-session", session,
+        ]
+        if hasProviderKey {
+            result += ["--provider-key-stdin", "--reregister"]
+        }
+        return result
+    }
+
+    private func childExited(_ process: ProcessGroupChild) {
+        guard child === process else { return }
+        let wasExpected = expectedStop
+        // The provider can publish its actionable terminal status and exit
+        // between two 250 ms polls. Read once at process-exit before removing
+        // the snapshot so a revoked credential does not degrade into the
+        // generic "stopped unexpectedly" message.
+        let finalSnapshot = currentStatusURL.flatMap(Self.loadStatus(at:)) ?? snapshot
+        if let finalSnapshot { snapshot = finalSnapshot }
+        statusTask?.cancel()
+        stopEscalationTask?.cancel()
+        removeCurrentStatusFile()
+        cleanupPipes()
+        child = nil
+        activeModel = nil
+        if wasExpected || shuttingDown {
+            state = .idle
+        } else if let finalSnapshot, finalSnapshot.phase == "error" {
+            state = Self.state(for: finalSnapshot)
+        } else if case .failed = state {
+            // Keep the actionable status published by the provider.
+        } else {
+            state = .failed(finalSnapshot?.message ?? "Share Compute stopped unexpectedly.")
+        }
+        if process.isProcessGroupAlive, !shuttingDown {
+            // The supervisor may exit a beat before its nested serve child.
+            // Keep exclusive residency until the kernel confirms the whole
+            // group is gone; otherwise restoration could overlap its weights.
+            ProcessGroupChild.monitorProcessGroupUntilExit(
+                processGroupID: process.processGroupID
+            ) { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.finishDeferredExit()
+                }
+            }
+        } else {
+            finishDeferredExit()
+        }
+    }
+
+    private func finishDeferredExit() {
+        releaseReservation()
+        restorePreviousModelIfNeeded()
+    }
+
+    private func releaseReservation() {
+        guard let reservation else { return }
+        server?.finishCommunityBenchmark(reservation)
+        self.reservation = nil
+    }
+
+    private func resetToIdle() {
+        removeCurrentStatusFile()
+        state = .idle
+        activeModel = nil
+        snapshot = nil
+    }
+
+    private func restorePreviousModelIfNeeded() {
+        guard !shuttingDown, let alias = restoreAlias, let server else {
+            restoreAlias = nil
+            return
+        }
+        restoreAlias = nil
+        Task { await server.start(alias: alias) }
+    }
+
+    private func installDiscardingDrainer(on pipe: Pipe) {
+        let drainer = PipeDrainer(pipe.fileHandleForReading)
+        pipe.fileHandleForReading.readabilityHandler = { _ in _ = drainer.drain() }
+    }
+
+    private func detachPipes(_ stdout: Pipe, _ stderr: Pipe) {
+        stdout.fileHandleForReading.readabilityHandler = nil
+        stderr.fileHandleForReading.readabilityHandler = nil
+    }
+
+    private func cleanupPipes() {
+        if let stdoutPipe, let stderrPipe { detachPipes(stdoutPipe, stderrPipe) }
+        stdoutPipe = nil
+        stderrPipe = nil
+    }
+
+    private func removeCurrentStatusFile() {
+        guard let currentStatusURL else { return }
+        try? FileManager.default.removeItem(at: currentStatusURL)
+        self.currentStatusURL = nil
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -44,6 +44,7 @@ final class ShareComputeManager {
     private var expectedStop = false
     private var restoreAlias: String?
     private var shuttingDown = false
+    private var shutdownSignalledAt: Date?
     private var currentStatusURL: URL?
     /// Invalidates a join that is still waiting for the shared residency
     /// lease. Without this, disabling the experiment during preparation could
@@ -99,6 +100,7 @@ final class ShareComputeManager {
 
         state = .preparing
         activeModel = model
+        snapshot = nil
         restoreAlias = server.servingAlias
         let operation = UUID()
         operationID = operation
@@ -217,6 +219,7 @@ final class ShareComputeManager {
     }
 
     func beginShutdown() {
+        if shutdownSignalledAt == nil { shutdownSignalledAt = Date() }
         shuttingDown = true
         operationID = nil
         restoreAlias = nil
@@ -229,11 +232,26 @@ final class ShareComputeManager {
     func finishShutdown() {
         beginShutdown()
         guard let child else { return }
-        let deadline = Date().addingTimeInterval(5)
+        // The server and provider are signalled together, then reaped in
+        // sequence. Measure this grace from the signal so their shutdown
+        // windows overlap instead of making app termination take 10 seconds.
+        let deadline = (shutdownSignalledAt ?? Date()).addingTimeInterval(5)
         while Date() < deadline && child.isProcessGroupAlive {
             Thread.sleep(forTimeInterval: 0.1)
         }
-        if child.isProcessGroupAlive { child.signalProcessGroup(SIGKILL) }
+        if child.isProcessGroupAlive {
+            child.signalProcessGroup(SIGKILL)
+            let killDeadline = Date().addingTimeInterval(0.5)
+            while Date() < killDeadline && child.isProcessGroupAlive {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+        }
+        // Never advertise the unified-memory reservation as free while the
+        // kernel can still see this process group. App termination is already
+        // irreversible; retaining bookkeeping is safer than permitting a
+        // later in-process owner to overlap a pathological uninterruptible
+        // child.
+        guard !child.isProcessGroupAlive else { return }
         removeCurrentStatusFile()
         cleanupPipes()
         self.child = nil

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -4,6 +4,12 @@ import Observation
 @MainActor
 @Observable
 final class ShareComputeManager {
+    struct SpawnRequest: Equatable {
+        let arguments: [String]
+        let environment: [String: String]
+        let standardInput: Data
+    }
+
     enum State: Equatable {
         case idle
         case preparing
@@ -100,10 +106,12 @@ final class ShareComputeManager {
         do {
             lease = try await server.prepareForCommunityBenchmark()
         } catch is CancellationError {
+            guard operationID == operation else { return }
             operationID = nil
             resetToIdle()
             return
         } catch {
+            guard operationID == operation else { return }
             operationID = nil
             state = .failed("Rapid couldn't pause the current model safely.")
             activeModel = nil
@@ -112,8 +120,9 @@ final class ShareComputeManager {
         }
         guard operationID == operation, !shuttingDown else {
             server.finishCommunityBenchmark(lease)
-            resetToIdle()
-            restorePreviousModelIfNeeded()
+            // This operation no longer owns manager state. A subsequent join
+            // may already have replaced activeModel and restoreAlias, so only
+            // release the lease acquired by this stale operation.
             return
         }
         reservation = lease
@@ -122,13 +131,6 @@ final class ShareComputeManager {
         let statusURL = Self.statusURL(session: session)
         currentStatusURL = statusURL
         try? FileManager.default.removeItem(at: statusURL)
-        let arguments = Self.arguments(
-            model: model,
-            worker: worker,
-            session: session,
-            hasProviderKey: trimmedKey?.isEmpty == false
-        )
-
         let inputPipe = Pipe()
         let out = Pipe()
         let err = Pipe()
@@ -142,21 +144,28 @@ final class ShareComputeManager {
             supervisorPID: ProcessInfo.processInfo.processIdentifier,
             modelsFolderOverride: ModelsFolderPreference.validatedOverrideURL()?.path
         )
+        let request = Self.spawnRequest(
+            model: model,
+            worker: worker,
+            session: session,
+            providerKey: trimmedKey,
+            environment: environment
+        )
 
         do {
             // Fill the bounded pipe while its read end is unquestionably open.
             // Writing after spawn creates a narrow SIGPIPE race if the child
             // fails before Swift gets scheduled again.
-            if let trimmedKey, !trimmedKey.isEmpty {
-                inputPipe.fileHandleForWriting.write(Data((trimmedKey + "\n").utf8))
+            if !request.standardInput.isEmpty {
+                inputPipe.fileHandleForWriting.write(request.standardInput)
             }
             let spawned = try ProcessGroupChild.spawn(
                 executableURL: binary,
-                arguments: arguments,
+                arguments: request.arguments,
                 standardInput: inputPipe.fileHandleForReading,
                 standardOutput: out,
                 standardError: err,
-                environmentAdditions: environment,
+                environmentAdditions: request.environment,
                 replaceEnvironment: true,
                 startMonitorImmediately: false
             ) { [weak self] process in
@@ -265,25 +274,33 @@ final class ShareComputeManager {
         }
     }
 
-    /// Pure spawn contract. The provider key is represented only by the
-    /// transport flag; its bytes must never be interpolated into argv.
-    nonisolated static func arguments(
+    /// Pure representation of every caller-controlled value handed to the
+    /// process boundary. Keeping stdin beside argv and environment makes the
+    /// credential transport invariant directly testable.
+    nonisolated static func spawnRequest(
         model: ShareComputeModel,
         worker: String,
         session: String,
-        hasProviderKey: Bool
-    ) -> [String] {
-        var result = [
+        providerKey: String?,
+        environment: [String: String]
+    ) -> SpawnRequest {
+        var arguments = [
             "share", model.alias,
             "--quicksilver",
             "--quicksilver-model", model.catalogID,
             "--worker", ShareComputeModel.sanitizedWorker(worker),
             "--desktop-session", session,
         ]
-        if hasProviderKey {
-            result += ["--provider-key-stdin", "--reregister"]
+        var standardInput = Data()
+        if let providerKey, !providerKey.isEmpty {
+            arguments += ["--provider-key-stdin", "--reregister"]
+            standardInput = Data((providerKey + "\n").utf8)
         }
-        return result
+        return SpawnRequest(
+            arguments: arguments,
+            environment: environment,
+            standardInput: standardInput
+        )
     }
 
     private func childExited(_ process: ProcessGroupChild) {

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -246,13 +246,7 @@ final class ShareComputeManager {
         state = .stopping
         statusTask?.cancel()
         child.signalProcessGroup(SIGTERM)
-        stopEscalationTask?.cancel()
-        stopEscalationTask = Task { [weak self, weak child] in
-            try? await Task.sleep(for: .seconds(5))
-            guard !Task.isCancelled, let self, let child,
-                  self.child === child, child.isProcessGroupAlive else { return }
-            child.signalProcessGroup(SIGKILL)
-        }
+        scheduleStopEscalation(for: child)
     }
 
     func beginShutdown() {
@@ -376,7 +370,6 @@ final class ShareComputeManager {
         let finalSnapshot = currentStatusURL.flatMap(Self.loadStatus(at:)) ?? snapshot
         if let finalSnapshot { snapshot = finalSnapshot }
         statusTask?.cancel()
-        stopEscalationTask?.cancel()
         removeCurrentStatusFile()
         cleanupPipes()
         if wasExpected || shuttingDown {
@@ -388,11 +381,18 @@ final class ShareComputeManager {
         } else {
             state = .failed(finalSnapshot?.message ?? "Share Compute stopped unexpectedly.")
         }
-        if groupIsAlive, !shuttingDown {
+        if groupIsAlive {
             // The supervisor may exit a beat before its nested serve child.
             // Keep exclusive residency until the kernel confirms the whole
             // group is gone; retain `child` too so leave/app shutdown can
             // still signal that surviving process group.
+            if !wasExpected, !shuttingDown {
+                // A model whose pool supervisor died cannot serve useful
+                // work. Give it the same bounded TERM→KILL teardown as an
+                // explicit Stop rather than monitoring an orphan forever.
+                process.signalProcessGroup(SIGTERM)
+                scheduleStopEscalation(for: process)
+            }
             ProcessGroupChild.monitorProcessGroupUntilExit(
                 processGroupID: process.processGroupID
             ) { [weak self] in
@@ -407,11 +407,23 @@ final class ShareComputeManager {
 
     private func finishDeferredExit(_ process: ProcessGroupChild) {
         guard child === process else { return }
+        stopEscalationTask?.cancel()
+        stopEscalationTask = nil
         child = nil
         activeModel = nil
         if expectedStop, !shuttingDown { state = .idle }
         releaseReservation()
         restorePreviousModelIfNeeded()
+    }
+
+    private func scheduleStopEscalation(for child: ProcessGroupChild) {
+        stopEscalationTask?.cancel()
+        stopEscalationTask = Task { [weak self, weak child] in
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, let self, let child,
+                  self.child === child, child.isProcessGroupAlive else { return }
+            child.signalProcessGroup(SIGKILL)
+        }
     }
 
     private func releaseReservation() {

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeManager.swift
@@ -109,8 +109,7 @@ final class ShareComputeManager {
             return
         }
         let trimmedKey = providerKey?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let trimmedKey,
-           (trimmedKey.count > 4095 || trimmedKey.contains("\n") || trimmedKey.contains("\r")) {
+        if let trimmedKey, !Self.isValidProviderKey(trimmedKey) {
             state = .failed("That provider key is not valid.")
             return
         }
@@ -328,6 +327,12 @@ final class ShareComputeManager {
         currentlyServing: String?
     ) -> String? {
         pending ?? currentlyServing
+    }
+
+    nonisolated static func isValidProviderKey(_ value: String) -> Bool {
+        value.utf8.count <= 4_095
+            && !value.contains("\n")
+            && !value.contains("\r")
     }
 
     /// Pure representation of every caller-controlled value handed to the

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeModels.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeModels.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+struct ShareComputeModel: Identifiable, Hashable, Sendable {
+    let catalogID: String
+    let alias: String
+    let title: String
+    let detail: String
+
+    var id: String { catalogID }
+
+    static let supported: [ShareComputeModel] = [
+        .init(
+            catalogID: "qwen3.8-27b",
+            alias: "qwen3.8-27b-4bit",
+            title: "Qwen3.8 27B · 4-bit",
+            detail: "Balanced capacity and memory use"
+        ),
+        .init(
+            catalogID: "qwen3.6-35b",
+            alias: "qwen3.6-35b",
+            title: "Qwen3.6 35B",
+            detail: "Higher-capacity pool model"
+        ),
+        .init(
+            catalogID: "nemotron-3.5-lightning",
+            alias: "nemotron-3.5-lightning-30b-4bit",
+            title: "Nemotron 3.5 Lightning 30B · 4-bit",
+            detail: "Fast reasoning-focused model"
+        ),
+    ]
+
+    static func sanitizedWorker(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let scalars = trimmed.unicodeScalars.filter { allowed.contains($0) }.prefix(64)
+        let cleaned = String(String.UnicodeScalarView(scalars))
+        return cleaned.isEmpty ? "node" : cleaned
+    }
+}
+
+struct ShareComputeStatusSnapshot: Decodable, Equatable, Sendable {
+    let schemaVersion: Int
+    let session: String
+    let phase: String
+    let catalogID: String?
+    let alias: String?
+    let worker: String?
+    let nodeID: String?
+    let payoutAccount: String?
+    let heartbeatInterval: Double?
+    let inflight: Int?
+    let connectedAt: Double?
+    let message: String?
+    let updatedAt: Double
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case session, phase
+        case catalogID = "catalog_id"
+        case alias, worker
+        case nodeID = "node_id"
+        case payoutAccount = "payout_account"
+        case heartbeatInterval = "heartbeat_interval_s"
+        case inflight
+        case connectedAt = "connected_at"
+        case message
+        case updatedAt = "updated_at"
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeModels.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeModels.swift
@@ -67,3 +67,15 @@ struct ShareComputeStatusSnapshot: Decodable, Equatable, Sendable {
         case updatedAt = "updated_at"
     }
 }
+
+struct ShareComputeRegistrationSnapshot: Decodable, Equatable, Sendable {
+    let schemaVersion: Int
+    let model: String
+    let alias: String
+    let worker: String
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case model, alias, worker
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeView.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeView.swift
@@ -83,6 +83,7 @@ struct ShareComputeView: View {
                     Spacer(minLength: RapidTheme.Space.md)
                     Link("Learn more", destination: URL(string: "https://quicksilverpro.io/")!)
                         .buttonStyle(.rapidSecondaryCompact)
+                        .accessibilityIdentifier("ShareCompute.ProviderLearnMore")
                 }
                 HStack(spacing: RapidTheme.Space.lg) {
                     proof("48", "models")
@@ -129,6 +130,7 @@ struct ShareComputeView: View {
                         Button("Checking…") {}
                             .buttonStyle(.rapidPrimaryCompact)
                             .disabled(true)
+                            .accessibilityIdentifier("ShareCompute.CatalogChecking")
                     } else if selectedIsCached {
                         Button(requiresRegistration ? "Connect & Share" : "Start Sharing") {
                             if !requiresRegistration {
@@ -233,12 +235,14 @@ struct ShareComputeView: View {
                 .accessibilityIdentifier("ShareCompute.Worker")
             HStack {
                 Link("Open QuickSilver", destination: URL(string: "https://quicksilverpro.io/")!)
+                    .accessibilityIdentifier("ShareCompute.OpenQuickSilver")
                 Spacer()
                 Button("Cancel") {
                     providerKey = ""
                     showingConnection = false
                 }
                 .buttonStyle(.rapidSecondary)
+                .accessibilityIdentifier("ShareCompute.Cancel")
                 Button("Connect & Share") {
                     let key = providerKey
                     providerKey = ""

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeView.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeView.swift
@@ -23,7 +23,7 @@ struct ShareComputeView: View {
     private var selectedIsCached: Bool { selectedEntry?.cached == true }
 
     private var requiresRegistration: Bool {
-        if !manager.hasRegistration(for: selected) { return true }
+        if !manager.hasRegistration(for: selected, worker: worker) { return true }
         if case .failed(let message) = manager.state {
             return message.localizedCaseInsensitiveContains("register again")
                 || message.localizedCaseInsensitiveContains("re-register")

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeView.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeView.swift
@@ -1,0 +1,256 @@
+import SwiftUI
+
+struct ShareComputeView: View {
+    @Bindable var manager: ShareComputeManager
+    @Bindable var downloads: DownloadManager
+    let catalog: [ModelEntry]
+    let catalogLoaded: Bool
+
+    @AppStorage("Rapid.shareCompute.selectedModel") private var selectedID = "qwen3.8-27b"
+    @AppStorage("Rapid.shareCompute.worker") private var worker = Host.current().localizedName ?? "Mac"
+    @State private var providerKey = ""
+    @State private var showingConnection = false
+
+    private var selected: ShareComputeModel {
+        ShareComputeModel.supported.first { $0.catalogID == selectedID }
+            ?? ShareComputeModel.supported[0]
+    }
+
+    private var selectedEntry: ModelEntry? {
+        catalog.first { $0.alias.caseInsensitiveCompare(selected.alias) == .orderedSame }
+    }
+
+    private var selectedIsCached: Bool { selectedEntry?.cached == true }
+
+    private var requiresRegistration: Bool {
+        if !manager.hasRegistration(for: selected) { return true }
+        if case .failed(let message) = manager.state {
+            return message.localizedCaseInsensitiveContains("register again")
+                || message.localizedCaseInsensitiveContains("re-register")
+        }
+        return false
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+                header
+                providerCard
+                if manager.state.isActive || manager.activeModel != nil {
+                    activeCard
+                } else {
+                    setupCard
+                }
+                safetyNotice
+            }
+            .frame(maxWidth: RapidTheme.Layout.contentMaxWidth)
+            .padding(RapidTheme.Space.xl)
+        }
+        .background(RapidTheme.surfaceCanvas)
+        .sheet(isPresented: $showingConnection) { connectionSheet }
+        .onChange(of: manager.state) { _, state in
+            if case .failed(let message) = state,
+               message.localizedCaseInsensitiveContains("provider key") {
+                showingConnection = true
+            }
+        }
+    }
+
+    private var header: some View {
+        SectionHeader(
+            "Share Compute",
+            subtitle: "Put your Mac's idle MLX capacity to work and earn through a compute provider.",
+            emphasis: .page
+        )
+        .accessibilityIdentifier("ShareCompute.Header")
+    }
+
+    private var providerCard: some View {
+        SettingsSection("Compute provider") {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
+                HStack(alignment: .top, spacing: RapidTheme.Space.md) {
+                    Image(systemName: "bolt.horizontal.circle.fill")
+                        .font(.system(size: 28))
+                        .foregroundStyle(RapidTheme.brandAmber)
+                    VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                        Text("QuickSilver")
+                            .font(RapidFont.sectionTitle)
+                        Text("One OpenAI-compatible API spanning 48 frontier and open models. Rapid Macs add high-quality open-model capacity at the edge, with public pricing and live status.")
+                            .font(RapidFont.secondary)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: RapidTheme.Space.md)
+                    Link("Learn more", destination: URL(string: "https://quicksilverpro.io/")!)
+                        .buttonStyle(.rapidSecondaryCompact)
+                }
+                HStack(spacing: RapidTheme.Space.lg) {
+                    proof("48", "models")
+                    proof("1", "compatible API")
+                    proof("Live", "status")
+                }
+            }
+        }
+    }
+
+    private func proof(_ value: String, _ label: String) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(value).font(RapidFont.body).fontWeight(.semibold)
+            Text(label).font(RapidFont.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    private var setupCard: some View {
+        SettingsSection("This Mac") {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+                if case .failed(let message) = manager.state {
+                    InlineNotice(message: message, tone: .warning)
+                }
+                Picker("Pool model", selection: $selectedID) {
+                    ForEach(ShareComputeModel.supported) { model in
+                        Text(model.title).tag(model.catalogID)
+                    }
+                }
+                .accessibilityIdentifier("ShareCompute.ModelPicker")
+
+                HStack {
+                    VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                        Text(selected.detail).font(RapidFont.body)
+                        Text(!catalogLoaded
+                             ? "Checking this Mac…"
+                             : selectedIsCached
+                                ? "Ready on this Mac"
+                                : "Download required before sharing")
+                            .font(RapidFont.secondary)
+                            .foregroundStyle(selectedIsCached ? .green : .secondary)
+                    }
+                    Spacer()
+                    if !catalogLoaded {
+                        Button("Checking…") {}
+                            .buttonStyle(.rapidPrimaryCompact)
+                            .disabled(true)
+                    } else if selectedIsCached {
+                        Button(requiresRegistration ? "Connect & Share" : "Start Sharing") {
+                            if !requiresRegistration {
+                                Task { await manager.join(model: selected, worker: worker) }
+                            } else {
+                                showingConnection = true
+                            }
+                        }
+                        .buttonStyle(.rapidPrimaryCompact)
+                        .accessibilityIdentifier("ShareCompute.Start")
+                    } else {
+                        Button(downloads.isDownloading(selected.alias) ? "Downloading…" : "Download Model") {
+                            _ = downloads.startDownload(
+                                alias: selected.alias,
+                                hfPath: selectedEntry?.hfRepo
+                            )
+                        }
+                        .buttonStyle(.rapidPrimaryCompact)
+                        .disabled(downloads.isDownloading(selected.alias))
+                        .accessibilityIdentifier("ShareCompute.Download")
+                    }
+                }
+            }
+        }
+    }
+
+    private var activeCard: some View {
+        SettingsSection("This Mac") {
+            VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+                HStack(spacing: RapidTheme.Space.md) {
+                    if manager.state == .online {
+                        Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+                    } else {
+                        ProgressView().controlSize(.small)
+                    }
+                    VStack(alignment: .leading, spacing: RapidTheme.Space.xs) {
+                        Text(statusTitle).font(RapidFont.body).fontWeight(.semibold)
+                        Text(manager.activeModel?.title ?? selected.title)
+                            .font(RapidFont.secondary).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button("Stop Sharing") { manager.leave() }
+                        .buttonStyle(.rapidSecondaryCompact)
+                        .disabled(manager.state == .stopping)
+                        .accessibilityIdentifier("ShareCompute.Stop")
+                }
+                if let node = manager.snapshot?.nodeID {
+                    Divider()
+                    HStack {
+                        Text("Node").foregroundStyle(.secondary)
+                        Spacer()
+                        Text(node).font(.system(.body, design: .monospaced))
+                    }
+                }
+                if manager.state == .online {
+                    Divider()
+                    HStack {
+                        Label("Online", systemImage: "checkmark.circle.fill").foregroundStyle(.green)
+                        Spacer()
+                        Text("\(manager.snapshot?.inflight ?? 0) active requests")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var statusTitle: String {
+        switch manager.state {
+        case .idle: "Ready"
+        case .preparing: "Pausing the current model…"
+        case .registering: "Registering with QuickSilver…"
+        case .starting: "Starting the model…"
+        case .warming: "Warming up…"
+        case .connecting: "Connecting to the pool…"
+        case .online: "Sharing compute"
+        case .reconnecting: "Reconnecting…"
+        case .stopping: "Stopping safely…"
+        case .failed(let message): message
+        }
+    }
+
+    private var safetyNotice: some View {
+        InlineNotice(
+            message: "While sharing, requests from QuickSilver customers run locally on this Mac. Rapid pauses your current model so two large models never compete for unified memory. Stop Sharing disconnects the pool and restores your previous model.",
+            tone: .info
+        )
+    }
+
+    private var connectionSheet: some View {
+        VStack(alignment: .leading, spacing: RapidTheme.Space.lg) {
+            SectionHeader(
+                "Connect QuickSilver",
+                subtitle: "Paste the one-time provider key from your QuickSilver account. Rapid sends it directly to the local provider process; it is never put in command arguments or saved by Rapid.",
+                emphasis: .page
+            )
+            SecureField("qsppk-…", text: $providerKey)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("ShareCompute.ProviderKey")
+            TextField("Worker name", text: $worker)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("ShareCompute.Worker")
+            HStack {
+                Link("Open QuickSilver", destination: URL(string: "https://quicksilverpro.io/")!)
+                Spacer()
+                Button("Cancel") {
+                    providerKey = ""
+                    showingConnection = false
+                }
+                .buttonStyle(.rapidSecondary)
+                Button("Connect & Share") {
+                    let key = providerKey
+                    providerKey = ""
+                    showingConnection = false
+                    Task { await manager.join(model: selected, worker: worker, providerKey: key) }
+                }
+                .buttonStyle(.rapidPrimary)
+                .disabled(providerKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityIdentifier("ShareCompute.Connect")
+            }
+        }
+        .padding(RapidTheme.Space.xl)
+        .frame(width: 520)
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -74,6 +74,7 @@ struct ContentView: View {
 
     @Environment(ServerManager.self) private var server
     @Environment(DownloadManager.self) private var downloads
+    @Environment(ShareComputeManager.self) private var shareCompute
     @Environment(ChatViewModel.self) private var chat
     @Environment(ImageGenViewModel.self) private var imageGen
     @Environment(AudioViewModel.self) private var audio
@@ -104,6 +105,8 @@ struct ContentView: View {
     private var computerUseEnabled = ComputerUseFeatureConfig.defaultEnabled
     @AppStorage(CommunityBenchmarkFeatureConfig.enabledKey)
     private var communityBenchmarkEnabled = CommunityBenchmarkFeatureConfig.defaultEnabled
+    @AppStorage(ShareComputeFeatureConfig.enabledKey)
+    private var shareComputeEnabled = ShareComputeFeatureConfig.defaultEnabled
     /// Window-level conversation search, opened from the toolbar.
     @State private var showConversationSearch = false
     // Was @SceneStorage. Moved to @AppStorage so the View menu command in
@@ -347,6 +350,11 @@ struct ContentView: View {
                 current: section,
                 enabled: state.benchmarkEnabled
             )
+            section = Self.sectionAfterShareComputeGateChange(
+                current: section,
+                enabled: state.shareComputeEnabled
+            )
+            if !state.shareComputeEnabled { shareCompute.leave() }
         }
         .onChange(of: server.state) { _, newState in
             // Sync the picker breadcrumb when the server lands in
@@ -621,6 +629,8 @@ struct ContentView: View {
                     videoGenerationEnabled: videoGenerationEnabled,
                     computerUseEnabled: computerUseEnabled,
                     benchmarkEnabled: communityBenchmarkEnabled,
+                    shareComputeEnabled: shareComputeEnabled,
+                    shareComputeActive: shareCompute.state.isActive,
                     chat: chat,
                 onNewChat: {
                     chat.newConversation()
@@ -1236,6 +1246,17 @@ struct ContentView: View {
                 // switches on `server.state`, not `section`.
                 mainArea
             }
+        case .shareCompute:
+            if shareComputeEnabled {
+                ShareComputeView(
+                    manager: shareCompute,
+                    downloads: downloads,
+                    catalog: catalogEntries,
+                    catalogLoaded: catalogLoaded
+                )
+            } else {
+                mainArea
+            }
         }
     }
 
@@ -1455,17 +1476,26 @@ struct ContentView: View {
         !enabled && current == .benchmark ? .chat : current
     }
 
+    static func sectionAfterShareComputeGateChange(
+        current: SidebarSection,
+        enabled: Bool
+    ) -> SidebarSection {
+        !enabled && current == .shareCompute ? .chat : current
+    }
+
     private struct ExperimentalDestinationState: Equatable {
         let videoEnabled: Bool
         let computerUseEnabled: Bool
         let benchmarkEnabled: Bool
+        let shareComputeEnabled: Bool
     }
 
     private var experimentalDestinationState: ExperimentalDestinationState {
         ExperimentalDestinationState(
             videoEnabled: videoGenerationEnabled,
             computerUseEnabled: computerUseEnabled,
-            benchmarkEnabled: communityBenchmarkEnabled
+            benchmarkEnabled: communityBenchmarkEnabled,
+            shareComputeEnabled: shareComputeEnabled
         )
     }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -29,6 +29,7 @@ struct SettingsView: View {
     /// running child alone and let the explicit restart land the
     /// new binary; the toggle copy already calls that out.
     @Environment(ServerManager.self) private var server
+    @Environment(ShareComputeManager.self) private var shareCompute
     /// #191: Settings → App panel binds the desktop self-update
     /// poller. ``RapidApp`` injects it into the Settings scene's
     /// environment chain so the panel can render the same
@@ -51,6 +52,8 @@ struct SettingsView: View {
     private var computerUseEnabled = ComputerUseFeatureConfig.defaultEnabled
     @AppStorage(CommunityBenchmarkFeatureConfig.enabledKey)
     private var communityBenchmarkEnabled = CommunityBenchmarkFeatureConfig.defaultEnabled
+    @AppStorage(ShareComputeFeatureConfig.enabledKey)
+    private var shareComputeEnabled = ShareComputeFeatureConfig.defaultEnabled
 
     /// Stable reference shared by the sidebar and detail canvas. Keeping the
     /// frequently-mutated category outside this large view's value state means
@@ -553,6 +556,18 @@ struct SettingsView: View {
                 }
                 .toggleStyle(TrailingSettingsToggleStyle())
                 .accessibilityIdentifier("Settings.Experimental.BenchmarkToggle")
+                SettingsRowDivider()
+                Toggle(isOn: $shareComputeEnabled) {
+                    SettingsRowLabel(
+                        title: "Enable Share Compute",
+                        description: "Adds the Share Compute tab for contributing this Mac to QuickSilver. Nothing connects, downloads, or runs until you explicitly start sharing."
+                    )
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityIdentifier("Settings.Experimental.ShareComputeToggle")
+                .onChange(of: shareComputeEnabled) { _, enabled in
+                    if !enabled { shareCompute.leave() }
+                }
             }
         }
         .accessibilityIdentifier("Settings.Experimental.Panel")

--- a/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SidebarView.swift
@@ -11,6 +11,7 @@ enum SidebarSection: Hashable {
     case computerUse
     case launch
     case benchmark
+    case shareCompute
 }
 
 /// The left sidebar — Ollama/ChatGPT layout: a "New Chat" action at the
@@ -43,6 +44,11 @@ struct SidebarView: View {
     /// The Benchmark tab is an opt-in experimental surface. Enabling
     /// discoverability does not start the server or run any measurement.
     var benchmarkEnabled: Bool = false
+    /// Compute sharing is an explicit experimental opt-in. Showing the row is
+    /// inert; the pool is joined only from its primary action.
+    var shareComputeEnabled: Bool = false
+    /// Keeps an active pool session visible after the user navigates away.
+    var shareComputeActive: Bool = false
     /// The chat model — source of the conversation history list + the
     /// active conversation id (for highlighting).
     @Bindable var chat: ChatViewModel
@@ -198,7 +204,7 @@ struct SidebarView: View {
             // the everyday tabs (rather than interleaved with them), so the
             // opt-in previews read as a distinct, still-being-validated set.
             // The header appears only when at least one is enabled.
-            if videoGenerationEnabled || computerUseEnabled || benchmarkEnabled {
+            if videoGenerationEnabled || computerUseEnabled || benchmarkEnabled || shareComputeEnabled {
                 SectionHeader("Experimental")
                     .padding(.horizontal, RapidTheme.Space.sm)
                     .padding(.top, RapidTheme.Space.lg)
@@ -230,6 +236,15 @@ struct SidebarView: View {
                         action: { selection = .benchmark }
                     )
                     .accessibilityIdentifier("Sidebar.CommunityBenchmark")
+                }
+                if shareComputeEnabled {
+                    row(
+                        title: shareComputeActive ? "Share Compute · On" : "Share Compute",
+                        systemImage: "bolt.horizontal.circle",
+                        isSelected: selection == .shareCompute,
+                        action: { selection = .shareCompute }
+                    )
+                    .accessibilityIdentifier("Sidebar.ShareCompute")
                 }
             }
 

--- a/apps/rapid-mac/Tests/RapidTests/AppTerminationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AppTerminationTests.swift
@@ -11,8 +11,10 @@ struct AppTerminationTests {
         AppDelegate.runTerminationSequence(
             stopDictation: { events.append("dictation") },
             stopStream: { events.append("stream") },
+            signalShareCompute: { events.append("signal-share-compute") },
             signalServer: { events.append("signal-server") },
             signalDownloads: { events.append("signal-downloads") },
+            reapShareCompute: { events.append("reap-share-compute") },
             reapServer: { events.append("reap-server") },
             reapDownloads: { events.append("reap-downloads") },
             flushConversations: { events.append("flush-conversations") },
@@ -22,9 +24,11 @@ struct AppTerminationTests {
         #expect(events == [
             "dictation",
             "stream",
+            "signal-share-compute",
             "signal-server",
             "signal-downloads",
             "reap-server",
+            "reap-share-compute",
             "reap-downloads",
             "flush-conversations",
             "flush-folders",

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -95,6 +95,37 @@ struct ShareComputeTests {
         manager.finishShutdown()
     }
 
+    @Test("A surviving model child is reaped after its supervisor exits")
+    @MainActor
+    func orphanedProcessGroupIsReaped() async throws {
+        let executable = FileManager.default.temporaryDirectory
+            .appendingPathComponent("share-compute-orphan-\(UUID().uuidString).sh")
+        defer { try? FileManager.default.removeItem(at: executable) }
+        try Data("#!/bin/sh\nsleep 60 &\nexit 0\n".utf8).write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: executable.path
+        )
+
+        let server = ServerManager(testingState: .idle, binaryPath: executable)
+        let manager = ShareComputeManager(server: server)
+        await manager.join(
+            model: ShareComputeModel.supported[0],
+            worker: "orphan-test",
+            providerKey: "test-key"
+        )
+        for _ in 0..<200 {
+            if manager.activeModel == nil { break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(manager.activeModel == nil)
+        if manager.activeModel == nil {
+            let lease = try await server.prepareForCommunityBenchmark()
+            server.finishCommunityBenchmark(lease)
+        }
+        manager.finishShutdown()
+    }
+
     @Test("A replacement join inherits the original restore model")
     func replacementInheritsRestoreAlias() {
         #expect(ShareComputeManager.restoreAliasForJoin(

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -40,16 +40,59 @@ struct ShareComputeTests {
     @Test("Provider key uses stdin and never argv")
     func providerKeyTransport() {
         let secret = "qsppk-never-in-argv"
-        let arguments = ShareComputeManager.arguments(
+        let request = ShareComputeManager.spawnRequest(
             model: ShareComputeModel.supported[0],
             worker: "Mini / west",
             session: String(repeating: "a", count: 32),
-            hasProviderKey: true
+            providerKey: secret,
+            environment: ["PATH": "/usr/bin"]
         )
-        #expect(arguments.contains("--provider-key-stdin"))
-        #expect(arguments.contains("--reregister"))
-        #expect(!arguments.contains(where: { $0.contains(secret) }))
-        #expect(!arguments.contains("--provider-key"))
+        #expect(request.arguments.contains("--provider-key-stdin"))
+        #expect(request.arguments.contains("--reregister"))
+        #expect(!request.arguments.contains(where: { $0.contains(secret) }))
+        #expect(!request.arguments.contains("--provider-key"))
+        #expect(!request.environment.contains(where: { key, value in
+            key.contains(secret) || value.contains(secret)
+        }))
+        #expect(request.standardInput == Data((secret + "\n").utf8))
+    }
+
+    @Test("A stale join cannot erase the next join's state")
+    @MainActor
+    func staleJoinOwnership() async throws {
+        let executable = FileManager.default.temporaryDirectory
+            .appendingPathComponent("share-compute-runner-\(UUID().uuidString).sh")
+        defer { try? FileManager.default.removeItem(at: executable) }
+        try Data("#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 60; done\n".utf8)
+            .write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: executable.path
+        )
+
+        let server = ServerManager(testingState: .idle, binaryPath: executable)
+        let blocker = try await server.prepareForCommunityBenchmark()
+        let manager = ShareComputeManager(server: server)
+        let firstModel = ShareComputeModel.supported[0]
+        let secondModel = ShareComputeModel.supported[1]
+
+        let staleJoin = Task { @MainActor in
+            await manager.join(model: firstModel, worker: "first", providerKey: "first-key")
+        }
+        for _ in 0..<10 { await Task.yield() }
+        manager.leave()
+
+        let currentJoin = Task { @MainActor in
+            await manager.join(model: secondModel, worker: "second", providerKey: "second-key")
+        }
+        for _ in 0..<10 { await Task.yield() }
+        server.finishCommunityBenchmark(blocker)
+
+        await staleJoin.value
+        await currentJoin.value
+        #expect(manager.activeModel == secondModel)
+        #expect(manager.state == .starting)
+        manager.finishShutdown()
     }
 
     @Test("Cache paths follow the HOME inherited by the provider child")

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -28,6 +28,10 @@ struct ShareComputeTests {
         let snapshot = try JSONDecoder().decode(ShareComputeStatusSnapshot.self, from: data)
         #expect(ShareComputeManager.state(for: snapshot) == .online)
         #expect(snapshot.inflight == 2)
+
+        let stoppedData = Data(#"{"schema_version":1,"session":"0123456789abcdef0123456789abcdef","phase":"stopped","catalog_id":"qwen3.8-27b","alias":"qwen3.8-27b-4bit","worker":"Mini","updated_at":3}"#.utf8)
+        let stopped = try JSONDecoder().decode(ShareComputeStatusSnapshot.self, from: stoppedData)
+        #expect(ShareComputeManager.state(for: stopped) == .stopping)
     }
 
     @Test("Disabling the gate routes the hidden destination to Chat")
@@ -82,6 +86,8 @@ struct ShareComputeTests {
             await manager.join(model: firstModel, worker: "first", providerKey: "first-key")
         }
         for _ in 0..<10 { await Task.yield() }
+        await manager.join(model: firstModel, worker: "first", providerKey: "first-key")
+        #expect(manager.state == .preparing)
         manager.leave()
 
         let currentJoin = Task { @MainActor in

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -55,6 +55,8 @@ struct ShareComputeTests {
             key.contains(secret) || value.contains(secret)
         }))
         #expect(request.standardInput == Data((secret + "\n").utf8))
+        #expect(ShareComputeManager.isValidProviderKey(String(repeating: "a", count: 4_095)))
+        #expect(!ShareComputeManager.isValidProviderKey(String(repeating: "🚀", count: 1_024)))
     }
 
     @Test("A stale join cannot erase the next join's state")

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -95,6 +95,18 @@ struct ShareComputeTests {
         manager.finishShutdown()
     }
 
+    @Test("A replacement join inherits the original restore model")
+    func replacementInheritsRestoreAlias() {
+        #expect(ShareComputeManager.restoreAliasForJoin(
+            pending: "previous-model",
+            currentlyServing: nil
+        ) == "previous-model")
+        #expect(ShareComputeManager.restoreAliasForJoin(
+            pending: nil,
+            currentlyServing: "current-model"
+        ) == "current-model")
+    }
+
     @Test("Cache paths follow the HOME inherited by the provider child")
     func runtimeHome() {
         let fallback = URL(fileURLWithPath: "/fallback", isDirectory: true)

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+@Suite("Share Compute")
+struct ShareComputeTests {
+    @Test("Feature is opt-in")
+    func featureGate() {
+        let suite = "ShareComputeTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        #expect(!ShareComputeFeatureConfig.isEnabled(in: defaults))
+        defaults.set(true, forKey: ShareComputeFeatureConfig.enabledKey)
+        #expect(ShareComputeFeatureConfig.isEnabled(in: defaults))
+    }
+
+    @Test("Worker labels match the provider's safe grammar")
+    func workerSanitizing() {
+        #expect(ShareComputeModel.sanitizedWorker("  Mini / west 🚀 ") == "Miniwest")
+        #expect(ShareComputeModel.sanitizedWorker("///") == "node")
+        #expect(ShareComputeModel.sanitizedWorker(String(repeating: "a", count: 80)).count == 64)
+    }
+
+    @Test("Desktop status maps without exposing a credential field")
+    @MainActor
+    func statusMapping() throws {
+        let data = Data(#"{"schema_version":1,"session":"0123456789abcdef0123456789abcdef","phase":"online","catalog_id":"qwen3.8-27b","alias":"qwen3.8-27b-4bit","worker":"Mini","node_id":"node-1","heartbeat_interval_s":10,"inflight":2,"connected_at":1,"updated_at":2}"#.utf8)
+        let snapshot = try JSONDecoder().decode(ShareComputeStatusSnapshot.self, from: data)
+        #expect(ShareComputeManager.state(for: snapshot) == .online)
+        #expect(snapshot.inflight == 2)
+    }
+
+    @Test("Disabling the gate routes the hidden destination to Chat")
+    @MainActor
+    func routeRecovery() {
+        #expect(ContentView.sectionAfterShareComputeGateChange(current: .shareCompute, enabled: false) == .chat)
+        #expect(ContentView.sectionAfterShareComputeGateChange(current: .shareCompute, enabled: true) == .shareCompute)
+    }
+
+    @Test("Provider key uses stdin and never argv")
+    func providerKeyTransport() {
+        let secret = "qsppk-never-in-argv"
+        let arguments = ShareComputeManager.arguments(
+            model: ShareComputeModel.supported[0],
+            worker: "Mini / west",
+            session: String(repeating: "a", count: 32),
+            hasProviderKey: true
+        )
+        #expect(arguments.contains("--provider-key-stdin"))
+        #expect(arguments.contains("--reregister"))
+        #expect(!arguments.contains(where: { $0.contains(secret) }))
+        #expect(!arguments.contains("--provider-key"))
+    }
+
+    @Test("Cache paths follow the HOME inherited by the provider child")
+    func runtimeHome() {
+        let fallback = URL(fileURLWithPath: "/fallback", isDirectory: true)
+        #expect(ShareComputeManager.runtimeHomeURL(
+            environment: ["HOME": "/private/tmp/provider-home"],
+            fallback: fallback
+        ).path == "/private/tmp/provider-home")
+        #expect(ShareComputeManager.runtimeHomeURL(
+            environment: ["HOME": "relative"],
+            fallback: fallback
+        ) == fallback)
+    }
+
+    @Test("Status reads are bounded")
+    func boundedStatusRead() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("share-compute-status-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data(repeating: 0x61, count: 65_537).write(to: url)
+        #expect(ShareComputeManager.loadStatus(at: url) == nil)
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -107,6 +107,32 @@ struct ShareComputeTests {
         ) == "current-model")
     }
 
+    @Test("Registration proof is non-secret and bound to model, alias, and worker")
+    func registrationProof() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("share-compute-registration-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let model = ShareComputeModel.supported[0]
+        let url = ShareComputeManager.registrationURL(catalogID: model.catalogID, home: home)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(#"{"schema_version":1,"model":"qwen3.8-27b","alias":"qwen3.8-27b-4bit","worker":"Miniwest"}"#.utf8)
+            .write(to: url)
+
+        #expect(ShareComputeManager.registrationMatches(
+            model: model,
+            worker: "Mini / west",
+            home: home
+        ))
+        #expect(!ShareComputeManager.registrationMatches(
+            model: model,
+            worker: "Other Mac",
+            home: home
+        ))
+    }
+
     @Test("Cache paths follow the HOME inherited by the provider child")
     func runtimeHome() {
         let fallback = URL(fileURLWithPath: "/fallback", isDirectory: true)

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -147,10 +147,15 @@ struct ShareComputeTests {
         defer { try? FileManager.default.removeItem(at: home) }
         let model = ShareComputeModel.supported[0]
         let url = ShareComputeManager.registrationURL(catalogID: model.catalogID, home: home)
+        let credentialURL = ShareComputeManager.credentialCacheURL(
+            catalogID: model.catalogID,
+            home: home
+        )
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
+        try Data("opaque credential cache".utf8).write(to: credentialURL)
         try Data(#"{"schema_version":1,"model":"qwen3.8-27b","alias":"qwen3.8-27b-4bit","worker":"Miniwest"}"#.utf8)
             .write(to: url)
 
@@ -162,6 +167,12 @@ struct ShareComputeTests {
         #expect(!ShareComputeManager.registrationMatches(
             model: model,
             worker: "Other Mac",
+            home: home
+        ))
+        try FileManager.default.removeItem(at: credentialURL)
+        #expect(!ShareComputeManager.registrationMatches(
+            model: model,
+            worker: "Mini / west",
             home: home
         ))
     }

--- a/docs/engineering/decisions/2026-09-08-share-compute-desktop-boundary.md
+++ b/docs/engineering/decisions/2026-09-08-share-compute-desktop-boundary.md
@@ -1,0 +1,43 @@
+# Share Compute desktop boundary
+
+Rapid Desktop exposes QuickSilver provider mode behind the experimental
+**Share Compute** gate. Enabling the gate only adds the workspace; connecting,
+downloading a supported model, and joining the pool remain separate explicit
+actions.
+
+## Process and credential boundary
+
+- Desktop launches the bundled `rapid-mlx share … --quicksilver` supervisor in
+  its own process group.
+- A first-run `qsppk-` provider key is sent as one bounded line over the
+  child's stdin. It is never placed in argv, the child environment, Desktop
+  preferences, or a Desktop-owned file.
+- Python owns the existing `0600` QuickSilver node cache. Swift deliberately
+  checks only whether the fixed catalog cache path exists; it never decodes
+  the cached share credential.
+- Python publishes a field-whitelisted, credential-scanned, atomically replaced
+  `0600` status snapshot under `~/.rapid-mlx/quicksilver/`. Desktop consumes
+  that snapshot instead of parsing human log text.
+
+## Model residency and teardown
+
+Share Compute takes the same exclusive large-model lease used by local
+benchmarks. The embedded chat/media server is fully stopped before the pool
+supervisor starts, so two large models cannot compete for unified memory. On
+explicit stop or provider failure, Desktop releases the lease and restores the
+previous local model. Disabling the experimental gate invalidates an in-flight
+join as well as stopping an established session.
+
+App termination signals Share Compute, the embedded server, and downloads
+before waiting on any of them. The pool supervisor has a bounded graceful exit
+followed by process-group SIGKILL, and its nested serve process also carries the
+Desktop parent watchdog.
+
+## Deliberate initial scope
+
+The first Desktop surface supports the three catalog mappings declared by the
+QuickSilver provider implementation and requires weights to be downloaded
+before joining. It does not install QuickSilver's login LaunchAgent. Background
+login service ownership needs cross-process residency arbitration with Desktop;
+shipping the CLI service toggle directly would permit a hidden pool model to
+contend with a later Desktop model.

--- a/docs/engineering/decisions/2026-09-08-share-compute-desktop-boundary.md
+++ b/docs/engineering/decisions/2026-09-08-share-compute-desktop-boundary.md
@@ -12,9 +12,10 @@ actions.
 - A first-run `qsppk-` provider key is sent as one bounded line over the
   child's stdin. It is never placed in argv, the child environment, Desktop
   preferences, or a Desktop-owned file.
-- Python owns the existing `0600` QuickSilver node cache. Swift deliberately
-  checks only whether the fixed catalog cache path exists; it never decodes
-  the cached share credential.
+- Python owns the existing `0600` QuickSilver node cache. After a successful
+  Desktop registration it also writes a separate non-secret, `0600` marker
+  bound to model, alias, and worker. Swift decodes only that bounded marker;
+  it never opens or decodes the node cache containing the share credential.
 - Python publishes a field-whitelisted, credential-scanned, atomically replaced
   `0600` status snapshot under `~/.rapid-mlx/quicksilver/`. Desktop consumes
   that snapshot instead of parsing human log text.

--- a/tests/test_share_quicksilver.py
+++ b/tests/test_share_quicksilver.py
@@ -1533,7 +1533,7 @@ def test_run_share_first_run_registers_caches_and_prints_keyless_banner(capsys):
         ),
         patch.object(qs, "_Heartbeat", return_value=_fake_heartbeat_class()),
     )
-    args = _make_args(provider_key=PROVIDER_KEY)
+    args = _make_args(provider_key=PROVIDER_KEY, desktop_session="a" * 32)
     with _enter(*ctxs):
         qs.run_share(args)
 
@@ -1874,7 +1874,7 @@ def test_run_share_tunnel_drop_reconnects_then_dies_on_401():
         patch.object(qs, "_Heartbeat", return_value=_fake_heartbeat_class()),
     )
     with pytest.raises(SystemExit) as ei, _enter(*ctxs):
-        qs.run_share(_make_args())
+        qs.run_share(_make_args(desktop_session="b" * 32))
     assert ei.value.code == 1
     assert sleeps == [1.0]  # one backoff between attempts
 
@@ -1897,7 +1897,7 @@ def test_run_share_ws_1008_close_is_terminal_no_spin():
         patch.object(qs, "_Heartbeat", return_value=_fake_heartbeat_class()),
     )
     with pytest.raises(SystemExit) as ei, _enter(*ctxs):
-        qs.run_share(_make_args())
+        qs.run_share(_make_args(desktop_session="c" * 32))
     assert ei.value.code == 1
     assert len(made) == 1  # no retry spin on a post-upgrade rejection
 
@@ -1965,7 +1965,7 @@ def test_run_share_server_echoed_share_key_is_rejected_and_never_printed(capsys)
         patch.object(qs, "_open", lambda req, timeout=None: _FakeResp(leaky)),
         pytest.raises(SystemExit) as exc,
     ):
-        qs.run_share(_make_args(provider_key=PROVIDER_KEY))
+        qs.run_share(_make_args(provider_key=PROVIDER_KEY, desktop_session="d" * 32))
     assert exc.value.code == 2
     out = capsys.readouterr()
     combined = out.out + out.err
@@ -2022,7 +2022,7 @@ def test_run_share_heartbeat_fatal_exits_nonzero(capsys):
         patch.object(qs, "_Heartbeat", return_value=hb),
     )
     with pytest.raises(SystemExit) as ei, _enter(*ctxs):
-        qs.run_share(_make_args())
+        qs.run_share(_make_args(desktop_session="e" * 32))
     assert ei.value.code == 1
     assert "--reregister" in capsys.readouterr().err
 
@@ -2438,6 +2438,10 @@ def test_provider_key_stdin_is_bounded_and_exclusive(monkeypatch):
     with pytest.raises(qs.QuickSilverError, match="missing a newline"):
         qs._resolve_provider_key(_make_args(provider_key_stdin=True))
 
+    monkeypatch.setattr(qs.sys, "stdin", io.StringIO("   \n"))
+    with pytest.raises(qs.QuickSilverError, match="empty provider key"):
+        qs._resolve_provider_key(_make_args(provider_key_stdin=True))
+
 
 def test_desktop_status_is_private_atomic_whitelisted_and_secret_free(
     monkeypatch, tmp_path
@@ -2463,6 +2467,20 @@ def test_desktop_status_is_private_atomic_whitelisted_and_secret_free(
     assert payload["inflight"] == 1
     assert stat.S_IMODE(status.path.stat().st_mode) == 0o600
     assert not list(status.path.parent.glob(f"{status.path.name}.tmp-*"))
+    prior_mtime = status.path.stat().st_mtime_ns
+    status.publish(
+        "online",
+        catalog_id="qwen3.8-27b",
+        alias="qwen3.8-27b-4bit",
+        worker="studio",
+        node_id="node-1",
+        payout_account="acct-1",
+        inflight=1,
+    )
+    assert status.path.stat().st_mtime_ns == prior_mtime
+
+    with pytest.raises(qs.QuickSilverError, match="invalid Desktop provider phase"):
+        status.publish("invented")
 
     with pytest.raises(
         qs.QuickSilverError, match="invalid Desktop provider status field"
@@ -2472,6 +2490,36 @@ def test_desktop_status_is_private_atomic_whitelisted_and_secret_free(
     qs._register_secret(SHARE_KEY)
     with pytest.raises(qs.QuickSilverError, match="credential"):
         status.publish("error", message=f"bad {SHARE_KEY}")
+
+
+def test_desktop_status_write_failure_is_actionable_and_cleans_tmp():
+    status = qs._DesktopStatus("b" * 32)
+    with (
+        patch.object(qs.os, "replace", side_effect=OSError("disk full")),
+        pytest.raises(qs.QuickSilverError, match="could not publish"),
+    ):
+        status.publish("online")
+    assert not list(status.path.parent.glob(f"{status.path.name}.tmp-*"))
+
+
+def test_desktop_registration_write_failure_is_actionable_and_cleans_tmp():
+    with (
+        patch.object(qs.os, "replace", side_effect=OSError("disk full")),
+        pytest.raises(qs.QuickSilverError, match="registration marker"),
+    ):
+        qs._save_desktop_registration(
+            "qwen3.6-35b", alias="qwen3.6-35b", worker="test-worker"
+        )
+    assert not list(qs._cache_dir().glob("*.registration.json.tmp-*"))
+
+    with (
+        patch.object(qs.os, "replace", side_effect=OSError("disk full")),
+        patch.object(qs.os, "unlink", side_effect=OSError("cleanup failed")),
+        pytest.raises(qs.QuickSilverError, match="registration marker"),
+    ):
+        qs._save_desktop_registration(
+            "qwen3.6-35b", alias="qwen3.6-35b", worker="test-worker"
+        )
 
 
 @pytest.mark.parametrize("session", ["short", "g" * 32, "a" * 31 + "/"])
@@ -2725,7 +2773,7 @@ def test_run_share_port_health_and_auth_startup_failures(capsys):
         patch.object(share_cli, "_pick_port", side_effect=RuntimeError("no port")),
         pytest.raises(SystemExit) as exc,
     ):
-        qs.run_share(_make_args())
+        qs.run_share(_make_args(desktop_session="f" * 32))
     assert exc.value.code == 1 and "no port" in capsys.readouterr().err
 
     for failed, expected in (
@@ -2796,7 +2844,7 @@ def test_run_share_propagates_serve_exit_and_resets_after_healthy_connection():
         patch.object(qs, "_Heartbeat", return_value=_fake_heartbeat_class()),
     )
     with pytest.raises(SystemExit) as exc, _enter(*ctxs):
-        qs.run_share(_make_args())
+        qs.run_share(_make_args(desktop_session="1" * 32))
     assert exc.value.code == 7
 
     healthy_drop = _fake_tunnel(closed=True)

--- a/tests/test_share_quicksilver.py
+++ b/tests/test_share_quicksilver.py
@@ -26,7 +26,7 @@ import threading
 import urllib.error
 import urllib.parse
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -809,6 +809,29 @@ def test_cache_save_never_persists_unexpected_response_fields(tmp_path):
     assert "secret-token-xyz" not in raw
     assert "provider_key" not in raw and "api_token" not in raw
     assert qs._load_cache("qwen3.6-35b", "qwen3.6-35b")["share_key"] == SHARE_KEY
+
+
+def test_desktop_registration_marker_is_nonsecret_worker_bound_and_invalidated():
+    payload = dict(_register_payload(), alias="qwen3.6-35b")
+    qs._save_cache("qwen3.6-35b", payload)
+    marker = qs._save_desktop_registration(
+        "qwen3.6-35b", alias="qwen3.6-35b", worker="test-worker"
+    )
+    raw = marker.read_text(encoding="utf-8")
+    assert json.loads(raw) == {
+        "schema_version": 1,
+        "model": "qwen3.6-35b",
+        "alias": "qwen3.6-35b",
+        "worker": "test-worker",
+    }
+    assert PROVIDER_KEY not in raw and SHARE_KEY not in raw
+    assert stat.S_IMODE(marker.stat().st_mode) == 0o600
+
+    qs._save_cache(
+        "qwen3.6-35b",
+        dict(payload, worker="different-worker"),
+    )
+    assert not marker.exists()
 
 
 def test_cache_alias_mismatch_is_not_reused(tmp_path):
@@ -2455,6 +2478,21 @@ def test_desktop_status_is_private_atomic_whitelisted_and_secret_free(
 def test_desktop_status_rejects_path_shaped_session_ids(session):
     with pytest.raises(qs.QuickSilverError, match="invalid Desktop provider session"):
         qs._DesktopStatus(session)
+
+
+def test_clean_exit_ignores_final_desktop_status_write_failure():
+    status = MagicMock()
+    status.phase = "online"
+    status.publish.side_effect = [None, qs.QuickSilverError("disk full")]
+    with (
+        patch.object(qs._DesktopStatus, "from_args", return_value=status),
+        patch.object(qs, "_run_share"),
+    ):
+        qs.run_share(_make_args(desktop_session="a" * 32))
+    assert status.publish.call_args_list == [
+        call("preparing"),
+        call("stopped"),
+    ]
 
 
 def test_open_uses_the_no_redirect_opener():

--- a/tests/test_share_quicksilver.py
+++ b/tests/test_share_quicksilver.py
@@ -64,6 +64,8 @@ def _make_args(**overrides) -> argparse.Namespace:
         chat_frontend=None,
         quicksilver=True,
         provider_key=None,
+        provider_key_stdin=False,
+        desktop_session=None,
         quicksilver_model=None,
         worker="test-worker",
         reregister=False,
@@ -2393,6 +2395,63 @@ def test_provider_key_interactive_prompt(monkeypatch):
         pytest.raises(qs.QuickSilverError, match="empty provider key"),
     ):
         qs._resolve_provider_key(_make_args())
+
+
+def test_provider_key_stdin_is_bounded_and_exclusive(monkeypatch):
+    monkeypatch.setattr(qs.sys, "stdin", io.StringIO(f" {PROVIDER_KEY} \n"))
+    assert qs._resolve_provider_key(_make_args(provider_key_stdin=True)) == PROVIDER_KEY
+
+    monkeypatch.setattr(qs.sys, "stdin", io.StringIO(f"{PROVIDER_KEY}\n"))
+    with pytest.raises(qs.QuickSilverError, match="cannot be combined"):
+        qs._resolve_provider_key(
+            _make_args(provider_key_stdin=True, provider_key=PROVIDER_KEY)
+        )
+
+    monkeypatch.setattr(qs.sys, "stdin", io.StringIO("x" * 4097 + "\n"))
+    with pytest.raises(qs.QuickSilverError, match="too long"):
+        qs._resolve_provider_key(_make_args(provider_key_stdin=True))
+
+    monkeypatch.setattr(qs.sys, "stdin", io.StringIO(PROVIDER_KEY))
+    with pytest.raises(qs.QuickSilverError, match="missing a newline"):
+        qs._resolve_provider_key(_make_args(provider_key_stdin=True))
+
+
+def test_desktop_status_is_private_atomic_whitelisted_and_secret_free():
+    session = "a" * 32
+    status = qs._DesktopStatus(session)
+    assert status.path.parent == qs._cache_dir()
+
+    status.publish(
+        "online",
+        catalog_id="qwen3.8-27b",
+        alias="qwen3.8-27b-4bit",
+        worker="studio",
+        node_id="node-1",
+        payout_account="acct-1",
+        inflight=1,
+    )
+    payload = json.loads(status.path.read_text())
+    assert payload["schema_version"] == 1
+    assert payload["session"] == session
+    assert payload["phase"] == "online"
+    assert payload["inflight"] == 1
+    assert stat.S_IMODE(status.path.stat().st_mode) == 0o600
+    assert not list(status.path.parent.glob(f"{status.path.name}.tmp-*"))
+
+    with pytest.raises(
+        qs.QuickSilverError, match="invalid Desktop provider status field"
+    ):
+        status.publish("online", share_key=SHARE_KEY)
+
+    qs._register_secret(SHARE_KEY)
+    with pytest.raises(qs.QuickSilverError, match="credential"):
+        status.publish("error", message=f"bad {SHARE_KEY}")
+
+
+@pytest.mark.parametrize("session", ["short", "g" * 32, "a" * 31 + "/"])
+def test_desktop_status_rejects_path_shaped_session_ids(session):
+    with pytest.raises(qs.QuickSilverError, match="invalid Desktop provider session"):
+        qs._DesktopStatus(session)
 
 
 def test_open_uses_the_no_redirect_opener():

--- a/tests/test_share_quicksilver.py
+++ b/tests/test_share_quicksilver.py
@@ -2416,7 +2416,10 @@ def test_provider_key_stdin_is_bounded_and_exclusive(monkeypatch):
         qs._resolve_provider_key(_make_args(provider_key_stdin=True))
 
 
-def test_desktop_status_is_private_atomic_whitelisted_and_secret_free():
+def test_desktop_status_is_private_atomic_whitelisted_and_secret_free(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(qs, "_cache_dir", lambda: tmp_path)
     session = "a" * 32
     status = qs._DesktopStatus(session)
     assert status.path.parent == qs._cache_dir()

--- a/tests/test_share_quicksilver.py
+++ b/tests/test_share_quicksilver.py
@@ -2421,25 +2421,36 @@ def test_provider_key_interactive_prompt(monkeypatch):
 
 
 def test_provider_key_stdin_is_bounded_and_exclusive(monkeypatch):
-    monkeypatch.setattr(qs.sys, "stdin", io.StringIO(f" {PROVIDER_KEY} \n"))
+    def stdin(value: bytes):
+        return io.TextIOWrapper(io.BytesIO(value), encoding="utf-8")
+
+    monkeypatch.setattr(qs.sys, "stdin", stdin(f" {PROVIDER_KEY} \n".encode()))
     assert qs._resolve_provider_key(_make_args(provider_key_stdin=True)) == PROVIDER_KEY
 
-    monkeypatch.setattr(qs.sys, "stdin", io.StringIO(f"{PROVIDER_KEY}\n"))
+    monkeypatch.setattr(qs.sys, "stdin", stdin(f"{PROVIDER_KEY}\n".encode()))
     with pytest.raises(qs.QuickSilverError, match="cannot be combined"):
         qs._resolve_provider_key(
             _make_args(provider_key_stdin=True, provider_key=PROVIDER_KEY)
         )
 
-    monkeypatch.setattr(qs.sys, "stdin", io.StringIO("x" * 4097 + "\n"))
+    monkeypatch.setattr(qs.sys, "stdin", stdin(("x" * 4097 + "\n").encode()))
     with pytest.raises(qs.QuickSilverError, match="too long"):
         qs._resolve_provider_key(_make_args(provider_key_stdin=True))
 
-    monkeypatch.setattr(qs.sys, "stdin", io.StringIO(PROVIDER_KEY))
+    monkeypatch.setattr(qs.sys, "stdin", stdin(PROVIDER_KEY.encode()))
     with pytest.raises(qs.QuickSilverError, match="missing a newline"):
         qs._resolve_provider_key(_make_args(provider_key_stdin=True))
 
-    monkeypatch.setattr(qs.sys, "stdin", io.StringIO("   \n"))
+    monkeypatch.setattr(qs.sys, "stdin", stdin(b"   \n"))
     with pytest.raises(qs.QuickSilverError, match="empty provider key"):
+        qs._resolve_provider_key(_make_args(provider_key_stdin=True))
+
+    monkeypatch.setattr(qs.sys, "stdin", stdin(("🚀" * 1024 + "\n").encode()))
+    with pytest.raises(qs.QuickSilverError, match="too long"):
+        qs._resolve_provider_key(_make_args(provider_key_stdin=True))
+
+    monkeypatch.setattr(qs.sys, "stdin", stdin(b"\xff\n"))
+    with pytest.raises(qs.QuickSilverError, match="valid UTF-8"):
         qs._resolve_provider_key(_make_args(provider_key_stdin=True))
 
 

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -985,6 +985,24 @@ def register(subparsers: argparse._SubParsersAction) -> None:
             "to other local users via ps. Never stored on disk."
         ),
     )
+    # Desktop's Share Compute surface must never put the account credential in
+    # argv (visible through ``ps``) or the child environment. The app writes one
+    # bounded line to stdin after spawn and closes the pipe. Hidden because it
+    # is an integration transport, not a second human-facing key workflow.
+    p.add_argument(
+        "--provider-key-stdin",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    # Opaque 32-hex session selected by Desktop. QuickSilver derives the
+    # status-file path inside its private 0700 cache directory, so an argv
+    # value can never redirect atomic status writes onto an arbitrary path.
+    p.add_argument(
+        "--desktop-session",
+        type=str,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
     p.add_argument(
         "--quicksilver-model",
         type=str,

--- a/vllm_mlx/share/quicksilver.py
+++ b/vllm_mlx/share/quicksilver.py
@@ -300,6 +300,40 @@ def _cache_path(catalog_id: str) -> Path:
     return _cache_dir() / f"{catalog_id}.json"
 
 
+def _desktop_registration_path(catalog_id: str) -> Path:
+    """Non-secret proof Desktop can inspect without reading the node cache."""
+    return _cache_path(catalog_id).with_suffix(".registration.json")
+
+
+def _save_desktop_registration(catalog_id: str, *, alias: str, worker: str) -> Path:
+    path = _desktop_registration_path(catalog_id)
+    tmp = path.with_name(f"{path.name}.tmp-{secrets.token_hex(4)}")
+    data = json.dumps(
+        {
+            "schema_version": 1,
+            "model": catalog_id,
+            "alias": alias,
+            "worker": worker,
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+    try:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp, path)
+        path.chmod(0o600)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise QuickSilverError(
+            f"could not write Desktop registration marker for {catalog_id}: {exc}"
+        ) from None
+    return path
+
+
 def _load_cache(
     catalog_id: str, alias: str, worker: str | None = None
 ) -> dict[str, Any] | None:
@@ -358,12 +392,17 @@ def _load_cache(
 
 def _save_cache(catalog_id: str, payload: dict[str, Any]) -> Path:
     path = _cache_path(catalog_id)
+    registration_path = _desktop_registration_path(catalog_id)
     tmp = path.with_name(f"{path.name}.tmp-{secrets.token_hex(4)}")
     # Whitelist, not passthrough — a server response carrying an extra
     # "provider_key_echo"-style field must never survive to disk.
     allowed = {k: payload[k] for k in _CACHE_ALLOWED_KEYS if k in payload}
     data = json.dumps(allowed, indent=2, sort_keys=True).encode("utf-8")
     try:
+        # Any writer outside the Desktop flow (including a CLI registration
+        # for another worker) invalidates Desktop's non-secret proof first.
+        # A crash can therefore cause an extra key prompt, never false reuse.
+        registration_path.unlink(missing_ok=True)
         fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         with os.fdopen(fd, "wb") as f:
             f.write(data)
@@ -1189,7 +1228,8 @@ def run_share(args: argparse.Namespace) -> None:
         raise
     else:
         if desktop_status is not None:
-            desktop_status.publish("stopped")
+            with contextlib.suppress(QuickSilverError):
+                desktop_status.publish("stopped")
 
 
 def _run_share(
@@ -1234,6 +1274,12 @@ def _run_share(
         _validate_wire_urls(cache, api_base, source="register response")
         interval = _resolve_heartbeat_interval(cache, source="register response")
         _save_cache(catalog_id, cache)
+        if desktop_status is not None:
+            _save_desktop_registration(
+                catalog_id,
+                alias=serve_alias,
+                worker=worker,
+            )
         print(
             _redact(
                 f"Node registered: {cache['node_id']} "

--- a/vllm_mlx/share/quicksilver.py
+++ b/vllm_mlx/share/quicksilver.py
@@ -719,12 +719,17 @@ def _resolve_provider_key(args: argparse.Namespace) -> str:
         # Bound the read itself, not only the post-read validation: stdin is a
         # Desktop-owned pipe, but a malformed/injected writer must not pin an
         # unbounded allocation in the long-lived provider supervisor.
-        value = sys.stdin.readline(_PROVIDER_KEY_STDIN_MAX_BYTES + 1)
-        if len(value) > _PROVIDER_KEY_STDIN_MAX_BYTES or not value.endswith("\n"):
+        value = sys.stdin.buffer.readline(_PROVIDER_KEY_STDIN_MAX_BYTES + 1)
+        if len(value) > _PROVIDER_KEY_STDIN_MAX_BYTES or not value.endswith(b"\n"):
             raise QuickSilverError(
                 "provider key from stdin is missing a newline or too long"
             )
-        key = value.strip()
+        try:
+            key = value.decode("utf-8").strip()
+        except UnicodeDecodeError:
+            raise QuickSilverError(
+                "provider key from stdin is not valid UTF-8"
+            ) from None
         if not key:
             raise QuickSilverError("empty provider key — nothing to register with.")
         return key

--- a/vllm_mlx/share/quicksilver.py
+++ b/vllm_mlx/share/quicksilver.py
@@ -135,6 +135,45 @@ _CACHE_REQUIRED_KEYS = _WIRE_REQUIRED_KEYS + ("heartbeat_interval_s", "alias")
 # cache).
 _CACHE_ALLOWED_KEYS = _CACHE_REQUIRED_KEYS + ("payout_account", "api_base", "worker")
 
+# Desktop provider-session bridge. The session id is an opaque capability for
+# locating one non-secret status snapshot; keeping the path under the existing
+# 0700 QuickSilver directory avoids accepting an arbitrary write target from
+# argv. Schema fields are deliberately enumerated so neither credential can
+# drift into the file through a future cache or exception refactor.
+_DESKTOP_SESSION_LENGTH = 32
+_DESKTOP_SESSION_CHARS = frozenset("0123456789abcdef")
+_DESKTOP_STATUS_ALLOWED_KEYS = frozenset(
+    {
+        "schema_version",
+        "session",
+        "phase",
+        "catalog_id",
+        "alias",
+        "worker",
+        "node_id",
+        "payout_account",
+        "heartbeat_interval_s",
+        "inflight",
+        "connected_at",
+        "message",
+        "updated_at",
+    }
+)
+_DESKTOP_STATUS_PHASES = frozenset(
+    {
+        "preparing",
+        "registering",
+        "starting",
+        "warming",
+        "connecting",
+        "online",
+        "reconnecting",
+        "stopped",
+        "error",
+    }
+)
+_PROVIDER_KEY_STDIN_MAX_BYTES = 4096
+
 # Socket timeout for one §3.3 beat. Bounded so ``_Heartbeat.stop()``
 # can join the thread faster than a hung heartbeat can block; the beat
 # is best-effort (a missed one never drops the node) so a short ceiling
@@ -146,6 +185,71 @@ class QuickSilverError(Exception):
     """Fatal, user-facing failure. Message must be redacted by the
     printer (:func:`run_share` catches and scrubs) — never trust an
     already-rendered string from deeper down."""
+
+
+class _DesktopStatus:
+    """Atomic, non-secret lifecycle snapshots consumed by Rapid Desktop."""
+
+    def __init__(self, session: str) -> None:
+        normalized = session.strip().lower()
+        if len(normalized) != _DESKTOP_SESSION_LENGTH or any(
+            ch not in _DESKTOP_SESSION_CHARS for ch in normalized
+        ):
+            raise QuickSilverError("invalid Desktop provider session id")
+        self.session = normalized
+        self.path = _cache_dir() / f"desktop-status-{normalized}.json"
+        self.phase: str | None = None
+        self._last_content: bytes | None = None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> _DesktopStatus | None:
+        session = getattr(args, "desktop_session", None)
+        return cls(str(session)) if session else None
+
+    def publish(self, phase: str, **values: Any) -> None:
+        if phase not in _DESKTOP_STATUS_PHASES:
+            raise QuickSilverError(f"invalid Desktop provider phase: {phase!r}")
+        payload: dict[str, Any] = {
+            "schema_version": 1,
+            "session": self.session,
+            "phase": phase,
+        }
+        for key, value in values.items():
+            if key not in _DESKTOP_STATUS_ALLOWED_KEYS:
+                raise QuickSilverError(f"invalid Desktop provider status field: {key}")
+            if value is not None:
+                payload[key] = value
+        # A caller may pass a server-controlled message only after _redact.
+        # Defense in depth: reject a snapshot containing either live secret
+        # even if a future call site forgets to scrub it first.
+        serialized_without_time = json.dumps(
+            payload, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        if any(
+            secret.encode("utf-8") in serialized_without_time for secret in _SECRETS
+        ):
+            raise QuickSilverError("refusing to write a credential to Desktop status")
+        if serialized_without_time == self._last_content:
+            return
+        payload["updated_at"] = time.time()
+        data = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        tmp = self.path.with_name(f"{self.path.name}.tmp-{secrets.token_hex(4)}")
+        try:
+            fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(data)
+            os.replace(tmp, self.path)
+            self.path.chmod(0o600)
+        except OSError as exc:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise QuickSilverError(
+                f"could not publish Desktop provider status: {exc}"
+            ) from None
+        self.phase = phase
+        self._last_content = serialized_without_time
 
 
 # ───────────────────────────── redaction (§6) ─────────────────────────────
@@ -568,6 +672,23 @@ def _resolve_provider_key(args: argparse.Namespace) -> str:
     # truthy, and the old order turned it into `Bearer ` — a remote 401
     # that reads like a bad key instead of the empty input it is.
     env_key = os.environ.pop(PROVIDER_KEY_ENV_VAR, "")
+    if getattr(args, "provider_key_stdin", False):
+        if getattr(args, "provider_key", None) or env_key:
+            raise QuickSilverError(
+                "--provider-key-stdin cannot be combined with another provider-key source"
+            )
+        # Bound the read itself, not only the post-read validation: stdin is a
+        # Desktop-owned pipe, but a malformed/injected writer must not pin an
+        # unbounded allocation in the long-lived provider supervisor.
+        value = sys.stdin.readline(_PROVIDER_KEY_STDIN_MAX_BYTES + 1)
+        if len(value) > _PROVIDER_KEY_STDIN_MAX_BYTES or not value.endswith("\n"):
+            raise QuickSilverError(
+                "provider key from stdin is missing a newline or too long"
+            )
+        key = value.strip()
+        if not key:
+            raise QuickSilverError("empty provider key — nothing to register with.")
+        return key
     key = (getattr(args, "provider_key", None) or env_key or "").strip()
     if key:
         return key
@@ -1044,14 +1165,36 @@ def install_service(
 def run_share(args: argparse.Namespace) -> None:
     """The ``--quicksilver`` branch of ``share_command``. Owns the whole
     lifecycle so cli.py's plain-share path stays byte-identical (§8)."""
+    desktop_status: _DesktopStatus | None = None
     try:
-        _run_share(args)
+        desktop_status = _DesktopStatus.from_args(args)
+        if desktop_status is not None:
+            desktop_status.publish("preparing")
+        _run_share(args, desktop_status=desktop_status)
     except QuickSilverError as exc:
-        print(f"share --quicksilver: {_redact(str(exc))}", file=sys.stderr)
+        message = _redact(str(exc))
+        if desktop_status is not None:
+            with contextlib.suppress(QuickSilverError):
+                desktop_status.publish("error", message=message[:500])
+        print(f"share --quicksilver: {message}", file=sys.stderr)
         sys.exit(2)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+        if code and desktop_status is not None and desktop_status.phase != "error":
+            with contextlib.suppress(QuickSilverError):
+                desktop_status.publish(
+                    "error",
+                    message="The local provider process stopped unexpectedly.",
+                )
+        raise
+    else:
+        if desktop_status is not None:
+            desktop_status.publish("stopped")
 
 
-def _run_share(args: argparse.Namespace) -> None:
+def _run_share(
+    args: argparse.Namespace, *, desktop_status: _DesktopStatus | None = None
+) -> None:
     catalog_id, serve_alias = resolve_catalog(args)
     if args.install_service:
         install_service(args, catalog_id=catalog_id, serve_alias=serve_alias)
@@ -1064,6 +1207,13 @@ def _run_share(args: argparse.Namespace) -> None:
     worker = _resolve_worker(args)
     cache = None if args.reregister else _load_cache(catalog_id, serve_alias, worker)
     if cache is None:
+        if desktop_status is not None:
+            desktop_status.publish(
+                "registering",
+                catalog_id=catalog_id,
+                alias=serve_alias,
+                worker=worker,
+            )
         provider_key = _resolve_provider_key(args)
         _register_secret(provider_key)
         print("Registering node with QuickSilver…", file=sys.stderr)
@@ -1128,6 +1278,16 @@ def _run_share(args: argparse.Namespace) -> None:
             raise QuickSilverError(f"{exc} — re-run with --reregister") from None
 
     relay_url = cache["relay_url"]
+    desktop_fields = {
+        "catalog_id": catalog_id,
+        "alias": serve_alias,
+        "worker": worker,
+        "node_id": cache["node_id"],
+        "payout_account": cache.get("payout_account"),
+        "heartbeat_interval_s": interval,
+    }
+    if desktop_status is not None:
+        desktop_status.publish("starting", **desktop_fields)
 
     # Lazy import: cli.py dispatches here from inside share_command, so
     # a top-level ``from . import cli`` here would deadlock on first
@@ -1243,6 +1403,8 @@ def _run_share(args: argparse.Namespace) -> None:
             sys.exit(1)
 
         display_model = _resolve_served_model_name(port, api_key) or serve_alias
+        if desktop_status is not None:
+            desktop_status.publish("warming", **desktop_fields)
         print("Warming up (pages weights into Metal)…", file=sys.stderr)
         _warmup(port, api_key, display_model)
 
@@ -1261,8 +1423,11 @@ def _run_share(args: argparse.Namespace) -> None:
         backoff = 1.0
         banner_printed = False
         served_at = 0.0
+        connected_at_epoch: float | None = None
         fast_reject_streak = 0
         while True:
+            if desktop_status is not None:
+                desktop_status.publish("connecting", **desktop_fields)
             tunnel = ws_tunnel.TunnelClient(
                 local_port=port,
                 tunnel_id=cache["node_id"],
@@ -1283,10 +1448,18 @@ def _run_share(args: argparse.Namespace) -> None:
             reconnect = False
             if connected:
                 served_at = time.monotonic()
+                connected_at_epoch = time.time()
                 heartbeat.enabled.set()
                 # §5.3: the first beat waits for tunnel-up AND warm-up
                 # (which already ran before the loop).
                 heartbeat.beat_now()
+                if desktop_status is not None:
+                    desktop_status.publish(
+                        "online",
+                        **desktop_fields,
+                        inflight=max(0, int(tunnel.inflight)),
+                        connected_at=connected_at_epoch,
+                    )
                 if not banner_printed:
                     payout = cache.get("payout_account")
                     print(
@@ -1304,9 +1477,22 @@ def _run_share(args: argparse.Namespace) -> None:
             # (§5.5: the key is revoked; spinning is worse than dying).
             while True:
                 assert serve_proc is not None and heartbeat is not None
+                if connected and desktop_status is not None:
+                    desktop_status.publish(
+                        "online",
+                        **desktop_fields,
+                        inflight=max(0, int(tunnel.inflight)),
+                        connected_at=connected_at_epoch,
+                    )
                 serve_rc = serve_proc.poll()
                 if serve_rc is not None:
                     exit_code = serve_rc if serve_rc != 0 else 1
+                    if desktop_status is not None:
+                        desktop_status.publish(
+                            "error",
+                            **desktop_fields,
+                            message="The local model server stopped unexpectedly.",
+                        )
                     print(
                         f"share: serve process exited — leaving the pool. "
                         f"See {serve_log}.",
@@ -1315,6 +1501,12 @@ def _run_share(args: argparse.Namespace) -> None:
                     break
                 if heartbeat.fatal.is_set():
                     exit_code = 1
+                    if desktop_status is not None:
+                        desktop_status.publish(
+                            "error",
+                            **desktop_fields,
+                            message="QuickSilver revoked this node credential. Register again.",
+                        )
                     print(
                         "share: QuickSilver revoked our node credential "
                         "(HTTP 401). Stop and re-run with --reregister to "
@@ -1338,6 +1530,12 @@ def _run_share(args: argparse.Namespace) -> None:
                     # built to avoid).
                     if tunnel.error_status == _WS_TERMINAL_STATUS:
                         exit_code = 1
+                        if desktop_status is not None:
+                            desktop_status.publish(
+                                "error",
+                                **desktop_fields,
+                                message="QuickSilver rejected this node credential. Register again.",
+                            )
                         print(
                             "share: QuickSilver relay rejected our share-key "
                             "(HTTP 401). Re-run with --reregister.",
@@ -1346,6 +1544,12 @@ def _run_share(args: argparse.Namespace) -> None:
                         break
                     if tunnel.close_code in _WS_TERMINAL_CLOSE_CODES:
                         exit_code = 1
+                        if desktop_status is not None:
+                            desktop_status.publish(
+                                "error",
+                                **desktop_fields,
+                                message="QuickSilver rejected this node credential. Register again.",
+                            )
                         print(
                             "share: QuickSilver relay rejected our share-key "
                             f"(WS close {tunnel.close_code}). Re-run with "
@@ -1393,6 +1597,8 @@ def _run_share(args: argparse.Namespace) -> None:
                 _supervisor_sleep(1)
             if not reconnect:
                 break
+            if desktop_status is not None:
+                desktop_status.publish("reconnecting", **desktop_fields, inflight=0)
             heartbeat.enabled.clear()
             tunnel.stop()
             tunnel_thread.join(timeout=5)


### PR DESCRIPTION
## Why

PR #3251 added QuickSilver compute-pool provider mode to the CLI, but Desktop users still had no safe, discoverable way to use it. Copying the CLI flags directly into a GUI would also expose two release-class risks: a provider key in process metadata and two large model processes competing for unified memory.

This adds an experimental **Share Compute** workspace that makes the provider flow understandable and preserves Desktop's single-residency and subprocess-cleanup guarantees.

## Scope

- Add an opt-in Settings → Experimental gate and a Share Compute sidebar workspace.
- Present QuickSilver as the initial provider: one OpenAI-compatible API spanning 48 frontier/open models, with public pricing and live status; make clear that Rapid Macs contribute the supported open-model capacity.
- Support the three QuickSilver catalog mappings shipped by #3251, with an explicit download-before-share path.
- Send the first-run provider key once over bounded stdin, never argv/environment/Desktop storage.
- Add a non-secret, field-whitelisted, atomic `0600` Python status snapshot for native lifecycle UI.
- Exclusively reserve large-model residency while sharing, restore the prior model on stop/failure, invalidate a join when the feature is disabled, and reap the provider process group during app shutdown.
- Document the trust boundary and initial product scope.

## Non-goals

- No additional compute provider beyond QuickSilver in this PR; the UI/model layer is provider-shaped for future additions.
- No QuickSilver login LaunchAgent toggle. That requires cross-process residency arbitration so a hidden background pool node cannot contend with Desktop.
- No changes to QuickSilver pricing, payout accounting, relay behavior, or its three-model catalog.
- No real provider credential or paid pool request was used during GUI dogfood.

## Acceptance

- The tab is absent by default and enabling it starts no process, network request, or download.
- A cached supported model can enter the connect/share flow; an uncached one offers an explicit Download Model action.
- A provider key is never present in argv, environment, Desktop preferences, logs, or the non-secret status snapshot.
- Share Compute cannot overlap Desktop's embedded model; stopping, provider failure, disabling the gate, and app quit all have bounded cleanup.
- The previous local model is restored only after the entire provider process group has left unified memory.
- The page and registration sheet remain readable and semantically operable in light and dark appearances.

## Verification

- `python3.12 -m pytest tests/test_share_quicksilver.py -q --tb=short` — 172 passed; changed Python statements are fully exercised.
- `python3.12 -m ruff check ...` and `ruff format --check ...` — passed for all changed Python files.
- `swift build` — passed with Swift 6.2.1 / Xcode 26.
- `bash apps/rapid-mac/scripts/desktop-test-timeout.sh` — 3,630 tests across 314 suites passed in 90.96 s on the final reviewed code.
- `bash apps/rapid-mac/scripts/build.sh` — assembled and ad-hoc signed a 0.13.4 Desktop app with the bundled sidecar.
- AX-first dogfood on the built app: enabled the gate, skipped onboarding, navigated to Share Compute, opened the registration sheet, verified stable selectors and SecureField behavior, and inspected the complete page at 1440×900 in both light and dark appearances.
- Bundled `rapid-mlx share --help` does not expose the two hidden Desktop transport flags; bundled sidecar reports `rapid-mlx 0.13.4`.
- Repeated adversarial review rounds converged to zero findings and fixed: join resurrection after gate disable, stale and duplicate join ownership, stale join/restore ownership, credential-cache and worker-bound registration proof, schema/session-bound terminal status, truthful stopped-process state, orphaned process-group reaping, stale-cache key rotation, prior-model restoration on failure, HOME/cache divergence, bounded status reads, post-spawn SIGPIPE risk, terminal-status polling races, confirmed post-SIGKILL teardown, stuck-stop escalation, cache-isolated tests, and incomplete AX coverage.
- `python3.12 -m scripts.pr_validate 3268 --skip-steps full_unit,stress_e2e_bench` — `MERGE-SAFE`, with zero review findings. Full Desktop tests are recorded above; GitHub runs the clean Python/Apple matrices.

## Behaviour delta

Desktop default: unchanged. After the user opts in, a new Share Compute workspace is available; it remains inert until the user explicitly downloads/selects a supported model and starts sharing.

## AI assistance disclosure

Codex wrote and reviewed the Swift, Python, tests, and decision record in this PR. I reviewed the complete diff and verified it with the targeted Python suite, full Desktop suite, release-style app assembly, credential-placement checks, and light/dark AX-driven GUI dogfood described above.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally
- [x] Lint and format checks pass
- [x] Self-validated with `scripts.pr_validate` (run after PR creation)
- [x] Critical credential/status tests were spot-checked against the production guardrails
- [x] Updated engineering documentation
- [x] No breaking changes to existing API

## Author
