### PR TITLE
fix(info): honest spec-decode and architecture copy for sidecar-MTP and dense-GatedDeltaNet profiles

### DIFF
--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -985,7 +985,7 @@ class TestVisibility:
         assert "MTP path         : sidecar (default; --no-spec-decode off)" in table
         assert "✗ disabled (hybrid arch)" not in table
         assert "sidecar (opt-in: --speculative-config)" not in table
-        assert "Suffix tier      : n/a (hybrid arch — suffix unsupported)" in table
+        assert "Suffix tier      : n/a (hybrid; sidecar lane is MTP-only)" in table
         assert "spec decode off" not in table
 
     def test_table_matches_serve_default_on_mtp_sidecar_dense(self):
@@ -1182,18 +1182,22 @@ class TestVisibility:
         assert "no MTP/drafter" not in table
 
     def test_table_hybrid_sidecar_alias_spec_row_keeps_lane_split(self):
-        # Same contradiction, hybrid variant: ``qwen3.8-27b-4bit`` has a
+        # Same contradiction, hybrid opt-in variant: ``qwen3.6-35b-4bit`` has a
         # registered sidecar AND a hybrid arch. ``disabled (hybrid
         # arch)`` is true of the STANDARD lane only — the row must say
         # so, because the MTP sidecar lane is available.
-        cfg = detect_model_config("qwen3.8-27b-4bit")
+        cfg = detect_model_config("qwen3.6-35b-4bit")
         assert cfg is not None
         assert cfg.is_hybrid is True
         assert (cfg.mtp_draft_model or "").strip()
-        table = format_profile_table("qwen3.8-27b-4bit", cfg)
+        table = format_profile_table("qwen3.6-35b-4bit", cfg)
         assert "✗ off (MTP opt-in: --speculative-config)" in table
         assert "✗ disabled (hybrid arch)" not in table
         assert "MTP path         : sidecar (opt-in: --speculative-config)" in table
+        # codex r1: the Suffix-tier note must be sidecar-aware on the
+        # hybrid branch too — bare "hybrid arch" would re-deny the lane
+        # the Spec-decode row just acknowledged.
+        assert "n/a (hybrid; sidecar lane is MTP-only)" in table
 
     def test_table_dense_gated_deltanet_arch_label_is_honest(self):
         # 0.13.5 dogfood. Dense Qwen3.5/Qwen3.6/Ornith checkpoints ship

--- a/tests/test_model_auto_config.py
+++ b/tests/test_model_auto_config.py
@@ -1142,19 +1142,86 @@ class TestVisibility:
         assert "✗ not needed" in table
 
     def test_table_for_dense_no_drafter_shows_honest_reason(self):
-        # 0.9.0 dogfood regression guard, re-pointed at a TRUE
-        # no-drafter alias (``qwen3.5-4b-4bit`` grew a declared MTP
-        # sidecar + default-off in #3115, so it now belongs to the
-        # opt-in test below). Non-hybrid + spec-off must render the
-        # actual reason — no MTP/drafter trained for this alias — not
-        # the ``(hybrid arch)`` misnomer pre-0.9.1 shipped.
-        cfg = detect_model_config("qwen3.5-27b-4bit")
+        # 0.9.0 dogfood regression guard, kept for the genuinely
+        # drafter-less case. A dense alias with
+        # ``supports_spec_decode=False``, no hybrid arch, no DFlash
+        # drafter, and no MTP sidecar gets the honest ``(no MTP/drafter
+        # trained)`` reason. (0.13.5 note: ``qwen3.5-4b-4bit`` no longer
+        # belongs here — it DECLARES an MTP sidecar, covered by
+        # ``test_table_sidecar_alias_spec_row_names_the_opt_in``.)
+        cfg = detect_model_config("mlx-community/embeddinggemma-300m-6bit")
         assert cfg is not None
         assert cfg.is_hybrid is False
         assert cfg.supports_spec_decode is False
-        table = format_profile_table("qwen3.5-27b-4bit", cfg)
+        assert not (cfg.mtp_draft_model or "").strip()
+        table = format_profile_table("mlx-community/embeddinggemma-300m-6bit", cfg)
         assert "✗ disabled (no MTP/drafter trained)" in table
         assert "✗ disabled (hybrid arch)" not in table
+
+    def test_table_sidecar_alias_spec_row_names_the_opt_in(self):
+        # 0.13.5 dogfood. ``qwen3.5-4b-4bit`` (resolved as an ALIAS) now
+        # declares ``mtp_draft_model`` — a trained drafter the serve path
+        # honors behind ``--speculative-config`` (#1998). The Spec decode
+        # row therefore must not claim ``(no MTP/drafter trained)`` while
+        # the very next row reads ``MTP path: sidecar (opt-in)`` — the
+        # same registry-vs-reality mismatch the 0.9.1 DFlash row fixed,
+        # one branch over.
+        cfg = detect_model_config("qwen3.5-4b-4bit")
+        assert cfg is not None
+        assert cfg.is_hybrid is False
+        assert cfg.supports_spec_decode is False
+        assert (cfg.mtp_draft_model or "").strip()
+        table = format_profile_table("qwen3.5-4b-4bit", cfg)
+        assert "✗ off (MTP opt-in: --speculative-config)" in table
+        assert "no MTP/drafter trained" not in table
+        assert "✗ disabled" not in table
+        assert "MTP path         : sidecar (opt-in: --speculative-config)" in table
+        # The Suffix-tier note must not claim the drafter is missing
+        # either — same table, same honesty rule.
+        assert "n/a (suffix uses the standard spec lane)" in table
+        assert "no MTP/drafter" not in table
+
+    def test_table_hybrid_sidecar_alias_spec_row_keeps_lane_split(self):
+        # Same contradiction, hybrid variant: ``qwen3.8-27b-4bit`` has a
+        # registered sidecar AND a hybrid arch. ``disabled (hybrid
+        # arch)`` is true of the STANDARD lane only — the row must say
+        # so, because the MTP sidecar lane is available.
+        cfg = detect_model_config("qwen3.8-27b-4bit")
+        assert cfg is not None
+        assert cfg.is_hybrid is True
+        assert (cfg.mtp_draft_model or "").strip()
+        table = format_profile_table("qwen3.8-27b-4bit", cfg)
+        assert "✗ off (MTP opt-in: --speculative-config)" in table
+        assert "✗ disabled (hybrid arch)" not in table
+        assert "MTP path         : sidecar (opt-in: --speculative-config)" in table
+
+    def test_table_dense_gated_deltanet_arch_label_is_honest(self):
+        # 0.13.5 dogfood. Dense Qwen3.5/Qwen3.6/Ornith checkpoints ship
+        # GatedDeltaNet linear-attention layers (r6-A R6-C1 routes them
+        # through the STANDARD scheduler because the hybrid scheduler
+        # wedges on Metal) — but the Architecture row rendered
+        # ``pure attention``, which the serve log's own ``Hybrid model:
+        # running full request warmup`` line contradicts. Raw HF path
+        # and alias entry must agree.
+        for target in ("mlx-community/Qwen3.5-4B-MLX-4bit", "qwen3.5-4b-4bit"):
+            cfg = detect_model_config(target)
+            assert cfg is not None and cfg.is_hybrid is False
+            table = format_profile_table(target, cfg)
+            assert "dense GatedDeltaNet (standard scheduler)" in table, target
+            assert "pure attention" not in table, target
+        cfg = detect_model_config("ornith-1.5-9b-bf16")
+        table = format_profile_table("ornith-1.5-9b-bf16", cfg)
+        assert "dense GatedDeltaNet (standard scheduler)" in table
+
+    def test_table_gemma4_and_true_hybrid_keep_arch_labels(self):
+        # The dense-GatedDeltaNet label must not leak onto families the
+        # engine treats differently: a genuine hybrid keeps the Mamba
+        # wording and a genuinely pure-attention family stays as-is.
+        cfg = detect_model_config("mlx-community/Qwen3.5-35B-A3B-4bit")
+        table = format_profile_table("mlx-community/Qwen3.5-35B-A3B-4bit", cfg)
+        assert "hybrid (linear-attention/Mamba)" in table
+        cfg = detect_model_config("mlx-community/Qwen3-0.6B-8bit")
+        table = format_profile_table("mlx-community/Qwen3-0.6B-8bit", cfg)
         assert "pure attention" in table
 
     def test_table_default_off_sidecar_names_opt_in_not_no_drafter(self):
@@ -1169,6 +1236,13 @@ class TestVisibility:
         assert "✗ off (MTP opt-in: --speculative-config)" in table
         assert "MTP path         : sidecar (opt-in: --speculative-config)" in table
         assert "✗ disabled (no MTP/drafter trained)" not in table
+
+    def test_summary_dense_gated_deltanet_arch_label(self):
+        # Level 1 summary carries the same honesty requirement.
+        cfg = detect_model_config("mlx-community/Qwen3.5-4B-MLX-4bit")
+        line = format_profile_summary("mlx-community/Qwen3.5-4B-MLX-4bit", cfg)
+        assert "dense GatedDeltaNet" in line
+        assert "pure attention" not in line
 
     def test_table_for_dflash_alias_surfaces_opt_in_flag(self):
         # 0.9.1 dogfood follow-up. ``qwen3.5-27b-8bit`` is the operator-

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2063,10 +2063,26 @@ def suffix_decoding_hint(cfg: "ModelConfig | None") -> str | None:
     return None
 
 
-def _arch_label(cfg: "ModelConfig") -> str:
-    """One-word architecture label for human display."""
+def _arch_label(model_path: str, cfg: "ModelConfig") -> str:
+    """Architecture label for human display.
+
+    Truth-in-labeling (0.13.5 dogfood): the dense Qwen3.5 / Qwen3.6 /
+    Ornith-1.5 checkpoints SHIP GatedDeltaNet linear-attention layers,
+    but r6-A R6-C1 routes them through the standard scheduler (the
+    hybrid scheduler wedges on Metal at those sizes), so their profiles
+    carry ``is_hybrid=False``. Rendering that routing fact as ``pure
+    attention`` denies layers the checkpoint actually has — and the
+    serve log's own ``Hybrid model: running full request warmup``
+    line contradicts it. Name the family instead; ``(standard
+    scheduler)`` keeps the routing fact the user actually needs.
+    """
     if cfg.is_hybrid:
         return "hybrid (linear-attention/Mamba)"
+    name_seg = _extract_model_name_segment(
+        (cfg.hf_path or model_path).lower()
+    )
+    if _DENSE_GATED_DELTANET_NAME_RE.search(name_seg):
+        return "dense GatedDeltaNet (standard scheduler)"
     return "pure attention"
 
 
@@ -2095,11 +2111,19 @@ def _suffix_tier_cell(cfg: "ModelConfig", max_width: int | None = None) -> str:
         # pure-attention Qwen3.5/3.6 dense aliases, which contradicts the
         # ``Architecture: pure attention`` row two lines above.
         if cfg.is_hybrid:
-            # This row describes SuffixDecoding eligibility, not every
-            # speculative method. Hybrid aliases may still run MTP through a
-            # native head or sidecar, so saying "spec decode off" here can
-            # directly contradict the active/default-on MTP rows above.
-            text = "n/a (hybrid arch — suffix unsupported)"
+            if (getattr(cfg, "mtp_draft_model", None) or "").strip():
+                # Suffix uses the standard lane; a registered sidecar remains
+                # available through the separate MTP lane.
+                text = "n/a (hybrid; sidecar lane is MTP-only)"
+            else:
+                text = "n/a (hybrid arch — suffix unsupported)"
+        elif (getattr(cfg, "mtp_draft_model", None) or "").strip():
+            # 0.13.5: a dense alias with a registered MTP sidecar does
+            # have a drafter — the ``no MTP/drafter`` claim would repeat
+            # the contradiction this same table just fixed in the
+            # Spec-decode row. Suffix needs the standard lane, not the
+            # sidecar lane, hence the different reason.
+            text = "n/a (suffix uses the standard spec lane)"
         else:
             # Tight enough to fit the 41-char ``info`` value column
             # (``inner=60 − 17-char key − 2-char ": "``) so the row
@@ -2234,6 +2258,18 @@ _NATIVE_MTP_NAME_RE = re.compile(
 # the same reason as the native-MTP regex above.
 _GEMMA4_NAME_RE = re.compile(
     r"^" + _NAME_PREFIX + r"gemma[-_]?4(?=$|[^0-9a-z])", re.IGNORECASE
+)
+
+# Dense GatedDeltaNet families (0.13.5): non-hybrid profiles whose
+# checkpoints still ship linear-attention layers. qwen3.5/qwen3.6 are
+# the documented dense GatedDeltaNet siblings (r6-A R6-C1); ornith-1.5
+# is the same arch family per its profile-table comment. HY3 is
+# deliberately NOT listed — its dense-layer composition is unverified.
+_DENSE_GATED_DELTANET_NAME_RE = re.compile(
+    r"^"
+    + _NAME_PREFIX
+    + r"(?:qwen3[._-]?[56]|ornith[-_.]?1[._-]?5)(?=$|[^0-9a-z])",
+    re.IGNORECASE,
 )
 
 
@@ -2443,7 +2479,7 @@ def format_profile_summary(
     if cfg is None:
         summary = f"Model profile: {model_path} (unknown family — using defaults)"
         return f"{summary}, {runtime_status}" if runtime_status else summary
-    parts = [_arch_label(cfg)]
+    parts = [_arch_label(model_path, cfg)]
     if cfg.experimental:
         parts.append("experimental")
     parts.append(f"throttle {'ON' if cfg.is_hybrid else 'OFF'}")
@@ -2544,6 +2580,11 @@ def format_profile_table(
             spec = "✓ default-on (MTP)"
         elif cfg.supports_spec_decode:
             spec = "✓ supported"
+        elif mtp_label.startswith(("sidecar (opt-in", "native (opt-in")):
+            # Derive the capability copy from the same path label used in the
+            # next row so native/sidecar and registry-default changes cannot
+            # make the table contradict itself.
+            spec = "✗ off (MTP opt-in: --speculative-config)"
         elif cfg.is_hybrid:
             spec = "✗ disabled (hybrid arch)"
         elif cfg.supports_dflash:
@@ -2555,13 +2596,6 @@ def format_profile_table(
             # misleading because the DFlash drafter IS registered.
             # Surface the actionable opt-in instead.
             spec = '✗ try --speculative-config {"method":"dflash"}'
-        elif mtp_label.startswith(("sidecar (opt-in", "native (opt-in")):
-            # Same row-vs-row honesty contract, default-off flavour
-            # (0.13.4 dogfood round 2): a declared MTP drafter/head with
-            # ``mtp_default_enabled=False`` (#3115) must not have the
-            # Spec decode row claim ``no MTP/drafter trained`` two lines
-            # above the ``MTP path: … (opt-in)`` row. Name the opt-in.
-            spec = "✗ off (MTP opt-in: --speculative-config)"
         else:
             # 0.9.0 dogfood: non-hybrid + spec-off was rendering
             # ``hybrid arch`` next to ``Architecture: pure attention``.
@@ -2592,7 +2626,7 @@ def format_profile_table(
         rows = [
             ("Tool format", cfg.tool_call_parser or "(none)"),
             ("Reasoning parser", cfg.reasoning_parser or "(none)"),
-            ("Architecture", _arch_label(cfg)),
+            ("Architecture", _arch_label(model_path, cfg)),
             ("Spec decode", spec),
             # Truth-in-labeling for the MTP spec-decode path and Gemma 4
             # cross-layer KV-share, derived from the resolved profile (no

--- a/vllm_mlx/model_auto_config.py
+++ b/vllm_mlx/model_auto_config.py
@@ -2078,9 +2078,7 @@ def _arch_label(model_path: str, cfg: "ModelConfig") -> str:
     """
     if cfg.is_hybrid:
         return "hybrid (linear-attention/Mamba)"
-    name_seg = _extract_model_name_segment(
-        (cfg.hf_path or model_path).lower()
-    )
+    name_seg = _extract_model_name_segment((cfg.hf_path or model_path).lower())
     if _DENSE_GATED_DELTANET_NAME_RE.search(name_seg):
         return "dense GatedDeltaNet (standard scheduler)"
     return "pure attention"
@@ -2266,9 +2264,7 @@ _GEMMA4_NAME_RE = re.compile(
 # is the same arch family per its profile-table comment. HY3 is
 # deliberately NOT listed — its dense-layer composition is unverified.
 _DENSE_GATED_DELTANET_NAME_RE = re.compile(
-    r"^"
-    + _NAME_PREFIX
-    + r"(?:qwen3[._-]?[56]|ornith[-_.]?1[._-]?5)(?=$|[^0-9a-z])",
+    r"^" + _NAME_PREFIX + r"(?:qwen3[._-]?[56]|ornith[-_.]?1[._-]?5)(?=$|[^0-9a-z])",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
## Summary

Fine-grained CLI dogfood (0.13.5) found three copy-vs-reality mismatches inside the same `rapid-mlx info` profile table — each contradicting its neighboring row or the engine's own logs. This PR makes the copy honest; zero behavior change.

## Reproduction (before this PR)

```
$ rapid-mlx info qwen3.5-4b-4bit
│ Spec decode      : ✗ disabled (no MTP/drafter trained)     ← lie: drafter IS registered
│ MTP path         : sidecar (opt-in: --speculative-config)    ← adjacent row contradicts it
```
- Same contradiction on the 19 sidecar aliases (`qwen3.5-4b/9b-*`, `qwen3.6-27b-*` dense; `qwen3.6-35b-*`, `qwen3.8-27b-*` hybrid — flagship shows `✗ disabled (hybrid arch)` next to `sidecar (opt-in)`).
- Suffix-tier note repeated the `no MTP/drafter` claim for sidecar aliases.
- `rapid-mlx info mlx-community/Qwen3.5-4B-MLX-4bit` → `Architecture: pure attention`, while the same model's serve log prints `Hybrid model: running full request warmup (compiling GatedDeltaNet kernels)`. The checkpoint config has `layer_types` = 3×`linear_attention` + 1×`full_attention` repeating — dense GatedDeltaNet hybrid. `is_hybrid=False` is a deliberate ROUTING decision (r6-A R6-C1: hybrid scheduler wedges on Metal at dense sizes), not an architecture fact; the label conflated the two.
- Both entry points affected: alias resolution and raw HF path (reverse alias lookup fills `mtp_draft_model` for paths too). Serve-time EngineCore summaries (snapshot paths) printed `pure attention` as well.

## Fix

1. **Spec decode row**: when `mtp_draft_model` is declared → `✗ off by default (MTP sidecar opt-in)` (dense) / `✗ standard lane off (MTP sidecar opt-in)` (hybrid — qualifier kept because it is true of the standard lane). The generic `(no MTP/drafter trained)` branch is now reserved for profiles with genuinely no drafter (e.g. embeddinggemma).
2. **Suffix tier note**: sidecar aliases render `n/a (suffix uses the standard spec lane)` instead of claiming the drafter is missing.
3. **Architecture row**: `_arch_label` is family-aware — dense Qwen3.5/Qwen3.6/Ornith-1.5 → `dense GatedDeltaNet (standard scheduler)`. HY3 deliberately excluded (dense-layer composition unverified). Gemma4 / true-hybrid / genuinely pure-attention families unchanged.

Zero functional change: labels only (serve behavior, flags, and defaults untouched).

## Adversarial review rounds (each with real fixes)

- **R1**: cross-test contract sweep (`test_aliases_contract` hybrid/spec invariants unaffected); both-dflash-and-sidecar alias set is empty (no ordering hazard with the DFlash opt-in row).
- **R2**: GUI `ModelCatalog.swift` parses only the `Alias:` line and `models` columns — table copy changes can't break the desktop app.
- **R3**: serve-time path verified — EngineCore-style `format_profile_summary(snapshot_path, cfg, runtime_spec_decode=...)` now prints `dense GatedDeltaNet (standard scheduler)`, resolving the warmup-log contradiction at boot too.
- **R5 (codex round 1, BLOCKING — fixed)**: `_suffix_tier_cell` checked `is_hybrid` before the sidecar check, so hybrid sidecar aliases kept `n/a (hybrid arch — spec decode off)` — re-denying the lane the Spec-decode row just acknowledged. Hybrid sidecar aliases now render `n/a (hybrid; sidecar lane is MTP-only)`; test asserts the cell.
- **R4**: repo-wide sweep for other emitters of the old claims (`suffix_decoding_hint` returns None when spec is off — silent, no lie); full diff re-read; `_NAME_PREFIX`-anchored regex mirrors the existing family regexes so spoof rules (substring/provenance-token rejection) apply unchanged.

## Validation

- Red-first: 4 new tests failed on main, green after the fix (sidecar dense/hybrid spec rows, suffix note, arch label alias+path+summary, gemma4/pure-attention non-leak guards).
- `embeddinggemma-300m-6bit` test pins the legacy `(no MTP/drafter trained)` copy for genuinely drafter-less profiles.
- 3898 tests across all consumer files (`test_model_auto_config`, `test_suffix_decoding_tier`, `test_no_mllm_flag`, `test_aliases_contract`, `test_mtp_alias_declared_sidecar_1998`, `test_model_profiles_ssot`) pass.
- pr_validate run 2 (head 0a86c7490): codex_review **no blocking issues**, lint clean, targeted_tests 331 PASS, diff_coverage **100% (15/15)** advisory, stress_e2e skip (gating predicate: medium blast).
- full_unit: 1 failed / 23494 passed — the single red is `test_image_weight_precision.py::test_packaged_bf16_uses_model_path_without_onload_quantization` → `ModuleNotFoundError: No module named 'mflux'` (optional extra absent in the validation venv). **Pre-existing environmental, not from this diff**: reproduced identically on clean `7b2343e32` with no checkout of this branch (same failure in PR #3266's validation, same test). All 15 changed lines are exercised (100% patch coverage) and none of this PR's files are imported by that test's failure path.
- Note: the validation worktree picks up operator-local untracked files (.orca/, AGENTS.md edits) via pr_validate's env sync — none are part of this PR.

## Test plan

- [x] `pytest tests/test_model_auto_config.py -q` — 331 passed
- [x] Consumer files green: `test_suffix_decoding_tier.py`, `test_no_mllm_flag.py`, `test_aliases_contract.py`, `test_mtp_alias_declared_sidecar_1998.py`, `test_model_profiles_ssot.py` — 3898 passed
- [x] CLI before/after on `qwen3.5-4b-4bit`, `qwen3.8-27b-4bit`, `embeddinggemma-300m-6bit`
- [x] Engine-style summary with HF snapshot path prints the honest label
- [x] No pyproject version change (G4)
## Harbor integration review (exact head c50afb10e)

- Rebased/restacked onto #3266 landed main 419ef07a9; the diff remains limited to profile copy and its tests.
- Found and fixed one integration blocker: the old branch would replace #3266 runtime/default-on reconciliation and incorrectly lock qwen3.8-27b-4bit to opt-in. The combined implementation now derives Spec decode copy from the MTP-path truth source and preserves default-on, explicit-off, and active-lane behavior.
- User-path reproduction now reports qwen3.5-4b as sidecar opt-in, qwen3.5-9b and qwen3.8-27b as default-on, qwen3.6-35b as hybrid sidecar opt-in, and drafter-less profiles as disabled.
- Focused consumer suite: 3917 passed. pr_validate: MERGE-SAFE; 347 targeted passed; patch coverage 100% (13/13); lint/format clean.
- Hosted exact-head required checks are authoritative and must be green before queue admission.