### PR TITLE
fix(serve): preserve alias in profile diagnostics

### DIFF
--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2634,7 +2634,7 @@ def test_routing_override_kwargs_are_keyword_only_in_load_model():
         )
 
 
-def _make_engine_core_for_override_test(monkeypatch, cfg, *, base=None):
+def _make_engine_core_for_override_test(monkeypatch, cfg, *, base=None, detector=None):
     """Build an ``EngineCore`` with heavy dependencies stubbed so the
     routing-override block in ``__init__`` can be exercised in
     isolation. Returns the constructed core (or raises if __init__
@@ -2683,7 +2683,11 @@ def _make_engine_core_for_override_test(monkeypatch, cfg, *, base=None):
     if base is None:
         base = ModelConfig(is_hybrid=True, supports_spec_decode=False)
 
-    monkeypatch.setattr(mac, "detect_model_config", lambda _name: base)
+    monkeypatch.setattr(
+        mac,
+        "detect_model_config",
+        detector if detector is not None else lambda _name: base,
+    )
 
     # Stub respects its argument (not closure). This means pre-enrich
     # mutation of ``base_cfg`` is invisible — matching production
@@ -2812,6 +2816,64 @@ def test_engine_core_profile_log_shows_explicit_mtp(monkeypatch, caplog):
 
     assert "spec decode MTP (active)" in caplog.text
     assert "spec decode OFF" not in caplog.text
+
+
+def test_engine_core_profile_log_uses_alias_capabilities(monkeypatch, caplog):
+    """Resolved snapshots must not erase alias-only sidecar facts in logs."""
+    try:
+        from vllm_mlx.engine_core import EngineConfig
+        from vllm_mlx.model_auto_config import ModelConfig
+        from vllm_mlx.scheduler import SchedulerConfig
+    except (ImportError, RuntimeError) as exc:
+        pytest.skip(f"MLX runtime unavailable ({exc})")
+
+    alias = "qwen3.5-9b-4bit"
+    snapshot = "/cache/models--mlx-community--Qwen3.5-9B-4bit/snapshots/rev"
+    loaded_cfg = ModelConfig(is_hybrid=False, supports_spec_decode=False)
+    alias_cfg = ModelConfig(
+        is_hybrid=False,
+        supports_spec_decode=False,
+        mtp_draft_model="mlx-community/Qwen3.5-9B-MTP-4bit",
+    )
+
+    def detect(name):
+        return alias_cfg if name == alias else loaded_cfg
+
+    cfg = EngineConfig(
+        model_name=snapshot,
+        profile_name=alias,
+        scheduler_config=SchedulerConfig(spec_decode="mtp"),
+    )
+    monkeypatch.setenv("RAPID_MLX_PROFILE_VERBOSE", "1")
+    with caplog.at_level("INFO", logger="vllm_mlx.engine_core"):
+        _make_engine_core_for_override_test(
+            monkeypatch,
+            cfg,
+            base=loaded_cfg,
+            detector=detect,
+        )
+
+    assert f"Model: {alias}" in caplog.text
+    assert "Spec decode      : ✓ default-on (MTP)" in caplog.text
+    assert "MTP path         : sidecar (default; --no-spec-decode off)" in caplog.text
+    assert "Suffix tier      : n/a (suffix uses the standard spec lane)" in caplog.text
+    assert "MTP path         : disabled" not in caplog.text
+    assert "no MTP/drafter" not in caplog.text
+
+
+def test_engine_config_profile_name_preserves_positional_scheduler_argument():
+    """Appending diagnostics must not shift the public dataclass constructor."""
+    try:
+        from vllm_mlx.engine_core import EngineConfig
+        from vllm_mlx.scheduler import SchedulerConfig
+    except (ImportError, RuntimeError) as exc:
+        pytest.skip(f"MLX runtime unavailable ({exc})")
+
+    scheduler = SchedulerConfig()
+    config = EngineConfig("model-under-test", scheduler)
+
+    assert config.scheduler_config is scheduler
+    assert config.profile_name is None
 
 
 def test_engine_core_suffix_lane_reconciles_profile_log(monkeypatch, caplog):

--- a/tests/test_server_load_model_order.py
+++ b/tests/test_server_load_model_order.py
@@ -649,6 +649,7 @@ def test_load_model_threads_saved_cli_alias_into_checkpoint_resolution(monkeypat
     assert seen == ["lfm2.5-2.6b-4bit"]
     assert server._engine is not None
     assert server._engine.kwargs["model_name"] == "/cache/snapshots/revision/4bit"
+    assert server._engine.kwargs["profile_name"] == "lfm2.5-2.6b-4bit"
 
 
 def test_load_model_detects_config_from_resolved_pulled_variant(monkeypatch):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -874,6 +874,7 @@ class BatchedEngine(BaseEngine):
         enable_disk_stream: bool = False,
         disk_stream_cache_gb: float = 1.0,
         chat_template_id: str | None = None,
+        profile_name: str | None = None,
         serving_lane_reason: str | None = None,
     ):
         """
@@ -915,11 +916,15 @@ class BatchedEngine(BaseEngine):
             chat_template_id: Keyword-only model-profile prompt contract.
                 Control-plane callers pass this when ``model_name`` is a local
                 snapshot path whose originating profile is already known.
+            profile_name: Optional registry/alias identity retained for
+                operator-facing diagnostics after ``model_name`` resolves to a
+                local snapshot. It never changes model loading or cache keys.
             serving_lane_reason: Machine-readable reason from the shared
                 serving-lane decision. Kept on the live engine so model and
                 residency APIs report the decision that was actually loaded.
         """
         self._model_name = model_name
+        self._profile_name = profile_name or model_name
         if chat_template_id is None:
             from ..model_aliases import resolve_profile
 
@@ -1901,6 +1906,7 @@ class BatchedEngine(BaseEngine):
         scheduler_config = self._scheduler_config or SchedulerConfig()
         engine_config = EngineConfig(
             model_name=self._model_name,
+            profile_name=self._profile_name,
             scheduler_config=scheduler_config,
             stream_interval=self._stream_interval,
             gpu_memory_utilization=self._gpu_memory_utilization,
@@ -4445,6 +4451,7 @@ class BatchedEngine(BaseEngine):
         scheduler_config = self._scheduler_config or SchedulerConfig()
         engine_config = EngineConfig(
             model_name=self._model_name,
+            profile_name=self._profile_name,
             scheduler_config=scheduler_config,
             stream_interval=self._stream_interval,
             tool_logits_processor_factory=self._tool_logits_processor_factory,

--- a/vllm_mlx/engine_core.py
+++ b/vllm_mlx/engine_core.py
@@ -162,6 +162,10 @@ class EngineConfig:
     no_hybrid: bool = False
     force_spec_decode: bool = False
     no_spec_decode: bool = False
+    # Registry identity used only for operator-facing profile diagnostics.
+    # Keep this appended after every established field so positional callers
+    # retain their historical constructor semantics.
+    profile_name: str | None = None
 
 
 def _resolve_model_identity(engine_config: Any, configured: str | None) -> str | None:
@@ -410,7 +414,20 @@ class EngineCore:
         # Level 1 — always emit a one-line profile summary on engine init.
         # Level 2 — verbose ASCII capability table when explicitly requested
         # via env var ``RAPID_MLX_PROFILE_VERBOSE=1`` (or set on EngineConfig).
-        display_path = model_path or "(unknown)"
+        display_path = self.config.profile_name or model_path or "(unknown)"
+        display_model_config = self.model_config
+        if self.config.profile_name and self.config.profile_name != model_path:
+            # Alias-only facts (for example an external MTP sidecar) are lost
+            # after the loader resolves an alias to its snapshot path. Restore
+            # those facts for diagnostics only; scheduler policy continues to
+            # use ``self.model_config`` derived from the loaded checkpoint.
+            alias_cfg = detect_model_config(self.config.profile_name)
+            if alias_cfg is not None:
+                display_model_config = replace(
+                    alias_cfg,
+                    is_hybrid=self.model_config.is_hybrid,
+                    supports_spec_decode=self.model_config.supports_spec_decode,
+                )
         runtime_spec_decode = getattr(scheduler_config, "spec_decode", "none")
         # spec_decode == "none" is not proof of plain decode: the
         # SuffixDecoding lane leaves it "none" while decoding speculatively
@@ -432,7 +449,7 @@ class EngineCore:
         logger.info(
             format_profile_summary(
                 display_path,
-                self.model_config,
+                display_model_config,
                 runtime_spec_decode=lane_active,
             )
         )
@@ -459,7 +476,9 @@ class EngineCore:
             else:
                 table_runtime_spec = None
             for line in format_profile_table(
-                display_path, self.model_config, runtime_spec_decode=table_runtime_spec
+                display_path,
+                display_model_config,
+                runtime_spec_decode=table_runtime_spec,
             ).splitlines():
                 logger.info(line)
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2515,6 +2515,7 @@ def load_model(
         )
         _engine = BatchedEngine(
             model_name=_engine_model_path,
+            profile_name=effective_model_alias,
             chat_template_id=(
                 _profile.chat_template_id if _profile is not None else None
             ),
@@ -2775,6 +2776,7 @@ async def _load_dynamic_resident_model(
 
         engine = BatchedEngine(
             model_name=load_path,
+            profile_name=model_name if model_name != load_path else None,
             chat_template_id=(
                 profile.chat_template_id if profile is not None else None
             ),


### PR DESCRIPTION
## Why

Fixes #3274. Final 0.14.0 server dogfood found that an alias resolved to a
local snapshot could print two contradictory startup claims: the summary said
`spec decode MTP (active)`, while the verbose table said `MTP path: disabled`.
That makes the release's new runtime-reporting contract misleading to operators.

## Scope

- Preserve the validated alias/profile identity as diagnostic-only metadata
  when `load_model` and dynamic residency construct `BatchedEngine`.
- Use that identity for the startup summary/table while retaining loaded
  checkpoint architecture facts and the actual runtime lane.
- Add regression coverage for alias-to-snapshot startup copy and constructor
  compatibility.

## Non-goals

- No scheduler, speculative-decoding, model-loading, cache-key, residency, or
  multimodal logging behavior changes.
- No policy/default changes and no new model aliases.

## Acceptance

- A resolved `qwen3.5-9b-4bit` startup names the alias and reports its sidecar
  MTP capability without contradicting the active runtime lane.
- The loaded checkpoint remains the engine and scheduler identity.
- Existing positional `EngineConfig(model_name, scheduler_config)` callers keep
  their historical argument mapping.

## Verification

- `uv sync --extra test --locked`
- `uv run pytest -q tests/test_no_mllm_flag.py tests/test_server_load_model_order.py tests/test_model_auto_config.py` — 440 passed
- `ruff check` and `ruff format --check` on all five changed files
- `git diff --check`
- Adversarial review caught and fixed one compatibility risk by appending the
  new dataclass field instead of shifting existing positional arguments.

## Behaviour delta

`serve --verbose` after alias-to-snapshot resolution: contradictory/anonymous
profile copy → alias-preserving copy reconciled with loaded architecture and the
active decoding lane. Runtime behavior is unchanged.

## Design precedent

The implementation follows the established split between a stable user-facing
model identity and a resolved runtime artifact identity: retain both, use the
former for presentation and the latter for execution. Rapid-MLX already applies
this separation to chat-template and serving-lane metadata; this change extends
the same boundary to diagnostics instead of introducing a parallel registry.

## AI assistance disclosure

Codex reproduced the release-dogfood contradiction, wrote and adversarially
reviewed the five-file patch, and verified it with the focused 440-test suite,
lint, formatting, and diff checks. The compatibility finding was fixed and
pinned by a regression test.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally (focused 440-test affected surface)
- [x] Lint passes (`ruff check && ruff format --check`)
- [x] Self-validated with `python3 -m scripts.pr_validate.pr_validate <PR#>`
- [x] New regression tests were spot-checked against the production failure
- [x] README/docs not applicable: operator output now matches existing docs
- [x] No breaking changes to existing API

## Author

X handle (optional, external contributors):
