### PR TITLE
fix(mac): move MCP connectors to Experimental and gate pool models by memory

### DIFF
--- a/.agents/handoffs/pixel-mcp-connectors-experimental.md
+++ b/.agents/handoffs/pixel-mcp-connectors-experimental.md
@@ -1,0 +1,63 @@
+# Pixel handoff: MCP connectors under Experimental
+
+- Owner: Pixel
+- Branch: `pixel/mcp-connectors-experimental`
+- Worktree: `/private/tmp/rapid-mlx-mtp-connectors-experimental`
+- Base: `origin/main` at `0d25f3bd`
+- Goal: remove the standalone Connectors settings category, expose MCP as an
+  explicit Experimental opt-in, rename the Share Compute provider section to
+  Inference Pool, and prevent pool models that do not fit the host's unified
+  memory from being offered as ready/actionable.
+- Non-goals: server port ownership/crash recovery, MCP protocol/runtime
+  behavior, QuickSilver registration or routing behavior, model catalog or
+  download changes.
+
+## Decisions and verified facts
+
+- The user confirmed the feature is MCP (Model Context Protocol), not MTP.
+- MCP expands the model's available tools/data; it does not improve the model
+  itself and can add latency. The Experimental toggle says this directly and
+  preserves approval-by-default behavior.
+- Disabling MCP still clears the live catalog immediately, so tools stop being
+  advertised before an eventual engine restart.
+- Pool-model compatibility now consumes the centralized
+  `ModelSizing.isAvailable` verdict. The same verdict is used by onboarding,
+  picker start, auto-start, and cache-aware default selection; it combines the
+  footprint classifier with the verified RAM-tier override.
+- All three current pool aliases are unavailable on an 18 GB fixture. An
+  unavailable selection cannot download, register, or join from Share Compute.
+- Removing the Experimental container accessibility identifier was necessary:
+  SwiftUI was overwriting every child toggle identifier with the parent's.
+  Runtime AX validation now sees five independent switches with readable values.
+
+## Reference check
+
+- Searched the available Orca workspace for an established Settings /
+  Experimental placement pattern; no reusable source was present.
+- Reused Rapid Desktop's existing Experimental opt-in row and settings section
+  components rather than introducing a new navigation or disclosure pattern.
+- Reused the existing RAM-tier/footprint compatibility policy and consolidated
+  duplicate call sites into its shared verdict.
+
+## Verification
+
+- 218 focused Swift tests passed across MCP, Settings, Share Compute,
+  ModelSizing, RAM tiers, model selection, accessibility, and command palette.
+- GUI golden flows passed: `settings-persistence`, `settings-mtp`, and
+  `no-dead-controls`.
+- The no-dead-controls flow toggled MCP on and back off through AX and verified
+  the state round trip.
+- Light and Dark Experimental + MCP-enabled snapshots were generated. Visual
+  inspection confirmed the new hierarchy, copy, scrolling, and empty state.
+- The broader legacy snapshot matrix generated the relevant images, then later
+  hit a pre-existing missing `ServerManager` environment on an unrelated
+  post-Settings fixture. Directly encountered Settings/Images/Tools fixture
+  dependencies were repaired; remaining unrelated harness cleanup is follow-up.
+- `git diff --check` passed.
+
+## Coordination
+
+The required PR-start FYI channel was not available in this session. This
+handoff records the same intention, boundaries, affected areas, and validation
+for Atlas, Vector, Harbor, and Echo. Send the matching PR-complete FYI when the
+messaging channel is available.

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -366,7 +366,7 @@ final class ChatViewModel {
     ///
     /// Issue #1716: since the registry became a ``CompositeToolRegistry``,
     /// ``tools/definitions`` also carries connector tools. Those get their own
-    /// switch in Settings → Connectors, backed by a different defaults key
+    /// switch in Settings → Experimental, backed by a different defaults key
     /// (``MCPToolRegistry``). Listing them in both panels would give one tool
     /// two independent off switches — flip the wrong one and the tool stays
     /// live with no indication why. Each surface owns exactly its own set.

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -72,6 +72,13 @@ enum DevSnapshot {
             catalog: snapshotMCPCatalog,
             approval: snapshotMCPApproval
         )
+        let snapshotShareCompute = ShareComputeManager(server: server)
+        let snapshotMemoryDefaults = UserDefaults(suiteName: "rapid.dev-snapshot.memory")!
+        snapshotMemoryDefaults.removePersistentDomain(forName: "rapid.dev-snapshot.memory")
+        let snapshotMemory = MemoryStore(
+            fileURL: URL(fileURLWithPath: dir).appendingPathComponent("snapshot-memory.json"),
+            defaults: snapshotMemoryDefaults
+        )
         let snapshotSparkleUpdater = SparkleUpdateController(infoDictionary: [:])
         let snapshotWebSearch = WebSearchConfig()
         let snapshotPerfDefaults = UserDefaults(suiteName: "rapid.dev-snapshot.perf")!
@@ -259,6 +266,7 @@ enum DevSnapshot {
                     .environment(snapshotConsent)
                     .environment(snapshotStarPrompt)
                     .environment(dockPromptStore)
+                    .environment(snapshotShareCompute)
                     .environment(browseApproval)
                     .environment(imageGen)
                     .environment(audio)
@@ -299,6 +307,10 @@ enum DevSnapshot {
             AnyView(
                 ImagesView(viewModel: imageGen, server: server)
                     .tint(RapidTheme.brandAmber)
+                    // ``ReadinessBanner`` resolves the same manager through
+                    // the environment even though ``ImagesView`` also takes
+                    // it as an explicit argument.
+                    .environment(server)
                     // ``ImagesView`` deep-links to Settings → Model
                     // Management from its readiness banner, so it reads the
                     // router. Missing it trapped the harness here, one
@@ -836,9 +848,11 @@ enum DevSnapshot {
                     .environment(chat)
                     .environment(sampling)
                     .environment(chat.customInstructions)
+                    .environment(snapshotMemory)
                     .environment(appearance)
                     .environment(settingsRouter)
                     .environment(server)
+                    .environment(snapshotShareCompute)
                     // The capture loop walks Category.allCases, which in a
                     // debug build includes Developer — and that panel reads
                     // the coordinator.
@@ -897,6 +911,7 @@ enum DevSnapshot {
             AnyView(
                 SettingsToolsPanel(initiallyExpanded: expanded)
                     .environment(chat)
+                    .environment(server)
                     .environment(snapshotWebSearch)
                     .environment(browseApproval)
                     .frame(width: width, alignment: .top)
@@ -926,28 +941,18 @@ enum DevSnapshot {
         }
         snapshotWebSearch.provider = .duckduckgo
 
-        // Connectors with the master switch ON — the state that reveals
-        // the servers list, the empty hint and the approvals card.
+        // Experimental with MCP Connectors ON — the state that reveals the
+        // servers list, empty hint, and approvals card in its shipping home.
         snapshotMCPConfig.isEnabled = true
-        func connectorsPanel(width: CGFloat) -> AnyView {
-            AnyView(
-                SettingsConnectorsPanel()
-                    .environment(snapshotMCPConfig)
-                    .environment(snapshotMCPCatalog)
-                    .environment(snapshotMCPApproval)
-                    .environment(snapshotMCPTools)
-                    .environment(server)
-                    .frame(width: width, alignment: .top)
-                    .padding(RapidTheme.Space.xl)
-                    .background(RapidTheme.surfaceCanvas)
-                    .tint(RapidTheme.brandAmber)
-            )
-        }
         for (mode, name) in [("light", NSAppearance.Name.aqua),
                              ("dark", NSAppearance.Name.darkAqua)] {
-            renderHosted(connectorsPanel(width: 620),
-                         size: CGSize(width: 660, height: 900),
-                         appearance: name, to: "\(dir)/connectors-enabled-\(mode).png")
+            let size = CGSize(width: 900, height: 720)
+            renderHosted(
+                settingsShell(category: .experimentalFeatures, size: size),
+                size: size,
+                appearance: name,
+                to: "\(dir)/settings-experimental-connectors-enabled-\(mode).png"
+            )
         }
         snapshotMCPConfig.isEnabled = false
 

--- a/apps/rapid-mac/Sources/Rapid/MCP/MCPToolRegistry.swift
+++ b/apps/rapid-mac/Sources/Rapid/MCP/MCPToolRegistry.swift
@@ -100,7 +100,7 @@ final class MCPToolRegistry: ToolRegistry {
         guard connectorsEnabled else {
             return ToolCallResult(
                 toolCallID: call.id,
-                content: "Connectors are turned off in Settings → Connectors; '\(name)' was not run.",
+                content: "MCP Connectors are turned off in Settings → Experimental; '\(name)' was not run.",
                 isError: true,
                 failureKind: .userDeclined
             )
@@ -112,7 +112,7 @@ final class MCPToolRegistry: ToolRegistry {
         guard !disabledTools.contains(name) else {
             return ToolCallResult(
                 toolCallID: call.id,
-                content: "tool '\(name)' is turned off in Settings → Connectors and was not run.",
+                content: "tool '\(name)' is turned off in Settings → Experimental and was not run.",
                 isError: true,
                 failureKind: .userDeclined
             )

--- a/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ModelSizing.swift
@@ -203,6 +203,24 @@ enum ModelSizing {
         return .tooBig
     }
 
+    /// One compatibility verdict shared by every model-selection surface.
+    /// The curated RAM-tier table may override the conservative estimator for
+    /// a measured recommendation; every other model must pass ``classify``.
+    static func isAvailable(
+        alias: String,
+        on hardware: MacHardware,
+        catalogEntry: ModelEntry? = nil
+    ) -> Bool {
+        if RAMBucketedDefault.isRecommendedPick(
+            alias: alias,
+            physicalRAMGB: hardware.physicalRAMGB,
+            catalogEntry: catalogEntry
+        ) {
+            return true
+        }
+        return classify(estimate(alias: alias), on: hardware) != .tooBig
+    }
+
     /// The largest total footprint that still classifies as something other
     /// than ``Fit/tooBig`` on this host — i.e. the actual ceiling ``classify``
     /// enforces, in GB.

--- a/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/RAMBucketedDefault.swift
@@ -711,12 +711,11 @@ enum CacheAwareDefault {
         // bug — but keeping the exemption catalog-scoped makes the
         // invariant local and obvious.)
         let bucketedFits = bucketedEntry.map {
-            RAMBucketedDefault.isRecommendedPick(
+            ModelSizing.isAvailable(
                 alias: bucketedDefault,
-                physicalRAMGB: hardware.physicalRAMGB,
+                on: hardware,
                 catalogEntry: $0
             )
-                || isSafe($0, on: hardware)
         } ?? false
 
         // Step 1: bucketed default is on disk AND runnable. No

--- a/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeView.swift
+++ b/apps/rapid-mac/Sources/Rapid/ShareCompute/ShareComputeView.swift
@@ -11,6 +11,8 @@ struct ShareComputeView: View {
     @State private var providerKey = ""
     @State private var showingConnection = false
 
+    private let hardware = MacHardware.detect()
+
     private var selected: ShareComputeModel {
         ShareComputeModel.supported.first { $0.catalogID == selectedID }
             ?? ShareComputeModel.supported[0]
@@ -21,6 +23,18 @@ struct ShareComputeView: View {
     }
 
     private var selectedIsCached: Bool { selectedEntry?.cached == true }
+    private var selectedIsSupported: Bool {
+        ModelSizing.isAvailable(alias: selected.alias, on: hardware, catalogEntry: selectedEntry)
+    }
+
+    private func isSupported(_ model: ShareComputeModel) -> Bool {
+        let entry = catalog.first { $0.alias.caseInsensitiveCompare(model.alias) == .orderedSame }
+        return ModelSizing.isAvailable(alias: model.alias, on: hardware, catalogEntry: entry)
+    }
+
+    private var memoryTierLabel: String {
+        "Doesn't fit this \(Int(hardware.physicalRAMGB.rounded())) GB Mac"
+    }
 
     private var requiresRegistration: Bool {
         if !manager.hasRegistration(for: selected, worker: worker) { return true }
@@ -66,7 +80,7 @@ struct ShareComputeView: View {
     }
 
     private var providerCard: some View {
-        SettingsSection("Compute provider") {
+        SettingsSection("Inference Pool") {
             VStack(alignment: .leading, spacing: RapidTheme.Space.md) {
                 HStack(alignment: .top, spacing: RapidTheme.Space.md) {
                     Image(systemName: "bolt.horizontal.circle.fill")
@@ -109,9 +123,14 @@ struct ShareComputeView: View {
                 }
                 Picker("Pool model", selection: $selectedID) {
                     ForEach(ShareComputeModel.supported) { model in
-                        Text(model.title).tag(model.catalogID)
+                        Text(!catalogLoaded || isSupported(model)
+                             ? model.title
+                             : "\(model.title) — Doesn't fit this Mac")
+                            .tag(model.catalogID)
+                            .disabled(catalogLoaded && !isSupported(model))
                     }
                 }
+                .disabled(!catalogLoaded)
                 .accessibilityIdentifier("ShareCompute.ModelPicker")
 
                 HStack {
@@ -119,11 +138,13 @@ struct ShareComputeView: View {
                         Text(selected.detail).font(RapidFont.body)
                         Text(!catalogLoaded
                              ? "Checking this Mac…"
+                             : !selectedIsSupported
+                                ? memoryTierLabel
                              : selectedIsCached
                                 ? "Ready on this Mac"
                                 : "Download required before sharing")
                             .font(RapidFont.secondary)
-                            .foregroundStyle(selectedIsCached ? .green : .secondary)
+                            .foregroundStyle(selectedIsSupported && selectedIsCached ? .green : .secondary)
                     }
                     Spacer()
                     if !catalogLoaded {
@@ -131,6 +152,11 @@ struct ShareComputeView: View {
                             .buttonStyle(.rapidPrimaryCompact)
                             .disabled(true)
                             .accessibilityIdentifier("ShareCompute.CatalogChecking")
+                    } else if !selectedIsSupported {
+                        Button("Unavailable") {}
+                            .buttonStyle(.rapidPrimaryCompact)
+                            .disabled(true)
+                            .accessibilityIdentifier("ShareCompute.ModelUnavailable")
                     } else if selectedIsCached {
                         Button(requiresRegistration ? "Connect & Share" : "Start Sharing") {
                             if !requiresRegistration {

--- a/apps/rapid-mac/Sources/Rapid/UI/CommandPaletteView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommandPaletteView.swift
@@ -198,7 +198,7 @@ enum CommandPalette {
             case .launch: return "Open Launch"
             case .settings: return "Open Settings"
             case .modelManagement: return "Open Model Management"
-            case .connectors: return "Open Connectors"
+            case .connectors: return "Open MCP Connectors"
             case .serverLogs: return "Show or hide server logs"
             case .exportDiagnostics: return "Export diagnostics…"
             case .checkUpdates: return "Check for updates"
@@ -246,7 +246,7 @@ enum CommandPalette {
             case .launch: return String(localized: String.LocalizationValue("Open Launch"))
             case .settings: return String(localized: String.LocalizationValue("Open Settings"))
             case .modelManagement: return String(localized: String.LocalizationValue("Open Model Management"))
-            case .connectors: return String(localized: String.LocalizationValue("Open Connectors"))
+            case .connectors: return String(localized: String.LocalizationValue("Open MCP Connectors"))
             case .serverLogs: return String(localized: String.LocalizationValue("Show or hide server logs"))
             case .exportDiagnostics: return String(localized: String.LocalizationValue("Export diagnostics…"))
             case .checkUpdates: return String(localized: String.LocalizationValue("Check for updates"))

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -794,7 +794,7 @@ struct ContentView: View {
                 openWindow(id: "settings")
             }
         case .connectors:
-            settingsRouter.route(to: .connectors) {
+            settingsRouter.route(to: .experimentalFeatures) {
                 openWindow(id: "settings")
             }
         case .serverLogs:
@@ -1843,12 +1843,11 @@ struct ContentView: View {
         // rejected here. Mirrors ModelPickerBar.handleStartTap, the switch
         // gate above, and CacheAwareDefault.bucketedFits.
         let rejectsAlias: (String) -> Bool = { candidate in
-            ModelSizing.classify(ModelSizing.estimate(alias: candidate), on: hardware) == .tooBig
-                && !RAMBucketedDefault.isRecommendedPick(
-                    alias: candidate,
-                    physicalRAMGB: hardware.physicalRAMGB,
-                    catalogEntry: catalogEntries.first { $0.alias == candidate }
-                )
+            !ModelSizing.isAvailable(
+                alias: candidate,
+                on: hardware,
+                catalogEntry: catalogEntries.first { $0.alias == candidate }
+            )
         }
         let decision = AutoStartDecision.decide(
             lastServedAlias: launchPlan.models.chatAlias,
@@ -2165,7 +2164,7 @@ private struct MCPToolApprovalSheet: View {
                 .foregroundStyle(.secondary)
 
             Text("Always allow applies to this tool only. You can review and "
-                + "revoke it in Settings → Connectors.")
+                + "revoke it in Settings → Experimental.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 

--- a/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ModelPickerBar.swift
@@ -1600,21 +1600,16 @@ struct ModelPickerBar: View {
             }
             return
         }
-        let fit = ModelSizing.classify(
-            ModelSizing.estimate(alias: trimmed),
-            on: hardware
-        )
         // A recommended pick trusts the curated table's measured
         // footprint over ModelSizing's estimate (which over-states
         // low-bit / MoE models), so it skips the .tooBig gate — the
         // table already vetted it fits this Mac's RAM tier.
         let catalogEntry = catalog.first(where: { $0.alias == trimmed })
-        let isRecommended = RAMBucketedDefault.isRecommendedPick(
+        if !ModelSizing.isAvailable(
             alias: trimmed,
-            physicalRAMGB: hardware.physicalRAMGB,
+            on: hardware,
             catalogEntry: catalogEntry
-        )
-        if fit == .tooBig && !isRecommended {
+        ) {
             pendingTooBigStart = trimmed
             return
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingModelSelection.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingModelSelection.swift
@@ -280,9 +280,9 @@ enum OnboardingModelSelection {
 
     // MARK: - Availability
 
-    /// Whether this Mac can run the alias, using the classification the model
-    /// picker already disables on. Not a new compatibility claim — the same
-    /// ``ModelSizing`` estimate, read in one more place.
+    /// Whether this Mac can run the alias. Delegates to the shared
+    /// ``ModelSizing/isAvailable(alias:on:catalogEntry:)`` verdict used by
+    /// launch, picker, and Share Compute surfaces.
     ///
     /// A curated recommendation is trusted over ``ModelSizing``'s estimate,
     /// which over-states low-bit / MoE footprints (the 32 GB tier's
@@ -303,14 +303,7 @@ enum OnboardingModelSelection {
         hardware: MacHardware,
         catalogEntry: ModelEntry? = nil
     ) -> Bool {
-        if RAMBucketedDefault.isRecommendedPick(
-            alias: alias,
-            physicalRAMGB: hardware.physicalRAMGB,
-            catalogEntry: catalogEntry
-        ) {
-            return true
-        }
-        return ModelSizing.classify(ModelSizing.estimate(alias: alias), on: hardware) != .tooBig
+        ModelSizing.isAvailable(alias: alias, on: hardware, catalogEntry: catalogEntry)
     }
 
     /// Build the row set for a catalogue slice. Cached-ness comes from the

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsConnectorsPanel.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Settings → Connectors. The whole user-facing surface for MCP (issue #1716).
+/// Settings → Experimental → MCP Connectors configuration (issue #1716).
 ///
 /// Before this, MCP was engine-complete and app-invisible: the only way to use
 /// it from the desktop was to hand-author `~/.config/rapid-mlx/mcp.json` and
@@ -57,21 +57,12 @@ struct SettingsConnectorsPanel: View {
     }
 
     var body: some View {
-        @Bindable var config = config
-        return VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
-            SectionHeader(
-                "Connectors",
-                subtitle: "Connect the model to MCP servers — programs on this Mac that expose tools like file access, databases or search. Off by default: a connector is a program that runs on your machine and that the model can invoke.",
-                emphasis: .page
-            )
-            masterSection
-            if config.isEnabled {
-                serversSection
-                if !catalog.tools.isEmpty {
-                    toolsSection
-                }
-                approvalSection
+        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+            serversSection
+            if !catalog.tools.isEmpty {
+                toolsSection
             }
+            approvalSection
         }
         .task(id: config.isEnabled) {
             // Reflect reality on open: the panel is the one place a user comes
@@ -107,37 +98,6 @@ struct SettingsConnectorsPanel: View {
         }
     }
 
-    // MARK: - Master switch
-
-    private var masterSection: some View {
-        @Bindable var config = config
-        return SettingsSection {
-                Toggle(isOn: $config.isEnabled) {
-                    SettingsRowLabel(
-                        title: "Enable connectors",
-                        description: "The local server only loads connectors when this is on."
-                    )
-                }
-                .toggleStyle(TrailingSettingsToggleStyle())
-                .accessibilityIdentifier("Settings.Connectors.MasterToggle")
-                // Turning the master switch on or off changes whether the child
-                // gets --mcp-config at all, which a hot reload cannot express —
-                // the flag is read once at spawn. ``needsRestart`` derives that
-                // from live state, so nothing is recorded here.
-                .onChange(of: config.isEnabled) { _, isOn in
-                    if !isOn {
-                        // Don't make the user wait for that restart to stop
-                        // offering connector tools. The child may still have
-                        // them loaded, but "connectors are off" has to mean
-                        // the model is not handed them on the very next turn —
-                        // dropping the catalog is what enforces that, since
-                        // ``MCPToolRegistry/definitions`` reads from it.
-                        catalog.clear()
-                    }
-                }
-        }
-    }
-
     // MARK: - Servers
 
     private var serversSection: some View {
@@ -164,7 +124,7 @@ struct SettingsConnectorsPanel: View {
                 InlineNotice(message: why, tone: .error)
             }
 
-            SettingsSection("Servers", subtitle: "Each server runs as its own program and exposes a set of tools.") {
+            SettingsSection("MCP connector servers", subtitle: "Each server exposes tools the model can request; local servers run as separate programs.") {
                 Button("Add…") { editing = EditorTarget(original: nil) }
                     .buttonStyle(.rapidSecondaryCompact)
                     .accessibilityIdentifier("Settings.Connectors.AddButton")

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -30,6 +30,8 @@ struct SettingsView: View {
     /// new binary; the toggle copy already calls that out.
     @Environment(ServerManager.self) private var server
     @Environment(ShareComputeManager.self) private var shareCompute
+    @Environment(MCPConfigStore.self) private var mcpConfig
+    @Environment(MCPCatalog.self) private var mcpCatalog
     /// #191: Settings → App panel binds the desktop self-update
     /// poller. ``RapidApp`` injects it into the Settings scene's
     /// environment chain so the panel can render the same
@@ -84,12 +86,6 @@ struct SettingsView: View {
         /// Built-in tools the model can call: on/off per tool, the
         /// web-search backend + key, and the browse approval mode.
         case tools
-        /// Issue #1716 — MCP connectors: which servers the engine runs, the
-        /// tools they expose, and the per-tool consent record. Separate from
-        /// ``tools`` because the two are different in kind: built-in tools
-        /// ship with the app and are audited by us, connectors are programs
-        /// the user installs and points us at.
-        case connectors
         /// Issue #1717 — per-model engine performance: KV-cache precision,
         /// prefix caching, cache budget. Deliberately NOT folded into
         /// ``modelManagement``'s sampling controls: those shape what the model
@@ -121,7 +117,6 @@ struct SettingsView: View {
             case .instructions: return "System Prompt"
             case .memory: return "Memory"
             case .tools: return "Tools"
-            case .connectors: return "Connectors"
             case .performance: return "Performance"
             case .experimentalFeatures: return "Experimental"
             case .appearance: return "Appearance"
@@ -138,7 +133,6 @@ struct SettingsView: View {
             case .instructions: return "text.bubble.fill"
             case .memory: return "brain"
             case .tools: return "wrench.and.screwdriver.fill"
-            case .connectors: return "powerplug.fill"
             case .performance: return "speedometer"
             case .experimentalFeatures: return "flask.fill"
             case .appearance: return "paintpalette.fill"
@@ -503,8 +497,6 @@ struct SettingsView: View {
             SettingsMemoryPanel()
         case .tools:
             SettingsToolsPanel()
-        case .connectors:
-            SettingsConnectorsPanel()
         case .performance:
             SettingsPerformancePanel()
         case .experimentalFeatures:
@@ -523,7 +515,8 @@ struct SettingsView: View {
     }
 
     private var experimentalFeaturesPanel: some View {
-        VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
+        @Bindable var mcpConfig = mcpConfig
+        return VStack(alignment: .leading, spacing: RapidTheme.Space.xl) {
             SectionHeader(
                 "Experimental",
                 subtitle: "Opt in to features that are still being validated across supported Macs.",
@@ -568,9 +561,23 @@ struct SettingsView: View {
                 .onChange(of: shareComputeEnabled) { _, enabled in
                     if !enabled { shareCompute.leave() }
                 }
+                SettingsRowDivider()
+                Toggle(isOn: $mcpConfig.isEnabled) {
+                    SettingsRowLabel(
+                        title: "Enable MCP Connectors",
+                        description: "Adds tools and data from MCP servers you configure. Useful for tasks that need external context or actions; it does not improve the model itself and may add latency. Off by default—connector tools ask for approval unless you explicitly allow them."
+                    )
+                }
+                .toggleStyle(TrailingSettingsToggleStyle())
+                .accessibilityIdentifier("Settings.Connectors.MasterToggle")
+                .onChange(of: mcpConfig.isEnabled) { _, enabled in
+                    if !enabled { mcpCatalog.clear() }
+                }
+            }
+            if mcpConfig.isEnabled {
+                SettingsConnectorsPanel()
             }
         }
-        .accessibilityIdentifier("Settings.Experimental.Panel")
     }
 
     private var instructionsPanel: some View {

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.enabled.txt
@@ -58,9 +58,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-mtp.unsupported.txt
@@ -58,9 +58,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-after-relaunch.txt
@@ -59,9 +59,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.instructions-saved.txt
@@ -59,9 +59,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-after-relaunch.txt
@@ -59,9 +59,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-idle.txt
@@ -59,9 +59,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.models-toggled.txt
@@ -59,9 +59,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.performance-saved.txt
@@ -59,9 +59,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/settings-persistence.settings-root.txt
@@ -59,9 +59,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-busy.app-panel.txt
@@ -65,9 +65,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.AheadOfManifest.txt
@@ -55,9 +55,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
+++ b/apps/rapid-mac/Tests/GUIGoldenFlows/__Snapshots__/update-state.app-panel.UpToDate.txt
@@ -58,9 +58,6 @@ AXApplication title="Rapid-MLX"
               AXButton id="Settings.Category.tools" desc="Tools" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true
-              AXButton id="Settings.Category.connectors" desc="Connectors" enabled=true
-          AXRow subrole=AXOutlineRow
-            AXCell enabled=true
               AXButton id="Settings.Category.performance" desc="Performance" enabled=true
           AXRow subrole=AXOutlineRow
             AXCell enabled=true

--- a/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AccessibilityIdentifierInventoryTests.swift
@@ -198,16 +198,15 @@ struct AccessibilityIdentifierInventoryTests {
         )
     }
 
-    // MARK: - Settings → Connectors (issue #1716)
+    // MARK: - Settings → Experimental → MCP Connectors (issue #1716)
 
     /// The connector surface is where a user authorises a program on their Mac
     /// to be driven by a model, so every control on it has to be reachable by
     /// the golden-flow harness — not just the happy-path ones.
-    @Test("Settings → Connectors names every control it offers")
+    @Test("Settings → Experimental → MCP Connectors names every control it offers")
     func settingsConnectorsPanelIdentifiers() throws {
         try assertDeclared(
             [
-                #""Settings.Connectors.MasterToggle""#,
                 #""Settings.Connectors.AddButton""#,
                 #""Settings.Connectors.SubsystemError""#,
                 #""Settings.Connectors.RestartButton""#,
@@ -226,7 +225,12 @@ struct AccessibilityIdentifierInventoryTests {
                 #""Settings.Connectors.ResetApprovals""#,
             ],
             in: "Sources/Rapid/UI/SettingsConnectorsPanel.swift",
-            surface: "Settings → Connectors"
+            surface: "Settings → Experimental → MCP Connectors"
+        )
+        try assertDeclared(
+            [#""Settings.Connectors.MasterToggle""#],
+            in: "Sources/Rapid/UI/SettingsView.swift",
+            surface: "Settings → Experimental → Enable MCP Connectors"
         )
     }
 
@@ -243,7 +247,7 @@ struct AccessibilityIdentifierInventoryTests {
                 #""Settings.Connectors.Editor.Cancel""#,
             ],
             in: "Sources/Rapid/UI/MCPServerEditorSheet.swift",
-            surface: "Settings → Connectors → editor"
+            surface: "Settings → Experimental → MCP Connectors → editor"
         )
         // The two code editors route their identifier through the shared
         // `codeEditor(text:height:axIdentifier:)` builder so the modifier
@@ -258,7 +262,7 @@ struct AccessibilityIdentifierInventoryTests {
             #expect(
                 sheet.contains(#"axIdentifier:"\#(id)""#),
                 """
-                Settings → Connectors → editor: MCPServerEditorSheet.swift no \
+                Settings → Experimental → MCP Connectors → editor: MCPServerEditorSheet.swift no \
                 longer passes \(id) into codeEditor(text:height:axIdentifier:). \
                 Golden flows address this field by AXIdentifier — update \
                 scripts/gui-golden-flows.sh and this inventory together.

--- a/apps/rapid-mac/Tests/RapidTests/CommandPaletteTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommandPaletteTests.swift
@@ -21,11 +21,16 @@ struct CommandPaletteTests {
             CommandPalette.Command.allCases,
             matching: "export diagnostics"
         )
+        let connectorResults = CommandPalette.filter(
+            CommandPalette.Command.allCases,
+            matching: "mcp connectors"
+        )
 
         #expect(titleResults == [.newChat])
         #expect(imageTitleResults == [.images])
         #expect(updateTitleResults == [.checkUpdates])
         #expect(punctuationResults == [.exportDiagnostics])
+        #expect(connectorResults == [.connectors])
     }
 
     @Test("Filtering is case-insensitive and ignores diacritics")

--- a/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SettingsVisualFoundationTests.swift
@@ -76,12 +76,13 @@ struct SettingsVisualFoundationTests {
     @MainActor
     @Test("Every category still exists, with a title and an icon")
     func everyCategorySurvives() {
-        // ``performance`` joined in #1717 (per-model engine knobs), as
-        // ``connectors`` did in #1716. The guard's job is to make a category
+        // ``performance`` joined in #1717 (per-model engine knobs). MCP
+        // connectors now live under Experimental rather than consuming a
+        // top-level category. The guard's job is to make a category
         // change deliberate and reviewed, not to freeze the list forever —
         // update this literal alongside the enum when a feature adds one.
         var expected: Set<String> = [
-            "modelManagement", "instructions", "memory", "tools", "connectors", "performance",
+            "modelManagement", "instructions", "memory", "tools", "performance",
             "experimentalFeatures", "appearance", "privacy", "app",
         ]
         // `swift test` builds debug, so the debug-only category is present
@@ -108,17 +109,16 @@ struct SettingsVisualFoundationTests {
     @Test("Category order is deliberate, so arrow-key navigation stays stable")
     func categoryOrderIsStable() {
         var expectedOrder = [
-            "modelManagement", "instructions", "memory", "tools", "connectors", "performance",
+            "modelManagement", "instructions", "memory", "tools", "performance",
             "experimentalFeatures", "appearance", "privacy", "app",
         ]
         #if DEBUG
         expectedOrder.append("developer")
         #endif
         #expect(SettingsView.Category.allCases.map(\.rawValue) == expectedOrder)
-        // #1717: ``performance`` sits after ``connectors`` — both are
-        // "what the engine is wired to do", ahead of the presentation and
-        // app-level sections.
-        #expect(SettingsView.category(.connectors, movedBy: 1) == .performance)
+        // #1717: ``performance`` remains ahead of experimental and app-level
+        // sections; connectors are configured inside Experimental.
+        #expect(SettingsView.category(.tools, movedBy: 1) == .performance)
         #expect(SettingsView.category(.performance, movedBy: 1) == .experimentalFeatures)
         #expect(SettingsView.category(.experimentalFeatures, movedBy: 1) == .appearance)
         // The rail's ↑/↓ handler walks this order and clamps at the ends.
@@ -150,6 +150,8 @@ struct SettingsVisualFoundationTests {
                 "@Environment(CustomInstructionsConfig.self)",
                 "@Environment(SettingsRouter.self)",
                 "@Environment(ServerManager.self)",
+                "@Environment(MCPConfigStore.self)",
+                "@Environment(MCPCatalog.self)",
                 "@Environment(UpdateChecker.self)",
                 "@Environment(SparkleUpdateController.self)",
                 "@Environment(DockVisibilityPromptStore.self)",
@@ -165,6 +167,9 @@ struct SettingsVisualFoundationTests {
                 "@Environment(MCPToolApprovalStore.self)",
                 "@Environment(MCPToolRegistry.self)",
                 "@Environment(ServerManager.self)",
+            ]),
+            ("Sources/Rapid/UI/SettingsMemoryPanel.swift", [
+                "@Environment(MemoryStore.self)",
             ]),
             ("Sources/Rapid/UI/SettingsModelManagementPanel.swift", [
                 "@Environment(ServerManager.self)",
@@ -189,6 +194,20 @@ struct SettingsVisualFoundationTests {
         let panel = try strippedSource("Sources/Rapid/UI/SettingsModelManagementPanel.swift")
         #expect(panel.contains("@AppStorage(ModelPickerVisibility.showAllStorageKey)"))
         #expect(panel.contains("@AppStorage(AutoStartPreference.storageKey)"))
+    }
+
+    @Test("MCP connectors are an experimental opt-in, not a top-level category")
+    func connectorsLiveUnderExperimental() throws {
+        let settings = try strippedSource("Sources/Rapid/UI/SettingsView.swift")
+        let snapshots = try strippedSource("Sources/Rapid/DevSnapshot.swift")
+        #expect(!SettingsView.Category.allCases.map(\.rawValue).contains("connectors"))
+        #expect(settings.contains("title:\"EnableMCPConnectors\""))
+        #expect(settings.contains("SettingsConnectorsPanel()"))
+        #expect(settings.contains("$mcpConfig.isEnabled"))
+        #expect(
+            snapshots.components(separatedBy: ".environment(snapshotShareCompute)").count - 1 == 2,
+            "both ContentView and SettingsView snapshots must inject Share Compute state"
+        )
     }
 
     // MARK: - Shared components are actually used

--- a/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ShareComputeTests.swift
@@ -4,6 +4,16 @@ import Testing
 
 @Suite("Share Compute")
 struct ShareComputeTests {
+    private static func hardware(memoryGB: Double) -> MacHardware {
+        MacHardware(
+            brandString: "Apple M3 Pro",
+            family: .m3,
+            tier: .pro,
+            physicalRAMBytes: UInt64(memoryGB * Double(1 << 30)),
+            memoryBandwidthGBs: 150
+        )
+    }
+
     @Test("Feature is opt-in")
     func featureGate() {
         let suite = "ShareComputeTests.\(UUID().uuidString)"
@@ -12,6 +22,20 @@ struct ShareComputeTests {
         #expect(!ShareComputeFeatureConfig.isEnabled(in: defaults))
         defaults.set(true, forKey: ShareComputeFeatureConfig.enabledKey)
         #expect(ShareComputeFeatureConfig.isEnabled(in: defaults))
+    }
+
+    @Test("All pool models are unavailable on an 18 GB Mac")
+    func poolModelMemoryTiers() {
+        let eighteenGB = Self.hardware(memoryGB: 18)
+
+        #expect(ShareComputeModel.supported.map(\.catalogID) == [
+            "qwen3.8-27b",
+            "qwen3.6-35b",
+            "nemotron-3.5-lightning",
+        ])
+        #expect(ShareComputeModel.supported.allSatisfy {
+            !ModelSizing.isAvailable(alias: $0.alias, on: eighteenGB)
+        })
     }
 
     @Test("Worker labels match the provider's safe grammar")

--- a/apps/rapid-mac/docs/userflows.md
+++ b/apps/rapid-mac/docs/userflows.md
@@ -333,13 +333,15 @@ auto-promotes the selection (`setAPIKey`, `WebSearchProvider.swift:272`).
 
 ## Flow 15 — Connectors (MCP)
 
-**Trigger.** Settings → Connectors.
+**Trigger.** Settings → Experimental → **Enable MCP Connectors**.
 
 **Expected.**
 
-1. A master **Enable connectors** toggle (`Settings.Connectors.MasterToggle`,
-   opt-in). The flag is read once at spawn, so toggling it raises a **Restart
-   to apply** banner (`…RestartButton`).
+1. A master **Enable MCP Connectors** toggle (`Settings.Connectors.MasterToggle`,
+   opt-in) explains that connectors add tools and data access rather than making
+   the model itself smarter or faster, and that calls can add latency. The flag
+   is read once at spawn, so toggling it raises a **Restart to apply** banner
+   (`…RestartButton`).
 2. **Add / edit** a server through `MCPServerEditorSheet` (name, transport,
    command/URL, env, enable — `Settings.Connectors.Editor.*`). Rows expose
    status, toggle, and an edit/remove menu (`…Row.{Status,Toggle,Menu,Edit,

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3105,7 +3105,7 @@ flow_no_dead_controls() {
     see_main "$OUT/dead-before.json"
 
     local category
-    local settings_categories=(modelManagement instructions tools connectors performance appearance privacy app)
+    local settings_categories=(modelManagement instructions tools performance experimentalFeatures appearance privacy app)
     if jq -e '.data.ui_elements[]?
               | select(.identifier == "Settings.Category.developer")' \
         "$OUT/dead-before.json" >/dev/null; then
@@ -3268,8 +3268,8 @@ flow_no_dead_controls() {
     press_and_require_selected Settings.Tools.WebSearch.Backend.duckduckgo dead-actions-backend-restore
 
     see_main "$OUT/dead-actions-tools-done.json"
-    press "$OUT/dead-actions-tools-done.json" Settings.Category.connectors \
-        "$OUT/dead-actions-connectors-open.json"
+    press "$OUT/dead-actions-tools-done.json" Settings.Category.experimentalFeatures \
+        "$OUT/dead-actions-experimental-open.json"
     round_trip_toggle Settings.Connectors.MasterToggle dead-actions-connectors-master
 
     see_main "$OUT/dead-actions-connectors-done.json"

--- a/docs/engineering/decisions/2026-09-08-share-compute-desktop-boundary.md
+++ b/docs/engineering/decisions/2026-09-08-share-compute-desktop-boundary.md
@@ -29,6 +29,14 @@ explicit stop or provider failure, Desktop releases the lease and restores the
 previous local model. Disabling the experimental gate invalidates an in-flight
 join as well as stopping an established session.
 
+Before download or join, each pool model consumes the same centralized
+`ModelSizing.isAvailable` verdict as local model selection and launch. That
+verdict combines the conservative footprint classifier with the verified
+RAM-tier recommendation override. Models that do not fit the current Mac stay
+visible for context but cannot be selected, downloaded, or joined from Share
+Compute; for example, all three current pool models are unavailable on an
+18 GB Mac.
+
 App termination signals Share Compute, the embedded server, and downloads
 before waiting on any of them. The pool supervisor has a bounded graceful exit
 followed by process-group SIGKILL, and its nested serve process also carries the


### PR DESCRIPTION
## Why

MCP was presented as a first-class Settings category even though it is still an opt-in integration surface, while Share Compute could label a cached model Ready on this Mac without checking whether the host had enough unified memory. That combination made experimental capabilities look safer and more runnable than they actually were.

## User-visible goal

Make two experimental Desktop surfaces honest and easier to understand before release:

- MCP Connectors no longer occupies a top-level Settings category. It now lives under Settings → Experimental behind an explicit Enable MCP Connectors switch.
- Share Compute calls its provider section Inference Pool and no longer reports an oversized cached model as Ready on this Mac.

## Scope

- Preserve the existing MCP preference key, server configuration, tool approvals, restart behavior, and immediate catalog clearing when disabled.
- Explain that MCP adds external tools/data, does not improve the model itself, may add latency, and asks for tool approval by default.
- Route the command-palette shortcut to Experimental.
- Centralize model availability in ModelSizing.isAvailable and reuse it across Share Compute, onboarding, picker start, auto-start, and cache-aware defaults.
- Keep all three current pool models visible, but disable selection and every download/join action when the shared memory verdict says they do not fit.

## Explicit non-goals

- No server port or crash-recovery changes.
- No MCP protocol/runtime changes.
- No QuickSilver registration, routing, catalog, or download changes.
- No model downloads during validation.

## Quantitative acceptance evidence

- 3/3 current pool models are rejected on the deterministic 18 GB Mac fixture: qwen3.8-27b, qwen3.6-35b, and nemotron-3.5-lightning.
- The verified RAM-tier override remains intact, so measured recommendations are not rejected by the conservative generic estimator.
- 218 focused tests passed across Settings, MCP, Share Compute, model sizing, RAM tiers, picker/onboarding, accessibility, and command palette.
- A final focused rerun passed 76/76 tests.
- GUI golden flows passed: settings-persistence, settings-mtp, and no-dead-controls.
- The no-dead-controls flow verified all 5 Experimental switches have independent accessibility identities and that MCP toggles on/off and restores its original value.
- Light and Dark MCP-enabled Experimental screenshots were generated and inspected.

## Compatibility and risk

The MCP persistence key and runtime safety behavior are unchanged. Pool compatibility now uses the same verdict as other model-launch surfaces. The main risk is Settings layout/automation drift; updated AX baselines, accessibility inventory checks, and live reversible-control validation cover it.
