### PR TITLE
fix(copy): contextualize engine attribution

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
+++ b/apps/rapid-mac/Sources/Rapid/AboutPanel.swift
@@ -27,6 +27,8 @@ enum AboutPanel {
 
     private static let website = "https://rapidmlx.com"
     private static let repoURL = "https://github.com/raullenchai/Rapid-MLX"
+    static let mtplxAttribution = "Powered by MTPLX"
+    static let mtplxURL = "https://github.com/youssofal/mtplx"
     /// The policy in the repository, not `rapidmlx.com/privacy` — that page
     /// has never been published and 404s, so the About window's "Privacy"
     /// link opened nothing. `apps/rapid-mac/PRIVACY.md` is the real,
@@ -55,7 +57,8 @@ enum AboutPanel {
             engine: engineIdentity(resolution: server.binaryResolution),
             website: website,
             repoURL: repoURL,
-            privacyURL: privacyURL
+            privacyURL: privacyURL,
+            mtplxURL: mtplxURL
         )
         let host = NSHostingController(rootView: view)
         let win = NSWindow(contentViewController: host)
@@ -152,6 +155,7 @@ private struct AboutView: View {
     let website: String
     let repoURL: String
     let privacyURL: String
+    let mtplxURL: String
 
     private var versionLine: String {
         AboutPanel.versionLine(
@@ -212,6 +216,11 @@ private struct AboutView: View {
             }
             .font(.callout)
             .padding(.top, 2)
+
+            Link(AboutPanel.mtplxAttribution, destination: URL(string: mtplxURL)!)
+                .font(.caption)
+                .tint(RapidTheme.brand)
+                .accessibilityIdentifier("About.Link.MTPLX")
 
             Spacer(minLength: 0)
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -2782,7 +2782,7 @@ final class ServerManager {
             isOperating = false
             state = .crashed(
                 alias: trimmedAlias,
-                message: "Couldn't start the model — another app may already be using what Rapid needs to run. Quit other local AI apps (LM Studio, Ollama) or development servers, then click Restart."
+                message: "Couldn't start the model — another app may already be using what Rapid needs to run. Quit other local AI apps or development servers, then click Restart."
             )
             return
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/DesktopServerPortField.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/DesktopServerPortField.swift
@@ -57,7 +57,7 @@ struct DesktopServerPortField: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            Text("Default 7659 (R M L X on a phone). 8000 fallback still probed. Like MTPLX path + port, this lets your gateway keep 8000.")
+            Text("Default 7659 (R M L X on a phone). 8000 fallback still probed. A custom port lets your gateway keep 8000.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/SettingsView.swift
@@ -717,12 +717,6 @@ struct SettingsView: View {
             // other link in the app used the steel-blue link token.
             .foregroundStyle(RapidTheme.linkLabel)
 
-            Link("Powered by MTPLX",
-                 destination: URL(string: "https://github.com/youssofal/mtplx")!)
-                .font(RapidFont.caption)
-                .foregroundStyle(RapidTheme.linkLabel)
-                .accessibilityIdentifier("Settings.Privacy.Link.MTPLX")
-
             Spacer(minLength: 0)
         }
     }

--- a/apps/rapid-mac/Tests/RapidTests/AboutPanelCandidateIdentityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AboutPanelCandidateIdentityTests.swift
@@ -3,6 +3,12 @@ import Testing
 
 @Suite("About candidate identity")
 struct AboutPanelCandidateIdentityTests {
+    @Test("required engine attribution is contextualized in About")
+    func engineAttribution() {
+        #expect(AboutPanel.mtplxAttribution == "Powered by MTPLX")
+        #expect(AboutPanel.mtplxURL == "https://github.com/youssofal/mtplx")
+    }
+
     @Test("release build keeps the stable version line")
     func releaseVersionLine() {
         #expect(

--- a/apps/rapid-mac/Tests/RapidTests/AboutPanelCandidateIdentityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/AboutPanelCandidateIdentityTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Rapid
 
@@ -7,6 +8,29 @@ struct AboutPanelCandidateIdentityTests {
     func engineAttribution() {
         #expect(AboutPanel.mtplxAttribution == "Powered by MTPLX")
         #expect(AboutPanel.mtplxURL == "https://github.com/youssofal/mtplx")
+    }
+
+    @Test("About renders the required attribution and Privacy does not")
+    func engineAttributionPlacement() throws {
+        let testsDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+        let rapidMacRoot = testsDirectory
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let aboutSource = try String(
+            contentsOf: rapidMacRoot.appendingPathComponent("Sources/Rapid/AboutPanel.swift"),
+            encoding: .utf8
+        )
+        let settingsSource = try String(
+            contentsOf: rapidMacRoot.appendingPathComponent("Sources/Rapid/UI/SettingsView.swift"),
+            encoding: .utf8
+        )
+
+        #expect(aboutSource.contains("Link(AboutPanel.mtplxAttribution"))
+        #expect(aboutSource.contains("destination: URL(string: mtplxURL)!"))
+        #expect(aboutSource.contains(".accessibilityIdentifier(\"About.Link.MTPLX\")"))
+        #expect(!settingsSource.contains("Powered by MTPLX"))
+        #expect(!settingsSource.contains("Settings.Privacy.Link.MTPLX"))
     }
 
     @Test("release build keeps the stable version line")

--- a/apps/rapid-mac/docs/userflows.md
+++ b/apps/rapid-mac/docs/userflows.md
@@ -649,7 +649,8 @@ Rail.ThisMac,Step2.Kicker,Subject.{Bytes,Percent,Rail,Rate}}`.
 `Settings.App.{AutomaticUpdatesToggle,Checking,RecheckCTA,UpdateCTA,
 ExportDiagnostics,HideDockOnCloseToggle,ResetDockOnboardingCTA}`,
 `Settings.Appearance.ThemePicker`, `Settings.Privacy.TelemetryToggle`,
-`Settings.Privacy.Link.{PrivacyPolicy,License,Credits,MTPLX}`.
+`Settings.Privacy.Link.{PrivacyPolicy,License,Credits}`. Required engine
+attribution is available in About as `About.Link.MTPLX`.
 
 **Model Management — `UI/SettingsModelManagementPanel.swift`:**
 `Settings.ModelManagement.{Search,ClearSearch,Filter,SortMenu,Sort.<order>,

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -3156,12 +3156,6 @@ flow_no_dead_controls() {
     press "$OUT/dead-appearance-light.json" Settings.Category.privacy "$OUT/dead-open-privacy-actions.json" \
         || die "Privacy category is not pressable"
     see_main "$OUT/dead-privacy-before.json"
-    jq -e '.data.ui_elements[]?
-           | select(.identifier == "Settings.Privacy.Link.MTPLX")' \
-        "$OUT/dead-privacy-before.json" >/dev/null \
-        || die "MTPLX attribution link is missing from Settings → Privacy"
-    [[ "$(element_field "$OUT/dead-privacy-before.json" Settings.Privacy.Link.MTPLX enabled)" == "true" ]] \
-        || die "MTPLX attribution link is disabled"
     local telemetry_before telemetry_after
     telemetry_before="$(element_field "$OUT/dead-privacy-before.json" Settings.Privacy.TelemetryToggle value)"
     press "$OUT/dead-privacy-before.json" Settings.Privacy.TelemetryToggle "$OUT/dead-privacy-toggle.json" \

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -1731,6 +1731,39 @@ APPLESCRIPT
     die "Settings window did not open"
 }
 
+open_about() {
+    osascript - "$APP_PID" > "$OUT/open-about.json" <<'APPLESCRIPT'
+on run argv
+    set targetPID to (item 1 of argv) as integer
+    tell application "System Events"
+        set targetProcess to first application process whose unix id is targetPID
+        set frontmost of targetProcess to true
+        tell targetProcess
+            repeat with menuBarItem in menu bar items of menu bar 1
+                try
+                    if exists menu item "About Rapid-MLX" of menu 1 of menuBarItem then
+                        click menu item "About Rapid-MLX" of menu 1 of menuBarItem
+                        return "{\"success\":true,\"method\":\"app-menu\"}"
+                    end if
+                end try
+            end repeat
+        end tell
+    end tell
+    error "About Rapid-MLX menu item not found"
+end run
+APPLESCRIPT
+
+    local probe=2
+    for _ in {1..40}; do
+        probe=0
+        ax_window_present "About Rapid-MLX" "$OUT/about-windows.json" || probe=$?
+        [[ "$probe" == 0 ]] && return
+        [[ "$probe" == 2 ]] && die "could not observe whether About opened"
+        sleep 0.25
+    done
+    die "About window did not open"
+}
+
 see_settings() {
     "$AX_DRIVER" dump "$APP_PID" > "$1"
 }
@@ -3166,6 +3199,18 @@ flow_no_dead_controls() {
         || die "Telemetry toggle accepted AXPress but its value did not change"
     press "$OUT/dead-privacy-after.json" Settings.Privacy.TelemetryToggle "$OUT/dead-privacy-restore.json" \
         || die "Telemetry toggle could not be restored"
+
+    # Attribution is product identity, not telemetry behavior. Exercise it in
+    # About so the exact legally required label remains visible and actionable
+    # without implying a data-sharing relationship in Settings → Privacy.
+    open_about
+    wait_identifier About.Link.MTPLX "$OUT/dead-about.json"
+    jq -e '.data.ui_elements[]?
+           | select(.identifier == "About.Link.MTPLX")
+           | select(.description == "Powered by MTPLX")
+           | select(.enabled == true)' \
+        "$OUT/dead-about.json" >/dev/null \
+        || die "About does not expose the enabled Powered by MTPLX attribution"
 
     local ax_contracts=(
         "dead-panel-tools.json|Settings.Tools.Toggle.web_search|Web search"

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -12786,7 +12786,7 @@ Examples:
         help="Interactive chat REPL with a model",
         description=(
             "Interactive chat REPL with a model.\n\n"
-            "Note: 'rapid-mlx run' is an alias for 'chat' (Ollama compatibility)."
+            "Note: 'rapid-mlx run' is an alias for 'chat'."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         # See serve_parser for the rationale: ``--think``/``--no-think`` +

--- a/vllm_mlx/share/cli.py
+++ b/vllm_mlx/share/cli.py
@@ -923,8 +923,8 @@ def register(subparsers: argparse._SubParsersAction) -> None:
             "rapidmlx chat-frontend allowlist (rapid-pro.pages.dev, "
             "rapid-pro.quicksilverpro.io, rapidmlx.com, chat.rapidmlx.com) "
             "plus whatever ``--chat-frontend`` resolves to. Pass '*' to "
-            "relax for browser chat UIs you host elsewhere (e.g. local "
-            "Open WebUI). Example: --cors-origins http://localhost:3000."
+            "relax for browser chat UIs you host elsewhere. Example: "
+            "--cors-origins http://localhost:3000."
         ),
     )
     p.add_argument(


### PR DESCRIPTION
## Why

The required engine attribution currently appears in Settings → Privacy, where it reads like a privacy or telemetry relationship and confuses users. A small number of user-facing diagnostics and CLI help strings also name unrelated products where generic, actionable language is clearer.

## What changed

- Keep the exact required `Powered by MTPLX` attribution and link, but move it to the About panel alongside product and open-source identity.
- Remove the attribution from the Privacy panel and update its GUI-flow contract.
- Replace incidental vendor names in a Desktop port hint, a port-conflict recovery message, and two CLI help strings with standalone Rapid-MLX language.
- Preserve intentional integration documentation, benchmark comparisons, internal engineering comments, dependency notices, and legally required attribution.

## Design precedent

Native macOS applications conventionally place engine and open-source credits in About/credits surfaces, while Privacy stays limited to data collection and handling. This change follows that separation without hiding or weakening attribution.

## Scope

Allowed: attribution placement, directly related accessibility/test documentation, and incidental user-visible competitor references.

Non-goals: license changes, dependency changes, benchmark copy, integration documentation, runtime behavior, or a broader copy rewrite.

## Verification

- [x] `swift test --no-parallel --filter AboutPanelCandidateIdentityTests` (3 passed)
- [x] `python3.12 -m pytest -q tests/test_share_cli.py tests/test_cli_chat.py` (187 passed)
- [x] `bash -n apps/rapid-mac/scripts/gui-golden-flows.sh`
- [x] `git diff --check`
- [x] Scoped source audit confirms the exact attribution remains in About and the removed incidental strings no longer appear in shipping Desktop/CLI copy.