### PR TITLE
feat(models): add MiniCPM5 2B support

### DIFF
--- a/.agents/handoffs/vector-minicpm5-2b-support.md
+++ b/.agents/handoffs/vector-minicpm5-2b-support.md
@@ -1,0 +1,30 @@
+# Vector handoff — MiniCPM5 2B support
+
+## PR-start FYI
+
+- Owner/host: Vector, Studio
+- Branch/worktree: `vector/minicpm5-2b-support`,
+  `/private/tmp/rapid-mlx-minicpm5-2b-support`
+- Intention: add the official MiniCPM5 2B MLX 4-bit checkpoint to the shared
+  Server/Desktop catalog with the already-supported native XML tool protocol.
+- Scope: alias metadata, offline size manifest, exact Desktop tool-capability
+  verdict, focused tests, user documentation, and reproducible qualification.
+- Non-goals: default-model changes, new model kernels, speculative/DSpark
+  support, broad MiniCPM family promotion, or sampling-policy changes.
+- Verification: alias/catalog/size tests, focused Swift capability tests,
+  real server load and 31-case tool suite, self-adversarial diff review, PR CI.
+
+The Orca agent messaging channel was unavailable in this session. This tracked
+handoff carries the equivalent non-blocking start FYI for Atlas, Pixel, Harbor,
+Echo, and ds0731.
+
+## Reference-first check
+
+The serving precedents use the checkpoint's standard `LlamaForCausalLM`
+implementation without a model-code fork. The MLX-native release has the same
+llama model type, 4-bit affine quantization, ChatML-style template, MiniCPM XML
+tool wire format, and Qwen-style reasoning envelope as mechanisms already
+present in Rapid. Reuse was selected; no new runtime or parser is justified.
+
+The separately published draft checkpoint targets a speculative algorithm not
+currently qualified in Rapid. It remains explicitly outside this PR.

--- a/.agents/handoffs/vector-minicpm5-2b-support.md
+++ b/.agents/handoffs/vector-minicpm5-2b-support.md
@@ -28,3 +28,23 @@ present in Rapid. Reuse was selected; no new runtime or parser is justified.
 
 The separately published draft checkpoint targets a speculative algorithm not
 currently qualified in Rapid. It remains explicitly outside this PR.
+
+## PR-complete FYI
+
+- PR: https://github.com/raullenchai/Rapid-MLX/pull/3285
+- Outcome: Server and Desktop now expose the official 2B MLX 4-bit checkpoint
+  through `minicpm5-2b-4bit`, with exact size and parser metadata.
+- Evidence: 3,590 focused Python contract tests and 42 Desktop capability tests
+  passed; the real alias booted, became ready, and reproduced 24/31 on the
+  tool-calling suite.
+- Quantitative result: 7.17 s summed request time versus 32.54 s for the 4B
+  comparison on the recorded M3 Ultra setup (78% less, about 4.5x faster), with
+  a 24/31 versus 26/31 correctness trade-off.
+- Risk/rollout: not a Smart default; speculative decoding stays disabled. One
+  failed selection case triggered the loop breaker and recovered, so repetition
+  stability remains something to monitor rather than a release blocker.
+- Follow-up owner: none required for this scoped support PR. A future draft-model
+  integration needs separate architecture and qualification work.
+
+As with the start FYI, this completion notice is recorded here because the Orca
+agent messaging channel was unavailable.

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ multiplication. The regular `qwen3.8-27b-4bit` alias remains unchanged for M3
 and newer Macs; Rapid does not silently swap checkpoint precision.
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
-→ [Every alias, quant, and family (190 text + 10 image + 10 video + 44 audio aliases, 254 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
+→ [Every alias, quant, and family (191 text + 10 image + 10 video + 44 audio aliases, 255 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
 
 ---
 

--- a/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ToolUseCapability.swift
@@ -117,6 +117,12 @@ enum ToolUseCapability {
     /// arbitrary size siblings by a family rule.
     static let exactKnownAliases: Set<String> = [
         "bonsai-1.7b-2bit",
+        // 2026-09-09 M3 Ultra qualification: official MLX 4-bit artifact
+        // passed 24/31 tool-call scenarios, including parallel calls,
+        // multi-step result continuation, error recovery, and valid JSON
+        // arguments. Keep this exact so future MiniCPM sizes do not inherit
+        // a capability verdict without their own product-path dogfood.
+        "minicpm5-2b-4bit",
         "ornith-1.5-9b-bf16",
         "ornith-1.5-35b-a3b-bf16",
     ]

--- a/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolUseCapabilityTests.swift
@@ -108,6 +108,17 @@ struct ToolUseCapabilityTests {
         #expect(ToolUseCapability.confidence(for: "ornith-1.5-135b") == .unknown)
     }
 
+    @Test("MiniCPM5-2B official MLX artifact is .known after product-path dogfood")
+    func miniCPM5_2BIsKnown() {
+        #expect(ToolUseCapability.confidence(for: "minicpm5-2b-4bit") == .known)
+    }
+
+    @Test("Unverified MiniCPM5 size siblings remain .unknown")
+    func miniCPM5UnverifiedSizesAreUnknown() {
+        #expect(ToolUseCapability.confidence(for: "minicpm5-1b-4bit") == .unknown)
+        #expect(ToolUseCapability.confidence(for: "minicpm5-3b-4bit") == .unknown)
+    }
+
     @Test("llama3-3b-4bit is .known — smallest empirically-good llama")
     func llama3_3bIsKnown() {
         #expect(ToolUseCapability.confidence(for: "llama3-3b-4bit") == .known)

--- a/docs/engineering/performance/2026-09-09-minicpm5-2b-qualification.md
+++ b/docs/engineering/performance/2026-09-09-minicpm5-2b-qualification.md
@@ -1,0 +1,94 @@
+# MiniCPM5 2B MLX qualification — 2026-09-09
+
+## Decision
+
+Register the official `openbmb/MiniCPM5-2B-MLX` artifact as
+`minicpm5-2b-4bit`. It fills the compact, latency-sensitive local-agent tier.
+It does not replace the existing Smart defaults: the measured speed advantage
+comes with a smaller but visible tool-selection reliability gap.
+
+## Artifact and compatibility
+
+- Checkpoint: `openbmb/MiniCPM5-2B-MLX`, revision
+  `35ac38ee7bdb0bf7fa748d0700eeb6d6675760a3`
+- Download footprint: 1,425,999,742 bytes
+- Quantization: 4-bit affine, group size 64
+- Architecture: dense `LlamaForCausalLM`, 42 layers, 2,516,756,480 total
+  parameters
+- Context declaration: 131,072 tokens
+- Tool wire format: MiniCPM native XML (`minicpm` parser)
+- Reasoning wire format: `<think>...</think>` (`qwen3` parser)
+
+No new model implementation or parser was required. The primary server
+precedents load the same standard architecture without a model-code fork, and
+the MLX-native release loads through the existing llama implementation. The
+published draft model uses a separate speculative method; this qualification
+does not infer compatibility with Rapid's current speculative paths.
+
+## Environment
+
+- Hardware: Mac Studio, M3 Ultra, 256 GB unified memory
+- OS/date: macOS, 2026-09-09
+- Rapid revision: `ef71b3484f009987cb37a28682ed52420cf00e03`
+- Engine: continuous batching, `max_num_seqs=2`
+- Server flags: `--enable-auto-tool-choice --tool-call-parser minicpm
+  --reasoning-parser qwen3`
+- Comparison artifact: `mlx-community/Qwen3.5-4B-MLX-4bit`
+- Comparison parser: `hermes`
+- Evaluation temperature: 0 for the tool-calling suite
+
+Both checkpoints were already warm before the timed suite. The evaluator
+cleared the server prefix cache before each model run.
+
+## Reproduction
+
+Start each server on the same port, then run:
+
+```bash
+python evals/run_eval.py \
+  --model minicpm5-2b \
+  --host 127.0.0.1 --port 18092 \
+  --parser minicpm --quantization 4bit \
+  --suite tool_calling \
+  --hardware 'Mac Studio M3 Ultra 256GB' \
+  --server-flags '--enable-auto-tool-choice --tool-call-parser minicpm --reasoning-parser qwen3' \
+  --model-path openbmb/MiniCPM5-2B-MLX
+```
+
+Repeat with the comparison checkpoint and its `hermes` parser.
+
+## Results
+
+| Official MLX 4-bit artifact | Correct | Summed request time | Median request | Slowest request |
+| --- | ---: | ---: | ---: | ---: |
+| MiniCPM5 2B | 24/31 (77%) | 7.17 s | 0.20 s | 0.58 s |
+| Qwen3.5 4B | 26/31 (84%) | 32.54 s | 0.99 s | 5.91 s |
+
+On this suite and hardware, MiniCPM used 22% of the comparison model's summed
+request time (78% less, about 4.5x faster). It missed seven cases: one basic
+image-generation selection, one ambiguous code-run selection, two three-step
+chains, two missing-argument refusal cases, and one dependent nested call. All
+emitted tool arguments that reached the parser were valid JSON.
+
+Manual product-path probes also passed:
+
+- strict JSON-only response, with no surrounding prose;
+- required single tool call with schema-valid arguments;
+- tool-result continuation into a final natural-language answer;
+- a thinking-enabled reasoning request terminating normally at 760 generated
+  tokens in 3.52 seconds (216.1 tokens/s reported by the server).
+
+## Caveats
+
+- These timings are M3 Ultra results and must not be projected to other chips.
+- The comparison measures official MLX 4-bit artifacts, not GGUF Q4_K_M.
+- One run of 31 scenarios establishes product compatibility, not a general
+  quality ranking.
+- During the alias-based confirmation run, Rapid's exact-token loop breaker
+  intervened in the failed basic image-generation selection case. The request
+  recovered and the remaining suite completed, but the intervention reinforces
+  keeping this model out of the default recommendations for now.
+- A third-party report observed repetition in a GGUF thinking workload at the
+  published sampling defaults. The MLX product-path probe terminated normally,
+  but broader stochastic stability should be monitored before changing a
+  default recommendation.

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -19,11 +19,31 @@ Families with registered aliases (run `rapid-mlx models` for the full, current l
 | Granite 4 / 4.2 | tiny, h-micro (4.0-H); 3B, 8B, 30B dense (4.2) | 4/8-bit |
 | Nemotron 3 / 3.5 | Nano 30B, Lightning 30B | 4-bit |
 | LFM 2 / 2.5 | 1B, 2.6B, 8B-A1B, 24B-A2B | 4-bit |
+| MiniCPM 5 | 1B, 2B | 4-bit, OptiQ 4-bit |
 | GPT-OSS | 20B, 120B | 4/8-bit, mxfp4 |
 | Ternary Bonsai | 1.7B, 27B | 2-bit (ternary) |
 | Hunyuan 3 (Hy3) | 295B MoE (21B active) — **Ultra-only** | 4-bit |
 | NeoHorse 1 | 9B (experimental Chat candidate) | 4-bit |
 | G9v3 (AI9Stars) | 39B MoE (5B active) | 4-bit |
+
+### MiniCPM5 2B
+
+`minicpm5-2b-4bit` is the compact, tool-capable option for latency-sensitive
+local assistants. It uses the official Apple Silicon 4-bit checkpoint (about
+1.3 GiB), the native MiniCPM XML tool-call parser, and the Qwen-style reasoning
+parser. It is available in both the CLI and Desktop model picker, but it does
+not replace the RAM-tier Smart defaults.
+
+```bash
+rapid-mlx serve minicpm5-2b-4bit
+```
+
+The exact checkpoint passed 24 of 31 tool-calling scenarios in product-path
+qualification. It completed the same suite in 7.17 seconds of summed request
+time versus 32.54 seconds for the current 4B comparison model, while the 4B
+model passed 26 of 31. Treat MiniCPM5 2B as the faster, smaller trade-off rather
+than a blanket quality replacement. Speculative decoding remains disabled
+until its separately published draft architecture is supported and qualified.
 
 ### Recommended Models
 

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -234,15 +234,25 @@ def test_experimental_alias_flag_requires_a_boolean(bad_value) -> None:
 
 
 def test_minicpm5_aliases_pin_the_verified_native_xml_contract() -> None:
-    """The two #1139 artifacts share MiniCPM5's native tool-call wire format."""
+    """Every curated MiniCPM5 artifact shares its native XML wire format."""
     profiles = list_profiles()
-    for alias in ("minicpm5-1b-4bit", "minicpm5-1b-optiq-4bit"):
+    expected_paths = {
+        "minicpm5-1b-4bit": "openbmb/MiniCPM5-1B-MLX",
+        "minicpm5-1b-optiq-4bit": "mlx-community/MiniCPM5-1B-OptiQ-4bit",
+        "minicpm5-2b-4bit": "openbmb/MiniCPM5-2B-MLX",
+    }
+    for alias, expected_path in expected_paths.items():
         profile = profiles[alias]
+        assert profile.hf_path == expected_path
         assert profile.tool_call_parser == "minicpm"
         assert profile.reasoning_parser == "qwen3"
+        assert profile.is_hybrid is False
+        assert profile.is_moe is False
         assert profile.supports_spec_decode is False
         assert detect_model_config(alias) == profile
         assert detect_model_config(profile.hf_path) == profile
+
+    assert profiles["minicpm5-2b-4bit"].is_text_only is True
 
 
 # =============================================================================

--- a/tests/test_minicpm5_2b_alias.py
+++ b/tests/test_minicpm5_2b_alias.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Product contracts for the official MiniCPM5 2B MLX checkpoint."""
+
+from __future__ import annotations
+
+from vllm_mlx import model_sizes
+from vllm_mlx.catalog import build_legacy_catalog_snapshot
+from vllm_mlx.model_aliases import list_profiles
+from vllm_mlx.model_auto_config import detect_model_config
+
+ALIAS = "minicpm5-2b-4bit"
+REPO = "openbmb/MiniCPM5-2B-MLX"
+DOWNLOAD_BYTES = 1_425_999_742
+
+
+def test_alias_pins_the_qualified_checkpoint_and_protocols() -> None:
+    profile = list_profiles()[ALIAS]
+    assert profile.hf_path == REPO
+    assert profile.is_text_only is True
+    assert profile.tool_call_parser == "minicpm"
+    assert profile.reasoning_parser == "qwen3"
+    assert profile.is_hybrid is False
+    assert profile.is_moe is False
+    assert profile.supports_spec_decode is False
+    assert detect_model_config(ALIAS) == profile
+    assert detect_model_config(REPO) == profile
+
+
+def test_alias_is_available_to_server_and_desktop_as_text_chat() -> None:
+    snapshot = build_legacy_catalog_snapshot()
+    record = next(item for item in snapshot["aliases"] if item["alias"] == ALIAS)
+
+    assert record["availability"]["server"] is True
+    assert record["availability"]["desktop"] is True
+    assert record["capabilities"]["task_types"] == ["text_generation"]
+    assert record["capabilities"]["operation_modes"] == ["chat"]
+    assert record["capabilities"]["runtime_adapter"] == "mlx_lm"
+    assert record["capabilities"]["is_text_only"] is True
+    assert record["capabilities"]["tool_call_parser"] == "minicpm"
+    assert record["capabilities"]["reasoning_parser"] == "qwen3"
+
+
+def test_download_manifest_pins_the_qualified_footprint() -> None:
+    assert model_sizes.size_bytes(REPO) == DOWNLOAD_BYTES

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -2372,6 +2372,15 @@
     "is_moe": false,
     "supports_spec_decode": false
   },
+  "minicpm5-2b-4bit": {
+    "hf_path": "openbmb/MiniCPM5-2B-MLX",
+    "is_text_only": true,
+    "tool_call_parser": "minicpm",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": false,
+    "is_moe": false,
+    "supports_spec_decode": false
+  },
   "ornith-1.5-9b-bf16": {
     "hf_path": "ornith-ai/Ornith-1.5-9B-MLX",
     "tool_call_parser": "hermes",

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -209,6 +209,7 @@
     "MrMofer/ltx-2.5-mlx-q8": 67695751883,
     "Wan-AI/Wan2.1-T2V-1.3B-Diffusers": 28935653511,
     "openbmb/MiniCPM5-1B-MLX": 617961816,
+    "openbmb/MiniCPM5-2B-MLX": 1425999742,
     "ornith-ai/Ornith-1.5-35B-A3B-MLX": 69341391877,
     "ornith-ai/Ornith-1.5-9B-MLX": 17927699601,
     "pipenetwork/GLM-5.2-REAP50-MLX-4bit": 214380689191,


### PR DESCRIPTION
## Why

Add a genuinely small, low-latency local-agent option without overstating it as a universal quality upgrade. The official 4-bit checkpoint is about 1.3 GiB and uses model/runtime paths Rapid already supports.

## What

- register `minicpm5-2b-4bit` for Server and Desktop text chat
- wire the existing MiniCPM XML tool parser and Qwen-style reasoning parser
- record the exact download footprint for memory/storage UI
- mark only this dogfooded alias as tool-capable in Desktop; unverified size siblings remain unknown
- add catalog, alias, size, CLI, and Desktop regression coverage
- document reproducible qualification evidence and limitations

## Measured user impact

On an M3 Ultra Mac Studio with 256 GB unified memory, temperature 0, warm official MLX 4-bit checkpoints, and the same 31-case tool suite:

| Model | Correct | Summed request time | Median | Slowest |
| --- | ---: | ---: | ---: | ---: |
| MiniCPM5 2B | 24/31 (77%) | 7.17 s | 0.20 s | 0.58 s |
| Current 4B comparison | 26/31 (84%) | 32.54 s | 0.99 s | 5.91 s |

MiniCPM used 22% of the comparison model's summed request time: 78% less, or about 4.5x faster on this specific workload and machine. It is therefore exposed as a fast compact choice, not promoted into Smart defaults. A confirmation run through the new alias reproduced 24/31; Rapid's loop breaker intervened in one failed selection case and the server recovered to finish the suite.

Manual product-path probes also passed strict JSON-only output, a schema-valid required tool call, tool-result continuation, and a thinking request that terminated normally at 760 generated tokens in 3.52 seconds (216.1 tokens/s reported by the server).

## Non-goals

- no default-model recommendation change
- no new model kernel or parser
- no speculative/draft-model support
- no sampling-policy change
- no family-wide tool-capability promotion

## Validation

- `3590 passed`: focused Python alias/catalog/size/CLI contract suite
- `42 passed`: Desktop `ToolUseCapability` suites
- Ruff and JSON validation passed
- real server boot by alias, model load, readiness, and full 31-case tool suite passed operationally
- self-adversarial review completed for correctness, compatibility, regression risk, scope, generated files, and secrets
