### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,7 +17,40 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-09-09
+
+Rapid-MLX 0.14.0 adds experimental local Computer Use and shared-compute
+workspaces, expands the model and image-generation catalog, makes Community
+Benchmark easier to understand and share, and improves long-running service
+operation and Desktop control.
+
+Measured on the documented M3 Ultra workloads, Qwen3.8 27B MTP GDN
+verification improves decode from 45.87 to 52.28 tok/s (+14.0%), the qualified
+Muse-Glimmer 30B 8-bit DFlash pairing reaches 1.83× chat and 2.00× code
+throughput, and the opt-in short-request policy lowers TTFT behind three long
+prompts from 3.067 s to 1.206 s. These paths retain their documented hardware
+and opt-in boundaries.
+
 ### Added
+- **Experimental Computer Use in Desktop.** Starter workflows can carry out a
+  bounded task across supported Mac apps, with local planning, scoped control,
+  visual recovery, and explicit review before consequential actions.
+- **Experimental Share Compute workspace.** A Mac can opt in to serve work from
+  a compatible compute pool, with fit checks, loopback-safe configuration, and
+  clearer diagnostics. It remains off until the user enables it.
+- **Broader model support.** This release adds NeoHorse 1 9B, MiniCPM5 2B,
+  G9v3-39A5B, Granite 4.2 30B/8B/3B, an experimental Qwen3.8 27B Abliterated
+  4-bit variant, and a Qwen3.8 27B MTP companion, alongside
+  new local image-generation choices including FLUX.1 schnell, Stable
+  Diffusion 3.5 Large, SDXL Base, Bonsai Image 4B 2-bit, HiDream O1 Dev, and
+  Qwen Image Edit.
+- **Measured compact-model choice.** MiniCPM5 2B used 78% less summed request
+  time (about 4.5× faster) than the 4B comparison on the same M3 Ultra 31-case
+  tool workload, scoring 24/31 versus 26/31. It remains a non-default option so
+  users can choose the documented speed/quality tradeoff.
+- **Always-on server operation.** `rapid-mlx start` and the headless macOS
+  service lifecycle provide a supported path for persistent local serving;
+  `doctor` now reports deeper lifecycle and configuration diagnostics.
 - `/metrics` now breaks MTP speculative decoding down per verify call: `rapid_mlx_spec_decode_verify_calls_total`, `..._correction_tokens_total`, `..._bonus_tokens_total`, and per-depth `..._drafted_by_depth_total{depth=}` / `..._accepted_by_depth_total{depth=}` alongside the existing attempts/accepts counters, so a workload that loses with MTP can be attributed to wrong drafts, verify cost, or rollback churn. The continuous-batching MTP route (the default for tier-verified aliases) now feeds these counters too; previously it bypassed them and every `rapid_mlx_spec_decode_*` series stayed at 0. (#3155)
 - **One-click model unload in Desktop.** The resident-memory footer now has an
   eject control that releases loaded models when the server is idle. It checks
@@ -25,6 +58,12 @@ can actually understand.
   itself during a visible active response.
 
 ### Changed
+- Community Benchmark now shows live progress and ETA, reports comparable
+  median throughput/latency values, groups models by recommendation and local
+  availability, and makes the local-versus-shared result boundary explicit.
+- Short requests see less time-to-first-token delay when long prompt work is
+  already contending for the scheduler. The opt-in policy measured 60.7% lower
+  median TTFT on the release workload; ordinary FCFS remains the default.
 - The Desktop app now honours the same `RAPID_MLX_TELEMETRY=0` kill switch as
   the engine: with it set, no telemetry leaves the process even if you opted
   in. Nothing changes for normal launches (the variable is not set, and a
@@ -38,7 +77,11 @@ can actually understand.
 - `qwen3.5-4b-4bit` no longer turns MTP speculative decoding on by default. Measured single-stream decode was 25–37% slower with the MTP drafter on M2 Pro and M3 Ultra, with no gain under concurrency. The preset stays available: `rapid-mlx serve qwen3.5-4b-4bit --speculative-config '{"method":"mtp"}'`, or the Speculative decoding toggle in Desktop Performance settings. New catalog field `mtp_default_enabled` carries the product default separately from the qualification tier. (#3115)
 
 ### Fixed
-
+- Desktop streaming text remains legible in dark mode, long Markdown updates
+  redraw less work, and draft-and-post can recover its composer in Safari and
+  Chrome.
+- Image models can start from complete offline snapshots more reliably and
+  surface memory/readiness problems before committing to a load.
 - Community Benchmark result rows now show median decode tok/s and TTFT for
   the short case (median wall seconds for image and video), with the long case
   underneath, instead of an average duration across cases. Decode tok/s uses
@@ -3727,7 +3770,8 @@ Older versions: see the
 [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases)
 for auto-generated notes against earlier tags.
 
-[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.4...HEAD
+[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.14.0...HEAD
+[0.14.0]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.4...rapid-mac-v0.14.0
 [0.13.4]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.3...rapid-mac-v0.13.4
 [0.13.3]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2...rapid-mac-v0.13.3
 [0.13.2]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2-rc1...rapid-mac-v0.13.2

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.4</string>
+	<string>0.14.0</string>
 	<key>CFBundleVersion</key>
-	<string>170</string>
+	<string>171</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.14.0.md
+++ b/docs/release-notes/v0.14.0.md
@@ -1,0 +1,131 @@
+# Rapid-MLX 0.14.0
+
+Rapid-MLX 0.14.0 makes a Mac faster and more useful as a private local-AI
+system. It ships measured decode and scheduling improvements, experimental
+Computer Use and Share Compute workspaces, a clearer Community Benchmark,
+one-command and always-on serving, one-click model unload, and a substantially
+larger text and image catalog.
+
+## Measured performance improvements
+
+These are product-path measurements, not synthetic peak-kernel claims. Results
+identify the tested Mac and preserve opt-in/default boundaries; other hardware,
+prompts, and sampling settings can differ.
+
+| Path | Before | 0.14.0 result | Measured change |
+| --- | ---: | ---: | ---: |
+| Qwen3.8 27B MTP GDN verification, M3 Ultra | 45.87 tok/s | 52.28 tok/s | **+14.0% decode**; verification synchronization 4.954 → 4.644 s |
+| Muse-Glimmer 30B 8-bit DFlash, M3 Ultra | 22.1–22.6 tok/s | 41.3–46.3 tok/s | **2.00× code median**, **1.83× chat**, 1.94× overall |
+| Qwen3.8 Flash-Next 4-bit fused GDN, M3 Ultra | 25.43 tok/s | 27.04 tok/s | **+6.35% end-to-end decode**; isolated GDN layer +26.28% |
+| Short request behind three long prompts, M3 Ultra | 3.067 s TTFT | 1.206 s TTFT | **60.7% lower TTFT / 2.54× faster** |
+
+The Qwen3.8 MTP result used the same checkpoint, prompt, seed, K=3 draft depth,
+and 256-token output in three alternating runs; output hashes, acceptance rate,
+and verify-round count matched. The Muse-Glimmer acceleration is enabled only
+for its qualified 8-bit pairing and needs the 48 GB memory tier. Fused
+Flash-Next GDN and shortest-validated-tail scheduling remain explicit opt-ins
+while their hardware coverage grows; normal fallback paths are unchanged.
+
+See the reproducible records for
+[Qwen3.8 MTP GDN verification](../engineering/performance/2026-09-07-qwen38-mtp-gdn-verify.md),
+[Muse-Glimmer DFlash](../engineering/performance/muse-glimmer-30b-dflash-qualification.md),
+[Flash-Next fused GDN](../engineering/performance/2026-09-01-qwen4-fused-gdn-decode.md),
+and [short-request admission](../engineering/performance/scheduler-admission-1950.md).
+
+## Experimental Computer Use
+
+Enable Computer Use under Experimental Features to try bounded workflows that
+plan and execute locally across supported Mac apps. The first usable journeys
+cover supervised Downloads cleanup and drafting content before posting it
+through Safari or Chrome. The visual recovery loop is tied to the active server
+session, permissions and app targets are scoped, retries are bounded, and
+consequential actions remain reviewable. This is an early preview, not a promise
+of unattended general-purpose automation.
+
+## Experimental Share Compute
+
+The new Share Compute workspace lets a user explicitly offer compatible local
+capacity to a configured compute pool. Server and Desktop validate model fit
+and configuration before accepting work, keep persistent service bindings on
+safe local interfaces, expose live health and lifecycle state, and propagate
+request cancellation back to the local server. It is disabled by default and
+does not participate until the user opts in.
+
+## Community Benchmark is easier to trust
+
+Desktop and CLI now show the selected model, current phase, elapsed time, and
+ETA while a benchmark runs. Result rows share one definition of median decode
+throughput and TTFT, record run conditions and cached model metadata, distinguish
+local results from shared ones, and preview contributor identity before upload.
+Results remain local unless the user explicitly shares them.
+
+## New text models
+
+- **G9v3-39A5B 4-bit** adds a 21.3 GiB mixed-precision MoE option for 32 GB+
+  Macs. Its real-server qualification passed ordinary chat, reasoning, streamed
+  output, structured tool calls, tool-result continuation, Chinese, and coding;
+  the reasoning probe decoded at 85 tok/s on an M3 Ultra.
+- **Granite 4.2 30B, 8B, and 3B** arrive in 4-bit and 8-bit variants. All six
+  aliases passed the same 38-check server journey. Measured thinking decode on
+  an M3 Ultra ranged from 20.8 tok/s for 30B 8-bit to 175.1 tok/s for 3B 4-bit;
+  choose precision and size according to memory and quality needs.
+- **NeoHorse 1 9B 4-bit** is an experimental 18 GB-tier chat option. It measured
+  44.5 tok/s on its qualification run but did not beat the default recommendation
+  across the full quality suite, so 0.14.0 does not silently change users' model.
+- **Qwen3.8 27B Abliterated 4-bit** is an experimental 16.99 GB checkpoint for
+  users who explicitly want a reduced-refusal variant. Real product-path checks
+  covered text, image understanding, tool calls, four concurrent requests, and
+  cancellation recovery; measured text decode was 20.9 tok/s on an M3 Ultra.
+  It is not recommended by default, and reduced refusal is not improved
+  correctness or safety.
+- **MiniCPM5 2B 4-bit** is a compact, non-default 1.3 GiB option. On the same
+  M3 Ultra 31-case tool workload it scored 24/31 in 7.17 s versus 26/31 in
+  32.54 s for the 4B comparison: **78% less summed request time / about 4.5×
+  faster**, with the documented quality tradeoff.
+- Qwen3.8 27B gains an M1/M2-friendly MTP companion profile.
+
+## More local image generation
+
+The catalog now includes FLUX.1 schnell, Stable Diffusion 3.5 Large, SDXL Base,
+Bonsai Image 4B 2-bit, HiDream O1 Dev, and Qwen Image Edit. Examples from the
+release qualification matrix include FLUX.1 schnell at 1024×1024 in 23.36 s
+with 9.46 GiB peak use, Bonsai 4B 2-bit at 512×512 in 5.39 s with 6.52 GiB peak
+use, and SDXL Base at 1024×1024 in 16.46 s after model construction. These are
+single-machine measurements; the catalog and readiness UI expose the relevant
+memory tier before a costly load. Complete cached snapshots also behave more
+reliably offline.
+
+## Better day-to-day operation
+
+- Desktop can unload an idle resident model with one click while preserving the
+  current selection for an easy restart. The action refuses active chat, image,
+  audio, video, and dictation work rather than interrupting it silently.
+- `rapid-mlx start` selects a fitting cached model, starts the canonical server,
+  waits for readiness, and configures a supported agent profile from one command;
+  `--dry-run` previews every mutation.
+- `rapid-mlx service` installs and operates a least-privileged headless macOS
+  service with status, logs, restart, uninstall, rollback, and dry-run support.
+- `rapid-mlx doctor` adds structured lifecycle, import, cache, configuration,
+  and service diagnostics with verified repairs where a safe repair exists.
+- Streaming Markdown redraws less work, streaming text stays legible in dark
+  mode, and draft-and-post can recover its composer in Safari and Chrome.
+- Telemetry respects `RAPID_MLX_TELEMETRY=0`, `DO_NOT_TRACK=1`, and common CI
+  markers in both the engine and Desktop app.
+
+## Honest defaults
+
+0.14.0 does not turn every promising optimization or model into a default.
+Notably, Qwen3.5 4B MTP is now off by default after release qualification found
+single-stream decode 25–37% slower on M2 Pro and M3 Ultra with no concurrency
+gain. The feature remains available explicitly. Experimental kernels,
+schedulers, model candidates, Computer Use, and Share Compute keep their
+documented opt-in boundaries.
+
+## Upgrade
+
+```bash
+pip install -U rapid-mlx
+```
+
+Homebrew follows the PyPI release through its normal autobump process. Desktop
+users receive the signed and notarized update through the production appcast.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.13.4"
+version = "0.14.0"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Publish Rapid-MLX 0.14.0 from the exact content-complete `main` after the final
Mergify batch. This dedicated bump keeps the engine, Desktop app, changelog,
and curated release notes synchronized and activates the guarded auto-release
pipeline only after exact-head preflight evidence is green.

## What

- bump the engine and Desktop marketing version from 0.13.4 to 0.14.0
- increment the Desktop build number from 170 to 171
- add the 0.14.0 changelog section and curated release notes
- reset the Unreleased comparison link to the new Desktop tag

## Validation

- `make release-smoke`
- release version/note/subject contract tests
- exact-parent non-publishing auto-release dry run: https://github.com/raullenchai/Rapid-MLX/actions/runs/34432111426
- exact-head Release pre-flight: https://github.com/raullenchai/Rapid-MLX/actions/runs/34432024063

Release-Preflight: https://github.com/raullenchai/Rapid-MLX/actions/runs/34432024063