### PR TITLE
feat(models): support Qwen3.8 27B Abliterated

### DIFF
--- a/.agents/handoffs/vector-qwen38-27b-abliterated.md
+++ b/.agents/handoffs/vector-qwen38-27b-abliterated.md
@@ -1,0 +1,48 @@
+# Vector handoff — Qwen3.8 27B Abliterated support
+
+## Ownership and scope
+
+- Receiving roles: Atlas for integration; Vector for any speculative follow-up
+- Owner/host: Vector, Studio
+- Branch: `feat/qwen38-27b-abliterated`
+- Worktree: `/private/tmp/rapid-qwen38-27b-abliterated`
+- Goal: expose the evidence-best abliterated Qwen3.8 27B MLX checkpoint through
+  the shared Server/Desktop catalog, with exact artifact selection and honest
+  capability gates.
+- Non-goals: changing Smart/Fast defaults, endorsing model safety or accuracy,
+  enabling an unmatched speculative drafter, or changing public APIs.
+
+## Verified facts
+
+- Alias `qwen3.8-27b-abliterated-4bit` selects only `oQ4e/` from
+  `windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP`. Qualification used the
+  immutable revision `5b6802378702c89de48c990b29f3e55a3c84a2e3`; the current
+  general alias schema does not pin target revisions.
+- The selected 18-file artifact is 16,998,765,834 bytes. The normal
+  Hugging Face cache was used and no sibling quantization was downloaded.
+- Real Rapid-MLX inference passed coherent text, required tool calling, image
+  input, four-way concurrency, streaming cancellation, and immediate recovery.
+- Measured single-machine decode was 20.9 tok/s for the text smoke, 12.1 tok/s
+  for the tool call, and 15.6 tok/s for the image response. These prompts differ
+  and are not an A/B throughput comparison.
+- The product path applied its `qwen3_5_norm_shift` repair to 161 gains. This
+  addresses the conversion-layout issue that makes the publisher's stock
+  mlx-lm 0.31.3 test produce invalid output.
+- Vision loaded with mlx-vlm 0.6.17, the release-pinned version. A system
+  installation at 0.6.16 correctly failed the dependency preflight rather than
+  serving an unqualified combination.
+- The alias is experimental, is not a recommendation, and keeps speculative
+  decoding and MTP defaults disabled.
+
+## Risk and next action
+
+The repository's `drafter/` directory is a matching MTP head modified alongside
+the abliterated trunk, but current alias metadata cannot pin a drafter subfolder
+inside the target repository. Vector may propose a separate, scope-limited
+change for `mtp_draft_subfolder` resolution. It must prove subtree-only fetch,
+revision pinning, target/drafter compatibility, acceptance, correctness, and
+net latency before Atlas enables the capability. The base-Qwen DFlash2/DSpark
+drafter must not be substituted.
+
+The reproducible evidence and commands are recorded in
+`docs/engineering/performance/2026-09-09-qwen38-27b-abliterated-qualification.md`.

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ multiplication. The regular `qwen3.8-27b-4bit` alias remains unchanged for M3
 and newer Macs; Rapid does not silently swap checkpoint precision.
 
 → [Full RAM tier map + serve flags per tier](https://rapidmlx.com/docs/hardware-tiers.html)
-→ [Every alias, quant, and family (191 text + 10 image + 10 video + 44 audio aliases, 255 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
+→ [Every alias, quant, and family (192 text + 10 image + 10 video + 44 audio aliases, 256 total)](https://rapidmlx.com/docs/aliases.html) · interactive at [models.rapidmlx.com](https://models.rapidmlx.com/)
 
 ---
 

--- a/docs/engineering/performance/2026-09-09-qwen38-27b-abliterated-qualification.md
+++ b/docs/engineering/performance/2026-09-09-qwen38-27b-abliterated-qualification.md
@@ -1,0 +1,104 @@
+# Qwen3.8 27B Abliterated qualification
+
+Date: 2026-09-09
+
+This note records the evidence used to add
+`qwen3.8-27b-abliterated-4bit` as an experimental Server and Desktop catalog
+entry. It does not support making the model a default or enabling speculative
+decoding for it.
+
+## Artifacts and environment
+
+- Machine: Apple M3 Ultra, 256 GB unified memory
+- macOS: 26.5.2 (25F84)
+- Python: 3.11
+- MLX: 0.32.2
+- mlx-lm: 0.31.3
+- Text-lane mlx-vlm installation: 0.6.16
+- Vision qualification mlx-vlm installation: 0.6.17, in a worktree-local
+  virtual environment with the system packages inherited
+- Source: `windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP`
+- Immutable source revision: `5b6802378702c89de48c990b29f3e55a3c84a2e3`
+- Selected repository subfolder: `oQ4e/`
+- Selected 18-file subfolder size: 16,998,765,834 bytes (15.83 GiB)
+- Size-manifest weight/config/tokenizer footprint: 16,998,733,375 bytes;
+  the 32,459-byte difference is the subfolder's license, README, and chat
+  template, which the manifest deliberately excludes
+- Rapid-MLX base revision under test:
+  `d32277189476be85bd1867b71ef99eab4ff40a29`
+
+The standard Hugging Face cache was checked before download. `rapid-mlx pull`
+fetched 18 files under `oQ4e/` and did not fetch the repository's sibling
+quantizations or `drafter/` directory.
+
+## Rapid-MLX product-path results
+
+All requests used `temperature: 0`. These are smoke and operational
+qualification measurements from one machine, not a general performance
+benchmark.
+
+| Journey | Result | Observed decode |
+|---|---|---:|
+| Text factual/arithmetic | Exact coherent answer: Tokyo and `17 * 23 = 391` | 22 tokens in 1.05 s, 20.9 tok/s |
+| Required Qwen tool call | `get_weather` with `{"city":"Tokyo"}` and `finish_reason: tool_calls` | 27 tokens in 2.24 s, 12.1 tok/s |
+| Image description | Correctly described the checked-in cartoon cheetah asset | 25 tokens in 1.60 s, 15.6 tok/s |
+| Four simultaneous requests | Exact `PARALLEL_1` through `PARALLEL_4`; no errors | 0.827 s wall time; each 5 tokens in 0.79 s |
+| Cancelled streaming request | Engine aborted after the client disconnected; server stayed healthy | Recovery returned exact `RECOVERED` |
+
+The loader emitted the expected `qwen3_5_norm_shift` compatibility patch for
+161 standard-form gains. This is important for this conversion: the publisher
+reports that unpatched mlx-lm 0.31.3 produces invalid output, while the
+Rapid-MLX text path produced the coherent results above.
+
+## Reproduction
+
+Use the normal cache location; do not override Hugging Face cache variables or
+pass a custom cache directory.
+
+```bash
+rapid-mlx pull qwen3.8-27b-abliterated-4bit
+
+# Text path used for the text, tool, cancellation, and concurrency checks.
+rapid-mlx serve qwen3.8-27b-abliterated-4bit \
+  --host 127.0.0.1 --port 8498 --no-thinking --no-mllm
+
+# Vision path used with the release-pinned mlx-vlm 0.6.17 environment.
+rapid-mlx serve qwen3.8-27b-abliterated-4bit \
+  --host 127.0.0.1 --port 8499 --no-thinking --mllm
+```
+
+The text request was sent through `/v1/chat/completions`; the tool check used a
+required OpenAI-compatible function named `get_weather`; and the image check
+sent `apps/rapid-mac/Sources/Rapid/Resources/cheetah-sm.png` as an image data
+URL through the same endpoint. The cancellation probe terminated a streaming
+client after one second and immediately issued a normal recovery request.
+
+## Publisher-reported checkpoint evidence
+
+The model card reports the following measurements for `oQ4e`. These are the
+checkpoint author's results and were not independently reproduced here:
+
+| Evaluation | oQ4e | Comparison |
+|---|---:|---:|
+| Seeded 400-question MMLU sample | 81.75% | 82.50% for the bf16 conversion |
+| AdvBench refusals | 0/80 | refusal-oriented evaluation |
+| HarmBench-safety refusals | 0/119 | refusal-oriented evaluation |
+| oMLX MTP decode | about 34 tok/s | about 21.8 tok/s without MTP |
+
+Abliteration removes refusal behavior; it is not evidence that answers are
+more correct or safe. The publisher's oMLX MTP throughput is also not a
+Rapid-MLX claim.
+
+## Speculative-decoding gate
+
+This repository contains a matching, modified MTP head under `drafter/`, but
+the Rapid-MLX alias schema currently identifies MTP artifacts by repository and
+does not identify a drafter subfolder within the target repository. The model
+therefore ships with `supports_spec_decode: false` and
+`mtp_default_enabled: false`.
+
+Do not substitute the curated base-Qwen DFlash2 or DSpark drafter. Abliteration
+changed the target trunk, and the publisher changed the matching MTP head as
+well. A follow-up may add pinned drafter-subfolder resolution, but it must
+download only that subtree and qualify acceptance, output correctness,
+streaming cancellation, concurrency, and end-to-end speed before enabling it.

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -75,6 +75,39 @@ evidence. See the
 [reproducible qualification note](../engineering/performance/2026-09-08-neohorse-9b-chat-qualification.md)
 for the current evidence and limitations.
 
+### Experimental research model: Qwen3.8 27B Abliterated
+
+`qwen3.8-27b-abliterated-4bit` serves the `oQ4e/` Apple-Silicon build of
+[`windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP`](https://huggingface.co/windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP).
+The alias downloads only that 16.99 GB checkpoint rather than every build in
+the multi-quant repository. It supports text and image input and is deliberately
+not a Smart/Fast default.
+
+```bash
+# Text-only (does not require the optional vision runtime).
+rapid-mlx serve qwen3.8-27b-abliterated-4bit --no-mllm
+
+# Image input requires the exact optional vision stack shipped with Rapid-MLX.
+rapid-mlx serve qwen3.8-27b-abliterated-4bit --mllm
+```
+
+The publisher reports 81.75% on its seeded 400-question MMLU sample for this
+quantization, versus 82.50% for its bf16 conversion, and 0/80 AdvBench plus
+0/119 HarmBench-safety refusals. Those are checkpoint-author measurements, not
+Rapid-MLX qualification results. Abliteration removes refusal behavior; it does
+not make answers more accurate or safe.
+
+The repository also carries an MTP head, but Rapid-MLX keeps speculative
+decoding off for this alias until the exact abliterated target/drafter pair is
+qualified on our runtime. Do not pair it with the curated base-Qwen DFlash2
+drafter: the publisher modified both the trunk and MTP head, so a draft trained
+for the original target is not an equivalent artifact.
+
+See the
+[reproducible qualification note](../engineering/performance/2026-09-09-qwen38-27b-abliterated-qualification.md)
+for the pinned artifact, product-path smoke results, measured throughput, and
+the remaining speculative-decoding gate.
+
 ### Ultra-only: Hunyuan 3 (Hy3)
 
 > ⚠️ **Validated only on an M3 Ultra with 256 GB unified memory.** The

--- a/tests/test_alias_subfolder.py
+++ b/tests/test_alias_subfolder.py
@@ -33,6 +33,8 @@ from vllm_mlx.utils.tokenizer import _resolve_subfolder_checkpoint
 
 ALIAS = "lfm2.5-2.6b-4bit"
 REPO = "LiquidAI/LFM2.5-2.6B-MLX"
+ABLITERATED_ALIAS = "qwen3.8-27b-abliterated-4bit"
+ABLITERATED_REPO = "windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP"
 
 
 # --------------------------------------------------------------------------
@@ -67,7 +69,7 @@ def test_most_aliases_have_no_subfolder():
     with_subfolder = {
         alias for alias, p in list_profiles().items() if p.subfolder is not None
     }
-    assert with_subfolder == {ALIAS}, (
+    assert with_subfolder == {ALIAS, ABLITERATED_ALIAS}, (
         "A new subfolder alias landed without updating this test. That is "
         "fine — but confirm the download path passes allow_patterns for it, "
         "or the pull fetches every quant in the repo."
@@ -184,6 +186,16 @@ def test_unknown_and_flat_models_report_no_subfolder():
 def test_allow_patterns_fetch_only_the_declared_folder():
     assert subfolder_allow_patterns(ALIAS) == ["4bit/*"]
     assert subfolder_allow_patterns(REPO) == ["4bit/*"]
+
+
+def test_abliterated_alias_fetches_only_the_oq4e_checkpoint():
+    """Do not download the sibling 6/8-bit, bf16, eval, or drafter trees."""
+
+    assert resolve_model(ABLITERATED_ALIAS) == ABLITERATED_REPO
+    assert resolve_subfolder(ABLITERATED_ALIAS) == "oQ4e"
+    assert resolve_subfolder(ABLITERATED_REPO) == "oQ4e"
+    assert subfolder_allow_patterns(ABLITERATED_ALIAS) == ["oQ4e/*"]
+    assert subfolder_allow_patterns(ABLITERATED_REPO) == ["oQ4e/*"]
 
 
 def test_allow_patterns_is_none_for_flat_repos():

--- a/tests/test_aliases_contract.py
+++ b/tests/test_aliases_contract.py
@@ -176,6 +176,33 @@ def test_qwen38_27b_aliases_pin_the_native_named_xml_tool_contract() -> None:
         assert detect_model_config(profile.hf_path) == profile
 
 
+def test_qwen38_27b_abliterated_alias_is_scoped_and_conservative() -> None:
+    """The research checkpoint loads one build and borrows no base drafter."""
+
+    alias = "qwen3.8-27b-abliterated-4bit"
+    profile = list_profiles()[alias]
+
+    assert profile.hf_path == ("windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP")
+    assert profile.subfolder == "oQ4e"
+    assert profile.supports_image_input is True
+    assert profile.experimental is True
+    assert profile.tool_call_parser == "qwen3_coder_xml"
+    assert profile.reasoning_parser == "qwen3"
+    assert profile.is_hybrid is True
+    assert profile.is_moe is False
+    assert profile.supports_spec_decode is False
+    assert profile.supports_native_mtp is False
+    assert profile.mtp_draft_model is None
+    assert profile.dflash_draft_model is None
+    assert profile.ddtree_draft_model is None
+    assert profile.mtp_default_enabled is False
+    assert profile.pflash_tier == "unknown"
+    assert profile.turboquant_tier == "unknown"
+    assert detect_model_config(alias) == profile
+    assert detect_model_config(profile.hf_path) == profile
+    assert alias not in POPULAR_ALIASES
+
+
 def test_native_mtp_alias_metadata_is_strict_and_unambiguous() -> None:
     from vllm_mlx.model_aliases import _coerce
 

--- a/tests/test_atomic_model_catalog.py
+++ b/tests/test_atomic_model_catalog.py
@@ -114,6 +114,19 @@ def test_legacy_projection_is_complete_deduplicated_and_schema_valid() -> None:
         "image_understanding",
     ]
     assert aliases["qwen3.8-27b-4bit"]["capabilities"]["is_text_only"] is False
+    abliterated = aliases["qwen3.8-27b-abliterated-4bit"]
+    abliterated_model = models[abliterated["target"]["registry_model_id"]]
+    assert abliterated["capabilities"]["experimental"] is True
+    assert abliterated["capabilities"]["task_types"] == [
+        "text_generation",
+        "vision_language",
+    ]
+    assert abliterated_model["source"] == {
+        "provider": "huggingface",
+        "repo_id": "windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP",
+        "subfolder": "oQ4e",
+    }
+    assert abliterated_model["estimated_download_size_bytes"] == 16_998_733_375
     assert aliases["flux2-klein-4b"]["capabilities"]["operation_modes"] == [
         "text_to_image",
         "image_to_image",

--- a/tests/test_ddtree_integration.py
+++ b/tests/test_ddtree_integration.py
@@ -177,6 +177,20 @@ def test_info_ddtree_marks_4bit_alias_experimental(capsys) -> None:
     assert "4-bit" in captured.out
 
 
+def test_ddtree_report_recognizes_four_bit_subfolder() -> None:
+    """A neutral multi-quant repo must not bypass the 4-bit runtime gate."""
+
+    from vllm_mlx.model_aliases import resolve_profile
+    from vllm_mlx.speculative.ddtree.eligibility import report
+
+    profile = resolve_profile("qwen3.8-27b-abliterated-4bit")
+    assert profile is not None
+
+    result = report(profile, alias="qwen3.8-27b-abliterated-4bit")
+    assert result.is_4bit is True
+    assert "4-bit quantized" in " ".join(result.warnings)
+
+
 def test_models_listing_renders_ddtree_column(capsys) -> None:
     from vllm_mlx.cli import models_command
 

--- a/tests/test_dflash_eligibility.py
+++ b/tests/test_dflash_eligibility.py
@@ -51,6 +51,7 @@ def _good_profile() -> AliasProfile:
         ("user/Qwen3.5-9B-4-bit", True),
         ("user/Qwen3.5-9B_4bit", True),
         ("user/model-4bit-instruct", True),
+        ("oQ4e", True),
         # 8-bit + higher should NOT match
         ("mlx-community/Qwen3.5-27B-8bit", False),
         ("mlx-community/Qwen3.6-35B-A3B-8bit", False),
@@ -306,6 +307,22 @@ def test_qwen3_8_27b_dflash2_pair_remains_explicit_after_negative_bench() -> Non
     assert explicit_result.reasons == ()
     assert explicit_result.recommendation == "experimental"
     assert "performance-validated" in " ".join(explicit_result.warnings)
+
+
+def test_abliterated_oq4e_subfolder_is_reported_as_four_bit() -> None:
+    """Precision lives in the selected build, not this multi-quant repo name."""
+
+    from vllm_mlx.model_aliases import resolve_profile
+
+    alias = "qwen3.8-27b-abliterated-4bit"
+    profile = resolve_profile(alias)
+    assert profile is not None
+
+    # Deliberately omit the alias: its own ``-4bit`` suffix must not hide a
+    # regression where the neutral repository ignores its selected subfolder.
+    result = report(profile)
+    assert result.is_4bit is True
+    assert "4-bit quantized" in " ".join(result.warnings)
 
 
 def test_default_qwen3_5_27b_alias_fails_check_with_4bit_reason() -> None:

--- a/tests/test_dflash_integration.py
+++ b/tests/test_dflash_integration.py
@@ -371,6 +371,19 @@ def test_info_dflash_marks_4bit_alias_experimental(capsys) -> None:
     assert "experimental" in captured.out
 
 
+def test_info_recognizes_four_bit_subfolder_in_neutral_repo(capsys) -> None:
+    """The oQ4e build must not be presented as an 8-bit-or-higher target."""
+
+    from vllm_mlx.cli import info_command
+
+    args = type("Args", (), {"model": "qwen3.8-27b-abliterated-4bit"})()
+    info_command(args)
+    output = capsys.readouterr().out
+
+    assert "Target precision  : ⚠ 4-bit (experimental pair)" in output
+    assert "Precision ≥8-bit  : ✗ no (4-bit/mxfp4/nvfp4)" in output
+
+
 def test_info_dflash_marks_pinned_4bit_dflash2_pair_qualified(capsys) -> None:
     from vllm_mlx.cli import _print_dflash_status
     from vllm_mlx.model_aliases import AliasProfile

--- a/tests/test_spec_capability_report_2176.py
+++ b/tests/test_spec_capability_report_2176.py
@@ -25,6 +25,18 @@ def test_4bit_is_recommendation_evidence_not_capability_ban():
         assert assessment.capable is not False
 
 
+def test_ddtree_report_recognizes_quantized_subfolder_without_mlx():
+    """Linux coverage must exercise the real gate, not only the macOS suite."""
+
+    from vllm_mlx.speculative.ddtree.eligibility import report
+
+    profile = AliasProfile(hf_path="user/multi-quant", subfolder="oQ4e")
+    result = report(profile)
+
+    assert result.is_4bit is True
+    assert "4-bit quantized" in " ".join(result.warnings)
+
+
 def test_true_verifier_incompatibility_remains_hard_failure():
     hybrid = AliasProfile(hf_path="user/hybrid", is_hybrid=True)
     suffix = assess_method(hybrid, "suffix")

--- a/vllm_mlx/aliases.json
+++ b/vllm_mlx/aliases.json
@@ -452,6 +452,17 @@
     "mtp_speculative_tokens": 3,
     "mtp_continuous_batching_tier": "verified"
   },
+  "qwen3.8-27b-abliterated-4bit": {
+    "supports_image_input": true,
+    "hf_path": "windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP",
+    "subfolder": "oQ4e",
+    "tool_call_parser": "qwen3_coder_xml",
+    "reasoning_parser": "qwen3",
+    "is_hybrid": true,
+    "supports_spec_decode": false,
+    "mtp_default_enabled": false,
+    "experimental": true
+  },
   "qwen3.8-27b-mixed-3.5bpw": {
     "supports_image_input": true,
     "hf_path": "rapid-mlx/Qwen3.8-27B-mixed-3.5bpw-MLX",

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -10150,9 +10150,8 @@ def _print_dflash_status(alias: str, profile) -> None:
     Shows qualification, target precision, declared pairing, and runtime
     identity so an explicit experiment cannot be mistaken for a recommendation.
     """
-    from vllm_mlx.spec_decode.capability import assess_method
+    from vllm_mlx.spec_decode.capability import assess_method, profile_looks_like_4bit
     from vllm_mlx.speculative.dflash.eligibility import (
-        _looks_like_4bit,
         have_runtime,
     )
 
@@ -10165,7 +10164,7 @@ def _print_dflash_status(alias: str, profile) -> None:
     def _yes(ok: bool, msg_ok: str, msg_no: str) -> str:
         return ("✓ " + msg_ok) if ok else ("✗ " + msg_no)
 
-    quantized_target = _looks_like_4bit(profile.hf_path)
+    quantized_target = profile_looks_like_4bit(profile)
     if not quantized_target:
         precision_status = "✓ 8-bit or higher"
     elif (
@@ -10250,9 +10249,8 @@ def _print_dflash_status(alias: str, profile) -> None:
 
 def _print_ddtree_status(alias: str, profile) -> None:
     """Render DDTree status for ``rapid-mlx info <alias>``."""
-    from vllm_mlx.spec_decode.capability import assess_method
+    from vllm_mlx.spec_decode.capability import assess_method, profile_looks_like_4bit
     from vllm_mlx.speculative.ddtree.eligibility import have_runtime
-    from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
 
     inner = 60
     sep = "─" * inner
@@ -10272,7 +10270,7 @@ def _print_ddtree_status(alias: str, profile) -> None:
         (
             "Precision ≥8-bit",
             _yes(
-                not _looks_like_4bit(profile.hf_path),
+                not profile_looks_like_4bit(profile),
                 "yes",
                 "no (4-bit/mxfp4/nvfp4)",
             ),

--- a/vllm_mlx/model_sizes.json
+++ b/vllm_mlx/model_sizes.json
@@ -233,6 +233,7 @@
     "unsloth/Qwen3.6-27B-UD-MLX-3bit": 24071897617,
     "unsloth/Qwen3.6-27B-UD-MLX-4bit": 26210992727,
     "unsloth/Qwen3.6-27B-UD-MLX-6bit": 30522606211,
-    "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit": 21655301364
+    "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit": 21655301364,
+    "windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP": 16998733375
   }
 }

--- a/vllm_mlx/spec_decode/capability.py
+++ b/vllm_mlx/spec_decode/capability.py
@@ -13,18 +13,33 @@ from dataclasses import asdict, dataclass
 from vllm_mlx.model_profile import ModelProfile
 
 
-def looks_like_4bit(hf_path: str) -> bool:
-    """Detect delimiter-bounded 4-bit quantization tags in repo names."""
+def looks_like_4bit(identity: str) -> bool:
+    """Detect delimiter-bounded 4-bit tags in a repo, alias, or subfolder."""
     return bool(
         re.search(
-            r"(?<![a-z0-9])(?:4[-_]?bit|mxfp4|nvfp4)(?![a-z0-9])",
-            hf_path.lower(),
+            r"(?<![a-z0-9])(?:4[-_]?bit|mxfp4|nvfp4|oq4e)(?![a-z0-9])",
+            identity.lower(),
         )
     )
 
 
+def profile_looks_like_4bit(profile: ModelProfile) -> bool:
+    """Detect quantization from both a repository and its selected build.
+
+    Multi-quant repositories often have a neutral root name and put the only
+    precision signal in ``subfolder``. Looking only at ``hf_path`` would then
+    present a four-bit target as eight-bit-or-higher in diagnostics and relax
+    speculative-decoding qualification incorrectly.
+    """
+
+    return any(
+        looks_like_4bit(identity)
+        for identity in (profile.hf_path, profile.subfolder or "")
+    )
+
+
 def _is_experimental_quantization(profile: ModelProfile) -> bool:
-    return looks_like_4bit(profile.hf_path)
+    return profile_looks_like_4bit(profile)
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/speculative/ddtree/eligibility.py
+++ b/vllm_mlx/speculative/ddtree/eligibility.py
@@ -13,7 +13,7 @@ import logging
 from dataclasses import dataclass
 
 from vllm_mlx.model_aliases import AliasProfile
-from vllm_mlx.speculative.dflash.eligibility import _looks_like_4bit
+from vllm_mlx.spec_decode.capability import profile_looks_like_4bit
 
 logger = logging.getLogger(__name__)
 _runtime_probe_error: str | None = None
@@ -58,7 +58,7 @@ def report(
             "alias is MoE (is_moe=true) — DDTree verifier support is only "
             "validated for dense Qwen3.5/Qwen3-family targets in the MVP"
         )
-    is_4bit = _looks_like_4bit(profile.hf_path)
+    is_4bit = profile_looks_like_4bit(profile)
     if is_4bit:
         warnings.append(
             f"main model hf_path={profile.hf_path!r} is 4-bit quantized; "

--- a/vllm_mlx/speculative/dflash/eligibility.py
+++ b/vllm_mlx/speculative/dflash/eligibility.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from vllm_mlx.model_aliases import AliasProfile
-from vllm_mlx.spec_decode.capability import looks_like_4bit
+from vllm_mlx.spec_decode.capability import looks_like_4bit, profile_looks_like_4bit
 
 
 class DFlashUnavailable(RuntimeError):  # noqa: N818 — domain-specific error name
@@ -79,7 +79,9 @@ def report(
             "~1.5 tokens/round on expert-routing churn; regression "
             "measured on Qwen3.6-35B-A3B"
         )
-    is_4bit = _looks_like_4bit(profile.hf_path)
+    is_4bit = profile_looks_like_4bit(profile) or bool(
+        alias and _looks_like_4bit(alias)
+    )
     curated_pair = (
         profile.supports_dflash
         and bool(profile.dflash_algorithm)


### PR DESCRIPTION
## Summary

- add the experimental `qwen3.8-27b-abliterated-4bit` alias for the `oQ4e/` checkpoint in `windowsxp811203/Qwen3.8-27B-Abliterated-MLX-MTP`
- expose text, image, Qwen tool-call, and reasoning capabilities to the shared Server/Desktop catalog without changing Smart/Fast defaults
- keep speculative decoding off until the matching abliterated MTP subfolder can be pinned and qualified
- make DFlash/DDTree 4-bit diagnostics and eligibility account for quantization encoded in a selected subfolder
- document pinned provenance, publisher evals, real product-path dogfood, limitations, and a scoped follow-up

## Quantitative qualification

Apple M3 Ultra, 256 GB, macOS 26.5.2; model revision `5b6802378702c89de48c990b29f3e55a3c84a2e3`; `oQ4e/` is 18 files / 16,998,765,834 bytes.

| Journey | Result | Observed decode |
|---|---|---:|
| Text factual/arithmetic | Exact coherent answer: Tokyo and 17×23=391 | 22 tokens / 1.05 s / 20.9 tok/s |
| Required tool call | Correct `get_weather({"city":"Tokyo"})`, `finish_reason=tool_calls` | 27 tokens / 2.24 s / 12.1 tok/s |
| Image understanding | Correct description of checked-in cheetah asset | 25 tokens / 1.60 s / 15.6 tok/s |
| Four concurrent requests | Exact `PARALLEL_1`…`PARALLEL_4`, no errors | 0.827 s wall; each 5 tokens / 0.79 s |
| Stream cancellation | Request aborted cleanly; server stayed healthy | immediate exact `RECOVERED` response |

Publisher-reported, not independently reproduced: oQ4e MMLU-400 81.75% versus bf16 82.50%; refusals 0/80 AdvBench and 0/119 HarmBench-safety; oMLX MTP about 34 tok/s versus about 21.8 tok/s plain. Rapid-MLX makes no MTP speed claim in this PR.

## Verification

- `rapid-mlx pull` fetched only `oQ4e/*`, not sibling quantizations or `drafter/`
- real text, tool-call, image, cancellation/recovery, and concurrency dogfood passed
- full Swift debug build passed; `ToolUseCapabilityCatalogCoverageTests` passed 4/4
- focused Python matrix: 3,809 passed, 1 skipped
- ruff lint/format, JSON validation, CLI↔Config audit, and `git diff --check` passed
- broader unit run reached 10,829 passed, 82 skipped, 6 xfailed, 1 xpassed before an existing Hub access in a Harmony grammar test stalled; the repository's 300-second smoke wrapper times out at the same point

## Safety and rollout

The model is explicitly experimental and abliterated. Documentation warns that reduced refusal is not improved correctness or safety. The alias is not recommended by default and does not inherit the base-Qwen DFlash2/DSpark drafter.
