### PR TITLE
fix(mac): surface model unload beside the picker

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,12 @@ can actually understand.
 
 ## [Unreleased]
 
+### Changed
+- Model unload is now a prominent labelled action beside the active model in
+  the chat composer, while the resident-memory footer remains available as a
+  secondary entry point. Multi-model pools say `Unload all`, and active work
+  retains the existing guarded/disabled behaviour.
+
 ## [0.14.0] — 2026-09-09
 
 Rapid-MLX 0.14.0 adds experimental local Computer Use and shared-compute

--- a/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
+++ b/apps/rapid-mac/Sources/Rapid/DevSnapshot.swift
@@ -138,6 +138,21 @@ enum DevSnapshot {
                     .tint(RapidTheme.brandAmber)
                 )
             }
+            func chatSurface(width: CGFloat) -> AnyView {
+                AnyView(
+                    ChatView(
+                        viewModel: chat,
+                        server: previewServer,
+                        alias: .constant(model.id),
+                        readiness: .ready(alias: model.id)
+                    )
+                    .environment(downloads)
+                    .environment(quickstart)
+                    .frame(width: width, height: 560)
+                    .background(RapidTheme.surfaceCanvas)
+                    .tint(RapidTheme.brandAmber)
+                )
+            }
             let size = CGSize(width: SidebarView.columnIdealWidth, height: 640)
             renderHosted(
                 sidebar(), size: size, appearance: .aqua,
@@ -146,6 +161,28 @@ enum DevSnapshot {
             renderHosted(
                 sidebar(), size: size, appearance: .darkAqua,
                 to: "\(dir)/resident-unload-sidebar-dark.png"
+            )
+            let chatSize = CGSize(width: 720, height: 560)
+            renderHosted(
+                chatSurface(width: chatSize.width), size: chatSize, appearance: .aqua,
+                to: "\(dir)/resident-unload-composer-light.png"
+            )
+            renderHosted(
+                chatSurface(width: chatSize.width), size: chatSize, appearance: .darkAqua,
+                to: "\(dir)/resident-unload-composer-dark.png"
+            )
+            let compactChatSize = CGSize(width: 440, height: 560)
+            renderHosted(
+                chatSurface(width: compactChatSize.width),
+                size: compactChatSize,
+                appearance: .aqua,
+                to: "\(dir)/resident-unload-composer-compact-light.png"
+            )
+            renderHosted(
+                chatSurface(width: compactChatSize.width),
+                size: compactChatSize,
+                appearance: .darkAqua,
+                to: "\(dir)/resident-unload-composer-compact-dark.png"
             )
             NSApp.terminate(nil)
             return

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -253,6 +253,9 @@ struct ChatView: View {
     /// "never asked" value; ``ComposeTextEditor`` ignores it, so a plain
     /// mount does not steal focus from whatever the user was doing.
     var composerFocusRequest: Int = 0
+    /// Test seam for the composer-adjacent resident unload action. Production
+    /// leaves this nil and uses ``ServerManager``'s guarded whole-pool unload.
+    var onUnloadResidentModels: (() async -> Void)? = nil
 
     /// Backing state for the composer's inline model picker (Ollama-style).
     /// The picker lives in the compose box now, not a top control bar.
@@ -273,6 +276,10 @@ struct ChatView: View {
     @State private var blockedSendAttempts: Int = 0
     @State private var showsAttachmentMenu = false
     @State private var showsConversationInstructions = false
+    /// Keeps the new composer action visibly busy during the fresh residency
+    /// check, before ``ServerManager`` enters its own operating state.
+    @State private var isUnloadingResidentModels = false
+    @State private var residentUnloadNotice: String?
     /// Refreshed from the active conversation every time the popover opens.
     /// SwiftUI may otherwise reuse the popover's old local `@State` when the
     /// same conversation closes and reopens it.
@@ -984,8 +991,112 @@ struct ChatView: View {
                 composerStyle: true,
                 onUserSelection: onUserModelSelection
             )
+            // Require the live residency snapshot, not merely a ready process:
+            // legacy engines and the brief pre-refresh window can expose a
+            // serving alias without confirming anything this control can free.
+            if server.residency.contains(alias) {
+                composerResidentUnloadButton(snapshot: server.residency)
+            }
             sendOrStopButton
         }
+    }
+
+    /// A discoverable release valve beside the model it affects. The engine's
+    /// primary is pinned, so the action still unloads the whole resident pool;
+    /// when more than one workload is present the visible copy says so rather
+    /// than pretending this is a per-model eviction.
+    private func composerResidentUnloadButton(
+        snapshot: ModelResidencySnapshot
+    ) -> some View {
+        let modelCount = SidebarView.residentWorkloadCount(snapshot)
+        let hasActiveRequests = SidebarView.hasActiveResidentRequests(snapshot)
+        let disabled = SidebarView.residentUnloadDisabled(
+            isOperating: server.isOperating || isUnloadingResidentModels,
+            hasActiveModelWork: viewModel.isStreaming,
+            hasActiveRequests: hasActiveRequests
+        )
+        let accessibleLabel = SidebarView.residentUnloadLabel(
+            modelCount: modelCount,
+            memoryUsedBytes: snapshot.memoryUsedBytes
+        )
+
+        return Button {
+            Task {
+                guard !isUnloadingResidentModels else { return }
+                isUnloadingResidentModels = true
+                defer { isUnloadingResidentModels = false }
+                if let onUnloadResidentModels {
+                    await onUnloadResidentModels()
+                } else {
+                    residentUnloadNotice = SidebarView.residentUnloadMessage(
+                        for: await server.unloadResidentModelsIfIdle()
+                    )
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                if server.isOperating || isUnloadingResidentModels {
+                    ProgressView()
+                        .controlSize(.mini)
+                } else {
+                    Image(systemName: "eject.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                Text(Self.composerResidentUnloadTitle(modelCount: modelCount))
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+                    // The composer still has flexible space at its 440pt
+                    // detail-width floor. Spend that before abbreviating the
+                    // action back into the undiscoverable glyph we replaced.
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .foregroundStyle(disabled ? Color.secondary : RapidTheme.brandAmber)
+            .padding(.horizontal, 9)
+            .frame(height: RapidTheme.ControlHeight.small)
+            .background(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .fill(RapidTheme.brandAmber.opacity(disabled ? 0.04 : 0.12))
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+                    .strokeBorder(
+                        RapidTheme.brandAmber.opacity(disabled ? 0.12 : 0.42),
+                        lineWidth: 1
+                    )
+            }
+            .contentShape(
+                RoundedRectangle(cornerRadius: RapidTheme.Radius.row, style: .continuous)
+            )
+        }
+        .buttonStyle(.pressable)
+        .disabled(disabled)
+        .help(
+            SidebarView.residentUnloadHelp(
+                isOperating: server.isOperating || isUnloadingResidentModels,
+                hasActiveResponse: viewModel.isStreaming || hasActiveRequests,
+                enabledLabel: accessibleLabel
+            )
+        )
+        .accessibilityLabel(accessibleLabel)
+        .accessibilityIdentifier("ChatView.Residency.Unload")
+        .alert(
+            "Models are still loaded",
+            isPresented: Binding(
+                get: { residentUnloadNotice != nil },
+                set: { if !$0 { residentUnloadNotice = nil } }
+            )
+        ) {
+            Button("OK") {
+                residentUnloadNotice = nil
+            }
+            .accessibilityIdentifier("ChatView.Residency.UnloadNotice.OK")
+        } message: {
+            Text(residentUnloadNotice ?? "")
+        }
+    }
+
+    nonisolated static func composerResidentUnloadTitle(modelCount: Int) -> String {
+        modelCount > 1 ? "Unload all" : "Unload"
     }
 
     /// Resolve status from the engine's live policy and the exact tool list the

--- a/apps/rapid-mac/Tests/RapidTests/ComposerResidentUnloadTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ComposerResidentUnloadTests.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+import Testing
+@testable import Rapid
+
+@Suite("Composer resident unload")
+struct ComposerResidentUnloadTests {
+    @MainActor
+    private final class UnloadProbe {
+        var calls = 0
+    }
+
+    private func residentSnapshot(
+        alias: String = "qwen3.5-4b-4bit",
+        activeRequests: Int = 0,
+        extraModel: Bool = false
+    ) -> ModelResidencySnapshot {
+        let gib = UInt64(1) << 30
+        var models = [
+            ResidentModelStatus(
+                id: alias,
+                modelPath: "mlx-community/\(alias)",
+                aliases: [alias],
+                modality: "text",
+                state: "resident",
+                pinned: true,
+                primary: true,
+                activeRequests: activeRequests,
+                estimatedBytes: 6 * gib,
+                measuredBytes: nil,
+                idleSeconds: 12
+            ),
+        ]
+        if extraModel {
+            models.append(
+                ResidentModelStatus(
+                    id: "secondary-model",
+                    modelPath: "test/secondary-model",
+                    aliases: [],
+                    modality: "image",
+                    state: "resident",
+                    pinned: false,
+                    primary: false,
+                    activeRequests: 0,
+                    estimatedBytes: 2 * gib,
+                    measuredBytes: nil,
+                    idleSeconds: 8
+                )
+            )
+        }
+        return ModelResidencySnapshot(
+            memoryLimitBytes: 14 * gib,
+            memoryUsedBytes: extraModel ? 8 * gib : 6 * gib,
+            memoryAvailableBytes: extraModel ? 6 * gib : 8 * gib,
+            idleTTLSeconds: 900,
+            loadsTotal: models.count,
+            evictionsTotal: 0,
+            models: models,
+            audioLanes: []
+        )
+    }
+
+    @MainActor
+    private func stage(
+        selectedAlias: String = "qwen3.5-4b-4bit",
+        snapshot: ModelResidencySnapshot,
+        onUnload: @escaping () async -> Void = {}
+    ) -> GoldenStage {
+        let server = ServerManager(
+            testingState: .ready(alias: "qwen3.5-4b-4bit"),
+            residency: snapshot
+        )
+        let chat = ChatViewModel(persistsConversations: false)
+        return GoldenStage(
+            ChatView(
+                viewModel: chat,
+                server: server,
+                alias: .constant(selectedAlias),
+                readiness: .ready(alias: selectedAlias),
+                onUnloadResidentModels: onUnload
+            )
+            .environment(DownloadManager())
+            .environment(QuickstartCoordinator())
+            .frame(width: 720, height: 560)
+        )
+    }
+
+    @MainActor
+    @Test("The model-adjacent control unloads an idle selected resident model")
+    func idleControlWiring() async throws {
+        let probe = UnloadProbe()
+        let stage = stage(snapshot: residentSnapshot()) {
+            probe.calls += 1
+        }
+
+        try await stage.waitForIdentifier("ChatView.Residency.Unload")
+        try stage.press("ChatView.Residency.Unload")
+        try await stage.wait(for: "the composer unload action") { probe.calls == 1 }
+    }
+
+    @MainActor
+    @Test("A busy resident pool disables the composer control")
+    func busyControlIsDisabled() async throws {
+        let stage = stage(snapshot: residentSnapshot(activeRequests: 1))
+        try await stage.waitForIdentifier("ChatView.Residency.Unload")
+        #expect(throws: GoldenStage.StageError.self) {
+            try stage.press("ChatView.Residency.Unload")
+        }
+    }
+
+    @MainActor
+    @Test("The control does not imply an unloaded picker selection is resident")
+    func coldSelectionHidesControl() async throws {
+        let stage = stage(
+            selectedAlias: "different-model",
+            snapshot: residentSnapshot()
+        )
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(!stage.tree().contains { $0.id == "ChatView.Residency.Unload" })
+    }
+
+    @MainActor
+    @Test("A ready legacy server without residency truth does not show zero-byte unload")
+    func missingResidencyTruthHidesControl() async throws {
+        let stage = stage(snapshot: .empty)
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(!stage.tree().contains { $0.id == "ChatView.Residency.Unload" })
+    }
+
+    @Test("Visible copy names whole-pool scope when more than one model is resident")
+    func visibleScopeCopy() {
+        #expect(ChatView.composerResidentUnloadTitle(modelCount: 1) == "Unload")
+        #expect(ChatView.composerResidentUnloadTitle(modelCount: 2) == "Unload all")
+    }
+}

--- a/apps/rapid-mac/docs/userflows.md
+++ b/apps/rapid-mac/docs/userflows.md
@@ -590,6 +590,7 @@ interactive control under `Sources/` without an identifier.
 
 **Chat — `UI/ChatView.swift`:** `ChatView.SendOrStopButton`,
 `ChatView.AddAttachments`, `ChatView.ConversationInstructions`,
+`ChatView.Residency.{Unload,UnloadNotice.OK}`,
 `ToolCallChip.<action>`, `ToolCallChip.Toggle.<call.id>`,
 `ChatView.Message.<action>.<UUID>` (action ∈ {`EditField`, `CancelEdit`,
 `SaveEdit`, `Edit`, `Copy`, `SelectText`, `Retry`, `ReasoningDisclosure`}).


### PR DESCRIPTION
## Why

The v0.14.0 model-unload action existed only in the server sidebar, so users could miss it even while looking directly at the loaded model in Chat. This makes the memory-release action discoverable at the point where the active model is selected.

## Scope

- Show an amber Unload action beside the selected model when authoritative residency reports that model as loaded.
- Use Unload all when the pool contains multiple resident workloads so the action scope is explicit.
- Reuse the existing idle-only server unload path, busy-state guards, result copy, and sidebar behavior.
- Add composer-focused unit coverage, snapshot fixtures for regular/compact light and dark layouts, changelog copy, and accessibility inventory.

## Non-goals

- No server API, model lifecycle, or unload semantics change.
- No replacement of the sidebar residency controls; they remain the secondary/global entry point.
- No composer action for an unrelated audio-only pool or legacy ready state without authoritative residency data.

## Acceptance

- A resident selected chat model exposes a clearly labeled Unload action beside the picker.
- Multiple resident workloads are labeled Unload all.
- The control is hidden without authoritative residency and disabled while chat/server/pool work is active.
- The action remains fully visible at the 440-point compact test width in both appearances.
- Existing sidebar unload behavior remains intact.

## Verification

- swift test --filter ComposerResidentUnloadTests\|SidebarResidentUnloadTests — 12 tests passed in 2 suites.
- ./scripts/desktop-test-timeout.sh — 3,658 tests passed in 317 suites (94.484 s).
- bash scripts/build.sh — produced the v0.14.0 release app successfully.
- codesign --verify --deep --strict --verbose=2 — app valid on disk and satisfies its designated requirement.
- Visual dogfood: inspected 720x560 and 440x560 snapshots in light and dark mode; fixed compact label truncation found during review.
- git diff origin/main...HEAD --check — clean.
- No model downloads were performed.
- Local pr_validate preflight passed; the backend full_unit lane hung in os.listdir for 15 minutes and was stopped. GitHub backend and macOS checks provide the authoritative gates for this Swift-only PR.

## Behaviour delta

Before: unloading resident models was discoverable only in the server sidebar. After: Chat also shows an explicit Unload / Unload all action beside the active loaded model, while retaining the sidebar control.

## AI assistance disclosure

Codex implemented and self-reviewed the SwiftUI change, tests, snapshot coverage, changelog, and user-flow documentation. Verification included focused and full Swift test suites, a release package build, signature validation, accessibility-string inspection, and manual light/dark compact visual review.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Checklist

- [x] Relevant tests pass locally (focused and full macOS suite)
- [x] Formatting/diff checks pass
- [x] PR validation preflight completed with Python 3.12 (Codex and stress lanes intentionally disabled); its backend full_unit lane was stopped after a 15-minute directory-enumeration hang, unrelated to this Swift-only diff
- [x] New tests are UI-state coverage, not a critical parser/scheduler/security path
- [x] Updated docs/changelog
- [x] No breaking changes to existing API

## Author

X handle (optional, external contributors):