### PR TITLE
fix(mllm): stop runaway repetition before Metal exhaustion

### DIFF
--- a/tests/headless_mlx/test_mllm_process_loop_errors.py
+++ b/tests/headless_mlx/test_mllm_process_loop_errors.py
@@ -11,7 +11,147 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vllm_mlx.mllm_scheduler import MLLMRequest, MLLMScheduler  # noqa: E402
+from vllm_mlx.mllm_batch_generator import MLLMBatchResponse  # noqa: E402
+from vllm_mlx.mllm_scheduler import (  # noqa: E402
+    MLLMRequest,
+    MLLMScheduler,
+    MLLMSchedulerConfig,
+)
+from vllm_mlx.request import (  # noqa: E402
+    ClientRequestError,
+    InferenceAbortedError,
+    RequestOutput,
+    RequestStatus,
+    SamplingParams,
+)
+
+
+def _repetition_scheduler() -> MLLMScheduler:
+    tokenizer = MagicMock()
+    tokenizer.decode = lambda tokens, **_kwargs: " ".join(map(str, tokens))
+    tokenizer.eos_token_id = 0
+    processor = MagicMock()
+    processor.tokenizer = tokenizer
+    scheduler = MLLMScheduler(
+        MagicMock(),
+        processor,
+        MLLMSchedulerConfig(enable_vision_cache=False),
+        model_name="headless-mllm-repetition-test",
+    )
+    scheduler.batch_generator = MagicMock()
+    return scheduler
+
+
+def _repeating_mllm_request(scheduler: MLLMScheduler) -> MLLMRequest:
+    pattern = list(range(61))
+    request = MLLMRequest(
+        request_id="vision-repeat",
+        prompt="extract the table",
+        images=["statement.png"],
+        sampling_params=SamplingParams(max_tokens=32_768),
+    )
+    request.status = RequestStatus.RUNNING
+    request.output_tokens = pattern * 3
+    request.num_output_tokens = len(request.output_tokens)
+    scheduler.running[request.request_id] = request
+    scheduler.uid_to_request_id[7] = request.request_id
+    return request
+
+
+def test_mllm_repetition_stop_retires_live_row_without_mlx() -> None:
+    scheduler = _repetition_scheduler()
+    request = _repeating_mllm_request(scheduler)
+    response = MLLMBatchResponse(
+        uid=7,
+        request_id=request.request_id,
+        token=0,
+        logprobs=None,
+        finish_reason=None,
+    )
+
+    outputs, finished = scheduler._process_batch_responses([response])
+
+    assert finished == {request.request_id}
+    assert request.status == RequestStatus.FINISHED_ABORTED
+    assert outputs[0].finish_reason == "abort"
+    assert outputs[0].error_kind == "repetition"
+    assert "period_tokens=61" in (outputs[0].error or "")
+    scheduler.batch_generator.remove.assert_called_once_with([7])
+    assert scheduler.num_repetition_loop_stops == 1
+
+
+def test_mllm_repetition_stop_refuses_unowned_batch_row() -> None:
+    scheduler = _repetition_scheduler()
+    request = _repeating_mllm_request(scheduler)
+    scheduler.batch_generator = None
+    response = MLLMBatchResponse(
+        uid=7,
+        request_id=request.request_id,
+        token=0,
+        logprobs=None,
+        finish_reason=None,
+    )
+
+    with pytest.raises(RuntimeError, match="without a batch generator"):
+        scheduler._process_batch_responses([response])
+
+
+@pytest.mark.asyncio
+async def test_mllm_repetition_stop_streams_valid_partial_response() -> None:
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"vision-repeat": asyncio.Queue()}
+    scheduler.abort_request = MagicMock()
+    await scheduler.output_queues["vision-repeat"].put(
+        RequestOutput(
+            request_id="vision-repeat",
+            output_text="partial valid answer",
+            finished=True,
+            finish_reason="abort",
+            error="Model generation aborted: exact repetition loop detected",
+            error_kind="repetition",
+        )
+    )
+
+    outputs = [output async for output in scheduler.stream_outputs("vision-repeat")]
+
+    assert len(outputs) == 1
+    assert outputs[0].output_text == "partial valid answer"
+    assert outputs[0].finish_reason == "length"
+    assert outputs[0].error is None
+    scheduler.abort_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_kind", "expected_error"),
+    [
+        ("lifecycle", InferenceAbortedError),
+        ("invalid_request", ClientRequestError),
+        (None, ValueError),
+    ],
+)
+async def test_mllm_non_repetition_errors_keep_existing_exception_contract(
+    error_kind: str | None,
+    expected_error: type[Exception],
+) -> None:
+    """The repetition exception must not soften unrelated error classes."""
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"failed": asyncio.Queue()}
+    scheduler.abort_request = MagicMock()
+    await scheduler.output_queues["failed"].put(
+        RequestOutput(
+            request_id="failed",
+            finished=True,
+            finish_reason="abort",
+            error="terminal failure",
+            error_kind=error_kind,
+        )
+    )
+
+    with pytest.raises(expected_error, match="terminal failure"):
+        _ = [output async for output in scheduler.stream_outputs("failed")]
+
+    scheduler.abort_request.assert_not_called()
 
 
 def test_batch_generator_uses_worker_default_stream(monkeypatch) -> None:

--- a/tests/test_mllm_stats.py
+++ b/tests/test_mllm_stats.py
@@ -66,6 +66,8 @@ def test_batched_engine_promotes_mllm_stats_to_common_top_level():
                 "num_requests_processed": 3,
                 "total_prompt_tokens": 40,
                 "total_completion_tokens": 7,
+                "num_repetition_loop_stops": 4,
+                "num_repetition_loop_breaks": 0,
                 "prefix_cache": {
                     "hits": 2,
                     "misses": 1,
@@ -96,6 +98,8 @@ def test_batched_engine_promotes_mllm_stats_to_common_top_level():
     assert stats["num_requests_processed"] == 3
     assert stats["total_prompt_tokens"] == 40
     assert stats["total_completion_tokens"] == 7
+    assert stats["num_repetition_loop_stops"] == 4
+    assert stats["num_repetition_loop_breaks"] == 0
     assert stats["prefix_cache"]["tokens_saved"] == 30
     assert stats["model_performance"]["model_name"] == "gemma-test"
     assert stats["steps_executed"] == 12

--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Regression coverage for the agent repetition-loop safety stop."""
 
-import asyncio
-
 import pytest
 
 pytest.importorskip("mlx")
@@ -222,90 +220,3 @@ def test_guard_only_reads_bounded_suffix_under_large_history():
     history = _BoundedSequence(1_000_000)
     assert detect_repeated_token_suffix(history) is None
     assert history.requested_slice == slice(-768, None, None)
-
-
-def _mllm_scheduler_for_repetition_test():
-    from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
-
-    tokenizer = MagicMock()
-    tokenizer.decode = lambda tokens, **_kwargs: " ".join(map(str, tokens))
-    tokenizer.eos_token_id = 0
-    processor = MagicMock()
-    processor.tokenizer = tokenizer
-    scheduler = MLLMScheduler(
-        MagicMock(),
-        processor,
-        MLLMSchedulerConfig(enable_vision_cache=False),
-        model_name="mllm-repetition-test",
-    )
-    scheduler.batch_generator = MagicMock()
-    return scheduler
-
-
-def test_mllm_scheduler_stops_tool_free_exact_loop_and_retires_batch_row():
-    from vllm_mlx.mllm_batch_generator import MLLMBatchResponse
-    from vllm_mlx.mllm_scheduler import MLLMRequest
-
-    scheduler = _mllm_scheduler_for_repetition_test()
-    # Mirror the reporter's 61-token cycle. Three complete repetitions plus
-    # the first token of the next cycle land on the guard's 8-token cadence
-    # (184 tokens) while preserving a three-repeat suffix.
-    pattern = list(range(61))
-    request = MLLMRequest(
-        request_id="vision-repeat",
-        prompt="extract the table",
-        images=["statement.png"],
-        sampling_params=SamplingParams(max_tokens=32_768),
-    )
-    request.status = RequestStatus.RUNNING
-    request.output_tokens = pattern * 3
-    request.num_output_tokens = len(request.output_tokens)
-    scheduler.running[request.request_id] = request
-    scheduler.uid_to_request_id[7] = request.request_id
-
-    response = MLLMBatchResponse(
-        uid=7,
-        request_id=request.request_id,
-        token=pattern[0],
-        logprobs=None,
-        finish_reason=None,
-    )
-    outputs, finished = scheduler._process_batch_responses([response])
-
-    assert finished == {request.request_id}
-    assert request.status == RequestStatus.FINISHED_ABORTED
-    assert outputs[0].finished is True
-    assert outputs[0].finish_reason == "abort"
-    assert outputs[0].error_kind == "repetition"
-    assert "repetition" in (outputs[0].error or "").lower()
-    assert "period_tokens=61" in (outputs[0].error or "")
-    scheduler.batch_generator.remove.assert_called_once_with([7])
-    assert scheduler.num_repetition_loop_stops == 1
-
-
-@pytest.mark.asyncio
-async def test_mllm_stream_maps_repetition_abort_to_partial_length_finish():
-    from vllm_mlx.mllm_scheduler import MLLMScheduler
-    from vllm_mlx.request import RequestOutput
-
-    scheduler = MLLMScheduler.__new__(MLLMScheduler)
-    scheduler.output_queues = {"vision-repeat": asyncio.Queue()}
-    scheduler.abort_request = MagicMock()
-    await scheduler.output_queues["vision-repeat"].put(
-        RequestOutput(
-            request_id="vision-repeat",
-            output_text="partial valid answer",
-            finished=True,
-            finish_reason="abort",
-            error="Model generation aborted: exact repetition loop detected",
-            error_kind="repetition",
-        )
-    )
-
-    outputs = [output async for output in scheduler.stream_outputs("vision-repeat")]
-
-    assert len(outputs) == 1
-    assert outputs[0].output_text == "partial valid answer"
-    assert outputs[0].finish_reason == "length"
-    assert outputs[0].error is None
-    scheduler.abort_request.assert_not_called()

--- a/tests/test_repetition_guard.py
+++ b/tests/test_repetition_guard.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Regression coverage for the agent repetition-loop safety stop."""
 
+import asyncio
+
 import pytest
 
 pytest.importorskip("mlx")
@@ -220,3 +222,90 @@ def test_guard_only_reads_bounded_suffix_under_large_history():
     history = _BoundedSequence(1_000_000)
     assert detect_repeated_token_suffix(history) is None
     assert history.requested_slice == slice(-768, None, None)
+
+
+def _mllm_scheduler_for_repetition_test():
+    from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
+
+    tokenizer = MagicMock()
+    tokenizer.decode = lambda tokens, **_kwargs: " ".join(map(str, tokens))
+    tokenizer.eos_token_id = 0
+    processor = MagicMock()
+    processor.tokenizer = tokenizer
+    scheduler = MLLMScheduler(
+        MagicMock(),
+        processor,
+        MLLMSchedulerConfig(enable_vision_cache=False),
+        model_name="mllm-repetition-test",
+    )
+    scheduler.batch_generator = MagicMock()
+    return scheduler
+
+
+def test_mllm_scheduler_stops_tool_free_exact_loop_and_retires_batch_row():
+    from vllm_mlx.mllm_batch_generator import MLLMBatchResponse
+    from vllm_mlx.mllm_scheduler import MLLMRequest
+
+    scheduler = _mllm_scheduler_for_repetition_test()
+    # Mirror the reporter's 61-token cycle. Three complete repetitions plus
+    # the first token of the next cycle land on the guard's 8-token cadence
+    # (184 tokens) while preserving a three-repeat suffix.
+    pattern = list(range(61))
+    request = MLLMRequest(
+        request_id="vision-repeat",
+        prompt="extract the table",
+        images=["statement.png"],
+        sampling_params=SamplingParams(max_tokens=32_768),
+    )
+    request.status = RequestStatus.RUNNING
+    request.output_tokens = pattern * 3
+    request.num_output_tokens = len(request.output_tokens)
+    scheduler.running[request.request_id] = request
+    scheduler.uid_to_request_id[7] = request.request_id
+
+    response = MLLMBatchResponse(
+        uid=7,
+        request_id=request.request_id,
+        token=pattern[0],
+        logprobs=None,
+        finish_reason=None,
+    )
+    outputs, finished = scheduler._process_batch_responses([response])
+
+    assert finished == {request.request_id}
+    assert request.status == RequestStatus.FINISHED_ABORTED
+    assert outputs[0].finished is True
+    assert outputs[0].finish_reason == "abort"
+    assert outputs[0].error_kind == "repetition"
+    assert "repetition" in (outputs[0].error or "").lower()
+    assert "period_tokens=61" in (outputs[0].error or "")
+    scheduler.batch_generator.remove.assert_called_once_with([7])
+    assert scheduler.num_repetition_loop_stops == 1
+
+
+@pytest.mark.asyncio
+async def test_mllm_stream_maps_repetition_abort_to_partial_length_finish():
+    from vllm_mlx.mllm_scheduler import MLLMScheduler
+    from vllm_mlx.request import RequestOutput
+
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"vision-repeat": asyncio.Queue()}
+    scheduler.abort_request = MagicMock()
+    await scheduler.output_queues["vision-repeat"].put(
+        RequestOutput(
+            request_id="vision-repeat",
+            output_text="partial valid answer",
+            finished=True,
+            finish_reason="abort",
+            error="Model generation aborted: exact repetition loop detected",
+            error_kind="repetition",
+        )
+    )
+
+    outputs = [output async for output in scheduler.stream_outputs("vision-repeat")]
+
+    assert len(outputs) == 1
+    assert outputs[0].output_text == "partial valid answer"
+    assert outputs[0].finish_reason == "length"
+    assert outputs[0].error is None
+    scheduler.abort_request.assert_not_called()

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -3907,6 +3907,8 @@ class BatchedEngine(BaseEngine):
                 "total_completion_tokens",
                 "num_requests_cancelled",
                 "num_requests_cancelled_via_disconnect",
+                "num_repetition_loop_stops",
+                "num_repetition_loop_breaks",
                 "metal_active_memory_gb",
                 "metal_peak_memory_gb",
                 "metal_cache_memory_gb",

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -48,6 +48,7 @@ from .mllm_batch_generator import (  # noqa: E402
 )
 from .mllm_cache import MLLMCacheManager  # noqa: E402
 from .multimodal_processor import MultimodalProcessor  # noqa: E402
+from .repetition_guard import detect_repeated_token_suffix  # noqa: E402
 from .request import (  # noqa: E402
     ClientRequestError,
     RequestOutput,
@@ -389,6 +390,14 @@ class MLLMScheduler:
         # rationale. Observability only — abort semantics unchanged.
         self.num_requests_cancelled = 0
         self.num_requests_cancelled_via_disconnect = 0
+        # Exact-token repetition protection is a scheduler lifecycle policy,
+        # not a tool-calling feature. Keep the same terminal counter as the
+        # text scheduler so metrics remain lane-independent.
+        self.num_repetition_loop_stops = 0
+        # The MLLM lane currently has no preventative logits intervention;
+        # publish the common zero-valued series rather than making metrics
+        # consumers infer lane support from a missing key.
+        self.num_repetition_loop_breaks = 0
         self.performance = get_model_performance_ledger(model_name)
 
     def _request_timings(
@@ -1039,6 +1048,36 @@ class MLLMScheduler:
                 request.first_token_time = time.time()
 
             finish_reason = response.finish_reason
+            repetition_error: str | None = None
+            if finish_reason is None and request.num_output_tokens % 8 == 0:
+                repetition_match = detect_repeated_token_suffix(request.output_tokens)
+                if repetition_match is not None:
+                    finish_reason = "abort"
+                    repetition_error = (
+                        "Model generation aborted: exact repetition loop "
+                        "detected "
+                        f"(period_tokens={repetition_match.period_tokens}, "
+                        f"repeats={repetition_match.repeats})"
+                    )
+                    self.num_repetition_loop_stops += 1
+                    # The batch generator only retires rows for its own EOS or
+                    # length finishes. This stop is scheduler-generated, so
+                    # remove the row now; otherwise it keeps decoding after the
+                    # public request has finished and recreates the Metal-handle
+                    # exhaustion this guard is meant to prevent.
+                    if self.batch_generator is None:
+                        raise RuntimeError(
+                            "MLLM repetition stop without a batch generator"
+                        )
+                    self.batch_generator.remove([response.uid])
+                    logger.warning(
+                        "Stopping multimodal request %s after exact token loop "
+                        "(period_tokens=%d repeats=%d completion_tokens=%d)",
+                        request_id,
+                        repetition_match.period_tokens,
+                        repetition_match.repeats,
+                        request.num_output_tokens,
+                    )
 
             # Decode the new token using streaming detokenizer (UTF-8 safe).
             # Backend EOS/control stop tokens are not decoded. Backend
@@ -1222,6 +1261,8 @@ class MLLMScheduler:
                     request.status = RequestStatus.FINISHED_STOPPED
                 elif finish_reason == "length":
                     request.status = RequestStatus.FINISHED_LENGTH_CAPPED
+                elif finish_reason == "abort":
+                    request.status = RequestStatus.FINISHED_ABORTED
 
                 output_finished = True
                 output_finish_reason = finish_reason
@@ -1283,6 +1324,8 @@ class MLLMScheduler:
                     cached_tokens=request.cached_tokens,
                     logprobs=getattr(response, "logprobs", None),
                     matched_stop=output_matched_stop,
+                    error=repetition_error,
+                    error_kind="repetition" if repetition_error is not None else None,
                 )
             )
 
@@ -2058,16 +2101,25 @@ class MLLMScheduler:
                     # Mark finished BEFORE raising so the finally block
                     # doesn't double-abort what's already cleaned up.
                     finished_normally = True
-                    if output.error_kind == "lifecycle":
+                    if output.error_kind == "repetition":
+                        logger.warning(
+                            "MLLM repetition-guard stop for %s; returning "
+                            "partial output with finish_reason=length",
+                            request_id,
+                        )
+                        output.finish_reason = "length"
+                        output.error = None
+                    elif output.error_kind == "lifecycle":
                         from .request import InferenceAbortedError
 
                         raise InferenceAbortedError(
                             output.error,
                             error_kind=output.error_kind,
                         )
-                    if output.error_kind == "invalid_request":
+                    elif output.error_kind == "invalid_request":
                         raise ClientRequestError(output.error)
-                    raise ValueError(output.error)
+                    elif output.error:
+                        raise ValueError(output.error)
                 # Mark terminal output before yielding it. A consumer of an
                 # async generator may stop immediately after receiving the
                 # final item, so code after ``yield`` is not guaranteed to
@@ -2155,6 +2207,13 @@ class MLLMScheduler:
             "num_requests_cancelled": self.num_requests_cancelled,
             "num_requests_cancelled_via_disconnect": (
                 self.num_requests_cancelled_via_disconnect
+            ),
+            # A few lifecycle/error tests construct a scheduler with
+            # ``__new__`` to exercise cleanup without loading a model. Keep
+            # stats readable for that defensive partial-construction shape.
+            "num_repetition_loop_stops": getattr(self, "num_repetition_loop_stops", 0),
+            "num_repetition_loop_breaks": getattr(
+                self, "num_repetition_loop_breaks", 0
             ),
             "model_performance": self.performance.snapshot().__dict__,
         }

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -2118,7 +2118,7 @@ class MLLMScheduler:
                         )
                     elif output.error_kind == "invalid_request":
                         raise ClientRequestError(output.error)
-                    elif output.error:
+                    else:
                         raise ValueError(output.error)
                 # Mark terminal output before yielding it. A consumer of an
                 # async generator may stop immediately after receiving the

--- a/vllm_mlx/request.py
+++ b/vllm_mlx/request.py
@@ -385,7 +385,7 @@ class RequestOutput:
     # raises InferenceAbortedError (→ HTTP 503) for genuine mid-flight failures
     # (Metal runtime errors, engine-loop crashes) where the partial output may
     # be corrupt. A repetition-guard hard-stop is different: the scheduler
-    # deliberately terminated a runaway exact-token loop on a has_tools request,
+    # deliberately terminated a runaway exact-token loop on a guarded request,
     # and the partial output up to that point is VALID. Those set
     # ``error_kind="repetition"`` so the engine returns 200 + partial (with
     # ``finish_reason`` remapped to a spec-valid value) instead of raising 503 —


### PR DESCRIPTION
## Why

Tool-free multimodal requests can enter an exact token loop and continue until Metal reaches its resource-handle ceiling. The client then waits several minutes and receives an empty HTTP 500 even though the generated prefix is valid.

Fixes #3270

## What changed

- apply the existing bounded exact-token repetition detector to the MLLM scheduler every eight generated tokens
- immediately retire scheduler-stopped rows from the live multimodal batch
- return the valid partial response with a spec-valid length finish instead of surfacing a runtime 500
- promote repetition-stop counters through the common engine metrics surface
- cover the reported 61-token cycle, row retirement, graceful streaming completion, metrics, and partial-construction lifecycle compatibility

## Design precedent

Continuous-serving schedulers treat terminal policy as per-request lifecycle state: evaluate it at the scheduler boundary after token commit, retire the live batch row before publishing completion, and preserve already-valid output. This change adapts that established pattern using Rapid-MLX existing conservative detector rather than introducing a new sampling heuristic.

## Scope

The change is limited to MLLM repetition termination, lifecycle cleanup, and metrics parity. It does not change sampling penalties, detector thresholds, text-lane semantics, timeout policy, or model-specific behavior.

## Verification

- 180 lifecycle, MLLM batching, repetition, metrics, and process-loop tests passed
- focused reported-cycle regression detects period_tokens=61 at token 184
- Ruff lint and format checks passed
- git diff --check passed
- full repository unit command reached its existing 300-second harness ceiling; before timeout it exposed two partial-construction compatibility failures introduced by the first patch, both fixed and revalidated in the 180-test set
- repository-wide mypy remains red on the pre-existing error budget; no new diagnostics point at the changed lines