### PR TITLE
test(mtp): behavioural coverage for the sampled MTP path (from #2140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,7 @@ jobs:
             tests/test_g9v3_model.py \
             tests/test_bailing_hybrid_model.py \
             tests/test_mtp_spec_decode.py \
+            tests/test_mtp_nongreedy_distribution.py \
             tests/test_speculative_request_policy.py \
             tests/test_deepseek_v4_vendored.py \
             tests/test_dspark_scheduler.py \

--- a/tests/test_mtp_nongreedy_distribution.py
+++ b/tests/test_mtp_nongreedy_distribution.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Distribution-level tests for non-greedy MTP speculative decoding.
+
+Why this file exists (and why wiring tests are not enough)
+---------------------------------------------------------
+
+``tests/test_mtp_cli_wiring.py`` proves that ``temp`` / ``top_p`` reach
+``mtp_generate_step``. That says nothing about whether the tokens that
+come out are drawn from the right distribution. Speculative decoding is
+only "free" if the emitted sequence is distributed EXACTLY as plain
+autoregressive sampling from the target — a sampler that is merely
+"close" is a silent quality regression that no wiring assertion can see.
+
+The specific failure this file pins: the verify path needs an
+INDEPENDENT ``u ~ U(0,1)`` per proposed position, because the accept
+test is a Bernoulli(min(1, p/q)) trial at each position. Sharing one
+scalar ``u`` across all K positions keeps the accept probability at the
+FIRST proposed position correct while making accept events across
+positions perfectly rank-correlated. Conditioning on position 1 being
+accepted implies ``u < p(d1)/q(d1)``, which biases ``u`` small and so
+RAISES the acceptance probability at position 2; the emitted token
+there skews toward the draft distribution ``q`` instead of being
+resampled from the residual. The defect exists only for K >= 2, since
+at K = 1 there is nothing for the single draw to correlate with.
+
+Measured, not assumed: reverting ``generator.py``'s draw to a scalar
+makes the K=2 stream miss plain autoregressive sampling by TV 0.029 on
+the marginal alone (0.066 at K=3, 0.024 under top-p). So the bias
+reaches the per-token marginal too, not only the joint — the correct
+statement is that a shared draw skews BOTH, because the stream contains
+those biased position-2+ tokens. Both statistics are asserted below;
+either one alone would catch this particular defect, and the joint
+additionally catches a class of errors that preserve marginals.
+
+So every test here compares a K >= 2 run against a K = 0 run of the
+SAME generator over the SAME mocked model. ``max_k=0`` with
+``disable_auto_k=True`` parks the depth controller at zero every round,
+which walks ``generator.py``'s "Round K=0 ... Plain backbone forward
+emits ONE committed token" branch — i.e. plain autoregressive sampling
+through the identical filter chain. Using the generator itself as the
+reference (rather than a hand-rolled softmax) means the test cannot
+pass by re-implementing top-p truncation the same wrong way twice.
+
+Test statistic
+--------------
+
+The mocked model returns the SAME logits at every position, so under
+correct sampling the emitted stream is i.i.d. Categorical(p_filtered).
+We therefore compare two things between the K = 0 and K >= 2 streams:
+
+* the per-token marginal distribution, and
+* the lag-1 pair distribution (t_i, t_{i+1}).
+
+Correct sampling makes consecutive tokens independent, so the lag-1
+joint must factor into the marginals; the shared draw induces exactly
+the within-round dependence described above, and also shifts the
+marginal. Asserting both keeps the file sensitive to sampler errors
+that move only one of them.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+
+@pytest.fixture(autouse=True)
+def _reset_mtp_module_state():
+    """Reset the MTP module-level singletons + ``generation_stream``.
+
+    Same three pieces of cross-test state as the autouse fixture in
+    ``test_mtp_spec_decode.py`` / ``test_mtp_lossless.py``; see the
+    fixture there for the full rationale on each.
+    """
+    import sys
+
+    import mlx.core as mx
+    import mlx_lm.generate  # noqa: F401 — ensure module exists in sys.modules
+
+    from vllm_mlx.spec_decode.mtp.accept_counter import (
+        reset_global_counter_for_tests,
+    )
+    from vllm_mlx.spec_decode.mtp.cache_patch import _unpatch_for_tests
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import reset_controllers
+
+    def _reset():
+        _unpatch_for_tests()
+        reset_global_counter_for_tests()
+        reset_controllers()
+        sys.modules["mlx_lm.generate"].generation_stream = mx.default_stream(
+            mx.default_device()
+        )
+
+    _reset()
+    yield
+    _reset()
+
+
+class _FixedDistributionModel:
+    """Mocked Qwen3.5-shaped model with POSITION-INDEPENDENT distributions.
+
+    Satisfies the same contract surface as
+    ``tests.test_mtp_spec_decode._MockedQwen35Model`` (``__call__`` with
+    ``return_hidden`` / ``n_confirmed``, ``mtp_forward``,
+    ``make_mtp_cache``, ``layers``), but scripts DISTRIBUTIONS rather
+    than argmax tokens — which is what a sampling test needs and what
+    the argmax-scripting mock cannot express.
+
+    The backbone returns ``log(target_probs)`` and the MTP head returns
+    ``log(draft_probs)`` at every position, ignoring the input tokens
+    entirely. Combined with ``temp=1.0`` (the generator computes
+    ``logprobs - logsumexp`` then divides by ``temp``), the target
+    sampling distribution is exactly ``target_probs`` and the draft's is
+    exactly ``draft_probs``.
+
+    Position-independence is the point: it makes the ground-truth
+    autoregressive stream i.i.d., so any dependence between consecutive
+    emitted tokens is attributable to the speculative machinery rather
+    than to the model.
+    """
+
+    def __init__(
+        self,
+        target_probs: list[float],
+        draft_probs: list[float],
+        hidden_size: int = 8,
+    ):
+        assert len(target_probs) == len(draft_probs)
+        assert math.isclose(sum(target_probs), 1.0, rel_tol=1e-6)
+        assert math.isclose(sum(draft_probs), 1.0, rel_tol=1e-6)
+        self.vocab = len(target_probs)
+        self.hidden_size = hidden_size
+        # log(p) as logits: the generator renormalises with logsumexp,
+        # which is a no-op on an already-normalised log-prob vector.
+        self._target_logits = mx.log(mx.array(target_probs))
+        self._draft_logits = mx.log(mx.array(draft_probs))
+        self.layers = []
+
+    @staticmethod
+    def _tile(row: mx.array, batch: int, steps: int) -> mx.array:
+        return mx.broadcast_to(row[None, None, :], (batch, steps, row.shape[0]))
+
+    def __call__(
+        self,
+        inputs,
+        cache=None,
+        input_embeddings=None,
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
+    ):
+        batch, steps = inputs.shape
+        logits = self._tile(self._target_logits, batch, steps)
+        if return_hidden:
+            return logits, mx.zeros((batch, steps, self.hidden_size))
+        return logits
+
+    def mtp_forward(self, hidden, next_token_ids, mtp_cache):
+        batch, steps = next_token_ids.shape
+        return self._tile(self._draft_logits, batch, steps)
+
+    def make_mtp_cache(self):
+        return []
+
+
+def _run_stream(
+    target_probs: list[float],
+    draft_probs: list[float],
+    *,
+    max_k: int,
+    max_tokens: int,
+    seed: int,
+    temp: float = 1.0,
+    top_p: float = 0.0,
+) -> list[int]:
+    """Emit ``max_tokens`` tokens from ``mtp_generate_step`` at depth ``max_k``.
+
+    ``disable_auto_k=True`` pins the depth: ``max_k=0`` parks every
+    round (plain autoregressive reference), ``max_k=K`` runs a full
+    chain-of-K verify every round. Both paths share the same filter
+    chain and the same mocked distributions, so a difference in the
+    emitted stream's statistics is a difference in the SAMPLER.
+    """
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    mx.random.seed(seed)
+    model = _FixedDistributionModel(target_probs, draft_probs)
+    return [
+        tok
+        for tok, _lp, _fd in mtp_generate_step(
+            mx.array([0], mx.uint32),
+            model,
+            max_tokens=max_tokens,
+            temp=temp,
+            top_p=top_p,
+            disable_auto_k=True,
+            max_k=max_k,
+        )
+    ]
+
+
+def _marginal(stream: list[int], vocab: int) -> list[float]:
+    counts = [0] * vocab
+    for tok in stream:
+        counts[tok] += 1
+    total = float(len(stream))
+    return [c / total for c in counts]
+
+
+def _lag1_joint(stream: list[int], vocab: int) -> list[float]:
+    """Empirical distribution of consecutive emitted pairs, flattened."""
+    counts = [0] * (vocab * vocab)
+    for first, second in zip(stream, stream[1:]):
+        counts[first * vocab + second] += 1
+    total = float(len(stream) - 1)
+    return [c / total for c in counts]
+
+
+def _tv(a: list[float], b: list[float]) -> float:
+    """Total variation distance between two discrete distributions."""
+    return 0.5 * sum(abs(x - y) for x, y in zip(a, b))
+
+
+# A target/draft pair chosen so the accept ratio p/q spans a wide range
+# (4.0, 1.5, 0.667, 0.25 across the four tokens). The wider that spread,
+# the more a shared ``u`` couples the per-position accept events — and
+# so the larger the joint-distribution error a shared draw produces.
+_TARGET = [0.4, 0.3, 0.2, 0.1]
+_DRAFT = [0.1, 0.2, 0.3, 0.4]
+
+# Sample budget. The lag-1 table has ``vocab**2`` cells; at 24k tokens
+# the Monte-Carlo noise floor on its TV distance is well under the
+# thresholds asserted below, which were set from the observed spread
+# across seeds with margin.
+_N_TOKENS = 24_000
+_TV_MARGINAL_MAX = 0.02
+_TV_JOINT_MAX = 0.03
+
+
+@pytest.mark.parametrize("max_k", [2, 3])
+def test_kge2_joint_matches_autoregressive(max_k):
+    """Chain-of-K sampling must match plain autoregressive JOINTLY, not just marginally.
+
+    This is the regression test for the shared-``u`` defect. Verified
+    against the defect: restoring the scalar draw fails this test at
+    TV 0.029 (K=2) and 0.066 (K=3) on the marginal, both far outside the
+    thresholds, because accepting position 1 biases ``u`` low, inflating
+    position 2's accept rate and pulling the following token toward the
+    draft distribution.
+    """
+    vocab = len(_TARGET)
+    baseline = _run_stream(_TARGET, _DRAFT, max_k=0, max_tokens=_N_TOKENS, seed=1234)
+    spec = _run_stream(_TARGET, _DRAFT, max_k=max_k, max_tokens=_N_TOKENS, seed=1234)
+
+    assert _tv(_marginal(spec, vocab), _marginal(baseline, vocab)) < _TV_MARGINAL_MAX
+    assert _tv(_lag1_joint(spec, vocab), _lag1_joint(baseline, vocab)) < _TV_JOINT_MAX
+
+
+def test_k2_joint_matches_autoregressive_under_top_p():
+    """The same joint contract must hold with a top-p filter engaged.
+
+    top_p truncates and renormalises BOTH the target and the draft
+    distribution before the accept ratio and the residual are computed,
+    so the accept test operates on a different (and much peakier) pair
+    of distributions than the unfiltered case. Pinning it separately
+    guards the filtered path's accept/residual arithmetic.
+    """
+    # Both distributions put their tail on the SAME token (t4, 2%), so
+    # top_p=0.95 truncates t4 out of BOTH and leaves a shared support
+    # {0,1,2,3}. That matters: if truncation left the drafter's top
+    # token outside the target's kept set, that token would reject
+    # deterministically (p=0) regardless of ``u``, closing the very
+    # correlation channel this test exists to probe. Over the shared
+    # support the accept ratio still spans 1.94 -> 0.52, so a shared
+    # draw has room to couple the positions.
+    target = [0.35, 0.25, 0.20, 0.18, 0.02]
+    draft = [0.18, 0.20, 0.25, 0.35, 0.02]
+    vocab = len(target)
+    baseline = _run_stream(
+        target, draft, max_k=0, max_tokens=_N_TOKENS, seed=99, top_p=0.95
+    )
+    spec = _run_stream(
+        target, draft, max_k=2, max_tokens=_N_TOKENS, seed=99, top_p=0.95
+    )
+
+    assert _tv(_marginal(spec, vocab), _marginal(baseline, vocab)) < _TV_MARGINAL_MAX
+    assert _tv(_lag1_joint(spec, vocab), _lag1_joint(baseline, vocab)) < _TV_JOINT_MAX
+
+
+def test_k2_joint_matches_autoregressive_residual_dominant():
+    """Rejection/residual path: a drafter that proposes mostly-wrong tokens.
+
+    The draft mass sits almost entirely where the target has almost
+    none, so most positions REJECT and the emitted token comes from the
+    normalised residual ``max(p - q, 0)`` rather than from the draft.
+    That makes this the case where residual arithmetic — not accept
+    arithmetic — determines the output distribution, and it is the one
+    a test built only around high-accept-rate drafters would never
+    exercise.
+    """
+    target = [0.55, 0.25, 0.15, 0.05]
+    draft = [0.02, 0.03, 0.15, 0.80]
+    vocab = len(target)
+
+    baseline = _run_stream(target, draft, max_k=0, max_tokens=_N_TOKENS, seed=7)
+    spec = _run_stream(target, draft, max_k=2, max_tokens=_N_TOKENS, seed=7)
+
+    assert _tv(_marginal(spec, vocab), _marginal(baseline, vocab)) < _TV_MARGINAL_MAX
+    assert _tv(_lag1_joint(spec, vocab), _lag1_joint(baseline, vocab)) < _TV_JOINT_MAX
+
+
+def test_baseline_stream_is_iid():
+    """Sanity-check the reference: the K=0 stream must itself be i.i.d.
+
+    Every other test in this file reads a lag-1 dependence as evidence
+    of a speculative-sampling defect. That inference is only valid if
+    the reference stream has no lag-1 dependence to begin with — which
+    holds because the mocked model's distribution is position-
+    independent. If this test ever fails, the others' diagnosis is
+    unsound and should not be trusted.
+    """
+    vocab = len(_TARGET)
+    baseline = _run_stream(_TARGET, _DRAFT, max_k=0, max_tokens=_N_TOKENS, seed=2024)
+    marginal = _marginal(baseline, vocab)
+    product = [marginal[i] * marginal[j] for i in range(vocab) for j in range(vocab)]
+    assert _tv(_lag1_joint(baseline, vocab), product) < _TV_JOINT_MAX

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -304,3 +304,122 @@ def test_mtp_lossless_byte_equal_against_baseline(loaded_model, baseline_tokens)
             f"baseline {base_tokens} vs mtp {mtp_tokens}. "
             f"Accept rate this run: {counter.snapshot()}."
         )
+
+
+# Sampled-smoke settings. temp>0 with a top_p filter is what ordinary
+# chat traffic uses; the temp=0 test above cannot reach the
+# probabilistic accept/residual arithmetic at all, because at temp=0
+# the verify accepts iff the argmaxes match and the random draw is
+# ignored outright.
+_SAMPLED_TEMP = 0.8
+_SAMPLED_TOP_P = 0.95
+_SAMPLED_N_TOKENS = 120
+_SAMPLED_PROMPT = "Explain how a Bloom filter works, in three sentences."
+
+
+def _longest_draft_run(from_draft_flags: list[bool]) -> int:
+    """Longest run of consecutive draft-sourced tokens.
+
+    A run of length N means some round had N draft positions accepted
+    back-to-back, which is direct evidence that a chain of depth >= N
+    was verified — the property the K>=2 accept arithmetic depends on.
+    """
+    best = current = 0
+    for flag in from_draft_flags:
+        current = current + 1 if flag else 0
+        best = max(best, current)
+    return best
+
+
+@pytest.mark.parametrize("max_k", [2, 3])
+def test_mtp_nongreedy_real_sampled_smoke(loaded_model, max_k):
+    """Sampled (temp>0) MTP decode on real weights must reach depth K and accept.
+
+    Why this exists alongside the temp=0 lossless test: at temp=0 the
+    verify path never consults its random draw, so the entire
+    probabilistic accept / residual-resample branch — the branch every
+    non-greedy chat request now takes — is untested on real weights by
+    that test. This one drives it.
+
+    Why the depth is pinned rather than left to the EV controller:
+    measured on this checkpoint, the controller settles on K=1 for this
+    prompt, giving a longest-consecutive-draft-run of exactly 1. A
+    K=1 chain has no cross-position accept arithmetic to get wrong, so
+    an auto-K run would report a healthy acceptance rate while never
+    executing the K>=2 code path at all. ``disable_auto_k=True`` with
+    ``max_k=K`` fixes the chain depth at K every round so the path is
+    actually exercised. Both settings are ordinary generator kwargs;
+    nothing about the sampling math changes.
+
+    Observed at the time of writing (Qwen3.5-9B-4bit + sidecar, 120
+    tokens): K=2 accepted 60/118 draft positions (51%) with a longest
+    run of 2; K=3 accepted 74/138 (54%) with a longest run of 3. Both
+    produced coherent prose. The thresholds below sit well under those
+    numbers so ordinary sampling variance does not flake the test.
+    """
+    import mlx.core as _mx
+
+    from vllm_mlx.spec_decode.mtp import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+
+    model, tokenizer = loaded_model
+    inner = model.language_model
+
+    _mx.random.seed(1234)
+    counter = MTPAcceptCounter()
+    prompt_ids = _mx.array(tokenizer.encode(_SAMPLED_PROMPT), _mx.uint32)
+
+    tokens: list[int] = []
+    from_draft: list[bool] = []
+    for tok, _lp, fd in mtp_generate_step(
+        prompt_ids,
+        inner,
+        max_tokens=_SAMPLED_N_TOKENS,
+        temp=_SAMPLED_TEMP,
+        top_p=_SAMPLED_TOP_P,
+        accept_counter=counter,
+        disable_auto_k=True,
+        max_k=max_k,
+    ):
+        tokens.append(int(tok))
+        from_draft.append(bool(fd))
+        if len(tokens) >= _SAMPLED_N_TOKENS:
+            break
+
+    snap = counter.snapshot()
+
+    assert len(tokens) == _SAMPLED_N_TOKENS, (
+        f"Sampled MTP run produced {len(tokens)} tokens, expected "
+        f"{_SAMPLED_N_TOKENS}. The generator terminated early."
+    )
+
+    # The spec path must actually have run. A zero here means MTP
+    # silently degraded to plain autoregressive decode and every other
+    # assertion in this test would pass vacuously.
+    assert snap.attempts > 0, (
+        f"No draft positions were attempted at max_k={max_k}: {snap}. "
+        f"MTP spec decode did not engage."
+    )
+
+    accept_rate = snap.accepts / snap.attempts
+    assert accept_rate > 0.15, (
+        f"Sampled accept rate {accept_rate:.3f} ({snap.accepts}/"
+        f"{snap.attempts}) at max_k={max_k} is far below the ~0.5 "
+        f"measured on this checkpoint. Either the draft head regressed "
+        f"or the accept arithmetic is rejecting valid proposals."
+    )
+
+    # The point of the test: prove a chain of depth >= 2 was verified
+    # and accepted, i.e. the multi-position accept path really ran.
+    longest = _longest_draft_run(from_draft)
+    assert longest >= 2, (
+        f"Longest consecutive draft-sourced run was {longest} at "
+        f"max_k={max_k}; expected >= 2. The K>=2 accept path was never "
+        f"exercised, so this run proves nothing about it."
+    )
+
+    text = tokenizer.decode(tokens)
+    assert text.strip(), (
+        f"Sampled MTP decode at max_k={max_k} produced no printable text "
+        f"from {len(tokens)} tokens."
+    )

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -352,11 +352,13 @@ def test_mtp_nongreedy_real_sampled_smoke(loaded_model, max_k):
     actually exercised. Both settings are ordinary generator kwargs;
     nothing about the sampling math changes.
 
-    Observed at the time of writing (Qwen3.5-9B-4bit + sidecar, 120
-    tokens): K=2 accepted 60/118 draft positions (51%) with a longest
-    run of 2; K=3 accepted 74/138 (54%) with a longest run of 3. Both
-    produced coherent prose. The thresholds below sit well under those
-    numbers so ordinary sampling variance does not flake the test.
+    Observed on main @ 0.14.0 (Qwen3.5-9B-4bit + sidecar, 120 tokens,
+    M3 Ultra) across seeds 1234/7/99/2024: K=2 accepted 61-66 of
+    106-116 draft positions (0.53-0.62) and K=3 accepted 65-70 of
+    147-165 (0.39-0.48). The longest consecutive draft-sourced run came
+    out exactly equal to max_k in all eight runs, and every run produced
+    coherent prose. The thresholds below sit well under the measured
+    accept rates so ordinary sampling variance does not flake the test.
     """
     import mlx.core as _mx
 
@@ -410,13 +412,17 @@ def test_mtp_nongreedy_real_sampled_smoke(loaded_model, max_k):
         f"or the accept arithmetic is rejecting valid proposals."
     )
 
-    # The point of the test: prove a chain of depth >= 2 was verified
-    # and accepted, i.e. the multi-position accept path really ran.
+    # The point of the test: prove a chain of depth ``max_k`` was
+    # verified and accepted, i.e. the multi-position accept path really
+    # ran to the pinned depth. Asserting a fixed >= 2 instead would let
+    # the max_k=3 case pass on a run that never accepted a third
+    # position, making that parametrization prove nothing K=2 did not.
     longest = _longest_draft_run(from_draft)
-    assert longest >= 2, (
+    assert longest >= max_k, (
         f"Longest consecutive draft-sourced run was {longest} at "
-        f"max_k={max_k}; expected >= 2. The K>=2 accept path was never "
-        f"exercised, so this run proves nothing about it."
+        f"max_k={max_k}; expected >= {max_k}. The full depth-{max_k} "
+        f"accept path was never exercised, so this run proves nothing "
+        f"about it."
     )
 
     text = tokenizer.decode(tokens)

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -331,6 +331,7 @@ def _longest_draft_run(from_draft_flags: list[bool]) -> int:
     return best
 
 
+@pytest.mark.real_hf_cache
 @pytest.mark.parametrize("max_k", [2, 3])
 def test_mtp_nongreedy_real_sampled_smoke(loaded_model, max_k):
     """Sampled (temp>0) MTP decode on real weights must reach depth K and accept.

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -412,6 +412,22 @@ def test_mtp_nongreedy_real_sampled_smoke(loaded_model, max_k):
         f"or the accept arithmetic is rejecting valid proposals."
     )
 
+    # The accept rate needs a ceiling as well as a floor. A verifier
+    # that accepted every proposal would satisfy every other assertion
+    # in this test while never entering the reject-and-resample-from-
+    # residual branch — which is half of what the sampled path does and
+    # the more delicate half. Measured rejections on this checkpoint are
+    # 41-55 at K=2 and 77-93 at K=3 across four seeds, so requiring 10
+    # keeps four-fold margin over the smallest observed run.
+    rejections = snap.attempts - snap.accepts
+    assert rejections >= 10, (
+        f"Only {rejections} of {snap.attempts} draft positions were "
+        f"rejected at max_k={max_k} (accept rate {accept_rate:.3f}). "
+        f"The residual-resample branch is essentially unexercised, so "
+        f"this run does not cover it. A verifier that accepts "
+        f"everything reaches this line."
+    )
+
     # The point of the test: prove a chain of depth ``max_k`` was
     # verified and accepted, i.e. the multi-position accept path really
     # ran to the pinned depth. Asserting a fixed >= 2 instead would let


### PR DESCRIPTION
Lands the part of #2140 that current `main` does not already have: behavioural coverage for the sampled (temp>0) MTP path. Opened on a maintainer branch because the original head lives on a fork; both test files are cherry-picked with `@nmorgowicz` preserved as the commit author.

**The runtime half of #2140 is deliberately not here.** #2655 (merged 2026-08-29) landed the same two runtime changes and more: it forwards each request's `temperature`/`top_p`/`top_k`/`min_p` into target-verified MTP instead of gating the lane to greedy, and it draws one independent uniform per speculative position. On top of that it supports request-local seeded RNG (which #2140 explicitly punted to plain decode), transfers exact penalty-processor history across the handoff, and reads processor eligibility from the scheduler's uid-keyed admission state. `_sampling_options_for_uid` on `main` is a strict superset of #2140's `_sampling_for_uid`, so the cherry-pick keeps `main`'s `generator.py` and `scheduler.py` untouched.

## Why the tests are not redundant

`main` already guards the historical shared-draw defect with `test_generator_sampled_k3_draws_acceptance_independently_per_position`, but that assertion checks the **shape** of the acceptance draw. It catches that one defect and nothing else. Measured on this branch by mutating `generator.py` and running the suites:

| mutation to `generator.py` | `test_mtp_spec_decode` + `test_mtp_lossless` + `test_mtp_cli_wiring` + `test_mtp_stream_contract` (246 tests) | `test_mtp_nongreedy_distribution.py` (new) |
|---|---|---|
| `u = _uniform()` — one scalar draw shared across K positions | 1 failure (the shape assertion) | 5 failures |
| `dist = p_target` — resample from the target instead of the rejection residual `max(p-q, 0)` | **246 passed** | 4 of 5 fail, TV up to 0.14 |

The second mutation is the classic speculative-sampling error and it is silent today. Sampled decode has been the default Desktop path since #2655, and it had no distributional guard.

The second file closes a matching gap on real weights: `test_mtp_real_weights.py` only covered `temp=0`, where the verify accepts iff the argmaxes match and the random draw is never consulted, so the probabilistic accept/residual branch had zero real-weight coverage. The new smoke pins the chain depth because the EV controller settles on K=1 for that prompt on that checkpoint, which would let an auto-K run report a healthy accept rate while never executing the K>=2 arithmetic.

## Not included from #2140

- `bench/bench_spec_decode_mtp_server.py` and the `bench/bench_spec_decode_mtp.py` rework: `main` has since grown `--temp/--top-p/--top-k` arms on the in-process bench and `bench/bench_continuous_mtp_server.py` for the server path with per-request output hashes and concurrency. Landing 1.4k more lines of overlapping harness is not worth it.
- `reports/benchmarks/pr2140-mtp-server/*.json`: single-trial M5 Max receipts against a three-week-old commit. Stale in-tree evidence is worse than none.
- `bench/repro_mtp_forced_k_parity.py`: its finding is real and reproduces on `main`, but it belongs to a separate contract question filed as its own issue rather than to a test-coverage PR.

## Test plan

- [x] `pytest tests/test_mtp_nongreedy_distribution.py` — 5 passed (87s, M3 Ultra).
- [x] `RAPID_MLX_RUN_HEAVY_TESTS=1 pytest tests/test_mtp_real_weights.py` — 4 passed, real `mlx-community/Qwen3.5-9B-4bit` + `Qwen3.5-9B-MTP-4bit`. The two new arms engage speculation (K=2: 118 attempts; K=3: 147) and reach the pinned depth.
- [x] `pytest tests/test_mtp_spec_decode.py tests/test_mtp_lossless.py tests/test_mtp_cli_wiring.py tests/test_mtp_stream_contract.py tests/test_mtp_inject_and_install.py tests/test_mtp_prepared_state.py` — 300 passed, no runtime file touched.
- [x] Both mutations above applied and reverted; `git diff HEAD -- vllm_mlx/` is empty on this branch.
- [x] `ruff check` and `ruff format --check` clean on both files.

## CI cost

The distribution guard adds ~90s on an M3 Ultra to the Apple-silicon lane. The 24k-token sample budget is load-bearing: the shared-draw arm it also covers shows up at TV 0.024 against a 0.02 threshold, so a smaller budget would make that arm marginal. Left at the contributor's calibration rather than trimmed.

Credit: `@nmorgowicz` (#2140) wrote both test files and diagnosed the per-position-draw defect they pin.

## Review rounds

- **Round 1 (codex, BLOCKING).** The sampled smoke asserted `longest >= 2` for both parametrizations, so `max_k=3` could pass without ever accepting a third position. Now asserts `longest >= max_k`; measured across seeds 1234/7/99/2024 the longest run equals `max_k` in all eight runs.
- **Round 2 (codex, BLOCKING).** The accept rate had a floor but no ceiling, so a verifier that accepted every proposal would satisfy every assertion while never entering the reject-and-resample-from-residual branch. Now also requires at least 10 rejected positions; measured rejections are 41-55 at K=2 and 77-93 at K=3.
- **Round 3 (codex).** No blocking issues.

`full_unit` failures seen on earlier rounds were the validator venv, not this branch: `mflux` missing (image extra) and the Gemma 4 tokenizer tests needing a checkpoint that is not in the local cache while the validator runs with network disabled. Both resolved by completing the venv; no model was downloaded.
