### PR TITLE
bench: qualify DeepSeek V4.1 Flash runtime paths

### DIFF
--- a/.agents/handoffs/vector-deepseek-v41-flash-support.md
+++ b/.agents/handoffs/vector-deepseek-v41-flash-support.md
@@ -15,7 +15,8 @@
   integration, default-model changes, unrelated V4 performance work, or silent
   fallback from native vision to text-only behavior.
 - Constraints: single standard Hugging Face cache under the Studio storage
-  policy; no cache relocation or deletion; no production/release operation.
+  policy; delete only caches explicitly authorized by the administrator; no
+  cache relocation and no production/release operation.
 - Verification: official-source and architecture check, existing-runtime
   precedent audit, config-level compatibility tests before any large download,
   real Server/Desktop path dogfood if runnable weights exist, self-adversarial
@@ -27,28 +28,42 @@ Echo, and ds0731.
 
 ## PR-complete FYI
 
-- Outcome: experiment complete; do not add catalog/runtime/Desktop support yet.
-- Storage blocker: the 222.4 GiB community 2-bit checkpoint is absent and the
-  policy-managed Hugging Face cache has only about 80 GiB free. No shards were
-  downloaded, no models were deleted, and no cache was redirected.
-- Evidence: on M3 Ultra, 256 GiB, 2-bit/group-64 synthetic published shapes,
-  pre-packed active-expert batching reduced one-layer MoE time from 0.601 ms to
-  0.454 ms. Stacking separately stored experts per call took 0.796 ms and was
-  slower than the serial path. Removing 40 layer syncs reduced the serial
-  synthetic MoE graph from 24.18 ms to 11.36 ms.
+- Outcome: real-weight qualification complete; do not add catalog/runtime or
+  Desktop support yet because 20+ tok/s is not demonstrated.
+- Artifact: all 238,796,133,496 indexed bytes, 48 shards, and 143,982 tensors
+  are present in the standard cache at revision
+  `802f1a00982705d81b79ad1c83aa0ccc0b863ebc`; `hf cache verify` checked all 64
+  files. No cache was redirected.
+- Baseline: M3 Ultra 60-core GPU, 256 GiB, MLX 0.32.2, resident text backbone.
+  The unchanged 32-warmup/128-measure control reached 6.055 tok/s and 165.96 ms
+  median latency. Resident weights occupy about 173.5 GB active memory.
+- Safe candidate: expert-local gate/up fusion is bit-identical in the focused
+  quantized test, preserves the greedy chain, and reaches 6.216 tok/s (+2.65%)
+  with 160.55 ms median latency (-3.26%). Packing takes 4.76 seconds without a
+  memory spike.
+- Rejected candidate: all-expert `gather_qmm` is 2.02x faster for one isolated
+  real layer but collapses to 0.436 tok/s at 40 layers because 4.25 GB layer
+  buffers destroy full-model Metal memory locality.
+- Quality-blocked candidate: fused pipelined mHC reaches 8.030 tok/s (+32.6%)
+  but only 43.75% top-1 agreement over 16 teacher-forced tokens, with 15.80
+  maximum logit error after 40-layer amplification. Keep benchmark-only.
+- MTP: the bundled three-stage DSpark verifier advances target tokens serially
+  and is documented as slower. The next material gate is parallel target block
+  verification with commit-on-accepted-prefix KV semantics.
 - Guardrail: these are MoE-only synthetic measurements and not end-to-end model
-  throughput claims. Full results and excluded work are documented in
+  throughput claims unless explicitly labeled as real-weight results. Full
+  results and excluded work are documented in
   `docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md`.
-- Verification: benchmark outputs matched bit-for-bit; Ruff passed; 33 benchmark
-  metadata tests passed; diff check passed.
+- Verification: focused quantized fusion output is bit-identical; Ruff and 43
+  profiler/benchmark-metadata tests pass; diff check passes.
 - Prepared gate: `scripts/bench_deepseek_v41_runtime.py` can run the unchanged
   local checkpoint, capture continuous warm decode latency, existing eval-barrier
-  waits, Engram/disk counters, and memory. It refuses
-  downloads and checkpoint Python execution is explicit opt-in. Its focused and
-  metadata suites pass 42 tests, including a tiny local-runtime end-to-end run.
+  waits, Engram/disk counters, memory, and explicit experimental HC/MoE
+  overrides. It refuses downloads and checkpoint Python execution is explicit
+  opt-in.
 - Safety finding: whole-process Metal capture is forbidden for this model. A
   one-token capture grew to about 112 GiB before it was terminated and removed;
   system free space recovered fully. Use isolated layer/kernel benchmarks.
-- Next owner/action: Vector, when at least 223 GiB of policy-compliant cache
-  capacity exists, run the unchanged real checkpoint with per-layer profiling,
-  then validate a one-layer expert-major conversion and batched kernel.
+- Next owner/action: Vector, design a bounded multi-token target forward for
+  DSpark block verification. Catalog/GUI/server work remains out of scope until
+  throughput and quality gates pass.

--- a/.agents/handoffs/vector-deepseek-v41-flash-support.md
+++ b/.agents/handoffs/vector-deepseek-v41-flash-support.md
@@ -43,9 +43,12 @@ Echo, and ds0731.
   metadata tests passed; diff check passed.
 - Prepared gate: `scripts/bench_deepseek_v41_runtime.py` can run the unchanged
   local checkpoint, capture continuous warm decode latency, existing eval-barrier
-  waits, Engram/disk counters, memory, and an optional Metal trace. It refuses
+  waits, Engram/disk counters, and memory. It refuses
   downloads and checkpoint Python execution is explicit opt-in. Its focused and
   metadata suites pass 42 tests, including a tiny local-runtime end-to-end run.
+- Safety finding: whole-process Metal capture is forbidden for this model. A
+  one-token capture grew to about 112 GiB before it was terminated and removed;
+  system free space recovered fully. Use isolated layer/kernel benchmarks.
 - Next owner/action: Vector, when at least 223 GiB of policy-compliant cache
   capacity exists, run the unchanged real checkpoint with per-layer profiling,
   then validate a one-layer expert-major conversion and batched kernel.

--- a/.agents/handoffs/vector-deepseek-v41-flash-support.md
+++ b/.agents/handoffs/vector-deepseek-v41-flash-support.md
@@ -41,6 +41,11 @@ Echo, and ds0731.
   `docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md`.
 - Verification: benchmark outputs matched bit-for-bit; Ruff passed; 33 benchmark
   metadata tests passed; diff check passed.
+- Prepared gate: `scripts/bench_deepseek_v41_runtime.py` can run the unchanged
+  local checkpoint, capture continuous warm decode latency, existing eval-barrier
+  waits, Engram/disk counters, memory, and an optional Metal trace. It refuses
+  downloads and checkpoint Python execution is explicit opt-in. Its focused and
+  metadata suites pass 42 tests, including a tiny local-runtime end-to-end run.
 - Next owner/action: Vector, when at least 223 GiB of policy-compliant cache
   capacity exists, run the unchanged real checkpoint with per-layer profiling,
   then validate a one-layer expert-major conversion and batched kernel.

--- a/.agents/handoffs/vector-deepseek-v41-flash-support.md
+++ b/.agents/handoffs/vector-deepseek-v41-flash-support.md
@@ -1,0 +1,46 @@
+# Vector handoff — DeepSeek V4.1 Flash performance qualification
+
+## PR-start FYI
+
+- Owner/host: Vector, Studio
+- Branch/worktree: `vector/deepseek-v41-flash-support`,
+  `/private/tmp/rapid-mlx-deepseek-v41-flash-support`
+- User-visible goal: determine whether DeepSeek V4.1 Flash has a credible path
+  to at least 20 tok/s on a 256 GiB Mac before exposing unsupported catalog or
+  product claims.
+- Scope: official artifact/config qualification, a reproducible synthetic MLX
+  MoE scheduling benchmark, quantization layout comparison, and a bounded next
+  real-weight gate.
+- Non-goals: inventing an alias for an unpublished checkpoint, cloud-provider
+  integration, default-model changes, unrelated V4 performance work, or silent
+  fallback from native vision to text-only behavior.
+- Constraints: single standard Hugging Face cache under the Studio storage
+  policy; no cache relocation or deletion; no production/release operation.
+- Verification: official-source and architecture check, existing-runtime
+  precedent audit, config-level compatibility tests before any large download,
+  real Server/Desktop path dogfood if runnable weights exist, self-adversarial
+  review, focused/full tests, and PR validation.
+
+The Orca agent messaging channel is unavailable in this session. This tracked
+handoff carries the equivalent non-blocking start FYI for Atlas, Pixel, Harbor,
+Echo, and ds0731.
+
+## PR-complete FYI
+
+- Outcome: experiment complete; do not add catalog/runtime/Desktop support yet.
+- Storage blocker: the 222.4 GiB community 2-bit checkpoint is absent and the
+  policy-managed Hugging Face cache has only about 80 GiB free. No shards were
+  downloaded, no models were deleted, and no cache was redirected.
+- Evidence: on M3 Ultra, 256 GiB, 2-bit/group-64 synthetic published shapes,
+  pre-packed active-expert batching reduced one-layer MoE time from 0.601 ms to
+  0.454 ms. Stacking separately stored experts per call took 0.796 ms and was
+  slower than the serial path. Removing 40 layer syncs reduced the serial
+  synthetic MoE graph from 24.18 ms to 11.36 ms.
+- Guardrail: these are MoE-only synthetic measurements and not end-to-end model
+  throughput claims. Full results and excluded work are documented in
+  `docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md`.
+- Verification: benchmark outputs matched bit-for-bit; Ruff passed; 33 benchmark
+  metadata tests passed; diff check passed.
+- Next owner/action: Vector, when at least 223 GiB of policy-compliant cache
+  capacity exists, run the unchanged real checkpoint with per-layer profiling,
+  then validate a one-layer expert-major conversion and batched kernel.

--- a/bench/README.md
+++ b/bench/README.md
@@ -8,3 +8,7 @@ end-to-end serving benchmarks use `rapid-mlx bench`).
 - `bench_spec_decode_mtp.py` — MTP speculative-decode bench (#302): decode
   tok/s of `--spec-decode mtp` vs `none` on a Qwen3.5/3.6 MTP checkpoint,
   interleaved runs to avoid thermal drift.
+
+Model-specific exploratory benchmarks live under `scripts/`; for example,
+`scripts/bench_deepseek_v41_moe.py` isolates the synthetic DeepSeek V4.1 Flash
+decode-time MoE dispatch path without requiring the full checkpoint.

--- a/bench/README.md
+++ b/bench/README.md
@@ -12,3 +12,5 @@ end-to-end serving benchmarks use `rapid-mlx bench`).
 Model-specific exploratory benchmarks live under `scripts/`; for example,
 `scripts/bench_deepseek_v41_moe.py` isolates the synthetic DeepSeek V4.1 Flash
 decode-time MoE dispatch path without requiring the full checkpoint.
+`scripts/bench_deepseek_v41_runtime.py` records the corresponding real-weight
+runtime baseline once a complete local checkpoint is already available.

--- a/docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md
+++ b/docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md
@@ -4,27 +4,30 @@ Date: 2026-09-10
 
 ## Decision
 
-Do not add DeepSeek V4.1 Flash to the Rapid model catalog yet. A synthetic
-Metal experiment shows that the decode-time MoE path has worthwhile scheduling
-headroom, but a real-weight end-to-end run is blocked on this host and the
-20+ tok/s target is not yet demonstrated.
+Do not add DeepSeek V4.1 Flash to the Rapid model catalog yet. The complete
+2-bit checkpoint fits on this 256 GiB host and generates correct text, but the
+unchanged warm runtime reaches only 6.055 tok/s. The fastest experimental
+runtime reaches 8.030 tok/s but fails the numerical/quality gate, while the
+safe expert-local optimization reaches 6.216 tok/s. The 20+ tok/s target is not
+demonstrated.
 
-The next prototype should combine an expert-major packed checkpoint layout
-with batched active-expert quantized matmuls and fewer layer-boundary host
-synchronizations. Converting only the runtime while retaining separately stored
-expert tensors recovers little of the potential gain.
+The next material prototype is parallel target block verification for the
+three native MTP stages. The checkpoint's current verifier advances target
+tokens serially and is slower than non-MTP decoding. Ordinary quantization,
+expert packing, and launch reduction do not supply the missing 3.3x by
+themselves.
 
-## Storage gate
+## Artifact acquisition
 
-The candidate baseline is
-`Vontra/DeepSeek-V4.1-Flash-MLX-2bit-MTP`. Its indexed checkpoint size is
-238,796,133,496 bytes (222.4 GiB). It was not present in the Hugging Face cache,
-which had about 80 GiB free before this experiment. The studio storage policy
-forbids deleting other cached models or redirecting the download, so no model
-shards were downloaded.
+The candidate baseline is `Vontra/DeepSeek-V4.1-Flash-MLX-2bit-MTP`. Its indexed
+checkpoint size is 238,796,133,496 bytes (222.4 GiB). It was initially blocked
+by cache capacity. After the administrator explicitly approved removal of
+named, unused model caches, the checkpoint was downloaded into the standard
+Hugging Face cache. No cache path was overridden or redirected.
 
-Consequently, this note makes no quality, memory-residency, vision, long-context,
-tool-use, or end-to-end throughput claim.
+All 143,982 indexed tensors across 48 shards were present, no incomplete files
+remained, and `hf cache verify` checked all 64 repository files successfully.
+This note still makes no vision, long-context, or tool-use quality claim.
 
 ## Method
 
@@ -137,21 +140,19 @@ changes alone therefore cannot deliver the earlier 165--185 GB target. That
 target still needs structured pruning, sub-2-bit packing, special Engram
 compression, or a combination, followed by quality evaluation.
 
-## Next real-weight gate
+## Next engineering gate
 
-When a policy-compliant host has at least 223 GiB of cache capacity available:
-
-1. run the community checkpoint unchanged with the prepared profiler and record
-   per-token, existing-barrier, Engram-cache, disk-read, and peak-memory
-   measurements;
-2. convert one layer to expert-major packed storage and compare numerics and
-   latency against the original separately keyed tensors;
-3. prototype a 2-bit/group-64 batched active-expert path;
-4. remove only correctness-safe synchronization boundaries and validate
-   cancellation plus memory growth;
-5. run at least 128 warm decode tokens at 8K context before making a throughput
-   claim;
-6. evaluate quantization quality before considering REAP or group size 128.
+1. implement a bounded multi-token target forward that verifies one DSpark
+   block without serially mutating target KV state;
+2. preserve rejection semantics by committing only the accepted KV prefix;
+3. measure proposal cost, accepted tokens per block, target block cost, and net
+   tok/s separately;
+4. adapt mHC fusion to reproduce the checkpoint graph's numerical order, or
+   pass a representative quality eval before accepting different numerics;
+5. combine only individually qualified optimizations and run at least 128 warm
+   decode tokens at 8K context;
+6. evaluate quantization quality before considering REAP, pruning, or larger
+   affine group sizes.
 
 Only after those gates pass should Rapid model loading, catalog metadata,
 server routing, GUI exposure, or a downloadable quantization artifact enter
@@ -199,25 +200,54 @@ barriers per token. Existing barrier wait averaged about 130.6 ms/token:
 Barrier attribution identifies where queued work is observed, rather than the
 exclusive cost of the Python caller.
 
-Two real-weight candidate experiments then bounded straightforward runtime
+Real-weight candidate experiments then bounded straightforward runtime
 headroom:
 
 1. Removing the redundant layer-boundary `mx.eval` and per-layer finite-value
    diagnostic preserved the exact generated text and improved alternating warm
    runs from 6.16--6.22 tok/s to 7.57--7.63 tok/s, a 22--24% gain.
-2. Packing all 384 routed experts for one real layer into an expert-major
-   4,246,732,800-byte tensor set kept routing and top-6 selection on GPU. Output
-   remained numerically close (`max_abs=0.0001221`, `rtol=atol=1e-3`) and layer
-   latency improved from 1.111 ms to 0.918 ms, or 1.21x. Compiling the batched
-   path improved a separate run from 1.164 ms to 1.007 ms, another 13.5%, but
-   was not sufficient to change the end-to-end conclusion.
+2. Reusing Rapid's fused gate/up `gather_qmm` path for one real layer improved
+   routed MoE latency from 1.276 ms to 0.714 ms (1.79x). The maximum absolute
+   BF16 difference was 0.0001221. A smaller fixed-route reproduction of the
+   same math was bit-identical and improved 0.815 ms to 0.404 ms (2.02x).
+3. Scaling the expert-major layout to all 40 layers failed badly. It packed
+   169,869,312,000 bytes in 10.94 seconds without a memory spike, but the large
+   Metal buffers were consistent with a severe full-model VM/page-locality
+   penalty: throughput fell to 0.436 tok/s and median latency rose to 2.306
+   seconds. This layout is rejected even though its isolated one-layer
+   benchmark is fast.
+4. Fusing gate/up inside each existing small expert buffer retained locality
+   and produced bit-identical quantized-matmul output in the focused test. It
+   packed 113,246,208,000 bytes in 4.76 seconds, reduced active memory slightly,
+   preserved the greedy token chain, and improved 64-token decode from the
+   6.055 tok/s control to 6.216 tok/s (+2.65%). Median latency fell from 165.96
+   ms to 160.55 ms (-3.26%). This is safe but not material enough alone.
+5. A V4.1-specific fused mHC mixing kernel preserved the architecture's
+   pipelined `pre` timing and reduced a real mixing/collapse microbenchmark from
+   951 microseconds to 315 microseconds (3.02x). In the full model it improved
+   throughput from 6.055 to 8.030 tok/s (+32.6%) and median latency from 165.96
+   to 123.95 ms (-25.3%). It did not pass the quality gate: tiny per-layer
+   differences were amplified across 40 hyper-connected layers, producing only
+   43.75% top-1 agreement across a 16-token teacher-forced comparison and up to
+   15.80 absolute logit error. This kernel remains an explicit experimental
+   upper bound and must not be enabled in a product runtime.
 
-Even optimistically combining these changes predicts only about 9 tok/s on
-this machine. Reaching 20 tok/s therefore requires large improvements outside
-ordinary tensor layout and graph compilation: attention/indexer/mHC fusion, a
-specialized fused expert kernel, effective parallel MTP verification, or a
-post-trained reduction in active computation. Quantization or REAP that only
-reduces stored bytes does not close the throughput gap.
+The resident backbone is 172,741,563,840 bytes. The minimum per-token text
+weight traffic is about 5.34 GB: 2.69 GB of dense text weights plus 2.65 GB for
+six active routed experts across 40 layers. At 20 tok/s this is about 107 GB/s,
+so nominal memory bandwidth is not the physical blocker. The reference path
+instead performs about 840 routed expert quantized matmuls per token and
+observes 80 host barriers. Launch count, reduction scheduling, and target
+verification are the useful levers.
+
+The bundled three-stage DSpark implementation does not provide the missing
+multiplier. Its verifier is deliberately serial: each proposed token advances
+the target model one token at a time. The checkpoint report also records it as
+slower than non-MTP decoding, with only about 1.00--1.33 accepted draft tokens
+per block on its short diagnostics. A credible 20+ tok/s path therefore needs
+multi-token target block verification, plus the correctness-safe synchronization
+and kernel work above. Quantization or REAP that only reduces stored bytes does
+not close the throughput gap.
 
 The real-weight profiler is plan-only unless both execution flags are supplied.
 It never downloads a model and requires explicit consent before importing the

--- a/docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md
+++ b/docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md
@@ -157,6 +157,68 @@ Only after those gates pass should Rapid model loading, catalog metadata,
 server routing, GUI exposure, or a downloadable quantization artifact enter
 scope.
 
+## Real-weight baseline on the 60-core M3 Ultra
+
+After policy-compliant cache cleanup, the 238,796,133,496-byte checkpoint was
+downloaded into the standard Hugging Face cache. All 143,982 indexed tensors
+across 48 shards were present, no incomplete files remained, and `hf cache
+verify` checked all 64 repository files successfully. The HF volume retained
+107 GiB free after download.
+
+Environment:
+
+- Apple M3 Ultra, 60 GPU cores, 256 GB unified memory
+- MLX 0.32.2
+- checkpoint revision `802f1a00982705d81b79ad1c83aa0ccc0b863ebc`
+- checkpoint runtime SHA-256
+  `55ab20f116a663d79fc6980fbb4613bb60d6cba7ab64dfa4d580d65eeba60645`
+- compiled execution mode and resident text backbone
+
+The checkpoint author's exact arithmetic command was reproduced with its
+default 16,384-row Engram cache. It generated the expected
+`2 plus 2 equals 4.` text, but achieved 5.29 tok/s on the first run and 6.05
+tok/s on the repeated warm-cache run. The published 9.46 tok/s short result was
+not reproduced on this 60-core GPU configuration.
+
+A separate 32-token warmup followed by 128 continuous decode tokens measured:
+
+- 6.018 tok/s
+- 165.95 ms median token latency
+- 173.96 ms p95 and 208.94 ms maximum
+- 173,505,743,338 active MLX bytes and 173,589,483,108 peak bytes
+- 491,520 Engram-related disk bytes across 18,432 small read calls
+
+An instrumented 16-token phase observed 40 router barriers and 40 layer
+barriers per token. Existing barrier wait averaged about 130.6 ms/token:
+
+- router selection barrier: 75.6 ms/token
+- layer boundary barrier: 53.7 ms/token
+- final logits barrier: 1.1 ms/token
+- small indexed reads: 0.2 ms/token
+
+Barrier attribution identifies where queued work is observed, rather than the
+exclusive cost of the Python caller.
+
+Two real-weight candidate experiments then bounded straightforward runtime
+headroom:
+
+1. Removing the redundant layer-boundary `mx.eval` and per-layer finite-value
+   diagnostic preserved the exact generated text and improved alternating warm
+   runs from 6.16--6.22 tok/s to 7.57--7.63 tok/s, a 22--24% gain.
+2. Packing all 384 routed experts for one real layer into an expert-major
+   4,246,732,800-byte tensor set kept routing and top-6 selection on GPU. Output
+   remained numerically close (`max_abs=0.0001221`, `rtol=atol=1e-3`) and layer
+   latency improved from 1.111 ms to 0.918 ms, or 1.21x. Compiling the batched
+   path improved a separate run from 1.164 ms to 1.007 ms, another 13.5%, but
+   was not sufficient to change the end-to-end conclusion.
+
+Even optimistically combining these changes predicts only about 9 tok/s on
+this machine. Reaching 20 tok/s therefore requires large improvements outside
+ordinary tensor layout and graph compilation: attention/indexer/mHC fusion, a
+specialized fused expert kernel, effective parallel MTP verification, or a
+post-trained reduction in active computation. Quantization or REAP that only
+reduces stored bytes does not close the throughput gap.
+
 The real-weight profiler is plan-only unless both execution flags are supplied.
 It never downloads a model and requires explicit consent before importing the
 checkpoint-bundled Python runtime:
@@ -166,14 +228,19 @@ uv run python scripts/bench_deepseek_v41_runtime.py \
   --model ~/.cache/huggingface/hub/models--Vontra--DeepSeek-V4.1-Flash-MLX-2bit-MTP/snapshots/<revision> \
   --execute-real-weights --trust-checkpoint-runtime \
   --resident-backbone --execution-mode compiled \
+  --engram-cache-rows 16384 \
   --context-tokens 8192 --warmup-tokens 16 --measure-tokens 128 \
-  --trace /private/tmp/deepseek-v41-flash-8k.gputrace --trace-tokens 4 \
+  --diagnostic-tokens 8 \
   --output /private/tmp/deepseek-v41-flash-8k.json
 ```
 
 The JSON attributes wait time to existing `mx.eval` call sites without adding
 new synchronization points. This identifies where queued work is observed, not
-exclusive kernel time; the optional Metal trace is required for kernel-level
-attribution. To bound scratch growth, tracing is a separate post-measurement
-probe capped at eight tokens and is refused when `/private/tmp` has less than
-20 GiB free.
+exclusive kernel time.
+
+Do not enable whole-process Metal capture for this model. A one-token capture
+grew to approximately 112 GiB before termination, reducing system-volume free
+space to 14 GiB. The capture process was stopped, the single generated scratch
+artifact was removed, and free space returned to 126 GiB. Kernel experiments
+must isolate a bounded layer or operation instead of capturing the resident
+whole-model process.

--- a/docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md
+++ b/docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md
@@ -1,0 +1,157 @@
+# DeepSeek V4.1 Flash MLX MoE scheduling experiment
+
+Date: 2026-09-10
+
+## Decision
+
+Do not add DeepSeek V4.1 Flash to the Rapid model catalog yet. A synthetic
+Metal experiment shows that the decode-time MoE path has worthwhile scheduling
+headroom, but a real-weight end-to-end run is blocked on this host and the
+20+ tok/s target is not yet demonstrated.
+
+The next prototype should combine an expert-major packed checkpoint layout
+with batched active-expert quantized matmuls and fewer layer-boundary host
+synchronizations. Converting only the runtime while retaining separately stored
+expert tensors recovers little of the potential gain.
+
+## Storage gate
+
+The candidate baseline is
+`Vontra/DeepSeek-V4.1-Flash-MLX-2bit-MTP`. Its indexed checkpoint size is
+238,796,133,496 bytes (222.4 GiB). It was not present in the Hugging Face cache,
+which had about 80 GiB free before this experiment. The studio storage policy
+forbids deleting other cached models or redirecting the download, so no model
+shards were downloaded.
+
+Consequently, this note makes no quality, memory-residency, vision, long-context,
+tool-use, or end-to-end throughput claim.
+
+## Method
+
+The benchmark uses the published text-model dimensions and the community
+checkpoint's quantization configuration:
+
+- Apple M3 Ultra, 256 GiB unified memory
+- MLX GPU (`applegpu_g15d`)
+- hidden size 5,120
+- MoE intermediate size 2,304
+- six active routed experts plus one shared expert
+- 40 layers
+- affine 2-bit weights, group size 64
+- one decode token, batch size one
+- synthetic BF16 weights quantized by MLX and kept resident
+- 8 warm-up observations and 100 timed observations, alternating order
+
+Command:
+
+```shell
+uv run python scripts/bench_deepseek_v41_moe.py \
+  --execute-metal --bits 2 --group-size 64 \
+  --warmup 8 --repeats 100 \
+  --output /private/tmp/deepseek-v41-moe-token.json
+```
+
+The benchmark deliberately excludes routing, expert selection from the full
+384-expert layer, attention, KV cache, Engram lookup, mHC residuals, MTP,
+tokenization, and server overhead. The derived MoE-only TPS values are upper
+bounds, not predicted model throughput.
+
+## Results
+
+All compared paths produced bit-identical outputs for the synthetic input.
+
+| One-layer MoE path | Median ms/layer | MoE-only 40-layer upper bound |
+| --- | ---: | ---: |
+| Serial experts, sync after every expert | 2.088 | 11.97 tok/s |
+| Serial experts, sync once per layer | 0.601 | 41.62 tok/s |
+| Batched experts from pre-packed tensors, sync once per layer | 0.454 | 55.11 tok/s |
+| Batched experts, stack separate tensors each layer | 0.796 | 31.39 tok/s |
+
+The current community runtime's compiled/deferred mode does not synchronize
+after every expert. Its closest micro-benchmark analogue is therefore the
+serial, once-per-layer row, not the 9.23 tok/s row.
+
+Composing 40 synthetic MoE layers gives a second scheduling diagnostic:
+
+| Synthetic 40-layer graph | Median ms/token | MoE-only throughput |
+| --- | ---: | ---: |
+| Serial experts, sync every layer | 24.18 | 41.35 tok/s |
+| Serial experts, one token-level sync | 11.36 | 88.04 tok/s |
+| Batched pre-packed experts, sync every layer | 17.36 | 57.61 tok/s |
+| Batched pre-packed experts, one token-level sync | 8.00 | 124.95 tok/s |
+
+These graph results reuse the same synthetic weights at every layer and omit
+all non-MoE work. They establish direction and relative scheduling cost only.
+They must not be quoted as DeepSeek V4.1 Flash throughput.
+
+## Quantization layout sweep
+
+The same one-layer benchmark was repeated with 60 observations per case.
+
+| Bits / group | Serial layer-sync ms | Pre-packed batched ms | Split-layout batched ms |
+| --- | ---: | ---: | ---: |
+| 2 / 32 | 0.582 | 0.425 | 0.847 |
+| 2 / 64 | 0.601 | 0.454 | 0.796 |
+| 2 / 128 | 0.589 | 0.431 | 0.757 |
+| 3 / 64 | 0.577 | 0.442 | 0.878 |
+| 4 / 64 | 0.583 | 0.470 | 0.957 |
+
+The integer bit width and affine group sizes were close on this kernel-level
+test; none showed enough advantage to select on speed alone. Group size 128
+reduces affine scale/bias overhead by 0.25 bits per quantized parameter versus
+group size 64. That saving still needs a real-weight quality and end-to-end
+speed gate before adoption.
+
+## Interpretation
+
+The experiment supports three bounded conclusions:
+
+1. Active-expert batching is worth prototyping, but only with an expert-major
+   packed artifact or a one-time conversion that does not copy selected weights
+   on every layer and token.
+2. Layer-boundary synchronization is material. A production implementation
+   should make the longest correctness-safe graph possible while retaining
+   cancellation and bounded memory behavior.
+3. MLX's existing integer affine formats are sufficient for the first runtime
+   prototype. Fractional-BPW packing and a custom Metal kernel remain separate
+   experiments; neither is required to validate the scheduling hypothesis.
+
+The experiment does **not** show that 20+ end-to-end tok/s is achieved. Starting
+from the community report of roughly 9 tok/s, expert batching alone cannot be
+linearly extrapolated because non-MoE work and storage behavior are unmeasured.
+
+As a deliberately optimistic Amdahl bound, the reported 8.8--9.5 tok/s baseline
+costs about 114--105 ms/token. Replacing the synthetic current-runtime analogue
+(24.18 ms) with the fastest synthetic batched/token-sync path (8.00 ms) saves
+only 16.18 ms. Even if that saving transferred perfectly, it would imply only
+about 10.3--11.2 tok/s. Reaching 20 tok/s still requires another 47--39 ms/token
+from the unmeasured attention, Engram, residual, weight-access, or speculative
+decode paths. This is why a real-weight profile is the next gate rather than a
+catalog integration.
+
+For size, moving affine quantized tensors from group 64 to group 128 saves 0.25
+bits per affected parameter. Applying that to every approximately 754.6 billion
+parameter is an intentionally generous ceiling of about 23.6 GB; the real
+saving is smaller because not every tensor uses affine quantization. Group-size
+changes alone therefore cannot deliver the earlier 165--185 GB target. That
+target still needs structured pruning, sub-2-bit packing, special Engram
+compression, or a combination, followed by quality evaluation.
+
+## Next real-weight gate
+
+When a policy-compliant host has at least 223 GiB of cache capacity available:
+
+1. run the community checkpoint unchanged and record per-token, per-layer,
+   Engram-cache, disk-read, and peak-memory measurements;
+2. convert one layer to expert-major packed storage and compare numerics and
+   latency against the original separately keyed tensors;
+3. prototype a 2-bit/group-64 batched active-expert path;
+4. remove only correctness-safe synchronization boundaries and validate
+   cancellation plus memory growth;
+5. run at least 128 warm decode tokens at 8K context before making a throughput
+   claim;
+6. evaluate quantization quality before considering REAP or group size 128.
+
+Only after those gates pass should Rapid model loading, catalog metadata,
+server routing, GUI exposure, or a downloadable quantization artifact enter
+scope.

--- a/docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md
+++ b/docs/engineering/performance/2026-09-10-deepseek-v41-flash-moe-experiment.md
@@ -141,8 +141,9 @@ compression, or a combination, followed by quality evaluation.
 
 When a policy-compliant host has at least 223 GiB of cache capacity available:
 
-1. run the community checkpoint unchanged and record per-token, per-layer,
-   Engram-cache, disk-read, and peak-memory measurements;
+1. run the community checkpoint unchanged with the prepared profiler and record
+   per-token, existing-barrier, Engram-cache, disk-read, and peak-memory
+   measurements;
 2. convert one layer to expert-major packed storage and compare numerics and
    latency against the original separately keyed tensors;
 3. prototype a 2-bit/group-64 batched active-expert path;
@@ -155,3 +156,24 @@ When a policy-compliant host has at least 223 GiB of cache capacity available:
 Only after those gates pass should Rapid model loading, catalog metadata,
 server routing, GUI exposure, or a downloadable quantization artifact enter
 scope.
+
+The real-weight profiler is plan-only unless both execution flags are supplied.
+It never downloads a model and requires explicit consent before importing the
+checkpoint-bundled Python runtime:
+
+```shell
+uv run python scripts/bench_deepseek_v41_runtime.py \
+  --model ~/.cache/huggingface/hub/models--Vontra--DeepSeek-V4.1-Flash-MLX-2bit-MTP/snapshots/<revision> \
+  --execute-real-weights --trust-checkpoint-runtime \
+  --resident-backbone --execution-mode compiled \
+  --context-tokens 8192 --warmup-tokens 16 --measure-tokens 128 \
+  --trace /private/tmp/deepseek-v41-flash-8k.gputrace --trace-tokens 4 \
+  --output /private/tmp/deepseek-v41-flash-8k.json
+```
+
+The JSON attributes wait time to existing `mx.eval` call sites without adding
+new synchronization points. This identifies where queued work is observed, not
+exclusive kernel time; the optional Metal trace is required for kernel-level
+attribution. To bound scratch growth, tracing is a separate post-measurement
+probe capped at eight tokens and is refused when `/private/tmp` has less than
+20 GiB free.

--- a/scripts/bench_deepseek_v41_moe.py
+++ b/scripts/bench_deepseek_v41_moe.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Synthetic decode micro-benchmark for the DeepSeek V4.1 Flash MoE path.
+
+This intentionally measures only the expert MLP portion of one decode layer.
+It uses the published dimensions and quantization shape, but random weights;
+the result is a kernel/scheduling diagnostic, not an end-to-end model claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+try:
+    from scripts.bench_metadata import format_bench_json, write_bench_json
+except ImportError:  # direct `python scripts/bench_*.py` execution
+    from bench_metadata import format_bench_json, write_bench_json
+
+
+PLAN = {
+    "scope": "one decode-token MoE MLP layer with synthetic resident weights",
+    "model_shape": {
+        "hidden_size": 5120,
+        "moe_intermediate_size": 2304,
+        "active_routed_experts": 6,
+        "shared_experts": 1,
+        "layers": 40,
+    },
+    "comparison": [
+        "serial expert loop with a host synchronization after every expert",
+        "serial expert loop with one synchronization at the layer boundary",
+        "three batched quantized matmuls across all active experts",
+        "the same batched path after stacking separately stored expert tensors",
+    ],
+    "excluded": [
+        "router and expert-weight gathering",
+        "attention and KV cache",
+        "Engram lookup",
+        "mHC residuals",
+        "MTP speculative decoding",
+        "model quality",
+    ],
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--execute-metal", action="store_true")
+    parser.add_argument("--bits", type=int, choices=(2, 3, 4, 5, 6, 8), default=2)
+    parser.add_argument("--group-size", type=int, choices=(32, 64, 128), default=64)
+    parser.add_argument("--warmup", type=int, default=4)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--output")
+    return parser.parse_args()
+
+
+def _quantize_experts(mx, count, shape, *, bits, group_size, seed):
+    experts = []
+    for index in range(count):
+        weights = mx.random.normal(shape, key=mx.random.key(seed + index)).astype(
+            mx.bfloat16
+        )
+        quantized = mx.quantize(weights, bits=bits, group_size=group_size)
+        mx.eval(*quantized)
+        experts.append(quantized)
+    return experts
+
+
+def _stack_experts(mx, experts):
+    stacked = tuple(
+        mx.stack([expert[part] for expert in experts]) for part in range(3)
+    )
+    mx.eval(*stacked)
+    return stacked
+
+
+def _qmm(mx, x, packed, *, bits, group_size):
+    weight, scales, biases = packed
+    return mx.quantized_matmul(
+        x,
+        weight,
+        scales,
+        biases,
+        transpose=True,
+        bits=bits,
+        group_size=group_size,
+    )
+
+
+def _silu(mx, x):
+    return x * mx.sigmoid(x)
+
+
+def run(args):
+    import mlx.core as mx
+
+    mx.set_default_device(mx.gpu)
+    hidden_size = PLAN["model_shape"]["hidden_size"]
+    intermediate_size = PLAN["model_shape"]["moe_intermediate_size"]
+    expert_count = (
+        PLAN["model_shape"]["active_routed_experts"]
+        + PLAN["model_shape"]["shared_experts"]
+    )
+
+    # Only active experts are materialized. This isolates dispatch granularity
+    # without allocating the full 384-expert checkpoint.
+    split_gate = _quantize_experts(
+        mx,
+        expert_count,
+        (intermediate_size, hidden_size),
+        bits=args.bits,
+        group_size=args.group_size,
+        seed=4101,
+    )
+    split_up = _quantize_experts(
+        mx,
+        expert_count,
+        (intermediate_size, hidden_size),
+        bits=args.bits,
+        group_size=args.group_size,
+        seed=4201,
+    )
+    split_down = _quantize_experts(
+        mx,
+        expert_count,
+        (hidden_size, intermediate_size),
+        bits=args.bits,
+        group_size=args.group_size,
+        seed=4301,
+    )
+    gate = _stack_experts(mx, split_gate)
+    up = _stack_experts(mx, split_up)
+    down = _stack_experts(mx, split_down)
+    x = mx.random.normal((hidden_size,), key=mx.random.key(4104)).astype(mx.bfloat16)
+    routing = mx.softmax(
+        mx.random.normal((expert_count,), key=mx.random.key(4105)).astype(mx.float32)
+    ).astype(mx.bfloat16)
+    mx.eval(x, routing)
+
+    def one_expert(token_x, index):
+        gated = _silu(
+            mx,
+            _qmm(
+                mx,
+                token_x,
+                split_gate[index],
+                bits=args.bits,
+                group_size=args.group_size,
+            ),
+        )
+        up_value = _qmm(
+            mx,
+            token_x,
+            split_up[index],
+            bits=args.bits,
+            group_size=args.group_size,
+        )
+        return _qmm(
+            mx,
+            gated * up_value,
+            split_down[index],
+            bits=args.bits,
+            group_size=args.group_size,
+        )
+
+    def serial_graph(token_x):
+        output = mx.zeros((hidden_size,), dtype=mx.bfloat16)
+        for index in range(expert_count):
+            expert = one_expert(token_x, index)
+            output = output + routing[index] * expert
+        return output
+
+    def serial_sync_each():
+        output = mx.zeros((hidden_size,), dtype=mx.bfloat16)
+        for index in range(expert_count):
+            expert = one_expert(x, index)
+            mx.eval(expert)
+            output = output + routing[index] * expert
+        mx.eval(output)
+        return output
+
+    def serial_layer_sync():
+        output = serial_graph(x)
+        mx.eval(output)
+        return output
+
+    def batched_graph(token_x):
+        batch_x = mx.broadcast_to(token_x, (expert_count, 1, hidden_size))
+        gated = _silu(
+            mx,
+            _qmm(
+                mx,
+                batch_x,
+                gate,
+                bits=args.bits,
+                group_size=args.group_size,
+            ),
+        )
+        up_value = _qmm(
+            mx,
+            batch_x,
+            up,
+            bits=args.bits,
+            group_size=args.group_size,
+        )
+        expert_outputs = _qmm(
+            mx,
+            gated * up_value,
+            down,
+            bits=args.bits,
+            group_size=args.group_size,
+        )[:, 0, :]
+        return mx.sum(expert_outputs * routing[:, None], axis=0)
+
+    def batched_layer_sync():
+        output = batched_graph(x)
+        mx.eval(output)
+        return output
+
+    def batched_from_split_sync():
+        # The community checkpoint stores every expert under a distinct tensor
+        # key. A production batched path either pays this stack/copy cost or
+        # converts the artifact to an expert-major packed layout once.
+        stacked_gate = tuple(
+            mx.stack([expert[part] for expert in split_gate]) for part in range(3)
+        )
+        stacked_up = tuple(
+            mx.stack([expert[part] for expert in split_up]) for part in range(3)
+        )
+        stacked_down = tuple(
+            mx.stack([expert[part] for expert in split_down]) for part in range(3)
+        )
+        batch_x = mx.broadcast_to(x, (expert_count, 1, hidden_size))
+        gated = _silu(
+            mx,
+            _qmm(
+                mx,
+                batch_x,
+                stacked_gate,
+                bits=args.bits,
+                group_size=args.group_size,
+            ),
+        )
+        up_value = _qmm(
+            mx,
+            batch_x,
+            stacked_up,
+            bits=args.bits,
+            group_size=args.group_size,
+        )
+        expert_outputs = _qmm(
+            mx,
+            gated * up_value,
+            stacked_down,
+            bits=args.bits,
+            group_size=args.group_size,
+        )[:, 0, :]
+        output = mx.sum(expert_outputs * routing[:, None], axis=0)
+        mx.eval(output)
+        return output
+
+    modes = {
+        "serial_sync_each": serial_sync_each,
+        "serial_layer_sync": serial_layer_sync,
+        "batched_layer_sync": batched_layer_sync,
+        "batched_from_split_sync": batched_from_split_sync,
+    }
+    reference = serial_layer_sync()
+    correctness = {}
+    for name, function in modes.items():
+        candidate = function()
+        delta = mx.abs(candidate.astype(mx.float32) - reference.astype(mx.float32))
+        correctness[name] = {
+            "max_abs": float(mx.max(delta).item()),
+            "mean_abs": float(mx.mean(delta).item()),
+        }
+
+    for _ in range(args.warmup):
+        for function in modes.values():
+            function()
+
+    timings = {name: [] for name in modes}
+    names = tuple(modes)
+    for repeat in range(args.repeats):
+        order = names if repeat % 2 == 0 else tuple(reversed(names))
+        for name in order:
+            started = time.perf_counter()
+            modes[name]()
+            timings[name].append(time.perf_counter() - started)
+
+    medians = {name: statistics.median(values) for name, values in timings.items()}
+    baseline = medians["serial_sync_each"]
+
+    token_modes = {}
+    for graph_name, graph in (("serial", serial_graph), ("batched", batched_graph)):
+        def layer_sync(graph=graph):
+            state = x
+            for _ in range(PLAN["model_shape"]["layers"]):
+                state = graph(state)
+                mx.eval(state)
+            return state
+
+        def token_sync(graph=graph):
+            state = x
+            for _ in range(PLAN["model_shape"]["layers"]):
+                state = graph(state)
+            mx.eval(state)
+            return state
+
+        token_modes[f"{graph_name}_sync_each_layer"] = layer_sync
+        token_modes[f"{graph_name}_single_sync"] = token_sync
+
+    # Multi-layer graphs are much larger, so cap this diagnostic while keeping
+    # alternating order to limit thermal and ordering bias.
+    token_timings = {name: [] for name in token_modes}
+    token_names = tuple(token_modes)
+    token_repeats = min(args.repeats, 12)
+    for repeat in range(token_repeats):
+        order = token_names if repeat % 2 == 0 else tuple(reversed(token_names))
+        for name in order:
+            started = time.perf_counter()
+            token_modes[name]()
+            token_timings[name].append(time.perf_counter() - started)
+    token_medians = {
+        name: statistics.median(values) for name, values in token_timings.items()
+    }
+    return {
+        "plan": PLAN,
+        "parameters": {
+            "bits": args.bits,
+            "group_size": args.group_size,
+            "warmup": args.warmup,
+            "repeats": args.repeats,
+        },
+        "device": mx.device_info(),
+        "correctness": correctness,
+        "timing": {
+            "raw_seconds": timings,
+            "median_layer_milliseconds": {
+                name: seconds * 1000 for name, seconds in medians.items()
+            },
+            "speedup_vs_serial_sync_each": {
+                name: baseline / seconds for name, seconds in medians.items()
+            },
+            "moe_only_40_layer_upper_bound_tps": {
+                name: 1.0 / (seconds * PLAN["model_shape"]["layers"])
+                for name, seconds in medians.items()
+            },
+            "token_graph_raw_seconds": token_timings,
+            "token_graph_median_seconds": token_medians,
+            "token_graph_moe_only_tps": {
+                name: 1.0 / seconds for name, seconds in token_medians.items()
+            },
+        },
+        "interpretation_guardrail": (
+            "The TPS projection excludes non-MoE model work and is only an upper bound."
+        ),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.execute_metal:
+        print(format_bench_json({"plan_only": True, "plan": PLAN}, __file__))
+        return 0
+    result = run(args)
+    payload = format_bench_json(result, __file__, indent=2, sort_keys=True)
+    print(payload)
+    if args.output:
+        write_bench_json(args.output, result, __file__, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_deepseek_v41_moe.py
+++ b/scripts/bench_deepseek_v41_moe.py
@@ -68,9 +68,7 @@ def _quantize_experts(mx, count, shape, *, bits, group_size, seed):
 
 
 def _stack_experts(mx, experts):
-    stacked = tuple(
-        mx.stack([expert[part] for expert in experts]) for part in range(3)
-    )
+    stacked = tuple(mx.stack([expert[part] for expert in experts]) for part in range(3))
     mx.eval(*stacked)
     return stacked
 
@@ -294,6 +292,7 @@ def run(args):
 
     token_modes = {}
     for graph_name, graph in (("serial", serial_graph), ("batched", batched_graph)):
+
         def layer_sync(graph=graph):
             state = x
             for _ in range(PLAN["model_shape"]["layers"]):

--- a/scripts/bench_deepseek_v41_runtime.py
+++ b/scripts/bench_deepseek_v41_runtime.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Profile the standalone DeepSeek V4.1 Flash MLX runtime with real weights."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import math
+import shutil
+import statistics
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    from scripts.bench_metadata import format_bench_json, write_bench_json
+except ImportError:  # direct `python scripts/profile_*.py` execution
+    from bench_metadata import format_bench_json, write_bench_json
+
+
+PLAN = {
+    "scope": "real-weight standalone DeepSeek V4.1 Flash text-runtime profile",
+    "baseline": "unchanged checkpoint-bundled runtime",
+    "measurements": [
+        "load and sequential context-build wall time",
+        "warm decode token latency and throughput",
+        "existing mx.eval barrier wait time by Python call site",
+        "runtime disk-read and Engram-cache counters",
+        "MLX active, cache, and peak memory",
+        "optional Metal GPU trace",
+    ],
+    "guardrails": [
+        "never downloads or relocates model files",
+        "requires explicit opt-in before executing checkpoint-bundled Python",
+        "barrier wait is not kernel attribution",
+        "text-only; vision and MTP are excluded",
+    ],
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--execute-real-weights", action="store_true")
+    parser.add_argument("--trust-checkpoint-runtime", action="store_true")
+    parser.add_argument("--resident-backbone", action="store_true")
+    parser.add_argument("--execution-mode", choices=("reference", "deferred", "compiled"), default="compiled")
+    parser.add_argument("--prompt", default="Explain why local inference latency matters.")
+    parser.add_argument("--context-tokens", type=int, default=0)
+    parser.add_argument("--warmup-tokens", type=int, default=16)
+    parser.add_argument("--measure-tokens", type=int, default=128)
+    parser.add_argument("--trace", type=Path)
+    parser.add_argument("--trace-tokens", type=int, default=4)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def _percentile(values, percentile):
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _checkpoint_total_size(model_path):
+    index_path = model_path / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    size = (index.get("metadata") or {}).get("total_size")
+    return int(size) if size is not None else None
+
+
+def _resolve_runtime(model_path):
+    candidates = (model_path / "runtime" / "runtime.py", model_path / "runtime.py")
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(
+        "checkpoint has no runtime/runtime.py or runtime.py; no fallback download is allowed"
+    )
+
+
+def _load_runtime(runtime_path):
+    spec = importlib.util.spec_from_file_location(
+        "rapid_deepseek_v41_checkpoint_runtime", runtime_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import checkpoint runtime: {runtime_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class EvalBarrierProfiler:
+    """Measure waits at existing eval barriers without adding new barriers."""
+
+    def __init__(self, original):
+        self.original = original
+        self.reset()
+
+    def reset(self):
+        self.calls = 0
+        self.seconds = 0.0
+        self.by_caller = defaultdict(lambda: {"calls": 0, "seconds": 0.0})
+
+    def __call__(self, *args, **kwargs):
+        frame = sys._getframe(1)
+        caller = f"{frame.f_code.co_name}:{frame.f_lineno}"
+        started = time.perf_counter()
+        result = self.original(*args, **kwargs)
+        elapsed = time.perf_counter() - started
+        self.calls += 1
+        self.seconds += elapsed
+        bucket = self.by_caller[caller]
+        bucket["calls"] += 1
+        bucket["seconds"] += elapsed
+        return result
+
+    def snapshot(self):
+        return {
+            "calls": self.calls,
+            "seconds": self.seconds,
+            "by_caller": dict(
+                sorted(
+                    self.by_caller.items(),
+                    key=lambda item: item[1]["seconds"],
+                    reverse=True,
+                )
+            ),
+            "interpretation": (
+                "Time is charged to the existing barrier that waited for queued work; "
+                "it is not exclusive time for the caller."
+            ),
+        }
+
+
+def _weight_counters(runtime):
+    weights = runtime.w
+    return {
+        "disk_bytes_read": int(getattr(weights, "disk_bytes_read", 0)),
+        "disk_read_calls": int(getattr(weights, "disk_read_calls", 0)),
+        "engram_cache_hits": int(getattr(weights, "engram_cache_hits", 0)),
+        "engram_cache_misses": int(getattr(weights, "engram_cache_misses", 0)),
+        "resident_bytes": int(getattr(weights, "resident_bytes", 0)),
+    }
+
+
+def _counter_delta(after, before):
+    return {key: after[key] - before[key] for key in after}
+
+
+def _memory_snapshot(mx):
+    return {
+        "active_bytes": int(mx.metal.get_active_memory()),
+        "cache_bytes": int(mx.metal.get_cache_memory()),
+        "peak_bytes": int(mx.metal.get_peak_memory()),
+    }
+
+
+def _run_tokens(
+    runtime,
+    count,
+    barrier,
+    mx,
+    *,
+    initial_token,
+    teacher_tokens=None,
+):
+    latencies = []
+    counters_before = _weight_counters(runtime)
+    barrier.reset()
+    next_token = int(initial_token)
+    started = time.perf_counter()
+    for index in range(count):
+        token = teacher_tokens[index] if teacher_tokens is not None else next_token
+        token_started = time.perf_counter()
+        logits, _ = runtime.step(int(token))
+        next_token = int(mx.argmax(logits).item())
+        latencies.append(time.perf_counter() - token_started)
+    elapsed = time.perf_counter() - started
+    return {
+        "tokens": count,
+        "seconds": elapsed,
+        "tokens_per_second": count / elapsed if elapsed else None,
+        "latency_seconds": {
+            "median": statistics.median(latencies) if latencies else None,
+            "p95": _percentile(latencies, 0.95),
+            "max": max(latencies) if latencies else None,
+            "raw": latencies,
+        },
+        "eval_barriers": barrier.snapshot(),
+        "weight_counters": _counter_delta(_weight_counters(runtime), counters_before),
+        "memory": _memory_snapshot(mx),
+        "last_token_id": next_token,
+    }
+
+
+def _validate_args(args):
+    if args.model is None or not args.model.is_dir():
+        raise SystemExit("--model must name an existing local checkpoint directory")
+    if not args.trust_checkpoint_runtime:
+        raise SystemExit(
+            "refusing to execute checkpoint-bundled Python without "
+            "--trust-checkpoint-runtime"
+        )
+    if min(args.context_tokens, args.warmup_tokens, args.measure_tokens) < 0:
+        raise SystemExit("token counts may not be negative")
+    if args.measure_tokens < 1:
+        raise SystemExit("--measure-tokens must be at least 1")
+    if args.trace is not None:
+        trace = args.trace.expanduser().resolve()
+        scratch = Path("/private/tmp").resolve()
+        if trace.suffix != ".gputrace" or scratch not in trace.parents:
+            raise SystemExit("--trace must be a .gputrace path under /private/tmp")
+        if not 1 <= args.trace_tokens <= 8:
+            raise SystemExit("--trace-tokens must be between 1 and 8")
+
+
+def run(args):
+    _validate_args(args)
+    model_path = args.model.expanduser().resolve()
+    runtime_path = _resolve_runtime(model_path)
+    total_size = _checkpoint_total_size(model_path)
+    trace_path = args.trace.expanduser().resolve() if args.trace else None
+
+    started = time.perf_counter()
+    module = _load_runtime(runtime_path)
+    import mlx.core as mx
+
+    mx.set_default_device(mx.gpu)
+    mx.metal.reset_peak_memory()
+    runtime = module.TextRuntime(
+        model_path,
+        max_tokens=args.context_tokens + args.warmup_tokens + args.measure_tokens + 8,
+        resident_backbone=args.resident_backbone,
+        execution_mode=args.execution_mode,
+    )
+    load_seconds = time.perf_counter() - started
+    encoded = runtime.tokenizer.encode(args.prompt).ids
+    if not encoded:
+        raise RuntimeError("prompt encoded to zero tokens")
+    original_eval = module.mx.eval
+    barrier = EvalBarrierProfiler(original_eval)
+    module.mx.eval = barrier
+    load_memory = _memory_snapshot(mx)
+    mx.metal.reset_peak_memory()
+
+    context = [encoded[index % len(encoded)] for index in range(args.context_tokens)]
+    trace_started = False
+    trace_result = None
+    try:
+        context_result = _run_tokens(
+            runtime,
+            len(context),
+            barrier,
+            mx,
+            initial_token=encoded[-1],
+            teacher_tokens=context,
+        )
+        warmup_result = _run_tokens(
+            runtime,
+            args.warmup_tokens,
+            barrier,
+            mx,
+            initial_token=context_result["last_token_id"],
+        )
+        measured = _run_tokens(
+            runtime,
+            args.measure_tokens,
+            barrier,
+            mx,
+            initial_token=warmup_result["last_token_id"],
+        )
+        if trace_path is not None:
+            if trace_path.exists():
+                raise FileExistsError(f"refusing to overwrite Metal trace: {trace_path}")
+            trace_path.parent.mkdir(parents=True, exist_ok=True)
+            free_bytes = shutil.disk_usage(trace_path.parent).free
+            if free_bytes < 20 * 1024**3:
+                raise RuntimeError(
+                    "refusing Metal capture with less than 20 GiB scratch free"
+                )
+            mx.metal.start_capture(str(trace_path))
+            trace_started = True
+            trace_result = _run_tokens(
+                runtime,
+                args.trace_tokens,
+                barrier,
+                mx,
+                initial_token=measured["last_token_id"],
+            )
+            mx.metal.stop_capture()
+            trace_started = False
+    finally:
+        if trace_started:
+            mx.metal.stop_capture()
+        module.mx.eval = original_eval
+
+    return {
+        "plan": PLAN,
+        "checkpoint": {
+            "path": str(model_path),
+            "runtime_path": str(runtime_path),
+            "indexed_total_size_bytes": total_size,
+            "runtime_sha256": hashlib.sha256(runtime_path.read_bytes()).hexdigest(),
+        },
+        "parameters": {
+            "execution_mode": args.execution_mode,
+            "resident_backbone": args.resident_backbone,
+            "context_tokens": args.context_tokens,
+            "warmup_tokens": args.warmup_tokens,
+            "measure_tokens": args.measure_tokens,
+            "trace": str(trace_path) if trace_path else None,
+            "trace_tokens": args.trace_tokens if args.trace else 0,
+        },
+        "device": mx.device_info(),
+        "load": {"seconds": load_seconds, "memory": load_memory},
+        "context_build": context_result,
+        "warmup": warmup_result,
+        "measurement": measured,
+        "trace_probe": trace_result,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.execute_real_weights:
+        print(format_bench_json({"plan_only": True, "plan": PLAN}, __file__))
+        return 0
+    result = run(args)
+    print(format_bench_json(result, __file__, indent=2, sort_keys=True))
+    if args.output is not None:
+        write_bench_json(args.output, result, __file__, indent=2, sort_keys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_deepseek_v41_runtime.py
+++ b/scripts/bench_deepseek_v41_runtime.py
@@ -8,7 +8,6 @@ import hashlib
 import importlib.util
 import json
 import math
-import shutil
 import statistics
 import sys
 import time
@@ -30,7 +29,6 @@ PLAN = {
         "existing mx.eval barrier wait time by Python call site",
         "runtime disk-read and Engram-cache counters",
         "MLX active, cache, and peak memory",
-        "optional Metal GPU trace",
     ],
     "guardrails": [
         "never downloads or relocates model files",
@@ -47,13 +45,13 @@ def parse_args():
     parser.add_argument("--execute-real-weights", action="store_true")
     parser.add_argument("--trust-checkpoint-runtime", action="store_true")
     parser.add_argument("--resident-backbone", action="store_true")
+    parser.add_argument("--engram-cache-rows", type=int, default=16384)
     parser.add_argument("--execution-mode", choices=("reference", "deferred", "compiled"), default="compiled")
     parser.add_argument("--prompt", default="Explain why local inference latency matters.")
     parser.add_argument("--context-tokens", type=int, default=0)
     parser.add_argument("--warmup-tokens", type=int, default=16)
     parser.add_argument("--measure-tokens", type=int, default=128)
-    parser.add_argument("--trace", type=Path)
-    parser.add_argument("--trace-tokens", type=int, default=4)
+    parser.add_argument("--diagnostic-tokens", type=int, default=8)
     parser.add_argument("--output", type=Path)
     return parser.parse_args()
 
@@ -155,9 +153,9 @@ def _counter_delta(after, before):
 
 def _memory_snapshot(mx):
     return {
-        "active_bytes": int(mx.metal.get_active_memory()),
-        "cache_bytes": int(mx.metal.get_cache_memory()),
-        "peak_bytes": int(mx.metal.get_peak_memory()),
+        "active_bytes": int(mx.get_active_memory()),
+        "cache_bytes": int(mx.get_cache_memory()),
+        "peak_bytes": int(mx.get_peak_memory()),
     }
 
 
@@ -172,7 +170,8 @@ def _run_tokens(
 ):
     latencies = []
     counters_before = _weight_counters(runtime)
-    barrier.reset()
+    if barrier is not None:
+        barrier.reset()
     next_token = int(initial_token)
     started = time.perf_counter()
     for index in range(count):
@@ -192,7 +191,7 @@ def _run_tokens(
             "max": max(latencies) if latencies else None,
             "raw": latencies,
         },
-        "eval_barriers": barrier.snapshot(),
+        "eval_barriers": barrier.snapshot() if barrier is not None else None,
         "weight_counters": _counter_delta(_weight_counters(runtime), counters_before),
         "memory": _memory_snapshot(mx),
         "last_token_id": next_token,
@@ -207,17 +206,19 @@ def _validate_args(args):
             "refusing to execute checkpoint-bundled Python without "
             "--trust-checkpoint-runtime"
         )
-    if min(args.context_tokens, args.warmup_tokens, args.measure_tokens) < 0:
+    if min(
+        args.context_tokens,
+        args.warmup_tokens,
+        args.measure_tokens,
+        args.diagnostic_tokens,
+    ) < 0:
         raise SystemExit("token counts may not be negative")
     if args.measure_tokens < 1:
         raise SystemExit("--measure-tokens must be at least 1")
-    if args.trace is not None:
-        trace = args.trace.expanduser().resolve()
-        scratch = Path("/private/tmp").resolve()
-        if trace.suffix != ".gputrace" or scratch not in trace.parents:
-            raise SystemExit("--trace must be a .gputrace path under /private/tmp")
-        if not 1 <= args.trace_tokens <= 8:
-            raise SystemExit("--trace-tokens must be between 1 and 8")
+    if args.diagnostic_tokens < 1:
+        raise SystemExit("--diagnostic-tokens must be at least 1")
+    if not 0 <= args.engram_cache_rows <= 16384:
+        raise SystemExit("--engram-cache-rows must be between 0 and 16384")
 
 
 def run(args):
@@ -225,38 +226,41 @@ def run(args):
     model_path = args.model.expanduser().resolve()
     runtime_path = _resolve_runtime(model_path)
     total_size = _checkpoint_total_size(model_path)
-    trace_path = args.trace.expanduser().resolve() if args.trace else None
 
     started = time.perf_counter()
     module = _load_runtime(runtime_path)
     import mlx.core as mx
 
     mx.set_default_device(mx.gpu)
-    mx.metal.reset_peak_memory()
+    mx.reset_peak_memory()
     runtime = module.TextRuntime(
         model_path,
-        max_tokens=args.context_tokens + args.warmup_tokens + args.measure_tokens + 8,
+        max_tokens=(
+            args.context_tokens
+            + args.warmup_tokens
+            + args.measure_tokens
+            + args.diagnostic_tokens
+            + 8
+        ),
         resident_backbone=args.resident_backbone,
         execution_mode=args.execution_mode,
     )
+    runtime.w.engram_cache_rows = args.engram_cache_rows
     load_seconds = time.perf_counter() - started
     encoded = runtime.tokenizer.encode(args.prompt).ids
     if not encoded:
         raise RuntimeError("prompt encoded to zero tokens")
     original_eval = module.mx.eval
     barrier = EvalBarrierProfiler(original_eval)
-    module.mx.eval = barrier
     load_memory = _memory_snapshot(mx)
-    mx.metal.reset_peak_memory()
+    mx.reset_peak_memory()
 
     context = [encoded[index % len(encoded)] for index in range(args.context_tokens)]
-    trace_started = False
-    trace_result = None
     try:
         context_result = _run_tokens(
             runtime,
             len(context),
-            barrier,
+            None,
             mx,
             initial_token=encoded[-1],
             teacher_tokens=context,
@@ -264,40 +268,27 @@ def run(args):
         warmup_result = _run_tokens(
             runtime,
             args.warmup_tokens,
-            barrier,
+            None,
             mx,
             initial_token=context_result["last_token_id"],
         )
         measured = _run_tokens(
             runtime,
             args.measure_tokens,
-            barrier,
+            None,
             mx,
             initial_token=warmup_result["last_token_id"],
         )
-        if trace_path is not None:
-            if trace_path.exists():
-                raise FileExistsError(f"refusing to overwrite Metal trace: {trace_path}")
-            trace_path.parent.mkdir(parents=True, exist_ok=True)
-            free_bytes = shutil.disk_usage(trace_path.parent).free
-            if free_bytes < 20 * 1024**3:
-                raise RuntimeError(
-                    "refusing Metal capture with less than 20 GiB scratch free"
-                )
-            mx.metal.start_capture(str(trace_path))
-            trace_started = True
-            trace_result = _run_tokens(
-                runtime,
-                args.trace_tokens,
-                barrier,
-                mx,
-                initial_token=measured["last_token_id"],
-            )
-            mx.metal.stop_capture()
-            trace_started = False
+        module.mx.eval = barrier
+        diagnostic = _run_tokens(
+            runtime,
+            args.diagnostic_tokens,
+            barrier,
+            mx,
+            initial_token=measured["last_token_id"],
+        )
+        module.mx.eval = original_eval
     finally:
-        if trace_started:
-            mx.metal.stop_capture()
         module.mx.eval = original_eval
 
     return {
@@ -311,18 +302,18 @@ def run(args):
         "parameters": {
             "execution_mode": args.execution_mode,
             "resident_backbone": args.resident_backbone,
+            "engram_cache_rows": args.engram_cache_rows,
             "context_tokens": args.context_tokens,
             "warmup_tokens": args.warmup_tokens,
             "measure_tokens": args.measure_tokens,
-            "trace": str(trace_path) if trace_path else None,
-            "trace_tokens": args.trace_tokens if args.trace else 0,
+            "diagnostic_tokens": args.diagnostic_tokens,
         },
         "device": mx.device_info(),
         "load": {"seconds": load_seconds, "memory": load_memory},
         "context_build": context_result,
         "warmup": warmup_result,
         "measurement": measured,
-        "trace_probe": trace_result,
+        "barrier_diagnostic": diagnostic,
     }
 
 

--- a/scripts/bench_deepseek_v41_runtime.py
+++ b/scripts/bench_deepseek_v41_runtime.py
@@ -49,7 +49,11 @@ def parse_args():
     parser.add_argument("--trust-checkpoint-runtime", action="store_true")
     parser.add_argument("--resident-backbone", action="store_true")
     parser.add_argument("--engram-cache-rows", type=int, default=16384)
-    parser.add_argument("--execution-mode", choices=("reference", "deferred", "compiled"), default="compiled")
+    parser.add_argument(
+        "--execution-mode",
+        choices=("reference", "deferred", "compiled"),
+        default="compiled",
+    )
     parser.add_argument(
         "--optimized-hc",
         action="store_true",
@@ -60,7 +64,9 @@ def parse_args():
         action="store_true",
         help="fuse resident routed-expert gate/up projections before profiling",
     )
-    parser.add_argument("--prompt", default="Explain why local inference latency matters.")
+    parser.add_argument(
+        "--prompt", default="Explain why local inference latency matters."
+    )
     parser.add_argument("--context-tokens", type=int, default=0)
     parser.add_argument("--warmup-tokens", type=int, default=16)
     parser.add_argument("--measure-tokens", type=int, default=128)
@@ -328,8 +334,7 @@ def _install_optimized_moe(runtime, mx):
     missing = [key for key in required if key not in runtime.w.resident]
     if missing:
         raise RuntimeError(
-            "--optimized-moe requires a fully resident backbone; missing "
-            + missing[0]
+            "--optimized-moe requires a fully resident backbone; missing " + missing[0]
         )
     for layer in range(config["num_hidden_layers"]):
         base = f"layers.{layer}.ffn"
@@ -376,14 +381,12 @@ def _install_optimized_moe(runtime, mx):
         )
         scores = mx.sqrt(mx.logaddexp(logits, mx.zeros_like(logits)))
         top_k = self.c["num_experts_per_tok"]
-        picks = mx.argsort(
-            scores + self.w.read(base + ".gate.bias"), axis=-1
-        )[..., -top_k:]
+        picks = mx.argsort(scores + self.w.read(base + ".gate.bias"), axis=-1)[
+            ..., -top_k:
+        ]
         selected = mx.take_along_axis(scores, picks, axis=-1)
         if self.c["norm_topk_prob"] and top_k > 1:
-            selected = selected / (
-                mx.sum(selected, axis=-1, keepdims=True) + 1e-20
-            )
+            selected = selected / (mx.sum(selected, axis=-1, keepdims=True) + 1e-20)
         selected = selected * self.c["routed_scaling_factor"]
         mx.eval(picks, selected)
 
@@ -409,9 +412,9 @@ def _install_optimized_moe(runtime, mx):
                 gate = gate.astype(mx.float32)
                 up = up.astype(mx.float32)
             hidden = (gate * mx.sigmoid(gate) * up * routing).astype(x.dtype)
-            down = self.w.linear(
-                base + f".experts.{expert}.w2", hidden
-            ).astype(mx.float32)
+            down = self.w.linear(base + f".experts.{expert}.w2", hidden).astype(
+                mx.float32
+            )
             routed = routed + down
             if self.execution_mode == "reference":
                 mx.eval(routed)
@@ -426,9 +429,9 @@ def _install_optimized_moe(runtime, mx):
         for expert_pack in layer_pack
         for value in expert_pack.values()
     )
-    runtime.w.resident_bytes = sum(
-        value.nbytes for value in runtime.w.resident.values()
-    ) + packed_bytes
+    runtime.w.resident_bytes = (
+        sum(value.nbytes for value in runtime.w.resident.values()) + packed_bytes
+    )
     return {
         "name": "expert_local_fused_gate_up_quantized_matmul",
         "layers": len(packed),
@@ -484,12 +487,15 @@ def _validate_args(args):
             "refusing to execute checkpoint-bundled Python without "
             "--trust-checkpoint-runtime"
         )
-    if min(
-        args.context_tokens,
-        args.warmup_tokens,
-        args.measure_tokens,
-        args.diagnostic_tokens,
-    ) < 0:
+    if (
+        min(
+            args.context_tokens,
+            args.warmup_tokens,
+            args.measure_tokens,
+            args.diagnostic_tokens,
+        )
+        < 0
+    ):
         raise SystemExit("token counts may not be negative")
     if args.measure_tokens < 1:
         raise SystemExit("--measure-tokens must be at least 1")

--- a/scripts/bench_deepseek_v41_runtime.py
+++ b/scripts/bench_deepseek_v41_runtime.py
@@ -11,6 +11,7 @@ import math
 import statistics
 import sys
 import time
+import types
 from collections import defaultdict
 from pathlib import Path
 
@@ -29,6 +30,8 @@ PLAN = {
         "existing mx.eval barrier wait time by Python call site",
         "runtime disk-read and Engram-cache counters",
         "MLX active, cache, and peak memory",
+        "optional fused mHC mixing with V4.1 pipelined-pre semantics",
+        "optional expert-local fused gate/up quantized matmul execution",
     ],
     "guardrails": [
         "never downloads or relocates model files",
@@ -47,6 +50,16 @@ def parse_args():
     parser.add_argument("--resident-backbone", action="store_true")
     parser.add_argument("--engram-cache-rows", type=int, default=16384)
     parser.add_argument("--execution-mode", choices=("reference", "deferred", "compiled"), default="compiled")
+    parser.add_argument(
+        "--optimized-hc",
+        action="store_true",
+        help="benchmark-only fused mHC path; not quality validated",
+    )
+    parser.add_argument(
+        "--optimized-moe",
+        action="store_true",
+        help="fuse resident routed-expert gate/up projections before profiling",
+    )
     parser.add_argument("--prompt", default="Explain why local inference latency matters.")
     parser.add_argument("--context-tokens", type=int, default=0)
     parser.add_argument("--warmup-tokens", type=int, default=16)
@@ -159,6 +172,271 @@ def _memory_snapshot(mx):
     }
 
 
+def _make_v41_hc_mix_kernel(mx):
+    """Build a V4.1 mixing kernel without collapsing the current residual.
+
+    V4.1 pipelines the ``pre`` weights across the intervening attention or FFN
+    update.  The existing V4 kernel cannot be reused directly because it also
+    collapses the residual supplied to the mixer.  This bounded benchmark
+    kernel fuses only sigmoid + Sinkhorn and returns ``pre/post/comb`` so the
+    checkpoint runtime can apply ``pre`` at its original, later point.
+    """
+
+    if mx.default_device() != mx.gpu or not mx.metal.is_available():
+        raise RuntimeError("--optimized-hc requires the MLX Metal GPU backend")
+
+    source = r"""
+        uint row  = threadgroup_position_in_grid.x;
+        uint lane = thread_position_in_threadgroup.x;
+
+        constexpr int MIX      = (2 + HC) * HC;
+        constexpr int BASE_OFF = 2 * HC;
+        constexpr float EPS = EPS_INT * 1e-9;
+
+        const device float* mix = (const device float*)mixes + row * MIX;
+        device float* pre_out = (device float*)pre + row * HC;
+        device float* post_out = (device float*)post + row * HC;
+        device float* comb_out = (device float*)comb + row * HC * HC;
+
+        const float active = (lane < (uint)HC) ? 1.0f : 0.0f;
+        const uint llane = metal::min(lane, (uint)(HC - 1));
+        const float pre_scale = scale[0];
+        const float post_scale = scale[1];
+        const float comb_scale = scale[2];
+
+        float pre_z = mix[llane] * pre_scale + base[llane];
+        float post_z = mix[HC + llane] * post_scale + base[HC + llane];
+        float pre_v = 1.0f / (1.0f + metal::fast::exp(-pre_z)) + EPS;
+        float post_v = 2.0f / (1.0f + metal::fast::exp(-post_z));
+        if (lane < (uint)HC) {
+            pre_out[lane] = pre_v;
+            post_out[lane] = post_v;
+        }
+
+        float4 v = (*(const device float4*)(mix + BASE_OFF + llane * HC)
+                        * comb_scale
+                    + *(const device float4*)(base + BASE_OFF + llane * HC))
+                    * active;
+        float row_max = metal::max(metal::max(v.x, v.y),
+                                   metal::max(v.z, v.w));
+        float4 e = metal::fast::exp(v - row_max) * active;
+        float4 result = e * (1.0f / (e.x + e.y + e.z + e.w + EPS))
+                      + EPS * active;
+        result *= 1.0f / (float4(
+            simd_sum(result.x), simd_sum(result.y),
+            simd_sum(result.z), simd_sum(result.w)) + EPS);
+
+        for (int iter = 1; iter < ITERS; ++iter) {
+            result *= (1.0f / (result.x + result.y + result.z
+                               + result.w + EPS)) * active;
+            result *= 1.0f / (float4(
+                simd_sum(result.x), simd_sum(result.y),
+                simd_sum(result.z), simd_sum(result.w)) + EPS);
+        }
+        if (lane < (uint)HC) {
+            *(device float4*)(comb_out + lane * HC) = result;
+        }
+    """
+    return mx.fast.metal_kernel(
+        name="deepseek_v41_hc_mix",
+        input_names=["mixes", "scale", "base"],
+        output_names=["pre", "post", "comb"],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+
+
+def _install_optimized_hc(runtime, mx):
+    """Replace only checkpoint mHC mixing while preserving V4.1 timing."""
+
+    if runtime.c.get("hc_mult") != 4:
+        raise RuntimeError("--optimized-hc currently requires hc_mult=4")
+    kernel = _make_v41_hc_mix_kernel(mx)
+
+    @mx.compile
+    def project(x, weight, norm_eps):
+        flat = x.reshape(*x.shape[:-2], -1).astype(mx.float32)
+        projected = flat @ weight.T
+        return projected * mx.rsqrt(
+            mx.mean(flat * flat, axis=-1, keepdims=True) + norm_eps
+        )
+
+    def mixes(self, base, kind, x):
+        config = self.c
+        weight = self.w.read(base + ".hc_" + kind + "_fn")
+        scale = self.w.read(base + ".hc_" + kind + "_scale").astype(mx.float32)
+        bias = self.w.read(base + ".hc_" + kind + "_base").astype(mx.float32)
+        projected = project(x, weight, config["rms_norm_eps"])
+        rows = math.prod(projected.shape[:-1])
+        return kernel(
+            inputs=[projected, scale, bias],
+            template=[
+                ("HC", config["hc_mult"]),
+                ("ITERS", config["hc_sinkhorn_iters"]),
+                ("EPS_INT", round(config["hc_eps"] / 1e-9)),
+            ],
+            grid=(rows * 32, 1, 1),
+            threadgroup=(32, 1, 1),
+            output_shapes=[
+                (*projected.shape[:-1], config["hc_mult"]),
+                (*projected.shape[:-1], config["hc_mult"]),
+                (
+                    *projected.shape[:-1],
+                    config["hc_mult"],
+                    config["hc_mult"],
+                ),
+            ],
+            output_dtypes=[mx.float32, mx.float32, mx.float32],
+        )
+
+    runtime.mixes = types.MethodType(mixes, runtime)
+    return {
+        "name": "v41_fused_hc_mix",
+        "preserves_pipelined_pre": True,
+        "quality_validated": False,
+        "warning": "40-layer numerical amplification failed teacher-forced parity",
+    }
+
+
+def _install_optimized_moe(runtime, mx):
+    """Fuse each expert's gate/up projections without giant expert buffers."""
+
+    if not runtime.w.resident:
+        raise RuntimeError("--optimized-moe requires --resident-backbone")
+    config = runtime.c
+    num_experts = config["n_routed_experts"]
+    quantization = runtime.w.q
+    if (
+        quantization.get("bits"),
+        quantization.get("group_size"),
+        quantization.get("mode"),
+    ) != (2, 64, "affine"):
+        raise RuntimeError(
+            "--optimized-moe currently accepts only affine 2-bit/group-64 weights"
+        )
+
+    started = time.perf_counter()
+    packed = {}
+    components = ("weight", "scales", "biases")
+    required = [
+        f"layers.{layer}.ffn.experts.{expert}.{projection}.{component}"
+        for layer in range(config["num_hidden_layers"])
+        for expert in range(num_experts)
+        for projection in ("w1", "w3")
+        for component in components
+    ]
+    missing = [key for key in required if key not in runtime.w.resident]
+    if missing:
+        raise RuntimeError(
+            "--optimized-moe requires a fully resident backbone; missing "
+            + missing[0]
+        )
+    for layer in range(config["num_hidden_layers"]):
+        base = f"layers.{layer}.ffn"
+        layer_pack = []
+        original_keys = []
+        fused_arrays = []
+        for expert in range(num_experts):
+            expert_pack = {}
+            for component in components:
+                w1_key = f"{base}.experts.{expert}.w1.{component}"
+                w3_key = f"{base}.experts.{expert}.w3.{component}"
+                fused = mx.concatenate(
+                    [runtime.w.resident[w1_key], runtime.w.resident[w3_key]],
+                    axis=0,
+                )
+                expert_pack[component] = fused
+                fused_arrays.append(fused)
+                original_keys.extend((w1_key, w3_key))
+            layer_pack.append(expert_pack)
+        mx.eval(fused_arrays)
+        for key in original_keys:
+            del runtime.w.resident[key]
+        packed[base] = layer_pack
+        mx.clear_cache()
+        if (layer + 1) % 5 == 0 or layer + 1 == config["num_hidden_layers"]:
+            print(
+                json.dumps(
+                    {
+                        "phase": "expert_pack",
+                        "completed_layers": layer + 1,
+                        "total_layers": config["num_hidden_layers"],
+                        "active_bytes": int(mx.get_active_memory()),
+                        "seconds": time.perf_counter() - started,
+                    }
+                ),
+                flush=True,
+            )
+
+    def moe(self, base, x):
+        layer_pack = packed[base]
+        logits = (
+            x.astype(mx.float32)
+            @ self.w.read(base + ".gate.weight").astype(mx.float32).T
+        )
+        scores = mx.sqrt(mx.logaddexp(logits, mx.zeros_like(logits)))
+        top_k = self.c["num_experts_per_tok"]
+        picks = mx.argsort(
+            scores + self.w.read(base + ".gate.bias"), axis=-1
+        )[..., -top_k:]
+        selected = mx.take_along_axis(scores, picks, axis=-1)
+        if self.c["norm_topk_prob"] and top_k > 1:
+            selected = selected / (
+                mx.sum(selected, axis=-1, keepdims=True) + 1e-20
+            )
+        selected = selected * self.c["routed_scaling_factor"]
+        mx.eval(picks, selected)
+
+        routed = mx.zeros_like(x).astype(mx.float32)
+        for expert, routing in zip(picks.tolist()[0], selected.tolist()[0]):
+            expert_pack = layer_pack[expert]
+            gate_up = mx.quantized_matmul(
+                x,
+                expert_pack["weight"],
+                expert_pack["scales"],
+                expert_pack["biases"],
+                transpose=True,
+                group_size=64,
+                bits=2,
+                mode="affine",
+            )
+            gate, up = mx.split(gate_up, 2, axis=-1)
+            limit = self.c["swiglu_limit"]
+            if limit > 0:
+                gate = mx.minimum(gate.astype(mx.float32), limit)
+                up = mx.clip(up.astype(mx.float32), -limit, limit)
+            else:
+                gate = gate.astype(mx.float32)
+                up = up.astype(mx.float32)
+            hidden = (gate * mx.sigmoid(gate) * up * routing).astype(x.dtype)
+            down = self.w.linear(
+                base + f".experts.{expert}.w2", hidden
+            ).astype(mx.float32)
+            routed = routed + down
+            if self.execution_mode == "reference":
+                mx.eval(routed)
+        shared = self.expert(base + ".shared_experts", x).astype(mx.float32)
+        return (routed + shared).astype(x.dtype)
+
+    runtime._rapid_packed_experts = packed
+    runtime.moe = types.MethodType(moe, runtime)
+    packed_bytes = sum(
+        value.nbytes
+        for layer_pack in packed.values()
+        for expert_pack in layer_pack
+        for value in expert_pack.values()
+    )
+    runtime.w.resident_bytes = sum(
+        value.nbytes for value in runtime.w.resident.values()
+    ) + packed_bytes
+    return {
+        "name": "expert_local_fused_gate_up_quantized_matmul",
+        "layers": len(packed),
+        "packed_bytes": packed_bytes,
+        "seconds": time.perf_counter() - started,
+    }
+
+
 def _run_tokens(
     runtime,
     count,
@@ -246,6 +524,12 @@ def run(args):
         execution_mode=args.execution_mode,
     )
     runtime.w.engram_cache_rows = args.engram_cache_rows
+    optimized_hc = None
+    if getattr(args, "optimized_hc", False):
+        optimized_hc = _install_optimized_hc(runtime, mx)
+    optimized_moe = None
+    if getattr(args, "optimized_moe", False):
+        optimized_moe = _install_optimized_moe(runtime, mx)
     load_seconds = time.perf_counter() - started
     encoded = runtime.tokenizer.encode(args.prompt).ids
     if not encoded:
@@ -307,6 +591,12 @@ def run(args):
             "warmup_tokens": args.warmup_tokens,
             "measure_tokens": args.measure_tokens,
             "diagnostic_tokens": args.diagnostic_tokens,
+            "optimized_hc": bool(getattr(args, "optimized_hc", False)),
+            "optimized_moe": bool(getattr(args, "optimized_moe", False)),
+        },
+        "runtime_overrides": {
+            "hyper_connection": optimized_hc,
+            "routed_moe": optimized_moe,
         },
         "device": mx.device_info(),
         "load": {"seconds": load_seconds, "memory": load_memory},

--- a/scripts/bench_metadata.py
+++ b/scripts/bench_metadata.py
@@ -42,6 +42,7 @@ JSON_BENCH_SCRIPTS = frozenset(
     {
         "bench_attention.py",
         "bench_decode_tps.py",
+        "bench_deepseek_v41_moe.py",
         "bench_deepseek_restart_cache.py",
         "bench_dflash.py",
         "bench_diffusion_gemma.py",

--- a/scripts/bench_metadata.py
+++ b/scripts/bench_metadata.py
@@ -43,6 +43,7 @@ JSON_BENCH_SCRIPTS = frozenset(
         "bench_attention.py",
         "bench_decode_tps.py",
         "bench_deepseek_v41_moe.py",
+        "bench_deepseek_v41_runtime.py",
         "bench_deepseek_restart_cache.py",
         "bench_dflash.py",
         "bench_diffusion_gemma.py",

--- a/tests/test_profile_deepseek_v41_runtime.py
+++ b/tests/test_profile_deepseek_v41_runtime.py
@@ -117,6 +117,7 @@ def test_run_tokens_can_teacher_force_context():
     assert result["last_token_id"] == 7
 
 
+@pytest.mark.requires_mlx
 def test_real_weight_harness_with_tiny_local_runtime(tmp_path):
     runtime_dir = tmp_path / "runtime"
     runtime_dir.mkdir()
@@ -176,6 +177,7 @@ class TextRuntime:
     assert result["barrier_diagnostic"]["eval_barriers"]["calls"] == 1
 
 
+@pytest.mark.requires_mlx
 def test_expert_local_gate_up_fusion_matches_separate_quantized_matmuls():
     mx = pytest.importorskip("mlx.core")
 
@@ -243,9 +245,7 @@ def test_expert_local_gate_up_fusion_matches_separate_quantized_matmuls():
 
     x = mx.random.normal((1, 64)).astype(mx.bfloat16)
     routing = mx.sqrt(mx.logaddexp(mx.array(0.0), mx.array(0.0)))
-    expected = runtime.expert(
-        base + ".experts.0", x, routing
-    ).astype(x.dtype)
+    expected = runtime.expert(base + ".experts.0", x, routing).astype(x.dtype)
     metadata = _install_optimized_moe(runtime, mx)
     actual = runtime.moe(base, x)
     mx.eval(expected, actual)
@@ -257,6 +257,7 @@ def test_expert_local_gate_up_fusion_matches_separate_quantized_matmuls():
     assert base + ".experts.0.w2.weight" in runtime.w.resident
 
 
+@pytest.mark.requires_mlx
 def test_fused_hc_kernel_stays_close_to_reference_sinkhorn():
     mx = pytest.importorskip("mlx.core")
     if mx.default_device() != mx.gpu or not mx.metal.is_available():
@@ -272,12 +273,11 @@ def test_fused_hc_kernel_stays_close_to_reference_sinkhorn():
 
     pre = mx.sigmoid(mixes[..., :hc_mult] * scale[0] + base[:hc_mult]) + epsilon
     post = 2 * mx.sigmoid(
-        mixes[..., hc_mult : 2 * hc_mult] * scale[1]
-        + base[hc_mult : 2 * hc_mult]
+        mixes[..., hc_mult : 2 * hc_mult] * scale[1] + base[hc_mult : 2 * hc_mult]
     )
-    comb = (
-        mixes[..., 2 * hc_mult :] * scale[2] + base[2 * hc_mult :]
-    ).reshape(2, hc_mult, hc_mult)
+    comb = (mixes[..., 2 * hc_mult :] * scale[2] + base[2 * hc_mult :]).reshape(
+        2, hc_mult, hc_mult
+    )
     comb = mx.softmax(comb, axis=-1) + epsilon
     comb = comb / (mx.sum(comb, axis=-2, keepdims=True) + epsilon)
     for _ in range(sinkhorn_iters - 1):

--- a/tests/test_profile_deepseek_v41_runtime.py
+++ b/tests/test_profile_deepseek_v41_runtime.py
@@ -53,14 +53,10 @@ class _Scalar:
         return self.value
 
 
-class _FakeMetal:
+class _FakeMx:
     get_active_memory = staticmethod(lambda: 1)
     get_cache_memory = staticmethod(lambda: 2)
     get_peak_memory = staticmethod(lambda: 3)
-
-
-class _FakeMx:
-    metal = _FakeMetal()
     argmax = staticmethod(lambda logits: logits)
 
 
@@ -159,13 +155,13 @@ class TextRuntime:
         model=tmp_path,
         trust_checkpoint_runtime=True,
         resident_backbone=False,
+        engram_cache_rows=16,
         execution_mode="compiled",
         prompt="test",
         context_tokens=2,
         warmup_tokens=1,
         measure_tokens=2,
-        trace=None,
-        trace_tokens=4,
+        diagnostic_tokens=1,
     )
 
     result = run(args)
@@ -174,5 +170,5 @@ class TextRuntime:
     assert result["context_build"]["tokens"] == 2
     assert result["warmup"]["tokens"] == 1
     assert result["measurement"]["tokens"] == 2
-    assert result["measurement"]["eval_barriers"]["calls"] == 2
-    assert result["trace_probe"] is None
+    assert result["measurement"]["eval_barriers"] is None
+    assert result["barrier_diagnostic"]["eval_barriers"]["calls"] == 1

--- a/tests/test_profile_deepseek_v41_runtime.py
+++ b/tests/test_profile_deepseek_v41_runtime.py
@@ -1,0 +1,178 @@
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.bench_deepseek_v41_runtime import (
+    _checkpoint_total_size,
+    _counter_delta,
+    _percentile,
+    _resolve_runtime,
+    _run_tokens,
+    run,
+)
+
+
+def test_percentile_uses_nearest_rank():
+    assert _percentile([], 0.95) is None
+    assert _percentile([4, 1, 3, 2], 0.50) == 2
+    assert _percentile([4, 1, 3, 2], 0.95) == 4
+
+
+def test_checkpoint_total_size(tmp_path):
+    (tmp_path / "model.safetensors.index.json").write_text(
+        '{"metadata":{"total_size":238796133496},"weight_map":{}}',
+        encoding="utf-8",
+    )
+    assert _checkpoint_total_size(tmp_path) == 238_796_133_496
+
+
+def test_runtime_resolution_prefers_nested_runtime(tmp_path):
+    nested = tmp_path / "runtime" / "runtime.py"
+    nested.parent.mkdir()
+    nested.touch()
+    (tmp_path / "runtime.py").touch()
+    assert _resolve_runtime(tmp_path) == nested
+
+
+def test_runtime_resolution_does_not_download(tmp_path):
+    with pytest.raises(FileNotFoundError, match="no fallback download"):
+        _resolve_runtime(tmp_path)
+
+
+def test_counter_delta():
+    before = {"reads": 2, "bytes": 10}
+    after = {"reads": 5, "bytes": 42}
+    assert _counter_delta(after, before) == {"reads": 3, "bytes": 32}
+
+
+class _Scalar:
+    def __init__(self, value):
+        self.value = value
+
+    def item(self):
+        return self.value
+
+
+class _FakeMetal:
+    get_active_memory = staticmethod(lambda: 1)
+    get_cache_memory = staticmethod(lambda: 2)
+    get_peak_memory = staticmethod(lambda: 3)
+
+
+class _FakeMx:
+    metal = _FakeMetal()
+    argmax = staticmethod(lambda logits: logits)
+
+
+class _FakeBarrier:
+    def reset(self):
+        pass
+
+    def snapshot(self):
+        return {"calls": 0}
+
+
+class _FakeWeights:
+    disk_bytes_read = 0
+    disk_read_calls = 0
+    engram_cache_hits = 0
+    engram_cache_misses = 0
+    resident_bytes = 0
+
+
+class _FakeRuntime:
+    def __init__(self):
+        self.w = _FakeWeights()
+        self.tokens = []
+
+    def step(self, token):
+        self.tokens.append(token)
+        return _Scalar(token + 1), None
+
+
+def test_run_tokens_continues_generated_chain():
+    runtime = _FakeRuntime()
+    result = _run_tokens(
+        runtime,
+        3,
+        _FakeBarrier(),
+        _FakeMx(),
+        initial_token=10,
+    )
+
+    assert runtime.tokens == [10, 11, 12]
+    assert result["last_token_id"] == 13
+
+
+def test_run_tokens_can_teacher_force_context():
+    runtime = _FakeRuntime()
+    result = _run_tokens(
+        runtime,
+        2,
+        _FakeBarrier(),
+        _FakeMx(),
+        initial_token=99,
+        teacher_tokens=[5, 6],
+    )
+
+    assert runtime.tokens == [5, 6]
+    assert result["last_token_id"] == 7
+
+
+def test_real_weight_harness_with_tiny_local_runtime(tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    (tmp_path / "model.safetensors.index.json").write_text(
+        '{"metadata":{"total_size":4},"weight_map":{}}', encoding="utf-8"
+    )
+    (runtime_dir / "runtime.py").write_text(
+        """\
+import mlx.core as mx
+
+class _Encoding:
+    ids = [1, 2]
+
+class _Tokenizer:
+    def encode(self, prompt):
+        return _Encoding()
+
+class _Weights:
+    disk_bytes_read = 0
+    disk_read_calls = 0
+    engram_cache_hits = 0
+    engram_cache_misses = 0
+    resident_bytes = 4
+
+class TextRuntime:
+    def __init__(self, path, max_tokens, resident_backbone, execution_mode):
+        self.tokenizer = _Tokenizer()
+        self.w = _Weights()
+
+    def step(self, token):
+        logits = mx.array([token, token + 1])
+        mx.eval(logits)
+        return logits, None
+""",
+        encoding="utf-8",
+    )
+    args = SimpleNamespace(
+        model=tmp_path,
+        trust_checkpoint_runtime=True,
+        resident_backbone=False,
+        execution_mode="compiled",
+        prompt="test",
+        context_tokens=2,
+        warmup_tokens=1,
+        measure_tokens=2,
+        trace=None,
+        trace_tokens=4,
+    )
+
+    result = run(args)
+
+    assert result["checkpoint"]["indexed_total_size_bytes"] == 4
+    assert result["context_build"]["tokens"] == 2
+    assert result["warmup"]["tokens"] == 1
+    assert result["measurement"]["tokens"] == 2
+    assert result["measurement"]["eval_barriers"]["calls"] == 2
+    assert result["trace_probe"] is None

--- a/tests/test_profile_deepseek_v41_runtime.py
+++ b/tests/test_profile_deepseek_v41_runtime.py
@@ -5,6 +5,8 @@ import pytest
 from scripts.bench_deepseek_v41_runtime import (
     _checkpoint_total_size,
     _counter_delta,
+    _install_optimized_moe,
+    _make_v41_hc_mix_kernel,
     _percentile,
     _resolve_runtime,
     _run_tokens,
@@ -172,3 +174,130 @@ class TextRuntime:
     assert result["measurement"]["tokens"] == 2
     assert result["measurement"]["eval_barriers"] is None
     assert result["barrier_diagnostic"]["eval_barriers"]["calls"] == 1
+
+
+def test_expert_local_gate_up_fusion_matches_separate_quantized_matmuls():
+    mx = pytest.importorskip("mlx.core")
+
+    class Weights:
+        q = {"bits": 2, "group_size": 64, "mode": "affine"}
+
+        def __init__(self):
+            self.resident = {}
+            self.resident_bytes = 0
+
+        def read(self, key):
+            return self.resident[key]
+
+        def linear(self, base, x):
+            return mx.quantized_matmul(
+                x,
+                self.resident[base + ".weight"],
+                self.resident[base + ".scales"],
+                self.resident[base + ".biases"],
+                transpose=True,
+                group_size=64,
+                bits=2,
+                mode="affine",
+            )
+
+    class Runtime:
+        execution_mode = "compiled"
+        c = {
+            "n_routed_experts": 2,
+            "num_hidden_layers": 1,
+            "num_experts_per_tok": 1,
+            "norm_topk_prob": True,
+            "routed_scaling_factor": 1.0,
+            "swiglu_limit": 0.0,
+        }
+
+        def __init__(self):
+            self.w = Weights()
+
+        def expert(self, base, x, routing=None):
+            if base.endswith("shared_experts"):
+                return mx.zeros_like(x)
+            gate = self.w.linear(base + ".w1", x).astype(mx.float32)
+            up = self.w.linear(base + ".w3", x).astype(mx.float32)
+            hidden = gate * mx.sigmoid(gate) * up
+            if routing is not None:
+                hidden = hidden * routing
+            return self.w.linear(base + ".w2", hidden.astype(x.dtype))
+
+    runtime = Runtime()
+    mx.random.seed(19)
+    base = "layers.0.ffn"
+    for expert in range(2):
+        for projection in ("w1", "w2", "w3"):
+            dense = mx.random.normal((64, 64)).astype(mx.float32)
+            weight, scales, biases = mx.quantize(
+                dense, group_size=64, bits=2, mode="affine"
+            )
+            prefix = f"{base}.experts.{expert}.{projection}"
+            runtime.w.resident[prefix + ".weight"] = weight
+            runtime.w.resident[prefix + ".scales"] = scales
+            runtime.w.resident[prefix + ".biases"] = biases
+    runtime.w.resident[base + ".gate.weight"] = mx.zeros((2, 64))
+    runtime.w.resident[base + ".gate.bias"] = mx.array([1.0, 0.0])
+
+    x = mx.random.normal((1, 64)).astype(mx.bfloat16)
+    routing = mx.sqrt(mx.logaddexp(mx.array(0.0), mx.array(0.0)))
+    expected = runtime.expert(
+        base + ".experts.0", x, routing
+    ).astype(x.dtype)
+    metadata = _install_optimized_moe(runtime, mx)
+    actual = runtime.moe(base, x)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+    assert metadata["name"] == "expert_local_fused_gate_up_quantized_matmul"
+    assert base + ".experts.0.w1.weight" not in runtime.w.resident
+    assert base + ".experts.0.w3.weight" not in runtime.w.resident
+    assert base + ".experts.0.w2.weight" in runtime.w.resident
+
+
+def test_fused_hc_kernel_stays_close_to_reference_sinkhorn():
+    mx = pytest.importorskip("mlx.core")
+    if mx.default_device() != mx.gpu or not mx.metal.is_available():
+        pytest.skip("Metal GPU required")
+
+    mx.random.seed(23)
+    hc_mult = 4
+    sinkhorn_iters = 20
+    epsilon = 1e-6
+    mixes = mx.random.normal((2, (2 + hc_mult) * hc_mult)).astype(mx.float32)
+    scale = mx.random.normal((3,)).astype(mx.float32)
+    base = mx.random.normal(((2 + hc_mult) * hc_mult,)).astype(mx.float32)
+
+    pre = mx.sigmoid(mixes[..., :hc_mult] * scale[0] + base[:hc_mult]) + epsilon
+    post = 2 * mx.sigmoid(
+        mixes[..., hc_mult : 2 * hc_mult] * scale[1]
+        + base[hc_mult : 2 * hc_mult]
+    )
+    comb = (
+        mixes[..., 2 * hc_mult :] * scale[2] + base[2 * hc_mult :]
+    ).reshape(2, hc_mult, hc_mult)
+    comb = mx.softmax(comb, axis=-1) + epsilon
+    comb = comb / (mx.sum(comb, axis=-2, keepdims=True) + epsilon)
+    for _ in range(sinkhorn_iters - 1):
+        comb = comb / (mx.sum(comb, axis=-1, keepdims=True) + epsilon)
+        comb = comb / (mx.sum(comb, axis=-2, keepdims=True) + epsilon)
+
+    kernel = _make_v41_hc_mix_kernel(mx)
+    actual = kernel(
+        inputs=[mixes, scale, base],
+        template=[
+            ("HC", hc_mult),
+            ("ITERS", sinkhorn_iters),
+            ("EPS_INT", round(epsilon / 1e-9)),
+        ],
+        grid=(2 * 32, 1, 1),
+        threadgroup=(32, 1, 1),
+        output_shapes=[(2, 4), (2, 4), (2, 4, 4)],
+        output_dtypes=[mx.float32, mx.float32, mx.float32],
+    )
+    mx.eval(pre, post, comb, *actual)
+
+    for expected, observed in zip((pre, post, comb), actual):
+        assert mx.allclose(expected, observed, rtol=1e-6, atol=1e-6).item()


### PR DESCRIPTION
## Intention

Determine whether DeepSeek V4.1 Flash has a credible, reproducible path to 20+ tok/s on a 256 GiB Mac before exposing it in the product.

## Scope

- Add guarded synthetic and real-weight profiling tools that never download or relocate model files.
- Measure resident memory, decode latency, existing synchronization waits, disk reads, and Engram cache behavior.
- Exercise two explicit benchmark-only runtime candidates: expert-local gate/up fusion and pipelined-semantics mHC fusion.
- Record successful, rejected, and quality-blocked paths so later work does not repeat misleading one-layer results.

Non-goals: catalog aliases, server or GUI exposure, vision support, production runtime enablement, default-model changes, or a downloadable quantization artifact.

## Quantitative results

Hardware: Apple M3 Ultra, 60 GPU cores, 256 GiB unified memory, MLX 0.32.2. Checkpoint revision `802f1a00982705d81b79ad1c83aa0ccc0b863ebc`, 238,796,133,496 indexed bytes.

- Unchanged control: **6.055 tok/s**, 165.96 ms median, about 173.5 GB active memory.
- Expert-local gate/up fusion: **6.216 tok/s** (**+2.65%**), 160.55 ms median (**-3.26%**); focused quantized output is bit-identical and the greedy chain is preserved.
- Experimental fused mHC: **8.030 tok/s** (**+32.6%**), but rejected for product use because a 16-token teacher-forced check reached only 43.75% top-1 agreement and 15.80 maximum logit error after 40-layer amplification.
- All-expert giant-buffer packing: rejected; despite a 2.02x isolated one-layer speedup, full-model throughput collapsed to **0.436 tok/s**.
- Removing redundant per-layer validation barriers separately improved warm runs by **22-24%**, but does not close the 20+ tok/s gap.

The bundled three-stage speculative path verifies target tokens serially and is slower. The next material experiment is bounded parallel target block verification with commit-on-accepted-prefix KV semantics.

## Validation

- `uv run ruff check scripts/bench_deepseek_v41_runtime.py tests/test_profile_deepseek_v41_runtime.py`
- `uv run pytest -q tests/test_profile_deepseek_v41_runtime.py tests/test_bench_metadata.py` — 44 passed
- Checkpoint runtime unit suite — 17 passed
- Full checkpoint integrity verified: 64 repository files, 48 shards, 143,982 indexed tensors
- Real-weight 32-warmup/128-measure control plus focused numerical, memory, and failure-mode experiments

Whole-process Metal capture is explicitly prohibited by the recorded safety finding; only bounded operation/layer profiling is allowed.