### PR TITLE
feat(polls): send coarse os + chip on the update check

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Updater/UpdateChecker.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/UpdateChecker.swift
@@ -13,6 +13,13 @@ import Observation
 /// PAT, no GH API rate-limit:
 ///
 ///   GET https://rapidmlx.com/api/desktop-update?v=<app-version>
+///       &os=<major.minor>&chip=<apple-silicon-tier>
+///
+/// `os` and `chip` describe the installed base in aggregate — which macOS
+/// versions and which chips are actually running Rapid. Both are coarse and
+/// optional, and no identifier accompanies them: the endpoint stores the CF
+/// country code and never the raw IP, which is what rapidmlx.com/docs/telemetry
+/// tells users.
 ///
 /// If that Worker fetch fails for any reason (down, non-2xx, or a
 /// manifest that fails decode/validation) the check falls back to the
@@ -309,7 +316,11 @@ final class UpdateChecker {
     /// state instead of doubling the request.
     private static let defaultFetch: Fetcher = {
         try await fetchWithFallback(
-            primary: endpointURL(forVersion: bundleVersion()),
+            primary: endpointURL(
+                forVersion: bundleVersion(),
+                os: pollOSLabel(),
+                chip: pollChipLabel()
+            ),
             fallback: URL(string: fallbackEndpoint),
             using: { try await fetchManifest(from: $0) }
         )
@@ -459,10 +470,49 @@ final class UpdateChecker {
     /// compile-time-constant base fails to parse (never in practice),
     /// in which case ``defaultFetch`` throws ``invalidURL`` and the
     /// fail-open path keeps the app on its current version.
-    nonisolated static func endpointURL(forVersion version: String) -> URL? {
+    nonisolated static func endpointURL(
+        forVersion version: String,
+        os osLabel: String? = nil,
+        chip chipLabel: String? = nil
+    ) -> URL? {
         guard var components = URLComponents(string: endpoint) else { return nil }
-        components.queryItems = [URLQueryItem(name: "v", value: version)]
+        var items = [URLQueryItem(name: "v", value: version)]
+        // Both are optional on the wire: an unreadable value is omitted rather
+        // than sent as a placeholder, which would pollute the breakdown with a
+        // bucket that means "we did not know".
+        if let osLabel { items.append(URLQueryItem(name: "os", value: osLabel)) }
+        if let chipLabel { items.append(URLQueryItem(name: "chip", value: chipLabel)) }
+        components.queryItems = items
         return components.url
+    }
+
+    /// macOS version for the poll, as `major.minor`.
+    ///
+    /// The patch level is dropped HERE rather than at the endpoint. The
+    /// endpoint discards it either way, and this is a channel the user cannot
+    /// meaningfully decline — it is on by default because updates depend on
+    /// it — so the honest thing is to never send what we do not keep.
+    nonisolated static func pollOSLabel(
+        _ version: OperatingSystemVersion =
+            ProcessInfo.processInfo.operatingSystemVersion
+    ) -> String {
+        "\(version.majorVersion).\(version.minorVersion)"
+    }
+
+    /// Apple silicon tier for the poll, e.g. `"Apple M4 Pro"`.
+    ///
+    /// Reuses ``TelemetryClient/chipBrand()``: it is a pure `sysctl` read with
+    /// no consent semantics attached, and duplicating its careful buffer
+    /// handling to avoid importing a name would be worse than the coupling.
+    ///
+    /// Returns nil on Intel. MLX is Apple-silicon only, so an Intel machine is
+    /// not a bucket anyone will act on, and its brand string carries the exact
+    /// SKU and clock — more identifying than the tier this is meant to report.
+    nonisolated static func pollChipLabel(
+        _ brand: String? = TelemetryClient.chipBrand()
+    ) -> String? {
+        guard let brand, brand.hasPrefix("Apple ") else { return nil }
+        return brand
     }
 
     /// UserDefaults key for the update-check opt-out toggle. Default is

--- a/apps/rapid-mac/Tests/RapidTests/UpdateCheckerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/UpdateCheckerTests.swift
@@ -536,6 +536,53 @@ struct UpdateCheckerTests {
         #expect(UpdateChecker.endpoint == "https://rapidmlx.com/api/desktop-update")
     }
 
+    @Test("endpointURL carries optional os + chip labels when supplied")
+    func endpointCarriesOSAndChip() throws {
+        let url = try #require(
+            UpdateChecker.endpointURL(forVersion: "0.14.0", os: "26.1", chip: "Apple M4 Pro")
+        )
+        let comps = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = try #require(comps.queryItems)
+        #expect(items.count == 3)
+        #expect(items.first(where: { $0.name == "v" })?.value == "0.14.0")
+        #expect(items.first(where: { $0.name == "os" })?.value == "26.1")
+        #expect(items.first(where: { $0.name == "chip" })?.value == "Apple M4 Pro")
+    }
+
+    @Test("endpointURL omits a label it could not read")
+    func endpointOmitsUnknownLabels() throws {
+        // An unreadable value is left off the wire rather than sent as a
+        // placeholder, which would mint a bucket meaning "we did not know".
+        let url = try #require(UpdateChecker.endpointURL(forVersion: "0.14.0", os: "26.1"))
+        let comps = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = try #require(comps.queryItems)
+        #expect(items.count == 2)
+        #expect(items.contains { $0.name == "os" })
+        #expect(!items.contains { $0.name == "chip" })
+    }
+
+    @Test("pollOSLabel keeps major.minor and drops the patch level")
+    func pollOSLabelIsCoarse() {
+        // Dropped at the client, not the endpoint: the poll is on by default,
+        // so it should never carry what the server does not keep.
+        #expect(UpdateChecker.pollOSLabel(
+            OperatingSystemVersion(majorVersion: 26, minorVersion: 1, patchVersion: 3)
+        ) == "26.1")
+        #expect(UpdateChecker.pollOSLabel(
+            OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0)
+        ) == "15.0")
+    }
+
+    @Test("pollChipLabel reports Apple silicon only")
+    func pollChipLabelRejectsIntel() {
+        #expect(UpdateChecker.pollChipLabel("Apple M4 Max") == "Apple M4 Max")
+        // Intel brand strings carry the exact SKU and clock — more identifying
+        // than the tier this is meant to report.
+        #expect(UpdateChecker.pollChipLabel("Intel") == nil)
+        #expect(UpdateChecker.pollChipLabel("Intel(R) Core(TM) i9-9880H @ 2.30GHz") == nil)
+        #expect(UpdateChecker.pollChipLabel(nil) == nil)
+    }
+
     @Test("endpointURL defensively encodes a malformed version string")
     func endpointEncodesMalformedVersion() throws {
         // A hostile/garbled CFBundleShortVersionString must not be able

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -11,6 +11,8 @@ break the CLI on an offline laptop.
 from __future__ import annotations
 
 import json
+import re
+import sys
 import os
 import urllib.parse
 from pathlib import Path
@@ -119,7 +121,16 @@ def test_fetch_latest_targets_cli_update_endpoint_with_version(monkeypatch):
     assert parsed.scheme == "https"
     assert parsed.netloc == "rapidmlx.com"  # never api.github.com
     assert parsed.path == "/api/cli-update"  # exact path, no suffix
-    assert urllib.parse.parse_qs(parsed.query) == {"v": ["0.6.61"]}
+    qs = urllib.parse.parse_qs(parsed.query)
+    assert qs["v"] == ["0.6.61"]
+    # ``os``/``chip`` are coarse fleet labels and are omitted when unreadable,
+    # so assert their SHAPE rather than pinning the whole query string — this
+    # test broke once already by encoding the exact URL.
+    assert set(qs) <= {"v", "os", "chip"}, qs
+    for value in qs.get("os", []):
+        assert re.fullmatch(r"\d{1,2}(\.\d{1,2})?", value), value
+    for value in qs.get("chip", []):
+        assert value.startswith("Apple "), value
     # Timeout guard preserved.
     assert captured["timeout"] == vc.NETWORK_TIMEOUT_SECONDS
 
@@ -290,10 +301,14 @@ def test_fetch_latest_ignores_desktop_release_and_selects_engine_tag(monkeypatch
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     assert vc._fetch_latest() == "0.12.7"
-    assert urls == [
-        "https://rapidmlx.com/api/cli-update?v=0.12.7",
-        f"{vc.GITHUB_RELEASES_ENDPOINT}&page=1",
-    ]
+    # The poll URL carries optional os/chip labels, so match the endpoint and
+    # the version rather than the whole string.
+    assert len(urls) == 2
+    poll = urllib.parse.urlparse(urls[0])
+    assert poll.netloc == "rapidmlx.com"
+    assert poll.path == "/api/cli-update"
+    assert urllib.parse.parse_qs(poll.query)["v"] == ["0.12.7"]
+    assert urls[1] == f"{vc.GITHUB_RELEASES_ENDPOINT}&page=1"
 
 
 def test_desktop_fallback_paginates_until_engine_release(monkeypatch):
@@ -1260,3 +1275,94 @@ def test_prompt_returns_false_on_keyboard_interrupt(monkeypatch, interactive):
     ):
         assert vc.prompt_upgrade_if_available() is False
         run.assert_not_called()
+
+
+def test_poll_os_label_is_major_minor_only(monkeypatch):
+    """The patch level is dropped at the client, not at the endpoint.
+
+    The update poll is on by default — updates depend on it — so anything it
+    carries is carried about people who never opted into analytics. Sending a
+    value the server discards would be collecting it for no reason.
+    """
+    monkeypatch.setattr(vc.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(vc.platform, "mac_ver", lambda: ("26.1.3", ("", "", ""), ""))
+    assert vc._poll_os_label() == "26.1"
+    monkeypatch.setattr(vc.platform, "mac_ver", lambda: ("26", ("", "", ""), ""))
+    assert vc._poll_os_label() == "26"
+
+
+def test_poll_os_label_is_none_off_darwin(monkeypatch):
+    monkeypatch.setattr(vc.platform, "system", lambda: "Linux")
+    assert vc._poll_os_label() is None
+
+
+def test_poll_os_label_rejects_a_malformed_release(monkeypatch):
+    monkeypatch.setattr(vc.platform, "system", lambda: "Darwin")
+    for bogus in ("", "not-a-version", "..", "x.y"):
+        monkeypatch.setattr(vc.platform, "mac_ver", lambda b=bogus: (b, ("", "", ""), ""))
+        assert vc._poll_os_label() is None, bogus
+
+
+def test_poll_chip_label_only_reports_apple_silicon(monkeypatch):
+    """Intel brand strings carry the exact SKU and clock — more identifying
+    than the tier this is meant to report, and MLX is Apple-silicon only."""
+    monkeypatch.setattr(vc.platform, "system", lambda: "Darwin")
+    import vllm_mlx.telemetry.redact as redact
+
+    monkeypatch.setattr(redact, "_read_chip_brand", lambda: "Apple M3 Ultra")
+    assert vc._poll_chip_label() == "Apple M3 Ultra"
+    monkeypatch.setattr(
+        redact, "_read_chip_brand", lambda: "Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz"
+    )
+    assert vc._poll_chip_label() is None
+
+
+def test_poll_chip_label_survives_an_unreadable_brand(monkeypatch):
+    """Fail-open: a version check must never break because a sysctl did."""
+    monkeypatch.setattr(vc.platform, "system", lambda: "Darwin")
+    import vllm_mlx.telemetry.redact as redact
+
+    def boom():
+        raise OSError("sysctl unavailable")
+
+    monkeypatch.setattr(redact, "_read_chip_brand", boom)
+    assert vc._poll_chip_label() is None
+
+
+def test_poll_omits_labels_it_cannot_read(monkeypatch):
+    """An unreadable value is left off the wire rather than sent as a
+    placeholder, which would invent a bucket meaning 'we did not know'."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.14.0")
+    monkeypatch.setattr(vc, "_poll_os_label", lambda: None)
+    monkeypatch.setattr(vc, "_poll_chip_label", lambda: None)
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        return _FakeResp(json.dumps({"tag_name": "v0.14.0"}).encode())
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    vc._fetch_latest()
+    qs = urllib.parse.parse_qs(urllib.parse.urlparse(captured["url"]).query)
+    assert qs == {"v": ["0.14.0"]}
+
+
+def test_poll_never_sends_an_identifier(monkeypatch):
+    """The endpoint's standing promise is that it stores a country code and
+    never the raw IP. The client half of that is: carry no client id, no
+    interpreter version, no arch."""
+    monkeypatch.setattr(vc, "_installed_version", lambda: "0.14.0")
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.headers)
+        return _FakeResp(json.dumps({"tag_name": "v0.14.0"}).encode())
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    vc._fetch_latest()
+    qs = urllib.parse.parse_qs(urllib.parse.urlparse(captured["url"]).query)
+    assert set(qs) <= {"v", "os", "chip"}, qs
+    joined = captured["url"] + json.dumps(captured["headers"])
+    assert sys.version.split()[0] not in joined
+    assert "arm64" not in joined and "x86_64" not in joined

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -11,9 +11,9 @@ break the CLI on an offline laptop.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
-import os
 import urllib.parse
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1299,7 +1299,9 @@ def test_poll_os_label_is_none_off_darwin(monkeypatch):
 def test_poll_os_label_rejects_a_malformed_release(monkeypatch):
     monkeypatch.setattr(vc.platform, "system", lambda: "Darwin")
     for bogus in ("", "not-a-version", "..", "x.y"):
-        monkeypatch.setattr(vc.platform, "mac_ver", lambda b=bogus: (b, ("", "", ""), ""))
+        monkeypatch.setattr(
+            vc.platform, "mac_ver", lambda b=bogus: (b, ("", "", ""), "")
+        )
         assert vc._poll_os_label() is None, bogus
 
 

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import http.client
 import json
 import os
+import platform
 import re
 import sys
 import time
@@ -67,8 +68,51 @@ from pathlib import Path
 # ``Python-urllib/<x.y.z>``, exposing the interpreter patch version). This
 # is the SAME network exposure the previous direct ``api.github.com`` call
 # already had — the only change is the recipient is now our own endpoint.
-# Never sent: client id, os/arch, flag values, prompt or generated content.
+# Sent: the installed version, plus a coarse ``os`` (macOS major.minor) and
+# ``chip`` (Apple silicon tier) so the endpoint can describe the installed base
+# it is already counting. Never sent: client id, arch, flag values, interpreter
+# version, prompt or generated content.
 CLI_UPDATE_ENDPOINT = "https://rapidmlx.com/api/cli-update"
+
+
+def _poll_os_label() -> str | None:
+    """macOS version as ``major.minor``, or None off Darwin.
+
+    The patch level is dropped here rather than at the endpoint. The endpoint
+    discards it either way, and the update poll is on by default — it has to
+    be, updates depend on it — so the honest thing is to never send what is
+    not kept.
+    """
+    if platform.system() != "Darwin":
+        return None
+    try:
+        release = platform.mac_ver()[0]
+    except Exception:  # pragma: no cover - mac_ver is not documented to raise
+        return None
+    parts = release.split(".")
+    if not parts or not parts[0].isdigit():
+        return None
+    return ".".join(parts[:2]) if len(parts) > 1 and parts[1].isdigit() else parts[0]
+
+
+def _poll_chip_label() -> str | None:
+    """Apple silicon tier, e.g. ``"Apple M3 Ultra"``. None when not applicable.
+
+    Reuses the telemetry module's cached reader rather than forking a second
+    ``sysctl``; the import is deferred so a version check never pulls telemetry
+    in at import time. Only ``Apple ...`` brands are returned: an Intel brand
+    string carries the exact SKU and clock, which is more identifying than the
+    tier this is meant to report, and MLX is Apple-silicon only anyway.
+    """
+    if platform.system() != "Darwin":
+        return None
+    try:
+        from vllm_mlx.telemetry.redact import _read_chip_brand
+
+        brand = _read_chip_brand()
+    except Exception:
+        return None
+    return brand if isinstance(brand, str) and brand.startswith("Apple ") else None
 GITHUB_RELEASES_ENDPOINT = (
     "https://api.github.com/repos/raullenchai/Rapid-MLX/releases?per_page=100"
 )
@@ -198,16 +242,26 @@ def _fetch_latest() -> str | None:
     URL-encoded as the ``v`` query param (empty string when running from
     an uninstalled source tree). Like any HTTP request it also exposes the
     client IP and a User-Agent — we pin the fixed, non-identifying
-    ``USER_AGENT`` so nothing beyond the version + unavoidable transport
-    metadata leaves the machine (no client id, no os/arch, no interpreter
-    version, no headers that identify the host). Same network exposure as
+    ``USER_AGENT`` so nothing beyond the version, the coarse ``os``/``chip``
+    labels and unavoidable transport metadata leaves the machine (no client
+    id, no arch, no interpreter version, no headers that identify the host).
+    The two labels are deliberately blunt: macOS keeps ``major.minor`` and the
+    chip keeps its tier, which describes a fleet without identifying a
+    machine. Same network exposure as
     the prior direct GitHub call; only the recipient changed. Fail-open:
     any network / parse / sandbox error returns None silently, exactly as
     before.
     """
     try:
         installed = _installed_version() or ""
-        query = urllib.parse.urlencode({"v": installed})
+        params = {"v": installed}
+        os_label = _poll_os_label()
+        if os_label:
+            params["os"] = os_label
+        chip_label = _poll_chip_label()
+        if chip_label:
+            params["chip"] = chip_label
+        query = urllib.parse.urlencode(params)
         url = f"{CLI_UPDATE_ENDPOINT}?{query}"
         req = urllib.request.Request(
             url,

--- a/vllm_mlx/_version_check.py
+++ b/vllm_mlx/_version_check.py
@@ -113,6 +113,8 @@ def _poll_chip_label() -> str | None:
     except Exception:
         return None
     return brand if isinstance(brand, str) and brand.startswith("Apple ") else None
+
+
 GITHUB_RELEASES_ENDPOINT = (
     "https://api.github.com/repos/raullenchai/Rapid-MLX/releases?per_page=100"
 )


### PR DESCRIPTION
## Why

The update check is opt-out and is a product function, so it reaches roughly every running install. Telemetry is opt-in and, by design, is only invited *after* the app has delivered a result — launch, model download, first reply, then a non-modal banner that a dismissal declines permanently.

The gap between the two is about two orders of magnitude: **~1200 Desktop launches a day against 5-7 telemetry DAU**. That makes the poll the only broad view of the installed base — and it carried the app version and nothing else, so "which macOS and which chips are our users actually on" had no answer outside the ~0.5% who opted in.

## What

`GET /api/desktop-update?v=<version>&os=<major.minor>&chip=<tier>` — same for `/api/cli-update`.

- **Coarse on purpose.** macOS keeps `major.minor`, the chip keeps its tier (`Apple M4 Pro`).
- **Minimised at the client.** The patch level is dropped here, not at the endpoint. The server discards it either way, and this is a channel a user cannot meaningfully decline — updates depend on it — so it should never carry what is not kept.
- **Omitted when unreadable**, never sent as a placeholder that would mint a bucket meaning "we did not know".
- **Intel returns nil** on both clients: its brand string carries the exact SKU and clock, more identifying than the tier this reports, and MLX is Apple-silicon only.

## Privacy

No identifier joins these. The endpoint stores the CF country code and **never the raw IP** — which is what `rapidmlx.com/docs/telemetry` and `/leaderboard` tell users. `os + chip + country + an address` would have turned an opt-out product ping into a fingerprint collected from people who never agreed to analytics, so the address stays out.

`_version_check.py` previously stated `Never sent: client id, os/arch, ...` in both its header comment and its docstring. Both are corrected here rather than left to drift into being false.

The receiving end (shape validation, bounded keyspace, and a test that pins `recordUpdateCheck` to never read `CF-Connecting-IP` / `X-Forwarded-For` / `User-Agent`) shipped separately in rapidmlx.com — the worker already accepts and ignores these params, so this PR is additive and safe to land in either order.

## Tests

- `swift test --filter UpdateChecker` — **44 passed** (4 new: os/chip carried, label omitted when unreadable, `pollOSLabel` coarseness, `pollChipLabel` rejects Intel)
- `pytest tests/test_version_check.py` — **95 passed** (7 new, including one that asserts the poll never carries the interpreter version or arch)

Two existing tests pinned the exact poll URL and broke on contact. They now assert the endpoint, the version, and the *shape* of the optional labels, so the next addition does not break them again.

## Follow-up (not in this PR)

The update endpoints are not described on `/docs/telemetry` at all — it documents only the opt-in path. Adding collection to an undisclosed channel is the part worth fixing next; that is a rapidmlx.com change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019A88kUrTwWXNnbhhXbSPcx