### PR TITLE
test(mtp): align greedy checks with batched consistency

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -8,3 +8,12 @@ end-to-end serving benchmarks use `rapid-mlx bench`).
 - `bench_spec_decode_mtp.py` — MTP speculative-decode bench (#302): decode
   tok/s of `--spec-decode mtp` vs `none` on a Qwen3.5/3.6 MTP checkpoint,
   interleaved runs to avoid thermal drift.
+- `repro_mtp_forced_k_parity.py` — opt-in real-weight correctness
+  diagnostic for #3295. It compares stock `mlx_lm` AR, the same Rapid
+  generator parked at K=0, and fixed K=1/2/3 arms across the eight MTP bench
+  prompts. It requires every speculative arm to engage and reports first-token
+  divergence without treating byte inequality as a verifier failure:
+
+  ```bash
+  python3 bench/repro_mtp_forced_k_parity.py --format markdown
+  ```

--- a/bench/repro_mtp_forced_k_parity.py
+++ b/bench/repro_mtp_forced_k_parity.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Compare greedy MTP at fixed draft depths with same-generator K=0.
+
+This is a correctness diagnostic, not a throughput benchmark or a byte-parity
+gate. It records stock ``mlx_lm`` output as context, uses the Rapid MTP
+generator parked at K=0 as the contract reference, and reports the first token
+divergence for fixed K>0 arms. A divergence may be caused by the known
+``q_len=1`` versus ``q_len>=2`` numerical fork under quantized weights; it does
+not by itself prove an acceptance or rollback defect.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bench.bench_spec_decode_mtp import (
+    _BENCH_PROMPTS,
+    _resolve_mtp_sidecar,
+    _tokenizer_stop_tokens,
+)
+
+_DEFAULT_MODEL = "mlx-community/Qwen3.5-9B-4bit"
+
+
+def _parse_k_values(raw: str) -> tuple[int, ...]:
+    try:
+        values = tuple(int(part.strip()) for part in raw.split(",") if part.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "K values must be comma-separated integers"
+        ) from exc
+    if not values or values[0] != 0:
+        raise argparse.ArgumentTypeError("K values must start with the K=0 control")
+    if len(values) < 2:
+        raise argparse.ArgumentTypeError(
+            "K values must include at least one speculative depth"
+        )
+    if any(value < 0 for value in values):
+        raise argparse.ArgumentTypeError("K values must be non-negative")
+    if len(set(values)) != len(values):
+        raise argparse.ArgumentTypeError("K values must not contain duplicates")
+    return values
+
+
+def _first_divergence(
+    control: tuple[int, ...], candidate: tuple[int, ...]
+) -> dict[str, int | None] | None:
+    shared = min(len(control), len(candidate))
+    for index in range(shared):
+        if control[index] != candidate[index]:
+            return {
+                "index": index,
+                "control_token": control[index],
+                "candidate_token": candidate[index],
+            }
+    if len(control) == len(candidate):
+        return None
+    return {
+        "index": shared,
+        "control_token": control[shared] if shared < len(control) else None,
+        "candidate_token": candidate[shared] if shared < len(candidate) else None,
+    }
+
+
+def _token_sha256(tokens: tuple[int, ...]) -> str:
+    return hashlib.sha256(
+        ",".join(str(token) for token in tokens).encode("ascii")
+    ).hexdigest()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default=_DEFAULT_MODEL)
+    parser.add_argument("--mtp-sidecar")
+    parser.add_argument(
+        "--prompts",
+        type=int,
+        default=len(_BENCH_PROMPTS),
+        help=f"Number of built-in prompts to run (default: {len(_BENCH_PROMPTS)})",
+    )
+    parser.add_argument("--prompt-text", help="Run one explicit prompt instead")
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--k-values",
+        type=_parse_k_values,
+        default=_parse_k_values("0,1,2,3"),
+        help="Comma-separated fixed depths beginning with 0 (default: 0,1,2,3)",
+    )
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    return parser.parse_args()
+
+
+def _render_markdown(report: dict[str, Any]) -> None:
+    print("# Fixed-K real-weight MTP consistency diagnostic\n")
+    print(f"- model: `{report['model']}`")
+    print(f"- sidecar: `{report['mtp_sidecar']}`")
+    print(f"- max tokens: {report['max_tokens']}")
+    print(f"- seed: {report['seed']}")
+    print("- sampling: greedy (`temp=0`)")
+    print("- reference: same Rapid generator with speculation parked at K=0\n")
+    print(
+        "| Prompt | stock/K=0 | K | attempts | accepts | verify calls | "
+        "K=0 parity | first divergence | source |"
+    )
+    print("|---:|---|---:|---:|---:|---:|---|---|---|")
+    for prompt in report["prompts"]:
+        stock_matches = prompt["stock_vs_k0_first_divergence"] is None
+        for row in prompt["rows"]:
+            divergence = row["first_divergence"]
+            divergence_text = (
+                "—"
+                if divergence is None
+                else (
+                    f"{divergence['index']}: {divergence['control_token']} → "
+                    f"{divergence['candidate_token']}"
+                )
+            )
+            print(
+                f"| {prompt['index']} | {'yes' if stock_matches else 'no'} | "
+                f"{row['k']} | {row['attempts']} | {row['accepts']} | "
+                f"{row['verify_calls']} | "
+                f"{'yes' if row['matches_k0'] else 'no'} | {divergence_text} | "
+                f"{row['candidate_source_at_divergence'] or '—'} |"
+            )
+    print(
+        "\nA K=0 mismatch with stock AR localizes a generator/harness difference. "
+        "A fixed-K mismatch whose first differing token is target/non-draft can "
+        "be the expected batched-forward numerical fork and is not, by itself, "
+        "an acceptance or rollback failure."
+    )
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.max_tokens <= 0:
+        raise SystemExit("--max-tokens must be greater than zero")
+    if args.prompts <= 0 or args.prompts > len(_BENCH_PROMPTS):
+        raise SystemExit(f"--prompts must be between 1 and {len(_BENCH_PROMPTS)}")
+
+    sidecar = _resolve_mtp_sidecar(args.model, args.mtp_sidecar)
+    if sidecar is None:
+        raise SystemExit(
+            "No MTP sidecar is known for this model; pass --mtp-sidecar explicitly"
+        )
+    prompts = (
+        (args.prompt_text,) if args.prompt_text else _BENCH_PROMPTS[: args.prompts]
+    )
+
+    import mlx.core as mx
+    from mlx_lm import load
+    from mlx_lm.generate import stream_generate
+    from mlx_lm.sample_utils import make_sampler
+
+    from vllm_mlx.spec_decode.mtp import MTPAcceptCounter
+    from vllm_mlx.spec_decode.mtp.generator import mtp_generate_step
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+        inject_mtp_support,
+        validate_mtp_support,
+    )
+
+    model, tokenizer = load(args.model)
+    stop_tokens = _tokenizer_stop_tokens(tokenizer)
+    stock_by_prompt: list[tuple[int, ...]] = []
+    for index, prompt in enumerate(prompts):
+        print(f"[fixed-k-consistency] stock AR prompt {index + 1}", file=sys.stderr)
+        tokens: list[int] = []
+        for response in stream_generate(
+            model,
+            tokenizer,
+            prompt,
+            max_tokens=args.max_tokens,
+            sampler=make_sampler(temp=0.0),
+        ):
+            tokens.append(int(response.token))
+            if len(tokens) >= args.max_tokens:
+                break
+        stock_by_prompt.append(tuple(tokens))
+
+    if not inject_mtp_support(model, mtp_sidecar=sidecar):
+        raise RuntimeError(f"MTP injection failed for {args.model!r} with {sidecar!r}")
+    if not validate_mtp_support(model):
+        raise RuntimeError("MTP validation failed after injection")
+    inner = model.language_model if hasattr(model, "language_model") else model
+
+    prompt_reports: list[dict[str, Any]] = []
+    activity_valid = True
+    for index, prompt in enumerate(prompts):
+        prompt_ids = mx.array(tokenizer.encode(prompt), mx.uint32)
+        runs: dict[int, tuple[tuple[int, ...], tuple[bool, ...], Any, int]] = {}
+        for k in args.k_values:
+            print(f"[fixed-k-consistency] prompt {index + 1} K={k}", file=sys.stderr)
+            mx.random.seed(args.seed)
+            counter = MTPAcceptCounter()
+            timing: dict[str, float] = {}
+            tokens: list[int] = []
+            from_draft: list[bool] = []
+            for token, _logprobs, drafted in mtp_generate_step(
+                prompt_ids,
+                inner,
+                max_tokens=args.max_tokens,
+                temp=0.0,
+                accept_counter=counter,
+                disable_auto_k=True,
+                max_k=k,
+                stop_tokens=stop_tokens,
+                timing_stats=timing,
+            ):
+                token_id = int(token)
+                tokens.append(token_id)
+                from_draft.append(bool(drafted))
+                if token_id in stop_tokens or len(tokens) >= args.max_tokens:
+                    break
+            runs[k] = (
+                tuple(tokens),
+                tuple(from_draft),
+                counter.snapshot(),
+                int(timing.get("verify_calls", 0.0)),
+            )
+
+        control = runs[0][0]
+        rows = []
+        for k in args.k_values:
+            tokens, sources, counter, verify_calls = runs[k]
+            divergence = _first_divergence(control, tokens)
+            divergence_index = divergence["index"] if divergence else None
+            source = None
+            if isinstance(divergence_index, int) and divergence_index < len(sources):
+                source = "draft" if sources[divergence_index] else "target/non-draft"
+            arm_active = (
+                counter.attempts == 0 and verify_calls == 0
+                if k == 0
+                else counter.attempts > 0 and verify_calls > 0
+            )
+            activity_valid = activity_valid and arm_active
+            rows.append(
+                {
+                    "k": k,
+                    "active": arm_active,
+                    "attempts": counter.attempts,
+                    "accepts": counter.accepts,
+                    "verify_calls": verify_calls,
+                    "token_sha256": _token_sha256(tokens),
+                    "matches_k0": divergence is None,
+                    "first_divergence": divergence,
+                    "candidate_source_at_divergence": source,
+                }
+            )
+        prompt_reports.append(
+            {
+                "index": index + 1,
+                "prompt": prompt,
+                "stock_token_sha256": _token_sha256(stock_by_prompt[index]),
+                "stock_vs_k0_first_divergence": _first_divergence(
+                    stock_by_prompt[index], control
+                ),
+                "rows": rows,
+            }
+        )
+
+    report = {
+        "model": args.model,
+        "mtp_sidecar": sidecar,
+        "max_tokens": args.max_tokens,
+        "seed": args.seed,
+        "sampling": {"temperature": 0.0},
+        "controller": "disabled_fixed_k",
+        "reference": "same_generator_k0",
+        "activity_valid": activity_valid,
+        "prompts": prompt_reports,
+    }
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        _render_markdown(report)
+
+    if not activity_valid:
+        print(
+            "[fixed-k-consistency] INVALID: K=0 drafted or a K>0 arm did not engage",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/benchmarks/qwen38-flash-next-sampled-evals/README.md
+++ b/docs/benchmarks/qwen38-flash-next-sampled-evals/README.md
@@ -38,7 +38,11 @@ Read: on this sample the 4-bit Flash-Next matches or edges the 4-bit dense 27B o
 1. Sampled: first N examples per task (N=100; MMLU-Redux 4/subject = 228). ± is the harness stderr; differences of 1–4 points are not significant.
 2. Non-thinking mode, temperature 0, single run, greedy — upstream's published numbers are bf16 with thinking ON and are NOT comparable.
 3. Two harness adaptations, applied identically to both models: chat-safe HumanEval variant; GSM8K bold-aware re-score reported beside (never instead of) the harness number.
-4. 27B reference ran without speculative decoding; quality is unaffected by MTP anyway (lossless contract), speed is.
+4. The 27B reference ran without speculative decoding. MTP preserves the
+   verified target distribution, but greedy output is not guaranteed to be
+   byte-equal to stock single-token AR under quantized near ties (#3295).
+   Keeping speculation off makes this model-quality comparison independent of
+   that batched-forward numerical fork.
 5. Both models are 4-bit; there is no bf16 baseline here (Flash bf16 = 335 GiB does not fit the 256 GB box). Quantization fidelity vs bf16 remains unmeasured — the comparison isolates "Flash-Next-4bit vs dense-27B-4bit", not "4bit vs bf16".
 
 ## Publication

--- a/docs/specdecoding-validation-notes.md
+++ b/docs/specdecoding-validation-notes.md
@@ -11,24 +11,37 @@ Target:
 
 Result:
 
-- Correctness failed: 3 of 4 greedy HTTP prompts diverged from baseline text.
-- MTP metrics on the failed run showed activity (`attempts=102`, `accepts=71`, accept ratio about `0.696`), and some prompts were faster, but this is not acceptable because greedy output was not lossless.
+- Three of four greedy HTTP prompts diverged from baseline text.
+- MTP metrics on the run showed activity (`attempts=102`, `accepts=71`, accept
+  ratio about `0.696`), and some prompts were faster. At the time, the text
+  divergence was treated as a correctness failure.
 - Offline probes:
   - Injecting the assistant did not change fresh target logits (`max_abs_diff=0.0` on a direct target-logit check).
   - Forced-all-reject drafter matched baseline, so the reject rollback path is basically sound.
   - Forced-correct-draft all-accept matched baseline, so the simple all-accept path can be sound.
-  - The real assistant still caused divergence under the vendored generator/server path; root cause remains open.
+- The real assistant still caused divergence under the vendored generator/server path.
+
+Later Qwen3.5 investigation in #3295 established that byte equality with stock
+single-token AR is stronger than the engine's batched-consistency contract.
+Quantized near ties can flip when the target forward changes from `q_len=1` to
+`q_len>=2`; that numerical difference is not, by itself, an acceptance or
+rollback defect. The Gemma 4 result therefore cannot be classified as a
+correctness failure from text divergence alone.
 
 Decision:
 
 - Gemma 4 assistant-sidecar MTP is not supported or advertised.
-- Detection and dispatch fail closed for Gemma 4 MTP until a future implementation passes greedy-lossless correctness, stability, and performance validation end to end.
+- Detection and dispatch continue to fail closed until the family is
+  re-evaluated under the batched-consistency contract, with separate stability
+  and performance validation. This note does not reclassify the old result as
+  sufficient evidence to enable the family.
 
 Next validation targets:
 
 - Qwen3.5 / Qwen3.6 native MTP checkpoints with `mtp_num_hidden_layers >= 1`.
 - Confirm pre/post behavior for:
-  - greedy correctness: exact token/text equality vs baseline
+  - greedy correctness: K=0 same-generator reference, speculative activity,
+    and first-divergence source; do not use stock-AR byte equality alone
   - performance: TTFT, decode tok/s, acceptance ratio
   - stability: repeated runs, multiple prompt classes, no mid-stream fallback corruption
 

--- a/tests/test_mtp_lossless.py
+++ b/tests/test_mtp_lossless.py
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Lossless contract integration test for MTP spec decode (R15-P1 #302).
+"""Shape-stable arithmetic tests for greedy MTP spec decode (R15-P1 #302).
 
-The lossless contract says: for the SAME prompt + seed at temp=0,
-``--spec-decode mtp`` must emit byte-identical decoded tokens to
-``--spec-decode none``. Accept rate is a *speedup* signal; lossless-
-ness is a *correctness* contract that holds at every accept rate
-between 0% (every draft rejected) and 100% (every draft accepted).
+For a fixed target-logit sequence at temp=0, both the accept and reject paths
+must emit the target argmax. These mocked tests pin that arithmetic and cache
+rollback behavior. They do not assert byte equality between real batched
+verification (`q_len>=2`) and stock single-token AR (`q_len=1`), whose logits
+can differ at quantized near ties; see #3295.
 
-The standard way to test this is to load a real Qwen3.5 / 3.6
-checkpoint with MTP weights and run both paths back-to-back. That
-requires:
+The complementary real-weight consistency probe loads a Qwen3.5 / 3.6
+checkpoint with MTP weights and compares fixed K against the same generator
+parked at K=0. That requires:
 
 * A 4-50 GB model download (Qwen3.5-9B-w4 is ~5 GB).
 * GPU time on M-series silicon.
@@ -39,12 +39,12 @@ We then run TWO full sequences through ``mtp_generate_step``:
    token the standard ``generate_step`` would have decoded. So the
    emitted sequence STILL matches the reference, just slower.
 
-A passing test pins the contract: at temp=0, BOTH accept and reject
-branches emit the same tokens the non-spec-decode path would have
-emitted. Tests do NOT pin the per-step latency.
+A passing test pins the shape-stable arithmetic: at temp=0, BOTH accept and
+reject branches emit the scripted target token. Tests do NOT pin real-weight
+cross-shape byte parity or per-step latency.
 
-Why this is a meaningful lossless test
---------------------------------------
+Why this is a meaningful arithmetic test
+-----------------------------------------
 
 The two scripts above are the only two arithmetic paths through
 ``mtp_generate_step`` at temp=0:
@@ -56,7 +56,7 @@ The two scripts above are the only two arithmetic paths through
 Both paths therefore emit ``verify_pred`` — which is exactly what
 ``generate_step`` emits (it argmax's the same backbone logits).
 
-If the lossless contract ever breaks at temp=0, it breaks here:
+If the greedy accept/reject arithmetic breaks, it breaks here:
 
 * If the accept comparison were wrong (e.g. ``!=`` instead of
   ``==``), the accept-path token would not match.
@@ -68,9 +68,8 @@ If the lossless contract ever breaks at temp=0, it breaks here:
   the next backbone call's logits would change shape and the
   scripted token would not match.
 
-The bench script (``bench/bench_spec_decode_mtp.py``) covers the
-end-to-end correctness check against a real Qwen3.5 checkpoint when
-the GPU is free — see PR body for the follow-up plan.
+The real-weight test and ``bench/repro_mtp_forced_k_parity.py`` cover the
+same-generator K=0 comparison on a real Qwen3.5 checkpoint.
 """
 
 from __future__ import annotations

--- a/tests/test_mtp_real_weights.py
+++ b/tests/test_mtp_real_weights.py
@@ -10,16 +10,16 @@ disk → real-forward** chain — exactly the chain whose absence shipped
 PR #918 with an inject pipeline that built a random-init MTP module
 and never loaded weights.
 
-This file fills the gap with one end-to-end probe:
+This file fills the gap with end-to-end probes:
 
 * Load ``mlx-community/Qwen3.5-9B-4bit`` via ``mlx_lm.load``.
 * Call :func:`inject_mtp_support` with the cached sidecar repo
   ``mlx-community/Qwen3.5-9B-MTP-4bit``.
 * Verify the four contract surfaces land
   (:func:`validate_mtp_support`).
-* Run a single 20-token MTP-spec-decode pass and a single 20-token
-  baseline pass, then compare them byte-equally — the lossless
-  contract at temp=0 says they MUST match.
+* Compare fixed-depth greedy MTP with the same Rapid generator parked at
+  K=0. Byte equality with stock single-token AR is not the contract: the
+  batched verify forward can flip a near-tied argmax under quantized weights.
 
 Heavy by default (5 GB base + 131 MB sidecar download on cold cache,
 ~15 s wall on warm cache). Gated on ``RAPID_MLX_RUN_HEAVY_TESTS=1``
@@ -35,6 +35,8 @@ from __future__ import annotations
 import os
 
 import pytest
+
+from bench.bench_spec_decode_mtp import _BENCH_PROMPTS
 
 mx = pytest.importorskip("mlx.core")
 
@@ -56,61 +58,12 @@ _BASE_MODEL = "mlx-community/Qwen3.5-9B-4bit"
 _MTP_SIDECAR = "mlx-community/Qwen3.5-9B-MTP-4bit"
 
 
-_BASELINE_PROMPTS = (
-    "Write a short Python Fibonacci function with type hints.",
-    "Explain how a Bloom filter works.",
-    "Two trains travel toward each other at 60 and 80 km/h, 350 km "
-    "apart. When do they meet?",
-)
-_BASELINE_N_TOKENS = 20
+_CONSISTENCY_N_TOKENS = 128
 
 
 @pytest.fixture(scope="module")
-def baseline_tokens():
-    """Capture baseline (no MTP) tokens BEFORE any inject runs.
-
-    Codex flagged on PR #954 that running ``stream_generate`` after
-    ``inject_mtp_support`` compares MTP against the *patched* model,
-    not the original Qwen3.5 forward — which silently weakens the
-    lossless guard. Fix: load a separate, un-injected model in this
-    fixture and tear it down before the MTP fixture loads. This
-    guarantees the baseline tokens were produced by the pristine
-    upstream code path.
-    """
-    import gc
-
-    from mlx_lm import load
-    from mlx_lm.generate import stream_generate
-
-    model, tokenizer = load(_BASE_MODEL)
-    baselines: dict[str, list[int]] = {}
-    for prompt in _BASELINE_PROMPTS:
-        toks: list[int] = []
-        for resp in stream_generate(
-            model, tokenizer, prompt, max_tokens=_BASELINE_N_TOKENS
-        ):
-            toks.append(int(resp.token))
-            if len(toks) >= _BASELINE_N_TOKENS:
-                break
-        baselines[prompt] = toks
-
-    # Release the un-injected model before the patched fixture loads
-    # the second copy. Two 9B-4bit copies briefly coexist; cleanup is
-    # explicit to keep peak GPU mem bounded.
-    del model
-    del tokenizer
-    gc.collect()
-    return baselines
-
-
-@pytest.fixture(scope="module")
-def loaded_model(baseline_tokens):
-    """Load the base + inject MTP exactly once for all tests in the file.
-
-    Depends on ``baseline_tokens`` so the un-injected baseline pass
-    completes (and releases its model) before this fixture mutates a
-    fresh copy via ``inject_mtp_support``.
-    """
+def loaded_model():
+    """Load the base + inject MTP exactly once for all tests in the file."""
     from mlx_lm import load
 
     from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
@@ -247,26 +200,20 @@ def test_inject_loads_real_sidecar_weights(loaded_model):
         )
 
 
-def test_mtp_lossless_byte_equal_against_baseline(loaded_model, baseline_tokens):
-    """At temp=0, MTP spec decode must be byte-equal to non-spec decode.
+def test_mtp_greedy_fixed_depth_consistency_against_k0(loaded_model):
+    """Greedy divergence from K=0 must not move with fixed draft depth.
 
-    The ``baseline_tokens`` fixture captured ground-truth tokens
-    against a *fresh, un-injected* Qwen3.5-9B-4bit model BEFORE the
-    ``loaded_model`` fixture mutated a separate copy with
-    ``inject_mtp_support``. This test then runs the MTP generator on
-    the patched copy and asserts the decoded token sequences match
-    byte-equally.
+    K=0 through the same generator is the reference for the current
+    batched-consistency contract. Fixed-K verification is allowed to differ
+    because its ``q_len>=2`` target forward can flip a near-tied argmax versus
+    K=0's ``q_len=1`` forward under quantized weights. That shape-driven first
+    divergence should be identical at K=1/2/3. A depth-dependent first
+    divergence would instead point back toward chained accept or rollback
+    behavior and fail this guard.
 
-    Any divergence indicates either:
-
-    * The MTP head is producing wrong drafts AND the verify accepts
-      them anyway (probabilistic-accept arithmetic broken at temp=0).
-    * The cache rollback on draft rejection is failing to restore
-      linear-attention SSM state — output then drifts from the
-      baseline after the first rejected draft.
-
-    Both failure modes would invalidate the lossless contract; this
-    test is the canonical guard for it on a real checkpoint.
+    The full eight-prompt benchmark set and 128-token horizon deliberately
+    include the near ties that the old three-prompt, 20-token byte-equality
+    assertion missed. See #3295.
     """
     import mlx.core as _mx
 
@@ -276,33 +223,58 @@ def test_mtp_lossless_byte_equal_against_baseline(loaded_model, baseline_tokens)
     model, tokenizer = loaded_model
     inner = model.language_model
 
-    for prompt in _BASELINE_PROMPTS:
-        base_tokens = baseline_tokens[prompt]
-        assert len(base_tokens) == _BASELINE_N_TOKENS, (
-            f"baseline_tokens fixture returned {len(base_tokens)} tokens for "
-            f"prompt {prompt[:40]!r}; expected {_BASELINE_N_TOKENS}."
-        )
-
-        # MTP on the patched model.
-        counter = MTPAcceptCounter()
+    def run(prompt: str, max_k: int):
         prompt_ids = _mx.array(tokenizer.encode(prompt), _mx.uint32)
-        mtp_tokens: list[int] = []
-        for tok, _, _ in mtp_generate_step(
+        counter = MTPAcceptCounter()
+        timing: dict[str, float] = {}
+        tokens: list[int] = []
+        for tok, _logprobs, _from_draft in mtp_generate_step(
             prompt_ids,
             inner,
-            max_tokens=_BASELINE_N_TOKENS,
+            max_tokens=_CONSISTENCY_N_TOKENS,
             temp=0.0,
             accept_counter=counter,
+            disable_auto_k=True,
+            max_k=max_k,
+            timing_stats=timing,
         ):
-            mtp_tokens.append(int(tok))
-            if len(mtp_tokens) >= _BASELINE_N_TOKENS:
+            tokens.append(int(tok))
+            if len(tokens) >= _CONSISTENCY_N_TOKENS:
                 break
+        return tokens, counter.snapshot(), timing
 
-        # Lossless contract: byte-equal at temp=0.
-        assert mtp_tokens == base_tokens, (
-            f"MTP-vs-baseline divergence on prompt {prompt[:40]!r}: "
-            f"baseline {base_tokens} vs mtp {mtp_tokens}. "
-            f"Accept rate this run: {counter.snapshot()}."
+    def first_divergence(control: list[int], candidate: list[int]):
+        return next(
+            (
+                (index, control_token, candidate_token)
+                for index, (control_token, candidate_token) in enumerate(
+                    zip(control, candidate, strict=True)
+                )
+                if control_token != candidate_token
+            ),
+            None,
+        )
+
+    for prompt in _BENCH_PROMPTS:
+        k0_tokens, k0_counter, k0_timing = run(prompt, 0)
+        assert k0_counter.attempts == 0
+        assert int(k0_timing.get("verify_calls", 0.0)) == 0
+        assert len(k0_tokens) == _CONSISTENCY_N_TOKENS
+
+        by_depth = {}
+        for max_k in (1, 2, 3):
+            mtp_tokens, mtp_counter, mtp_timing = run(prompt, max_k)
+            assert mtp_counter.attempts > 0, (
+                f"Fixed K={max_k} did not attempt speculation for {prompt[:40]!r}"
+            )
+            assert int(mtp_timing.get("verify_calls", 0.0)) > 0
+            assert len(mtp_tokens) == _CONSISTENCY_N_TOKENS
+            by_depth[max_k] = first_divergence(k0_tokens, mtp_tokens)
+
+        assert len(set(by_depth.values())) == 1, (
+            f"First K=0 divergence changed with fixed draft depth for "
+            f"{prompt[:40]!r}: {by_depth}. This is not explained by the "
+            f"depth-independent q_len=1 versus q_len>=2 numerical fork."
         )
 
 
@@ -336,7 +308,7 @@ def _longest_draft_run(from_draft_flags: list[bool]) -> int:
 def test_mtp_nongreedy_real_sampled_smoke(loaded_model, max_k):
     """Sampled (temp>0) MTP decode on real weights must reach depth K and accept.
 
-    Why this exists alongside the temp=0 lossless test: at temp=0 the
+    Why this exists alongside the temp=0 consistency test: at temp=0 the
     verify path never consults its random draw, so the entire
     probabilistic accept / residual-resample branch — the branch every
     non-greedy chat request now takes — is untested on real weights by

--- a/tests/test_repro_mtp_forced_k_parity.py
+++ b/tests/test_repro_mtp_forced_k_parity.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from bench.repro_mtp_forced_k_parity import (
+    _first_divergence,
+    _parse_k_values,
+    _token_sha256,
+)
+
+
+def test_parse_k_values_requires_control_first():
+    assert _parse_k_values("0,1,2,3") == (0, 1, 2, 3)
+    with pytest.raises(argparse.ArgumentTypeError, match="start with the K=0 control"):
+        _parse_k_values("1,2,3")
+    with pytest.raises(argparse.ArgumentTypeError, match="speculative depth"):
+        _parse_k_values("0")
+
+
+def test_parse_k_values_rejects_duplicates_and_negative_depths():
+    with pytest.raises(argparse.ArgumentTypeError, match="duplicates"):
+        _parse_k_values("0,1,1")
+    with pytest.raises(argparse.ArgumentTypeError, match="non-negative"):
+        _parse_k_values("0,-1")
+
+
+def test_first_divergence_reports_token_flip_and_early_termination():
+    assert _first_divergence((10, 20, 30), (10, 21, 30)) == {
+        "index": 1,
+        "control_token": 20,
+        "candidate_token": 21,
+    }
+    assert _first_divergence((10, 20, 30), (10, 20)) == {
+        "index": 2,
+        "control_token": 30,
+        "candidate_token": None,
+    }
+    assert _first_divergence((10, 20), (10, 20)) is None
+
+
+def test_token_hash_is_stable_and_sequence_sensitive():
+    assert _token_sha256((10, 20)) == _token_sha256((10, 20))
+    assert _token_sha256((10, 20)) != _token_sha256((20, 10))


### PR DESCRIPTION
## Why

Closes #3295.

The existing real-weight guard requires byte equality between MTP's batched
verify forward and stock single-token AR. Current-main measurements show that
this is stronger than the batched-consistency contract and passes only because
its three short prompts avoid quantized near ties. The repository also contains
two documentation claims that apply the stronger contract inconsistently.

## Scope

- Add a standalone forced-K diagnostic that compares stock AR, the same Rapid
  generator parked at K=0, and fixed K=1/2/3 across the eight MTP benchmark
  prompts.
- Reframe the real-weight greedy guard around K=0 and require first divergence
  to remain depth-independent across K=1/2/3 over 128 tokens.
- Qualify the mocked lossless tests as shape-stable arithmetic coverage.
- Correct the two affected documentation claims and retain Gemma 4's
  fail-closed status pending family validation under the stated contract.

## Non-goals

- No runtime, sampling, scheduler, model-gating, or performance changes.
- This does not enable or advertise Gemma 4 assistant-sidecar MTP.
- The diagnostic reports byte divergence; it does not treat divergence alone
  as an acceptance or rollback failure.

## Acceptance

- The diagnostic fails invalid runs where K=0 drafts or any K>0 arm records no
  speculative attempts or verify calls.
- The real-weight guard uses all eight benchmark prompts and compares K=1/2/3
  against the same-generator K=0 reference.
- A depth-dependent first divergence fails, while a consistent cross-depth
  numerical fork is allowed.
- Documentation no longer claims universal byte equality with stock AR.

## Verification

- `ruff check .`
- `ruff format --check .`
- Focused MTP suite: 250 passed.
- Heavy real-weight file: 4 passed in 171.69s.
- Standalone diagnostic on the default Qwen3.5 base plus MTP sidecar: K=0
  matched stock AR on 8/8 prompts, every K>0 arm engaged, and the five
  diverging prompts had the same first divergence across K=1/2/3, all on a
  target/non-draft emission.
- Repository PR validator: metadata, description, supply-chain, environment,
  review-vocabulary, and targeted-test steps passed; targeted result was 9
  passed and 4 heavy tests skipped.
- Validator full-unit result: 23,641 passed, 142 skipped, 6 xfailed, with 18
  failures and 4 errors across unrelated model, GUI, and optional-runtime
  tests. None of the failing paths is changed by this PR. The first numeric
  failure also reproduces in isolation.
- The validator initially could not launch `ruff` from its subprocess PATH;
  after installing the same pinned tool into its venv, direct repository-wide
  `ruff check .` and `ruff format --check .` both pass.

## Behaviour delta

Test and documentation contract only. Before, the heavy greedy guard required
stock-AR byte equality over three prompts and 20 tokens. After, it compares the
same generator at K=0 and fixed K=1/2/3 over eight prompts and 128 tokens,
allowing depth-independent batched-forward numerical divergence. Runtime
behavior is unchanged.

## AI assistance disclosure

Codex authored and reviewed the diagnostic, test refactor, and documentation
edits under my direction. I verified the result with repository-wide Ruff,
250 focused MTP tests, the four real-weight tests, and a full real-model run of
the new standalone diagnostic. The files touched by AI are exactly the seven
files in this PR.

By submitting this PR I confirm I can explain the intent, risk, and behavior of
every non-generated change in the PR.

## Checklist status

- Targeted and real-weight tests pass locally.
- Lint and formatting pass.
- README and affected documentation are updated.
- No breaking API or runtime behavior changes.
- PR self-validation was run against #3300; its targeted checks pass, with the
  unrelated full-unit/environment failures disclosed above.
