### PR TITLE
bench: qualify native 2-bit V4.1 REAP artifact

### DIFF
--- a/.agents/handoffs/vector-deepseek-v41-native-2bit.md
+++ b/.agents/handoffs/vector-deepseek-v41-native-2bit.md
@@ -1,0 +1,86 @@
+# Vector handoff: DeepSeek V4.1 native 2-bit
+
+- Owner: Vector
+- Host: Studio (256 GiB unified memory)
+- Branch: `raullenchai/deepseek-v41-native-2bit`
+- Worktree: `/Users/raullenstudio/orca/workspaces/rapid-mlx/deepseek-v41-native-2bit`
+- Status: qualification complete; product gate failed; no upload or exposure
+
+## Intention and gates
+
+Build a native packed affine 2-bit DeepSeek V4.1 Flash text checkpoint from the
+already-cached Vontra checkpoint, then expose it through Rapid-MLX only if a
+real 256 GiB sustained-greedy benchmark reaches at least 12 token/s with
+acceptable parity/coherence. The optimization target is 20+ token/s.
+
+Non-goals are MTP, visual input, cloud execution, downloading the raw 754B
+checkpoint, and product exposure below the 12 token/s gate.
+
+## Verified facts
+
+- Source checkpoint: 238.796 GB indexed, affine 2-bit/group-64.
+- Text-only native repack estimate: 234.183 GB without pruning.
+- Routed experts occupy 174.116 GB; REAP12.5 would reduce the candidate to
+  approximately 212.4 GB.
+- Layer-0 real-weight repack is byte-preserving and loads all 21 MoE tensors.
+  Against the source execution path, output cosine is 0.999988, max absolute
+  difference 0.0625, and mean absolute difference 0.00708.
+- Single-token layer-0 MoE compute does not improve from packing alone:
+  1.81 ms packed versus 1.11 ms source direct-QMV after warmup. Full-runtime
+  qualification is therefore mandatory.
+- The REAP12.5 artifact contains 212,930,051,680 tensor bytes (~199 GiB on
+  disk), strict-loads with zero missing/unexpected parameters, and peaks at
+  213.51 GB MLX memory when resident.
+- Correct V4.1 chat framing generates `The capital of France is Paris.` and
+  EOS. Raw completion probes without the model's role tokens are invalid.
+- Standard `(N-1)/elapsed` decode is 7.31 tok/s at evaluation interval 4 and
+  7.92 tok/s in the one-graph short-decode ceiling. The latter is not a
+  long-context safety claim.
+- Gate/up fusion is rejected: it reaches only 7.87 fixed model steps/s and
+  raises the load transient to 263.72 GB.
+- The complete tiny-config parity suite passes: <=1.4e-6 relative differences,
+  100% argmax agreement, bit-exact quant/dequant cases, strict float/quantized
+  layouts, and bit-equal streaming.
+- The qualification runtime lives under `scripts/`, outside the production
+  model package and registry. The pinned Python 3.11 mypy budget and 16 focused
+  tests pass. A local full-suite run reached 23,679 passes; its remaining four
+  tokenizer errors and one missing optional image dependency were unrelated
+  offline-environment gaps, not failures in this change.
+- The 12 tok/s product floor is missed by 51.5%; the artifact was not uploaded
+  and Rapid catalog/server/GUI support was not added.
+
+## Reference check (internal only)
+
+- Primary engine precedents were checked for reusable model/runtime support;
+  neither currently exposes this architecture.
+- MLX-native implementations were inspected next. The active native port at
+  revision `8bdd543c7160800f3451d9595c996129b7abecdf` provides strict parity,
+  shared compressed attention, Engram, and packed SwitchGLU. Its public builds
+  require at least 275 GB, so Rapid adapts the runtime and reuses the cached
+  2-bit tensors without re-quantization.
+- A separate multimodal integration is draft-only and lacks a complete load and
+  generation path; it is not a viable dependency for this task.
+
+## Storage log
+
+2026-09-10 — task `DeepSeek V4.1 native 2-bit qualification`; model
+`DeepSeek-V4.1-Flash native packed affine 2-bit`; planned generated build
+234.2 GB at
+`/Volumes/RTL-2T/models-cold/local/DeepSeek-V4.1-Flash-native-2bit-unpruned`.
+This is a local byte-preserving conversion, not a download. No Hugging Face
+cache variables or alternate download directories are used.
+
+2026-09-10 — same task; calibrated REAP12.5 candidate; expected generated
+size 212.93 GB at
+`/Volumes/RTL-2T/models-cold/local/DeepSeek-V4.1-Flash-native-2bit-reap12_5`.
+The selection uses 2,048 real causal tokens and keeps an expert when either
+disjoint corpus half assigns material normalized routing weight.
+
+## Disposition
+
+Keep this as a bounded, reproducible negative qualification. Do not productize
+the model unless a future exact target-forward implementation independently
+passes correctness, long-context stability, and at least 12 tok/s on the same
+hardware class. More routed-expert count pruning or a storage-only fractional
+BPW format does not reduce the six active expert widths per token and is not a
+credible way to close the gap.

--- a/docs/engineering/performance/2026-09-10-deepseek-v41-native-2bit-reap.md
+++ b/docs/engineering/performance/2026-09-10-deepseek-v41-native-2bit-reap.md
@@ -1,0 +1,155 @@
+# DeepSeek V4.1 Flash native 2-bit REAP qualification
+
+Date: 2026-09-10
+
+## Decision
+
+Do not publish the generated artifact or expose DeepSeek V4.1 Flash in the
+Rapid catalog. A native affine 2-bit text build pruned from 384 to 336 routed
+experts fits in 256 GiB unified memory and passes a correctly framed greedy
+smoke test, but its best observed decode result is 7.92 tok/s. An opt-in gate/up
+fusion reaches only 7.87 model steps/s while transient memory rises to 263.72
+GB. Neither passes the agreed 12 tok/s product floor, and the fused load is too
+close to physical memory capacity for a safe 256 GiB default.
+
+This work therefore stops before model upload, catalog registration, server
+routing, or GUI exposure. The 20+ tok/s target remains unproven.
+
+## Environment and source
+
+- Apple M3 Ultra, 60 GPU cores, 256 GiB unified memory
+- MLX 0.32.2
+- Source checkpoint revision:
+  `802f1a00982705d81b79ad1c83aa0ccc0b863ebc`
+- Source indexed size: 238,796,133,496 bytes
+- Source quantization: MLX affine 2-bit, group size 64
+- Native runtime reference revision:
+  `8bdd543c7160800f3451d9595c996129b7abecdf`
+- Calibration: 2,048 causal corpus tokens, split into two disjoint halves
+- Product floor: at least 12 decode tok/s; target: 20+ tok/s
+
+The checkpoint was already present in the standard Hugging Face cache. The
+experiment did not redirect the cache or download another model. Generated
+artifacts were written only below the Studio warm tier's `models-cold/`
+directory.
+
+## Artifact construction
+
+The repacker streams safetensors bytes without materializing the full source.
+It preserves existing packed affine values exactly, stacks split routed expert
+tensors along an expert axis for the native runtime, and drops the unqualified
+vision and MTP components. It does not claim to re-quantize original weights.
+
+The calibration records normalized routing-weight saliency independently for
+each corpus half. The conservative score is the maximum normalized saliency
+from either half, so an expert is considered low value only when both halves
+assign it little mass. Keeping 336 of 384 experts per layer produced:
+
+- mean retained robust routing mass: 99.9949%
+- worst-layer retained robust routing mass: 99.8564%
+- split-half keep-set overlap: 92.1354%
+- never-routed layer/expert cells: 4,910
+
+The final text artifact contains 212,930,051,680 tensor bytes (approximately
+199 GiB on disk), compared with 234,183,391,840 tensor bytes for the unpruned
+native repack. Every routed projection and router row was checked for the
+expected 336-expert leading dimension, and the strict loader reported no
+missing or unexpected parameters.
+
+## Correctness
+
+Raw completion text is not a valid V4.1 quality probe. The required chat
+framing is:
+
+```text
+<｜begin▁of▁sentence｜><｜User｜>...<｜Assistant｜></think>
+```
+
+With that framing, the prompt `What is the capital of France? Answer in one
+short sentence.` generated `The capital of France is Paris.` followed by EOS.
+All tested evaluation intervals produced the same greedy token chain.
+
+The native runtime also passes the upstream tiny-config parity battery:
+
+- prefill, decode, and chunked-prefill relative differences at or below
+  1.4e-6;
+- 100% argmax agreement;
+- bit-exact fake-quant and dequant unit cases;
+- strict float and quantized release-layout round trips;
+- layer-at-a-time streaming equal to the loaded model.
+
+That battery exposed and led to fixes for two bugs that a one-token smoke test
+did not catch: grouped `wo_a` must retain its logical group axis when affine
+quantized, and the original flat float layout must still work for multi-token
+prefill and streaming loads.
+
+This remains a smoke/parity result, not a broad task-quality, tool-use, vision,
+or long-context evaluation.
+
+## Performance results
+
+The standard-metric run materialized the 199 GiB build in 239.44 seconds. Peak
+MLX memory was 213.51 GB. Decode throughput uses Rapid's `(N-1)/elapsed`
+definition: the 17-token correctly framed prompt produces the first token, then
+seven measured target transitions produce the remaining tokens through EOS.
+
+| Runtime path | Evaluation interval | Decode tok/s | Steady last-half tok/s | Peak MLX GB |
+| --- | ---: | ---: | ---: | ---: |
+| Native packed, watchdog-conservative | 4 | 7.31 | 7.43 | 213.51 |
+| Native packed, short-decode ceiling | 20 | 7.86 | 7.89 | 213.51 |
+| Native packed, one short decode graph | 40 | **7.92** | **7.90** | 213.51 |
+| Gate/up fusion, model-step diagnostic | 20 | 7.87 steps/s | 7.84 steps/s | 263.72 |
+
+The 40-layer graph completed this short decode, but it is not declared safe for
+long-context serving: the cold unpruned build previously triggered the Metal
+watchdog. The fused run's first prompt also paid 15.91 seconds of graph/fusion
+warmup; later prefills were 0.25-0.26 seconds. Fusion is rejected because it is
+not faster than the non-fused ceiling and its transient is only about 11 GB
+below physical memory, leaving insufficient operational margin. Its older
+diagnostic counted fixed model steps rather than Rapid's token-transition
+metric, so the row is intentionally labeled separately.
+
+## Why more REAP does not close the speed gap
+
+REAP removes routed experts that are unlikely to be selected. It reduces the
+stored model and router dimensions, but each decode token still executes six
+experts of the same 2,304-wide shape in every layer. More aggressive expert
+count pruning therefore does not proportionally reduce active expert compute.
+It can also weaken routing coverage while leaving the main per-token kernels
+unchanged.
+
+Likewise, changing 2-bit affine group size or introducing a fractional-BPW
+storage format primarily changes bytes and metadata. It does not create a
+faster MLX execution kernel. A new packing format without a qualified native
+kernel would either be decoded back into the current layout or run slower.
+
+The remaining gap from 7.92 to 12 tok/s is 51.5%; the gap to 20 tok/s is
+152.5%. Reaching either target needs a materially cheaper exact target forward,
+not another catalog alias or a more aggressive storage-only prune.
+
+## Reproduction
+
+Calibration and repacking are explicit local operations. The calibration
+command executes checkpoint-bundled code and therefore requires an affirmative
+trust flag:
+
+```shell
+python scripts/calibrate_deepseek_v41_reap.py \
+  --model <cached-source-snapshot> \
+  --output /private/tmp/rapid-mlx-deepseek-v41-calibration/routing-2048.npz \
+  --tokens 2048 --keep-experts 336 \
+  --trust-checkpoint-runtime <calibration-corpus>
+
+python scripts/repack_deepseek_v41_native.py \
+  --source <cached-source-snapshot> \
+  --destination <warm-tier-output> \
+  --keep-experts 336 \
+  --saliency /private/tmp/rapid-mlx-deepseek-v41-calibration/routing-2048.npz
+
+DSV41_WIRED_GB=235 python scripts/qualify_deepseek_v41_native.py \
+  <warm-tier-output> --tokens 16 --intervals 1 2 4
+```
+
+Do not use whole-process Metal capture for this model. Use bounded operation or
+layer probes; a full capture can consume enough storage to endanger the system
+volume.

--- a/scripts/calibrate_deepseek_v41_reap.py
+++ b/scripts/calibrate_deepseek_v41_reap.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Collect conservative routing saliency from the cached V4.1 checkpoint.
+
+This calibration executes checkpoint-bundled Python and therefore requires an
+explicit trust flag. Saliency is the sum of normalized routing weights for each
+selected expert. Two disjoint token halves are retained so a pruning recipe can
+be rejected when the keep set is unstable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import time
+from pathlib import Path
+from types import MethodType
+
+import mlx.core as mx
+import numpy as np
+
+
+def _load_runtime(model: Path):
+    path = model / "runtime" / "runtime.py"
+    spec = importlib.util.spec_from_file_location(
+        "rapid_deepseek_v41_calibration_runtime", path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import checkpoint runtime: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _corpus_tokens(runtime, paths: list[Path], count: int) -> list[int]:
+    text = "\n\n".join(path.read_text(errors="replace") for path in paths)
+    ids = runtime.tokenizer.encode(text).ids
+    if len(ids) < count:
+        raise ValueError(f"corpus has {len(ids)} tokens, need {count}")
+    return ids[:count]
+
+
+def _overlap(a: np.ndarray, b: np.ndarray, keep: int) -> float:
+    values = []
+    for layer in range(a.shape[0]):
+        left = set(np.argsort(-a[layer])[:keep].tolist())
+        right = set(np.argsort(-b[layer])[:keep].tolist())
+        values.append(len(left & right) / keep)
+    return float(np.mean(values))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--tokens", type=int, default=1024)
+    parser.add_argument("--keep-experts", type=int, default=336)
+    parser.add_argument("--trust-checkpoint-runtime", action="store_true")
+    parser.add_argument("corpus", type=Path, nargs="+")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.trust_checkpoint_runtime:
+        raise SystemExit(
+            "refusing to execute checkpoint-bundled Python without "
+            "--trust-checkpoint-runtime"
+        )
+    model = args.model.resolve()
+    module = _load_runtime(model)
+    runtime = module.TextRuntime(
+        model,
+        max_tokens=args.tokens,
+        resident_backbone=True,
+        execution_mode="compiled",
+    )
+    layers = int(runtime.c["num_hidden_layers"])
+    experts = int(runtime.c["n_routed_experts"])
+    if not 1 <= args.keep_experts <= experts:
+        raise SystemExit(f"--keep-experts must be in [1, {experts}]")
+    ids = _corpus_tokens(runtime, args.corpus, args.tokens)
+    saliency_halves = np.zeros((2, layers, experts), dtype=np.float64)
+    counts_halves = np.zeros((2, layers, experts), dtype=np.int64)
+    layer_re = re.compile(r"^layers\.(\d+)\.ffn$")
+
+    def instrumented_moe(self, base, x):
+        match = layer_re.match(base)
+        if match is None:
+            raise ValueError(f"unexpected MoE path: {base}")
+        layer = int(match.group(1))
+        config = self.c
+        logits = (
+            x.astype(mx.float32)
+            @ self.w.read(base + ".gate.weight").astype(mx.float32).T
+        )
+        scores = mx.sqrt(mx.logaddexp(logits, mx.zeros_like(logits)))
+        topk = config["num_experts_per_tok"]
+        picks = mx.argsort(scores + self.w.read(base + ".gate.bias"), axis=-1)[
+            :, -topk:
+        ]
+        selected = mx.take_along_axis(scores, picks, axis=-1)
+        if config["norm_topk_prob"] and topk > 1:
+            selected = selected / (mx.sum(selected, axis=-1, keepdims=True) + 1e-20)
+        selected = selected * config["routed_scaling_factor"]
+        mx.eval(picks, selected)
+        chosen = picks.tolist()[0]
+        weights = selected.tolist()[0]
+        half = min(1, self.position * 2 // args.tokens)
+        for expert, weight in zip(chosen, weights):
+            saliency_halves[half, layer, expert] += weight
+            counts_halves[half, layer, expert] += 1
+
+        result = mx.zeros_like(x).astype(mx.float32)
+        for expert, weight in zip(chosen, weights):
+            result = result + self.expert(
+                base + f".experts.{expert}", x, weight
+            ).astype(mx.float32)
+        return (
+            result + self.expert(base + ".shared_experts", x).astype(mx.float32)
+        ).astype(x.dtype)
+
+    runtime.moe = MethodType(instrumented_moe, runtime)
+    started = time.monotonic()
+    for index, token in enumerate(ids, 1):
+        runtime.step(token)
+        if index % 32 == 0 or index == len(ids):
+            elapsed = time.monotonic() - started
+            print(
+                json.dumps(
+                    {
+                        "tokens": index,
+                        "total": len(ids),
+                        "tok_s": index / elapsed,
+                        "active_gb": mx.get_active_memory() / 1e9,
+                        "peak_gb": mx.get_peak_memory() / 1e9,
+                    }
+                ),
+                flush=True,
+            )
+
+    saliency = saliency_halves.sum(axis=0)
+    counts = counts_halves.sum(axis=0)
+    normalized_halves = saliency_halves / np.maximum(
+        saliency_halves.sum(axis=2, keepdims=True), 1e-12
+    )
+    # Conservative across domains: an expert is low-value only when both
+    # corpus halves assign it little or no normalized routing mass.
+    robust_saliency = np.maximum(normalized_halves[0], normalized_halves[1])
+    split_overlap = _overlap(saliency_halves[0], saliency_halves[1], args.keep_experts)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        args.output,
+        saliency=saliency,
+        robust_saliency=robust_saliency,
+        counts=counts,
+        saliency_halves=saliency_halves,
+        counts_halves=counts_halves,
+        tokens=np.array(args.tokens),
+        keep_experts=np.array(args.keep_experts),
+        split_keep_overlap=np.array(split_overlap),
+        method=np.array("normalized_routing_weight"),
+        selection_policy=np.array("max_normalized_half"),
+    )
+    print(
+        json.dumps(
+            {
+                "output": str(args.output),
+                "tokens": args.tokens,
+                "keep_experts": args.keep_experts,
+                "split_keep_overlap": split_overlap,
+                "never_routed": int((counts == 0).sum()),
+                "elapsed_seconds": time.monotonic() - started,
+            },
+            indent=2,
+        ),
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deepseek_v41_native/LICENSE
+++ b/scripts/deepseek_v41_native/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/scripts/deepseek_v41_native/NOTICE
+++ b/scripts/deepseek_v41_native/NOTICE
@@ -1,0 +1,6 @@
+DeepSeek V4.1 native MLX runtime
+
+This directory contains code derived from PipeNetwork/deepseek-v41-mlx,
+revision 8bdd543c7160800f3451d9595c996129b7abecdf, licensed under the
+Apache License 2.0. Rapid-MLX modifications include quantized group-aware
+output projection support and qualification tooling.

--- a/scripts/deepseek_v41_native/__init__.py
+++ b/scripts/deepseek_v41_native/__init__.py
@@ -1,0 +1,6 @@
+"""MLX runtime for deepseek-ai/DeepSeek-V4.1-Flash (model_type: deepseek_v41)."""
+
+from .config import ModelArgs
+from .model import Model
+
+__all__ = ["ModelArgs", "Model"]

--- a/scripts/deepseek_v41_native/attention.py
+++ b/scripts/deepseek_v41_native/attention.py
@@ -1,0 +1,222 @@
+"""V4.1 attention — MLA over a sliding window plus shared compressed positions.
+
+One layer:
+
+* queries through a low-rank bottleneck (``wq_a`` -> ``q_norm`` -> ``wq_b``),
+  rope on the last 64 channels (no per-head q normalization — that was V4);
+* a **single** shared 512-d KV vector per position (key and value are the same
+  tensor), FP8 fake-quantized whole — rope tail included — before caching;
+* every layer attends over the last ``window_size`` tokens; layers with
+  ``compress_ratio > 0`` additionally attend over ``index_topk`` compressed
+  positions. Only kv_source layers *produce* the compressed cache and only
+  index_source layers *select* — everything else consumes through the per-forward
+  ``shared`` state, exactly mirroring the reference's SharedAttentionRuntime;
+* the attention output gets the rope **inverse** applied to its tail, then the
+  grouped block-diagonal ``wo_a`` and the shared ``wo_b``. ``wo_a`` stays
+  group-aware so affine packed weights can be used without reshaping bytes.
+
+Rope: compressing layers use YaRN on ``compress_rope_theta``; pure sliding-window
+layers use the base theta with YaRN off. One freqs table serves the queries, the
+window KV, the compressed latents (at each group's first-token position), the
+indexer, and the inverse on the way out.
+
+The forward is chunk-general: full prefill, chunked prefill and 1-token decode
+are the same code path.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from vllm_mlx import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.mla import MultiLinear  # noqa: E402
+
+from .compressor import Compressor
+from .config import ModelArgs
+from .fakequant import fake_quant_fp4_e4m3, fake_quant_fp8_ue8m0
+from .indexer import Indexer
+from .layers import RMSNorm, precompute_freqs_cis, rope_tail
+from .sparse_attention import sparse_attn
+
+
+class GroupedOutputLinear(MultiLinear):
+    """Grouped projection accepting logical and release-flat float weights."""
+
+    def __init__(self, input_dims: int, output_dims: int, num_heads: int):
+        super().__init__(input_dims, output_dims, num_heads)
+        self.output_dims = output_dims
+        self.num_heads = num_heads
+
+    def __call__(self, x, transpose=True):
+        weight = self.weight
+        if weight.ndim == 2:
+            weight = weight.reshape(self.num_heads, self.output_dims, -1)
+            return x @ (weight.swapaxes(-1, -2) if transpose else weight)
+        return super().__call__(x, transpose=transpose)
+
+
+def window_idx_matrix(wp: int, n: int, window: int) -> mx.array:
+    """[n, W_eff] window indices into concat([prev_window(wp), chunk(n)]).
+
+    Query i (concat end position wp+i) sees the last ``window`` concat positions
+    that exist; -1 pads. W_eff = min(window, wp+n).
+    """
+    w_eff = min(window, wp + n)
+    end = mx.arange(n) + wp
+    start = mx.maximum(end - window + 1, 0)
+    idx = start[:, None] + mx.arange(w_eff)[None, :]
+    return mx.where(idx > end[:, None], mx.array(-1, mx.int32), idx.astype(mx.int32))
+
+
+class Attention(nn.Module):
+    def __init__(self, layer_id: int, args: ModelArgs):
+        super().__init__()
+        self.layer_id = layer_id
+        self.dim = args.dim
+        self.n_heads = args.n_heads
+        self.head_dim = args.head_dim
+        self.rope_head_dim = args.rope_head_dim
+        self.q_lora_rank = args.q_lora_rank
+        self.o_lora_rank = args.o_lora_rank
+        self.n_groups = args.o_groups
+        self.window_size = args.window_size
+        self.ratio = args.compress_ratio(layer_id)
+        self.eps = args.norm_eps
+        self.softmax_scale = args.head_dim**-0.5
+
+        self.attn_sink = mx.zeros((self.n_heads,), dtype=mx.float32)
+        self.wq_a = nn.Linear(self.dim, self.q_lora_rank, bias=False)
+        self.q_norm = RMSNorm(self.q_lora_rank, self.eps)
+        self.wq_b = nn.Linear(
+            self.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wkv = nn.Linear(self.dim, self.head_dim, bias=False)
+        self.kv_norm = RMSNorm(self.head_dim, self.eps)
+        # Modified by Rapid-MLX: retain the logical group axis so 2-bit affine
+        # weights can be loaded without interpreting packed uint32 storage as
+        # a dense matrix.
+        self.wo_a = GroupedOutputLinear(
+            self.n_heads * self.head_dim // self.n_groups,
+            self.o_lora_rank,
+            self.n_groups,
+        )
+        self.wo_b = nn.Linear(self.n_groups * self.o_lora_rank, self.dim, bias=False)
+
+        self.is_kv_source = layer_id in args.kv_source_layers
+        self.is_index_source = layer_id in args.index_source_layers
+        if self.is_kv_source:
+            self.compressor = Compressor(args, layer_id)
+        if self.is_index_source:
+            self.indexer = Indexer(args, layer_id)
+
+        if self.ratio:
+            orig_len, theta = args.original_seq_len, args.compress_rope_theta
+        else:
+            orig_len, theta = 0, args.rope_theta
+        self._rope = (
+            args.rope_head_dim,
+            orig_len,
+            theta,
+            args.rope_factor,
+            args.beta_fast,
+            args.beta_slow,
+        )
+        self._cos = None
+        self._sin = None
+
+        # test hooks (negative controls)
+        self._break_rope_inverse = False
+        self._break_sink = False
+
+    def _freqs(self, upto: int):
+        if self._cos is None or self._cos.shape[0] < upto:
+            rd, orig_len, theta, factor, bf, bs = self._rope
+            self._cos, self._sin = precompute_freqs_cis(
+                rd, max(upto, 64), orig_len, theta, factor, bf, bs
+            )
+        return self._cos, self._sin
+
+    def __call__(self, x: mx.array, start_pos: int, cache, shared) -> mx.array:
+        """x [b, n, dim] (post attn_norm), absolute positions [start_pos, start_pos+n)."""
+        bsz, n, _ = x.shape
+        rd = self.rope_head_dim
+        end_pos = start_pos + n
+        cos, sin = self._freqs(end_pos)
+        c_q, s_q = cos[start_pos:end_pos], sin[start_pos:end_pos]
+
+        # --- queries ---
+        qr = self.q_norm(self.wq_a(x))
+        q = self.wq_b(qr).reshape(bsz, n, self.n_heads, self.head_dim)
+        q = rope_tail(q, rd, c_q, s_q)
+
+        # --- window KV: rope tail, FP8 fake-quant over the whole vector ---
+        kv = self.kv_norm(self.wkv(x))
+        kv = rope_tail(kv, rd, c_q, s_q)
+        kv = fake_quant_fp8_ue8m0(kv, 32)
+
+        lc = cache.layers[self.layer_id]
+        prev = lc.window_chrono(start_pos)  # [b, Wp, hd]
+        wp = prev.shape[1]
+        kv_all = mx.concatenate([prev.astype(kv.dtype), kv], axis=1) if wp else kv
+        idxs = mx.broadcast_to(
+            window_idx_matrix(wp, n, self.window_size)[None],
+            (bsz, n, min(self.window_size, wp + n)),
+        )
+        lc.write_window(start_pos, kv)
+        offset = wp + n  # compressed entries follow
+
+        if self.ratio:
+            src = shared.kv_src_cache  # the source layer's LayerCache
+            compress_len = end_pos // self.ratio
+
+            latents = None
+            if self.is_kv_source:
+                latents = self.compressor(x, start_pos, lc.comp_state)
+                shared.kv_src_cache = src = lc
+
+            # indexer runs on the pre-RoPE latents, before the cache write
+            if self.is_index_source:
+                if self.indexer.owns_k:
+                    if latents is not None:
+                        self.indexer.publish_keys(latents, start_pos, cos, sin, lc)
+                    shared.index_src_cache = lc  # an owner always reads its own keys
+                if compress_len == 0:
+                    cidx = mx.zeros((bsz, n, 0), dtype=mx.int32)
+                else:
+                    index_k = shared.index_src_cache.index_k[:bsz, :compress_len]
+                    cidx = self.indexer(
+                        x, qr, start_pos, offset, cos, sin, index_k, shared
+                    )
+                shared.topk_idxs = cidx
+            else:
+                cidx = shared.topk_idxs
+
+            if latents is not None:
+                g0 = start_pos // self.ratio
+                g = latents.shape[1]
+                pos = (g0 + mx.arange(g)) * self.ratio  # group j at position j*ratio
+                latents = rope_tail(latents, rd, cos[pos], sin[pos])
+                latents = fake_quant_fp4_e4m3(latents, 16)
+                lc.comp_kv[:bsz, g0 : g0 + g] = latents.astype(lc.dtype)
+
+            if compress_len:
+                comp = src.comp_kv[:bsz, :compress_len].astype(kv.dtype)
+                kv_all = mx.concatenate([kv_all, comp], axis=1)
+                idxs = mx.concatenate([idxs, cidx], axis=-1)
+
+        sink = mx.zeros_like(self.attn_sink) if self._break_sink else self.attn_sink
+        o = sparse_attn(q, kv_all, sink, idxs, self.softmax_scale)
+
+        # --- inverse rope, grouped block-diagonal output LoRA ---
+        if not self._break_rope_inverse:
+            o = rope_tail(o, rd, c_q, s_q, inverse=True)
+        o = o.reshape(bsz, n, self.n_groups, -1)
+        # QuantizedMultiLinear treats the penultimate axis as matrix rows;
+        # retain a singleton row so the group axis broadcasts against the
+        # leading weight axis instead of being consumed as M.
+        o = self.wo_a(o.astype(mx.float32)[..., None, :]).squeeze(-2)
+        return self.wo_b(o.reshape(bsz, n, -1).astype(x.dtype))

--- a/scripts/deepseek_v41_native/cache.py
+++ b/scripts/deepseek_v41_native/cache.py
@@ -1,0 +1,94 @@
+"""Incremental state for DeepSeek-V4.1 decode and chunked prefill.
+
+Per layer:
+
+* **window ring** — every layer: a circular buffer of ``window_size`` KV
+  entries (position p at slot p % window), values already FP8 fake-quantized;
+* **compressed KV** — kv_source layers only: one FP4-fake-quantized latent per
+  complete group, append-only. Consumer layers hold a *reference* to their
+  source's buffer, so a source's write is immediately visible downstream;
+* **compressor partial group** — ratio>1 sources: fp32 kv/score rows of the
+  open group;
+* **index keys** — layers that are both kv and index sources: the FP4-fake-
+  quantized index-key cache, read by every index source below them.
+
+Model-level: the engram compressed-token-id history, and the global offset.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+
+from .compressor import CompressorState
+from .config import ModelArgs
+
+
+class LayerCache:
+    def __init__(
+        self,
+        bsz: int,
+        args: ModelArgs,
+        layer_id: int,
+        max_seq_len: int,
+        dtype=mx.float32,
+    ):
+        self.window = args.window_size
+        self.ratio = args.compress_ratio(layer_id)
+        self.is_kv_source = layer_id in args.kv_source_layers
+        self.dtype = dtype
+
+        self.win_kv = mx.zeros((bsz, self.window, args.head_dim), dtype=dtype)
+
+        self.comp_kv = None
+        self.comp_state = None
+        self.index_k = None
+        if self.is_kv_source:
+            n_comp = max_seq_len // self.ratio
+            self.comp_kv = mx.zeros((bsz, n_comp, args.head_dim), dtype=dtype)
+            if self.ratio > 1:
+                self.comp_state = CompressorState(bsz, self.ratio, args.head_dim)
+            if layer_id in args.index_source_layers:
+                self.index_k = mx.zeros((bsz, n_comp, args.index_head_dim), dtype=dtype)
+
+    # ---- window ring ----
+
+    def window_chrono(self, pos: int) -> mx.array:
+        """The cached window KV in chronological order: positions
+        [pos - Wp, pos) where Wp = min(pos, window). [b, Wp, head_dim]."""
+        w = self.window
+        wp = min(pos, w)
+        if wp == 0:
+            return self.win_kv[:, :0]
+        first = pos - wp
+        slots = (first + mx.arange(wp)) % w
+        return self.win_kv[:, slots]
+
+    def write_window(self, pos: int, kv: mx.array):
+        """Write chunk KV at positions [pos, pos+n) into the ring."""
+        n = kv.shape[1]
+        keep = min(n, self.window)
+        tail = kv[:, n - keep :]
+        slots = (pos + n - keep + mx.arange(keep)) % self.window
+        self.win_kv[:, slots] = tail.astype(self.dtype)
+
+
+class ModelCache:
+    def __init__(
+        self,
+        args: ModelArgs,
+        bsz: int = 1,
+        max_seq_len: int | None = None,
+        dtype=mx.float32,
+    ):
+        self.max_seq_len = max_seq_len or min(args.max_seq_len, 4096)
+        self.offset = 0
+        self.layers = [
+            LayerCache(bsz, args, i, self.max_seq_len, dtype)
+            for i in range(args.n_layers)
+        ]
+        self.engram_ids = (
+            np.zeros((bsz, self.max_seq_len), dtype=np.int64)
+            if args.engram_layer_ids
+            else None
+        )

--- a/scripts/deepseek_v41_native/compressor.py
+++ b/scripts/deepseek_v41_native/compressor.py
@@ -1,0 +1,92 @@
+"""Learned KV compression — V4.1 pools ``ratio`` consecutive tokens into one latent.
+
+Only the four ``kv_source_layers`` own a compressor; every other compressing
+layer reads the source's cache. Two regimes:
+
+* ``ratio > 1`` (layers 2..19, ratio 2): a learned softmax gate — ``wgate``
+  scores each position, scores softmax across the group, KV vectors summed under
+  those weights. Runs in fp32 (the checkpoint stores these projections wider).
+  No overlap and no ``ape`` slot embedding — both were V4 features that V4.1
+  dropped.
+* ``ratio == 1`` (layer 20, feeding 20..39): a plain per-token projection —
+  no gate, no pooling state, checkpoint-dtype compute.
+
+The returned latent is **pre-RoPE and pre-quantization**: the indexer derives
+its keys from exactly this form, so Attention applies the rope tail and the FP4
+fake-quant afterwards, before writing the shared cache.
+
+This implementation is chunk-general: a chunk starting at ``start_pos`` first
+completes the carried partial group (``kv_state`` / ``score_state`` in the layer
+cache), emits every group the chunk closes, and saves the new remainder. The
+reference only implements full prefill and 1-token decode; both are special
+cases of this path.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ModelArgs
+from .layers import RMSNorm
+
+NEG_INF = float("-inf")
+
+
+class Compressor(nn.Module):
+    def __init__(self, args: ModelArgs, layer_id: int):
+        super().__init__()
+        self.ratio = args.compress_ratio(layer_id)
+        self.head_dim = args.head_dim
+        self.norm = RMSNorm(args.head_dim, args.norm_eps)
+        self.wkv = nn.Linear(args.dim, args.head_dim, bias=False)
+        if self.ratio > 1:
+            self.wgate = nn.Linear(args.dim, args.head_dim, bias=False)
+
+    def __call__(self, x: mx.array, start_pos: int, comp_state) -> mx.array | None:
+        """x [b, n, dim] at absolute positions [start_pos, start_pos+n).
+
+        Returns the pre-RoPE latents [b, g, head_dim] for the ``g`` groups this
+        chunk completes (group indices start_pos//ratio ..), or None when no
+        group completes. ``comp_state`` carries the partial group across calls
+        (unused at ratio 1).
+        """
+        ratio, dtype = self.ratio, x.dtype
+        if ratio == 1:
+            return self.norm(self.wkv(x))
+
+        bsz, n, _ = x.shape
+        xf = x.astype(mx.float32)
+        # Call the modules rather than reading their physical weight arrays.
+        # The 256 GB build retains these projections in affine 2-bit form;
+        # direct matmul would interpret packed uint32 columns as logical input
+        # features. The module call is identical for dense public builds.
+        kv = self.wkv(xf)
+        score = self.wgate(xf)
+
+        m = start_pos % ratio  # carried tokens of the open group
+        if m:
+            kv = mx.concatenate([comp_state.kv_state[:bsz, :m], kv], axis=1)
+            score = mx.concatenate([comp_state.score_state[:bsz, :m], score], axis=1)
+        total = m + n
+        g = total // ratio
+        rem = total % ratio
+        if rem:
+            comp_state.kv_state[:bsz, :rem] = kv[:, total - rem :]
+            comp_state.score_state[:bsz, :rem] = score[:, total - rem :]
+            kv, score = kv[:, : total - rem], score[:, : total - rem]
+        if g == 0:
+            return None
+        kv = kv.reshape(bsz, g, ratio, -1)
+        score = score.reshape(bsz, g, ratio, -1)
+        pooled = mx.sum(kv * mx.softmax(score, axis=2), axis=2)
+        return self.norm(pooled.astype(dtype))
+
+
+class CompressorState:
+    """The open group's per-token kv/score rows, fp32 (mirrors the reference's
+    ``kv_state`` / ``score_state`` buffers)."""
+
+    def __init__(self, bsz: int, ratio: int, head_dim: int):
+        self.kv_state = mx.zeros((bsz, ratio, head_dim), dtype=mx.float32)
+        self.score_state = mx.full((bsz, ratio, head_dim), NEG_INF, dtype=mx.float32)

--- a/scripts/deepseek_v41_native/config.py
+++ b/scripts/deepseek_v41_native/config.py
@@ -1,0 +1,225 @@
+"""Configuration for DeepSeek-V4.1-Flash (MLX port).
+
+Accepts both config layouts that ship with the release:
+
+* the inference-style flat ``config.json`` (``dim``, ``n_layers``,
+  ``kv_source_layers`` ...), and
+* the HF hub ``config.json`` with nested ``text_config`` (``hidden_size``,
+  ``num_hidden_layers``, ``kv_source_layer_ids`` ...).
+
+``compress_ratios`` in the release has ``n_layers + n_mtp_layers`` entries (43 =
+40 + 3); only the first ``n_layers`` matter for this text-only runtime, but the
+full tuple is preserved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+def _get(d: dict, *names, default=None):
+    for n in names:
+        if n in d and d[n] is not None:
+            return d[n]
+    return default
+
+
+@dataclass
+class ModelArgs:
+    vocab_size: int = 129280
+    dim: int = 5120
+    n_layers: int = 40
+    moe_inter_dim: int = 2304
+
+    # attention (MLA): one shared 512-d KV vector per position
+    n_heads: int = 64
+    head_dim: int = 512
+    rope_head_dim: int = 64
+    q_lora_rank: int = 1280
+    o_lora_rank: int = 1024
+    o_groups: int = 8
+    window_size: int = 128
+    norm_eps: float = 1e-20
+
+    # MoE
+    n_routed_experts: int = 384
+    n_shared_experts: int = 1
+    n_activated_experts: int = 6
+    score_func: str = "sqrtsoftplus"
+    gate_temp: float = 1.0
+    norm_topk_prob: bool = True
+    route_scale: float = 1.5
+    swiglu_limit: float = 10.0
+
+    # KV compression / cross-layer sharing.
+    # compress_ratios: one per layer (0 = pure sliding window, 1 = one latent per
+    # token, r>1 = r tokens pooled per latent). Only kv_source_layers own a
+    # compressor + compressed-KV cache; every later layer with the same ratio
+    # reads that cache. index_source_layers own an indexer (top-k selection);
+    # layers in between reuse the most recent source's selection.
+    compress_ratios: tuple[int, ...] = ()
+    kv_source_layers: tuple[int, ...] = ()
+    index_source_layers: tuple[int, ...] = ()
+    compress_rope_theta: float = 160000.0
+
+    # candidate pre-filtering (two-level top-k); -1 disables
+    candidate_source_layer: int = -1
+    candidate_topk_blocks: int = 0
+    candidate_block_size: int = 0
+
+    # rope / YaRN
+    original_seq_len: int = 65536
+    rope_theta: float = 10000.0
+    rope_factor: float = 16.0
+    beta_fast: int = 32
+    beta_slow: int = 1
+    max_seq_len: int = 1048576
+
+    # sparse-attention indexer
+    index_n_heads: int = 32
+    index_head_dim: int = 128
+    index_topk: int = 512
+
+    # hyper-connections
+    hc_mult: int = 4
+    hc_sinkhorn_iters: int = 20
+    hc_eps: float = 1e-6
+
+    # engram: n-gram hash tables added into the residual stream
+    engram_layer_ids: tuple[int, ...] = ()
+    engram_num_embeddings: tuple[int, ...] = ()
+    engram_max_ngram_size: int = 4
+    engram_vocab_size: int = 0
+    engram_n_heads: int = 0
+    engram_head_dim: int = 0
+    engram_pad_id: int = 2
+    engram_compressed_vocab_size: int = 0
+
+    # side-paths dropped for inference (kept for provenance)
+    n_mtp_layers: int = 0
+    dspark_target_layer_ids: tuple[int, ...] = ()
+    vision_n_layers: int = 0
+
+    @property
+    def nope_head_dim(self) -> int:
+        return self.head_dim - self.rope_head_dim
+
+    def compress_ratio(self, layer_id: int) -> int:
+        if layer_id < len(self.compress_ratios):
+            return int(self.compress_ratios[layer_id])
+        return 0
+
+    def kv_source_for(self, layer_id: int) -> int:
+        """The layer whose compressed-KV cache layer ``layer_id`` reads.
+
+        The reference threads a single mutable slot down the layer stack, so a
+        consumer sees whatever the most recent source above it published.
+        """
+        srcs = [s for s in self.kv_source_layers if s <= layer_id]
+        if not srcs:
+            raise ValueError(
+                f"layer {layer_id} compresses but has no kv source above it"
+            )
+        src = max(srcs)
+        if self.compress_ratio(src) != self.compress_ratio(layer_id):
+            raise ValueError(
+                f"layer {layer_id} (ratio {self.compress_ratio(layer_id)}) would read "
+                f"source {src} (ratio {self.compress_ratio(src)})"
+            )
+        return src
+
+    def index_source_for(self, layer_id: int) -> int:
+        srcs = [s for s in self.index_source_layers if s <= layer_id]
+        if not srcs:
+            raise ValueError(f"layer {layer_id} has no index source above it")
+        return max(srcs)
+
+    @classmethod
+    def from_dict(cls, c: dict) -> ModelArgs:
+        if "text_config" in c:  # HF hub layout: fold text_config over the top level
+            top = dict(c)
+            tc = top.pop("text_config")
+            c = {**top, **tc}
+        rope = _get(c, "rope_scaling", default={}) or {}
+        return cls(
+            vocab_size=_get(c, "vocab_size", default=129280),
+            dim=_get(c, "hidden_size", "dim", default=5120),
+            n_layers=_get(c, "num_hidden_layers", "n_layers", default=40),
+            moe_inter_dim=_get(
+                c, "moe_intermediate_size", "moe_inter_dim", default=2304
+            ),
+            n_heads=_get(c, "num_attention_heads", "n_heads", default=64),
+            head_dim=_get(c, "head_dim", default=512),
+            rope_head_dim=_get(c, "qk_rope_head_dim", "rope_head_dim", default=64),
+            q_lora_rank=_get(c, "q_lora_rank", default=1280),
+            o_lora_rank=_get(c, "o_lora_rank", default=1024),
+            o_groups=_get(c, "o_groups", default=8),
+            window_size=_get(c, "sliding_window", "window_size", default=128),
+            norm_eps=_get(c, "rms_norm_eps", "norm_eps", default=1e-20),
+            n_routed_experts=_get(c, "n_routed_experts", default=384),
+            n_shared_experts=_get(c, "n_shared_experts", default=1),
+            n_activated_experts=_get(
+                c, "num_experts_per_tok", "n_activated_experts", default=6
+            ),
+            score_func=_get(c, "scoring_func", "score_func", default="sqrtsoftplus"),
+            gate_temp=_get(c, "gate_temp", default=1.0),
+            norm_topk_prob=_get(c, "norm_topk_prob", default=True),
+            route_scale=_get(c, "routed_scaling_factor", "route_scale", default=1.5),
+            swiglu_limit=_get(c, "swiglu_limit", default=0.0),
+            compress_ratios=tuple(_get(c, "compress_ratios", default=()) or ()),
+            kv_source_layers=tuple(
+                _get(c, "kv_source_layer_ids", "kv_source_layers", default=()) or ()
+            ),
+            index_source_layers=tuple(
+                _get(c, "index_source_layer_ids", "index_source_layers", default=())
+                or ()
+            ),
+            compress_rope_theta=_get(c, "compress_rope_theta", default=160000.0),
+            candidate_source_layer=_get(
+                c, "candidate_source_layer_id", "candidate_source_layer", default=-1
+            ),
+            candidate_topk_blocks=_get(c, "candidate_topk_blocks", default=0),
+            candidate_block_size=_get(c, "candidate_block_size", default=0),
+            original_seq_len=_get(
+                rope,
+                "original_max_position_embeddings",
+                default=_get(c, "original_seq_len", default=65536),
+            ),
+            rope_theta=_get(c, "rope_theta", default=10000.0),
+            rope_factor=_get(
+                rope, "factor", default=_get(c, "rope_factor", default=16.0)
+            ),
+            beta_fast=_get(rope, "beta_fast", default=_get(c, "beta_fast", default=32)),
+            beta_slow=_get(rope, "beta_slow", default=_get(c, "beta_slow", default=1)),
+            max_seq_len=_get(
+                c, "max_position_embeddings", "max_seq_len", default=1048576
+            ),
+            index_n_heads=_get(c, "index_n_heads", default=32),
+            index_head_dim=_get(c, "index_head_dim", default=128),
+            index_topk=_get(c, "index_topk", default=512),
+            hc_mult=_get(c, "hc_mult", default=4),
+            hc_sinkhorn_iters=_get(c, "hc_sinkhorn_iters", default=20),
+            hc_eps=_get(c, "hc_eps", default=1e-6),
+            engram_layer_ids=tuple(_get(c, "engram_layer_ids", default=()) or ()),
+            engram_num_embeddings=tuple(
+                _get(c, "engram_num_embeddings", default=()) or ()
+            ),
+            engram_max_ngram_size=_get(c, "engram_max_ngram_size", default=4),
+            engram_vocab_size=_get(c, "engram_vocab_size", default=0),
+            engram_n_heads=_get(c, "engram_n_heads", default=0),
+            engram_head_dim=_get(c, "engram_head_dim", default=0),
+            engram_pad_id=_get(c, "engram_pad_token_id", "engram_pad_id", default=2),
+            engram_compressed_vocab_size=_get(
+                c, "engram_compressed_vocab_size", default=0
+            ),
+            n_mtp_layers=_get(c, "num_nextn_predict_layers", "n_mtp_layers", default=0),
+            dspark_target_layer_ids=tuple(
+                _get(c, "dspark_target_layer_ids", default=()) or ()
+            ),
+            vision_n_layers=0,  # text-only runtime
+        )
+
+    @property
+    def raw(self) -> dict[str, Any]:
+        return {"model_type": "deepseek_v41"}

--- a/scripts/deepseek_v41_native/convert.py
+++ b/scripts/deepseek_v41_native/convert.py
@@ -1,0 +1,493 @@
+"""Convert the raw DeepSeek-V4.1-Flash release to an MLX build.
+
+The hub release already uses inference-style names (``layers.N.attn.wq_a.weight``,
+``ffn``, ``.scale`` — no ``model.`` prefix, no ``self_attn``/``mlp``/
+``weight_scale_inv``), so sanitizing is mostly dequantization plus expert
+stacking:
+
+* fp8 ``weight``+``scale`` pairs (32x32 ue8m0 blocks) -> bf16;
+* fp4 routed experts (packed nibbles, per-32 ue8m0) -> bf16, stacked per layer
+  into SwitchGLU's ``experts.{gate,up,down}_proj.weight`` (w1/w3/w2);
+* ``engram.embed`` stays in its native fp8+scale form (dequantizing ~197B
+  parameters to bf16 would double 40% of the model); both tensors pass through
+  as uint8;
+* ``hc_*``, ``attn_sink``, ``gate.bias``, ``gate.bias_vl`` -> fp32;
+* ``mtp.*`` (the DSpark/MTP draft stack) is dropped — it hangs off the
+  reference's separate ``forward_spec`` path;
+* the vision tower (``vision.*``, ``aligner.*``, ``image_start/end/newline``)
+  is carried through **unchanged** under its original names. The text-only
+  runtime does not load it, but the tensors stay in the build (they are bf16
+  and small, ~0.8 GB) so nothing silently vanishes; ``load.py`` accounts for
+  them explicitly.
+
+Quantization (optional): MLX affine quantization applied per module, experts at
+``expert_bits`` and everything else at ``bits``. Rapid-MLX represents ``wo_a``
+as a group-aware ``MultiLinear``, so it can remain quantized without reshaping
+packed uint32 storage.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+from typing import Any, cast
+
+import mlx.core as mx
+
+from .dequant import dequant_fp4, dequant_fp8, is_fp4_expert
+
+VISION_PREFIXES = ("vision.", "aligner.", "image_start", "image_end", "image_newline")
+
+# modules kept at bf16 even when quantizing (beyond shape-ineligible ones):
+#   engram.embed  — stays in native fp8+ue8m0, dequantized per lookup
+#   compressor.*  — tiny, and the ratio>1 projections run in fp32
+#   indexer.wk / weights_proj — tiny, and they drive discrete top-k selection
+_NEVER_QUANT = re.compile(
+    r"(\.engram\.embed\.|\.compressor\.|\.indexer\.wk\.|\.weights_proj\.)"
+)
+
+
+def is_quant_target(name: str, in_dim: int, group_size: int) -> bool:
+    if not name.endswith(".weight"):
+        return False
+    if _NEVER_QUANT.search(name):
+        return False
+    if in_dim % group_size:
+        return False
+    tail = name.rsplit(".", 2)
+    quantizable = (
+        "wq_a",
+        "wq_b",
+        "wkv",
+        "wo_a",
+        "wo_b",
+        "w1",
+        "w2",
+        "w3",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+        "embed",
+        "head",
+    )
+    return len(tail) >= 2 and tail[-2] in quantizable
+
+
+def bits_for(name: str, bits: int, expert_bits: int | None) -> int:
+    if expert_bits and is_fp4_expert(name):
+        return expert_bits
+    return bits
+
+
+def _shard_iter(src: str):
+    index_path = os.path.join(src, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        wmap = json.load(open(index_path))["weight_map"]
+        return wmap
+    wmap = {}
+    for f in sorted(glob.glob(os.path.join(src, "*.safetensors"))):
+        for k in mx.load(f):
+            wmap[k] = os.path.basename(f)
+    return wmap
+
+
+def _to_u8(a: mx.array) -> mx.array:
+    """Raw release bytes (fp8 values / ue8m0 scales) as uint8, however stored."""
+    if a.dtype in (mx.uint8, mx.int8):
+        return a.view(mx.uint8)
+    return a.view(mx.uint8)
+
+
+def sanitize_group(
+    names: list[str], tensors: dict[str, mx.array], dtype=mx.bfloat16
+) -> dict[str, mx.array]:
+    """Sanitize one coherent group of raw tensors (a layer, or the top level).
+
+    Returns final-name -> array. ``mtp.*`` must be filtered by the caller;
+    vision tensors pass through unchanged.
+    """
+    out: dict[str, mx.array] = {}
+    consumed = set()
+    expert_parts: dict[str, dict[int, mx.array]] = {}
+
+    for name in names:
+        if name in consumed:
+            continue
+        if name.startswith(VISION_PREFIXES):
+            out[name] = tensors[name]
+            continue
+        if name.endswith(".scale"):
+            continue  # handled with its weight
+        t = tensors[name]
+
+        if ".engram.embed." in name:  # stays native fp8 + ue8m0
+            out[name] = _to_u8(t)
+            engram_scale_name = name[: -len(".weight")] + ".scale"
+            out[engram_scale_name] = _to_u8(tensors[engram_scale_name])
+            consumed.add(engram_scale_name)
+            continue
+
+        scale_name = (
+            name[: -len(".weight")] + ".scale" if name.endswith(".weight") else None
+        )
+        if scale_name is not None and scale_name in tensors:
+            consumed.add(scale_name)
+            s = _to_u8(tensors[scale_name])
+            if is_fp4_expert(name):
+                w = dequant_fp4(t, s, dtype)
+            else:
+                w = dequant_fp8(_to_u8(t), s, dtype)
+        else:
+            w = t
+
+        m = re.match(r"(layers\.\d+\.ffn\.experts)\.(\d+)\.(w[123])\.weight$", name)
+        if m:
+            prefix, idx, wn = m.group(1), int(m.group(2)), m.group(3)
+            proj = {"w1": "gate_proj", "w3": "up_proj", "w2": "down_proj"}[wn]
+            expert_parts.setdefault(f"{prefix}.{proj}.weight", {})[idx] = w
+            continue
+
+        if re.search(r"(hc_\w+|attn_sink|gate\.bias(_vl)?)$", name):
+            w = w.astype(mx.float32)
+        out[name] = w
+
+    for final, parts in expert_parts.items():
+        n = len(parts)
+        assert sorted(parts) == list(range(n)), f"missing experts for {final}"
+        out[final] = mx.stack([parts[i] for i in range(n)])
+
+    orphans = [
+        n
+        for n in names
+        if n.endswith(".scale")
+        and n not in consumed
+        and not n.startswith(VISION_PREFIXES)
+    ]
+    if orphans:
+        raise ValueError(
+            f"{len(orphans)} scale tensors without a weight, "
+            f"e.g. {orphans[:3]} — layout change?"
+        )
+    return out
+
+
+def quantize_tree(
+    weights: dict[str, mx.array], bits: int, expert_bits: int | None, group_size: int
+) -> tuple[dict[str, mx.array], dict[str, dict]]:
+    """Replace eligible ``.weight`` tensors with MLX affine (weight, scales,
+    biases) triples, matching what ``nn.quantize`` produces at load time.
+    Also returns the per-module map {module path: {group_size, bits}} that
+    config.json carries for the loader to replay."""
+    out = {}
+    modules: dict[str, dict] = {}
+    for name, w in weights.items():
+        if name.startswith(VISION_PREFIXES) or not is_quant_target(
+            name, w.shape[-1], group_size
+        ):
+            out[name] = w
+            continue
+        b = bits_for(name, bits, expert_bits)
+        wq, scales, biases = mx.quantize(w, group_size=group_size, bits=b)
+        base = name[: -len(".weight")]
+        out[f"{base}.weight"] = wq
+        out[f"{base}.scales"] = scales
+        out[f"{base}.biases"] = biases
+        modules[base] = {"group_size": group_size, "bits": b}
+    return out, modules
+
+
+def quantize_engram_table(
+    weight_u8: mx.array, scale_u8: mx.array, bits: int, group_size: int
+) -> dict[str, mx.array]:
+    """Native fp8+ue8m0 table (already in memory) -> MLX affine triple, in row
+    chunks. NOTE: evaluating any chunk of a lazily-loaded mx tensor
+    materializes the WHOLE load node, so for the 98 GB release tables use
+    :func:`quantize_engram_table_from_file`, which slices rows from disk.
+    This in-memory variant serves tests and the ladder's gathered rows."""
+    from .dequant import dequant_fp8_rows
+
+    rows = weight_u8.shape[0]
+    step = 1 << 22
+    cw, cs, cb = [], [], []
+    for i in range(0, rows, step):
+        deq = dequant_fp8_rows(weight_u8[i : i + step], scale_u8[i : i + step])
+        w, s, b = mx.quantize(deq.astype(mx.bfloat16), group_size=group_size, bits=bits)
+        mx.eval(w, s, b)
+        cw.append(w)
+        cs.append(s)
+        cb.append(b)
+    return {
+        "weight": mx.concatenate(cw),
+        "scales": mx.concatenate(cs),
+        "biases": mx.concatenate(cb),
+    }
+
+
+def quantize_engram_table_from_file(
+    src_dir: str,
+    wmap: dict,
+    wname: str,
+    bits: int,
+    group_size: int,
+    step: int = 1 << 22,
+) -> dict[str, mx.array]:
+    """Stream a release engram table off disk in row chunks (safetensors row
+    slicing — never materializes the 98 GB tensor) into an MLX affine triple.
+    Chunk arithmetic is identical to :func:`quantize_engram_table` (affine
+    quantization is row-local)."""
+    import torch
+    from safetensors import safe_open
+
+    from .dequant import dequant_fp8_rows
+
+    sname = wname[: -len(".weight")] + ".scale"
+    fw = safe_open(os.path.join(src_dir, wmap[wname]), framework="pt")
+    fs = (
+        fw
+        if wmap[sname] == wmap[wname]
+        else safe_open(os.path.join(src_dir, wmap[sname]), framework="pt")
+    )
+    slw, sls = fw.get_slice(wname), fs.get_slice(sname)
+    rows = slw.get_shape()[0]
+    cw, cs, cb = [], [], []
+    for i in range(0, rows, step):
+        w_u8 = mx.array(slw[i : i + step].view(torch.uint8).numpy())
+        s_u8 = mx.array(sls[i : i + step].view(torch.uint8).numpy())
+        deq = dequant_fp8_rows(w_u8, s_u8)
+        w, s, b = mx.quantize(deq.astype(mx.bfloat16), group_size=group_size, bits=bits)
+        mx.eval(w, s, b)
+        cw.append(w)
+        cs.append(s)
+        cb.append(b)
+        del w_u8, s_u8, deq
+        mx.clear_cache()
+    return {
+        "weight": mx.concatenate(cw),
+        "scales": mx.concatenate(cs),
+        "biases": mx.concatenate(cb),
+    }
+
+
+def _group_tag(g: str) -> str:
+    if g.startswith("layers."):
+        return f"layers-{int(g.split('.')[1]):02d}"
+    return g
+
+
+def _stream_raw_copy(
+    src_dir: str,
+    wmap: dict,
+    names: list[str],
+    out_path: str,
+    chunk_bytes: int = 1 << 28,
+):
+    """Byte-stream tensors from source shards into one new safetensors file,
+    preserving their stored dtype tags, without materializing them (the native
+    engram tables are ~101 GB each). All passthrough dtypes are 1 byte/elt."""
+    import struct
+
+    from safetensors import safe_open
+
+    handles: dict[str, Any] = {}
+    entries = []
+    off = 0
+    for n in names:
+        f = os.path.join(src_dir, wmap[n])
+        if f not in handles:
+            handles[f] = safe_open(f, framework="pt")
+        sl = handles[f].get_slice(n)
+        shape, dt = sl.get_shape(), sl.get_dtype()
+        nbytes = 1
+        for s in shape:
+            nbytes *= s
+        entries.append((n, dt, shape, off, off + nbytes, sl))
+        off += nbytes
+    header = {
+        n: {"dtype": dt, "shape": list(shape), "data_offsets": [a, b]}
+        for n, dt, shape, a, b, _ in entries
+    }
+    hjson = json.dumps(header, separators=(",", ":")).encode()
+    pad = (-len(hjson)) % 8
+    hjson += b" " * pad
+    tmp = out_path + ".tmp"
+    with open(tmp, "wb") as out:
+        out.write(struct.pack("<Q", len(hjson)))
+        out.write(hjson)
+        for n, dt, shape, a, b, sl in entries:
+            row_bytes = max(1, (b - a) // max(shape[0], 1))
+            step = max(1, chunk_bytes // row_bytes)
+            for i in range(0, shape[0], step):
+                t = sl[i : i + step]
+                out.write(t.view(__import__("torch").uint8).numpy().tobytes())
+    os.replace(tmp, out_path)
+
+
+def _read_st_header(path: str) -> dict:
+    import struct
+
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        return cast(dict[Any, Any], json.loads(f.read(n)))
+
+
+def convert(
+    src: str,
+    dst: str,
+    bits: int | None = None,
+    expert_bits: int | None = None,
+    engram_bits: int | None = None,
+    group_size: int = 64,
+    dtype=mx.bfloat16,
+    resume: bool = False,
+) -> dict:
+    """Stream the release group by group (top level, each layer, vision) into
+    an MLX build at ``dst`` — one output shard per group, written to a temp
+    name and renamed on completion, so ``resume=True`` skips every finished
+    group at a clean layer boundary.
+
+    ``engram_bits`` re-quantizes the two engram tables from native fp8+ue8m0
+    (203 GB total) to MLX affine, streamed in row chunks (never materialized
+    whole); ``None`` keeps them native, byte-streamed into their own shard.
+
+    ``config.json`` gets a ``quantization`` block with defaults plus an
+    explicit per-module map keyed by runtime-internal module paths.
+    Returns {kept, dropped_mtp, vision_passthrough}.
+    """
+    os.makedirs(dst, exist_ok=True)
+    wmap = _shard_iter(src)
+
+    def owner(name: str) -> str:
+        m = re.match(r"(layers\.\d+)\.", name)
+        if m:
+            return m.group(1)
+        if name.startswith("mtp."):
+            return "mtp"
+        if name.startswith(VISION_PREFIXES):
+            return "vision"
+        return "top"
+
+    groups: dict[str, list[str]] = {}
+    for name in wmap:
+        groups.setdefault(owner(name), []).append(name)
+    accounting = {
+        "kept": 0,
+        "dropped_mtp": len(groups.pop("mtp", [])),
+        "vision_passthrough": 0,
+    }
+
+    shard_cache: dict[str, dict] = {}
+
+    def fetch(names):
+        res = {}
+        for n in names:
+            f = wmap[n]
+            if f not in shard_cache:
+                shard_cache.clear()
+                shard_cache[f] = mx.load(os.path.join(src, f))
+            res[n] = shard_cache[f][n]
+        return res
+
+    order = ["top"] + sorted(
+        (g for g in groups if g.startswith("layers.")),
+        key=lambda s: int(s.split(".")[1]),
+    )
+    if "vision" in groups:
+        order.append("vision")
+
+    index: dict[str, str] = {}
+    module_map: dict[str, dict] = {}
+
+    for g in order:
+        tag = _group_tag(g)
+        names = sorted(groups[g])
+        out_files = {"main": os.path.join(dst, f"model-{tag}.safetensors")}
+        engram_pair = [n for n in names if ".engram.embed." in n]
+        if engram_pair:
+            out_files["engram"] = os.path.join(dst, f"model-{tag}-engram.safetensors")
+        manifest_path = os.path.join(dst, f"model-{tag}.manifest.json")
+
+        if (
+            resume
+            and os.path.exists(manifest_path)
+            and all(os.path.exists(p) for p in out_files.values())
+        ):
+            man = json.load(open(manifest_path))
+        else:
+            work = [n for n in names if n not in engram_pair]
+            sane = sanitize_group(work, fetch(work), dtype)
+            grp_modules: dict[str, dict] = {}
+            if bits and g != "vision":
+                sane, grp_modules = quantize_tree(sane, bits, expert_bits, group_size)
+            for v in sane.values():
+                mx.eval(v)
+            tmp = out_files["main"] + ".tmp.safetensors"
+            mx.save_safetensors(tmp, sane)
+            os.replace(tmp, out_files["main"])
+            engram_names = []
+            if engram_pair and engram_bits:
+                wname = next(n for n in engram_pair if n.endswith(".weight"))
+                base = wname[: -len(".weight")]
+                triple = quantize_engram_table_from_file(
+                    src, wmap, wname, engram_bits, group_size
+                )
+                shard = {f"{base}.{suf}": v for suf, v in triple.items()}
+                tmp = out_files["engram"] + ".tmp.safetensors"
+                mx.save_safetensors(tmp, shard)
+                os.replace(tmp, out_files["engram"])
+                engram_names = sorted(shard)
+                del triple, shard
+                mx.clear_cache()
+            elif engram_pair:
+                _stream_raw_copy(src, wmap, engram_pair, out_files["engram"])
+                engram_names = engram_pair
+            man = {
+                "files": {
+                    os.path.basename(out_files["main"]): sorted(sane),
+                    **(
+                        {os.path.basename(out_files["engram"]): engram_names}
+                        if engram_pair
+                        else {}
+                    ),
+                },
+                "modules": grp_modules,
+            }
+            json.dump(man, open(manifest_path, "w"))
+            del sane
+            mx.clear_cache()
+
+        for fname, tnames in man["files"].items():
+            for t in tnames:
+                index[t] = fname
+            accounting["kept"] += len(tnames)
+            if g == "vision":
+                accounting["vision_passthrough"] += len(tnames)
+        module_map.update(man["modules"])
+
+    json.dump(
+        {"metadata": {}, "weight_map": index},
+        open(os.path.join(dst, "model.safetensors.index.json"), "w"),
+    )
+
+    cfg_path = os.path.join(src, "config.json")
+    cfg = json.load(open(cfg_path)) if os.path.exists(cfg_path) else {}
+    out_cfg = dict(cfg)
+    out_cfg["model_type"] = "deepseek_v41"
+    if bits or engram_bits:
+        out_cfg["quantization"] = {
+            "group_size": group_size,
+            "bits": bits,
+            "expert_bits": expert_bits,
+            "engram_bits": engram_bits,
+            "modules": module_map,
+        }
+    json.dump(out_cfg, open(os.path.join(dst, "config.json"), "w"), indent=2)
+
+    for f in ("tokenizer.json", "tokenizer_config.json"):
+        p = os.path.join(src, f)
+        if os.path.exists(p):
+            import shutil
+
+            shutil.copyfile(p, os.path.join(dst, f))
+    return accounting

--- a/scripts/deepseek_v41_native/dequant.py
+++ b/scripts/deepseek_v41_native/dequant.py
@@ -1,0 +1,102 @@
+"""Dequantize the natively-quantized V4.1 release to bf16.
+
+Release formats (``quantization_config``: fp8, weight_block_size [32,32],
+scale_fmt ue8m0, expert_dtype fp4; every scale tensor is named ``<w>.scale``):
+
+* **FP8 matmul weights** — e4m3 ``[out, in]`` with one **ue8m0** scale per
+  ``32x32`` block: ``scale[ceil(out/32), ceil(in/32)]``. (V4 used 128x128.)
+* **Routed experts** — FP4 e2m1 packed two per byte ``[out, in//2]`` (low nibble
+  = even input index) with one ue8m0 scale per 32 values along in:
+  ``scale[out, in//32]``.
+* **Engram tables** — FP8 e4m3 ``[rows, 256]`` with one ue8m0 scale per 32
+  values along the row: ``scale[rows, 8]``. These stay quantized at runtime
+  (198 GB dequantized to bf16 would double their footprint); rows are
+  dequantized on lookup, exactly as the reference does.
+
+ue8m0 is exponent-only: byte ``b`` means ``2**(b-127)``. Every scale is an exact
+power of two, so applying it is lossless in fp32.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+FP8_BLOCK = 32  # e4m3 weights: 32x32 scale blocks
+FP4_BLOCK = 32  # e2m1 experts: 32 values per scale, along the input dim
+
+# FP4 e2m1 code -> value; code 8 ("negative zero") maps to +0.0, matching
+# FP4_TABLE in the reference convert.py.
+_E2M1 = [
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+]
+
+
+def e8m0_to_float(scale_u8: mx.array) -> mx.array:
+    """Decode exponent-only scales: byte b -> 2**(b-127)."""
+    e = scale_u8.astype(mx.int32)
+    return mx.power(mx.array(2.0, mx.float32), (e - 127).astype(mx.float32))
+
+
+def _expand_blocks(scale: mx.array, rows: int, cols: int, br: int, bc: int) -> mx.array:
+    """Broadcast a per-block scale grid to full [rows, cols], cropping ceil overhang."""
+    s = mx.repeat(mx.repeat(scale, br, axis=0), bc, axis=1)
+    return s[:rows, :cols]
+
+
+def dequant_fp8(weight_u8: mx.array, scale_u8: mx.array, dtype=mx.bfloat16) -> mx.array:
+    """FP8 e4m3 [out, in] + ue8m0 [ceil(out/32), ceil(in/32)] -> dtype."""
+    w = mx.from_fp8(weight_u8, mx.float32)
+    rows, cols = w.shape
+    s = _expand_blocks(e8m0_to_float(scale_u8), rows, cols, FP8_BLOCK, FP8_BLOCK)
+    return (w * s).astype(dtype)
+
+
+def unpack_fp4(packed: mx.array) -> mx.array:
+    """[out, in//2] of two e2m1 nibbles -> float32 [out, in]. Low nibble = even index."""
+    b = packed.view(mx.uint8).astype(mx.int32)
+    lo = b & 0x0F
+    hi = (b >> 4) & 0x0F
+    lut = mx.array(_E2M1, mx.float32)
+    vals = mx.stack([lut[lo], lut[hi]], axis=-1)  # [out, in//2, 2]
+    return vals.reshape(vals.shape[0], -1)
+
+
+def dequant_fp4(packed: mx.array, scale_u8: mx.array, dtype=mx.bfloat16) -> mx.array:
+    """Packed FP4 e2m1 [out, in//2] + ue8m0 [out, in//32] -> dtype."""
+    w = unpack_fp4(packed)
+    rows, cols = w.shape
+    s = _expand_blocks(e8m0_to_float(scale_u8), rows, cols, 1, FP4_BLOCK)
+    return (w * s).astype(dtype)
+
+
+def dequant_fp8_rows(
+    weight_u8: mx.array, scale_u8: mx.array, block: int = 32
+) -> mx.array:
+    """Engram-table layout: e4m3 [..., d] + ue8m0 [..., d//block] -> float32.
+
+    Row-wise groups along the last axis (matches ParallelEngramEmbedding.forward).
+    """
+    w = mx.from_fp8(weight_u8, mx.float32)
+    s = e8m0_to_float(scale_u8)
+    wv = w.reshape(*w.shape[:-1], w.shape[-1] // block, block)
+    return (wv * s[..., None]).reshape(w.shape)
+
+
+def is_fp4_expert(name: str) -> bool:
+    """Routed-expert matmuls are the FP4 ones; shared experts are FP8."""
+    return ".experts." in name and ".shared_experts." not in name

--- a/scripts/deepseek_v41_native/engram.py
+++ b/scripts/deepseek_v41_native/engram.py
@@ -1,0 +1,291 @@
+"""Engram — n-gram hash lookups added into the residual stream at a few layers.
+
+Layers 1 and 14 of the release each carry a ~384M-row fp8 embedding table
+(~100 GB each; together ~40% of the checkpoint). A position is hashed as the
+2-, 3- and 4-gram ending there, each split over 8 heads; every (n-gram size,
+head) pair owns a disjoint prime-sized bucket range, primes drawn in order from
+``engram_vocab_size`` upward and never reused. Hashing runs over a *compressed*
+token map (case/accent/whitespace-normalized), so " The"/"the"/"THE" collapse.
+
+The hash: per layer, one odd int64 multiplier per lookback position (seeded
+``default_rng(10007 * layer_id)``); the running XOR of ``token * multiplier``
+after i steps is the (i+1)-gram hash, taken mod each head's prime. Lookback
+stops at the sequence start (and at image spans, which this text-only runtime
+never produces); blocked slots read the compressed pad token.
+
+Decode needs the previous 3 compressed ids, so :class:`EngramHasher` keeps a
+per-sequence id cache — the model's cache object owns one.
+
+The lookup itself (:class:`Engram`) fetches 24 rows of 256, projects them with
+``wkv`` into one key per hyper-connection copy plus one shared value, and gates
+the value into the stream by a normalized stream-key dot product pushed through
+``sigmoid(signed sqrt)``.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .config import ModelArgs
+from .dequant import dequant_fp8_rows
+
+
+def _isprime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n % 2 == 0:
+        return n == 2
+    i = 3
+    while i * i <= n:
+        if n % i == 0:
+            return False
+        i += 2
+    return True
+
+
+def find_next_prime(start: int, seen: set[int]) -> int:
+    c = start + 1
+    while not _isprime(c) or c in seen:
+        c += 1
+    return c
+
+
+def build_layout(args: ModelArgs):
+    """Per-layer primes [n_layers][ngram-1][heads], and per-layer flat offsets.
+
+    Primes are drawn sequentially across layers from ``engram_vocab_size - 1``
+    upward, matching ``EngramLayout.from_args`` — so the sum of one layer's 24
+    primes must equal its ``engram_num_embeddings`` entry.
+    """
+    primes, seen = [], set[int]()
+    for _ in args.engram_layer_ids:
+        per_ngram = []
+        for _ in range(args.engram_max_ngram_size - 1):
+            sizes, current = [], args.engram_vocab_size - 1
+            for _ in range(args.engram_n_heads):
+                current = find_next_prime(current, seen)
+                seen.add(current)
+                sizes.append(current)
+            per_ngram.append(sizes)
+        primes.append(per_ngram)
+    flat = [[p for per_ngram in layer for p in per_ngram] for layer in primes]
+    offsets = [np.cumsum([0, *sizes[:-1]]) for sizes in flat]
+    return np.asarray(primes, dtype=np.int64), np.asarray(offsets, dtype=np.int64)
+
+
+def compute_hash_multipliers(
+    layer_ids, max_ngram_size: int, compressed_vocab_size: int
+) -> np.ndarray:
+    """One odd multiplier per (layer, lookback), bounded so token*mult fits int64."""
+    max_long = np.iinfo(np.int64).max
+    bound = max(1, (max_long // compressed_vocab_size) // 2)
+    rows = []
+    for layer_id in layer_ids:
+        g = np.random.default_rng(10007 * layer_id)
+        v = g.integers(low=0, high=bound, size=(max_ngram_size,), dtype=np.int64)
+        rows.append(v * 2 + 1)
+    return np.stack(rows)
+
+
+def build_compressed_token_map(tokenizer):
+    """Token id -> compressed id, collapsing tokens that normalize alike.
+
+    Transcribed from the reference ``engram.py``; needs the ``tokenizers``
+    package and the release tokenizer. Tests inject a map directly instead.
+    """
+    from tokenizers import Regex, normalizers
+
+    sentinel = ""
+    normalizer = normalizers.Sequence(
+        [
+            normalizers.NFKC(),
+            normalizers.NFD(),
+            normalizers.StripAccents(),
+            normalizers.Lowercase(),
+            normalizers.Replace(Regex(r"[ \t\r\n]+"), " "),
+            normalizers.Replace(Regex(r"^ $"), sentinel),
+            normalizers.Strip(),
+            normalizers.Replace(sentinel, " "),
+        ]
+    )
+    backend = tokenizer.backend_tokenizer
+    key_to_new: dict = {}
+    lookup = [0] * len(tokenizer)
+    for token_id in range(len(tokenizer)):
+        text = backend.decode([token_id], skip_special_tokens=False)
+        if "�" in text:
+            key = backend.id_to_token(token_id)
+        else:
+            normalized = normalizer.normalize_str(text)
+            key = normalized if normalized else text
+        new_id = key_to_new.get(key)
+        if new_id is None:
+            new_id = len(key_to_new)
+            key_to_new[key] = new_id
+        lookup[token_id] = new_id
+    return lookup, len(key_to_new)
+
+
+class EngramHasher:
+    """Maps positions to the hash ids of the n-grams ending there (numpy, int64).
+
+    Stateless over weights; the per-sequence compressed-id history lives in the
+    ``ids_cache`` array the caller passes (see ``cache.ModelCache.engram_ids``).
+    """
+
+    def __init__(self, args: ModelArgs, token_map):
+        self.args = args
+        self.max_ngram = args.engram_max_ngram_size
+        self.token_map = np.asarray(token_map, dtype=np.int64)
+        n_compressed = int(self.token_map.max()) + 1
+        if (
+            args.engram_compressed_vocab_size
+            and n_compressed != args.engram_compressed_vocab_size
+        ):
+            raise ValueError(
+                f"compressed vocab {n_compressed} != config "
+                f"{args.engram_compressed_vocab_size}; every hash multiplier is "
+                f"derived from it, so a mismatch silently rehashes the table"
+            )
+        self.pad_id = int(self.token_map[args.engram_pad_id])
+        self.primes, self.offsets = build_layout(args)  # [L, G-1, H], [L, cols]
+        self.multipliers = compute_hash_multipliers(
+            args.engram_layer_ids, self.max_ngram, n_compressed
+        )  # [L, G]
+        # sanity: bucket layout must match the declared table sizes
+        sums = self.primes.reshape(len(args.engram_layer_ids), -1).sum(-1)
+        if tuple(int(s) for s in sums) != tuple(args.engram_num_embeddings):
+            raise ValueError(
+                f"prime sums {sums} != engram_num_embeddings "
+                f"{args.engram_num_embeddings}"
+            )
+
+    def __call__(
+        self, input_ids: np.ndarray, start_pos: int, ids_cache: np.ndarray
+    ) -> np.ndarray:
+        """input_ids [B, L] -> hash ids [B, L, n_engram_layers, (G-1)*H].
+
+        ``ids_cache`` [B, max_seq] carries compressed ids across chunks; this
+        call writes positions [start_pos, start_pos+L) into it.
+        """
+        input_ids = np.asarray(input_ids)
+        batch, seqlen = input_ids.shape
+        compressed = self.token_map[input_ids]
+        ids_cache[:batch, start_pos : start_pos + seqlen] = compressed
+
+        positions = np.broadcast_to(
+            np.arange(start_pos, start_pos + seqlen), (batch, seqlen)
+        )
+        tokens, blocked = [], np.zeros_like(positions, dtype=bool)
+        for shift in range(self.max_ngram):
+            src_pos = np.clip(positions - shift, 0, None)
+            source = np.take_along_axis(ids_cache[:batch], src_pos, axis=1)
+            blocked = blocked | (positions < shift)
+            tokens.append(np.where(blocked, self.pad_id, source))
+        tokens = np.stack(tokens, axis=-1)  # [B, L, G]
+
+        products = tokens[:, :, None, :] * self.multipliers  # [B, L, nL, G]
+        rolling, hashes = products[..., 0], []
+        for i in range(1, self.max_ngram):
+            rolling = np.bitwise_xor(rolling, products[..., i])
+            hashes.append(rolling[..., None] % self.primes[:, i - 1])  # [B, L, nL, H]
+        return np.concatenate(hashes, axis=-1) + self.offsets
+
+
+class EngramEmbedding(nn.Module):
+    """The hash table; stays fp8 in memory, rows dequantized on lookup.
+
+    ``weight`` uint8 [rows, d] (fp8 e4m3 bytes) + ``scale`` uint8 [rows, d//32]
+    (ue8m0) for the real checkpoint; float ``weight``/``scale`` (fp8 values and
+    power-of-two scales as floats) for tests.
+    """
+
+    def __init__(self, num_embeddings: int, dim: int, block: int = 32):
+        super().__init__()
+        self.block = block
+        self.weight = mx.zeros((num_embeddings, dim), dtype=mx.uint8)
+        self.scale = mx.ones((num_embeddings, dim // block), dtype=mx.uint8)
+
+    def __call__(self, indices: mx.array) -> mx.array:
+        v = self.weight[indices]  # [..., d]
+        s = self.scale[indices]  # [..., d//block]
+        if self.weight.dtype == mx.uint8:
+            return dequant_fp8_rows(v, s, self.block)
+        vf = v.astype(mx.float32).reshape(
+            *v.shape[:-1], v.shape[-1] // self.block, self.block
+        )
+        return (vf * s.astype(mx.float32)[..., None]).reshape(v.shape)
+
+
+class QuantizedEngramEmbedding(nn.Module):
+    """The hash table in MLX affine quantization (weight/scales/biases), rows
+    dequantized on lookup. Used when the build was converted with
+    ``engram_bits`` — the native fp8 table alone is 203 GB, which does not
+    leave room for the rest of the model on a 512 GB machine."""
+
+    def __init__(
+        self, num_embeddings: int, dim: int, group_size: int = 64, bits: int = 4
+    ):
+        super().__init__()
+        self.group_size, self.bits = group_size, bits
+        self.weight = mx.zeros((num_embeddings, dim * bits // 32), dtype=mx.uint32)
+        self.scales = mx.zeros((num_embeddings, dim // group_size), dtype=mx.bfloat16)
+        self.biases = mx.zeros((num_embeddings, dim // group_size), dtype=mx.bfloat16)
+
+    def __call__(self, indices: mx.array) -> mx.array:
+        out = mx.dequantize(
+            self.weight[indices],
+            scales=self.scales[indices],
+            biases=self.biases[indices],
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+        return out.astype(mx.float32)
+
+
+class Engram(nn.Module):
+    """Gated write of the n-gram lookup into the hc-expanded residual stream."""
+
+    def __init__(self, args: ModelArgs, layer_hash_index: int):
+        super().__init__()
+        self.layer_hash_index = layer_hash_index
+        self.dim = args.dim
+        self.hc_mult = args.hc_mult
+        self.eps = args.norm_eps
+        self.clamp_value = 1e-6
+
+        n_hash_cols = (args.engram_max_ngram_size - 1) * args.engram_n_heads
+        self.embed = EngramEmbedding(
+            args.engram_num_embeddings[layer_hash_index], args.engram_head_dim
+        )
+        self.wkv = nn.Linear(
+            n_hash_cols * args.engram_head_dim,
+            args.dim * (args.hc_mult + 1),
+            bias=False,
+        )
+        self.q_weight = mx.ones((args.hc_mult, args.dim), dtype=mx.float32)
+        self.k_weight = mx.ones((args.hc_mult, args.dim), dtype=mx.float32)
+
+    def __call__(self, x: mx.array, hash_ids: mx.array) -> mx.array:
+        """x [B, L, hc, dim]; hash_ids [B, L, n_hash_cols]."""
+        rows = self.embed(hash_ids)  # [B, L, cols, hd] fp32
+        rows = rows.reshape(*rows.shape[:-2], -1).astype(x.dtype)
+        kv = self.wkv(rows)  # [B, L, (hc+1)*dim]
+        key = kv[..., : self.hc_mult * self.dim].astype(mx.float32)
+        value = kv[..., self.hc_mult * self.dim :].astype(mx.float32)
+        key = key.reshape(*key.shape[:-1], self.hc_mult, self.dim)
+
+        weight = self.q_weight.astype(mx.float32) * self.k_weight.astype(mx.float32)
+        h = x.astype(mx.float32)
+        # normalized per (token, hc copy) over dim, NOT jointly over the copies
+        rstd = mx.rsqrt(mx.mean(mx.square(h), axis=-1) + self.eps) * mx.rsqrt(
+            mx.mean(mx.square(key), axis=-1) + self.eps
+        )
+        dot = mx.sum(h * weight * key, axis=-1) * rstd * self.dim**-0.5
+        # signed sqrt before the sigmoid, matching the training kernel
+        mag = mx.sqrt(mx.maximum(mx.abs(dot), self.clamp_value))
+        gate = mx.sigmoid(mx.where(dot < 0, -mag, mag))
+        out = h + gate[..., None] * value[..., None, :]
+        return out.astype(x.dtype)

--- a/scripts/deepseek_v41_native/fakequant.py
+++ b/scripts/deepseek_v41_native/fakequant.py
@@ -1,0 +1,119 @@
+"""Activation fake-quantization — the inference-time half of V4.1's QAT.
+
+The reference *simulates* its training-time quantization on several activations:
+they are rounded through FP8 or FP4 and written back before use (the
+``inplace=True`` calls to ``act_quant`` / ``fp4_act_quant``). Skipping them
+changes the numbers the model was trained to see. V4.1 applies:
+
+* **window KV** — FP8 e4m3, blocks of 32, ue8m0 (power-of-two) scales, over the
+  *whole* 512-d vector, rope tail included (V4 spared the rope tail; V4.1 does not);
+* **compressed KV latents** — FP4 e2m1, blocks of **16**, **e4m3** scales;
+* **indexer queries and keys** — FP4 e2m1, blocks of 32, ue8m0 scales.
+
+Scale semantics (from ``kernel.py``):
+
+* ue8m0: ``2**ceil(log2(amax * (1/max)))`` with amax clamped to a format-specific
+  floor first (1e-4 for FP8, 6*2^-126 for FP4). The ceil is computed here by IEEE
+  bit manipulation, exactly as ``fast_round_scale`` does, so boundary cases match.
+* e4m3-scale: ``amax`` clamped to ``6*2^-9`` (the smallest e4m3 subnormal times
+  fp4_max), then ``amax/6`` rounded to the nearest e4m3 value.
+
+FP4 rounding is round-to-nearest-even on the e2m1 grid
+{0, .5, 1, 1.5, 2, 3, 4, 6}: ties at .25/1.25/2.5/5 round down (even code below),
+ties at .75/1.75/3.5 round up (even code above).
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+FP8_MAX = 448.0  # e4m3fn
+FP4_MAX = 6.0  # e2m1
+
+# Test hook: parity tests compare the continuous math with the QAT simulation
+# switched off on BOTH sides (quantization grids amplify ~1e-7 implementation
+# noise to one full code step whenever a value lands on a rounding midpoint,
+# so the fake-quant paths are held to a looser threshold separately).
+DISABLE = False
+FP8_MAX_INV = mx.array(1.0 / 448.0, dtype=mx.float32)
+FP4_MAX_INV = mx.array(1.0 / 6.0, dtype=mx.float32)
+
+_E2M1_LUT = mx.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=mx.float32)
+# comparison per midpoint chosen so exact ties land on the even-mantissa code
+_E2M1_GT = mx.array([0.25, 1.25, 2.5, 5.0], dtype=mx.float32)  # tie rounds DOWN
+_E2M1_GE = mx.array([0.75, 1.75, 3.5], dtype=mx.float32)  # tie rounds UP
+
+
+def _log2_ceil_bits(x: mx.array) -> mx.array:
+    """ceil(log2(x)) for positive normal fp32 x, via IEEE 754 bits (fast_log2_ceil)."""
+    bits = x.astype(mx.float32).view(mx.uint32)
+    exp = ((bits >> 23) & 0xFF).astype(mx.int32) - 127
+    man = (bits & 0x7FFFFF).astype(mx.int32)
+    return exp + (man != 0).astype(mx.int32)
+
+
+def _pow2(e: mx.array) -> mx.array:
+    """2**e for integer e, via IEEE 754 bits (fast_pow2)."""
+    return ((e + 127) << 23).astype(mx.uint32).view(mx.float32)
+
+
+def _ue8m0_scale(amax: mx.array, max_inv: mx.array) -> mx.array:
+    """The kernel's fast_round_scale: 2**ceil(log2(amax * (1/max)))."""
+    return _pow2(_log2_ceil_bits(amax * max_inv))
+
+
+def _e2m1_round(v: mx.array) -> mx.array:
+    """Round |v| <= 6 to the nearest e2m1 value, ties to even, keeping the sign."""
+    mag = mx.abs(v)
+    idx = mx.zeros(mag.shape, dtype=mx.int32)
+    for t in [0.25, 1.25, 2.5, 5.0]:
+        idx = idx + (mag > t).astype(mx.int32)
+    for t in [0.75, 1.75, 3.5]:
+        idx = idx + (mag >= t).astype(mx.int32)
+    return mx.sign(v) * _E2M1_LUT[idx]
+
+
+def _blockify(x: mx.array, block: int):
+    n = x.shape[-1]
+    if n % block:
+        raise ValueError(f"last dim {n} not divisible by block {block}")
+    return x.reshape(*x.shape[:-1], n // block, block)
+
+
+def fake_quant_fp8_ue8m0(x: mx.array, block: int = 32) -> mx.array:
+    """act_quant(..., scale_fmt='ue8m0', inplace=True): fp8 round-trip, pow2 scales."""
+    if DISABLE:
+        return x
+    dtype = x.dtype
+    shape = x.shape
+    xb = _blockify(x.astype(mx.float32), block)
+    amax = mx.maximum(mx.max(mx.abs(xb), axis=-1, keepdims=True), 1e-4)
+    s = _ue8m0_scale(amax, FP8_MAX_INV)
+    q = mx.from_fp8(mx.to_fp8(mx.clip(xb / s, -FP8_MAX, FP8_MAX)), mx.float32) * s
+    return q.reshape(shape).astype(dtype)
+
+
+def fake_quant_fp4_ue8m0(x: mx.array, block: int = 32) -> mx.array:
+    """fp4_act_quant(..., scale_dtype=e8m0, inplace=True): the indexer's q/k path."""
+    if DISABLE:
+        return x
+    dtype = x.dtype
+    shape = x.shape
+    xb = _blockify(x.astype(mx.float32), block)
+    amax = mx.maximum(mx.max(mx.abs(xb), axis=-1, keepdims=True), 6.0 * 2.0**-126)
+    s = _ue8m0_scale(amax, FP4_MAX_INV)
+    q = _e2m1_round(mx.clip(xb / s, -FP4_MAX, FP4_MAX)) * s
+    return q.reshape(shape).astype(dtype)
+
+
+def fake_quant_fp4_e4m3(x: mx.array, block: int = 16) -> mx.array:
+    """fp4_act_quant(..., 16, scale_dtype=e4m3, inplace=True): the compressed-KV path."""
+    if DISABLE:
+        return x
+    dtype = x.dtype
+    shape = x.shape
+    xb = _blockify(x.astype(mx.float32), block)
+    amax = mx.maximum(mx.max(mx.abs(xb), axis=-1, keepdims=True), 6.0 * 2.0**-9)
+    s = mx.from_fp8(mx.to_fp8(amax / FP4_MAX), mx.float32)
+    q = _e2m1_round(mx.clip(xb / s, -FP4_MAX, FP4_MAX)) * s
+    return q.reshape(shape).astype(dtype)

--- a/scripts/deepseek_v41_native/generate.py
+++ b/scripts/deepseek_v41_native/generate.py
@@ -1,0 +1,110 @@
+"""Minimal greedy generation for DeepSeek-V4.1 MLX.
+
+The prefill is chunked (default 512 tokens) with an eval between chunks — a
+single prefill graph over a 400+ GB build can exceed Metal's command-buffer
+watchdog. Each chunk/step snapshots the cache first (MLX setitem mutates
+through aliases, but ``x[:]`` pins the pre-step node, so snapshots are free)
+and retries once on the CPU stream if the GPU deadline is hit — the pattern
+from qwen38-mlx's quantize_stream.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from .model import Model
+
+
+def _cache_snapshot(cache):
+    layers = []
+    for lc in cache.layers:
+        layers.append(
+            (
+                lc.win_kv[:],
+                lc.comp_kv[:] if lc.comp_kv is not None else None,
+                lc.index_k[:] if lc.index_k is not None else None,
+                (lc.comp_state.kv_state[:], lc.comp_state.score_state[:])
+                if lc.comp_state is not None
+                else None,
+            )
+        )
+    eng = cache.engram_ids.copy() if cache.engram_ids is not None else None
+    return cache.offset, layers, eng
+
+
+def _cache_restore(cache, snap):
+    offset, layers, eng = snap
+    cache.offset = offset
+    for lc, (win, comp, idxk, cst) in zip(cache.layers, layers):
+        lc.win_kv = win
+        if comp is not None:
+            lc.comp_kv = comp
+        if idxk is not None:
+            lc.index_k = idxk
+        if cst is not None:
+            lc.comp_state.kv_state, lc.comp_state.score_state = cst
+    if eng is not None:
+        cache.engram_ids[:] = eng
+
+
+def _forward(model, ids, cache):
+    """One forward with eval; on a Metal timeout, roll the cache back and
+    recompute the same chunk on the CPU stream (last resort, ~20x slower)."""
+    snap = _cache_snapshot(cache)
+    try:
+        lg = model(ids, cache, last_logit_only=True)
+        mx.eval(lg)
+        return lg
+    except RuntimeError as err:
+        # After one Metal timeout the process's further GPU submissions are
+        # ignored (SubmissionsIgnored), so the only in-process retry that can
+        # work is the CPU stream — slow, a true last resort.
+        if "Timeout" not in str(err) and "Ignored" not in str(err):
+            raise
+        print("(metal timeout — recomputing this chunk on the CPU stream)", flush=True)
+        _cache_restore(cache, snap)
+        mx.clear_cache()
+        with mx.stream(mx.cpu):
+            lg = model(ids, cache, last_logit_only=True)
+            mx.eval(lg)
+        return lg
+
+
+def greedy_generate(
+    model: Model,
+    input_ids,
+    max_new_tokens: int = 64,
+    max_seq_len: int | None = None,
+    eos_id: int = 1,
+    dtype=mx.float32,
+    prefill_chunk: int = 512,
+):
+    """input_ids: list[int] or [1, n] array. Returns the generated ids."""
+    ids = mx.array([input_ids] if not hasattr(input_ids[0], "__len__") else input_ids)
+    total = ids.shape[1] + max_new_tokens
+    cache = model.make_cache(
+        bsz=ids.shape[0], max_seq_len=max_seq_len or (total + 8), dtype=dtype
+    )
+    logits = None
+    for a in range(0, ids.shape[1], prefill_chunk):
+        logits = _forward(model, ids[:, a : a + prefill_chunk], cache)
+    if logits is None:
+        raise ValueError("input_ids must contain at least one token")
+    out = []
+    tok = mx.argmax(logits[:, -1], axis=-1)
+    for _ in range(max_new_tokens):
+        t = int(tok[0])
+        if t == eos_id:
+            break
+        out.append(t)
+        logits = _forward(model, tok[:, None], cache)
+        tok = mx.argmax(logits[:, -1], axis=-1)
+    return out
+
+
+def load_tokenizer(path: str):
+    import os
+
+    from transformers import PreTrainedTokenizerFast
+
+    return PreTrainedTokenizerFast(tokenizer_file=os.path.join(path, "tokenizer.json"))

--- a/scripts/deepseek_v41_native/hyper_connections.py
+++ b/scripts/deepseek_v41_native/hyper_connections.py
@@ -1,0 +1,98 @@
+"""Hyper-Connections — the residual stream is ``hc_mult`` (=4) parallel copies.
+
+V4.1 keeps V4's Sinkhorn machinery but **staggers** the coefficients: the mixes a
+sub-layer computes are consumed one sub-layer *later*. From the reference
+``Block.forward``:
+
+* ``hc_mixes`` on the attention input yields ``(attn_pre, attn_post, attn_comb)``;
+  attention's own ``hc_pre`` uses the ``pre`` produced by the *previous* layer's
+  FFN (identity one-hot on copy 0 at the very first layer), while ``attn_post`` /
+  ``attn_comb`` are used by attention's ``hc_post`` immediately;
+* ``attn_pre`` then collapses the FFN input, whose own mixes hand ``ffn_pre`` to
+  the *next* layer — and after the last layer, to the LM head's final collapse.
+
+``comb`` is pushed toward doubly-stochastic by 20 Sinkhorn sweeps.
+``hc_post`` computes ``out[k] = post[k]*x + sum_j comb[j,k]*residual[j]`` —
+the residual is indexed by the **summed** axis j (comb's first index), a
+known bug magnet; broadcasting residual onto k instead stays finite and
+plausible but wrong.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+def split_sinkhorn(
+    mixes: mx.array,
+    hc_scale: mx.array,
+    hc_base: mx.array,
+    hc_mult: int = 4,
+    sinkhorn_iters: int = 20,
+    eps: float = 1e-6,
+):
+    """Split one projection into (pre, post, comb) — transcribed from
+    ``hc_split_sinkhorn_kernel``. Layout: first hc entries -> pre, next hc ->
+    post, remaining hc*hc -> comb row-major."""
+    hc = hc_mult
+    m = mixes.astype(mx.float32)
+    scale = hc_scale.astype(mx.float32)
+    base = hc_base.astype(mx.float32)
+
+    pre = mx.sigmoid(m[..., :hc] * scale[0] + base[:hc]) + eps
+    post = 2.0 * mx.sigmoid(m[..., hc : 2 * hc] * scale[1] + base[hc : 2 * hc])
+
+    comb = m[..., 2 * hc :] * scale[2] + base[2 * hc :]
+    comb = comb.reshape(*comb.shape[:-1], hc, hc)
+    # row softmax + eps, one column normalization, then (iters-1) full sweeps;
+    # the eps sits inside the divisions, as in the kernel
+    comb = mx.softmax(comb, axis=-1) + eps
+    comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    for _ in range(sinkhorn_iters - 1):
+        comb = comb / (comb.sum(axis=-1, keepdims=True) + eps)
+        comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    return pre, post, comb
+
+
+def hc_mixes(
+    x: mx.array,
+    hc_fn: mx.array,
+    hc_scale: mx.array,
+    hc_base: mx.array,
+    hc_mult: int,
+    sinkhorn_iters: int,
+    norm_eps: float,
+    hc_eps: float,
+):
+    """The coefficient projection: RMS-normalize the flattened [b,s,hc*d] stream
+    (rsqrt applied AFTER the linear, matching the reference's operation order),
+    project, split. Returns (pre, post, comb)."""
+    xf = x.reshape(*x.shape[:2], -1).astype(mx.float32)
+    rsqrt = mx.rsqrt(mx.mean(mx.square(xf), axis=-1, keepdims=True) + norm_eps)
+    mixes = (xf @ hc_fn.astype(mx.float32).T) * rsqrt
+    return split_sinkhorn(mixes, hc_scale, hc_base, hc_mult, sinkhorn_iters, hc_eps)
+
+
+def hc_pre(x: mx.array, pre_mix: mx.array) -> mx.array:
+    """Collapse the hc copies into one: [b,s,hc,d] x [b,s,hc] -> [b,s,d], fp32 sum."""
+    y = mx.sum(pre_mix[..., None].astype(mx.float32) * x.astype(mx.float32), axis=2)
+    return y.astype(x.dtype)
+
+
+def hc_post(
+    x: mx.array, residual: mx.array, post: mx.array, comb: mx.array
+) -> mx.array:
+    """out[k] = post[k]*x + sum_j comb[j,k]*residual[j].
+
+    x [b,s,d], residual [b,s,hc,d], post [b,s,hc], comb [b,s,hc,hc] -> [b,s,hc,d].
+    The residual must sit on the j (summed) axis of the product.
+    """
+    prod = comb[..., None] * residual[..., :, None, :]  # [b, s, j, k, d]
+    out = post[..., None] * x[..., None, :] + mx.sum(prod, axis=2)
+    return out.astype(x.dtype)
+
+
+def make_identity_pre_mix(b: int, s: int, hc_mult: int) -> mx.array:
+    """The initial one-hot mix: copy 0 only."""
+    m = mx.zeros((b, s, hc_mult), dtype=mx.float32)
+    return mx.concatenate([mx.ones((b, s, 1), dtype=mx.float32), m[..., 1:]], axis=-1)

--- a/scripts/deepseek_v41_native/indexer.py
+++ b/scripts/deepseek_v41_native/indexer.py
@@ -1,0 +1,164 @@
+"""The sparse-attention indexer — a second attention deciding what the first reads.
+
+The eight ``index_source_layers`` own one. Only the four that are *also*
+``kv_source_layers`` (2, 8, 14, 20) own index **keys** (``wk``/``k_norm`` + a key
+cache): keys are derived from the compressor's pre-RoPE latent. Index sources
+that are not kv sources (24, 28, 32, 36) score with their own ``wq_b`` /
+``weights_proj`` against the *most recent owner's* key cache (layer 20's).
+
+Two-level selection: layer 20 is the candidate source — it scores all latents,
+keeps the ``candidate_topk_blocks`` best blocks of ``candidate_block_size`` (the
+block holding the newest position is pinned in), and publishes the boolean mask.
+Sources after it (24..36) mask their own scores with those candidates before the
+final per-query top-``index_topk``.
+
+Queries and keys are FP4 fake-quantized (blocks of 32, power-of-two scales), no
+Hadamard rotation (a V4 feature V4.1 dropped). Scores are ReLU'd, then collapsed
+over heads by ``weights_proj(x) * head_dim**-0.5 * n_heads**-0.5``.
+
+Reference artifact worth knowing (documented in docs/upstream-notes.md): the
+reference reads keys through a process-global pointer that the *last* owner set.
+During decode, a ratio-2 owner whose group is incomplete therefore scores
+against layer 20's keys. This port always reads the owner's own cache.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import ModelArgs
+from .fakequant import fake_quant_fp4_ue8m0
+from .layers import RMSNorm, rope_tail
+
+NEG_INF = float("-inf")
+POS_INF = float("inf")
+
+
+def select_candidate_blocks(
+    scores: mx.array, lens: mx.array, topk_blocks: int, block_size: int
+) -> mx.array:
+    """Level one of the two-level top-k. scores [b, n, nb] with unreachable
+    positions already at -inf; lens [n, 1] (positions visible per query).
+    Returns a bool mask shaped like scores."""
+    width = scores.shape[-1]
+    pad = (-width) % block_size
+    if pad:
+        scores_p = mx.concatenate(
+            [scores, mx.full((*scores.shape[:-1], pad), NEG_INF, dtype=scores.dtype)],
+            axis=-1,
+        )
+    else:
+        scores_p = scores
+    blocks = scores_p.reshape(*scores.shape[:-1], -1, block_size).max(
+        axis=-1
+    )  # [b, n, NB]
+    nb_blocks = blocks.shape[-1]
+
+    # pin the block holding each query's newest position: it is only partly
+    # filled and could otherwise be outscored by an older, full block
+    last = (lens - 1) // block_size  # [n, 1]
+    pin = mx.arange(nb_blocks)[None, :] == last  # [n, NB]
+    blocks = mx.where(pin[None], POS_INF, blocks)
+
+    k = min(topk_blocks, nb_blocks)
+    top_idx = mx.argpartition(-blocks, k - 1, axis=-1)[..., :k]
+    top_val = mx.take_along_axis(blocks, top_idx, axis=-1)
+    keep = mx.zeros(blocks.shape, dtype=mx.bool_)
+    keep = mx.put_along_axis(keep, top_idx, top_val > NEG_INF, axis=-1)
+    return mx.repeat(keep, block_size, axis=-1)[..., :width]
+
+
+class Indexer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_id: int):
+        super().__init__()
+        self.layer_id = layer_id
+        self.owns_k = layer_id in args.kv_source_layers
+        self.ratio = args.compress_ratio(layer_id)
+        self.is_candidate_source = layer_id == args.candidate_source_layer
+        self.uses_candidates = 0 <= args.candidate_source_layer < layer_id
+        self.candidate_topk_blocks = args.candidate_topk_blocks
+        self.candidate_block_size = args.candidate_block_size
+        self.n_heads = args.index_n_heads
+        self.head_dim = args.index_head_dim
+        self.rope_head_dim = args.rope_head_dim
+        self.index_topk = args.index_topk
+        self.softmax_scale = self.head_dim**-0.5
+
+        self.wq_b = nn.Linear(
+            args.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.weights_proj = nn.Linear(args.dim, self.n_heads, bias=False)
+        if self.owns_k:
+            self.wk = nn.Linear(args.head_dim, self.head_dim, bias=False)
+            self.k_norm = RMSNorm(self.head_dim, args.norm_eps)
+
+    def publish_keys(self, latents: mx.array, start_pos: int, cos, sin, cache):
+        """Turn this chunk's pre-RoPE latents into index keys and cache them.
+
+        Must run before Attention overwrites the latents with their RoPE'd,
+        quantized form. ``latents`` [b, g, head_dim] for groups g0.., where
+        g0 = start_pos // ratio; a latent's rope position is its group's first
+        token, g*ratio.
+        """
+        rd = self.rope_head_dim
+        g0 = start_pos // self.ratio
+        g = latents.shape[1]
+        pos = (g0 + mx.arange(g)) * self.ratio
+        k = self.k_norm(self.wk(latents))
+        k = rope_tail(k, rd, cos[pos], sin[pos])
+        k = fake_quant_fp4_ue8m0(k, 32)
+        cache.index_k[: k.shape[0], g0 : g0 + g] = k
+
+    def __call__(
+        self,
+        x: mx.array,
+        qr: mx.array,
+        start_pos: int,
+        offset: int,
+        cos,
+        sin,
+        index_k: mx.array,
+        shared,
+    ) -> mx.array:
+        """Score and pick top-k compressed positions for each query.
+
+        x [b, n, dim] (post-attn-norm), qr [b, n, q_lora_rank],
+        index_k [b, nb, head_dim] — the owner's key cache, already sliced to the
+        nb = (start_pos+n)//ratio complete groups. Returns [b, n, k] int32
+        indices into the concatenated window+compressed KV, -1 = masked.
+        """
+        bsz, n, _ = x.shape
+        ratio, rd = self.ratio, self.rope_head_dim
+        nb = index_k.shape[1]
+
+        q = self.wq_b(qr).reshape(bsz, n, self.n_heads, self.head_dim)
+        q = rope_tail(
+            q, rd, cos[start_pos : start_pos + n], sin[start_pos : start_pos + n]
+        )
+        q = fake_quant_fp4_ue8m0(q, 32)
+
+        w = self.weights_proj(x) * (self.softmax_scale * self.n_heads**-0.5)
+        scores = mx.einsum(
+            "bshd,btd->bsht", q.astype(mx.float32), index_k.astype(mx.float32)
+        )
+        scores = mx.maximum(scores, 0.0) * w[..., None].astype(mx.float32)
+        scores = mx.sum(scores, axis=2)  # [b, n, nb]
+
+        # visibility: group j is visible to query i once the query passed its last token
+        lens = ((start_pos + mx.arange(n) + 1) // ratio)[:, None]  # [n, 1]
+        vis = mx.arange(nb)[None, :] < lens  # [n, nb]
+        scores = mx.where(vis[None], scores, NEG_INF)
+
+        if self.is_candidate_source:
+            shared.candidates = select_candidate_blocks(
+                scores, lens, self.candidate_topk_blocks, self.candidate_block_size
+            )
+        elif self.uses_candidates and shared.candidates is not None:
+            scores = mx.where(shared.candidates, scores, NEG_INF)
+
+        k = min(self.index_topk, nb)
+        idx = mx.argpartition(-scores, k - 1, axis=-1)[..., :k].astype(mx.int32)
+        idx = mx.sort(idx, axis=-1)  # position order
+        visible = idx < lens.astype(mx.int32)[None]
+        return mx.where(visible, idx + offset, mx.array(-1, mx.int32))

--- a/scripts/deepseek_v41_native/layers.py
+++ b/scripts/deepseek_v41_native/layers.py
@@ -1,0 +1,114 @@
+"""Core layers: RMSNorm, YaRN rope with the inverse path, clamped SwiGLU.
+
+Transcribed from the reference ``model.py``. Details that matter:
+
+* ``rms_norm_eps`` is ``1e-20`` in the release — effectively zero, kept exact;
+* rope pairs *adjacent* elements as (real, imag) — not split halves — and is
+  applied to the **last** ``rope_head_dim`` channels only;
+* attention applies the rope **inverse** (conjugate) to its output before the
+  grouped output projection, which is why the conjugate path exists.
+"""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class RMSNorm(nn.Module):
+    """RMSNorm computed in fp32, returning the input dtype (matches reference)."""
+
+    def __init__(self, dim: int, eps: float = 1e-20):
+        super().__init__()
+        self.eps = eps
+        self.weight = mx.ones((dim,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        dtype = x.dtype
+        xf = x.astype(mx.float32)
+        var = mx.mean(mx.square(xf), axis=-1, keepdims=True)
+        xf = xf * mx.rsqrt(var + self.eps)
+        return (self.weight * xf).astype(dtype)
+
+
+def precompute_freqs_cis(
+    dim: int,
+    seqlen: int,
+    original_seq_len: int,
+    base: float,
+    factor: float,
+    beta_fast: int,
+    beta_slow: int,
+):
+    """YaRN-scaled rotary frequencies as a (cos, sin) pair of shape [seqlen, dim//2].
+
+    ``original_seq_len == 0`` disables YaRN entirely — the reference uses that for
+    the pure sliding-window layers (which also drop back to the base theta).
+    """
+
+    def corrected_dim(rotations):
+        return (
+            dim
+            * math.log(original_seq_len / (rotations * 2 * math.pi))
+            / (2 * math.log(base))
+        )
+
+    freqs = 1.0 / (base ** (mx.arange(0, dim, 2, dtype=mx.float32) / dim))
+    if original_seq_len > 0:
+        low = max(math.floor(corrected_dim(beta_fast)), 0)
+        high = min(math.ceil(corrected_dim(beta_slow)), dim - 1)
+        ramp = mx.clip(
+            (mx.arange(dim // 2, dtype=mx.float32) - low) / max(high - low, 1e-3), 0, 1
+        )
+        smooth = 1 - ramp
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+
+    t = mx.arange(seqlen, dtype=mx.float32)
+    ang = t[:, None] * freqs[None, :]
+    return mx.cos(ang), mx.sin(ang)
+
+
+def apply_rotary_emb(
+    x: mx.array, cos: mx.array, sin: mx.array, inverse: bool = False
+) -> mx.array:
+    """Rotate ``x`` [..., s, (h,) d] by adjacent-pair complex multiplication.
+
+    ``cos``/``sin``: [s, d//2]. ``inverse=True`` conjugates — attention uses this
+    on its output to remove the query rotation again.
+    """
+    dtype = x.dtype
+    xf = x.astype(mx.float32)
+    shape = xf.shape
+    xf = xf.reshape(*shape[:-1], shape[-1] // 2, 2)
+    xr, xi = xf[..., 0], xf[..., 1]
+
+    if xr.ndim == 4:  # [b, s, h, d//2]
+        c, s = cos[None, :, None, :], sin[None, :, None, :]
+    else:  # [b, s, d//2]
+        c, s = cos[None, :, :], sin[None, :, :]
+    if inverse:
+        s = -s
+
+    out = mx.stack([xr * c - xi * s, xr * s + xi * c], axis=-1)
+    return out.reshape(shape).astype(dtype)
+
+
+def rope_tail(
+    x: mx.array, rd: int, cos: mx.array, sin: mx.array, inverse: bool = False
+) -> mx.array:
+    """Apply rope to the last ``rd`` channels, leave the rest untouched."""
+    return mx.concatenate(
+        [x[..., :-rd], apply_rotary_emb(x[..., -rd:], cos, sin, inverse)], axis=-1
+    )
+
+
+def clamped_swiglu(gate: mx.array, up: mx.array, limit: float) -> mx.array:
+    """SwiGLU with the asymmetric clamp: ``up`` two-sided, ``gate`` upper-only. fp32."""
+    g = gate.astype(mx.float32)
+    u = up.astype(mx.float32)
+    if limit > 0:
+        u = mx.clip(u, -limit, limit)
+        g = mx.minimum(g, limit)
+    return (g * mx.sigmoid(g)) * u

--- a/scripts/deepseek_v41_native/load.py
+++ b/scripts/deepseek_v41_native/load.py
@@ -1,0 +1,235 @@
+"""Load a converted DeepSeek-V4.1 MLX build — strictly.
+
+``mlx_lm.load`` uses ``strict=False`` and lets missing weights silently stay
+random-initialized (the GLM-5.2 lesson); this loader refuses that:
+
+* every parameter the model owns must come from the checkpoint;
+* every checkpoint tensor must either land in a parameter or belong to the
+  explicitly-declared vision passthrough (``vision.*`` / ``aligner.*`` /
+  ``image_*`` — carried by the conversion for a future VL runtime, reported,
+  never silently ignored);
+* quantization is replayed from ``config.json``: the converter writes an
+  explicit per-module map (``quantization`` carries defaults plus
+  ``<module path>: {group_size, bits} | false`` entries keyed by
+  runtime-internal module paths); when the map is absent the loader falls back
+  to the same ``is_quant_target`` / ``bits_for`` rules the converter used.
+
+Builds bundle **nothing executable**: no ``model_file`` mechanism exists here —
+a build is loaded through this package (``deepseek_v41_mlx.load.load``), never
+through ``mlx_lm.load``.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from .config import ModelArgs
+from .convert import VISION_PREFIXES, bits_for, is_quant_target
+from .model import Model
+
+
+def reshape_grouped_wo_a(items, args: ModelArgs):
+    """Restore the logical group axis from flat release/checkpoint storage."""
+    output = []
+    suffixes = (".attn.wo_a.weight", ".attn.wo_a.scales", ".attn.wo_a.biases")
+    expected_rows = args.o_groups * args.o_lora_rank
+    for name, value in items:
+        if name.endswith(suffixes) and value.ndim == 2:
+            if value.shape[0] != expected_rows:
+                raise ValueError(
+                    f"{name} has {value.shape[0]} rows; expected {expected_rows} "
+                    "for grouped wo_a"
+                )
+            value = value.reshape(args.o_groups, args.o_lora_rank, -1)
+        output.append((name, value))
+    return output
+
+
+def quant_predicate(
+    group_size: int, bits: int, expert_bits: int | None, module_map: dict | None = None
+):
+    """Per-module predicate. With ``module_map`` (the converter's explicit map,
+    keyed by runtime-internal module paths) the map is authoritative; without
+    it, fall back to the converter's rule set."""
+
+    def pred(path, module):
+        if not hasattr(module, "to_quantized"):
+            return False
+        if module_map is not None:
+            entry = module_map.get(path, False)
+            return dict(entry) if entry else False
+        w = getattr(module, "weight", None)
+        if w is None:
+            return False
+        name = path + ".weight"
+        if not is_quant_target(name, w.shape[-1], group_size):
+            return False
+        return {"group_size": group_size, "bits": bits_for(name, bits, expert_bits)}
+
+    return pred
+
+
+def load_token_map(path: str, args: ModelArgs, cache_dir: str | None = None):
+    """The engram compressed-token map, built from the release tokenizer.
+
+    Cached (building it decodes+normalizes all 129,280 tokens, ~a minute) in
+    ``cache_dir`` when given — use that when ``path`` must stay read-only —
+    else beside the tokenizer. Returns None when no tokenizer is present.
+    """
+    cache_file = os.path.join(cache_dir or path, "engram_token_map.json")
+    if os.path.exists(cache_file):
+        return json.load(open(cache_file))
+    tok_file = os.path.join(path, "tokenizer.json")
+    if not os.path.exists(tok_file):
+        return None
+    from transformers import PreTrainedTokenizerFast
+
+    from .engram import build_compressed_token_map
+
+    tok = PreTrainedTokenizerFast(tokenizer_file=tok_file)
+    token_map, n = build_compressed_token_map(tok)
+    if args.engram_compressed_vocab_size and n != args.engram_compressed_vocab_size:
+        raise ValueError(
+            f"compressed vocab {n} != config {args.engram_compressed_vocab_size}"
+        )
+    json.dump(token_map, open(cache_file, "w"))
+    return token_map
+
+
+def load(
+    path: str,
+    lazy: bool | None = None,
+    strict: bool = True,
+    fuse_moe_gate_up: bool = False,
+):
+    """``lazy=None`` auto-selects: builds that fit comfortably in physical RAM
+    are materialized at load time (CPU-side, avoiding cold-mmap page-in inside
+    a GPU command buffer — that trips Metal's watchdog); builds larger than
+    ~80% of RAM stay mmap-lazy, because materialized buffers are unevictable
+    and drive the machine into compressor thrash, while clean file-backed
+    pages stream from disk per forward (measured: a 476 GB build on 512 GiB
+    stalled the box when materialized, runs lazily)."""
+    try:
+        requested_gb = os.environ.get("DSV41_WIRED_GB")
+        if requested_gb is None:
+            # Never inherit the upstream 470 GB assumption on a 256 GiB Mac.
+            # Metal's own budget leaves the OS enough operational headroom.
+            wired = int(mx.device_info()["max_recommended_working_set_size"])
+        else:
+            wired = int(float(requested_gb) * 1e9)
+        mx.set_wired_limit(wired)
+    except (KeyError, RuntimeError, TypeError, ValueError):
+        pass
+    if os.environ.get("DSV41_LAZY") in ("0", "1"):
+        lazy = os.environ["DSV41_LAZY"] == "1"
+        print(f"[load] lazy={lazy} forced via DSV41_LAZY", flush=True)
+    if lazy is None:
+        size = sum(
+            os.path.getsize(p) for p in glob.glob(os.path.join(path, "*.safetensors"))
+        )
+        try:
+            phys = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+        except (ValueError, OSError):
+            phys = int(550e9)
+        lazy = size > 0.8 * phys
+        if lazy:
+            print(
+                f"[load] {size / 1e9:.0f} GB build vs {phys / 1e9:.0f} GB RAM: "
+                f"staying mmap-lazy (materializing would thrash the compressor)",
+                flush=True,
+            )
+            # Prewarm the page cache sequentially (clean, evictable pages) so
+            # the first forward's page-ins are cache hits — cold-disk faults
+            # inside a GPU command buffer trip Metal's ~watchdog.
+            import time as _time
+
+            t0 = _time.time()
+            buf = bytearray(1 << 28)
+            for p in sorted(glob.glob(os.path.join(path, "*.safetensors"))):
+                with open(p, "rb", buffering=0) as fh:
+                    while fh.readinto(buf):
+                        pass
+            print(
+                f"[load] page-cache prewarm: {size / 1e9:.0f} GB in "
+                f"{_time.time() - t0:.0f}s",
+                flush=True,
+            )
+    cfg = json.load(open(os.path.join(path, "config.json")))
+    args = ModelArgs.from_dict(cfg)
+    token_map = load_token_map(path, args) if args.engram_layer_ids else None
+    model = Model(args, token_map=token_map)
+
+    q = cfg.get("quantization")
+    if q:
+        if q.get("bits"):
+            module_map = q.get("modules")
+            nn.quantize(
+                model,
+                group_size=q["group_size"],
+                bits=q["bits"],
+                class_predicate=quant_predicate(
+                    q["group_size"], q["bits"], q.get("expert_bits"), module_map
+                ),
+            )
+        if q.get("engram_bits"):
+            from .engram import QuantizedEngramEmbedding
+
+            for layer in model.layers:
+                if layer.engram is not None:
+                    e = layer.engram.embed
+                    layer.engram.embed = QuantizedEngramEmbedding(
+                        e.weight.shape[0],
+                        e.weight.shape[1],
+                        q["group_size"],
+                        q["engram_bits"],
+                    )
+
+    loaded: set[str] = set()
+    vision_skipped: set[str] = set()
+    for shard in sorted(glob.glob(os.path.join(path, "*.safetensors"))):
+        w = mx.load(shard)
+        items = []
+        for k, v in w.items():
+            if k.startswith(VISION_PREFIXES):
+                vision_skipped.add(k)  # declared passthrough, text-only runtime
+                continue
+            items.append((k, v))
+        items = reshape_grouped_wo_a(items, args)
+        model.load_weights(items, strict=False)
+        if not lazy:
+            mx.eval([v for _, v in items])
+        loaded.update(k for k, _ in items)
+        del w
+
+    expected = {k for k, _ in tree_flatten(model.parameters())}
+    missing = expected - loaded
+    unexpected = loaded - expected
+    if strict and missing:
+        raise ValueError(
+            f"{len(missing)} params missing from checkpoint, e.g. {sorted(missing)[:4]}"
+        )
+    if strict and unexpected:
+        raise ValueError(
+            f"{len(unexpected)} checkpoint tensors have no home, "
+            f"e.g. {sorted(unexpected)[:4]}"
+        )
+    model.eval()
+    model._vision_passthrough = sorted(vision_skipped)
+    if fuse_moe_gate_up:
+        # Reuse Rapid's qualified SwitchGLU fusion instead of maintaining a
+        # V4.1-only copy. Keep it opt-in until this model passes its end-to-end
+        # throughput and greedy-equivalence qualification gate.
+        from vllm_mlx.moe_fusion import fuse_gate_up
+
+        fused = fuse_gate_up(model)
+        if fused != args.n_layers:
+            raise RuntimeError(
+                f"fused {fused} MoE layers; expected all {args.n_layers}"
+            )
+    return model, args

--- a/scripts/deepseek_v41_native/model.py
+++ b/scripts/deepseek_v41_native/model.py
@@ -1,0 +1,190 @@
+"""DeepSeek-V4.1 block and full model (text stack).
+
+The block wires Hyper-Connections in V4.1's *staggered* form: the coefficient
+set a sub-layer computes is consumed by the **next** sub-layer's collapse.
+Attention collapses with the previous layer's FFN ``pre`` (identity one-hot at
+the start), the FFN collapses with this layer's attention ``pre``, and the LM
+head collapses with the last layer's FFN ``pre``.
+
+Cross-layer sharing flows through a per-forward :class:`SharedState`, mirroring
+the reference's process-global ``SharedAttentionRuntime``: kv sources publish
+their compressed-KV cache and index-key cache, index sources publish their
+top-k selection, the candidate source publishes its block mask, and every layer
+in between consumes the most recent value. Layers run top-down, so every source
+writes before its consumers read.
+
+Engram layers apply their gated n-gram lookup to the hc-expanded stream
+*before* the block runs, exactly as the reference does in ``Transformer.forward``.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .attention import Attention
+from .cache import ModelCache
+from .config import ModelArgs
+from .engram import Engram, EngramHasher
+from .hyper_connections import hc_mixes, hc_post, hc_pre, make_identity_pre_mix
+from .layers import RMSNorm
+from .moe import MoE
+
+
+class SharedState:
+    """What attention layers hand down the stack instead of recomputing.
+
+    Fresh per forward; every source writes before its consumers read."""
+
+    def __init__(self):
+        self.kv_src_cache = None  # LayerCache of the most recent kv source
+        self.index_src_cache = None  # LayerCache of the most recent index-key owner
+        self.topk_idxs = None  # [b, n, k] from the most recent index source
+        self.candidates = None  # [b, n, nb] bool from the candidate source
+
+
+class Block(nn.Module):
+    def __init__(self, layer_id: int, args: ModelArgs):
+        super().__init__()
+        self.layer_id = layer_id
+        self.norm_eps = args.norm_eps
+        self.hc_mult = args.hc_mult
+        self.hc_iters = args.hc_sinkhorn_iters
+        self.hc_eps = args.hc_eps
+
+        self.attn = Attention(layer_id, args)
+        self.ffn = MoE(args)
+        self.attn_norm = RMSNorm(args.dim, args.norm_eps)
+        self.ffn_norm = RMSNorm(args.dim, args.norm_eps)
+
+        mix_hc = (2 + args.hc_mult) * args.hc_mult
+        hc_dim = args.hc_mult * args.dim
+        self.hc_attn_fn = mx.zeros((mix_hc, hc_dim), dtype=mx.float32)
+        self.hc_ffn_fn = mx.zeros((mix_hc, hc_dim), dtype=mx.float32)
+        self.hc_attn_base = mx.zeros((mix_hc,), dtype=mx.float32)
+        self.hc_ffn_base = mx.zeros((mix_hc,), dtype=mx.float32)
+        self.hc_attn_scale = mx.zeros((3,), dtype=mx.float32)
+        self.hc_ffn_scale = mx.zeros((3,), dtype=mx.float32)
+
+        self.engram: Engram | None
+        if layer_id in args.engram_layer_ids:
+            self.engram = Engram(args, args.engram_layer_ids.index(layer_id))
+        else:
+            self.engram = None
+
+    def __call__(self, x: mx.array, pre_mix: mx.array, start_pos: int, cache, shared):
+        """x [b, s, hc, d]; pre_mix [b, s, hc] from the previous sub-layer.
+        Returns (x, ffn_pre) — ffn_pre feeds the next layer (or the head)."""
+        residual = x
+        attn_pre, attn_post, attn_comb = hc_mixes(
+            x,
+            self.hc_attn_fn,
+            self.hc_attn_scale,
+            self.hc_attn_base,
+            self.hc_mult,
+            self.hc_iters,
+            self.norm_eps,
+            self.hc_eps,
+        )
+        h = hc_pre(x, pre_mix)
+        h = self.attn(self.attn_norm(h), start_pos, cache, shared)
+        x = hc_post(h, residual, attn_post, attn_comb)
+
+        residual = x
+        ffn_pre, ffn_post, ffn_comb = hc_mixes(
+            x,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            self.hc_mult,
+            self.hc_iters,
+            self.norm_eps,
+            self.hc_eps,
+        )
+        h = hc_pre(x, attn_pre)
+        h = self.ffn(self.ffn_norm(h))
+        x = hc_post(h, residual, ffn_post, ffn_comb)
+        return x, ffn_pre
+
+
+class Model(nn.Module):
+    """embed -> expand to hc copies -> blocks -> collapse (last ffn_pre) -> logits."""
+
+    def __init__(self, args: ModelArgs, token_map=None):
+        super().__init__()
+        self.args = args
+        self.hc_mult = args.hc_mult
+        self.embed = nn.Embedding(args.vocab_size, args.dim)
+        self.layers = [Block(i, args) for i in range(args.n_layers)]
+        self.norm = RMSNorm(args.dim, args.norm_eps)
+        self.head = nn.Linear(args.dim, args.vocab_size, bias=False)
+        # A 40-layer V4.1 decode graph can exceed Metal's command-buffer
+        # deadline on a 256 GiB host. Keep a correctness-first per-layer
+        # boundary; qualification may raise this interval after proving the
+        # larger graph stays below the watchdog.
+        self.eval_interval = 1
+        self.engram_hasher = None
+        if args.engram_layer_ids and token_map is not None:
+            self.set_token_map(token_map)
+        # test hook: remap which source each consumer reads (negative control)
+        self._break_sharing = False
+
+    def set_token_map(self, token_map):
+        self.engram_hasher = EngramHasher(self.args, token_map)
+
+    def make_cache(
+        self, bsz: int = 1, max_seq_len: int | None = None, dtype=mx.float32
+    ) -> ModelCache:
+        return ModelCache(self.args, bsz, max_seq_len, dtype)
+
+    def __call__(
+        self, input_ids: mx.array, cache: ModelCache, last_logit_only: bool = False
+    ) -> mx.array:
+        """input_ids [b, n] continue the sequence at cache.offset. Advances the cache."""
+        start_pos = cache.offset
+        b, n = input_ids.shape
+
+        hashes = None
+        if self.engram_hasher is not None:
+            ids_np = np.array(input_ids, dtype=np.int64)
+            hashes = self.engram_hasher(ids_np, start_pos, cache.engram_ids)
+            hashes = mx.array(hashes)  # [b, n, n_engram_layers, cols]
+        elif self.args.engram_layer_ids:
+            raise RuntimeError(
+                "model has engram layers but no token map — call "
+                "set_token_map() (load.py builds it from the release tokenizer)"
+            )
+
+        h = self.embed(input_ids)
+        h = mx.broadcast_to(h[:, :, None, :], (b, n, self.hc_mult, h.shape[-1]))
+
+        pre_mix = make_identity_pre_mix(b, n, self.hc_mult)
+        shared = SharedState()
+        for layer_index, layer in enumerate(self.layers, 1):
+            if layer.engram is not None:
+                assert hashes is not None
+                h = layer.engram(h, hashes[:, :, layer.engram.layer_hash_index])
+            if self._break_sharing and not layer.attn.is_kv_source and layer.attn.ratio:
+                shared_use = SharedState()  # sever the link: consumers see nothing
+                shared_use.kv_src_cache = shared.kv_src_cache
+                shared_use.index_src_cache = shared.index_src_cache
+                zero = (
+                    mx.full(shared.topk_idxs.shape, -1, dtype=mx.int32)
+                    if shared.topk_idxs is not None
+                    else None
+                )
+                shared_use.topk_idxs = zero
+                h, pre_mix = layer(h, pre_mix, start_pos, cache, shared_use)
+            else:
+                h, pre_mix = layer(h, pre_mix, start_pos, cache, shared)
+            if self.eval_interval and layer_index % self.eval_interval == 0:
+                mx.eval(h, pre_mix)
+
+        h = hc_pre(h, pre_mix)  # collapse with the last ffn_pre
+        h = self.norm(h)
+        if last_logit_only:
+            h = h[:, -1:]
+        logits = self.head(h.astype(mx.float32))  # fp32 logits, as the reference
+        cache.offset = start_pos + n
+        return logits

--- a/scripts/deepseek_v41_native/moe.py
+++ b/scripts/deepseek_v41_native/moe.py
@@ -1,0 +1,126 @@
+"""V4.1 MoE: sqrt-softplus scored routing over 384 experts, top-6, one shared expert.
+
+Hash routing is gone (a V4 feature); every MoE layer scores. What remains
+non-standard:
+
+* ``sqrt(softplus(x))`` scoring;
+* **the selection bias does not reach the routing weights** — scores are read
+  before the bias is added; the bias only reorders the top-k. The checkpoint
+  carries a second bias, ``gate.bias_vl``, selected for tokens inside image
+  spans (training's ``noaux_tc_for_vl``). This text-only runtime always uses
+  ``gate.bias`` but keeps ``bias_vl`` loaded so the checkpoint round-trips;
+* top-k weights are normalized by ``sum + 1e-20`` (not ``norm_eps``) and scaled
+  by ``routed_scaling_factor`` 1.5;
+* clamped SwiGLU (limit 10): ``up`` clamped two-sided, ``gate`` upper-only.
+
+Routing weights are applied after ``down_proj`` instead of before (one scalar per
+token — linear, so identical), which lets the batched SwitchGLU gather-matmul
+replace the reference's per-expert Python loop.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from vllm_mlx import _mlx_compat as _mlx_compat
+
+_mlx_compat.install()
+
+from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
+
+from .config import ModelArgs
+
+
+class ClampedSwiGLU(nn.Module):
+    """Called by SwitchGLU as activation(x_up, x_gate)."""
+
+    def __init__(self, limit: float = 0.0):
+        super().__init__()
+        self.limit = limit
+
+    def __call__(self, x, gate):
+        x = x.astype(mx.float32)
+        gate = gate.astype(mx.float32)
+        if self.limit > 0:
+            x = mx.clip(x, -self.limit, self.limit)
+            gate = mx.minimum(gate, self.limit)
+        return nn.silu(gate) * x
+
+
+class Gate(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.topk = args.n_activated_experts
+        self.score_func = args.score_func
+        self.gate_temp = args.gate_temp
+        self.norm_topk_prob = args.norm_topk_prob
+        self.route_scale = args.route_scale
+        self.weight = mx.zeros((args.n_routed_experts, args.dim))
+        self.bias = mx.zeros((args.n_routed_experts,), dtype=mx.float32)
+        self.bias_vl = mx.zeros((args.n_routed_experts,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array):
+        scores = (
+            x.astype(mx.float32) @ self.weight.astype(mx.float32).T
+        ) / self.gate_temp
+        if self.score_func == "softmax":
+            scores = mx.softmax(scores, axis=-1)
+        elif self.score_func == "sigmoid":
+            scores = mx.sigmoid(scores)
+        else:  # sqrtsoftplus
+            scores = mx.sqrt(nn.softplus(scores))
+
+        # the bias picks experts but does not scale them
+        biased = scores + self.bias
+        indices = mx.argpartition(-biased, self.topk - 1, axis=-1)[..., : self.topk]
+        weights = mx.take_along_axis(scores, indices, axis=-1)
+        if self.norm_topk_prob and self.topk > 1:
+            weights = weights / (mx.sum(weights, axis=-1, keepdims=True) + 1e-20)
+        weights = weights * self.route_scale
+        return weights, indices
+
+
+class SharedExpert(nn.Module):
+    def __init__(self, dim: int, inter_dim: int, limit: float = 0.0):
+        super().__init__()
+        self.w1 = nn.Linear(dim, inter_dim, bias=False)
+        self.w2 = nn.Linear(inter_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, inter_dim, bias=False)
+        self.limit = limit
+
+    def __call__(self, x: mx.array) -> mx.array:
+        dtype = x.dtype
+        gate = self.w1(x).astype(mx.float32)
+        up = self.w3(x).astype(mx.float32)
+        if self.limit > 0:
+            up = mx.clip(up, -self.limit, self.limit)
+            gate = mx.minimum(gate, self.limit)
+        h = nn.silu(gate) * up
+        return self.w2(h.astype(dtype))
+
+
+class MoE(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.dim = args.dim
+        self.gate = Gate(args)
+        self.experts = SwitchGLU(
+            args.dim,
+            args.moe_inter_dim,
+            args.n_routed_experts,
+            activation=ClampedSwiGLU(args.swiglu_limit),
+            bias=False,
+        )
+        self.shared_experts = SharedExpert(
+            args.dim, args.moe_inter_dim, args.swiglu_limit
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        shape = x.shape
+        xf = x.reshape(-1, self.dim)
+        weights, indices = self.gate(xf)
+        y = self.experts(xf, indices)  # [tokens, topk, dim]
+        y = mx.sum(y.astype(mx.float32) * weights[..., None], axis=-2)
+        y = y + self.shared_experts(xf).astype(mx.float32)
+        return y.reshape(shape).astype(x.dtype)

--- a/scripts/deepseek_v41_native/sparse_attention.py
+++ b/scripts/deepseek_v41_native/sparse_attention.py
@@ -1,0 +1,66 @@
+"""Gather-based sparse attention — the MLX stand-in for the TileLang kernel.
+
+Semantics from ``sparse_attn_kernel`` in the reference ``kernel.py``:
+
+* ``kv`` is a **single** shared vector per position (MLA): key and value are the
+  same tensor;
+* an index of ``-1`` means "not visible": its logit is -inf, contributing nothing;
+* the learned per-head ``attn_sink`` enters the softmax **denominator only** — it
+  carries no value vector, so a head with weak logits attends to nearly nothing;
+* a row with no valid index yields an all-zero output (the kernel's finite
+  -1e30 max floor).
+
+The kernel keeps its running max over the real logits only and adds
+``exp(sink - max)`` at the end; here the sink also competes for the max, which is
+mathematically identical (softmax shift invariance) and safer numerically.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+NEG_INF = -1e30
+
+
+def _gather_kv(kv: mx.array, idx: mx.array) -> mx.array:
+    """kv [b, n, d], idx [b, m, k] -> [b, m, k, d]; row 0 for negative idx."""
+    b, n, d = kv.shape
+    flat = kv.reshape(b * n, d)
+    safe = mx.maximum(idx, 0).astype(mx.int32)
+    base = (mx.arange(b, dtype=mx.int32) * n).reshape(b, 1, 1)
+    return flat[(safe + base).reshape(-1)].reshape(*idx.shape, d)
+
+
+def sparse_attn(
+    q: mx.array,
+    kv: mx.array,
+    attn_sink: mx.array,
+    topk_idxs: mx.array,
+    softmax_scale: float,
+    chunk: int = 256,
+) -> mx.array:
+    """q [b,m,h,d], kv [b,n,d], attn_sink [h], topk_idxs [b,m,k] (-1 = masked)."""
+    b, m, h, d = q.shape
+    sink = attn_sink.astype(mx.float32).reshape(1, 1, h, 1)
+
+    outs = []
+    for start in range(0, m, chunk):
+        stop = min(start + chunk, m)
+        qc = q[:, start:stop].astype(mx.float32)
+        ic = topk_idxs[:, start:stop]
+        kvc = _gather_kv(kv, ic).astype(mx.float32)  # [b, c, k, d]
+
+        logits = mx.einsum("bchd,bckd->bchk", qc, kvc) * softmax_scale
+        valid = (ic >= 0)[:, :, None, :]
+        logits = mx.where(valid, logits, NEG_INF)
+
+        mmax = mx.max(logits, axis=-1, keepdims=True)
+        mmax = mx.maximum(mx.maximum(mmax, sink), NEG_INF)
+        w = mx.exp(logits - mmax)
+        w = mx.where(valid, w, 0.0)
+        denom = mx.sum(w, axis=-1, keepdims=True) + mx.exp(sink - mmax)
+
+        o = mx.einsum("bchk,bckd->bchd", w, kvc) / denom
+        outs.append(o.astype(q.dtype))
+
+    return mx.concatenate(outs, axis=1) if len(outs) > 1 else outs[0]

--- a/scripts/deepseek_v41_native/stream.py
+++ b/scripts/deepseek_v41_native/stream.py
@@ -1,0 +1,126 @@
+"""Layer-at-a-time access to the raw release, for divergence ladders and the
+streaming quantizer (pattern from glm53-mlx).
+
+A V4.1 layer cannot run in isolation the way a plain transformer layer can:
+the hyper-connection stream carries a staggered ``pre_mix`` and the attention
+layers share compressed KV / index selections through a ``SharedState``. The
+carried state is therefore explicit: :func:`run_layer` takes and returns a
+:class:`StreamState` alongside the hidden stream.
+
+Consumer layers reference their kv/index source's caches through the shared
+state, so a streaming pass must keep each source layer's ``LayerCache`` alive
+until its last consumer has run — :class:`StreamState` owns the full
+``ModelCache`` (per-layer caches are small next to the weights: window ring +
+compressed latents).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .cache import ModelCache
+from .config import ModelArgs
+from .convert import sanitize_group
+from .hyper_connections import hc_pre, make_identity_pre_mix
+from .model import Block, SharedState
+
+_SHARD_CACHE: dict[str, dict[str, mx.array]] = {}
+
+
+def read_config(src: Path):
+    raw = json.load(open(Path(src) / "config.json"))
+    return raw, ModelArgs.from_dict(raw)
+
+
+def shard_map(src: Path) -> dict[str, str]:
+    raw = json.load(open(Path(src) / "model.safetensors.index.json"))
+    return cast(dict[str, str], raw["weight_map"])
+
+
+def load_subset(src: Path, smap: dict[str, str], prefix: str) -> dict[str, mx.array]:
+    """All tensors whose name starts with ``prefix``, memory-mapped lazily."""
+    out = {}
+    for k, shard in smap.items():
+        if k.startswith(prefix):
+            shard_path = str((Path(src) / shard).resolve())
+            if shard_path not in _SHARD_CACHE:
+                _SHARD_CACHE.clear()
+                _SHARD_CACHE[shard_path] = mx.load(shard_path)
+            out[k] = _SHARD_CACHE[shard_path][k]
+    return out
+
+
+def build_layer(
+    margs: ModelArgs, layer_i: int, src: Path, smap: dict[str, str]
+) -> nn.Module:
+    """One Block holding the raw release weights for layer ``layer_i``,
+    sanitized (dequantized + experts stacked) on the fly."""
+    prefix = f"layers.{layer_i}."
+    raw = load_subset(src, smap, prefix)
+    sane = sanitize_group(sorted(raw), raw)
+    # ``wo_a`` is stored flat in the release but represented as MultiLinear
+    # so the same module can execute both float and grouped affine weights.
+    # Keep the streaming path consistent with the strict full-model loader.
+    from .load import reshape_grouped_wo_a
+
+    sane = dict(reshape_grouped_wo_a(sane.items(), margs))
+    layer = Block(layer_i, margs)
+    layer.load_weights([(k[len(prefix) :], v) for k, v in sane.items()], strict=True)
+    return layer
+
+
+class StreamState:
+    """Everything a 40-layer streaming pass carries between layers."""
+
+    def __init__(self, margs: ModelArgs, bsz: int, max_seq_len: int, token_map=None):
+        self.margs = margs
+        self.cache = ModelCache(margs, bsz, max_seq_len)
+        self.shared = SharedState()
+        self.pre_mix = None
+        self.hashes = None
+        self.hasher: Any
+        if margs.engram_layer_ids and token_map is not None:
+            from .engram import EngramHasher
+
+            self.hasher = EngramHasher(margs, token_map)
+        else:
+            self.hasher = None
+
+    def begin(self, input_ids_np, h_embedded: mx.array, hc_mult: int) -> mx.array:
+        """Start a pass: expand the embedding to hc copies, hash for engram."""
+        b, n = input_ids_np.shape
+        if self.hasher is not None:
+            self.hashes = mx.array(
+                self.hasher(input_ids_np, self.cache.offset, self.cache.engram_ids)
+            )
+        self.pre_mix = make_identity_pre_mix(b, n, hc_mult)
+        self.shared = SharedState()
+        return mx.broadcast_to(
+            h_embedded[:, :, None, :], (b, n, hc_mult, h_embedded.shape[-1])
+        )
+
+
+def run_layer(layer: Block, h: mx.array, state: StreamState) -> mx.array:
+    """Run one Block, threading the carried state. Returns the new hc stream."""
+    if layer.engram is not None and state.hashes is not None:
+        h = layer.engram(h, state.hashes[:, :, layer.engram.layer_hash_index])
+    h, state.pre_mix = layer(
+        h, state.pre_mix, state.cache.offset, state.cache, state.shared
+    )
+    return h
+
+
+def finish(
+    h: mx.array, state: StreamState, norm, head_weight: mx.array, seqlen: int
+) -> mx.array:
+    """Collapse with the last ffn_pre, norm, project to logits; advance offset."""
+    h = hc_pre(h, state.pre_mix)
+    h = norm(h)
+    logits = h.astype(mx.float32) @ head_weight.astype(mx.float32).T
+    state.cache.offset += seqlen
+    return logits

--- a/scripts/qualify_deepseek_v41_native.py
+++ b/scripts/qualify_deepseek_v41_native.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Qualify a native DeepSeek-V4.1 build on one resident model instance.
+
+This is deliberately a direct-runtime gate rather than a server benchmark: it
+checks the model's required chat framing, greedy token stability across Metal
+evaluation intervals, decode throughput, and peak memory before any catalog or
+server integration is attempted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import mlx.core as mx
+from transformers import PreTrainedTokenizerFast
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from deepseek_v41_native.load import load  # noqa: E402
+
+BOS = "<｜begin▁of▁sentence｜>"
+USER = "<｜User｜>"
+ASSISTANT = "<｜Assistant｜>"
+CHAT_START = "</think>"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model", type=Path)
+    parser.add_argument("--tokens", type=int, default=16)
+    parser.add_argument("--intervals", type=int, nargs="+", default=[1, 2, 4])
+    parser.add_argument("--fuse-moe-gate-up", action="store_true")
+    parser.add_argument(
+        "--prompt",
+        default="What is the capital of France? Answer in one short sentence.",
+    )
+    return parser.parse_args()
+
+
+def framed_prompt(text: str) -> str:
+    """DeepSeek-V4.1 chat mode framing from the release encoding contract."""
+    return f"{BOS}{USER}{text}{ASSISTANT}{CHAT_START}"
+
+
+def run_once(model, token_ids: list[int], output_tokens: int, eos_id: int) -> dict:
+    cache = model.make_cache(
+        bsz=1,
+        max_seq_len=len(token_ids) + output_tokens + 8,
+        dtype=mx.bfloat16,
+    )
+    started = time.monotonic()
+    logits = model(mx.array([token_ids]), cache, last_logit_only=True)
+    mx.eval(logits)
+    prefill_seconds = time.monotonic() - started
+
+    generated: list[int] = []
+    decode_times: list[float] = []
+    token = mx.argmax(logits[:, -1], axis=-1)
+    for _ in range(output_tokens):
+        token_id = int(token[0])
+        generated.append(token_id)
+        if token_id == eos_id:
+            break
+        started = time.monotonic()
+        logits = model(token[:, None], cache, last_logit_only=True)
+        mx.eval(logits)
+        decode_times.append(time.monotonic() - started)
+        token = mx.argmax(logits[:, -1], axis=-1)
+
+    decode_seconds = sum(decode_times)
+    decode_tokens = len(decode_times)
+    steady_times = decode_times[len(decode_times) // 2 :]
+    return {
+        "input_tokens": len(token_ids),
+        "output_tokens": generated,
+        "prefill_seconds": prefill_seconds,
+        "decode_seconds": decode_seconds,
+        "decode_transitions": decode_tokens,
+        "decode_tok_s": decode_tokens / decode_seconds if decode_seconds else None,
+        "steady_last_half_tok_s": (
+            len(steady_times) / sum(steady_times) if steady_times else None
+        ),
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    started = time.monotonic()
+    model, _ = load(
+        str(args.model.resolve()),
+        lazy=False,
+        fuse_moe_gate_up=args.fuse_moe_gate_up,
+    )
+    load_seconds = time.monotonic() - started
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_file=str(args.model.resolve() / "tokenizer.json")
+    )
+    prompt = framed_prompt(args.prompt)
+    token_ids = tokenizer.encode(prompt, add_special_tokens=False)
+    print(
+        json.dumps(
+            {
+                "event": "loaded",
+                "load_seconds": load_seconds,
+                "active_gb": mx.get_active_memory() / 1e9,
+                "peak_gb": mx.get_peak_memory() / 1e9,
+                "prompt": prompt,
+                "prompt_tokens": token_ids,
+            }
+        ),
+        flush=True,
+    )
+
+    reference_tokens = None
+    for interval in args.intervals:
+        model.eval_interval = interval
+        result = run_once(model, token_ids, args.tokens, eos_id=1)
+        result.update(
+            {
+                "event": "interval",
+                "eval_interval": interval,
+                "text": tokenizer.decode(result["output_tokens"]),
+                "active_gb": mx.get_active_memory() / 1e9,
+                "peak_gb": mx.get_peak_memory() / 1e9,
+            }
+        )
+        if reference_tokens is None:
+            reference_tokens = result["output_tokens"]
+            result["greedy_matches_first_interval"] = True
+        else:
+            result["greedy_matches_first_interval"] = (
+                result["output_tokens"] == reference_tokens
+            )
+        print(json.dumps(result), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repack_deepseek_v41_native.py
+++ b/scripts/repack_deepseek_v41_native.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Stream a split-expert DeepSeek V4.1 MLX checkpoint into native layout.
+
+The source checkpoint already contains MLX affine 2-bit tensors. Repacking is
+byte-preserving: routed-expert tensors are stacked along a new leading expert
+axis and all other quantized tensors retain their stored bytes. This avoids a
+second quantization pass and its associated quality loss.
+
+The destination must not exist. Large generated builds belong on the Studio
+warm tier, not in or beside the Hugging Face cache.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import struct
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+import numpy as np
+
+_EXPERT_RE = re.compile(
+    r"^layers\.(\d+)\.ffn\.experts\.(\d+)\.(w[123])\."
+    r"(weight|scales|biases)$"
+)
+_LAYER_RE = re.compile(r"^layers\.(\d+)\.")
+_ROUTER_RE = re.compile(r"^layers\.(\d+)\.ffn\.gate\.(weight|bias|bias_vl)$")
+_DROP_PREFIXES = ("mtp.", "vision.", "aligner.", "image_")
+_PROJECTION_NAMES = {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}
+_DTYPE_BYTES = {
+    "BOOL": 1,
+    "U8": 1,
+    "I8": 1,
+    "U16": 2,
+    "I16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "U32": 4,
+    "I32": 4,
+    "F32": 4,
+    "U64": 8,
+    "I64": 8,
+    "F64": 8,
+}
+_COPY_CHUNK = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class SourceTensor:
+    name: str
+    path: Path
+    offset: int
+    nbytes: int
+    dtype: str
+    shape: tuple[int, ...]
+
+    @property
+    def row_bytes(self) -> int:
+        if not self.shape or self.shape[0] <= 0:
+            raise ValueError(f"{self.name} cannot be sliced by row")
+        if self.nbytes % self.shape[0]:
+            raise ValueError(f"{self.name} has non-integral row storage")
+        return self.nbytes // self.shape[0]
+
+
+@dataclass(frozen=True)
+class TensorPlan:
+    name: str
+    dtype: str
+    shape: tuple[int, ...]
+    sources: tuple[SourceTensor, ...]
+    rows: tuple[int, ...] | None = None
+
+    @property
+    def nbytes(self) -> int:
+        return math.prod(self.shape) * _DTYPE_BYTES[self.dtype]
+
+
+class CheckpointIndex:
+    def __init__(self, root: Path):
+        self.root = root
+        index_path = root / "model.safetensors.index.json"
+        weight_map = json.loads(index_path.read_text())["weight_map"]
+        by_shard: dict[str, list[str]] = defaultdict(list)
+        for name, shard in weight_map.items():
+            by_shard[shard].append(name)
+
+        self.tensors: dict[str, SourceTensor] = {}
+        for shard, expected_names in sorted(by_shard.items()):
+            path = root / shard
+            with path.open("rb") as handle:
+                header_len = struct.unpack("<Q", handle.read(8))[0]
+                header = json.loads(handle.read(header_len))
+            data_start = 8 + header_len
+            for name in expected_names:
+                meta = header[name]
+                begin, end = meta["data_offsets"]
+                tensor = SourceTensor(
+                    name=name,
+                    path=path,
+                    offset=data_start + begin,
+                    nbytes=end - begin,
+                    dtype=meta["dtype"],
+                    shape=tuple(meta["shape"]),
+                )
+                expected = math.prod(tensor.shape) * _DTYPE_BYTES[tensor.dtype]
+                if expected != tensor.nbytes:
+                    raise ValueError(
+                        f"{name}: header stores {tensor.nbytes} bytes, expected {expected}"
+                    )
+                self.tensors[name] = tensor
+        if set(self.tensors) != set(weight_map):
+            raise ValueError("checkpoint index and safetensors headers disagree")
+
+
+def _copy_range(source: SourceTensor, output: BinaryIO) -> None:
+    remaining = source.nbytes
+    with source.path.open("rb", buffering=0) as handle:
+        handle.seek(source.offset)
+        while remaining:
+            block = handle.read(min(remaining, _COPY_CHUNK))
+            if not block:
+                raise EOFError(f"short read from {source.path} for {source.name}")
+            output.write(block)
+            remaining -= len(block)
+
+
+def _copy_rows(source: SourceTensor, rows: Sequence[int], output: BinaryIO) -> None:
+    row_bytes = source.row_bytes
+    with source.path.open("rb", buffering=0) as handle:
+        for row in rows:
+            if row < 0 or row >= source.shape[0]:
+                raise IndexError(f"row {row} outside {source.name} {source.shape}")
+            handle.seek(source.offset + row * row_bytes)
+            remaining = row_bytes
+            while remaining:
+                block = handle.read(min(remaining, _COPY_CHUNK))
+                if not block:
+                    raise EOFError(f"short row read from {source.name}")
+                output.write(block)
+                remaining -= len(block)
+
+
+def write_safetensors(path: Path, plans: Sequence[TensorPlan]) -> None:
+    offset = 0
+    header: dict[str, object] = {"__metadata__": {"format": "mlx"}}
+    for plan in plans:
+        header[plan.name] = {
+            "dtype": plan.dtype,
+            "shape": list(plan.shape),
+            "data_offsets": [offset, offset + plan.nbytes],
+        }
+        offset += plan.nbytes
+
+    encoded = json.dumps(header, separators=(",", ":")).encode()
+    encoded += b" " * ((-len(encoded)) % 8)
+    temporary = path.with_suffix(path.suffix + ".partial")
+    with temporary.open("xb") as output:
+        output.write(struct.pack("<Q", len(encoded)))
+        output.write(encoded)
+        for plan in plans:
+            before = output.tell()
+            if plan.rows is not None:
+                if len(plan.sources) != 1:
+                    raise ValueError(f"row plan {plan.name} must have one source")
+                _copy_rows(plan.sources[0], plan.rows, output)
+            else:
+                for source in plan.sources:
+                    _copy_range(source, output)
+            written = output.tell() - before
+            if written != plan.nbytes:
+                raise ValueError(
+                    f"{plan.name}: wrote {written} bytes, expected {plan.nbytes}"
+                )
+        output.flush()
+        os.fsync(output.fileno())
+    temporary.replace(path)
+
+
+def _selection_from_saliency(
+    path: Path | None, layers: int, experts: int, keep: int
+) -> dict[int, tuple[int, ...]]:
+    if keep == experts:
+        return {layer: tuple(range(experts)) for layer in range(layers)}
+    if path is None:
+        raise ValueError("--saliency is required when pruning experts")
+    data = np.load(path)
+    score_key = "robust_saliency" if "robust_saliency" in data else "saliency"
+    saliency = np.asarray(data[score_key])
+    if saliency.shape != (layers, experts):
+        raise ValueError(
+            f"saliency shape {saliency.shape} != expected {(layers, experts)}"
+        )
+    return {
+        layer: tuple(sorted(np.argsort(-saliency[layer])[:keep].tolist()))
+        for layer in range(layers)
+    }
+
+
+def build_plans(
+    checkpoint: CheckpointIndex,
+    *,
+    layer_count: int,
+    expert_count: int,
+    selection: dict[int, tuple[int, ...]],
+    selected_layers: set[int] | None = None,
+) -> dict[str, list[TensorPlan]]:
+    ordinary: dict[str, SourceTensor] = {}
+    expert_parts: dict[tuple[int, str, str], dict[int, SourceTensor]] = defaultdict(
+        dict
+    )
+
+    for name, source in checkpoint.tensors.items():
+        if name.startswith(_DROP_PREFIXES):
+            continue
+        layer_match = _LAYER_RE.match(name)
+        if selected_layers is not None:
+            if layer_match is None or int(layer_match.group(1)) not in selected_layers:
+                continue
+        match = _EXPERT_RE.match(name)
+        if match:
+            layer, expert, projection, suffix = match.groups()
+            expert_parts[(int(layer), projection, suffix)][int(expert)] = source
+        else:
+            ordinary[name] = source
+
+    groups: dict[str, list[TensorPlan]] = defaultdict(list)
+    for name, source in ordinary.items():
+        layer_match = _LAYER_RE.match(name)
+        group = f"layer-{int(layer_match.group(1)):02d}" if layer_match else "top"
+        router_match = _ROUTER_RE.match(name)
+        rows = None
+        shape = source.shape
+        if router_match:
+            layer = int(router_match.group(1))
+            rows = selection[layer]
+            shape = (len(rows), *shape[1:])
+        groups[group].append(
+            TensorPlan(name, source.dtype, shape, (source,), rows=rows)
+        )
+
+    for (layer, projection, suffix), parts in expert_parts.items():
+        if set(parts) != set(range(expert_count)):
+            missing = sorted(set(range(expert_count)) - set(parts))
+            raise ValueError(
+                f"layer {layer} {projection}.{suffix} missing experts {missing[:8]}"
+            )
+        chosen = selection[layer]
+        sources = tuple(parts[expert] for expert in chosen)
+        exemplar = sources[0]
+        if any(
+            (item.dtype, item.shape) != (exemplar.dtype, exemplar.shape)
+            for item in sources
+        ):
+            raise ValueError(
+                f"inconsistent expert tensors for layer {layer} {projection}"
+            )
+        name = f"layers.{layer}.ffn.experts.{_PROJECTION_NAMES[projection]}.{suffix}"
+        groups[f"layer-{layer:02d}"].append(
+            TensorPlan(
+                name,
+                exemplar.dtype,
+                (len(sources), *exemplar.shape),
+                sources,
+            )
+        )
+
+    expected_layers: Iterable[int]
+    if selected_layers is None:
+        expected_layers = range(layer_count)
+    else:
+        expected_layers = selected_layers
+    for layer in expected_layers:
+        if f"layer-{layer:02d}" not in groups:
+            raise ValueError(f"no tensors planned for layer {layer}")
+    for plans in groups.values():
+        plans.sort(key=lambda plan: plan.name)
+    return dict(groups)
+
+
+def _module_map(groups: dict[str, list[TensorPlan]], bits: int, group_size: int):
+    names = {plan.name for plans in groups.values() for plan in plans}
+    modules = {}
+    for name in sorted(names):
+        if not name.endswith(".scales") or ".engram.embed." in name:
+            continue
+        base = name.removesuffix(".scales")
+        if f"{base}.weight" in names:
+            modules[base] = {"group_size": group_size, "bits": bits}
+    return modules
+
+
+def _copy_metadata_files(source: Path, destination: Path) -> None:
+    allowed = {
+        "LICENSE",
+        "chat_template.jinja",
+        "generation_config.json",
+        "preprocessor_config.json",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    }
+    for name in allowed:
+        src = source / name
+        if src.is_file():
+            shutil.copy2(src, destination / name)
+
+
+def _write_model_card(destination: Path, metadata: dict, tensor_bytes: int) -> None:
+    """Prevent a derived artifact from inheriting incorrect source claims."""
+    original = metadata["original_experts"]
+    kept = metadata["kept_experts"]
+    (destination / "README.md").write_text(
+        "# Experimental DeepSeek V4.1 native MLX repack\n\n"
+        "This local text-only artifact is a byte-preserving MLX affine 2-bit "
+        "repack. It is **not product-qualified and must not be published or "
+        "cataloged without separate quality, performance, and license review**.\n\n"
+        f"- Tensor bytes: {tensor_bytes:,}\n"
+        f"- Routed experts kept: {kept} of {original}\n"
+        "- Vision: omitted\n"
+        "- MTP: omitted\n"
+        "- Runtime: Rapid-MLX experimental native V4.1 loader\n"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--destination", type=Path, required=True)
+    parser.add_argument("--keep-experts", type=int, default=None)
+    parser.add_argument("--saliency", type=Path)
+    parser.add_argument(
+        "--layers",
+        help="comma-separated layer ids for a small parity fixture; default is all",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    source = args.source.resolve()
+    destination = args.destination.resolve()
+    if not source.is_dir():
+        raise SystemExit(f"source checkpoint does not exist: {source}")
+    if destination.exists():
+        raise SystemExit(f"destination already exists: {destination}")
+
+    config = json.loads((source / "config.json").read_text())
+    text_config = config.get("text_config", config)
+    layer_count = int(text_config["num_hidden_layers"])
+    expert_count = int(text_config["n_routed_experts"])
+    keep = args.keep_experts or expert_count
+    if not 1 <= keep <= expert_count:
+        raise SystemExit(f"--keep-experts must be in [1, {expert_count}]")
+    selected_layers = (
+        {int(item) for item in args.layers.split(",")} if args.layers else None
+    )
+    if selected_layers and not selected_layers <= set(range(layer_count)):
+        raise SystemExit("--layers contains an out-of-range layer")
+
+    q = config.get("quantization", config.get("quantization_config", {}))
+    bits = int(q.get("bits", 0))
+    group_size = int(q.get("group_size", 0))
+    if (bits, group_size, q.get("mode", "affine")) != (2, 64, "affine"):
+        raise SystemExit(
+            "source must be the validated affine 2-bit/group-64 checkpoint"
+        )
+
+    selection = _selection_from_saliency(args.saliency, layer_count, expert_count, keep)
+    checkpoint = CheckpointIndex(source)
+    groups = build_plans(
+        checkpoint,
+        layer_count=layer_count,
+        expert_count=expert_count,
+        selection=selection,
+        selected_layers=selected_layers,
+    )
+    total_bytes = sum(plan.nbytes for plans in groups.values() for plan in plans)
+    print(
+        json.dumps(
+            {
+                "source": str(source),
+                "destination": str(destination),
+                "layers": sorted(selected_layers) if selected_layers else "all",
+                "experts": {"source": expert_count, "kept": keep},
+                "tensor_bytes": total_bytes,
+                "tensor_gb": round(total_bytes / 1e9, 3),
+                "shards": len(groups),
+                "dry_run": args.dry_run,
+            },
+            indent=2,
+        )
+    )
+    if args.dry_run:
+        return
+
+    destination.mkdir(parents=True)
+    shard_names: dict[str, str] = {}
+    weight_map: dict[str, str] = {}
+    ordered_groups = sorted(groups, key=lambda item: (item == "top", item))
+    for index, group in enumerate(ordered_groups, 1):
+        filename = f"model-{index:05d}-of-{len(groups):05d}.safetensors"
+        shard_names[group] = filename
+        print(f"[{index}/{len(groups)}] {group} -> {filename}", flush=True)
+        write_safetensors(destination / filename, groups[group])
+        weight_map.update({plan.name: filename for plan in groups[group]})
+
+    output_config = json.loads(json.dumps(config))
+    output_config["model_type"] = "deepseek_v41"
+    output_config["n_routed_experts"] = keep
+    if "text_config" in output_config:
+        output_config["text_config"]["n_routed_experts"] = keep
+    output_config["quantization"] = {
+        "group_size": group_size,
+        "bits": bits,
+        "mode": "affine",
+        "expert_bits": bits,
+        "engram_bits": bits,
+        "modules": _module_map(groups, bits, group_size),
+    }
+    output_config["rapid_quantization"] = {
+        "format": "native-packed-affine",
+        "source_bits": bits,
+        "group_size": group_size,
+        "byte_preserving_repack": True,
+        "original_experts": expert_count,
+        "kept_experts": keep,
+        "vision": False,
+        "mtp": False,
+    }
+    if args.saliency is not None:
+        calibration = np.load(args.saliency)
+        output_config["rapid_quantization"]["pruning"] = {
+            "saliency_file": args.saliency.name,
+            "calibration_tokens": int(calibration.get("tokens", 0)),
+            "selection_policy": str(
+                calibration.get("selection_policy", "combined_saliency")
+            ),
+        }
+    if selected_layers is not None:
+        output_config["rapid_quantization"]["partial_layers"] = sorted(selected_layers)
+    (destination / "config.json").write_text(json.dumps(output_config, indent=2) + "\n")
+    (destination / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {"metadata": {"total_size": total_bytes}, "weight_map": weight_map},
+            indent=2,
+        )
+        + "\n"
+    )
+    _copy_metadata_files(source, destination)
+    _write_model_card(destination, output_config["rapid_quantization"], total_bytes)
+    print(f"wrote {total_bytes / 1e9:.1f} GB to {destination}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_calibrate_deepseek_v41_reap.py
+++ b/tests/test_calibrate_deepseek_v41_reap.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+
+def _load_module():
+    path = Path(__file__).parents[1] / "scripts" / "calibrate_deepseek_v41_reap.py"
+    spec = importlib.util.spec_from_file_location("calibrate_deepseek_v41_reap", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+calibrate = _load_module()
+
+
+def test_overlap_measures_per_layer_keep_set_stability() -> None:
+    left = np.array([[9.0, 8.0, 1.0, 0.0], [7.0, 6.0, 5.0, 0.0]])
+    right = np.array([[9.0, 7.0, 8.0, 0.0], [7.0, 6.0, 0.0, 5.0]])
+
+    assert calibrate._overlap(left, right, keep=2) == 0.75
+
+
+def test_corpus_tokens_requires_requested_sample(tmp_path: Path) -> None:
+    corpus = tmp_path / "tiny.txt"
+    corpus.write_text("one two")
+
+    class Encoding:
+        ids = [1, 2]
+
+    class Tokenizer:
+        @staticmethod
+        def encode(_text):
+            return Encoding()
+
+    class Runtime:
+        tokenizer = Tokenizer()
+
+    try:
+        calibrate._corpus_tokens(Runtime(), [corpus], count=3)
+    except ValueError as error:
+        assert "need 3" in str(error)
+    else:
+        raise AssertionError("short calibration corpus must be rejected")
+
+
+def test_main_refuses_checkpoint_code_without_explicit_trust(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "calibrate_deepseek_v41_reap.py",
+            "--model",
+            str(tmp_path / "model"),
+            "--output",
+            str(tmp_path / "result.npz"),
+            str(tmp_path / "corpus.txt"),
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="refusing to execute"):
+        calibrate.main()

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mlx")
+pytest.importorskip("mlx_lm")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.core as mx
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "scripts"))
+
+from deepseek_v41_native.attention import Attention, GroupedOutputLinear  # noqa: E402
+from deepseek_v41_native.compressor import Compressor, CompressorState  # noqa: E402
+from deepseek_v41_native.config import ModelArgs  # noqa: E402
+from deepseek_v41_native.load import reshape_grouped_wo_a  # noqa: E402
+from deepseek_v41_native.model import Model  # noqa: E402
+
+
+def test_reshape_grouped_wo_a_restores_quantized_parameter_axes() -> None:
+    args = ModelArgs(o_groups=2, o_lora_rank=3)
+    weight = mx.arange(24, dtype=mx.uint32).reshape(6, 4)
+    scales = mx.arange(12, dtype=mx.float32).reshape(6, 2)
+
+    values = dict(
+        reshape_grouped_wo_a(
+            [
+                ("layers.0.attn.wo_a.weight", weight),
+                ("layers.0.attn.wo_a.scales", scales),
+                ("layers.0.attn.wq_a.weight", weight),
+            ],
+            args,
+        )
+    )
+
+    assert values["layers.0.attn.wo_a.weight"].shape == (2, 3, 4)
+    assert values["layers.0.attn.wo_a.scales"].shape == (2, 3, 2)
+    assert values["layers.0.attn.wq_a.weight"].shape == (6, 4)
+
+
+def test_reshape_grouped_wo_a_rejects_incompatible_rows() -> None:
+    args = ModelArgs(o_groups=2, o_lora_rank=3)
+    with pytest.raises(ValueError, match="expected 6"):
+        reshape_grouped_wo_a([("layers.0.attn.wo_a.weight", mx.zeros((5, 4)))], args)
+
+
+def test_quantized_grouped_wo_a_preserves_batch_sequence_and_group_axes() -> None:
+    args = ModelArgs(
+        dim=16,
+        n_heads=8,
+        head_dim=8,
+        rope_head_dim=2,
+        q_lora_rank=8,
+        o_lora_rank=3,
+        o_groups=2,
+        n_layers=1,
+        compress_ratios=(0,),
+    )
+    attention = Attention(0, args)
+    attention.wo_a = attention.wo_a.to_quantized(group_size=32, bits=2)
+    grouped = mx.zeros((1, 5, args.o_groups, 32), dtype=mx.float32)
+
+    projected = attention.wo_a(grouped[..., None, :]).squeeze(-2)
+
+    assert projected.shape == (1, 5, args.o_groups, args.o_lora_rank)
+
+
+def test_grouped_wo_a_accepts_release_flat_float_layout_for_prefill() -> None:
+    layer = GroupedOutputLinear(input_dims=8, output_dims=3, num_heads=2)
+    flat = mx.arange(48, dtype=mx.float32).reshape(6, 8)
+    layer.weight = flat
+    values = mx.arange(2 * 5 * 2 * 8, dtype=mx.float32).reshape(2, 5, 2, 8)
+
+    actual = layer(values[..., None, :]).squeeze(-2)
+    expected = mx.einsum("bsgd,grd->bsgr", values, flat.reshape(2, 3, 8))
+    mx.eval(actual, expected)
+
+    assert actual.shape == (2, 5, 2, 3)
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_quantized_compressor_uses_logical_module_projection() -> None:
+    args = ModelArgs(
+        dim=64,
+        head_dim=32,
+        n_layers=1,
+        compress_ratios=(2,),
+    )
+    compressor = Compressor(args, 0)
+    compressor.wkv = compressor.wkv.to_quantized(group_size=32, bits=2)
+    compressor.wgate = compressor.wgate.to_quantized(group_size=32, bits=2)
+    state = CompressorState(bsz=1, ratio=2, head_dim=args.head_dim)
+
+    output = compressor(mx.zeros((1, 2, args.dim)), start_pos=0, comp_state=state)
+    mx.eval(output)
+
+    assert output.shape == (1, 1, args.head_dim)
+
+
+def test_native_model_defaults_to_watchdog_safe_layer_boundaries() -> None:
+    args = ModelArgs(
+        dim=64,
+        vocab_size=32,
+        n_layers=0,
+        n_heads=1,
+        head_dim=64,
+        rope_head_dim=32,
+        hc_mult=1,
+        compress_ratios=(),
+    )
+
+    assert Model(args).eval_interval == 1

--- a/tests/test_repack_deepseek_v41_native.py
+++ b/tests/test_repack_deepseek_v41_native.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+from safetensors.numpy import load_file, save_file
+
+
+def _load_module():
+    path = Path(__file__).parents[1] / "scripts" / "repack_deepseek_v41_native.py"
+    spec = importlib.util.spec_from_file_location("repack_deepseek_v41_native", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+repack = _load_module()
+
+
+def _fixture(tmp_path: Path, experts: int = 4) -> Path:
+    root = tmp_path / "source"
+    root.mkdir()
+    tensors: dict[str, np.ndarray] = {
+        "layers.0.ffn.gate.weight": np.arange(experts * 3, dtype=np.float32).reshape(
+            experts, 3
+        ),
+        "layers.0.ffn.gate.bias": np.arange(experts, dtype=np.float32),
+        "layers.0.ffn.gate.bias_vl": np.arange(experts, dtype=np.float32) + 10,
+        "layers.0.attn.wq_a.weight": np.arange(8, dtype=np.uint32).reshape(2, 4),
+        "layers.0.attn.wq_a.scales": np.ones((2, 1), dtype=np.float32),
+        "layers.0.attn.wq_a.biases": np.zeros((2, 1), dtype=np.float32),
+        "mtp.0.norm.weight": np.ones((2,), dtype=np.float32),
+        "vision.block.weight": np.ones((2,), dtype=np.float32),
+    }
+    for expert in range(experts):
+        for projection in ("w1", "w2", "w3"):
+            prefix = f"layers.0.ffn.experts.{expert}.{projection}"
+            value = 100 * expert + 10 * int(projection[-1])
+            tensors[f"{prefix}.weight"] = np.full((2, 2), value, dtype=np.uint32)
+            tensors[f"{prefix}.scales"] = np.full((2, 1), value + 1, dtype=np.float32)
+            tensors[f"{prefix}.biases"] = np.full((2, 1), value + 2, dtype=np.float32)
+    shard = "model-00001-of-00001.safetensors"
+    save_file(tensors, root / shard)
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {},
+                "weight_map": {name: shard for name in tensors},
+            }
+        )
+    )
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v41",
+                "text_config": {
+                    "num_hidden_layers": 1,
+                    "n_routed_experts": experts,
+                },
+                "quantization": {
+                    "bits": 2,
+                    "group_size": 64,
+                    "mode": "affine",
+                },
+            }
+        )
+    )
+    return root
+
+
+def test_repack_stacks_experts_byte_exactly(tmp_path: Path) -> None:
+    source = _fixture(tmp_path)
+    checkpoint = repack.CheckpointIndex(source)
+    selection = {0: tuple(range(4))}
+    groups = repack.build_plans(
+        checkpoint,
+        layer_count=1,
+        expert_count=4,
+        selection=selection,
+    )
+    output = tmp_path / "layer.safetensors"
+    repack.write_safetensors(output, groups["layer-00"])
+    tensors = load_file(output)
+
+    packed = tensors["layers.0.ffn.experts.gate_proj.weight"]
+    assert packed.shape == (4, 2, 2)
+    for expert in range(4):
+        np.testing.assert_array_equal(packed[expert], 100 * expert + 10)
+    assert "mtp.0.norm.weight" not in tensors
+    assert "vision.block.weight" not in tensors
+
+
+def test_repack_pruning_subsets_experts_and_router_together(tmp_path: Path) -> None:
+    source = _fixture(tmp_path)
+    checkpoint = repack.CheckpointIndex(source)
+    selection = {0: (1, 3)}
+    groups = repack.build_plans(
+        checkpoint,
+        layer_count=1,
+        expert_count=4,
+        selection=selection,
+    )
+    output = tmp_path / "pruned.safetensors"
+    repack.write_safetensors(output, groups["layer-00"])
+    tensors = load_file(output)
+
+    np.testing.assert_array_equal(
+        tensors["layers.0.ffn.experts.up_proj.weight"][:, 0, 0],
+        np.array([130, 330], dtype=np.uint32),
+    )
+    np.testing.assert_array_equal(
+        tensors["layers.0.ffn.gate.weight"],
+        np.array([[3, 4, 5], [9, 10, 11]], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        tensors["layers.0.ffn.gate.bias_vl"],
+        np.array([11, 13], dtype=np.float32),
+    )
+
+
+def test_module_map_tracks_quantized_native_names(tmp_path: Path) -> None:
+    source = _fixture(tmp_path)
+    groups = repack.build_plans(
+        repack.CheckpointIndex(source),
+        layer_count=1,
+        expert_count=4,
+        selection={0: tuple(range(4))},
+    )
+    modules = repack._module_map(groups, bits=2, group_size=64)
+
+    assert modules["layers.0.ffn.experts.down_proj"] == {
+        "bits": 2,
+        "group_size": 64,
+    }
+    assert modules["layers.0.attn.wq_a"] == {"bits": 2, "group_size": 64}
+
+
+def test_pruning_requires_calibrated_saliency() -> None:
+    try:
+        repack._selection_from_saliency(None, layers=1, experts=4, keep=2)
+    except ValueError as error:
+        assert "--saliency is required" in str(error)
+    else:
+        raise AssertionError("uncalibrated pruning must be rejected")
+
+
+def test_selection_prefers_cross_half_robust_saliency(tmp_path: Path) -> None:
+    path = tmp_path / "saliency.npz"
+    np.savez(
+        path,
+        saliency=np.array([[100.0, 90.0, 80.0, 70.0]]),
+        robust_saliency=np.array([[0.1, 0.2, 0.9, 0.8]]),
+    )
+
+    selected = repack._selection_from_saliency(path, layers=1, experts=4, keep=2)
+
+    assert selected == {0: (2, 3)}
+
+
+def test_generated_model_card_refuses_unqualified_publication(tmp_path: Path) -> None:
+    repack._write_model_card(
+        tmp_path,
+        {"original_experts": 384, "kept_experts": 336},
+        tensor_bytes=212_930_051_680,
+    )
+
+    card = (tmp_path / "README.md").read_text()
+    assert "not product-qualified" in card
+    assert "must not be published or cataloged" in card
+    assert "336 of 384" in card


### PR DESCRIPTION
## Intention

Determine whether a native affine 2-bit, REAP-pruned DeepSeek V4.1 Flash text
artifact can meet the agreed performance floor on a 256 GiB Mac, while keeping
the result reproducible and preventing an unqualified artifact from reaching
users.

## Why

A 199 GiB model would impose a large download, a four-minute cold load, and
most of a 256 GiB machine's usable memory. Quantifying the real speed and
correctness boundary before publishing prevents users from paying that cost
for a model that misses Rapid's minimum responsiveness standard.

## Scope

- Add an isolated native runtime and strict loader under `scripts/` for
  qualification only.
- Add a byte-streaming repacker that preserves the source checkpoint's packed
  affine values and can prune routed experts from calibrated saliency.
- Add an explicit-trust calibration tool with conservative split-half scoring.
- Add a direct-runtime qualification harness using the model's required chat
  framing and Rapid's `(N-1)/elapsed` decode metric.
- Record the measured go/no-go decision and storage/runtime safety boundaries.

Non-goals: model upload, catalog alias, server or GUI exposure, vision, MTP,
cloud execution, or production runtime registration. The new runtime is not
reachable through Rapid's production model registry.

## Quantitative result

Hardware: Apple M3 Ultra, 60 GPU cores, 256 GiB unified memory, MLX 0.32.2.

- Source indexed size: 238,796,133,496 bytes.
- Generated REAP12.5 text artifact: 212,930,051,680 tensor bytes (~199 GiB),
  keeping 336 of 384 routed experts per layer.
- Mean retained robust routing mass: 99.9949%; worst layer: 99.8564%; split-half
  keep-set overlap: 92.1354% over 2,048 causal calibration tokens.
- Strict resident load: 239.44 seconds; 213.51 GB peak MLX memory.
- Watchdog-conservative decode: 7.31 tok/s.
- Best short-decode ceiling: 7.92 tok/s with the exact same greedy chain.
- Gate/up fusion was rejected: 7.87 fixed model steps/s and a 263.72 GB
  transient, too close to physical capacity.
- Correctly framed smoke output: `The capital of France is Paris.` followed by
  EOS.

The artifact misses the 12 tok/s product floor by 34.0% (equivalently, it needs
51.5% more throughput) and the 20+ tok/s target by 60.4%. It is therefore not exposed through Rapid-MLX. For reproducibility, the\nunqualified artifact is published separately as an explicitly experimental checkpoint.

## Validation

- Ruff on all added Python files: passed.
- Focused tests: 16 passed.
- Pinned Python 3.11 mypy error budget: passed with no new debt.
- Upstream tiny-config parity battery: passed; prefill/decode/chunked-prefill
  relative differences <=1.4e-6, 100% argmax agreement, bit-exact quant/dequant
  cases, strict float/quantized round trips, and equal streaming output.
- Full artifact dry-run plan: 41 shards and 212,930,051,680 tensor bytes.
- Real 256 GiB resident load and correctly framed greedy decode at evaluation
  intervals 4, 20, and 40 with identical tokens.

## Decision

This is a negative product qualification with reusable experimental tooling.
It should not be interpreted as model support. Any future product attempt must
independently pass correctness, long-context stability, operational memory
margin, and at least 12 tok/s before upload or exposure.


## Experimental artifact

The measured checkpoint is publicly archived at
https://huggingface.co/rapid-mlx/DeepSeek-V4.1-Flash-REAP-2bit-MLX (commit
`a25fec277b9e7cedc0e9f3f15da874a5cf9d491b`) so the negative qualification can
be reproduced. Publication does not change the product decision: it remains absent
from Rapid-MLX catalog, Server, and Desktop, and the model card prominently records
the 256 GiB requirement, 7.31–7.92 tok/s result, and unsupported experimental status.
The upload was performed separately and does not alter this PR head or code scope.