### PR TITLE
chore: bump version to 0.14.1

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,37 @@ can actually understand.
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-09-10
+
+Rapid-MLX 0.14.1 is a focused reliability update for document analysis,
+multimodal chat, and sampled speculative decoding.
+
+### Added
+- **Large and scanned PDF analysis.** Desktop can analyze long selectable PDFs,
+  image-only scans, and documents that mix both forms. Extraction continues in
+  a bounded background cache, document reads have hard deadlines, and follow-up
+  questions can retrieve the relevant page ranges instead of placing an entire
+  large document in one prompt.
+- **Stronger sampled-MTP regression coverage.** Distribution-level and
+  real-weight checks now protect independent acceptance draws and rejection-
+  residual sampling, including bugs that the prior 246-test MTP suite could
+  miss.
+
+### Fixed
+- **Multimodal repetition no longer exhausts Metal.** Exact token loops are
+  stopped at the scheduler boundary, the completed row is retired immediately,
+  and the valid partial response finishes normally instead of ending in a
+  delayed empty HTTP 500.
+- PDF extraction now reports incomplete OCR honestly, respects cancellation and
+  removal races, bounds malformed document identifiers, and forces synthesis
+  when a model repeatedly exceeds the document/tool budget.
+
+### Qualification
+- A 199 GiB experimental DeepSeek V4.1 Flash REAP 2-bit checkpoint loaded in
+  239.44 seconds with 213.51 GB peak MLX memory on a 256 GiB M3 Ultra, but
+  decoded at only 7.31–7.92 tok/s. It remains outside the model catalog,
+  Server, and Desktop because it missed the 12 tok/s product floor.
+
 ## [0.14.0] — 2026-09-09
 
 Rapid-MLX 0.14.0 adds experimental local Computer Use and shared-compute
@@ -3770,7 +3801,8 @@ Older versions: see the
 [GitHub Releases page](https://github.com/machinefi/rapid-desktop/releases)
 for auto-generated notes against earlier tags.
 
-[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.14.0...HEAD
+[Unreleased]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.14.1...HEAD
+[0.14.1]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.14.0...rapid-mac-v0.14.1
 [0.14.0]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.4...rapid-mac-v0.14.0
 [0.13.4]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.3...rapid-mac-v0.13.4
 [0.13.3]: https://github.com/raullenchai/Rapid-MLX/compare/rapid-mac-v0.13.2...rapid-mac-v0.13.3

--- a/apps/rapid-mac/Resources/Info.plist
+++ b/apps/rapid-mac/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.14.0</string>
+	<string>0.14.1</string>
 	<key>CFBundleVersion</key>
-	<string>171</string>
+	<string>172</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccentColorName</key>

--- a/docs/release-notes/v0.14.1.md
+++ b/docs/release-notes/v0.14.1.md
@@ -1,0 +1,88 @@
+# Rapid-MLX 0.14.1
+
+Rapid-MLX 0.14.1 makes long-document work and multimodal chat more dependable,
+while adding stronger regression protection for sampled MTP decoding. It also
+records an intentionally negative large-model qualification so users can see
+why an expensive checkpoint was not added to the product catalog.
+
+## Large and scanned PDFs
+
+Desktop can now analyze large selectable PDFs, image-only scans, and documents
+that mix selectable and scanned pages. Extraction runs behind a bounded cache,
+document reads use hard deadlines, and follow-up questions can retrieve
+specific outlines, pages, or sections instead of forcing the entire file into
+one prompt. ([#3292](https://github.com/raullenchai/Rapid-MLX/pull/3292))
+
+The product-path dogfood covered both ends of the workflow:
+
+| Document | Verified result |
+| --- | --- |
+| 300-page selectable Chinese PDF | 125,833 characters cached; all 300 pages completed; 30 chapter rows resolved to real page and character offsets |
+| 6-page image-only PDF | OCR text reached the model and multi-turn synthesis decoded at 45 tok/s |
+| Mixed selectable + scanned PDF | Scanned pages were retained and the extraction reached an honest complete state |
+
+The same change closes several failure boundaries: OCR/render failures no
+longer masquerade as complete extraction, progress heartbeats cannot extend a
+read forever, removal races cannot publish an orphaned document, invalid IDs
+are bounded, and a model that keeps asking for tools is forced into synthesis.
+
+## Multimodal chat stops runaway repetition safely
+
+An exact token loop in a tool-free multimodal request could previously continue
+until Metal exhausted its resource handles, leaving the client waiting for an
+empty HTTP 500. The scheduler now evaluates the existing conservative detector
+every eight generated tokens, retires the stopped batch row immediately, and
+returns the valid partial response with a normal length finish.
+([#3291](https://github.com/raullenchai/Rapid-MLX/pull/3291))
+
+The reported 61-token cycle is detected at token 184. The focused lifecycle,
+batching, repetition, metrics, and process-loop validation passed 180 tests.
+
+## Sampled MTP has a stronger correctness net
+
+New distribution-level tests cover independent speculative acceptance draws
+and rejection-residual sampling, and real-weight checks force K=2 and K=3
+paths. ([#3294](https://github.com/raullenchai/Rapid-MLX/pull/3294))
+
+This guards a subtle false-green boundary: replacing rejection-residual
+sampling with target-distribution sampling passed all 246 tests in the prior
+focused MTP suite, while four of the five new distribution checks failed and
+exposed total-variation error up to 0.14. Real-weight smoke recorded 118 K=2
+and 147 K=3 speculative attempts, so the deeper arithmetic is exercised rather
+than inferred from a nonzero acceptance rate.
+
+## An honest 256 GiB model qualification
+
+The repository now contains isolated tooling and reproducible evidence for an
+experimental DeepSeek V4.1 Flash REAP 2-bit checkpoint. This is not product
+model support: the runtime is outside package discovery and there is no catalog,
+Server, or Desktop entry. ([#3301](https://github.com/raullenchai/Rapid-MLX/pull/3301))
+
+The measurements below used an Apple M3 Ultra with 60 GPU cores, 256 GiB of
+unified memory, and MLX 0.32.2.
+
+| Measurement | Result |
+| --- | ---: |
+| Artifact tensor size | 212,930,051,680 bytes (about 199 GiB) |
+| Strict resident load | 239.44 s |
+| Peak MLX memory | 213.51 GB |
+| Conservative decode | 7.31 tok/s |
+| Best short-decode ceiling | 7.92 tok/s |
+| Rapid-MLX product floor | 12 tok/s |
+
+The checkpoint preserved 99.9949% mean robust routing mass and passed tiny-
+configuration parity within 1.4e-6 with 100% argmax agreement, but speed missed
+the product floor by 34.0%. The checkpoint is
+[archived separately for expert reproduction](https://huggingface.co/rapid-mlx/DeepSeek-V4.1-Flash-REAP-2bit-MLX),
+but remains explicitly experimental and outside the product catalog rather than
+becoming a catalog-managed download.
+
+## Upgrade
+
+```bash
+pip install -U rapid-mlx
+```
+
+Homebrew follows the package release through its normal autobump process.
+Desktop users receive the signed and notarized update through the production
+appcast.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapid-mlx"
-version = "0.14.0"
+version = "0.14.1"
 description = "Rapid-MLX — AI inference for Apple Silicon. Drop-in OpenAI API, up to 3x Ollama's measured throughput."
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Why

Publish Rapid-MLX 0.14.1 as a focused reliability release for large/scanned PDF analysis, multimodal repetition termination, and sampled-MTP correctness coverage. This PR contains only the canonical version/build bump and curated release notes.

## User impact and quantitative evidence

- Large/scanned PDF dogfood completed a 300-page Chinese PDF with 125,833 cached characters and 30 chapter rows mapped to real page/character offsets. A 6-page image-only PDF reached multi-turn model synthesis at 45 tok/s.
- Multimodal repetition protection detects the reported 61-token cycle at token 184, retires the batch row, and returns the valid partial response. Focused lifecycle/batching/repetition validation passed 180 tests.
- Sampled-MTP distribution checks catch a mutation that passed the previous 246-test suite: 4 of 5 new checks fail with total-variation error up to 0.14. Real-weight coverage recorded 118 K=2 and 147 K=3 speculative attempts.
- The experimental DeepSeek V4.1 Flash REAP 2-bit artifact measures 212,930,051,680 tensor bytes, 239.44 s strict load, 213.51 GB peak MLX memory, and 7.31–7.92 tok/s on a 256 GiB M3 Ultra. It missed the 12 tok/s product floor by 34.0%, so it remains outside the model catalog, Server, and Desktop.

## Release qualification

- Exact-parent source: `cc8681a2b4903d2142e96c26f56f52e036a438d4`
- Exact-parent dry run: https://github.com/raullenchai/Rapid-MLX/actions/runs/34560482439
  - Tier-1 agent/release gate: PASS in 8m41s
  - Signed Desktop candidate gate: PASS in 15m55s
  - Five Tier-1 agents: PASS
  - Output coherence: 6/6
  - Measured advisory decode: 55.56 tok/s
  - Gemma, Bonsai, and MTP residency sequences: PASS
- Local release smoke, version sync, release-note sync, subject validation, 43 version/note tests, and 63 release-body tests: PASS.
- Independent adversarial review of the full `v0.14.0..cc8681a2` release delta found no P0/P1 issues.

## Scope

Changed only:

- `pyproject.toml`
- `apps/rapid-mac/Resources/Info.plist`
- `apps/rapid-mac/CHANGELOG.md`
- `docs/release-notes/v0.14.1.md`

Non-goals: no runtime, catalog, Server, Desktop behavior, dependency, or workflow changes in this PR.

Release-Preflight: https://github.com/raullenchai/Rapid-MLX/actions/runs/34561600954
