### PR TITLE
perf: qualify DeepSeek V4.1 DSpark decoding

### DIFF
--- a/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-speed.md
+++ b/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-speed.md
@@ -1,0 +1,130 @@
+# DeepSeek V4.1 Flash 2-bit decode experiments
+
+Date: 2026-09-10/11
+
+Status: experimental; the 12 tok/s product gate was not met.
+
+## Goal and boundary
+
+Determine whether the existing 2-bit REAP12.5 build can reach at least 12
+generated tokens/s on a 256 GiB Mac by using its checkpoint-native three-stage
+DSpark network, batched verification, or a faster MoE kernel. The stretch goal
+is 20 tok/s. This work does not expose the model in the catalog or server.
+
+All generation measurements use `(output_tokens - 1) / decode_seconds`; prompt
+processing, model loading, and MTP packing are excluded from decode throughput.
+Greedy equivalence means exact token equality with the autoregressive run in the
+same process.
+
+## Environment
+
+- Apple M3 Ultra, 256 GiB unified memory
+- MLX recommended working-set limit: 239.144 GB
+- Target: `DeepSeek-V4.1-Flash-native-2bit-reap12_5`
+- Target tensor bytes: 212.930 GB; 336 routed experts, six active
+- DSpark sidecar: three stages, block size five, 128 routed experts, three active
+- DSpark tensor bytes: 4.460 GB
+- Prompt: 24 tokens, concise Python interval-merging task
+- Output: 32 tokens, 31 measured transitions
+- Target graph boundary: 40 layers
+- Warm-tier weights were read sequentially before qualification; the reported
+  ~240 second load is therefore not a cold-storage first-load claim.
+
+Representative command:
+
+```shell
+python scripts/benchmark_deepseek_v41_dspark.py \
+  --target <reap12.5-target> \
+  --overlay <target-plus-dspark-overlay> \
+  --checkpoint-runtime <trusted-checkpoint-runtime> \
+  --trust-checkpoint-runtime \
+  --packed-mtp-only \
+  --tokens 32
+```
+
+## Results
+
+| Candidate | tok/s | Change vs 7.90 AR | Greedy equivalent | Peak MLX memory |
+| --- | ---: | ---: | --- | ---: |
+| Autoregressive baseline | 7.90 | — | reference | 213.54 GB |
+| Serial DSpark verification | 7.11 | -10.0% | yes | 218.02 GB |
+| Batched K4, deferred correction | 9.76 | +23.5% | yes | 218.02 GB |
+| Batched K4 + packed MTP MoE | 10.07 | +27.5% | yes | 218.00 GB |
+| Batched K4 + packed/vectorized MTP | **10.55** | **+33.5%** | **yes** | 218.00 GB |
+| Batched K5 + packed MTP MoE | 11.03 | +39.6% | no | 218.00 GB |
+| Batched K5 + packed/vectorized MTP | **11.53** | **+46.0%** | no | 218.00 GB |
+| Native small-route MoE AR | 9.24 | +17.0% | no | 213.54 GB |
+
+K4 accepted 1.00 additional draft token per block. K5 accepted 1.21. The K5
+token difference is produced by the target's batched numerical path, not by an
+unverified draft token escaping verification. The product gate nevertheless
+requires a broader quality qualification before treating it as acceptable.
+
+The packed MTP MoE replaces five-position-by-three-expert Python loops with
+three batched gather-QMM projections. Its one-token output is bit-exact with the
+checkpoint implementation after preserving the checkpoint's required order:
+apply route weights before the BF16 cast and down projection. Packing uses
+4.247 GB, releases the equivalent individual resident expert tensors, and adds
+only about 0.4 GB to peak memory.
+
+Vectorizing the MTP attention output projection reduces its 5 x 8 grouped QMM
+dispatch pattern to one group-and-position-batched call. This changes low-bit
+drafter numerics and may change proposals, but target verification remains
+authoritative. On the qualification prompt it preserved the same acceptance
+length and added 4.8% over packed MTP alone at K5.
+
+## Target-forward ceiling
+
+Oracle runs feed known-correct target tokens in chunks and measure only the
+target forward:
+
+| Verify rows | Target rows/s | Greedy rows matching sequential path |
+| ---: | ---: | ---: |
+| 2 | 13.6–14.0 | 30/31 |
+| 3 | 19.0–19.3 | 30/31 |
+| 4 | 24.6–24.9 | 30/31 |
+| 5 | 27.4–27.6 | 30/31 |
+
+The target is fast enough when rows batch, but observed DSpark acceptance is
+only 1.0–1.2 extra tokens/block. K5 spends 2.40 seconds of its 2.77-second
+decode in target verification, so further draft-only optimization cannot reach
+20 tok/s and is unlikely to clear 12 tok/s by itself.
+
+## Rejected paths
+
+- Immediate singleton correction erases batching gains. Exact cache rollback
+  plus delayed correction is required; rollback itself costs about 4–6 ms for
+  the complete 32-token run.
+- Confidence thresholds 0.3, 0.5, and 0.7 did not improve the speed/equivalence
+  frontier. The checkpoint confidence scores are not calibrated well enough to
+  compensate for shorter target batches on this workload.
+- A native affine small-route MoE kernel is 1.76x faster in the isolated
+  six-route microbenchmark and improves AR by 17%, but changes greedy output.
+  At the 24–36 routes used by verification it is 21–33% slower than the stock
+  gather-QMM path.
+- Gate/up projection fusion is bit-exact but improves a real K5-shaped MoE layer
+  by only 2.8%. Full-model post-load fusion exceeds 256 GiB transient capacity
+  and fails with Metal insufficient memory, so an offline fused artifact is not
+  justified.
+- Moving both Engram tables (61.442 GB) to SSD lowers the unpruned target's
+  active memory from about 234 GB to 172.74 GB, but random row reads reduce AR
+  to 5.49 tok/s and K5 to 6.42 tok/s. This is a capacity option, not a speed
+  option, and was removed from the implementation.
+- The unpruned target did not materially improve DSpark acceptance (1.13 extra
+  tokens/block versus 1.21 for REAP12.5 on this task), rejecting the hypothesis
+  that REAP target/drafter mismatch is the dominant loss.
+
+## Product decision and next experiments
+
+Do not enable DSpark for DeepSeek V4.1 Flash yet. The best exact-greedy result is
+10.55 tok/s, below the explicit 12 tok/s floor; the fastest result is 11.53
+tok/s and still needs broader numerical/quality qualification.
+
+Reaching 20 tok/s requires a new capability rather than threshold tuning:
+
+1. A persistent affine-2bit MoE verify kernel specialized for six target rows,
+   fusing routing, gate/up, activation, down projection, and weighted reduction.
+2. A model-trained MHC-aligned block drafter with materially higher accepted
+   length. No compatible V4.1 checkpoint was available during this experiment.
+3. After either exists, re-run a multi-domain, 128-token suite and long-context
+   cache qualification before server/catalog integration.

--- a/scripts/attach_deepseek_v41_dspark.py
+++ b/scripts/attach_deepseek_v41_dspark.py
@@ -73,9 +73,7 @@ def _inference_config(config: dict) -> dict:
         "dspark_target_layer_ids": list(config["dspark_target_layer_ids"]),
         "dspark_markov_rank": int(config["dspark_markov_rank"]),
         "dspark_n_routed_experts": int(config["dspark_n_routed_experts"]),
-        "dspark_num_experts_per_tok": int(
-            config["dspark_num_experts_per_tok"]
-        ),
+        "dspark_num_experts_per_tok": int(config["dspark_num_experts_per_tok"]),
     }
 
 
@@ -95,6 +93,15 @@ def _copy_metadata(target: Path, destination: Path) -> None:
             shutil.copy2(source, destination / name)
 
 
+def _safe_shard_name(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"invalid target shard name: {value!r}")
+    shard = Path(value)
+    if shard.is_absolute() or shard.name != value:
+        raise ValueError(f"target shard must be a basename: {value!r}")
+    return value
+
+
 def build_overlay(source: Path, target: Path, destination: Path) -> dict:
     if destination.exists():
         raise FileExistsError(f"destination already exists: {destination}")
@@ -104,19 +111,22 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
     target_weights = target_index.get("weight_map")
     if not isinstance(target_weights, dict) or not target_weights:
         raise ValueError("target checkpoint has no indexed weights")
+    target_shards = {_safe_shard_name(value) for value in target_weights.values()}
+    mtp_shard = "model-mtp.safetensors"
+    if mtp_shard in target_shards:
+        raise ValueError(f"target checkpoint already uses reserved shard {mtp_shard}")
 
     plans = _mtp_plans(CheckpointIndex(source))
     mtp_bytes = sum(plan.nbytes for plan in plans)
     destination.mkdir(parents=True)
     try:
-        for shard in sorted(set(target_weights.values())):
+        for shard in sorted(target_shards):
             source_shard = target / shard
             if not source_shard.is_file():
                 raise FileNotFoundError(source_shard)
             relative_target = os.path.relpath(source_shard, destination)
             (destination / shard).symlink_to(relative_target)
 
-        mtp_shard = "model-mtp.safetensors"
         write_safetensors(destination / mtp_shard, plans)
         weight_map = dict(target_weights)
         weight_map.update({plan.name: mtp_shard for plan in plans})
@@ -124,9 +134,7 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
         inference = _inference_config(config)
 
         (destination / "inference").mkdir()
-        (destination / "config.json").write_text(
-            json.dumps(config, indent=2) + "\n"
-        )
+        (destination / "config.json").write_text(json.dumps(config, indent=2) + "\n")
         (destination / "inference" / "config.json").write_text(
             json.dumps(inference, indent=2) + "\n"
         )
@@ -155,7 +163,7 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
         raise
     return {
         "destination": str(destination),
-        "target_shards": len(set(target_weights.values())),
+        "target_shards": len(target_shards),
         "mtp_tensors": len(plans),
         "mtp_bytes": mtp_bytes,
         "mtp_gb": round(mtp_bytes / 1e9, 3),

--- a/scripts/attach_deepseek_v41_dspark.py
+++ b/scripts/attach_deepseek_v41_dspark.py
@@ -138,6 +138,8 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
     try:
         for shard in sorted(target_shards):
             source_shard = target / shard
+            if source_shard.is_symlink():
+                raise ValueError(f"target shard must not be a symlink: {source_shard}")
             if not source_shard.is_file():
                 raise FileNotFoundError(source_shard)
             relative_target = os.path.relpath(source_shard, staging)

--- a/scripts/attach_deepseek_v41_dspark.py
+++ b/scripts/attach_deepseek_v41_dspark.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Attach checkpoint-native DSpark weights to a native V4.1 target artifact.
+
+The target checkpoint is exposed through relative symlinks; only the compact
+``mtp.*`` draft network is copied from the source.  This makes an A/B artifact
+without duplicating the approximately 200 GB target model or mutating either
+input checkpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+
+from repack_deepseek_v41_native import (
+    CheckpointIndex,
+    TensorPlan,
+    write_safetensors,
+)
+
+
+def _read_json(path: Path) -> dict:
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return value
+
+
+def _mtp_plans(source: CheckpointIndex) -> list[TensorPlan]:
+    plans = [
+        TensorPlan(name, tensor.dtype, tensor.shape, (tensor,))
+        for name, tensor in source.tensors.items()
+        if name.startswith("mtp.")
+    ]
+    plans.sort(key=lambda plan: plan.name)
+    if not plans:
+        raise ValueError("source checkpoint has no mtp.* tensors")
+    return plans
+
+
+def _dspark_config(target_config: dict, source_config: dict) -> dict:
+    source_text = source_config.get("text_config", source_config)
+    target_text = target_config.get("text_config", target_config)
+    config = {**target_config, **target_text}
+    config["model_type"] = "deepseek_v4"
+    config["architectures"] = ["DeepseekV4ForCausalLM"]
+    for key in (
+        "dspark_block_size",
+        "dspark_markov_rank",
+        "dspark_n_routed_experts",
+        "dspark_noise_token_id",
+        "dspark_num_experts_per_tok",
+        "dspark_target_layer_ids",
+        "num_nextn_predict_layers",
+    ):
+        config[key] = source_text[key]
+    config["rapid_quantization"] = {
+        **target_config.get("rapid_quantization", {}),
+        "mtp": True,
+        "mtp_source": "checkpoint-native-dspark",
+    }
+    return config
+
+
+def _inference_config(config: dict) -> dict:
+    return {
+        "n_mtp_layers": int(config["num_nextn_predict_layers"]),
+        "dspark_block_size": int(config["dspark_block_size"]),
+        "dspark_noise_token_id": int(config["dspark_noise_token_id"]),
+        "dspark_target_layer_ids": list(config["dspark_target_layer_ids"]),
+        "dspark_markov_rank": int(config["dspark_markov_rank"]),
+        "dspark_n_routed_experts": int(config["dspark_n_routed_experts"]),
+        "dspark_num_experts_per_tok": int(
+            config["dspark_num_experts_per_tok"]
+        ),
+    }
+
+
+def _copy_metadata(target: Path, destination: Path) -> None:
+    for name in (
+        "LICENSE",
+        "NOTICE",
+        "chat_template.jinja",
+        "engram_token_map.json",
+        "generation_config.json",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ):
+        source = target / name
+        if source.is_file():
+            shutil.copy2(source, destination / name)
+
+
+def build_overlay(source: Path, target: Path, destination: Path) -> dict:
+    if destination.exists():
+        raise FileExistsError(f"destination already exists: {destination}")
+    source_config = _read_json(source / "config.json")
+    target_config = _read_json(target / "config.json")
+    target_index = _read_json(target / "model.safetensors.index.json")
+    target_weights = target_index.get("weight_map")
+    if not isinstance(target_weights, dict) or not target_weights:
+        raise ValueError("target checkpoint has no indexed weights")
+
+    plans = _mtp_plans(CheckpointIndex(source))
+    mtp_bytes = sum(plan.nbytes for plan in plans)
+    destination.mkdir(parents=True)
+    try:
+        for shard in sorted(set(target_weights.values())):
+            source_shard = target / shard
+            if not source_shard.is_file():
+                raise FileNotFoundError(source_shard)
+            relative_target = os.path.relpath(source_shard, destination)
+            (destination / shard).symlink_to(relative_target)
+
+        mtp_shard = "model-mtp.safetensors"
+        write_safetensors(destination / mtp_shard, plans)
+        weight_map = dict(target_weights)
+        weight_map.update({plan.name: mtp_shard for plan in plans})
+        config = _dspark_config(target_config, source_config)
+        inference = _inference_config(config)
+
+        (destination / "inference").mkdir()
+        (destination / "config.json").write_text(
+            json.dumps(config, indent=2) + "\n"
+        )
+        (destination / "inference" / "config.json").write_text(
+            json.dumps(inference, indent=2) + "\n"
+        )
+        total_size = int(target_index.get("metadata", {}).get("total_size", 0))
+        (destination / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {
+                    "metadata": {"total_size": total_size + mtp_bytes},
+                    "weight_map": weight_map,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        _copy_metadata(target, destination)
+        (destination / "README.md").write_text(
+            "# Experimental DeepSeek V4.1 REAP + DSpark overlay\n\n"
+            "This local benchmark artifact reuses the target checkpoint via "
+            "relative symlinks and adds its checkpoint-native three-stage "
+            "DSpark draft network. It is not a standalone distribution.\n\n"
+            f"- Added DSpark tensor bytes: {mtp_bytes:,}\n"
+            f"- Target artifact: `{target.name}`\n"
+        )
+    except BaseException:
+        shutil.rmtree(destination)
+        raise
+    return {
+        "destination": str(destination),
+        "target_shards": len(set(target_weights.values())),
+        "mtp_tensors": len(plans),
+        "mtp_bytes": mtp_bytes,
+        "mtp_gb": round(mtp_bytes / 1e9, 3),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--target", type=Path, required=True)
+    parser.add_argument("--destination", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = build_overlay(
+        args.source.resolve(), args.target.resolve(), args.destination.resolve()
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/attach_deepseek_v41_dspark.py
+++ b/scripts/attach_deepseek_v41_dspark.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import shutil
+import tempfile
 from pathlib import Path
 
 from repack_deepseek_v41_native import (
@@ -47,7 +48,7 @@ def _dspark_config(target_config: dict, source_config: dict) -> dict:
     config = {**target_config, **target_text}
     config["model_type"] = "deepseek_v4"
     config["architectures"] = ["DeepseekV4ForCausalLM"]
-    for key in (
+    dspark_keys = (
         "dspark_block_size",
         "dspark_markov_rank",
         "dspark_n_routed_experts",
@@ -55,8 +56,13 @@ def _dspark_config(target_config: dict, source_config: dict) -> dict:
         "dspark_num_experts_per_tok",
         "dspark_target_layer_ids",
         "num_nextn_predict_layers",
-    ):
+    )
+    for key in dspark_keys:
         config[key] = source_text[key]
+    config["text_config"] = {
+        **target_text,
+        **{key: source_text[key] for key in dspark_keys},
+    }
     config["rapid_quantization"] = {
         **target_config.get("rapid_quantization", {}),
         "mtp": True,
@@ -118,28 +124,31 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
 
     plans = _mtp_plans(CheckpointIndex(source))
     mtp_bytes = sum(plan.nbytes for plan in plans)
-    destination.mkdir(parents=True)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.staging-", dir=destination.parent)
+    )
     try:
         for shard in sorted(target_shards):
             source_shard = target / shard
             if not source_shard.is_file():
                 raise FileNotFoundError(source_shard)
-            relative_target = os.path.relpath(source_shard, destination)
-            (destination / shard).symlink_to(relative_target)
+            relative_target = os.path.relpath(source_shard, staging)
+            (staging / shard).symlink_to(relative_target)
 
-        write_safetensors(destination / mtp_shard, plans)
+        write_safetensors(staging / mtp_shard, plans)
         weight_map = dict(target_weights)
         weight_map.update({plan.name: mtp_shard for plan in plans})
         config = _dspark_config(target_config, source_config)
         inference = _inference_config(config)
 
-        (destination / "inference").mkdir()
-        (destination / "config.json").write_text(json.dumps(config, indent=2) + "\n")
-        (destination / "inference" / "config.json").write_text(
+        (staging / "inference").mkdir()
+        (staging / "config.json").write_text(json.dumps(config, indent=2) + "\n")
+        (staging / "inference" / "config.json").write_text(
             json.dumps(inference, indent=2) + "\n"
         )
         total_size = int(target_index.get("metadata", {}).get("total_size", 0))
-        (destination / "model.safetensors.index.json").write_text(
+        (staging / "model.safetensors.index.json").write_text(
             json.dumps(
                 {
                     "metadata": {"total_size": total_size + mtp_bytes},
@@ -149,8 +158,8 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
             )
             + "\n"
         )
-        _copy_metadata(target, destination)
-        (destination / "README.md").write_text(
+        _copy_metadata(target, staging)
+        (staging / "README.md").write_text(
             "# Experimental DeepSeek V4.1 REAP + DSpark overlay\n\n"
             "This local benchmark artifact reuses the target checkpoint via "
             "relative symlinks and adds its checkpoint-native three-stage "
@@ -158,8 +167,11 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
             f"- Added DSpark tensor bytes: {mtp_bytes:,}\n"
             f"- Target artifact: `{target.name}`\n"
         )
+        if destination.exists():
+            raise FileExistsError(f"destination appeared during build: {destination}")
+        staging.rename(destination)
     except BaseException:
-        shutil.rmtree(destination)
+        shutil.rmtree(staging)
         raise
     return {
         "destination": str(destination),

--- a/scripts/attach_deepseek_v41_dspark.py
+++ b/scripts/attach_deepseek_v41_dspark.py
@@ -123,11 +123,18 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
         raise ValueError(f"target checkpoint already uses reserved shard {mtp_shard}")
 
     plans = _mtp_plans(CheckpointIndex(source))
+    target_names = set(target_weights)
+    generated_names = {plan.name for plan in plans}
+    collisions = sorted(target_names & generated_names)
+    if collisions:
+        preview = ", ".join(collisions[:3])
+        raise ValueError(f"target checkpoint already contains MTP tensors: {preview}")
     mtp_bytes = sum(plan.nbytes for plan in plans)
     destination.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(
         tempfile.mkdtemp(prefix=f".{destination.name}.staging-", dir=destination.parent)
     )
+    owns_destination = False
     try:
         for shard in sorted(target_shards):
             source_shard = target / shard
@@ -168,8 +175,10 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
             f"- Target artifact: `{target.name}`\n"
         )
         # mkdir is the portable atomic no-replace reservation for a directory.
-        # A marker keeps an interrupted publication visibly incomplete.
+        # Once it succeeds this invocation owns the directory, so a failed
+        # publication can safely remove only that directory and be retried.
         destination.mkdir()
+        owns_destination = True
         incomplete = destination / ".rapid-overlay-incomplete"
         incomplete.touch(exist_ok=False)
         for child in staging.iterdir():
@@ -177,7 +186,9 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
         staging.rmdir()
         incomplete.unlink()
     except BaseException:
-        shutil.rmtree(staging)
+        shutil.rmtree(staging, ignore_errors=True)
+        if owns_destination and destination.exists():
+            shutil.rmtree(destination)
         raise
     return {
         "destination": str(destination),

--- a/scripts/attach_deepseek_v41_dspark.py
+++ b/scripts/attach_deepseek_v41_dspark.py
@@ -167,9 +167,15 @@ def build_overlay(source: Path, target: Path, destination: Path) -> dict:
             f"- Added DSpark tensor bytes: {mtp_bytes:,}\n"
             f"- Target artifact: `{target.name}`\n"
         )
-        if destination.exists():
-            raise FileExistsError(f"destination appeared during build: {destination}")
-        staging.rename(destination)
+        # mkdir is the portable atomic no-replace reservation for a directory.
+        # A marker keeps an interrupted publication visibly incomplete.
+        destination.mkdir()
+        incomplete = destination / ".rapid-overlay-incomplete"
+        incomplete.touch(exist_ok=False)
+        for child in staging.iterdir():
+            child.rename(destination / child.name)
+        staging.rmdir()
+        incomplete.unlink()
     except BaseException:
         shutil.rmtree(staging)
         raise

--- a/scripts/benchmark_deepseek_v41_dspark.py
+++ b/scripts/benchmark_deepseek_v41_dspark.py
@@ -468,6 +468,7 @@ def _run_batched_dspark(
             cache,
             last_logit_only=False,
             return_dspark_hidden=True,
+            enable_rollback=True,
         )
         mx.eval(target_logits, target_hidden)
         target_seconds += time.perf_counter() - started

--- a/scripts/benchmark_deepseek_v41_dspark.py
+++ b/scripts/benchmark_deepseek_v41_dspark.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import importlib
+import importlib.util
 import json
 import os
 import sys
@@ -31,6 +32,43 @@ BOS = "<｜begin▁of▁sentence｜>"
 USER = "<｜User｜>"
 ASSISTANT = "<｜Assistant｜>"
 CHAT_START = "</think>"
+
+
+def _load_module_file(name: str, path: Path):
+    path = path.absolute()
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load checkpoint runtime module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    if Path(module.__file__).absolute() != path:
+        raise ImportError(f"checkpoint runtime resolved outside requested file: {path}")
+    return module
+
+
+def _load_checkpoint_runtime(root: Path):
+    """Load the two trusted files exactly, without ambient module fallback."""
+    root = root.absolute()
+    if not root.is_dir():
+        raise NotADirectoryError(root)
+    previous_runtime = sys.modules.get("runtime")
+    previous_dspark = sys.modules.get("_rapid_checkpoint_dspark")
+    try:
+        runtime = _load_module_file("runtime", root / "runtime.py")
+        dspark = _load_module_file("_rapid_checkpoint_dspark", root / "dspark.py")
+    finally:
+        if previous_runtime is None:
+            sys.modules.pop("runtime", None)
+        else:
+            sys.modules["runtime"] = previous_runtime
+        if previous_dspark is None:
+            sys.modules.pop("_rapid_checkpoint_dspark", None)
+        else:
+            sys.modules["_rapid_checkpoint_dspark"] = previous_dspark
+    return runtime, dspark
 
 
 def _prompt(text: str) -> str:
@@ -149,6 +187,10 @@ def _pin_mtp_with_headroom(weights, reserve_gb: float = 8.0) -> int:
     return total
 
 
+def _dspark_topk(config: dict) -> int:
+    return int(config["dspark_num_experts_per_tok"])
+
+
 def _install_packed_mtp_moe(adapter) -> int:
     """Pack per-expert DSpark tensors and replace its serial Python MoE loop."""
     weights = adapter.w
@@ -191,7 +233,7 @@ def _install_packed_mtp_moe(adapter) -> int:
             @ self.w.read(base + ".gate.weight").astype(mx.float32).T
         )
         scores = mx.sqrt(mx.logaddexp(logits, mx.zeros_like(logits)))
-        topk = config["num_experts_per_tok"]
+        topk = _dspark_topk(config)
         picks = mx.argsort(scores + self.w.read(base + ".gate.bias"), axis=-1)[
             ..., -topk:
         ]
@@ -591,9 +633,9 @@ def main() -> None:
             "refusing to execute checkpoint-bundled Python without "
             "--trust-checkpoint-runtime"
         )
-    sys.path.insert(0, str(args.checkpoint_runtime.resolve()))
-    checkpoint_runtime = importlib.import_module("runtime")
-    dspark_module = importlib.import_module("dspark")
+    checkpoint_runtime, dspark_module = _load_checkpoint_runtime(
+        args.checkpoint_runtime
+    )
 
     started = time.perf_counter()
     model, _ = load(

--- a/scripts/benchmark_deepseek_v41_dspark.py
+++ b/scripts/benchmark_deepseek_v41_dspark.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+"""Measure V4.1 target-only decode against checkpoint-native DSpark drafting.
+
+This first gate deliberately uses serial target verification.  It establishes
+draft latency, greedy acceptance, output equivalence, and memory headroom before
+we invest in exact batched verification and rollback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+
+import mlx.core as mx
+from transformers import PreTrainedTokenizerFast
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from deepseek_v41_native.load import load  # noqa: E402
+
+BOS = "<｜begin▁of▁sentence｜>"
+USER = "<｜User｜>"
+ASSISTANT = "<｜Assistant｜>"
+CHAT_START = "</think>"
+
+
+def _prompt(text: str) -> str:
+    return f"{BOS}{USER}{text}{ASSISTANT}{CHAT_START}"
+
+
+def _run_ar(model, input_ids, output_tokens, eos_id):
+    cache = model.make_cache(max_seq_len=len(input_ids) + output_tokens + 8)
+    logits = model(mx.array([input_ids]), cache, last_logit_only=True)
+    mx.eval(logits)
+    output = []
+    started = time.perf_counter()
+    for index in range(output_tokens):
+        token = int(mx.argmax(logits[:, -1]))
+        output.append(token)
+        if token == eos_id or index == output_tokens - 1:
+            break
+        logits = model(mx.array([[token]]), cache, last_logit_only=True)
+        mx.eval(logits)
+    seconds = time.perf_counter() - started
+    transitions = max(len(output) - 1, 0)
+    return output, {
+        "decode_seconds": seconds,
+        "decode_transitions": transitions,
+        "decode_tok_s": transitions / seconds if seconds else None,
+    }
+
+
+def _run_oracle_verify(model, input_ids, output, verify_k):
+    """Measure target chunk execution using the known-correct greedy sequence."""
+    cache = model.make_cache(max_seq_len=len(input_ids) + len(output) + 8)
+    logits = model(mx.array([input_ids]), cache, last_logit_only=True)
+    mx.eval(logits)
+    checked = 0
+    rows = 0
+    rounds = 0
+    seconds = 0.0
+    # Feeding output[i:i+k] yields target predictions for output[i+1:i+k+1].
+    for start in range(0, max(len(output) - 1, 0), verify_k):
+        chunk = output[start : min(start + verify_k, len(output) - 1)]
+        started = time.perf_counter()
+        chunk_logits = model(mx.array([chunk]), cache, last_logit_only=False)
+        mx.eval(chunk_logits)
+        seconds += time.perf_counter() - started
+        expected = output[start + 1 : start + 1 + len(chunk)]
+        actual = mx.argmax(chunk_logits, axis=-1).tolist()[0]
+        checked += sum(left == right for left, right in zip(actual, expected))
+        rows += len(chunk)
+        rounds += 1
+    return {
+        "event": "target_oracle_verify",
+        "verify_k": verify_k,
+        "target_seconds": seconds,
+        "target_rows": rows,
+        "target_rows_per_second": rows / seconds if seconds else None,
+        "rounds": rounds,
+        "greedy_rows_checked": checked,
+        "greedy_rows_match": checked == rows,
+    }
+
+
+def _install_native_single_stream_moe(model, source_root: Path) -> int:
+    """Switch loaded MoE modules to the native implementation without copies."""
+    os.environ["OMLX_DEEPSEEK_SORT_MIN_ROUTES"] = "1"
+    os.environ["OMLX_DEEPSEEK_AFFINE_BLOCK_MIN_ROUTES"] = "1"
+    sys.path.insert(0, str(source_root))
+    switch = importlib.import_module("omlx.patches.deepseek_v4.switch_layers")
+    replaced = 0
+    for layer in model.layers:
+        experts = layer.ffn.experts
+        experts.__class__ = switch.SwitchGLU
+        for name in ("gate_proj", "up_proj", "down_proj"):
+            projection = getattr(experts, name)
+            projection.__class__ = switch.QuantizedSwitchLinear
+        replaced += 1
+    return replaced
+
+
+def _share_target_head(weights, model):
+    for suffix in ("weight", "scales", "biases"):
+        value = getattr(model.head, suffix, None)
+        key = f"head.{suffix}"
+        if value is not None and key in weights.entries:
+            weights.resident[key] = value
+
+
+def _pin_mtp_with_headroom(weights, reserve_gb: float = 8.0) -> int:
+    import psutil
+
+    keys = [
+        key
+        for key in weights.entries
+        if key.startswith("mtp.") and key not in weights.resident
+    ]
+    total = sum(
+        weights.entries[key]["data_offsets"][1]
+        - weights.entries[key]["data_offsets"][0]
+        for key in keys
+    )
+    reserve = int(reserve_gb * 1e9)
+    metal_available = (
+        int(mx.device_info()["max_recommended_working_set_size"])
+        - mx.get_active_memory()
+    )
+    safe = min(psutil.virtual_memory().available, metal_available) - reserve
+    if total > safe:
+        raise MemoryError(
+            f"MTP needs {total / 1e9:.2f} GB but only {safe / 1e9:.2f} GB "
+            f"remains after the {reserve_gb:.1f} GB safety reserve"
+        )
+    for key in keys:
+        value = weights.read(key, _pin=True)
+        weights.resident[key] = value
+        weights.resident_bytes += value.nbytes
+    mx.clear_cache()
+    return total
+
+
+def _install_packed_mtp_moe(adapter) -> int:
+    """Pack per-expert DSpark tensors and replace its serial Python MoE loop."""
+    weights = adapter.w
+    expert_count = adapter.c["dspark_n_routed_experts"]
+    packed = {}
+    packed_bytes = 0
+    bases = sorted(
+        {
+            key.split(".experts.", 1)[0]
+            for key in weights.entries
+            if key.startswith("mtp.") and ".ffn.experts." in key
+        }
+    )
+    for base in bases:
+        projections = {}
+        for projection in ("w1", "w3", "w2"):
+            values = {}
+            for suffix in ("weight", "scales", "biases"):
+                keys = [
+                    f"{base}.experts.{expert}.{projection}.{suffix}"
+                    for expert in range(expert_count)
+                ]
+                value = mx.stack([weights.read(key) for key in keys])
+                mx.eval(value)
+                values[suffix] = value
+                packed_bytes += value.nbytes
+                for key in keys:
+                    old = weights.resident.pop(key, None)
+                    if old is not None:
+                        weights.resident_bytes -= old.nbytes
+            values["config"] = weights.quant_config(
+                f"{base}.experts.0.{projection}"
+            )
+            projections[projection] = values
+        packed[base] = projections
+        mx.clear_cache()
+
+    def packed_moe(self, base, x):
+        config = self.c
+        logits = x.astype(mx.float32) @ self.w.read(
+            base + ".gate.weight"
+        ).astype(mx.float32).T
+        scores = mx.sqrt(mx.logaddexp(logits, mx.zeros_like(logits)))
+        topk = config["num_experts_per_tok"]
+        picks = mx.argsort(
+            scores + self.w.read(base + ".gate.bias"), axis=-1
+        )[..., -topk:]
+        selected = mx.take_along_axis(scores, picks, axis=-1)
+        if config["norm_topk_prob"] and topk > 1:
+            selected = selected / (
+                mx.sum(selected, axis=-1, keepdims=True) + 1e-20
+            )
+        selected = selected * config["routed_scaling_factor"]
+        expanded = mx.expand_dims(x, (-2, -3))
+
+        def project(name, values):
+            projection = packed[base][name]
+            return mx.gather_qmm(
+                values,
+                projection["weight"],
+                projection["scales"],
+                projection["biases"],
+                rhs_indices=picks,
+                transpose=True,
+                sorted_indices=False,
+                **projection["config"],
+            )
+
+        gate = project("w1", expanded).astype(mx.float32)
+        up = project("w3", expanded).astype(mx.float32)
+        limit = config["swiglu_limit"]
+        if limit > 0:
+            gate = mx.minimum(gate, limit)
+            up = mx.clip(up, -limit, limit)
+        # Match the checkpoint runtime exactly: route weights are applied to
+        # the activation before its bfloat16 cast and down projection.
+        hidden = (
+            gate * mx.sigmoid(gate) * up * selected[..., None, None]
+        ).astype(x.dtype)
+        routed = project("w2", hidden).squeeze(-2).astype(mx.float32)
+        routed = mx.sum(routed, axis=-2)
+        shared = self.expert(base + ".shared_experts", x).astype(mx.float32)
+        return (routed + shared).astype(x.dtype)
+
+    adapter.moe = MethodType(packed_moe, adapter)
+    adapter._packed_mtp_moe = packed
+    return packed_bytes
+
+
+def _install_vectorized_mtp_attention(draft) -> None:
+    """Batch DSpark's five positions through grouped output projections."""
+    runtime_globals = draft.attention.__func__.__globals__
+    draft_attention = runtime_globals["draft_attention"]
+    quantize_cache = runtime_globals["quantize_cache"]
+
+    def rotate_positions(x, positions, config, inverse=False):
+        rope_dim = config["qk_rope_head_dim"]
+        frequencies = 1 / (
+            config["rope_theta"]
+            ** (mx.arange(0, rope_dim, 2, dtype=mx.float32) / rope_dim)
+        )
+        angles = positions[:, None] * frequencies[None, :]
+        if inverse:
+            angles = -angles
+        tail = x[..., -rope_dim:].astype(mx.float32)
+        tail = tail.reshape(*tail.shape[:-1], rope_dim // 2, 2)
+        real, imag = tail[..., 0], tail[..., 1]
+        expand = (slice(None),) + (None,) * (real.ndim - 2) + (slice(None),)
+        cosine = mx.cos(angles)[expand]
+        sine = mx.sin(angles)[expand]
+        rotated = mx.stack(
+            (real * cosine - imag * sine, real * sine + imag * cosine),
+            axis=-1,
+        ).reshape(*x.shape[:-1], rope_dim)
+        return mx.concatenate((x[..., :-rope_dim], rotated.astype(x.dtype)), axis=-1)
+
+    def vectorized_attention(self, base, x, stage):
+        adapter = self.adapter
+        config = self.c
+        count = x.shape[0]
+        positions = mx.arange(count, dtype=mx.float32) + self.position + 1
+        query_a = adapter.norm(base + ".q_norm", adapter.w.linear(base + ".wq_a", x))
+        query = adapter.w.linear(base + ".wq_b", query_a).reshape(
+            count, config["num_attention_heads"], config["head_dim"]
+        )
+        key_value = adapter.norm(base + ".kv_norm", adapter.w.linear(base + ".wkv", x))
+        query = rotate_positions(query, positions, config)
+        key_value = quantize_cache(
+            rotate_positions(key_value, positions, config), 8, 32
+        )
+        keys = mx.concatenate([*self.windows[stage], key_value])
+        output = draft_attention(query, keys, adapter.w.read(base + ".attn_sink"))
+        output = rotate_positions(output, positions, config, inverse=True)
+        output = output.reshape(count, config["o_groups"], -1)
+
+        shape = adapter.w.entries[base + ".wo_a.weight"]["shape"]
+        rows = shape[0] // config["o_groups"]
+        weight = adapter.w.read(base + ".wo_a.weight").reshape(
+            config["o_groups"], rows, -1
+        )
+        scales = adapter.w.read(base + ".wo_a.scales").reshape(
+            config["o_groups"], rows, -1
+        )
+        biases = adapter.w.read(base + ".wo_a.biases").reshape(
+            config["o_groups"], rows, -1
+        )
+        grouped = mx.quantized_matmul(
+            output.swapaxes(0, 1),
+            weight,
+            scales,
+            biases,
+            transpose=True,
+            **adapter.w.quant_config(base + ".wo_a"),
+        )
+        projected = grouped.swapaxes(0, 1).reshape(count, -1)
+        return adapter.w.linear(base + ".wo_b", projected)
+
+    draft.attention = MethodType(vectorized_attention, draft)
+
+
+def _run_serial_dspark(
+    model, input_ids, output_tokens, eos_id, weights_cls, dspark_cls, verify_greedy
+):
+    target = SimpleNamespace()
+    target.w = weights_cls(model._dspark_overlay_path)
+    target.c = target.w.config["text_config"]
+    target.execution_mode = "compiled"
+    _share_target_head(target.w, model)
+    mtp_bytes = _pin_mtp_with_headroom(target.w)
+    with contextlib.redirect_stdout(sys.stderr):
+        draft = dspark_cls(target, pin_weights=False)
+
+    cache = model.make_cache(max_seq_len=len(input_ids) + output_tokens + 8)
+    logits, hidden = model(
+        mx.array([input_ids]),
+        cache,
+        last_logit_only=False,
+        return_dspark_hidden=True,
+    )
+    mx.eval(logits, hidden)
+    logits = logits[:, -1]
+    for position in range(hidden.shape[1]):
+        draft.observe(hidden[:, position], position)
+
+    output = []
+    blocks = 0
+    accepted = 0
+    draft_seconds = 0.0
+    target_seconds = 0.0
+
+    def advance(token):
+        nonlocal target_seconds
+        started = time.perf_counter()
+        next_logits, next_hidden = model(
+            mx.array([[token]]),
+            cache,
+            last_logit_only=True,
+            return_dspark_hidden=True,
+        )
+        mx.eval(next_logits, next_hidden)
+        target_seconds += time.perf_counter() - started
+        return next_logits[:, -1], next_hidden[:, -1]
+
+    started_all = time.perf_counter()
+    while len(output) < output_tokens:
+        seed = int(mx.argmax(logits))
+        started = time.perf_counter()
+        proposals, _confidence = draft.propose(seed)
+        draft_seconds += time.perf_counter() - started
+        blocks += 1
+        verified, logits, stats = verify_greedy(
+            proposals,
+            logits,
+            advance,
+            lambda value: draft.observe(value, cache.offset - 1),
+            eos_id,
+            output_tokens - len(output),
+        )
+        output.extend(verified)
+        accepted += stats["accepted_draft_tokens"]
+        if output[-1] == eos_id:
+            break
+    seconds = time.perf_counter() - started_all
+    transitions = max(len(output) - 1, 0)
+    return output, {
+        "decode_seconds": seconds,
+        "decode_transitions": transitions,
+        "decode_tok_s": transitions / seconds if seconds else None,
+        "draft_seconds": draft_seconds,
+        "target_seconds": target_seconds,
+        "draft_blocks": blocks,
+        "accepted_draft_tokens": accepted,
+        "accepted_per_block": accepted / blocks if blocks else 0.0,
+        "mtp_bytes": mtp_bytes,
+    }
+
+
+def _run_batched_dspark(
+    model,
+    input_ids,
+    output_tokens,
+    eos_id,
+    weights_cls,
+    dspark_cls,
+    verify_k,
+    confidence_threshold=0.0,
+    packed_mtp=False,
+):
+    target = SimpleNamespace()
+    target.w = weights_cls(model._dspark_overlay_path)
+    target.c = target.w.config["text_config"]
+    target.execution_mode = "compiled"
+    _share_target_head(target.w, model)
+    mtp_bytes = _pin_mtp_with_headroom(target.w)
+    with contextlib.redirect_stdout(sys.stderr):
+        draft = dspark_cls(target, pin_weights=False)
+    if packed_mtp:
+        _install_vectorized_mtp_attention(draft)
+        packed_mtp_bytes = _install_packed_mtp_moe(draft.adapter)
+    else:
+        packed_mtp_bytes = 0
+
+    cache = model.make_cache(max_seq_len=len(input_ids) + output_tokens + 8)
+    logits, hidden = model(
+        mx.array([input_ids]),
+        cache,
+        last_logit_only=False,
+        return_dspark_hidden=True,
+    )
+    mx.eval(logits, hidden)
+    logits = logits[:, -1]
+    for position in range(hidden.shape[1]):
+        draft.observe(hidden[:, position], position)
+
+    output = []
+    blocks = 0
+    accepted = 0
+    deferred_corrections = 0
+    seed_already_emitted = False
+    draft_seconds = 0.0
+    target_seconds = 0.0
+    rollback_seconds = 0.0
+    proposed_depths = []
+    confidence_values = []
+    started_all = time.perf_counter()
+    while len(output) < output_tokens:
+        seed = int(mx.argmax(logits))
+        started = time.perf_counter()
+        proposals, confidence = draft.propose(seed)
+        draft_seconds += time.perf_counter() - started
+        confidence_probs = mx.sigmoid(confidence.reshape(-1)).tolist()
+        confidence_values.extend(float(value) for value in confidence_probs)
+        confident_depth = len(confidence_probs)
+        if confidence_threshold > 0:
+            confident_depth = next(
+                (
+                    index
+                    for index, value in enumerate(confidence_probs)
+                    if value < confidence_threshold
+                ),
+                len(confidence_probs),
+            )
+        proposed_depth = min(verify_k, confident_depth)
+        proposed_depths.append(proposed_depth)
+        candidate = proposals[
+            : min(
+                proposed_depth + 1,
+                output_tokens - len(output) + int(seed_already_emitted),
+            )
+        ]
+        blocks += 1
+
+        base_offset = cache.offset
+        started = time.perf_counter()
+        target_logits, target_hidden = model(
+            mx.array([candidate]),
+            cache,
+            last_logit_only=False,
+            return_dspark_hidden=True,
+        )
+        mx.eval(target_logits, target_hidden)
+        target_seconds += time.perf_counter() - started
+
+        committed = [] if seed_already_emitted else [seed]
+        mismatch = None
+        for index in range(1, len(candidate)):
+            expected = int(mx.argmax(target_logits[:, index - 1]))
+            if candidate[index] != expected:
+                committed.append(expected)
+                mismatch = index
+                break
+            committed.append(expected)
+            accepted += 1
+
+        if mismatch is None:
+            for index in range(len(candidate)):
+                draft.observe(target_hidden[:, index], base_offset + index)
+            logits = target_logits[:, -1]
+            seed_already_emitted = False
+        else:
+            started = time.perf_counter()
+            cache.rollback(base_offset + mismatch)
+            rollback_seconds += time.perf_counter() - started
+            for index in range(mismatch):
+                draft.observe(target_hidden[:, index], base_offset + index)
+            # The mismatch token is target-authoritative and may be emitted
+            # immediately, but advancing it with a singleton target call would
+            # erase most batching gains. Keep the cache/logits one token behind
+            # and fold that correction into the next verify block's first row.
+            logits = target_logits[:, mismatch - 1]
+            seed_already_emitted = True
+            deferred_corrections += 1
+
+        output.extend(committed)
+        if output[-1] == eos_id:
+            break
+
+    seconds = time.perf_counter() - started_all
+    transitions = max(len(output) - 1, 0)
+    return output, {
+        "decode_seconds": seconds,
+        "decode_transitions": transitions,
+        "decode_tok_s": transitions / seconds if seconds else None,
+        "verify_k": verify_k,
+        "confidence_threshold": confidence_threshold,
+        "draft_seconds": draft_seconds,
+        "target_seconds": target_seconds,
+        "rollback_seconds": rollback_seconds,
+        "draft_blocks": blocks,
+        "accepted_draft_tokens": accepted,
+        "accepted_per_block": accepted / blocks if blocks else 0.0,
+        "mean_proposed_depth": (
+            sum(proposed_depths) / len(proposed_depths) if proposed_depths else 0.0
+        ),
+        "confidence_min": min(confidence_values) if confidence_values else None,
+        "confidence_mean": (
+            sum(confidence_values) / len(confidence_values)
+            if confidence_values
+            else None
+        ),
+        "confidence_max": max(confidence_values) if confidence_values else None,
+        "deferred_corrections": deferred_corrections,
+        "mtp_bytes": mtp_bytes,
+        "packed_mtp_bytes": packed_mtp_bytes,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", type=Path, required=True)
+    parser.add_argument("--overlay", type=Path, required=True)
+    parser.add_argument("--checkpoint-runtime", type=Path, required=True)
+    parser.add_argument("--trust-checkpoint-runtime", action="store_true")
+    parser.add_argument("--omlx-source", type=Path)
+    parser.add_argument(
+        "--native-moe-only",
+        action="store_true",
+        help="Run baseline and native single-stream MoE A/B, skipping DSpark.",
+    )
+    parser.add_argument(
+        "--packed-mtp-only",
+        action="store_true",
+        help="Run baseline and packed-MTP K4/K5, skipping other DSpark variants.",
+    )
+    parser.add_argument(
+        "--fuse-target-moe",
+        action="store_true",
+        help="Fuse target gate/up expert projections after loading.",
+    )
+    parser.add_argument("--tokens", type=int, default=32)
+    parser.add_argument("--eval-interval", type=int, default=40)
+    parser.add_argument(
+        "--prompt",
+        default=(
+            "Write a Python function that merges overlapping integer intervals. "
+            "Return only the function and keep it concise."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.trust_checkpoint_runtime:
+        raise SystemExit(
+            "refusing to execute checkpoint-bundled Python without "
+            "--trust-checkpoint-runtime"
+        )
+    sys.path.insert(0, str(args.checkpoint_runtime.resolve()))
+    checkpoint_runtime = importlib.import_module("runtime")
+    dspark_module = importlib.import_module("dspark")
+
+    started = time.perf_counter()
+    model, _ = load(
+        str(args.target.resolve()),
+        lazy=False,
+        fuse_moe_gate_up=args.fuse_target_moe,
+    )
+    model.eval_interval = args.eval_interval
+    model._dspark_overlay_path = str(args.overlay.resolve())
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_file=str(args.target.resolve() / "tokenizer.json")
+    )
+    input_ids = tokenizer.encode(_prompt(args.prompt), add_special_tokens=False)
+    print(
+        json.dumps(
+            {
+                "event": "loaded",
+                "seconds": time.perf_counter() - started,
+                "active_gb": mx.get_active_memory() / 1e9,
+                "peak_gb": mx.get_peak_memory() / 1e9,
+                "prompt_tokens": len(input_ids),
+                "eval_interval": args.eval_interval,
+                "fuse_target_moe": args.fuse_target_moe,
+            }
+        ),
+        flush=True,
+    )
+
+    ar_tokens, ar = _run_ar(model, input_ids, args.tokens, eos_id=1)
+    ar.update(
+        event="ar",
+        output_tokens=ar_tokens,
+        text=tokenizer.decode(ar_tokens),
+        active_gb=mx.get_active_memory() / 1e9,
+        peak_gb=mx.get_peak_memory() / 1e9,
+    )
+    print(json.dumps(ar), flush=True)
+
+    if args.native_moe_only:
+        if args.omlx_source is None:
+            raise SystemExit("--native-moe-only requires --omlx-source")
+        replaced = _install_native_single_stream_moe(
+            model, args.omlx_source.resolve()
+        )
+        native_tokens, native = _run_ar(model, input_ids, args.tokens, eos_id=1)
+        native.update(
+            event="ar_native_small_route_moe",
+            replaced_layers=replaced,
+            output_tokens=native_tokens,
+            text=tokenizer.decode(native_tokens),
+            greedy_matches_ar=native_tokens == ar_tokens,
+            active_gb=mx.get_active_memory() / 1e9,
+            peak_gb=mx.get_peak_memory() / 1e9,
+        )
+        print(json.dumps(native), flush=True)
+        return
+
+    if args.packed_mtp_only:
+        for verify_k in (4, 5):
+            batched_tokens, batched = _run_batched_dspark(
+                model,
+                input_ids,
+                args.tokens,
+                1,
+                checkpoint_runtime.Weights,
+                dspark_module.DSpark,
+                verify_k,
+                packed_mtp=True,
+            )
+            batched.update(
+                event="dspark_batched_packed_mtp",
+                output_tokens=batched_tokens,
+                text=tokenizer.decode(batched_tokens),
+                greedy_matches_ar=batched_tokens == ar_tokens,
+                active_gb=mx.get_active_memory() / 1e9,
+                peak_gb=mx.get_peak_memory() / 1e9,
+            )
+            print(json.dumps(batched), flush=True)
+        return
+
+    for verify_k in (2, 3, 4, 5):
+        oracle = _run_oracle_verify(model, input_ids, ar_tokens, verify_k)
+        oracle.update(
+            active_gb=mx.get_active_memory() / 1e9,
+            peak_gb=mx.get_peak_memory() / 1e9,
+        )
+        print(json.dumps(oracle), flush=True)
+
+    dspark_tokens, dspark = _run_serial_dspark(
+        model,
+        input_ids,
+        args.tokens,
+        1,
+        checkpoint_runtime.Weights,
+        dspark_module.DSpark,
+        dspark_module.verify_greedy,
+    )
+    dspark.update(
+        event="dspark_serial",
+        output_tokens=dspark_tokens,
+        text=tokenizer.decode(dspark_tokens),
+        greedy_matches_ar=dspark_tokens == ar_tokens,
+        active_gb=mx.get_active_memory() / 1e9,
+        peak_gb=mx.get_peak_memory() / 1e9,
+    )
+    print(json.dumps(dspark), flush=True)
+
+    for verify_k, confidence_threshold in (
+        (3, 0.0),
+        (4, 0.0),
+        (5, 0.0),
+        (5, 0.3),
+        (5, 0.5),
+        (5, 0.7),
+    ):
+        batched_tokens, batched = _run_batched_dspark(
+            model,
+            input_ids,
+            args.tokens,
+            1,
+            checkpoint_runtime.Weights,
+            dspark_module.DSpark,
+            verify_k,
+            confidence_threshold,
+        )
+        batched.update(
+            event="dspark_batched",
+            output_tokens=batched_tokens,
+            text=tokenizer.decode(batched_tokens),
+            greedy_matches_ar=batched_tokens == ar_tokens,
+            active_gb=mx.get_active_memory() / 1e9,
+            peak_gb=mx.get_peak_memory() / 1e9,
+        )
+        print(json.dumps(batched), flush=True)
+
+    if args.omlx_source is not None:
+        replaced = _install_native_single_stream_moe(
+            model, args.omlx_source.resolve()
+        )
+        native_tokens, native = _run_ar(
+            model, input_ids, args.tokens, eos_id=1
+        )
+        native.update(
+            event="ar_native_small_route_moe",
+            replaced_layers=replaced,
+            output_tokens=native_tokens,
+            text=tokenizer.decode(native_tokens),
+            greedy_matches_ar=native_tokens == ar_tokens,
+            active_gb=mx.get_active_memory() / 1e9,
+            peak_gb=mx.get_peak_memory() / 1e9,
+        )
+        print(json.dumps(native), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_deepseek_v41_dspark.py
+++ b/scripts/benchmark_deepseek_v41_dspark.py
@@ -502,7 +502,7 @@ def _run_batched_dspark(
             deferred_corrections += 1
 
         output.extend(committed)
-        if output[-1] == eos_id:
+        if output and output[-1] == eos_id:
             break
 
     seconds = time.perf_counter() - started_all

--- a/scripts/benchmark_deepseek_v41_dspark.py
+++ b/scripts/benchmark_deepseek_v41_dspark.py
@@ -179,28 +179,25 @@ def _install_packed_mtp_moe(adapter) -> int:
                     old = weights.resident.pop(key, None)
                     if old is not None:
                         weights.resident_bytes -= old.nbytes
-            values["config"] = weights.quant_config(
-                f"{base}.experts.0.{projection}"
-            )
+            values["config"] = weights.quant_config(f"{base}.experts.0.{projection}")
             projections[projection] = values
         packed[base] = projections
         mx.clear_cache()
 
     def packed_moe(self, base, x):
         config = self.c
-        logits = x.astype(mx.float32) @ self.w.read(
-            base + ".gate.weight"
-        ).astype(mx.float32).T
+        logits = (
+            x.astype(mx.float32)
+            @ self.w.read(base + ".gate.weight").astype(mx.float32).T
+        )
         scores = mx.sqrt(mx.logaddexp(logits, mx.zeros_like(logits)))
         topk = config["num_experts_per_tok"]
-        picks = mx.argsort(
-            scores + self.w.read(base + ".gate.bias"), axis=-1
-        )[..., -topk:]
+        picks = mx.argsort(scores + self.w.read(base + ".gate.bias"), axis=-1)[
+            ..., -topk:
+        ]
         selected = mx.take_along_axis(scores, picks, axis=-1)
         if config["norm_topk_prob"] and topk > 1:
-            selected = selected / (
-                mx.sum(selected, axis=-1, keepdims=True) + 1e-20
-            )
+            selected = selected / (mx.sum(selected, axis=-1, keepdims=True) + 1e-20)
         selected = selected * config["routed_scaling_factor"]
         expanded = mx.expand_dims(x, (-2, -3))
 
@@ -225,9 +222,9 @@ def _install_packed_mtp_moe(adapter) -> int:
             up = mx.clip(up, -limit, limit)
         # Match the checkpoint runtime exactly: route weights are applied to
         # the activation before its bfloat16 cast and down projection.
-        hidden = (
-            gate * mx.sigmoid(gate) * up * selected[..., None, None]
-        ).astype(x.dtype)
+        hidden = (gate * mx.sigmoid(gate) * up * selected[..., None, None]).astype(
+            x.dtype
+        )
         routed = project("w2", hidden).squeeze(-2).astype(mx.float32)
         routed = mx.sum(routed, axis=-2)
         shared = self.expert(base + ".shared_experts", x).astype(mx.float32)
@@ -436,6 +433,9 @@ def _run_batched_dspark(
     started_all = time.perf_counter()
     while len(output) < output_tokens:
         seed = int(mx.argmax(logits))
+        if not seed_already_emitted and seed == eos_id:
+            output.append(seed)
+            break
         started = time.perf_counter()
         proposals, confidence = draft.propose(seed)
         draft_seconds += time.perf_counter() - started
@@ -472,16 +472,14 @@ def _run_batched_dspark(
         mx.eval(target_logits, target_hidden)
         target_seconds += time.perf_counter() - started
 
-        committed = [] if seed_already_emitted else [seed]
-        mismatch = None
-        for index in range(1, len(candidate)):
-            expected = int(mx.argmax(target_logits[:, index - 1]))
-            if candidate[index] != expected:
-                committed.append(expected)
-                mismatch = index
-                break
-            committed.append(expected)
-            accepted += 1
+        committed, mismatch, hit_eos, accepted_now = _match_greedy_prefix(
+            candidate, target_logits, eos_id, seed_already_emitted
+        )
+        accepted += accepted_now
+
+        if hit_eos:
+            output.extend(committed)
+            break
 
         if mismatch is None:
             for index in range(len(candidate)):
@@ -534,6 +532,21 @@ def _run_batched_dspark(
         "mtp_bytes": mtp_bytes,
         "packed_mtp_bytes": packed_mtp_bytes,
     }
+
+
+def _match_greedy_prefix(candidate, target_logits, eos_id, seed_already_emitted):
+    """Return only target-authoritative tokens through the first EOS/mismatch."""
+    committed = [] if seed_already_emitted else [candidate[0]]
+    accepted = 0
+    for index in range(1, len(candidate)):
+        expected = int(mx.argmax(target_logits[:, index - 1]))
+        committed.append(expected)
+        if candidate[index] != expected:
+            return committed, index, expected == eos_id, accepted
+        accepted += 1
+        if expected == eos_id:
+            return committed, None, True, accepted
+    return committed, None, False, accepted
 
 
 def parse_args() -> argparse.Namespace:
@@ -621,9 +634,7 @@ def main() -> None:
     if args.native_moe_only:
         if args.omlx_source is None:
             raise SystemExit("--native-moe-only requires --omlx-source")
-        replaced = _install_native_single_stream_moe(
-            model, args.omlx_source.resolve()
-        )
+        replaced = _install_native_single_stream_moe(model, args.omlx_source.resolve())
         native_tokens, native = _run_ar(model, input_ids, args.tokens, eos_id=1)
         native.update(
             event="ar_native_small_route_moe",
@@ -716,12 +727,8 @@ def main() -> None:
         print(json.dumps(batched), flush=True)
 
     if args.omlx_source is not None:
-        replaced = _install_native_single_stream_moe(
-            model, args.omlx_source.resolve()
-        )
-        native_tokens, native = _run_ar(
-            model, input_ids, args.tokens, eos_id=1
-        )
+        replaced = _install_native_single_stream_moe(model, args.omlx_source.resolve())
+        native_tokens, native = _run_ar(model, input_ids, args.tokens, eos_id=1)
         native.update(
             event="ar_native_small_route_moe",
             replaced_layers=replaced,

--- a/scripts/benchmark_deepseek_v41_dspark.py
+++ b/scripts/benchmark_deepseek_v41_dspark.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import time
+import weakref
 from pathlib import Path
 from types import MethodType, SimpleNamespace
 
@@ -49,8 +50,9 @@ def _load_module_file(name: str, path: Path):
     return module
 
 
-def _load_checkpoint_runtime(root: Path):
-    """Load the two trusted files exactly, without ambient module fallback."""
+@contextlib.contextmanager
+def _checkpoint_runtime(root: Path):
+    """Bind the two trusted files exactly for the benchmark lifetime."""
     root = root.absolute()
     if not root.is_dir():
         raise NotADirectoryError(root)
@@ -59,6 +61,7 @@ def _load_checkpoint_runtime(root: Path):
     try:
         runtime = _load_module_file("runtime", root / "runtime.py")
         dspark = _load_module_file("_rapid_checkpoint_dspark", root / "dspark.py")
+        yield runtime, dspark
     finally:
         if previous_runtime is None:
             sys.modules.pop("runtime", None)
@@ -68,7 +71,6 @@ def _load_checkpoint_runtime(root: Path):
             sys.modules.pop("_rapid_checkpoint_dspark", None)
         else:
             sys.modules["_rapid_checkpoint_dspark"] = previous_dspark
-    return runtime, dspark
 
 
 def _prompt(text: str) -> str:
@@ -272,7 +274,9 @@ def _install_packed_mtp_moe(adapter) -> int:
         shared = self.expert(base + ".shared_experts", x).astype(mx.float32)
         return (routed + shared).astype(x.dtype)
 
-    adapter.moe = MethodType(packed_moe, adapter)
+    # Bind through a weak proxy so adapter -> bound method does not retain
+    # adapter (and its 4+ GB packed tensors) in a reference cycle between runs.
+    adapter.moe = MethodType(packed_moe, weakref.proxy(adapter))
     adapter._packed_mtp_moe = packed
     return packed_bytes
 
@@ -592,6 +596,13 @@ def _match_greedy_prefix(candidate, target_logits, eos_id, seed_already_emitted)
     return committed, None, False, accepted
 
 
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--target", type=Path, required=True)
@@ -614,7 +625,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Fuse target gate/up expert projections after loading.",
     )
-    parser.add_argument("--tokens", type=int, default=32)
+    parser.add_argument("--tokens", type=_positive_int, default=32)
     parser.add_argument("--eval-interval", type=int, default=40)
     parser.add_argument(
         "--prompt",
@@ -626,17 +637,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
-    args = parse_args()
-    if not args.trust_checkpoint_runtime:
-        raise SystemExit(
-            "refusing to execute checkpoint-bundled Python without "
-            "--trust-checkpoint-runtime"
-        )
-    checkpoint_runtime, dspark_module = _load_checkpoint_runtime(
-        args.checkpoint_runtime
-    )
-
+def _run_benchmark(args, checkpoint_runtime, dspark_module) -> None:
     started = time.perf_counter()
     model, _ = load(
         str(args.target.resolve()),
@@ -782,6 +783,20 @@ def main() -> None:
             peak_gb=mx.get_peak_memory() / 1e9,
         )
         print(json.dumps(native), flush=True)
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.trust_checkpoint_runtime:
+        raise SystemExit(
+            "refusing to execute checkpoint-bundled Python without "
+            "--trust-checkpoint-runtime"
+        )
+    with _checkpoint_runtime(args.checkpoint_runtime) as (
+        checkpoint_runtime,
+        dspark_module,
+    ):
+        _run_benchmark(args, checkpoint_runtime, dspark_module)
 
 
 if __name__ == "__main__":

--- a/scripts/benchmark_deepseek_v41_moe_kernel.py
+++ b/scripts/benchmark_deepseek_v41_moe_kernel.py
@@ -22,6 +22,23 @@ from deepseek_v41_native.config import ModelArgs  # noqa: E402
 from deepseek_v41_native.moe import MoE  # noqa: E402
 
 
+def _load_prefix_items(model_path: Path, index: dict, prefix: str):
+    shards = sorted({shard for key, shard in index.items() if key.startswith(prefix)})
+    if not shards:
+        raise ValueError(f"no checkpoint tensors found for {prefix}")
+    items = {}
+    for shard in shards:
+        weights = mx.load(str(model_path / shard))
+        for key, value in weights.items():
+            if not key.startswith(prefix):
+                continue
+            name = key.removeprefix(prefix)
+            if name in items:
+                raise ValueError(f"duplicate tensor across checkpoint shards: {key}")
+            items[name] = value
+    return sorted(items.items())
+
+
 class HybridPairSwitch(nn.Module):
     """Native affine gate+up pair, stock gather_qmm down projection."""
 
@@ -80,15 +97,7 @@ def _load_layer(model_path: Path, layer_id: int):
         "weight_map"
     ]
     prefix = f"layers.{layer_id}.ffn."
-    shards = sorted({shard for key, shard in index.items() if key.startswith(prefix)})
-    if len(shards) != 1:
-        raise ValueError(f"expected one MoE shard, got {shards}")
-    weights = mx.load(str(model_path / shards[0]))
-    items = [
-        (key.removeprefix(prefix), value)
-        for key, value in weights.items()
-        if key.startswith(prefix)
-    ]
+    items = _load_prefix_items(model_path, index, prefix)
 
     moe = MoE(args)
     quantized = {

--- a/scripts/benchmark_deepseek_v41_moe_kernel.py
+++ b/scripts/benchmark_deepseek_v41_moe_kernel.py
@@ -84,7 +84,11 @@ def _load_layer(model_path: Path, layer_id: int):
     if len(shards) != 1:
         raise ValueError(f"expected one MoE shard, got {shards}")
     weights = mx.load(str(model_path / shards[0]))
-    items = [(key.removeprefix(prefix), value) for key, value in weights.items() if key.startswith(prefix)]
+    items = [
+        (key.removeprefix(prefix), value)
+        for key, value in weights.items()
+        if key.startswith(prefix)
+    ]
 
     moe = MoE(args)
     quantized = {

--- a/scripts/benchmark_deepseek_v41_moe_kernel.py
+++ b/scripts/benchmark_deepseek_v41_moe_kernel.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Microbenchmark one real V4.1 affine-2bit MoE layer on stock vs native QMM."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from deepseek_v41_native.config import ModelArgs  # noqa: E402
+from deepseek_v41_native.moe import MoE  # noqa: E402
+
+
+class HybridPairSwitch(nn.Module):
+    """Native affine gate+up pair, stock gather_qmm down projection."""
+
+    def __init__(self, native, switch, block_rows, variant):
+        super().__init__()
+        self.gate_proj = native.gate_proj
+        self.up_proj = native.up_proj
+        self.down_proj = native.down_proj
+        self.activation = native.activation
+        self.switch = switch
+        self.block_rows = block_rows
+        self.variant = variant
+
+    def __call__(self, x, indices):
+        x = mx.expand_dims(x, (-2, -3))
+        x, idx, inv_order = self.switch._gather_sort(x, indices)
+        block_meta, block_count = self.switch._build_mxfp4_blocks(
+            idx, self.up_proj.num_experts, self.block_rows
+        )
+        pair = self.switch.glm_fast.deepseek_affine_gather_qmm_pair_concat_blocks(
+            x,
+            self.up_proj.weight,
+            self.up_proj.scales,
+            self.up_proj.biases,
+            self.gate_proj.weight,
+            self.gate_proj.scales,
+            self.gate_proj.biases,
+            block_meta,
+            block_count,
+            self.up_proj.group_size,
+            self.up_proj.bits,
+            self.variant,
+        )
+        hidden = self.up_proj.output_dims
+        x = self.activation(pair[..., :hidden], pair[..., hidden:])
+        x = mx.gather_qmm(
+            x,
+            self.down_proj.weight,
+            self.down_proj.scales,
+            self.down_proj.biases,
+            rhs_indices=idx,
+            transpose=True,
+            group_size=self.down_proj.group_size,
+            bits=self.down_proj.bits,
+            mode=self.down_proj.mode,
+            sorted_indices=True,
+        )
+        x = self.switch._scatter_unsort(x, inv_order, indices.shape)
+        return x.squeeze(-2)
+
+
+def _load_layer(model_path: Path, layer_id: int):
+    config = json.loads((model_path / "config.json").read_text())
+    args = ModelArgs.from_dict(config)
+    index = json.loads((model_path / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    prefix = f"layers.{layer_id}.ffn."
+    shards = sorted({shard for key, shard in index.items() if key.startswith(prefix)})
+    if len(shards) != 1:
+        raise ValueError(f"expected one MoE shard, got {shards}")
+    weights = mx.load(str(model_path / shards[0]))
+    items = [(key.removeprefix(prefix), value) for key, value in weights.items() if key.startswith(prefix)]
+
+    moe = MoE(args)
+    quantized = {
+        "experts.gate_proj",
+        "experts.up_proj",
+        "experts.down_proj",
+        "shared_experts.w1",
+        "shared_experts.w2",
+        "shared_experts.w3",
+    }
+    nn.quantize(
+        moe,
+        group_size=64,
+        bits=2,
+        class_predicate=lambda path, _module: path in quantized,
+    )
+    moe.load_weights(items, strict=True)
+    mx.eval(moe.parameters())
+    return moe, args
+
+
+def _native_experts(stock, args, source_root: Path):
+    os.environ["OMLX_DEEPSEEK_SORT_MIN_ROUTES"] = "1"
+    os.environ["OMLX_DEEPSEEK_AFFINE_BLOCK_MIN_ROUTES"] = "1"
+    sys.path.insert(0, str(source_root))
+    switch = importlib.import_module("omlx.patches.deepseek_v4.switch_layers")
+    native = switch.SwitchGLU(
+        args.dim,
+        args.moe_inter_dim,
+        args.n_routed_experts,
+        activation=stock.activation,
+        bias=False,
+    )
+    nn.quantize(native, group_size=64, bits=2)
+    for name in ("gate_proj", "up_proj", "down_proj"):
+        old = getattr(stock, name)
+        new = getattr(native, name)
+        new.weight = old.weight
+        new.scales = old.scales
+        new.biases = old.biases
+    return native, switch
+
+
+def _measure(moe, values, iterations):
+    for _ in range(3):
+        output = moe(values)
+        mx.eval(output)
+    started = time.perf_counter()
+    for _ in range(iterations):
+        output = moe(values)
+        mx.eval(output)
+    return output, (time.perf_counter() - started) / iterations
+
+
+def _stock_experts(native, config):
+    stock = importlib.import_module("mlx_lm.models.switch_layers").SwitchGLU(
+        config.dim,
+        config.moe_inter_dim,
+        config.n_routed_experts,
+        activation=native.activation,
+        bias=False,
+    )
+    nn.quantize(stock, group_size=64, bits=2)
+    for name in ("gate_proj", "up_proj", "down_proj"):
+        source = getattr(native, name)
+        target = getattr(stock, name)
+        target.weight = source.weight
+        target.scales = source.scales
+        target.biases = source.biases
+    return stock
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--omlx-source", type=Path, required=True)
+    parser.add_argument("--layer", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=20)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    moe, config = _load_layer(args.model.resolve(), args.layer)
+    native, switch = _native_experts(moe.experts, config, args.omlx_source.resolve())
+    print(
+        json.dumps(
+            {
+                "event": "loaded",
+                "layer": args.layer,
+                "active_gb": mx.get_active_memory() / 1e9,
+                "native_affine_symbol": switch.glm_fast.has_symbol(
+                    "deepseek_affine_gather_qmm_blocks"
+                ),
+                "native_pair_symbol": switch.glm_fast.has_symbol(
+                    "deepseek_affine_gather_qmm_pair_concat_blocks"
+                ),
+            }
+        ),
+        flush=True,
+    )
+    rng = mx.random.key(42)
+    for tokens in (1, 4, 5, 6):
+        values = mx.random.normal((1, tokens, config.dim), key=rng).astype(mx.bfloat16)
+        moe.experts = _stock_experts(native, config)
+        stock_output, stock_seconds = _measure(moe, values, args.iterations)
+        for variant, experts in (
+            ("native_all", native),
+            ("hybrid_pair_bm16", HybridPairSwitch(native, switch, 16, 1)),
+            ("hybrid_pair_bm32", HybridPairSwitch(native, switch, 32, 2)),
+        ):
+            moe.experts = experts
+            output, seconds = _measure(moe, values, args.iterations)
+            print(
+                json.dumps(
+                    {
+                        "event": "moe",
+                        "variant": variant,
+                        "tokens": tokens,
+                        "routes": tokens * config.n_activated_experts,
+                        "stock_ms": stock_seconds * 1000,
+                        "candidate_ms": seconds * 1000,
+                        "speedup": stock_seconds / seconds,
+                        "allclose": mx.allclose(
+                            stock_output, output, rtol=2e-3, atol=2e-3
+                        ).item(),
+                        "max_abs_diff": mx.max(
+                            mx.abs(
+                                stock_output.astype(mx.float32)
+                                - output.astype(mx.float32)
+                            )
+                        ).item(),
+                    }
+                ),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_deepseek_v41_moe_kernel.py
+++ b/scripts/benchmark_deepseek_v41_moe_kernel.py
@@ -28,7 +28,19 @@ def _load_prefix_items(model_path: Path, index: dict, prefix: str):
         raise ValueError(f"no checkpoint tensors found for {prefix}")
     items = {}
     for shard in shards:
-        weights = mx.load(str(model_path / shard))
+        if not isinstance(shard, str) or not shard:
+            raise ValueError(f"invalid checkpoint shard name: {shard!r}")
+        shard_name = Path(shard)
+        if shard_name.is_absolute() or shard_name.name != shard:
+            raise ValueError(f"checkpoint shard must be a basename: {shard!r}")
+        shard_path = model_path / shard
+        if shard_path.is_symlink():
+            raise ValueError(f"checkpoint shard must not be a symlink: {shard_path}")
+        if not shard_path.is_file():
+            raise FileNotFoundError(shard_path)
+        if shard_path.resolve().parent != model_path.resolve():
+            raise ValueError(f"checkpoint shard escapes model directory: {shard_path}")
+        weights = mx.load(str(shard_path))
         for key, value in weights.items():
             if not key.startswith(prefix):
                 continue

--- a/scripts/deepseek_v41_native/cache.py
+++ b/scripts/deepseek_v41_native/cache.py
@@ -83,6 +83,7 @@ class ModelCache:
     ):
         self.max_seq_len = max_seq_len or min(args.max_seq_len, 4096)
         self.offset = 0
+        self.rollback_start = 0
         self.layers = [
             LayerCache(bsz, args, i, self.max_seq_len, dtype)
             for i in range(args.n_layers)
@@ -94,9 +95,12 @@ class ModelCache:
         )
 
     def rollback(self, offset: int) -> None:
-        """Discard a speculative suffix while retaining its correct prefix."""
-        if not 0 <= offset <= self.offset:
-            raise ValueError(f"rollback offset {offset} outside [0, {self.offset}]")
+        """Discard a suffix from the most recent speculative target call."""
+        if not self.rollback_start <= offset <= self.offset:
+            raise ValueError(
+                f"rollback offset {offset} outside latest forward "
+                f"[{self.rollback_start}, {self.offset}]"
+            )
         for layer in self.layers:
             if layer.comp_state is not None:
                 layer.comp_state.rollback(offset)

--- a/scripts/deepseek_v41_native/cache.py
+++ b/scripts/deepseek_v41_native/cache.py
@@ -105,3 +105,16 @@ class ModelCache:
             if layer.comp_state is not None:
                 layer.comp_state.rollback(offset)
         self.offset = offset
+
+    def begin_forward(self) -> None:
+        """Open the only rollback window supported by this cache."""
+        self.rollback_start = self.offset
+        snapshots = []
+        for layer in self.layers:
+            if layer.comp_state is not None:
+                layer.comp_state.begin_forward(self.offset)
+                snapshots.extend(
+                    (layer.comp_state.snapshot_kv, layer.comp_state.snapshot_score)
+                )
+        if snapshots:
+            mx.eval(*snapshots)

--- a/scripts/deepseek_v41_native/cache.py
+++ b/scripts/deepseek_v41_native/cache.py
@@ -83,7 +83,7 @@ class ModelCache:
     ):
         self.max_seq_len = max_seq_len or min(args.max_seq_len, 4096)
         self.offset = 0
-        self.rollback_start = 0
+        self.rollback_start: int | None = None
         self.layers = [
             LayerCache(bsz, args, i, self.max_seq_len, dtype)
             for i in range(args.n_layers)
@@ -96,7 +96,10 @@ class ModelCache:
 
     def rollback(self, offset: int) -> None:
         """Discard a suffix from the most recent speculative target call."""
-        if not self.rollback_start <= offset <= self.offset:
+        if (
+            self.rollback_start is None
+            or not self.rollback_start <= offset <= self.offset
+        ):
             raise ValueError(
                 f"rollback offset {offset} outside latest forward "
                 f"[{self.rollback_start}, {self.offset}]"
@@ -105,6 +108,7 @@ class ModelCache:
             if layer.comp_state is not None:
                 layer.comp_state.rollback(offset)
         self.offset = offset
+        self.disable_rollback()
 
     def begin_forward(self) -> None:
         """Open the only rollback window supported by this cache."""
@@ -118,3 +122,10 @@ class ModelCache:
                 )
         if snapshots:
             mx.eval(*snapshots)
+
+    def disable_rollback(self) -> None:
+        """Close any prior rollback window without synchronizing device work."""
+        self.rollback_start = None
+        for layer in self.layers:
+            if layer.comp_state is not None:
+                layer.comp_state.disable_rollback()

--- a/scripts/deepseek_v41_native/cache.py
+++ b/scripts/deepseek_v41_native/cache.py
@@ -92,3 +92,12 @@ class ModelCache:
             if args.engram_layer_ids
             else None
         )
+
+    def rollback(self, offset: int) -> None:
+        """Discard a speculative suffix while retaining its correct prefix."""
+        if not 0 <= offset <= self.offset:
+            raise ValueError(f"rollback offset {offset} outside [0, {self.offset}]")
+        for layer in self.layers:
+            if layer.comp_state is not None:
+                layer.comp_state.rollback(offset)
+        self.offset = offset

--- a/scripts/deepseek_v41_native/compressor.py
+++ b/scripts/deepseek_v41_native/compressor.py
@@ -104,6 +104,9 @@ class CompressorState:
         """Restore the open compression group at ``offset`` after chunk verify."""
         remainder = offset % self.kv_state.shape[1]
         if remainder == 0:
+            self.kv_state[:] = 0
+            self.score_state[:] = NEG_INF
+            mx.eval(self.kv_state, self.score_state)
             return
         if (
             self.pending_start is None

--- a/scripts/deepseek_v41_native/compressor.py
+++ b/scripts/deepseek_v41_native/compressor.py
@@ -63,6 +63,12 @@ class Compressor(nn.Module):
         # features. The module call is identical for dense public builds.
         kv = self.wkv(xf)
         score = self.wgate(xf)
+        # Retain this call's unpooled source rows so speculative verification
+        # can restore the one-token partial group after rolling back a chunk.
+        # The arrays are tiny (three source layers x at most six rows x 512).
+        comp_state.pending_start = start_pos
+        comp_state.pending_kv = kv
+        comp_state.pending_score = score
 
         m = start_pos % ratio  # carried tokens of the open group
         if m:
@@ -90,3 +96,27 @@ class CompressorState:
     def __init__(self, bsz: int, ratio: int, head_dim: int):
         self.kv_state = mx.zeros((bsz, ratio, head_dim), dtype=mx.float32)
         self.score_state = mx.full((bsz, ratio, head_dim), NEG_INF, dtype=mx.float32)
+        self.pending_start: int | None = None
+        self.pending_kv: mx.array | None = None
+        self.pending_score: mx.array | None = None
+
+    def rollback(self, offset: int) -> None:
+        """Restore the open compression group at ``offset`` after chunk verify."""
+        remainder = offset % self.kv_state.shape[1]
+        if remainder == 0:
+            return
+        if (
+            self.pending_start is None
+            or self.pending_kv is None
+            or self.pending_score is None
+        ):
+            raise RuntimeError("compression rollback has no pending chunk")
+        first = offset - remainder
+        start = first - self.pending_start
+        if start < 0 or start + remainder > self.pending_kv.shape[1]:
+            raise RuntimeError("compression rollback precedes the pending chunk")
+        self.kv_state[:, :remainder] = self.pending_kv[:, start : start + remainder]
+        self.score_state[:, :remainder] = self.pending_score[
+            :, start : start + remainder
+        ]
+        mx.eval(self.kv_state, self.score_state)

--- a/scripts/deepseek_v41_native/compressor.py
+++ b/scripts/deepseek_v41_native/compressor.py
@@ -99,9 +99,25 @@ class CompressorState:
         self.pending_start: int | None = None
         self.pending_kv: mx.array | None = None
         self.pending_score: mx.array | None = None
+        self.snapshot_offset: int | None = None
+        self.snapshot_kv: mx.array | None = None
+        self.snapshot_score: mx.array | None = None
+
+    def begin_forward(self, offset: int) -> None:
+        """Snapshot the carried partial group for latest-forward rollback."""
+        self.snapshot_offset = offset
+        self.snapshot_kv = self.kv_state + mx.zeros_like(self.kv_state)
+        self.snapshot_score = self.score_state + mx.zeros_like(self.score_state)
 
     def rollback(self, offset: int) -> None:
         """Restore the open compression group at ``offset`` after chunk verify."""
+        if offset == self.snapshot_offset:
+            if self.snapshot_kv is None or self.snapshot_score is None:
+                raise RuntimeError("compression rollback has no forward snapshot")
+            self.kv_state[:] = self.snapshot_kv
+            self.score_state[:] = self.snapshot_score
+            mx.eval(self.kv_state, self.score_state)
+            return
         remainder = offset % self.kv_state.shape[1]
         if remainder == 0:
             self.kv_state[:] = 0

--- a/scripts/deepseek_v41_native/compressor.py
+++ b/scripts/deepseek_v41_native/compressor.py
@@ -66,9 +66,10 @@ class Compressor(nn.Module):
         # Retain this call's unpooled source rows so speculative verification
         # can restore the one-token partial group after rolling back a chunk.
         # The arrays are tiny (three source layers x at most six rows x 512).
-        comp_state.pending_start = start_pos
-        comp_state.pending_kv = kv
-        comp_state.pending_score = score
+        if comp_state.rollback_enabled:
+            comp_state.pending_start = start_pos
+            comp_state.pending_kv = kv
+            comp_state.pending_score = score
 
         m = start_pos % ratio  # carried tokens of the open group
         if m:
@@ -102,15 +103,19 @@ class CompressorState:
         self.snapshot_offset: int | None = None
         self.snapshot_kv: mx.array | None = None
         self.snapshot_score: mx.array | None = None
+        self.rollback_enabled = False
 
     def begin_forward(self, offset: int) -> None:
         """Snapshot the carried partial group for latest-forward rollback."""
+        self.rollback_enabled = True
         self.snapshot_offset = offset
         self.snapshot_kv = self.kv_state + mx.zeros_like(self.kv_state)
         self.snapshot_score = self.score_state + mx.zeros_like(self.score_state)
 
     def rollback(self, offset: int) -> None:
         """Restore the open compression group at ``offset`` after chunk verify."""
+        if not self.rollback_enabled:
+            raise RuntimeError("compression rollback was not enabled for this forward")
         if offset == self.snapshot_offset:
             if self.snapshot_kv is None or self.snapshot_score is None:
                 raise RuntimeError("compression rollback has no forward snapshot")
@@ -139,3 +144,12 @@ class CompressorState:
             :, start : start + remainder
         ]
         mx.eval(self.kv_state, self.score_state)
+
+    def disable_rollback(self) -> None:
+        self.rollback_enabled = False
+        self.pending_start = None
+        self.pending_kv = None
+        self.pending_score = None
+        self.snapshot_offset = None
+        self.snapshot_kv = None
+        self.snapshot_score = None

--- a/scripts/deepseek_v41_native/model.py
+++ b/scripts/deepseek_v41_native/model.py
@@ -147,7 +147,7 @@ class Model(nn.Module):
     ) -> mx.array | tuple[mx.array, mx.array]:
         """input_ids [b, n] continue the sequence at cache.offset. Advances the cache."""
         start_pos = cache.offset
-        cache.rollback_start = start_pos
+        cache.begin_forward()
         b, n = input_ids.shape
 
         hashes = None
@@ -166,13 +166,13 @@ class Model(nn.Module):
 
         pre_mix = make_identity_pre_mix(b, n, self.hc_mult)
         shared = SharedState()
-        dspark_hiddens = []
+        dspark_hiddens = {}
         for layer_index, layer in enumerate(self.layers):
             if (
                 return_dspark_hidden
                 and layer_index in self.args.dspark_target_layer_ids
             ):
-                dspark_hiddens.append(mx.mean(h, axis=2))
+                dspark_hiddens[layer_index] = mx.mean(h, axis=2)
             if layer.engram is not None:
                 assert hashes is not None
                 h = layer.engram(h, hashes[:, :, layer.engram.layer_hash_index])
@@ -199,7 +199,16 @@ class Model(nn.Module):
         logits = self.head(h.astype(mx.float32))  # fp32 logits, as the reference
         cache.offset = start_pos + n
         if return_dspark_hidden:
-            if len(dspark_hiddens) != len(self.args.dspark_target_layer_ids):
+            missing = [
+                layer_id
+                for layer_id in self.args.dspark_target_layer_ids
+                if layer_id not in dspark_hiddens
+            ]
+            if missing:
                 raise RuntimeError("DSpark target hidden-state capture is incomplete")
-            return logits, mx.concatenate(dspark_hiddens, axis=-1)
+            ordered = [
+                dspark_hiddens[layer_id]
+                for layer_id in self.args.dspark_target_layer_ids
+            ]
+            return logits, mx.concatenate(ordered, axis=-1)
         return logits

--- a/scripts/deepseek_v41_native/model.py
+++ b/scripts/deepseek_v41_native/model.py
@@ -147,6 +147,7 @@ class Model(nn.Module):
     ) -> mx.array | tuple[mx.array, mx.array]:
         """input_ids [b, n] continue the sequence at cache.offset. Advances the cache."""
         start_pos = cache.offset
+        cache.rollback_start = start_pos
         b, n = input_ids.shape
 
         hashes = None
@@ -167,7 +168,10 @@ class Model(nn.Module):
         shared = SharedState()
         dspark_hiddens = []
         for layer_index, layer in enumerate(self.layers):
-            if return_dspark_hidden and layer_index in self.args.dspark_target_layer_ids:
+            if (
+                return_dspark_hidden
+                and layer_index in self.args.dspark_target_layer_ids
+            ):
                 dspark_hiddens.append(mx.mean(h, axis=2))
             if layer.engram is not None:
                 assert hashes is not None

--- a/scripts/deepseek_v41_native/model.py
+++ b/scripts/deepseek_v41_native/model.py
@@ -139,8 +139,12 @@ class Model(nn.Module):
         return ModelCache(self.args, bsz, max_seq_len, dtype)
 
     def __call__(
-        self, input_ids: mx.array, cache: ModelCache, last_logit_only: bool = False
-    ) -> mx.array:
+        self,
+        input_ids: mx.array,
+        cache: ModelCache,
+        last_logit_only: bool = False,
+        return_dspark_hidden: bool = False,
+    ) -> mx.array | tuple[mx.array, mx.array]:
         """input_ids [b, n] continue the sequence at cache.offset. Advances the cache."""
         start_pos = cache.offset
         b, n = input_ids.shape
@@ -161,7 +165,10 @@ class Model(nn.Module):
 
         pre_mix = make_identity_pre_mix(b, n, self.hc_mult)
         shared = SharedState()
-        for layer_index, layer in enumerate(self.layers, 1):
+        dspark_hiddens = []
+        for layer_index, layer in enumerate(self.layers):
+            if return_dspark_hidden and layer_index in self.args.dspark_target_layer_ids:
+                dspark_hiddens.append(mx.mean(h, axis=2))
             if layer.engram is not None:
                 assert hashes is not None
                 h = layer.engram(h, hashes[:, :, layer.engram.layer_hash_index])
@@ -178,7 +185,7 @@ class Model(nn.Module):
                 h, pre_mix = layer(h, pre_mix, start_pos, cache, shared_use)
             else:
                 h, pre_mix = layer(h, pre_mix, start_pos, cache, shared)
-            if self.eval_interval and layer_index % self.eval_interval == 0:
+            if self.eval_interval and (layer_index + 1) % self.eval_interval == 0:
                 mx.eval(h, pre_mix)
 
         h = hc_pre(h, pre_mix)  # collapse with the last ffn_pre
@@ -187,4 +194,8 @@ class Model(nn.Module):
             h = h[:, -1:]
         logits = self.head(h.astype(mx.float32))  # fp32 logits, as the reference
         cache.offset = start_pos + n
+        if return_dspark_hidden:
+            if len(dspark_hiddens) != len(self.args.dspark_target_layer_ids):
+                raise RuntimeError("DSpark target hidden-state capture is incomplete")
+            return logits, mx.concatenate(dspark_hiddens, axis=-1)
         return logits

--- a/scripts/deepseek_v41_native/model.py
+++ b/scripts/deepseek_v41_native/model.py
@@ -171,12 +171,10 @@ class Model(nn.Module):
         pre_mix = make_identity_pre_mix(b, n, self.hc_mult)
         shared = SharedState()
         dspark_hiddens = {}
-        for layer_index, layer in enumerate(self.layers):
-            if (
-                return_dspark_hidden
-                and layer_index in self.args.dspark_target_layer_ids
-            ):
-                dspark_hiddens[layer_index] = mx.mean(h, axis=2)
+        for execution_index, layer in enumerate(self.layers, 1):
+            layer_id = execution_index - 1
+            if return_dspark_hidden and layer_id in self.args.dspark_target_layer_ids:
+                dspark_hiddens[layer_id] = mx.mean(h, axis=2)
             if layer.engram is not None:
                 assert hashes is not None
                 h = layer.engram(h, hashes[:, :, layer.engram.layer_hash_index])
@@ -193,7 +191,7 @@ class Model(nn.Module):
                 h, pre_mix = layer(h, pre_mix, start_pos, cache, shared_use)
             else:
                 h, pre_mix = layer(h, pre_mix, start_pos, cache, shared)
-            if self.eval_interval and (layer_index + 1) % self.eval_interval == 0:
+            if self.eval_interval and execution_index % self.eval_interval == 0:
                 mx.eval(h, pre_mix)
 
         h = hc_pre(h, pre_mix)  # collapse with the last ffn_pre

--- a/scripts/deepseek_v41_native/model.py
+++ b/scripts/deepseek_v41_native/model.py
@@ -144,10 +144,14 @@ class Model(nn.Module):
         cache: ModelCache,
         last_logit_only: bool = False,
         return_dspark_hidden: bool = False,
+        enable_rollback: bool = False,
     ) -> mx.array | tuple[mx.array, mx.array]:
         """input_ids [b, n] continue the sequence at cache.offset. Advances the cache."""
         start_pos = cache.offset
-        cache.begin_forward()
+        if enable_rollback:
+            cache.begin_forward()
+        elif cache.rollback_start is not None:
+            cache.disable_rollback()
         b, n = input_ids.shape
 
         hashes = None

--- a/tests/test_attach_deepseek_v41_dspark.py
+++ b/tests/test_attach_deepseek_v41_dspark.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_script():
+    path = Path(__file__).parents[1] / "scripts" / "attach_deepseek_v41_dspark.py"
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location("attach_deepseek_v41_dspark", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dspark_config_flattens_target_and_preserves_separate_experts():
+    module = _load_script()
+    target = {
+        "model_type": "deepseek_v41",
+        "n_routed_experts": 336,
+        "text_config": {
+            "hidden_size": 7168,
+            "n_routed_experts": 336,
+            "num_experts_per_tok": 6,
+        },
+        "rapid_quantization": {"mtp": False, "kept_experts": 336},
+    }
+    source = {
+        "text_config": {
+            "num_nextn_predict_layers": 3,
+            "dspark_block_size": 5,
+            "dspark_markov_rank": 256,
+            "dspark_n_routed_experts": 128,
+            "dspark_noise_token_id": 128799,
+            "dspark_num_experts_per_tok": 3,
+            "dspark_target_layer_ids": [37, 38, 39],
+        }
+    }
+
+    config = module._dspark_config(target, source)
+
+    assert config["model_type"] == "deepseek_v4"
+    assert config["hidden_size"] == 7168
+    assert config["n_routed_experts"] == 336
+    assert config["num_experts_per_tok"] == 6
+    assert config["dspark_n_routed_experts"] == 128
+    assert config["dspark_num_experts_per_tok"] == 3
+    assert config["rapid_quantization"]["mtp"] is True
+
+
+def test_inference_config_carries_detection_geometry():
+    module = _load_script()
+    config = {
+        "num_nextn_predict_layers": 3,
+        "dspark_block_size": 5,
+        "dspark_markov_rank": 256,
+        "dspark_n_routed_experts": 128,
+        "dspark_noise_token_id": 128799,
+        "dspark_num_experts_per_tok": 3,
+        "dspark_target_layer_ids": [37, 38, 39],
+    }
+
+    inference = module._inference_config(config)
+
+    assert inference == {
+        "n_mtp_layers": 3,
+        "dspark_block_size": 5,
+        "dspark_noise_token_id": 128799,
+        "dspark_target_layer_ids": [37, 38, 39],
+        "dspark_markov_rank": 256,
+        "dspark_n_routed_experts": 128,
+        "dspark_num_experts_per_tok": 3,
+    }
+
+
+def test_script_refuses_to_overwrite_destination(tmp_path):
+    module = _load_script()
+    destination = tmp_path / "exists"
+    destination.mkdir()
+
+    try:
+        module.build_overlay(tmp_path / "source", tmp_path / "target", destination)
+    except FileExistsError as exc:
+        assert str(destination) in str(exc)
+    else:
+        raise AssertionError("existing destination was overwritten")
+
+
+def test_script_has_no_cache_redirect_flags():
+    module = _load_script()
+    source = Path(module.__file__).read_text()
+    assert "cache_dir" not in source
+    assert "local_dir" not in source

--- a/tests/test_attach_deepseek_v41_dspark.py
+++ b/tests/test_attach_deepseek_v41_dspark.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 
 def _load_script():
@@ -93,3 +96,36 @@ def test_script_has_no_cache_redirect_flags():
     source = Path(module.__file__).read_text()
     assert "cache_dir" not in source
     assert "local_dir" not in source
+
+
+def _write_overlay_inputs(tmp_path, shard_name):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    source.mkdir()
+    target.mkdir()
+    (source / "config.json").write_text("{}")
+    (target / "config.json").write_text("{}")
+    (target / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"head.weight": shard_name}})
+    )
+    return source, target
+
+
+def test_overlay_rejects_traversing_target_shard(tmp_path):
+    module = _load_script()
+    source, target = _write_overlay_inputs(tmp_path, "../outside.safetensors")
+
+    with pytest.raises(ValueError, match="must be a basename"):
+        module.build_overlay(source, target, tmp_path / "output")
+
+    assert not (tmp_path / "output").exists()
+
+
+def test_overlay_rejects_reserved_mtp_shard_collision(tmp_path):
+    module = _load_script()
+    source, target = _write_overlay_inputs(tmp_path, "model-mtp.safetensors")
+
+    with pytest.raises(ValueError, match="reserved shard"):
+        module.build_overlay(source, target, tmp_path / "output")
+
+    assert not (tmp_path / "output").exists()

--- a/tests/test_attach_deepseek_v41_dspark.py
+++ b/tests/test_attach_deepseek_v41_dspark.py
@@ -134,6 +134,25 @@ def test_overlay_rejects_reserved_mtp_shard_collision(tmp_path):
     assert not (tmp_path / "output").exists()
 
 
+def test_overlay_rejects_symlinked_target_shard(tmp_path, monkeypatch):
+    module = _load_script()
+    source, target = _write_overlay_inputs(tmp_path, "model-1.safetensors")
+    outside = tmp_path / "outside.safetensors"
+    outside.write_bytes(b"outside")
+    (target / "model-1.safetensors").symlink_to(outside)
+    monkeypatch.setattr(module, "CheckpointIndex", lambda _path: object())
+    monkeypatch.setattr(
+        module,
+        "_mtp_plans",
+        lambda _index: [SimpleNamespace(name="mtp.test", nbytes=1)],
+    )
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        module.build_overlay(source, target, tmp_path / "output")
+
+    assert not (tmp_path / "output").exists()
+
+
 def test_overlay_rejects_existing_mtp_tensor_mapping(tmp_path, monkeypatch):
     module = _load_script()
     source, target = _write_overlay_inputs(tmp_path, "model-1.safetensors")

--- a/tests/test_attach_deepseek_v41_dspark.py
+++ b/tests/test_attach_deepseek_v41_dspark.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -50,6 +51,8 @@ def test_dspark_config_flattens_target_and_preserves_separate_experts():
     assert config["num_experts_per_tok"] == 6
     assert config["dspark_n_routed_experts"] == 128
     assert config["dspark_num_experts_per_tok"] == 3
+    assert config["text_config"]["dspark_n_routed_experts"] == 128
+    assert config["text_config"]["dspark_num_experts_per_tok"] == 3
     assert config["rapid_quantization"]["mtp"] is True
 
 
@@ -129,3 +132,31 @@ def test_overlay_rejects_reserved_mtp_shard_collision(tmp_path):
         module.build_overlay(source, target, tmp_path / "output")
 
     assert not (tmp_path / "output").exists()
+
+
+def test_overlay_failure_does_not_delete_destination_created_during_build(
+    tmp_path, monkeypatch
+):
+    module = _load_script()
+    source, target = _write_overlay_inputs(tmp_path, "model-1.safetensors")
+    (target / "model-1.safetensors").write_bytes(b"target")
+    destination = tmp_path / "output"
+    monkeypatch.setattr(module, "CheckpointIndex", lambda _path: object())
+    monkeypatch.setattr(
+        module,
+        "_mtp_plans",
+        lambda _index: [SimpleNamespace(name="mtp.test", nbytes=1)],
+    )
+
+    def fail_after_destination_appears(_path, _plans):
+        destination.mkdir()
+        (destination / "other-owner.txt").write_text("keep")
+        raise RuntimeError("synthetic writer failure")
+
+    monkeypatch.setattr(module, "write_safetensors", fail_after_destination_appears)
+
+    with pytest.raises(RuntimeError, match="synthetic writer failure"):
+        module.build_overlay(source, target, destination)
+
+    assert (destination / "other-owner.txt").read_text() == "keep"
+    assert not list(tmp_path.glob(".output.staging-*"))

--- a/tests/test_attach_deepseek_v41_dspark.py
+++ b/tests/test_attach_deepseek_v41_dspark.py
@@ -134,6 +134,32 @@ def test_overlay_rejects_reserved_mtp_shard_collision(tmp_path):
     assert not (tmp_path / "output").exists()
 
 
+def test_overlay_rejects_existing_mtp_tensor_mapping(tmp_path, monkeypatch):
+    module = _load_script()
+    source, target = _write_overlay_inputs(tmp_path, "model-1.safetensors")
+    (target / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "head.weight": "model-1.safetensors",
+                    "mtp.test": "model-1.safetensors",
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(module, "CheckpointIndex", lambda _path: object())
+    monkeypatch.setattr(
+        module,
+        "_mtp_plans",
+        lambda _index: [SimpleNamespace(name="mtp.test", nbytes=1)],
+    )
+
+    with pytest.raises(ValueError, match="already contains MTP tensors"):
+        module.build_overlay(source, target, tmp_path / "output")
+
+    assert not (tmp_path / "output").exists()
+
+
 def test_overlay_failure_does_not_delete_destination_created_during_build(
     tmp_path, monkeypatch
 ):
@@ -159,4 +185,39 @@ def test_overlay_failure_does_not_delete_destination_created_during_build(
         module.build_overlay(source, target, destination)
 
     assert (destination / "other-owner.txt").read_text() == "keep"
+    assert not list(tmp_path.glob(".output.staging-*"))
+
+
+def test_overlay_publish_failure_removes_owned_destination(tmp_path, monkeypatch):
+    module = _load_script()
+    source, target = _write_overlay_inputs(tmp_path, "model-1.safetensors")
+    (target / "model-1.safetensors").write_bytes(b"target")
+    destination = tmp_path / "output"
+    monkeypatch.setattr(module, "CheckpointIndex", lambda _path: object())
+    monkeypatch.setattr(
+        module,
+        "_mtp_plans",
+        lambda _index: [SimpleNamespace(name="mtp.test", nbytes=1)],
+    )
+    monkeypatch.setattr(module, "write_safetensors", lambda path, _plans: path.touch())
+    monkeypatch.setattr(module, "_dspark_config", lambda _target, _source: {})
+    monkeypatch.setattr(module, "_inference_config", lambda _config: {})
+
+    original_rename = Path.rename
+    moves = 0
+
+    def fail_second_move(path, target_path):
+        nonlocal moves
+        if path.parent.name.startswith(".output.staging-"):
+            moves += 1
+            if moves == 2:
+                raise RuntimeError("synthetic publish failure")
+        return original_rename(path, target_path)
+
+    monkeypatch.setattr(Path, "rename", fail_second_move)
+
+    with pytest.raises(RuntimeError, match="synthetic publish failure"):
+        module.build_overlay(source, target, destination)
+
+    assert not destination.exists()
     assert not list(tmp_path.glob(".output.staging-*"))

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -4,6 +4,7 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import mlx.core as mx
 
@@ -11,6 +12,19 @@ import mlx.core as mx
 def _load_script():
     path = Path(__file__).parents[1] / "scripts" / "benchmark_deepseek_v41_dspark.py"
     spec = importlib.util.spec_from_file_location("benchmark_deepseek_v41_dspark", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_moe_script():
+    path = (
+        Path(__file__).parents[1] / "scripts" / "benchmark_deepseek_v41_moe_kernel.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "benchmark_deepseek_v41_moe_kernel", path
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -70,3 +84,57 @@ def test_zero_depth_deferred_seed_advances_without_duplicate_output() -> None:
     assert mismatch is None
     assert hit_eos is False
     assert accepted == 0
+
+
+def test_checkpoint_runtime_loads_exact_files_and_restores_ambient_module(
+    tmp_path,
+) -> None:
+    module = _load_script()
+    (tmp_path / "runtime.py").write_text("MARKER = 'requested'\n")
+    (tmp_path / "dspark.py").write_text(
+        "from runtime import MARKER\nclass DSpark: pass\n"
+    )
+    ambient = ModuleType("runtime")
+    ambient.MARKER = "ambient"
+    previous = sys.modules.get("runtime")
+    sys.modules["runtime"] = ambient
+    try:
+        runtime, dspark = module._load_checkpoint_runtime(tmp_path)
+        assert runtime.MARKER == "requested"
+        assert dspark.MARKER == "requested"
+        assert sys.modules["runtime"] is ambient
+    finally:
+        if previous is None:
+            sys.modules.pop("runtime", None)
+        else:
+            sys.modules["runtime"] = previous
+
+
+def test_packed_mtp_uses_dspark_specific_topk() -> None:
+    module = _load_script()
+    config = {"num_experts_per_tok": 6, "dspark_num_experts_per_tok": 3}
+
+    assert module._dspark_topk(config) == 3
+
+
+def test_moe_layer_loader_merges_indexed_shards(tmp_path, monkeypatch) -> None:
+    module = _load_moe_script()
+    prefix = "layers.20.ffn."
+    index = {
+        prefix + "gate.weight": "model-1.safetensors",
+        prefix + "experts.weight": "model-2.safetensors",
+    }
+    contents = {
+        "model-1.safetensors": {prefix + "gate.weight": "gate"},
+        "model-2.safetensors": {prefix + "experts.weight": "experts"},
+    }
+    monkeypatch.setattr(
+        module.mx,
+        "load",
+        lambda path: contents[Path(path).name],
+    )
+
+    assert module._load_prefix_items(tmp_path, index, prefix) == [
+        ("experts.weight", "experts"),
+        ("gate.weight", "gate"),
+    ]

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
+import mlx.core as mx
+
+
+def _load_script():
+    path = Path(__file__).parents[1] / "scripts" / "benchmark_deepseek_v41_dspark.py"
+    spec = importlib.util.spec_from_file_location("benchmark_deepseek_v41_dspark", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
 
 def test_benchmark_requires_explicit_checkpoint_runtime_trust(tmp_path) -> None:
-    script = (
-        Path(__file__).parents[1] / "scripts" / "benchmark_deepseek_v41_dspark.py"
-    )
+    script = Path(__file__).parents[1] / "scripts" / "benchmark_deepseek_v41_dspark.py"
     result = subprocess.run(
         [
             sys.executable,
@@ -27,3 +37,21 @@ def test_benchmark_requires_explicit_checkpoint_runtime_trust(tmp_path) -> None:
 
     assert result.returncode != 0
     assert "--trust-checkpoint-runtime" in result.stderr
+
+
+def test_greedy_prefix_stops_at_accepted_eos() -> None:
+    module = _load_script()
+    eos_id = 1
+    candidate = [9, eos_id, 7]
+    logits = mx.zeros((1, 3, 10))
+    logits[0, 0, eos_id] = 1
+    logits[0, 1, 7] = 1
+
+    committed, mismatch, hit_eos, accepted = module._match_greedy_prefix(
+        candidate, logits, eos_id, False
+    )
+
+    assert committed == [9, eos_id]
+    assert mismatch is None
+    assert hit_eos is True
+    assert accepted == 1

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -6,8 +6,12 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
-import mlx.core as mx
 import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.core as mx
 
 
 def _load_script():

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_benchmark_requires_explicit_checkpoint_runtime_trust(tmp_path) -> None:
+    script = (
+        Path(__file__).parents[1] / "scripts" / "benchmark_deepseek_v41_dspark.py"
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--target",
+            str(tmp_path / "target"),
+            "--overlay",
+            str(tmp_path / "overlay"),
+            "--checkpoint-runtime",
+            str(tmp_path / "runtime"),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "--trust-checkpoint-runtime" in result.stderr

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import ModuleType
 
 import mlx.core as mx
+import pytest
 
 
 def _load_script():
@@ -128,6 +129,8 @@ def test_moe_layer_loader_merges_indexed_shards(tmp_path, monkeypatch) -> None:
         "model-1.safetensors": {prefix + "gate.weight": "gate"},
         "model-2.safetensors": {prefix + "experts.weight": "experts"},
     }
+    for shard in contents:
+        (tmp_path / shard).touch()
     monkeypatch.setattr(
         module.mx,
         "load",
@@ -138,3 +141,28 @@ def test_moe_layer_loader_merges_indexed_shards(tmp_path, monkeypatch) -> None:
         ("experts.weight", "experts"),
         ("gate.weight", "gate"),
     ]
+
+
+def test_moe_layer_loader_rejects_traversing_shard(tmp_path) -> None:
+    module = _load_moe_script()
+    prefix = "layers.20.ffn."
+
+    with pytest.raises(ValueError, match="must be a basename"):
+        module._load_prefix_items(
+            tmp_path, {prefix + "gate.weight": "../outside.safetensors"}, prefix
+        )
+
+
+def test_moe_layer_loader_rejects_symlinked_shard(tmp_path) -> None:
+    module = _load_moe_script()
+    prefix = "layers.20.ffn."
+    outside = tmp_path / "outside.safetensors"
+    outside.touch()
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+    (model_path / "model-1.safetensors").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        module._load_prefix_items(
+            model_path, {prefix + "gate.weight": "model-1.safetensors"}, prefix
+        )

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -104,9 +104,10 @@ def test_checkpoint_runtime_loads_exact_files_and_restores_ambient_module(
     previous = sys.modules.get("runtime")
     sys.modules["runtime"] = ambient
     try:
-        runtime, dspark = module._load_checkpoint_runtime(tmp_path)
-        assert runtime.MARKER == "requested"
-        assert dspark.MARKER == "requested"
+        with module._checkpoint_runtime(tmp_path) as (runtime, dspark):
+            assert runtime.MARKER == "requested"
+            assert dspark.MARKER == "requested"
+            assert sys.modules["runtime"] is runtime
         assert sys.modules["runtime"] is ambient
     finally:
         if previous is None:
@@ -120,6 +121,32 @@ def test_packed_mtp_uses_dspark_specific_topk() -> None:
     config = {"num_experts_per_tok": 6, "dspark_num_experts_per_tok": 3}
 
     assert module._dspark_topk(config) == 3
+
+
+def test_tokens_must_be_positive() -> None:
+    module = _load_script()
+
+    assert module._positive_int("1") == 1
+    with pytest.raises(module.argparse.ArgumentTypeError, match="at least 1"):
+        module._positive_int("0")
+
+
+def test_packed_mtp_method_binding_does_not_retain_adapter() -> None:
+    module = _load_script()
+
+    class Adapter:
+        pass
+
+    adapter = Adapter()
+
+    def method(self):
+        return self
+
+    adapter.method = module.MethodType(method, module.weakref.proxy(adapter))
+    reference = module.weakref.ref(adapter)
+    del adapter
+
+    assert reference() is None
 
 
 def test_moe_layer_loader_merges_indexed_shards(tmp_path, monkeypatch) -> None:

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -55,3 +55,18 @@ def test_greedy_prefix_stops_at_accepted_eos() -> None:
     assert mismatch is None
     assert hit_eos is True
     assert accepted == 1
+
+
+def test_zero_depth_deferred_seed_advances_without_duplicate_output() -> None:
+    module = _load_script()
+    candidate = [9]
+    logits = mx.zeros((1, 1, 10))
+
+    committed, mismatch, hit_eos, accepted = module._match_greedy_prefix(
+        candidate, logits, eos_id=1, seed_already_emitted=True
+    )
+
+    assert committed == []
+    assert mismatch is None
+    assert hit_eos is False
+    assert accepted == 0

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -14,6 +14,7 @@ import mlx.core as mx
 sys.path.insert(0, str(Path(__file__).parents[1] / "scripts"))
 
 from deepseek_v41_native.attention import Attention, GroupedOutputLinear  # noqa: E402
+from deepseek_v41_native.cache import ModelCache  # noqa: E402
 from deepseek_v41_native.compressor import Compressor, CompressorState  # noqa: E402
 from deepseek_v41_native.config import ModelArgs  # noqa: E402
 from deepseek_v41_native.load import reshape_grouped_wo_a  # noqa: E402
@@ -113,3 +114,60 @@ def test_native_model_defaults_to_watchdog_safe_layer_boundaries() -> None:
     )
 
     assert Model(args).eval_interval == 1
+
+
+def test_native_model_captures_configured_dspark_inputs() -> None:
+    args = ModelArgs(
+        dim=64,
+        vocab_size=32,
+        n_layers=0,
+        n_heads=1,
+        head_dim=64,
+        rope_head_dim=32,
+        hc_mult=1,
+        compress_ratios=(),
+        dspark_target_layer_ids=(0,),
+    )
+    model = Model(args)
+
+    class IdentityBlock:
+        engram = None
+
+        def __call__(self, h, pre_mix, *_args):
+            return h, pre_mix
+
+    model.layers = [IdentityBlock()]
+    cache = model.make_cache(max_seq_len=8)
+
+    logits, hidden = model(
+        mx.array([[1, 2]]), cache, return_dspark_hidden=True
+    )
+    mx.eval(logits, hidden)
+
+    assert logits.shape == (1, 2, args.vocab_size)
+    assert hidden.shape == (1, 2, args.dim)
+
+
+def test_speculative_cache_rollback_restores_partial_compressor_group() -> None:
+    args = ModelArgs(
+        dim=64,
+        n_layers=1,
+        head_dim=32,
+        compress_ratios=(2,),
+        kv_source_layers=(0,),
+    )
+    cache = ModelCache(args, max_seq_len=16)
+    state = cache.layers[0].comp_state
+    assert state is not None
+    state.pending_start = 4
+    state.pending_kv = mx.arange(3 * 32).reshape(1, 3, 32).astype(mx.float32)
+    state.pending_score = state.pending_kv + 100
+    cache.offset = 7
+
+    cache.rollback(5)
+
+    assert cache.offset == 5
+    assert mx.array_equal(state.kv_state[:, :1], state.pending_kv[:, :1]).item()
+    assert mx.array_equal(
+        state.score_state[:, :1], state.pending_score[:, :1]
+    ).item()

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -146,6 +146,38 @@ def test_native_model_captures_configured_dspark_inputs() -> None:
     assert hidden.shape == (1, 2, args.dim)
 
 
+def test_native_model_captures_dspark_inputs_in_configured_order() -> None:
+    args = ModelArgs(
+        dim=64,
+        vocab_size=32,
+        n_layers=0,
+        n_heads=1,
+        head_dim=64,
+        rope_head_dim=32,
+        hc_mult=1,
+        compress_ratios=(),
+        dspark_target_layer_ids=(1, 0),
+    )
+    model = Model(args)
+
+    class AddBlock:
+        engram = None
+
+        def __init__(self, value):
+            self.value = value
+
+        def __call__(self, h, pre_mix, *_args):
+            return h + self.value, pre_mix
+
+    model.layers = [AddBlock(1), AddBlock(2)]
+    cache = model.make_cache(max_seq_len=8)
+
+    _, hidden = model(mx.array([[1]]), cache, return_dspark_hidden=True)
+    first, second = mx.split(hidden, 2, axis=-1)
+
+    assert mx.array_equal(first, second + 1).item()
+
+
 def test_speculative_cache_rollback_restores_partial_compressor_group() -> None:
     args = ModelArgs(
         dim=64,
@@ -189,3 +221,17 @@ def test_compressor_rollback_to_group_boundary_clears_partial_state() -> None:
 
     assert mx.array_equal(state.kv_state, mx.zeros_like(state.kv_state)).item()
     assert mx.all(mx.isneginf(state.score_state)).item()
+
+
+def test_compressor_rollback_to_forward_start_restores_carried_partial() -> None:
+    state = CompressorState(bsz=1, ratio=2, head_dim=4)
+    state.kv_state[:, :1] = 3
+    state.score_state[:, :1] = 5
+    state.begin_forward(3)
+    state.kv_state[:] = 9
+    state.score_state[:] = 11
+
+    state.rollback(3)
+
+    assert mx.all(state.kv_state[:, :1] == 3).item()
+    assert mx.all(state.score_state[:, :1] == 5).item()

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -189,17 +189,20 @@ def test_speculative_cache_rollback_restores_partial_compressor_group() -> None:
     cache = ModelCache(args, max_seq_len=16)
     state = cache.layers[0].comp_state
     assert state is not None
+    cache.offset = 4
+    cache.begin_forward()
     state.pending_start = 4
     state.pending_kv = mx.arange(3 * 32).reshape(1, 3, 32).astype(mx.float32)
     state.pending_score = state.pending_kv + 100
-    cache.rollback_start = 4
+    expected_kv = state.pending_kv[:, :1]
+    expected_score = state.pending_score[:, :1]
     cache.offset = 7
 
     cache.rollback(5)
 
     assert cache.offset == 5
-    assert mx.array_equal(state.kv_state[:, :1], state.pending_kv[:, :1]).item()
-    assert mx.array_equal(state.score_state[:, :1], state.pending_score[:, :1]).item()
+    assert mx.array_equal(state.kv_state[:, :1], expected_kv).item()
+    assert mx.array_equal(state.score_state[:, :1], expected_score).item()
 
 
 def test_speculative_cache_rollback_rejects_older_forward() -> None:
@@ -214,6 +217,7 @@ def test_speculative_cache_rollback_rejects_older_forward() -> None:
 
 def test_compressor_rollback_to_group_boundary_clears_partial_state() -> None:
     state = CompressorState(bsz=1, ratio=2, head_dim=4)
+    state.begin_forward(3)
     state.kv_state[:] = 7
     state.score_state[:] = 9
 
@@ -235,3 +239,24 @@ def test_compressor_rollback_to_forward_start_restores_carried_partial() -> None
 
     assert mx.all(state.kv_state[:, :1] == 3).item()
     assert mx.all(state.score_state[:, :1] == 5).item()
+
+
+def test_model_only_snapshots_cache_when_rollback_is_enabled(monkeypatch) -> None:
+    args = ModelArgs(dim=64, n_layers=0, head_dim=32, compress_ratios=())
+    model = Model(args)
+    cache = model.make_cache(max_seq_len=8)
+    calls = 0
+    original = cache.begin_forward
+
+    def record_begin_forward():
+        nonlocal calls
+        calls += 1
+        original()
+
+    monkeypatch.setattr(cache, "begin_forward", record_begin_forward)
+
+    model(mx.array([[1]]), cache)
+    assert calls == 0
+
+    model(mx.array([[1]]), cache, enable_rollback=True)
+    assert calls == 1

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -139,9 +139,7 @@ def test_native_model_captures_configured_dspark_inputs() -> None:
     model.layers = [IdentityBlock()]
     cache = model.make_cache(max_seq_len=8)
 
-    logits, hidden = model(
-        mx.array([[1, 2]]), cache, return_dspark_hidden=True
-    )
+    logits, hidden = model(mx.array([[1, 2]]), cache, return_dspark_hidden=True)
     mx.eval(logits, hidden)
 
     assert logits.shape == (1, 2, args.vocab_size)
@@ -162,12 +160,21 @@ def test_speculative_cache_rollback_restores_partial_compressor_group() -> None:
     state.pending_start = 4
     state.pending_kv = mx.arange(3 * 32).reshape(1, 3, 32).astype(mx.float32)
     state.pending_score = state.pending_kv + 100
+    cache.rollback_start = 4
     cache.offset = 7
 
     cache.rollback(5)
 
     assert cache.offset == 5
     assert mx.array_equal(state.kv_state[:, :1], state.pending_kv[:, :1]).item()
-    assert mx.array_equal(
-        state.score_state[:, :1], state.pending_score[:, :1]
-    ).item()
+    assert mx.array_equal(state.score_state[:, :1], state.pending_score[:, :1]).item()
+
+
+def test_speculative_cache_rollback_rejects_older_forward() -> None:
+    args = ModelArgs(dim=64, n_layers=0, head_dim=32, compress_ratios=())
+    cache = ModelCache(args, max_seq_len=16)
+    cache.rollback_start = 4
+    cache.offset = 7
+
+    with pytest.raises(ValueError, match="outside latest forward"):
+        cache.rollback(3)

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -178,3 +178,14 @@ def test_speculative_cache_rollback_rejects_older_forward() -> None:
 
     with pytest.raises(ValueError, match="outside latest forward"):
         cache.rollback(3)
+
+
+def test_compressor_rollback_to_group_boundary_clears_partial_state() -> None:
+    state = CompressorState(bsz=1, ratio=2, head_dim=4)
+    state.kv_state[:] = 7
+    state.score_state[:] = 9
+
+    state.rollback(4)
+
+    assert mx.array_equal(state.kv_state, mx.zeros_like(state.kv_state)).item()
+    assert mx.all(mx.isneginf(state.score_state)).item()


### PR DESCRIPTION
## Why

DeepSeek V4.1 Flash native 2-bit decoding reaches about 7.9 tok/s on a 256 GiB M3 Ultra, below the 12 tok/s product floor. This PR adds the correctness machinery and reproducible benchmark infrastructure needed to measure its checkpoint-native DSpark path instead of making an unverified performance claim.

The measured best exact-greedy configuration reaches 10.56 tok/s (+33.0% versus the same-run 7.94 tok/s baseline). The fastest configuration reaches 11.51 tok/s (+45.0%) but changes the greedy stream under batched target numerics, so the model remains deliberately unexposed.

## Scope

- Capture the three configured target hidden states required by DSpark.
- Add latest-forward speculative cache rollback, including ratio-2 compressor partial groups.
- Build a local target-plus-DSpark benchmark overlay without duplicating the ~213 GB target.
- Benchmark serial/batched verification, confidence scheduling, packed MTP MoE, grouped MTP attention, and native MoE candidates.
- Record reproducible throughput, memory, correctness, and rejected-path evidence.
- Require explicit trust before importing checkpoint-bundled Python.

## Non-goals

- No server, catalog, GUI, alias, or download exposure.
- No default inference behavior change.
- No visual-input support.
- No claim that the 12 tok/s product gate or 20 tok/s stretch goal has been met.
- No model weights or generated benchmark artifacts in the repository.

## Acceptance

- Batched rejection can roll the target cache back within the latest target forward without corrupting ratio-2 compressor state.
- DSpark target hidden capture follows the configured layer IDs.
- The overlay accepts only basename shard names, rejects the reserved MTP shard collision, references target shards by relative symlink, and refuses to overwrite an existing destination.
- Batched verification stops at the first target-authoritative EOS.
- Checkpoint Python cannot execute without `--trust-checkpoint-runtime`.
- The performance note includes environment, commands, throughput, peak memory, equivalence status, and negative results.

## Verification

- `ruff check` and `ruff format --check` on every changed Python file: pass.
- `git diff --check`: pass.
- DeepSeek V4.1 focused suite: 42 passed.
- Packed MTP MoE comparison: bit-exact, max absolute difference 0.
- Real 212.93 GB model on M3 Ultra 256 GiB:
  - AR: 7.94 tok/s, 213.54 GB peak.
  - K4 packed/grouped DSpark: 10.56 tok/s, exact greedy match, 218.00 GB peak.
  - K5 packed/grouped DSpark: 11.51 tok/s, non-matching greedy stream, 218.00 GB peak.
- Full unit suite executed: 23,741 passed; nine failures were reproduced unchanged on base (`ef9f1cba1`) in a focused A/B (nine failed, 20 passed). Seven are an installed image dependency API mismatch and two are environment-sensitive doctor expectations; this PR does not touch those areas.
- Ten scope-locked self-adversarial review rounds reached the repository cap; every final-round finding was addressed, and no eleventh review was requested. The rounds found and fixed routing-order correctness, rollback isolation, overlay transactionality, exact runtime binding, path traversal and symlink confinement, shard collisions, EOS truncation, layer-index semantics, and multi-shard loading.

## AI assistance disclosure

Codex wrote and self-reviewed the changed runtime hooks, benchmark/overlay scripts, tests, and performance note. Every path was reviewed against the stated non-goals; rejected experiments were removed from the diff. Verification included focused tests, static checks, negative tests, bit-exact component comparisons, base-branch failure reproduction, and multiple end-to-end runs on the real model.

## Checklist

- [x] Focused tests pass locally (42 passed); full-suite baseline failures are documented above
- [x] Lint and format checks pass
- [x] PR validation executed; findings addressed and baseline failures isolated
- [x] Critical security/cache changes have negative regression tests
- [x] Updated performance documentation
- [x] No breaking changes to existing API or default behavior

## Author



