### PR TITLE
fix(mllm): expose retryable batch failures

### DIFF
--- a/tests/headless_mlx/test_mllm_process_loop_errors.py
+++ b/tests/headless_mlx/test_mllm_process_loop_errors.py
@@ -410,8 +410,7 @@ def test_scheduler_step_marks_internal_failure_retryable_without_leaking_details
     assert terminal.finished is True
     assert terminal.finish_reason == "length"
     assert terminal.error == (
-        "MLLM inference was interrupted by a transient engine error; "
-        "retry the request"
+        "MLLM inference was interrupted by a transient engine error; retry the request"
     )
     assert terminal.error_kind == "lifecycle"
     assert "/Users/example" not in terminal.error

--- a/tests/headless_mlx/test_mllm_process_loop_errors.py
+++ b/tests/headless_mlx/test_mllm_process_loop_errors.py
@@ -361,7 +361,11 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     for output in outputs[:-1]:
         assert output.finished is True
         assert output.finish_reason == "length"
-        assert output.error == "MLLM inference failed due to an internal engine error"
+        assert output.error == (
+            "MLLM inference was interrupted by a transient engine error; "
+            "retry the request"
+        )
+        assert output.error_kind == "lifecycle"
         assert "mask" not in output.error
     assert scheduler._step_no_queue.call_count == 1
     batch_generator.close.assert_called_once_with()
@@ -376,8 +380,10 @@ async def test_process_loop_failure_unblocks_every_inflight_request() -> None:
     assert not scheduler._aborted_queue_ids
 
 
-def test_scheduler_step_does_not_turn_internal_failure_into_fake_success() -> None:
-    """A model/runtime error must terminate as an error without leaking details."""
+def test_scheduler_step_marks_internal_failure_retryable_without_leaking_details(
+    caplog,
+) -> None:
+    """A runtime batch failure is an observable, retryable lifecycle error."""
     scheduler = MLLMScheduler.__new__(MLLMScheduler)
     request = MLLMRequest(request_id="runtime-failure", prompt="hello")
     scheduler.requests = {request.request_id: request}
@@ -403,6 +409,38 @@ def test_scheduler_step_does_not_turn_internal_failure_into_fake_success() -> No
     terminal = output.outputs[0]
     assert terminal.finished is True
     assert terminal.finish_reason == "length"
-    assert terminal.error == "MLLM inference failed due to an internal engine error"
+    assert terminal.error == (
+        "MLLM inference was interrupted by a transient engine error; "
+        "retry the request"
+    )
+    assert terminal.error_kind == "lifecycle"
     assert "/Users/example" not in terminal.error
+    assert "RuntimeError" in caplog.text
+    assert request.request_id in caplog.text
+    assert "private runtime detail" in caplog.text
     scheduler.batch_generator.remove.assert_called_once_with([42])
+
+
+@pytest.mark.asyncio
+async def test_scheduler_internal_failure_streams_as_retryable_503_class() -> None:
+    """The scheduler-to-route boundary preserves the retryable error type."""
+    scheduler = MLLMScheduler.__new__(MLLMScheduler)
+    scheduler.output_queues = {"failed": asyncio.Queue()}
+    scheduler.abort_request = MagicMock()
+    await scheduler.output_queues["failed"].put(
+        RequestOutput(
+            request_id="failed",
+            finished=True,
+            finish_reason="abort",
+            error=(
+                "MLLM inference was interrupted by a transient engine error; "
+                "retry the request"
+            ),
+            error_kind="lifecycle",
+        )
+    )
+
+    with pytest.raises(InferenceAbortedError, match="retry the request"):
+        _ = [output async for output in scheduler.stream_outputs("failed")]
+
+    scheduler.abort_request.assert_not_called()

--- a/tests/test_chat_route_vlm_image.py
+++ b/tests/test_chat_route_vlm_image.py
@@ -38,7 +38,7 @@ from fastapi.testclient import TestClient
 
 from vllm_mlx.config import reset_config
 from vllm_mlx.engine.base import GenerationOutput
-from vllm_mlx.request import ClientRequestError
+from vllm_mlx.request import ClientRequestError, InferenceAbortedError
 from vllm_mlx.routes.chat import router as chat_router
 
 
@@ -106,6 +106,15 @@ class _StubMLLMEngine:
 class _StubTextFallbackEngine(_StubMLLMEngine):
     is_mllm = False
     serving_lane_reason = "vision_hybrid_runtime_unsupported"
+
+
+class _StubRetryableFailureEngine(_StubMLLMEngine):
+    async def chat(self, *, messages, **kwargs):
+        raise InferenceAbortedError(
+            "MLLM inference was interrupted by a transient engine error; "
+            "retry the request",
+            error_kind="lifecycle",
+        )
 
 
 def _make_client(engine: _StubMLLMEngine) -> TestClient:
@@ -233,6 +242,26 @@ def test_chat_route_forwards_image_url_content_to_mllm_engine():
     assert stream_resp.text.count('"content":"A blue background."') == 1
     assert stream_resp.text.rstrip().endswith("data: [DONE]")
     assert len(engine.stream_calls) == 1
+
+
+def test_chat_route_returns_503_for_retryable_mllm_batch_failure():
+    """A scheduler lifecycle interruption must reach HTTP clients as 503."""
+    client = _make_client(_StubRetryableFailureEngine())
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-vl-8b-4bit",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 8,
+            "stream": False,
+        },
+    )
+
+    assert response.status_code == 503, response.text
+    assert response.json()["detail"] == (
+        "MLLM inference was interrupted by a transient engine error; retry the request"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mllm_continuous_batching.py
+++ b/tests/test_mllm_continuous_batching.py
@@ -1867,7 +1867,7 @@ class TestPrefillErrorCleanup:
 
         from vllm_mlx.mllm_batch_generator import MLLMBatchRequest
         from vllm_mlx.mllm_scheduler import MLLMScheduler, MLLMSchedulerConfig
-        from vllm_mlx.request import RequestStatus
+        from vllm_mlx.request import ClientRequestError, RequestStatus
 
         mock_model = MagicMock()
         mock_processor = MagicMock()
@@ -1906,8 +1906,11 @@ class TestPrefillErrorCleanup:
         scheduler.request_id_to_uid[req_id] = 42
         scheduler.uid_to_request_id[42] = req_id
 
-        # Make next() raise to simulate prefill error
-        bg.next = MagicMock(side_effect=ValueError("prompt too large"))
+        # Make next() raise the typed client-error shape used by prompt/media
+        # validation. This branch must stay distinct from runtime failures:
+        # bounded input diagnostics are logged without a crash traceback and
+        # retain their HTTP 400 classification.
+        bg.next = MagicMock(side_effect=ClientRequestError("prompt too large"))
 
         scheduler.step()
 
@@ -1916,12 +1919,12 @@ class TestPrefillErrorCleanup:
         # Scheduler bookkeeping should be clean
         assert req_id not in scheduler.running
         assert req_id not in scheduler.request_id_to_uid
-        # Error output should have been queued. finish_reason is "length"
-        # (OpenAI-spec-compliant abort signal), not the legacy "error"
-        # literal — see scheduler.py rationale.
+        # Error output should have been queued with the client-owned type.
         queued = scheduler.output_queues[req_id].get_nowait()
         assert queued.finished is True
-        assert queued.finish_reason == "length"
+        assert queued.finish_reason == "error"
+        assert queued.error == "prompt too large"
+        assert queued.error_kind == "invalid_request"
         performance = scheduler.performance.snapshot()
         assert performance.requests_failed == 1
         assert performance.prompt_tokens == 7

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1390,25 +1390,33 @@ class MLLMScheduler:
                 err_msg = str(e)
                 error_ids = set(self.running.keys())
                 failed_requests = [self.running[rid] for rid in error_ids]
+                is_client_error = isinstance(e, ClientRequestError)
                 # Do not collapse the only actionable copy of a backend
                 # failure into the bounded client message below. Request IDs
                 # are safe to log and let an operator correlate the traceback
                 # with access logs without exposing prompts or local model
                 # paths to API clients.
-                logger.exception(
-                    "MLLM batch generation failed "
-                    "(exception=%s requests=%s active_rows=%d waiting=%d)",
-                    type(e).__name__,
-                    sorted(error_ids),
-                    len(
-                        getattr(
-                            getattr(self.batch_generator, "active_batch", None),
-                            "uids",
-                            (),
-                        )
-                    ),
-                    len(self.waiting),
-                )
+                if is_client_error:
+                    logger.warning(
+                        "MLLM batch rejected client input (requests=%s error=%s)",
+                        sorted(error_ids),
+                        err_msg,
+                    )
+                else:
+                    logger.exception(
+                        "MLLM batch generation failed "
+                        "(exception=%s requests=%s active_rows=%d waiting=%d)",
+                        type(e).__name__,
+                        sorted(error_ids),
+                        len(
+                            getattr(
+                                getattr(self.batch_generator, "active_batch", None),
+                                "uids",
+                                (),
+                            )
+                        ),
+                        len(self.waiting),
+                    )
 
                 # Remove from batch generator BEFORE scheduler cleanup so
                 # stale requests don't poison subsequent batches.
@@ -1436,7 +1444,6 @@ class MLLMScheduler:
                 # An explicit type owns the public-message trust boundary.
                 # Arbitrary RuntimeError/ValueError text may include caller
                 # data or local paths that happen to match the old markers.
-                is_client_error = isinstance(e, ClientRequestError)
                 public_error = (
                     err_msg
                     if is_client_error

--- a/vllm_mlx/mllm_scheduler.py
+++ b/vllm_mlx/mllm_scheduler.py
@@ -1388,9 +1388,27 @@ class MLLMScheduler:
                 # Oversized prompt or other unrecoverable error — fail all
                 # running requests instead of retrying forever.
                 err_msg = str(e)
-                logger.error(f"Batch generation failed: {err_msg}")
                 error_ids = set(self.running.keys())
                 failed_requests = [self.running[rid] for rid in error_ids]
+                # Do not collapse the only actionable copy of a backend
+                # failure into the bounded client message below. Request IDs
+                # are safe to log and let an operator correlate the traceback
+                # with access logs without exposing prompts or local model
+                # paths to API clients.
+                logger.exception(
+                    "MLLM batch generation failed "
+                    "(exception=%s requests=%s active_rows=%d waiting=%d)",
+                    type(e).__name__,
+                    sorted(error_ids),
+                    len(
+                        getattr(
+                            getattr(self.batch_generator, "active_batch", None),
+                            "uids",
+                            (),
+                        )
+                    ),
+                    len(self.waiting),
+                )
 
                 # Remove from batch generator BEFORE scheduler cleanup so
                 # stale requests don't poison subsequent batches.
@@ -1422,7 +1440,10 @@ class MLLMScheduler:
                 public_error = (
                     err_msg
                     if is_client_error
-                    else "MLLM inference failed due to an internal engine error"
+                    else (
+                        "MLLM inference was interrupted by a transient engine "
+                        "error; retry the request"
+                    )
                 )
                 # Create error outputs (queue delivery deferred to caller).
                 for request_id in error_ids:
@@ -1432,7 +1453,9 @@ class MLLMScheduler:
                             output_text="",
                             finished=True,
                             error=public_error,
-                            error_kind=("invalid_request" if is_client_error else None),
+                            error_kind=(
+                                "invalid_request" if is_client_error else "lifecycle"
+                            ),
                             # Preserve the established terminal reason for
                             # internal aborts; the non-None error is what
                             # prevents routes from serializing fake success.
@@ -1570,8 +1593,11 @@ class MLLMScheduler:
         request_ids.update(self._pending_abort_ids)
         # Third-party exceptions can contain paths, prompt fragments, or model
         # internals. The detailed traceback is logged by the caller; clients
-        # receive only this stable 500-class message.
-        err_text = "MLLM inference failed due to an internal engine error"
+        # receive only this stable retryable (HTTP 503) message.
+        err_text = (
+            "MLLM inference was interrupted by a transient engine error; "
+            "retry the request"
+        )
 
         output = MLLMSchedulerOutput(
             finished_request_ids=request_ids,
@@ -1586,6 +1612,7 @@ class MLLMScheduler:
                     # this compatibility literal for a successful truncation.
                     finish_reason="length",
                     error=err_text,
+                    error_kind="lifecycle",
                 )
                 for request_id in request_ids
             ],


### PR DESCRIPTION
## Why

Overlapping requests on the MLLM lane can intermittently abort a shared batch on constrained Apple Silicon. The scheduler currently removes the poisoned batch correctly, but it hides the underlying exception from operators and returns an untyped HTTP 500 to clients. That makes the failure impossible to diagnose and prevents normal retry handling.

## What changed

- Log the exception type, full server-side traceback, safe request IDs, active-row count, and waiting count when an MLLM batch fails.
- Keep third-party exception text behind the server log boundary; API clients receive a bounded message without prompts, paths, or model internals.
- Classify internal MLLM batch and process-loop failures as lifecycle interruptions so OpenAI chat clients receive HTTP 503 and can retry.
- Preserve existing cleanup: every affected request is detached and terminally signalled, and a potentially mutated batch is never reused.

## Scope

Allowed scope is MLLM scheduler failure observability, retry semantics, cleanup preservation, and focused regression tests.

Non-goals: automatic replay after a partially-mutated decode step, batching policy, cache policy, memory admission, timeout defaults, model support, or changes to the text lane.

## Acceptance criteria

- Internal MLLM batch failures leave a traceback and request correlation in server logs.
- Runtime details do not cross the API boundary.
- Affected OpenAI chat requests surface through the existing retryable 503 path.
- Client-caused multimodal errors retain their existing 400 behavior.
- All in-flight waiters are unblocked and the poisoned batch is removed.

## Design precedent

Production continuous-batching systems treat a shared backend batch exception as a request-lifecycle interruption: retain detailed diagnostics server-side, detach the potentially mutated batch, signal every affected waiter, and return a retryable unavailable response. They do not automatically replay a batch after output may have been emitted, because that can duplicate streamed content. This change adopts that boundary.

## Verification

- `python3.12 -m scripts.pr_validate 3308 --skip-steps full_unit,stress_e2e_bench` — MERGE-SAFE; adversarial Codex review found no blocking issues; 84 targeted tests passed
- Focused MLLM scheduler, cleanup, corrupt-media, route, and Metal recovery suite — 106 passed, 3 deselected
- Ruff check and format — passed
- Full local unit run reached 23,740 passed; 9 environment-sensitive failures were confined to the installed image-runtime and Doctor host-state suites and are unrelated to this diff. Exact-head GitHub matrices are authoritative for those environments.
- Reporter reproduction against cached Gemma 4 12B on Studio: 180/180 successful on `v0.14.0`, and 180/180 on current main across concurrency 1/2/3/4/8. The original 16 GB M4 failure is therefore hardware-sensitive and still needs a reporter retest with the new diagnostics.

Part of #3303
