### PR TITLE
perf: specialize DeepSeek V4.1 affine down QMV

### DIFF
--- a/.agents/handoffs/vector-deepseek-v41-moe-megakernel.md
+++ b/.agents/handoffs/vector-deepseek-v41-moe-megakernel.md
@@ -1,0 +1,53 @@
+# Vector handoff: DeepSeek V4.1 exact affine-2bit MoE kernel
+
+- Owner: Vector
+- Host: Studio (M3 Ultra, 256 GiB unified memory)
+- Branch: `vector/deepseek-v41-moe-megakernel`
+- Base: `vector/deepseek-v41-speed-20tps` / PR #3307
+- Worktree: `/private/tmp/rapid-mlx-deepseek-v41-moe-megakernel`
+- Status: exact target optimization qualified; combined DSpark rerun pending
+
+## Intention and boundary
+
+Reduce the target verification bottleneck with an exact affine 2-bit expert
+kernel. Keep this PR to benchmark tooling, correctness tests, and reproducible
+performance evidence. Server, catalog, GUI, model conversion, downloads, and
+default runtime changes are explicit non-goals until the complete path passes
+the 12 tok/s product floor.
+
+## Verified facts
+
+- The route-direct kernel specializes only FP32 activation into affine 2-bit,
+  group-64 expert down projections with 1--36 routed rows.
+- Real layer 20 is element-for-element equal to the stock projection for 1, 6,
+  24, 30, and 36 routes.
+- Layer speedups are 2.65x at six routes, 1.94x at 24, 1.82x at 30, and 1.72x
+  at 36.
+- Two real 32-token target-only runs reach 9.66--9.83 tok/s from 7.90--7.92
+  tok/s (+22.2% to +24.0%), preserve the exact token sequence, and leave peak
+  MLX memory unchanged at 213.5387 GB.
+- Target oracle throughput reaches 17.91--18.13/25.38--25.49/32.39--33.86/
+  34.49--36.32 rows/s at K2--K5.
+- The prior trusted checkpoint runtime was ephemeral and is no longer present.
+  Based on its earlier timing split, K4 is estimated at 14--15 tok/s with this
+  kernel, but the combined result is not measured and must not be advertised.
+
+## Reference check (internal only)
+
+- vLLM and SGLang were checked first. Their current V4.1 speculative paths use
+  dedicated draft networks, batched/ragged verification, and fused target MoE
+  execution; neither exposes a drop-in MLX kernel for this artifact.
+- Current oMLX was checked next. It has V4.1 DSpark and adaptive acceptance, but
+  its converted tensor namespace is incompatible with the existing 212.93 GB
+  Rapid artifact. Rewriting another full copy would exceed the scoped storage
+  and time budget.
+- Its block-shaped affine kernels use row tiles that are inefficient when
+  24--36 routes are spread across 336 experts. This experiment instead assigns
+  one QMV grid to each real route and preserves stock arithmetic order.
+
+## Next concrete action
+
+Recover or reconstruct a trusted DSpark adapter without copying the target
+artifact, then rerun K4 end to end with `--direct-down-qmv`. Product integration
+requires measured throughput of at least 12 tok/s plus multi-domain 128-token
+quality and long-context cache qualification.

--- a/.agents/handoffs/vector-deepseek-v41-moe-megakernel.md
+++ b/.agents/handoffs/vector-deepseek-v41-moe-megakernel.md
@@ -5,7 +5,7 @@
 - Branch: `vector/deepseek-v41-moe-megakernel`
 - Base: `vector/deepseek-v41-speed-20tps` / PR #3307
 - Worktree: `/private/tmp/rapid-mlx-deepseek-v41-moe-megakernel`
-- Status: exact target optimization qualified; combined DSpark rerun pending
+- Status: combined K4 performance gate passed; broader qualification pending
 
 ## Intention and boundary
 
@@ -23,14 +23,16 @@ the 12 tok/s product floor.
   24, 30, and 36 routes.
 - Layer speedups are 2.65x at six routes, 1.94x at 24, 1.82x at 30, and 1.72x
   at 36.
-- Two real 32-token target-only runs reach 9.66--9.83 tok/s from 7.90--7.92
-  tok/s (+22.2% to +24.0%), preserve the exact token sequence, and leave peak
+- Three real 32-token target-only runs reach 9.49--9.83 tok/s from 7.81--7.92
+  tok/s (+21.5% to +24.0%), preserve the exact token sequence, and leave peak
   MLX memory unchanged at 213.5387 GB.
 - Target oracle throughput reaches 17.91--18.13/25.38--25.49/32.39--33.86/
   34.49--36.32 rows/s at K2--K5.
-- The prior trusted checkpoint runtime was ephemeral and is no longer present.
-  Based on its earlier timing split, K4 is estimated at 14--15 tok/s with this
-  kernel, but the combined result is not measured and must not be advertised.
+- The trusted checkpoint runtime was recovered from the existing Hugging Face
+  cache; no model data was downloaded or copied.
+- Combined K4 reaches 12.70 tok/s (+62.5% over the same-run 7.81 AR), preserves
+  the exact 32-token greedy stream, and peaks at 218.00 GB. K5 reaches 13.96
+  tok/s but remains non-equivalent and is not a product candidate.
 
 ## Reference check (internal only)
 
@@ -47,7 +49,6 @@ the 12 tok/s product floor.
 
 ## Next concrete action
 
-Recover or reconstruct a trusted DSpark adapter without copying the target
-artifact, then rerun K4 end to end with `--direct-down-qmv`. Product integration
-requires measured throughput of at least 12 tok/s plus multi-domain 128-token
-quality and long-context cache qualification.
+Run exact K4 across a multi-domain 128-token suite and long-context cache
+qualification. The single-prompt performance floor is now met; product
+integration remains blocked on those broader correctness and stability gates.

--- a/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-speed.md
+++ b/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-speed.md
@@ -90,6 +90,45 @@ only 1.0–1.2 extra tokens/block. K5 spends 2.40 seconds of its 2.77-second
 decode in target verification, so further draft-only optimization cannot reach
 20 tok/s and is unlikely to clear 12 tok/s by itself.
 
+## Exact affine 2-bit down-projection follow-up
+
+A route-direct QMV kernel now specializes only the expert down projection. It
+keeps gate/up, activation, routing, and weighted reduction on their stock paths.
+That boundary matters: attempts to specialize gate/up changed BF16 arithmetic,
+while the down-only candidate is element-for-element equal to the stock result.
+
+Real layer 20 measurements, using the same target and six routes per token:
+
+| Input tokens | Routed rows | Layer speedup | Maximum absolute difference |
+| ---: | ---: | ---: | ---: |
+| 1 | 6 | 2.65x | 0 |
+| 4 | 24 | 1.94x | 0 |
+| 5 | 30 | 1.82x | 0 |
+| 6 | 36 | 1.72x | 0 |
+
+Across two full target-only 32-token runs, the specialization reached
+**9.66–9.83 tok/s** from 7.90–7.92 tok/s (+22.2% to +24.0%). The complete
+generated token sequence was identical and peak MLX memory remained 213.5387
+GB. Oracle target throughput was 17.91–18.13, 25.38–25.49, 32.39–33.86, and
+34.49–36.32 rows/s at K2 through K5 respectively. K4 is 30–36% faster than the
+earlier 24.6–24.9 rows/s range.
+
+Representative target-only command:
+
+```shell
+python scripts/benchmark_deepseek_v41_dspark.py \
+  --target <reap12.5-target> \
+  --direct-down-qmv \
+  --target-only \
+  --tokens 32
+```
+
+The original trusted checkpoint runtime was ephemeral and no longer available,
+so the combined DSpark run has not yet been remeasured. Applying the measured
+verification reduction to the previous K4 timing predicts roughly 14–15 tok/s,
+but that is an estimate, not a product claim. Server/catalog integration remains
+blocked on a reproduced end-to-end run and the existing quality qualification.
+
 ## Rejected paths
 
 - Immediate singleton correction erases batching gains. Exact cache rollback
@@ -122,8 +161,8 @@ tok/s and still needs broader numerical/quality qualification.
 
 Reaching 20 tok/s requires a new capability rather than threshold tuning:
 
-1. A persistent affine-2bit MoE verify kernel specialized for six target rows,
-   fusing routing, gate/up, activation, down projection, and weighted reduction.
+1. Combine the exact route-direct down QMV with the checkpoint DSpark runtime
+   and measure the complete K4 path; do not substitute the 14–15 tok/s estimate.
 2. A model-trained MHC-aligned block drafter with materially higher accepted
    length. No compatible V4.1 checkpoint was available during this experiment.
 3. After either exists, re-run a multi-domain, 128-token suite and long-context

--- a/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-speed.md
+++ b/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-speed.md
@@ -2,7 +2,8 @@
 
 Date: 2026-09-10/11
 
-Status: experimental; the 12 tok/s product gate was not met.
+Status: experimental; the single-prompt K4 performance gate is met, while the
+broader quality and long-context gates remain open.
 
 ## Goal and boundary
 
@@ -106,8 +107,8 @@ Real layer 20 measurements, using the same target and six routes per token:
 | 5 | 30 | 1.82x | 0 |
 | 6 | 36 | 1.72x | 0 |
 
-Across two full target-only 32-token runs, the specialization reached
-**9.66–9.83 tok/s** from 7.90–7.92 tok/s (+22.2% to +24.0%). The complete
+Across three full target-only 32-token runs, the specialization reached
+**9.49–9.83 tok/s** from 7.81–7.92 tok/s (+21.5% to +24.0%). The complete
 generated token sequence was identical and peak MLX memory remained 213.5387
 GB. Oracle target throughput was 17.91–18.13, 25.38–25.49, 32.39–33.86, and
 34.49–36.32 rows/s at K2 through K5 respectively. K4 is 30–36% faster than the
@@ -123,11 +124,20 @@ python scripts/benchmark_deepseek_v41_dspark.py \
   --tokens 32
 ```
 
-The original trusted checkpoint runtime was ephemeral and no longer available,
-so the combined DSpark run has not yet been remeasured. Applying the measured
-verification reduction to the previous K4 timing predicts roughly 14–15 tok/s,
-but that is an estimate, not a product claim. Server/catalog integration remains
-blocked on a reproduced end-to-end run and the existing quality qualification.
+The trusted checkpoint runtime was recovered from the already-present model
+cache and the combined path was remeasured without downloading or copying model
+weights:
+
+| Candidate | tok/s | Change vs same-run 7.81 AR | Greedy equivalent | Peak MLX memory |
+| --- | ---: | ---: | --- | ---: |
+| K4 packed DSpark + direct down QMV | **12.70** | **+62.5%** | **yes** | 218.00 GB |
+| K5 packed DSpark + direct down QMV | 13.96 | +78.8% | no | 218.00 GB |
+
+K4 accepted exactly one additional draft token per block. Its 2.442-second
+decode spent 0.297 seconds in the draft, 2.096 seconds in target verification,
+and 0.006 seconds in rollback. This is the first exact-greedy configuration to
+cross the 12 tok/s performance floor, but it is still one 32-token prompt rather
+than the multi-domain, long-context qualification required for product exposure.
 
 ## Rejected paths
 
@@ -155,14 +165,16 @@ blocked on a reproduced end-to-end run and the existing quality qualification.
 
 ## Product decision and next experiments
 
-Do not enable DSpark for DeepSeek V4.1 Flash yet. The best exact-greedy result is
-10.55 tok/s, below the explicit 12 tok/s floor; the fastest result is 11.53
-tok/s and still needs broader numerical/quality qualification.
+Do not enable DSpark for DeepSeek V4.1 Flash by default yet. K4 now reaches
+12.70 tok/s with an exact greedy stream on the qualification prompt, clearing
+the performance floor. It still needs multi-domain 128-token and long-context
+cache qualification. K5 reaches 13.96 tok/s but remains excluded because its
+batched target numerics change the greedy stream.
 
 Reaching 20 tok/s requires a new capability rather than threshold tuning:
 
-1. Combine the exact route-direct down QMV with the checkpoint DSpark runtime
-   and measure the complete K4 path; do not substitute the 14–15 tok/s estimate.
+1. Run K4 on a multi-domain 128-token prompt suite and verify exact target
+   authority, sustained throughput, and cache rollback at longer contexts.
 2. A model-trained MHC-aligned block drafter with materially higher accepted
    length. No compatible V4.1 checkpoint was available during this experiment.
 3. After either exists, re-run a multi-domain, 128-token suite and long-context

--- a/scripts/benchmark_deepseek_v41_dspark.py
+++ b/scripts/benchmark_deepseek_v41_dspark.py
@@ -27,7 +27,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+from deepseek_v41_affine_route_qmv import affine2_route_down_qmv  # noqa: E402
 from deepseek_v41_native.load import load  # noqa: E402
+from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
 BOS = "<｜begin▁of▁sentence｜>"
 USER = "<｜User｜>"
@@ -145,6 +147,46 @@ def _install_native_single_stream_moe(model, source_root: Path) -> int:
         for name in ("gate_proj", "up_proj", "down_proj"):
             projection = getattr(experts, name)
             projection.__class__ = switch.QuantizedSwitchLinear
+        replaced += 1
+    return replaced
+
+
+class ExactDirectDownSwitchGLU(SwitchGLU):
+    """Preserve stock gate/up numerics while specializing the down projection."""
+
+    def __call__(self, x, indices):
+        if int(x.shape[0]) * int(indices.shape[-1]) > 36:
+            return super().__call__(x, indices)
+        expanded = mx.expand_dims(x, (-2, -3))
+        up = self.up_proj(expanded, indices).squeeze(-2)
+        gate = self.gate_proj(expanded, indices).squeeze(-2)
+        activated = self.activation(up, gate)
+        tokens, topk, width = map(int, activated.shape)
+        down = affine2_route_down_qmv(
+            self.down_proj,
+            activated.reshape(tokens * topk, width),
+            indices.reshape(tokens * topk, 1),
+        )
+        return down.reshape(tokens, topk, -1)
+
+
+def _install_direct_down_qmv(model) -> int:
+    """Specialize affine-2bit expert down projections without copying weights."""
+
+    experts_by_layer = [layer.ffn.experts for layer in model.layers]
+    unsupported = [
+        type(experts).__name__
+        for experts in experts_by_layer
+        if not isinstance(experts, SwitchGLU)
+    ]
+    if unsupported:
+        raise TypeError(f"unsupported expert module: {unsupported[0]}")
+
+    replaced = 0
+    for experts in experts_by_layer:
+        if type(experts) is ExactDirectDownSwitchGLU:
+            continue
+        experts.__class__ = ExactDirectDownSwitchGLU
         replaced += 1
     return replaced
 
@@ -606,8 +648,8 @@ def _positive_int(value: str) -> int:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--target", type=Path, required=True)
-    parser.add_argument("--overlay", type=Path, required=True)
-    parser.add_argument("--checkpoint-runtime", type=Path, required=True)
+    parser.add_argument("--overlay", type=Path)
+    parser.add_argument("--checkpoint-runtime", type=Path)
     parser.add_argument("--trust-checkpoint-runtime", action="store_true")
     parser.add_argument("--omlx-source", type=Path)
     parser.add_argument(
@@ -625,6 +667,16 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Fuse target gate/up expert projections after loading.",
     )
+    parser.add_argument(
+        "--direct-down-qmv",
+        action="store_true",
+        help="Use the experimental exact affine-2bit route QMV for target down projections.",
+    )
+    parser.add_argument(
+        "--target-only",
+        action="store_true",
+        help="Run target AR/oracle checks without loading checkpoint draft code.",
+    )
     parser.add_argument("--tokens", type=_positive_int, default=32)
     parser.add_argument("--eval-interval", type=int, default=40)
     parser.add_argument(
@@ -637,6 +689,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _validate_mode(args) -> None:
+    if args.target_only and (args.native_moe_only or args.packed_mtp_only):
+        raise SystemExit(
+            "--target-only cannot be combined with --native-moe-only or "
+            "--packed-mtp-only"
+        )
+
+
 def _run_benchmark(args, checkpoint_runtime, dspark_module) -> None:
     started = time.perf_counter()
     model, _ = load(
@@ -645,7 +705,8 @@ def _run_benchmark(args, checkpoint_runtime, dspark_module) -> None:
         fuse_moe_gate_up=args.fuse_target_moe,
     )
     model.eval_interval = args.eval_interval
-    model._dspark_overlay_path = str(args.overlay.resolve())
+    if args.overlay is not None:
+        model._dspark_overlay_path = str(args.overlay.resolve())
     tokenizer = PreTrainedTokenizerFast(
         tokenizer_file=str(args.target.resolve() / "tokenizer.json")
     )
@@ -674,6 +735,20 @@ def _run_benchmark(args, checkpoint_runtime, dspark_module) -> None:
         peak_gb=mx.get_peak_memory() / 1e9,
     )
     print(json.dumps(ar), flush=True)
+
+    if args.direct_down_qmv:
+        replaced = _install_direct_down_qmv(model)
+        direct_tokens, direct = _run_ar(model, input_ids, args.tokens, eos_id=1)
+        direct.update(
+            event="ar_direct_down_qmv",
+            replaced_layers=replaced,
+            output_tokens=direct_tokens,
+            text=tokenizer.decode(direct_tokens),
+            greedy_matches_ar=direct_tokens == ar_tokens,
+            active_gb=mx.get_active_memory() / 1e9,
+            peak_gb=mx.get_peak_memory() / 1e9,
+        )
+        print(json.dumps(direct), flush=True)
 
     if args.native_moe_only:
         if args.omlx_source is None:
@@ -722,6 +797,9 @@ def _run_benchmark(args, checkpoint_runtime, dspark_module) -> None:
             peak_gb=mx.get_peak_memory() / 1e9,
         )
         print(json.dumps(oracle), flush=True)
+
+    if args.target_only:
+        return
 
     dspark_tokens, dspark = _run_serial_dspark(
         model,
@@ -787,6 +865,12 @@ def _run_benchmark(args, checkpoint_runtime, dspark_module) -> None:
 
 def main() -> None:
     args = parse_args()
+    _validate_mode(args)
+    if args.target_only:
+        _run_benchmark(args, None, None)
+        return
+    if args.overlay is None or args.checkpoint_runtime is None:
+        raise SystemExit("--overlay and --checkpoint-runtime are required for DSpark")
     if not args.trust_checkpoint_runtime:
         raise SystemExit(
             "refusing to execute checkpoint-bundled Python without "

--- a/scripts/benchmark_deepseek_v41_moe_kernel.py
+++ b/scripts/benchmark_deepseek_v41_moe_kernel.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+from deepseek_v41_affine_route_qmv import affine2_route_down_qmv  # noqa: E402
 from deepseek_v41_native.config import ModelArgs  # noqa: E402
 from deepseek_v41_native.moe import MoE  # noqa: E402
 
@@ -100,6 +101,35 @@ class HybridPairSwitch(nn.Module):
         )
         x = self.switch._scatter_unsort(x, inv_order, indices.shape)
         return x.squeeze(-2)
+
+
+class StockPairDirectDown(nn.Module):
+    """Preserve stock gate/up numerics and specialize the exact down QMV."""
+
+    def __init__(self, native):
+        super().__init__()
+        self.gate_proj = native.gate_proj
+        self.up_proj = native.up_proj
+        self.down_proj = native.down_proj
+        self.activation = native.activation
+
+    def __call__(self, x, indices):
+        if int(x.shape[0]) * int(indices.shape[-1]) > 36:
+            expanded = mx.expand_dims(x, (-2, -3))
+            up = self.up_proj(expanded, indices)
+            gate = self.gate_proj(expanded, indices)
+            return self.down_proj(self.activation(up, gate), indices).squeeze(-2)
+        expanded = mx.expand_dims(x, (-2, -3))
+        up = self.up_proj(expanded, indices).squeeze(-2)
+        gate = self.gate_proj(expanded, indices).squeeze(-2)
+        activated = self.activation(up, gate)
+        tokens, topk, width = map(int, activated.shape)
+        down = affine2_route_down_qmv(
+            self.down_proj,
+            activated.reshape(tokens * topk, width),
+            indices.reshape(tokens * topk, 1),
+        )
+        return down.reshape(tokens, topk, -1)
 
 
 def _load_layer(model_path: Path, layer_id: int):
@@ -220,6 +250,7 @@ def main():
             ("native_all", native),
             ("hybrid_pair_bm16", HybridPairSwitch(native, switch, 16, 1)),
             ("hybrid_pair_bm32", HybridPairSwitch(native, switch, 32, 2)),
+            ("stock_pair_direct_down", StockPairDirectDown(native)),
         ):
             moe.experts = experts
             output, seconds = _measure(moe, values, args.iterations)

--- a/scripts/deepseek_v41_affine_route_qmv.py
+++ b/scripts/deepseek_v41_affine_route_qmv.py
@@ -1,0 +1,161 @@
+"""Experimental exact down-projection affine 2-bit QMV for V4.1.
+
+The verification batch has only 24--36 routed rows spread over hundreds of
+experts.  A block GEMM therefore pads most expert groups to a much larger row
+tile.  This kernel instead assigns one QMV grid to each real route.  It is
+restricted to the mixed-dtype FP32 activation / affine-weight down projection,
+where it is bit-exact with the stock path.  Gate/up deliberately stay stock.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import mlx.core as mx
+
+_SOURCE = r"""
+    // Match the stock affine 2-bit QMV lane geometry and operation order:
+    // one uint32 pack (16 values) per lane and a 512-wide K block.
+    constexpr int VALUES_PER_THREAD = 16;
+    constexpr int BLOCK_SIZE = VALUES_PER_THREAD * 32;
+    constexpr int RESULTS_PER_SIMDGROUP = 4;
+    constexpr int OUTPUTS_PER_THREADGROUP = 8;
+
+    const uint simd_group = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const int route = int(threadgroup_position_in_grid.z);
+    const int output_base =
+        int(threadgroup_position_in_grid.y) * OUTPUTS_PER_THREADGROUP
+        + int(simd_group) * RESULTS_PER_SIMDGROUP;
+    if (route >= ROUTES || output_base >= OUT) {
+        return;
+    }
+
+    const int token = route / TOPK;
+    const uint expert = indices[route];
+    const device T* input_ptr = input + token * K + int(lane) * VALUES_PER_THREAD;
+    device T* output_ptr = output + route * OUT + output_base;
+
+    constexpr int PACKED_K_BYTES = K / 4;
+    constexpr int GROUPS = K / 64;
+    float accum[RESULTS_PER_SIMDGROUP] = {0};
+
+    for (int k = 0; k < K; k += BLOCK_SIZE) {
+        float input_values[VALUES_PER_THREAD];
+        float input_sum = 0.0f;
+        const bool active_lane = k + int(lane) * VALUES_PER_THREAD < K;
+        if (active_lane) {
+            for (int idx = 0; idx < VALUES_PER_THREAD; idx += 4) {
+                const float x0 = float(input_ptr[idx]);
+                const float x1 = float(input_ptr[idx + 1]);
+                const float x2 = float(input_ptr[idx + 2]);
+                const float x3 = float(input_ptr[idx + 3]);
+                input_sum += x0 + x1 + x2 + x3;
+                input_values[idx] = x0;
+                input_values[idx + 1] = x1 / 4.0f;
+                input_values[idx + 2] = x2 / 16.0f;
+                input_values[idx + 3] = x3 / 64.0f;
+            }
+        }
+        const int group = k / 64 + int(lane) / 4;
+        const int packed_col = k / 4 + int(lane) * 4;
+        for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+            const int out_col = output_base + result;
+            if (out_col >= OUT) {
+                continue;
+            }
+            if (!active_lane) {
+                continue;
+            }
+            const device uint8_t* row_weight =
+                reinterpret_cast<const device uint8_t*>(weight)
+                + (size_t(expert) * OUT + out_col) * PACKED_K_BYTES
+                + packed_col;
+            const Q scale = scales[(size_t(expert) * OUT + out_col) * GROUPS + group];
+            const Q bias = biases[(size_t(expert) * OUT + out_col) * GROUPS + group];
+            float dot = 0.0f;
+            for (int pack = 0; pack < 4; ++pack) {
+                const uint value = row_weight[pack];
+                const int base = 4 * pack;
+                dot +=
+                    input_values[base] * float(value & 0x03) +
+                    input_values[base + 1] * float(value & 0x0c) +
+                    input_values[base + 2] * float(value & 0x30) +
+                    input_values[base + 3] * float(value & 0xc0);
+            }
+            accum[result] += float(scale) * dot + float(bias) * input_sum;
+        }
+        input_ptr += BLOCK_SIZE;
+    }
+
+    for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+        const float value = simd_sum(accum[result]);
+        if (lane == 0 && output_base + result < OUT) {
+            output_ptr[result] = T(value);
+        }
+    }
+"""
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_v41_affine2_route_qmv",
+        input_names=["input", "weight", "scales", "biases", "indices"],
+        output_names=["output"],
+        source=_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+def _shape(module, inputs: mx.array, indices: mx.array) -> tuple[int, int, int, int]:
+    if inputs.ndim != 2 or indices.ndim != 2:
+        raise ValueError("inputs and indices must both be rank two")
+    tokens, input_dims = map(int, inputs.shape)
+    if int(indices.shape[0]) != tokens:
+        raise ValueError("indices must have one row per input token")
+    topk = int(indices.shape[1])
+    routes = tokens * topk
+    required = ("weight", "scales", "biases", "bits", "group_size")
+    if any(not hasattr(module, name) for name in required):
+        raise ValueError("unsupported exact affine down-route QMV layout")
+    output_dims = int(module.scales.shape[1]) if module.scales.ndim == 3 else 0
+    if not (
+        module.weight.ndim == module.scales.ndim == module.biases.ndim == 3
+        and int(module.bits) == 2
+        and int(module.group_size) == 64
+        and getattr(module, "mode", "affine") == "affine"
+        and inputs.dtype == mx.float32
+        and module.scales.dtype in (mx.bfloat16, mx.float16)
+        and module.biases.dtype == module.scales.dtype
+        and input_dims % 64 == 0
+        and output_dims % 8 == 0
+        and tuple(module.scales.shape) == tuple(module.biases.shape)
+        and tuple(module.weight.shape[:2]) == tuple(module.scales.shape[:2])
+        and int(module.scales.shape[2]) == input_dims // 64
+        and int(module.weight.shape[2]) * 16 == input_dims
+        and 1 <= routes <= 36
+    ):
+        raise ValueError("unsupported exact affine down-route QMV layout")
+    return routes, topk, input_dims, output_dims
+
+
+def affine2_route_down_qmv(module, inputs: mx.array, indices: mx.array) -> mx.array:
+    routes, topk, input_dims, output_dims = _shape(module, inputs, indices)
+    flat_indices = mx.contiguous(indices.astype(mx.uint32).reshape(-1))
+    (output,) = _kernel()(
+        inputs=[inputs, module.weight, module.scales, module.biases, flat_indices],
+        template=[
+            ("T", inputs.dtype),
+            ("Q", module.scales.dtype),
+            ("ROUTES", routes),
+            ("TOPK", topk),
+            ("K", input_dims),
+            ("OUT", output_dims),
+        ],
+        grid=(32, output_dims // 4, routes),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(routes, output_dims)],
+        output_dtypes=[inputs.dtype],
+    )
+    return output.reshape((int(inputs.shape[0]), topk, output_dims))

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -4,7 +4,7 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -12,6 +12,7 @@ pytest.importorskip("mlx")
 pytestmark = pytest.mark.requires_mlx
 
 import mlx.core as mx
+from mlx_lm.models.switch_layers import SwitchGLU
 
 
 def _load_script():
@@ -131,6 +132,20 @@ def test_tokens_must_be_positive() -> None:
         module._positive_int("0")
 
 
+@pytest.mark.parametrize("conflict", ["native_moe_only", "packed_mtp_only"])
+def test_target_only_rejects_modes_that_require_other_runtimes(conflict) -> None:
+    module = _load_script()
+    args = SimpleNamespace(
+        target_only=True,
+        native_moe_only=False,
+        packed_mtp_only=False,
+    )
+    setattr(args, conflict, True)
+
+    with pytest.raises(SystemExit, match="cannot be combined"):
+        module._validate_mode(args)
+
+
 def test_packed_mtp_method_binding_does_not_retain_adapter() -> None:
     module = _load_script()
 
@@ -147,6 +162,53 @@ def test_packed_mtp_method_binding_does_not_retain_adapter() -> None:
     del adapter
 
     assert reference() is None
+
+
+def test_direct_down_install_is_atomic_and_idempotent() -> None:
+    module = _load_script()
+    first = SwitchGLU(64, 64, 2, bias=False)
+    second = SwitchGLU(64, 64, 2, bias=False)
+    model = SimpleNamespace(
+        layers=[
+            SimpleNamespace(ffn=SimpleNamespace(experts=first)),
+            SimpleNamespace(ffn=SimpleNamespace(experts=second)),
+        ]
+    )
+
+    assert module._install_direct_down_qmv(model) == 2
+    assert type(first) is module.ExactDirectDownSwitchGLU
+    assert type(second) is module.ExactDirectDownSwitchGLU
+    assert module._install_direct_down_qmv(model) == 0
+
+    valid = SwitchGLU(64, 64, 2, bias=False)
+    invalid = object()
+    mixed = SimpleNamespace(
+        layers=[
+            SimpleNamespace(ffn=SimpleNamespace(experts=valid)),
+            SimpleNamespace(ffn=SimpleNamespace(experts=invalid)),
+        ]
+    )
+    with pytest.raises(TypeError, match="unsupported expert module"):
+        module._install_direct_down_qmv(mixed)
+    assert type(valid) is SwitchGLU
+
+
+def test_direct_down_falls_back_for_prefill_sized_route_batch() -> None:
+    module = _load_script()
+    experts = SwitchGLU(64, 64, 8, bias=False)
+    model = SimpleNamespace(
+        layers=[SimpleNamespace(ffn=SimpleNamespace(experts=experts))]
+    )
+    inputs = mx.random.normal((7, 64))
+    indices = mx.broadcast_to(mx.arange(6, dtype=mx.uint32), (7, 6))
+    expected = experts(inputs, indices)
+    mx.eval(expected)
+
+    assert module._install_direct_down_qmv(model) == 1
+    actual = experts(inputs, indices)
+    mx.eval(actual)
+
+    assert mx.array_equal(actual, expected).item()
 
 
 def test_moe_layer_loader_merges_indexed_shards(tmp_path, monkeypatch) -> None:

--- a/tests/test_deepseek_v41_affine_route_qmv.py
+++ b/tests/test_deepseek_v41_affine_route_qmv.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+nn = pytest.importorskip("mlx.nn")
+switch_layers = pytest.importorskip("mlx_lm.models.switch_layers")
+
+from scripts.deepseek_v41_affine_route_qmv import affine2_route_down_qmv
+
+
+def _projection(*, bits: int = 2):
+    switch = switch_layers.SwitchGLU(512, 64, 8, bias=False)
+    nn.quantize(switch, group_size=64, bits=bits)
+    projection = switch.down_proj
+    projection.scales = projection.scales.astype(mx.bfloat16)
+    projection.biases = projection.biases.astype(mx.bfloat16)
+    return projection
+
+
+@pytest.mark.parametrize("routes", [1, 6, 24, 30, 36])
+def test_affine2_route_down_qmv_is_bit_exact(routes: int) -> None:
+    if mx.default_device() == mx.cpu:
+        pytest.skip("Metal kernel requires a GPU")
+    projection = _projection()
+    inputs = mx.random.normal((routes, 64)).astype(mx.float32)
+    indices = (mx.arange(routes) % 8).reshape(routes, 1).astype(mx.uint32)
+
+    actual = affine2_route_down_qmv(projection, inputs, indices)
+    expected = projection(inputs[:, None, None, :], indices).squeeze(-2)
+    mx.eval(actual, expected)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_affine2_route_down_qmv_rejects_non_exact_shapes() -> None:
+    projection = _projection()
+    indices = mx.zeros((1, 1), dtype=mx.uint32)
+    with pytest.raises(ValueError, match="unsupported exact"):
+        affine2_route_down_qmv(
+            projection, mx.zeros((1, 64), dtype=mx.bfloat16), indices
+        )
+
+    with pytest.raises(ValueError, match="unsupported exact"):
+        affine2_route_down_qmv(
+            projection,
+            mx.zeros((37, 64), dtype=mx.float32),
+            mx.zeros((37, 1), dtype=mx.uint32),
+        )
+
+    four_bit = _projection(bits=4)
+    with pytest.raises(ValueError, match="unsupported exact"):
+        affine2_route_down_qmv(four_bit, mx.zeros((1, 64), dtype=mx.float32), indices)


### PR DESCRIPTION
## Why

DeepSeek V4.1 Flash native 2-bit autoregressive decode is bottlenecked by its routed expert projections. This stacked experimental PR adds a route-direct affine 2-bit QMV specialized for the small 6–36-row batches used during decode and speculative verification.

Across three real 32-token target-only runs on an M3 Ultra with 256 GiB unified memory, throughput improves from 7.81–7.92 to **9.49–9.83 tok/s** (**+21.5% to +24.0%**). Generated tokens are exactly identical and peak MLX memory is unchanged at 213.54 GB. Real layer-20 speedups are 2.65x at 6 routes, 1.94x at 24, 1.82x at 30, and 1.72x at 36, all with maximum absolute difference 0.

Combined with packed K4 DSpark, the exact-greedy path reaches **12.70 tok/s**, **+62.5%** over the same-run 7.81 tok/s AR baseline, at 218.00 GB peak. This clears the single-prompt 12 tok/s performance floor. Broader 128-token, multi-domain, and long-context qualification remains required before product exposure; the 20+ tok/s stretch goal is not met.

## Scope

- Add a Metal route-direct QMV for FP32 activations and affine 2-bit/group-64 expert down projections.
- Preserve the stock gate/up, activation, routing, and weighted-reduction paths.
- Fall back to the stock implementation for prefill batches above the bounded 36-route acceleration window.
- Add target-only benchmark mode, real-layer candidate measurement, correctness and CLI regression tests.
- Record reproducible throughput, memory, exactness, limitations, and next gate.

## Non-goals

- No server, catalog, GUI, alias, or download exposure.
- No default inference behavior change.
- No gate/up numerical substitution.
- No model weights or generated artifacts.
- No claim that the full product-quality gate or 20 tok/s stretch goal is met.

## Acceptance and evidence

- Route-direct output is bit-exact for 1, 6, 24, 30, and 36 routes.
- Prefill-sized batches automatically use the original implementation and remain bit-exact.
- Installation is atomic and idempotent.
- Unsupported dtype, quantization, layout, and oversized direct-kernel shapes fail closed.
- Target-only: 9.49–9.83 tok/s versus 7.81–7.92 baseline; exact generated-token match; 213.54 GB peak.
- Oracle K2/K3/K4/K5 target throughput: 17.91–18.13 / 25.38–25.49 / 32.39–33.86 / 34.49–36.32 rows/s.
- Combined K4 packed DSpark: 12.70 tok/s, +62.5%, exact 32-token greedy match, 218.00 GB peak.
- Combined K5: 13.96 tok/s but a non-matching greedy stream, so it is excluded from the exact product candidate.
- K4 spends 0.297 seconds in draft, 2.096 seconds in target verification, and 0.006 seconds in rollback across the 2.442-second decode.

## Verification

- DeepSeek V4.1 focused suite: 52 passed.
- Diff-aware PR tests: 20 passed.
- Full suite: 23,771 passed, 107 skipped, 22 deselected, 6 xfailed, 1 xpassed; all 9 failures reproduce unchanged on the exact base commit. Seven are an installed image dependency API mismatch and two are environment-sensitive doctor expectations.
- Ruff check and format check: pass.
- Git diff check: pass.
- Three complete real-model target runs and one combined K4/K5 run.
- Scope-locked self-adversarial review found and fixed unsafe long-prompt routing and incompatible CLI-mode combinations.
- No credentials, model files, cache paths, or generated artifacts in the diff.

## AI assistance disclosure

Codex implemented and self-reviewed the experimental kernel, benchmark integration, regression tests, and performance note. Performance claims come from the real 212.93 GB target plus its 4.46 GB draft sidecar on the stated hardware.