### PR TITLE
fix(mllm): isolate worker tokenizer state

### DIFF
--- a/tests/test_mllm_tokenizer_thread_isolation.py
+++ b/tests/test_mllm_tokenizer_thread_isolation.py
@@ -1,0 +1,82 @@
+"""Regression contracts for MLLM tokenizer execution-domain isolation."""
+
+from __future__ import annotations
+
+import copy
+import threading
+
+from vllm_mlx.engine.batched import _clone_mllm_worker_processor
+
+
+class _BorrowCheckedTokenizer:
+    """Model the exclusive mutable borrow used by a fast-tokenizer backend."""
+
+    def __init__(self) -> None:
+        self._borrowed = False
+        self._state_lock = threading.Lock()
+
+    def __deepcopy__(self, memo):
+        clone = type(self)()
+        memo[id(self)] = clone
+        return clone
+
+    def enter_mutation(self) -> None:
+        with self._state_lock:
+            if self._borrowed:
+                raise RuntimeError("Already borrowed")
+            self._borrowed = True
+
+    def leave_mutation(self) -> None:
+        with self._state_lock:
+            self._borrowed = False
+
+
+class _Processor:
+    def __init__(self) -> None:
+        self.tokenizer = _BorrowCheckedTokenizer()
+        self.image_processor = object()
+
+
+def test_mllm_worker_processor_owns_an_independent_tokenizer_backend():
+    request_processor = _Processor()
+
+    worker_processor = _clone_mllm_worker_processor(request_processor)
+
+    assert worker_processor is not request_processor
+    assert worker_processor.tokenizer is not request_processor.tokenizer
+    assert worker_processor.image_processor is request_processor.image_processor
+
+    # Hold the request-side mutable borrow while the worker enters its own.
+    # Reusing the original tokenizer would deterministically raise the exact
+    # ``Already borrowed`` failure observed in #3303.
+    request_processor.tokenizer.enter_mutation()
+    try:
+        worker_processor.tokenizer.enter_mutation()
+        worker_processor.tokenizer.leave_mutation()
+    finally:
+        request_processor.tokenizer.leave_mutation()
+
+
+def test_tokenizer_like_processor_is_deep_copied():
+    request_tokenizer = _BorrowCheckedTokenizer()
+
+    worker_tokenizer = _clone_mllm_worker_processor(request_tokenizer)
+
+    assert worker_tokenizer is not request_tokenizer
+    request_tokenizer.enter_mutation()
+    try:
+        worker_tokenizer.enter_mutation()
+        worker_tokenizer.leave_mutation()
+    finally:
+        request_tokenizer.leave_mutation()
+
+
+def test_processor_copy_does_not_mutate_request_side_tokenizer():
+    request_processor = _Processor()
+    original_tokenizer = request_processor.tokenizer
+
+    worker_processor = _clone_mllm_worker_processor(request_processor)
+
+    assert request_processor.tokenizer is original_tokenizer
+    assert worker_processor.tokenizer is not original_tokenizer
+    assert copy.deepcopy(worker_processor.tokenizer) is not worker_processor.tokenizer

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -13,6 +13,7 @@ LLM engine), so text-only requests must also be routed through it.
 
 import asyncio
 import contextvars
+import copy
 import functools
 import json
 import logging
@@ -39,6 +40,30 @@ from .base import BaseEngine, GenerationOutput
 ADMISSION_ORPHAN_GRACE_SECONDS = 2.0
 
 logger = logging.getLogger(__name__)
+
+
+def _clone_mllm_worker_processor(processor: Any) -> Any:
+    """Give the MLLM worker an independently mutable tokenizer backend.
+
+    Hugging Face fast-tokenizer calls temporarily mutate padding/truncation
+    state. The request/event-loop side renders chat templates while the MLLM
+    worker calls ``mlx_vlm.prepare_inputs``; sharing one Rust backend across
+    those execution domains can therefore raise ``RuntimeError: Already
+    borrowed`` under concurrent requests.
+
+    Keep the usually stateless media processor shared by shallow-copying the
+    wrapper, but deep-copy its tokenizer. Tokenizer-less processors are
+    themselves tokenizer-like, so copy the whole object in that case. This is
+    a one-time model-start cost, not a per-request copy.
+    """
+
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None:
+        return copy.deepcopy(processor)
+
+    worker_processor = copy.copy(processor)
+    worker_processor.tokenizer = copy.deepcopy(tokenizer)
+    return worker_processor
 
 
 @dataclass(frozen=True, slots=True)
@@ -1720,11 +1745,21 @@ class BatchedEngine(BaseEngine):
             vision_max_pixels=vision_max_pixels,
         )
 
+        # The event loop renders request chat templates while the model worker
+        # tokenizes prepared MLLM inputs. Both operations temporarily mutate a
+        # fast tokenizer's padding/truncation state, so they must not share the
+        # same Rust backend (#3303). Give the worker its own tokenizer-bearing
+        # processor before handing it to the scheduler. This follows the
+        # established execution-domain ownership pattern already used for the
+        # model's MLX stream and avoids serializing unrelated request
+        # preparation behind a global lock.
+        worker_processor = _clone_mllm_worker_processor(self._processor)
+
         # Create and start MLLM scheduler — pass the model-owning executor so
         # _step_no_queue runs on the same thread as model load.
         self._mllm_scheduler = MLLMScheduler(
             model=self._model,
-            processor=self._processor,
+            processor=worker_processor,
             config=mllm_config,
             step_executor=self._model_load_executor,
             model_name=self._model_name,


### PR DESCRIPTION
## Why

Concurrent requests to multimodal models could make the request thread render a chat template while the MLLM worker mutated padding state on the same Hugging Face tokenizer backend. The backend then intermittently raised `RuntimeError: Already borrowed`, aborting an otherwise healthy batch. This was reproduced on a 48 GB M4 Pro with the reporter workload.

## What changed

- Give the MLLM worker a one-time processor copy with an independently deep-copied tokenizer backend.
- Keep request-side chat-template rendering and worker-side `prepare_inputs` in separate state ownership domains.
- Add deterministic regression contracts for processor/tokenizer identity and concurrent mutable borrows.
- Preserve the bounded HTTP 503 diagnostics landed in #3308; this removes the underlying tokenizer race rather than replaying a possibly mutated batch.

## Design precedent

Mature inference servers avoid sharing a mutable fast-tokenizer backend across concurrent execution domains. This adapts that established per-worker tokenizer ownership pattern while retaining the single MLX model-worker thread; a global lock was rejected because it would serialize unrelated request preparation.

## Validation

- M4 Pro before fix: 52/54 HTTP 200, 2/54 HTTP 503 at concurrency 4; traceback ended at tokenizer `enable_padding` with `RuntimeError: Already borrowed`.
- M4 Pro after fix: reporter workload 180/180 HTTP 200 at concurrency 1/2/3/4/8.
- M4 Pro after fix: longer ~250-token workload 60/60 HTTP 200.
- M4 Pro after fix: real image requests 6/6 HTTP 200.
- Fixed-server log contained no ERROR, traceback, MLLM batch failure, or `Already borrowed` entry.
- Focused local suites: 249 passed; 3 unrelated tests deselected by existing markers.
- Full local suite: 23,743 passed, 108 skipped, 22 deselected, 6 xfailed, 1 xpassed, 9 failed. The same nine failures reproduce unchanged on exact `origin/main@8229eb35`: seven Bonsai image tests reflect the locally installed image dependency `TilingConfig` API, and two doctor tests reflect local environment assumptions. No affected file or dependency overlaps this PR. Exact-head GitHub validation runs in its clean environment.
- Ruff and `git diff --check` passed.

## Non-goals

- No scheduling, capacity, cache, retry, model-output, image runtime, doctor, or automatic replay changes.

Fixes #3303