### PR TITLE
Own the DeepSeek V4.1 DSpark runtime

### DIFF
--- a/.agents/handoffs/vector-deepseek-v41-native-dspark.md
+++ b/.agents/handoffs/vector-deepseek-v41-native-dspark.md
@@ -1,0 +1,49 @@
+# Vector handoff: product-owned DeepSeek V4.1 DSpark runtime
+
+- Owner: Vector
+- Host: Studio (M3 Ultra, 256 GiB unified memory)
+- Branch: `vector/deepseek-v41-native-dspark`
+- Base: PR #3311 (`vector/deepseek-v41-dspark-adapter`)
+- Worktree: `/private/tmp/rapid-mlx-deepseek-v41-native-dspark`
+- Status: implementation and full-model dogfood complete; PR/review pending
+
+## Scope
+
+Replace the default benchmark dependency on checkpoint-bundled Python with a
+minimal Rapid-owned DSpark runtime. Server/catalog/GUI integration, artifact
+download, sampling, and resolution of the 128-token batch-numerics divergence
+are explicit non-goals.
+
+## Verified facts
+
+- The owned loader reads data only and rejects path traversal, symlinked MTP
+  shards, index/shard mismatch, incomplete three-stage tensor contracts, and
+  allocations that violate host or Metal headroom.
+- The target owns and shares the quantized embedding/head; the sidecar does not
+  load their linked target shards.
+- Actual-sidecar A/B against the explicitly trusted oracle is bit-exact: all six
+  observed KV windows, proposal tokens, and five confidence logits match, with
+  maximum absolute difference 0.
+- The final full-model K4 run reaches 13.42 tok/s versus 7.82 target AR (+71.7%),
+  with identical 32-token greedy output and 218.00 GB peak MLX memory.
+- K5 reaches 14.61 tok/s but diverges and remains excluded.
+- Adversarial dogfood caught and fixed two P1 integration defects: a provider
+  class-name mismatch and 4.25 GB of retained unpacked expert tensors. The
+  final pack releases all 3,456 replaced arrays and restores the 218 GB peak.
+- Focused tests: 21 passed. Ruff and diff whitespace checks pass.
+
+## Reference check (internal only)
+
+- vLLM and SGLang use product-owned draft architectures with shared target I/O
+  and explicit verification state rather than loading executable checkpoint
+  code; this boundary was adopted.
+- Current oMLX also owns its V4.1/MTP runtime, but its converted tensor namespace
+  is incompatible with this 212.93 GB target, so no runtime or artifact was
+  copied.
+- Existing Rapid native RMS/RoPE/fake-quant/Hyper-Connection behavior was reused
+  where shapes matched; draft-specific rank conventions remain isolated here.
+
+## Next concrete action
+
+Open the scoped stacked PR, run author-owned adversarial review and PR validation,
+then address 128-token target batch numerical stability in a separate PR.

--- a/NOTICE
+++ b/NOTICE
@@ -91,6 +91,13 @@ repository. Each keeps its upstream license text alongside the code.
   bffd4856a4504b76a242536f2dd356093c8e2e92.
   Licensed under the MIT License.
 
+* scripts/deepseek_v41_native/
+  DeepSeek V4.1 native MLX runtime. The target runtime is adapted under the
+  Apache License 2.0; the DSpark draft algorithm follows the model publisher's
+  MIT-licensed reference implementation.
+  See scripts/deepseek_v41_native/LICENSE,
+  scripts/deepseek_v41_native/LICENSE-DSPARK, and NOTICE.
+
 
 Runtime dependencies
 ====================

--- a/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-speed.md
+++ b/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-speed.md
@@ -139,6 +139,31 @@ and 0.006 seconds in rollback. This is the first exact-greedy configuration to
 cross the 12 tok/s performance floor, but it is still one 32-token prompt rather
 than the multi-domain, long-context qualification required for product exposure.
 
+## Product-owned draft runtime
+
+The K4 path was then moved behind a Rapid-owned, data-only DSpark runtime. The
+default benchmark no longer imports Python from the model directory; the old
+runtime remains available only as an explicit trusted A/B oracle. The sidecar
+loader validates a basename-only index, rejects symlinked MTP shards, requires
+the complete three-stage tensor contract, shares the target embedding and head,
+and admits its 4.46 GB allocation against both host and Metal headroom.
+
+On actual sidecar tensors, six observed KV windows, the six-token proposal, and
+all five confidence logits were element-for-element equal between the old and
+owned implementations (maximum difference 0). A complete default-path run on
+the same Studio measured:
+
+| Candidate | tok/s | Change vs same-run 7.82 AR | Greedy equivalent | Peak MLX memory |
+| --- | ---: | ---: | --- | ---: |
+| K4 owned packed DSpark + direct down QMV | **13.42** | **+71.7%** | **yes** | **218.00 GB** |
+| K5 owned packed DSpark + direct down QMV | 14.61 | +86.9% | no | 218.00 GB |
+
+An adversarial full-path run first exposed a 4.25 GB ownership leak: after
+packing experts, the loader retained the unpacked arrays as well. The final
+implementation explicitly releases all 3,456 replaced expert tensors; a repeat
+run reduced peak memory from 222.27 GB back to 218.00 GB without changing K4
+output. K5 remains excluded regardless of its higher throughput.
+
 ## Rejected paths
 
 - Immediate singleton correction erases batching gains. Exact cache rollback
@@ -165,11 +190,11 @@ than the multi-domain, long-context qualification required for product exposure.
 
 ## Product decision and next experiments
 
-Do not enable DSpark for DeepSeek V4.1 Flash by default yet. K4 now reaches
-12.70 tok/s with an exact greedy stream on the qualification prompt, clearing
-the performance floor. It still needs multi-domain 128-token and long-context
-cache qualification. K5 reaches 13.96 tok/s but remains excluded because its
-batched target numerics change the greedy stream.
+Do not enable DSpark for DeepSeek V4.1 Flash by default yet. Product-owned K4
+now reaches 13.42 tok/s with an exact greedy stream on the qualification prompt,
+clearing the performance floor. It still needs stable multi-domain 128-token
+and long-context cache qualification. K5 reaches 14.61 tok/s but remains
+excluded because its batched target numerics change the greedy stream.
 
 Reaching 20 tok/s requires a new capability rather than threshold tuning:
 

--- a/scripts/benchmark_deepseek_v41_dspark.py
+++ b/scripts/benchmark_deepseek_v41_dspark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Measure V4.1 target-only decode against checkpoint-native DSpark drafting.
+"""Measure V4.1 target-only decode against Rapid-owned DSpark drafting.
 
 This first gate deliberately uses serial target verification.  It establishes
 draft latency, greedy acceptance, output equivalence, and memory headroom before
@@ -28,6 +28,7 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from deepseek_v41_affine_route_qmv import affine2_route_down_qmv  # noqa: E402
+from deepseek_v41_native import dspark as rapid_dspark  # noqa: E402
 from deepseek_v41_native.load import load  # noqa: E402
 from mlx_lm.models.switch_layers import SwitchGLU  # noqa: E402
 
@@ -192,6 +193,9 @@ def _install_direct_down_qmv(model) -> int:
 
 
 def _share_target_head(weights, model):
+    if hasattr(weights, "attach_target"):
+        weights.attach_target(model)
+        return
     for suffix in ("weight", "scales", "biases"):
         value = getattr(model.head, suffix, None)
         key = f"head.{suffix}"
@@ -200,6 +204,8 @@ def _share_target_head(weights, model):
 
 
 def _pin_mtp_with_headroom(weights, reserve_gb: float = 8.0) -> int:
+    if hasattr(weights, "pin_mtp"):
+        return weights.pin_mtp(reserve_gb)
     import psutil
 
     keys = [
@@ -261,10 +267,14 @@ def _install_packed_mtp_moe(adapter) -> int:
                 mx.eval(value)
                 values[suffix] = value
                 packed_bytes += value.nbytes
-                for key in keys:
-                    old = weights.resident.pop(key, None)
-                    if old is not None:
-                        weights.resident_bytes -= old.nbytes
+                if hasattr(weights, "release_tensor"):
+                    for key in keys:
+                        weights.release_tensor(key)
+                else:
+                    for key in keys:
+                        old = weights.resident.pop(key, None)
+                        if old is not None:
+                            weights.resident_bytes -= old.nbytes
             values["config"] = weights.quant_config(f"{base}.experts.0.{projection}")
             projections[projection] = values
         packed[base] = projections
@@ -880,18 +890,18 @@ def main() -> None:
     if args.target_only:
         _run_benchmark(args, None, None)
         return
-    if args.overlay is None or args.checkpoint_runtime is None:
-        raise SystemExit("--overlay and --checkpoint-runtime are required for DSpark")
+    if args.overlay is None:
+        raise SystemExit("--overlay is required for DSpark")
+    if args.checkpoint_runtime is None:
+        _run_benchmark(args, rapid_dspark, rapid_dspark)
+        return
     if not args.trust_checkpoint_runtime:
         raise SystemExit(
             "refusing to execute checkpoint-bundled Python without "
             "--trust-checkpoint-runtime"
         )
-    with _checkpoint_runtime(args.checkpoint_runtime) as (
-        checkpoint_runtime,
-        dspark_module,
-    ):
-        _run_benchmark(args, checkpoint_runtime, dspark_module)
+    with _checkpoint_runtime(args.checkpoint_runtime) as (runtime, dspark_module):
+        _run_benchmark(args, runtime, dspark_module)
 
 
 if __name__ == "__main__":

--- a/scripts/deepseek_v41_native/LICENSE-DSPARK
+++ b/scripts/deepseek_v41_native/LICENSE-DSPARK
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) DeepSeek AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/deepseek_v41_native/NOTICE
+++ b/scripts/deepseek_v41_native/NOTICE
@@ -4,3 +4,9 @@ This directory contains code derived from PipeNetwork/deepseek-v41-mlx,
 revision 8bdd543c7160800f3451d9595c996129b7abecdf, licensed under the
 Apache License 2.0. Rapid-MLX modifications include quantized group-aware
 output projection support and qualification tooling.
+
+The DSpark draft algorithm in dspark.py follows the model publisher's
+MIT-licensed DeepSeek V4.1 reference inference implementation. The Rapid-MLX
+implementation adds a strict data-only sidecar loader, target weight sharing,
+memory admission, validation, and benchmark integration.
+See LICENSE-DSPARK in this directory.

--- a/scripts/deepseek_v41_native/dspark.py
+++ b/scripts/deepseek_v41_native/dspark.py
@@ -1,0 +1,666 @@
+"""Product-owned DeepSeek V4.1 DSpark draft runtime.
+
+This module consumes checkpoint data only. It never imports or executes Python
+from a model directory. The supported contract is the released three-stage MTP
+sidecar with greedy speculative decoding; sampling is deliberately excluded.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import mlx.core as mx
+
+from .fakequant import fake_quant_fp8_ue8m0
+
+_REQUIRED_CONFIG = {
+    "dspark_block_size",
+    "dspark_n_routed_experts",
+    "dspark_noise_token_id",
+    "dspark_num_experts_per_tok",
+    "dspark_target_layer_ids",
+    "hc_eps",
+    "hc_mult",
+    "hc_sinkhorn_iters",
+    "head_dim",
+    "hidden_size",
+    "norm_topk_prob",
+    "num_attention_heads",
+    "o_groups",
+    "qk_rope_head_dim",
+    "rms_norm_eps",
+    "rope_theta",
+    "routed_scaling_factor",
+    "sliding_window",
+    "swiglu_limit",
+}
+
+_RELEASE_ARCHITECTURE = {
+    "dspark_block_size": 5,
+    "dspark_n_routed_experts": 128,
+    "dspark_num_experts_per_tok": 3,
+    "hc_mult": 4,
+    "head_dim": 512,
+    "hidden_size": 5120,
+    "num_attention_heads": 64,
+    "o_groups": 8,
+    "qk_rope_head_dim": 64,
+}
+
+
+def _read_object(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid JSON file: {path.name}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.name} must contain a JSON object")
+    return value
+
+
+def _safe_shard(root: Path, name: object) -> Path:
+    if not isinstance(name, str) or not name or Path(name).name != name:
+        raise ValueError("DSpark shard names must be non-empty basenames")
+    path = root / name
+    if path.is_symlink():
+        raise ValueError(f"DSpark shard must not be a symlink: {name}")
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path
+
+
+def _validate_config(config: dict) -> None:
+    missing = sorted(_REQUIRED_CONFIG - config.keys())
+    if missing:
+        raise ValueError(f"DSpark config is missing: {', '.join(missing)}")
+    positive = (
+        "dspark_block_size",
+        "dspark_n_routed_experts",
+        "dspark_num_experts_per_tok",
+        "hc_mult",
+        "hc_sinkhorn_iters",
+        "head_dim",
+        "hidden_size",
+        "num_attention_heads",
+        "o_groups",
+        "qk_rope_head_dim",
+        "sliding_window",
+    )
+    for key in positive:
+        if isinstance(config[key], bool) or not isinstance(config[key], int):
+            raise ValueError(f"DSpark config {key} must be an integer")
+        if config[key] <= 0:
+            raise ValueError(f"DSpark config {key} must be positive")
+    if config["dspark_num_experts_per_tok"] > config["dspark_n_routed_experts"]:
+        raise ValueError("DSpark top-k exceeds routed expert count")
+    if config["qk_rope_head_dim"] > config["head_dim"]:
+        raise ValueError("DSpark RoPE width exceeds attention head width")
+    if config.get("model_type") not in ("deepseek_v4", "deepseek_v41"):
+        raise ValueError("DSpark sidecar model_type is not DeepSeek V4.1")
+    for key, expected in _RELEASE_ARCHITECTURE.items():
+        if config[key] != expected:
+            raise ValueError(
+                f"unsupported DSpark architecture: {key}={config[key]!r}, "
+                f"expected {expected}"
+            )
+    for key in ("hc_eps", "rms_norm_eps", "rope_theta", "routed_scaling_factor"):
+        value = config[key]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"DSpark config {key} must be numeric")
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f"DSpark config {key} must be finite and positive")
+    targets = config["dspark_target_layer_ids"]
+    if not isinstance(targets, (list, tuple)) or len(targets) != 3:
+        raise ValueError("DSpark requires exactly three target hidden layers")
+
+
+def _required_tensors(config: dict) -> set[str]:
+    required = {"mtp.0.main_norm.weight"}
+    required.update(
+        f"mtp.0.main_proj.{suffix}" for suffix in ("weight", "scales", "biases")
+    )
+    for stage in range(3):
+        base = f"mtp.{stage}"
+        required.update(
+            f"{base}.{name}"
+            for name in (
+                "attn.attn_sink",
+                "attn.kv_norm.weight",
+                "attn.q_norm.weight",
+                "attn_norm.weight",
+                "ffn.gate.bias",
+                "ffn.gate.weight",
+                "ffn_norm.weight",
+                "hc_attn_base",
+                "hc_attn_fn",
+                "hc_attn_scale",
+                "hc_ffn_base",
+                "hc_ffn_fn",
+                "hc_ffn_scale",
+            )
+        )
+        for projection in (
+            "attn.wkv",
+            "attn.wo_a",
+            "attn.wo_b",
+            "attn.wq_a",
+            "attn.wq_b",
+        ):
+            required.update(
+                f"{base}.{projection}.{suffix}"
+                for suffix in ("weight", "scales", "biases")
+            )
+        for projection in ("w1", "w2", "w3"):
+            required.update(
+                f"{base}.ffn.shared_experts.{projection}.{suffix}"
+                for suffix in ("weight", "scales", "biases")
+            )
+            for expert in range(config["dspark_n_routed_experts"]):
+                required.update(
+                    f"{base}.ffn.experts.{expert}.{projection}.{suffix}"
+                    for suffix in ("weight", "scales", "biases")
+                )
+    final = "mtp.2"
+    required.add(final + ".norm.weight")
+    for projection in ("confidence_head.proj", "markov_head.embed", "markov_head.head"):
+        required.update(
+            f"{final}.{projection}.{suffix}"
+            for suffix in ("weight", "scales", "biases")
+        )
+    return required
+
+
+class DSparkWeights:
+    """Strict loader for MTP tensors plus target-owned shared I/O weights."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path).resolve()
+        if not self.path.is_dir():
+            raise NotADirectoryError(self.path)
+        raw = _read_object(self.path / "config.json")
+        nested = raw.get("text_config")
+        self.config = {**raw, **nested} if isinstance(nested, dict) else dict(raw)
+        _validate_config(self.config)
+        index = _read_object(self.path / "model.safetensors.index.json")
+        weight_map = index.get("weight_map")
+        if not isinstance(weight_map, dict) or not weight_map:
+            raise ValueError("model index must contain a non-empty weight_map")
+        mtp_map = {}
+        for key, shard in weight_map.items():
+            if not isinstance(key, str):
+                raise ValueError("model index tensor names must be strings")
+            if key.startswith("mtp."):
+                if not isinstance(shard, str):
+                    raise ValueError("model index shard names must be strings")
+                mtp_map[key] = shard
+        if not mtp_map:
+            raise ValueError("model index contains no MTP tensors")
+        self._arrays: dict[str, mx.array] = {}
+        self.mtp_file_bytes = 0
+        for shard_name in sorted(set(mtp_map.values())):
+            shard = _safe_shard(self.path, shard_name)
+            self.mtp_file_bytes += shard.stat().st_size
+            loaded = mx.load(str(shard))
+            if not isinstance(loaded, dict):
+                raise ValueError(f"DSpark shard is not a tensor map: {shard.name}")
+            for key, value in loaded.items():
+                if key.startswith("mtp."):
+                    if key in self._arrays:
+                        raise ValueError(f"duplicate DSpark tensor: {key}")
+                    if value.dtype not in (mx.bfloat16, mx.float32, mx.uint32):
+                        raise ValueError(f"unsupported DSpark tensor dtype: {key}")
+                    if not value.shape or any(int(size) <= 0 for size in value.shape):
+                        raise ValueError(f"invalid DSpark tensor shape: {key}")
+                    self._arrays[key] = value
+        if set(self._arrays) != set(mtp_map):
+            missing = sorted(set(mtp_map) - set(self._arrays))
+            extra = sorted(set(self._arrays) - set(mtp_map))
+            raise ValueError(
+                f"DSpark index/shard mismatch (missing={missing[:1]}, extra={extra[:1]})"
+            )
+        missing_contract = sorted(_required_tensors(self.config) - set(self._arrays))
+        if missing_contract:
+            raise ValueError(
+                f"DSpark tensor contract is missing: {missing_contract[0]}"
+            )
+        self.entries = {
+            key: {"shape": tuple(value.shape)} for key, value in self._arrays.items()
+        }
+        self.resident: dict[str, mx.array] = {}
+        self.resident_bytes = 0
+        self.q = raw.get("quantization") or raw.get("quantization_config", {})
+        if not isinstance(self.q, dict):
+            raise ValueError("DSpark quantization config must be an object")
+
+    def attach_target(self, model) -> None:
+        """Share target embedding/head arrays without loading their sidecar shards."""
+        for base, module in (("embed", model.embed), ("head", model.head)):
+            attached = 0
+            for suffix in ("weight", "scales", "biases", "bias"):
+                value = getattr(module, suffix, None)
+                if value is not None:
+                    key = f"{base}.{suffix}"
+                    self._arrays[key] = value
+                    self.entries[key] = {"shape": tuple(value.shape)}
+                    self.resident[key] = value
+                    attached += 1
+            if not attached:
+                raise ValueError(f"target model has no shareable {base} weights")
+
+    def pin_mtp(self, reserve_gb: float = 8.0) -> int:
+        import psutil
+
+        keys = sorted(key for key in self._arrays if key.startswith("mtp."))
+        total = sum(self._arrays[key].nbytes for key in keys)
+        reserve = int(reserve_gb * 1e9)
+        device_free = (
+            int(mx.device_info()["max_recommended_working_set_size"])
+            - mx.get_active_memory()
+        )
+        safe = min(int(psutil.virtual_memory().available), device_free) - reserve
+        if total > safe:
+            raise MemoryError(
+                f"MTP needs {total / 1e9:.2f} GB but only {safe / 1e9:.2f} GB "
+                f"remains after the {reserve_gb:.1f} GB safety reserve"
+            )
+        values = [self._arrays[key] for key in keys]
+        mx.eval(*values)
+        for key, value in zip(keys, values):
+            if key not in self.resident:
+                self.resident[key] = value
+                self.resident_bytes += value.nbytes
+        mx.clear_cache()
+        return total
+
+    def read(self, key: str, rows=None, _pin: bool = False):
+        del _pin
+        try:
+            value = self._arrays[key]
+        except KeyError as exc:
+            raise KeyError(f"missing DSpark tensor: {key}") from exc
+        return value if rows is None else value[mx.array(rows, dtype=mx.int32)]
+
+    def release_tensor(self, key: str) -> None:
+        """Drop a tensor after a product-owned packed replacement is evaluated."""
+        value = self.resident.pop(key, None)
+        if value is not None:
+            self.resident_bytes -= value.nbytes
+        self._arrays.pop(key, None)
+        self.entries.pop(key, None)
+
+    def quant_config(self, base: str) -> dict:
+        modules = self.q.get("modules", {})
+        specific = modules.get(base) if isinstance(modules, dict) else None
+        source = specific if isinstance(specific, dict) else self.q
+        try:
+            return {
+                "bits": int(source["bits"]),
+                "group_size": int(source["group_size"]),
+                "mode": source.get("mode", self.q.get("mode", "affine")),
+            }
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"missing quantization contract for {base}") from exc
+
+    def linear(self, base: str, x):
+        if base + ".scales" in self._arrays:
+            bias = (
+                self.read(base + ".biases")
+                if base + ".biases" in self._arrays
+                else None
+            )
+            y = mx.quantized_matmul(
+                x,
+                self.read(base + ".weight"),
+                self.read(base + ".scales"),
+                bias,
+                transpose=True,
+                **self.quant_config(base),
+            )
+        else:
+            weight = self.read(base + ".weight")
+            y = x.astype(weight.dtype) @ weight.T
+        if base + ".bias" in self._arrays:
+            y = y + self.read(base + ".bias")
+        return y.astype(x.dtype)
+
+    def embedding(self, base: str, ids):
+        ids = mx.array(ids, dtype=mx.int32)
+        weight = self.read(base + ".weight", ids)
+        if base + ".scales" in self._arrays:
+            scales = self.read(base + ".scales", ids)
+            biases = (
+                self.read(base + ".biases", ids)
+                if base + ".biases" in self._arrays
+                else None
+            )
+            weight = mx.dequantize(weight, scales, biases, **self.quant_config(base))
+        return weight
+
+    def grouped(self, base: str, x, groups: int):
+        rows = self.entries[base + ".weight"]["shape"][0] // groups
+        output = []
+        for group in range(groups):
+            ids = mx.arange(group * rows, (group + 1) * rows, dtype=mx.int32)
+            weight = self.read(base + ".weight", ids)
+            if base + ".scales" in self._arrays:
+                output.append(
+                    mx.quantized_matmul(
+                        x[group : group + 1],
+                        weight,
+                        self.read(base + ".scales", ids),
+                        self.read(base + ".biases", ids),
+                        transpose=True,
+                        **self.quant_config(base),
+                    )
+                )
+            else:
+                output.append(x[group : group + 1] @ weight.T)
+        return mx.concatenate(output, axis=-1)
+
+
+# Keep the benchmark/runtime adapter contract intentionally tiny: a provider
+# exposes ``Weights`` and ``DSpark``. The descriptive class name remains useful
+# to callers that want to construct the sidecar loader directly.
+Weights = DSparkWeights
+
+
+def _rms_impl(x, weight, eps: float):
+    value = x.astype(mx.float32)
+    return (
+        value * mx.rsqrt(mx.mean(value * value, axis=-1, keepdims=True) + eps) * weight
+    ).astype(x.dtype)
+
+
+def _hc_mixes_impl(x, weight, scale, base, hc, iterations, eps, norm_eps):
+    flat = x.reshape(*x.shape[:-2], -1).astype(mx.float32)
+    mixed = (flat @ weight.T) * mx.rsqrt(
+        mx.mean(flat * flat, axis=-1, keepdims=True) + norm_eps
+    )
+    pre = mx.sigmoid(mixed[..., :hc] * scale[0] + base[:hc]) + eps
+    post = 2 * mx.sigmoid(mixed[..., hc : 2 * hc] * scale[1] + base[hc : 2 * hc])
+    combine = (mixed[..., 2 * hc :] * scale[2] + base[2 * hc :]).reshape(
+        *flat.shape[:-1], hc, hc
+    )
+    combine = mx.softmax(combine, axis=-1) + eps
+    combine = combine / (mx.sum(combine, axis=-2, keepdims=True) + eps)
+    for _ in range(iterations - 1):
+        combine = combine / (mx.sum(combine, axis=-1, keepdims=True) + eps)
+        combine = combine / (mx.sum(combine, axis=-2, keepdims=True) + eps)
+    return pre, post, combine
+
+
+_compiled_rms = mx.compile(_rms_impl)
+_compiled_hc_mixes = mx.compile(_hc_mixes_impl)
+
+
+def _hc_pre(x, pre):
+    return mx.sum(x.astype(mx.float32) * pre[..., None], axis=-2).astype(x.dtype)
+
+
+def _hc_post(x, residual, post, combine):
+    carried = mx.einsum("...ij,...id->...jd", combine, residual.astype(mx.float32))
+    return (post[..., None] * x[..., None, :] + carried).astype(x.dtype)
+
+
+def _rotary(x, position, dim: int, base: float, inverse: bool = False):
+    frequency = 1 / (base ** (mx.arange(0, dim, 2, dtype=mx.float32) / dim))
+    angle = frequency * position * (-1 if inverse else 1)
+    tail = x[..., -dim:].astype(mx.float32).reshape(*x.shape[:-1], dim // 2, 2)
+    real, imag = tail[..., 0], tail[..., 1]
+    rotated = mx.stack(
+        (
+            real * mx.cos(angle) - imag * mx.sin(angle),
+            real * mx.sin(angle) + imag * mx.cos(angle),
+        ),
+        axis=-1,
+    )
+    return mx.concatenate(
+        (x[..., :-dim], rotated.reshape(*x.shape[:-1], dim).astype(x.dtype)), axis=-1
+    )
+
+
+def quantize_cache(x, bits: int, group: int, scale_format: str = "e8m0"):
+    if (bits, group, scale_format) != (8, 32, "e8m0"):
+        raise ValueError("DSpark supports only FP8/e8m0 cache blocks of 32")
+    return fake_quant_fp8_ue8m0(x, block=group)
+
+
+def draft_attention(query, key_value, sink):
+    scores = (
+        mx.einsum("thd,kd->thk", query.astype(mx.float32), key_value.astype(mx.float32))
+        * query.shape[-1] ** -0.5
+    )
+    sinks = mx.broadcast_to(sink[None, :, None], (*scores.shape[:-1], 1))
+    probabilities = mx.softmax(mx.concatenate((scores, sinks), axis=-1), axis=-1)
+    return mx.einsum(
+        "thk,kd->thd", probabilities[..., :-1], key_value.astype(mx.float32)
+    ).astype(query.dtype)
+
+
+class _DraftAdapter:
+    def __init__(self, weights: DSparkWeights, config: dict):
+        self.w, self.c = weights, config
+
+    def norm(self, name, x):
+        return _compiled_rms(x, self.w.read(name + ".weight"), self.c["rms_norm_eps"])
+
+    def rotate(self, x, position, ratio, inverse=False):
+        if ratio:
+            raise ValueError("DSpark draft attention does not use compressed RoPE")
+        return _rotary(
+            x, position, self.c["qk_rope_head_dim"], self.c["rope_theta"], inverse
+        )
+
+    def mixes(self, base, kind, x):
+        return _compiled_hc_mixes(
+            x,
+            self.w.read(f"{base}.hc_{kind}_fn"),
+            self.w.read(f"{base}.hc_{kind}_scale"),
+            self.w.read(f"{base}.hc_{kind}_base"),
+            self.c["hc_mult"],
+            self.c["hc_sinkhorn_iters"],
+            self.c["hc_eps"],
+            self.c["rms_norm_eps"],
+        )
+
+    def expert(self, base, x, routing=None):
+        gate = self.w.linear(base + ".w1", x).astype(mx.float32)
+        up = self.w.linear(base + ".w3", x).astype(mx.float32)
+        limit = self.c["swiglu_limit"]
+        if limit > 0:
+            gate, up = mx.minimum(gate, limit), mx.clip(up, -limit, limit)
+        hidden = gate * mx.sigmoid(gate) * up
+        if routing is not None:
+            hidden = hidden * routing
+        return self.w.linear(base + ".w2", hidden.astype(x.dtype))
+
+    def moe(self, base, x):
+        logits = (
+            x.astype(mx.float32)
+            @ self.w.read(base + ".gate.weight").astype(mx.float32).T
+        )
+        scores = mx.sqrt(mx.logaddexp(logits, mx.zeros_like(logits)))
+        topk = self.c["dspark_num_experts_per_tok"]
+        picks = mx.argsort(scores + self.w.read(base + ".gate.bias"), axis=-1)[
+            ..., -topk:
+        ]
+        selected = mx.take_along_axis(scores, picks, axis=-1)
+        if self.c["norm_topk_prob"] and topk > 1:
+            selected = selected / (mx.sum(selected, axis=-1, keepdims=True) + 1e-20)
+        selected = selected * self.c["routed_scaling_factor"]
+        mx.eval(picks, selected)
+        result = mx.zeros_like(x).astype(mx.float32)
+        for index, weight in zip(picks.tolist()[0], selected.tolist()[0]):
+            result = result + self.expert(f"{base}.experts.{index}", x, weight).astype(
+                mx.float32
+            )
+        return (
+            result + self.expert(base + ".shared_experts", x).astype(mx.float32)
+        ).astype(x.dtype)
+
+
+class DSpark:
+    """Greedy draft state driven only by contiguous verified target states."""
+
+    def __init__(self, target, pin_weights: bool = True):
+        self.w, self.c = target.w, target.c
+        self.layers = sorted(
+            {int(key.split(".")[1]) for key in self.w.entries if key.startswith("mtp.")}
+        )
+        if not self.layers or self.layers != list(range(len(self.layers))):
+            raise ValueError("missing contiguous DSpark MTP stages")
+        self.block_size = self.c["dspark_block_size"]
+        self.adapter = _DraftAdapter(self.w, self.c)
+        self.position = -1
+        self.windows = {layer: [] for layer in self.layers}
+        if pin_weights:
+            self.w.pin_mtp()
+
+    def observe(self, main_hidden, position: int):
+        if position != self.position + 1:
+            raise ValueError("DSpark observations must be contiguous target positions")
+        main = self.adapter.norm(
+            "mtp.0.main_norm", self.w.linear("mtp.0.main_proj", main_hidden)
+        )
+        values = []
+        for layer in self.layers:
+            base = f"mtp.{layer}.attn"
+            key_value = self.adapter.norm(
+                base + ".kv_norm", self.w.linear(base + ".wkv", main)
+            )
+            key_value = quantize_cache(
+                self.adapter.rotate(key_value, position, 0), 8, 32
+            )
+            self.windows[layer] = (self.windows[layer] + [key_value])[
+                -self.c["sliding_window"] :
+            ]
+            values.append(key_value)
+        mx.eval(*values)
+        self.position = position
+
+    def attention(self, base, x, stage: int):
+        count = x.shape[0]
+        query = self.adapter.norm(base + ".q_norm", self.w.linear(base + ".wq_a", x))
+        query = self.w.linear(base + ".wq_b", query).reshape(
+            count, self.c["num_attention_heads"], self.c["head_dim"]
+        )
+        key_value = self.adapter.norm(
+            base + ".kv_norm", self.w.linear(base + ".wkv", x)
+        )
+        query = mx.stack(
+            [
+                self.adapter.rotate(query[i], self.position + 1 + i, 0)
+                for i in range(count)
+            ]
+        )
+        key_value = mx.concatenate(
+            [
+                quantize_cache(
+                    self.adapter.rotate(key_value[i : i + 1], self.position + 1 + i, 0),
+                    8,
+                    32,
+                )
+                for i in range(count)
+            ]
+        )
+        keys = mx.concatenate([*self.windows[stage], key_value])
+        output = draft_attention(query, keys, self.w.read(base + ".attn_sink"))
+        output = mx.stack(
+            [
+                self.adapter.rotate(output[i], self.position + 1 + i, 0, inverse=True)
+                for i in range(count)
+            ]
+        )
+        projected = mx.concatenate(
+            [
+                self.w.grouped(
+                    base + ".wo_a",
+                    output[i].reshape(self.c["o_groups"], -1),
+                    self.c["o_groups"],
+                )
+                for i in range(count)
+            ]
+        )
+        return self.w.linear(base + ".wo_b", projected)
+
+    def propose(self, next_token: int):
+        if self.position < 1:
+            raise ValueError("seed at least two verified positions before drafting")
+        ids = [next_token] + [self.c["dspark_noise_token_id"]] * (self.block_size - 1)
+        hidden = mx.repeat(
+            self.w.embedding("embed", ids)[:, None, :], self.c["hc_mult"], axis=1
+        )
+        pre = mx.broadcast_to(
+            mx.array([[1.0] + [0.0] * (self.c["hc_mult"] - 1)]),
+            (self.block_size, self.c["hc_mult"]),
+        )
+        for stage in self.layers:
+            base = f"mtp.{stage}"
+            attn_pre, post, combine = self.adapter.mixes(base, "attn", hidden)
+            attention = self.attention(
+                base + ".attn",
+                self.adapter.norm(base + ".attn_norm", _hc_pre(hidden, pre)),
+                stage,
+            )
+            hidden = _hc_post(attention, hidden, post, combine)
+            pre, post, combine = self.adapter.mixes(base, "ffn", hidden)
+            x = self.adapter.norm(base + ".ffn_norm", _hc_pre(hidden, attn_pre))
+            ffn = mx.concatenate(
+                [
+                    self.adapter.moe(base + ".ffn", x[i : i + 1])
+                    for i in range(self.block_size)
+                ]
+            )
+            hidden = _hc_post(ffn, hidden, post, combine)
+            mx.eval(hidden, pre)
+        base = f"mtp.{self.layers[-1]}"
+        collapsed = _hc_pre(hidden, pre)
+        logits = self.w.linear(
+            "head", self.adapter.norm(base + ".norm", collapsed).astype(mx.float32)
+        )
+        output, biased_logits, markov_embeddings = [next_token], [], []
+        for index in range(self.block_size):
+            markov = self.w.embedding(base + ".markov_head.embed", [output[-1]])
+            biased = logits[index : index + 1] + self.w.linear(
+                base + ".markov_head.head", markov.astype(mx.float32)
+            )
+            output.append(int(mx.argmax(biased)))
+            biased_logits.append(biased)
+            markov_embeddings.append(markov)
+        logits = mx.concatenate(biased_logits)
+        confidence = self.w.linear(
+            base + ".confidence_head.proj",
+            mx.concatenate(
+                (collapsed, mx.concatenate(markov_embeddings)), axis=-1
+            ).astype(mx.float32),
+        )
+        mx.eval(logits, confidence)
+        if not bool(mx.all(mx.isfinite(logits))) or not bool(
+            mx.all(mx.isfinite(confidence))
+        ):
+            raise FloatingPointError("non-finite DSpark output")
+        return output, confidence
+
+
+def verify_greedy(proposals, logits, advance, observe, eos, remaining):
+    """Serial oracle: rejected proposals never advance target state."""
+    output, stats = [], {"accepted_draft_tokens": 0, "rejected_blocks": 0}
+    for index, proposal in enumerate(proposals):
+        if len(output) >= remaining:
+            break
+        expected = int(mx.argmax(logits))
+        matched = proposal == expected
+        output.append(expected)
+        if matched and index > 0:
+            stats["accepted_draft_tokens"] += 1
+        if not matched:
+            stats["rejected_blocks"] += 1
+        if expected == eos or len(output) == remaining:
+            break
+        logits, hidden = advance(expected)
+        observe(hidden)
+        if not matched:
+            break
+    return output, logits, stats

--- a/scripts/deepseek_v41_native/dspark.py
+++ b/scripts/deepseek_v41_native/dspark.py
@@ -97,7 +97,11 @@ def _validate_config(config: dict) -> None:
         raise ValueError("DSpark top-k exceeds routed expert count")
     if config["qk_rope_head_dim"] > config["head_dim"]:
         raise ValueError("DSpark RoPE width exceeds attention head width")
-    if config.get("model_type") not in ("deepseek_v4", "deepseek_v41"):
+    if config.get("model_type") not in (
+        "deepseek_v4",
+        "deepseek_v41",
+        "deepseek_v41_text",
+    ):
         raise ValueError("DSpark sidecar model_type is not DeepSeek V4.1")
     for key, expected in _RELEASE_ARCHITECTURE.items():
         if config[key] != expected:

--- a/tests/test_benchmark_deepseek_v41_dspark.py
+++ b/tests/test_benchmark_deepseek_v41_dspark.py
@@ -59,6 +59,28 @@ def test_benchmark_requires_explicit_checkpoint_runtime_trust(tmp_path) -> None:
     assert "--trust-checkpoint-runtime" in result.stderr
 
 
+def test_benchmark_defaults_to_product_owned_runtime(tmp_path, monkeypatch) -> None:
+    module = _load_script()
+    observed = {}
+    args = SimpleNamespace(
+        target_only=False,
+        overlay=tmp_path / "overlay",
+        checkpoint_runtime=None,
+        trust_checkpoint_runtime=False,
+    )
+    monkeypatch.setattr(module, "parse_args", lambda: args)
+    monkeypatch.setattr(module, "_validate_mode", lambda value: None)
+    monkeypatch.setattr(
+        module,
+        "_run_benchmark",
+        lambda value, weights, draft: observed.update(weights=weights, draft=draft),
+    )
+
+    module.main()
+
+    assert observed == {"weights": module.rapid_dspark, "draft": module.rapid_dspark}
+
+
 def test_greedy_prefix_stops_at_accepted_eos() -> None:
     module = _load_script()
     eos_id = 1

--- a/tests/test_deepseek_v41_dspark.py
+++ b/tests/test_deepseek_v41_dspark.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.core as mx
+
+from scripts.deepseek_v41_native.dspark import (
+    DSparkWeights,
+    Weights,
+    _safe_shard,
+    _validate_config,
+    verify_greedy,
+)
+
+
+def test_runtime_provider_exposes_weights_contract() -> None:
+    assert Weights is DSparkWeights
+
+
+def _config():
+    return {
+        "dspark_block_size": 5,
+        "dspark_n_routed_experts": 128,
+        "dspark_noise_token_id": 3,
+        "dspark_num_experts_per_tok": 3,
+        "dspark_target_layer_ids": [7, 8, 9],
+        "hc_eps": 1e-6,
+        "hc_mult": 4,
+        "hc_sinkhorn_iters": 20,
+        "head_dim": 512,
+        "hidden_size": 5120,
+        "model_type": "deepseek_v4",
+        "norm_topk_prob": True,
+        "num_attention_heads": 64,
+        "o_groups": 8,
+        "qk_rope_head_dim": 64,
+        "rms_norm_eps": 1e-20,
+        "rope_theta": 10000,
+        "routed_scaling_factor": 1.5,
+        "sliding_window": 8,
+        "swiglu_limit": 10.0,
+    }
+
+
+def test_config_rejects_invalid_expert_topk() -> None:
+    config = _config()
+    config["dspark_num_experts_per_tok"] = 129
+    with pytest.raises(ValueError, match="top-k"):
+        _validate_config(config)
+
+
+def test_safe_shard_rejects_traversal_and_symlink(tmp_path) -> None:
+    with pytest.raises(ValueError, match="basenames"):
+        _safe_shard(tmp_path, "../model.safetensors")
+    outside = tmp_path / "outside.safetensors"
+    outside.touch()
+    link = tmp_path / "model.safetensors"
+    link.symlink_to(outside)
+    with pytest.raises(ValueError, match="symlink"):
+        _safe_shard(tmp_path, link.name)
+
+
+def test_loader_rejects_non_string_index_shard(tmp_path) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(_config()))
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"mtp.0.weight": 7}})
+    )
+    with pytest.raises(ValueError, match="shard names must be strings"):
+        DSparkWeights(tmp_path)
+
+
+def test_loader_rejects_index_shard_mismatch(tmp_path, monkeypatch) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(_config()))
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"mtp.0.weight": "model.safetensors"}})
+    )
+    (tmp_path / "model.safetensors").touch()
+    monkeypatch.setattr(mx, "load", lambda path: {"mtp.0.other": mx.zeros((1,))})
+    with pytest.raises(ValueError, match="index/shard mismatch"):
+        DSparkWeights(tmp_path)
+
+
+def test_release_tensor_drops_both_backing_and_resident_references() -> None:
+    weights = DSparkWeights.__new__(DSparkWeights)
+    value = mx.zeros((8,), dtype=mx.float32)
+    weights._arrays = {"mtp.0.weight": value}
+    weights.entries = {"mtp.0.weight": {"shape": value.shape}}
+    weights.resident = {"mtp.0.weight": value}
+    weights.resident_bytes = value.nbytes
+
+    weights.release_tensor("mtp.0.weight")
+
+    assert weights._arrays == {}
+    assert weights.entries == {}
+    assert weights.resident == {}
+    assert weights.resident_bytes == 0
+
+
+def test_verify_greedy_never_observes_rejected_token() -> None:
+    observations = []
+    advances = []
+
+    def advance(token):
+        advances.append(token)
+        logits = mx.array([[0.0, 0.0, 1.0]])
+        return logits, mx.array([token])
+
+    output, _, stats = verify_greedy(
+        [1, 9],
+        mx.array([[0.0, 1.0, 0.0]]),
+        advance,
+        observations.append,
+        eos=99,
+        remaining=3,
+    )
+
+    assert output == [1, 2]
+    assert advances == [1, 2]
+    assert 9 not in advances
+    assert len(observations) == 2
+    assert stats == {"accepted_draft_tokens": 0, "rejected_blocks": 1}

--- a/tests/test_deepseek_v41_dspark.py
+++ b/tests/test_deepseek_v41_dspark.py
@@ -54,6 +54,15 @@ def test_config_rejects_invalid_expert_topk() -> None:
         _validate_config(config)
 
 
+@pytest.mark.parametrize(
+    "model_type", ["deepseek_v4", "deepseek_v41", "deepseek_v41_text"]
+)
+def test_config_accepts_release_model_type_aliases(model_type) -> None:
+    config = _config()
+    config["model_type"] = model_type
+    _validate_config(config)
+
+
 def test_safe_shard_rejects_traversal_and_symlink(tmp_path) -> None:
     with pytest.raises(ValueError, match="basenames"):
         _safe_shard(tmp_path, "../model.safetensors")


### PR DESCRIPTION
## Intent

Run DeepSeek V4.1 Flash MTP drafting through reviewed Rapid-MLX code by default, instead of executing Python shipped inside a model checkpoint.

## Scope

- add a data-only three-stage DSpark runtime and strict sidecar loader
- validate model/index/shard/tensor/config contracts and memory headroom
- share the target embedding and head without reloading linked target shards
- retain checkpoint runtime loading only as an explicit trusted A/B oracle
- release unpacked expert tensors after the packed replacement is evaluated

## Non-goals

- server, catalog, GUI, or download integration
- sampling support
- changing K4/K5 verification policy
- solving the known 128-token target batch-numerics divergence

## Acceptance and evidence

- actual-sidecar oracle parity: 6/6 observed KV windows equal, proposal tokens equal, 5/5 confidence logits equal, max absolute difference 0
- full 32-token K4 dogfood: 13.42 tok/s vs 7.82 AR (+71.7%), greedy output identical
- peak MLX memory: 218.00 GB after releasing 3,456 replaced expert tensors (down from the initial faulty 222.27 GB run)
- K5 reaches 14.61 tok/s but remains excluded because output diverges
- 59 focused native/DSpark tests pass; Ruff and diff checks pass

## Compatibility

The benchmark defaults to the owned runtime when no checkpoint runtime is supplied. Existing explicit trusted-oracle behavior remains available for controlled comparison. This is stacked on #3311.