### PR TITLE
fix(mac): fail closed on malformed document cursors

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,6 +17,10 @@ can actually understand.
 
 ## [Unreleased]
 
+### Fixed
+- Document follow-ups now reject malformed retrieval cursors instead of
+  silently reading from the beginning and returning a plausible wrong page.
+
 ## [0.14.1] — 2026-09-10
 
 Rapid-MLX 0.14.1 is a focused reliability update for document analysis,

--- a/apps/rapid-mac/Sources/Rapid/Chat/ToolKit.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ToolKit.swift
@@ -219,8 +219,9 @@ protocol ToolRegistry: AnyObject, Sendable {
 ///
 /// The model chooses a tool from the definitions advertised on this round.
 /// This executor then applies the same policy to every built-in and connector:
-/// refuse tools that were not advertised, require an arguments object, remove
-/// top-level fields outside the tool's JSON schema, and only then dispatch.
+/// refuse tools that were not advertised, require an arguments object, enforce
+/// strict schemas (or remove unknown top-level fields for permissive schemas),
+/// and only then dispatch.
 /// Tool-specific intent parsing does not belong here or in the view model.
 @MainActor
 struct NativeToolCallExecutor {
@@ -285,6 +286,10 @@ struct NativeToolCallExecutor {
         if case .object(let schema) = definition.function.parameters,
            case .object(let properties)? = schema["properties"]
         {
+            if schema["additionalProperties"] == .bool(false),
+               object.keys.contains(where: { !properties.keys.contains($0) }) {
+                return nil
+            }
             object = object.filter { properties.keys.contains($0.key) }
         }
         guard JSONSerialization.isValidJSONObject(object),

--- a/apps/rapid-mac/Sources/Rapid/Tools/ReadDocumentTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/ReadDocumentTool.swift
@@ -17,6 +17,7 @@ enum ReadDocumentTool {
         description: "Read a document the user attached to this conversation. Attachments show only a short preview inline; use this to see the rest. THREE modes: (1) mode='outline' returns the document's table of contents — section titles with their page and character offset. Start here for any question about the document AS A WHOLE, such as summarizing it or asking what it covers, then read the sections that matter. (2) 'grep' with a regular expression jumps straight to matching passages — use when you already know the term you want. (3) 'offset' reads sequentially from a character position; the result carries 'next_offset' and 'has_more' to continue. Sequential reading is the slowest way to cover a long document, so prefer outline or grep first.",
         parameters: .object([
             "type": .string("object"),
+            "additionalProperties": .bool(false),
             "properties": .object([
                 "document_id": .object([
                     "type": .string("string"),
@@ -54,8 +55,16 @@ enum ReadDocumentTool {
     ) async -> ToolCallResult {
         let tool = "read_document"
         guard let data = arguments.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let args = try? JSONDecoder().decode(Args.self, from: data) else {
             return err(tool, "could not parse arguments JSON")
+        }
+        let allowedKeys: Set<String> = ["document_id", "mode", "offset", "grep"]
+        let unknownKeys = object.keys.filter { !allowedKeys.contains($0) }.sorted()
+        guard unknownKeys.isEmpty else {
+            let names = unknownKeys.prefix(5).map { String($0.prefix(80)) }.joined(separator: ", ")
+            let suffix = unknownKeys.count > 5 ? ", …" : ""
+            return err(tool, "unknown argument(s): \(names)\(suffix) — use only document_id, mode, offset, or grep; use offset (not offset_len) to read from an outline position")
         }
 
         let rawID = args.document_id.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
@@ -84,6 +84,19 @@ final class BuiltinToolsTests {
         #expect(object["invented"] == nil)
     }
 
+    @Test("Native executor rejects unknown arguments for strict tool schemas")
+    func nativeExecutorEnforcesStrictSchema() {
+        let call = ToolCall(
+            id: "document_1",
+            name: "read_document",
+            arguments: #"{"document_id":"00000000-0000-0000-0000-000000000000","offset_len":117524}"#
+        )
+        #expect(NativeToolCallExecutor.normalized(
+            call,
+            for: ReadDocumentTool.definition
+        ) == nil)
+    }
+
     @Test("Native executor rejects non-object or malformed arguments generically")
     func nativeExecutorRejectsMalformedArguments() {
         #expect(NativeToolCallExecutor.normalized(

--- a/apps/rapid-mac/Tests/RapidTests/ReadDocumentToolTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadDocumentToolTests.swift
@@ -77,6 +77,21 @@ struct ReadDocumentToolTests {
         #expect(result.content.contains("not a valid document id"))
     }
 
+    @Test("Unknown arguments fail closed instead of silently reading offset zero")
+    func unknownArgumentIsRejected() async throws {
+        let cache = freshCache()
+        let id = store("page one must not leak through a malformed cursor", in: cache)
+
+        let result = await run(
+            ["document_id": id.uuidString, "offset_len": 117_524], cache: cache
+        )
+        #expect(result.isError)
+        #expect(result.content.contains("unknown argument"))
+        #expect(result.content.contains("offset_len"))
+        #expect(result.content.contains("use offset"))
+        #expect(!result.content.contains("page one"))
+    }
+
     // MARK: - Sequential paging
 
     @Test("A short document is returned whole with no continuation cursor")


### PR DESCRIPTION
## Why

0.14.1 document dogfood found a correctness failure in the native tool boundary. Qwen3.5-4B correctly requested the 300-page PDF outline, then emitted `offset_len: 117524` instead of `offset`. Desktop silently removed the unknown key, defaulted to offset 0, and returned a plausible but wrong answer (`RMX723` instead of page 221 `RMX921`). A pure-scan request also produced no parseable call for 180 seconds before timeout.

## Scope

- Close the `read_document` schema with `additionalProperties: false`.
- Reject unknown fields at the native executor for strict schemas; retain filtering for permissive tools.
- Apply the same fail-closed validation inside `ReadDocumentTool.run`.
- Add regressions and Unreleased changelog copy.

## Non-goals

- No document extraction, OCR, cache, prompt-budget, or model changes.
- No behavior change for permissive tool schemas.
- No attempt to refactor the repository-wide Swift Testing concurrency/time-budget flakes observed during the broad stress run.

## Acceptance

- A malformed document cursor cannot silently become offset 0 or expose first-page content.
- The model is constrained to the documented `document_id`, `mode`, `offset`, and `grep` keys.
- Valid outline-to-offset retrieval, scanned PDFs, mixed PDFs, and cached follow-ups still work end to end.
- Permissive tools retain their existing normalization behavior.

## Verification

Host: Apple M3 Ultra, 256 GB; macOS 26.5.2; cached `mlx-community/Qwen3.5-4B-MLX-4bit`; no model downloads. The official 0.14.1 DMG SHA-256 was verified and the app passed codesign/Gatekeeper checks. The fix was tested in a release-config main-HEAD candidate with the same sidecar, model, prompts, and generated fixtures.

| Fixture / prompt | 0.14.1 | Patched main HEAD |
| --- | --- | --- |
| 300-page selectable Chinese PDF; outline then chapter 23 | Wrong `offset_len`; silently read offset 0; answered `RMX723` | `outline` then `offset: 117524`; page 221; correct `RMX921`; 23 s wall, 41 tok/s, 14.5 s TTFT |
| 6-page image-only Chinese scan; page 6 | No output; failed at 180 s inactivity timeout | Correct `RMX706`; 6 s observed wall, 55 tok/s, 2.4 s TTFT |
| 10-page mixed selectable/scan PDF; pages 5 and 6 | Extraction independently confirmed complete | Correct `RMX705` + `RMX706`; 4 s observed wall, 58 tok/s, 4.6 s TTFT |
| Same conversation; follow up for page 10 without reattaching | — | Correct `RMX710`; 49 tok/s, 4.3 s TTFT |

The 300-page cache contained 160,403 normalized characters, all 300 pages, and 30 bookmark rows. Chapter 23 resolved to page 221 / offset 117,524. The persisted candidate transcript confirms `mode: outline` followed by `offset: 117524`.

- Release-config local app build (`candidate-8229eb35`): pass
- Real GUI selectable/scanned/mixed/follow-up paths: pass
- `bash apps/rapid-mac/scripts/smoke.sh`: pass
- Strict regressions plus permissive compatibility: 3/3 pass
- Initial focused `ReadDocumentToolTests` + `BuiltinToolsTests`: 65/65 pass
- Tool-loop budget and dispatch integration: pass
- `git diff --check`: pass

A broad local `swift test` stress run starts hundreds of Swift Testing cases concurrently and hit pre-existing shared-regex/WebKit/subprocess wall-clock flakes. In particular, normal grep tests time out behind the same suite own catastrophic-regex test; the changed regressions pass in isolation and in the initial focused run, and no failing stack crosses this diff.

## Validator baseline note

The Python 3.12 full-unit gate completed 23,740 passing tests and 9 failures. The exact same 9 failures reproduce from a fresh detached worktree at this PR’s base commit (`8229eb359`): seven existing Bonsai/mflux `TilingConfig` compatibility failures and two existing Doctor expectation failures. None imports or traverses this Swift-only diff. The final scoped validation therefore waives only `full_unit`; all Desktop checks, focused regressions, build, smoke, and real-model GUI dogfood remain required and pass.

## Behaviour delta

Malformed `read_document` arguments: silently remove unknown cursor and read from offset 0 → reject/constrain the malformed call so it cannot masquerade as a successful document read.

## AI assistance disclosure

Codex wrote and self-reviewed the Swift implementation, regressions, changelog entry, and this PR description. It was verified with focused automated tests, a release-config build, exact official-versus-patched real-model GUI dogfood, persisted tool-call inspection, and scoped adversarial review. No reviewer sub-agent or Spark2 review was used.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I have identified them above and can describe how I verified them.

## Checklist

- [x] Desktop tests pass for the changed paths; broad-suite pre-existing timing flakes are disclosed above
- [x] Python lint is not applicable to this Swift-only diff
- [x] Self-validated with `python3.12 -m scripts.pr_validate.pr_validate 3314`
- [x] Regression tests were spot-checked against the pre-fix behavior
- [x] Updated changelog
- [x] No breaking public API changes

## Author

X handle (optional, external contributors):