### PR TITLE
fix(serve): honor explicit multimodal lane

### DIFF
--- a/tests/test_mtp_default_off_3115.py
+++ b/tests/test_mtp_default_off_3115.py
@@ -103,6 +103,32 @@ def test_serve_9b_without_flags_still_auto_selects_mtp() -> None:
     assert args.mtp_continuous_batching is True
 
 
+def test_explicit_mllm_suppresses_only_alias_auto_mtp_default() -> None:
+    args = _args("qwen3.5-9b-4bit", mllm=True)
+
+    cli._normalize_speculative_config_or_exit(args)
+
+    assert args._speculative_config is None
+    assert args.spec_decode == "none"
+    assert args.enable_mtp is False
+
+
+def test_explicit_mllm_rejects_explicit_speculative_config(capsys) -> None:
+    args = _args(
+        "qwen3.5-9b-4bit",
+        json.dumps({"method": "mtp"}),
+        mllm=True,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli._normalize_speculative_config_or_exit(args)
+
+    assert exc_info.value.code == 2
+    error = capsys.readouterr().err
+    assert "--mllm is mutually exclusive" in error
+    assert "vision lane cannot honour speculative decoding" in error
+
+
 def test_explicit_opt_in_runs_qualified_continuous_route() -> None:
     args = _args("qwen3.5-4b-4bit", json.dumps({"method": "mtp"}))
     cli._normalize_speculative_config_or_exit(args)

--- a/tests/test_no_mllm_flag.py
+++ b/tests/test_no_mllm_flag.py
@@ -2471,6 +2471,19 @@ def test_spec_decode_overrides_mutually_exclusive_in_load_model(monkeypatch):
         )
 
 
+def test_force_mllm_rejects_direct_speculative_scheduler_config():
+    """Programmatic callers get a clear conflict before model resolution."""
+    from vllm_mlx.scheduler import SchedulerConfig
+    from vllm_mlx.server import load_model
+
+    with pytest.raises(ValueError, match="vision lane cannot honour"):
+        load_model(
+            "fake/model",
+            scheduler_config=SchedulerConfig(spec_decode="mtp"),
+            force_mllm=True,
+        )
+
+
 def test_server_main_no_mllm_skips_routing_config_fail_fast(monkeypatch):
     """BLOCKING (#1178 codex r5): standalone ``python -m vllm_mlx.server`` must
     NOT run the config-materialization fail-fast when the user passes an

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -2522,6 +2522,12 @@ def _normalize_speculative_config_or_exit(args):
             args.speculative_config = raw_config
         elif (
             not getattr(args, "no_spec_decode", False)
+            # An explicit modality request outranks an alias-owned performance
+            # default.  The MLLM lane cannot honour speculative decoding, so
+            # injecting MTP here would silently undo ``--mllm`` later in the
+            # shared lane resolver.  Explicit speculative requests are
+            # rejected below instead of being dropped.
+            and not getattr(args, "mllm", False)
             and _alias_continuous_mtp_tier(getattr(args, "model", None)) == "verified"
             and _alias_mtp_default_enabled(getattr(args, "model", None))
         ):
@@ -2547,6 +2553,16 @@ def _normalize_speculative_config_or_exit(args):
                 require_migrated_speculative_config(config)
         except SpeculativeConfigError as exc:
             print(f"error: {exc}", file=sys.stderr)
+            sys.exit(2)
+        if config is not None and getattr(args, "mllm", False):
+            print(
+                "error: --mllm is mutually exclusive with an explicit "
+                "speculative-decoding request because the vision lane cannot "
+                "honour speculative decoding. Remove the speculative option "
+                "to serve images, or remove --mllm to use the accelerated "
+                "text lane.",
+                file=sys.stderr,
+            )
             sys.exit(2)
         if getattr(args, "no_spec_decode", False):
             print(
@@ -3557,6 +3573,12 @@ def serve_command(args):
 
         require_mlx_embeddings_or_exit()
 
+    # Resolve speculative intent before selecting the final serving lane.
+    # This lets an explicit --mllm suppress an alias-owned MTP default while
+    # rejecting an explicit MLLM/speculative conflict before optional-runtime
+    # checks or model downloads can obscure the actionable error.
+    _normalize_speculative_config_or_exit(args)
+
     # R-10 (PyPI 0.8.6 dogfood): same boot-guard shape for vision /
     # multimodal aliases. ``mlx-vlm`` lives behind the ``[vision]``
     # extra, but ``rapid-mlx serve ui-tars-1.5-7b-4bit`` on a fresh
@@ -3610,8 +3632,6 @@ def serve_command(args):
 
     if is_audio_model_alias(getattr(args, "model", None)):
         require_audio_or_exit(args.model)
-
-    _normalize_speculative_config_or_exit(args)
 
     # DDTree has an external experimental runtime and its validated target
     # can be multi-GB. Fail the cheap config/alias/runtime gates before the
@@ -12127,7 +12147,7 @@ Examples:
     serve_parser.add_argument(
         "--mllm",
         action="store_true",
-        help="Force load model as multimodal (vision) even if name doesn't match auto-detection patterns. Also DISABLES the automatic text-only fallback: normally a vision-config checkpoint that ships no usable vision tower auto-degrades to text-only serving (#1187); with --mllm it hard-fails instead so a deliberate demand for the vision lane is never silently downgraded.",
+        help="Force load model as multimodal (vision) even if name doesn't match auto-detection patterns. Also DISABLES automatic text-only fallbacks and alias-owned speculative-decoding defaults; an explicitly requested speculative decoder conflicts and is rejected. A vision-config checkpoint with no usable vision tower hard-fails instead of silently downgrading (#1187).",
     )
     serve_parser.add_argument(
         "--no-mllm",

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2178,6 +2178,17 @@ def load_model(
                 1, int(getattr(scheduler_config, "mtp_num_draft_tokens", 1))
             )
 
+    requested_spec_decode = (
+        getattr(scheduler_config, "spec_decode", "none")
+        if scheduler_config is not None
+        else "none"
+    )
+    if force_mllm and requested_spec_decode not in (None, "none"):
+        raise ValueError(
+            "force_mllm is mutually exclusive with speculative decoding "
+            "because the vision lane cannot honour the requested decoder"
+        )
+
     if prefill_step_size is not None:
         import warnings
 
@@ -2353,11 +2364,7 @@ def load_model(
             effective_model_alias or model_name,
             force_mllm=force_mllm,
             force_text=force_text,
-            requested_spec_decode=(
-                getattr(scheduler_config, "spec_decode", "none")
-                if scheduler_config is not None
-                else "none"
-            ),
+            requested_spec_decode=requested_spec_decode,
         )
         _engine_model_path = _serving_checkpoint.load_path
         _auto_text_fallback = _serving_checkpoint.auto_text_fallback
@@ -3318,7 +3325,7 @@ Examples:
     parser.add_argument(
         "--mllm",
         action="store_true",
-        help="Force loading as MLLM (multimodal language model). Also disables the automatic text-only fallback: a vision-config checkpoint with no usable vision tower normally auto-degrades to text-only serving (#1187), but with --mllm it hard-fails instead.",
+        help="Force loading as MLLM (multimodal language model). Also disables automatic text-only fallbacks and alias-owned speculative-decoding defaults; an explicitly requested speculative decoder conflicts and is rejected. A vision-config checkpoint with no usable vision tower hard-fails instead (#1187).",
     )
     parser.add_argument(
         "--no-mllm",


### PR DESCRIPTION
## Why

An explicit `--mllm` currently loses to a verified alias's automatic MTP preset. Startup claims the override was enabled but silently boots the text-only lane, so the user's first image request fails with HTTP 400. The documented recovery action therefore does not work by itself.

## What

- make an explicit `--mllm` suppress only an alias-injected speculative-decoding default
- reject an explicitly requested speculative decoder combined with `--mllm`, before loading a model
- enforce the same conflict for direct `load_model(...)` callers
- align both CLI entry points' help copy with the runtime contract
- preserve the bare-alias MTP text default

## Non-goals

- enabling speculative decoding inside the serialized vision lane
- changing scheduler, cache, model-profile, or Desktop policy
- changing the default behavior of a bare model alias

## Design precedent

Production inference servers treat incompatible startup capabilities as configuration validation: explicit operator intent is either honored or rejected before model allocation. This change applies that established pattern while keeping performance presets subordinate to an explicit modality choice.

## Verification

- focused routing/speculative/CLI contract selection: 117 passed
- broader routing selection: 71 passed; 3 unrelated pre-existing failures from the Studio's stale optional vision runtime (0.6.16 installed vs 0.6.17 required)
- Ruff check and format: passed
- `git diff --check`: passed
- M4 Pro 48 GB, real Qwen 3.5 9B 4-bit:
  - before: `--mllm` still booted `mllm=False`; image requests returned 400
  - control: `--mllm --no-spec-decode` passed
  - fixed: `--mllm` alone booted the vision lane and passed Chat, SSE, Responses, Anthropic Messages, forced tool call, 8-way text concurrency, cancellation recovery, and 12 real image requests at concurrency 4
  - server exited cleanly with no lingering listener

Fixes #3317
