### PR TITLE
fix(doctor): trust wheel site-packages

### DIFF
--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -1772,6 +1772,31 @@ def test_trusted_sys_path_roots_exclude_dynamic_paths(
     assert source_root not in trusted_roots
 
 
+def test_trusted_sys_path_roots_keep_wheel_site_packages(
+    tmp_path,
+    monkeypatch,
+):
+    site_root = tmp_path / "venv" / "lib" / "python3.12" / "site-packages"
+    module_file = site_root / "vllm_mlx" / "doctor" / "env_health.py"
+    module_file.parent.mkdir(parents=True)
+    module_file.write_text("# installed wheel layout\n")
+    probe_module = site_root / "wheel_dependency_probe.py"
+    probe_module.write_text("installed = True\n")
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    monkeypatch.setattr(eh, "__file__", str(module_file))
+    monkeypatch.setattr(eh.sys, "path", [str(site_root)])
+    monkeypatch.chdir(workdir)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+
+    trusted_roots = eh._trusted_sys_path_roots()
+
+    assert trusted_roots == {site_root.resolve()}
+    monkeypatch.setattr(eh, "_TRUSTED_SYS_PATH_ROOTS", tuple(trusted_roots))
+    assert eh._module_origin_is_trusted("wheel_dependency_probe")
+
+
 def test_local_pillow_probe_rejects_source_tree_shadow_module(
     tmp_path,
     monkeypatch,

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -455,7 +455,20 @@ def _trusted_sys_path_roots() -> set[Path]:
         if entry:
             unsafe_roots.add(Path(entry).expanduser().resolve())
     unsafe_roots.add(Path.cwd().resolve())
-    unsafe_roots.add(Path(__file__).resolve().parents[2])
+
+    # A source checkout is intentionally untrusted: importing dependencies
+    # from beside the checkout would let a shadow module make ``doctor``
+    # report a healthy runtime.  In an installed wheel, however,
+    # ``parents[2]`` is the virtualenv's *site-packages* directory itself.
+    # Treat that directory as a source root only when it has the repository
+    # shape, otherwise every legitimate wheel dependency is rejected before
+    # the isolated import probe can verify it (#3320).
+    package_root = Path(__file__).resolve().parents[1]
+    source_root = package_root.parent
+    if (source_root / "pyproject.toml").is_file() and (
+        source_root / "vllm_mlx"
+    ).resolve() == package_root:
+        unsafe_roots.add(source_root)
 
     trusted_roots: set[Path] = set()
     for entry in sys.path:


### PR DESCRIPTION
## Why

`rapid-mlx doctor` must distinguish a broken install from a healthy wheel environment. In a clean M4 Pro virtualenv, the current trust classifier mistakes the wheel's own `site-packages` directory for a source checkout. It therefore reports every required dependency as broken even though the exact isolated imports succeed, prompting users toward unnecessary reinstalls.

Fixes #3320

## What changed

- Classify the package parent as an unsafe source root only when it has an actual repository shape (`pyproject.toml` plus the resolved `vllm_mlx` package).
- Keep ordinary wheel/virtualenv `site-packages` in the trusted runtime roots.
- Add regression coverage for wheel layout while retaining the existing source-shadow rejection coverage.

## Design precedent

The fix follows the interpreter's established isolation boundary: dynamic working-directory and `PYTHONPATH` entries remain untrusted, while the active environment's installed package root is authoritative and the actual import is still verified in a separate isolated subprocess. This preserves fail-closed shadow-module protection without treating a standard wheel layout as hostile.

## Scope

Allowed: doctor import-origin classification and focused regression tests.

Non-goals: changing doctor time budgets, optional-package support policy, shell PATH guidance, package version bounds, or model/runtime behavior.

## Verification

- `226 passed` in `tests/test_doctor_env_health.py` in a worktree-local environment built from `.[test]`.
- Ruff check/format and `git diff --check` pass.
- Built a wheel and installed it into a new virtualenv on an M4 Pro 48 GB host.
- Cold doctor run no longer reports false broken-package failures; it safely degrades slow cold imports to warnings.
- Warm doctor run: exit 0, all six required package rows OK, about 5.1 seconds.
- Exact isolated imports for `mlx`, `mlx_lm`, `transformers`, `fastapi`, `uvicorn`, and `PIL.Image` all pass.

## Risk

Low and bounded to diagnostics. Runtime serving behavior is unchanged. A real source checkout, current working directory, and `PYTHONPATH` remain excluded from trusted origins.
