### PR TITLE
fix(mac): repair the document-analysis friction found dogfooding 0.14.1

### DIFF
--- a/apps/rapid-mac/CHANGELOG.md
+++ b/apps/rapid-mac/CHANGELOG.md
@@ -17,9 +17,32 @@ can actually understand.
 
 ## [Unreleased]
 
+### Added
+- **What changed after an update.** The first launch on a new version shows a
+  one-line "Updated to vX.Y.Z" notice with a link to that release's notes.
+  Updates install silently in the background, so until now the only sign that
+  anything had changed was the version number in the status bar.
+
 ### Fixed
 - Document follow-ups now reject malformed retrieval cursors instead of
   silently reading from the beginning and returning a plausible wrong page.
+- **Searching a document no longer reports a false "nothing found".** Asking
+  for a document's outline and a search term in the same request ran the
+  outline and dropped the search without saying so, and the answer came back
+  as if the term were absent. The search now wins and the result says the
+  outline was skipped.
+- **A document's section list is no longer returned empty.** A long report
+  whose headings are numbered several levels deep ("118.14 …") produced no
+  sections at all alongside the note "showing the first 0 entries of 800".
+- **An answer that breaks off mid-way keeps its text.** When a model garbles
+  its own request for a tool, the part it had already written stays on screen
+  above the explanation, instead of the whole turn being replaced by a caption
+  or the raw machine syntax being dumped into the transcript.
+- A tool call the model gets wrong now tells the model which argument was
+  wrong, so it can correct itself instead of repeating the same call.
+- A failed tool no longer asks the user to "check its input" — the input is
+  written by the model, not by them — and the arguments shown on an expanded
+  failure are now labelled as the model's request.
 
 ## [0.14.1] — 2026-09-10
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1178,14 +1178,17 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///   * A marker inside a fenced code block is never a leak. An answer to
     ///     "show me what a tool call looks like" puts its example in a
     ///     ```` ``` ```` fence, and that fence is the whole point of asking.
+    ///     A fenced marker is SKIPPED, not a verdict: the scan carries on to
+    ///     the next candidate, so an answer that shows a fenced example and
+    ///     then trails off into a real envelope is still caught.
     ///   * There must be real prose before it. With none, the leading check
     ///     owns the turn and this returns nil, so the caption-only render
     ///     stays exactly as it was.
     static func trailingToolCallArtifactProse(in content: String) -> String? {
-        // The tail starts at the FIRST place machine syntax opens a payload.
+        // Candidate openers for the machine-syntax tail.
         //
-        // Strict on purpose: each pattern requires the payload to follow the
-        // marker immediately (whitespace only in between). The leading check
+        // Strict on purpose: each pattern requires that format's payload to
+        // follow the marker (whitespace only in between). The leading check
         // can afford its looser "carries a closing tag somewhere" fallback,
         // because it has already established that the envelope IS the whole
         // turn; a tail cannot. An answer that mentions `<tool_call>` in a
@@ -1194,30 +1197,71 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // along with the example.
         let patterns = [
             #"</?(tool_call|function_call)[^>]*>\s*[\{\[<]"#,
-            #"<(function|parameter)="#,
+            // `<function=NAME>` must OPEN a payload: JSON, or the nested
+            // `<parameter=` block the llama/qwen fragment shape uses. The
+            // bare tag is not enough — `Use <parameter=name> to identify the
+            // field` is ordinary prose ABOUT the syntax, and truncating an
+            // answer there is exactly the false positive this detector must
+            // not have. (The leading check can keep accepting the bare
+            // prefix: prose never OPENS with `<function=`.)
+            #"<function=[^<>\s]+>\s*(?:[\{\[]|<parameter=)"#,
+            // A `<parameter=…>` block that stands on its own line AND is
+            // closed by `</parameter>`. Both halves are required for the
+            // same reason: inline inside a sentence it is documentation.
+            #"(?m)^[ \t]*<parameter=[^<>\s]+>[\s\S]{0,4096}?</parameter>"#,
             #"\[TOOL_CALLS\]\s*[\{\[]"#,
             // The `<\u{FF5C}` opener is folded into the match so the prose
             // above it does not keep a dangling half-tag.
             "[<\u{FF5C}]*tool\u{2581}calls\u{2581}begin",
         ]
-        var start: String.Index?
+
+        // Collect EVERY candidate, not just the first match of each pattern.
+        // A fenced example earlier in the turn must not hide a genuine
+        // unfenced envelope after it: the fence check below skips the fenced
+        // candidate and the scan continues with the next one.
+        var starts: [String.Index] = []
         for pattern in patterns {
-            guard let found = content.range(
-                of: pattern, options: [.regularExpression]
-            ) else { continue }
-            if start == nil || found.lowerBound < start! { start = found.lowerBound }
+            var from = content.startIndex
+            while starts.count < maxTrailingArtifactCandidates,
+                  from < content.endIndex,
+                  let found = content.range(
+                      of: pattern, options: [.regularExpression],
+                      range: from..<content.endIndex
+                  ) {
+                starts.append(found.lowerBound)
+                from = found.upperBound > found.lowerBound
+                    ? found.upperBound
+                    : content.index(after: found.lowerBound)
+            }
         }
-        guard let start, start > content.startIndex else { return nil }
 
-        // Inside a fence? An odd number of ``` before the marker means the
-        // marker sits in an open code block — i.e. the example the user
-        // asked to see, not a leak.
-        let before = content[content.startIndex..<start]
-        if before.components(separatedBy: "```").count % 2 == 0 { return nil }
+        // The turn OPENS with machine syntax: the leading check owns it and
+        // the caption stands alone. Bailing here rather than scanning on also
+        // keeps a SECOND envelope later in the turn from being reported as
+        // the "prose" of the first.
+        let ordered = starts.sorted()
+        guard let earliest = ordered.first, earliest > content.startIndex else { return nil }
 
-        let prose = String(before).trimmingCharacters(in: .whitespacesAndNewlines)
-        return prose.isEmpty ? nil : prose
+        for start in ordered {
+            // An ODD number of ``` fences before the marker means the marker
+            // sits inside an open code block — the example the user asked to
+            // see, not a leak. Skip it; a later unfenced candidate still counts.
+            let before = content[content.startIndex..<start]
+            if before.components(separatedBy: "```").count % 2 == 0 { continue }
+            let prose = String(before).trimmingCharacters(in: .whitespacesAndNewlines)
+            // Whitespace only: the artifact is effectively the whole turn, so
+            // the leading check owns it and the caption stands alone.
+            return prose.isEmpty ? nil : prose
+        }
+        return nil
     }
+
+    /// Upper bound on candidate tail openers scanned per message. Each
+    /// pattern is re-run from the previous match, so a pathological message
+    /// (thousands of `<parameter=…>` pairs) would otherwise scan the tail
+    /// repeatedly on the main actor during render. The first unfenced
+    /// candidate is all the caller needs; 64 is far past any real turn.
+    private static let maxTrailingArtifactCandidates = 64
 
     /// What to render above the suppression caption: the prose of a turn
     /// whose tail was machine syntax, or nil when the artifact was the whole

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1172,9 +1172,12 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// replaced by ``toolCallArtifactSuppressedCaptionCopy``.
     ///
     /// Conservative in the same three ways as the leading check:
-    ///   * The marker must be followed by that format's payload — the same
-    ///     ``leadingEnvelopeLeak`` gate, applied to the tail — so an answer
-    ///     that ENDS by explaining `<tool_call>` in prose is left alone.
+    ///   * The marker must OPEN A LINE and be followed by that format's
+    ///     payload — the ``leadingEnvelopeLeak`` gate, applied to the tail,
+    ///     plus a block anchor — so an answer that explains `<tool_call>` in
+    ///     a sentence is left alone whether or not it fences the example.
+    ///     (The DeepSeek U+2581 token is exempt from the anchor: it never
+    ///     appears in prose, so there is no inline shape to protect.)
     ///   * A marker inside a fenced code block is never a leak. An answer to
     ///     "show me what a tool call looks like" puts its example in a fence,
     ///     and that fence is the whole point of asking. Fences are parsed
@@ -1198,30 +1201,36 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // the sentence onward under the loose gate, and eat the explanation
         // along with the example.
         let patterns = [
-            #"</?(tool_call|function_call)[^>]*>\s*[\{\[<]"#,
-            // `<function=NAME>` must OPEN a payload: JSON, or the nested
-            // `<parameter=` block the llama/qwen fragment shape uses. The
-            // bare tag is not enough — `Use <parameter=name> to identify the
-            // field` is ordinary prose ABOUT the syntax, and truncating an
-            // answer there is exactly the false positive this detector must
-            // not have. (The leading check can keep accepting the bare
-            // prefix: prose never OPENS with `<function=`.)
-            #"<function=[^<>\s]+>\s*(?:[\{\[]|<parameter=)"#,
-            // A `<parameter=…>` block that stands on its own line AND is
-            // closed by `</parameter>`. Both halves are required for the
-            // same reason: inline inside a sentence it is documentation.
+            // Every XML/bracket envelope must OPEN A LINE (leading whitespace
+            // allowed). A leaked call is emitted as its own block after the
+            // model stops writing prose; an answer that documents the syntax
+            // does it mid-sentence — `Use <tool_call>{"name":"search"}` — and
+            // truncating that sentence at the tag is the false positive this
+            // detector must not have. The dogfood repro and every other real
+            // leak shape put the envelope on its own line.
+            #"(?m)^[ \t]*</?(tool_call|function_call)[^>]*>\s*[\{\[<]"#,
+            // `<function=NAME>` must also OPEN a payload: JSON, or the nested
+            // `<parameter=` block the llama/qwen fragment shape uses. The bare
+            // tag is not enough — prose about the syntax carries it too. (The
+            // leading check can keep accepting the bare prefix: prose never
+            // OPENS a turn with `<function=`.)
+            #"(?m)^[ \t]*<function=[^<>\s]+>\s*(?:[\{\[]|<parameter=)"#,
+            // A `<parameter=…>` block on its own line AND closed by
+            // `</parameter>`. Both halves are required for the same reason:
+            // inline inside a sentence it is documentation.
             #"(?m)^[ \t]*<parameter=[^<>\s]+>[\s\S]{0,4096}?</parameter>"#,
-            #"\[TOOL_CALLS\]\s*[\{\[]"#,
-            // The `<\u{FF5C}` opener is folded into the match so the prose
-            // above it does not keep a dangling half-tag.
+            #"(?m)^[ \t]*\[TOOL_CALLS\]\s*[\{\[]"#,
+            // The DeepSeek marker is deliberately NOT line-anchored: its
+            // U+2581 separators never occur in human prose, so there is no
+            // inline-documentation shape to protect and a real emit can follow
+            // the last prose character directly. The `<\u{FF5C}` opener is folded
+            // into the match so the prose above it does not keep a dangling
+            // half-tag.
             "[<\u{FF5C}]*tool\u{2581}calls\u{2581}begin",
         ]
 
         // Fences first: one line pass, reused by every pattern below.
         let fenced = fencedRanges(in: content)
-        func fence(containing index: String.Index) -> Range<String.Index>? {
-            fenced.first { $0.contains(index) }
-        }
 
         // The earliest UNFENCED candidate across every pattern.
         //
@@ -1236,13 +1245,22 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         var earliest: String.Index?
         for pattern in patterns {
             var from = content.startIndex
+            // `fenced` is ascending and disjoint and a pattern's matches only
+            // move forward, so one cursor walks the fence list ONCE per
+            // pattern. Asking `fenced.first { … }` per match instead rescans
+            // every range from the start, which is quadratic in the number of
+            // fenced examples — on the transcript render path.
+            var block = 0
             while from < content.endIndex,
                   let found = content.range(
                       of: pattern, options: [.regularExpression],
                       range: from..<content.endIndex
                   ) {
-                if let block = fence(containing: found.lowerBound) {
-                    from = max(block.upperBound, content.index(after: found.lowerBound))
+                while block < fenced.count, fenced[block].upperBound <= found.lowerBound {
+                    block += 1
+                }
+                if block < fenced.count, fenced[block].contains(found.lowerBound) {
+                    from = max(fenced[block].upperBound, content.index(after: found.lowerBound))
                     continue
                 }
                 // Matches arrive in increasing order, so the first unfenced

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1176,11 +1176,13 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///     ``leadingEnvelopeLeak`` gate, applied to the tail — so an answer
     ///     that ENDS by explaining `<tool_call>` in prose is left alone.
     ///   * A marker inside a fenced code block is never a leak. An answer to
-    ///     "show me what a tool call looks like" puts its example in a
-    ///     ```` ``` ```` fence, and that fence is the whole point of asking.
-    ///     A fenced marker is SKIPPED, not a verdict: the scan carries on to
-    ///     the next candidate, so an answer that shows a fenced example and
-    ///     then trails off into a real envelope is still caught.
+    ///     "show me what a tool call looks like" puts its example in a fence,
+    ///     and that fence is the whole point of asking. Fences are parsed
+    ///     (``fencedRanges``), not counted: backticks and tildes, three or
+    ///     more, closer matching the opener. A fenced marker is SKIPPED, not
+    ///     a verdict: the scan carries on to the next candidate, so an answer
+    ///     that shows a fenced example and then trails off into a real
+    ///     envelope is still caught.
     ///   * There must be real prose before it. With none, the leading check
     ///     owns the turn and this returns nil, so the caption-only render
     ///     stays exactly as it was.
@@ -1222,13 +1224,19 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         var starts: [String.Index] = []
         for pattern in patterns {
             var from = content.startIndex
-            while starts.count < maxTrailingArtifactCandidates,
+            var matched = 0
+            // The cap is PER PATTERN, not shared. A shared budget spent by
+            // 64 fenced `<tool_call>` examples would stop the scan before
+            // the `[TOOL_CALLS]` / DeepSeek patterns ran at all, hiding a
+            // genuine trailing envelope in one of those formats.
+            while matched < maxTrailingArtifactCandidates,
                   from < content.endIndex,
                   let found = content.range(
                       of: pattern, options: [.regularExpression],
                       range: from..<content.endIndex
                   ) {
                 starts.append(found.lowerBound)
+                matched += 1
                 from = found.upperBound > found.lowerBound
                     ? found.upperBound
                     : content.index(after: found.lowerBound)
@@ -1242,18 +1250,82 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         let ordered = starts.sorted()
         guard let earliest = ordered.first, earliest > content.startIndex else { return nil }
 
+        let fenced = fencedRanges(in: content)
         for start in ordered {
-            // An ODD number of ``` fences before the marker means the marker
-            // sits inside an open code block — the example the user asked to
+            // A marker inside a code fence is the example the user asked to
             // see, not a leak. Skip it; a later unfenced candidate still counts.
+            if fenced.contains(where: { $0.contains(start) }) { continue }
             let before = content[content.startIndex..<start]
-            if before.components(separatedBy: "```").count % 2 == 0 { continue }
             let prose = String(before).trimmingCharacters(in: .whitespacesAndNewlines)
             // Whitespace only: the artifact is effectively the whole turn, so
             // the leading check owns it and the caption stands alone.
             return prose.isEmpty ? nil : prose
         }
         return nil
+    }
+
+    /// The character ranges of ``content`` that sit inside a fenced code
+    /// block, opening fence line included.
+    ///
+    /// CommonMark's actual rule, not a count of literal ```` ``` ````
+    /// sequences: a fence opens on a line whose first non-space content is a
+    /// run of three or more backticks OR tildes, and closes on a later line
+    /// whose run uses the SAME character and is at least as long. Counting
+    /// triple-backtick occurrences — the shape this check started as —
+    /// misreads a ```` ~~~ ```` fence (no backticks at all) and a
+    /// four-backtick fence (the standard way to show a nested example) as
+    /// unfenced, which turns the example the user asked for into a "leak"
+    /// and truncates the answer at it. Same fence vocabulary the release-notes
+    /// renderer already accepts.
+    static func fencedRanges(in content: String) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var openStart: String.Index?
+        var openMarker: (marker: Character, run: Int)?
+        var index = content.startIndex
+        while index < content.endIndex {
+            let lineEnd = content[index...].firstIndex(of: "\n") ?? content.endIndex
+            let next = lineEnd < content.endIndex ? content.index(after: lineEnd) : content.endIndex
+            if let found = fenceMarker(in: content[index..<lineEnd]) {
+                if let open = openMarker, let start = openStart {
+                    // A closer must use the opener's character and be at least
+                    // as long; a shorter or different run is fence CONTENT
+                    // (that is how a ```` fence shows a ``` example).
+                    if found.marker == open.marker, found.run >= open.run {
+                        ranges.append(start..<next)
+                        openMarker = nil
+                        openStart = nil
+                    }
+                } else {
+                    openMarker = found
+                    openStart = index
+                }
+            }
+            index = next
+        }
+        // An unterminated fence runs to the end of the turn: a streamed answer
+        // cut off mid-example is still an example, not a leak.
+        if let start = openStart { ranges.append(start..<content.endIndex) }
+        return ranges
+    }
+
+    /// The fence run a line opens or closes with — its character and length —
+    /// or nil when the line is not a fence line. Up to three leading spaces
+    /// are allowed (CommonMark); a backtick fence's info string may not
+    /// contain a backtick, which is what keeps inline `` `code` `` off this
+    /// path.
+    private static func fenceMarker(in line: Substring) -> (marker: Character, run: Int)? {
+        var rest = line
+        var leading = 0
+        while let first = rest.first, first == " " || first == "\t" {
+            leading += 1
+            if leading > 3 { return nil }
+            rest = rest.dropFirst()
+        }
+        guard let marker = rest.first, marker == "`" || marker == "~" else { return nil }
+        let run = rest.prefix { $0 == marker }.count
+        guard run >= 3 else { return nil }
+        if marker == "`", rest.dropFirst(run).contains("`") { return nil }
+        return (marker, run)
     }
 
     /// Upper bound on candidate tail openers scanned per message. Each

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1314,14 +1314,20 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// Where the turn's terminal run of machine syntax begins, or nil when
     /// the turn does not end in machine syntax at all.
     ///
-    /// Walks lines from the end: a blank line or a line whose first non-space
-    /// character opens machine syntax (`<`, `{`, `[`, `}`, `]`, `"`, `,`)
-    /// belongs to the run; the first line that reads as prose stops it. That
-    /// one character is enough because the run only has to distinguish an
-    /// envelope dump — which is what a model emits when the parser lost its
-    /// call and generation simply stopped — from a sentence. A closing ```` ```
-    /// ```` also stops the run, which is correct: a turn that ENDS with a
-    /// fenced example is showing the example, not leaking a call.
+    /// Walks lines from the end: a blank line, a line whose first non-space
+    /// character opens machine syntax (`<`, `{`, `[`, `}`, `]`, `"`, `,`), or
+    /// a bare JSON scalar (a pretty-printed array element — `10,`, `true`,
+    /// `null`) belongs to the run; the first line that reads as prose stops
+    /// it. Deliberately a line-shape test rather than a JSON/XML parse: the
+    /// run only has to tell an envelope dump — what a model emits when the
+    /// parser lost its call and generation simply stopped — from a sentence,
+    /// and the input is by definition syntax no parser could read. The scalar
+    /// test is kept strict (a number, `true`, `false`, `null`, optional
+    /// trailing comma — never "ends with a colon", which is how the dogfood
+    /// repro's last prose line reads) because widening it moves the boundary
+    /// EARLIER, and an over-early boundary eats real prose. A closing
+    /// ```` ``` ```` stops the run too, which is correct: a turn that ENDS
+    /// with a fenced example is showing the example, not leaking a call.
     private static func terminalMachineSyntaxRunStart(in content: String) -> String.Index? {
         let openers: Set<Character> = ["<", "{", "[", "}", "]", "\"", ","]
         var runStart: String.Index?
@@ -1335,7 +1341,8 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             let trimmed = content[lineStart..<lineEnd]
                 .trimmingCharacters(in: .whitespaces)
             if !trimmed.isEmpty {
-                if let first = trimmed.first, openers.contains(first) {
+                if let first = trimmed.first,
+                   openers.contains(first) || isJSONScalarLine(trimmed) {
                     if runStart == nil { runStart = lineStart }
                     sawContent = true
                 } else {
@@ -1349,6 +1356,21 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             lineStart = index
         }
         return sawContent ? runStart : nil
+    }
+
+    /// True for a line that is nothing but a JSON scalar with an optional
+    /// trailing comma — the continuation lines of a pretty-printed array
+    /// (`10,`, `true`, `null`). Quoted strings and the bracket/brace forms are
+    /// already covered by the first-character test.
+    private static func isJSONScalarLine(_ trimmed: String) -> Bool {
+        var body = Substring(trimmed)
+        if body.hasSuffix(",") { body = body.dropLast() }
+        body = Substring(body.trimmingCharacters(in: .whitespaces))
+        if body == "true" || body == "false" || body == "null" { return true }
+        return body.range(
+            of: #"^-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][-+]?[0-9]+)?$"#,
+            options: .regularExpression
+        ) != nil
     }
 
     /// The character ranges of ``content`` that sit inside a fenced code

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1217,51 +1217,64 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             "[<\u{FF5C}]*tool\u{2581}calls\u{2581}begin",
         ]
 
-        // Collect EVERY candidate, not just the first match of each pattern.
-        // A fenced example earlier in the turn must not hide a genuine
-        // unfenced envelope after it: the fence check below skips the fenced
-        // candidate and the scan continues with the next one.
-        var starts: [String.Index] = []
+        // Fences first: one line pass, reused by every pattern below.
+        let fenced = fencedRanges(in: content)
+        func fence(containing index: String.Index) -> Range<String.Index>? {
+            fenced.first { $0.contains(index) }
+        }
+
+        // The earliest UNFENCED candidate across every pattern.
+        //
+        // Two things this must not do. It must not stop at the first match of
+        // a pattern and decide on it alone — a legitimate fenced example
+        // earlier in the turn would then hide the genuine unfenced envelope
+        // after it, and that envelope renders raw. And it must not cap the
+        // number of candidates it will look at — a cap is spent by the
+        // examples and loses the real tail that follows them. Instead a match
+        // inside a fence advances the cursor past the WHOLE fenced block, so a
+        // fence holding a thousand examples costs one step, not a thousand.
+        var earliest: String.Index?
         for pattern in patterns {
             var from = content.startIndex
-            var matched = 0
-            // The cap is PER PATTERN, not shared. A shared budget spent by
-            // 64 fenced `<tool_call>` examples would stop the scan before
-            // the `[TOOL_CALLS]` / DeepSeek patterns ran at all, hiding a
-            // genuine trailing envelope in one of those formats.
-            while matched < maxTrailingArtifactCandidates,
-                  from < content.endIndex,
+            while from < content.endIndex,
                   let found = content.range(
                       of: pattern, options: [.regularExpression],
                       range: from..<content.endIndex
                   ) {
-                starts.append(found.lowerBound)
-                matched += 1
-                from = found.upperBound > found.lowerBound
-                    ? found.upperBound
-                    : content.index(after: found.lowerBound)
+                if let block = fence(containing: found.lowerBound) {
+                    from = max(block.upperBound, content.index(after: found.lowerBound))
+                    continue
+                }
+                // Matches arrive in increasing order, so the first unfenced
+                // one is this pattern's earliest; no need to scan its tail.
+                if earliest == nil || found.lowerBound < earliest! { earliest = found.lowerBound }
+                break
             }
         }
 
-        // The turn OPENS with machine syntax: the leading check owns it and
-        // the caption stands alone. Bailing here rather than scanning on also
-        // keeps a SECOND envelope later in the turn from being reported as
-        // the "prose" of the first.
-        let ordered = starts.sorted()
-        guard let earliest = ordered.first, earliest > content.startIndex else { return nil }
+        // Nothing unfenced, or the turn OPENS with machine syntax: either way
+        // this returns nil — in the second case the leading check owns the
+        // turn and the caption stands alone. Testing the first UNFENCED
+        // candidate (rather than the first candidate of any kind) is what
+        // keeps a turn that opens with a fenced example from bailing here.
+        guard let start = earliest, start > content.startIndex else { return nil }
+        let prose = String(content[content.startIndex..<start])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Whitespace only: the artifact is effectively the whole turn, so the
+        // leading check owns it and the caption stands alone.
+        return prose.isEmpty ? nil : prose
+    }
 
-        let fenced = fencedRanges(in: content)
-        for start in ordered {
-            // A marker inside a code fence is the example the user asked to
-            // see, not a leak. Skip it; a later unfenced candidate still counts.
-            if fenced.contains(where: { $0.contains(start) }) { continue }
-            let before = content[content.startIndex..<start]
-            let prose = String(before).trimmingCharacters(in: .whitespacesAndNewlines)
-            // Whitespace only: the artifact is effectively the whole turn, so
-            // the leading check owns it and the caption stands alone.
-            return prose.isEmpty ? nil : prose
-        }
-        return nil
+    /// What to render above the suppression caption: the prose of a turn
+    /// whose tail was machine syntax, or nil when the artifact was the whole
+    /// turn and the caption stands alone.
+    static func proseAboveSuppressedToolCallArtifact(content: String) -> String? {
+        // Trailing wins when it fires: its own gates already establish that
+        // there is real prose before the machine syntax, which the leading
+        // check cannot tell (it matches the DeepSeek marker ANYWHERE in the
+        // turn, so a prose answer that trailed off into one used to lose the
+        // prose as well as the tail).
+        trailingToolCallArtifactProse(in: content)
     }
 
     /// The character ranges of ``content`` that sit inside a fenced code
@@ -1270,7 +1283,8 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// CommonMark's actual rule, not a count of literal ```` ``` ````
     /// sequences: a fence opens on a line whose first non-space content is a
     /// run of three or more backticks OR tildes, and closes on a later line
-    /// whose run uses the SAME character and is at least as long. Counting
+    /// whose run uses the SAME character, is at least as long, and carries
+    /// nothing but whitespace after it. Counting
     /// triple-backtick occurrences — the shape this check started as —
     /// misreads a ```` ~~~ ```` fence (no backticks at all) and a
     /// four-backtick fence (the standard way to show a nested example) as
@@ -1280,17 +1294,20 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     static func fencedRanges(in content: String) -> [Range<String.Index>] {
         var ranges: [Range<String.Index>] = []
         var openStart: String.Index?
-        var openMarker: (marker: Character, run: Int)?
+        var openMarker: FenceRun?
         var index = content.startIndex
         while index < content.endIndex {
             let lineEnd = content[index...].firstIndex(of: "\n") ?? content.endIndex
             let next = lineEnd < content.endIndex ? content.index(after: lineEnd) : content.endIndex
-            if let found = fenceMarker(in: content[index..<lineEnd]) {
+            if let found = fenceRun(in: content[index..<lineEnd]) {
                 if let open = openMarker, let start = openStart {
-                    // A closer must use the opener's character and be at least
-                    // as long; a shorter or different run is fence CONTENT
-                    // (that is how a ```` fence shows a ``` example).
-                    if found.marker == open.marker, found.run >= open.run {
+                    // A closer must use the opener's character, be at least as
+                    // long, and carry NOTHING but whitespace after the run.
+                    // CommonMark gives a closing fence no info string, so a
+                    // ```` ```swift ```` line inside a ``` block is content —
+                    // treating it as a closer would leave the rest of the
+                    // example unfenced and truncate the answer there.
+                    if found.marker == open.marker, found.run >= open.run, found.isBare {
                         ranges.append(start..<next)
                         openMarker = nil
                         openStart = nil
@@ -1308,43 +1325,39 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         return ranges
     }
 
-    /// The fence run a line opens or closes with — its character and length —
-    /// or nil when the line is not a fence line. Up to three leading spaces
-    /// are allowed (CommonMark); a backtick fence's info string may not
-    /// contain a backtick, which is what keeps inline `` `code` `` off this
-    /// path.
-    private static func fenceMarker(in line: Substring) -> (marker: Character, run: Int)? {
+    /// A fence line's delimiter run: which character, how long, and whether
+    /// anything follows it (an info string, which only an OPENER may have).
+    private struct FenceRun {
+        let marker: Character
+        let run: Int
+        let isBare: Bool
+    }
+
+    /// The fence run a line carries, or nil when the line is not a fence line.
+    ///
+    /// Indentation is measured in COLUMNS with tabs expanded to the next
+    /// four-column stop, because that is what decides the CommonMark cutoff:
+    /// four columns in is an indented code block, not a fence opener, and a
+    /// single leading tab already reaches four. A backtick fence's info string
+    /// may not contain a backtick, which is what keeps inline `` `code` ``
+    /// spans off this path.
+    private static func fenceRun(in line: Substring) -> FenceRun? {
         var rest = line
-        var leading = 0
+        var column = 0
         while let first = rest.first, first == " " || first == "\t" {
-            leading += 1
-            if leading > 3 { return nil }
+            column = first == "\t" ? (column / 4 + 1) * 4 : column + 1
+            if column > 3 { return nil }
             rest = rest.dropFirst()
         }
         guard let marker = rest.first, marker == "`" || marker == "~" else { return nil }
         let run = rest.prefix { $0 == marker }.count
         guard run >= 3 else { return nil }
-        if marker == "`", rest.dropFirst(run).contains("`") { return nil }
-        return (marker, run)
-    }
-
-    /// Upper bound on candidate tail openers scanned per message. Each
-    /// pattern is re-run from the previous match, so a pathological message
-    /// (thousands of `<parameter=…>` pairs) would otherwise scan the tail
-    /// repeatedly on the main actor during render. The first unfenced
-    /// candidate is all the caller needs; 64 is far past any real turn.
-    private static let maxTrailingArtifactCandidates = 64
-
-    /// What to render above the suppression caption: the prose of a turn
-    /// whose tail was machine syntax, or nil when the artifact was the whole
-    /// turn and the caption stands alone.
-    static func proseAboveSuppressedToolCallArtifact(content: String) -> String? {
-        // Trailing wins when it fires: its own gates already establish that
-        // there is real prose before the machine syntax, which the leading
-        // check cannot tell (it matches the DeepSeek marker ANYWHERE in the
-        // turn, so a prose answer that trailed off into one used to lose the
-        // prose as well as the tail).
-        trailingToolCallArtifactProse(in: content)
+        let info = rest.dropFirst(run)
+        if marker == "`", info.contains("`") { return nil }
+        return FenceRun(
+            marker: marker, run: run,
+            isBare: info.allSatisfy { $0 == " " || $0 == "\t" }
+        )
     }
 
     /// True when ``content`` is *essentially just* a malformed tool-call

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1141,6 +1141,20 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // leading-only check below cannot see it, because the artifact is
         // the TAIL of an otherwise real answer.
         if trailingToolCallArtifactProse(in: content) != nil { return true }
+        // Not a gate, but the question every reviewer asks here: what about a
+        // COMPLETE, well-formed, unfenced example that legitimately ends an
+        // answer? Two things cover it. Gates 1-3 are themselves the
+        // "parser-rejected" evidence — tools were advertised and the turn came
+        // back with no tool call at all, so an envelope the engine's parser
+        // could read would have been dispatched and never reached this line.
+        // And #513 documents the remainder as an accepted residual: a turn
+        // that IS only a raw call shape cannot be told apart from a leak by
+        // content, suppression is non-destructive (the raw text stays on the
+        // message; copy and export reproduce it verbatim, and since this PR
+        // the prose above it renders), and in the target population — a local
+        // model whose call the parser lost — a leak is far likelier than a
+        // deliberately-requested example. A fenced example, which is how a
+        // model actually answers "show me one", is never touched.
         // Gate 4: the content must actually look like a raw tool-call
         // artifact, not a genuine answer that merely embeds JSON.
         //

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1328,22 +1328,19 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// Where the turn's terminal run of machine syntax begins, or nil when
     /// the turn does not end in machine syntax at all.
     ///
-    /// Walks lines from the end: a blank line, a line whose first non-space
-    /// character opens machine syntax (`<`, `{`, `[`, `}`, `]`, `"`, `,`), or
-    /// a bare JSON scalar (a pretty-printed array element — `10,`, `true`,
-    /// `null`) belongs to the run; the first line that reads as prose stops
-    /// it. Deliberately a line-shape test rather than a JSON/XML parse: the
-    /// run only has to tell an envelope dump — what a model emits when the
-    /// parser lost its call and generation simply stopped — from a sentence,
-    /// and the input is by definition syntax no parser could read. The scalar
-    /// test is kept strict (a number, `true`, `false`, `null`, optional
-    /// trailing comma — never "ends with a colon", which is how the dogfood
-    /// repro's last prose line reads) because widening it moves the boundary
-    /// EARLIER, and an over-early boundary eats real prose. A closing
-    /// ```` ``` ```` stops the run too, which is correct: a turn that ENDS
-    /// with a fenced example is showing the example, not leaking a call.
+    /// Walks lines from the end: a blank line or a machine-syntax line
+    /// (``isMachineSyntaxLine``) belongs to the run, and the first line that
+    /// reads as prose stops it.
+    ///
+    /// Deliberately a line-shape test rather than a JSON/XML parse: the run
+    /// only has to tell an envelope dump — what a model emits when the parser
+    /// lost its call and generation simply stopped — from a sentence, and the
+    /// input is by definition syntax no parser could read. Every test is kept
+    /// strict, because widening one moves the boundary EARLIER, and an
+    /// over-early boundary eats real prose. A closing ```` ``` ```` stops the
+    /// run too, which is correct: a turn that ENDS with a fenced example is
+    /// showing the example, not leaking a call.
     private static func terminalMachineSyntaxRunStart(in content: String) -> String.Index? {
-        let openers: Set<Character> = ["<", "{", "[", "}", "]", "\"", ","]
         var runStart: String.Index?
         var sawContent = false
         var lineStart = content.startIndex
@@ -1355,8 +1352,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             let trimmed = content[lineStart..<lineEnd]
                 .trimmingCharacters(in: .whitespaces)
             if !trimmed.isEmpty {
-                if let first = trimmed.first,
-                   openers.contains(first) || isJSONScalarLine(trimmed) {
+                if isMachineSyntaxLine(trimmed) {
                     if runStart == nil { runStart = lineStart }
                     sawContent = true
                 } else {
@@ -1370,6 +1366,50 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             lineStart = index
         }
         return sawContent ? runStart : nil
+    }
+
+    /// True when a line is a piece of an envelope dump rather than a sentence.
+    ///
+    /// Structural per opener, not "the first character is punctuation". Prose
+    /// opens with punctuation often enough that the loose form ate real
+    /// content: a Markdown link (`[That syntax](…) is invalid`), a reference
+    /// definition (`[1]: …`), a quoted sentence. Each case below accepts the
+    /// shape an envelope actually produces and nothing wider.
+    private static func isMachineSyntaxLine(_ trimmed: String) -> Bool {
+        // Never in prose, wherever it appears.
+        if trimmed.contains("tool\u{2581}calls\u{2581}") { return true }
+        guard let first = trimmed.first else { return false }
+        switch first {
+        case "{", "}", "]", ",":
+            // None of these open a sentence.
+            return true
+        case "[":
+            // Reject Markdown first: a link (`[label](url)`) or a reference
+            // definition (`[1]: url`). The digit branch below has to accept
+            // `[1, 2]`, so `[1]: url` would otherwise read as an array.
+            if trimmed.range(
+                of: #"^\[[^\]\n]*\]\s*[:(]"#,
+                options: .regularExpression) != nil {
+                return false
+            }
+            // A JSON array opening, or the Mistral marker.
+            return trimmed.range(
+                of: #"^\[(\s*$|\s*[\{\[\]"'\-0-9]|TOOL_CALLS\])"#,
+                options: .regularExpression) != nil
+        case "\"":
+            // A JSON key or a bare string element, not a quoted sentence.
+            return trimmed.range(
+                of: #"^"(\\.|[^"\\])*"\s*(:|,?$)"#,
+                options: .regularExpression) != nil
+        case "<":
+            // A tag, not prose that happens to open with a less-than sign.
+            return trimmed.contains(">")
+                && trimmed.range(
+                    of: #"^</?[A-Za-z\uFF5C|]"#,
+                    options: .regularExpression) != nil
+        default:
+            return isJSONScalarLine(trimmed)
+        }
     }
 
     /// True for a line that is nothing but a JSON scalar with an optional

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1131,6 +1131,16 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // the last moment even if the captured array reads empty — be
         // conservative and leave it alone.
         if finishReason == "tool_calls" { return false }
+        // Gate 4b: a turn that answered in prose and THEN emitted an
+        // envelope. The 0.14.1 dogfood repro: 5,413 characters of
+        // "Let me read the first page more carefully…" followed by
+        // `<tool_call> {"name":"read_document","arguments":{…,"greP":…`,
+        // which no parser claimed — so no tool round fired, the model kept
+        // generating for six more minutes, and the user watched a sentence
+        // that promised an action be followed by nothing at all. The
+        // leading-only check below cannot see it, because the artifact is
+        // the TAIL of an otherwise real answer.
+        if trailingToolCallArtifactProse(in: content) != nil { return true }
         // Gate 4: the content must actually look like a raw tool-call
         // artifact, not a genuine answer that merely embeds JSON.
         //
@@ -1150,6 +1160,75 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // deliberately-requested example. Prose-FRAMED examples ("here's a
         // JSON example: …") are NOT suppressed — see the detector.
         return contentLooksLikeToolCallArtifact(content)
+    }
+
+    /// The prose an assistant turn actually said, when its content is real
+    /// text followed by a malformed tool-call envelope — or nil when there
+    /// is no such tail.
+    ///
+    /// Companion to ``contentLooksLikeToolCallArtifact``, which only fires
+    /// when the artifact IS the whole turn. Here the answer is genuine and
+    /// only its tail is machine syntax, so the prose is kept and the tail is
+    /// replaced by ``toolCallArtifactSuppressedCaptionCopy``.
+    ///
+    /// Conservative in the same three ways as the leading check:
+    ///   * The marker must be followed by that format's payload — the same
+    ///     ``leadingEnvelopeLeak`` gate, applied to the tail — so an answer
+    ///     that ENDS by explaining `<tool_call>` in prose is left alone.
+    ///   * A marker inside a fenced code block is never a leak. An answer to
+    ///     "show me what a tool call looks like" puts its example in a
+    ///     ```` ``` ```` fence, and that fence is the whole point of asking.
+    ///   * There must be real prose before it. With none, the leading check
+    ///     owns the turn and this returns nil, so the caption-only render
+    ///     stays exactly as it was.
+    static func trailingToolCallArtifactProse(in content: String) -> String? {
+        // The tail starts at the FIRST place machine syntax opens a payload.
+        //
+        // Strict on purpose: each pattern requires the payload to follow the
+        // marker immediately (whitespace only in between). The leading check
+        // can afford its looser "carries a closing tag somewhere" fallback,
+        // because it has already established that the envelope IS the whole
+        // turn; a tail cannot. An answer that mentions `<tool_call>` in a
+        // sentence and shows a fenced example further down would match from
+        // the sentence onward under the loose gate, and eat the explanation
+        // along with the example.
+        let patterns = [
+            #"</?(tool_call|function_call)[^>]*>\s*[\{\[<]"#,
+            #"<(function|parameter)="#,
+            #"\[TOOL_CALLS\]\s*[\{\[]"#,
+            // The `<\u{FF5C}` opener is folded into the match so the prose
+            // above it does not keep a dangling half-tag.
+            "[<\u{FF5C}]*tool\u{2581}calls\u{2581}begin",
+        ]
+        var start: String.Index?
+        for pattern in patterns {
+            guard let found = content.range(
+                of: pattern, options: [.regularExpression]
+            ) else { continue }
+            if start == nil || found.lowerBound < start! { start = found.lowerBound }
+        }
+        guard let start, start > content.startIndex else { return nil }
+
+        // Inside a fence? An odd number of ``` before the marker means the
+        // marker sits in an open code block — i.e. the example the user
+        // asked to see, not a leak.
+        let before = content[content.startIndex..<start]
+        if before.components(separatedBy: "```").count % 2 == 0 { return nil }
+
+        let prose = String(before).trimmingCharacters(in: .whitespacesAndNewlines)
+        return prose.isEmpty ? nil : prose
+    }
+
+    /// What to render above the suppression caption: the prose of a turn
+    /// whose tail was machine syntax, or nil when the artifact was the whole
+    /// turn and the caption stands alone.
+    static func proseAboveSuppressedToolCallArtifact(content: String) -> String? {
+        // Trailing wins when it fires: its own gates already establish that
+        // there is real prose before the machine syntax, which the leading
+        // check cannot tell (it matches the DeepSeek marker ANYWHERE in the
+        // turn, so a prose answer that trailed off into one used to lose the
+        // prose as well as the tail).
+        trailingToolCallArtifactProse(in: content)
     }
 
     /// True when ``content`` is *essentially just* a malformed tool-call

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1381,8 +1381,11 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         guard let first = trimmed.first else { return false }
         switch first {
         case "{", "}", "]", ",":
-            // None of these open a sentence.
-            return true
+            // These open no sentence BY THEMSELVES, but prose can open with
+            // one: "} closes the object; this is why …". A JSON fragment — `}`,
+            // `},`, `},{"name":"x"}`, `{"limit": 10,` — carries no unquoted
+            // word; a sentence does.
+            return hasNoUnquotedWord(trimmed)
         case "[":
             // Reject Markdown first: a link (`[label](url)`) or a reference
             // definition (`[1]: url`). The digit branch below has to accept
@@ -1410,6 +1413,38 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         default:
             return isJSONScalarLine(trimmed)
         }
+    }
+
+    /// True when a line carries no word outside a string literal.
+    ///
+    /// This is what separates a JSON fragment from a sentence that merely
+    /// OPENS with a brace or bracket. Words inside string literals do not
+    /// count — they are data, and a leaked call is full of them. The JSON
+    /// keywords are allowed through unquoted, since `{"ok": true}` is a
+    /// fragment; a run that stops matching one of them (`"trus"`) is a word.
+    private static func hasNoUnquotedWord(_ line: String) -> Bool {
+        let keywords = ["true", "false", "null"]
+        var inString = false
+        var escaped = false
+        var run = ""
+        for character in line {
+            if escaped { escaped = false; continue }
+            if inString, character == "\\" { escaped = true; continue }
+            if character == "\"" {
+                inString.toggle()
+                run = ""
+                continue
+            }
+            if inString { continue }
+            guard character.isLetter else { run = ""; continue }
+            run.append(character)
+            // One letter is never a word here — `1e5` and a bare `n` in a
+            // truncated `null` both have to pass.
+            guard run.count >= 2 else { continue }
+            let lowered = run.lowercased()
+            if !keywords.contains(where: { $0.hasPrefix(lowered) }) { return false }
+        }
+        return true
     }
 
     /// True for a line that is nothing but a JSON scalar with an optional

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1189,6 +1189,9 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///   * There must be real prose before it. With none, the leading check
     ///     owns the turn and this returns nil, so the caption-only render
     ///     stays exactly as it was.
+    ///   * The envelope must be the turn's TAIL — inside the terminal run of
+    ///     machine syntax (``terminalMachineSyntaxRunStart``). An answer that
+    ///     shows a raw call and then explains it keeps its explanation.
     static func trailingToolCallArtifactProse(in content: String) -> String? {
         // Candidate openers for the machine-syntax tail.
         //
@@ -1229,7 +1232,20 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             "[<\u{FF5C}]*tool\u{2581}calls\u{2581}begin",
         ]
 
-        // Fences first: one line pass, reused by every pattern below.
+        // The turn must END in machine syntax, and only the terminal run of
+        // it is a candidate tail.
+        //
+        // This is what "tail" means, and without it a genuine answer that
+        // shows a raw (unfenced) call on its own line and then EXPLAINS it
+        // lost the explanation: suppression ran from the marker to the end of
+        // the turn, so the closing sentences went with the example. Confining
+        // the search to the terminal machine-syntax run also fixes the general
+        // case — example, prose, then a real envelope — because the earlier
+        // example is no longer even a candidate.
+        guard let runStart = terminalMachineSyntaxRunStart(in: content) else { return nil }
+        let searchRange = runStart..<content.endIndex
+
+        // Fences next: one line pass, reused by every pattern below.
         let fenced = fencedRanges(in: content)
 
         // The earliest UNFENCED candidate across every pattern.
@@ -1244,7 +1260,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // fence holding a thousand examples costs one step, not a thousand.
         var earliest: String.Index?
         for pattern in patterns {
-            var from = content.startIndex
+            var from = runStart
             // `fenced` is ascending and disjoint and a pattern's matches only
             // move forward, so one cursor walks the fence list ONCE per
             // pattern. Asking `fenced.first { … }` per match instead rescans
@@ -1254,7 +1270,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             while from < content.endIndex,
                   let found = content.range(
                       of: pattern, options: [.regularExpression],
-                      range: from..<content.endIndex
+                      range: from..<searchRange.upperBound
                   ) {
                 while block < fenced.count, fenced[block].upperBound <= found.lowerBound {
                     block += 1
@@ -1293,6 +1309,46 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // turn, so a prose answer that trailed off into one used to lose the
         // prose as well as the tail).
         trailingToolCallArtifactProse(in: content)
+    }
+
+    /// Where the turn's terminal run of machine syntax begins, or nil when
+    /// the turn does not end in machine syntax at all.
+    ///
+    /// Walks lines from the end: a blank line or a line whose first non-space
+    /// character opens machine syntax (`<`, `{`, `[`, `}`, `]`, `"`, `,`)
+    /// belongs to the run; the first line that reads as prose stops it. That
+    /// one character is enough because the run only has to distinguish an
+    /// envelope dump — which is what a model emits when the parser lost its
+    /// call and generation simply stopped — from a sentence. A closing ```` ```
+    /// ```` also stops the run, which is correct: a turn that ENDS with a
+    /// fenced example is showing the example, not leaking a call.
+    private static func terminalMachineSyntaxRunStart(in content: String) -> String.Index? {
+        let openers: Set<Character> = ["<", "{", "[", "}", "]", "\"", ","]
+        var runStart: String.Index?
+        var sawContent = false
+        var lineStart = content.startIndex
+        var index = content.startIndex
+        // Forward pass recording the last prose line's successor, which is the
+        // same answer as walking backwards and cheaper on String.Index.
+        while true {
+            let lineEnd = content[index...].firstIndex(of: "\n") ?? content.endIndex
+            let trimmed = content[lineStart..<lineEnd]
+                .trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty {
+                if let first = trimmed.first, openers.contains(first) {
+                    if runStart == nil { runStart = lineStart }
+                    sawContent = true
+                } else {
+                    // Prose: everything up to and including this line is the
+                    // answer, so any run starts after it.
+                    runStart = nil
+                }
+            }
+            guard lineEnd < content.endIndex else { break }
+            index = content.index(after: lineEnd)
+            lineStart = index
+        }
+        return sawContent ? runStart : nil
     }
 
     /// The character ranges of ``content`` that sit inside a fenced code

--- a/apps/rapid-mac/Sources/Rapid/Chat/ToolKit.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ToolKit.swift
@@ -247,10 +247,19 @@ struct NativeToolCallExecutor {
             )
         }
 
-        guard let normalized = Self.normalized(call, for: definition) else {
+        let normalized: ToolCall
+        switch Self.normalize(call, for: definition) {
+        case .success(let value):
+            normalized = value
+        case .failure(let rejection):
+            // Name what was wrong. A generic "arguments must match the
+            // advertised schema" leaves a small model guessing which key it
+            // got wrong, and it re-emits the same call — the strict-schema
+            // path (#3314) makes that retry loop reachable often enough to
+            // matter.
             return ToolCallResult(
                 toolCallID: call.id,
-                content: "tool '\(call.function.name)' error: arguments must be a JSON object matching the advertised schema",
+                content: "tool '\(call.function.name)' error: \(rejection.reason)",
                 isError: true,
                 failureKind: .toolFailed
             )
@@ -278,25 +287,58 @@ struct NativeToolCallExecutor {
         _ call: ToolCall,
         for definition: ToolDefinition
     ) -> ToolCall? {
+        try? normalize(call, for: definition).get()
+    }
+
+    /// Why a tool call's arguments were rejected, in wording meant for the
+    /// model that wrote them.
+    struct ArgumentRejection: Error {
+        let reason: String
+    }
+
+    /// Same filtering as ``normalized(_:for:)``, but carries WHY a call was
+    /// rejected so the model gets a message it can act on.
+    nonisolated static func normalize(
+        _ call: ToolCall,
+        for definition: ToolDefinition
+    ) -> Result<ToolCall, ArgumentRejection> {
         let raw = call.function.arguments.trimmingCharacters(in: .whitespacesAndNewlines)
         let data = Data((raw.isEmpty ? "{}" : raw).utf8)
         guard var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return nil }
+        else {
+            return .failure(ArgumentRejection(
+                reason: "arguments must be a single JSON object, e.g. {\"key\": \"value\"}"
+            ))
+        }
 
         if case .object(let schema) = definition.function.parameters,
            case .object(let properties)? = schema["properties"]
         {
-            if schema["additionalProperties"] == .bool(false),
-               object.keys.contains(where: { !properties.keys.contains($0) }) {
-                return nil
+            let allowed = properties.keys.sorted()
+            if schema["additionalProperties"] == .bool(false) {
+                let unknown = object.keys.filter { !properties.keys.contains($0) }.sorted()
+                if !unknown.isEmpty {
+                    // Bound the echo: keys are model-supplied and unbounded.
+                    let names = unknown.prefix(5)
+                        .map { String($0.prefix(80)) }
+                        .joined(separator: ", ")
+                    let suffix = unknown.count > 5 ? ", …" : ""
+                    return .failure(ArgumentRejection(
+                        reason: "unknown argument(s): \(names)\(suffix) — this tool accepts only: \(allowed.joined(separator: ", "))"
+                    ))
+                }
             }
             object = object.filter { properties.keys.contains($0.key) }
         }
         guard JSONSerialization.isValidJSONObject(object),
               let normalized = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
               let arguments = String(data: normalized, encoding: .utf8)
-        else { return nil }
-        return ToolCall(id: call.id, name: call.function.name, arguments: arguments)
+        else {
+            return .failure(ArgumentRejection(
+                reason: "arguments could not be re-encoded as JSON — re-send them as a plain JSON object"
+            ))
+        }
+        return .success(ToolCall(id: call.id, name: call.function.name, arguments: arguments))
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ToolKit.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ToolKit.swift
@@ -319,8 +319,16 @@ struct NativeToolCallExecutor {
                 let unknown = object.keys.filter { !properties.keys.contains($0) }.sorted()
                 if !unknown.isEmpty {
                     // Bound the echo: keys are model-supplied and unbounded.
+                    // By SCALARS, not characters — `String.prefix` counts
+                    // grapheme clusters, and one cluster can carry thousands
+                    // of combining marks, so a character bound is not a bound
+                    // at all.
                     let names = unknown.prefix(5)
-                        .map { String($0.prefix(80)) }
+                        .map { key -> String in
+                            let scalars = key.unicodeScalars
+                            guard scalars.count > 80 else { return key }
+                            return String(String.UnicodeScalarView(scalars.prefix(80)))
+                        }
                         .joined(separator: ", ")
                     let suffix = unknown.count > 5 ? ", …" : ""
                     return .failure(ArgumentRejection(

--- a/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
+++ b/apps/rapid-mac/Sources/Rapid/Services/FailureDiagnosis.swift
@@ -314,7 +314,12 @@ enum FailureDiagnoser {
             message = "Rapid doesn't have access to that file."
             action = nil
         case .toolFailed:
-            message = "The tool couldn't finish. Check its input, then try again."
+            // "Check its input" pointed the user at the one thing they do not
+            // control: the arguments are written by the model, and a user
+            // reading "check its input" over an invented `{"url": ""}` has
+            // nothing to check (0.14.1 mini dogfood). State whose step failed
+            // and leave the recovery — asking again — on the button.
+            message = "A tool step didn't go through. The model can usually recover if you ask again."
             action = .retry
         case .userDeclined:
             // Nothing went wrong, so the copy states the outcome and stops.

--- a/apps/rapid-mac/Sources/Rapid/Tools/ReadDocumentTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/ReadDocumentTool.swift
@@ -11,6 +11,16 @@ enum ReadDocumentTool {
     static let grepTimeBudget: TimeInterval = 2.0
     static let outlineTokenBudget = 2_000
     static let maxOutlineRows = 400
+    /// Hard cap on a single outline row's title, in characters.
+    ///
+    /// A row's title comes from the document — a PDF bookmark or an inferred
+    /// heading line — so its length is attacker- or accident-controlled. The
+    /// budget trimmer must always return at least one row (an empty outline
+    /// reads as "this document has no structure"), and without a per-title
+    /// cap that one row could be a 200 KB bookmark title that blows through
+    /// ``outlineTokenBudget`` and eats the model's context. Clamping every
+    /// title before the budget math also keeps that math honest.
+    static let maxOutlineTitleLength = 160
 
     static let definition = ToolDefinition(
         name: "read_document",
@@ -215,8 +225,19 @@ enum ReadDocumentTool {
     /// list (0.14.1 mini dogfood). Inference now normalizes depth, and this
     /// trims relative to the shallowest level present either way.
     static func budgeted(
-        _ rows: [DocumentContentCache.OutlineNode]
+        _ unclamped: [DocumentContentCache.OutlineNode]
     ) -> (rows: [DocumentContentCache.OutlineNode], trim: OutlineTrim) {
+        // Clamp titles FIRST, so every row is bounded before any budget
+        // decision is made — including the one row the prefix branch is
+        // required to return. The offset is what the model actually needs
+        // from a row; a truncated title still names the section.
+        let rows = unclamped.map { node -> DocumentContentCache.OutlineNode in
+            guard node.title.count > maxOutlineTitleLength else { return node }
+            return DocumentContentCache.OutlineNode(
+                title: String(node.title.prefix(maxOutlineTitleLength - 1)) + "…",
+                depth: node.depth, page: node.page, offset: node.offset
+            )
+        }
         func cost(_ rows: [DocumentContentCache.OutlineNode]) -> Int {
             TokenEstimate.tokens(in: rows.map(\.title).joined(separator: "\n"))
                 + rows.count * 12

--- a/apps/rapid-mac/Sources/Rapid/Tools/ReadDocumentTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/ReadDocumentTool.swift
@@ -11,7 +11,7 @@ enum ReadDocumentTool {
     static let grepTimeBudget: TimeInterval = 2.0
     static let outlineTokenBudget = 2_000
     static let maxOutlineRows = 400
-    /// Hard cap on a single outline row's title, in characters.
+    /// Hard cap on a single outline row's title, in Unicode SCALARS.
     ///
     /// A row's title comes from the document — a PDF bookmark or an inferred
     /// heading line — so its length is attacker- or accident-controlled. The
@@ -20,6 +20,12 @@ enum ReadDocumentTool {
     /// cap that one row could be a 200 KB bookmark title that blows through
     /// ``outlineTokenBudget`` and eats the model's context. Clamping every
     /// title before the budget math also keeps that math honest.
+    ///
+    /// Scalars, not characters: `String.count` measures grapheme clusters, so
+    /// a single cluster carrying thousands of combining marks — one
+    /// "character" — walks straight through a character cap. A scalar cap
+    /// bounds the payload for any input, and for ordinary titles (Latin, CJK,
+    /// one scalar per character) the two measures agree.
     static let maxOutlineTitleLength = 160
 
     static let definition = ToolDefinition(
@@ -232,9 +238,12 @@ enum ReadDocumentTool {
         // required to return. The offset is what the model actually needs
         // from a row; a truncated title still names the section.
         let rows = unclamped.map { node -> DocumentContentCache.OutlineNode in
-            guard node.title.count > maxOutlineTitleLength else { return node }
+            let scalars = node.title.unicodeScalars
+            guard scalars.count > maxOutlineTitleLength else { return node }
+            let head = String(String.UnicodeScalarView(
+                scalars.prefix(maxOutlineTitleLength - 1)))
             return DocumentContentCache.OutlineNode(
-                title: String(node.title.prefix(maxOutlineTitleLength - 1)) + "…",
+                title: head + "…",
                 depth: node.depth, page: node.page, offset: node.offset
             )
         }

--- a/apps/rapid-mac/Sources/Rapid/Tools/ReadDocumentTool.swift
+++ b/apps/rapid-mac/Sources/Rapid/Tools/ReadDocumentTool.swift
@@ -26,7 +26,7 @@ enum ReadDocumentTool {
                 "mode": .object([
                     "type": .string("string"),
                     "enum": .array([.string("outline"), .string("read")]),
-                    "description": .string("'outline' returns the section map of the whole document in one call — best for summarizing or working out what the document covers. 'read' (the default) returns document text at 'offset'. Regex search is NOT this parameter — pass the separate 'grep' argument for it.")
+                    "description": .string("'outline' returns the section map of the whole document in one call — best for summarizing or working out what the document covers. 'read' (the default) returns document text at 'offset'. Regex search is NOT this parameter — pass the separate 'grep' argument for it. When 'grep' is set it wins and 'mode' is ignored.")
                 ]),
                 "offset": .object([
                     "type": .string("integer"),
@@ -91,19 +91,27 @@ enum ReadDocumentTool {
         }
         let entry = awaited.entry
 
-        if mode == "outline" {
-            return outlineResult(
-                id: rawID,
-                entry: entry,
-                extractionPending: awaited.extractionPending
-            )
-        }
+        // `grep` outranks `mode`. A model that sends BOTH means "search":
+        // the pattern is the specific intent, the outline the generic one.
+        // The outline branch used to run first and drop the pattern without
+        // echoing it anywhere in the payload, so the model read a table of
+        // contents back as "the search found nothing" — a false negative it
+        // had no way to detect. The `mode` copy itself ("pass the separate
+        // 'grep' argument") invites exactly that call shape.
         if let pattern = args.grep?.trimmingCharacters(in: .whitespacesAndNewlines), !pattern.isEmpty {
             return grepResult(
                 tool: tool,
                 id: rawID,
                 entry: entry,
                 pattern: pattern,
+                ignoredMode: mode == "outline" ? "outline" : nil,
+                extractionPending: awaited.extractionPending
+            )
+        }
+        if mode == "outline" {
+            return outlineResult(
+                id: rawID,
+                entry: entry,
                 extractionPending: awaited.extractionPending
             )
         }
@@ -144,7 +152,7 @@ enum ReadDocumentTool {
             )
         }
 
-        let (trimmed, keptDepth) = budgeted(rows)
+        let (trimmed, trim) = budgeted(rows)
         var payload: [String: Any] = [
             "document_id": id,
             "filename": entry.filename,
@@ -162,10 +170,15 @@ enum ReadDocumentTool {
         var note = "Each entry's 'offset' can be passed back as read_document's 'offset' to read that section."
         if trimmed.count < rows.count {
             payload["entries_omitted"] = rows.count - trimmed.count
-            if let depth = keptDepth, depth > 0 {
-                note += " Showing the top \(depth + 1) level(s) of \(rows.count) total entries; deeper subsections are omitted."
-            } else {
-                note += " Showing the first \(trimmed.count) top-level entries of \(rows.count) total; the later sections are omitted."
+            switch trim {
+            case .complete:
+                break
+            case .levels(let maxDepth, let shallowest):
+                // "top N levels", counted from the outline's own shallowest
+                // level — an inferred outline need not start at depth 0.
+                note += " Showing the top \(maxDepth - shallowest + 1) level(s) of \(rows.count) total entries; deeper subsections are omitted."
+            case .prefix:
+                note += " Showing the first \(trimmed.count) of \(rows.count) entries; the later sections are omitted."
             }
         }
         if source == "inferred" {
@@ -180,33 +193,60 @@ enum ReadDocumentTool {
         )
     }
 
+    /// How ``budgeted(_:)`` had to cut an over-budget outline, so the note
+    /// can describe the actual cut instead of guessing from a depth number.
+    enum OutlineTrim: Equatable {
+        case complete
+        /// Every row at depth ≤ ``maxDepth`` survived; deeper ones went.
+        case levels(maxDepth: Int, shallowest: Int)
+        /// Even the shallowest level alone was over budget, so a leading
+        /// prefix of it is all that fits.
+        case prefix
+    }
+
     /// Drops deepest levels first to preserve the outline's overall shape.
+    ///
+    /// Never returns an empty outline for a non-empty one. The old loop
+    /// trimmed down to depth 0 and kept `rows.filter { $0.depth == 0 }`,
+    /// which is empty for any outline with no depth-0 row — every heading in
+    /// a `118.14 Foo`-style report infers to depth 1. It then reported
+    /// `keptDepth: 0`, and the caller rendered the self-contradictory
+    /// "Showing the first 0 top-level entries of 800 total" over an empty
+    /// list (0.14.1 mini dogfood). Inference now normalizes depth, and this
+    /// trims relative to the shallowest level present either way.
     static func budgeted(
         _ rows: [DocumentContentCache.OutlineNode]
-    ) -> (rows: [DocumentContentCache.OutlineNode], keptDepth: Int?) {
+    ) -> (rows: [DocumentContentCache.OutlineNode], trim: OutlineTrim) {
         func cost(_ rows: [DocumentContentCache.OutlineNode]) -> Int {
             TokenEstimate.tokens(in: rows.map(\.title).joined(separator: "\n"))
                 + rows.count * 12
         }
 
         if rows.count <= maxOutlineRows, cost(rows) <= outlineTokenBudget {
-            return (rows, nil)
+            return (rows, .complete)
         }
+        let shallowest = rows.map(\.depth).min() ?? 0
         var depth = rows.map(\.depth).max() ?? 0
-        while depth > 0 {
+        while depth > shallowest {
             depth -= 1
             let kept = rows.filter { $0.depth <= depth }
             if kept.count <= maxOutlineRows, cost(kept) <= outlineTokenBudget {
-                return (kept, depth)
+                return (kept, .levels(maxDepth: depth, shallowest: shallowest))
             }
         }
         var kept: [DocumentContentCache.OutlineNode] = []
-        for row in rows where row.depth == 0 {
+        for row in rows where row.depth == shallowest {
             let next = kept + [row]
-            if next.count > maxOutlineRows || cost(next) > outlineTokenBudget { break }
+            // Always keep one row: a single usable offset beats an empty
+            // outline that reads as "this document has no structure".
+            if !kept.isEmpty,
+               next.count > maxOutlineRows || cost(next) > outlineTokenBudget {
+                break
+            }
             kept = next
         }
-        return (kept, kept.isEmpty ? nil : 0)
+        if kept.isEmpty { kept = Array(rows.prefix(1)) }
+        return (kept, .prefix)
     }
 
     /// Infers a conservative outline from numbered or explicit chapter headings.
@@ -260,6 +300,20 @@ enum ReadDocumentTool {
                 }
             }
             if lineEnd == text.endIndex { break }
+        }
+        // Normalize to a 0-based depth. Inferred depth is the number of dots
+        // in the leading numeric run, so a report whose headings all read
+        // `118.14 Foo` yields nothing at depth 0 — an outline with no top
+        // level is one the budget trimmer cannot shape.
+        if let shallowest = nodes.map(\.depth).min(), shallowest > 0 {
+            nodes = nodes.map {
+                DocumentContentCache.OutlineNode(
+                    title: $0.title,
+                    depth: $0.depth - shallowest,
+                    page: $0.page,
+                    offset: $0.offset
+                )
+            }
         }
         return nodes
     }
@@ -357,6 +411,7 @@ enum ReadDocumentTool {
         id: String,
         entry: DocumentContentCache.Entry,
         pattern: String,
+        ignoredMode: String? = nil,
         extractionPending: Bool = false
     ) -> ToolCallResult {
         guard pattern.count <= maxGrepPatternLength else {
@@ -384,6 +439,7 @@ enum ReadDocumentTool {
             entry: entry,
             pattern: pattern,
             regex: regex,
+            ignoredMode: ignoredMode,
             extractionPending: extractionPending
         )
         // Admission control: an abandoned backtracking worker cannot be
@@ -454,6 +510,7 @@ enum ReadDocumentTool {
         private let entry: DocumentContentCache.Entry
         private let pattern: String
         private let regex: NSRegularExpression
+        private let ignoredMode: String?
         private let extractionPending: Bool
 
         private let lock = NSLock()
@@ -466,6 +523,7 @@ enum ReadDocumentTool {
             entry: DocumentContentCache.Entry,
             pattern: String,
             regex: NSRegularExpression,
+            ignoredMode: String?,
             extractionPending: Bool
         ) {
             self.tool = tool
@@ -473,6 +531,7 @@ enum ReadDocumentTool {
             self.entry = entry
             self.pattern = pattern
             self.regex = regex
+            self.ignoredMode = ignoredMode
             self.extractionPending = extractionPending
         }
 
@@ -494,6 +553,7 @@ enum ReadDocumentTool {
                 entry: entry,
                 pattern: pattern,
                 regex: regex,
+                ignoredMode: ignoredMode,
                 extractionPending: extractionPending,
                 isAbandoned: { [weak self] in self?.isAbandoned ?? true }
             )
@@ -517,9 +577,15 @@ enum ReadDocumentTool {
         entry: DocumentContentCache.Entry,
         pattern: String,
         regex: NSRegularExpression,
+        ignoredMode: String?,
         extractionPending: Bool,
         isAbandoned: @escaping () -> Bool
     ) -> ToolCallResult {
+        // Stated in the payload, not swallowed: a dropped argument the model
+        // cannot see is how a search turns into a silent false negative.
+        let modeNotice = ignoredMode.map {
+            " A 'grep' pattern was supplied, so mode='\($0)' was ignored — search wins over the section map. Call read_document again without 'grep' if you want the outline."
+        } ?? ""
         // Convert UTF-16 regex ranges through String so returned cursors are reusable.
         let text = entry.text
         let ns = text as NSString
@@ -588,9 +654,10 @@ enum ReadDocumentTool {
                 "search_complete": searchComplete,
                 "total_chars": entry.count,
             ]
-            payload["note"] = searchComplete
+            if let ignoredMode { payload["mode_ignored"] = ignoredMode }
+            payload["note"] = (searchComplete
                 ? "No match for '\(pattern)' in this document. Try a broader pattern, or read sequentially with offset=0."
-                : "Search for '\(pattern)' was stopped after \(Int(grepTimeBudget))s without finding a match — the pattern is too expensive to run over this document. Try a plain phrase instead of an elaborate expression."
+                : "Search for '\(pattern)' was stopped after \(Int(grepTimeBudget))s without finding a match — the pattern is too expensive to run over this document. Try a plain phrase instead of an elaborate expression.") + modeNotice
             return result(
                 payload,
                 entry: entry,
@@ -609,10 +676,11 @@ enum ReadDocumentTool {
             "total_chars": entry.count,
         ]
         if let pages = entry.pageCount { payload["total_pages"] = pages }
+        if let ignoredMode { payload["mode_ignored"] = ignoredMode }
         if searchComplete {
-            payload["note"] = "Each passage includes surrounding context. Use a passage 'offset' with read_document to read forward from there."
+            payload["note"] = "Each passage includes surrounding context. Use a passage 'offset' with read_document to read forward from there." + modeNotice
         } else {
-            payload["note"] = "Showing the first \(passages.count) matches; the document contains at least that many and the search stopped before reaching the end. Narrow the pattern, or use the 'offset' of a passage to read around it sequentially."
+            payload["note"] = "Showing the first \(passages.count) matches; the document contains at least that many and the search stopped before reaching the end. Narrow the pattern, or use the 'offset' of a passage to read around it sequentially." + modeNotice
         }
         return result(
             payload,

--- a/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ChatView.swift
@@ -1795,6 +1795,16 @@ private struct MessageRow: View {
                 // The model tried to call a tool and the parser couldn't read
                 // the request. Show the quiet explainer instead of dumping the
                 // raw envelope syntax at the user.
+                //
+                // When the turn ANSWERED and then trailed off into an
+                // envelope, the answer is kept and only the tail is replaced:
+                // dropping 5 kB of real prose to show a one-line caption
+                // would be a worse outcome than the raw syntax was.
+                if let prose = ChatMessage.proseAboveSuppressedToolCallArtifact(
+                    content: message.content
+                ) {
+                    TextKitMarkdownView(content: prose)
+                }
                 Text(ChatMessage.toolCallArtifactSuppressedCaptionCopy)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
@@ -2323,6 +2333,15 @@ private struct ToolCallChip: View {
             if expanded {
                 VStack(alignment: .leading, spacing: 6) {
                     Divider()
+                    // Captioned, because an expanded failure chip shows the
+                    // model's own arguments — sometimes invented keys the app
+                    // has never heard of. Unlabelled monospaced JSON under a
+                    // red error reads as Rapid's output and sends the user
+                    // hunting for a setting to fix (0.14.1 mini dogfood).
+                    Text("Requested by the model")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                        .textCase(.uppercase)
                     Text(prettyArguments)
                         .font(.system(size: 11, design: .monospaced))
                         .foregroundStyle(.secondary)

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -611,8 +611,10 @@ struct ContentView: View {
             // but was never mounted, so a failed Finder replacement was
             // detected and then silently discarded.
             FailedReplaceBanner()
-            // Mutually exclusive with the banner above by construction: that
-            // one fires when the version did NOT move, this one when it did.
+            // Suppresses itself while the banner above is showing — see the
+            // note in `WhatsNewBanner.body`. They are NOT mutually exclusive
+            // by construction any more: the upgrade notice is sticky until the
+            // user acknowledges it.
             WhatsNewBanner()
             if deferredTelemetryConsent.isPresented {
                 DeferredTelemetryConsentBanner()

--- a/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/ContentView.swift
@@ -611,6 +611,9 @@ struct ContentView: View {
             // but was never mounted, so a failed Finder replacement was
             // detected and then silently discarded.
             FailedReplaceBanner()
+            // Mutually exclusive with the banner above by construction: that
+            // one fires when the version did NOT move, this one when it did.
+            WhatsNewBanner()
             if deferredTelemetryConsent.isPresented {
                 DeferredTelemetryConsentBanner()
             }

--- a/apps/rapid-mac/Sources/Rapid/UI/WhatsNewBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/WhatsNewBanner.swift
@@ -69,8 +69,18 @@ struct WhatsNewBanner: View {
                     HStack(spacing: 8) {
                         if let url = Self.releaseNotesURL(for: current) {
                             Button("See what's new") {
-                                openURL(url)
-                                installTracker.dismissUpgradeNotice()
+                                // Dismiss only once the browser actually took
+                                // the URL. `openURL` can be declined (no
+                                // handler, a policy block), and dismissing
+                                // regardless would retire the only route to the
+                                // notes for a click that opened nothing — the
+                                // banner cannot come back, because
+                                // `lastSeenVersion` already rolled forward.
+                                // Same shape as `GitHubStarPrompt`.
+                                openURL(url) { accepted in
+                                    guard accepted else { return }
+                                    installTracker.dismissUpgradeNotice()
+                                }
                             }
                             .buttonStyle(.borderedProminent)
                             .controlSize(.small)

--- a/apps/rapid-mac/Sources/Rapid/UI/WhatsNewBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/WhatsNewBanner.swift
@@ -40,7 +40,14 @@ struct WhatsNewBanner: View {
     }
 
     var body: some View {
-        if let from = installTracker.upgradedFrom {
+        // `FailedReplaceBanner` wins when both fire. They are no longer
+        // mutually exclusive by construction: the upgrade notice is sticky
+        // until acknowledged, so a launch that upgraded and a LATER launch
+        // whose Finder Replace failed can both be true at once — and stacking
+        // "Updated to v0.14.2" on top of "your update didn't install" would
+        // contradict itself. The stale-bundle warning is the one the user has
+        // to act on, so it stands alone.
+        if let from = installTracker.upgradedFrom, !installTracker.failedReplaceDetected {
             let current = installTracker.currentVersion
             let headline = "Updated to v\(current)"
             let detail = "You were on v\(from). The release notes list what changed."

--- a/apps/rapid-mac/Sources/Rapid/UI/WhatsNewBanner.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/WhatsNewBanner.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+/// Sticky banner shown once after the app updates itself, above the model
+/// picker, when ``InstallTracker.upgradedFrom`` is set.
+///
+/// Sparkle's default path is deliberately silent: it downloads in the
+/// background, installs on quit, and relaunches into the new build with no
+/// prompt at any point. That is the right behaviour for the update itself —
+/// nobody wants a modal on launch — but it also means the app never tells
+/// the user that anything changed. Crossing 0.13.1 → 0.14.1 in the 0.14.1
+/// dogfood added Computer Use, Share Compute, PDF analysis, model unload and
+/// six image models, and the window came back byte-identical apart from the
+/// number in the version pill.
+///
+/// So: one line naming both versions, one link to that release's notes, one
+/// Dismiss. No modal, no feature tour, and nothing that has to be clicked
+/// before the user can type.
+///
+/// It cannot collide with ``FailedReplaceBanner``: that one requires the
+/// version to have stayed PUT across the launch, this one requires it to
+/// have moved forward.
+struct WhatsNewBanner: View {
+    @Environment(InstallTracker.self) private var installTracker
+    @Environment(\.openURL) private var openURL
+
+    /// The release page for a desktop version. Tags are published as
+    /// ``rapid-mac-v<version>`` (see RELEASING.md), and GitHub renders the
+    /// release body — the same notes the appcast carries.
+    static func releaseNotesURL(for version: String) -> URL? {
+        let trimmed = version.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tag = trimmed.hasPrefix("v") ? String(trimmed.dropFirst()) : trimmed
+        // Only a plain dotted-numeric version becomes a tag URL — no link
+        // beats a 404, and only released versions have a release page.
+        // ``strictNumericParts`` is not the gate here: it drops a
+        // pre-release suffix, so "0.14.1-dev" would pass it and then point
+        // at a tag that was never published.
+        guard tag.range(of: #"^[0-9]+(\.[0-9]+)*$"#, options: .regularExpression) != nil
+        else { return nil }
+        return URL(string: "https://github.com/raullenchai/Rapid-MLX/releases/tag/rapid-mac-v\(tag)")
+    }
+
+    var body: some View {
+        if let from = installTracker.upgradedFrom {
+            let current = installTracker.currentVersion
+            let headline = "Updated to v\(current)"
+            let detail = "You were on v\(from). The release notes list what changed."
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(RapidTheme.brand)
+                    .font(.system(size: 14, weight: .semibold))
+                    .padding(.top, 1)
+                VStack(alignment: .leading, spacing: 4) {
+                    // Headline + detail combine into ONE VoiceOver element so
+                    // the update is announced as a sentence; the buttons stay
+                    // siblings so each remains focusable. Same shape as
+                    // ``FailedReplaceBanner`` — see the note there.
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(headline)
+                            .scaledSystemFont(13, weight: .semibold)
+                        Text(detail)
+                            .scaledSystemFont(12)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .textSelection(.enabled)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(headline). \(detail)")
+                    .accessibilityAddTraits(.isHeader)
+                    HStack(spacing: 8) {
+                        if let url = Self.releaseNotesURL(for: current) {
+                            Button("See what's new") {
+                                openURL(url)
+                                installTracker.dismissUpgradeNotice()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                            .accessibilityIdentifier("WhatsNew.OpenNotes")
+                        }
+                        Button("Dismiss") {
+                            installTracker.dismissUpgradeNotice()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .accessibilityIdentifier("WhatsNew.Dismiss")
+                    }
+                    .padding(.top, 2)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(RapidTheme.brand.opacity(0.10))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(RapidTheme.brand.opacity(0.30), lineWidth: 1)
+            )
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            // `.contain`, not the default: an identifier on a plain container
+            // ABSORBS its descendants' identifiers, so both buttons came back
+            // from an AX dump as `WhatsNewBanner` and neither could be pressed
+            // by name. ``CampaignBanner`` is the pattern being matched here.
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("WhatsNewBanner")
+        }
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
@@ -42,8 +42,15 @@ final class InstallTracker {
     /// didn't move. Banner-driving flag for the chat surface.
     private(set) var failedReplaceDetected: Bool = false
 
-    /// The version this launch upgraded FROM, or nil when the version did
-    /// not move forward since the last launch. Drives ``WhatsNewBanner``.
+    /// The version this launch upgraded FROM, or nil when there is nothing
+    /// left to announce. Drives ``WhatsNewBanner``.
+    ///
+    /// Compared against the ACKNOWLEDGED version, not the last-seen one. The
+    /// two differ on purpose: last-seen rolls forward on every launch because
+    /// the failed-Replace detector needs a per-launch baseline, but the notice
+    /// is sticky — quitting or crashing before reading it must not consume it.
+    /// Acknowledged only advances when the user dismisses the banner or opens
+    /// the notes.
     ///
     /// Sparkle installs on quit and relaunches into the new build with no
     /// prompt of any kind, so a user who crossed two feature releases (the
@@ -65,6 +72,10 @@ final class InstallTracker {
     /// other ``rapid.*`` keys in the same suite.
     static let lastSeenMtimeKey = "rapid.install.lastSeenInfoPlistMtime"
     static let lastSeenVersionKey = "rapid.install.lastSeenVersion"
+    /// The newest version whose "what's new" notice the user actually saw.
+    /// Separate from ``lastSeenVersionKey`` because that one is the
+    /// failed-Replace baseline and has to advance every launch.
+    static let acknowledgedVersionKey = "rapid.install.acknowledgedVersion"
 
     /// Production init — reads the running bundle's Info.plist mtime
     /// and ``CFBundleShortVersionString``, compares against the
@@ -106,8 +117,15 @@ final class InstallTracker {
         // Forward moves only. A downgrade (a rollback, or a dev build run
         // over a newer release) is not something to celebrate, and "Updated
         // to v0.13.1" over an intentional rollback reads as a bug.
-        if let prevVersion, UpdateChecker.isNewer(currentVersion, than: prevVersion) {
-            self.upgradedFrom = prevVersion
+        let acknowledged = defaults.string(forKey: Self.acknowledgedVersionKey)
+        if let acknowledged, UpdateChecker.isNewer(currentVersion, than: acknowledged) {
+            self.upgradedFrom = acknowledged
+        } else if acknowledged == nil {
+            // First launch under this key: there is nothing to announce (a
+            // fresh install, or the launch that introduced the key), so seed
+            // the baseline. Without the seed the NEXT upgrade would compare
+            // against nil and stay silent.
+            defaults.set(currentVersion, forKey: Self.acknowledgedVersionKey)
         }
 
         self.failedReplaceDetected = Self.detect(
@@ -193,11 +211,13 @@ final class InstallTracker {
         failedReplaceDetected = false
     }
 
-    /// User dismissed the "what's new" banner. Only the in-process flag is
-    /// cleared: ``lastSeenVersionKey`` was already advanced on construction,
-    /// so the next launch computes ``upgradedFrom == nil`` on its own and the
-    /// banner cannot come back for a version the user has already seen.
+    /// User dismissed the "what's new" banner, or opened the release notes
+    /// from it. Records the acknowledgement so the notice does not come back
+    /// for a version the user has already seen — and, because this is the ONLY
+    /// writer of that key, so that quitting or crashing before reading the
+    /// notice leaves it pending for the next launch.
     func dismissUpgradeNotice() {
         upgradedFrom = nil
+        defaults.set(currentVersion, forKey: Self.acknowledgedVersionKey)
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
@@ -42,6 +42,18 @@ final class InstallTracker {
     /// didn't move. Banner-driving flag for the chat surface.
     private(set) var failedReplaceDetected: Bool = false
 
+    /// The version this launch upgraded FROM, or nil when the version did
+    /// not move forward since the last launch. Drives ``WhatsNewBanner``.
+    ///
+    /// Sparkle installs on quit and relaunches into the new build with no
+    /// prompt of any kind, so a user who crossed two feature releases (the
+    /// 0.13.1 → 0.14.1 dogfood: Computer Use, Share Compute, PDF analysis,
+    /// model unload, six image models) saw an identical window with a
+    /// different number in the version pill and nothing else. This is the
+    /// one signal the app already had and never used — ``lastSeenVersion``
+    /// is read on every launch for the failed-Replace check.
+    private(set) var upgradedFrom: String?
+
     /// The version string the app booted with. Cached so the banner
     /// copy can echo what the user is currently running (matches what
     /// the About panel + status bar already show).
@@ -90,6 +102,13 @@ final class InstallTracker {
 
         let prevMtime = defaults.object(forKey: Self.lastSeenMtimeKey) as? Date
         let prevVersion = defaults.string(forKey: Self.lastSeenVersionKey)
+
+        // Forward moves only. A downgrade (a rollback, or a dev build run
+        // over a newer release) is not something to celebrate, and "Updated
+        // to v0.13.1" over an intentional rollback reads as a bug.
+        if let prevVersion, UpdateChecker.isNewer(currentVersion, than: prevVersion) {
+            self.upgradedFrom = prevVersion
+        }
 
         self.failedReplaceDetected = Self.detect(
             previousMtime: prevMtime,
@@ -172,5 +191,13 @@ final class InstallTracker {
     /// Finder Replace happens between now and then.
     func dismiss() {
         failedReplaceDetected = false
+    }
+
+    /// User dismissed the "what's new" banner. Only the in-process flag is
+    /// cleared: ``lastSeenVersionKey`` was already advanced on construction,
+    /// so the next launch computes ``upgradedFrom == nil`` on its own and the
+    /// banner cannot come back for a version the user has already seen.
+    func dismissUpgradeNotice() {
+        upgradedFrom = nil
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
@@ -133,9 +133,17 @@ final class InstallTracker {
         // nobody has this key yet, and the alternative — seeding it to the
         // current version — would swallow the notice on exactly the upgrade
         // that ships the feature.
+        // A launch that went BACKWARDS cancels an owed notice even when the
+        // version is still ahead of the one the notice is about: 0.13.1 →
+        // 0.15.0 → rollback to 0.14.0 is a rollback, and "Updated to v0.14.0"
+        // over one reads as a bug — the same reason a plain downgrade is not
+        // celebrated.
+        let downgradeLaunch = prevVersion.map {
+            UpdateChecker.isNewer($0, than: currentVersion)
+        } ?? false
         let pending = defaults.string(forKey: Self.pendingUpgradeNoticeFromKey)
         if let pending {
-            if UpdateChecker.isNewer(currentVersion, than: pending) {
+            if !downgradeLaunch, UpdateChecker.isNewer(currentVersion, than: pending) {
                 self.upgradedFrom = pending
             } else {
                 defaults.removeObject(forKey: Self.pendingUpgradeNoticeFromKey)

--- a/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
+++ b/apps/rapid-mac/Sources/Rapid/Updater/InstallTracker.swift
@@ -45,12 +45,11 @@ final class InstallTracker {
     /// The version this launch upgraded FROM, or nil when there is nothing
     /// left to announce. Drives ``WhatsNewBanner``.
     ///
-    /// Compared against the ACKNOWLEDGED version, not the last-seen one. The
-    /// two differ on purpose: last-seen rolls forward on every launch because
-    /// the failed-Replace detector needs a per-launch baseline, but the notice
-    /// is sticky — quitting or crashing before reading it must not consume it.
-    /// Acknowledged only advances when the user dismisses the banner or opens
-    /// the notes.
+    /// Backed by its own persisted key, not by the last-seen version. The two
+    /// differ on purpose: last-seen rolls forward on every launch because the
+    /// failed-Replace detector needs a per-launch baseline, but the notice is
+    /// sticky — quitting or crashing before reading it must not consume it.
+    /// Only dismissing the banner (or opening the notes from it) clears it.
     ///
     /// Sparkle installs on quit and relaunches into the new build with no
     /// prompt of any kind, so a user who crossed two feature releases (the
@@ -72,10 +71,16 @@ final class InstallTracker {
     /// other ``rapid.*`` keys in the same suite.
     static let lastSeenMtimeKey = "rapid.install.lastSeenInfoPlistMtime"
     static let lastSeenVersionKey = "rapid.install.lastSeenVersion"
-    /// The newest version whose "what's new" notice the user actually saw.
+    /// The version an UNREAD "what's new" notice is about — what the user was
+    /// running before the upgrade. Present means a notice is owed; absent
+    /// means nothing is pending.
+    ///
     /// Separate from ``lastSeenVersionKey`` because that one is the
-    /// failed-Replace baseline and has to advance every launch.
-    static let acknowledgedVersionKey = "rapid.install.acknowledgedVersion"
+    /// failed-Replace baseline and has to advance on every launch, which is
+    /// precisely what a sticky notice must not do: comparing against it
+    /// consumed the notice on the launch that detected it, so quitting or
+    /// crashing before reading it lost it for good.
+    static let pendingUpgradeNoticeFromKey = "rapid.install.pendingUpgradeNoticeFrom"
 
     /// Production init — reads the running bundle's Info.plist mtime
     /// and ``CFBundleShortVersionString``, compares against the
@@ -117,15 +122,27 @@ final class InstallTracker {
         // Forward moves only. A downgrade (a rollback, or a dev build run
         // over a newer release) is not something to celebrate, and "Updated
         // to v0.13.1" over an intentional rollback reads as a bug.
-        let acknowledged = defaults.string(forKey: Self.acknowledgedVersionKey)
-        if let acknowledged, UpdateChecker.isNewer(currentVersion, than: acknowledged) {
-            self.upgradedFrom = acknowledged
-        } else if acknowledged == nil {
-            // First launch under this key: there is nothing to announce (a
-            // fresh install, or the launch that introduced the key), so seed
-            // the baseline. Without the seed the NEXT upgrade would compare
-            // against nil and stay silent.
-            defaults.set(currentVersion, forKey: Self.acknowledgedVersionKey)
+        // A notice already owed stays owed, unchanged, until it is dismissed —
+        // that is the whole point of the separate key. An owed notice that no
+        // longer describes a forward move (the user rolled back) is dropped.
+        //
+        // Otherwise a forward move against the last-seen version opens a new
+        // notice and RECORDS it, so the next launch shows the same one rather
+        // than recomputing against a baseline that has meanwhile rolled
+        // forward. Falling back to `prevVersion` is also the migration path:
+        // nobody has this key yet, and the alternative — seeding it to the
+        // current version — would swallow the notice on exactly the upgrade
+        // that ships the feature.
+        let pending = defaults.string(forKey: Self.pendingUpgradeNoticeFromKey)
+        if let pending {
+            if UpdateChecker.isNewer(currentVersion, than: pending) {
+                self.upgradedFrom = pending
+            } else {
+                defaults.removeObject(forKey: Self.pendingUpgradeNoticeFromKey)
+            }
+        } else if let prevVersion, UpdateChecker.isNewer(currentVersion, than: prevVersion) {
+            self.upgradedFrom = prevVersion
+            defaults.set(prevVersion, forKey: Self.pendingUpgradeNoticeFromKey)
         }
 
         self.failedReplaceDetected = Self.detect(
@@ -218,6 +235,6 @@ final class InstallTracker {
     /// notice leaves it pending for the next launch.
     func dismissUpgradeNotice() {
         upgradedFrom = nil
-        defaults.set(currentVersion, forKey: Self.acknowledgedVersionKey)
+        defaults.removeObject(forKey: Self.pendingUpgradeNoticeFromKey)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
@@ -97,6 +97,48 @@ final class BuiltinToolsTests {
         ) == nil)
     }
 
+    /// A rejection the model cannot read is a rejection it repeats. The
+    /// executor used to answer every schema violation with "arguments must be
+    /// a JSON object matching the advertised schema", which names neither the
+    /// offending key nor the accepted ones — so a 4B model re-sent the same
+    /// `offset_len` call. Fail closed, but say what closed it.
+    @Test("A strict-schema rejection names the unknown key and the allowed ones")
+    func strictSchemaRejectionNamesKeys() throws {
+        switch NativeToolCallExecutor.normalize(
+            ToolCall(
+                id: "document_1",
+                name: "read_document",
+                arguments: #"{"document_id":"00000000-0000-0000-0000-000000000000","offset_len":117524}"#
+            ),
+            for: ReadDocumentTool.definition
+        ) {
+        case .success:
+            Issue.record("an unknown key must not normalize")
+        case .failure(let rejection):
+            #expect(rejection.reason.contains("offset_len"))
+            #expect(rejection.reason.contains("document_id, grep, mode, offset"))
+        }
+    }
+
+    @Test("An unbounded key list is truncated in the rejection text")
+    func strictSchemaRejectionBoundsItsEcho() throws {
+        let junk = (0..<9).map { "\"k\($0)\": 1" }.joined(separator: ",")
+        switch NativeToolCallExecutor.normalize(
+            ToolCall(
+                id: "document_2",
+                name: "read_document",
+                arguments: #"{"document_id":"x",\#(junk)}"#
+            ),
+            for: ReadDocumentTool.definition
+        ) {
+        case .success:
+            Issue.record("unknown keys must not normalize")
+        case .failure(let rejection):
+            #expect(rejection.reason.contains("…"))
+            #expect(!rejection.reason.contains("k8"))
+        }
+    }
+
     @Test("Native executor rejects non-object or malformed arguments generically")
     func nativeExecutorRejectsMalformedArguments() {
         #expect(NativeToolCallExecutor.normalized(

--- a/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/BuiltinToolsTests.swift
@@ -346,4 +346,28 @@ private final class InMemoryKeychain: KeychainStoring, @unchecked Sendable {
         store.removeValue(forKey: account)
         return true
     }
+    @Test("The rejected-key echo is bounded by scalars, not characters")
+    func rejectionEchoBoundsCombiningMarks() throws {
+        // Adversarial review round 11 (codex, blocking): `prefix(80)` counts
+        // grapheme clusters, so one cluster carrying thousands of combining
+        // marks was not bounded at all.
+        let zalgo = "k" + String(repeating: "\u{0301}", count: 20_000)
+        #expect(zalgo.count == 1)   // one grapheme cluster, 20_001 scalars
+        switch NativeToolCallExecutor.normalize(
+            ToolCall(
+                id: "document_1",
+                name: "read_document",
+                arguments: "{\"document_id\":\"00000000-0000-0000-0000-000000000000\",\"\(zalgo)\":1}"
+            ),
+            for: ReadDocumentTool.definition
+        ) {
+        case .success:
+            Issue.record("an unknown key must not normalize")
+        case .failure(let rejection):
+            // 80 scalars of key plus the surrounding copy — not 20 001.
+            #expect(rejection.reason.unicodeScalars.count < 400)
+            #expect(rejection.reason.contains("unknown argument(s)"))
+        }
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/DeclinedToolDiagnosisTests.swift
@@ -6,9 +6,10 @@ import Testing
 ///
 /// The regression these lock down: a declined `browse` approval used to fall
 /// through to ``FailureDiagnosis/Kind/toolFailed``, so clicking **Don't allow**
-/// painted a red tool card reading *"The tool couldn't finish. Check its input,
-/// then try again."* — the app reporting a fault, blaming the user's own input
-/// for it, and offering to retry the very thing they had just refused.
+/// painted a red tool card reading *"The tool couldn't finish. Check its
+/// input, then try again."* (the ``.toolFailed`` copy of the day) — the app
+/// reporting a fault, blaming the user's own input for it, and offering to
+/// retry the very thing they had just refused.
 ///
 /// Four properties are pinned here, and all four matter:
 ///   1. A decline classifies as ``FailureDiagnosis/Kind/userDeclined`` and

--- a/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
@@ -225,6 +225,9 @@ struct InstallTrackerTests {
         let defaults = freshDefaults()
         defaults.set(Date(timeIntervalSince1970: 2_000_000), forKey: InstallTracker.lastSeenMtimeKey)
         defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
+        // The notice compares against the ACKNOWLEDGED version, which only the
+        // user's dismiss advances — see `upgradeNoticeIsStickyUntilAcknowledged`.
+        defaults.set("0.13.1", forKey: InstallTracker.acknowledgedVersionKey)
 
         let tracker = InstallTracker(
             currentVersion: "0.14.1",
@@ -252,6 +255,7 @@ struct InstallTrackerTests {
         // Routine relaunch.
         let same = freshDefaults()
         same.set("0.14.1", forKey: InstallTracker.lastSeenVersionKey)
+        same.set("0.14.1", forKey: InstallTracker.acknowledgedVersionKey)
         #expect(InstallTracker(
             currentVersion: "0.14.1",
             currentInfoPlistMtime: mtime,
@@ -262,6 +266,7 @@ struct InstallTrackerTests {
         // Deliberate rollback: "Updated to v0.13.1" would read as a bug.
         let back = freshDefaults()
         back.set("0.14.1", forKey: InstallTracker.lastSeenVersionKey)
+        back.set("0.14.1", forKey: InstallTracker.acknowledgedVersionKey)
         #expect(InstallTracker(
             currentVersion: "0.13.1",
             currentInfoPlistMtime: mtime,
@@ -276,6 +281,7 @@ struct InstallTrackerTests {
     func upgradeNoticeIgnoresBundleLocation() {
         let defaults = freshDefaults()
         defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
+        defaults.set("0.13.1", forKey: InstallTracker.acknowledgedVersionKey)
         let tracker = InstallTracker(
             currentVersion: "0.14.1",
             currentInfoPlistMtime: Date(timeIntervalSince1970: 2_000_000),
@@ -291,6 +297,7 @@ struct InstallTrackerTests {
         let mtime = Date(timeIntervalSince1970: 2_000_000)
         defaults.set(mtime, forKey: InstallTracker.lastSeenMtimeKey)
         defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
+        defaults.set("0.13.1", forKey: InstallTracker.acknowledgedVersionKey)
 
         let tracker = InstallTracker(
             currentVersion: "0.14.1",
@@ -302,9 +309,8 @@ struct InstallTrackerTests {
         tracker.dismissUpgradeNotice()
         #expect(tracker.upgradedFrom == nil)
 
-        // Construction already rolled the stored version forward, so the
-        // banner cannot come back for a version the user has seen — no
-        // separate "acknowledged" key to keep in sync.
+        // Dismissing recorded the acknowledgement, so the banner cannot come
+        // back for a version the user has seen.
         let relaunch = InstallTracker(
             currentVersion: "0.14.1",
             currentInfoPlistMtime: mtime.addingTimeInterval(3_600),
@@ -401,4 +407,43 @@ struct InstallTrackerTests {
         #expect(storedMtime == prevMtime)
         #expect(storedVersion == "0.7.6")
     }
+    @Test("The upgrade notice survives a quit before it is read")
+    func upgradeNoticeIsStickyUntilAcknowledged() {
+        // Adversarial review round 5 (codex, nit): the notice used to be
+        // consumed by the launch that detected it, because it compared against
+        // `lastSeenVersion` — which has to advance every launch for the
+        // failed-Replace baseline. Quitting or crashing before reading it lost
+        // it for good, contradicting the sticky-banner contract.
+        let defaults = freshDefaults()
+        let bundle = installedBundleURL
+
+        // Launch 1: first ever. Nothing to announce; baseline seeded.
+        _ = InstallTracker(
+            currentVersion: "0.13.1", currentInfoPlistMtime: Date(),
+            currentBundleURL: bundle, defaults: defaults)
+        #expect(defaults.string(forKey: InstallTracker.acknowledgedVersionKey) == "0.13.1")
+
+        // Launch 2: upgraded, notice shown — and the user quits without
+        // touching it.
+        let upgraded = InstallTracker(
+            currentVersion: "0.14.1", currentInfoPlistMtime: Date(),
+            currentBundleURL: bundle, defaults: defaults)
+        #expect(upgraded.upgradedFrom == "0.13.1")
+
+        // Launch 3: still pending, still announcing the same origin version.
+        let relaunched = InstallTracker(
+            currentVersion: "0.14.1", currentInfoPlistMtime: Date(),
+            currentBundleURL: bundle, defaults: defaults)
+        #expect(relaunched.upgradedFrom == "0.13.1")
+
+        // Dismissing (or opening the notes) is what consumes it.
+        relaunched.dismissUpgradeNotice()
+        #expect(relaunched.upgradedFrom == nil)
+        #expect(defaults.string(forKey: InstallTracker.acknowledgedVersionKey) == "0.14.1")
+        let afterDismiss = InstallTracker(
+            currentVersion: "0.14.1", currentInfoPlistMtime: Date(),
+            currentBundleURL: bundle, defaults: defaults)
+        #expect(afterDismiss.upgradedFrom == nil)
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
@@ -225,9 +225,6 @@ struct InstallTrackerTests {
         let defaults = freshDefaults()
         defaults.set(Date(timeIntervalSince1970: 2_000_000), forKey: InstallTracker.lastSeenMtimeKey)
         defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
-        // The notice compares against the ACKNOWLEDGED version, which only the
-        // user's dismiss advances — see `upgradeNoticeIsStickyUntilAcknowledged`.
-        defaults.set("0.13.1", forKey: InstallTracker.acknowledgedVersionKey)
 
         let tracker = InstallTracker(
             currentVersion: "0.14.1",
@@ -255,7 +252,6 @@ struct InstallTrackerTests {
         // Routine relaunch.
         let same = freshDefaults()
         same.set("0.14.1", forKey: InstallTracker.lastSeenVersionKey)
-        same.set("0.14.1", forKey: InstallTracker.acknowledgedVersionKey)
         #expect(InstallTracker(
             currentVersion: "0.14.1",
             currentInfoPlistMtime: mtime,
@@ -266,7 +262,6 @@ struct InstallTrackerTests {
         // Deliberate rollback: "Updated to v0.13.1" would read as a bug.
         let back = freshDefaults()
         back.set("0.14.1", forKey: InstallTracker.lastSeenVersionKey)
-        back.set("0.14.1", forKey: InstallTracker.acknowledgedVersionKey)
         #expect(InstallTracker(
             currentVersion: "0.13.1",
             currentInfoPlistMtime: mtime,
@@ -281,7 +276,6 @@ struct InstallTrackerTests {
     func upgradeNoticeIgnoresBundleLocation() {
         let defaults = freshDefaults()
         defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
-        defaults.set("0.13.1", forKey: InstallTracker.acknowledgedVersionKey)
         let tracker = InstallTracker(
             currentVersion: "0.14.1",
             currentInfoPlistMtime: Date(timeIntervalSince1970: 2_000_000),
@@ -297,7 +291,6 @@ struct InstallTrackerTests {
         let mtime = Date(timeIntervalSince1970: 2_000_000)
         defaults.set(mtime, forKey: InstallTracker.lastSeenMtimeKey)
         defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
-        defaults.set("0.13.1", forKey: InstallTracker.acknowledgedVersionKey)
 
         let tracker = InstallTracker(
             currentVersion: "0.14.1",
@@ -417,11 +410,11 @@ struct InstallTrackerTests {
         let defaults = freshDefaults()
         let bundle = installedBundleURL
 
-        // Launch 1: first ever. Nothing to announce; baseline seeded.
-        _ = InstallTracker(
+        // Launch 1: first ever. Nothing to announce, nothing owed.
+        #expect(InstallTracker(
             currentVersion: "0.13.1", currentInfoPlistMtime: Date(),
-            currentBundleURL: bundle, defaults: defaults)
-        #expect(defaults.string(forKey: InstallTracker.acknowledgedVersionKey) == "0.13.1")
+            currentBundleURL: bundle, defaults: defaults).upgradedFrom == nil)
+        #expect(defaults.string(forKey: InstallTracker.pendingUpgradeNoticeFromKey) == nil)
 
         // Launch 2: upgraded, notice shown — and the user quits without
         // touching it.
@@ -439,11 +432,72 @@ struct InstallTrackerTests {
         // Dismissing (or opening the notes) is what consumes it.
         relaunched.dismissUpgradeNotice()
         #expect(relaunched.upgradedFrom == nil)
-        #expect(defaults.string(forKey: InstallTracker.acknowledgedVersionKey) == "0.14.1")
+        #expect(defaults.string(forKey: InstallTracker.pendingUpgradeNoticeFromKey) == nil)
         let afterDismiss = InstallTracker(
             currentVersion: "0.14.1", currentInfoPlistMtime: Date(),
             currentBundleURL: bundle, defaults: defaults)
         #expect(afterDismiss.upgradedFrom == nil)
+    }
+
+    @Test("Existing users get the notice on the upgrade that ships it")
+    func upgradeNoticeMigratesFromLastSeenVersion() {
+        // Adversarial review round 7 (codex, blocking): the acknowledgement key
+        // does not exist yet for anyone already running the app, and seeding it
+        // to the current version swallowed the notice on exactly the upgrade
+        // that introduces the feature. It falls back to the last-seen version.
+        let defaults = freshDefaults()
+        defaults.set("0.14.1", forKey: InstallTracker.lastSeenVersionKey)
+        defaults.set(Date(timeIntervalSince1970: 2_000_000), forKey: InstallTracker.lastSeenMtimeKey)
+        #expect(defaults.string(forKey: InstallTracker.pendingUpgradeNoticeFromKey) == nil)
+
+        let tracker = InstallTracker(
+            currentVersion: "0.14.2",
+            currentInfoPlistMtime: Date(timeIntervalSince1970: 2_003_600),
+            currentBundleURL: installedBundleURL,
+            defaults: defaults
+        )
+        #expect(tracker.upgradedFrom == "0.14.1")
+        // Recorded as owed, so the next launch shows the same notice.
+        #expect(defaults.string(forKey: InstallTracker.pendingUpgradeNoticeFromKey) == "0.14.1")
+    }
+
+    @Test("A fresh install stays silent, and the upgrade after it does not")
+    func freshInstallHasNothingToAnnounce() {
+        let defaults = freshDefaults()
+        let first = InstallTracker(
+            currentVersion: "0.14.1", currentInfoPlistMtime: Date(timeIntervalSince1970: 2_000_000),
+            currentBundleURL: installedBundleURL, defaults: defaults)
+        #expect(first.upgradedFrom == nil)
+        // The failed-Replace baseline the first launch DID write is enough for
+        // the next upgrade to compare against.
+        let next = InstallTracker(
+            currentVersion: "0.14.2", currentInfoPlistMtime: Date(timeIntervalSince1970: 2_003_600),
+            currentBundleURL: installedBundleURL, defaults: defaults)
+        #expect(next.upgradedFrom == "0.14.1")
+    }
+
+    @Test("Both install banners can fire at once; the stale-bundle one wins")
+    func upgradeNoticeYieldsToFailedReplace() {
+        // Adversarial review round 7 (codex, nit): the two stopped being
+        // mutually exclusive when the notice became sticky. "Updated to
+        // v0.14.2" over "your update didn't install" contradicts itself.
+        let defaults = freshDefaults()
+        let mtime = Date(timeIntervalSince1970: 2_000_000)
+        defaults.set(mtime, forKey: InstallTracker.lastSeenMtimeKey)
+        defaults.set("0.14.1", forKey: InstallTracker.lastSeenVersionKey)
+
+        // Launch 1: upgraded to 0.14.2, notice pending (never dismissed).
+        _ = InstallTracker(
+            currentVersion: "0.14.2", currentInfoPlistMtime: mtime.addingTimeInterval(60),
+            currentBundleURL: installedBundleURL, defaults: defaults)
+        // Launch 2: a Finder Replace touched the bundle but the version stuck.
+        let tracker = InstallTracker(
+            currentVersion: "0.14.2", currentInfoPlistMtime: mtime.addingTimeInterval(3_600),
+            currentBundleURL: installedBundleURL, defaults: defaults)
+        #expect(tracker.failedReplaceDetected)
+        #expect(tracker.upgradedFrom == "0.14.1")
+        // Both true, so the view-level precedence is what keeps them from
+        // stacking — see `WhatsNewBanner.body`.
     }
 
 }

--- a/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
@@ -214,6 +214,118 @@ struct InstallTrackerTests {
         #expect(storedMtime == newMtime)
     }
 
+    // MARK: - Post-upgrade "what's new" notice
+
+    /// Sparkle's silent install means the version moving forward is the only
+    /// evidence the user ever gets that something changed. 0.13.1 → 0.14.1
+    /// crossed two feature releases and the window came back identical apart
+    /// from the version pill.
+    @Test("version moved forward: reports what it upgraded from")
+    func upgradeReportsPreviousVersion() {
+        let defaults = freshDefaults()
+        defaults.set(Date(timeIntervalSince1970: 2_000_000), forKey: InstallTracker.lastSeenMtimeKey)
+        defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
+
+        let tracker = InstallTracker(
+            currentVersion: "0.14.1",
+            currentInfoPlistMtime: Date(timeIntervalSince1970: 2_003_600),
+            currentBundleURL: installedBundleURL,
+            defaults: defaults
+        )
+        #expect(tracker.upgradedFrom == "0.13.1")
+        #expect(tracker.failedReplaceDetected == false)
+    }
+
+    @Test("first launch, same version, and downgrade: no upgrade notice")
+    func noUpgradeNoticeWithoutAForwardMove() {
+        let mtime = Date(timeIntervalSince1970: 2_000_000)
+
+        // First ever launch: nothing to have upgraded from.
+        let first = freshDefaults()
+        #expect(InstallTracker(
+            currentVersion: "0.14.1",
+            currentInfoPlistMtime: mtime,
+            currentBundleURL: installedBundleURL,
+            defaults: first
+        ).upgradedFrom == nil)
+
+        // Routine relaunch.
+        let same = freshDefaults()
+        same.set("0.14.1", forKey: InstallTracker.lastSeenVersionKey)
+        #expect(InstallTracker(
+            currentVersion: "0.14.1",
+            currentInfoPlistMtime: mtime,
+            currentBundleURL: installedBundleURL,
+            defaults: same
+        ).upgradedFrom == nil)
+
+        // Deliberate rollback: "Updated to v0.13.1" would read as a bug.
+        let back = freshDefaults()
+        back.set("0.14.1", forKey: InstallTracker.lastSeenVersionKey)
+        #expect(InstallTracker(
+            currentVersion: "0.13.1",
+            currentInfoPlistMtime: mtime,
+            currentBundleURL: installedBundleURL,
+            defaults: back
+        ).upgradedFrom == nil)
+    }
+
+    /// A dev build outside /Applications still upgraded — the location gate
+    /// belongs to the failed-Replace signal, not to this one.
+    @Test("an upgrade outside /Applications still reports the notice")
+    func upgradeNoticeIgnoresBundleLocation() {
+        let defaults = freshDefaults()
+        defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
+        let tracker = InstallTracker(
+            currentVersion: "0.14.1",
+            currentInfoPlistMtime: Date(timeIntervalSince1970: 2_000_000),
+            currentBundleURL: URL(fileURLWithPath: "/Users/x/build/Rapid-MLX Desktop.app"),
+            defaults: defaults
+        )
+        #expect(tracker.upgradedFrom == "0.13.1")
+    }
+
+    @Test("dismissUpgradeNotice(): clears the notice; the next launch stays clean")
+    func dismissUpgradeNoticeIsSticky() {
+        let defaults = freshDefaults()
+        let mtime = Date(timeIntervalSince1970: 2_000_000)
+        defaults.set(mtime, forKey: InstallTracker.lastSeenMtimeKey)
+        defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
+
+        let tracker = InstallTracker(
+            currentVersion: "0.14.1",
+            currentInfoPlistMtime: mtime.addingTimeInterval(3_600),
+            currentBundleURL: installedBundleURL,
+            defaults: defaults
+        )
+        #expect(tracker.upgradedFrom == "0.13.1")
+        tracker.dismissUpgradeNotice()
+        #expect(tracker.upgradedFrom == nil)
+
+        // Construction already rolled the stored version forward, so the
+        // banner cannot come back for a version the user has seen — no
+        // separate "acknowledged" key to keep in sync.
+        let relaunch = InstallTracker(
+            currentVersion: "0.14.1",
+            currentInfoPlistMtime: mtime.addingTimeInterval(3_600),
+            currentBundleURL: installedBundleURL,
+            defaults: defaults
+        )
+        #expect(relaunch.upgradedFrom == nil)
+    }
+
+    @Test("release-notes link is built only for a real version")
+    func releaseNotesLinkGrammar() {
+        #expect(
+            WhatsNewBanner.releaseNotesURL(for: "0.14.1")?.absoluteString
+                == "https://github.com/raullenchai/Rapid-MLX/releases/tag/rapid-mac-v0.14.1"
+        )
+        // No tag exists for these, so no link is offered rather than a 404.
+        #expect(WhatsNewBanner.releaseNotesURL(for: "0.14.1-dev") == nil)
+        #expect(WhatsNewBanner.releaseNotesURL(for: "dev") == nil)
+        #expect(WhatsNewBanner.releaseNotesURL(for: "") == nil)
+    }
+
     @Test("dismiss(): clears the flag without touching persistence")
     func dismissClearsFlag() {
         let defaults = freshDefaults()

--- a/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/InstallTrackerTests.swift
@@ -500,4 +500,30 @@ struct InstallTrackerTests {
         // stacking — see `WhatsNewBanner.body`.
     }
 
+    @Test("A rollback cancels an owed notice even from further back")
+    func rollbackCancelsAPendingNotice() {
+        // Adversarial review round 8 (codex, blocking): the pending notice was
+        // kept whenever the current version beat the version it was ABOUT, so
+        // 0.13.1 -> 0.15.0 -> rollback to 0.14.0 announced "Updated to
+        // v0.14.0" over a rollback.
+        let defaults = freshDefaults()
+        let mtime = Date(timeIntervalSince1970: 2_000_000)
+        defaults.set(mtime, forKey: InstallTracker.lastSeenMtimeKey)
+        defaults.set("0.13.1", forKey: InstallTracker.lastSeenVersionKey)
+
+        // Upgrade to 0.15.0; the notice is owed and never read.
+        let upgraded = InstallTracker(
+            currentVersion: "0.15.0", currentInfoPlistMtime: mtime.addingTimeInterval(60),
+            currentBundleURL: installedBundleURL, defaults: defaults)
+        #expect(upgraded.upgradedFrom == "0.13.1")
+
+        // Roll back to 0.14.0: still ahead of 0.13.1, but this launch went
+        // backwards, so there is nothing to celebrate.
+        let rolledBack = InstallTracker(
+            currentVersion: "0.14.0", currentInfoPlistMtime: mtime.addingTimeInterval(120),
+            currentBundleURL: installedBundleURL, defaults: defaults)
+        #expect(rolledBack.upgradedFrom == nil)
+        #expect(defaults.string(forKey: InstallTracker.pendingUpgradeNoticeFromKey) == nil)
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/ReadDocumentToolTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadDocumentToolTests.swift
@@ -1252,13 +1252,29 @@ struct ReadDocumentToolTests {
         }
         let (kept, _) = ReadDocumentTool.budgeted(rows)
         #expect(!kept.isEmpty)
-        #expect(kept.allSatisfy { $0.title.count <= ReadDocumentTool.maxOutlineTitleLength })
+        #expect(kept.allSatisfy {
+            $0.title.unicodeScalars.count <= ReadDocumentTool.maxOutlineTitleLength
+        })
         #expect(kept.allSatisfy { $0.title.hasSuffix("…") })
         // The offset — what the model actually needs from a row — survives.
         #expect(kept.map(\.offset) == Array(0..<kept.count))
         let cost = TokenEstimate.tokens(in: kept.map(\.title).joined(separator: "\n"))
             + kept.count * 12
         #expect(cost <= ReadDocumentTool.outlineTokenBudget)
+    }
+
+    @Test("budgeted() clamps by scalars, so combining marks cannot escape it")
+    func budgetedClampsCombiningMarks() {
+        // Adversarial review round 9 (codex, blocking): `String.count` measures
+        // grapheme clusters, so ONE cluster carrying thousands of combining
+        // marks read as one character and walked through a character cap.
+        let zalgo = "A" + String(repeating: "\u{0301}", count: 20_000)
+        #expect(zalgo.count == 1)   // one grapheme cluster, 20_001 scalars
+        let rows = [DocumentContentCache.OutlineNode(title: zalgo, depth: 0, offset: 0)]
+        let (kept, _) = ReadDocumentTool.budgeted(rows)
+        #expect(kept.count == 1)
+        #expect(kept[0].title.unicodeScalars.count <= ReadDocumentTool.maxOutlineTitleLength)
+        #expect(kept[0].offset == 0)
     }
 
     @Test("budgeted() never returns an empty outline")

--- a/apps/rapid-mac/Tests/RapidTests/ReadDocumentToolTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadDocumentToolTests.swift
@@ -1082,4 +1082,171 @@ struct ReadDocumentToolTests {
 
         #expect(ReadDocumentTool.inferredOutline(in: entry).map(\.title) == ["3 Conclusion"])
     }
+
+    // MARK: - grep outranks mode
+
+    /// The 0.14.1 regression this pins: the model asked for a scanned
+    /// statement's purchase-order number with BOTH `mode: "outline"` and a
+    /// `grep` pattern, the outline branch ran first, the pattern was dropped
+    /// without appearing anywhere in the payload, and the model reported that
+    /// the search had found nothing. A dropped argument the caller cannot see
+    /// is indistinguishable from a genuine miss.
+    @Test("grep wins over mode='outline' instead of being silently dropped")
+    func grepOutranksOutlineMode() async throws {
+        let cache = freshCache()
+        let body = "[Page 1]\n1 Preamble\n" + String(repeating: "filler line\n", count: 40)
+            + "PO-5592-KX is the purchase order\n"
+        let id = store(
+            body,
+            outline: [.init(title: "Preamble", depth: 0, page: 1, offset: 9)],
+            in: cache
+        )
+
+        let json = try payload(await run(
+            ["document_id": id.uuidString, "mode": "outline", "grep": "PO-[0-9]+-[A-Z]+"],
+            cache: cache
+        ))
+
+        // Searched, not outlined.
+        #expect(json["grep"] as? String == "PO-[0-9]+-[A-Z]+")
+        #expect(json["match_count"] as? Int == 1)
+        #expect(json["outline"] == nil)
+        let passages = try #require(json["passages"] as? [[String: Any]])
+        #expect((passages[0]["match"] as? String) == "PO-5592-KX")
+        // And it SAYS the mode was overridden, so a model that wanted the
+        // outline knows how to get it.
+        #expect(json["mode_ignored"] as? String == "outline")
+        let note = try #require(json["note"] as? String)
+        #expect(note.contains("mode='outline' was ignored"))
+    }
+
+    @Test("A no-match search still reports that mode was overridden")
+    func grepMissStillReportsIgnoredMode() async throws {
+        let cache = freshCache()
+        let id = store("[Page 1]\n1 Preamble\nnothing to find here\n", in: cache)
+
+        let json = try payload(await run(
+            ["document_id": id.uuidString, "mode": "outline", "grep": "PO-[0-9]+"],
+            cache: cache
+        ))
+
+        #expect(json["match_count"] as? Int == 0)
+        #expect(json["mode_ignored"] as? String == "outline")
+        // The distinction that matters: "searched and found nothing" must not
+        // be reachable by "never searched at all".
+        #expect(json["search_complete"] as? Bool == true)
+    }
+
+    @Test("mode='outline' alone still outlines, and reports no override")
+    func outlineModeAloneIsUnchanged() async throws {
+        let cache = freshCache()
+        let id = store(
+            "[Page 1]\nbody",
+            outline: [.init(title: "Preamble", depth: 0, page: 1, offset: 9)],
+            in: cache
+        )
+
+        let json = try payload(await run(
+            ["document_id": id.uuidString, "mode": "outline"],
+            cache: cache
+        ))
+        #expect((json["outline"] as? [[String: Any]])?.count == 1)
+        #expect(json["mode_ignored"] == nil)
+    }
+
+    @Test("An all-whitespace grep falls through to the requested mode")
+    func blankGrepDoesNotOverrideMode() async throws {
+        let cache = freshCache()
+        let id = store(
+            "[Page 1]\nbody",
+            outline: [.init(title: "Preamble", depth: 0, page: 1, offset: 9)],
+            in: cache
+        )
+
+        let json = try payload(await run(
+            ["document_id": id.uuidString, "mode": "outline", "grep": "   "],
+            cache: cache
+        ))
+        #expect((json["outline"] as? [[String: Any]])?.count == 1)
+        #expect(json["mode_ignored"] == nil)
+    }
+
+    // MARK: - Outline budget
+
+    /// The other half of the same dogfood turn: a 140-page report whose
+    /// headings all read `118.14 …` produced `"outline": []` alongside
+    /// `"entries_omitted": 800` and the note "Showing the first 0 top-level
+    /// entries of 800 total". Every heading inferred to depth 1, the budget
+    /// loop trimmed to depth 0, and `rows.filter { $0.depth == 0 }` is empty.
+    @Test("An outline whose headings all infer to depth 1 is not returned empty")
+    func deepOnlyInferredOutlineIsNeverEmpty() async throws {
+        let cache = freshCache()
+        var body = "[Page 1]\n"
+        for i in 1...600 {
+            body += "\(i).14 Section heading number \(i) of this long report\n"
+            body += "Body text for that section, long enough not to look like a heading.\n"
+        }
+        let id = store(body, pageCount: 140, in: cache)
+
+        let json = try payload(await run(
+            ["document_id": id.uuidString, "mode": "outline"],
+            cache: cache
+        ))
+        let rows = try #require(json["outline"] as? [[String: Any]])
+        #expect(!rows.isEmpty)
+        // Normalized: the shallowest inferred level is the top level.
+        #expect(rows.allSatisfy { ($0["depth"] as? Int) == 0 })
+        // Every returned row carries a usable cursor.
+        for row in rows { #expect(row["offset"] as? Int != nil) }
+        let note = try #require(json["note"] as? String)
+        #expect(!note.contains("first 0"))
+        #expect(note.contains("Showing the first \(rows.count) of"))
+    }
+
+    @Test("Inferred depth is normalized so an outline always has a top level")
+    func inferredOutlineDepthIsNormalized() throws {
+        let entry = DocumentContentCache.Entry(
+            filename: "report.pdf",
+            text: "[Page 1]\n118.14 Deep heading one\n"
+                + "prose that is long enough to not be mistaken for a heading here.\n"
+                + "118.15.2 Deeper heading two\n"
+        )
+
+        let rows = ReadDocumentTool.inferredOutline(in: entry)
+        #expect(rows.map(\.title) == ["118.14 Deep heading one", "118.15.2 Deeper heading two"])
+        // Raw dot-counts are 1 and 2; normalized they are 0 and 1.
+        #expect(rows.map(\.depth) == [0, 1])
+    }
+
+    @Test("A depth-trimmed outline reports the levels it kept, not a row count")
+    func depthTrimNoteCountsLevels() async throws {
+        let cache = freshCache()
+        var nodes: [DocumentContentCache.OutlineNode] = []
+        for chapter in 0..<40 {
+            nodes.append(.init(title: "Chapter \(chapter) of the document", depth: 0, page: chapter + 1, offset: chapter * 100))
+            for section in 0..<20 {
+                nodes.append(.init(title: "Section \(chapter).\(section) with a reasonably long heading", depth: 1, page: chapter + 1, offset: chapter * 100 + section))
+            }
+        }
+        let id = store("body", outline: nodes, in: cache)
+
+        let json = try payload(await run(["document_id": id.uuidString, "mode": "outline"], cache: cache))
+        let note = try #require(json["note"] as? String)
+        // All 40 chapters survived, so the honest note is "the top 1 level" —
+        // the old copy read "the first 40 top-level entries … the later
+        // sections are omitted", which claims chapters were dropped.
+        #expect(note.contains("Showing the top 1 level(s) of 840 total entries"))
+        #expect(!note.contains("top-level entries"))
+    }
+
+    @Test("budgeted() keeps one row even when a single title blows the budget")
+    func budgetedAlwaysKeepsARow() {
+        let giant = String(repeating: "very long heading word ", count: 400)
+        let rows = (0..<3).map {
+            DocumentContentCache.OutlineNode(title: "\($0) \(giant)", depth: 0, offset: $0)
+        }
+        let (kept, trim) = ReadDocumentTool.budgeted(rows)
+        #expect(kept.count == 1)
+        #expect(trim == .prefix)
+    }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ReadDocumentToolTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ReadDocumentToolTests.swift
@@ -1239,14 +1239,40 @@ struct ReadDocumentToolTests {
         #expect(!note.contains("top-level entries"))
     }
 
-    @Test("budgeted() keeps one row even when a single title blows the budget")
-    func budgetedAlwaysKeepsARow() {
+    @Test("budgeted() clamps titles so no single row can defeat the budget")
+    func budgetedClampsGiantTitles() {
+        // Adversarial review round 5 (codex, blocking): the trimmer has to
+        // return at least one row, so an arbitrarily long bookmark title —
+        // document-controlled — used to walk straight through
+        // `outlineTokenBudget` and into the model's context. Titles are
+        // clamped before any budget decision now.
         let giant = String(repeating: "very long heading word ", count: 400)
         let rows = (0..<3).map {
             DocumentContentCache.OutlineNode(title: "\($0) \(giant)", depth: 0, offset: $0)
         }
+        let (kept, _) = ReadDocumentTool.budgeted(rows)
+        #expect(!kept.isEmpty)
+        #expect(kept.allSatisfy { $0.title.count <= ReadDocumentTool.maxOutlineTitleLength })
+        #expect(kept.allSatisfy { $0.title.hasSuffix("…") })
+        // The offset — what the model actually needs from a row — survives.
+        #expect(kept.map(\.offset) == Array(0..<kept.count))
+        let cost = TokenEstimate.tokens(in: kept.map(\.title).joined(separator: "\n"))
+            + kept.count * 12
+        #expect(cost <= ReadDocumentTool.outlineTokenBudget)
+    }
+
+    @Test("budgeted() never returns an empty outline")
+    func budgetedAlwaysKeepsARow() {
+        // 900 rows at one depth, each within the title clamp: over both caps,
+        // so the prefix branch runs — and must still hand back a usable offset
+        // rather than an empty list that reads as "no structure here".
+        let title = String(repeating: "heading ", count: 18)
+        let rows = (0..<900).map {
+            DocumentContentCache.OutlineNode(title: "\($0) \(title)", depth: 0, offset: $0)
+        }
         let (kept, trim) = ReadDocumentTool.budgeted(rows)
-        #expect(kept.count == 1)
+        #expect(!kept.isEmpty)
+        #expect(kept.count <= ReadDocumentTool.maxOutlineRows)
         #expect(trim == .prefix)
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -336,6 +336,70 @@ struct ToolCallArtifactSuppressionTests {
             content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
     }
 
+    @Test("A CLOSED fenced example does not hide a real envelope after it")
+    func trailingEnvelopeAfterFencedExampleIsStillCaught() {
+        // Adversarial review round 1 (codex, blocking): the detector used to
+        // take the FIRST match of each pattern and then decide on it alone,
+        // so a legitimate fenced example earlier in the turn made the whole
+        // function answer nil — and the genuine unfenced envelope after it
+        // rendered raw. The scan now skips the fenced candidate and keeps
+        // going.
+        let content = """
+        A Hermes call looks like this:
+
+        ```xml
+        <tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>
+        ```
+
+        Now let me actually run it:
+
+        <tool_call> {"name":"search","arguments":{"q":"Statement
+        """
+        let prose = ChatMessage.trailingToolCallArtifactProse(in: content)
+        // Everything up to the real envelope is kept — the fenced example
+        // included, because that example IS part of the answer.
+        #expect(prose?.hasPrefix("A Hermes call looks like this:") == true)
+        #expect(prose?.hasSuffix("Now let me actually run it:") == true)
+        #expect(prose?.contains("```xml") == true)
+        #expect(ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+    }
+
+    @Test("Prose that documents <parameter=…> inline is not an artifact")
+    func trailingParameterMentionIsNotAnArtifact() {
+        // Adversarial review round 1 (codex, blocking): `<(function|parameter)=`
+        // carried no payload requirement, so an answer EXPLAINING the syntax
+        // was truncated at the tag. `<function=` now needs a payload and
+        // `<parameter=` needs both its own line and a closing tag.
+        for content in [
+            "Use <parameter=name> to identify the field, then send the call.",
+            "The fragment shape is <function=get_weather> with no arguments at all.",
+            "Qwen writes <parameter=query> inline and closes it later; that is the format.",
+        ] {
+            #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+            #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+                content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+        }
+    }
+
+    @Test("A real <function=…><parameter=…> args block IS an artifact")
+    func trailingParameterBlockIsAnArtifact() {
+        let content = """
+        I will look up the weather for you.
+
+        <function=get_weather>
+        <parameter=city>NYC</parameter>
+        </function>
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content)
+            == "I will look up the weather for you.")
+        // …and the `<parameter=` block alone (no `<function=` opener) too,
+        // as long as it stands on its own line and closes.
+        #expect(ChatMessage.trailingToolCallArtifactProse(
+            in: "Checking now.\n<parameter=city>NYC</parameter>"
+        ) == "Checking now.")
+    }
+
     @Test("An unclosed fence still counts as inside a fence")
     func trailingUnclosedFenceIsNotAnArtifact() {
         let content = "Example:\n\n```xml\n<tool_call>{\"name\": \"search\"}"

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -278,6 +278,132 @@ struct ToolCallArtifactSuppressionTests {
         #expect(!decoded.toolCallArtifactSuppressed)
     }
 
+    // MARK: - Trailing artifact: prose answered, then the tail broke
+
+    /// The 0.14.1 dogfood repro, abbreviated: a real answer that ends by
+    /// promising an action, then an envelope nothing claimed. No tool round
+    /// fired, so the promise was never kept and the user saw only the
+    /// promise — for six minutes.
+    @Test("Prose followed by a <tool_call> envelope keeps the prose and flags the tail")
+    func trailingEnvelopeKeepsProse() {
+        let content = """
+        Let me read the first page more carefully with a higher offset:
+
+        <tool_call> {"name":"read_document","arguments":{"document_id":"abc","greP":"Statement
+        """
+        let prose = ChatMessage.trailingToolCallArtifactProse(in: content)
+        #expect(prose == "Let me read the first page more carefully with a higher offset:")
+        // Whole-turn detection does NOT fire — the artifact is the tail.
+        #expect(!ChatMessage.contentLooksLikeToolCallArtifact(content))
+        // …but the gate does, so the row gets the caption.
+        #expect(ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+        #expect(ChatMessage.proseAboveSuppressedToolCallArtifact(content: content) == prose)
+    }
+
+    @Test("A trailing [TOOL_CALLS] / DeepSeek marker is caught the same way")
+    func trailingOtherFormats() {
+        #expect(ChatMessage.trailingToolCallArtifactProse(
+            in: "Sure, let me look that up.\n\n[TOOL_CALLS] [{\"name\":\"search\"}]"
+        ) == "Sure, let me look that up.")
+        #expect(ChatMessage.trailingToolCallArtifactProse(
+            in: "I will check.\n<function=get_weather>{\"city\":\"NYC\"}"
+        ) == "I will check.")
+    }
+
+    @Test("A trailing tag the answer only TALKS about is not an artifact")
+    func trailingProseMentionIsNotAnArtifact() {
+        // No payload after the marker → the `leadingEnvelopeLeak` gate holds.
+        #expect(ChatMessage.trailingToolCallArtifactProse(
+            in: "Hermes-style models wrap their calls in <tool_call> tags."
+        ) == nil)
+        #expect(ChatMessage.trailingToolCallArtifactProse(
+            in: "The prefix Mistral uses is [TOOL_CALLS] and nothing else."
+        ) == nil)
+    }
+
+    @Test("A fenced example ending the answer is not an artifact")
+    func trailingFencedExampleIsNotAnArtifact() {
+        let content = """
+        Here is what a Hermes call looks like:
+
+        ```xml
+        <tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>
+        ```
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+    }
+
+    @Test("An unclosed fence still counts as inside a fence")
+    func trailingUnclosedFenceIsNotAnArtifact() {
+        let content = "Example:\n\n```xml\n<tool_call>{\"name\": \"search\"}"
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+    }
+
+    @Test("A whole-turn artifact still renders the caption alone")
+    func wholeTurnArtifactHasNoProse() {
+        let content = "<tool_call>{\"name\": \"search\", \"arguments\": {\"q\": \"x\"}}</tool_call>"
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+        #expect(ChatMessage.proseAboveSuppressedToolCallArtifact(content: content) == nil)
+        #expect(ChatMessage.contentLooksLikeToolCallArtifact(content))
+    }
+
+    @Test("A trailing artifact is still gated on tools + zero calls")
+    func trailingArtifactRespectsTheGates() {
+        let content = "Let me look.\n\n<tool_call> {\"name\":\"search\",\"arguments\":{"
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop", toolsRequested: false))
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: content,
+            toolCalls: [ToolCall(id: "1", name: "search", arguments: "{}")],
+            finishReason: "stop",
+            toolsRequested: true))
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "tool_calls", toolsRequested: true))
+    }
+
+    /// The dangerous false positive the strict payload gate exists for: an
+    /// answer that names the tag in a sentence and shows the example in a
+    /// fence further down. A loose "carries a closing tag somewhere" gate
+    /// would start the tail at the sentence and delete the explanation.
+    @Test("An answer that names the tag then fences an example keeps all of it")
+    func mentionThenFencedExampleIsNotAnArtifact() {
+        let content = """
+        Hermes models wrap their calls in <tool_call> tags. For example:
+
+        ```xml
+        <tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>
+        ```
+
+        The engine strips them before you see the result.
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+    }
+
+    /// A prose turn that trailed off into the DeepSeek marker used to be
+    /// suppressed WHOLE (the marker matches anywhere), taking the answer
+    /// with it.
+    @Test("A trailing DeepSeek marker keeps the prose above it")
+    func trailingDeepSeekMarkerKeepsProse() {
+        let content = "I will look that up for you.\n<\u{FF5C}tool\u{2581}calls\u{2581}begin\u{FF5C}>"
+        #expect(ChatMessage.contentLooksLikeToolCallArtifact(content))
+        #expect(
+            ChatMessage.proseAboveSuppressedToolCallArtifact(content: content)
+                == "I will look that up for you."
+        )
+    }
+
+    @Test("An ordinary long answer is untouched")
+    func ordinaryAnswerHasNoTrailingArtifact() {
+        #expect(ChatMessage.trailingToolCallArtifactProse(
+            in: "The purchase order number is PO-5592-KX and the total is 14,208.55."
+        ) == nil)
+    }
+
     @Test("The suppressed-body caption carries no machine jargon")
     func captionHasNoJargon() {
         let copy = ChatMessage.toolCallArtifactSuppressedCaptionCopy.lowercased()

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -612,6 +612,48 @@ struct ToolCallArtifactSuppressionTests {
         #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
     }
 
+    @Test("A pretty-printed envelope with array values is still a tail")
+    func trailingPrettyPrintedEnvelopeIsAnArtifact() {
+        // Adversarial review round 6 (codex, blocking): a pretty-printed call
+        // puts bare scalars on their own lines, and those reset the terminal
+        // run, so the raw envelope stayed visible.
+        let content = """
+        Let me search for those records:
+
+        <tool_call>
+        {
+          "name": "search",
+          "arguments": {
+            "ids": [
+              10,
+              -2.5,
+              true,
+              null
+            ]
+          }
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content)
+            == "Let me search for those records:")
+        #expect(ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+    }
+
+    @Test("Prose that merely ends in a comma or colon is not machine syntax")
+    func proseLinesEndingInPunctuationStopTheRun() {
+        // The scalar test must stay strict: a looser one moves the boundary
+        // EARLIER, and an over-early boundary eats real prose. Here the run
+        // has to stop at the last sentence, so the example above it survives.
+        let content = """
+        The shape is:
+
+        <tool_call>{"name":"search","arguments":{}}</tool_call>
+
+        First, note the name field,
+        and second, the arguments object.
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+    }
+
     @Test("A whole-turn artifact still renders the caption alone")
     func wholeTurnArtifactHasNoProse() {
         let content = "<tool_call>{\"name\": \"search\", \"arguments\": {\"q\": \"x\"}}</tool_call>"

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -471,18 +471,72 @@ struct ToolCallArtifactSuppressionTests {
         #expect(ChatMessage.fencedRanges(in: "    ```\nx\n    ```").isEmpty)
     }
 
-    @Test("An earlier format's fenced examples do not exhaust the scan budget")
-    func perPatternCandidateBudget() {
-        // Adversarial review round 2 (codex, nit): the candidate cap used to
-        // be shared, so a wall of fenced `<tool_call>` examples spent it
-        // before the `[TOOL_CALLS]` pattern ran and a genuine Mistral tail
-        // went unnoticed.
+    @Test("Any number of fenced examples still cannot hide a real tail")
+    func fencedExamplesNeverHideTheTail() {
+        // Adversarial review rounds 2-3 (codex): a candidate CAP — shared or
+        // per pattern — is spent by the examples and loses the real envelope
+        // after them. There is no cap now: a match inside a fence advances
+        // the cursor past the whole fenced block, so 200 examples cost 200
+        // cheap steps and the tail is still found. Same syntax as the tail on
+        // purpose: that is the case a per-pattern cap still got wrong.
         let example = "```xml\n<tool_call>{\"name\": \"s\"}</tool_call>\n```\n"
         let content = "Examples:\n\n"
-            + String(repeating: example, count: 80)
-            + "\nNow running it:\n\n[TOOL_CALLS] [{\"name\":\"search\"}]"
+            + String(repeating: example, count: 200)
+            + "\nNow running it:\n\n<tool_call> {\"name\":\"search\",\"arguments\":{\"q\":\"x\"\n"
         #expect(ChatMessage.trailingToolCallArtifactProse(in: content)?
             .hasSuffix("Now running it:") == true)
+    }
+
+    @Test("A turn that OPENS with a fenced example is still scanned on")
+    func leadingFencedExampleDoesNotEndTheScan() {
+        // Adversarial review round 3 (codex, blocking): the start-index guard
+        // ran before the fence check, so the leading detector could be handed
+        // a turn whose first candidate was merely a fenced example — and the
+        // genuine envelope further down rendered raw. The guard now applies to
+        // the first UNFENCED candidate.
+        let content = """
+        ```xml
+        <tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>
+        ```
+
+        That is the shape. Running it:
+
+        <tool_call> {"name":"search","arguments":{"q":"Statement
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content)?
+            .hasSuffix("That is the shape. Running it:") == true)
+        #expect(ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+    }
+
+    @Test("A fence line with an info string never closes a fence")
+    func infoStringLineIsFenceContent() {
+        // Adversarial review round 3 (codex, blocking): CommonMark gives a
+        // CLOSING fence no info string, so a ```` ```swift ```` line inside a
+        // ``` block is content. Closing on it left the rest of the example
+        // unfenced, and the answer was truncated mid-example.
+        let content = """
+        Two examples, one block:
+
+        ```
+        ```swift
+        <tool_call>{"name": "search"}</tool_call>
+        ```
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+        let ranges = ChatMessage.fencedRanges(in: content)
+        #expect(ranges.count == 1)
+        // Trailing whitespace after the run is still a valid closer.
+        #expect(ChatMessage.fencedRanges(in: "```\nx\n```   \nafter").count == 1)
+    }
+
+    @Test("A leading tab is four columns, not one")
+    func tabIndentIsNotAFenceOpener() {
+        // Adversarial review round 3 (codex, nit): indentation decides the
+        // CommonMark cutoff, and a single tab already reaches column four —
+        // an indented code block, not a fence opener.
+        #expect(ChatMessage.fencedRanges(in: "\t```\nx\n\t```").isEmpty)
+        #expect(ChatMessage.fencedRanges(in: "   ```\nx\n   ```").count == 1)
     }
 
     @Test("A whole-turn artifact still renders the caption alone")

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -406,6 +406,85 @@ struct ToolCallArtifactSuppressionTests {
         #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
     }
 
+    @Test("Tilde and four-backtick fences hide their examples too")
+    func trailingNonBacktickFencesAreRespected() {
+        // Adversarial review round 2 (codex, blocking): the fence check
+        // counted literal ``` runs, so a `~~~` fence (no backticks at all)
+        // and a ```` fence (the standard way to show a ``` example nested
+        // inside one) both read as UNFENCED — and the example the user asked
+        // for was truncated as a leak. Fences are parsed now.
+        let tilde = """
+        Here is the shape:
+
+        ~~~
+        <tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>
+        ~~~
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: tilde) == nil)
+
+        let nested = """
+        Here is the shape:
+
+        ````markdown
+        ```xml
+        <tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>
+        ```
+        ````
+        """
+        // The inner ``` is shorter than the ```` opener, so it is fence
+        // CONTENT and does not close the block — the marker stays covered.
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: nested) == nil)
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: nested, toolCalls: [], finishReason: "stop", toolsRequested: true))
+    }
+
+    @Test("A tilde-fenced example does not hide a real envelope after it")
+    func trailingEnvelopeAfterTildeFenceIsStillCaught() {
+        let content = """
+        The shape is:
+
+        ~~~xml
+        <tool_call>{"name": "search"}</tool_call>
+        ~~~
+
+        Running it now:
+
+        <tool_call> {"name":"search","arguments":{"q":"Statement
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content)?
+            .hasSuffix("Running it now:") == true)
+    }
+
+    @Test("Fence ranges follow the opener's delimiter and length")
+    func fenceRangeParsing() {
+        // A closer must match the opener's character AND be at least as long.
+        #expect(ChatMessage.fencedRanges(in: "```\nx\n```\nafter").count == 1)
+        #expect(ChatMessage.fencedRanges(in: "~~~\nx\n~~~\nafter").count == 1)
+        // `~~~` cannot close a ``` fence, so the block runs to the end.
+        let mismatched = ChatMessage.fencedRanges(in: "```\nx\n~~~\nafter")
+        #expect(mismatched.count == 1)
+        #expect(mismatched.first?.upperBound == "```\nx\n~~~\nafter".endIndex)
+        // Inline code is not a fence, and neither is a two-character run.
+        #expect(ChatMessage.fencedRanges(in: "use `tool_call` here").isEmpty)
+        #expect(ChatMessage.fencedRanges(in: "``\nx\n``").isEmpty)
+        // Four leading spaces is an indented code block, not a fence opener.
+        #expect(ChatMessage.fencedRanges(in: "    ```\nx\n    ```").isEmpty)
+    }
+
+    @Test("An earlier format's fenced examples do not exhaust the scan budget")
+    func perPatternCandidateBudget() {
+        // Adversarial review round 2 (codex, nit): the candidate cap used to
+        // be shared, so a wall of fenced `<tool_call>` examples spent it
+        // before the `[TOOL_CALLS]` pattern ran and a genuine Mistral tail
+        // went unnoticed.
+        let example = "```xml\n<tool_call>{\"name\": \"s\"}</tool_call>\n```\n"
+        let content = "Examples:\n\n"
+            + String(repeating: example, count: 80)
+            + "\nNow running it:\n\n[TOOL_CALLS] [{\"name\":\"search\"}]"
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content)?
+            .hasSuffix("Now running it:") == true)
+    }
+
     @Test("A whole-turn artifact still renders the caption alone")
     func wholeTurnArtifactHasNoProse() {
         let content = "<tool_call>{\"name\": \"search\", \"arguments\": {\"q\": \"x\"}}</tool_call>"

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -539,6 +539,28 @@ struct ToolCallArtifactSuppressionTests {
         #expect(ChatMessage.fencedRanges(in: "   ```\nx\n   ```").count == 1)
     }
 
+    @Test("An UNFENCED inline example mid-sentence is not an artifact")
+    func trailingInlineExampleIsNotAnArtifact() {
+        // Adversarial review round 4 (codex, blocking): the payload gate alone
+        // still matched an answer that documents a call inline without a
+        // fence, and truncated the sentence at the tag. Envelopes must open a
+        // line now — which every real leak shape does, the dogfood repro
+        // included.
+        for content in [
+            "Use <tool_call>{\"name\":\"search\"}</tool_call> to run a search.",
+            "Mistral writes [TOOL_CALLS] [{\"name\":\"search\"}] on one line.",
+            "The fragment is <function=get_weather>{\"city\":\"NYC\"} in that dialect.",
+        ] {
+            #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+            #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+                content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+        }
+        // Indented is still "opening a line" — a leak inside a list item.
+        #expect(ChatMessage.trailingToolCallArtifactProse(
+            in: "Running it:\n  <tool_call> {\"name\":\"search\",\"arguments\":{"
+        ) == "Running it:")
+    }
+
     @Test("A whole-turn artifact still renders the caption alone")
     func wholeTurnArtifactHasNoProse() {
         let content = "<tool_call>{\"name\": \"search\", \"arguments\": {\"q\": \"x\"}}</tool_call>"

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -654,6 +654,28 @@ struct ToolCallArtifactSuppressionTests {
         #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
     }
 
+    @Test("A parsed tool call is never suppressed, however it was written")
+    func parsedCallIsNeverSuppressed() {
+        // The standing answer to "what about a complete unfenced example?"
+        // (raised in adversarial review rounds 5 and 8): gates 1-3 ARE the
+        // parser-rejected evidence. An envelope the engine could read comes
+        // back as a real `tool_calls` entry, and gate 2 then declines to
+        // suppress anything — whatever the content looks like.
+        let content = """
+        Hermes models emit this:
+
+        <tool_call>{"name":"search","arguments":{"q":"x"}}</tool_call>
+        """
+        let call = ToolCall(id: "call_1", name: "search", arguments: "{\"q\":\"x\"}")
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [call], finishReason: "tool_calls",
+            toolsRequested: true))
+        // And a turn that never advertised tools is out of scope entirely.
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop",
+            toolsRequested: false))
+    }
+
     @Test("A whole-turn artifact still renders the caption alone")
     func wholeTurnArtifactHasNoProse() {
         let content = "<tool_call>{\"name\": \"search\", \"arguments\": {\"q\": \"x\"}}</tool_call>"

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -561,6 +561,57 @@ struct ToolCallArtifactSuppressionTests {
         ) == "Running it:")
     }
 
+    @Test("A raw example the answer goes on to EXPLAIN keeps its explanation")
+    func trailingExampleFollowedByProseIsNotAnArtifact() {
+        // Adversarial review round 5 (codex, blocking): suppression ran from
+        // the marker to the end of the turn without checking that only machine
+        // syntax followed, so an answer that showed an unfenced call and then
+        // explained it lost the explanation. The envelope has to be the TAIL.
+        let content = """
+        Here is the call, unfenced:
+
+        <tool_call>{"name":"search","arguments":{"q":"x"}}</tool_call>
+
+        As you can see, the name field picks the tool and arguments carries
+        the payload.
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+        #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+            content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+    }
+
+    @Test("Example, prose, then a real envelope keeps everything but the tail")
+    func trailingRealEnvelopeAfterRawExampleKeepsTheProse() {
+        let content = """
+        The shape is:
+
+        <tool_call>{"name":"search","arguments":{"q":"x"}}</tool_call>
+
+        Now running it for real:
+
+        <tool_call> {"name":"search","arguments":{"q":"Statement
+        """
+        let prose = ChatMessage.trailingToolCallArtifactProse(in: content)
+        // The earlier raw example is part of the answer, not the tail.
+        #expect(prose?.contains("The shape is:") == true)
+        #expect(prose?.hasSuffix("Now running it for real:") == true)
+    }
+
+    @Test("A turn ending in a fenced example is never a tail")
+    func trailingFenceCloserEndsTheRun() {
+        // The closing ``` is not machine syntax for this purpose, so the run
+        // never starts and the answer is left alone — which is the same
+        // verdict the fence check gives, reached one step earlier.
+        let content = """
+        Example:
+
+        ```json
+        {"name":"search","arguments":{"q":"x"}}
+        ```
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+    }
+
     @Test("A whole-turn artifact still renders the caption alone")
     func wholeTurnArtifactHasNoProse() {
         let content = "<tool_call>{\"name\": \"search\", \"arguments\": {\"q\": \"x\"}}</tool_call>"

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -676,6 +676,56 @@ struct ToolCallArtifactSuppressionTests {
             toolsRequested: false))
     }
 
+    @Test("Punctuation-led prose after an example stops the terminal run")
+    func punctuationLedProseIsNotMachineSyntax() {
+        // Adversarial review round 10 (codex, blocking): the run test was
+        // "the first character is punctuation", and prose opens with
+        // punctuation often enough for that to eat real content — a Markdown
+        // link, a reference definition, a quoted sentence. Each opener is
+        // matched structurally now.
+        let shapes = [
+            "[That syntax](https://example.com) is invalid, by the way.",
+            "[1]: https://example.com/tool-calling",
+            "\"That syntax\" is invalid, by the way.",
+            "<- that is what a leaked call looks like.",
+        ]
+        for tail in shapes {
+            let content = """
+            Here is the call:
+
+            <tool_call>{"name":"search","arguments":{"q":"x"}}</tool_call>
+
+            \(tail)
+            """
+            #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+            #expect(!ChatMessage.shouldSuppressToolCallArtifact(
+                content: content, toolCalls: [], finishReason: "stop", toolsRequested: true))
+        }
+    }
+
+    @Test("Real JSON continuation lines still count as machine syntax")
+    func jsonContinuationLinesStayInTheRun() {
+        // The other half of round 10: tightening the openers must not drop the
+        // shapes an envelope dump actually produces.
+        let content = """
+        Let me search those records:
+
+        <tool_call>
+        {
+          "name": "search",
+          "arguments": {
+            "queries": [
+              "first",
+              "second"
+            ],
+            "limit": 10
+          }
+        }
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content)
+            == "Let me search those records:")
+    }
+
     @Test("A whole-turn artifact still renders the caption alone")
     func wholeTurnArtifactHasNoProse() {
         let content = "<tool_call>{\"name\": \"search\", \"arguments\": {\"q\": \"x\"}}</tool_call>"

--- a/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolCallArtifactSuppressionTests.swift
@@ -726,6 +726,45 @@ struct ToolCallArtifactSuppressionTests {
             == "Let me search those records:")
     }
 
+    @Test("Prose that opens with a brace or bracket stops the run")
+    func braceLedProseIsNotMachineSyntax() {
+        // Adversarial review round 11 (codex, blocking): `{ } ] ,` passed
+        // unconditionally, so a sentence opening with one — "} closes the
+        // object; this is why …" — extended the run and was hidden along with
+        // the example above it.
+        let shapes = [
+            "} closes the object; this is why the call is complete.",
+            "] ends the array, and the rest is up to the tool.",
+            ", separating the two arguments, is easy to miss.",
+            "{ opens it, in case that was not obvious.",
+        ]
+        for tail in shapes {
+            let content = """
+            Here is the call:
+
+            <tool_call>{"name":"search","arguments":{"q":"x"}}</tool_call>
+
+            \(tail)
+            """
+            #expect(ChatMessage.trailingToolCallArtifactProse(in: content) == nil)
+        }
+    }
+
+    @Test("Multi-call and keyword-valued fragments stay in the run")
+    func jsonFragmentLinesStayInTheRun() {
+        // The other half of round 11: an unquoted JSON keyword and a
+        // `},{`-style multi-call boundary are fragments, not sentences.
+        let content = """
+        Searching both indexes:
+
+        <tool_call>
+        [{"name":"search","arguments":{"q":"x","exact": true}},
+        {"name":"search","arguments":{"q":"y","exact": false}}]
+        """
+        #expect(ChatMessage.trailingToolCallArtifactProse(in: content)
+            == "Searching both indexes:")
+    }
+
     @Test("A whole-turn artifact still renders the caption alone")
     func wholeTurnArtifactHasNoProse() {
         let content = "<tool_call>{\"name\": \"search\", \"arguments\": {\"q\": \"x\"}}</tool_call>"


### PR DESCRIPTION
## Why

A 0.14.1 GUI dogfood on a Mac mini (M2 Pro, 32 GB, macOS 26.5.2), driven as a
user rather than as a test, found six defects on the document-analysis path —
the headline feature 0.14.1 shipped. The worst of them is silent: a model that
searches an attached document and is told "nothing found" when the search never
ran. Each fix below names the observation it answers; the 0.14.1 build, the
persisted transcript and the sidecar's `/metrics` counters are the evidence.

The single user-visible incident that motivated most of this: "What is the
purchase order number and the invoice total in this statement?" against a
9-page scanned PDF whose answer is on page 6. Three tool rounds in 136 s, then
no answer for ten minutes, then the user cancelled. Read back from
`conversations.json`, that turn contains a dropped `grep`, two identical empty
outlines, and a garbled tool call whose envelope nothing claimed.

## Scope

* `ReadDocumentTool` — `grep` now outranks `mode`; inferred outline depth is
  normalized; `budgeted()` never returns an empty outline and reports which cut
  it made (`OutlineTrim`).
* `ChatMessage` — a tool-call artifact that TRAILS a real answer is detected
  (`trailingToolCallArtifactProse`) so #513's caption applies without discarding
  the prose.
* `NativeToolCallExecutor` — `normalize()` returns the rejection reason, so a
  strict-schema violation names the offending key and the accepted ones.
* `FailureDiagnosis.toolFailed` copy; the arguments block on an expanded failed
  tool chip is captioned.
* `InstallTracker.upgradedFrom` + new `WhatsNewBanner`, mounted in
  `ContentView`'s production shell beside `FailedReplaceBanner`.
* CHANGELOG under `[Unreleased]`.

### The six

**1. `grep` was dropped when `mode` was also set.** The model sent
`mode: "outline"` and a `grep` pattern together. `if mode == "outline"` ran
first, the pattern was discarded, and the payload neither echoed `grep` nor
warned — so a table of contents came back and the model reported the term
absent. `grep` now wins, and the result carries `mode_ignored` plus a note so a
model that wanted the outline knows how to ask again. The `mode` description
itself ("pass the separate 'grep' argument") invites this exact call shape.

**2. An outline came back empty, and said so contradictorily.** A 140-page
report whose headings all read `118.14 …` produced `"outline": []` beside
`"entries_omitted": 800` and "Showing the first 0 top-level entries of 800
total". Inferred depth is the dot count of the leading numeric run, so every
row was depth 1 and the trimmer's `rows.filter { $0.depth == 0 }` was empty.
Inference normalizes depth to 0-based; `budgeted` trims relative to the
shallowest level present and keeps at least one row; the note describes the cut
it made. That last part also fixes the bookmark case, where keeping all 40
chapters and dropping their 800 sections was reported as "the first 40
top-level entries … the later sections are omitted".

**3. A turn that answered and then garbled a tool call lost its answer.** The
same conversation ended with 5,413 characters of prose followed by
`<tool_call> {"name":"read_document",…,"greP":…`. #513's suppression fires only
when the artifact IS the whole turn, so the raw envelope was rendered instead.
A trailing artifact now gets the same caption with the prose kept above it. The
trailing detector is deliberately stricter than the leading one: the payload
must follow the marker immediately, and a marker inside a fence is never a leak
— an answer that names the tag and then shows a fenced example has to survive
untouched, and there is a test for exactly that.

**4. A rejected tool call did not say what was wrong.** #3314 made the executor
fail closed on unknown arguments, but every violation answered "arguments must
be a JSON object matching the advertised schema" — naming neither the offending
key nor the accepted ones, so a 4B model re-sent the same call. `offset_len` now
comes back as "unknown argument(s): offset_len — this tool accepts only:
document_id, grep, mode, offset".

**5. A failed tool blamed the user.** "The tool couldn't finish. Check its
input, then try again." pointed at the one thing the user does not control, and
on screen it sat under `{ "offset_type": null, "url": "" }` — keys this app has
never had. The copy now says whose step failed; the arguments block is captioned
as the model's request instead of looking like Rapid's output.

**6. Nothing told an upgrading user what changed.** Sparkle installs on quit and
relaunches silently, so 0.13.1 → 0.14.1 — Computer Use, Share Compute, PDF
analysis, model unload, six image models — produced an identical window with a
different number in the version pill. `InstallTracker` already reads the previous
version on every launch for its failed-Replace check; `WhatsNewBanner` spends it
on a one-line notice with a link to that release's notes. Forward moves only,
dismissible, and mutually exclusive with the failed-Replace banner by
construction (that one requires the version to have stayed put).

## Non-goals

* **Idle CPU burn and the frozen transcript.** The dogfood also measured ~0.8
  CPU core at idle on the mini and a 4-minute transcript freeze during a
  document answer (99.6% CPU in SwiftUI layout; Stop took 44 s to land). Neither
  reproduces on an M3 Ultra — a settled production-shell window measures 0.0–0.7%
  CPU across 7 threads. They need a mini-side profile, not a speculative fix, and
  they are filed separately.
* **Zero prefix-cache reuse.** `rapid_mlx_prefix_cache_hits_total` stayed 0 for
  every request of the session because `prefix_boundary` is forwarded only for
  hybrid models, so `_store_exact_text_prefix` never stores. That is an engine
  change with its own perf comparison; separate PR.
* **The engine-side tool parser.** Finding 3 makes the UI honest about a
  malformed call; it does not try to salvage the call or to stop a runaway
  generation. Recovering a `<tool_call>` the hermes parser missed belongs in the
  engine parser, ported from vLLM/SGLang rather than invented here.
* No version bump — batched for a later release PR.

## Acceptance

* A `read_document` call carrying both `mode: "outline"` and a non-empty `grep`
  searches, returns `passages`, and reports `mode_ignored: "outline"`. A
  whitespace-only `grep` still honours `mode`.
* A no-match search is distinguishable from a search that never ran:
  `match_count: 0` with `search_complete: true`, never an outline payload.
* `mode: "outline"` on a document whose headings all infer to one level returns
  a non-empty outline, every row carrying an `offset`, and a note that does not
  contain "first 0".
* A depth-trimmed outline that kept every chapter says "Showing the top 1
  level(s) of 840 total entries", not "the first 40 top-level entries".
* An assistant turn of prose + a malformed `<tool_call>` envelope renders the
  prose plus the existing caption. An answer that explains the tag and fences an
  example renders unchanged.
* A tool call with an unknown argument returns a message naming that argument
  and the accepted set.
* First launch on a newer version shows one dismissible "Updated to vX.Y.Z"
  notice with a release-notes link; a first launch, a same-version relaunch, a
  downgrade, and a relaunch after dismissal show nothing.

## Verification

* `apps/rapid-mac/scripts/desktop-test-timeout.sh` (the serialized runner CI
  uses): **3793 tests in 319 suites pass** in 113 s, including 33 new ones
  across `ReadDocumentToolTests`, `ToolCallArtifactSuppressionTests`,
  `BuiltinToolsTests` and `InstallTrackerTests`.
* `apps/rapid-mac/scripts/build.sh` — release bundle assembles and signs clean.
* The upgrade notice driven end-to-end through the real UI, not a unit test: a
  CFPreferences-isolated release build (`scripts/dogfood-isolate.sh`) with
  `rapid.install.lastSeenVersion` seeded to `0.13.1`, inspected with
  `scripts/rapid-ax.swift`. The banner renders as
  `AXHeading desc="Updated to v0.14.1. You were on v0.13.1. The release notes
  list what changed."` with `WhatsNew.OpenNotes` and `WhatsNew.Dismiss` both
  addressable; `rapid-ax press … WhatsNew.Dismiss` removes it, and a relaunch
  does not bring it back.
* That AX pass also caught a real bug in my own change: an
  `accessibilityIdentifier` on a plain container ABSORBS its descendants', so
  both buttons first came back as `WhatsNewBanner` and neither could be pressed
  by name. Fixed with `.accessibilityElement(children: .contain)`, matching
  `CampaignBanner`.
* Existing AX golden-flow baselines are unaffected: every flow either starts
  fresh (no previous version) or relaunches the same version, so
  `upgradedFrom` is nil and no banner enters those trees.

### One finding withdrawn

The dogfood also reported that the four sidebar nav rows publish no
accessibility label. They do — `desc="New Chat"`, `"Images"`, `"Audio"`,
`"Launch"`, confirmed with `scripts/rapid-ax.swift` against a live build and
already pinned in `Tests/GUIGoldenFlows/__Snapshots__`. The original reading
came from a System Events probe rather than the accessibility API, and the
change that had been written for it was reverted rather than shipped as a
no-op.

## Behaviour delta

* `read_document` with both `grep` and `mode: "outline"`: returned the outline
  and silently discarded the pattern → runs the search and reports
  `mode_ignored`.
* `read_document` `mode: "outline"` on an outline with no depth-0 row: `[]` with
  "first 0 of N" → the shallowest level present, normalized to depth 0.
* An assistant turn whose tail is a malformed tool-call envelope: raw envelope
  rendered → prose kept, envelope replaced by the existing caption.
* A tool call with unknown arguments: generic schema message → the offending key
  and the accepted set.
* `FailureDiagnosis.toolFailed` copy: "The tool couldn't finish. Check its input,
  then try again." → "A tool step didn't go through. The model can usually
  recover if you ask again."
* First launch after a version increase: nothing → one dismissible notice.

## Adversarial review rounds

Twelve rounds of `pr_validate`'s codex (`gpt-5.6-sol`) review ran against this
diff. Nineteen findings were accepted and fixed, each with a regression test
that reproduces the exact shape the finding describes; two were declined, with
reasoning. Every round ended with the full desktop suite green.

Rounds 1-11 each produced at least one genuine defect, overwhelmingly in one
direction: the trailing-artifact detector is destructive by design (it hides
content), so every loose gate in it eats real prose. That is why the rounds were
worth running to the end rather than stopped at three. Round 12 produced nothing
new — only a third restatement of the finding declined in rounds 8 and 9 — which
is where this stops.

| Round | Finding | Outcome |
| --- | --- | --- |
| 1 | Fenced example hid a later real envelope (scan took one candidate) | fixed — scan all candidates, skip fenced |
| 1 | `<(function\|parameter)=` had no payload gate, truncating prose | fixed — payload / own-line + closing tag |
| 2 | Fence check counted ``` runs, missing `~~~` and ```` fences | fixed — `fencedRanges` parses CommonMark fences |
| 2 | Candidate cap shared across patterns | fixed, then removed entirely (round 3) |
| 2 | "See what's new" dismissed before the browser accepted the URL | fixed — dismiss from the completion handler |
| 3 | Start-index guard ran before the fence check | fixed — guard applies to the first *unfenced* candidate |
| 3 | A closing fence may not carry an info string | fixed — closer must be a bare run |
| 3 | Cap could still lose a tail behind many same-syntax examples | fixed — no cap; cursor jumps whole fenced blocks |
| 3 | Leading tabs counted as one column | fixed — indentation measured in columns |
| 4 | Unfenced inline example mid-sentence was truncated | fixed — envelopes must open a line |
| 4 | Fence lookup was quadratic on the render path | fixed — one forward cursor per pattern |
| 5 | Envelope was not required to be the turn's tail | fixed — search confined to the terminal machine-syntax run |
| 5 | One giant bookmark title defeated the outline budget | fixed — titles clamped before budgeting |
| 5 | Upgrade notice consumed by the launch that detected it | fixed — own persisted key |
| 6 | Pretty-printed array values broke the terminal run | fixed — bare JSON scalars count as machine syntax |
| 6 | Suppressed rows recompute the prose per body evaluation | declined — the gate is not re-run at render; the persisted flag is. One scan, only on suppressed rows, which are rare by construction |
| 7 | Acknowledgement key seeded to the current version swallowed the notice on the upgrade that ships it | fixed — key records the *pending* origin; falls back to last-seen |
| 7 | Both install banners could show at once | fixed — stale-bundle banner wins |
| 8 | A rollback from further back kept an owed notice | fixed — a backwards launch cancels it |
| 8, 9 | A complete unfenced example ending an answer is suppressed | **declined, twice** — see below |
| 9 | Title clamp counted grapheme clusters | fixed — clamped by Unicode scalars |
| 10 | Punctuation-led prose (`[link](…)`, `[1]: …`, a quoted sentence) stayed in the terminal run | fixed — `isMachineSyntaxLine` matches structurally per opener |
| 11 | `{ } ] ,` still passed on the first character alone | fixed — those lines must carry no unquoted word |
| 11 | Rejected-key echo bounded by grapheme clusters | fixed — bounded by Unicode scalars |
| 12 | *(the declined finding, restated a third time)* | declined — no new findings; review stopped here |

### The declined finding (rounds 8, 9, 12)

Gates 1–3 already *are* the "parser-rejected" evidence the finding asks for:
tools were advertised, and the turn came back with no tool call at all, so an
envelope the engine's parser could read would have been dispatched and never
reached the gate. A complete, well-formed envelope that nothing claimed is not
evidence of an example — it is #513's case verbatim, which is what happens on a
manually-selected `.unknown` model or an unwired parser. Requiring "malformed or
truncated" evidence would turn the feature off for exactly the population it was
written for.

What remains is the residual #513 names and accepts: a turn that is *only* a raw
call shape cannot be told from a leak by content. Suppression is
non-destructive — the raw text stays on the message, copy and export reproduce
it verbatim, and since this PR the prose above it renders rather than being
dropped. A fenced example, which is how a model actually answers "show me one",
is never touched. The reasoning is a comment at the gate so the next reader does
not have to re-derive it.

### Hands-on re-verification after the review rounds

The upgrade notice changed materially in rounds 5–8, so it was re-driven
end-to-end on a freshly built, signed `.app` in a CFPreferences-isolated bundle
(`dogfood-isolate.sh`), seeded as an existing 0.13.1 user with **no** pending
key — the migration path:

1. Launch: `AXGroup WhatsNewBanner` → heading *"Updated to v0.14.1. You were on
   v0.13.1. The release notes list what changed."*, with `WhatsNew.OpenNotes`
   and `WhatsNew.Dismiss` both addressable.
2. Quit **without** dismissing: `lastSeenVersion` rolled forward to `0.14.1`
   (the old design's bug) while `pendingUpgradeNoticeFrom` held `0.13.1`.
   Relaunch showed the same banner, still naming 0.13.1.
3. Dismiss: key removed, banner gone — and still gone after another
   quit/relaunch.

## AI assistance disclosure

Claude (Opus 5) ran the dogfood that produced the findings, wrote the
implementation and the tests, and ran the verification above. Every fix was
traced to the specific source line responsible before being changed, and each
claim in this description is backed by a command whose output is quoted above.
The withdrawn finding and the self-inflicted AX-identifier bug were both found
by re-measuring rather than by re-reading the diff.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR.

## Checklist

- [x] Tests pass locally — `apps/rapid-mac/scripts/desktop-test-timeout.sh`: 3822 tests in 320 suites pass in 115.9s (3793 at first review, +29 from the review rounds below). Two Mermaid WebKit suites time out when a `pr_validate` run holds the machine in parallel (133s wall vs. the usual 113s) and pass with nothing else running; they are untouched by this diff. (No Python in this diff, so `pytest tests/` is not the relevant suite.)
- [x] Lint passes — no Python in the diff; `swift build` is clean with no new warnings.
- [x] Self-validated with `pr_validate` — twelve rounds; scorecard posted below. The final run's scorecard is not clean, and both remaining reds are accounted for:
  - `codex_review` still reports the finding declined above. Merging over it is the documented call, not an oversight — the gate this repo actually relies on is a green suite plus hands-on verification on a built app, both recorded above.
  - `full_unit` reports `8 failed, 23789 passed, 108 skipped, 22 deselected, 6 xfailed, 1 xpassed`. **All eight are pre-existing on `main` and cannot be caused by this PR:** `git diff --name-only origin/main...HEAD | grep -v '^apps/rapid-mac/'` is empty, so the diff contains no Python at all. Proven rather than asserted — a throwaway worktree pinned to `origin/main` (`35d2b8ac8`) reproduces exactly the same eight, same test IDs, same assertions: `8 failed, 245 passed in 60.28s`. Seven are `tests/test_bonsai_image_alias.py` (`test_runtime_checkpoint_validation_is_fail_closed`, `test_engine_builds_only_the_fixed_bonsai_checkpoint`, `test_runtime_definitions_and_json_failures`, `test_checkpoint_rejects_wrong_pipeline_and_text_quantization`, `test_runtime_load_helpers_apply_the_fixed_quantization`, `test_runtime_constructor_and_prompt_cache_lifecycle`, `test_tiled_vae_uses_bonsai_default_and_honors_override`); the eighth is `tests/test_doctor_env_health.py::test_cli_install_still_warns_about_missing_embeddings`, failing on `assert "pip install" in row.label` where the label is `mlx-embeddings (embeddings extras) importability unknown — doctor probe did not complete` (a probe that does not complete in this environment). Both belong to recently landed engine work, not to a desktop diff, and are left for their own owners rather than smuggled into this PR.
- [x] New tests spot-checked against the unpatched code path, in a worktree pinned to this PR's base (`17a4dbdd3`) — not asserted, run:
  - The five behaviour tests that compile on the base all fail there, reproducing the dogfood payload verbatim: the `grep`/`mode` tests see `json["grep"] == nil` and no `passages`; the empty-outline test gets `rows == []` with the note *"Showing the first 0 top-level entries of 600 total"*; `inferredOutlineDepthIsNormalized` gets `[1, 2]`; `depthTrimNoteCountsLevels` gets *"the first 40 top-level entries of 840 total"*. `54 tests … failed with 13 issues`.
  - The two control tests (`outlineModeAloneIsUnchanged`, `blankGrepDoesNotOverrideMode`) PASS on the base, so the new precedence is scoped to the both-arguments case.
  - The trailing-artifact gap was probed with a base-only assertion: on `17a4dbdd3`, `shouldSuppressToolCallArtifact` returns **false** for prose + a `<tool_call>` tail, which is exactly why the raw envelope reached the transcript.
  - The remaining new tests (`budgeted()` prefix, `normalize` rejection text, `upgradedFrom`, `WhatsNewBanner`) exercise API this PR introduces, so on the base they do not compile rather than fail; that is stated plainly instead of being counted as a red-then-green check.
- [x] Docs updated — `apps/rapid-mac/CHANGELOG.md` under `[Unreleased]`.
- [x] No breaking changes to an existing API. `budgeted()`'s second return value changed from `Int?` to `OutlineTrim`; it is internal to `ReadDocumentTool` with no other callers.



