### PR TITLE
docs: add M4 Pro 48 GB benchmark matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,44 @@ MTP path was not physically qualified on a 32 GB Mac.
 
 ---
 
+## M4 Pro 48 GB Community Benchmarks
+
+Seven popular models were run on a 12-CPU / 16-GPU-core **Apple M4 Pro with
+48 GB unified memory** using the unmodified PyPI `rapid-mlx==0.14.1` release.
+These are single-request (`B=1`) Community Benchmark v2 medians: one warmup
+plus five measured rounds per case, greedy decode, prefix cache off, and no
+speculative decoding. The Mac was on AC power with nominal thermals and normal
+memory pressure throughout.
+
+| Model | 512 prompt → 128 output | 2K prompt → 512 output | Peak active memory |
+|---|---:|---:|---:|
+| `qwen3.5-4b-4bit` | 0.75s TTFT / **83.45 tok/s** | 2.95s / **82.02 tok/s** | 4.4 GiB |
+| `qwen3.5-9b-4bit` | 1.37s / **49.76 tok/s** | 5.59s / **48.68 tok/s** | 6.7 GiB |
+| `gemma-4-12b-4bit` | 2.19s / **31.87 tok/s** | 9.16s / **30.92 tok/s** | 11.9 GiB |
+| `gpt-oss-20b-mxfp4-q8` | 0.75s / **73.24 tok/s** | 2.82s / **70.10 tok/s** | 12.4 GiB |
+| `gemma-4-26b-4bit` | 0.78s / **75.59 tok/s** | 3.06s / **71.33 tok/s** | 16.9 GiB |
+| `qwen3.6-27b-4bit` | 4.87s / **15.53 tok/s** | 19.25s / **15.30 tok/s** | 18.1 GiB |
+| `qwen3.8-27b-4bit` | 4.87s / **15.53 tok/s** | 19.31s / **15.28 tok/s** | 18.4 GiB |
+
+Run any row as a local server with `rapid-mlx serve <alias>`. To reproduce the
+fixed benchmark instead, preview its exact workload first:
+
+```bash
+rapid-mlx benchmark plan qwen3.5-9b-4bit
+rapid-mlx benchmark run qwen3.5-9b-4bit
+rapid-mlx benchmark share <run-id>   # previews the payload; default is No
+```
+
+Normal serving can enable qualified per-model accelerations that this fixed,
+non-speculative protocol deliberately excludes, so do not compare this table
+directly with the MTP serving measurements above. All seven public rows include
+the model revision, Rapid-MLX version, run conditions, and anonymous submission
+ID.
+
+→ [Full methodology, revisions, commands, and public submission IDs](docs/benchmarks/m4-pro-48gb-community.md) · [Community Benchmark board](https://rapidmlx.com/leaderboard/contributors/jolly-rooted-zebra-edc)
+
+---
+
 ## Choose Your Model
 
 The installer and desktop app use the same RAM-tier recommendation catalog. Run `rapid-mlx recipe` to see its Smart and Fast picks for this Mac (`--max-ram 32` simulates another tier; `--json` is machine-readable). If you want to shop the full catalog: `rapid-mlx models` lists every alias, `rapid-mlx info <alias>` shows the per-alias profile (parser, MoE / hybrid flags, KV codec eligibility, speculative-decoding gates).

--- a/docs/benchmarks/m4-pro-48gb-community.md
+++ b/docs/benchmarks/m4-pro-48gb-community.md
@@ -1,0 +1,148 @@
+# M4 Pro 48 GB Community Benchmark
+
+This record captures seven public Community Benchmark submissions produced on
+an Apple M4 Pro Mac with 48 GB of unified memory. It is intended to answer two
+practical questions: what popular model sizes look like on this hardware, and
+how another user can reproduce the same fixed workload rather than relying on
+an unexplained headline number.
+
+## Environment
+
+| Component | Value |
+|---|---|
+| Machine | Mac16,11 |
+| SoC | Apple M4 Pro |
+| CPU / GPU cores | 12 / 16 |
+| Unified memory | 48 GiB |
+| macOS | 26.5.1 |
+| Power / thermal state | AC power, Low Power Mode off, nominal thermals |
+| Memory pressure | Normal before and after every run |
+| Rapid-MLX | 0.14.1, unmodified PyPI distribution |
+| Python | 3.12.13 |
+| MLX / mlx-lm | 0.32.2 / 0.31.3 |
+
+No two models were loaded concurrently. Models were measured one at a time,
+and no cache transfer or other heavy I/O ran during a measurement.
+
+## Fixed workload
+
+Every row uses registered protocol `rapid-community-speed` v2:
+
+- batch/concurrency: 1;
+- deterministic greedy decode;
+- prefix cache disabled;
+- speculative decoding disabled;
+- `pp512-tg128`: 512 prompt tokens, 128 output tokens;
+- `pp2048-tg512`: 2,048 prompt tokens, 512 output tokens;
+- one warmup and five measured rounds for each case.
+
+The synthetic prompt corpus is fixed by the protocol. It contains no user
+content. Decode throughput is `(output_tokens - 1) / decode_duration`; TTFT is
+measured separately and is included below.
+
+## Results
+
+| Alias | Short TTFT | Short decode | Long TTFT | Long decode | Peak active memory |
+|---|---:|---:|---:|---:|---:|
+| `qwen3.5-4b-4bit` | 0.75 s | 83.45 tok/s | 2.95 s | 82.02 tok/s | 4,505 MiB |
+| `qwen3.5-9b-4bit` | 1.37 s | 49.76 tok/s | 5.59 s | 48.68 tok/s | 6,821 MiB |
+| `gemma-4-12b-4bit` | 2.19 s | 31.87 tok/s | 9.16 s | 30.92 tok/s | 12,191 MiB |
+| `gpt-oss-20b-mxfp4-q8` | 0.75 s | 73.24 tok/s | 2.82 s | 70.10 tok/s | 12,733 MiB |
+| `gemma-4-26b-4bit` | 0.78 s | 75.59 tok/s | 3.06 s | 71.33 tok/s | 17,337 MiB |
+| `qwen3.6-27b-4bit` | 4.87 s | 15.53 tok/s | 19.25 s | 15.30 tok/s | 18,572 MiB |
+| `qwen3.8-27b-4bit` | 4.87 s | 15.53 tok/s | 19.31 s | 15.28 tok/s | 18,810 MiB |
+
+These are runtime performance measurements, not model-quality scores. Parameter
+count alone does not predict throughput: architecture, active parameter count,
+quantization and memory traffic all matter. In particular, the 20B and 26B
+mixture-of-experts models activate only part of their total parameters per
+token, so their decode rate should not be compared with the dense 27B rows on
+parameter count alone.
+
+Normal `rapid-mlx serve` startup can select qualified accelerations from a
+model profile. The Community Benchmark protocol intentionally holds
+speculative decoding off to preserve cross-machine comparability; its
+Qwen3.8 row therefore must not be compared directly with an MTP-enabled
+serving result.
+
+## Run a model
+
+Use the short alias from the table. The default server is local-only on port
+8000:
+
+```bash
+rapid-mlx serve qwen3.5-9b-4bit
+```
+
+Choose another port when 8000 is occupied:
+
+```bash
+rapid-mlx serve gpt-oss-20b-mxfp4-q8 --port 8100
+```
+
+For an endpoint reachable by another machine, bind explicitly and require an
+API key:
+
+```bash
+RAPID_MLX_API_KEY='replace-with-a-secret' \
+  rapid-mlx serve gemma-4-26b-4bit --host 0.0.0.0 --port 8000
+```
+
+Then use the OpenAI-compatible API:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer replace-with-a-secret' \
+  -d '{"model":"default","messages":[{"role":"user","content":"Say hello"}]}'
+```
+
+Do not expose an unauthenticated server outside the Mac. See the
+[server guide](../guides/server.md) for API-key, TLS and deployment guidance.
+
+## Reproduce and optionally share
+
+The model-first flow separates planning, measurement and publication:
+
+```bash
+# See registered models and whether they fit this machine.
+rapid-mlx benchmark catalog
+
+# Inspect the exact cases before loading anything.
+rapid-mlx benchmark plan qwen3.5-9b-4bit
+
+# Run locally. The result is archived; nothing is uploaded.
+rapid-mlx benchmark run qwen3.5-9b-4bit
+
+# Inspect the complete local record.
+rapid-mlx benchmark results
+rapid-mlx benchmark inspect <run-id>
+
+# Preview the exact upload and answer y/N. The default is No.
+rapid-mlx benchmark share <run-id>
+```
+
+To simulate the catalog fit decision for a 48 GB machine without running a
+model, use `rapid-mlx benchmark catalog --memory-gib 48`.
+
+## Public records
+
+| Alias | Hugging Face revision | Submission ID |
+|---|---|---|
+| `qwen3.5-4b-4bit` | `32f3e8ecf65426fc3306969496342d504bfa13f3` | `74ee01b3-3211-4f01-8878-80e636e592e5` |
+| `qwen3.5-9b-4bit` | `8b2b98c00a6b4d291155e4890773ca8f769aee53` | `6e0c67d0-9eed-4cd2-aa89-8be6aef2b720` |
+| `gemma-4-12b-4bit` | `73bcf09092aa277861d5a191b989b666f7f32e8f` | `f0fd8a0a-c859-4eb1-a869-eaf8e23657d7` |
+| `gpt-oss-20b-mxfp4-q8` | `773a7da77e569019bb0fd17a554b263738d669a3` | `f90c0569-cbcb-4964-a385-d03eaffe976e` |
+| `gemma-4-26b-4bit` | `0d77464eeb233a2da68ebf9d7dc4edaac7db956d` | `e646b8fc-a9b8-432f-9d82-d50858f2eb21` |
+| `qwen3.6-27b-4bit` | `c000ac2c2057d94be3fa931000c31723aac53282` | `7401c891-3feb-4b88-9085-eedb7b34d675` |
+| `qwen3.8-27b-4bit` | `aa985c29ff5b334cbfdcbbc787d47e66e9d9e456` | `bfa944b3-182d-40ac-8290-b45832c1d174` |
+
+All seven rows were accepted on 2026-09-11 under the anonymous contributor
+identity [`jolly-rooted-zebra·edc`](https://rapidmlx.com/leaderboard/contributors/jolly-rooted-zebra-edc).
+The public board currently labels atomic Community Benchmark observations as
+beta and `unverified_not_ranked`; they are public measurements, not automatic
+recommendation-policy evidence.
+
+The privacy-safe public projection is also available as JSON at
+`https://rapidmlx.com/api/benchmarks/atomic/public`. It omits the install ID,
+payload digest, local paths and other private execution details.

--- a/docs/benchmarks/m4-pro-48gb-community.md
+++ b/docs/benchmarks/m4-pro-48gb-community.md
@@ -91,6 +91,8 @@ RAPID_MLX_API_KEY='replace-with-a-secret' \
 Then use the OpenAI-compatible API:
 
 ```bash
+# Run this on the server Mac. From another machine, replace localhost with
+# the server Mac's LAN address.
 curl http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer replace-with-a-secret' \

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ GPU acceleration to local AI workloads by integrating:
 
 ### Benchmarks
 - [LLM Benchmarks](benchmarks/llm.md)
+- [M4 Pro 48 GB Community Benchmark](benchmarks/m4-pro-48gb-community.md)
 - [Image Benchmarks](benchmarks/image.md)
 - [Video Benchmarks](benchmarks/video.md)
 - [Audio Benchmarks](benchmarks/audio.md)


### PR DESCRIPTION
## Why

The repository documents M3-class performance but had no reproducible M4 Pro reference. Users with a 48 GB M4 Pro could not compare popular model sizes, understand why parameter count alone does not predict speed, or reproduce the measurements with the current Community Benchmark workflow.

## What changed

- adds a compact seven-model M4 Pro 48 GB matrix to the root README
- adds a detailed benchmark record with hardware, software, thermal, power, and protocol conditions
- documents local serving, port selection, authenticated LAN binding, and the OpenAI-compatible request path
- documents the privacy-safe `benchmark catalog` / `plan` / `run` / `results` / `inspect` / `share` flow
- records exact model revisions and public anonymous submission IDs
- links the new record from the documentation index

## Methodology

All rows came from the unmodified PyPI `rapid-mlx==0.14.1` release on one Apple M4 Pro (12 CPU / 16 GPU cores, 48 GiB), with models loaded serially. Community Benchmark v2 uses B=1, greedy decode, prefix cache off, speculative decoding off, one warmup, and five measured rounds for pp512→tg128 and pp2048→tg512. The committed values were checked directly against the public projection API.

## Design precedent

This extends the repository's existing split between a concise README comparison and detailed reproducible benchmark records. It uses the product-owned registered Community Benchmark protocol and its explicit-consent publication flow rather than adding a second measurement format or ad-hoc benchmark command.

## Scope

Docs only. No runtime, model catalog, recommendation policy, upload contract, or benchmark protocol behavior changes.

## Verification

- `python3.12 -m pytest -q tests/test_docs_cli_defaults.py tests/test_community_benchmark_workspace.py` — 238 passed
- public API value check — 7/7 submissions matched within 0.001
- changed Markdown local-link check — passed
- contributor board and public API — HTTP 200
- `git diff --check` — passed
