### PR TITLE
perf: ship mixed-precision DeepSeek V4.1 DSpark head

### DIFF
--- a/.agents/handoffs/vector-deepseek-v41-drafter-precision.md
+++ b/.agents/handoffs/vector-deepseek-v41-drafter-precision.md
@@ -41,7 +41,7 @@
   records the required fallback; implementation continues because the FYI is
   non-blocking.
 
-## 2026-09-11 — experiment complete, publication gated
+## 2026-09-11 — experiment complete and experimental sidecar published
 
 - Draft PR: https://github.com/raullenchai/Rapid-MLX/pull/3328 at commit
   `0e9b2abf2` (dependent on #3325).
@@ -75,10 +75,20 @@
   filenames, enforced the qualified 2-bit/4-bit pair, added config/index hashes,
   kept target-shared embed/head explicitly 2-bit, and removed the K4-hardcoded
   stability error.
+- The owner explicitly expanded scope after reviewing the evidence. Published
+  the head-only public repository
+  `rapid-mlx/DeepSeek-V4.1-Flash-DSpark-4d2e-MLX` at immutable revision
+  `9530d6d2bf59e0d05177bd538095d5704ded1488`; it contains no target weights.
+  The Model Card states the required target/revision, K4 recommendation,
+  measured approximately-20-tok/s boundary, memory floor, non-standalone
+  behavior, deterministic target-authoritative contract, and quality caveat.
+- Rapid's artifact contract now pins that repo/revision plus the exact sizes
+  and SHA-256 values for config, index, manifest, and all three stage shards.
+  User documentation now reports the mixed-head result instead of the replaced
+  2-bit head result.
 - Next concrete action: compare mixed/current/AR task correctness on a larger,
-  scored prompt set. If it passes, publish the immutable mixed artifact and open
-  a separate product pin. Do not publish or make it default from throughput
-  evidence alone.
+  scored prompt set before removing the experimental label or widening
+  admission. Publication does not make this an unconditional default.
 - Completion FYI is recorded here because Orca messaging remains unavailable
   from this shell. Receiving roles: Atlas (publication decision), Harbor
   (artifact/rollout integrity), Echo (dependent PR tracking), Pixel (awareness;

--- a/.agents/handoffs/vector-deepseek-v41-drafter-precision.md
+++ b/.agents/handoffs/vector-deepseek-v41-drafter-precision.md
@@ -43,6 +43,8 @@
 
 ## 2026-09-11 — experiment complete, publication gated
 
+- Draft PR: https://github.com/raullenchai/Rapid-MLX/pull/3328 at commit
+  `0e9b2abf2` (dependent on #3325).
 - Extracted the revision-pinned official DSpark tensors to affine 4-bit, then
   composed a 4-bit-dense/2-bit-routed-expert candidate. The mixed artifact is
   4,617,792,648 bytes, 157,710,560 bytes larger than the current 2-bit head.

--- a/.agents/handoffs/vector-deepseek-v41-drafter-precision.md
+++ b/.agents/handoffs/vector-deepseek-v41-drafter-precision.md
@@ -1,0 +1,83 @@
+# Vector handoff — DeepSeek V4.1 drafter precision experiment
+
+## 2026-09-11 — starting
+
+- Owner: Vector on Studio. Branch `vector/deepseek-v41-drafter-precision`,
+  worktree `/private/tmp/rapid-mlx-deepseek-v41-drafter-precision`, based on PR
+  #3325 exact head `9abd21d9d` because the experiment uses that candidate's
+  product-owned DSpark K4 runtime and benchmark contract.
+- Intention: determine whether the official source-precision DeepSeek V4.1
+  three-stage DSpark tensors increase accepted draft length and end-to-end TPS
+  relative to the currently pinned affine 2-bit head, then derive the smallest
+  mixed-precision head justified by measured quality and memory. Success is a
+  reproducible multi-domain gain with target-authoritative output, not drafter
+  microbenchmark speed alone.
+- Scope: source-head extraction tooling, immutable artifact manifests, isolated
+  A/B benchmarks, memory accounting, and internal performance evidence. Explicit
+  non-goals: training, changing the released/default model or K, catalog/GUI/API
+  changes, target-model requantization, release, deployment, and deleting other
+  cached models.
+- Storage constraint: the enforced Hugging Face cache currently has about 5.1
+  GiB free while the three official source shards total about 7.4 GiB. Downloads
+  must use the global cache and stop on quota failure. Extraction may stream one
+  task-owned shard at a time into the allowed warm-tier model directory, but
+  must not remove unrelated cache entries or redirect Hub downloads.
+- Verification: fingerprint every source revision/shard/tensor; compare 2-bit,
+  source precision, and any selected mixed-precision candidate on code,
+  reasoning, structured output, Chinese, and longer-context prompts; report
+  accepted tokens per block, K2-K6 profitability, end-to-end decode TPS,
+  target-authority/parity, peak MLX memory, and failure/regression rows. Run
+  focused tests, scope-locked adversarial self-review, and PR validation only if
+  a shippable artifact/tooling change survives the performance gate.
+- Private precedent check: current vLLM DeepSeek V4.1 DSpark keeps a dedicated
+  three-stage model and gates adaptive verification on confidence-head support;
+  current SGLang DSpark separates draft, verification-window planning,
+  confidence/accept estimation, and calibration. MLX-LM and oMLX expose no
+  directly reusable V4.1 higher-precision sidecar path. This experiment retains
+  Rapid's existing lossless target-authoritative verifier and changes only
+  drafter weights; controller/calibration work remains a follow-up.
+- Start FYI for Atlas, Pixel, Harbor, and Echo could not be delivered through
+  Orca because this shell has no stable Orca pane identity. This tracked handoff
+  records the required fallback; implementation continues because the FYI is
+  non-blocking.
+
+## 2026-09-11 — experiment complete, publication gated
+
+- Extracted the revision-pinned official DSpark tensors to affine 4-bit, then
+  composed a 4-bit-dense/2-bit-routed-expert candidate. The mixed artifact is
+  4,617,792,648 bytes, 157,710,560 bytes larger than the current 2-bit head.
+  It passes strict runtime loading and peaks at 218.232 GB with the target.
+- A uniform affine 4-bit head is 8,015,180,738 bytes. Two load attempts were
+  killed at target/head residency, so it is rejected for the 256 GiB boundary.
+- Mixed K4, four domains x two 128-token repeats: 19.390 tok/s weighted versus
+  9.580 AR (2.024x), 1.850 accepted tokens/block, and 4/4 repeat-stable outputs.
+  This is 80.9% above the previous head's conservative 10.72 tok/s suite result.
+- Mixed K5: 18.488 tok/s versus 9.565 AR (1.933x), 2.136 accepted/block, and 4/4
+  repeat-stable. Extra verification cost outweighs acceptance, so K4 remains
+  the measured fixed-K sweet spot and no product default changes here.
+- The target-authoritative fixed-batch output contract is retained, but none of
+  the four K4 streams is bitwise equal to sequential AR because target batch
+  shape crosses low-margin numerical decisions. Manual task inspection clears
+  only the Chinese sample; code, reasoning, and structured samples are poor or
+  repetitive. Similar defects exist in AR/current-head probes, so the speed
+  experiment passes but publication is explicitly gated on a broader comparative
+  task-quality qualification.
+- Added a fail-closed offline extractor/composer with source/output hashes and
+  immutable precision metadata, extended the suite to bounded K2-K6 experiments,
+  and recorded full reproducibility evidence in
+  `docs/engineering/performance/2026-09-11-deepseek-v41-dspark-mixed-precision.md`.
+  Focused result: 27 tests pass. The complete 12-file DeepSeek/DSpark regression
+  set passes 128/128; ruff and `git diff --check` pass.
+- Adversarial self-review fixes: rejected mislabeled resume outputs instead of
+  inferring their precision, validated source weight-map structure and state
+  filenames, enforced the qualified 2-bit/4-bit pair, added config/index hashes,
+  kept target-shared embed/head explicitly 2-bit, and removed the K4-hardcoded
+  stability error.
+- Next concrete action: compare mixed/current/AR task correctness on a larger,
+  scored prompt set. If it passes, publish the immutable mixed artifact and open
+  a separate product pin. Do not publish or make it default from throughput
+  evidence alone.
+- Completion FYI is recorded here because Orca messaging remains unavailable
+  from this shell. Receiving roles: Atlas (publication decision), Harbor
+  (artifact/rollout integrity), Echo (dependent PR tracking), Pixel (awareness;
+  no GUI impact).

--- a/README.md
+++ b/README.md
@@ -468,7 +468,8 @@ complete `rapid-mlx serve` process tree on an M2 Pro 32 GB Mac mini (the 32 GB+ 
 
 The experimental `deepseek-v41-flash-reap-2bit` alias is a separate
 256 GB Mac Studio lane, not a recommendation for the table above. It pins the
-199 GiB REAP checkpoint and its 4.47 GB DSpark sidecar, refuses to start below
+199 GiB REAP checkpoint and its separate 4.62 GB mixed-precision DSpark
+sidecar, refuses to start below
 224 GiB unified memory, and serves deterministic greedy K4 decoding through a
 serial OpenAI-compatible endpoint:
 
@@ -477,10 +478,13 @@ rapid-mlx pull deepseek-v41-flash-reap-2bit
 rapid-mlx serve deepseek-v41-flash-reap-2bit
 ```
 
-Sustained four-workload qualification measured 10.72 tok/s overall; the
-isolated stable K4 run measured 11.76 tok/s, with a 217.97 GB product-path peak.
-This first lane is text-only, caps input at 8,192 tokens and output at 4,096,
-and does not claim sampling, tool calling, MCP, or continuous batching.
+The mixed head keeps routed experts at 2-bit and raises the smaller dense paths
+to 4-bit. Sustained four-workload qualification measured **19.39 tok/s** overall
+at K4 versus 9.58 tok/s autoregressive (**2.02x**), with a 218.23 GB peak. This
+is approximately 20 tok/s for the measured configuration, not a per-prompt
+guarantee. This lane remains experimental and text-only, caps input at 8,192
+tokens and output at 4,096, and does not claim sampling, tool calling, MCP, or
+continuous batching.
 
 Every Mac from 32 GB up gets the same pick, and that is the point: Qwen3.8-27B
 scores 52 on the Artificial Analysis Intelligence Index (2026-08-18) —

--- a/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-mixed-precision.md
+++ b/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-mixed-precision.md
@@ -1,0 +1,147 @@
+# DeepSeek V4.1 Flash DSpark mixed-precision experiment
+
+Date: 2026-09-11
+
+Status: the 4-bit-dense/2-bit-expert head passes the performance and memory
+experiment. It is not yet a published or default artifact; output-quality
+qualification and artifact publication remain separate product gates.
+
+## Question and boundary
+
+The shipped candidate uses an affine 2-bit three-stage DSpark head. This
+experiment asks whether selectively preserving more precision in the small
+dense paths improves draft acceptance enough to raise end-to-end throughput,
+without making a 256 GiB target fail to load.
+
+Only drafter weights and offline extraction tooling change. The target model,
+target kernels, verifier, catalog, server, GUI, and default K remain unchanged.
+
+## Environment and provenance
+
+- Apple M3 Ultra, 256 GiB unified memory (`hw.memsize=274877906944`)
+- macOS 26.5.2 (25F84)
+- Rapid commit `9abd21d9dd3b85091aaa0c1018f232fbf79953c9`
+- Target: local 212.93 GB REAP12.5 native affine 2-bit checkpoint
+- Low-precision head source: `Vontra/DeepSeek-V4.1-Flash-MLX-2bit-MTP`
+  revision `802f1a00982705d81b79ad1c83aa0ccc0b863ebc`
+- Official source: `deepseek-ai/DeepSeek-V4.1-Flash` revision
+  `dba1be0a40aa45a94ad051997016db3960a90277`
+
+The official DSpark tensors occupy shards 44 through 46. Each source shard was
+read and converted separately because the Hub cache did not have enough free
+space for all three simultaneously. Source shard bytes and SHA-256 values:
+
+| Shard | Bytes | SHA-256 |
+| --- | ---: | --- |
+| 44 | 2,652,728,736 | `9a6b39fb88a2510487a8efaef77aa7864e8061f6b62c95a0f010e9dd538f3b05` |
+| 45 | 2,573,998,176 | `0cc9d5f6ca3a2158ccc63ce2c70c76aeda8177d54913340481af566680329eb5` |
+| 46 | 2,706,402,896 | `e625902027b9d23d416f8818c665fab4704e0b96dc1bc778321601b700475a9d` |
+
+The extraction tool requires revision-pinned files already present in the
+global cache and exposes no download or cache-redirection option. A typical
+per-shard conversion and final composition is:
+
+```shell
+python3.12 scripts/extract_deepseek_v41_dspark_precision.py convert-shard \
+  --source <cached-official-shard> \
+  --source-index <pinned-official-index> \
+  --destination <affine4-head-dir> \
+  --bits 4 --group-size 64
+
+python3.12 scripts/extract_deepseek_v41_dspark_precision.py finalize \
+  --destination <affine4-head-dir> \
+  --source-config <pinned-official-config> \
+  --source-index <pinned-official-index> \
+  --source-revision dba1be0a40aa45a94ad051997016db3960a90277
+
+python3.12 scripts/extract_deepseek_v41_dspark_precision.py compose-mixed \
+  --low <pinned-affine2-checkpoint> \
+  --high <affine4-head-dir> \
+  --destination <mixed-head-dir> \
+  --low-revision 802f1a00982705d81b79ad1c83aa0ccc0b863ebc \
+  --high-revision dba1be0a40aa45a94ad051997016db3960a90277
+```
+
+## Precision choice and capacity result
+
+The full affine 4-bit head is 8,015,180,738 bytes (7.47 GiB). Two attempts were
+killed while the 212.93 GB target and head were becoming resident. It is
+rejected for the 256 GiB product boundary.
+
+The selected mixed head keeps the bandwidth-dominant routed expert matrices at
+the proven affine 2-bit precision. Attention, shared experts, main projection,
+Markov, and confidence paths use affine 4-bit. Target-shared embedding and LM
+head metadata remain explicitly 2-bit.
+
+- Total: 4,617,792,648 bytes (4.30 GiB)
+- Increase over the 4,460,082,088-byte 2-bit head: 157,710,560 bytes (3.5%)
+- Tensors: 3,584 across three independently hashed stage shards
+- Strict DSpark loader: passed
+- Peak MLX memory in qualification: 218.232 GB
+
+Stage shard SHA-256 values are:
+
+| Stage | Bytes | SHA-256 |
+| --- | ---: | --- |
+| 0 | 1,556,346,856 | `381a7fbc8758cd86baab55e8f1ae3020e49e2977f067d4269416889c1aee8118` |
+| 1 | 1,512,099,424 | `2ca7dc77528ebe3220e6e1633733925ca3420e346b4475163e1639541333876e` |
+| 2 | 1,549,346,368 | `1ed4663f0487e13372e753b2a5e8b760ae8fd43ba661fae891dfdff62384e64b` |
+
+## Multi-domain result
+
+The fixed suite covers code, arithmetic reasoning, JSON-only structured output,
+and Chinese. Each row is a weighted result over two consecutive 128-token
+passes in one loaded process. Chinese K4 reached EOS after 41 output tokens.
+
+```shell
+python3.12 scripts/qualify_deepseek_v41_dspark_suite.py \
+  --target <reap12.5-target> \
+  --overlay <mixed-head-dir> \
+  --tokens 128 --repeats 2 --verify-k 4 \
+  --collect-target-margins
+```
+
+| Domain | Mixed K4 tok/s | Accepted tokens/block | Repeat stable |
+| --- | ---: | ---: | --- |
+| Code | 22.52 | 2.37 | yes |
+| Reasoning | 16.27 | 1.42 | yes |
+| Structured | 25.93 | 2.88 | yes |
+| Chinese | 11.87 | 0.74 | yes |
+
+Across all eight prompt-runs, mixed K4 produces 842 transitions in 43.425
+seconds: **19.39 tok/s**, versus **9.58 tok/s** for same-process AR
+(**2.02x**). Mean acceptance is 1.85 extra draft tokens per block. Compared
+with the prior 2-bit head's identically shaped 10.72 tok/s conservative A/B
+result, throughput rises by **80.9%**, while the head grows by only 3.5%.
+
+K5 was also tested with the same four prompts and two repeats. It reaches 18.49
+tok/s (1.93x AR) and accepts 2.14 extra tokens/block, but the larger verification
+window costs more than the added acceptance repays. K4 is the measured sweet
+spot; this experiment does not justify changing the default K.
+
+## Correctness and quality limits
+
+All four outputs are token-for-token stable across two repetitions for both K4
+and K5. No K4 output is bitwise identical to the sequential AR stream; first
+differences occur at indices 79, 7, 15, and 7. The verifier remains
+target-authoritative: every emitted draft token is accepted by target logits,
+and corrections come from the target. As previously isolated, different target
+batch shapes can cross low-margin decisions, so the supported contract is
+determinism for the fixed execution shape rather than equality with sequential
+AR.
+
+Manual inspection also finds that only the Chinese K4 sample is clearly good.
+The code sample becomes repetitive, the reasoning answer misreads a complete
+word problem, and the structured sample violates JSON-only output. Similar
+repetition exists in the target-only and prior-head probes, so this experiment
+does not establish an instruction-quality regression, but it also cannot clear
+the artifact for broad publication. A larger task-quality gate must compare the
+mixed head, current head, and AR outputs before productization.
+
+## Decision
+
+Mixed precision is the right head direction for this 256 GiB target: it raises
+the conservative multi-domain DSpark result from about 10.72 to 19.39 tok/s and
+stays within the existing memory envelope. Full 4-bit and fixed K5 are rejected.
+The next scoped work is quality qualification and, only if it passes, immutable
+artifact publication plus a separately reviewed product pin.

--- a/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-mixed-precision.md
+++ b/docs/engineering/performance/2026-09-11-deepseek-v41-dspark-mixed-precision.md
@@ -3,8 +3,9 @@
 Date: 2026-09-11
 
 Status: the 4-bit-dense/2-bit-expert head passes the performance and memory
-experiment. It is not yet a published or default artifact; output-quality
-qualification and artifact publication remain separate product gates.
+experiment and is published as a revision-pinned experimental sidecar. It is
+not an unconditional default; broader output-quality qualification remains a
+separate product gate.
 
 ## Question and boundary
 
@@ -143,5 +144,7 @@ mixed head, current head, and AR outputs before productization.
 Mixed precision is the right head direction for this 256 GiB target: it raises
 the conservative multi-domain DSpark result from about 10.72 to 19.39 tok/s and
 stays within the existing memory envelope. Full 4-bit and fixed K5 are rejected.
-The next scoped work is quality qualification and, only if it passes, immutable
-artifact publication plus a separately reviewed product pin.
+The sidecar is published at revision
+`rapid-mlx/DeepSeek-V4.1-Flash-DSpark-4d2e-MLX@9530d6d2bf59e0d05177bd538095d5704ded1488`.
+Rapid pins and verifies that byte set. Broader quality qualification remains
+required before removing the experimental label or widening admission.

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -31,8 +31,9 @@ Families with registered aliases (run `rapid-mlx models` for the full, current l
 `deepseek-v41-flash-reap-2bit` serves the pinned Rapid-MLX REAP 2-bit
 checkpoint with its pinned DSpark K4 sidecar. The target contains about 199 GiB
 of tensors; the sidecar download is narrowed to the three required MTP shards
-plus its data index and config (4.47 GB), rather than fetching the full source
-repository.
+plus its manifest, data index, and config (4.62 GB). It is published separately
+at [DeepSeek V4.1 Flash DSpark 4d2e MLX](https://huggingface.co/rapid-mlx/DeepSeek-V4.1-Flash-DSpark-4d2e-MLX),
+so users who do not enable this path do not download it.
 
 ```bash
 rapid-mlx pull deepseek-v41-flash-reap-2bit
@@ -49,9 +50,10 @@ This is a deliberately narrow product lane:
   output tokens. Sampling, images, tools, MCP, and structured output are not
   yet qualified.
 - The four-workload 128-token suite was deterministic across two repeats. It
-  measured 10.72 tok/s overall; the isolated stable K4 run measured 11.76
-  tok/s. The product wrapper loaded in 300.81 seconds and peaked at 217.97 GB
-  on the qualification Studio.
+  measured 19.39 tok/s overall at K4 versus 9.58 tok/s autoregressive (2.02x).
+  This is approximately 20 tok/s for the measured configuration, not a
+  per-prompt guarantee. Peak MLX memory was 218.23 GB on the qualification
+  Studio.
 
 The runtime verifies immutable revisions, expected file sizes, SHA-256 values
 for every sidecar data file, and the complete tensor/config contract before it

--- a/scripts/extract_deepseek_v41_dspark_precision.py
+++ b/scripts/extract_deepseek_v41_dspark_precision.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Convert official V4.1 DSpark shards to an MLX affine sidecar.
+
+The official release stores routed experts as packed FP4 and the remaining
+matmuls as FP8.  MLX cannot load the release's E8M0 scale dtype directly, so
+this tool reads one source shard through safetensors/PyTorch, dequantizes each
+weight with Rapid's reviewed release-format implementation, and requantizes the
+draft-only linears.  Processing one shard at a time keeps the Hub-cache and RAM
+working sets bounded.
+
+This tool never downloads files and has no cache-location option.  Operators
+must supply already-cached, revision-pinned release files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import struct
+import sys
+import tempfile
+from pathlib import Path
+
+import mlx.core as mx
+import torch
+from safetensors import safe_open
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from repack_deepseek_v41_native import (  # noqa: E402
+    CheckpointIndex,
+    TensorPlan,
+    write_safetensors,
+)
+
+from vllm_mlx.models.deepseek_v41_native.convert import sanitize_group  # noqa: E402
+
+_QUANTIZED_SUFFIXES = (
+    ".attn.wq_a",
+    ".attn.wq_b",
+    ".attn.wkv",
+    ".attn.wo_a",
+    ".attn.wo_b",
+    ".main_proj",
+    ".shared_experts.w1",
+    ".shared_experts.w2",
+    ".shared_experts.w3",
+    ".confidence_head.proj",
+    ".markov_head.embed",
+    ".markov_head.head",
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb", buffering=0) as handle:
+        for block in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _read_json(path: Path) -> dict:
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _weight_map(path: Path) -> dict[str, str]:
+    weight_map = _read_json(path).get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError(f"index has no weight_map: {path}")
+    if not all(
+        isinstance(name, str) and isinstance(shard, str)
+        for name, shard in weight_map.items()
+    ):
+        raise ValueError(f"index weight_map must map strings to strings: {path}")
+    return weight_map
+
+
+def _source_array(handle, name: str) -> mx.array:
+    tensor_slice = handle.get_slice(name)
+    dtype = tensor_slice.get_dtype()
+    tensor = tensor_slice[:]
+    if dtype in ("F8_E4M3", "F8_E8M0"):
+        return mx.array(tensor.view(torch.uint8).numpy())
+    if dtype == "I8":
+        return mx.array(tensor.numpy())
+    if dtype == "BF16":
+        return mx.array(tensor.view(torch.uint16).numpy()).view(mx.bfloat16)
+    if dtype == "F32":
+        return mx.array(tensor.numpy(), dtype=mx.float32)
+    raise ValueError(f"unsupported official DSpark dtype {dtype}: {name}")
+
+
+def _quantized_base(name: str, array: mx.array, group_size: int) -> str | None:
+    if not name.startswith("mtp.") or not name.endswith(".weight"):
+        return None
+    if array.ndim != 2 or int(array.shape[-1]) % group_size:
+        return None
+    base = name[: -len(".weight")]
+    if base.endswith(_QUANTIZED_SUFFIXES):
+        return base
+    if ".experts." in base and base.endswith((".w1", ".w2", ".w3")):
+        return base
+    return None
+
+
+def _convert_shard(
+    source: Path,
+    source_index: Path,
+    destination: Path,
+    *,
+    bits: int,
+    group_size: int,
+) -> dict:
+    if bits not in (2, 3, 4, 6, 8):
+        raise ValueError("MLX affine bits must be one of 2, 3, 4, 6, or 8")
+    index = _weight_map(source_index)
+    expected = sorted(
+        name
+        for name, shard in index.items()
+        if name.startswith("mtp.") and shard == source.name
+    )
+    if not expected:
+        raise ValueError(f"source index maps no MTP tensors to {source.name}")
+    if destination.exists():
+        raise FileExistsError(
+            f"refusing to infer precision for an untracked output: {destination}"
+        )
+
+    handle = safe_open(str(source), framework="pt")
+    actual = sorted(name for name in handle.keys() if name.startswith("mtp."))  # noqa: SIM118 - safetensors handle is not iterable
+    if actual != expected:
+        raise ValueError("source index and shard MTP tensors disagree")
+    raw = {name: _source_array(handle, name) for name in expected}
+    converted = sanitize_group(expected, raw, dtype=mx.bfloat16)
+    del raw
+
+    output: dict[str, mx.array] = {}
+    modules: dict[str, dict] = {}
+    for name, array in converted.items():
+        base = _quantized_base(name, array, group_size)
+        if base is None:
+            output[name] = array
+            continue
+        weight, scales, biases = mx.quantize(array, group_size=group_size, bits=bits)
+        mx.eval(weight, scales, biases)
+        output[base + ".weight"] = weight
+        output[base + ".scales"] = scales
+        output[base + ".biases"] = biases
+        modules[base] = {
+            "bits": bits,
+            "group_size": group_size,
+            "mode": "affine",
+        }
+    mx.eval(*output.values())
+    temporary = destination.with_name(
+        destination.name.removesuffix(".safetensors") + ".partial.safetensors"
+    )
+    mx.save_safetensors(str(temporary), output, metadata={"format": "mlx"})
+    os.replace(temporary, destination)
+    return {
+        "source_file": source.name,
+        "source_bytes": source.stat().st_size,
+        "source_sha256": _sha256(source),
+        "output_file": destination.name,
+        "output_bytes": destination.stat().st_size,
+        "output_sha256": _sha256(destination),
+        "tensor_count": len(output),
+        "quantized_modules": modules,
+    }
+
+
+def _header(path: Path) -> dict:
+    with path.open("rb") as handle:
+        length = struct.unpack("<Q", handle.read(8))[0]
+        value = json.loads(handle.read(length))
+    value.pop("__metadata__", None)
+    return value
+
+
+def _finalize(
+    destination: Path,
+    source_config: Path,
+    source_index: Path,
+    source_revision: str,
+) -> dict:
+    state_files = sorted(destination.glob("*.conversion.json"))
+    if not state_files:
+        raise ValueError("destination has no converted shard state")
+    states = [_read_json(path) for path in state_files]
+    weight_map: dict[str, str] = {}
+    modules: dict[str, dict] = {}
+    for state in states:
+        output_file = state.get("output_file")
+        if not isinstance(output_file, str) or Path(output_file).name != output_file:
+            raise ValueError("converted shard state has an unsafe output filename")
+        output = destination / output_file
+        if output.stat().st_size != state["output_bytes"]:
+            raise ValueError(f"converted shard size changed: {output.name}")
+        if _sha256(output) != state["output_sha256"]:
+            raise ValueError(f"converted shard digest changed: {output.name}")
+        for name in _header(output):
+            if name in weight_map:
+                raise ValueError(f"duplicate converted tensor: {name}")
+            weight_map[name] = output.name
+        modules.update(state["quantized_modules"])
+
+    expected_map = _weight_map(source_index)
+    expected = {name for name in expected_map if name.startswith("mtp.")}
+
+    def logical_name(name: str) -> str:
+        for suffix in (".scales", ".biases"):
+            if name.endswith(suffix):
+                return name[: -len(suffix)] + ".weight"
+        return name
+
+    logical = {logical_name(name) for name in weight_map}
+    # Source .scale tensors are consumed into each affine weight triple.
+    expected_logical = {
+        name[: -len(".scale")] + ".weight" if name.endswith(".scale") else name
+        for name in expected
+    }
+    if logical != expected_logical:
+        missing = sorted(expected_logical - logical)
+        extra = sorted(logical - expected_logical)
+        raise ValueError(
+            f"converted MTP contract mismatch (missing={missing[:1]}, extra={extra[:1]})"
+        )
+
+    config = _read_json(source_config)
+    bits = {entry["bits"] for entry in modules.values()}
+    groups = {entry["group_size"] for entry in modules.values()}
+    if len(bits) != 1 or len(groups) != 1:
+        raise ValueError("converted shards do not share one affine configuration")
+    config["quantization"] = {
+        "bits": bits.pop(),
+        "group_size": groups.pop(),
+        "mode": "affine",
+        "modules": modules,
+    }
+    config["rapid_quantization"] = {
+        "mtp": True,
+        "mtp_source": "official-source-requantized",
+        "source_revision": source_revision,
+    }
+    (destination / "config.json").write_text(json.dumps(config, indent=2) + "\n")
+    (destination / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map}, indent=2) + "\n"
+    )
+    manifest = {
+        "format": 1,
+        "source_repo": "deepseek-ai/DeepSeek-V4.1-Flash",
+        "source_revision": source_revision,
+        "source_index_sha256": _sha256(source_index),
+        "config_sha256": _sha256(destination / "config.json"),
+        "index_sha256": _sha256(destination / "model.safetensors.index.json"),
+        "shards": states,
+        "tensor_count": len(weight_map),
+    }
+    (destination / "rapid-dspark-manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n"
+    )
+    return manifest
+
+
+def _use_low_precision(name: str) -> bool:
+    """Keep bandwidth-dominant routed experts at the proven 2-bit precision."""
+    return name.startswith("mtp.") and ".ffn.experts." in name
+
+
+def _mixed_quantization(high_config: dict, low_config: dict) -> dict:
+    high = high_config.get("quantization")
+    low = low_config.get("quantization")
+    if not isinstance(high, dict) or not isinstance(low, dict):
+        raise ValueError("both inputs require MLX quantization metadata")
+    low_bits = int(low["bits"])
+    high_bits = int(high["bits"])
+    if (low_bits, high_bits) != (2, 4):
+        raise ValueError(
+            "mixed DSpark artifact requires a 2-bit low input and 4-bit high input"
+        )
+    modules = high.get("modules")
+    if not isinstance(modules, dict) or not modules:
+        raise ValueError("high-precision input requires an explicit module map")
+    result = {
+        "bits": int(high["bits"]),
+        "group_size": int(high["group_size"]),
+        "mode": high.get("mode", "affine"),
+        "modules": dict(modules),
+    }
+    low_entry = {
+        "bits": int(low["bits"]),
+        "group_size": int(low["group_size"]),
+        "mode": low.get("mode", "affine"),
+    }
+    for base in list(result["modules"]):
+        if _use_low_precision(base):
+            result["modules"][base] = low_entry
+    # The drafter shares these two matrices from the 2-bit target at runtime;
+    # they are not present in the standalone high-precision head itself.
+    result["modules"]["embed"] = low_entry
+    result["modules"]["head"] = low_entry
+    return result
+
+
+def _compose_mixed(
+    low_path: Path,
+    high_path: Path,
+    destination: Path,
+    *,
+    low_revision: str,
+    high_revision: str,
+) -> dict:
+    if destination.exists():
+        raise FileExistsError(destination)
+    low = CheckpointIndex(low_path)
+    high = CheckpointIndex(high_path)
+    low_names = {name for name in low.tensors if name.startswith("mtp.")}
+    high_names = {name for name in high.tensors if name.startswith("mtp.")}
+    if low_names != high_names:
+        raise ValueError("low/high DSpark tensor contracts differ")
+    low_config = _read_json(low_path / "config.json")
+    high_config = _read_json(high_path / "config.json")
+    quantization = _mixed_quantization(high_config, low_config)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.staging-", dir=destination.parent)
+    )
+    try:
+        weight_map: dict[str, str] = {}
+        shard_rows = []
+        stages = sorted({int(name.split(".")[1]) for name in high_names})
+        for stage in stages:
+            names = sorted(
+                name for name in high_names if name.startswith(f"mtp.{stage}.")
+            )
+            plans = []
+            low_count = 0
+            for name in names:
+                source = (
+                    low.tensors[name]
+                    if _use_low_precision(name)
+                    else high.tensors[name]
+                )
+                low_count += int(_use_low_precision(name))
+                plans.append(
+                    TensorPlan(name, source.dtype, source.shape, sources=(source,))
+                )
+            filename = f"dspark-mixed-stage-{stage}.safetensors"
+            output = staging / filename
+            write_safetensors(output, plans)
+            for name in _header(output):
+                weight_map[name] = filename
+            shard_rows.append(
+                {
+                    "file": filename,
+                    "bytes": output.stat().st_size,
+                    "sha256": _sha256(output),
+                    "tensor_count": len(plans),
+                    "low_precision_tensors": low_count,
+                }
+            )
+
+        config = dict(high_config)
+        config["quantization"] = quantization
+        config["rapid_quantization"] = {
+            "mtp": True,
+            "mtp_source": "mixed-official-source-and-affine2",
+            "dense_bits": quantization["bits"],
+            "expert_bits": int(low_config["quantization"]["bits"]),
+            "source_revision": high_revision,
+            "low_revision": low_revision,
+        }
+        (staging / "config.json").write_text(json.dumps(config, indent=2) + "\n")
+        (staging / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {}, "weight_map": weight_map}, indent=2) + "\n"
+        )
+        manifest = {
+            "format": 1,
+            "policy": "routed experts 2-bit; remaining DSpark linears 4-bit",
+            "low_repo": "Vontra/DeepSeek-V4.1-Flash-MLX-2bit-MTP",
+            "low_revision": low_revision,
+            "high_source_repo": "deepseek-ai/DeepSeek-V4.1-Flash",
+            "high_source_revision": high_revision,
+            "tensor_count": len(weight_map),
+            "config_sha256": _sha256(staging / "config.json"),
+            "index_sha256": _sha256(staging / "model.safetensors.index.json"),
+            "shards": shard_rows,
+        }
+        (staging / "rapid-dspark-manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n"
+        )
+        staging.rename(destination)
+        return manifest
+    except BaseException:
+        shutil.rmtree(staging)
+        raise
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    shard = sub.add_parser("convert-shard")
+    shard.add_argument("--source", type=Path, required=True)
+    shard.add_argument("--source-index", type=Path, required=True)
+    shard.add_argument("--destination", type=Path, required=True)
+    shard.add_argument("--bits", type=int, default=4)
+    shard.add_argument("--group-size", type=int, default=64)
+    final = sub.add_parser("finalize")
+    final.add_argument("--destination", type=Path, required=True)
+    final.add_argument("--source-config", type=Path, required=True)
+    final.add_argument("--source-index", type=Path, required=True)
+    final.add_argument("--source-revision", required=True)
+    mixed = sub.add_parser("compose-mixed")
+    mixed.add_argument("--low", type=Path, required=True)
+    mixed.add_argument("--high", type=Path, required=True)
+    mixed.add_argument("--destination", type=Path, required=True)
+    mixed.add_argument("--low-revision", required=True)
+    mixed.add_argument("--high-revision", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "convert-shard":
+        args.destination.mkdir(parents=True, exist_ok=True)
+        output = args.destination / args.source.name.replace("model-", "dspark-")
+        state_path = output.with_suffix(".conversion.json")
+        if state_path.exists():
+            raise FileExistsError(state_path)
+        result = _convert_shard(
+            args.source.absolute(),
+            args.source_index.resolve(),
+            output,
+            bits=args.bits,
+            group_size=args.group_size,
+        )
+        state_path.write_text(json.dumps(result, indent=2) + "\n")
+    elif args.command == "finalize":
+        result = _finalize(
+            args.destination.resolve(),
+            args.source_config.resolve(),
+            args.source_index.resolve(),
+            args.source_revision,
+        )
+    else:
+        result = _compose_mixed(
+            args.low.resolve(),
+            args.high.resolve(),
+            args.destination.absolute(),
+            low_revision=args.low_revision,
+            high_revision=args.high_revision,
+        )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qualify_deepseek_v41_dspark_suite.py
+++ b/scripts/qualify_deepseek_v41_dspark_suite.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the exact K4 V4.1 DSpark candidate across a fixed prompt suite."""
+"""Run one fixed-K V4.1 DSpark candidate across a fixed prompt suite."""
 
 from __future__ import annotations
 
@@ -95,6 +95,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--overlay", type=Path, required=True)
     parser.add_argument("--tokens", type=_positive_int, default=128)
     parser.add_argument("--repeats", type=_at_least_two, default=2)
+    parser.add_argument(
+        "--verify-k", type=_positive_int, choices=range(2, 7), default=4
+    )
     parser.add_argument("--eval-interval", type=_positive_int, default=40)
     parser.add_argument("--collect-target-margins", action="store_true")
     parser.add_argument("--skip-ar", action="store_true")
@@ -177,13 +180,13 @@ def main() -> None:
                     1,
                     rapid_dspark.Weights,
                     rapid_dspark.DSpark,
-                    verify_k=4,
+                    verify_k=args.verify_k,
                     packed_mtp=True,
                     collect_target_margins=args.collect_target_margins,
                 )
             reference = references.get(prompt_id)
             row = {
-                "event": "suite_k4",
+                "event": f"suite_k{args.verify_k}",
                 "repeat": repeat,
                 "prompt_id": prompt_id,
                 **metrics,
@@ -219,6 +222,7 @@ def main() -> None:
         json.dumps(
             {
                 "event": "suite_summary",
+                "verify_k": args.verify_k,
                 "repeats": args.repeats,
                 "repeat_stable_prompts": len(stable_prompts),
                 "replaced_layers": replaced,
@@ -232,7 +236,7 @@ def main() -> None:
     )
     if len(stable_prompts) != len(encoded):
         raise SystemExit(
-            "K4 repeat-stability gate failed: "
+            f"K{args.verify_k} repeat-stability gate failed: "
             f"{len(stable_prompts)}/{len(encoded)} prompts were stable"
         )
 

--- a/tests/test_deepseek_v41_artifacts.py
+++ b/tests/test_deepseek_v41_artifacts.py
@@ -249,7 +249,7 @@ def test_implicit_download_tolerates_profile_resolution_failure(monkeypatch):
         cli._ensure_model_downloaded("owner/model")
 
 
-def test_product_alias_pulls_pinned_target_and_three_shard_sidecar(monkeypatch):
+def test_product_alias_pulls_pinned_target_and_mixed_sidecar(monkeypatch):
     calls = []
     disk_checks = []
     monkeypatch.setattr(
@@ -281,6 +281,16 @@ def test_product_alias_pulls_pinned_target_and_three_shard_sidecar(monkeypatch):
 
     cli.pull_command(args)
 
+    assert artifacts.MTP_REPO == ("rapid-mlx/DeepSeek-V4.1-Flash-DSpark-4d2e-MLX")
+    assert artifacts.MTP_REVISION == "9530d6d2bf59e0d05177bd538095d5704ded1488"
+    assert [file.name for file in artifacts.MTP_FILES] == [
+        "config.json",
+        "dspark-mixed-stage-0.safetensors",
+        "dspark-mixed-stage-1.safetensors",
+        "dspark-mixed-stage-2.safetensors",
+        "model.safetensors.index.json",
+        "rapid-dspark-manifest.json",
+    ]
     assert calls[0] == (
         artifacts.TARGET_REPO,
         {"revision_override": artifacts.TARGET_REVISION},

--- a/tests/test_extract_deepseek_v41_dspark_precision.py
+++ b/tests/test_extract_deepseek_v41_dspark_precision.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.core as mx
+
+
+def _load_script():
+    path = (
+        Path(__file__).parents[1]
+        / "scripts"
+        / "extract_deepseek_v41_dspark_precision.py"
+    )
+    spec = importlib.util.spec_from_file_location("dspark_precision", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "mtp.0.attn.wq_a.weight",
+        "mtp.0.main_proj.weight",
+        "mtp.1.ffn.shared_experts.w2.weight",
+        "mtp.2.ffn.experts.127.w3.weight",
+        "mtp.2.confidence_head.proj.weight",
+        "mtp.2.markov_head.embed.weight",
+    ],
+)
+def test_quantized_base_covers_every_dspark_linear(name):
+    module = _load_script()
+    assert module._quantized_base(name, mx.zeros((64, 64)), 64) == name[:-7]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "mtp.0.attn_norm.weight",
+        "mtp.0.ffn.gate.weight",
+        "mtp.0.hc_attn_fn",
+        "layers.0.attn.wq_a.weight",
+    ],
+)
+def test_quantized_base_keeps_non_linear_contract_tensors_unquantized(name):
+    module = _load_script()
+    assert module._quantized_base(name, mx.zeros((64, 64)), 64) is None
+
+
+def test_script_cannot_redirect_or_download_hub_cache():
+    module = _load_script()
+    source = Path(module.__file__).read_text()
+    assert "hf_hub_download" not in source
+    assert "snapshot_download" not in source
+    assert "cache_dir" not in source
+    assert "local_dir" not in source
+
+
+def test_weight_map_rejects_missing_or_malformed_map(tmp_path):
+    module = _load_script()
+    missing = tmp_path / "missing.json"
+    malformed = tmp_path / "malformed.json"
+    missing.write_text("{}")
+    malformed.write_text('{"weight_map":{"tensor":3}}')
+
+    with pytest.raises(ValueError, match="has no weight_map"):
+        module._weight_map(missing)
+    with pytest.raises(ValueError, match="map strings to strings"):
+        module._weight_map(malformed)
+
+
+def test_finalize_rejects_state_output_outside_destination(tmp_path):
+    module = _load_script()
+    destination = tmp_path / "output"
+    destination.mkdir()
+    (destination / "bad.conversion.json").write_text(
+        '{"output_file":"../foreign.safetensors"}'
+    )
+
+    with pytest.raises(ValueError, match="unsafe output filename"):
+        module._finalize(
+            destination,
+            tmp_path / "config.json",
+            tmp_path / "index.json",
+            "revision",
+        )
+
+
+def test_mixed_policy_changes_only_routed_experts():
+    module = _load_script()
+    assert module._use_low_precision("mtp.0.ffn.experts.127.w2.weight")
+    assert not module._use_low_precision("mtp.0.ffn.shared_experts.w2.weight")
+    assert not module._use_low_precision("mtp.0.attn.wq_a.weight")
+
+
+def test_mixed_quantization_preserves_dense_four_bit_and_experts_two_bit():
+    module = _load_script()
+    high = {
+        "quantization": {
+            "bits": 4,
+            "group_size": 64,
+            "mode": "affine",
+            "modules": {
+                "mtp.0.attn.wq_a": {"bits": 4},
+                "mtp.0.ffn.experts.0.w1": {"bits": 4},
+            },
+        }
+    }
+    low = {"quantization": {"bits": 2, "group_size": 64, "mode": "affine"}}
+
+    result = module._mixed_quantization(high, low)
+
+    assert result["modules"]["mtp.0.attn.wq_a"] == {"bits": 4}
+    assert result["modules"]["mtp.0.ffn.experts.0.w1"] == {
+        "bits": 2,
+        "group_size": 64,
+        "mode": "affine",
+    }
+    assert result["modules"]["embed"]["bits"] == 2
+    assert result["modules"]["head"]["bits"] == 2
+
+
+def test_mixed_quantization_rejects_an_unqualified_precision_pair():
+    module = _load_script()
+    high = {
+        "quantization": {
+            "bits": 6,
+            "group_size": 64,
+            "modules": {"mtp.0.attn.wq_a": {"bits": 6}},
+        }
+    }
+    low = {"quantization": {"bits": 3, "group_size": 64}}
+
+    with pytest.raises(ValueError, match="requires a 2-bit low input and 4-bit high"):
+        module._mixed_quantization(high, low)

--- a/tests/test_qualify_deepseek_v41_dspark_suite.py
+++ b/tests/test_qualify_deepseek_v41_dspark_suite.py
@@ -73,6 +73,17 @@ def test_tokens_must_be_positive() -> None:
         module._positive_int("0")
 
 
+def test_suite_exposes_bounded_fixed_k_for_precision_experiments(monkeypatch) -> None:
+    module = _load_script()
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["suite", "--target", ".", "--overlay", ".", "--verify-k", "5"],
+    )
+
+    assert module.parse_args().verify_k == 5
+
+
 def test_stability_qualification_requires_two_repeats() -> None:
     module = _load_script()
 

--- a/vllm_mlx/models/deepseek_v41_native/artifacts.py
+++ b/vllm_mlx/models/deepseek_v41_native/artifacts.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 TARGET_REPO = "rapid-mlx/DeepSeek-V4.1-Flash-REAP-2bit-MLX"
 TARGET_REVISION = "a25fec277b9e7cedc0e9f3f15da874a5cf9d491b"
-MTP_REPO = "Vontra/DeepSeek-V4.1-Flash-MLX-2bit-MTP"
-MTP_REVISION = "802f1a00982705d81b79ad1c83aa0ccc0b863ebc"
+MTP_REPO = "rapid-mlx/DeepSeek-V4.1-Flash-DSpark-4d2e-MLX"
+MTP_REVISION = "9530d6d2bf59e0d05177bd538095d5704ded1488"
 
 
 @dataclass(frozen=True)
@@ -22,28 +22,33 @@ class ArtifactFile:
 MTP_FILES = (
     ArtifactFile(
         "config.json",
-        23_617,
-        "c615d9c9469bc66273306b08c5a92670abdbefd7edc31de7e01dd7d9719f489e",
+        138_476,
+        "3518b608fd8b90bc518c7d4533c751367fe3c2416aa3a4f7fde40bc6e498f012",
     ),
     ArtifactFile(
-        "model-00044-of-00048.safetensors",
-        1_496_184_720,
-        "772bdc5044bc8acfdb38e38749d784d50019b1846ed2b85337993a5fba530663",
+        "dspark-mixed-stage-0.safetensors",
+        1_556_346_856,
+        "381a7fbc8758cd86baab55e8f1ae3020e49e2977f067d4269416889c1aee8118",
     ),
     ArtifactFile(
-        "model-00045-of-00048.safetensors",
-        1_471_598_024,
-        "b200f6ce5e726e38a684a04f941e1321fc58a1c0ba6a2b7ab747f7ddb753ff3e",
+        "dspark-mixed-stage-1.safetensors",
+        1_512_099_424,
+        "2ca7dc77528ebe3220e6e1633733925ca3420e346b4475163e1639541333876e",
     ),
     ArtifactFile(
-        "model-00046-of-00048.safetensors",
-        1_492_295_832,
-        "6890e30fcb9b6fa759f43ab21424cd748242a734f263b469b148da0834449352",
+        "dspark-mixed-stage-2.safetensors",
+        1_549_346_368,
+        "1ed4663f0487e13372e753b2a5e8b760ae8fd43ba661fae891dfdff62384e64b",
     ),
     ArtifactFile(
         "model.safetensors.index.json",
-        11_268_410,
-        "796eb8ceeeec2cba865fa1986238aa5214d9479d8225151b8b79b04126b33d62",
+        265_016,
+        "70cbf70324c1b8d7d7c3d5f7f522f38d0be6cba673e90430a0f9a1d8b1ab8cff",
+    ),
+    ArtifactFile(
+        "rapid-dspark-manifest.json",
+        1_261,
+        "5b50b23fa1d30f445eab71de601075a3dab1f4463b5a4930c1d7ac4451f70b9e",
     ),
 )
 MTP_ALLOW_PATTERNS = tuple(file.name for file in MTP_FILES)
@@ -114,7 +119,7 @@ def verify_mtp_snapshot(snapshot: str | Path) -> Path:
 
 
 def download_mtp_snapshot() -> Path:
-    """Resolve only the 4.47 GB data subset needed by the owned runtime."""
+    """Resolve only the 4.62 GB data subset needed by the owned runtime."""
     from huggingface_hub import snapshot_download
 
     path = snapshot_download(


### PR DESCRIPTION
## Why

The existing affine 2-bit drafter leaves most target verification blocks
under-filled, so the experimental 256 GiB lane sustains only about 10.72 tok/s.
Selective precision is the best measured tradeoff because it nearly doubles
end-to-end throughput while adding only 3.5% to the optional head and remaining
inside the qualified memory envelope.

## User-visible goal

Raise the experimental DeepSeek V4.1 Flash REAP 2-bit lane from roughly 11
tok/s to approximately 20 tok/s on a qualified 256 GiB Mac, while keeping the
optional drafter small, immutable, and independently downloadable.

## Scope

- Publish a head-only mixed-precision DSpark sidecar with a complete Model Card,
  license, provenance manifest, and file hashes.
- Pin the Rapid-owned sidecar repository, revision, sizes, and SHA-256 values.
- Add revision-pinned offline extraction/composition tooling.
- Extend the qualification suite to bounded K2-K6 experiments without changing
  the product K4 setting.
- Update user and engineering documentation with reproducible performance and
  limitations.

Non-goals: target-model changes, sampling, tools, MCP, images, continuous
batching, memory-floor reduction, release, deployment, or a broad model-quality
claim. The lane remains experimental and K4 remains fixed.

## Artifact contract

The public repository contains only the 4.62 GB DSpark head; it is not a
standalone language model and contains none of the approximately 213 GB REAP
target weights:

https://huggingface.co/rapid-mlx/DeepSeek-V4.1-Flash-DSpark-4d2e-MLX

Rapid pins revision `9530d6d2bf59e0d05177bd538095d5704ded1488` and verifies
config, index, manifest, and all three stage shards before loading. Users
outside this experimental lane do not download the sidecar.

The 4d2e policy keeps bandwidth-dominant routed experts at affine 2-bit and
uses affine 4-bit for attention, shared-expert, main-projection, Markov, and
confidence paths.

## Quantitative result

Apple M3 Ultra, 256 GiB unified memory, 212.93 GB REAP12.5 target, four prompt
domains, up to 128 output tokens, two consecutive repeats per prompt:

- Mixed DSpark K4: **19.39 tok/s** weighted.
- Same-process autoregressive target: 9.58 tok/s.
- Speedup over AR: **2.02x**.
- Improvement over the prior 2-bit head conservative suite result of 10.72
  tok/s: **80.9%**.
- Mean acceptance: 1.85 extra draft tokens/block.
- Head size: 4,617,792,648 bytes, 3.5% above the prior head.
- Peak MLX memory: 218.232 GB.
- K5: 18.49 tok/s despite higher acceptance; rejected as the fixed default.
- Uniform affine 4-bit: killed during residency in two attempts; rejected for
  256 GiB.

Approximately 20 tok/s describes this measured configuration, not a guarantee
for every prompt, context length, thermal state, or Mac.

## Correctness and limitations

All four K4 outputs are token-for-token stable across two repetitions.
Verification is target-authoritative: emitted draft tokens are accepted by
target logits and corrections come from the target. Fixed-batch output is not
promised to be bitwise identical to sequential AR at low-margin decisions.

Manual probes also show weak or repetitive English instruction-following in
the 2-bit target/current paths. This PR does not claim that the speed result
clears broad model quality; the experimental label and narrow serving contract
remain.

## Validation

- Public head-only repository and immutable revision resolve on the Hub: passed.
- Uploaded LFS SHA-256 values equal the locally qualified byte set: passed.
- Product verifier accepts config, index, manifest, sizes, and hashes: passed.
- Strict mixed-precision DSpark loader: passed.
- DeepSeek/DSpark regression set: 128/128 passed across 12 files.
- Diff-targeted PR validation: 46/46 passed; supply-chain and lint passed.
- Full local suite: 23,857 passed. Its 10 failures reproduce identically on the
  exact base `9abd21d9d` and lie in Bonsai Image, Doctor, and image-memory tests;
  they are not caused by this diff and are intentionally not absorbed here.
- Four-domain K4 repeat stability: 4/4 prompts across two repetitions.

Depends on #3325, which owns the dedicated product runtime and serving boundary.
