### PR TITLE
docs: add M4 multimodal and MTP benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,9 +401,9 @@ MTP path was not physically qualified on a 32 GB Mac.
 
 ## M4 Pro 48 GB Community Benchmarks
 
-Seven popular models were run on a 12-CPU / 16-GPU-core **Apple M4 Pro with
+Nine public measurements were run on a 12-CPU / 16-GPU-core **Apple M4 Pro with
 48 GB unified memory** using the unmodified PyPI `rapid-mlx==0.14.1` release.
-These are single-request (`B=1`) Community Benchmark v2 medians: one warmup
+The text rows are single-request (`B=1`) Community Benchmark v2 medians: one warmup
 plus five measured rounds per case, greedy decode, prefix cache off, and no
 speculative decoding. The Mac was on AC power with nominal thermals and normal
 memory pressure throughout.
@@ -418,6 +418,16 @@ memory pressure throughout.
 | `qwen3.6-27b-4bit` | 4.87s / **15.53 tok/s** | 19.25s / **15.30 tok/s** | 18.1 GiB |
 | `qwen3.8-27b-4bit` | 4.87s / **15.53 tok/s** | 19.31s / **15.28 tok/s** | 18.4 GiB |
 
+The same released CLI completed a 1024x1024 FLUX.2 Klein 4B image in **272.34s**
+and an 832x480, 81-frame Wan2.2 TI2V 5B video job in **15m57.53s**. These use
+registered image/video protocols and are complete job times, so they are not
+throughput comparisons with the text table.
+
+Normal Qwen3.8 serving also activated its pinned MTP path. In a separate
+same-model A/B, the repeated-run median improved from **13.0 to 17.2 tok/s
+(+32.3%)**. This serving workload differs from the fixed public protocol; the
+full record shows every observation and the acceptance metrics.
+
 Run any row as a local server with `rapid-mlx serve <alias>`. To reproduce the
 fixed benchmark instead, preview its exact workload first:
 
@@ -429,9 +439,11 @@ rapid-mlx benchmark share <run-id>   # previews the payload; default is No
 
 Normal serving can enable qualified per-model accelerations that this fixed,
 non-speculative protocol deliberately excludes, so do not compare this table
-directly with the MTP serving measurements above. All seven public rows include
-the model revision, Rapid-MLX version, run conditions, and anonymous submission
-ID.
+directly with the MTP serving measurements above. All nine public rows include
+the Rapid-MLX version, run conditions, and anonymous submission ID. The seven
+text rows also expose resolved model revisions; the generation rows currently
+report unresolved identity in the public projection, with their exact local
+snapshot revisions preserved in the full record.
 
 → [Full methodology, revisions, commands, and public submission IDs](docs/benchmarks/m4-pro-48gb-community.md) · [Community Benchmark board](https://rapidmlx.com/leaderboard/contributors/jolly-rooted-zebra-edc)
 

--- a/docs/benchmarks/m4-pro-48gb-community.md
+++ b/docs/benchmarks/m4-pro-48gb-community.md
@@ -83,9 +83,9 @@ only speculative decoding changed.
 The repeated-run median improved by 32.3%. A separate initial cold MTP
 observation measured 12.8 tok/s and is excluded from that median; the table
 shows the next three runs instead of selecting the fastest sample. Across the
-measured MTP activity, 189 of 297 drafted tokens were accepted (63.64%), saving
-189 target-model token steps. Thermal state remained nominal and memory
-pressure remained normal.
+measured MTP activity, the runtime counters recorded 297 attempts, 189 accepts
+(63.64%), and 189 saved target tokens. Thermal state remained nominal and
+memory pressure remained normal.
 
 This is a serving result, not a Community Benchmark submission. Its workload
 and acceleration policy differ from the fixed protocol table above.

--- a/docs/benchmarks/m4-pro-48gb-community.md
+++ b/docs/benchmarks/m4-pro-48gb-community.md
@@ -1,7 +1,8 @@
 # M4 Pro 48 GB Community Benchmark
 
-This record captures seven public Community Benchmark submissions produced on
-an Apple M4 Pro Mac with 48 GB of unified memory. It is intended to answer two
+This record captures nine public Community Benchmark submissions produced on
+an Apple M4 Pro Mac with 48 GB of unified memory, plus a serving-path MTP A/B.
+It is intended to answer two
 practical questions: what popular model sizes look like on this hardware, and
 how another user can reproduce the same fixed workload rather than relying on
 an unexplained headline number.
@@ -65,6 +66,46 @@ speculative decoding off to preserve cross-machine comparability; its
 Qwen3.8 row therefore must not be compared directly with an MTP-enabled
 serving result.
 
+## Default Qwen3.8 serving acceleration
+
+The fixed protocol above is the comparable baseline. A separate serving-path
+A/B measured what a user gets from the normal `qwen3.8-27b-4bit` alias on this
+Mac. The alias selected its pinned MTP model, loaded all 31 MTP tensors and
+activated the continuous MTP scheduler with a maximum draft depth of three.
+Both sides used the same `rapid-mlx bench ... --tier speed` workload and model;
+only speculative decoding changed.
+
+| Serving mode | Three decode observations | Median |
+|---|---|---:|
+| `--no-spec-decode` | 12.8, 13.0, 13.0 tok/s | 13.0 tok/s |
+| Alias default (MTP), after cold run | 15.4, 17.5, 17.2 tok/s | 17.2 tok/s |
+
+The repeated-run median improved by 32.3%. A separate initial cold MTP
+observation measured 12.8 tok/s and is excluded from that median; the table
+shows the next three runs instead of selecting the fastest sample. Across the
+measured MTP activity, 189 of 297 drafted tokens were accepted (63.64%), saving
+189 target-model token steps. Thermal state remained nominal and memory
+pressure remained normal.
+
+This is a serving result, not a Community Benchmark submission. Its workload
+and acceleration policy differ from the fixed protocol table above.
+
+## Image and video generation
+
+The same released CLI also completed and published the registered generation
+protocols. Total time covers the complete measured job, not only a selected
+kernel or diffusion step.
+
+| Modality | Model | Registered case | Complete job time |
+|---|---|---|---:|
+| Image | `flux2-klein-4b` | 1024x1024, 20 steps, one image | 272.34 s |
+| Video | `wan2.2-ti2v-5b-q8` | 832x480, 81 frames, 24 fps, 20 steps | 957.53 s |
+
+The video case produces 3.375 seconds of output and took 15m57.53s end to end;
+its diffusion phase took 13m43s. Both jobs ran on AC power with Low Power Mode
+off, nominal thermal state and normal memory pressure. Peak active memory is
+not yet emitted by these two registered protocols, so it is not estimated here.
+
 ## Run a model
 
 Use the short alias from the table. The default server is local-only on port
@@ -127,6 +168,18 @@ rapid-mlx benchmark share <run-id>
 To simulate the catalog fit decision for a 48 GB machine without running a
 model, use `rapid-mlx benchmark catalog --memory-gib 48`.
 
+Image and video protocols require their runtime extras. The video path also
+requires `ffmpeg`:
+
+```bash
+pip install 'rapid-mlx[image,video]'
+brew install ffmpeg
+rapid-mlx benchmark plan flux2-klein-4b
+rapid-mlx benchmark run flux2-klein-4b
+rapid-mlx benchmark plan wan2.2-ti2v-5b-q8
+rapid-mlx benchmark run wan2.2-ti2v-5b-q8
+```
+
 ## Public records
 
 | Alias | Hugging Face revision | Submission ID |
@@ -138,9 +191,15 @@ model, use `rapid-mlx benchmark catalog --memory-gib 48`.
 | `gemma-4-26b-4bit` | `0d77464eeb233a2da68ebf9d7dc4edaac7db956d` | `e646b8fc-a9b8-432f-9d82-d50858f2eb21` |
 | `qwen3.6-27b-4bit` | `c000ac2c2057d94be3fa931000c31723aac53282` | `7401c891-3feb-4b88-9085-eedb7b34d675` |
 | `qwen3.8-27b-4bit` | `aa985c29ff5b334cbfdcbbc787d47e66e9d9e456` | `bfa944b3-182d-40ac-8290-b45832c1d174` |
+| `flux2-klein-4b` | `7ee1b3aa8178a1240050490072196a57da2bf2a9` | `fb718d98-f112-4565-a8eb-7415ba204220` |
+| `wan2.2-ti2v-5b-q8` | `9624723c94ddf509832555c45e223a035baa7d1c` | `83df7d65-b0c9-492c-9129-a5cbf679b28e` |
 
-All seven rows were accepted on 2026-09-11 under the anonymous contributor
+All nine rows were accepted on 2026-09-11 under the anonymous contributor
 identity [`jolly-rooted-zebra·edc`](https://rapidmlx.com/leaderboard/contributors/jolly-rooted-zebra-edc).
+The two generation revisions above are the exact local snapshot directories
+used for the runs. Their current public projection reports model identity as
+`unresolved`; it does not yet expose those revision hashes. The seven text rows
+carry resolved identity and revision metadata in the public payload.
 The public board currently labels atomic Community Benchmark observations as
 beta and `unverified_not_ranked`; they are public measurements, not automatic
 recommendation-policy evidence.


### PR DESCRIPTION
## Why

The M4 Pro 48 GB benchmark record previously covered only seven comparable text runs. Users also need measured expectations for normal Qwen3.8 MTP serving and for image/video generation on this common hardware tier.

## What

- adds a same-model Qwen3.8 MTP on/off serving A/B with every recorded observation and acceptance evidence;
- adds production-published FLUX.2 Klein image and Wan2.2 video benchmark results;
- documents the exact generation protocols, complete job times, snapshot revisions, submission IDs, and required extras;
- distinguishes fixed public protocol results from the separate accelerated serving workload;
- states the current unresolved identity limitation of the generation public projection.

## Scope

Documentation only: `README.md` and `docs/benchmarks/m4-pro-48gb-community.md`.

Non-goals: runtime changes, benchmark protocol changes, recommendation-policy changes, or claiming an audio score where no registered audio protocol exists.

## Acceptance criteria

- all numbers come from completed runs on the same Mac16,11 M4 Pro (12 CPU / 16 GPU, 48 GiB);
- the image and video submission IDs are readable from the production public API;
- model aliases resolve in the shipped alias catalog;
- protocol differences and unresolved generation identity are explicit.

## Verification

- `git diff --check`
- `/opt/homebrew/bin/python3.12 -m pytest -q tests/test_docs_cli_defaults.py tests/test_readme_image_matrix.py` — 7 passed
- alias resolution check against `vllm_mlx/aliases.json`
- production API readback for submissions `fb718d98-f112-4565-a8eb-7415ba204220` and `83df7d65-b0c9-492c-9129-a5cbf679b28e`

## Design precedent

The existing benchmark documentation pattern is retained: comparable registered-protocol results remain separate from serving-path optimization evidence, full conditions are shown next to headline measurements, and public records remain opt-in and privacy-previewed.
