### PR TITLE
fix(benchmark): preflight generation runtimes

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/CommunityBenchmarkView.swift
@@ -13,8 +13,11 @@ struct CommunityBenchmarkModel: Identifiable, Hashable {
     let isFocus: Bool
     let estimatedMemoryGib: Int?
     let memoryFit: String
+    let runtimeStatus: String?
+    let runtimeMessage: String?
 
     var id: String { entry.alias }
+    var runtimeCanRun: Bool { runtimeStatus != "unavailable" }
 
     static let focusAliases: Set<String> = [
         "qwen3.8-27b-4bit", "qwen3.5-9b-4bit", "gemma-4-e4b-4bit",
@@ -76,7 +79,9 @@ struct CommunityBenchmarkModel: Identifiable, Hashable {
                 protocolName: protocolName,
                 isFocus: catalogModel?.focus ?? focusAliases.contains(entry.alias),
                 estimatedMemoryGib: catalogModel?.estimatedMemoryGib,
-                memoryFit: catalogModel?.memoryFit ?? "unknown"
+                memoryFit: catalogModel?.memoryFit ?? "unknown",
+                runtimeStatus: catalogModel?.runtime?.status,
+                runtimeMessage: catalogModel?.runtime?.message
             )
         }
         .sorted {
@@ -141,14 +146,20 @@ struct CommunityBenchmarkModel: Identifiable, Hashable {
 }
 
 struct CommunityBenchmarkCatalogModel: Decodable, Sendable {
+    struct RuntimeReadiness: Decodable, Sendable {
+        let status: String
+        let message: String?
+    }
+
     let alias: String
     let focus: Bool
     let estimatedMemoryGib: Int?
     let memoryFit: String
     let protocolVersion: Int?
+    let runtime: RuntimeReadiness?
 
     enum CodingKeys: String, CodingKey {
-        case alias, focus
+        case alias, focus, runtime
         case estimatedMemoryGib = "estimated_memory_gib"
         case memoryFit = "memory_fit"
         case protocolVersion = "protocol_version"
@@ -1348,6 +1359,14 @@ struct CommunityBenchmarkView: View {
                 Text(protocolDescription(selected.task))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if selected.runtimeStatus == "unavailable",
+                   let message = selected.runtimeMessage {
+                    Label(message, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("CommunityBenchmark.RuntimeUnavailable")
+                }
             }
 
             if let errorMessage {
@@ -1369,7 +1388,10 @@ struct CommunityBenchmarkView: View {
                 .accessibilityIdentifier("CommunityBenchmark.RunOrStop")
                 .disabled(
                     !isRunning
-                        && (selected == nil || binary == nil || !benchmarkCLIAvailable)
+                        && (
+                            selected == nil || binary == nil || !benchmarkCLIAvailable
+                                || selected?.runtimeCanRun == false
+                        )
                 )
                 if isRunning {
                     ProgressView().controlSize(.small)

--- a/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CommunityBenchmarkModelTests.swift
@@ -154,7 +154,8 @@ struct CommunityBenchmarkModelTests {
             focus: true,
             estimatedMemoryGib: 64,
             memoryFit: "does_not_fit",
-            protocolVersion: 1
+            protocolVersion: 1,
+            runtime: nil
         )
         let model = try #require(
             CommunityBenchmarkModel.models(
@@ -163,6 +164,46 @@ struct CommunityBenchmarkModelTests {
         )
         #expect(model.estimatedMemoryGib == 64)
         #expect(model.memoryFit == "does_not_fit")
+    }
+
+    @Test("CLI runtime readiness disables an unavailable benchmark")
+    func runtimeReadiness() throws {
+        let image = ModelEntry(
+            alias: "flux2-klein-4b",
+            hfRepo: "Runpod/FLUX.2-klein-4B-mflux-4bit",
+            sizeOnDisk: "4.3 GiB",
+            cached: true,
+            taskTypes: [.imageGeneration],
+            operationModes: [.textToImage]
+        )
+        let message = "image generation requires the rapid-mlx image extra"
+        let metadata = try JSONDecoder().decode(
+            CommunityBenchmarkCatalogModel.self,
+            from: Data(
+                """
+                {
+                  "alias": "flux2-klein-4b",
+                  "focus": true,
+                  "estimated_memory_gib": 12,
+                  "memory_fit": "fits",
+                  "protocol_version": 1,
+                  "runtime": {
+                    "status": "unavailable",
+                    "message": "image generation requires the rapid-mlx image extra"
+                  }
+                }
+                """.utf8
+            )
+        )
+
+        let model = try #require(
+            CommunityBenchmarkModel.models(
+                from: [image], metadata: [image.alias: metadata]
+            ).first
+        )
+        #expect(model.runtimeStatus == "unavailable")
+        #expect(model.runtimeMessage == message)
+        #expect(model.runtimeCanRun == false)
     }
 
     @Test("CLI catalog filtering repairs an asynchronously selected alias")
@@ -186,7 +227,8 @@ struct CommunityBenchmarkModelTests {
             focus: true,
             estimatedMemoryGib: 8,
             memoryFit: "fits",
-            protocolVersion: 2
+            protocolVersion: 2,
+            runtime: nil
         )
         let filtered = CommunityBenchmarkModel.models(
             from: [removed, retained],
@@ -654,7 +696,7 @@ struct CommunityBenchmarkModelTests {
         func meta(_ alias: String, focus: Bool, fit: String) -> CommunityBenchmarkCatalogModel {
             CommunityBenchmarkCatalogModel(
                 alias: alias, focus: focus, estimatedMemoryGib: 8,
-                memoryFit: fit, protocolVersion: 2
+                memoryFit: fit, protocolVersion: 2, runtime: nil
             )
         }
         let catalog = [

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -50,6 +50,7 @@ from vllm_mlx.community_bench.upload import SubmitError
 from vllm_mlx.community_bench.workspace import (
     LocalRunArchive,
     benchmark_catalog,
+    benchmark_runtime_readiness,
     describe_case,
     plan_for_alias,
 )
@@ -156,6 +157,54 @@ def test_catalog_is_model_first_and_derives_protocol_from_atomic_task() -> None:
     assert by_alias["qwen-image"]["memory_fit"] == "does_not_fit"
     assert by_alias["qwen-image"]["memory_estimate_source"] == "profile_minimum"
     assert all("modality" not in model for model in catalog["models"])
+
+
+def test_runtime_readiness_reuses_fail_fast_generation_guards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.runtime import image_lane, video_lane
+
+    assert benchmark_runtime_readiness("qwen3.5-4b-4bit", "text_generation") == {
+        "status": "ready",
+        "message": None,
+    }
+
+    def missing_image(_alias: str) -> str:
+        return (
+            "image generation requires the `rapid-mlx[image]` Python extra "
+            "(`pip install 'rapid-mlx[image]'`)."
+        )
+
+    monkeypatch.setattr(image_lane, "image_runtime_issue", missing_image)
+    image = benchmark_runtime_readiness("flux2-klein-4b", "image_generation")
+    assert image == {
+        "status": "unavailable",
+        "message": (
+            "image generation requires the `rapid-mlx[image]` Python extra "
+            "(`pip install 'rapid-mlx[image]'`)."
+        ),
+    }
+
+    monkeypatch.setattr(video_lane, "registered_wan_runtime_issue", lambda _alias: None)
+    assert benchmark_runtime_readiness("wan2.2-ti2v-5b-q8", "video_generation") == {
+        "status": "ready",
+        "message": None,
+    }
+
+
+def test_runtime_readiness_degrades_probe_faults_to_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm_mlx.runtime import image_lane
+
+    def probe_fault(_alias: str) -> str | None:
+        raise RuntimeError("probe fault must not escape planning")
+
+    monkeypatch.setattr(image_lane, "image_runtime_issue", probe_fault)
+    assert benchmark_runtime_readiness("flux2-klein-4b", "image_generation") == {
+        "status": "unknown",
+        "message": "Runtime readiness could not be verified; run will check again.",
+    }
 
 
 def test_memory_fit_requires_headroom_for_the_os_and_kv_cache() -> None:
@@ -3222,6 +3271,7 @@ def test_cli_plan_prints_protocol_and_local_storage(
                 "estimated_memory_gib": 6,
                 "memory_estimate_source": "artifact_size_fallback",
                 "memory_fit": "fits",
+                "runtime": {"status": "ready", "message": None},
             },
             "workload": {
                 "protocol_version": 2,
@@ -3253,6 +3303,7 @@ def test_cli_plan_prints_protocol_and_local_storage(
         "Memory:   ~6 GB estimated (from download size); fits this Mac (18 GB)" in out
     )
     assert "Download: not cached yet; `benchmark run` downloads it" in out
+    assert "Runtime:  ready" in out
     assert (
         "Storage:  local; upload requires a separate share command and consent" in out
     )
@@ -5207,6 +5258,11 @@ def test_plan_for_alias_adds_memory_fit_and_cache_state_without_downloading(
     assert "memory_gib" not in base
     assert "model_cached" not in base
     assert base["model"]["memory_fit"] == "unknown"
+    assert base["model"]["runtime"]["status"] in {
+        "ready",
+        "unavailable",
+        "unknown",
+    }
 
     # The probe is the modality-aware one behind ``models --cached`` (mflux
     # image and Wan video layouts are not the text ``model*.safetensors``

--- a/tests/test_community_benchmark_workspace.py
+++ b/tests/test_community_benchmark_workspace.py
@@ -190,6 +190,10 @@ def test_runtime_readiness_reuses_fail_fast_generation_guards(
         "status": "ready",
         "message": None,
     }
+    assert benchmark_runtime_readiness("qwen3.5-4b-4bit", "unsupported") == {
+        "status": "unknown",
+        "message": "Runtime readiness could not be verified; run will check again.",
+    }
 
 
 def test_runtime_readiness_degrades_probe_faults_to_unknown(
@@ -3259,6 +3263,7 @@ def test_cli_plan_prints_protocol_and_local_storage(
 ) -> None:
     _cli_archive(monkeypatch, SimpleNamespace())
     seen: dict[str, object] = {}
+    runtime_readiness: dict[str, object] = {"status": "ready", "message": None}
 
     def fake_plan(alias, **kwargs):
         seen.update(kwargs)
@@ -3271,7 +3276,7 @@ def test_cli_plan_prints_protocol_and_local_storage(
                 "estimated_memory_gib": 6,
                 "memory_estimate_source": "artifact_size_fallback",
                 "memory_fit": "fits",
-                "runtime": {"status": "ready", "message": None},
+                "runtime": runtime_readiness,
             },
             "workload": {
                 "protocol_version": 2,
@@ -3317,6 +3322,17 @@ def test_cli_plan_prints_protocol_and_local_storage(
     assert payload["workload"]["protocol_version"] == 2
     assert payload["memory_gib"] == 18
     assert payload["model_cached"] is False
+
+    args.json = False
+    runtime_readiness.update(status="unavailable", message="install the image runtime")
+    assert community_cli.benchmark_command(args) == 0
+    assert (
+        "Runtime:  unavailable — install the image runtime" in capsys.readouterr().out
+    )
+
+    runtime_readiness.update(status="unknown", message=None)
+    assert community_cli.benchmark_command(args) == 0
+    assert "Runtime:  unknown" in capsys.readouterr().out
 
 
 def test_cli_plan_memory_and_download_lines_cover_every_verdict(

--- a/tests/test_image_lane.py
+++ b/tests/test_image_lane.py
@@ -9,6 +9,7 @@ validation / dispatch / transport contract rather than the diffusion pipeline.
 import base64
 import io
 import types
+from collections import namedtuple
 
 import pytest
 from fastapi.testclient import TestClient
@@ -23,6 +24,22 @@ from vllm_mlx.image.engine import (
 from vllm_mlx.runtime.image_lane import ImageEngine
 
 _PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def test_image_runtime_probe_and_guard_report_unsupported_python(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from vllm_mlx.runtime import image_lane
+
+    version_info = namedtuple("version_info", "major minor")
+    monkeypatch.setattr(image_lane.sys, "version_info", version_info(3, 10))
+
+    issue = image_lane.image_runtime_issue("flux2-klein-4b")
+    assert issue is not None
+    assert "Python 3.11 or newer (current: 3.10)" in issue
+    with pytest.raises(SystemExit, match="2"):
+        image_lane.require_image_runtime_or_exit("flux2-klein-4b")
+    assert "Python 3.11 or newer" in capsys.readouterr().err
 
 
 class _FakeGeneratedImage:

--- a/tests/test_wan_video.py
+++ b/tests/test_wan_video.py
@@ -16,7 +16,11 @@ from fastapi import HTTPException
 
 from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
-from vllm_mlx.runtime.video_lane import VideoEngine, require_video_runtime_or_exit
+from vllm_mlx.runtime.video_lane import (
+    VideoEngine,
+    registered_wan_runtime_issue,
+    require_video_runtime_or_exit,
+)
 from vllm_mlx.video.wan import WanBackendError, WanRequestError, WanVideoEngine
 
 
@@ -123,6 +127,18 @@ def test_wan_runtime_guard_handles_missing_parent_package(monkeypatch, capsys) -
     with pytest.raises(SystemExit):
         require_video_runtime_or_exit("Anes1032/Wan2.2-TI2V-5B-mlx-q8")
     assert "rapid-mlx[video]" in capsys.readouterr().err
+
+
+def test_wan_runtime_probe_reports_missing_ffmpeg_without_exiting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "version_info", (3, 11))
+    monkeypatch.setattr("importlib.util.find_spec", lambda _module: object())
+    monkeypatch.setattr("vllm_mlx.runtime.video_lane._resolve_ffmpeg", lambda: None)
+
+    issue = registered_wan_runtime_issue("wan2.2-ti2v-5b-q8")
+
+    assert issue == "video generation requires ffmpeg (`brew install ffmpeg`)."
 
 
 def test_wan_engine_maps_current_mlx_video_api(monkeypatch, tmp_path) -> None:

--- a/tests/test_wan_video.py
+++ b/tests/test_wan_video.py
@@ -8,6 +8,7 @@ import json
 import subprocess
 import sys
 import threading
+from collections import namedtuple
 from pathlib import Path
 from types import ModuleType
 
@@ -141,6 +142,9 @@ def test_wan_submodule_probe_does_not_import_parent(monkeypatch, tmp_path) -> No
     assert marker.exists() is False
     assert "probe_parent" not in sys.modules
 
+    monkeypatch.setattr("importlib.util.find_spec", lambda _module: None)
+    assert _submodule_spec_exists_without_import("missing_parent", "child") is False
+
 
 def test_wan_runtime_probe_reports_missing_ffmpeg_without_exiting(
     monkeypatch: pytest.MonkeyPatch,
@@ -156,6 +160,27 @@ def test_wan_runtime_probe_reports_missing_ffmpeg_without_exiting(
     issue = registered_wan_runtime_issue("wan2.2-ti2v-5b-q8")
 
     assert issue == "video generation requires ffmpeg (`brew install ffmpeg`)."
+
+
+def test_wan_runtime_probe_reports_unsupported_python_and_ready_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    version_info = namedtuple("version_info", "major minor")
+    monkeypatch.setattr(sys, "version_info", version_info(3, 10))
+    issue = registered_wan_runtime_issue("wan2.2-ti2v-5b-q8")
+    assert issue is not None
+    assert "Python 3.11 or newer (current: 3.10)" in issue
+
+    monkeypatch.setattr(sys, "version_info", version_info(3, 11))
+    monkeypatch.setattr(
+        "vllm_mlx.runtime.video_lane._default_video_runtime_requirements",
+        lambda _model: [],
+    )
+    monkeypatch.setattr(
+        "vllm_mlx.runtime.video_lane._resolve_ffmpeg",
+        lambda: "/opt/homebrew/bin/ffmpeg",
+    )
+    assert registered_wan_runtime_issue("wan2.2-ti2v-5b-q8") is None
 
 
 def test_wan_engine_maps_current_mlx_video_api(monkeypatch, tmp_path) -> None:

--- a/tests/test_wan_video.py
+++ b/tests/test_wan_video.py
@@ -18,6 +18,7 @@ from vllm_mlx.model_aliases import resolve_profile
 from vllm_mlx.routes import video
 from vllm_mlx.runtime.video_lane import (
     VideoEngine,
+    _submodule_spec_exists_without_import,
     registered_wan_runtime_issue,
     require_video_runtime_or_exit,
 )
@@ -99,18 +100,15 @@ def test_wan_wraps_non_utf8_config(monkeypatch, tmp_path) -> None:
 
 
 def test_wan_runtime_guard_checks_wan_module(monkeypatch, capsys) -> None:
-    checked = []
     monkeypatch.setattr(sys, "version_info", (3, 11))
-
-    def fake_find_spec(module):
-        checked.append(module)
-        return None if module == "mlx_video.generate_wan" else object()
-
-    monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+    monkeypatch.setattr("importlib.util.find_spec", lambda _module: object())
+    monkeypatch.setattr(
+        "vllm_mlx.runtime.video_lane._submodule_spec_exists_without_import",
+        lambda parent, child: False,
+    )
     monkeypatch.setattr("shutil.which", lambda _: "/opt/homebrew/bin/ffmpeg")
     with pytest.raises(SystemExit):
         require_video_runtime_or_exit("Anes1032/Wan2.2-TI2V-5B-mlx-q8")
-    assert "mlx_video.generate_wan" in checked
     assert "rapid-mlx[video]" in capsys.readouterr().err
 
 
@@ -129,11 +127,30 @@ def test_wan_runtime_guard_handles_missing_parent_package(monkeypatch, capsys) -
     assert "rapid-mlx[video]" in capsys.readouterr().err
 
 
+def test_wan_submodule_probe_does_not_import_parent(monkeypatch, tmp_path) -> None:
+    package = tmp_path / "probe_parent"
+    package.mkdir()
+    marker = tmp_path / "parent-imported"
+    (package / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).touch()\n"
+    )
+    (package / "child.py").write_text("AVAILABLE = True\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    assert _submodule_spec_exists_without_import("probe_parent", "child") is True
+    assert marker.exists() is False
+    assert "probe_parent" not in sys.modules
+
+
 def test_wan_runtime_probe_reports_missing_ffmpeg_without_exiting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(sys, "version_info", (3, 11))
     monkeypatch.setattr("importlib.util.find_spec", lambda _module: object())
+    monkeypatch.setattr(
+        "vllm_mlx.runtime.video_lane._submodule_spec_exists_without_import",
+        lambda parent, child: True,
+    )
     monkeypatch.setattr("vllm_mlx.runtime.video_lane._resolve_ffmpeg", lambda: None)
 
     issue = registered_wan_runtime_issue("wan2.2-ti2v-5b-q8")

--- a/vllm_mlx/community_bench/cli.py
+++ b/vllm_mlx/community_bench/cli.py
@@ -194,6 +194,16 @@ def _print_plan(value: dict[str, Any]) -> None:
             "Download: could not verify the local cache; `benchmark run` "
             "downloads anything that is missing"
         )
+    runtime = model.get("runtime")
+    if isinstance(runtime, dict):
+        status = runtime.get("status")
+        message = runtime.get("message")
+        if status == "ready":
+            print("Runtime:  ready")
+        elif isinstance(message, str) and message:
+            print(f"Runtime:  {status} — {message}")
+        else:
+            print(f"Runtime:  {status}")
     print("Storage:  local; upload requires a separate share command and consent")
     print("Nothing is uploaded by this command or by `benchmark run`.")
 

--- a/vllm_mlx/community_bench/workspace.py
+++ b/vllm_mlx/community_bench/workspace.py
@@ -65,12 +65,8 @@ def benchmark_runtime_readiness(alias: str, task_type: str) -> dict[str, Any]:
         return {"status": "ready", "message": None}
     if task_type == "image_generation":
         from vllm_mlx.runtime.image_lane import image_runtime_issue
-
-        probe = image_runtime_issue
     elif task_type == "video_generation" and alias in _REGISTERED_WAN_ALIASES:
         from vllm_mlx.runtime.video_lane import registered_wan_runtime_issue
-
-        probe = registered_wan_runtime_issue
     else:
         return {
             "status": "unknown",
@@ -78,7 +74,10 @@ def benchmark_runtime_readiness(alias: str, task_type: str) -> dict[str, Any]:
         }
 
     try:
-        issue = probe(alias)
+        if task_type == "image_generation":
+            issue = image_runtime_issue(alias)
+        else:
+            issue = registered_wan_runtime_issue(alias)
     except Exception:
         return {
             "status": "unknown",

--- a/vllm_mlx/community_bench/workspace.py
+++ b/vllm_mlx/community_bench/workspace.py
@@ -47,6 +47,48 @@ _REGISTERED_WAN_ALIASES = frozenset(
 )
 
 
+def benchmark_runtime_readiness(alias: str, task_type: str) -> dict[str, Any]:
+    """Probe whether this process can execute a registered workload.
+
+    The serving lanes expose their side-effect-free dependency probes so
+    planning and execution stay on one contract without loading a model,
+    downloading anything, or duplicating dependency rules. The registered
+    video protocol admits only Wan aliases; other video families never reach
+    this function through the catalog.
+
+    Probe faults are ``unknown`` rather than ``unavailable``. A diagnostic
+    must not invent a missing dependency, and ``benchmark run`` retains the
+    authoritative fail-closed guard if the environment changes after planning.
+    """
+
+    if task_type == "text_generation":
+        return {"status": "ready", "message": None}
+    if task_type == "image_generation":
+        from vllm_mlx.runtime.image_lane import image_runtime_issue
+
+        probe = image_runtime_issue
+    elif task_type == "video_generation" and alias in _REGISTERED_WAN_ALIASES:
+        from vllm_mlx.runtime.video_lane import registered_wan_runtime_issue
+
+        probe = registered_wan_runtime_issue
+    else:
+        return {
+            "status": "unknown",
+            "message": "Runtime readiness could not be verified; run will check again.",
+        }
+
+    try:
+        issue = probe(alias)
+    except Exception:
+        return {
+            "status": "unknown",
+            "message": "Runtime readiness could not be verified; run will check again.",
+        }
+    if issue:
+        return {"status": "unavailable", "message": issue}
+    return {"status": "ready", "message": None}
+
+
 def _primary_task(task_types: list[str]) -> str | None:
     # A multimodal chat alias also advertises vision_language. Text is the
     # registered output-speed protocol until a VLM workload is published.
@@ -236,6 +278,7 @@ def benchmark_catalog(*, memory_gib: int | None = None) -> dict[str, Any]:
                 "memory_fit": fit,
                 "identity_strength": alias["target"]["resolution_status"],
                 "comparable": alias["target"]["resolution_status"] != "unresolved",
+                "runtime": benchmark_runtime_readiness(alias["alias"], task),
             }
         )
     entries.sort(key=lambda item: (not item["focus"], item["alias"]))

--- a/vllm_mlx/runtime/image_lane.py
+++ b/vllm_mlx/runtime/image_lane.py
@@ -23,22 +23,22 @@ __all__ = [
     "ImageEngine",
     "ImageGenerationCancelled",
     "ImageRuntimeError",
+    "image_runtime_issue",
     "require_image_runtime_or_exit",
 ]
 
 
-def require_image_runtime_or_exit(model_name: str | None = None) -> None:
-    """Fail before model download when the optional image stack is absent."""
+def image_runtime_issue(model_name: str | None = None) -> str | None:
+    """Return an actionable, side-effect-free image runtime problem."""
+
     family = _detect_family(model_name) if model_name else ""
     if sys.version_info < (3, 11) and family not in {"sdxl-base", "sd35-large"}:
-        print(
-            "\n  Error: image generation requires Python 3.11 or newer "
+        return (
+            "image generation requires Python 3.11 or newer "
             f"(current: {sys.version_info.major}.{sys.version_info.minor}). "
             "Rapid-MLX core still supports Python 3.10, but the mflux runtime "
-            "does not.\n",
-            file=sys.stderr,
+            "does not."
         )
-        raise SystemExit(2)
     runtime_module = (
         "mlx_vlm"
         if family == "hidream-o1-dev"
@@ -47,11 +47,18 @@ def require_image_runtime_or_exit(model_name: str | None = None) -> None:
         else "mflux"
     )
     if importlib.util.find_spec(runtime_module) is None:
-        print(
-            "\n  Error: image generation requires the `rapid-mlx[image]` "
-            "Python extra (`pip install 'rapid-mlx[image]'`).\n",
-            file=sys.stderr,
+        return (
+            "image generation requires the `rapid-mlx[image]` "
+            "Python extra (`pip install 'rapid-mlx[image]'`)."
         )
+    return None
+
+
+def require_image_runtime_or_exit(model_name: str | None = None) -> None:
+    """Fail before model download when the optional image stack is absent."""
+
+    if issue := image_runtime_issue(model_name):
+        print(f"\n  Error: {issue.rstrip()}\n", file=sys.stderr)
         raise SystemExit(2)
 
 

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+from importlib.machinery import PathFinder
 from pathlib import Path
 
 
@@ -91,13 +92,27 @@ def _is_ltx25_name(model_name: str | None) -> bool:
     return is_ltx25_model(model_name)
 
 
+def _submodule_spec_exists_without_import(parent: str, child: str) -> bool:
+    """Find a child module without executing the parent's ``__init__``."""
+
+    parent_spec = importlib.util.find_spec(parent)
+    if parent_spec is None or parent_spec.submodule_search_locations is None:
+        return False
+    return (
+        PathFinder.find_spec(
+            f"{parent}.{child}", parent_spec.submodule_search_locations
+        )
+        is not None
+    )
+
+
 def _default_video_runtime_requirements(model_name: str | None) -> list[str]:
     """Pure dependency probe for the default/Wan mlx-video runtime."""
 
     mlx_video_available = importlib.util.find_spec("mlx_video") is not None
     wan_available = not _is_wan_name(model_name) or (
         mlx_video_available
-        and importlib.util.find_spec("mlx_video.generate_wan") is not None
+        and _submodule_spec_exists_without_import("mlx_video", "generate_wan")
     )
     if not mlx_video_available or not wan_available:
         return ["the `rapid-mlx[video]` Python extra"]

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -91,6 +91,37 @@ def _is_ltx25_name(model_name: str | None) -> bool:
     return is_ltx25_model(model_name)
 
 
+def _default_video_runtime_requirements(model_name: str | None) -> list[str]:
+    """Pure dependency probe for the default/Wan mlx-video runtime."""
+
+    mlx_video_available = importlib.util.find_spec("mlx_video") is not None
+    wan_available = not _is_wan_name(model_name) or (
+        mlx_video_available
+        and importlib.util.find_spec("mlx_video.generate_wan") is not None
+    )
+    if not mlx_video_available or not wan_available:
+        return ["the `rapid-mlx[video]` Python extra"]
+    return []
+
+
+def registered_wan_runtime_issue(model_name: str) -> str | None:
+    """Return an actionable, side-effect-free Wan benchmark runtime problem."""
+
+    if sys.version_info < (3, 11):
+        return (
+            "video generation requires Python 3.11 or newer "
+            f"(current: {sys.version_info.major}.{sys.version_info.minor}). "
+            "Rapid-MLX core still supports Python 3.10, but the upstream "
+            "mlx-video runtime does not."
+        )
+    missing = _default_video_runtime_requirements(model_name)
+    if _resolve_ffmpeg() is None:
+        missing.append("ffmpeg (`brew install ffmpeg`)")
+    if missing:
+        return "video generation requires " + " and ".join(missing) + "."
+    return None
+
+
 def require_video_runtime_or_exit(model_name: str | None = None) -> None:
     """Fail before model download when the optional video stack is absent."""
     if sys.version_info < (3, 11):
@@ -165,13 +196,7 @@ def require_video_runtime_or_exit(model_name: str | None = None) -> None:
             if importlib.util.find_spec(module) is None
         )
     else:
-        mlx_video_available = importlib.util.find_spec("mlx_video") is not None
-        wan_available = not _is_wan_name(model_name) or (
-            mlx_video_available
-            and importlib.util.find_spec("mlx_video.generate_wan") is not None
-        )
-        if not mlx_video_available or not wan_available:
-            missing.append("the `rapid-mlx[video]` Python extra")
+        missing.extend(_default_video_runtime_requirements(model_name))
     if _resolve_ffmpeg() is None:
         missing.append("ffmpeg (`brew install ffmpeg`)")
     if missing:


### PR DESCRIPTION
## Why

Community Benchmark planning currently reports cache and memory fit without
checking whether the installed process can execute an image or video workload.
Users can therefore start a long benchmark only to discover that an optional
runtime or `ffmpeg` is missing.

This change adds a side-effect-free runtime readiness result to the existing
catalog/plan contract, shows the same actionable result in the CLI and Desktop,
and disables Desktop's Run button when a prerequisite is known to be missing.
The execution-time guards remain authoritative and fail closed if the
environment changes after planning.

Fixes #3331

## Scope

- expose pure image and registered-Wan runtime dependency probes
- attach machine-readable `ready`, `unavailable`, or `unknown` readiness to
  each benchmark catalog entry
- render the shared remediation in CLI and Desktop planning surfaces
- preserve compatibility with catalog producers that do not yet emit runtime
  readiness

## Non-goals

- downloading or installing optional dependencies
- loading models during planning
- changing benchmark workloads, model selection, or public result protocols
- changing runtime support for non-registered video families

## Acceptance criteria

- planning performs no download and no model load
- missing image/video extras and `ffmpeg` are reported before execution
- Desktop prevents a known-unavailable run while keeping Stop usable
- execution retains its independent fail-closed dependency guard

## Design precedent

Mature local-model clients separate static model metadata from machine-local
runtime readiness, surface actionable setup state before execution, and keep
the execution-time check authoritative because the environment may change.
This adapts that pattern by sharing pure probes with Rapid-MLX's existing
runtime guards instead of duplicating dependency policy in the benchmark UI.

## Verification

- `python3.12 -m pytest -q tests/test_community_benchmark_workspace.py tests/test_wan_video.py -k 'not requires_mlx'` — 264 passed, 1 deselected
- focused image/video runtime regression selection — 42 passed, 251 deselected
- `swift test --no-parallel --filter CommunityBenchmarkModelTests` — 30 passed
- Ruff check/format and `git diff --check` — passed
