### PR TITLE
perf(glm): fuse routed projections in the multimodal lane

### DIFF
--- a/.agents/handoffs/vector-glm53-flash-moe-fusion.md
+++ b/.agents/handoffs/vector-glm53-flash-moe-fusion.md
@@ -1,0 +1,45 @@
+# Vector handoff: GLM-5.3-Flash MLLM MoE fusion
+
+- Owner: Vector
+- Receiving owner: Atlas
+- Branch: `vector/glm53-flash-perf`
+- Worktree: `/private/tmp/CommunityBenchMark-glm53-perf`
+- Base: `origin/main@cae3412e4e45b07ee6fbcb9426fb9dba64a2791b`
+
+## Goal and scope
+
+Compare Rapid's published GLM-5.3-Flash results with oMLX and mlx-vlm, then
+recover a low-risk decode optimization that Rapid already applies to text MoE
+models but omitted from the forced MLLM lane. No MTP enablement, quantizer
+change, native-extension import, alias change, or other VLM enrollment belongs
+in this task.
+
+## Verified facts
+
+- Rapid's checked-in official-checkpoint campaign reports 27.20-32.38 decode
+  tok/s across 128-32K prompts. oMLX's separately published oQ4e campaign
+  reports 23.5-24.1 tok/s decode and stronger long-prefill numbers, but the
+  campaigns are not directly comparable.
+- GLM-5.3 routes through `MLXMultimodalLM`, so it missed the existing post-load
+  gate/up fusion. mlx-vlm also owns a distinct `SwitchGLU` class family, which
+  the helper did not recognize.
+- The change enrolls only `model_type == "glm5_next"`, discovers mlx-vlm only
+  when already loaded, keeps the environment kill switch, and fails closed if
+  upstream changes the verified `(self, x, indices)` call contract.
+- A production-shape q4-g64 layer microbenchmark measured a 1.037x median paired
+  speedup across five fresh processes (range 1.000x-1.119x), with byte-identical
+  output in every run. This is not an end-to-end model claim.
+- The 189 MB architecture fixture fused 2/2 sparse MoE layers and completed a
+  real OpenAI-compatible server request.
+- The official 181.7 GB checkpoint is not currently present in the fixed HF
+  cache or warm tier. With only about 6 GB quota free, storage policy correctly
+  prevented a new full-model download.
+
+## Risks and next action
+
+The rewrite is already qualified in the text lane, but the whole-model benefit
+for GLM must be measured when the exact cached snapshot becomes available.
+Atlas should review the architecture-scoped MLLM load hook and merge only after
+the focused/full test gates and PR validation pass. The follow-up campaign and
+stop criteria are recorded in
+`docs/engineering/performance/2026-09-11-glm53-flash-runtime-comparison.md`.

--- a/docs/engineering/performance/2026-09-11-glm53-flash-runtime-comparison.md
+++ b/docs/engineering/performance/2026-09-11-glm53-flash-runtime-comparison.md
@@ -1,0 +1,131 @@
+# GLM-5.3-Flash runtime comparison and first Rapid optimization
+
+- Date: 2026-09-11
+- Rapid baseline: `origin/main@cae3412e4e45b07ee6fbcb9426fb9dba64a2791b`
+- Host: Mac Studio (`Mac15,14`), Apple M3 Ultra, 256 GB, macOS 26.5.2
+- Rapid runtime: MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.6.17
+
+## What can and cannot be compared
+
+Rapid's production alias is
+`Vontra/GLM-5.3-Flash-MLX-4bit-MTP@06d6c7530e8290e20fabdc37a825ce07bdfc490c`:
+uniform affine q4-g64, 43 shards, 181,709,451,790 bytes. The checked-in
+[same-machine campaign](../../benchmarks/recent-large-models-m3-ultra.md)
+recorded:
+
+| Prompt tokens | Rapid prompt tok/s | Rapid decode tok/s | Rapid TTFT |
+| ---: | ---: | ---: | ---: |
+| 128 | 156.3 | 32.38 | 0.819 s |
+| 2,048 | 372.8 | 28.36 | 5.493 s |
+| 8,192 | 359.6 | 27.75 | 22.779 s |
+| 32,768 | 276.9 | 27.20 | 118.341 s |
+
+Those are medians of three 256-token completions, with the prefix cache cleared
+between requests. A separate sustained native-MTP experiment recorded 32.00
+tok/s without MTP and 31.65 tok/s with fixed K=1, so MTP remains correctly
+disabled.
+
+[oMLX 0.6.4](https://github.com/jundot/omlx/releases/tag/v0.6.4) publishes a
+different strict oQ4e conversion (169 GiB) on an M3 Ultra with 512 GB. Its
+uncached 128-token rows are:
+
+| Prompt | Prompt tok/s | Decode tok/s | TTFT |
+| ---: | ---: | ---: | ---: |
+| 4,096 | 482.3 | 24.1 | 8.49 s |
+| 16,384 | 443.2 | 23.7 | 36.97 s |
+| 32,768 | 449.6 | 23.5 | 72.89 s |
+
+These rows are useful targets, not an apples-to-apples ranking. At the published
+rows, Rapid's decode is numerically higher (27.20-32.38 versus 23.5-24.1 tok/s),
+while oMLX's long-context prefill is numerically higher (443-482 versus
+277-373 tok/s). The checkpoint, quantizer, prompts, output length, memory
+capacity, and runtime differ, so neither difference supports a product-level
+speed claim. [mlx-vlm 0.7.0](https://github.com/Blaizzy/mlx-vlm/releases/tag/v0.7.0)
+has GLM-5.3 and native MTP support but does not publish a comparable
+official-size Apple-silicon benchmark.
+
+The Studio Hugging Face quota volume had only 6.0 GiB free and no GLM-5.3
+snapshot or warm-tier symlink. Storage policy forbids deleting other models or
+redirecting the cache, so a new 181.7 GB identical-checkpoint campaign was not
+run in this task.
+
+## Gap found: the MLLM lane skipped Rapid's MoE fusion
+
+Rapid already fuses an eligible `SwitchGLU` gate/up pair after text-model load.
+Affine quantization packs every output row independently, so concatenating the
+two projections removes one `gather_qmm` launch while preserving the exact
+arithmetic. The text path previously measured 86.4 -> 92.5 tok/s (+7.0%) on
+Qwen3.6-35B-A3B-8bit.
+
+GLM-5.3 is forced through `MLXMultimodalLM`, and mlx-vlm owns a separate copy of
+the `SwitchGLU`, `SwitchLinear`, and `QuantizedSwitchLinear` classes. Therefore:
+
+1. the MLLM loader never called the existing fusion; and
+2. calling it unchanged still found zero layers because it recognized only the
+   mlx-lm class family.
+
+The fix enrolls the already-loaded mlx-vlm class family in the same structural
+and bit-exact rewrite, then invokes it only for `model_type == "glm5_next"` at
+the model-owning MLLM load boundary. Other VLM families remain unchanged until
+they receive their own real-model qualification. The environment kill switch
+`RAPID_MLX_MOE_GATE_UP_FUSION=0` remains authoritative.
+
+GLM-5.3 has 42 sparse-MoE layers (layers 3 through 44). The production geometry
+is hidden 4096, expert intermediate 2048, 288 routed experts, top-8, affine
+q4-g64.
+
+## Weight-free performance and correctness evidence
+
+The harness `scripts/benchmark_glm53_moe_fusion.py` constructs exactly one
+production-shape mlx-vlm `SwitchGLU`, quantizes it q4-g64, and compares 31 warm
+decode calls before and after the rewrite. Five fresh-process runs produced a
+median paired speedup of 1.037x (range 1.000x-1.119x). Every run was byte-equal;
+the representative output SHA-256 was
+`7b8413896b503763c97c71b8990106c7bf1739da5eec8817b40b533635c51fc6`.
+
+This is a layer microbenchmark, not a whole-model claim. Attention, routing,
+shared experts, normalization, sampling, and server overhead are absent, so the
+expected whole-model win is smaller and must be measured once the exact
+checkpoint is available again.
+
+Reproduce with an MLX 0.32.2 / mlx-vlm 0.6.17 environment:
+
+```bash
+PYTHONPATH=. python3 scripts/benchmark_glm53_moe_fusion.py
+```
+
+The 189 MB
+`inference-optimization/GLM-5.3-Flash-0.1B-A0.1B@8311399447eba9c9b215e3209ab6f25e59c7d21e`
+fixture provided a real architecture smoke. Rapid found and fused both of its
+sparse MoE layers, the server reached ready, `/health` returned healthy, and an
+OpenAI-compatible non-streaming request completed. Stock mlx-vlm, the Rapid
+correctness overlays, and oMLX produced the same deterministic 128-token text
+hash on the direct harness. Tiny-model throughput is deliberately not reported
+as a proxy for the 321B checkpoint.
+
+## Next optimization assessed
+
+oMLX also routes long affine projections through a native q4 prefill tile. A
+shape-faithful test of GLM's largest fused KDA input projection
+(`4096 -> 24,896`) on the same host and oMLX's MLX 0.32.0 environment measured:
+
+| Tokens | Stock MLX | Native tile | Native / stock | Max abs error |
+| ---: | ---: | ---: | ---: | ---: |
+| 128 | 1.885 ms | 2.184 ms | 0.863x | 0 |
+| 512 | 6.484 ms | 6.211 ms | 1.044x | 0 |
+| 2,048 | 24.380 ms | 23.015 ms | 1.059x | 0 |
+
+That kernel is a modest win only at larger chunks and a regression at 128
+tokens. It also requires shipping and maintaining a native extension. It is not
+the next low-risk Rapid change without an official-checkpoint end-to-end
+campaign proving a material net gain.
+
+## Required full-model follow-up
+
+When storage capacity exposes the exact alias snapshot again, run fresh-process
+stock/fused pairs with identical prompt bytes and seeds at 128, 4K, 16K, and
+32K context, 128 and 512 output tokens, prefix cache off, MTP off, and both text
+and image requests. Record TTFT, prompt tok/s, decode tok/s, peak MLX/process
+memory, output token hashes, and whether all 42 layers fused. The change should
+remain gated if the median whole-model decode improvement is not positive or
+any output hash differs.

--- a/scripts/benchmark_glm53_moe_fusion.py
+++ b/scripts/benchmark_glm53_moe_fusion.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Benchmark Rapid's rewrite on one production-shape GLM-5.3 MoE layer.
+
+This weight-free microbenchmark uses the official 4096 -> 2048, 288-expert,
+top-8 contract and the Rapid alias's affine q4-g64 quantization. It is a layer
+benchmark, not a substitute for an end-to-end official-checkpoint campaign.
+Run each sample in a fresh process to avoid comparing against a class that was
+already patched by an earlier sample.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import statistics
+import time
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_vlm.models.switch_layers import SwitchGLU
+
+from vllm_mlx.moe_fusion import fuse_gate_up
+
+HIDDEN = 4096
+INTERMEDIATE = 2048
+EXPERTS = 288
+TOP_K = 8
+WARMUP = 8
+RUNS = 31
+
+
+class OneLayer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.moe = SwitchGLU(HIDDEN, INTERMEDIATE, EXPERTS)
+
+
+def measure(
+    model: OneLayer, x: mx.array, indices: mx.array
+) -> tuple[list[float], mx.array]:
+    out = model.moe(x, indices)
+    mx.eval(out)
+    for _ in range(WARMUP):
+        out = model.moe(x, indices)
+        mx.eval(out)
+    samples = []
+    for _ in range(RUNS):
+        started = time.perf_counter()
+        out = model.moe(x, indices)
+        mx.eval(out)
+        samples.append((time.perf_counter() - started) * 1_000)
+    return samples, out
+
+
+def digest(array: mx.array) -> str:
+    return hashlib.sha256(bytes(array.astype(mx.float16))).hexdigest()
+
+
+def main() -> None:
+    mx.random.seed(53)
+    model = OneLayer()
+    nn.quantize(model, group_size=64, bits=4)
+    x = mx.random.normal((1, 1, HIDDEN)).astype(mx.bfloat16)
+    indices = mx.array([[[3, 17, 41, 89, 144, 201, 233, 287]]], dtype=mx.uint32)
+    mx.eval(model.parameters(), x, indices)
+
+    stock_samples, stock = measure(model, x, indices)
+    fused_layers = fuse_gate_up(model)
+    fused_samples, fused = measure(model, x, indices)
+    equal = bool(mx.array_equal(stock, fused))
+    stock_ms = statistics.median(stock_samples)
+    fused_ms = statistics.median(fused_samples)
+    result = {
+        "hardware": platform.machine(),
+        "mlx_version": mx.__version__,
+        "shape": {
+            "hidden": HIDDEN,
+            "intermediate": INTERMEDIATE,
+            "experts": EXPERTS,
+            "top_k": TOP_K,
+            "bits": 4,
+            "group_size": 64,
+        },
+        "warmup": WARMUP,
+        "runs": RUNS,
+        "stock_median_ms": stock_ms,
+        "fused_median_ms": fused_ms,
+        "speedup": stock_ms / fused_ms,
+        "fused_layers": fused_layers,
+        "byte_equal": equal,
+        "stock_sha256": digest(stock),
+        "fused_sha256": digest(fused),
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if fused_layers != 1 or not equal:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_glm5_next_processor_patch.py
+++ b/tests/test_glm5_next_processor_patch.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -519,3 +520,38 @@ assert events == ["runtime", "processor", "quant"]
         capture_output=True,
         text=True,
     )
+
+
+def test_mllm_load_enables_moe_fusion_for_glm5(monkeypatch) -> None:
+    import mlx_vlm
+    import mlx_vlm.utils
+
+    from vllm_mlx import moe_fusion
+    from vllm_mlx.models import mllm
+    from vllm_mlx.utils import tokenizer as tokenizer_utils
+
+    model = SimpleNamespace(config=SimpleNamespace())
+    processor = SimpleNamespace(tokenizer=SimpleNamespace())
+    fused = []
+    monkeypatch.setattr(mllm, "_require_mlx_vlm", lambda: None)
+    monkeypatch.setattr(mlx_vlm, "load", lambda *args, **kwargs: (model, processor))
+    monkeypatch.setattr(
+        mlx_vlm.utils,
+        "load_config",
+        lambda *args, **kwargs: {"model_type": "glm5_next"},
+    )
+    monkeypatch.setattr(moe_fusion, "fuse_gate_up", fused.append)
+    monkeypatch.setattr(
+        tokenizer_utils,
+        "augment_eos_token_ids_from_generation_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tokenizer_utils,
+        "repair_byte_level_decoder",
+        lambda *args, **kwargs: None,
+    )
+
+    mllm.MLXMultimodalLM("local/glm5-next").load()
+
+    assert fused == [model]

--- a/tests/test_glm5_next_runtime_patch.py
+++ b/tests/test_glm5_next_runtime_patch.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import builtins
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -23,6 +25,49 @@ class _Quantized:
         self.group_size = group_size
         self.bits = bits
         self.mode = mode
+
+
+@pytest.mark.requires_mlx
+def test_moe_fusion_declines_uninspectable_call_contract() -> None:
+    from vllm_mlx import moe_fusion
+
+    class UninspectableSwitchGLU:
+        __call__ = 1
+
+    assert not moe_fusion._supports_fused_call_contract(UninspectableSwitchGLU)
+
+
+@pytest.mark.requires_mlx
+def test_moe_family_discovery_survives_optional_import_failure(monkeypatch) -> None:
+    from vllm_mlx import moe_fusion
+
+    real_import = builtins.__import__
+
+    def import_without_mlx_lm_switch(name, *args, **kwargs):
+        if name == "mlx_lm.models.switch_layers":
+            raise ImportError("simulated optional dependency failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_mlx_lm_switch)
+    monkeypatch.delitem(sys.modules, "mlx_vlm.models.switch_layers", raising=False)
+
+    assert moe_fusion._switch_layer_families() == ()
+
+
+@pytest.mark.requires_mlx
+def test_moe_family_discovery_ignores_incomplete_vlm_module(monkeypatch) -> None:
+    from vllm_mlx import moe_fusion
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_vlm.models.switch_layers",
+        SimpleNamespace(),
+    )
+
+    families = moe_fusion._switch_layer_families()
+    assert any(
+        family[1].__module__ == "mlx_lm.models.switch_layers" for family in families
+    )
 
 
 def test_kda_projection_fusion_requires_one_quantization() -> None:

--- a/tests/test_moe_gate_up_fusion.py
+++ b/tests/test_moe_gate_up_fusion.py
@@ -36,6 +36,18 @@ class TinyMoE(nn.Module):
             nn.quantize(self, group_size=32, bits=4)
 
 
+class TinyVLMMoE(nn.Module):
+    """mlx-vlm owns a separate, API-compatible SwitchGLU class family."""
+
+    def __init__(self, n_layers=2, quantize=True):
+        super().__init__()
+        from mlx_vlm.models.switch_layers import SwitchGLU as VLMSwitchGLU
+
+        self.layers = [VLMSwitchGLU(HID, INTER, E) for _ in range(n_layers)]
+        if quantize:
+            nn.quantize(self, group_size=32, bits=4)
+
+
 def _decode_inputs(seed=3, tokens=1):
     mx.random.seed(seed)
     x = mx.random.normal((1, tokens, HID)).astype(mx.float16)
@@ -117,8 +129,120 @@ class TestRewriteSemantics:
 
         assert moe_fusion.fuse_gate_up(Dense()) == 0
 
+    def test_mllm_wrapper_applies_fusion_after_load(self, monkeypatch):
+        """The VLM lane must not leave eligible MoE projections unfused.
+
+        GLM-5.3-Flash is forced through ``MLXMultimodalLM``. Before this
+        regression guard, only the text BatchedEngine called ``fuse_gate_up``
+        after loading, so all 42 GLM sparse layers missed the optimization.
+        """
+        import mlx_vlm
+        import mlx_vlm.utils
+
+        from vllm_mlx.models import mllm
+        from vllm_mlx.utils import tokenizer as tokenizer_utils
+
+        model = TinyVLMMoE(n_layers=1)
+        model.config = type("Config", (), {})()
+        processor = type(
+            "Processor",
+            (),
+            {"tokenizer": type("Tokenizer", (), {})()},
+        )()
+        monkeypatch.setattr(mllm, "_require_mlx_vlm", lambda: None)
+        monkeypatch.setattr(mlx_vlm, "load", lambda *args, **kwargs: (model, processor))
+        monkeypatch.setattr(
+            mlx_vlm.utils,
+            "load_config",
+            lambda *args, **kwargs: {"model_type": "glm5_next"},
+        )
+        monkeypatch.setattr(
+            tokenizer_utils,
+            "augment_eos_token_ids_from_generation_config",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            tokenizer_utils,
+            "repair_byte_level_decoder",
+            lambda *args, **kwargs: None,
+        )
+
+        wrapper = mllm.MLXMultimodalLM("unit-test/glm5-next")
+        wrapper.load()
+
+        assert hasattr(model.layers[0], "gate_up_proj")
+        assert not hasattr(model.layers[0], "gate_proj")
+        assert not hasattr(model.layers[0], "up_proj")
+
+    def test_mlx_vlm_family_is_byte_identical(self):
+        model = TinyVLMMoE(n_layers=1)
+        mx.eval(model.parameters())
+        x, inds = _decode_inputs()
+        before = _run_all(model, x, inds)[0]
+
+        assert moe_fusion.fuse_gate_up(model) == 1
+        after = _run_all(model, x, inds)[0]
+
+        assert bool(mx.array_equal(before, after))
+
+    def test_mlx_vlm_sorted_path_is_byte_identical(self):
+        model = TinyVLMMoE(n_layers=1)
+        mx.eval(model.parameters())
+        x, inds = _decode_inputs(tokens=40)
+        before = _run_all(model, x, inds)[0]
+
+        assert moe_fusion.fuse_gate_up(model) == 1
+        after = _run_all(model, x, inds)[0]
+
+        assert bool(mx.array_equal(before, after))
+
+    def test_non_glm_mllm_does_not_enable_unqualified_fusion(self, monkeypatch):
+        import mlx_vlm
+        import mlx_vlm.utils
+
+        from vllm_mlx.models import mllm
+        from vllm_mlx.utils import tokenizer as tokenizer_utils
+
+        model = TinyVLMMoE(n_layers=1)
+        model.config = type("Config", (), {})()
+        processor = type(
+            "Processor",
+            (),
+            {"tokenizer": type("Tokenizer", (), {})()},
+        )()
+        monkeypatch.setattr(mllm, "_require_mlx_vlm", lambda: None)
+        monkeypatch.setattr(mlx_vlm, "load", lambda *args, **kwargs: (model, processor))
+        monkeypatch.setattr(
+            mlx_vlm.utils,
+            "load_config",
+            lambda *args, **kwargs: {"model_type": "other_vlm"},
+        )
+        monkeypatch.setattr(
+            tokenizer_utils,
+            "augment_eos_token_ids_from_generation_config",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            tokenizer_utils,
+            "repair_byte_level_decoder",
+            lambda *args, **kwargs: None,
+        )
+
+        wrapper = mllm.MLXMultimodalLM("unit-test/other-vlm")
+        wrapper.load()
+
+        assert hasattr(model.layers[0], "gate_proj")
+        assert hasattr(model.layers[0], "up_proj")
+
 
 class TestGates:
+    def test_changed_switch_glu_call_contract_fails_closed(self):
+        class FutureSwitchGLU:
+            def __call__(self, x, indices, routing_weights):
+                return x, indices, routing_weights
+
+        assert not moe_fusion._supports_fused_call_contract(FutureSwitchGLU)
+
     def test_env_opt_out(self, monkeypatch):
         monkeypatch.setenv("RAPID_MLX_MOE_GATE_UP_FUSION", "0")
         model = TinyMoE()

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1598,6 +1598,25 @@ class MLXMultimodalLM:
                     trust_remote_code=False,
                 )
 
+            config_model_type = (
+                self.config.get("model_type")
+                if isinstance(self.config, dict)
+                else getattr(self.config, "model_type", None)
+            )
+            if config_model_type == "glm5_next":
+                # Keep GLM's MLLM lane at parity with BatchedEngine's text
+                # lane: collapse each eligible MoE gate/up pair into one
+                # gather_qmm. GLM-5.3-Flash always routes through this wrapper,
+                # so without this step its 42 sparse expert layers issue an
+                # extra quantized projection for every generated token. Keep
+                # the first rollout architecture-scoped; other MoE VLMs need
+                # their own real-model qualification before enrollment.
+                # Server use runs this method on the model-owning mllm-step
+                # worker, preserving the stream contract from #170.
+                from ..moe_fusion import fuse_gate_up
+
+                fuse_gate_up(self.model)
+
             # Augment the wrapped tokenizer's EOS set with the chat-
             # template terminator ids from ``generation_config.json``.
             # Gemma 3 / 3n VL variants are the canonical case:

--- a/vllm_mlx/moe_fusion.py
+++ b/vllm_mlx/moe_fusion.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fuse MoE routed gate/up expert projections into one ``gather_qmm``.
 
-At single-token decode, mlx-lm's stock ``SwitchGLU`` issues three tiny
+At single-token decode, the stock ``SwitchGLU`` implementations in mlx-lm
+and mlx-vlm issue three tiny
 ``gather_qmm`` launches per MoE layer (gate, up, down). Affine
 quantization packs each output row independently, so concatenating the
 gate and up expert weights along the output axis and issuing ONE
@@ -16,8 +17,8 @@ Fusion design adapted from the oMLX project
 (https://github.com/jundot/omlx, Apache-2.0), which ships it default-on
 for the same layer type.
 
-``fuse_gate_up(model)`` runs once post-load: it patches
-``SwitchGLU.__call__`` with a fused-aware branch (class-level, once per
+``fuse_gate_up(model)`` runs once post-load: it patches each loaded
+``SwitchGLU.__call__`` family with a fused-aware branch (class-level, once per
 process, stock path preserved for unfused instances) and rewrites each
 eligible instance in place — the gate module becomes the fused container
 so quantization parameters carry over, and the original gate/up buffers
@@ -28,19 +29,35 @@ gate/up pair fails the structural checks are left untouched. Set
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
+import sys
 from typing import Any
 
 import mlx.core as mx
 
 logger = logging.getLogger(__name__)
 
-_CALL_PATCHED = False
+
+def _supports_fused_call_contract(switch_glu_cls) -> bool:
+    """Fail closed if an upstream SwitchGLU changes its calling convention."""
+    try:
+        parameters = tuple(inspect.signature(switch_glu_cls.__call__).parameters)
+    except (TypeError, ValueError):
+        return False
+    return parameters == ("self", "x", "indices")
 
 
-def _switch_layer_types():
-    """Import lazily so a changed mlx-lm degrades to no-fusion, never a crash."""
+def _switch_layer_families():
+    """Return loaded compatible SwitchGLU families without importing mlx-vlm.
+
+    mlx-vlm carries a private copy of the switch layers rather than re-exporting
+    mlx-lm's classes. Importing mlx-vlm from a text-only process would defeat
+    Rapid's optional vision dependency, so enroll that family only after its
+    module is already resident (which is necessarily true for a loaded VLM).
+    """
+    families = []
     try:
         from mlx_lm.models.switch_layers import (
             QuantizedSwitchLinear,
@@ -50,8 +67,37 @@ def _switch_layer_types():
             _scatter_unsort,
         )
     except ImportError:
-        return None
-    return QuantizedSwitchLinear, SwitchGLU, SwitchLinear, _gather_sort, _scatter_unsort
+        pass
+    else:
+        if _supports_fused_call_contract(SwitchGLU):
+            families.append(
+                (
+                    QuantizedSwitchLinear,
+                    SwitchGLU,
+                    SwitchLinear,
+                    _gather_sort,
+                    _scatter_unsort,
+                )
+            )
+
+    vlm_switch = sys.modules.get("mlx_vlm.models.switch_layers")
+    if vlm_switch is not None:
+        try:
+            family = (
+                vlm_switch.QuantizedSwitchLinear,
+                vlm_switch.SwitchGLU,
+                vlm_switch.SwitchLinear,
+                vlm_switch._gather_sort,
+                vlm_switch._scatter_unsort,
+            )
+        except AttributeError:
+            pass
+        else:
+            if _supports_fused_call_contract(family[1]) and all(
+                family[1] is not existing[1] for existing in families
+            ):
+                families.append(family)
+    return tuple(families)
 
 
 def _can_fuse(switch_mlp: Any, quantized_cls, plain_cls) -> bool:
@@ -137,15 +183,12 @@ def _make_fused_call(orig_call, gather_sort, scatter_unsort):
 
 
 def _ensure_call_patch(switch_glu_cls, gather_sort, scatter_unsort) -> None:
-    global _CALL_PATCHED
-    if _CALL_PATCHED or getattr(switch_glu_cls, "_rapid_gate_up_fused_call", False):
-        _CALL_PATCHED = True
+    if getattr(switch_glu_cls, "_rapid_gate_up_fused_call", False):
         return
     orig = switch_glu_cls.__call__
     switch_glu_cls.__call__ = _make_fused_call(orig, gather_sort, scatter_unsort)
     switch_glu_cls._rapid_gate_up_fused_call = True
     switch_glu_cls._rapid_gate_up_original_call = orig
-    _CALL_PATCHED = True
 
 
 def fuse_gate_up(model: Any) -> int:
@@ -160,10 +203,9 @@ def fuse_gate_up(model: Any) -> int:
     if os.environ.get("RAPID_MLX_MOE_GATE_UP_FUSION", "1") == "0":
         logger.info("[moe_fusion] disabled via RAPID_MLX_MOE_GATE_UP_FUSION=0")
         return 0
-    layer_types = _switch_layer_types()
-    if layer_types is None:
+    families = _switch_layer_families()
+    if not families:
         return 0
-    quantized_cls, switch_glu_cls, plain_cls, gather_sort, scatter_unsort = layer_types
 
     try:
         modules = [m for _, m in model.named_modules()]
@@ -172,19 +214,29 @@ def fuse_gate_up(model: Any) -> int:
     # Exact type only: a subclass may override __call__ and never consult
     # gate_up_proj, so fusing it would silently waste memory (or worse if
     # it reads gate_proj directly).
-    targets = [
-        m
-        for m in modules
-        if type(m) is switch_glu_cls and _can_fuse(m, quantized_cls, plain_cls)
-    ]
-    if not targets:
-        return 0
-    _ensure_call_patch(switch_glu_cls, gather_sort, scatter_unsort)
-    for switch_mlp in targets:
-        _fuse_one(switch_mlp, quantized_cls)
-        # The freed gate/up buffers land in the MLX buffer pool. Drain per
-        # fused layer so the load-time transient stays bounded to a single
-        # layer's worth instead of ~2/3 of the whole routed expert set.
-        mx.clear_cache()
-    logger.info("[moe_fusion] gate+up fusion applied: %d MoE layers", len(targets))
-    return len(targets)
+    fused_count = 0
+    for (
+        quantized_cls,
+        switch_glu_cls,
+        plain_cls,
+        gather_sort,
+        scatter_unsort,
+    ) in families:
+        targets = [
+            m
+            for m in modules
+            if type(m) is switch_glu_cls and _can_fuse(m, quantized_cls, plain_cls)
+        ]
+        if not targets:
+            continue
+        _ensure_call_patch(switch_glu_cls, gather_sort, scatter_unsort)
+        for switch_mlp in targets:
+            _fuse_one(switch_mlp, quantized_cls)
+            fused_count += 1
+            # The freed gate/up buffers land in the MLX buffer pool. Drain per
+            # fused layer so the load-time transient stays bounded to a single
+            # layer's worth instead of ~2/3 of the whole routed expert set.
+            mx.clear_cache()
+    if fused_count:
+        logger.info("[moe_fusion] gate+up fusion applied: %d MoE layers", fused_count)
+    return fused_count


### PR DESCRIPTION
## Why

GLM-5.3-Flash is forced through Rapid's multimodal loader. That lane never invoked the bit-exact MoE gate/up fusion already used by the text engine, and mlx-vlm owns a separate `SwitchGLU` class family that the existing helper did not recognize. As a result, all 42 routed layers kept issuing one avoidable quantized projection per decoded token.

## Scope

- Discover an already-loaded, API-compatible mlx-vlm SwitchGLU family without importing the optional vision dependency into text-only processes.
- Apply the existing structural fusion after `glm5_next` MLLM load.
- Fail closed if upstream changes the verified `(self, x, indices)` call contract.
- Add regression tests, a production-shape microbenchmark, and a reproducible Rapid/oMLX/mlx-vlm comparison note.

## Non-goals

- No MTP enablement: its separate sustained qualification regressed GLM decode by 1.09%.
- No quantizer, checkpoint, alias, sampling, or API changes.
- No enrollment of other MoE VLM architectures without their own real-model qualification.
- No native oMLX prefill-kernel port; the measured tile regressed at 128 tokens and improved only 4.4-5.9% at 512-2,048 tokens.

## Acceptance

- A loaded `glm5_next` model fuses every structurally eligible mlx-vlm SwitchGLU gate/up pair.
- Non-GLM MLLM models remain unchanged.
- Both one-token and sorted paths remain byte-identical before/after fusion.
- The existing environment kill switch remains authoritative.
- An incompatible future SwitchGLU call signature declines fusion safely.

## Verification

- `python3.12 -m ruff check ...`: passed.
- Focused GLM/MLLM/MoE suites: 122 passed.
- `PYTHONPATH=. python3.12 scripts/benchmark_glm53_moe_fusion.py`: byte-identical; latest fresh process 1.016x. Five-run fresh-process campaign median 1.037x (range 1.000x-1.119x), same SHA-256 every run.
- 189 MB GLM-5.3 architecture fixture: Rapid fused 2/2 sparse layers, reached healthy, and completed an OpenAI-compatible request.
- `python3.12 -m build --wheel --no-isolation`: passed.
- Full-suite attempt reached unrelated local-environment failures: this host has `mflux 0.18.1`, while `pyproject.toml` requires `>=0.19` (seven Bonsai import failures), and one doctor test's deliberately empty fake interpreter reports an inconclusive probe rather than a missing extra. The authoritative CI Python 3.10/3.11/3.12 and Apple Silicon suites passed on the first revision. No image, doctor, or dependency file is touched here.
- Initial changed-lines coverage identified seven unexercised fail-closed/load-hook lines. Added explicit negative-path and loader-wiring tests; local coverage now executes all seven.
- Exact 181.7 GB checkpoint was not re-downloaded: the policy-fixed HF cache had about 6 GB free and no current/warm snapshot. The checked-in official-model baseline and required paired follow-up are documented.

## Behaviour delta

`glm5.3-flash-4bit` MLLM load: eligible mlx-vlm routed experts remained stock -> gate/up projections are fused once after load. Output arithmetic and public API are unchanged.

## External reference

- Refs [jundot/omlx#3410](https://github.com/jundot/omlx/pull/3410) by `pedroberaldo87`, an independent GLM-5.3 gate/up fusion implementation. It reports an isolated MoE improvement from 0.60 to 0.53 ms and a full decode-step improvement from 44.7 to 42.4 ms on M1 Ultra/oQ2e. Rapid reuses its existing bit-exact MLX affine rewrite rather than oMLX's native tile path.

## AI assistance disclosure

Codex researched the upstream implementations, wrote the implementation/tests/benchmark/docs, and performed the adversarial review. Every changed path was inspected; correctness was checked with byte-equality tests and a real architecture fixture; performance claims are explicitly separated into published full-model data and this PR's layer microbenchmark.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- Focused tests and lint pass locally.
- The wheel builds locally.
- Critical production-line tests were mutation-spot-checked during development.
- Durable benchmark and follow-up documentation is included.
- No breaking API change.
