### PR TITLE
fix(mac): make follow-up turns reuse the prompt cache (7.3s -> 0.5s), plus five dogfood fixes

### DIFF
--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -582,6 +582,22 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     var parentID: UUID?
     let createdAt: Date
 
+    /// Wire-only trailer appended after this row's prose AND its attachment
+    /// extracts — see ``modelContent``.
+    ///
+    /// Deliberately absent from ``CodingKeys``: it is set on the throwaway
+    /// array ``ChatViewModel`` builds for one request, never on the
+    /// transcript, so it is not part of the conversation and must not reach
+    /// `conversations.json`. ``init(from:)`` therefore restores it as `nil`.
+    ///
+    /// The one producer is ``ChatViewModel/stampingClockContext(on:calendar:)``,
+    /// which needs each user turn's wall clock to land after that turn's
+    /// attachment extracts. Writing it into ``content`` instead would put it
+    /// in FRONT of the extract, so the first request carrying a document and
+    /// the next one would diverge before the document rather than after it,
+    /// and the engine's prefix cache could not reuse the document.
+    var wireSuffix: String?
+
     init(
         id: UUID = UUID(),
         role: Role,
@@ -602,7 +618,8 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         toolCallArtifactSuppressed: Bool = false,
         wireVisibility: WireVisibility = .model,
         parentID: UUID? = nil,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        wireSuffix: String? = nil
     ) {
         self.id = id
         self.role = role
@@ -624,6 +641,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         self.wireVisibility = wireVisibility
         self.parentID = parentID
         self.createdAt = createdAt
+        self.wireSuffix = wireSuffix
     }
 
     /// Codex r1 MAJOR-1: keep ``reasoningTruncated`` decodable from
@@ -746,17 +764,32 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // assumed to mean "root" until that repair has run.
         self.parentID = try c.decodeIfPresent(UUID.self, forKey: .parentID)
         self.createdAt = try c.decode(Date.self, forKey: .createdAt)
+        // Transient by construction — a persisted turn carries no wire
+        // trailer, and the next request mints a fresh one.
+        self.wireSuffix = nil
     }
 
     /// Text sent to the model. Document extracts stay out of the visible
     /// ``content`` property but remain part of this turn on every retry and
     /// follow-up request.
+    /// ``wireSuffix`` is joined LAST, after the attachment extracts, so a
+    /// per-request trailer cannot displace the document text that the
+    /// engine's prefix cache needs to find unchanged.
     var modelContent: String {
-        guard !fileAttachments.isEmpty else { return content }
+        let trailer = wireSuffix.flatMap {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : [$0]
+        } ?? []
+        guard !fileAttachments.isEmpty else {
+            guard !trailer.isEmpty else { return content }
+            // An empty prose row must not gain a leading blank line.
+            let head = content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? [] : [content]
+            return (head + trailer).joined(separator: "\n\n")
+        }
         let request = content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? "Analyze the attached file and summarize the important findings."
             : content
-        return ([request] + fileAttachments.map(\.promptText))
+        return ([request] + fileAttachments.map(\.promptText) + trailer)
             .joined(separator: "\n\n")
     }
 
@@ -1022,6 +1055,9 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///     would contradict the chip on screen. A tool that ERRORED does
     ///     NOT count as succeeded — a hallucinated raw answer after a
     ///     failed tool is exactly the shape we still want to flag.
+    ///   * ``promptHadAttachment == false`` — the user's turn carried
+    ///     no document. An answer read off an attached file is
+    ///     grounded, not guessed, and no tool would have helped.
     ///   * ``finishReason`` is ``nil`` or anything OTHER than
     ///     ``"tool_calls"`` — a real tool-call turn doesn't need
     ///     the caption (the chip row already speaks for it). A
@@ -1033,12 +1069,17 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///     numeric-or-short heuristic AND the user's prompt looks
     ///     calculator-shaped (see ``promptLooksCalculatorish``).
     ///
-    /// The heuristic is intentionally loose — a false-positive
-    /// caption ("model probably tool-called; this caption is wrong")
-    /// is annoying but harmless; a false-negative (silent wrong
-    /// answer) is the bug we're fixing. The view layer is
-    /// responsible for making the caption dismissible (one-shot per
-    /// session) so a user who knows better can mute it.
+    /// The heuristic leans towards firing — a false-negative (a
+    /// silent wrong answer) is the bug we're fixing, and the view
+    /// layer makes the caption dismissible (one-shot per session) so
+    /// a user who knows better can mute it. But false positives are
+    /// NOT free, which the original #308 note understated: the
+    /// caption's whole value is that the user believes it, and each
+    /// time it appears under a demonstrably correct answer it teaches
+    /// them to ignore the next one. That is why the prompt heuristic
+    /// matches whole words (see ``promptLooksCalculatorish``) and why
+    /// a document-grounded turn is exempt (Gate 1c) instead of
+    /// relying on the user to dismiss it.
     ///
     /// Role-agnostic (assertion-only check); the view layer enforces
     /// "only paint on assistant rows".
@@ -1048,7 +1089,8 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         toolCalls: [ToolCall]?,
         finishReason: String?,
         toolsRequested: Bool,
-        toolSucceededThisTurn: Bool = false
+        toolSucceededThisTurn: Bool = false,
+        promptHadAttachment: Bool = false
     ) -> Bool {
         // Gate 1: tools must have actually been advertised. Without
         // this gate every short numeric answer would wear the caption.
@@ -1067,6 +1109,19 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // computed at the call site from the turn's message history (see
         // ``ChatViewModel.turnHadSuccessfulTool``).
         guard !toolSucceededThisTurn else { return false }
+        // Gate 1c: the user's turn carried no document. When it did,
+        // the answer is grounded in text the user supplied in the
+        // prompt, so "answered without calling any of the available
+        // tools" is not a caution — it is the correct behaviour, and
+        // no tool on the roster could have improved it. Dogfooding
+        // 0.14.1 hit exactly this: a scanned-invoice turn whose
+        // grounded, correct total wore the caption, which reads as
+        // "this number may be a guess" directly under a number the
+        // model had in fact read off the page. Flagging a right answer
+        // is not a harmless false positive — it spends the user's
+        // trust in the caption, so the next one (a real hallucinated
+        // total) gets ignored too.
+        guard !promptHadAttachment else { return false }
         // Gate 2: model must have produced no tool_calls. A real
         // tool-call turn doesn't need the caption.
         let noToolCalls = (toolCalls?.isEmpty ?? true)
@@ -1788,8 +1843,10 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// True when the user's prompt reads as a calculator-, web-
     /// search-, or weather-style query — i.e. the kind of question
     /// where a tool-call SHOULD have been the right shape. The
-    /// match is keyword-based and intentionally inclusive; the
-    /// caption is dismissible and a false-positive is harmless.
+    /// match is keyword-based and inclusive, but WHOLE-WORD (see
+    /// ``containsKeyword``): substring matching flagged any prose
+    /// containing "computer", "sometimes" or "surplus", and a
+    /// caption under a correct answer costs more than #308 assumed.
     ///
     /// Heuristics:
     ///   * Math operators (``+``, ``-``, ``*``, ``/``, ``%``, ``=``,
@@ -1803,6 +1860,50 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///     ``news``, ``today``, ``current``).
     ///   * Weather-shaped keywords (``weather``, ``temperature``,
     ///     ``forecast``).
+    /// True when ``keyword`` appears in ``haystack`` as a whole word
+    /// (or whole phrase) rather than as a substring of a longer word.
+    ///
+    /// ``lowered.contains(kw)`` is what shipped with #308, and it
+    /// misfires on ordinary English: ``compute`` matches "computer"
+    /// and "computing", ``times`` matches "sometimes", ``plus``
+    /// matches "surplus", ``minus`` matches "minuscule",
+    /// ``forecast`` matches "forecasting", ``sum of`` matches
+    /// "consum[er] of". Every one of those turns a normal prose
+    /// question into a "calculator-shaped" one, and a short answer
+    /// containing any digit then wears the caution. Dogfooding
+    /// 0.14.1 tripped it on a document question with "computed" in
+    /// the prose.
+    ///
+    /// A boundary is anything that is not a letter or a digit, plus
+    /// the ends of the string — so "compute 17*23", "(compute)" and
+    /// "compute." all match while "computer" does not. Multi-word
+    /// keywords keep working because only the outer edges of the
+    /// phrase are checked.
+    static func containsKeyword(_ keyword: String, in haystack: String) -> Bool {
+        guard !keyword.isEmpty else { return false }
+        func isWordScalar(_ scalar: Unicode.Scalar) -> Bool {
+            CharacterSet.alphanumerics.contains(scalar)
+        }
+        var searchStart = haystack.startIndex
+        while let range = haystack.range(
+            of: keyword,
+            range: searchStart..<haystack.endIndex
+        ) {
+            let leftOK = range.lowerBound == haystack.startIndex
+                || !isWordScalar(
+                    haystack[haystack.index(before: range.lowerBound)]
+                        .unicodeScalars.first!
+                )
+            let rightOK = range.upperBound == haystack.endIndex
+                || !isWordScalar(haystack[range.upperBound].unicodeScalars.first!)
+            if leftOK && rightOK { return true }
+            // Overlapping matches matter ("timestimes"), so advance by
+            // one character rather than past the whole keyword.
+            searchStart = haystack.index(after: range.lowerBound)
+        }
+        return false
+    }
+
     static func promptLooksCalculatorish(_ prompt: String) -> Bool {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
@@ -1822,7 +1923,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             "divide", "multiply", "sum of", "product of", "plus", "minus",
             "times", "divided by"
         ]
-        for kw in mathKeywords where lowered.contains(kw) { return true }
+        for kw in mathKeywords where containsKeyword(kw, in: lowered) { return true }
 
         // Web-search keywords. Note: codex r1 MAJOR-1 (#308 PR)
         // dropped the bare ``"what is the"`` keyword — it matched
@@ -1838,11 +1939,11 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             "current price", "stock price", "exchange rate",
             "current weather"
         ]
-        for kw in webKeywords where lowered.contains(kw) { return true }
+        for kw in webKeywords where containsKeyword(kw, in: lowered) { return true }
 
         // Weather keywords (looser than the web list above).
         let weatherKeywords: [String] = ["weather", "temperature", "forecast"]
-        for kw in weatherKeywords where lowered.contains(kw) { return true }
+        for kw in weatherKeywords where containsKeyword(kw, in: lowered) { return true }
 
         return false
     }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1055,9 +1055,12 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///     would contradict the chip on screen. A tool that ERRORED does
     ///     NOT count as succeeded — a hallucinated raw answer after a
     ///     failed tool is exactly the shape we still want to flag.
-    ///   * ``promptHadAttachment == false`` — the user's turn carried
-    ///     no document. An answer read off an attached file is
-    ///     grounded, not guessed, and no tool would have helped.
+    ///   * ``promptHadAttachment == false``, OR the prompt asks for
+    ///     live data (see ``promptAsksForLiveData``). An answer read
+    ///     off an attached file is grounded, not guessed — but an
+    ///     attachment cannot ground "what is today's stock price",
+    ///     so the exemption is withheld for prompts that name a
+    ///     moving target.
     ///   * ``finishReason`` is ``nil`` or anything OTHER than
     ///     ``"tool_calls"`` — a real tool-call turn doesn't need
     ///     the caption (the chip row already speaks for it). A
@@ -1079,7 +1082,9 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     /// them to ignore the next one. That is why the prompt heuristic
     /// matches whole words (see ``promptLooksCalculatorish``) and why
     /// a document-grounded turn is exempt (Gate 1c) instead of
-    /// relying on the user to dismiss it.
+    /// relying on the user to dismiss it — and equally why that
+    /// exemption is *narrow*: an attachment on the turn does not make
+    /// a live-data question answerable from the page.
     ///
     /// Role-agnostic (assertion-only check); the view layer enforces
     /// "only paint on assistant rows".
@@ -1109,19 +1114,26 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // computed at the call site from the turn's message history (see
         // ``ChatViewModel.turnHadSuccessfulTool``).
         guard !toolSucceededThisTurn else { return false }
-        // Gate 1c: the user's turn carried no document. When it did,
-        // the answer is grounded in text the user supplied in the
-        // prompt, so "answered without calling any of the available
-        // tools" is not a caution — it is the correct behaviour, and
-        // no tool on the roster could have improved it. Dogfooding
-        // 0.14.1 hit exactly this: a scanned-invoice turn whose
-        // grounded, correct total wore the caption, which reads as
-        // "this number may be a guess" directly under a number the
-        // model had in fact read off the page. Flagging a right answer
-        // is not a harmless false positive — it spends the user's
-        // trust in the caption, so the next one (a real hallucinated
-        // total) gets ignored too.
-        guard !promptHadAttachment else { return false }
+        // Gate 1c: the user's turn carried a document AND the question
+        // is one that document could answer. When it is, the answer is
+        // grounded in text the user supplied in the prompt, so
+        // "answered without calling any of the available tools" is not
+        // a caution — it is the correct behaviour, and no tool on the
+        // roster could have improved it. Dogfooding 0.14.1 hit exactly
+        // this: a scanned-invoice turn whose grounded, correct total
+        // wore the caption, which reads as "this number may be a
+        // guess" directly under a number the model had in fact read
+        // off the page. Flagging a right answer is not a harmless
+        // false positive — it spends the user's trust in the caption,
+        // so the next one (a real hallucinated total) gets ignored too.
+        //
+        // But the exemption has to be narrow, because an attachment is
+        // not a general licence: attach a PDF and ask "what is today's
+        // stock price?" and the page cannot possibly hold the answer,
+        // so a bare number with no tool call is precisely the
+        // hallucination this caption exists to catch. So the turn is
+        // exempt only when the prompt is NOT asking for live data.
+        if promptHadAttachment, !promptAsksForLiveData(userPrompt) { return false }
         // Gate 2: model must have produced no tool_calls. A real
         // tool-call turn doesn't need the caption.
         let noToolCalls = (toolCalls?.isEmpty ?? true)
@@ -1925,26 +1937,61 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         ]
         for kw in mathKeywords where containsKeyword(kw, in: lowered) { return true }
 
-        // Web-search keywords. Note: codex r1 MAJOR-1 (#308 PR)
-        // dropped the bare ``"what is the"`` keyword — it matched
-        // every plain factual question ("What is the capital of
-        // France?") and false-flagged short prose answers like
-        // "Paris." Web-search keywords must point at LIVE / DATED
-        // information; an evergreen factual lookup is not the
-        // failure mode this caption guards against.
-        let webKeywords: [String] = [
-            "search for", "google for", "look up", "look it up",
+        // Live-data keywords — see ``promptAsksForLiveData``, which owns
+        // the list so Gate 1c and this heuristic cannot drift apart.
+        //
+        // Note: codex r1 MAJOR-1 (#308 PR) dropped the bare
+        // ``"what is the"`` keyword — it matched every plain factual
+        // question ("What is the capital of France?") and false-flagged
+        // short prose answers like "Paris." Web-search keywords must
+        // point at LIVE / DATED information; an evergreen factual
+        // lookup is not the failure mode this caption guards against.
+        if promptAsksForLiveData(lowered) { return true }
+
+        // Retrieval-shaped keywords that an ATTACHED document can still
+        // satisfy — "look up the invoice number" is answered by the
+        // page, which is why these are not in the live-data list above
+        // and so do not withhold Gate 1c's exemption.
+        let retrievalKeywords: [String] = ["search for", "look up", "look it up"]
+        for kw in retrievalKeywords where containsKeyword(kw, in: lowered) { return true }
+
+        return false
+    }
+
+    /// True when `prompt` names a MOVING target — something that
+    /// changes without the conversation changing, so no document the
+    /// user attached can contain the answer.
+    ///
+    /// This is the line that makes Gate 1c of
+    /// ``shouldFlagToolNotCalled`` safe to draw. Without it, any
+    /// attachment on the turn silences the caption, including for
+    /// "here is my portfolio PDF — what is today's stock price?",
+    /// where a bare number with no tool call is exactly the
+    /// hallucination the caption exists to flag.
+    ///
+    /// ``"google for"`` lives here rather than with the
+    /// retrieval-shaped keywords in ``promptLooksCalculatorish``
+    /// because it names an external service outright; ``"search
+    /// for"`` / ``"look up"`` do not, and pointing either of those at
+    /// an attached document is an ordinary thing for a user to do.
+    ///
+    /// Whole-word matching throughout (see ``containsKeyword``), so
+    /// "temperature" does not fire on "temperatures"' neighbours and
+    /// "current" does not fire on "concurrent".
+    static func promptAsksForLiveData(_ prompt: String) -> Bool {
+        let lowered = prompt.lowercased()
+        let liveKeywords: [String] = [
+            "google for",
             "latest news", "latest version", "news about",
             "today's", "this week's", "right now",
             "current price", "stock price", "exchange rate",
-            "current weather"
+            "current weather",
+            // Looser than the phrases above, and deliberately so: a
+            // bare "weather" / "temperature" / "forecast" is always a
+            // live-data question, attachment or not.
+            "weather", "temperature", "forecast"
         ]
-        for kw in webKeywords where containsKeyword(kw, in: lowered) { return true }
-
-        // Weather keywords (looser than the web list above).
-        let weatherKeywords: [String] = ["weather", "temperature", "forecast"]
-        for kw in weatherKeywords where containsKeyword(kw, in: lowered) { return true }
-
+        for kw in liveKeywords where containsKeyword(kw, in: lowered) { return true }
         return false
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1056,11 +1056,13 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///     NOT count as succeeded — a hallucinated raw answer after a
     ///     failed tool is exactly the shape we still want to flag.
     ///   * ``promptHadAttachment == false``, OR the prompt asks for
-    ///     live data (see ``promptAsksForLiveData``). An answer read
+    ///     live data (``promptAsksForLiveData``), OR it carries
+    ///     self-contained arithmetic
+    ///     (``promptContainsSelfContainedArithmetic``). An answer read
     ///     off an attached file is grounded, not guessed — but an
     ///     attachment cannot ground "what is today's stock price",
-    ///     so the exemption is withheld for prompts that name a
-    ///     moving target.
+    ///     and it has nothing to do with "calculate 17*23", so the
+    ///     exemption is withheld in both cases.
     ///   * ``finishReason`` is ``nil`` or anything OTHER than
     ///     ``"tool_calls"`` — a real tool-call turn doesn't need
     ///     the caption (the chip row already speaks for it). A
@@ -1128,12 +1130,23 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // so the next one (a real hallucinated total) gets ignored too.
         //
         // But the exemption has to be narrow, because an attachment is
-        // not a general licence: attach a PDF and ask "what is today's
-        // stock price?" and the page cannot possibly hold the answer,
-        // so a bare number with no tool call is precisely the
-        // hallucination this caption exists to catch. So the turn is
-        // exempt only when the prompt is NOT asking for live data.
-        if promptHadAttachment, !promptAsksForLiveData(userPrompt) { return false }
+        // not a general licence. Two ways a prompt can carry a document
+        // and still be unanswerable from it, both raised by codex on
+        // this PR:
+        //
+        //   * live data — "attach my portfolio PDF, what is today's
+        //     stock price?" (``promptAsksForLiveData``); and
+        //   * self-contained arithmetic — "attached is my resume;
+        //     calculate 17*23", where the document is simply
+        //     irrelevant and the calculator is the tool that should
+        //     have run (``promptContainsSelfContainedArithmetic``).
+        //
+        // In both, a bare number with no tool call is precisely the
+        // hallucination this caption exists to catch, so the turn is
+        // exempt only when neither holds.
+        if promptHadAttachment,
+           !promptAsksForLiveData(userPrompt),
+           !promptContainsSelfContainedArithmetic(userPrompt) { return false }
         // Gate 2: model must have produced no tool_calls. A real
         // tool-call turn doesn't need the caption.
         let noToolCalls = (toolCalls?.isEmpty ?? true)
@@ -1896,6 +1909,28 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         func isWordScalar(_ scalar: Unicode.Scalar) -> Bool {
             CharacterSet.alphanumerics.contains(scalar)
         }
+        /// A boundary, or a regular English plural immediately followed by
+        /// one. codex flagged the regression this closes: moving from
+        /// substring to whole-word matching silently dropped "temperatures",
+        /// "forecasts" and "current prices", all of which the old substring
+        /// match caught and all of which are ordinary live-data questions.
+        /// Accepting a trailing "s"/"es" before the boundary keeps the
+        /// inflections without reopening the substring bug — "forecasting"
+        /// is still rejected (the next scalar is "i"), "forecasted" too
+        /// ("ed" is not "es"), and "concurrent" never contained a keyword to
+        /// begin with.
+        func boundaryFollows(_ index: String.Index) -> Bool {
+            if index == haystack.endIndex { return true }
+            if !isWordScalar(haystack[index].unicodeScalars.first!) { return true }
+            for suffix in ["es", "s"] where haystack[index...].hasPrefix(suffix) {
+                let after = haystack.index(index, offsetBy: suffix.count)
+                if after == haystack.endIndex
+                    || !isWordScalar(haystack[after].unicodeScalars.first!) {
+                    return true
+                }
+            }
+            return false
+        }
         var searchStart = haystack.startIndex
         while let range = haystack.range(
             of: keyword,
@@ -1906,9 +1941,7 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
                     haystack[haystack.index(before: range.lowerBound)]
                         .unicodeScalars.first!
                 )
-            let rightOK = range.upperBound == haystack.endIndex
-                || !isWordScalar(haystack[range.upperBound].unicodeScalars.first!)
-            if leftOK && rightOK { return true }
+            if leftOK && boundaryFollows(range.upperBound) { return true }
             // Overlapping matches matter ("timestimes"), so advance by
             // one character rather than past the whole keyword.
             searchStart = haystack.index(after: range.lowerBound)
@@ -1992,6 +2025,41 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
             "weather", "temperature", "forecast"
         ]
         for kw in liveKeywords where containsKeyword(kw, in: lowered) { return true }
+        return false
+    }
+
+    /// True when `prompt` carries arithmetic that stands on its own — a
+    /// digit and an operator, as in "17*23" or "1200 * 0.15".
+    ///
+    /// Such a question does not become document-grounded just because a
+    /// document happens to be attached: the numbers are in the prompt,
+    /// the page is irrelevant, and the calculator is exactly the tool
+    /// that should have run. So this withholds Gate 1c's exemption
+    /// alongside ``promptAsksForLiveData``.
+    ///
+    /// Note what it deliberately does NOT cover: math *keywords* with
+    /// no literal expression — "what is the total due? calculate it
+    /// from the invoice", the 0.14.1 dogfood case — where the operands
+    /// live on the page and reading them off it is the grounded,
+    /// correct answer. The discriminator is whether the prompt brought
+    /// its own numbers.
+    static func promptContainsSelfContainedArithmetic(_ prompt: String) -> Bool {
+        let hasDigit = prompt.unicodeScalars.contains { scalar in
+            scalar.value >= 0x30 && scalar.value <= 0x39
+        }
+        guard hasDigit else { return false }
+        let mathOperators: Set<Character> = ["+", "*", "/", "%", "=", "^"]
+        if prompt.contains(where: { mathOperators.contains($0) }) { return true }
+        // "-" only counts between two digits: a hyphenated filename or a
+        // dashed aside ("attached is my resume - what does it say?") is
+        // not arithmetic, but "1200-180" is.
+        let scalars = Array(prompt.unicodeScalars)
+        func isDigit(_ index: Int) -> Bool {
+            scalars.indices.contains(index) && scalars[index].value >= 0x30 && scalars[index].value <= 0x39
+        }
+        for (offset, scalar) in scalars.enumerated() where scalar == "-" {
+            if isDigit(offset - 1) && isDigit(offset + 1) { return true }
+        }
         return false
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -1055,14 +1055,13 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
     ///     would contradict the chip on screen. A tool that ERRORED does
     ///     NOT count as succeeded — a hallucinated raw answer after a
     ///     failed tool is exactly the shape we still want to flag.
-    ///   * ``promptHadAttachment == false``, OR the prompt asks for
-    ///     live data (``promptAsksForLiveData``), OR it carries
-    ///     self-contained arithmetic
-    ///     (``promptContainsSelfContainedArithmetic``). An answer read
-    ///     off an attached file is grounded, not guessed — but an
-    ///     attachment cannot ground "what is today's stock price",
-    ///     and it has nothing to do with "calculate 17*23", so the
-    ///     exemption is withheld in both cases.
+    ///   * ``promptHadAttachment == false``, OR the prompt is not one
+    ///     an attached document could answer
+    ///     (``promptIsAttachmentAnswerable``). An answer read off an
+    ///     attached file is grounded, not guessed — but a page cannot
+    ///     ground "what is today's stock price", has nothing to do
+    ///     with "calculate 17*23", and is not what "search for Ada
+    ///     Lovelace's biography" asks for.
     ///   * ``finishReason`` is ``nil`` or anything OTHER than
     ///     ``"tool_calls"`` — a real tool-call turn doesn't need
     ///     the caption (the chip row already speaks for it). A
@@ -1130,23 +1129,13 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // so the next one (a real hallucinated total) gets ignored too.
         //
         // But the exemption has to be narrow, because an attachment is
-        // not a general licence. Two ways a prompt can carry a document
-        // and still be unanswerable from it, both raised by codex on
-        // this PR:
-        //
-        //   * live data — "attach my portfolio PDF, what is today's
-        //     stock price?" (``promptAsksForLiveData``); and
-        //   * self-contained arithmetic — "attached is my resume;
-        //     calculate 17*23", where the document is simply
-        //     irrelevant and the calculator is the tool that should
-        //     have run (``promptContainsSelfContainedArithmetic``).
-        //
-        // In both, a bare number with no tool call is precisely the
-        // hallucination this caption exists to catch, so the turn is
-        // exempt only when neither holds.
-        if promptHadAttachment,
-           !promptAsksForLiveData(userPrompt),
-           !promptContainsSelfContainedArithmetic(userPrompt) { return false }
+        // not a general licence — three review rounds each found a
+        // prompt that carried a document and still could not be
+        // answered from it. So the test is stated positively, as the
+        // one shape a page CAN answer: math vocabulary whose operands
+        // live on that page. See ``promptIsAttachmentAnswerable`` for
+        // the table of what that excludes and why.
+        if promptHadAttachment, promptIsAttachmentAnswerable(userPrompt) { return false }
         // Gate 2: model must have produced no tool_calls. A real
         // tool-call turn doesn't need the caption.
         let noToolCalls = (toolCalls?.isEmpty ?? true)
@@ -1962,17 +1951,10 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         let hasOperator = lowered.contains(where: { mathOperators.contains($0) })
         if hasDigit && hasOperator { return true }
 
-        // Math keywords.
-        let mathKeywords: [String] = [
-            "square root", "sqrt", "percent", "calculate", "compute", "solve",
-            "divide", "multiply", "sum of", "product of", "plus", "minus",
-            "times", "divided by"
-        ]
-        for kw in mathKeywords where containsKeyword(kw, in: lowered) { return true }
-
-        // Live-data keywords — see ``promptAsksForLiveData``, which owns
-        // the list so Gate 1c and this heuristic cannot drift apart.
-        //
+        // The three remaining lanes each live in their own predicate, so
+        // Gate 1c can name exactly which of them an attachment neutralises
+        // without either copy of the keyword lists drifting.
+        if promptContainsMathKeyword(lowered) { return true }
         // Note: codex r1 MAJOR-1 (#308 PR) dropped the bare
         // ``"what is the"`` keyword — it matched every plain factual
         // question ("What is the capital of France?") and false-flagged
@@ -1980,15 +1962,68 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         // point at LIVE / DATED information; an evergreen factual
         // lookup is not the failure mode this caption guards against.
         if promptAsksForLiveData(lowered) { return true }
-
-        // Retrieval-shaped keywords that an ATTACHED document can still
-        // satisfy — "look up the invoice number" is answered by the
-        // page, which is why these are not in the live-data list above
-        // and so do not withhold Gate 1c's exemption.
-        let retrievalKeywords: [String] = ["search for", "look up", "look it up"]
-        for kw in retrievalKeywords where containsKeyword(kw, in: lowered) { return true }
+        if promptAsksForExternalRetrieval(lowered) { return true }
 
         return false
+    }
+
+    /// Math vocabulary with no literal expression — "calculate the total",
+    /// "sum of the line items", "what percent of it".
+    ///
+    /// This is the ONE lane an attachment neutralises (see Gate 1c of
+    /// ``shouldFlagToolNotCalled``): the operands can live on the page, so
+    /// reading them off it is the grounded, correct answer.
+    static func promptContainsMathKeyword(_ prompt: String) -> Bool {
+        let lowered = prompt.lowercased()
+        let mathKeywords: [String] = [
+            "square root", "sqrt", "percent", "calculate", "compute", "solve",
+            "divide", "multiply", "sum of", "product of", "plus", "minus",
+            "times", "divided by"
+        ]
+        for kw in mathKeywords where containsKeyword(kw, in: lowered) { return true }
+        return false
+    }
+
+    /// Asks for something to be fetched from outside the conversation.
+    ///
+    /// These used to sit with the math keywords on the theory that "look up
+    /// the invoice number" is answered by an attached page. codex was right
+    /// that the theory does not survive its own counterexample: attach a
+    /// résumé and ask to "search for Ada Lovelace's biography" and the page
+    /// grounds nothing, yet the exemption silenced the caption on a
+    /// completely ungrounded answer — the #308 failure mode itself.
+    ///
+    /// So external-retrieval language now withholds the exemption. The cost
+    /// is accepted knowingly: "look up the invoice number" with the invoice
+    /// attached will wear a caution it does not deserve. Of the two errors,
+    /// the false negative is the one this feature exists to prevent, and the
+    /// caption is dismissible while a silent wrong answer is not.
+    static func promptAsksForExternalRetrieval(_ prompt: String) -> Bool {
+        let lowered = prompt.lowercased()
+        let retrievalKeywords: [String] = ["search for", "look up", "look it up"]
+        for kw in retrievalKeywords where containsKeyword(kw, in: lowered) { return true }
+        return false
+    }
+
+    /// True when an attached document could actually answer `prompt`.
+    ///
+    /// Stated as what IS exempt rather than as a list of disqualifiers,
+    /// because the disqualifier form grew a hole every review round. Of the
+    /// four lanes that make a prompt tool-shaped at all
+    /// (``promptLooksCalculatorish``), exactly one is answerable from a page
+    /// the user attached:
+    ///
+    /// | lane | attached document can answer it? |
+    /// | --- | --- |
+    /// | math keywords, no literal expression | **yes** — operands are on the page |
+    /// | self-contained arithmetic (`17*23`) | no — prompt brought its own numbers |
+    /// | live data (today's price, the weather) | no — no page holds a moving target |
+    /// | external retrieval (search for, look up) | no — it asks to leave the document |
+    static func promptIsAttachmentAnswerable(_ prompt: String) -> Bool {
+        guard !promptAsksForLiveData(prompt) else { return false }
+        guard !promptContainsSelfContainedArithmetic(prompt) else { return false }
+        guard !promptAsksForExternalRetrieval(prompt) else { return false }
+        return promptContainsMathKeyword(prompt)
     }
 
     /// True when `prompt` names a MOVING target — something that

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatMessage.swift
@@ -2050,15 +2050,31 @@ struct ChatMessage: Identifiable, Codable, Equatable, Hashable {
         guard hasDigit else { return false }
         let mathOperators: Set<Character> = ["+", "*", "/", "%", "=", "^"]
         if prompt.contains(where: { mathOperators.contains($0) }) { return true }
-        // "-" only counts between two digits: a hyphenated filename or a
-        // dashed aside ("attached is my resume - what does it say?") is
-        // not arithmetic, but "1200-180" is.
+        // "-" only counts with a number on each side: a hyphenated filename
+        // or a dashed aside ("attached is my resume - what does it say?") is
+        // not arithmetic, but "1200-180" and "1200 - 180" both are. codex
+        // caught the spaced form being missed, which is the way most people
+        // actually type it.
         let scalars = Array(prompt.unicodeScalars)
         func isDigit(_ index: Int) -> Bool {
-            scalars.indices.contains(index) && scalars[index].value >= 0x30 && scalars[index].value <= 0x39
+            scalars.indices.contains(index)
+                && scalars[index].value >= 0x30
+                && scalars[index].value <= 0x39
+        }
+        func digitLookingBack(from index: Int) -> Bool {
+            var i = index
+            while scalars.indices.contains(i), scalars[i] == " " || scalars[i] == "\t" { i -= 1 }
+            return isDigit(i)
+        }
+        func digitLookingForward(from index: Int) -> Bool {
+            var i = index
+            while scalars.indices.contains(i), scalars[i] == " " || scalars[i] == "\t" { i += 1 }
+            return isDigit(i)
         }
         for (offset, scalar) in scalars.enumerated() where scalar == "-" {
-            if isDigit(offset - 1) && isDigit(offset + 1) { return true }
+            if digitLookingBack(from: offset - 1), digitLookingForward(from: offset + 1) {
+                return true
+            }
         }
         return false
     }

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatStreamClient.swift
@@ -435,7 +435,34 @@ struct ChatStreamClient {
                 : .init(enable_thinking: false)
         )
         let encoder = JSONEncoder()
-        encoder.outputFormatting = []
+        // Deterministic key order, because this body is not just transport:
+        // the engine renders `tools` (and the message list) into the prompt
+        // TEXT through the model's chat template, and its prefix cache reuses
+        // a stored request only when the new one is a byte-exact token prefix
+        // of it. Any reordering between two turns therefore rewrites the
+        // prompt's head and costs the whole conversation a re-prefill.
+        //
+        // And the order DOES move. `ToolDefinition.Function.parameters` is a
+        // ``CodableJSON`` blob whose `.object` case is a Swift dictionary, and
+        // dictionary iteration order is randomized per instance. Captured
+        // bodies from two consecutive turns of one conversation (0.14.1,
+        // 2026-09-11):
+        //
+        //     turn 1  "tools":[{"function":{"name":"web_search","description":…
+        //     turn 2  "tools":[{"type":"function","function":{"name":"web_search","parameters":…
+        //
+        // Same four tools, same order, different bytes. The engine saw
+        // `shared=96 entry_len=1460 requested_len=1511` and re-prefilled all
+        // 1511 tokens — 4.6 s to first token on a follow-up that should have
+        // cost ~0.5 s, and 15–17 s once an 8-page PDF is in the conversation.
+        // No amount of append-only message discipline can recover a prompt
+        // whose tool block is re-shuffled underneath it.
+        //
+        // `.sortedKeys` is the whole fix: JSON objects are unordered by spec,
+        // the engine parses into dicts, and sorting makes every level stable
+        // across requests AND across app launches (so a reloaded conversation
+        // can still reuse the engine's on-disk prefix cache).
+        encoder.outputFormatting = [.sortedKeys]
         req.httpBody = try encoder.encode(body)
 
         // URLSession.shared inherits app-level timeouts which can be

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1674,6 +1674,27 @@ final class ChatViewModel {
         return ""
     }
 
+    /// True when the user message that opened the turn ending at
+    /// ``placeholderIndex`` carried at least one file attachment.
+    ///
+    /// Feeds ``ChatMessage.shouldFlagToolNotCalled``'s
+    /// ``promptHadAttachment`` gate: an answer read off a document the
+    /// user attached is grounded in the prompt, so the "didn't call a
+    /// tool" caution is wrong on it (see that method's Gate 1c).
+    /// Walks back the same way as ``lastUserPromptBefore`` so the two
+    /// always describe the same user message.
+    static func lastUserPromptHadAttachmentBefore(
+        messages: [ChatMessage],
+        placeholderIndex: Int
+    ) -> Bool {
+        guard placeholderIndex > 0 else { return false }
+        let upper = min(placeholderIndex, messages.count)
+        for i in stride(from: upper - 1, through: 0, by: -1) where messages[i].role == .user {
+            return !messages[i].fileAttachments.isEmpty
+        }
+        return false
+    }
+
     /// True when the assistant turn ending at ``placeholderIndex`` was
     /// preceded — since the most recent user message — by a tool that
     /// SUCCEEDED (a ``.tool`` result message with status ``.complete``).
@@ -2517,7 +2538,7 @@ final class ChatViewModel {
             history = ChatViewModel.addingInstructionLayers(
                 to: history,
                 ambientPreamble: ambientPreamble,
-                dateContext: ChatViewModel.currentDateTimeContext(),
+                dateContext: ChatViewModel.currentDateContext(),
                 memoryContext: memoryContext,
                 global: globalInstruction,
                 conversation: conversationInstruction
@@ -2562,6 +2583,14 @@ final class ChatViewModel {
             if forceGroundingCorrection {
                 history = ChatViewModel.addingGroundingCorrectionPreamble(to: history)
             }
+            // LAST, after the trim and every preamble: each user turn carries
+            // the clock of the moment it was sent, so the prompt stays
+            // append-only between turns and the engine's prefix cache can
+            // reuse it. See ``currentDateContext`` for the measurement that
+            // motivates moving the clock out of the system row, and
+            // ``stampingClockContext`` for why it is every user row rather
+            // than just the newest one.
+            history = ChatViewModel.stampingClockContext(on: history)
             let request: ChatStreamClient.Request
             if let s = sampling {
                 let resolved = s.resolved(toolsEnabled: !definitions.isEmpty)
@@ -2994,7 +3023,12 @@ final class ChatViewModel {
         addingInstructionLayers(
             to: [],
             ambientPreamble: nil,
-            dateContext: dateContext ?? currentDateTimeContext(),
+            // The preview shows what actually goes on the wire: the system
+            // row carries the DATE only. The wall clock rides each user turn
+            // as a wire-only trailer (``stampingClockContext``), so quoting it
+            // here would show the reader a system row Rapid never sends. The
+            // editor's caption tells them where the time went.
+            dateContext: dateContext ?? currentDateContext(),
             memoryContext: memoryContext,
             global: global,
             conversation: conversation
@@ -3005,22 +3039,42 @@ final class ChatViewModel {
     /// model does not guess "today" from training memory (issue #2330, where
     /// `qwen3.5-4b-4bit` answered "Friday, May 24, 2024" and then insisted it
     /// had no way to know the date). This supplies the Mac's authoritative
-    /// local date/time as a system-prompt template variable at request time —
-    /// the pattern peer desktop chat products use — rather than relying on the
+    /// local date as a system-prompt template variable at request time — the
+    /// pattern peer desktop chat products use — rather than relying on the
     /// model to infer it must search for the date, and without adding a
     /// local-clock tool or touching tool routing.
     ///
     /// Injected per `send` (each request recomputes it against the live clock),
     /// so it cannot go stale across midnight, a time-zone change, a restored
-    /// conversation, or a long-lived session. `now` and the calendar's
-    /// time zone are injectable so tests can pin the exact output and cover
+    /// conversation, or a long-lived session. `now` and the calendar's time
+    /// zone are injectable so tests can pin the exact output and cover
     /// rollover.
-    nonisolated static func currentDateTimeContext(
+    ///
+    /// The calendar day, time zone and nothing finer — the half of #2330's
+    /// context that belongs in the leading system row.
+    ///
+    /// The wall CLOCK deliberately does not appear here; it rides each user
+    /// turn instead (``clockContext(at:calendar:)`` +
+    /// ``stampingClockContext(on:calendar:)``). The engine's prompt cache
+    /// reuses a request only when its token prefix is byte-identical to a
+    /// stored one, and the system row is the FIRST thing in every request: a
+    /// minute-resolution string there rewrites the head of the prompt the
+    /// moment the clock ticks, which turns an append-only follow-up into a
+    /// full re-prefill of the whole conversation, document and all.
+    ///
+    /// Measured against this engine on an M3 Ultra (qwen3.8-27b-4bit, a
+    /// 2.3k-token prompt): an append-only second turn with a byte-identical
+    /// system row answers in 0.6 s; the same second turn with only the minute
+    /// changed costs 7.3 s — the cold-start prefill, paid again. With an
+    /// 8-page PDF attached the desktop was paying 15–17 s on EVERY follow-up.
+    ///
+    /// Day granularity still moves once per day, so a conversation spanning
+    /// local midnight re-prefills exactly once. That is the price of keeping
+    /// #2330's guarantee that the model never has to guess the date.
+    nonisolated static func currentDateContext(
         now: Date = Date(),
         calendar inputCalendar: Calendar = .autoupdatingCurrent
     ) -> String {
-        // Fixed gregorian calendar + en_US_POSIX so output never depends on the
-        // user's locale for date/time names or AM/PM rendering.
         var gregorian = Calendar(identifier: .gregorian)
         gregorian.timeZone = inputCalendar.timeZone
         let zone = inputCalendar.timeZone
@@ -3028,17 +3082,75 @@ final class ChatViewModel {
         formatter.calendar = gregorian
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = zone
-
         formatter.dateFormat = "EEEE, MMMM d, yyyy"
         let dateText = formatter.string(from: now)
-        formatter.dateFormat = "h:mm a"
-        let timeText = formatter.string(from: now)
-
         let abbreviation = zone.abbreviation(for: now) ?? zone.identifier
         return """
-        [CURRENT DATE AND TIME]
-        Today is \(dateText). The current local time is \(timeText) (\(abbreviation), \(zone.identifier)).
+        [CURRENT DATE]
+        Today is \(dateText) (\(abbreviation), \(zone.identifier)).
         """
+    }
+
+    /// The wall clock at `instant`, for the trailer stamped on a user turn.
+    ///
+    /// Split out of the system row for the prefix-cache reason documented on
+    /// ``currentDateContext``. It keeps #2330's contract — the newest user row
+    /// always carries the time it was sent, so the model is still told the
+    /// current local time on every request and never answers a "what time is
+    /// it" from training memory — while keeping the volatile tokens out of the
+    /// prompt's head.
+    nonisolated static func clockContext(
+        at instant: Date,
+        calendar inputCalendar: Calendar = .autoupdatingCurrent
+    ) -> String {
+        var gregorian = Calendar(identifier: .gregorian)
+        gregorian.timeZone = inputCalendar.timeZone
+        let zone = inputCalendar.timeZone
+        let formatter = DateFormatter()
+        formatter.calendar = gregorian
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = zone
+        formatter.dateFormat = "h:mm a"
+        let timeText = formatter.string(from: instant)
+        let abbreviation = zone.abbreviation(for: instant) ?? zone.identifier
+        return """
+        [CURRENT LOCAL TIME]
+        The current local time is \(timeText) (\(abbreviation), \(zone.identifier)).
+        """
+    }
+
+    /// Stamp every user row with the wall clock of the moment it was sent,
+    /// as a wire-only trailer.
+    ///
+    /// Derived from each row's own ``ChatMessage/createdAt`` — which is
+    /// persisted and immutable — rather than from "now", so the rendering of
+    /// a turn never changes after the fact and each request is a strict
+    /// EXTENSION of the one before it. That is the precise shape the engine's
+    /// prompt cache requires: it reuses a stored entry only when that entry is
+    /// a token-exact prefix of the new request.
+    ///
+    /// Stamping only the newest row was tried first and does not work. The
+    /// trailer then has to be removed from that row on the following turn, the
+    /// stored entry stops being a prefix, and reuse is lost exactly as it was
+    /// with the clock in the system row. Measured on this engine
+    /// (qwen3.8-27b-4bit, ~2.3k-token prompt, M3 Ultra): newest-row-only
+    /// trailer 7.4 s on turn two; stamped-per-turn 0.8 s against 7.5 s cold.
+    ///
+    /// The cost is roughly twenty tokens per user turn, bought with the entire
+    /// prefill of every follow-up — 15–17 s in the 0.14.1 document dogfood.
+    nonisolated static func stampingClockContext(
+        on messages: [ChatMessage],
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> [ChatMessage] {
+        guard messages.contains(where: { $0.role == .user }) else { return messages }
+        var result = messages
+        for index in result.indices where result[index].role == .user {
+            result[index].wireSuffix = clockContext(
+                at: result[index].createdAt,
+                calendar: calendar
+            )
+        }
+        return result
     }
 
     /// Remove an exact first component from the merged system row. Used when
@@ -3408,7 +3520,12 @@ Your previous draft refused the question by claiming you lack real-time access o
                             toolSucceededThisTurn: ChatViewModel.turnHadSuccessfulTool(
                                 messages: self.messages,
                                 placeholderIndex: placeholderIndex
-                            )
+                            ),
+                            promptHadAttachment:
+                                ChatViewModel.lastUserPromptHadAttachmentBefore(
+                                    messages: self.messages,
+                                    placeholderIndex: placeholderIndex
+                                )
                         )
                         // Issue #513 (defense-in-depth, layer 3): when
                         // the request offered tools but the model emitted

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1675,24 +1675,35 @@ final class ChatViewModel {
     }
 
     /// True when the user message that opened the turn ending at
-    /// ``placeholderIndex`` carried at least one file attachment.
+    /// True when the request for this turn carried at least one file
+    /// attachment's extracted text.
     ///
     /// Feeds ``ChatMessage.shouldFlagToolNotCalled``'s
     /// ``promptHadAttachment`` gate: an answer read off a document the
     /// user attached is grounded in the prompt, so the "didn't call a
     /// tool" caution is wrong on it (see that method's Gate 1c).
-    /// Walks back the same way as ``lastUserPromptBefore`` so the two
-    /// always describe the same user message.
-    static func lastUserPromptHadAttachmentBefore(
-        messages: [ChatMessage],
-        placeholderIndex: Int
+    ///
+    /// Takes the history that actually went on the wire, NOT the
+    /// transcript, and scans EVERY user row in it rather than only the
+    /// newest. Both choices are corrections of an earlier version of
+    /// this helper, which walked back to the nearest user row and
+    /// stopped:
+    ///
+    ///   * **Every row**, because ``ChatMessage/modelContent`` re-sends
+    ///     each attachment's extracted text on every follow-up. So
+    ///     "what was the invoice total?" two turns after the invoice
+    ///     was attached IS answered from a document in front of the
+    ///     model, and the earlier helper captioned it as a guess.
+    ///   * **The wire history**, because
+    ///     ``trimMessagesForContextWindow`` drops the oldest rows on a
+    ///     long conversation. A document that was trimmed away is no
+    ///     longer grounding anything, and scanning the transcript would
+    ///     claim it still is — silencing the caption exactly when the
+    ///     evidence is gone, which is the worst moment to silence it.
+    nonisolated static func historyCarriesAttachmentGrounding(
+        _ messages: [ChatMessage]
     ) -> Bool {
-        guard placeholderIndex > 0 else { return false }
-        let upper = min(placeholderIndex, messages.count)
-        for i in stride(from: upper - 1, through: 0, by: -1) where messages[i].role == .user {
-            return !messages[i].fileAttachments.isEmpty
-        }
-        return false
+        messages.contains { $0.role == .user && !$0.fileAttachments.isEmpty }
     }
 
     /// True when the assistant turn ending at ``placeholderIndex`` was
@@ -1733,6 +1744,13 @@ final class ChatViewModel {
         }
         return false
     }
+
+    /// Set on every request from the post-trim wire history, read at the
+    /// completion site by the tool-not-called caption. A per-turn fact rather
+    /// than derived state: by the time the stream finishes, the trim that
+    /// decided whether a document extract reached the model is no longer
+    /// recomputable from ``messages``.
+    private var wireHistoryCarriesAttachmentGrounding = false
 
     /// Keeps the system row and latest complete user/tool turn, then fills the
     /// remaining context newest-first. Oversized tool bodies are shortened in place.
@@ -2591,6 +2609,13 @@ final class ChatViewModel {
             // ``stampingClockContext`` for why it is every user row rather
             // than just the newest one.
             history = ChatViewModel.stampingClockContext(on: history)
+            // Whether any document extract survived onto THIS request, read
+            // off the same array that is about to be encoded. The
+            // tool-not-called caption is decided later, at the completion
+            // site, where the trim is no longer visible — see
+            // ``historyCarriesAttachmentGrounding``.
+            wireHistoryCarriesAttachmentGrounding =
+                ChatViewModel.historyCarriesAttachmentGrounding(history)
             let request: ChatStreamClient.Request
             if let s = sampling {
                 let resolved = s.resolved(toolsEnabled: !definitions.isEmpty)
@@ -3110,17 +3135,30 @@ final class ChatViewModel {
         formatter.calendar = gregorian
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = zone
-        formatter.dateFormat = "h:mm a"
-        let timeText = formatter.string(from: instant)
+        formatter.dateFormat = "EEEE, MMMM d, yyyy 'at' h:mm a"
+        let stampText = formatter.string(from: instant)
         let abbreviation = zone.abbreviation(for: instant) ?? zone.identifier
         return """
-        [CURRENT LOCAL TIME]
-        The current local time is \(timeText) (\(abbreviation), \(zone.identifier)).
+        [MESSAGE SENT]
+        This message was sent \(stampText) (\(abbreviation), \(zone.identifier)).
         """
     }
 
-    /// Stamp every user row with the wall clock of the moment it was sent,
-    /// as a wire-only trailer.
+    /// Stamp every user row with the moment it was sent, as a wire-only
+    /// trailer.
+    ///
+    /// The trailer reads "This message was sent <full date> at <time>", not
+    /// "the current local time is …", and it carries the date as well as the
+    /// clock. Both were codex findings on this PR, and both are about the
+    /// same thing: every user row in the history wears one of these, so
+    /// anything phrased as "current" would have the prompt asserting three
+    /// contradictory current times, and a bare time on an old row would
+    /// silently attach yesterday's clock to today's ``[CURRENT DATE]`` in a
+    /// conversation that crossed midnight. A send-time stamp is true of every
+    /// row forever, which is also exactly what makes it cacheable.
+    ///
+    /// The model still knows what time it is now: the newest user row is the
+    /// one being sent, so its stamp IS the request time.
     ///
     /// Derived from each row's own ``ChatMessage/createdAt`` — which is
     /// persisted and immutable — rather than from "now", so the rendering of
@@ -3543,10 +3581,7 @@ Your previous draft refused the question by claiming you lack real-time access o
                                 placeholderIndex: placeholderIndex
                             ),
                             promptHadAttachment:
-                                ChatViewModel.lastUserPromptHadAttachmentBefore(
-                                    messages: self.messages,
-                                    placeholderIndex: placeholderIndex
-                                )
+                                self.wireHistoryCarriesAttachmentGrounding
                         )
                         // Issue #513 (defense-in-depth, layer 3): when
                         // the request offered tools but the model emitted

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -3109,10 +3109,15 @@ final class ChatViewModel {
         formatter.timeZone = zone
         formatter.dateFormat = "EEEE, MMMM d, yyyy"
         let dateText = formatter.string(from: now)
-        let abbreviation = zone.abbreviation(for: now) ?? zone.identifier
+        // Identifier only, no abbreviation. codex caught that "PST"/"PDT" is
+        // instant-specific: it flips mid-day at a daylight-saving transition
+        // and would re-prefill every open conversation at 2 a.m. twice a
+        // year, in the one block this whole change exists to hold still. The
+        // abbreviation still rides on each message trailer, where it is
+        // describing a specific instant and is therefore correct there.
         return """
         [CURRENT DATE]
-        Today is \(dateText) (\(abbreviation), \(zone.identifier)).
+        Today is \(dateText) (\(zone.identifier)).
         """
     }
 

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -3138,6 +3138,27 @@ final class ChatViewModel {
     ///
     /// The cost is roughly twenty tokens per user turn, bought with the entire
     /// prefill of every follow-up — 15–17 s in the 0.14.1 document dogfood.
+    ///
+    /// What this means for the three ways a turn can be re-sent, because codex
+    /// asked and the answer is not uniform:
+    ///
+    ///   * **A new send** mints a fresh row (``send(_:alias:…)`` builds a
+    ///     ``ChatMessage`` with the default ``createdAt`` of `Date()`), so the
+    ///     trailer is the live clock. This is the common case.
+    ///   * **An edited send** goes through ``editUserMessage(id:newContent:…)``,
+    ///     which rewinds the path and calls ``send`` — so it, too, mints a new
+    ///     row and gets the live clock. Free: the edited text already broke
+    ///     the shared prefix at that row, so there is no reuse to protect.
+    ///   * **Regenerate / Retry** (``regenerateAnswer(afterUserAt:…)``) reuse
+    ///     the existing user row deliberately — the question was asked then,
+    ///     and re-answering it is not asking it again. Its trailer therefore
+    ///     keeps the original ask time. This is not a shortcut: a "live"
+    ///     clock here would have to be stable on every LATER turn as well, or
+    ///     the prefix breaks for the rest of the conversation, so "live clock
+    ///     on regenerate" and "reuse the prefix" cannot both hold. Reporting
+    ///     when the user actually asked is the more defensible half, and a
+    ///     model that needs the wall clock right now is answering a live-data
+    ///     question, which wants a tool rather than a prompt trailer.
     nonisolated static func stampingClockContext(
         on messages: [ChatMessage],
         calendar: Calendar = .autoupdatingCurrent

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -1745,13 +1745,6 @@ final class ChatViewModel {
         return false
     }
 
-    /// Set on every request from the post-trim wire history, read at the
-    /// completion site by the tool-not-called caption. A per-turn fact rather
-    /// than derived state: by the time the stream finishes, the trim that
-    /// decided whether a document extract reached the model is no longer
-    /// recomputable from ``messages``.
-    private var wireHistoryCarriesAttachmentGrounding = false
-
     /// Keeps the system row and latest complete user/tool turn, then fills the
     /// remaining context newest-first. Oversized tool bodies are shortened in place.
     static func trimMessagesForContextWindow(
@@ -2608,13 +2601,26 @@ final class ChatViewModel {
             // motivates moving the clock out of the system row, and
             // ``stampingClockContext`` for why it is every user row rather
             // than just the newest one.
-            history = ChatViewModel.stampingClockContext(on: history)
+            // ``answeringAt`` is this request's instant: it changes nothing
+            // for an ordinary send (the newest row was minted just now) and
+            // only speaks up when a regenerate is re-answering a question
+            // asked in an earlier minute — see ``answeringNowLine``.
+            history = ChatViewModel.stampingClockContext(
+                on: history,
+                answeringAt: Date()
+            )
             // Whether any document extract survived onto THIS request, read
             // off the same array that is about to be encoded. The
             // tool-not-called caption is decided later, at the completion
             // site, where the trim is no longer visible — see
             // ``historyCarriesAttachmentGrounding``.
-            wireHistoryCarriesAttachmentGrounding =
+            //
+            // A request-scoped `let`, captured by the completion closure
+            // alongside `request` itself, NOT view-model state: codex caught
+            // that a stored property is read by whichever stream finishes
+            // last, so two overlapping sends could decide each other's
+            // caption.
+            let wireCarriesAttachmentGrounding =
                 ChatViewModel.historyCarriesAttachmentGrounding(history)
             let request: ChatStreamClient.Request
             if let s = sampling {
@@ -2647,6 +2653,7 @@ final class ChatViewModel {
             let outcome = await runOneStream(
                 placeholderIndex: currentPlaceholder,
                 request: request,
+                wireCarriesAttachmentGrounding: wireCarriesAttachmentGrounding,
                 epoch: epoch
             )
             switch outcome {
@@ -3121,15 +3128,11 @@ final class ChatViewModel {
         """
     }
 
-    /// The wall clock at `instant`, for the trailer stamped on a user turn.
-    ///
-    /// Split out of the system row for the prefix-cache reason documented on
-    /// ``currentDateContext``. It keeps #2330's contract — the newest user row
-    /// always carries the time it was sent, so the model is still told the
-    /// current local time on every request and never answers a "what time is
-    /// it" from training memory — while keeping the volatile tokens out of the
-    /// prompt's head.
-    nonisolated static func clockContext(
+    /// One minute-resolution wall-clock stamp: "<full date> at <h:mm a>
+    /// (<abbreviation>, <identifier>)". Shared by the "sent" trailer and the
+    /// regenerate line so the two can never drift in format — and so
+    /// comparing them for equality is a reliable "does this say anything new".
+    nonisolated static func clockStampText(
         at instant: Date,
         calendar inputCalendar: Calendar = .autoupdatingCurrent
     ) -> String {
@@ -3143,10 +3146,57 @@ final class ChatViewModel {
         formatter.dateFormat = "EEEE, MMMM d, yyyy 'at' h:mm a"
         let stampText = formatter.string(from: instant)
         let abbreviation = zone.abbreviation(for: instant) ?? zone.identifier
-        return """
-        [MESSAGE SENT]
-        This message was sent \(stampText) (\(abbreviation), \(zone.identifier)).
+        return "\(stampText) (\(abbreviation), \(zone.identifier))"
+    }
+
+    /// The wall clock at `instant`, for the trailer stamped on a user turn.
+    ///
+    /// Split out of the system row for the prefix-cache reason documented on
+    /// ``currentDateContext``. It keeps #2330's contract — the newest user row
+    /// always carries the time it was sent, so the model is still told the
+    /// current local time on every request and never answers a "what time is
+    /// it" from training memory — while keeping the volatile tokens out of the
+    /// prompt's head.
+    nonisolated static func clockContext(
+        at instant: Date,
+        calendar inputCalendar: Calendar = .autoupdatingCurrent
+    ) -> String {
         """
+        [MESSAGE SENT]
+        This message was sent \(clockStampText(at: instant, calendar: inputCalendar)).
+        """
+    }
+
+    /// The extra trailer line a REGENERATE or RETRY adds to the turn it is
+    /// re-answering, and only when it carries information: the question was
+    /// asked at one instant and is being answered at a materially later one.
+    ///
+    /// Returns "" when both instants render to the same minute-resolution
+    /// stamp, which is every ordinary send (the row was minted by this
+    /// request) and every regenerate within the same minute. So the common
+    /// path is byte-identical to having no such line at all.
+    ///
+    /// Why this exists: the reused row's "sent" stamp is honestly the original
+    /// ask time, but a model asked "what time is it?" and re-answering it 45
+    /// minutes later would otherwise report the stale clock — the exact
+    /// regression codex caught, against the pre-change behaviour where the
+    /// clock was recomputed per request. Appending rather than rewriting keeps
+    /// the row's own stamp immutable.
+    ///
+    /// The cache cost is bounded and paid only by the user who regenerated:
+    /// the line is gone again on the NEXT turn (which re-stamps from
+    /// ``ChatMessage/createdAt``), so that turn's shared prefix ends just
+    /// before this row instead of after it — a re-prefill of the last exchange,
+    /// not of the conversation. The document in the first turn stays cached.
+    nonisolated static func answeringNowLine(
+        asked: Date,
+        answeringAt: Date,
+        calendar: Calendar = .autoupdatingCurrent
+    ) -> String {
+        let askedText = clockStampText(at: asked, calendar: calendar)
+        let nowText = clockStampText(at: answeringAt, calendar: calendar)
+        guard askedText != nowText else { return "" }
+        return "\nThis answer is being generated \(nowText)."
     }
 
     /// Stamp every user row with the moment it was sent, as a wire-only
@@ -3194,25 +3244,35 @@ final class ChatViewModel {
     ///     the shared prefix at that row, so there is no reuse to protect.
     ///   * **Regenerate / Retry** (``regenerateAnswer(afterUserAt:…)``) reuse
     ///     the existing user row deliberately — the question was asked then,
-    ///     and re-answering it is not asking it again. Its trailer therefore
-    ///     keeps the original ask time. This is not a shortcut: a "live"
-    ///     clock here would have to be stable on every LATER turn as well, or
-    ///     the prefix breaks for the rest of the conversation, so "live clock
-    ///     on regenerate" and "reuse the prefix" cannot both hold. Reporting
-    ///     when the user actually asked is the more defensible half, and a
-    ///     model that needs the wall clock right now is answering a live-data
-    ///     question, which wants a tool rather than a prompt trailer.
+    ///     and re-answering it is not asking it again — so its "sent" stamp
+    ///     keeps the original ask time. But re-answering "what time is it?"
+    ///     three quarters of an hour later must not report the stale clock,
+    ///     which is why ``answeringNowLine`` APPENDS the answer time to that
+    ///     one row when the two instants differ. Append, not rewrite: the
+    ///     row's own stamp stays immutable, the common regenerate (same
+    ///     minute) adds nothing at all, and the bounded cache cost of the rare
+    ///     late one is documented on that helper.
     nonisolated static func stampingClockContext(
         on messages: [ChatMessage],
-        calendar: Calendar = .autoupdatingCurrent
+        calendar: Calendar = .autoupdatingCurrent,
+        answeringAt: Date? = nil
     ) -> [ChatMessage] {
         guard messages.contains(where: { $0.role == .user }) else { return messages }
         var result = messages
+        let newestUserIndex = result.lastIndex { $0.role == .user }
         for index in result.indices where result[index].role == .user {
-            result[index].wireSuffix = clockContext(
+            var trailer = clockContext(
                 at: result[index].createdAt,
                 calendar: calendar
             )
+            if index == newestUserIndex, let answeringAt {
+                trailer += answeringNowLine(
+                    asked: result[index].createdAt,
+                    answeringAt: answeringAt,
+                    calendar: calendar
+                )
+            }
+            result[index].wireSuffix = trailer
         }
         return result
     }
@@ -3387,6 +3447,11 @@ Your previous draft refused the question by claiming you lack real-time access o
     private func runOneStream(
         placeholderIndex: Int,
         request: ChatStreamClient.Request,
+        // Travels WITH the request rather than living on the view model:
+        // whether a document extract survived the trim onto this particular
+        // wire body. codex caught that a stored property would be read by
+        // whichever stream happens to finish last.
+        wireCarriesAttachmentGrounding: Bool,
         epoch: Int
     ) async -> StreamOutcome {
         var current = currentMessage(index: placeholderIndex)
@@ -3585,8 +3650,7 @@ Your previous draft refused the question by claiming you lack real-time access o
                                 messages: self.messages,
                                 placeholderIndex: placeholderIndex
                             ),
-                            promptHadAttachment:
-                                self.wireHistoryCarriesAttachmentGrounding
+                            promptHadAttachment: wireCarriesAttachmentGrounding
                         )
                         // Issue #513 (defense-in-depth, layer 3): when
                         // the request offered tools but the model emitted

--- a/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
+++ b/apps/rapid-mac/Sources/Rapid/Chat/ChatViewModel.swift
@@ -2543,13 +2543,19 @@ final class ChatViewModel {
                 && ChatViewModel.carriesToolResultForThisTurn(history)
                 ? ChatViewModel.toolGuidancePreamble
                 : nil
+            // ONE instant for the whole assembly, shared with the clock
+            // trailer below. codex caught that two `Date()` calls can straddle
+            // local midnight, which would have the same request asserting
+            // "Today is the 11th" in its system row and "sent … the 12th" on
+            // its newest message.
+            let requestInstant = Date()
             // Inserted BEFORE the trim so its tokens are inside the budget the
             // trim works to, not added on top of a body already sized to fill
             // the window.
             history = ChatViewModel.addingInstructionLayers(
                 to: history,
                 ambientPreamble: ambientPreamble,
-                dateContext: ChatViewModel.currentDateContext(),
+                dateContext: ChatViewModel.currentDateContext(now: requestInstant),
                 memoryContext: memoryContext,
                 global: globalInstruction,
                 conversation: conversationInstruction
@@ -2607,7 +2613,7 @@ final class ChatViewModel {
             // asked in an earlier minute — see ``answeringNowLine``.
             history = ChatViewModel.stampingClockContext(
                 on: history,
-                answeringAt: Date()
+                answeringAt: requestInstant
             )
             // Whether any document extract survived onto THIS request, read
             // off the same array that is about to be encoded. The

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerLogNoise.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerLogNoise.swift
@@ -28,10 +28,11 @@ import Foundation
 ///   * Only successful (2xx) polls. A `/healthz` that answers 503, or a
 ///     residency refresh that 500s, is exactly what someone opening the
 ///     drawer needs to see, so those lines are kept.
-///   * Only the access-log shape — the quoted `GET … HTTP/1.1` request
-///     line followed by a status code. A warning or traceback that
-///     merely mentions `/healthz` in prose is not an access line and is
-///     never suppressed.
+///   * Only a line that is *entirely* an access-log line. The pattern is
+///     anchored at both ends, so a warning or traceback that merely
+///     mentions `/healthz` — even one that quotes a whole request line
+///     back at you, e.g. `WARNING: probe failed: sent "GET /healthz
+///     HTTP/1.1" got 200 with an empty body` — is never suppressed.
 ///
 /// Pure function, no shared state, matching `LogScrubber`'s contract.
 enum ServerLogNoise {
@@ -42,14 +43,31 @@ enum ServerLogNoise {
     /// Uvicorn's default access format is
     /// `%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s`,
     /// e.g. `INFO:     127.0.0.1:57230 - "GET /healthz HTTP/1.1" 200 OK`.
-    /// The optional query-string branch covers a future poll that
-    /// carries parameters; the status branch is pinned to 2xx so
-    /// failures survive.
+    /// The server runs `uvicorn.run(app, …)` with no `log_config`, so
+    /// uvicorn installs its own default config and that *is* the shape
+    /// on the wire.
+    ///
+    /// Anchored at both ends (`^…$`), which is the whole safety
+    /// argument: the line must be nothing but an access line, so prose
+    /// that quotes a request line back at the reader stays visible. The
+    /// leading group absorbs either uvicorn's padded `levelprefix`
+    /// (`INFO:     `) or a `LEVEL:logger.name:` prefix, in case the
+    /// access logger is ever left to propagate to a root handler using
+    /// Python's default `%(levelname)s:%(name)s:%(message)s` format. The
+    /// optional query-string branch covers a future poll that carries
+    /// parameters; the status branch is pinned to 2xx so failures
+    /// survive; the trailing group is the HTTP reason phrase
+    /// (`OK`, `No Content`, `Non-Authoritative Information`).
     private static let accessLinePattern: String = {
         let alternation = polledPaths
             .map { NSRegularExpression.escapedPattern(for: $0) }
             .joined(separator: "|")
-        return "\"(?:GET|HEAD) (?:\(alternation))(?:\\?[^ \"]*)? HTTP/[0-9.]+\" 2[0-9][0-9]"
+        let levelPrefix = "(?:[A-Z]+:(?:[A-Za-z0-9_.]+:)?[ \\t]*)?"
+        let clientAddr = "[^ \"]+"
+        let requestLine = "\"(?:GET|HEAD) (?:\(alternation))(?:\\?[^ \"]*)? HTTP/[0-9.]+\""
+        let status = "2[0-9][0-9]"
+        let reasonPhrase = "(?: [A-Za-z][A-Za-z'\\- ]*)?"
+        return "^\(levelPrefix)\(clientAddr) - \(requestLine) \(status)\(reasonPhrase)$"
     }()
 
     /// True when `line` is a successful access-log line for one of the
@@ -65,6 +83,10 @@ enum ServerLogNoise {
             with: "",
             options: .regularExpression
         )
-        return stripped.range(of: accessLinePattern, options: .regularExpression) != nil
+        // Trimmed because the pattern is `$`-anchored and lines arrive from a
+        // pipe: a trailing `\r` (or indentation on a continuation line) must
+        // not be the thing that decides whether the filter fires.
+        let trimmed = stripped.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.range(of: accessLinePattern, options: .regularExpression) != nil
     }
 }

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerLogNoise.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerLogNoise.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Suppression for the access-log lines the app itself generates, so
+/// the user-visible "Server log" drawer shows the child's own output.
+///
+/// The drawer is a 200-line ring buffer fed from the child's
+/// stdout/stderr. Two app-side loops poll the child on a timer:
+/// `ServerManager`'s `/healthz` probe and the 5-second
+/// `/v1/models/residency` refresh that keeps the model rail current
+/// (see `ContentView`'s residency `.task`). Uvicorn logs one access
+/// line per request, so the two loops alone write several lines a
+/// minute — enough to evict the entire buffer within a few minutes of
+/// idling. Dogfooding 0.14.1, opening the drawer after a chat session
+/// showed *only* those lines: the startup banner, the resolved model
+/// path, and every warning worth reading had already scrolled off, so
+/// the one surface that answers "what is the server doing?" answered
+/// "polling itself".
+///
+/// This is the same move `DownloadProgress.isHeartbeatLogLine` makes
+/// for the R2 puller's `[bytes]` heartbeat, for the same reason: a
+/// machine-generated line at a fixed cadence carries no signal a human
+/// reads, and its real cost is the signal it evicts.
+///
+/// Deliberately narrow:
+///
+///   * Only the paths the app polls on a timer. A `/v1/chat/completions`
+///     or `/v1/models/load` line is a *user* action and stays.
+///   * Only successful (2xx) polls. A `/healthz` that answers 503, or a
+///     residency refresh that 500s, is exactly what someone opening the
+///     drawer needs to see, so those lines are kept.
+///   * Only the access-log shape — the quoted `GET … HTTP/1.1` request
+///     line followed by a status code. A warning or traceback that
+///     merely mentions `/healthz` in prose is not an access line and is
+///     never suppressed.
+///
+/// Pure function, no shared state, matching `LogScrubber`'s contract.
+enum ServerLogNoise {
+    /// Endpoints the app polls on a timer, quoted for use in a regex
+    /// alternation. Extend this when a new app-side poll loop lands.
+    static let polledPaths = ["/healthz", "/v1/models/residency"]
+
+    /// Uvicorn's default access format is
+    /// `%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s`,
+    /// e.g. `INFO:     127.0.0.1:57230 - "GET /healthz HTTP/1.1" 200 OK`.
+    /// The optional query-string branch covers a future poll that
+    /// carries parameters; the status branch is pinned to 2xx so
+    /// failures survive.
+    private static let accessLinePattern: String = {
+        let alternation = polledPaths
+            .map { NSRegularExpression.escapedPattern(for: $0) }
+            .joined(separator: "|")
+        return "\"(?:GET|HEAD) (?:\(alternation))(?:\\?[^ \"]*)? HTTP/[0-9.]+\" 2[0-9][0-9]"
+    }()
+
+    /// True when `line` is a successful access-log line for one of the
+    /// app's own polling endpoints, and so should not reach the
+    /// user-visible log tail.
+    static func isAppPollAccessLine(_ line: String) -> Bool {
+        // Colours are off when the child's stdout is a pipe (uvicorn
+        // defaults `use_colors` to `isatty()`), but strip them anyway so
+        // a future `--use-colors` or a TTY-attached child can't smuggle
+        // the noise back in past the quote anchor.
+        let stripped = line.replacingOccurrences(
+            of: "\u{1B}\\[[0-9;]*m",
+            with: "",
+            options: .regularExpression
+        )
+        return stripped.range(of: accessLinePattern, options: .regularExpression) != nil
+    }
+}

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerLogNoise.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerLogNoise.swift
@@ -25,6 +25,9 @@ import Foundation
 ///
 ///   * Only the paths the app polls on a timer. A `/v1/chat/completions`
 ///     or `/v1/models/load` line is a *user* action and stays.
+///   * Only loopback clients. A `/healthz` from another machine on the
+///     LAN is someone testing reachability, and dropping it would hide
+///     the one line that proves the request arrived.
 ///   * Only successful (2xx) polls. A `/healthz` that answers 503, or a
 ///     residency refresh that 500s, is exactly what someone opening the
 ///     drawer needs to see, so those lines are kept.
@@ -63,7 +66,14 @@ enum ServerLogNoise {
             .map { NSRegularExpression.escapedPattern(for: $0) }
             .joined(separator: "|")
         let levelPrefix = "(?:[A-Z]+:(?:[A-Za-z0-9_.]+:)?[ \\t]*)?"
-        let clientAddr = "[^ \"]+"
+        // Loopback only. codex caught that any client address matched, so a
+        // `/healthz` from a phone on the LAN — exactly the request someone
+        // debugging "why can't my other machine reach the server?" opened the
+        // drawer to look for — was filed as the app's own noise. Uvicorn
+        // renders `client_addr` as `host:port` (`127.0.0.1:57230`), with the
+        // port absent when the transport reports no peer.
+        let loopbackHost = "(?:127\\.0\\.0\\.1|localhost|\\[::1\\]|::1)"
+        let clientAddr = "\(loopbackHost)(?::[0-9]{1,5})?"
         let requestLine = "\"(?:GET|HEAD) (?:\(alternation))(?:\\?[^ \"]*)? HTTP/[0-9.]+\""
         let status = "2[0-9][0-9]"
         let reasonPhrase = "(?: [A-Za-z][A-Za-z'\\- ]*)?"

--- a/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
+++ b/apps/rapid-mac/Sources/Rapid/Server/ServerManager.swift
@@ -4046,9 +4046,19 @@ final class ServerManager {
         // carry no signal a human would want to read.
         var displayable: [String] = []
         displayable.reserveCapacity(lines.count)
+        //
+        // 0.14.1 dogfood: the app's own ``/healthz`` and
+        // ``/v1/models/residency`` poll loops each produce a uvicorn
+        // access line, and between them they evicted the whole ring
+        // buffer within minutes of idling — a user who opened the
+        // drawer saw the app talking to itself and nothing else. Same
+        // treatment as the byte heartbeat, same reasoning; see
+        // ``ServerLogNoise``, which keeps FAILED polls so a broken
+        // server still shows up here.
         for line in lines {
             downloadProgress.ingest(line)
-            if !DownloadProgress.isHeartbeatLogLine(line) {
+            if !DownloadProgress.isHeartbeatLogLine(line),
+               !ServerLogNoise.isAppPollAccessLine(line) {
                 displayable.append(line)
             }
         }

--- a/apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
@@ -178,7 +178,7 @@ struct EffectiveSystemPromptDisclosure: View {
         conversation: String
     ) -> String {
         ChatViewModel.effectiveSystemPrompt(
-            dateContext: ChatViewModel.currentDateTimeContext(
+            dateContext: ChatViewModel.currentDateContext(
                 now: now,
                 calendar: calendar
             ),
@@ -190,7 +190,11 @@ struct EffectiveSystemPromptDisclosure: View {
     var body: some View {
         DisclosureGroup("Effective System Prompt", isExpanded: $expanded) {
             VStack(alignment: .leading, spacing: RapidTheme.Space.sm) {
-                Text("Preview includes current automatic context. Tool and attachment context may be added when you send.")
+                // The clock is deliberately absent from the system row (see
+                // ``ChatViewModel.currentDateContext``), so say where it went
+                // — otherwise this preview reads as "the model doesn't know
+                // what time it is".
+                Text("Preview includes current automatic context. The current time is attached to each message you send. Tool and attachment context may be added when you send.")
                     .font(RapidFont.caption)
                     .foregroundStyle(RapidTheme.textSecondary)
                 TimelineView(.periodic(from: .now, by: 60)) { context in

--- a/apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/InstructionTextEditor.swift
@@ -194,7 +194,7 @@ struct EffectiveSystemPromptDisclosure: View {
                 // ``ChatViewModel.currentDateContext``), so say where it went
                 // — otherwise this preview reads as "the model doesn't know
                 // what time it is".
-                Text("Preview includes current automatic context. The current time is attached to each message you send. Tool and attachment context may be added when you send.")
+                Text("Preview includes current automatic context. Each message you send carries the time you sent it. Tool and attachment context may be added when you send.")
                     .font(RapidFont.caption)
                     .foregroundStyle(RapidTheme.textSecondary)
                 TimelineView(.periodic(from: .now, by: 60)) { context in

--- a/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/OnboardingComponents.swift
@@ -155,6 +155,10 @@ struct QuickstartRecommendedCard: View {
     let choice: QuickstartModelChoice
     let selected: Bool
     let sizeText: String
+    /// True when the weights are already in the shared Hugging Face cache.
+    /// Without it this lane advertised a download for a model the Mac already
+    /// held — see ``QuickstartView/shortlistSizeText(for:cached:recommendedForPhysicalRAMGB:)``.
+    var isCached: Bool = false
     var onActivate: (() -> Void)? = nil
     let onTap: () -> Void
 
@@ -168,6 +172,9 @@ struct QuickstartRecommendedCard: View {
                             .scaledSystemFont(15, weight: .semibold)
                             .foregroundStyle(RapidTheme.textPrimary)
                         OnboardingBadge(text: "START HERE", tone: .ink)
+                        if isCached {
+                            OnboardingBadge(text: "ON THIS MAC", tone: .ready)
+                        }
                         Spacer(minLength: 8)
                         if !sizeText.isEmpty {
                             Text(sizeText)
@@ -194,7 +201,9 @@ struct QuickstartRecommendedCard: View {
         .modelRowActivation(onActivate)
         .accessibilityIdentifier("Quickstart.Choice.\(choice.alias)")
         .accessibilityAddTraits(selected ? .isSelected : [])
-        .accessibilityLabel(Self.accessibilityText(for: choice, sizeText: sizeText))
+        .accessibilityLabel(
+            Self.accessibilityText(for: choice, sizeText: sizeText, isCached: isCached)
+        )
     }
 
     /// Fold the framing, size and attribute pills into the spoken label — the
@@ -202,7 +211,8 @@ struct QuickstartRecommendedCard: View {
     /// and blurb only.
     static func accessibilityText(
         for choice: QuickstartModelChoice,
-        sizeText: String
+        sizeText: String,
+        isCached: Bool = false
     ) -> String {
         var parts = [choice.displayName]
         // Below 16 GB the existing lowest-memory choice is deliberately the
@@ -214,7 +224,11 @@ struct QuickstartRecommendedCard: View {
         }
         parts.append("recommended starter")
         parts.append(choice.blurb)
-        if !sizeText.isEmpty { parts.append("download \(sizeText)") }
+        if isCached {
+            parts.append(sizeText.isEmpty ? "on disk" : "on disk \(sizeText)")
+        } else if !sizeText.isEmpty {
+            parts.append("download \(sizeText)")
+        }
         parts.append("on-device, fits this Mac")
         return parts.joined(separator: ". ")
     }
@@ -228,6 +242,9 @@ struct QuickstartLowMemoryCard: View {
     let choice: QuickstartModelChoice
     let selected: Bool
     let sizeText: String
+    /// See ``QuickstartRecommendedCard/isCached`` — same defect, same lane
+    /// shape: LFM2.5 read "Download ~633 MB" with all 637 MB already on disk.
+    var isCached: Bool = false
     var onActivate: (() -> Void)? = nil
     let onTap: () -> Void
 
@@ -241,6 +258,9 @@ struct QuickstartLowMemoryCard: View {
                             .scaledSystemFont(14, weight: .semibold)
                             .foregroundStyle(RapidTheme.textPrimary)
                         OnboardingBadge(text: "LOWEST MEMORY", tone: .ready)
+                        if isCached {
+                            OnboardingBadge(text: "ON THIS MAC", tone: .ready)
+                        }
                         Spacer(minLength: 8)
                         if !sizeText.isEmpty {
                             Text(sizeText)
@@ -262,10 +282,21 @@ struct QuickstartLowMemoryCard: View {
         .modelRowActivation(onActivate)
         .accessibilityIdentifier("Quickstart.Choice.\(choice.alias)")
         .accessibilityAddTraits(selected ? .isSelected : [])
-        .accessibilityLabel(
-            "\(choice.displayName). Lowest memory. \(choice.blurb)"
-                + (sizeText.isEmpty ? "" : " Download \(sizeText)")
-        )
+        .accessibilityLabel(Self.accessibilityText(for: choice, sizeText: sizeText, isCached: isCached))
+    }
+
+    static func accessibilityText(
+        for choice: QuickstartModelChoice,
+        sizeText: String,
+        isCached: Bool = false
+    ) -> String {
+        var text = "\(choice.displayName). Lowest memory. \(choice.blurb)"
+        if isCached {
+            text += sizeText.isEmpty ? " On disk" : " On disk \(sizeText)"
+        } else if !sizeText.isEmpty {
+            text += " Download \(sizeText)"
+        }
+        return text
     }
 }
 

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -3738,6 +3738,17 @@ struct QuickstartView: View {
             guard let capability else { return onDisk }
             return "\(onDisk) · \(capability)%"
         }
+        // Cached, but we could not measure what it occupies. Falling through
+        // to the download estimate here is what codex caught on this PR: the
+        // caller has already decided this row is on this Mac, so the estimate
+        // would be rendered — and spoken — as an on-disk figure for a model
+        // that is not being downloaded at all. An unknown size is better said
+        // by saying nothing; the ON THIS MAC badge still carries the fact
+        // that matters, and the accessibility label already degrades to a
+        // bare "on disk" when the size text is empty.
+        // A percentage in the size slot would be spoken as "on disk 65%",
+        // which is the same defect one layer along, so say nothing at all.
+        if cached != nil { return "" }
         guard let physicalRAMGB else { return sizeText(for: choice) }
         return sizeText(forRecommended: choice, physicalRAMGB: physicalRAMGB)
     }

--- a/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
+++ b/apps/rapid-mac/Sources/Rapid/UI/QuickstartView.swift
@@ -2464,10 +2464,19 @@ struct QuickstartView: View {
                     }
 
                     ForEach(list.starters) { choice in
+                        let cached = Self.cachedModel(
+                            alias: choice.alias,
+                            cachedModels: cachedModels
+                        )
                         QuickstartRecommendedCard(
                             choice: choice,
                             selected: coordinator.selection.alias == choice.alias,
-                            sizeText: Self.sizeText(for: choice),
+                            sizeText: Self.shortlistSizeText(
+                                for: choice,
+                                cached: cached,
+                                recommendedForPhysicalRAMGB: nil
+                            ),
+                            isCached: cached != nil,
                             onActivate: { activatePrimary(in: .shortlist) }
                         ) { coordinator.select(choice) }
                     }
@@ -2480,13 +2489,19 @@ struct QuickstartView: View {
                         )
                         .padding(.top, 14)
                         ForEach(list.recommended) { choice in
+                            let cached = Self.cachedModel(
+                                alias: choice.alias,
+                                cachedModels: cachedModels
+                            )
                             QuickstartCompactCard(
                                 choice: choice,
                                 selected: coordinator.selection.alias == choice.alias,
-                                sizeText: Self.sizeText(
-                                    forRecommended: choice,
-                                    physicalRAMGB: hardware.physicalRAMGB
+                                sizeText: Self.shortlistSizeText(
+                                    for: choice,
+                                    cached: cached,
+                                    recommendedForPhysicalRAMGB: hardware.physicalRAMGB
                                 ),
+                                isCached: cached != nil,
                                 onActivate: { activatePrimary(in: .shortlist) }
                             ) { coordinator.select(choice) }
                         }
@@ -2496,10 +2511,19 @@ struct QuickstartView: View {
                         OnboardingGroupLabel(text: "NEED THE LIGHTEST OPTION?")
                             .padding(.top, 14)
                         ForEach(list.lowMemory) { choice in
+                            let cached = Self.cachedModel(
+                                alias: choice.alias,
+                                cachedModels: cachedModels
+                            )
                             QuickstartLowMemoryCard(
                                 choice: choice,
                                 selected: coordinator.selection.alias == choice.alias,
-                                sizeText: Self.sizeText(for: choice),
+                                sizeText: Self.shortlistSizeText(
+                                    for: choice,
+                                    cached: cached,
+                                    recommendedForPhysicalRAMGB: nil
+                                ),
+                                isCached: cached != nil,
                                 onActivate: { activatePrimary(in: .shortlist) }
                             ) { coordinator.select(choice) }
                         }
@@ -3059,10 +3083,19 @@ struct QuickstartView: View {
         OnboardingIntrinsicColumn {
             VStack(alignment: .leading, spacing: 10) {
                 ForEach(list.starters) { choice in
+                    let cached = Self.cachedModel(
+                        alias: choice.alias,
+                        cachedModels: cachedModels
+                    )
                     QuickstartRecommendedCard(
                         choice: choice,
                         selected: coordinator.selection.alias == choice.alias,
-                        sizeText: Self.sizeText(for: choice),
+                        sizeText: Self.shortlistSizeText(
+                            for: choice,
+                            cached: cached,
+                            recommendedForPhysicalRAMGB: nil
+                        ),
+                        isCached: cached != nil,
                         onActivate: { activatePrimary(in: .review) }
                     ) { coordinator.select(choice) }
                 }
@@ -3074,13 +3107,19 @@ struct QuickstartView: View {
                     )
                     .padding(.top, 14)
                     ForEach(list.recommended) { choice in
+                        let cached = Self.cachedModel(
+                            alias: choice.alias,
+                            cachedModels: cachedModels
+                        )
                         QuickstartCompactCard(
                             choice: choice,
                             selected: coordinator.selection.alias == choice.alias,
-                            sizeText: Self.sizeText(
-                                forRecommended: choice,
-                                physicalRAMGB: hardware.physicalRAMGB
+                            sizeText: Self.shortlistSizeText(
+                                for: choice,
+                                cached: cached,
+                                recommendedForPhysicalRAMGB: hardware.physicalRAMGB
                             ),
+                            isCached: cached != nil,
                             onActivate: { activatePrimary(in: .review) }
                         ) { coordinator.select(choice) }
                     }
@@ -3089,10 +3128,19 @@ struct QuickstartView: View {
                     OnboardingGroupLabel(text: "NEED THE LIGHTEST OPTION?")
                         .padding(.top, 14)
                     ForEach(list.lowMemory) { choice in
+                        let cached = Self.cachedModel(
+                            alias: choice.alias,
+                            cachedModels: cachedModels
+                        )
                         QuickstartLowMemoryCard(
                             choice: choice,
                             selected: coordinator.selection.alias == choice.alias,
-                            sizeText: Self.sizeText(for: choice),
+                            sizeText: Self.shortlistSizeText(
+                                for: choice,
+                                cached: cached,
+                                recommendedForPhysicalRAMGB: nil
+                            ),
+                            isCached: cached != nil,
                             onActivate: { activatePrimary(in: .review) }
                         ) { coordinator.select(choice) }
                     }
@@ -3656,6 +3704,42 @@ struct QuickstartView: View {
             return sizeText(for: choice)
         }
         return recommendationSizeText(from: pick)
+    }
+
+    /// The size lane for a shortlist row, cached-aware.
+    ///
+    /// Every lane has to answer "download, or already here?" the same way.
+    /// Only the trade-up lane did. The cached shortlist is bounded to six
+    /// rows, so on a Mac holding more than six chat models the seventh is
+    /// rendered by one of the download-shaped lanes — which is how
+    /// `qwen3.6-35b-4bit` came to read "download 20 GB · 87%" on a Mac that
+    /// already held all 19.03 GB of it, three rows below an "ALREADY ON THIS
+    /// MAC" heading and beside a rail reading "Free space 6 GB". Following
+    /// that row cost a 20 GB download the user did not need and, at 6 GB
+    /// free, could not complete.
+    ///
+    /// A cached row keeps its capability percentage when it has one: being on
+    /// disk changes what it costs, not how capable it is.
+    ///
+    /// `recommendedForPhysicalRAMGB` is the RAM bucket for lanes that quote
+    /// the SSOT recommendation footprint, and `nil` for lanes that quote the
+    /// authored download size.
+    static func shortlistSizeText(
+        for choice: QuickstartModelChoice,
+        cached: ModelEntry?,
+        recommendedForPhysicalRAMGB physicalRAMGB: Double?
+    ) -> String {
+        let capability = physicalRAMGB.flatMap { gb in
+            RAMBucketedDefault.picks(forPhysicalRAMGB: gb)
+                .first { $0.alias == choice.alias }?
+                .capabilityPct
+        }
+        if let onDisk = cached?.sizeOnDisk, !onDisk.isEmpty {
+            guard let capability else { return onDisk }
+            return "\(onDisk) · \(capability)%"
+        }
+        guard let physicalRAMGB else { return sizeText(for: choice) }
+        return sizeText(forRecommended: choice, physicalRAMGB: physicalRAMGB)
     }
 
     /// Stable, bounded presentation for models already on disk. The catalogue

--- a/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ChatMessageActionsGoldenTests.swift
@@ -127,7 +127,12 @@ struct ChatMessageActionsGoldenTests {
         )
         try stage.press("ChatView.Message.SaveEdit.\(saveSuffix)")
         try await stage.wait(for: "the edited prompt to be sent") {
-            surface.fake.recordedPrompts().contains("saved edited message prompt")
+            // Prefix, not equality: the wire text of a user turn carries the
+            // per-turn clock trailer after the prose (see
+            // ``ChatViewModel.stampingClockContext``).
+            surface.fake.recordedPrompts().contains {
+                $0.hasPrefix("saved edited message prompt")
+            }
         }
         try await Self.waitForSettledReply(on: surface)
         #expect(stage.treeText().contains("saved edited message prompt"))

--- a/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
@@ -410,4 +410,40 @@ struct CurrentDateContextWireTests {
         #expect(user.contains("[CURRENT LOCAL TIME]"))
         #expect(user.contains("The current local time is "))
     }
+    @MainActor
+    @Test("An edited send gets the live clock; regenerate keeps the original ask time")
+    func reSendPathsReportTheRightClock() throws {
+        // codex asked what happens on retry/regenerate/edit. The answer is
+        // not uniform and is worth pinning, because each path reaches the
+        // stamper with a different row.
+        let calendar = Calendar(identifier: .gregorian)
+        let asked = Date(timeIntervalSince1970: 1_757_000_000)     // the original send
+        let later = asked.addingTimeInterval(13 * 60)              // thirteen minutes on
+
+        // Regenerate / Retry reuse the SAME row, so its trailer keeps the
+        // time the question was asked. Stamping is a pure function of the
+        // row, so re-running it later must not move the clock.
+        let reused = ChatMessage(role: .user, content: "what time is it?", createdAt: asked)
+        let firstPass = ChatViewModel.stampingClockContext(on: [reused], calendar: calendar)
+        let secondPass = ChatViewModel.stampingClockContext(on: firstPass, calendar: calendar)
+        #expect(firstPass[0].wireSuffix == secondPass[0].wireSuffix,
+                "Re-answering the same row must not change what that row renders, or every later turn loses the shared prefix.")
+        #expect(try #require(firstPass[0].wireSuffix).contains(
+            ChatViewModel.clockContext(at: asked, calendar: calendar)))
+
+        // An edited send mints a NEW row (editUserMessage rewinds and calls
+        // send, which defaults createdAt to Date()), so it reports the live
+        // clock — and that costs nothing, because the edited text has already
+        // broken the shared prefix at that row.
+        let freshlySent = ChatMessage(role: .user, content: "what time is it now?", createdAt: later)
+        let edited = ChatViewModel.stampingClockContext(on: [reused, freshlySent], calendar: calendar)
+        #expect(try #require(edited[1].wireSuffix).contains(
+            ChatViewModel.clockContext(at: later, calendar: calendar)))
+        #expect(edited[0].wireSuffix != edited[1].wireSuffix,
+                "Two rows sent thirteen minutes apart must not render the same clock.")
+        // And the earlier row is untouched by the new one arriving: that is
+        // the append-only property the prefix cache needs.
+        #expect(edited[0].wireSuffix == firstPass[0].wireSuffix)
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
@@ -55,7 +55,7 @@ struct CurrentDateTimeContextTests {
         )
         #expect(out == """
         [CURRENT DATE]
-        Today is Tuesday, August 25, 2026 (PDT, America/Los_Angeles).
+        Today is Tuesday, August 25, 2026 (America/Los_Angeles).
         """)
     }
 
@@ -78,6 +78,27 @@ struct CurrentDateTimeContextTests {
         #expect(!before.contains("AM"))
         #expect(!before.contains("PM"))
         #expect(!before.contains("time"))
+    }
+
+    @Test("The day-stable block carries no instant-specific zone abbreviation")
+    func systemRowHoldsStillAcrossADaylightSavingTransition() {
+        // codex round 4: "PST"/"PDT" flips mid-day at a DST transition, which
+        // would re-prefill every open conversation twice a year inside the one
+        // block this change exists to hold still. Same day, either side of the
+        // 2 a.m. spring-forward, must render identically.
+        let calendar = Self.calendar("America/Los_Angeles")
+        let beforeSpringForward = Self.instant("2026-03-08T09:30:00Z")  // 01:30 PST
+        let afterSpringForward = Self.instant("2026-03-08T11:30:00Z")   // 04:30 PDT
+        let before = ChatViewModel.currentDateContext(now: beforeSpringForward, calendar: calendar)
+        let after = ChatViewModel.currentDateContext(now: afterSpringForward, calendar: calendar)
+        #expect(before == after)
+        #expect(!before.contains("PST"))
+        #expect(!before.contains("PDT"))
+        #expect(before.contains("America/Los_Angeles"))
+        // The abbreviation still rides on the message trailer, where it
+        // describes a specific instant and so is correct.
+        #expect(ChatViewModel.clockContext(at: beforeSpringForward, calendar: calendar).contains("PST"))
+        #expect(ChatViewModel.clockContext(at: afterSpringForward, calendar: calendar).contains("PDT"))
     }
 
     @Test("The clock trailer pins the wall clock of the instant it stamps")

--- a/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
@@ -86,9 +86,14 @@ struct CurrentDateTimeContextTests {
             at: Self.instant("2026-08-25T14:37:00Z"),
             calendar: Self.calendar("America/Los_Angeles")
         )
+        // Send-time wording, and the DATE as well as the clock. Both because
+        // every user row in the history wears one of these: "the current
+        // local time" would have the prompt asserting three contradictory
+        // current times, and a bare clock on an old row would attach
+        // yesterday's time to today's [CURRENT DATE] across midnight.
         #expect(out == """
-        [CURRENT LOCAL TIME]
-        The current local time is 7:37 AM (PDT, America/Los_Angeles).
+        [MESSAGE SENT]
+        This message was sent Tuesday, August 25, 2026 at 7:37 AM (PDT, America/Los_Angeles).
         """)
     }
 
@@ -122,7 +127,7 @@ struct CurrentDateTimeContextTests {
         // longer match and the engine would re-prefill from that row onward.
         #expect(stamped[1].modelContent.hasSuffix("7:37 AM (PDT, America/Los_Angeles)."))
         #expect(stamped[3].modelContent.hasSuffix("7:41 AM (PDT, America/Los_Angeles)."))
-        #expect(stamped[1].modelContent.hasPrefix("first question\n\n[CURRENT LOCAL TIME]"))
+        #expect(stamped[1].modelContent.hasPrefix("first question\n\n[MESSAGE SENT]"))
         // Non-user rows are never stamped: the assistant transcript has to
         // stay byte-identical to what the model produced, and the system row
         // is exactly where the clock must not be.
@@ -174,11 +179,11 @@ struct CurrentDateTimeContextTests {
             role: .user, content: "what is the total?",
             fileAttachments: [attachment], status: .complete
         )
-        message.wireSuffix = "[CURRENT LOCAL TIME]\nThe current local time is 7:37 AM."
+        message.wireSuffix = "[MESSAGE SENT]\nThis message was sent at 7:37 AM."
 
         let wire = message.modelContent
         let extractIndex = try #require(wire.range(of: "TOTAL DUE 1,204.55"))
-        let trailerIndex = try #require(wire.range(of: "[CURRENT LOCAL TIME]"))
+        let trailerIndex = try #require(wire.range(of: "[MESSAGE SENT]"))
         #expect(extractIndex.upperBound < trailerIndex.lowerBound,
                 "The trailer must follow the extract, or the prompt diverges before the document and the cache cannot reuse it.")
         #expect(wire.hasPrefix("what is the total?"))
@@ -187,8 +192,8 @@ struct CurrentDateTimeContextTests {
     @Test("An empty-prose row gains no leading blank line from the trailer")
     func blankPromptDoesNotGainLeadingNewlines() {
         var message = ChatMessage(role: .user, content: "   ", status: .complete)
-        message.wireSuffix = "[CURRENT LOCAL TIME]\nThe current local time is 7:37 AM."
-        #expect(message.modelContent.hasPrefix("[CURRENT LOCAL TIME]"))
+        message.wireSuffix = "[MESSAGE SENT]\nThis message was sent at 7:37 AM."
+        #expect(message.modelContent.hasPrefix("[MESSAGE SENT]"))
     }
 
     @Test("A blank trailer is dropped rather than appended")
@@ -201,7 +206,7 @@ struct CurrentDateTimeContextTests {
     @Test("The wire-only trailer is not persisted")
     func trailerIsNotPersisted() throws {
         var message = ChatMessage(role: .user, content: "hello", status: .complete)
-        message.wireSuffix = "[CURRENT LOCAL TIME]\nThe current local time is 7:37 AM."
+        message.wireSuffix = "[MESSAGE SENT]\nThis message was sent at 7:37 AM."
         let round = try JSONDecoder().decode(
             ChatMessage.self, from: JSONEncoder().encode(message)
         )
@@ -400,15 +405,15 @@ struct CurrentDateContextWireTests {
         #expect(system.contains("Today is "))
         // The wall clock must NOT be in the system row — it is the first
         // thing in the prompt and a minute tick there costs a full re-prefill.
-        #expect(!system.contains("[CURRENT LOCAL TIME]"))
+        #expect(!system.contains("[MESSAGE SENT]"))
         // …and it must still be on the wire, on the user turn, so #2330's
         // "the model is told the current time" contract survives the split.
         let user = try #require(
             messages.first { $0["role"] as? String == "user" }?["content"] as? String
         )
         #expect(user.contains("what is the date today"))
-        #expect(user.contains("[CURRENT LOCAL TIME]"))
-        #expect(user.contains("The current local time is "))
+        #expect(user.contains("[MESSAGE SENT]"))
+        #expect(user.contains("This message was sent "))
     }
     @MainActor
     @Test("An edited send gets the live clock; regenerate keeps the original ask time")

--- a/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
@@ -6,12 +6,25 @@ import Testing
 /// small model answered "what is the date today" with a training-memory date
 /// ("Friday, May 24, 2024") and then claimed it could not know today's date.
 ///
-/// The fix injects the Mac's local date/time/time-zone into the leading
-/// system prompt row as a request-time template variable (the established
-/// desktop-chat pattern), so the model never has to guess the date or infer it
-/// must search for it. These tests pin the pure formatter with an injected
-/// clock/time-zone and prove it stays correct across time zones, midnight
-/// rollover, and a restored conversation.
+/// The fix injects the Mac's local date/time/time-zone as a request-time
+/// template variable (the established desktop-chat pattern), so the model
+/// never has to guess the date or infer it must search for it.
+///
+/// 0.14.1 dogfood split that context in two, and these tests pin the split as
+/// much as the original contract. The DATE goes in the leading system row; the
+/// wall CLOCK rides each user turn as a wire-only trailer. Putting a
+/// minute-resolution string at the head of the prompt rewrote the first tokens
+/// of every request the moment the clock ticked, which cost the engine's
+/// prompt cache its prefix and re-prefilled the whole conversation — measured
+/// at 7.3 s against 0.6 s on a 2.3k-token prompt, and 15–17 s per follow-up
+/// with an 8-page PDF attached. So the assertions below care about two things
+/// that look pedantic and are not:
+///
+///   * the system row contains NO minute, and is byte-identical across a
+///     minute boundary (`systemRowIsStableAcrossAMinute`);
+///   * the clock trailer is derived from each row's immutable `createdAt`, so
+///     every request is a strict EXTENSION of the previous one rather than a
+///     rewrite of its tail (`stampsEveryUserRowFromItsOwnCreatedAt`).
 @Suite("Current date context")
 struct CurrentDateTimeContextTests {
 
@@ -33,27 +46,178 @@ struct CurrentDateTimeContextTests {
         iso.date(from: string)!
     }
 
-    @Test("The injected clock/time-zone pins today's local date, time, and zone")
-    func pinnedLocalDateTime() {
+    @Test("The injected clock/time-zone pins today's local date and zone")
+    func pinnedLocalDate() {
         let calendar = Self.calendar("America/Los_Angeles")
-        let out = ChatViewModel.currentDateTimeContext(
+        let out = ChatViewModel.currentDateContext(
             now: Self.instant("2026-08-25T14:37:00Z"),
             calendar: calendar
         )
-        #expect(out.contains("[CURRENT DATE AND TIME]"))
-        #expect(out.contains(
-            "Today is Tuesday, August 25, 2026. The current local time is 7:37 AM"
-        ))
-        #expect(out.contains("(PDT, America/Los_Angeles)"))
+        #expect(out == """
+        [CURRENT DATE]
+        Today is Tuesday, August 25, 2026 (PDT, America/Los_Angeles).
+        """)
+    }
+
+    @Test("The system row carries no wall clock and survives a minute boundary")
+    func systemRowIsStableAcrossAMinute() {
+        let calendar = Self.calendar("America/Los_Angeles")
+        // 07:37:59 and 07:38:01 local — a minute boundary crossed mid-chat,
+        // which is the common case for a follow-up question.
+        let before = ChatViewModel.currentDateContext(
+            now: Self.instant("2026-08-25T14:37:59Z"), calendar: calendar
+        )
+        let after = ChatViewModel.currentDateContext(
+            now: Self.instant("2026-08-25T14:38:01Z"), calendar: calendar
+        )
+        #expect(before == after,
+                "A minute tick must not change the head of the prompt — that is the whole prefix-cache fix; a differing system row re-prefills the entire conversation.")
+        // No minute, no AM/PM, no ":" — belt and braces against someone
+        // re-adding a "7:38 AM" to this row.
+        #expect(!before.contains(":"))
+        #expect(!before.contains("AM"))
+        #expect(!before.contains("PM"))
+        #expect(!before.contains("time"))
+    }
+
+    @Test("The clock trailer pins the wall clock of the instant it stamps")
+    func clockContextPinsTheInstant() {
+        let out = ChatViewModel.clockContext(
+            at: Self.instant("2026-08-25T14:37:00Z"),
+            calendar: Self.calendar("America/Los_Angeles")
+        )
+        #expect(out == """
+        [CURRENT LOCAL TIME]
+        The current local time is 7:37 AM (PDT, America/Los_Angeles).
+        """)
+    }
+
+    @Test("Every user row is stamped from its own createdAt; other roles are untouched")
+    func stampsEveryUserRowFromItsOwnCreatedAt() {
+        let calendar = Self.calendar("America/Los_Angeles")
+        let first = ChatMessage(
+            role: .user, content: "first question", status: .complete,
+            createdAt: Self.instant("2026-08-25T14:37:00Z")
+        )
+        let answer = ChatMessage(
+            role: .assistant, content: "first answer", status: .complete,
+            createdAt: Self.instant("2026-08-25T14:37:30Z")
+        )
+        let second = ChatMessage(
+            role: .user, content: "follow-up", status: .complete,
+            createdAt: Self.instant("2026-08-25T14:41:00Z")
+        )
+        let system = ChatMessage(
+            role: .system, content: "app context", status: .complete,
+            createdAt: Self.instant("2026-08-25T14:36:00Z")
+        )
+
+        let stamped = ChatViewModel.stampingClockContext(
+            on: [system, first, answer, second], calendar: calendar
+        )
+
+        // The OLDER user row keeps its own 7:37 — not "now". This is what
+        // makes turn two a strict extension of turn one: had the first row
+        // been restamped (or its trailer removed), the stored prefix would no
+        // longer match and the engine would re-prefill from that row onward.
+        #expect(stamped[1].modelContent.hasSuffix("7:37 AM (PDT, America/Los_Angeles)."))
+        #expect(stamped[3].modelContent.hasSuffix("7:41 AM (PDT, America/Los_Angeles)."))
+        #expect(stamped[1].modelContent.hasPrefix("first question\n\n[CURRENT LOCAL TIME]"))
+        // Non-user rows are never stamped: the assistant transcript has to
+        // stay byte-identical to what the model produced, and the system row
+        // is exactly where the clock must not be.
+        #expect(stamped[0].wireSuffix == nil)
+        #expect(stamped[2].wireSuffix == nil)
+        #expect(stamped[2].modelContent == "first answer")
+    }
+
+    @Test("Re-stamping the same history is idempotent")
+    func stampingIsIdempotent() {
+        let calendar = Self.calendar("America/Los_Angeles")
+        let history = [
+            ChatMessage(
+                role: .user, content: "hello", status: .complete,
+                createdAt: Self.instant("2026-08-25T14:37:00Z")
+            )
+        ]
+        let once = ChatViewModel.stampingClockContext(on: history, calendar: calendar)
+        let twice = ChatViewModel.stampingClockContext(on: once, calendar: calendar)
+        #expect(once.first?.modelContent == twice.first?.modelContent,
+                "Stamping twice must not glue on two trailers — the wire text has to be a pure function of the row.")
+    }
+
+    @Test("A history with no user row passes through untouched")
+    func noUserRowPassesThrough() {
+        let history = [
+            ChatMessage(role: .system, content: "app context", status: .complete)
+        ]
+        let stamped = ChatViewModel.stampingClockContext(
+            on: history, calendar: Self.calendar("America/Los_Angeles")
+        )
+        #expect(stamped.first?.wireSuffix == nil)
+        #expect(stamped.first?.modelContent == "app context")
+    }
+
+    @Test("The clock trailer lands AFTER the attachment extract")
+    func trailerFollowsTheDocumentExtract() throws {
+        // Ordering is load-bearing, not cosmetic. The document extract is the
+        // expensive part of the prompt and the part the cache must find
+        // unchanged; a trailer placed in FRONT of it would make two requests
+        // diverge BEFORE the document, so none of its tokens could be reused.
+        let attachment = try ChatFileAttachment(
+            filename: "invoice.pdf",
+            kind: .pdf,
+            extractedText: "TOTAL DUE 1,204.55",
+            sourceByteCount: 18
+        )
+        var message = ChatMessage(
+            role: .user, content: "what is the total?",
+            fileAttachments: [attachment], status: .complete
+        )
+        message.wireSuffix = "[CURRENT LOCAL TIME]\nThe current local time is 7:37 AM."
+
+        let wire = message.modelContent
+        let extractIndex = try #require(wire.range(of: "TOTAL DUE 1,204.55"))
+        let trailerIndex = try #require(wire.range(of: "[CURRENT LOCAL TIME]"))
+        #expect(extractIndex.upperBound < trailerIndex.lowerBound,
+                "The trailer must follow the extract, or the prompt diverges before the document and the cache cannot reuse it.")
+        #expect(wire.hasPrefix("what is the total?"))
+    }
+
+    @Test("An empty-prose row gains no leading blank line from the trailer")
+    func blankPromptDoesNotGainLeadingNewlines() {
+        var message = ChatMessage(role: .user, content: "   ", status: .complete)
+        message.wireSuffix = "[CURRENT LOCAL TIME]\nThe current local time is 7:37 AM."
+        #expect(message.modelContent.hasPrefix("[CURRENT LOCAL TIME]"))
+    }
+
+    @Test("A blank trailer is dropped rather than appended")
+    func blankTrailerIsDropped() {
+        var message = ChatMessage(role: .user, content: "hello", status: .complete)
+        message.wireSuffix = "  \n "
+        #expect(message.modelContent == "hello")
+    }
+
+    @Test("The wire-only trailer is not persisted")
+    func trailerIsNotPersisted() throws {
+        var message = ChatMessage(role: .user, content: "hello", status: .complete)
+        message.wireSuffix = "[CURRENT LOCAL TIME]\nThe current local time is 7:37 AM."
+        let round = try JSONDecoder().decode(
+            ChatMessage.self, from: JSONEncoder().encode(message)
+        )
+        #expect(round.wireSuffix == nil,
+                "The clock belongs to one request, not to the conversation — persisting it would replay a stale time forever and bloat conversations.json.")
+        #expect(round.content == "hello")
+        #expect(round.modelContent == "hello")
     }
 
     @Test("The same instant reads a different local date across time zones")
     func timeZoneChangesTheLocalDate() {
         let instant = Self.instant("2026-08-25T06:00:00Z")
-        let la = ChatViewModel.currentDateTimeContext(
+        let la = ChatViewModel.currentDateContext(
             now: instant, calendar: Self.calendar("America/Los_Angeles")
         )
-        let tokyo = ChatViewModel.currentDateTimeContext(
+        let tokyo = ChatViewModel.currentDateContext(
             now: instant, calendar: Self.calendar("Asia/Tokyo")
         )
         // 06:00Z is still August 24 in Los Angeles but already August 25 in
@@ -66,20 +230,31 @@ struct CurrentDateTimeContextTests {
 
     @Test("The context rolls over to a new date across local midnight")
     func dateRollsOverAtLocalMidnight() {
-        let before = ChatViewModel.currentDateTimeContext(
+        let before = ChatViewModel.currentDateContext(
             now: Self.instant("2026-08-25T06:59:59Z"),
             calendar: Self.calendar("America/Los_Angeles")
         )
-        let after = ChatViewModel.currentDateTimeContext(
+        let after = ChatViewModel.currentDateContext(
             now: Self.instant("2026-08-25T07:00:01Z"),
             calendar: Self.calendar("America/Los_Angeles")
         )
         // 23:59 PDT is still Monday Aug 24; 00:00 PDT is Tuesday Aug 25.
+        // Day granularity means a conversation spanning local midnight
+        // re-prefills exactly once — the accepted price of #2330's guarantee.
         #expect(before.contains("Monday, August 24, 2026"))
-        #expect(before.contains("11:59 PM"))
         #expect(after.contains("Tuesday, August 25, 2026"))
-        #expect(after.contains("12:00 AM"))
         #expect(before != after)
+        // The clock trailer rolls over too, from the same instants.
+        let clockBefore = ChatViewModel.clockContext(
+            at: Self.instant("2026-08-25T06:59:59Z"),
+            calendar: Self.calendar("America/Los_Angeles")
+        )
+        let clockAfter = ChatViewModel.clockContext(
+            at: Self.instant("2026-08-25T07:00:01Z"),
+            calendar: Self.calendar("America/Los_Angeles")
+        )
+        #expect(clockBefore.contains("11:59 PM"))
+        #expect(clockAfter.contains("12:00 AM"))
     }
 
     @Test("Date context merges into a restored conversation's single system row")
@@ -90,7 +265,7 @@ struct CurrentDateTimeContextTests {
             content: "App system context", status: .complete
         )
         let user = ChatMessage(role: .user, content: "Hello", status: .complete)
-        let dateContext = ChatViewModel.currentDateTimeContext(
+        let dateContext = ChatViewModel.currentDateContext(
             now: Self.instant("2026-08-25T14:37:00Z"),
             calendar: Self.calendar("America/Los_Angeles")
         )
@@ -105,7 +280,7 @@ struct CurrentDateTimeContextTests {
         #expect(result.filter { $0.role == .system }.count == 1,
                 "restored + date context must stay one system row")
         let content = result.first?.content ?? ""
-        #expect(content.contains("[CURRENT DATE AND TIME]"))
+        #expect(content.contains("[CURRENT DATE]"))
         #expect(content.contains("Today is Tuesday, August 25, 2026"))
         #expect(content.contains("App system context"))
         #expect(result.last?.id == user.id)
@@ -221,7 +396,18 @@ struct CurrentDateContextWireTests {
         let messages = try #require(json["messages"] as? [[String: Any]])
         #expect(messages.filter { $0["role"] as? String == "system" }.count == 1)
         let system = try #require(messages.first?["content"] as? String)
-        #expect(system.contains("[CURRENT DATE AND TIME]"))
+        #expect(system.contains("[CURRENT DATE]"))
         #expect(system.contains("Today is "))
+        // The wall clock must NOT be in the system row — it is the first
+        // thing in the prompt and a minute tick there costs a full re-prefill.
+        #expect(!system.contains("[CURRENT LOCAL TIME]"))
+        // …and it must still be on the wire, on the user turn, so #2330's
+        // "the model is told the current time" contract survives the split.
+        let user = try #require(
+            messages.first { $0["role"] as? String == "user" }?["content"] as? String
+        )
+        #expect(user.contains("what is the date today"))
+        #expect(user.contains("[CURRENT LOCAL TIME]"))
+        #expect(user.contains("The current local time is "))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
@@ -472,4 +472,67 @@ struct CurrentDateContextWireTests {
         #expect(edited[0].wireSuffix == firstPass[0].wireSuffix)
     }
 
+    @Test("A late regenerate appends the answer time without rewriting the ask")
+    func lateRegenerateAppendsTheAnswerTime() throws {
+        // codex round 5, blocking: reusing the row meant re-answering "what
+        // time is it?" 45 minutes later reported the 45-minute-old clock —
+        // worse than the pre-change behaviour, which recomputed per request.
+        let calendar = Calendar(identifier: .gregorian)
+        let asked = Date(timeIntervalSince1970: 1_757_000_000)
+        let muchLater = asked.addingTimeInterval(45 * 60)
+
+        let earlier = ChatMessage(role: .user, content: "hello", createdAt: asked.addingTimeInterval(-3600))
+        let reused = ChatMessage(role: .user, content: "what time is it?", createdAt: asked)
+        let regenerated = ChatViewModel.stampingClockContext(
+            on: [earlier, reused],
+            calendar: calendar,
+            answeringAt: muchLater
+        )
+        let trailer = try #require(regenerated[1].wireSuffix)
+
+        // The ask stamp is untouched and still leads: APPEND, not rewrite, so
+        // the row's own rendering never changes retroactively.
+        #expect(trailer.hasPrefix(ChatViewModel.clockContext(at: asked, calendar: calendar)))
+        // And the answer time is actually there, so the model can answer the
+        // question it was asked.
+        #expect(trailer.contains(ChatViewModel.clockStampText(at: muchLater, calendar: calendar)))
+        #expect(trailer.contains("This answer is being generated"))
+
+        // Only the newest user row. An earlier turn renders exactly as it did
+        // before, which is the append-only property the prefix cache needs.
+        #expect(regenerated[0].wireSuffix
+            == ChatViewModel.clockContext(at: earlier.createdAt, calendar: calendar))
+    }
+
+    @Test("An ordinary send and a same-minute regenerate add nothing at all")
+    func sameMinuteAnswerAddsNothing() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let asked = Date(timeIntervalSince1970: 1_757_000_000)
+        let row = ChatMessage(role: .user, content: "what time is it?", createdAt: asked)
+
+        // The common path: the row was minted by this very request.
+        let fresh = ChatViewModel.stampingClockContext(on: [row], calendar: calendar, answeringAt: asked)
+        let unstamped = ChatViewModel.stampingClockContext(on: [row], calendar: calendar)
+        #expect(fresh[0].wireSuffix == unstamped[0].wireSuffix,
+                "Passing this request's own instant must be byte-identical to passing nothing, or every ordinary send pays for the regenerate feature.")
+
+        // A regenerate twenty seconds on renders the same minute, so it still
+        // says nothing new and still costs no prefix.
+        let prompt = ChatViewModel.stampingClockContext(
+            on: [row], calendar: calendar, answeringAt: asked.addingTimeInterval(20))
+        #expect(prompt[0].wireSuffix == unstamped[0].wireSuffix)
+    }
+
+    @Test("answeringNowLine speaks only when it has something to say")
+    func answeringNowLineContract() {
+        let calendar = Calendar(identifier: .gregorian)
+        let asked = Date(timeIntervalSince1970: 1_757_000_000)
+        #expect(ChatViewModel.answeringNowLine(asked: asked, answeringAt: asked, calendar: calendar) == "")
+        #expect(ChatViewModel.answeringNowLine(
+            asked: asked, answeringAt: asked.addingTimeInterval(30), calendar: calendar) == "",
+                "Sub-minute differences render identically; emitting a line for them would break the prefix for nothing.")
+        #expect(!ChatViewModel.answeringNowLine(
+            asked: asked, answeringAt: asked.addingTimeInterval(90), calendar: calendar).isEmpty)
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CurrentDateTimeContextTests.swift
@@ -535,4 +535,34 @@ struct CurrentDateContextWireTests {
             asked: asked, answeringAt: asked.addingTimeInterval(90), calendar: calendar).isEmpty)
     }
 
+    @Test("The system row and the message trailer agree on the date")
+    func oneInstantRendersOneDate() {
+        // codex round 6, blocking: the send site sampled `Date()` twice, once
+        // for the system row and once for the clock trailer, so a request
+        // assembled across local midnight could say "Today is the 11th" and
+        // "this message was sent … the 12th" in the same prompt. The send site
+        // now threads one `requestInstant` into both. This pins the other half
+        // — that both renderings agree on the calendar day for a shared
+        // instant, including right at the boundary, where a mismatched
+        // calendar or time zone between the two formatters would show up.
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try! #require(TimeZone(identifier: "America/Los_Angeles"))
+        var components = DateComponents()
+        components.year = 2026; components.month = 9; components.day = 11
+        components.hour = 23; components.minute = 59; components.second = 59
+        let justBefore = calendar.date(from: components)!
+
+        for instant in [justBefore, justBefore.addingTimeInterval(1)] {
+            let systemRow = ChatViewModel.currentDateContext(now: instant, calendar: calendar)
+            let trailer = ChatViewModel.clockContext(at: instant, calendar: calendar)
+            // "Today is <EEEE, MMMM d, yyyy> (zone)." vs "… sent <EEEE,
+            // MMMM d, yyyy> at <time> (…)." — the date text is shared.
+            let day = systemRow
+                .replacingOccurrences(of: "[CURRENT DATE]\nToday is ", with: "")
+                .replacingOccurrences(of: " (America/Los_Angeles).", with: "")
+            #expect(trailer.contains(day),
+                    "The system row says \(day) but the trailer is \(trailer).")
+        }
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
@@ -137,8 +137,8 @@ struct CustomInstructionsTests {
             conversation: "Conversation"
         )
 
-        #expect(before.contains("Tuesday, August 25, 2026 (GMT, GMT)"))
-        #expect(after.contains("Wednesday, August 26, 2026 (GMT, GMT)"))
+        #expect(before.contains("Tuesday, August 25, 2026 (GMT)"))
+        #expect(after.contains("Wednesday, August 26, 2026 (GMT)"))
         #expect(before != after)
         // The preview shows what Rapid actually sends in the system row, and
         // since 0.14.1 that is the DATE only — the wall clock rides each user
@@ -158,7 +158,7 @@ struct CustomInstructionsTests {
             global: "Global",
             conversation: "Conversation"
         )
-        #expect(tokyoPreview.contains("Wednesday, August 26, 2026 (GMT+9, Asia/Tokyo)"))
+        #expect(tokyoPreview.contains("Wednesday, August 26, 2026 (Asia/Tokyo)"))
         #expect(tokyoPreview != before)
     }
 

--- a/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
@@ -99,12 +99,12 @@ struct CustomInstructionsTests {
     @Test("Effective prompt preview uses the wire assembly and includes automatic context")
     func effectivePromptPreviewUsesWireAssembly() {
         let preview = ChatViewModel.effectiveSystemPrompt(
-            dateContext: "[CURRENT DATE AND TIME]\nToday is Tuesday, August 25, 2026.",
+            dateContext: "[CURRENT DATE]\nToday is Tuesday, August 25, 2026.",
             global: "Reply in plain language.",
             conversation: "Use bullet points."
         )
 
-        #expect(preview.hasPrefix("[CURRENT DATE AND TIME]"))
+        #expect(preview.hasPrefix("[CURRENT DATE]"))
         #expect(preview.contains("[GLOBAL USER INSTRUCTIONS]"))
         #expect(preview.contains("Reply in plain language."))
         #expect(preview.contains("[CONVERSATION INSTRUCTIONS - HIGHEST USER PRIORITY]"))
@@ -137,10 +137,18 @@ struct CustomInstructionsTests {
             conversation: "Conversation"
         )
 
-        #expect(before.contains("Tuesday, August 25, 2026"))
-        #expect(before.contains("11:59 PM (GMT, GMT)"))
-        #expect(after.contains("Wednesday, August 26, 2026"))
-        #expect(after.contains("12:01 AM (GMT, GMT)"))
+        #expect(before.contains("Tuesday, August 25, 2026 (GMT, GMT)"))
+        #expect(after.contains("Wednesday, August 26, 2026 (GMT, GMT)"))
+        #expect(before != after)
+        // The preview shows what Rapid actually sends in the system row, and
+        // since 0.14.1 that is the DATE only — the wall clock rides each user
+        // turn instead, because a minute-resolution string at the head of the
+        // prompt costs the engine's prefix cache a full re-prefill of the
+        // conversation (measured 7.3 s vs 0.6 s). A preview that still quoted
+        // a time would be showing a system row the app never sends.
+        #expect(!before.contains("11:59 PM"))
+        #expect(!after.contains("12:01 AM"))
+        #expect(!before.contains("[CURRENT LOCAL TIME]"))
 
         var tokyo = utc
         tokyo.timeZone = try #require(TimeZone(identifier: "Asia/Tokyo"))
@@ -150,8 +158,7 @@ struct CustomInstructionsTests {
             global: "Global",
             conversation: "Conversation"
         )
-        #expect(tokyoPreview.contains("Wednesday, August 26, 2026"))
-        #expect(tokyoPreview.contains("8:59 AM (GMT+9, Asia/Tokyo)"))
+        #expect(tokyoPreview.contains("Wednesday, August 26, 2026 (GMT+9, Asia/Tokyo)"))
         #expect(tokyoPreview != before)
     }
 
@@ -168,6 +175,10 @@ struct CustomInstructionsTests {
         #expect(editor.contains("this prompt wins."))
         #expect(editor.contains("DisclosureGroup(\"Effective System Prompt\""))
         #expect(editor.contains("Tool and attachment context may be added when you send."))
+        // The system row no longer carries the wall clock, so the caption has
+        // to say where it went — otherwise the preview reads as "the model
+        // does not know what time it is".
+        #expect(editor.contains("The current time is attached to each message you send."))
         #expect(editor.contains("TimelineView(.periodic(from: .now, by: 60))"))
         #expect(editor.contains("at: context.date"))
         #expect(editor.contains("calendar: .autoupdatingCurrent"))

--- a/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/CustomInstructionsTests.swift
@@ -148,7 +148,7 @@ struct CustomInstructionsTests {
         // a time would be showing a system row the app never sends.
         #expect(!before.contains("11:59 PM"))
         #expect(!after.contains("12:01 AM"))
-        #expect(!before.contains("[CURRENT LOCAL TIME]"))
+        #expect(!before.contains("[MESSAGE SENT]"))
 
         var tokyo = utc
         tokyo.timeZone = try #require(TimeZone(identifier: "Asia/Tokyo"))
@@ -178,7 +178,7 @@ struct CustomInstructionsTests {
         // The system row no longer carries the wall clock, so the caption has
         // to say where it went — otherwise the preview reads as "the model
         // does not know what time it is".
-        #expect(editor.contains("The current time is attached to each message you send."))
+        #expect(editor.contains("Each message you send carries the time you sent it."))
         #expect(editor.contains("TimelineView(.periodic(from: .now, by: 60))"))
         #expect(editor.contains("at: context.date"))
         #expect(editor.contains("calendar: .autoupdatingCurrent"))

--- a/apps/rapid-mac/Tests/RapidTests/GoldenChatFakeContractTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GoldenChatFakeContractTests.swift
@@ -37,6 +37,16 @@ struct GoldenChatFakeContractTests {
         let surface = GoldenChatSurface.mount()
         try await surface.sendPrompt("probe prompt")
         try await surface.waitForSendIdle()
-        #expect(surface.fake.recordedPrompts() == ["probe prompt"])
+        // The mounted surface goes through the real request assembly, so the
+        // recorded prompt is the WIRE text: the user's prose followed by the
+        // per-turn clock trailer. Asserting both halves here makes this golden
+        // flow the end-to-end proof that #2330's "the model is told the
+        // current time" contract survived moving the clock off the system row
+        // (see ``ChatViewModel.stampingClockContext``).
+        let recorded = try #require(surface.fake.recordedPrompts().first)
+        #expect(surface.fake.recordedPrompts().count == 1)
+        #expect(recorded.hasPrefix("probe prompt"))
+        #expect(recorded.contains("[CURRENT LOCAL TIME]"))
+        #expect(recorded.contains("The current local time is "))
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/GoldenChatFakeContractTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/GoldenChatFakeContractTests.swift
@@ -46,7 +46,68 @@ struct GoldenChatFakeContractTests {
         let recorded = try #require(surface.fake.recordedPrompts().first)
         #expect(surface.fake.recordedPrompts().count == 1)
         #expect(recorded.hasPrefix("probe prompt"))
-        #expect(recorded.contains("[CURRENT LOCAL TIME]"))
-        #expect(recorded.contains("The current local time is "))
+        #expect(recorded.contains("[MESSAGE SENT]"))
+        #expect(recorded.contains("This message was sent "))
+    }
+
+    @MainActor
+    @Test("Regenerate reuses the user row; an edited send mints a new one")
+    func resendPathsMintOrReuseTheUserRow() async throws {
+        // codex asked for the REAL resend paths, not the stamper in isolation:
+        // a test that constructs rows by hand stays green if
+        // ``editUserMessage`` or ``regenerateAnswer`` stops minting or reusing
+        // rows correctly. This drives both through the mounted surface and
+        // reads the recorded wire bodies back.
+        let surface = GoldenChatSurface.mount()
+        try await surface.sendPrompt("first question")
+        try await surface.waitForSendIdle()
+
+        let firstRow = try #require(surface.chat.messages.first { $0.role == .user })
+        let firstWire = try #require(surface.fake.recordedPrompts().last)
+        let firstTrailer = try #require(
+            firstWire.range(of: "[MESSAGE SENT]").map { String(firstWire[$0.lowerBound...]) }
+        )
+
+        // Regenerate: the SAME row is re-sent, so the trailer must come back
+        // byte-identical. If it moved, every later turn in this conversation
+        // would lose the shared prefix.
+        let beforeRegenerate = surface.fake.recordedBodies().count
+        surface.chat.regenerateLast(alias: GoldenChatSurface.alias)
+        try await surface.stage.wait(for: "the regenerated request to be recorded") {
+            surface.fake.recordedBodies().count > beforeRegenerate
+        }
+        try await surface.waitForSendIdle()
+        let regeneratedRow = try #require(surface.chat.messages.first { $0.role == .user })
+        #expect(regeneratedRow.id == firstRow.id)
+        #expect(regeneratedRow.createdAt == firstRow.createdAt)
+        let regeneratedWire = try #require(surface.fake.recordedPrompts().last)
+        #expect(regeneratedWire == firstWire,
+                "Re-answering the same question must re-render it identically, trailer included.")
+        #expect(regeneratedWire.hasSuffix(firstTrailer))
+
+        // An edited send rewinds and calls `send`, which mints a fresh row —
+        // so it reports the live clock. Asserted on `createdAt` rather than on
+        // the rendered text, because the trailer has minute resolution and a
+        // test that edits within the same minute would see the same string.
+        #expect(surface.fake.recordedBodies().count == beforeRegenerate + 1,
+                "Sanity check: regenerate really did send a second request.")
+        let edited = surface.chat.editUserMessage(
+            id: firstRow.id,
+            newContent: "edited question",
+            alias: GoldenChatSurface.alias
+        )
+        #expect(edited, "editUserMessage must not be refused on a settled surface.")
+        try await surface.stage.wait(for: "the edited request to be recorded") {
+            surface.fake.recordedBodies().count > beforeRegenerate + 1
+        }
+        try await surface.waitForSendIdle()
+        let editedRow = try #require(surface.chat.messages.first { $0.role == .user })
+        #expect(editedRow.id != firstRow.id, "An edited send must mint a new row.")
+        #expect(editedRow.createdAt >= firstRow.createdAt)
+        let editedWire = try #require(surface.fake.recordedPrompts().last)
+        #expect(editedWire.hasPrefix("edited question"))
+        #expect(editedWire.contains(
+            ChatViewModel.clockContext(at: editedRow.createdAt)
+        ), "The edited row's trailer must be stamped from its OWN createdAt.")
     }
 }

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartShortlistLabelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartShortlistLabelTests.swift
@@ -1,0 +1,123 @@
+import Testing
+@testable import Rapid
+
+/// 0.14.1 dogfood: on a Mac that already held `qwen3.6-35b-4bit` — all 19.03
+/// GiB of it — the Quickstart shortlist offered it as "download 20 GB · 87%",
+/// three rows under an "ALREADY ON THIS MAC" heading, next to a rail reading
+/// "Free space 6 GB". Following that row means a 20 GB download the user does
+/// not need and, at 6 GB free, cannot finish.
+///
+/// The cause was lane-shaped, not data-shaped: the cached shortlist is bounded
+/// to six rows, so a seventh cached model is rendered by one of the
+/// download-shaped lanes — and only the trade-up lane passed `isCached`. These
+/// tests hold all four lanes to the same contract.
+@MainActor
+@Suite("Quickstart shortlist labels the models already on disk")
+struct QuickstartShortlistLabelTests {
+
+    private func entry(_ alias: String, sizeOnDisk: String? = "19.03 GiB") -> ModelEntry {
+        ModelEntry(
+            alias: alias,
+            hfRepo: "mlx-community/\(alias)",
+            sizeOnDisk: sizeOnDisk,
+            cached: true
+        )
+    }
+
+    @Test("A cached model quotes its bytes on disk, never a download estimate")
+    func cachedQuotesBytesOnDisk() {
+        let choice = QuickstartCoordinator.lowMemoryChoice
+        let download = QuickstartView.sizeText(for: choice)
+        let cached = QuickstartView.shortlistSizeText(
+            for: choice,
+            cached: entry(choice.alias),
+            recommendedForPhysicalRAMGB: nil
+        )
+        #expect(cached == "19.03 GiB")
+        #expect(cached != download)
+    }
+
+    @Test("A cached recommendation keeps its capability score")
+    func cachedKeepsCapabilityScore() throws {
+        // Derived from the SSOT rather than hard-coded, so a policy refresh
+        // does not silently retarget this test at a different model.
+        let ram = 256.0
+        let pick = try #require(RAMBucketedDefault.picks(forPhysicalRAMGB: ram).first)
+        let choice = QuickstartCoordinator.choice(forAlias: pick.alias)
+
+        let cached = QuickstartView.shortlistSizeText(
+            for: choice,
+            cached: entry(pick.alias),
+            recommendedForPhysicalRAMGB: ram
+        )
+        // Being on disk changes what it costs, not how capable it is.
+        #expect(cached == "19.03 GiB · \(pick.capabilityPct)%")
+    }
+
+    @Test("An uncached row is byte-identical to the lane it replaced")
+    func uncachedLanesAreUnchanged() {
+        // The fix must be invisible on a fresh Mac — any drift here is a
+        // regression in first-run copy, which is the most-seen screen we ship.
+        let ram = 64.0
+        for choice in QuickstartCoordinator.onboardingChoices {
+            #expect(
+                QuickstartView.shortlistSizeText(
+                    for: choice, cached: nil, recommendedForPhysicalRAMGB: nil
+                ) == QuickstartView.sizeText(for: choice)
+            )
+            #expect(
+                QuickstartView.shortlistSizeText(
+                    for: choice, cached: nil, recommendedForPhysicalRAMGB: ram
+                ) == QuickstartView.sizeText(forRecommended: choice, physicalRAMGB: ram)
+            )
+        }
+    }
+
+    @Test("A cached entry with no size falls back rather than showing nothing")
+    func cachedWithoutSizeFallsBack() {
+        // `rapid-mlx ls` can hand back a row with no size (an external model,
+        // a partial snapshot). An empty size lane would read as "free".
+        let choice = QuickstartCoordinator.lowMemoryChoice
+        for blank in [nil, ""] as [String?] {
+            #expect(
+                QuickstartView.shortlistSizeText(
+                    for: choice,
+                    cached: entry(choice.alias, sizeOnDisk: blank),
+                    recommendedForPhysicalRAMGB: nil
+                ) == QuickstartView.sizeText(for: choice)
+            )
+        }
+    }
+
+    @Test("VoiceOver says \"on disk\", not \"download\", in every lane")
+    func spokenLabelsFollowTheCachedState() {
+        let choice = QuickstartCoordinator.lowMemoryChoice
+        let recommendedCached = QuickstartRecommendedCard.accessibilityText(
+            for: choice, sizeText: "19.03 GiB", isCached: true
+        )
+        #expect(recommendedCached.contains("on disk 19.03 GiB"))
+        #expect(!recommendedCached.contains("download"))
+
+        let recommendedFresh = QuickstartRecommendedCard.accessibilityText(
+            for: choice, sizeText: "633 MB", isCached: false
+        )
+        #expect(recommendedFresh.contains("download 633 MB"))
+
+        let lowMemoryCached = QuickstartLowMemoryCard.accessibilityText(
+            for: choice, sizeText: "19.03 GiB", isCached: true
+        )
+        #expect(lowMemoryCached.contains("On disk 19.03 GiB"))
+        #expect(!lowMemoryCached.lowercased().contains("download"))
+
+        let lowMemoryFresh = QuickstartLowMemoryCard.accessibilityText(
+            for: choice, sizeText: "633 MB", isCached: false
+        )
+        #expect(lowMemoryFresh.contains("Download 633 MB"))
+
+        // A cached row with no size still says which side of the download it
+        // is on, rather than dropping the fact entirely.
+        #expect(QuickstartRecommendedCard.accessibilityText(
+            for: choice, sizeText: "", isCached: true
+        ).contains("on disk"))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/QuickstartShortlistLabelTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/QuickstartShortlistLabelTests.swift
@@ -73,22 +73,6 @@ struct QuickstartShortlistLabelTests {
         }
     }
 
-    @Test("A cached entry with no size falls back rather than showing nothing")
-    func cachedWithoutSizeFallsBack() {
-        // `rapid-mlx ls` can hand back a row with no size (an external model,
-        // a partial snapshot). An empty size lane would read as "free".
-        let choice = QuickstartCoordinator.lowMemoryChoice
-        for blank in [nil, ""] as [String?] {
-            #expect(
-                QuickstartView.shortlistSizeText(
-                    for: choice,
-                    cached: entry(choice.alias, sizeOnDisk: blank),
-                    recommendedForPhysicalRAMGB: nil
-                ) == QuickstartView.sizeText(for: choice)
-            )
-        }
-    }
-
     @Test("VoiceOver says \"on disk\", not \"download\", in every lane")
     func spokenLabelsFollowTheCachedState() {
         let choice = QuickstartCoordinator.lowMemoryChoice
@@ -120,4 +104,43 @@ struct QuickstartShortlistLabelTests {
             for: choice, sizeText: "", isCached: true
         ).contains("on disk"))
     }
+    @Test("A cached model with no measurable size claims no size at all")
+    func cachedWithoutSizeClaimsNothing() {
+        // `rapid-mlx ls` can hand back a cached row with no size (an external
+        // model, a partial snapshot). This test replaces an earlier one that
+        // asserted the opposite — fall through to the download estimate, on
+        // the theory that an empty size lane reads as "free". codex was right
+        // that the fallback is worse: it shows, and VoiceOver speaks, an
+        // estimated DOWNLOAD figure as an on-disk size for a model that is
+        // not being downloaded at all. That is the same defect this whole
+        // file exists for ("download 20 GB" on a model already holding 19.03
+        // GiB), one lane along. A wrong number is worse than no number, and
+        // the accessibility label already degrades to a bare "on disk" when
+        // the size text is empty.
+        let choice = QuickstartCoordinator.lowMemoryChoice
+        // Both shapes of "we could not measure it": absent and empty.
+        for unmeasured in [entry(choice.alias, sizeOnDisk: nil),
+                           entry(choice.alias, sizeOnDisk: "")] {
+            let text = QuickstartView.shortlistSizeText(
+                for: choice,
+                cached: unmeasured,
+                recommendedForPhysicalRAMGB: 256
+            )
+            #expect(text.isEmpty,
+                    "A cached row with no measured size must not borrow the download estimate.")
+            // The spoken label degrades to a bare "on disk" — no number, and
+            // in particular not a download figure described as one.
+            let spoken = QuickstartRecommendedCard.accessibilityText(
+                for: choice, sizeText: text, isCached: true
+            )
+            #expect(spoken.contains("on disk"))
+            #expect(!spoken.contains("download"))
+        }
+        // Sanity check: the uncached lane still produces a size, so the
+        // assertions above are about provenance and not about an empty helper.
+        #expect(!QuickstartView.shortlistSizeText(
+            for: choice, cached: nil, recommendedForPhysicalRAMGB: 256
+        ).isEmpty)
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/ServerLogNoiseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerLogNoiseTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// 0.14.1 dogfood: the "Server log" drawer contained nothing but the app's own
+/// `/healthz` and `/v1/models/residency` polls. Both loops run on a timer
+/// (health probe; 5-second residency refresh), uvicorn logs one access line
+/// per request, and the drawer is a 200-line ring buffer — so the startup
+/// banner, the resolved model path and every warning worth reading had already
+/// scrolled off by the time anyone opened it.
+///
+/// These tests pin the narrow shape of the suppression. The risk of a filter
+/// like this is that it hides something a user needed, so the negative cases
+/// below matter more than the positive ones.
+@Suite("Server log noise suppression")
+struct ServerLogNoiseTests {
+
+    @Test("Successful polls on the app's own endpoints are suppressed")
+    func suppressesSuccessfulPolls() {
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:57230 - "GET /healthz HTTP/1.1" 200 OK"#))
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:57231 - "GET /v1/models/residency HTTP/1.1" 200 OK"#))
+        // HEAD, HTTP/1.0, a query string, and a 2xx that is not 200.
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "HEAD /healthz HTTP/1.0" 204 No Content"#))
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "GET /v1/models/residency?verbose=1 HTTP/1.1" 200 OK"#))
+    }
+
+    @Test("A FAILED poll survives — that is what the drawer is for")
+    func keepsFailedPolls() {
+        // Someone opens the log drawer precisely because the server is not
+        // answering. Hiding the evidence would be the worse bug.
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "GET /healthz HTTP/1.1" 503 Service Unavailable"#))
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "GET /v1/models/residency HTTP/1.1" 500 Internal Server Error"#))
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "GET /healthz HTTP/1.1" 404 Not Found"#))
+    }
+
+    @Test("User-driven requests survive")
+    func keepsUserTraffic() {
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "POST /v1/chat/completions HTTP/1.1" 200 OK"#))
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "POST /v1/models/load HTTP/1.1" 200 OK"#))
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "GET /v1/models HTTP/1.1" 200 OK"#))
+    }
+
+    @Test("Prose that merely mentions an endpoint survives")
+    func keepsProseMentioningEndpoints() {
+        // The access-log shape (quoted request line + version + status) is the
+        // discriminator, so a warning, a traceback frame or a banner naming
+        // the endpoint is never swallowed.
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            "WARNING: /healthz answered slowly (2.4s) — model still loading"))
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            "  File \"/app/vllm_mlx/server.py\", line 1, in healthz"))
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            "INFO: probe endpoint is /v1/models/residency"))
+        #expect(!ServerLogNoise.isAppPollAccessLine(""))
+    }
+
+    @Test("Colourised access lines are suppressed too")
+    func suppressesColourisedLines() {
+        // uvicorn bolds the request line when `use_colors` is on. The app
+        // spawns the child on a pipe so colours are off today, but a future
+        // TTY-attached child must not smuggle the noise back in.
+        let bold = "\u{1B}[32mINFO\u{1B}[0m:     127.0.0.1:1 - \"\u{1B}[1mGET /healthz HTTP/1.1\u{1B}[0m\" \u{1B}[32m200 OK\u{1B}[0m"
+        #expect(ServerLogNoise.isAppPollAccessLine(bold))
+    }
+}

--- a/apps/rapid-mac/Tests/RapidTests/ServerLogNoiseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerLogNoiseTests.swift
@@ -64,6 +64,38 @@ struct ServerLogNoiseTests {
         #expect(!ServerLogNoise.isAppPollAccessLine(""))
     }
 
+    @Test("A diagnostic that QUOTES a poll's request line survives")
+    func keepsProseQuotingAnAccessLine() {
+        // codex, reviewing this PR: an unanchored pattern would suppress any
+        // line containing the quoted fragment, including the one message a
+        // user most needs when health checks are lying to the app. The
+        // pattern is anchored at both ends, so a line is only dropped when it
+        // is nothing but an access line.
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"WARNING: probe failed: sent "GET /healthz HTTP/1.1" 200 but the body was empty"#))
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"ERROR: residency refresh loop is wedged; last line was 127.0.0.1:1 - "GET /v1/models/residency HTTP/1.1" 200 OK"#))
+        // A trailing comment on an otherwise well-formed access line means
+        // someone wrapped it in prose, so it is not uvicorn's own output.
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:1 - "GET /healthz HTTP/1.1" 200 OK  <-- took 2.4s, model still loading"#))
+    }
+
+    @Test("The access logger propagating to a root handler is still suppressed")
+    func suppressesPropagatedAccessLines() {
+        // The server calls `uvicorn.run(app, ...)` with no `log_config`, so
+        // uvicorn's padded `levelprefix` is the shape today. If the access
+        // logger is ever left to propagate to a root handler instead, Python's
+        // default `%(levelname)s:%(name)s:%(message)s` is what comes out, and
+        // the filter must not quietly stop working.
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            #"INFO:uvicorn.access:127.0.0.1:57230 - "GET /healthz HTTP/1.1" 200 OK"#))
+        // IPv6 client address, and a line arriving with a trailing CR from the
+        // pipe.
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            "INFO:     [::1]:57230 - \"GET /healthz HTTP/1.1\" 200 OK\r"))
+    }
+
     @Test("Colourised access lines are suppressed too")
     func suppressesColourisedLines() {
         // uvicorn bolds the request line when `use_colors` is on. The app

--- a/apps/rapid-mac/Tests/RapidTests/ServerLogNoiseTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ServerLogNoiseTests.swift
@@ -104,4 +104,23 @@ struct ServerLogNoiseTests {
         let bold = "\u{1B}[32mINFO\u{1B}[0m:     127.0.0.1:1 - \"\u{1B}[1mGET /healthz HTTP/1.1\u{1B}[0m\" \u{1B}[32m200 OK\u{1B}[0m"
         #expect(ServerLogNoise.isAppPollAccessLine(bold))
     }
+    @Test("An access line from another machine is kept")
+    func keepsAccessLinesFromOtherClients() {
+        // codex round 6: any client address matched, so a reachability probe
+        // from a phone on the LAN was filed as the app's own polling noise —
+        // and that line is exactly what someone debugging "why can't my other
+        // machine reach this?" opened the drawer to find.
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     192.168.1.42:51234 - "GET /healthz HTTP/1.1" 200 OK"#))
+        #expect(!ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     10.0.0.7:8080 - "GET /v1/models/residency HTTP/1.1" 200 OK"#))
+        // Loopback in each of the forms uvicorn can render it stays filtered.
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     127.0.0.1:57230 - "GET /healthz HTTP/1.1" 200 OK"#))
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     ::1:57230 - "GET /healthz HTTP/1.1" 200 OK"#))
+        #expect(ServerLogNoise.isAppPollAccessLine(
+            #"INFO:     localhost:57230 - "GET /healthz HTTP/1.1" 200"#))
+    }
+
 }

--- a/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
@@ -270,6 +270,121 @@ struct ToolNotCalledCaptionTests {
         #expect(ChatMessage.promptLooksCalculatorish("Show me the forecast"))
     }
 
+    @Test("0.14.1 dogfood: keywords match whole words, not substrings")
+    func promptKeywordsAreWholeWords() {
+        // Every one of these is ordinary prose that the shipped
+        // `lowered.contains(kw)` classified as calculator-shaped:
+        // "computer"/"computed"/"computing" ⊃ compute, "sometimes" ⊃
+        // times, "surplus" ⊃ plus, "minuscule" ⊃ minus, "forecasting" ⊃
+        // forecast, "temperatures" is the plural of a keyword. Paired
+        // with the short-answer-with-a-digit content gate, any of them
+        // put the "didn't call a tool" caution under a perfectly good
+        // grounded answer.
+        #expect(!ChatMessage.promptLooksCalculatorish(
+            "Summarize what the computer vision section says"))
+        #expect(!ChatMessage.promptLooksCalculatorish(
+            "How was this computed in the report"))
+        #expect(!ChatMessage.promptLooksCalculatorish(
+            "Does it sometimes fail on startup"))
+        #expect(!ChatMessage.promptLooksCalculatorish(
+            "Explain the trade surplus argument"))
+        #expect(!ChatMessage.promptLooksCalculatorish(
+            "Is the risk minuscule or material"))
+        #expect(!ChatMessage.promptLooksCalculatorish(
+            "Who owns the forecasting process"))
+        // …while the whole words themselves still match.
+        #expect(ChatMessage.promptLooksCalculatorish("compute the total"))
+        #expect(ChatMessage.promptLooksCalculatorish("3 times 4 equals what"))
+        #expect(ChatMessage.promptLooksCalculatorish("what is the forecast"))
+        // Punctuation and line ends are boundaries too.
+        #expect(ChatMessage.promptLooksCalculatorish("(compute) the total"))
+        #expect(ChatMessage.promptLooksCalculatorish("weather?"))
+        #expect(ChatMessage.promptLooksCalculatorish("forecast"))
+    }
+
+    @Test("containsKeyword: boundaries, phrases, overlaps")
+    func containsKeywordContract() {
+        #expect(ChatMessage.containsKeyword("plus", in: "2 plus 2"))
+        #expect(!ChatMessage.containsKeyword("plus", in: "surplus"))
+        #expect(!ChatMessage.containsKeyword("plus", in: "plusher"))
+        // Multi-word phrases only need their outer edges checked.
+        #expect(ChatMessage.containsKeyword("look up", in: "please look up tokyo"))
+        #expect(!ChatMessage.containsKeyword("look up", in: "overlook upstream"))
+        // A later whole-word hit is still found after an embedded miss.
+        #expect(ChatMessage.containsKeyword("sum of", in: "consumer sum of costs"))
+        #expect(!ChatMessage.containsKeyword("", in: "anything"))
+    }
+
+    @Test("0.14.1 dogfood: a document-grounded answer wears no caution")
+    func attachmentGroundedAnswerIsNotFlagged() throws {
+        // The dogfood shape: a scanned invoice attached, a numeric
+        // question, and a short correct answer read straight off the
+        // page. Nothing on the tool roster could have done better, so
+        // "answered without calling any of the available tools" is not a
+        // caution — and firing it here spends the trust that makes the
+        // caption worth showing when a model really does invent a total.
+        let flaggedWithoutTheGate = ChatMessage.shouldFlagToolNotCalled(
+            userPrompt: "What is the total due? Calculate it from the invoice.",
+            assistantContent: "$1,204.55",
+            toolCalls: nil,
+            finishReason: "stop",
+            toolsRequested: true,
+            promptHadAttachment: false
+        )
+        #expect(flaggedWithoutTheGate,
+                "Sanity check: without the attachment the shape IS the #308 failure mode and must still fire.")
+
+        let flaggedWithTheGate = ChatMessage.shouldFlagToolNotCalled(
+            userPrompt: "What is the total due? Calculate it from the invoice.",
+            assistantContent: "$1,204.55",
+            toolCalls: nil,
+            finishReason: "stop",
+            toolsRequested: true,
+            promptHadAttachment: true
+        )
+        #expect(!flaggedWithTheGate)
+    }
+
+    // ``ChatViewModel`` is @MainActor; the rest of this suite is pure.
+    @MainActor
+    @Test("The attachment gate reads the user row that opened the turn")
+    func attachmentGateWalksBackToTheTurnsUserRow() throws {
+        let attachment = try ChatFileAttachment(
+            filename: "invoice.pdf",
+            kind: .pdf,
+            extractedText: "TOTAL DUE 1,204.55",
+            sourceByteCount: 18
+        )
+        let withDocument: [ChatMessage] = [
+            ChatMessage(role: .user, content: "earlier question"),
+            ChatMessage(role: .assistant, content: "earlier answer"),
+            ChatMessage(role: .user, content: "total?", fileAttachments: [attachment]),
+            ChatMessage(role: .assistant, content: "", status: .streaming),
+        ]
+        #expect(ChatViewModel.lastUserPromptHadAttachmentBefore(
+            messages: withDocument, placeholderIndex: 3
+        ))
+        // A document in an EARLIER turn does not exempt a later bare
+        // question: the model is answering from transcript, not from a
+        // document in front of it, and that is a shape worth captioning.
+        let documentIsStale: [ChatMessage] = [
+            ChatMessage(role: .user, content: "total?", fileAttachments: [attachment]),
+            ChatMessage(role: .assistant, content: "$1,204.55"),
+            ChatMessage(role: .user, content: "and 15 percent of that?"),
+            ChatMessage(role: .assistant, content: "", status: .streaming),
+        ]
+        #expect(!ChatViewModel.lastUserPromptHadAttachmentBefore(
+            messages: documentIsStale, placeholderIndex: 3
+        ))
+        // Degenerate indices must not exempt anything by accident.
+        #expect(!ChatViewModel.lastUserPromptHadAttachmentBefore(
+            messages: withDocument, placeholderIndex: 0
+        ))
+        #expect(!ChatViewModel.lastUserPromptHadAttachmentBefore(
+            messages: [], placeholderIndex: 3
+        ))
+    }
+
     @Test("promptLooksCalculatorish: casual prompt → FALSE")
     func promptCasual() {
         #expect(!ChatMessage.promptLooksCalculatorish("hello there"))

--- a/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
@@ -378,7 +378,7 @@ struct ToolNotCalledCaptionTests {
         // a bare wrong product is the #308 failure mode.
         for prompt in ["Attached is my resume; calculate 17*23",
                        "Here's the invoice. Also, what is 1200 * 0.15?",
-                       "Using this deck, confirm 1200-180 for me",
+                       "Using this deck, confirm 1200 - 180 for me",
                        "this pdf, plus: 88 / 7 = ?"] {
             #expect(ChatMessage.shouldFlagToolNotCalled(
                 userPrompt: prompt,
@@ -405,6 +405,9 @@ struct ToolNotCalledCaptionTests {
     @Test("promptContainsSelfContainedArithmetic: brought its own numbers?")
     func selfContainedArithmeticContract() {
         for prompt in ["17*23", "what is 1200 * 0.15", "88 / 7", "1200-180",
+                       // Spaced around the minus, which is how most people
+                       // actually type it (codex round 3).
+                       "1200 - 180", "what is 1200 -  180?",
                        "5 + 5 = ?", "2^10", "give me 40% of 250"] {
             #expect(ChatMessage.promptContainsSelfContainedArithmetic(prompt),
                     "should be self-contained: \(prompt)")
@@ -457,44 +460,47 @@ struct ToolNotCalledCaptionTests {
         #expect(ChatMessage.promptLooksCalculatorish("google for the spec"))
     }
 
-    // ``ChatViewModel`` is @MainActor; the rest of this suite is pure.
-    @MainActor
-    @Test("The attachment gate reads the user row that opened the turn")
-    func attachmentGateWalksBackToTheTurnsUserRow() throws {
+    @Test("The attachment gate reads the wire history, and every user row in it")
+    func attachmentGateReadsTheWireHistory() throws {
         let attachment = try ChatFileAttachment(
             filename: "invoice.pdf",
             kind: .pdf,
             extractedText: "TOTAL DUE 1,204.55",
             sourceByteCount: 18
         )
-        let withDocument: [ChatMessage] = [
+        let newestRowCarriesIt: [ChatMessage] = [
             ChatMessage(role: .user, content: "earlier question"),
             ChatMessage(role: .assistant, content: "earlier answer"),
             ChatMessage(role: .user, content: "total?", fileAttachments: [attachment]),
-            ChatMessage(role: .assistant, content: "", status: .streaming),
         ]
-        #expect(ChatViewModel.lastUserPromptHadAttachmentBefore(
-            messages: withDocument, placeholderIndex: 3
-        ))
-        // A document in an EARLIER turn does not exempt a later bare
-        // question: the model is answering from transcript, not from a
-        // document in front of it, and that is a shape worth captioning.
-        let documentIsStale: [ChatMessage] = [
+        #expect(ChatViewModel.historyCarriesAttachmentGrounding(newestRowCarriesIt))
+
+        // An EARLIER turn counts, which reverses what an earlier version of
+        // this test asserted. codex was right that the premise was wrong:
+        // ``ChatMessage/modelContent`` re-sends each attachment's extracted
+        // text on every follow-up, so "and 15 percent of that?" two turns on
+        // is still answered from a document in front of the model — and
+        // captioning it as a guess is the trust-spending false positive this
+        // gate exists to prevent.
+        let documentIsTwoTurnsBack: [ChatMessage] = [
             ChatMessage(role: .user, content: "total?", fileAttachments: [attachment]),
             ChatMessage(role: .assistant, content: "$1,204.55"),
             ChatMessage(role: .user, content: "and 15 percent of that?"),
-            ChatMessage(role: .assistant, content: "", status: .streaming),
         ]
-        #expect(!ChatViewModel.lastUserPromptHadAttachmentBefore(
-            messages: documentIsStale, placeholderIndex: 3
-        ))
-        // Degenerate indices must not exempt anything by accident.
-        #expect(!ChatViewModel.lastUserPromptHadAttachmentBefore(
-            messages: withDocument, placeholderIndex: 0
-        ))
-        #expect(!ChatViewModel.lastUserPromptHadAttachmentBefore(
-            messages: [], placeholderIndex: 3
-        ))
+        #expect(ChatViewModel.historyCarriesAttachmentGrounding(documentIsTwoTurnsBack))
+
+        // But it is the WIRE history, so a document the context trim dropped
+        // no longer grounds anything — the caption must come back rather than
+        // stay silent at the exact moment the evidence is gone.
+        let trimmedAway = Array(documentIsTwoTurnsBack.dropFirst(2))
+        #expect(!ChatViewModel.historyCarriesAttachmentGrounding(trimmedAway))
+
+        // An attachment on an ASSISTANT row is not user-supplied grounding,
+        // and an empty history exempts nothing.
+        #expect(!ChatViewModel.historyCarriesAttachmentGrounding([
+            ChatMessage(role: .assistant, content: "here", fileAttachments: [attachment])
+        ]))
+        #expect(!ChatViewModel.historyCarriesAttachmentGrounding([]))
     }
 
     @Test("promptLooksCalculatorish: casual prompt → FALSE")

--- a/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
@@ -370,6 +370,57 @@ struct ToolNotCalledCaptionTests {
         }
     }
 
+    @Test("An attachment does NOT exempt self-contained arithmetic")
+    func attachmentDoesNotExemptSelfContainedArithmetic() {
+        // codex, round 2: "Attached is my resume; calculate 17*23" carries a
+        // document that has nothing to do with the question. The numbers are
+        // in the prompt, the calculator is the tool that should have run, and
+        // a bare wrong product is the #308 failure mode.
+        for prompt in ["Attached is my resume; calculate 17*23",
+                       "Here's the invoice. Also, what is 1200 * 0.15?",
+                       "Using this deck, confirm 1200-180 for me",
+                       "this pdf, plus: 88 / 7 = ?"] {
+            #expect(ChatMessage.shouldFlagToolNotCalled(
+                userPrompt: prompt,
+                assistantContent: "391",
+                toolCalls: nil,
+                finishReason: "stop",
+                toolsRequested: true,
+                promptHadAttachment: true
+            ), "Self-contained arithmetic is not grounded by an attachment: \(prompt)")
+        }
+        // The dogfood case is the other side of the line and must stay
+        // exempt: the operands live on the page, so reading them off it is
+        // the grounded, correct answer.
+        #expect(!ChatMessage.shouldFlagToolNotCalled(
+            userPrompt: "What is the total due? Calculate it from the invoice.",
+            assistantContent: "$1,204.55",
+            toolCalls: nil,
+            finishReason: "stop",
+            toolsRequested: true,
+            promptHadAttachment: true
+        ))
+    }
+
+    @Test("promptContainsSelfContainedArithmetic: brought its own numbers?")
+    func selfContainedArithmeticContract() {
+        for prompt in ["17*23", "what is 1200 * 0.15", "88 / 7", "1200-180",
+                       "5 + 5 = ?", "2^10", "give me 40% of 250"] {
+            #expect(ChatMessage.promptContainsSelfContainedArithmetic(prompt),
+                    "should be self-contained: \(prompt)")
+        }
+        for prompt in ["calculate the total from the invoice",
+                       "sum of the line items", "what is the square root of it",
+                       // A hyphen is not a minus sign unless it sits between
+                       // two digits: a filename or a dashed aside is not math.
+                       "see q3-report.pdf - what does it say?",
+                       "the 2026 budget - summarise it",
+                       "no numbers here at all"] {
+            #expect(!ChatMessage.promptContainsSelfContainedArithmetic(prompt),
+                    "should not be self-contained: \(prompt)")
+        }
+    }
+
     @Test("promptAsksForLiveData draws the line at a moving target")
     func liveDataContract() {
         // Names a moving target: no attached document can hold the answer.
@@ -386,10 +437,20 @@ struct ToolNotCalledCaptionTests {
                        "sum of the line items"] {
             #expect(!ChatMessage.promptAsksForLiveData(prompt), "should not be live: \(prompt)")
         }
+        // codex round 2: moving to whole-word matching must not drop ordinary
+        // English plurals, which the old substring match caught.
+        for prompt in ["what are the temperatures today", "the forecasts for the week",
+                       "current prices on these", "latest versions of the spec",
+                       "exchange rates right now", "stock prices"] {
+            #expect(ChatMessage.promptAsksForLiveData(prompt), "plural should be live: \(prompt)")
+        }
         // Whole-word matching still holds here: "concurrent" is not "current",
-        // and a "forecasting model" question is not a weather question.
+        // a "forecasting model" question is not a weather question, and an
+        // "-ed" inflection is not an "-s" one.
         #expect(!ChatMessage.promptAsksForLiveData("explain concurrent map access"))
         #expect(!ChatMessage.promptAsksForLiveData("what is a temperate climate"))
+        #expect(!ChatMessage.promptAsksForLiveData("explain forecasting models"))
+        #expect(!ChatMessage.promptAsksForLiveData("the weathered stone wall"))
         // But the live list must still reach promptLooksCalculatorish, so the
         // two cannot drift apart.
         #expect(ChatMessage.promptLooksCalculatorish("what is the forecast"))

--- a/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
@@ -424,6 +424,43 @@ struct ToolNotCalledCaptionTests {
         }
     }
 
+    @Test("An attachment does NOT exempt an external-retrieval prompt")
+    func attachmentDoesNotExemptExternalRetrieval() {
+        // codex, round 4: "search for Ada Lovelace's biography" with a resume
+        // attached asks to leave the document entirely, so the page grounds
+        // nothing and a short confident answer is ungrounded.
+        for prompt in ["Attached is my resume. Search for Ada Lovelace's biography.",
+                       "Here's the invoice — look up the vendor's rating online",
+                       "google for the current spec, see attached"] {
+            #expect(ChatMessage.shouldFlagToolNotCalled(
+                userPrompt: prompt,
+                assistantContent: "1815.",
+                toolCalls: nil,
+                finishReason: "stop",
+                toolsRequested: true,
+                promptHadAttachment: true
+            ), "External retrieval is not grounded by an attachment: \(prompt)")
+        }
+    }
+
+    @Test("promptIsAttachmentAnswerable: only the math-keyword lane")
+    func attachmentAnswerableContract() {
+        // The ONE exempt shape: math vocabulary whose operands are on the page.
+        for prompt in ["what is the total due? calculate it from the invoice",
+                       "sum of the line items", "what percent of the total is tax",
+                       "compute the subtotal"] {
+            #expect(ChatMessage.promptIsAttachmentAnswerable(prompt),
+                    "should be answerable from the page: \(prompt)")
+        }
+        // The three lanes it excludes, one case each.
+        #expect(!ChatMessage.promptIsAttachmentAnswerable("calculate 17*23"))
+        #expect(!ChatMessage.promptIsAttachmentAnswerable("calculate today's stock price"))
+        #expect(!ChatMessage.promptIsAttachmentAnswerable("calculate it, then search for the source"))
+        // And a prompt with no math vocabulary at all is not exempted either —
+        // Gate 5 would reject it anyway, but the predicate must not claim it.
+        #expect(!ChatMessage.promptIsAttachmentAnswerable("what does this say?"))
+    }
+
     @Test("promptAsksForLiveData draws the line at a moving target")
     func liveDataContract() {
         // Names a moving target: no attached document can hold the answer.
@@ -433,8 +470,10 @@ struct ToolNotCalledCaptionTests {
                        "stock price now", "right now, how many users?"] {
             #expect(ChatMessage.promptAsksForLiveData(prompt), "should be live: \(prompt)")
         }
-        // Retrieval-shaped, but an attached document answers it — so these
-        // stay OUT of the live list and keep Gate 1c's exemption available.
+        // Not live-data (they name no moving target) — but note these no
+        // longer keep Gate 1c's exemption either: as of round 4 they are
+        // external-retrieval language, which withholds it. See
+        // ``promptAsksForExternalRetrieval``.
         for prompt in ["look up the invoice number", "search for the clause about refunds",
                        "what is the total due?", "calculate 15 percent of the subtotal",
                        "sum of the line items"] {

--- a/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/ToolNotCalledCaptionTests.swift
@@ -345,6 +345,57 @@ struct ToolNotCalledCaptionTests {
         #expect(!flaggedWithTheGate)
     }
 
+    @Test("An attachment does NOT exempt a live-data question")
+    func attachmentDoesNotExemptLiveDataQuestions() {
+        // codex, reviewing this PR: a blanket attachment exemption lets the
+        // exact failure mode straight through. Attach a portfolio PDF, ask
+        // for today's price, and no page on earth holds the answer — so a
+        // bare number with no tool call is a guess, and the caption is right.
+        let liveDataPrompts = [
+            "Here is my portfolio. What is today's stock price for it?",
+            "What's the current price of the first item on this invoice?",
+            "Given this itinerary, what is the weather in Lisbon?",
+            "Summarise this and add the latest news about the company.",
+            "What's the exchange rate to convert the total on this invoice?",
+        ]
+        for prompt in liveDataPrompts {
+            #expect(ChatMessage.shouldFlagToolNotCalled(
+                userPrompt: prompt,
+                assistantContent: "$1,204.55",
+                toolCalls: nil,
+                finishReason: "stop",
+                toolsRequested: true,
+                promptHadAttachment: true
+            ), "A live-data question is not answerable from an attachment: \(prompt)")
+        }
+    }
+
+    @Test("promptAsksForLiveData draws the line at a moving target")
+    func liveDataContract() {
+        // Names a moving target: no attached document can hold the answer.
+        for prompt in ["what is today's close?", "latest news about the merger",
+                       "the forecast for tomorrow", "current weather in Oslo",
+                       "google for the spec", "what's the temperature outside",
+                       "stock price now", "right now, how many users?"] {
+            #expect(ChatMessage.promptAsksForLiveData(prompt), "should be live: \(prompt)")
+        }
+        // Retrieval-shaped, but an attached document answers it — so these
+        // stay OUT of the live list and keep Gate 1c's exemption available.
+        for prompt in ["look up the invoice number", "search for the clause about refunds",
+                       "what is the total due?", "calculate 15 percent of the subtotal",
+                       "sum of the line items"] {
+            #expect(!ChatMessage.promptAsksForLiveData(prompt), "should not be live: \(prompt)")
+        }
+        // Whole-word matching still holds here: "concurrent" is not "current",
+        // and a "forecasting model" question is not a weather question.
+        #expect(!ChatMessage.promptAsksForLiveData("explain concurrent map access"))
+        #expect(!ChatMessage.promptAsksForLiveData("what is a temperate climate"))
+        // But the live list must still reach promptLooksCalculatorish, so the
+        // two cannot drift apart.
+        #expect(ChatMessage.promptLooksCalculatorish("what is the forecast"))
+        #expect(ChatMessage.promptLooksCalculatorish("google for the spec"))
+    }
+
     // ``ChatViewModel`` is @MainActor; the rest of this suite is pure.
     @MainActor
     @Test("The attachment gate reads the user row that opened the turn")

--- a/apps/rapid-mac/Tests/RapidTests/WireBodyDeterminismTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WireBodyDeterminismTests.swift
@@ -53,18 +53,50 @@ struct WireBodyDeterminismTests {
         )
     }
 
-    private static func request() -> ChatStreamClient.Request {
+    private static func request(lastUser: String = "Now name three animals.") -> ChatStreamClient.Request {
         ChatStreamClient.Request(
             alias: "test-model",
             messages: [
                 ChatMessage(role: .system, content: "[CURRENT DATE]\nToday is Friday."),
                 ChatMessage(role: .user, content: "Name three colors."),
                 ChatMessage(role: .assistant, content: "Red, blue, and green."),
-                ChatMessage(role: .user, content: "Now name three animals."),
+                ChatMessage(role: .user, content: lastUser),
             ],
             tools: [tool("web_search"), tool("browse"), tool("weather"), tool("read_document")],
             supportsImageInput: false
         )
+    }
+
+    /// Index of the `]` that closes the top-level `"messages":[...]` array,
+    /// found by bracket-depth counting (string- and escape-aware) rather
+    /// than by searching for a literal. The follow-up test compares
+    /// everything up to that point, so the window must be the real end of
+    /// the array even if a fixture later contains a bracket or a quote.
+    private static func messagesArrayClose(in text: String) -> String.Index? {
+        guard let open = text.range(of: "\"messages\":[") else { return nil }
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var index = text.index(before: open.upperBound)  // the `[` itself
+        while index < text.endIndex {
+            let character = text[index]
+            if escaped {
+                escaped = false
+            } else if character == "\\" {
+                escaped = true
+            } else if character == "\"" {
+                inString.toggle()
+            } else if !inString {
+                if character == "[" || character == "{" {
+                    depth += 1
+                } else if character == "]" || character == "}" {
+                    depth -= 1
+                    if depth == 0 { return index }
+                }
+            }
+            index = text.index(after: index)
+        }
+        return nil
     }
 
     @Test("Encoding the same request twice yields identical bytes")
@@ -133,50 +165,106 @@ struct WireBodyDeterminismTests {
         let one = try #require(String(data: oneData, encoding: .utf8))
         let two = try #require(String(data: twoData, encoding: .utf8))
         // Sorted keys put "messages" before "model"/"tools", so the messages
-        // array is the one region that legitimately grows; everything encoded
-        // before it must match, and the earlier turns inside it must match too.
-        let head = try #require(one.range(of: "\"messages\":["))
-        #expect(one[..<head.upperBound] == two[..<head.upperBound])
-        let firstTurns = try #require(
-            one.range(of: "{\"content\":\"Name three colors.\",\"role\":\"user\"}")
-        )
-        #expect(one[..<firstTurns.upperBound] == two[..<firstTurns.upperBound],
-                "Everything up to and including the first user turn must be byte-identical between the two requests.")
+        // array is the one region that legitimately grows. Three things have
+        // to hold, and all three are the property the prefix cache needs --
+        // comparing only through the FIRST user message (an earlier version
+        // of this test) would have stayed green while a later message, or the
+        // whole tools array, changed underneath.
+        let oneClose = try #require(Self.messagesArrayClose(in: one))
+        let twoClose = try #require(Self.messagesArrayClose(in: two))
+
+        // (1) Turn one's ENTIRE encoding up to the end of its last message
+        //     object -- the request head, every earlier message, and that
+        //     message's closing brace -- is a byte prefix of turn two.
+        let onePrefix = String(one[..<oneClose])
+        let sharedLength = zip(onePrefix, two).prefix(while: { $0 == $1 }).count
+        #expect(two.hasPrefix(onePrefix),
+                "Turn two must begin with every byte of turn one's message array, closing brace included; the two diverged after \(sharedLength) of \(onePrefix.count) characters.")
+
+        // (2) It EXTENDS that prefix rather than merely equalling it: the very
+        //     next bytes are the new assistant turn, appended.
+        #expect(two.dropFirst(onePrefix.count).hasPrefix(",{\"content\":\"Red, blue, and green.\""),
+                "Turn two must append the new turns after turn one's bytes, not re-serialize the array.")
+
+        // (3) Everything encoded AFTER the array -- `model`, `stream`, and the
+        //     whole `tools` array -- is byte-identical. The tools array is the
+        //     one this PR exists for: the engine renders it into the prompt
+        //     text, so a reordered schema is a reordered prompt.
+        #expect(one[oneClose...] == two[twoClose...],
+                "Every field after `messages` (`model`, `stream`, `tools`) must be byte-identical between turns.")
+    }
+
+    @Test("Two captures running concurrently do not read each other's bodies")
+    func concurrentCapturesStayIsolated() async throws {
+        // The capture harness is process-global, so without a per-capture key
+        // two overlapping sends would overwrite (or consume) one another and
+        // this suite would go flaky -- or, worse, falsely green, comparing one
+        // request against itself. The desktop suite runs `--no-parallel`
+        // today; correctness must not depend on a runner flag.
+        async let alpha = WireBodyCaptureProtocol.capture(Self.request(lastUser: "Alpha marker question."))
+        async let beta = WireBodyCaptureProtocol.capture(Self.request(lastUser: "Beta marker question."))
+        let (alphaData, betaData) = await (alpha, beta)
+        let alphaBody = try #require(alphaData)
+        let betaBody = try #require(betaData)
+        let alphaText = try #require(String(data: alphaBody, encoding: .utf8))
+        let betaText = try #require(String(data: betaBody, encoding: .utf8))
+        #expect(alphaText.contains("Alpha marker question."))
+        #expect(!alphaText.contains("Beta marker question."))
+        #expect(betaText.contains("Beta marker question."))
+        #expect(!betaText.contains("Alpha marker question."))
     }
 }
 
 /// Captures the encoded HTTP body of one ``ChatStreamClient/send`` call.
 ///
-/// The body is written on the `URLProtocol` loading thread and read from the
-/// caller afterwards, so it is boxed behind a lock (the pattern the other wire
-/// captures in this suite use).
+/// `URLProtocol` subclasses are instantiated by the loading system, so the
+/// captured body has to travel through process-global state. It is keyed by a
+/// token minted per capture and carried in the fake base URL's host, which the
+/// protocol reads back off the outgoing request: two captures in flight at once
+/// therefore write to (and consume) different slots instead of clobbering each
+/// other. The store is boxed behind a lock because the write happens on the
+/// loading thread and the read on the caller's.
 private final class WireBodyCaptureProtocol: URLProtocol, @unchecked Sendable {
     private final class Store: @unchecked Sendable {
         private let lock = NSLock()
-        private var body: Data?
-        func get() -> Data? { lock.lock(); defer { lock.unlock() }; return body }
-        func set(_ value: Data?) { lock.lock(); defer { lock.unlock() }; body = value }
+        private var bodies: [String: Data] = [:]
+        func put(_ value: Data?, for token: String) {
+            lock.lock()
+            defer { lock.unlock() }
+            if let value { bodies[token] = value }
+        }
+        /// Read-and-remove, so a capture can never see a stale body left
+        /// behind by an earlier one.
+        func take(_ token: String) -> Data? {
+            lock.lock()
+            defer { lock.unlock() }
+            return bodies.removeValue(forKey: token)
+        }
     }
 
     private static let store = Store()
 
     static func capture(_ request: ChatStreamClient.Request) async -> Data? {
-        store.set(nil)
+        // Lowercased because `URL.host` normalises case; hyphens and hex are
+        // valid host characters, so a UUID round-trips unchanged.
+        let token = UUID().uuidString.lowercased()
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [WireBodyCaptureProtocol.self]
         let client = ChatStreamClient(
-            baseURL: URL(string: "fake://wire-determinism")!,
+            baseURL: URL(string: "fake://\(token)")!,
             session: URLSession(configuration: config)
         )
         try? await client.send(request) { _ in }
-        return store.get()
+        return store.take(token)
     }
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        Self.store.set(Self.bodyData(from: request))
+        if let token = request.url?.host {
+            Self.store.put(Self.bodyData(from: request), for: token)
+        }
         let response = HTTPURLResponse(
             url: request.url!,
             statusCode: 200,

--- a/apps/rapid-mac/Tests/RapidTests/WireBodyDeterminismTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/WireBodyDeterminismTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Testing
+@testable import Rapid
+
+/// The chat request body is not just transport. The engine renders `tools` and
+/// the message list into the prompt TEXT through the model's chat template, and
+/// its prefix cache reuses a stored request only when the new one is a
+/// byte-exact token prefix of it. So the body's serialization is part of the
+/// prompt, and any reordering between two turns re-prefills the conversation.
+///
+/// 0.14.1 dogfood, captured from two consecutive turns of one conversation:
+///
+///     turn 1  "tools":[{"function":{"name":"web_search","description":…
+///     turn 2  "tools":[{"type":"function","function":{"name":"web_search","parameters":…
+///
+/// Same four tools in the same order, different bytes — `parameters` is a
+/// ``CodableJSON`` blob whose `.object` case is a Swift dictionary. The engine
+/// reported `shared=96 entry_len=1460 requested_len=1511` and re-prefilled all
+/// 1511 tokens: 4.6 s to first token on a follow-up, 15–17 s with an 8-page PDF
+/// in the conversation.
+///
+/// These tests pin the two properties that fix it: the body is byte-stable
+/// across encodes, and its keys are sorted (which is what makes it stable
+/// across app launches too, so a reloaded conversation can still hit the
+/// engine's on-disk prefix cache).
+@Suite("Chat request body is byte-stable")
+struct WireBodyDeterminismTests {
+
+    /// A tool whose schema has enough sibling keys at two levels that an
+    /// unordered encode would show up.
+    private static func tool(_ name: String) -> ToolDefinition {
+        ToolDefinition(
+            name: name,
+            description: "Tool \(name) for the determinism fixture.",
+            parameters: .object([
+                "type": .string("object"),
+                "required": .array([.string("query")]),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("Search query in natural language."),
+                    ]),
+                    "limit": .object([
+                        "type": .string("number"),
+                        "description": .string("How many results."),
+                    ]),
+                    "authority": .object([
+                        "type": .string("string"),
+                        "description": .string("Restrict to one site."),
+                    ]),
+                ]),
+            ])
+        )
+    }
+
+    private static func request() -> ChatStreamClient.Request {
+        ChatStreamClient.Request(
+            alias: "test-model",
+            messages: [
+                ChatMessage(role: .system, content: "[CURRENT DATE]\nToday is Friday."),
+                ChatMessage(role: .user, content: "Name three colors."),
+                ChatMessage(role: .assistant, content: "Red, blue, and green."),
+                ChatMessage(role: .user, content: "Now name three animals."),
+            ],
+            tools: [tool("web_search"), tool("browse"), tool("weather"), tool("read_document")],
+            supportsImageInput: false
+        )
+    }
+
+    @Test("Encoding the same request twice yields identical bytes")
+    func encodingIsByteStable() async throws {
+        let first = try #require(await WireBodyCaptureProtocol.capture(Self.request()))
+        let second = try #require(await WireBodyCaptureProtocol.capture(Self.request()))
+        #expect(first == second,
+                "Two sends of the same logical request must serialize identically — the engine's prefix cache compares bytes, not meaning.")
+    }
+
+    @Test("Body keys are sorted at every level, including inside a tool schema")
+    func keysAreSorted() async throws {
+        let body = try #require(await WireBodyCaptureProtocol.capture(Self.request()))
+        let text = try #require(String(data: body, encoding: .utf8))
+
+        // Sorted order is what makes the bytes stable across app launches as
+        // well as across requests, so assert the property directly rather than
+        // just observing stability within one process.
+        func index(_ needle: String) throws -> String.Index {
+            try #require(text.range(of: needle)?.lowerBound)
+        }
+        // Top level: "max_tokens" < "messages" < "model" < "stream".
+        #expect(try index("\"max_tokens\"") < index("\"messages\""))
+        #expect(try index("\"messages\"") < index("\"model\""))
+        #expect(try index("\"model\"") < index("\"stream\""))
+        // Inside a tool: "description" < "name" < "parameters", and the schema
+        // object's own keys sort too.
+        let toolsText = String(text[try index("\"tools\"")...])
+        func toolIndex(_ needle: String) throws -> String.Index {
+            try #require(toolsText.range(of: needle)?.lowerBound)
+        }
+        #expect(try toolIndex("\"description\"") < toolIndex("\"name\""))
+        #expect(try toolIndex("\"name\"") < toolIndex("\"parameters\""))
+        #expect(try toolIndex("\"properties\"") < toolIndex("\"required\""))
+        // The tool object itself: "function" sorts before "type".
+        #expect(toolsText.hasPrefix("\"tools\":[{\"function\""))
+    }
+
+    @Test("A follow-up turn's body extends the previous turn's byte-for-byte")
+    func followUpExtendsThePreviousBody() async throws {
+        // The property the prefix cache actually needs: turn two's prompt
+        // region must START with turn one's. Tool order and key order are part
+        // of that prefix, which is why they have to be stable.
+        let turnOne = ChatStreamClient.Request(
+            alias: "test-model",
+            messages: [
+                ChatMessage(role: .system, content: "[CURRENT DATE]\nToday is Friday."),
+                ChatMessage(role: .user, content: "Name three colors."),
+            ],
+            tools: [Self.tool("web_search"), Self.tool("browse")],
+            supportsImageInput: false
+        )
+        let turnTwo = ChatStreamClient.Request(
+            alias: "test-model",
+            messages: [
+                ChatMessage(role: .system, content: "[CURRENT DATE]\nToday is Friday."),
+                ChatMessage(role: .user, content: "Name three colors."),
+                ChatMessage(role: .assistant, content: "Red, blue, and green."),
+                ChatMessage(role: .user, content: "Now name three animals."),
+            ],
+            tools: [Self.tool("web_search"), Self.tool("browse")],
+            supportsImageInput: false
+        )
+        let oneData = try #require(await WireBodyCaptureProtocol.capture(turnOne))
+        let twoData = try #require(await WireBodyCaptureProtocol.capture(turnTwo))
+        let one = try #require(String(data: oneData, encoding: .utf8))
+        let two = try #require(String(data: twoData, encoding: .utf8))
+        // Sorted keys put "messages" before "model"/"tools", so the messages
+        // array is the one region that legitimately grows; everything encoded
+        // before it must match, and the earlier turns inside it must match too.
+        let head = try #require(one.range(of: "\"messages\":["))
+        #expect(one[..<head.upperBound] == two[..<head.upperBound])
+        let firstTurns = try #require(
+            one.range(of: "{\"content\":\"Name three colors.\",\"role\":\"user\"}")
+        )
+        #expect(one[..<firstTurns.upperBound] == two[..<firstTurns.upperBound],
+                "Everything up to and including the first user turn must be byte-identical between the two requests.")
+    }
+}
+
+/// Captures the encoded HTTP body of one ``ChatStreamClient/send`` call.
+///
+/// The body is written on the `URLProtocol` loading thread and read from the
+/// caller afterwards, so it is boxed behind a lock (the pattern the other wire
+/// captures in this suite use).
+private final class WireBodyCaptureProtocol: URLProtocol, @unchecked Sendable {
+    private final class Store: @unchecked Sendable {
+        private let lock = NSLock()
+        private var body: Data?
+        func get() -> Data? { lock.lock(); defer { lock.unlock() }; return body }
+        func set(_ value: Data?) { lock.lock(); defer { lock.unlock() }; body = value }
+    }
+
+    private static let store = Store()
+
+    static func capture(_ request: ChatStreamClient.Request) async -> Data? {
+        store.set(nil)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [WireBodyCaptureProtocol.self]
+        let client = ChatStreamClient(
+            baseURL: URL(string: "fake://wire-determinism")!,
+            session: URLSession(configuration: config)
+        )
+        try? await client.send(request) { _ in }
+        return store.get()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.store.set(Self.bodyData(from: request))
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/event-stream"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        let body = """
+        data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n
+        data: [DONE]\n
+        """.data(using: .utf8)!
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        guard let stream = request.httpBodyStream else { return request.httpBody }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = buffer.withUnsafeMutableBufferPointer { pointer in
+                stream.read(pointer.baseAddress!, maxLength: pointer.count)
+            }
+            if count > 0 { data.append(buffer, count: count) }
+            if count == 0 { return data }
+            if count < 0 { return nil }
+        }
+    }
+}


### PR DESCRIPTION
## Why

I dogfooded 0.14.1 (with #3322 on top) the way a user would — in a freshly built, CFPreferences-isolated app with its own throwaway `$HOME` — and went looking for friction rather than for bugs. Six things made the app feel worse than it is. This PR fixes all of them. One is a real performance defect and is most of the diff; the other five are small.

### The performance defect: every follow-up turn re-prefilled the entire conversation

Ask a question, get the first token in **0.6 s**. Ask a follow-up in the same conversation, wait **7.3 s**. Put an 8-page PDF in the history first and the follow-up takes **15–17 s**. The engine was reporting a prefix-cache `MISS` on every single follow-up:

```
[cache_fetch] LCP unavailable: shared=96 entry_len=1460 requested_len=1511 non_trimmable=True
[cache_fetch] request=… MISS prompt_tokens=1511
[schedule]    request=… tokens_to_prefill=1511
```

`shared=96` out of 1460 stored tokens. The conversation was 96% identical and we were reusing 6% of it.

There were two independent causes, and the first one alone does not fix it — I know because I shipped it locally, re-measured, and got `shared=90`.

**Cause 1 — a minute-resolution clock at the front of the prompt.** `currentDateTimeContext` rendered `Today is Thursday, September 11, 2026 at 4:07 PM` into the *system row*. The system row is the first thing in the prompt, so once the wall clock ticked over a minute, token ~30 changed and nothing after it could be reused. A cache that keys on a byte-exact token prefix cannot survive volatile content at position 30.

The fix is to split the two halves by how fast they change and put each where it belongs:

- `currentDateContext()` → `[CURRENT DATE]` in the system row. Date only, stable for the whole day, so the shared prefix survives.
- `clockContext(at:)` → `[MESSAGE SENT]` appended to each **user** message as a transient `wireSuffix`, stamped from that message's own immutable `createdAt`. It reads "This message was sent \<full date\> at \<time\> (zone)" rather than "the current local time is …": every user row in the history wears one, so anything phrased as "current" would have the prompt asserting three contradictory current times, and a bare clock on an old row would attach yesterday's time to today's `[CURRENT DATE]` in a conversation that crossed midnight. A send-time stamp is true of every row forever — which is also exactly what makes it cacheable. The model still knows the time *now*, because the newest user row is the one being sent.

The second half matters more than it looks. The naive version — stamp the clock only onto the newest user row — still invalidates the cache, because the trailer that was on last turn's row has to be *removed* this turn, and a removal is not a prefix extension. Stamping every user row from its own `createdAt` makes the prompt purely append-only across turns: measured **7.4 s vs 0.8 s**, for about 20 tokens per turn. `wireSuffix` is deliberately not in `CodingKeys` and is restored as `nil` on decode — it is wire-shaping, not conversation content, and persisting it would bake a stale clock into the transcript.

**Cause 2 — `JSONEncoder` does not promise a key order, and the request body is part of the prompt.** This is the one I would not have found by reading the code. After cause 1 was fixed the follow-up still missed, so I dumped the actual `req.httpBody` on consecutive turns and diffed them:

```
turn 1   "tools":[{"function":{"name":"web_search","description":…
turn 2   "tools":[{"type":"function","function":{"name":"web_search","parameters":…
```

Same tools, same semantics, different byte order. Swift's `JSONEncoder` emits keyed-container keys in non-deterministic order, and the engine renders `tools` into the prompt **text** through the model's chat template — so a reordered `tools` array is a reordered prompt, and the shared prefix collapses to wherever the first reorder lands.

`encoder.outputFormatting = [.sortedKeys]` is the entire fix. JSON objects are unordered by spec, the engine parses into dicts, and sorting makes every level stable across requests *and* across app launches. `WireBodyDeterminismTests` pins it against the real `URLProtocol` path; all three tests fail if you remove the flag (verified, not assumed).

**Measured, hands-on, in the isolated build** — same conversation, model `bonsai-27b-2bit`:

| turn | before | after |
|---|---|---|
| first question | 0.6 s | 0.6 s |
| follow-up (text only) | 7.3 s | **0.5 s** |
| follow-up with an 8-page PDF in history | 15–17 s | **0.5 s** |

```
[cache_fetch] request=chatcmpl-f9d HIT prompt_tokens=1557 cached=1491 remaining=66 time=0.001s
[schedule]    request=chatcmpl-f9d tokens_to_prefill=66, 1491 cached
[stream_outputs] chatcmpl-f9d first token after 0.5s
```

1491 of 1557 tokens reused instead of 96 of 1460.

### The five smaller ones

**"This model didn't call a tool — verify the answer." fired on answers that were grounded in an attachment.** I attached a scanned invoice, the model answered correctly from the extracted text, and the app told me to distrust it. The heuristic looks for retrieval-shaped keywords in the prompt and warns when no tool ran — but when the user attached the document themselves, the grounding is already in the prompt and there is nothing to retrieve. New Gate 1c: `guard !promptHadAttachment else { return false }`, walking back to the turn's own user row (`lastUserPromptHadAttachmentBefore`) rather than trusting the newest row.

**The same heuristic matched keywords as substrings.** "latest" fired on "translate", "current" on "concurrent". New `ChatMessage.containsKeyword(_:in:)` requires whole-word/phrase boundaries (non-alphanumeric or end of string, advancing one character so overlapping candidates still match). All three keyword loops use it.

**The server log drawer was mostly the app talking to itself.** Two timer loops poll `/healthz` and `/v1/models/residency`, and their `200` access lines flushed the 200-line ring buffer faster than anything real could appear in it — open the drawer to diagnose a problem and you see your own heartbeat. `ServerLogNoise.isAppPollAccessLine` drops *successful* `GET`/`HEAD` polls of exactly those two paths. Non-2xx polls are kept, because a failing health check is the most useful line in the drawer, and prose that merely mentions the paths is kept too.

**Quickstart never said a model was already downloaded.** With `qwen3.5-4b-4bit` sitting on disk, its card looked identical to one that would pull 2.3 GB, so the safe choice was invisible. Cached shortlist rows now carry an `ON THIS MAC` badge and read `<on-disk size> · <capability>%`, and the accessibility text says "on disk X" rather than "download X".

**The Settings prompt preview described the old behavior.** After the clock split it said the preview included the current time, which is no longer where the time lives. It now reads: "Preview includes current automatic context. Each message you send carries the time you sent it. Tool and attachment context may be added when you send."

## Adversarial review round 1

codex (`gpt-5.6-sol`) found four real holes in the first commit. All four are fixed, each with a test that fails without the fix (verified by reverting the fix and watching the test fail, not assumed):

1. **Gate 1c blanket-exempted any attachment.** "Here is my portfolio PDF — what is today's stock price?" has an attachment and no possible attachment-grounded answer, so silencing the caption there lets through exactly the hallucination it exists to flag. The exemption is now withheld when the prompt names a *moving target* — `promptAsksForLiveData`, which owns the live/dated keyword list and is shared with `promptLooksCalculatorish` so the two cannot drift. `google for` sits in the live list because it names an external service; `search for` / `look up` stay out, because "look up the invoice number" is answered by the page.
2. **`followUpExtendsThePreviousBody` compared only through the first user message** — it would have stayed green while a later message, or the entire tools array, changed underneath. It now finds the real end of the `messages` array by bracket-depth scan (string- and escape-aware, so a fixture containing a bracket can't silently shift the window) and asserts three things: turn one's whole array is a byte prefix of turn two, turn two *appends* rather than re-serializes, and every field after `messages` — `model`, `stream`, and the whole `tools` array — is byte-identical.
3. **The capture harness used one process-global slot** with non-atomic reset/send/read, so two concurrent captures could clobber each other, or worse compare a request against itself and pass. Captures are now keyed by a per-capture token carried in the fake base URL's host, with read-and-remove semantics. The new `concurrentCapturesStayIsolated` test fails against the single-slot version (it reads Beta's body back for Alpha's capture), so the suite no longer depends on `--no-parallel` for correctness.
4. **The access-line regex was unanchored** [NIT], so `WARNING: probe failed: sent "GET /healthz HTTP/1.1" 200 but the body was empty` — the single most useful line in the drawer when health checks are lying — was suppressed. It is now anchored at both ends, with the leading group covering both uvicorn's padded `levelprefix` and a propagated `LEVEL:logger.name:` prefix.

The negative controls are worth recording, because #1 showed something useful: with `outputFormatting = []`, the *same request* serializes its two tool objects with different key orders —

```
{"type":"function","function":{"name":"web_search","parameters":…
{"type":"function","function":{"parameters":{"required":…,"name":"browse",…
```

— which is the defect this PR fixes, reproduced on demand.

## Adversarial review round 2

Four more, all real, all fixed with a verified negative control:

1. **The exemption still covered self-contained arithmetic.** "Attached is my résumé; calculate 17*23" has a document that is simply irrelevant — the numbers are in the prompt and the calculator is the tool that should have run. `promptContainsSelfContainedArithmetic` now withholds the exemption when the prompt brought its own numbers (digit + operator, with `-` counting only between two digits so a hyphenated filename isn't arithmetic). The dogfood case stays exempt, and the line between them is explainable: "what is the total due? calculate it from the invoice" has its operands *on the page*.
2. **Whole-word matching had dropped ordinary plurals** that the old substring match caught — "temperatures", "forecasts", "current prices", "latest versions". `containsKeyword` now accepts a trailing `s`/`es` before the boundary, and still rejects "forecasting" (next scalar is `i`), "forecasted" (`ed` is not `es`), "temperate", and "concurrent".
3. **A cached row with no measurable size fell through to the download estimate**, which was then shown — and spoken as "on disk ~633 MB" — for a model that is not being downloaded. It now claims no size at all. This one **replaced an earlier test of mine that asserted the opposite** (fall back, on the theory that an empty size lane reads as "free"); the note on the new test records why that was wrong: it is the same defect this file exists for, one lane along, and a wrong number is worse than no number.
4. **What happens to the clock on retry / regenerate / edit** — verified and documented rather than changed, because the two options are not both available. A new send and an edited send each mint a fresh row (`editUserMessage` rewinds and calls `send`, whose `ChatMessage` defaults `createdAt` to `Date()`), so both carry the live clock, and the edited text has already broken the shared prefix at that row so it costs nothing. Regenerate/Retry reuse the row deliberately: a "live" clock there would have to stay stable on *every later turn* too, or the prefix breaks for the rest of the conversation — so "live clock on regenerate" and "reuse the prefix" cannot both hold. Reporting when the user actually asked is the defensible half. Pinned by a test.

## Adversarial review round 3

Four more, all real:

1. **Every user row said "The current local time is …"** — so a follow-up put three contradictory *current* times in one prompt, and a bare clock on an old row attached yesterday's time to today's `[CURRENT DATE]` in a conversation that crossed midnight. Fixed as described above: `[MESSAGE SENT]`, with the full date, uniform on every row. Note this is a copy change, not a mechanism change; the mechanism is what makes the copy possible.
2. **The attachment gate read only the newest user row** — but `ChatMessage.modelContent` re-sends every attachment's extracted text on each follow-up, so "what was the invoice total?" two turns after the invoice was attached *is* answered from a document in front of the model, and was being captioned as a guess. This reverses a judgement of mine that had its own test. It now scans every user row, **and scans the post-trim wire history rather than the transcript**: `trimMessagesForContextWindow` drops the oldest rows on a long conversation, and a document that was trimmed away is no longer grounding anything — treating it as grounding would silence the caption at the exact moment the evidence is gone. That needed one new per-turn field (`wireHistoryCarriesAttachmentGrounding`), set from the same array that is about to be encoded, because by the time the stream finishes the trim is no longer recomputable.
3. **`1200 - 180` was not recognised as arithmetic** — only a minus touching both digits was, so the spaced form (how most people type it) stayed exempt whenever an attachment was present.
4. **`reSendPathsReportTheRightClock` built rows by hand** and only called the stamper, so it would have stayed green if `editUserMessage` or `regenerateAnswer` stopped minting or reusing rows correctly. The golden surface now drives both for real and reads the recorded wire bodies back. Writing it earned its keep immediately: the first version failed on a race the hand-built test could not see (the edit landed while the regenerate stream was still in flight and `editUserMessage` refused it), which is now waited on explicitly.

## Adversarial review round 4

Two, both real:

1. **External-retrieval language still kept the exemption.** A résumé plus "search for Ada Lovelace's biography" asks to leave the document entirely, so the page grounds nothing — and the exemption silenced the caption on a completely ungrounded answer. The disqualifier form of this gate grew a hole in every single round, so it is now stated as what **is** exempt. Of the four lanes that make a prompt tool-shaped at all, exactly one is answerable from an attached page:

   | lane | can an attached document answer it? |
   | --- | --- |
   | math keywords, no literal expression ("calculate the total") | **yes** — the operands are on the page |
   | self-contained arithmetic (`17*23`) | no — the prompt brought its own numbers |
   | live data (today's price, the weather) | no — no page holds a moving target |
   | external retrieval (search for, look up) | no — it asks to leave the document |

   The cost is accepted knowingly and written down: "look up the invoice number" with the invoice attached now wears a caution it does not deserve. Of the two errors, the false negative is the one this feature exists to prevent, and the caption is dismissible while a silent wrong answer is not.
2. **`[CURRENT DATE]` carried the zone abbreviation** [NIT], which is instant-specific: `PST`/`PDT` flips mid-day at a daylight-saving transition and would re-prefill every open conversation twice a year — inside the one block this whole change exists to hold still. Identifier only now, pinned by a test that renders both sides of the 2026 spring-forward and expects byte-equality. The abbreviation still rides each message trailer, where it describes a specific instant and is therefore correct.

## Adversarial review round 5

Two fixed, two declined with the reasoning recorded here.

**Fixed — a late regenerate reported a stale clock.** Regenerate/retry reuse the user row, so its "sent" stamp is the original ask time. That is honest, but re-answering "what time is it?" 45 minutes later then handed the model a 45-minute-old clock — worse than the behaviour this PR replaced, which recomputed the clock per request. `answeringNowLine` now *appends* the answer time to that one row, and only when the two instants render to different minutes. An ordinary send (the row was minted by this very request) and a same-minute regenerate are byte-identical to having no such line at all, so the common path pays nothing; the rare late regenerate ends the next turn's shared prefix just before that row, a re-prefill of the last exchange rather than of the document. The row's own stamp is never rewritten.

**Fixed — the grounding flag was view-model state.** `wireHistoryCarriesAttachmentGrounding` was written at the send site and read at the completion site, so of two overlapping streams the one that finished last read the other's value and could suppress or show the wrong caption. It is now a request-scoped value threaded through `runOneStream` next to the request it describes; the stored property is gone.

**Declined — "any attachment in the wire history counts as grounding" is too broad.** Round 3 called the opposite reading a blocking bug: reading only the newest row was wrong, because a follow-up "calculate the total" about an invoice attached two turns ago *is* grounded. Round 5 calls the fix too broad, because an unrelated résumé attached earlier also exempts it. Both are true, and nothing in between is decidable without the model's own reading of the prompt — the suggested fix, "associate grounding with the relevant attachment reference", is that same judgment under another name. The chosen error is the recoverable one: a dismissible caption withheld inside a conversation that does contain a document, rather than a silent ungrounded answer wearing no caution.

**Declined — a date like `9/11` reads as arithmetic** [NIT]. True: "calculate the invoice total for report 9/11" loses the attachment exemption because of the date. The suggested fix (require operand–operator–operand) does not address it — `9/11` is exactly that shape — and no lexical rule separates a date from a division. The residual error is again the conservative one: a caution shown where none was needed.

## Adversarial review round 6

Two fixed, two declined. Round 6's third blocking finding is round 5's second and round 3's first, arriving for the third time with the verdict reversed in between — the diminishing-returns signal, so this is the last round.

**Fixed — two `Date()` calls in one assembly.** The `[CURRENT DATE]` system row and the clock trailer sampled the clock separately, so a request assembled across local midnight could assert "Today is the 11th" and "this message was sent … the 12th" in the same prompt. One `requestInstant` now feeds both. The new test pins the other half of the property — that the two renderings agree on the calendar day for a shared instant, including at the boundary, where a mismatched calendar or zone between the formatters would surface; the single-instant threading itself is a three-line read at the send site.

**Fixed — the log filter dropped everyone's polls, not the app's.** Any client address matched, so a `/healthz` from a phone on the LAN was filed as the app's own noise — the one line that proves a reachability probe arrived, hidden from the drawer someone opened to look for it. Loopback only now (`127.0.0.1`, `::1`, `[::1]`, `localhost`, with or without a port).

**Declined — historical trailers render in the current time zone.** True, and knowingly kept. Changing the Mac's time zone re-renders every prior trailer, which costs one re-prefill — the same accepted class as a conversation crossing midnight, already documented on `currentDateContext`. It does not misstate anything: the instant is unchanged and re-expressing it in the user's current zone is exactly what the message timestamps in the transcript itself do. Pinning each row to its send-time zone means a new persisted field on `ChatMessage` and a store migration, which is not this PR.

**Declined — the attachment-grounding breadth**, for the reasons recorded under round 5.

## Pre-existing Python failures

`full_unit` reports 8 failures. This PR is 100% Swift under `apps/rapid-mac/` and cannot affect them. Confirmed pre-existing by running the two files on a clean `origin/main` worktree with none of these changes — same 8 failures, `8 failed, 245 passed`:

```
tests/test_bonsai_image_alias.py  (7)  TypeError: TilingConfig.__init__() got an
                                       unexpected keyword argument 'vae_decode_tile_size'
tests/test_doctor_env_health.py   (1)  doctor probe did not complete
```

The `TilingConfig` one is an environment drift, not a code bug: `pyproject.toml` floors `mflux>=0.19.0,<0.20`, the validate environment has **0.18.1**, and `runtime.py` is written against the 0.19 field name (`vae_decode_tile_size`; 0.18.1 calls it `vae_decode_tiles_per_dim`). It is import-time fatal, so those 7 tests will fail for *every* PR until the validate environment is brought up to the project's own floor. Flagged rather than folded in here.

## Note on the engine side

While measuring I hit `[cache_fetch] LCP unavailable: … non_trimmable=True` against a stale cache entry whose length exceeded the shared prefix by 4 tokens. That is a pre-existing engine-side limitation (the LCP fallback is refused when any layer is non-trimmable) and it is **not** on the critical path any more: the point of this PR is that the desktop app now emits clean append-only prefix extensions, which is what the engine's fast path wants. No engine change is needed for the numbers above. Left out of this PR deliberately — different merge lane, different review scope.

## Test plan

- [x] `swift build` clean.
- [x] Full desktop suite green via `scripts/desktop-test-timeout.sh` (all suites, `--no-parallel`): 3865 tests in 323 suites, rebased on `main` so #3322's tests run alongside these.
- [x] Every review fix verified by reverting it and watching its test fail — round 1: blanket Gate 1c (5 failures), unanchored regex (3), single-slot capture store (2, reading Beta's body back for Alpha's capture), `outputFormatting = []` (all three determinism tests). Round 2: arithmetic exemption (4), plural keywords (6), cached size fallback (2, showing `~633 MB` for an on-disk model). Round 3: spaced-minus arithmetic (3), newest-row-only grounding (1). Round 4: retrieval exemption (3), DST-unstable abbreviation (3). Round 5: stale regenerate clock (2 tests / 3 issues). Round 6: LAN access line (1 test / 2 issues).
- [x] `WireBodyDeterminismTests` (new, 3 tests) verified as a real gate: with `outputFormatting = []` all three fail; with `.sortedKeys` all three pass.
- [x] `CurrentDateTimeContextTests` rewritten — exact `[CURRENT DATE]` / `[MESSAGE SENT]` output, stability across a minute boundary, per-row stamping from each row's own `createdAt`, idempotence, midnight rollover for both halves, and `wireSuffix` absent after a persist/restore round-trip.
- [x] `GoldenChatFakeContractTests` drives the real resend paths end to end: a regenerate re-sends the same row with a byte-identical trailer, an edited send mints a new row and stamps it from its own `createdAt`.
- [x] `ToolNotCalledCaptionTests` — whole-word matching contract, the attachment gate, and a sanity check that the same message shape still flags when the attachment is removed.
- [x] `ServerLogNoiseTests` and `QuickstartShortlistLabelTests` (new) cover the filter (including kept non-2xx polls) and the cached/uncached label lanes.
- [x] Hands-on in a freshly built, CFPreferences-isolated 0.14.1 with a throwaway `$HOME`: measured the turn table above from the engine log (`bonsai-27b-2bit`); confirmed the Quickstart cached badge, the Settings caption, and a log drawer that now shows real lines. The measurement was taken on this exact desktop diff before it was rebased onto #3322; after the rebase the app was rebuilt and relaunched to confirm it comes up clean, and the byte-level property the measurement depends on is pinned by `WireBodyDeterminismTests` rather than by a repeated stopwatch reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Measured impact on Qwen3.8-27B (2026-09-14 retrospective, Atlas)

Part of the 27B prefix-cache line (with #3435 and #3454). Before this PR every follow-up turn was a cold prefill on hybrid (GDN) models because the date/clock moved in the system row; after it, follow-up turns are append-only prefix hits. On Qwen3.8-27B (Studio) this is what makes #3435 and #3454 measurable at all: a follow-up on a 5.7k-token conversation goes from a ~20 s cold prefill to a ~1.5 s incremental one. Retrospective of the whole 27B line: decode is at the memory wall (AR ~64 ms/tok on M4 Pro, MTP rounds +31–49% per round after #3388/#3417), and this PR plus #3435/#3454 close the prefill side; no further 27B work is planned.
