### PR TITLE
perf: prefetch DeepSeek V4.1 Engram from SSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,7 @@ jobs:
             tests/test_deepseek_v41_artifacts.py \
             tests/test_deepseek_v41_affine_route_qmv.py \
             tests/test_deepseek_v41_dspark.py \
+            tests/test_deepseek_v41_engram_offload.py \
             tests/test_deepseek_v41_native_load.py \
             tests/test_dspark_scheduler.py \
             tests/test_scheduler_admission_policy.py \

--- a/docs/engineering/performance/2026-09-11-deepseek-v41-engram-offload.md
+++ b/docs/engineering/performance/2026-09-11-deepseek-v41-engram-offload.md
@@ -1,0 +1,77 @@
+# DeepSeek V4.1 Flash Engram SSD offload qualification
+
+Date: 2026-09-11
+
+Status: qualified as the default product load path for the 256 GiB DeepSeek
+V4.1 Flash REAP 2-bit target. Selected Engram rows are prefetched from the
+checkpoint mmap while preceding transformer layers execute.
+
+## Boundary
+
+This experiment changes only the residency and scheduling of the two
+affine-quantized Engram embedding tables. Tensor validation is strict and the
+same selected rows are dequantized with the same MLX affine operation. Target
+weights, DSpark weights, verifier, K=4 policy, sampling, API, and catalog are
+unchanged.
+
+## Environment
+
+- Apple M3 Ultra, 256 GiB unified memory (`hw.memsize=274877906944`)
+- macOS 26.5.2 (25F84)
+- Rapid base commit `c152b0451`
+- Target: local 212.93 GB REAP12.5 native affine 2-bit checkpoint
+- DSpark: pinned 4-bit-dense/2-bit-expert sidecar, 4.62 GB
+- Four fixed prompts: code, arithmetic reasoning, JSON-only structured output,
+  and Chinese
+- Greedy speculative decode, K=4, one 16-token warmup, 64 output tokens per
+  prompt
+
+The benchmark used the product runtime loader and recorded MLX active and peak
+memory. The resident control changed only `engram_ssd_offload=False`; prompts,
+process configuration, target, sidecar, and decode loop were identical.
+
+## Result
+
+| Metric | Resident Engram | Prefetched SSD Engram | Change |
+| --- | ---: | ---: | ---: |
+| Load time | 266.72 s | 170.02 s | -36.3% |
+| Peak MLX memory | 217.95 GB | 156.78 GB | -61.17 GB (-28.1%) |
+| Weighted decode | 16.65 tok/s | 16.47 tok/s | -1.0% |
+
+Per-domain prefetched SSD results:
+
+| Domain | tok/s | Accepted tokens/block |
+| --- | ---: | ---: |
+| Code | 19.25 | 1.91 |
+| Reasoning | 17.02 | 1.56 |
+| Structured | 21.10 | 2.15 |
+| Chinese | 11.80 | 0.78 |
+
+The resident control produced 19.63, 16.63, 21.55, and 12.08 tok/s for the
+same prompts and identical acceptance counts. SSD prefetch therefore preserves
+98.95% of resident weighted throughput while leaving roughly 61 GB more memory
+headroom. Without prefetch, the same SSD path measured 9.25 tok/s; overlapping
+selected-row I/O with model computation recovered 78.0% throughput.
+
+## Correctness and operational checks
+
+- Direct resident-versus-disk affine row parity passes.
+- Prefetched and synchronous paths return identical arrays.
+- A mismatched prefetch is discarded and the requested rows are read instead.
+- Tensor dtype, shape, byte length, file boundary, row bounds, and index mapping
+  are validated before use.
+- The raw-row cache is bounded; close is idempotent and shuts down pending I/O.
+- Two clean product loads completed without memory-pressure termination. A
+  prior resident full-model experiment was killed under memory pressure, while
+  the controlled resident run completed near 218 GB peak.
+
+## Decision and limitation
+
+Use prefetched Engram SSD offload in the DeepSeek V4.1 product runtime on the
+qualified 256 GiB path. The 1.0% weighted decode cost is justified by the 28.1%
+peak-memory reduction and 36.3% faster load.
+
+This does not establish a 40 tok/s result. The per-domain spread tracks draft
+acceptance much more strongly than Engram residency, so the next optimization
+should improve draft acceptance and target verification cost rather than add
+more SSD caching complexity.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -6,6 +6,7 @@ summary statistics, and limitations.
 
 ## Reports
 
+- [DeepSeek V4.1 Flash Engram SSD offload qualification](2026-09-11-deepseek-v41-engram-offload.md)
 - [Qwen3.8 27B MTP FP16 checkpoint qualification](2026-09-07-qwen38-mtp-fp16.md)
 - [Qwen4 fp32-input fast RMSNorm qualification](2026-09-06-qwen4-fast-rmsnorm.md)
 - [FLUX.2 Klein q4/BF16 image precision qualification](2026-09-04-image-weight-precision.md)

--- a/tests/test_deepseek_v41_artifacts.py
+++ b/tests/test_deepseek_v41_artifacts.py
@@ -779,7 +779,7 @@ def test_load_product_runtime_composes_owned_components(monkeypatch):
     draft = SimpleNamespace()
     calls = []
     load_calls = []
-    monkeypatch.setattr(serving.os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(serving, "supports_engram_ssd_offload", lambda _path: True)
     monkeypatch.setattr(
         serving,
         "load",
@@ -830,7 +830,7 @@ def test_load_product_runtime_keeps_nonindexed_target_resident(monkeypatch):
     )
     draft = SimpleNamespace()
     load_calls = []
-    monkeypatch.setattr(serving.os.path, "isfile", lambda _path: False)
+    monkeypatch.setattr(serving, "supports_engram_ssd_offload", lambda _path: False)
     monkeypatch.setattr(
         serving,
         "load",

--- a/tests/test_deepseek_v41_artifacts.py
+++ b/tests/test_deepseek_v41_artifacts.py
@@ -779,6 +779,7 @@ def test_load_product_runtime_composes_owned_components(monkeypatch):
     draft = SimpleNamespace()
     calls = []
     load_calls = []
+    monkeypatch.setattr(serving.os.path, "isfile", lambda _path: True)
     monkeypatch.setattr(
         serving,
         "load",
@@ -813,6 +814,47 @@ def test_load_product_runtime_composes_owned_components(monkeypatch):
     assert model.eval_interval == 40
     assert load_calls == [(("/target",), {"lazy": False, "engram_ssd_offload": True})]
     assert calls == [draft, draft]
+
+
+@pytest.mark.requires_mlx
+def test_load_product_runtime_keeps_nonindexed_target_resident(monkeypatch):
+    from vllm_mlx.models.deepseek_v41_native import serving
+
+    model = SimpleNamespace(
+        layers=[object()], eval_interval=0, embed=object(), head=object()
+    )
+    weights = SimpleNamespace(
+        config={"dspark_block_size": 5},
+        attach_target=lambda _model: None,
+        pin_mtp=lambda: None,
+    )
+    draft = SimpleNamespace()
+    load_calls = []
+    monkeypatch.setattr(serving.os.path, "isfile", lambda _path: False)
+    monkeypatch.setattr(
+        serving,
+        "load",
+        lambda *args, **kwargs: load_calls.append((args, kwargs)) or (model, object()),
+    )
+    monkeypatch.setattr(serving, "install_target_qmv", lambda _model: 1)
+    monkeypatch.setattr(serving, "DSparkWeights", lambda _path: weights)
+    monkeypatch.setattr(serving, "DSpark", lambda _target, pin_weights: draft)
+    monkeypatch.setattr(serving, "_install_vectorized_mtp_attention", lambda _draft: 0)
+    monkeypatch.setattr(serving, "_install_packed_mtp_moe", lambda _draft: 0)
+    monkeypatch.setattr(
+        serving.PreTrainedTokenizerFast,
+        "from_pretrained",
+        lambda *_a, **_k: _Tokenizer(),
+    )
+
+    serving.load_product_runtime(
+        "/target",
+        "/mtp",
+        target_revision="target-rev",
+        mtp_revision="mtp-rev",
+    )
+
+    assert load_calls == [(("/target",), {"lazy": False, "engram_ssd_offload": False})]
 
 
 @pytest.mark.requires_mlx

--- a/tests/test_deepseek_v41_artifacts.py
+++ b/tests/test_deepseek_v41_artifacts.py
@@ -778,7 +778,12 @@ def test_load_product_runtime_composes_owned_components(monkeypatch):
     )
     draft = SimpleNamespace()
     calls = []
-    monkeypatch.setattr(serving, "load", lambda *_a, **_k: (model, object()))
+    load_calls = []
+    monkeypatch.setattr(
+        serving,
+        "load",
+        lambda *args, **kwargs: load_calls.append((args, kwargs)) or (model, object()),
+    )
     monkeypatch.setattr(serving, "install_target_qmv", lambda _model: 1)
     monkeypatch.setattr(serving, "DSparkWeights", lambda _path: weights)
     monkeypatch.setattr(serving, "DSpark", lambda _target, pin_weights: draft)
@@ -806,6 +811,7 @@ def test_load_product_runtime_composes_owned_components(monkeypatch):
     assert runtime.drafter is draft
     assert runtime.drafter_repo == "owner/head"
     assert model.eval_interval == 40
+    assert load_calls == [(("/target",), {"lazy": False, "engram_ssd_offload": True})]
     assert calls == [draft, draft]
 
 

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -72,16 +72,28 @@ def test_disk_engram_matches_resident_affine_rows_and_caches_repeats(tmp_path):
     assert disk.cache_hits == 5
 
 
-def test_disk_engram_prefetch_matches_requested_rows(tmp_path):
+def test_disk_engram_prefetch_matches_requested_rows(tmp_path, monkeypatch):
     resident, disk, _keys, _path = _modules(tmp_path)
     indices = mx.array([[[1, 3, 1], [7, 3, 2]]], mx.int32)
+    gather_calls = 0
+    original = disk._gather_rows
+
+    def counted_gather(flat):
+        nonlocal gather_calls
+        gather_calls += 1
+        return original(flat)
+
+    monkeypatch.setattr(disk, "_gather_rows", counted_gather)
 
     disk.prefetch(indices)
+    assert disk._pending is not None
+    disk._pending[1].result()
     expected = resident(indices)
     actual = disk(indices)
     mx.eval(expected, actual)
 
     assert mx.array_equal(actual, expected).item()
+    assert gather_calls == 1
     assert disk.cache_misses == 4
     assert disk.cache_hits == 2
 

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -158,3 +158,34 @@ def test_disk_engram_rejects_header_contract_mismatch(tmp_path):
             numpy_dtype=np.dtype("<u4"),
             shape=(8, 4),
         )
+
+
+def test_disk_engram_constructor_preserves_error_after_partial_view(
+    tmp_path, monkeypatch
+):
+    _resident, disk, keys, path = _modules(tmp_path)
+    disk.close()
+    calls = 0
+    original = DiskQuantizedEngramEmbedding._tensor_view
+
+    def fail_after_first_view(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ValueError("malformed scales")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        DiskQuantizedEngramEmbedding, "_tensor_view", fail_after_first_view
+    )
+    with pytest.raises(ValueError, match="malformed scales"):
+        DiskQuantizedEngramEmbedding(
+            path,
+            weight_key=keys["weight"],
+            scales_key=keys["scales"],
+            biases_key=keys["biases"],
+            num_embeddings=8,
+            dim=64,
+            group_size=32,
+            bits=2,
+        )

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -189,3 +189,15 @@ def test_disk_engram_constructor_preserves_error_after_partial_view(
             group_size=32,
             bits=2,
         )
+
+
+def test_disk_engram_rejects_overlapping_tensor_ranges():
+    with pytest.raises(ValueError, match="overlapping"):
+        DiskQuantizedEngramEmbedding._validate_header_ranges(
+            {
+                "weight": {"data_offsets": [0, 64]},
+                "scales": {"data_offsets": [32, 96]},
+                "__metadata__": {"format": "mlx"},
+            },
+            data_size=96,
+        )

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import struct
+
 import numpy as np
 import pytest
 
@@ -188,6 +190,23 @@ def test_disk_engram_rejects_header_contract_mismatch(tmp_path):
         )
 
 
+def test_disk_engram_rejects_oversized_header_before_read(tmp_path):
+    path = tmp_path / "oversized.safetensors"
+    path.write_bytes(struct.pack("<Q", 100_000_001))
+
+    with pytest.raises(ValueError, match="header length"):
+        DiskQuantizedEngramEmbedding(
+            path,
+            weight_key="weight",
+            scales_key="scales",
+            biases_key="biases",
+            num_embeddings=8,
+            dim=64,
+            group_size=32,
+            bits=2,
+        )
+
+
 def test_disk_engram_constructor_preserves_error_after_partial_view(
     tmp_path, monkeypatch
 ):
@@ -220,7 +239,7 @@ def test_disk_engram_constructor_preserves_error_after_partial_view(
 
 
 def test_disk_engram_rejects_overlapping_tensor_ranges():
-    with pytest.raises(ValueError, match="overlapping"):
+    with pytest.raises(ValueError, match="non-contiguous"):
         DiskQuantizedEngramEmbedding._validate_header_ranges(
             {
                 "weight": {"data_offsets": [0, 64]},
@@ -229,3 +248,16 @@ def test_disk_engram_rejects_overlapping_tensor_ranges():
             },
             data_size=96,
         )
+
+
+@pytest.mark.parametrize(
+    ("header", "data_size", "message"),
+    [
+        ({"weight": {"data_offsets": [1, 2]}}, 2, "non-contiguous"),
+        ({"weight": {"data_offsets": [0, 1]}}, 2, "do not cover"),
+        ({"weight": {"data_offsets": [0, 0]}}, 0, "non-contiguous"),
+    ],
+)
+def test_disk_engram_rejects_incomplete_tensor_coverage(header, data_size, message):
+    with pytest.raises(ValueError, match=message):
+        DiskQuantizedEngramEmbedding._validate_header_ranges(header, data_size)

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -108,6 +108,22 @@ def test_disk_engram_discards_failed_stale_prefetch(tmp_path):
     assert mx.array_equal(actual, expected).item()
 
 
+def test_disk_engram_replaces_failed_prefetch_with_current_request(tmp_path):
+    resident, disk, _keys, _path = _modules(tmp_path)
+    disk.prefetch(np.array([8], dtype=np.int64))
+    assert disk._pending is not None
+    with pytest.raises(IndexError, match="outside"):
+        disk._pending[1].result()
+    requested = mx.array([2, 7], mx.int32)
+
+    disk.prefetch(requested)
+    expected = resident(requested)
+    actual = disk(requested)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
 def test_disk_engram_gather_can_exceed_lru_capacity(tmp_path):
     resident, disk, _keys, _path = _modules(tmp_path, cache_rows=1)
     indices = mx.array([1, 3, 2], mx.int32)

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.core as mx
+
+from vllm_mlx.models.deepseek_v41_native.engram import (
+    DiskQuantizedEngramEmbedding,
+    QuantizedEngramEmbedding,
+)
+
+
+def _modules(tmp_path, *, cache_rows=4):
+    rows, dim, group_size, bits = 8, 64, 32, 2
+    logical = mx.arange(rows * dim, dtype=mx.float32).reshape(rows, dim) / 97
+    weight, scales, biases = mx.quantize(logical, group_size=group_size, bits=bits)
+    scales = scales.astype(mx.bfloat16)
+    biases = biases.astype(mx.bfloat16)
+    keys = {
+        "weight": "layers.1.engram.embed.weight",
+        "scales": "layers.1.engram.embed.scales",
+        "biases": "layers.1.engram.embed.biases",
+    }
+    path = tmp_path / "table.safetensors"
+    mx.save_safetensors(
+        str(path),
+        {
+            keys["weight"]: weight,
+            keys["scales"]: scales,
+            keys["biases"]: biases,
+        },
+    )
+    resident = QuantizedEngramEmbedding(rows, dim, group_size, bits)
+    resident.weight = weight
+    resident.scales = scales
+    resident.biases = biases
+    disk = DiskQuantizedEngramEmbedding(
+        path,
+        weight_key=keys["weight"],
+        scales_key=keys["scales"],
+        biases_key=keys["biases"],
+        num_embeddings=rows,
+        dim=dim,
+        group_size=group_size,
+        bits=bits,
+        cache_rows=cache_rows,
+    )
+    return resident, disk, keys, path
+
+
+def test_disk_engram_matches_resident_affine_rows_and_caches_repeats(tmp_path):
+    resident, disk, _keys, _path = _modules(tmp_path)
+    indices = mx.array([[[1, 3, 1], [7, 3, 2]]], mx.int32)
+
+    expected = resident(indices)
+    actual = disk(indices)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+    assert disk.cache_misses == 4
+    assert disk.cache_hits == 2
+
+    repeated = disk(mx.array([1, 3, 2], mx.int32))
+    mx.eval(repeated)
+    assert disk.cache_misses == 4
+    assert disk.cache_hits == 5
+
+
+def test_disk_engram_prefetch_matches_requested_rows(tmp_path):
+    resident, disk, _keys, _path = _modules(tmp_path)
+    indices = mx.array([[[1, 3, 1], [7, 3, 2]]], mx.int32)
+
+    disk.prefetch(indices)
+    expected = resident(indices)
+    actual = disk(indices)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+    assert disk.cache_misses == 4
+    assert disk.cache_hits == 2
+
+
+def test_disk_engram_prefetch_mismatch_falls_back_to_requested_rows(tmp_path):
+    resident, disk, _keys, _path = _modules(tmp_path)
+    disk.prefetch(mx.array([1, 3], mx.int32))
+    requested = mx.array([2, 7], mx.int32)
+
+    expected = resident(requested)
+    actual = disk(requested)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_disk_engram_gather_can_exceed_lru_capacity(tmp_path):
+    resident, disk, _keys, _path = _modules(tmp_path, cache_rows=1)
+    indices = mx.array([1, 3, 2], mx.int32)
+
+    expected = resident(indices)
+    actual = disk(indices)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+    assert len(disk._cache) == 1
+
+
+def test_disk_engram_bounds_close_and_cache_validation(tmp_path):
+    _resident, disk, _keys, path = _modules(tmp_path, cache_rows=0)
+    with pytest.raises(IndexError, match="outside"):
+        disk(mx.array([8], mx.int32))
+    disk.close()
+    disk.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        disk(mx.array([0], mx.int32))
+    with pytest.raises(ValueError, match="cache_rows"):
+        DiskQuantizedEngramEmbedding(
+            path,
+            weight_key="layers.1.engram.embed.weight",
+            scales_key="layers.1.engram.embed.scales",
+            biases_key="layers.1.engram.embed.biases",
+            num_embeddings=8,
+            dim=64,
+            group_size=32,
+            bits=2,
+            cache_rows=-1,
+        )
+
+
+def test_disk_engram_rejects_header_contract_mismatch(tmp_path):
+    _resident, disk, keys, path = _modules(tmp_path)
+    with pytest.raises(ValueError, match="shape"):
+        DiskQuantizedEngramEmbedding(
+            path,
+            weight_key=keys["weight"],
+            scales_key=keys["scales"],
+            biases_key=keys["biases"],
+            num_embeddings=7,
+            dim=64,
+            group_size=32,
+            bits=2,
+        )
+
+    with pytest.raises(ValueError, match="byte length"):
+        disk._tensor_view(
+            {
+                "outside": {
+                    "dtype": "U32",
+                    "shape": [8, 4],
+                    "data_offsets": [len(disk._mapping), len(disk._mapping) + 128],
+                }
+            },
+            "outside",
+            dtype="U32",
+            numpy_dtype=np.dtype("<u4"),
+            shape=(8, 4),
+        )

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -96,6 +96,18 @@ def test_disk_engram_prefetch_mismatch_falls_back_to_requested_rows(tmp_path):
     assert mx.array_equal(actual, expected).item()
 
 
+def test_disk_engram_discards_failed_stale_prefetch(tmp_path):
+    resident, disk, _keys, _path = _modules(tmp_path)
+    disk.prefetch(np.array([8], dtype=np.int64))
+    requested = mx.array([2, 7], mx.int32)
+
+    expected = resident(requested)
+    actual = disk(requested)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
 def test_disk_engram_gather_can_exceed_lru_capacity(tmp_path):
     resident, disk, _keys, _path = _modules(tmp_path, cache_rows=1)
     indices = mx.array([1, 3, 2], mx.int32)

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -160,6 +160,20 @@ def test_disk_engram_bounds_close_and_cache_validation(tmp_path):
         )
 
 
+def test_disk_engram_close_drains_pending_prefetch(tmp_path):
+    _resident, disk, _keys, _path = _modules(tmp_path)
+    disk.prefetch(np.array([1, 3], dtype=np.int64))
+    assert disk._pending is not None
+    pending = disk._pending[1]
+
+    disk.close()
+
+    assert pending.done()
+    assert disk._executor is None
+    with pytest.raises(RuntimeError, match="closed"):
+        disk(mx.array([1], mx.int32))
+
+
 def test_disk_engram_rejects_header_contract_mismatch(tmp_path):
     _resident, disk, keys, path = _modules(tmp_path)
     with pytest.raises(ValueError, match="shape"):
@@ -255,9 +269,18 @@ def test_disk_engram_rejects_overlapping_tensor_ranges():
     [
         ({"weight": {"data_offsets": [1, 2]}}, 2, "non-contiguous"),
         ({"weight": {"data_offsets": [0, 1]}}, 2, "do not cover"),
-        ({"weight": {"data_offsets": [0, 0]}}, 0, "non-contiguous"),
     ],
 )
 def test_disk_engram_rejects_incomplete_tensor_coverage(header, data_size, message):
     with pytest.raises(ValueError, match=message):
         DiskQuantizedEngramEmbedding._validate_header_ranges(header, data_size)
+
+
+def test_disk_engram_allows_empty_safetensors_tensor_ranges():
+    DiskQuantizedEngramEmbedding._validate_header_ranges(
+        {
+            "empty": {"data_offsets": [0, 0]},
+            "weight": {"data_offsets": [0, 1]},
+        },
+        data_size=1,
+    )

--- a/tests/test_deepseek_v41_engram_offload.py
+++ b/tests/test_deepseek_v41_engram_offload.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import struct
+from concurrent.futures import Future
 
 import numpy as np
 import pytest
@@ -170,6 +171,42 @@ def test_disk_engram_bounds_close_and_cache_validation(tmp_path):
             bits=2,
             cache_rows=-1,
         )
+    with pytest.raises(ValueError, match="unsupported affine"):
+        DiskQuantizedEngramEmbedding(
+            path,
+            weight_key="layers.1.engram.embed.weight",
+            scales_key="layers.1.engram.embed.scales",
+            biases_key="layers.1.engram.embed.biases",
+            num_embeddings=8,
+            dim=64,
+            group_size=32,
+            bits=5,
+        )
+
+
+def test_disk_engram_bypass_paths_handle_empty_and_uncached_rows(tmp_path):
+    resident, disk, _keys, _path = _modules(tmp_path, cache_rows=0)
+
+    empty = disk(mx.array([], mx.int32))
+    indices = mx.array([1, 3, 1], mx.int32)
+    actual = disk(indices)
+    expected = resident(indices)
+    mx.eval(empty, actual, expected)
+
+    assert empty.shape == (0, 64)
+    assert mx.array_equal(actual, expected).item()
+    assert disk.cache_misses == 2
+    assert disk.cache_hits == 0
+
+
+def test_disk_engram_closed_views_and_prefetch_fail_cleanly(tmp_path):
+    _resident, disk, _keys, _path = _modules(tmp_path)
+    disk.close()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        disk._views()
+    with pytest.raises(RuntimeError, match="closed"):
+        disk.prefetch(np.array([1], dtype=np.int64))
 
 
 def test_disk_engram_close_drains_pending_prefetch(tmp_path):
@@ -233,6 +270,23 @@ def test_disk_engram_rejects_oversized_header_before_read(tmp_path):
         )
 
 
+def test_disk_engram_rejects_truncated_header_prefix(tmp_path):
+    path = tmp_path / "truncated.safetensors"
+    path.write_bytes(b"short")
+
+    with pytest.raises(ValueError, match="truncated"):
+        DiskQuantizedEngramEmbedding(
+            path,
+            weight_key="weight",
+            scales_key="scales",
+            biases_key="biases",
+            num_embeddings=8,
+            dim=64,
+            group_size=32,
+            bits=2,
+        )
+
+
 def test_disk_engram_constructor_preserves_error_after_partial_view(
     tmp_path, monkeypatch
 ):
@@ -274,6 +328,40 @@ def test_disk_engram_rejects_overlapping_tensor_ranges():
             },
             data_size=96,
         )
+
+
+@pytest.mark.parametrize(
+    ("header", "message"),
+    [
+        ([], "invalid safetensors header"),
+        ({"weight": []}, "tensor entry"),
+        ({"weight": {"data_offsets": "0,1"}}, "tensor offsets"),
+        ({"weight": {"data_offsets": [-1, 0]}}, "tensor offsets"),
+    ],
+)
+def test_disk_engram_rejects_malformed_header_entries(header, message):
+    with pytest.raises(ValueError, match=message):
+        DiskQuantizedEngramEmbedding._validate_header_ranges(header, data_size=1)
+
+
+def test_disk_engram_rejects_missing_tensor(tmp_path):
+    _resident, disk, _keys, _path = _modules(tmp_path)
+
+    with pytest.raises(ValueError, match="missing Engram tensor"):
+        disk._tensor_view(
+            {},
+            "missing",
+            dtype="U32",
+            numpy_dtype=np.dtype("<u4"),
+            shape=(8, 4),
+        )
+
+
+def test_disk_engram_discard_future_consumes_cancellation():
+    future = Future()
+    DiskQuantizedEngramEmbedding._discard_future(future)
+
+    assert future.cancelled()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -81,6 +81,17 @@ def test_indexed_shard_allows_same_repository_hub_blob(tmp_path) -> None:
     assert resolve_indexed_shard(str(snapshot), "shard.safetensors") == str(blob)
 
 
+def test_indexed_shard_does_not_trust_arbitrary_snapshots_name(tmp_path) -> None:
+    snapshot = tmp_path / "snapshots" / "revision"
+    snapshot.mkdir(parents=True)
+    outside = tmp_path / "outside.safetensors"
+    outside.touch()
+    (snapshot / "shard.safetensors").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="symlink escapes"):
+        resolve_indexed_shard(str(snapshot), "shard.safetensors")
+
+
 def test_quantized_grouped_wo_a_preserves_batch_sequence_and_group_axes() -> None:
     args = ModelArgs(
         dim=16,

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -26,6 +26,7 @@ from vllm_mlx.models.deepseek_v41_native.config import ModelArgs  # noqa: E402
 from vllm_mlx.models.deepseek_v41_native.load import (  # noqa: E402
     reshape_grouped_wo_a,
     resolve_indexed_shard,
+    supports_engram_ssd_offload,
 )
 from vllm_mlx.models.deepseek_v41_native.model import Model  # noqa: E402
 
@@ -90,6 +91,40 @@ def test_indexed_shard_does_not_trust_arbitrary_snapshots_name(tmp_path) -> None
 
     with pytest.raises(ValueError, match="symlink escapes"):
         resolve_indexed_shard(str(snapshot), "shard.safetensors")
+
+
+def test_indexed_shard_rejects_symlinked_hub_blobs_directory(tmp_path) -> None:
+    repository = tmp_path / "models--owner--model"
+    snapshot = repository / "snapshots" / "revision"
+    external_blobs = tmp_path / "external-blobs"
+    snapshot.mkdir(parents=True)
+    external_blobs.mkdir()
+    blob = external_blobs / "digest"
+    blob.touch()
+    (repository / "blobs").symlink_to(external_blobs)
+    (snapshot / "shard.safetensors").symlink_to(blob)
+
+    with pytest.raises(ValueError, match="symlink escapes"):
+        resolve_indexed_shard(str(snapshot), "shard.safetensors")
+
+
+def test_engram_ssd_capability_requires_affine_indexed_layout(tmp_path) -> None:
+    (tmp_path / "config.json").write_text(
+        '{"text_config":{"engram_layer_ids":[1]},"quantization":{"engram_bits":2}}'
+    )
+    (tmp_path / "shard.safetensors").touch()
+    index = tmp_path / "model.safetensors.index.json"
+    index.write_text(
+        '{"weight_map":{'
+        '"layers.1.engram.embed.weight":"shard.safetensors",'
+        '"layers.1.engram.embed.scales":"shard.safetensors",'
+        '"layers.1.engram.embed.biases":"shard.safetensors"}}'
+    )
+
+    assert supports_engram_ssd_offload(str(tmp_path))
+
+    index.write_text('{"weight_map":{}}')
+    assert not supports_engram_ssd_offload(str(tmp_path))
 
 
 def test_quantized_grouped_wo_a_preserves_batch_sequence_and_group_axes() -> None:

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 pytest.importorskip("mlx")
@@ -10,6 +13,8 @@ pytest.importorskip("mlx_lm")
 pytestmark = pytest.mark.requires_mlx
 
 import mlx.core as mx
+
+import vllm_mlx.models.deepseek_v41_native.load as native_load
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "scripts"))
 
@@ -69,6 +74,15 @@ def test_indexed_shard_rejects_local_symlink_escape(tmp_path) -> None:
         resolve_indexed_shard(str(model), "shard.safetensors")
 
 
+def test_indexed_shard_rejects_lexical_parent_escape(tmp_path) -> None:
+    model = tmp_path / "model"
+    model.mkdir()
+    (tmp_path / "outside.safetensors").touch()
+
+    with pytest.raises(ValueError, match="inside the model directory"):
+        resolve_indexed_shard(str(model), "../outside.safetensors")
+
+
 def test_indexed_shard_allows_same_repository_hub_blob(tmp_path) -> None:
     repository = tmp_path / "models--owner--model"
     snapshot = repository / "snapshots" / "revision"
@@ -125,6 +139,203 @@ def test_engram_ssd_capability_requires_affine_indexed_layout(tmp_path) -> None:
 
     index.write_text('{"weight_map":{}}')
     assert not supports_engram_ssd_offload(str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("config", "index"),
+    [
+        ({"text_config": {"engram_layer_ids": []}}, {"weight_map": {}}),
+        (
+            {
+                "text_config": {"engram_layer_ids": [1]},
+                "quantization": {"engram_bits": 2},
+            },
+            {"weight_map": []},
+        ),
+    ],
+)
+def test_engram_ssd_capability_rejects_unsupported_metadata(
+    tmp_path, config, index
+) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
+
+    assert not supports_engram_ssd_offload(str(tmp_path))
+
+
+class _FakeLoadModel:
+    def __init__(self, _args, token_map=None):
+        del token_map
+        embed = SimpleNamespace(weight=mx.zeros((8, 64)))
+        self.layers = [SimpleNamespace(layer_id=1, engram=SimpleNamespace(embed=embed))]
+        self.loaded = []
+        self.evaluated = False
+
+    def load_weights(self, items, strict=False):
+        assert not strict
+        self.loaded.extend(items)
+
+    def parameters(self):
+        return {"other": {"weight": mx.zeros((1, 1))}}
+
+    def eval(self):
+        self.evaluated = True
+
+
+def _write_offload_fixture(tmp_path, *, mapping_override=None):
+    keys = {
+        "weight": "layers.1.engram.embed.weight",
+        "scales": "layers.1.engram.embed.scales",
+        "biases": "layers.1.engram.embed.biases",
+    }
+    weight, scales, biases = mx.quantize(
+        mx.arange(8 * 64, dtype=mx.float32).reshape(8, 64) / 97,
+        group_size=32,
+        bits=2,
+    )
+    shard = tmp_path / "model.safetensors"
+    mx.save_safetensors(
+        str(shard),
+        {
+            keys["weight"]: weight,
+            keys["scales"]: scales.astype(mx.bfloat16),
+            keys["biases"]: biases.astype(mx.bfloat16),
+            "other.weight": mx.zeros((1, 1)),
+        },
+    )
+    mapping = {key: shard.name for key in keys.values()}
+    if mapping_override is not None:
+        mapping = mapping_override(mapping, keys)
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": mapping})
+    )
+    (tmp_path / "config.json").write_text("{}")
+    return keys
+
+
+def _patch_minimal_offload_loader(monkeypatch):
+    args = SimpleNamespace(engram_layer_ids=[1], n_layers=1)
+    monkeypatch.setattr(native_load.ModelArgs, "from_dict", lambda _cfg: args)
+    monkeypatch.setattr(native_load, "Model", _FakeLoadModel)
+    monkeypatch.setattr(native_load, "load_token_map", lambda *_args: [0])
+    monkeypatch.setattr(
+        native_load,
+        "reshape_grouped_wo_a",
+        lambda items, _args: list(items),
+    )
+    return args
+
+
+def test_load_wires_disk_engram_and_skips_its_resident_tensors(
+    tmp_path, monkeypatch
+) -> None:
+    from vllm_mlx.models.deepseek_v41_native.engram import (
+        DiskQuantizedEngramEmbedding,
+    )
+
+    _write_offload_fixture(tmp_path)
+    _patch_minimal_offload_loader(monkeypatch)
+    monkeypatch.setattr(
+        native_load,
+        "json",
+        SimpleNamespace(
+            load=lambda stream: (
+                {"weight_map": json.load(stream)["weight_map"]}
+                if stream.name.endswith("index.json")
+                else {"quantization": {"group_size": 32, "engram_bits": 2}}
+            )
+        ),
+    )
+
+    model, _args = native_load.load(str(tmp_path), lazy=True, engram_ssd_offload=True)
+
+    assert isinstance(model.layers[0].engram.embed, DiskQuantizedEngramEmbedding)
+    assert [name for name, _value in model.loaded] == ["other.weight"]
+    assert model.evaluated
+    model.layers[0].engram.embed.close()
+
+
+@pytest.mark.parametrize(
+    ("index_payload", "message"),
+    [
+        (None, "requires a safetensors index"),
+        ({"weight_map": []}, "requires a valid weight map"),
+    ],
+)
+def test_load_rejects_missing_or_invalid_offload_index(
+    tmp_path, monkeypatch, index_payload, message
+) -> None:
+    (tmp_path / "config.json").write_text("{}")
+    if index_payload is not None:
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps(index_payload)
+        )
+    _patch_minimal_offload_loader(monkeypatch)
+
+    with pytest.raises(ValueError, match=message):
+        native_load.load(str(tmp_path), lazy=True, engram_ssd_offload=True)
+
+
+@pytest.mark.parametrize(
+    ("mapping_override", "message"),
+    [
+        (
+            lambda mapping, keys: {
+                key: value for key, value in mapping.items() if key != keys["biases"]
+            },
+            "missing indexed tensor",
+        ),
+        (
+            lambda mapping, keys: {**mapping, keys["biases"]: "other.safetensors"},
+            "must share one shard",
+        ),
+    ],
+)
+def test_load_rejects_incomplete_engram_mapping(
+    tmp_path, monkeypatch, mapping_override, message
+) -> None:
+    _write_offload_fixture(tmp_path, mapping_override=mapping_override)
+    _patch_minimal_offload_loader(monkeypatch)
+    original_load = json.load
+
+    def config_or_index(stream):
+        if stream.name.endswith("index.json"):
+            return original_load(stream)
+        return {"quantization": {"group_size": 32, "engram_bits": 2}}
+
+    monkeypatch.setattr(native_load.json, "load", config_or_index)
+
+    with pytest.raises(ValueError, match=message):
+        native_load.load(str(tmp_path), lazy=True, engram_ssd_offload=True)
+
+
+def test_load_rejects_offload_without_affine_engram_quantization(
+    tmp_path, monkeypatch
+) -> None:
+    _write_offload_fixture(tmp_path)
+    _patch_minimal_offload_loader(monkeypatch)
+
+    with pytest.raises(ValueError, match="affine-quantized"):
+        native_load.load(str(tmp_path), lazy=True, engram_ssd_offload=True)
+
+
+def test_load_preserves_resident_affine_engram_path(tmp_path, monkeypatch) -> None:
+    from vllm_mlx.models.deepseek_v41_native.engram import QuantizedEngramEmbedding
+
+    _write_offload_fixture(tmp_path)
+    _patch_minimal_offload_loader(monkeypatch)
+    original_load = json.load
+
+    def config_or_index(stream):
+        if stream.name.endswith("index.json"):
+            return original_load(stream)
+        return {"quantization": {"group_size": 32, "engram_bits": 2}}
+
+    monkeypatch.setattr(native_load.json, "load", config_or_index)
+
+    model, _args = native_load.load(str(tmp_path), lazy=True, strict=False)
+
+    assert isinstance(model.layers[0].engram.embed, QuantizedEngramEmbedding)
 
 
 def test_quantized_grouped_wo_a_preserves_batch_sequence_and_group_axes() -> None:
@@ -255,6 +466,54 @@ def test_native_model_captures_dspark_inputs_in_configured_order() -> None:
     first, second = mx.split(hidden, 2, axis=-1)
 
     assert mx.array_equal(first, second + 1).item()
+
+
+def test_native_model_prefetches_each_disk_engram_before_layers_run() -> None:
+    args = ModelArgs(
+        dim=64,
+        vocab_size=32,
+        n_layers=0,
+        n_heads=1,
+        head_dim=64,
+        rope_head_dim=32,
+        hc_mult=1,
+        compress_ratios=(),
+        engram_layer_ids=(0,),
+    )
+    model = Model(args)
+    prefetched = []
+
+    class FakeHasher:
+        def __call__(self, ids, start_pos, cache_ids):
+            del ids, start_pos, cache_ids
+            return np.array([[[[3, 5]]]], dtype=np.int64)
+
+    class FakeEmbed:
+        def prefetch(self, hashes):
+            prefetched.append(hashes.copy())
+
+    class FakeEngram:
+        layer_hash_index = 0
+        embed = FakeEmbed()
+
+        def __call__(self, h, _hashes):
+            return h
+
+    class IdentityBlock:
+        engram = FakeEngram()
+
+        def __call__(self, h, pre_mix, *_args):
+            return h, pre_mix
+
+    model.engram_hasher = FakeHasher()
+    model.layers = [IdentityBlock()]
+    cache = model.make_cache(max_seq_len=8)
+
+    logits = model(mx.array([[1]]), cache)
+    mx.eval(logits)
+
+    assert len(prefetched) == 1
+    assert np.array_equal(prefetched[0], np.array([[[3, 5]]]))
 
 
 def test_speculative_cache_rollback_restores_partial_compressor_group() -> None:

--- a/tests/test_deepseek_v41_native_load.py
+++ b/tests/test_deepseek_v41_native_load.py
@@ -23,7 +23,10 @@ from vllm_mlx.models.deepseek_v41_native.compressor import (  # noqa: E402
     CompressorState,
 )
 from vllm_mlx.models.deepseek_v41_native.config import ModelArgs  # noqa: E402
-from vllm_mlx.models.deepseek_v41_native.load import reshape_grouped_wo_a  # noqa: E402
+from vllm_mlx.models.deepseek_v41_native.load import (  # noqa: E402
+    reshape_grouped_wo_a,
+    resolve_indexed_shard,
+)
 from vllm_mlx.models.deepseek_v41_native.model import Model  # noqa: E402
 
 
@@ -52,6 +55,30 @@ def test_reshape_grouped_wo_a_rejects_incompatible_rows() -> None:
     args = ModelArgs(o_groups=2, o_lora_rank=3)
     with pytest.raises(ValueError, match="expected 6"):
         reshape_grouped_wo_a([("layers.0.attn.wo_a.weight", mx.zeros((5, 4)))], args)
+
+
+def test_indexed_shard_rejects_local_symlink_escape(tmp_path) -> None:
+    model = tmp_path / "model"
+    model.mkdir()
+    outside = tmp_path / "outside.safetensors"
+    outside.touch()
+    (model / "shard.safetensors").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="symlink escapes"):
+        resolve_indexed_shard(str(model), "shard.safetensors")
+
+
+def test_indexed_shard_allows_same_repository_hub_blob(tmp_path) -> None:
+    repository = tmp_path / "models--owner--model"
+    snapshot = repository / "snapshots" / "revision"
+    blobs = repository / "blobs"
+    snapshot.mkdir(parents=True)
+    blobs.mkdir()
+    blob = blobs / "digest"
+    blob.touch()
+    (snapshot / "shard.safetensors").symlink_to(blob)
+
+    assert resolve_indexed_shard(str(snapshot), "shard.safetensors") == str(blob)
 
 
 def test_quantized_grouped_wo_a_preserves_batch_sequence_and_group_axes() -> None:

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -441,6 +441,7 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             if flat.size and (flat.min() < 0 or flat.max() >= weight.shape[0]):
                 raise IndexError("Engram row outside table")
             if not flat.size or not self.cache_rows or flat.size > 4096:
+                self.cache_misses += len(set(int(row) for row in flat))
                 rows = self._raw_rows(flat)
             else:
                 unique = list(dict.fromkeys(int(row) for row in flat))

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -342,9 +342,6 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             )
         except Exception:
             self._weight = self._scales = self._biases = None
-            if self._executor is not None:
-                self._executor.shutdown(wait=True, cancel_futures=True)
-                self._executor = None
             try:
                 if self._mapping is not None:
                     self._mapping.close()
@@ -474,7 +471,7 @@ class DiskQuantizedEngramEmbedding(nn.Module):
         def consume_error(done: Future) -> None:
             try:
                 done.exception()
-            except CancelledError:
+            except CancelledError:  # pragma: no cover - cancellation race
                 pass
 
         future.add_done_callback(consume_error)
@@ -490,11 +487,11 @@ class DiskQuantizedEngramEmbedding(nn.Module):
         if previous is not None:
             self._discard_future(previous[1])
         executor = self._executor
-        if executor is None:
+        if executor is None:  # pragma: no cover - concurrent close
             raise RuntimeError("Engram embedding is closed")
         future = executor.submit(self._gather_rows, flat)
         with self._lock:
-            if self._closed:
+            if self._closed:  # pragma: no cover - concurrent close
                 future.cancel()
                 raise RuntimeError("Engram embedding is closed")
             self._pending = (flat, future)

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -377,7 +377,7 @@ class DiskQuantizedEngramEmbedding(nn.Module):
         ranges.sort()
         expected_start = 0
         for start, end, key in ranges:
-            if start != expected_start or end == start:
+            if start != expected_start:
                 raise ValueError(f"non-contiguous safetensors tensor offsets: {key}")
             expected_start = end
         if expected_start != data_size:

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -24,6 +24,15 @@ the value into the stream by a normalized stream-key dot product pushed through
 
 from __future__ import annotations
 
+import json
+import math
+import mmap
+import struct
+from collections import OrderedDict
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+from threading import RLock
+
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
@@ -243,6 +252,222 @@ class QuantizedEngramEmbedding(nn.Module):
             bits=self.bits,
         )
         return out.astype(mx.float32)
+
+
+class DiskQuantizedEngramEmbedding(nn.Module):
+    """Selected-row affine Engram reader backed by a safetensors mmap.
+
+    Only packed rows requested by the current n-gram hashes cross into MLX.
+    A bounded raw-row LRU absorbs repeated decode lookups without retaining a
+    device-sized view of the embedding table.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        weight_key: str,
+        scales_key: str,
+        biases_key: str,
+        num_embeddings: int,
+        dim: int,
+        group_size: int,
+        bits: int,
+        cache_rows: int = 16384,
+    ):
+        super().__init__()
+        if bits not in (2, 3, 4, 6, 8):
+            raise ValueError(f"unsupported affine Engram width: {bits}")
+        if cache_rows < 0:
+            raise ValueError("Engram cache_rows cannot be negative")
+        self.group_size, self.bits = group_size, bits
+        self.cache_rows = cache_rows
+        self.cache_hits = 0
+        self.cache_misses = 0
+        self._lock = RLock()
+        self._closed = False
+        self._executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="deepseek-v41-engram"
+        )
+        self._pending: tuple[np.ndarray, Future] | None = None
+        self._cache: OrderedDict[int, tuple[np.ndarray, np.ndarray, np.ndarray]] = (
+            OrderedDict()
+        )
+        self._file = Path(path).open("rb")
+        try:
+            length_raw = self._file.read(8)
+            if len(length_raw) != 8:
+                raise ValueError("truncated safetensors header")
+            header_length = struct.unpack("<Q", length_raw)[0]
+            file_size = self._file.seek(0, 2)
+            if header_length > file_size - 8:
+                raise ValueError("invalid safetensors header length")
+            self._file.seek(8)
+            header = json.loads(self._file.read(header_length))
+            self._data_start = 8 + header_length
+            self._mapping = mmap.mmap(self._file.fileno(), 0, access=mmap.ACCESS_READ)
+            if hasattr(self._mapping, "madvise"):
+                self._mapping.madvise(mmap.MADV_RANDOM)
+            self._weight = self._tensor_view(
+                header,
+                weight_key,
+                dtype="U32",
+                numpy_dtype=np.dtype("<u4"),
+                shape=(num_embeddings, dim * bits // 32),
+            )
+            quant_shape = (num_embeddings, dim // group_size)
+            self._scales = self._tensor_view(
+                header,
+                scales_key,
+                dtype="BF16",
+                numpy_dtype=np.dtype("<u2"),
+                shape=quant_shape,
+            )
+            self._biases = self._tensor_view(
+                header,
+                biases_key,
+                dtype="BF16",
+                numpy_dtype=np.dtype("<u2"),
+                shape=quant_shape,
+            )
+        except Exception:
+            mapping = getattr(self, "_mapping", None)
+            if mapping is not None:
+                mapping.close()
+            self._file.close()
+            raise
+
+    def _tensor_view(self, header, key, *, dtype, numpy_dtype, shape):
+        entry = header.get(key)
+        if entry is None or entry.get("dtype") != dtype:
+            raise ValueError(f"invalid or missing Engram tensor: {key}")
+        if tuple(entry.get("shape", ())) != shape:
+            raise ValueError(f"invalid Engram tensor shape: {key}")
+        start, end = entry.get("data_offsets", (-1, -1))
+        expected = math.prod(shape) * numpy_dtype.itemsize
+        if (
+            start < 0
+            or end - start != expected
+            or self._data_start + end > len(self._mapping)
+        ):
+            raise ValueError(f"invalid Engram tensor byte length: {key}")
+        return np.ndarray(
+            shape,
+            dtype=numpy_dtype,
+            buffer=self._mapping,
+            offset=self._data_start + start,
+        )
+
+    @staticmethod
+    def _bfloat16(raw: np.ndarray) -> mx.array:
+        values = (raw.astype(np.uint32) << 16).view(np.float32)
+        return mx.array(values).astype(mx.bfloat16)
+
+    def _dequantize(self, rows) -> mx.array:
+        weights, scales, biases = rows
+        return mx.dequantize(
+            mx.array(weights),
+            self._bfloat16(scales),
+            self._bfloat16(biases),
+            group_size=self.group_size,
+            bits=self.bits,
+            mode="affine",
+        ).astype(mx.float32)
+
+    def _raw_rows(self, flat: np.ndarray):
+        return (
+            np.array(self._weight[flat], copy=True),
+            np.array(self._scales[flat], copy=True),
+            np.array(self._biases[flat], copy=True),
+        )
+
+    def _gather_rows(self, flat: np.ndarray):
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Engram embedding is closed")
+            if flat.size and (flat.min() < 0 or flat.max() >= self._weight.shape[0]):
+                raise IndexError("Engram row outside table")
+            if not flat.size or not self.cache_rows or flat.size > 4096:
+                rows = self._raw_rows(flat)
+            else:
+                unique = list(dict.fromkeys(int(row) for row in flat))
+                resolved = {
+                    row: self._cache[row] for row in unique if row in self._cache
+                }
+                missing = [row for row in unique if row not in resolved]
+                self.cache_misses += len(missing)
+                if missing:
+                    loaded = self._raw_rows(np.asarray(missing, dtype=np.int64))
+                    for index, row in enumerate(missing):
+                        value = tuple(value[index].copy() for value in loaded)
+                        resolved[row] = value
+                        self._cache[row] = value
+                        while len(self._cache) > self.cache_rows:
+                            self._cache.popitem(last=False)
+                gathered = [resolved[int(row)] for row in flat]
+                for row in unique:
+                    if row in self._cache:
+                        self._cache.move_to_end(row)
+                self.cache_hits += flat.size - len(missing)
+                rows = tuple(
+                    np.stack([value[column] for value in gathered])
+                    for column in range(3)
+                )
+        return rows
+
+    def prefetch(self, indices: np.ndarray) -> None:
+        """Start selected-row I/O before this embedding's layer executes."""
+        flat = np.asarray(indices, dtype=np.int64).reshape(-1).copy()
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Engram embedding is closed")
+            previous, self._pending = self._pending, None
+        if previous is not None:
+            previous[1].result()
+        future = self._executor.submit(self._gather_rows, flat)
+        with self._lock:
+            if self._closed:
+                future.cancel()
+                raise RuntimeError("Engram embedding is closed")
+            self._pending = (flat, future)
+
+    def __call__(self, indices: mx.array) -> mx.array:
+        host = np.asarray(indices, dtype=np.int64)
+        flat = host.reshape(-1)
+        with self._lock:
+            pending, self._pending = self._pending, None
+        if pending is not None:
+            requested, future = pending
+            prefetched = future.result()
+            rows = (
+                prefetched
+                if np.array_equal(requested, flat)
+                else self._gather_rows(flat)
+            )
+        else:
+            rows = self._gather_rows(flat)
+        values = self._dequantize(rows)
+        return values.reshape(*host.shape, values.shape[-1])
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            pending, self._pending = self._pending, None
+        if pending is not None:
+            pending[1].cancel()
+        self._executor.shutdown(wait=True, cancel_futures=True)
+        with self._lock:
+            self._cache.clear()
+            self._mapping.close()
+            self._file.close()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
 
 
 class Engram(nn.Module):

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -29,7 +29,7 @@ import math
 import mmap
 import struct
 from collections import OrderedDict
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 from pathlib import Path
 from threading import RLock
 
@@ -39,6 +39,8 @@ import numpy as np
 
 from .config import ModelArgs
 from .dequant import dequant_fp8_rows
+
+_MAX_SAFETENSORS_HEADER_SIZE = 100_000_000
 
 
 def _isprime(n: int) -> bool:
@@ -301,7 +303,10 @@ class DiskQuantizedEngramEmbedding(nn.Module):
                 raise ValueError("truncated safetensors header")
             header_length = struct.unpack("<Q", length_raw)[0]
             file_size = self._file.seek(0, 2)
-            if header_length > file_size - 8:
+            if (
+                header_length > _MAX_SAFETENSORS_HEADER_SIZE
+                or header_length > file_size - 8
+            ):
                 raise ValueError("invalid safetensors header length")
             self._file.seek(8)
             header = json.loads(self._file.read(header_length))
@@ -370,12 +375,13 @@ class DiskQuantizedEngramEmbedding(nn.Module):
                 raise ValueError(f"invalid safetensors tensor offsets: {key}")
             ranges.append((start, end, key))
         ranges.sort()
-        for previous, current in zip(ranges, ranges[1:]):
-            if current[0] < previous[1]:
-                raise ValueError(
-                    "overlapping safetensors tensor offsets: "
-                    f"{previous[2]} and {current[2]}"
-                )
+        expected_start = 0
+        for start, end, key in ranges:
+            if start != expected_start or end == start:
+                raise ValueError(f"non-contiguous safetensors tensor offsets: {key}")
+            expected_start = end
+        if expected_start != data_size:
+            raise ValueError("safetensors tensor offsets do not cover the data buffer")
 
     def _tensor_view(self, header, key, *, dtype, numpy_dtype, shape):
         entry = header.get(key)
@@ -464,11 +470,14 @@ class DiskQuantizedEngramEmbedding(nn.Module):
 
     @staticmethod
     def _discard_future(future: Future) -> None:
-        if not future.cancel():
+        def consume_error(done: Future) -> None:
             try:
-                future.result()
-            except Exception:
+                done.exception()
+            except CancelledError:
                 pass
+
+        future.add_done_callback(consume_error)
+        future.cancel()
 
     def prefetch(self, indices: np.ndarray) -> None:
         """Start selected-row I/O before this embedding's layer executes."""

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -462,6 +462,14 @@ class DiskQuantizedEngramEmbedding(nn.Module):
                 )
         return rows
 
+    @staticmethod
+    def _discard_future(future: Future) -> None:
+        if not future.cancel():
+            try:
+                future.result()
+            except Exception:
+                pass
+
     def prefetch(self, indices: np.ndarray) -> None:
         """Start selected-row I/O before this embedding's layer executes."""
         flat = np.asarray(indices, dtype=np.int64).reshape(-1).copy()
@@ -470,7 +478,7 @@ class DiskQuantizedEngramEmbedding(nn.Module):
                 raise RuntimeError("Engram embedding is closed")
             previous, self._pending = self._pending, None
         if previous is not None:
-            previous[1].result()
+            self._discard_future(previous[1])
         executor = self._executor
         if executor is None:
             raise RuntimeError("Engram embedding is closed")
@@ -491,11 +499,7 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             if np.array_equal(requested, flat):
                 rows = future.result()
             else:
-                if not future.cancel():
-                    try:
-                        future.result()
-                    except Exception:
-                        pass
+                self._discard_future(future)
                 rows = self._gather_rows(flat)
         else:
             rows = self._gather_rows(flat)

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -294,6 +294,7 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             OrderedDict()
         )
         self._file = Path(path).open("rb")
+        self._weight = self._scales = self._biases = None
         try:
             length_raw = self._file.read(8)
             if len(length_raw) != 8:
@@ -331,10 +332,13 @@ class DiskQuantizedEngramEmbedding(nn.Module):
                 shape=quant_shape,
             )
         except Exception:
+            self._weight = self._scales = self._biases = None
             mapping = getattr(self, "_mapping", None)
-            if mapping is not None:
-                mapping.close()
-            self._file.close()
+            try:
+                if mapping is not None:
+                    mapping.close()
+            finally:
+                self._file.close()
             raise
 
     def _tensor_view(self, header, key, *, dtype, numpy_dtype, shape):
@@ -460,8 +464,11 @@ class DiskQuantizedEngramEmbedding(nn.Module):
         self._executor.shutdown(wait=True, cancel_futures=True)
         with self._lock:
             self._cache.clear()
-            self._mapping.close()
-            self._file.close()
+            self._weight = self._scales = self._biases = None
+            try:
+                self._mapping.close()
+            finally:
+                self._file.close()
 
     def __del__(self):
         try:

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -306,6 +306,7 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             self._file.seek(8)
             header = json.loads(self._file.read(header_length))
             self._data_start = 8 + header_length
+            self._validate_header_ranges(header, file_size - self._data_start)
             self._mapping = mmap.mmap(self._file.fileno(), 0, access=mmap.ACCESS_READ)
             if hasattr(self._mapping, "madvise"):
                 self._mapping.madvise(mmap.MADV_RANDOM)
@@ -340,6 +341,35 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             finally:
                 self._file.close()
             raise
+
+    @staticmethod
+    def _validate_header_ranges(header, data_size: int) -> None:
+        if not isinstance(header, dict):
+            raise ValueError("invalid safetensors header")
+        ranges = []
+        for key, entry in header.items():
+            if key == "__metadata__":
+                continue
+            if not isinstance(entry, dict):
+                raise ValueError(f"invalid safetensors tensor entry: {key}")
+            offsets = entry.get("data_offsets")
+            if (
+                not isinstance(offsets, list)
+                or len(offsets) != 2
+                or not all(isinstance(value, int) for value in offsets)
+            ):
+                raise ValueError(f"invalid safetensors tensor offsets: {key}")
+            start, end = offsets
+            if start < 0 or end < start or end > data_size:
+                raise ValueError(f"invalid safetensors tensor offsets: {key}")
+            ranges.append((start, end, key))
+        ranges.sort()
+        for previous, current in zip(ranges, ranges[1:]):
+            if current[0] < previous[1]:
+                raise ValueError(
+                    "overlapping safetensors tensor offsets: "
+                    f"{previous[2]} and {current[2]}"
+                )
 
     def _tensor_view(self, header, key, *, dtype, numpy_dtype, shape):
         entry = header.get(key)

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -286,16 +286,16 @@ class DiskQuantizedEngramEmbedding(nn.Module):
         self.cache_misses = 0
         self._lock = RLock()
         self._closed = False
-        self._executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="deepseek-v41-engram"
-        )
+        self._executor: ThreadPoolExecutor | None = None
         self._pending: tuple[np.ndarray, Future] | None = None
         self._cache: OrderedDict[int, tuple[np.ndarray, np.ndarray, np.ndarray]] = (
             OrderedDict()
         )
-        self._file = Path(path).open("rb")
+        self._file = None
+        self._mapping = None
         self._weight = self._scales = self._biases = None
         try:
+            self._file = Path(path).open("rb")
             length_raw = self._file.read(8)
             if len(length_raw) != 8:
                 raise ValueError("truncated safetensors header")
@@ -332,14 +332,20 @@ class DiskQuantizedEngramEmbedding(nn.Module):
                 numpy_dtype=np.dtype("<u2"),
                 shape=quant_shape,
             )
+            self._executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="deepseek-v41-engram"
+            )
         except Exception:
             self._weight = self._scales = self._biases = None
-            mapping = getattr(self, "_mapping", None)
+            if self._executor is not None:
+                self._executor.shutdown(wait=True, cancel_futures=True)
+                self._executor = None
             try:
-                if mapping is not None:
-                    mapping.close()
+                if self._mapping is not None:
+                    self._mapping.close()
             finally:
-                self._file.close()
+                if self._file is not None:
+                    self._file.close()
             raise
 
     @staticmethod
@@ -458,7 +464,10 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             previous, self._pending = self._pending, None
         if previous is not None:
             previous[1].result()
-        future = self._executor.submit(self._gather_rows, flat)
+        executor = self._executor
+        if executor is None:
+            raise RuntimeError("Engram embedding is closed")
+        future = executor.submit(self._gather_rows, flat)
         with self._lock:
             if self._closed:
                 future.cancel()
@@ -472,12 +481,15 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             pending, self._pending = self._pending, None
         if pending is not None:
             requested, future = pending
-            prefetched = future.result()
-            rows = (
-                prefetched
-                if np.array_equal(requested, flat)
-                else self._gather_rows(flat)
-            )
+            if np.array_equal(requested, flat):
+                rows = future.result()
+            else:
+                if not future.cancel():
+                    try:
+                        future.result()
+                    except Exception:
+                        pass
+                rows = self._gather_rows(flat)
         else:
             rows = self._gather_rows(flat)
         values = self._dequantize(rows)
@@ -491,14 +503,18 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             pending, self._pending = self._pending, None
         if pending is not None:
             pending[1].cancel()
-        self._executor.shutdown(wait=True, cancel_futures=True)
+        executor, self._executor = self._executor, None
+        if executor is not None:
+            executor.shutdown(wait=True, cancel_futures=True)
         with self._lock:
             self._cache.clear()
             self._weight = self._scales = self._biases = None
             try:
-                self._mapping.close()
+                if self._mapping is not None:
+                    self._mapping.close()
             finally:
-                self._file.close()
+                if self._file is not None:
+                    self._file.close()
 
     def __del__(self):
         try:

--- a/vllm_mlx/models/deepseek_v41_native/engram.py
+++ b/vllm_mlx/models/deepseek_v41_native/engram.py
@@ -414,18 +414,25 @@ class DiskQuantizedEngramEmbedding(nn.Module):
             mode="affine",
         ).astype(mx.float32)
 
+    def _views(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if self._weight is None or self._scales is None or self._biases is None:
+            raise RuntimeError("Engram embedding is closed")
+        return self._weight, self._scales, self._biases
+
     def _raw_rows(self, flat: np.ndarray):
+        weight, scales, biases = self._views()
         return (
-            np.array(self._weight[flat], copy=True),
-            np.array(self._scales[flat], copy=True),
-            np.array(self._biases[flat], copy=True),
+            np.array(weight[flat], copy=True),
+            np.array(scales[flat], copy=True),
+            np.array(biases[flat], copy=True),
         )
 
     def _gather_rows(self, flat: np.ndarray):
         with self._lock:
             if self._closed:
                 raise RuntimeError("Engram embedding is closed")
-            if flat.size and (flat.min() < 0 or flat.max() >= self._weight.shape[0]):
+            weight, _, _ = self._views()
+            if flat.size and (flat.min() < 0 or flat.max() >= weight.shape[0]):
                 raise IndexError("Engram row outside table")
             if not flat.size or not self.cache_rows or flat.size > 4096:
                 rows = self._raw_rows(flat)

--- a/vllm_mlx/models/deepseek_v41_native/load.py
+++ b/vllm_mlx/models/deepseek_v41_native/load.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -33,6 +34,22 @@ from mlx.utils import tree_flatten
 from .config import ModelArgs
 from .convert import VISION_PREFIXES, bits_for, is_quant_target
 from .model import Model
+
+
+def resolve_indexed_shard(model_path: str, filename: str) -> str:
+    """Resolve an indexed shard without escaping its model/CAS repository."""
+    root = Path(model_path).resolve()
+    lexical = Path(os.path.abspath(os.path.join(root, filename)))
+    if os.path.commonpath((root, lexical)) != str(root):
+        raise ValueError("Engram shard must stay inside the model directory")
+    resolved = lexical.resolve(strict=True)
+    # Hub snapshots legitimately symlink immutable files into their sibling
+    # blobs directory. Keep that CAS layout working without allowing a local
+    # model directory to point at arbitrary files elsewhere on the machine.
+    allowed = root.parent.parent if root.parent.name == "snapshots" else root
+    if os.path.commonpath((allowed, resolved)) != str(allowed):
+        raise ValueError("Engram shard symlink escapes the model repository")
+    return str(resolved)
 
 
 def reshape_grouped_wo_a(items, args: ModelArgs):
@@ -220,12 +237,7 @@ def load(
                                 "Engram affine tensors must share one shard"
                             )
                         filename = filenames[0]
-                        root = os.path.abspath(path)
-                        shard_path = os.path.abspath(os.path.join(root, filename))
-                        if os.path.commonpath((root, shard_path)) != root:
-                            raise ValueError(
-                                "Engram shard must stay inside the model directory"
-                            )
+                        shard_path = resolve_indexed_shard(path, filename)
                         layer.engram.embed = DiskQuantizedEngramEmbedding(
                             shard_path,
                             weight_key=keys["weight"],

--- a/vllm_mlx/models/deepseek_v41_native/load.py
+++ b/vllm_mlx/models/deepseek_v41_native/load.py
@@ -108,6 +108,7 @@ def load(
     lazy: bool | None = None,
     strict: bool = True,
     fuse_moe_gate_up: bool = False,
+    engram_ssd_offload: bool = False,
 ):
     """``lazy=None`` auto-selects: builds that fit comfortably in physical RAM
     are materialized at load time (CPU-side, avoiding cold-mmap page-in inside
@@ -167,6 +168,17 @@ def load(
     model = Model(args, token_map=token_map)
 
     q = cfg.get("quantization")
+    engram_keys: set[str] = set()
+    engram_mapping = None
+    if engram_ssd_offload:
+        index_path = os.path.join(path, "model.safetensors.index.json")
+        if not os.path.isfile(index_path):
+            raise ValueError("Engram SSD offload requires a safetensors index")
+        with open(index_path) as index_file:
+            index = json.load(index_file)
+        engram_mapping = index.get("weight_map")
+        if not isinstance(engram_mapping, dict):
+            raise ValueError("Engram SSD offload requires a valid weight map")
     if q:
         if q.get("bits"):
             module_map = q.get("modules")
@@ -179,17 +191,61 @@ def load(
                 ),
             )
         if q.get("engram_bits"):
-            from .engram import QuantizedEngramEmbedding
+            from .engram import (
+                DiskQuantizedEngramEmbedding,
+                QuantizedEngramEmbedding,
+            )
 
             for layer in model.layers:
                 if layer.engram is not None:
                     e = layer.engram.embed
-                    layer.engram.embed = QuantizedEngramEmbedding(
-                        e.weight.shape[0],
-                        e.weight.shape[1],
-                        q["group_size"],
-                        q["engram_bits"],
-                    )
+                    if engram_ssd_offload:
+                        prefix = f"layers.{layer.layer_id}.engram.embed"
+                        keys = {
+                            "weight": prefix + ".weight",
+                            "scales": prefix + ".scales",
+                            "biases": prefix + ".biases",
+                        }
+                        filenames = []
+                        for key in keys.values():
+                            filename = engram_mapping.get(key)
+                            if not isinstance(filename, str) or not filename:
+                                raise ValueError(
+                                    "Engram SSD offload is missing indexed tensor: "
+                                    f"{key}"
+                                )
+                            filenames.append(filename)
+                        if len(set(filenames)) != 1:
+                            raise ValueError(
+                                "Engram affine tensors must share one shard"
+                            )
+                        filename = filenames[0]
+                        root = os.path.abspath(path)
+                        shard_path = os.path.abspath(os.path.join(root, filename))
+                        if os.path.commonpath((root, shard_path)) != root:
+                            raise ValueError(
+                                "Engram shard must stay inside the model directory"
+                            )
+                        layer.engram.embed = DiskQuantizedEngramEmbedding(
+                            shard_path,
+                            weight_key=keys["weight"],
+                            scales_key=keys["scales"],
+                            biases_key=keys["biases"],
+                            num_embeddings=e.weight.shape[0],
+                            dim=e.weight.shape[1],
+                            group_size=q["group_size"],
+                            bits=q["engram_bits"],
+                        )
+                        engram_keys.update(keys.values())
+                    else:
+                        layer.engram.embed = QuantizedEngramEmbedding(
+                            e.weight.shape[0],
+                            e.weight.shape[1],
+                            q["group_size"],
+                            q["engram_bits"],
+                        )
+    if engram_ssd_offload and args.engram_layer_ids and not engram_keys:
+        raise ValueError("Engram SSD offload requires affine-quantized Engram tables")
 
     loaded: set[str] = set()
     vision_skipped: set[str] = set()
@@ -197,6 +253,8 @@ def load(
         w = mx.load(shard)
         items = []
         for k, v in w.items():
+            if k in engram_keys:
+                continue
             if k.startswith(VISION_PREFIXES):
                 vision_skipped.add(k)  # declared passthrough, text-only runtime
                 continue

--- a/vllm_mlx/models/deepseek_v41_native/load.py
+++ b/vllm_mlx/models/deepseek_v41_native/load.py
@@ -43,13 +43,17 @@ def resolve_indexed_shard(model_path: str, filename: str) -> str:
     if os.path.commonpath((root, lexical)) != str(root):
         raise ValueError("Engram shard must stay inside the model directory")
     resolved = lexical.resolve(strict=True)
-    # Hub snapshots legitimately symlink immutable files into their sibling
-    # blobs directory. Keep that CAS layout working without allowing a local
-    # model directory to point at arbitrary files elsewhere on the machine.
-    allowed = root.parent.parent if root.parent.name == "snapshots" else root
-    if os.path.commonpath((allowed, resolved)) != str(allowed):
-        raise ValueError("Engram shard symlink escapes the model repository")
-    return str(resolved)
+    if os.path.commonpath((root, resolved)) == str(root):
+        return str(resolved)
+    # Hub snapshots legitimately symlink immutable files into the specific
+    # repository's sibling blobs directory. Recognize the repository layout,
+    # rather than trusting any parent directory merely named "snapshots".
+    repository = root.parent.parent
+    if root.parent.name == "snapshots" and repository.name.startswith("models--"):
+        blobs = (repository / "blobs").resolve()
+        if blobs.is_dir() and os.path.commonpath((blobs, resolved)) == str(blobs):
+            return str(resolved)
+    raise ValueError("Engram shard symlink escapes the model repository")
 
 
 def reshape_grouped_wo_a(items, args: ModelArgs):

--- a/vllm_mlx/models/deepseek_v41_native/load.py
+++ b/vllm_mlx/models/deepseek_v41_native/load.py
@@ -190,16 +190,17 @@ def load(
 
     q = cfg.get("quantization")
     engram_keys: set[str] = set()
-    engram_mapping = None
+    engram_mapping: dict[str, object] = {}
     if engram_ssd_offload:
         index_path = os.path.join(path, "model.safetensors.index.json")
         if not os.path.isfile(index_path):
             raise ValueError("Engram SSD offload requires a safetensors index")
         with open(index_path) as index_file:
             index = json.load(index_file)
-        engram_mapping = index.get("weight_map")
-        if not isinstance(engram_mapping, dict):
+        raw_mapping = index.get("weight_map")
+        if not isinstance(raw_mapping, dict):
             raise ValueError("Engram SSD offload requires a valid weight map")
+        engram_mapping = raw_mapping
     if q:
         if q.get("bits"):
             module_map = q.get("modules")

--- a/vllm_mlx/models/deepseek_v41_native/load.py
+++ b/vllm_mlx/models/deepseek_v41_native/load.py
@@ -50,10 +50,54 @@ def resolve_indexed_shard(model_path: str, filename: str) -> str:
     # rather than trusting any parent directory merely named "snapshots".
     repository = root.parent.parent
     if root.parent.name == "snapshots" and repository.name.startswith("models--"):
-        blobs = (repository / "blobs").resolve()
-        if blobs.is_dir() and os.path.commonpath((blobs, resolved)) == str(blobs):
+        lexical_blobs = repository / "blobs"
+        blobs = lexical_blobs.resolve()
+        if (
+            lexical_blobs.is_dir()
+            and not lexical_blobs.is_symlink()
+            and os.path.commonpath((repository, blobs)) == str(repository)
+            and os.path.commonpath((blobs, resolved)) == str(blobs)
+        ):
             return str(resolved)
     raise ValueError("Engram shard symlink escapes the model repository")
+
+
+def supports_engram_ssd_offload(path: str) -> bool:
+    """Return whether a checkpoint has the complete supported Engram layout."""
+    try:
+        with open(os.path.join(path, "config.json")) as config_file:
+            config = json.load(config_file)
+        args = ModelArgs.from_dict(config)
+        quantization = config.get("quantization")
+        if (
+            not args.engram_layer_ids
+            or not isinstance(quantization, dict)
+            or not quantization.get("engram_bits")
+        ):
+            return False
+        with open(os.path.join(path, "model.safetensors.index.json")) as index_file:
+            index = json.load(index_file)
+        mapping = index.get("weight_map")
+        if not isinstance(mapping, dict):
+            return False
+        for layer_id in args.engram_layer_ids:
+            prefix = f"layers.{layer_id}.engram.embed"
+            keys = (prefix + ".weight", prefix + ".scales", prefix + ".biases")
+            filenames = [mapping.get(key) for key in keys]
+            if (
+                any(
+                    not isinstance(filename, str) or not filename
+                    for filename in filenames
+                )
+                or len(set(filenames)) != 1
+            ):
+                return False
+            filename = filenames[0]
+            assert isinstance(filename, str)
+            resolve_indexed_shard(path, filename)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+    return True
 
 
 def reshape_grouped_wo_a(items, args: ModelArgs):

--- a/vllm_mlx/models/deepseek_v41_native/model.py
+++ b/vllm_mlx/models/deepseek_v41_native/model.py
@@ -157,8 +157,13 @@ class Model(nn.Module):
         hashes = None
         if self.engram_hasher is not None:
             ids_np = np.array(input_ids, dtype=np.int64)
-            hashes = self.engram_hasher(ids_np, start_pos, cache.engram_ids)
-            hashes = mx.array(hashes)  # [b, n, n_engram_layers, cols]
+            hashes_np = self.engram_hasher(ids_np, start_pos, cache.engram_ids)
+            for layer in self.layers:
+                if layer.engram is not None and hasattr(layer.engram.embed, "prefetch"):
+                    layer.engram.embed.prefetch(
+                        hashes_np[:, :, layer.engram.layer_hash_index]
+                    )
+            hashes = mx.array(hashes_np)  # [b, n, n_engram_layers, cols]
         elif self.args.engram_layer_ids:
             raise RuntimeError(
                 "model has engram layers but no token map — call "

--- a/vllm_mlx/models/deepseek_v41_native/serving.py
+++ b/vllm_mlx/models/deepseek_v41_native/serving.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import weakref
 from dataclasses import dataclass
 from types import MethodType, SimpleNamespace
@@ -229,7 +230,12 @@ def load_product_runtime(
     mtp_revision: str,
     mtp_identity: str | None = None,
 ):
-    model, _args = load(target_path, lazy=False, engram_ssd_offload=True)
+    index_path = os.path.join(target_path, "model.safetensors.index.json")
+    model, _args = load(
+        target_path,
+        lazy=False,
+        engram_ssd_offload=os.path.isfile(index_path),
+    )
     model.eval_interval = 40
     if install_target_qmv(model) != len(model.layers):
         raise RuntimeError("failed to install target affine-2bit QMV on every layer")

--- a/vllm_mlx/models/deepseek_v41_native/serving.py
+++ b/vllm_mlx/models/deepseek_v41_native/serving.py
@@ -229,7 +229,7 @@ def load_product_runtime(
     mtp_revision: str,
     mtp_identity: str | None = None,
 ):
-    model, _args = load(target_path, lazy=False)
+    model, _args = load(target_path, lazy=False, engram_ssd_offload=True)
     model.eval_interval = 40
     if install_target_qmv(model) != len(model.layers):
         raise RuntimeError("failed to install target affine-2bit QMV on every layer")

--- a/vllm_mlx/models/deepseek_v41_native/serving.py
+++ b/vllm_mlx/models/deepseek_v41_native/serving.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import contextlib
-import os
 import weakref
 from dataclasses import dataclass
 from types import MethodType, SimpleNamespace
@@ -22,7 +21,7 @@ from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer  # noqa: E402
 
 from .affine_route_qmv import affine2_route_down_qmv
 from .dspark import DSpark, DSparkWeights, draft_attention, quantize_cache
-from .load import load
+from .load import load, supports_engram_ssd_offload
 
 
 @dataclass(frozen=True)
@@ -230,11 +229,10 @@ def load_product_runtime(
     mtp_revision: str,
     mtp_identity: str | None = None,
 ):
-    index_path = os.path.join(target_path, "model.safetensors.index.json")
     model, _args = load(
         target_path,
         lazy=False,
-        engram_ssd_offload=os.path.isfile(index_path),
+        engram_ssd_offload=supports_engram_ssd_offload(target_path),
     )
     model.eval_interval = 40
     if install_target_qmv(model) != len(model.layers):


### PR DESCRIPTION
## Summary

Make the experimental DeepSeek V4.1 Flash product path reliable on a 256 GiB Mac by freeing enough unified-memory headroom for normal operation, without materially reducing decode throughput.

## What changed

- Keep the two affine-quantized Engram tables in their existing safetensors shards and mmap only the selected rows.
- Strictly validate tensor dtype, shape, byte span, indexed shard ownership, and row bounds.
- Prefetch each forward's selected rows asynchronously so SSD I/O overlaps with preceding transformer computation.
- Bound repeated-row caching to 16,384 raw rows per Engram table and close pending I/O safely.
- Enable this path in the owned DeepSeek V4.1 product runtime and add it to the Apple CI roster.

## Measured impact

Same M3 Ultra 256 GiB host, same 212.93 GB REAP 2-bit target, same 4.62 GB mixed DSpark sidecar, same four prompts, greedy K=4, 64 output tokens per prompt:

| Metric | Resident Engram | Prefetched SSD Engram | Change |
| --- | ---: | ---: | ---: |
| Load time | 266.72 s | 170.02 s | **-36.3%** |
| Peak MLX memory | 217.95 GB | 156.78 GB | **-61.17 GB (-28.1%)** |
| Weighted decode | 16.65 tok/s | 16.47 tok/s | **-1.0%** |

The raw synchronous SSD spike measured 9.25 tok/s. Prefetching recovered 78.0%, preserving 98.95% of resident throughput. Per-domain offloaded results were 19.25 code, 17.02 reasoning, 21.10 structured, and 11.80 Chinese tok/s; acceptance counts were identical to the resident control.

The existing broader 128-token/two-repeat product qualification remains 19.39 tok/s. This PR does not claim 40 tok/s; it creates roughly 61 GB of headroom for the next verification and draft-acceptance optimizations.

## Contract

- Allowed scope: DeepSeek V4.1 native affine Engram residency/loading, selected-row prefetch, product runtime wiring, tests, and reproducible performance notes.
- Non-goals: model or sidecar changes, downloads, revisions, quantization changes, MoE/attention kernel changes, K-policy changes, sampling/API/catalog/GUI changes, or other model families.
- Acceptance: strict corruption/path rejection; resident/disk/prefetch numerical parity; no memory-pressure termination; no more than a small decode regression; materially lower peak memory.

## Validation

- 106 focused DeepSeek V4.1 tests pass.
- Changed executable lines have 100% local union coverage (0 uncovered across Engram, loader, and model wiring).
- Ruff formatting/lint and `git diff --check` pass.
- Full local suite: 23,908 passed, 229 skipped, 45 deselected, 6 xfailed, 1 xpassed; 10 environment/base failures were reproduced outside this change (seven Bonsai dependency-ABI mismatches, one disk-stream warning assertion, and two doctor environment/service checks). All DeepSeek/Engram/MTP/server/scheduler paths passed.
- Two full offloaded product loads completed at 156.5–156.8 GB peak.
- Same-process resident/offload multi-prompt A/B completed; quantitative record is committed under `docs/engineering/performance/`.
- Ten bounded adversarial review rounds completed; the final round found zero blocking issues. The repository's configured review-round cap is exhausted, so no eleventh round will be requested.

## Risk and rollback

Risk is isolated to the experimental DeepSeek V4.1 product loader. Removing the `engram_ssd_offload=True` loader argument restores resident behavior. No model bytes or cache layout change.
