### PR TITLE
test: stage the host facts three tests assert on

### DIFF
--- a/tests/test_disk_stream_cli_wiring.py
+++ b/tests/test_disk_stream_cli_wiring.py
@@ -173,7 +173,15 @@ def test_check_alias_min_memory_warns_regardless_of_disk_stream(monkeypatch, cap
         "vllm_mlx.model_aliases.resolve_profile", lambda _name: fake_profile
     )
 
-    monkeypatch.setattr("vllm_mlx.optimizations.get_system_memory_gb", lambda: 64.0)
+    # Stage the host RAM the check actually reads. ``_check_alias_min_memory``
+    # deliberately reads ``psutil.virtual_memory()`` rather than the
+    # optimizations helper, to stay independent of the MLX import (it runs on
+    # Linux clients and in preflight commands). Patching the helper alone left
+    # the real machine deciding the outcome: on a 256 GB Mac the floor is met,
+    # the check returns silently, and the assertion below sees empty output.
+    # CI passes only because its runners are small.
+    fake_memory = types.SimpleNamespace(total=int(64 * 1024**3))
+    monkeypatch.setattr("psutil.virtual_memory", lambda: fake_memory)
 
     cli._check_alias_min_memory("hy3-preview-4bit")
 

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -17,6 +17,7 @@ mutation) so the suite runs identically on every Python and every OS.
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import json
 import os
@@ -3453,6 +3454,31 @@ def test_bundle_does_not_ask_user_to_reinstall_for_an_extra_it_never_ships(
     assert "reinstall" not in row.label.lower()
 
 
+@contextlib.contextmanager
+def _distribution_is_absent(distribution: str):
+    """Stage "this extra is not installed" instead of inheriting it from the
+    host.
+
+    ``_module_visibility`` answers from the interpreter that is running
+    pytest, not from the stub in ``tmp_path``. On a developer Mac that has
+    the extra installed, doctor therefore finds the module in-process and
+    goes on to verify it by running the stub as an interpreter — the stub is
+    an empty file, the subprocess raises, and the row becomes "importability
+    unknown — doctor probe did not complete" instead of the "not installed"
+    warning under test. Linux CI passes only because the extra happens to be
+    absent there, which is the host deciding which branch is exercised.
+    """
+    original = eh._module_visibility
+
+    def visibility(dist, *args, **kwargs):
+        if dist == distribution:
+            return (False, False)
+        return original(dist, *args, **kwargs)
+
+    with mock.patch.object(eh, "_module_visibility", visibility):
+        yield
+
+
 def test_cli_install_still_warns_about_missing_embeddings(tmp_path: Path):
     """The exclusion is bundle-only: an ordinary pip install that lacks
     mlx-embeddings must still get the ⚠ + install hint."""
@@ -3462,6 +3488,7 @@ def test_cli_install_still_warns_about_missing_embeddings(tmp_path: Path):
     with (
         mock.patch.object(eh.sys, "executable", str(exe)),
         mock.patch.object(eh, "_safe_version", return_value=None),
+        _distribution_is_absent("mlx-embeddings"),
     ):
         section = eh.section_optional_packages()
 

--- a/tests/test_doctor_service_health.py
+++ b/tests/test_doctor_service_health.py
@@ -437,7 +437,16 @@ def test_uninstalled_service_launchctl_error_is_unverified():
     assert section.checks[0].status is eh.CheckStatus.WARN
 
 
-def test_service_section_covers_runtime_and_owner_failure_variants(tmp_path):
+def test_service_section_covers_runtime_and_owner_failure_variants(
+    tmp_path, monkeypatch
+):
+    # Doctor suppresses the version comparison entirely when it cannot
+    # determine its OWN version (``__version__ == "0.0.0"``), which is exactly
+    # what happens in a bare checkout that was never pip-installed — the
+    # mismatch below then renders OK and the assertion fails for a reason that
+    # has nothing to do with the service. Pin doctor's version so the branch
+    # under test is the one that runs.
+    monkeypatch.setattr("vllm_mlx.__version__", "1.2.3")
     missing = tmp_path / "missing-rapid-mlx"
     section = eh.section_always_on_service(
         status_data=_status(owner=None, executable=str(missing)),

--- a/tests/test_doctor_service_health.py
+++ b/tests/test_doctor_service_health.py
@@ -446,6 +446,11 @@ def test_service_section_covers_runtime_and_owner_failure_variants(
     # mismatch below then renders OK and the assertion fails for a reason that
     # has nothing to do with the service. Pin doctor's version so the branch
     # under test is the one that runs.
+    #
+    # Patched on ``vllm_mlx``, not on ``env_health``: the comparison does
+    # ``from vllm_mlx import __version__`` inside the function body, so it
+    # re-reads the package attribute on every call and ``env_health`` has no
+    # ``__version__`` of its own to patch.
     monkeypatch.setattr("vllm_mlx.__version__", "1.2.3")
     missing = tmp_path / "missing-rapid-mlx"
     section = eh.section_always_on_service(


### PR DESCRIPTION
## What

Three tests stage the host fact they assert on instead of inheriting it from whatever the machine happens to be. Tests only — no product code changes.

These were the last red tests when running the full suite on a Mac that is set up to actually run Rapid-MLX. Each one passes on Linux CI because the runner happens to hold the state it wants, which means the host, not the test, is choosing which branch gets exercised.

## Why — 1. `test_cli_install_still_warns_about_missing_embeddings`

The test asserts that an ordinary pip install **lacking** `mlx-embeddings` still gets ⚠ plus the `pip install rapid-mlx[embeddings]` hint. It mocks `sys.executable` to a stub interpreter under `tmp_path` and `_safe_version` to `None` — but `_module_visibility` answers from the interpreter that is actually running pytest, not from the stub.

So on a developer Mac that has the extra installed:

1. doctor finds `mlx_embeddings` in-process → visible,
2. it goes on to verify importability by running the stub as an interpreter,
3. the stub is an empty file, `subprocess.run` raises `PermissionError` → `_ImportProbeOutcome.UNVERIFIED`,
4. `_add_inconclusive_import` fires first and the row reads `mlx-embeddings (embeddings extras) importability unknown — doctor probe did not complete`.

The `assert "pip install" in row.label` never reaches the branch the test is named after. Linux CI is green only because `mlx-embeddings` happens to be absent on the runner — the host is choosing which branch gets exercised, which is precisely what this file's own module docstring promises it does not do:

> Every test is dependency-injected (no real subprocess / network / disk mutation) so the suite runs identically on every Python and every OS.

Found while running the full suite locally during the 0.14.1 dogfood: this was the last red test on a Mac that has the product's own optional extras installed. Anyone who runs `pytest tests/` on a machine set up to actually use Rapid-MLX hits it.

**No product change.** Doctor's real-world behaviour here is right: when it cannot verify an import it must say "unknown", not "not installed". Only the test's staging was wrong.

## Why — 2. `test_check_alias_min_memory_warns_regardless_of_disk_stream`

The test patches `vllm_mlx.optimizations.get_system_memory_gb` to 64.0 and expects the floor warning for an alias declaring 192 GB. But `_check_alias_min_memory` deliberately reads `psutil.virtual_memory().total` instead — its docstring says why: it stays independent of the MLX import so it also runs on Linux clients and in preflight commands.

So the patched helper is never consulted. On a 256 GB Mac the real floor check passes, the function returns silently, and `assert "192" in out` sees `''`. CI is green only because its runners are small enough to trip the floor for real.

Now patches `psutil.virtual_memory`, which is what the code actually reads.

## Why — 3. `test_service_section_covers_runtime_and_owner_failure_variants`

The test stages a service runtime reporting version `9.9.9` and expects ⚠ "differs from Doctor". Doctor suppresses that comparison entirely when it cannot determine its *own* version:

```python
elif __version__ != "0.0.0" and Version(service_version) != Version(__version__):
```

`__version__` falls back to `0.0.0` in any checkout that was never pip-installed — including the bare worktree `pr_validate` runs `full_unit` in. The staged mismatch then renders OK and the assertion fails for a reason unrelated to the service.

Now pins doctor's own version for the duration of the test, so the branch under test is the one that runs.


## How

1. A small `_distribution_is_absent(...)` context manager that makes `_module_visibility` report that one distribution as absent and defers to the original for every other one, so the rest of the section still runs against real code.
2. `monkeypatch.setattr("psutil.virtual_memory", ...)` with a 64 GB total.
3. `monkeypatch.setattr("vllm_mlx.__version__", "1.2.3")`.

## Test plan

- [x] `pytest tests/test_disk_stream_cli_wiring.py tests/test_doctor_service_health.py tests/test_doctor_env_health.py -q` on this Mac (256 GB, mlx-embeddings installed, bare worktree): **266 passed**. Before: 3 failed.
- [x] Negative control on all three: revert just the staging lines and the same command goes back to failing — each test is really testing its staging, not passing by accident.
- [x] Root cause confirmed by instrumenting the branch: selected runtime = the `tmp_path` stub, recorded outcome = `_ImportProbeOutcome.UNVERIFIED`, label = `importability unknown — doctor probe did not complete`.
- [x] Confirmed the CI-green side is host luck, not correctness: the test is collected and PASSES in `test-matrix (3.10/3.11/3.12)` on Linux, where the extra is not installed.
- [x] `ruff check` + `ruff format` clean on the changed file.
