### PR TITLE
fix(glm5): support packed linear projection fallback

### DIFF
--- a/.agents/handoffs/vector-glm53-exl3-mvp.md
+++ b/.agents/handoffs/vector-glm53-exl3-mvp.md
@@ -1,0 +1,30 @@
+# Vector handoff: GLM-5.3-Flash-Next EXL3 MVP
+
+Receiving role: Atlas
+Branch: `vector/glm53-exl3-mvp`
+Base: `origin/main@233439e88`
+Status: experiment complete; EXL3 product integration is a no-go
+
+## Verified facts
+
+- A real tiny `glm5_next` checkpoint completed EXL3 Metal forward and cache
+  generation after the KDA fusion compatibility guard.
+- PonyExl3 direct K=4/K=2 did not beat MLX q4 end-to-end quality.
+- A K=5-body/q4-head hybrid reduced mean KL by about 70%, but decode throughput
+  fell from 92.9 to 48.7 tok/s on the tiny graph.
+- Production-shape K=4 expert projection GEMVs were about 1.6x slower than MLX
+  q4. Lower-bit experiments did not recover both quality and speed.
+- PonyExl3 does not currently convert GLM's individual routed-expert tensor
+  layout and requires Python 3.14.
+- Full-model validation was impossible under the enforced Hugging Face cache
+  quota; the full checkpoint was not downloaded or redirected.
+
+Detailed evidence and reproduction constraints are in
+`docs/engineering/performance/2026-09-11-glm53-exl3-mvp.md`.
+
+## Recommendation and next action
+
+Accept the small packed-linear compatibility guard if its focused and broader
+tests remain green. Do not advertise or enable EXL3 for GLM. Re-open only after
+the five gates in the performance note are met, beginning with upstream GLM
+expert-layout support and a production-shape MoE kernel win.

--- a/docs/engineering/performance/2026-09-11-glm53-exl3-mvp.md
+++ b/docs/engineering/performance/2026-09-11-glm53-exl3-mvp.md
@@ -1,0 +1,131 @@
+# GLM-5.3-Flash-Next EXL3 MVP
+
+Date: 2026-09-11
+Owner: Vector
+Host: Mac Studio, M3 Ultra (28 CPU cores), 256 GB unified memory
+Software: macOS 26.5.2, MLX 0.32.2, mlx-vlm 0.6.17, PonyExl3
+`8e7fa6b1556f59fc669e25087903b279b9b0346f`
+
+## Decision
+
+Do not ship EXL3 inference for GLM-5.3-Flash-Next yet. The MVP proved that a
+real `glm5_next` skeleton can execute EXL3 Metal linears end to end, but the
+available converter and kernels do not simultaneously beat Rapid-MLX's affine
+4-bit baseline on quality and decode speed.
+
+Keep the small runtime compatibility fix which makes GLM's KDA projection
+fusion fall back for callable linears that do not expose a materialized
+`weight`. This is required by EXL3 and is also the correct behavior for any
+external packed-linear implementation.
+
+## Constraints
+
+The permitted Hugging Face cache contained only
+`inference-optimization/GLM-5.3-Flash-0.1B-A0.1B` at revision
+`8311399447eba9c9b215e3209ab6f25e59c7d21e` (189 MB BF16). The cache volume had
+5.8 GiB free, so the approximately 180 GB full checkpoint could not be
+downloaded. No cache was moved, deleted, or redirected.
+
+The tiny checkpoint is a genuine five-layer `glm5_next` graph with two sparse
+MoE layers, but its weights are a test fixture rather than a useful language
+model. Its results prove runtime compatibility and expose relative numerical
+drift; they are not a language-quality evaluation.
+
+PonyExl3 currently requires Python 3.14 while Rapid-MLX supports Python 3.10+.
+It also recognizes Qwen's stacked expert source layout, not GLM's individual
+`experts.<n>.<projection>.weight` layout. Consequently its GLM conversion
+selected 42 dense/shared/attention linears but left the routed experts BF16.
+
+## End-to-end smoke
+
+The BF16 fixture was converted with PonyExl3's Metal direct converter. The
+Rapid GLM skeleton loaded all plain tensors strictly, replaced 42 linears with
+`EXL3Linear`, and completed prompt-cache construction and generation. Before
+the Rapid runtime guard, the same run crashed in `_fused_in_proj` while trying
+to read `EXL3Linear.weight`.
+
+Conversion command (after creating a plan-only checkpoint with the requested
+bits):
+
+```bash
+ponyexl3-convert-advanced \
+  --in-dir "$GLM_BF16" \
+  --oracle-dir "$GLM_EXL3_PLAN" \
+  --out-dir "$GLM_EXL3_OUT" \
+  --direct-layer --model-modules --include-routed-experts \
+  --scale-mode computed --skip-g-scale --search-backend metal --json
+```
+
+The K=4 conversion took 8.7 seconds and reduced this partial fixture bundle
+from 180 MB to 130 MB. This direct conversion is a bring-up path, not an
+activation-calibrated production recipe.
+
+## Quantitative results
+
+All latency figures are synchronized Metal execution. Logit comparisons used
+eight deterministic token sequences of lengths 7, 13, 31, 63, 11, 23, 47,
+and 59 with seed 20260911. Each candidate used the same BF16 source weights.
+
+### Production-shape linear GEMV
+
+GLM expert projection sizes were measured at batch/row M=1.
+
+| Projection (input x output) | EXL3 K=4 | MLX affine q4-g64 | Result |
+| --- | ---: | ---: | ---: |
+| gate/up, 4096 x 2048 | 0.303 ms | 0.186 ms | EXL3 1.63x slower |
+| down, 2048 x 4096 | 0.283 ms | 0.179 ms | EXL3 1.58x slower |
+
+The EXL3 forward agreed with its reconstructed public weight to relative RMS
+`6.3e-4`; requantizing that same public weight to MLX q4 produced relative RMS
+`9.1e-2`. This establishes the expected single-layer accuracy advantage, but
+not an end-to-end advantage.
+
+### Tiny GLM end-to-end logits
+
+The first comparison replaced the same 42 modules in every candidate. EXL3's
+head was K=6; the MLX baseline was q4-g64.
+
+| Candidate | Mean KL from BF16 | Mean logits relative RMS | Top-1 agreement |
+| --- | ---: | ---: | ---: |
+| MLX affine q4-g64 | 0.0350 | 0.0449 | 75% |
+| EXL3 direct K=4 | 0.1632 | 0.1160 | 50% |
+| EXL3 direct K=2 | 0.3135 | 0.1442 | 25% |
+
+Keeping the output head in MLX q4 and using EXL3 only for the body improved
+quality, confirming that the direct EXL3 output head was the largest problem:
+
+| Candidate | Mean KL from BF16 | Mean logits relative RMS | Top-1 agreement |
+| --- | ---: | ---: | ---: |
+| MLX affine q4-g64 | 0.0350 | 0.0449 | 75% |
+| EXL3 K=4 body + q4 head | 0.0291 | 0.0370 | 75% |
+| EXL3 K=5 body + q4 head | 0.0104 | 0.0216 | 75% |
+
+That quality win did not survive the performance gate. On the same tiny graph,
+with a 64-token prefill followed by synchronized single-token decoding:
+
+| Candidate | Prefill 64 | Decode |
+| --- | ---: | ---: |
+| MLX affine q4-g64 | 9.99 ms | 92.9 tok/s |
+| EXL3 K=5 body + q4 head | 18.28 ms | 48.7 tok/s |
+
+### Native mixed-bit control
+
+An EXL3-inspired native MLX allocation (2-bit routed experts, 5-bit selected
+body linears, q4 elsewhere) was 13.5% faster on the tiny graph in one paired
+run (92.3 versus 81.4 tok/s), but mean KL worsened from 0.0383 to 0.0568. K=3
+experts and higher-precision body variants also failed to improve both axes.
+This is not a releasable preset.
+
+## Reconsideration gates
+
+Resume this work only when all of the following are available:
+
+1. PonyExl3 can convert and stack GLM's individual routed-expert layout.
+2. The GLM 4096 x 2048 top-8 MoE decode kernel beats MLX q4-g64 in isolated,
+   fresh-process medians; K=4 currently does not.
+3. An activation-calibrated conversion beats the q4 baseline on held-out
+   perplexity or a representative GLM task suite, not only weight error.
+4. A permitted full checkpoint is already present in the Hugging Face cache,
+   allowing full-model prefill, decode, memory, and output-parity dogfood.
+5. The optional runtime supports Rapid-MLX's packaged Python version; a
+   Python-3.14-only dependency cannot be enabled in the desktop/server path.

--- a/tests/test_glm5_next_runtime_patch.py
+++ b/tests/test_glm5_next_runtime_patch.py
@@ -14,11 +14,18 @@ from vllm_mlx.patches.glm5_next_runtime import (
 
 
 class _Linear:
+    weight = object()
+
+
+class _ExternalLinear:
+    """Callable quantized linear whose packed weights are intentionally private."""
+
     pass
 
 
 class _Quantized:
     def __init__(self, *, group_size=64, bits=4, mode="affine"):
+        self.weight = object()
         self.scales = object()
         self.group_size = group_size
         self.bits = bits
@@ -28,6 +35,9 @@ class _Quantized:
 def test_kda_projection_fusion_requires_one_quantization() -> None:
     assert _projection_quantization_is_homogeneous([_Linear(), _Linear()])
     assert _projection_quantization_is_homogeneous([_Quantized(), _Quantized()])
+    assert not _projection_quantization_is_homogeneous(
+        [_ExternalLinear(), _ExternalLinear()]
+    )
     assert not _projection_quantization_is_homogeneous([_Linear(), _Quantized()])
     assert not _projection_quantization_is_homogeneous(
         [_Quantized(bits=4), _Quantized(bits=8)]

--- a/vllm_mlx/patches/glm5_next_runtime.py
+++ b/vllm_mlx/patches/glm5_next_runtime.py
@@ -24,6 +24,12 @@ _INSTALLED = False
 
 
 def _projection_quantization_is_homogeneous(modules: Sequence[Any]) -> bool:
+    # Third-party weight formats such as EXL3 deliberately expose a callable
+    # linear without a materialized ``weight`` tensor.  The released GLM
+    # fusion concatenates ``module.weight`` values, so those modules must use
+    # the equivalent per-projection fallback instead of entering that path.
+    if any(not hasattr(module, "weight") for module in modules):
+        return False
     quantized = [hasattr(module, "scales") for module in modules]
     if not all(quantized) and any(quantized):
         return False


### PR DESCRIPTION
## Summary

- keep GLM KDA projection fusion on the released fast path for homogeneous MLX weights
- fall back to the equivalent six projection calls for packed third-party linears without a public weight tensor
- record the GLM-5.3-Flash-Next EXL3 MVP measurements and no-go decision

## Validation

- 32 GLM runtime, quantization, and processor tests passed
- real five-layer glm5_next fixture completed EXL3 Metal forward plus cache generation
- diff check clean

## Performance decision

Do not enable EXL3 yet. Production-shape K=4 projection GEMVs were about 1.6x slower than MLX q4. A K5-body/q4-head hybrid reduced tiny-fixture mean KL from 0.0350 to 0.0104, but decode fell from 92.9 to 48.7 tok/s. The PR therefore ships only the safe compatibility fix and durable evidence, not an EXL3 product path.