### PR TITLE
perf: accelerate DeepSeek V4.1 hyper-connections

### DIFF
--- a/.agents/handoffs/vector-deepseek-v41-fast-hc.md
+++ b/.agents/handoffs/vector-deepseek-v41-fast-hc.md
@@ -10,7 +10,7 @@ Branch: `vector/deepseek-v41-fast-hc`
 
 Worktree: `/private/tmp/rapid-mlx-deepseek-v41-fast-hc`
 
-Base dependency: PR #3338 (`vector/deepseek-v41-engram-offload`)
+Base: `main` (PR #3338 has merged)
 
 ## Intention and boundary
 
@@ -59,10 +59,15 @@ adaptive verification, and other model families.
   separately, that the prior 19.39 tok/s comparison uses the same four-domain
   K4 shape, and that no drafter, quantization, or catalog change entered the
   diff. No in-contract defect remained.
+- Round 4, CI observability: the new Metal-path tests were absent from the
+  explicit Apple Silicon roster, so changed-lines coverage could not observe
+  the kernel execution. Added the focused test to that roster, guarded the
+  roster contract, and added a mocked Block wiring test for both fused
+  collapse-normalize call sites. Focused diff coverage is now 100% (58/58).
 
 ## PR validation
 
-- PR: #3343, stacked on #3338.
+- PR: #3343, rebased onto `main` after #3338 merged.
 - `pr_validate` exact head/base override: description, supply chain, test
   environment, vocabulary, lint, and 93.1% patch coverage passed. The external
   Codex step was intentionally skipped because this task uses the recorded
@@ -73,14 +78,14 @@ adaptive verification, and other model families.
   CLI assertion receives no warning. There is no head-only failure; these are
   not fixed here to preserve the PR boundary.
 
-## Remaining work
+## Follow-up experiment findings (outside this PR)
 
-1. Complete author-owned adversarial review and fix only in-contract findings.
-2. Run PR validation, commit, push, and open the stacked PR.
-3. Rebase onto `main` after #3338 lands, then queue.
-4. Separately re-evaluate the full 4-bit DSpark head under Engram offload; its
-   metadata currently needs explicit 2-bit overrides for target-shared embed
-   and head tensors. That is the next 40 tok/s experiment, not part of this PR.
+- The full 4-bit DSpark sidecar did not improve acceptance and regressed two
+  domains while adding about 3.4 GB; do not productize it.
+- A fixed-K sweep kept K4 as the best global setting. K selection is not a
+  credible route to 40 tok/s.
+- The next separate experiment is acceptance-aware drafter calibration against
+  the actual 2-bit target's verification labels. Do not add that work to #3343.
 
 ## Risks
 
@@ -88,4 +93,4 @@ adaptive verification, and other model families.
   warm measurements rather than quoting only 34.9 tok/s.
 - Low-acceptance domains remain below 30 tok/s. Kernel work alone does not prove
   a universal 40 tok/s claim.
-- The PR is stacked on #3338 and must not merge first.
+- Low-acceptance prompts are now dominated by drafter quality, not mHC dispatch.

--- a/.agents/handoffs/vector-deepseek-v41-fast-hc.md
+++ b/.agents/handoffs/vector-deepseek-v41-fast-hc.md
@@ -56,6 +56,19 @@ adaptive verification, and other model families.
   K4 shape, and that no drafter, quantization, or catalog change entered the
   diff. No in-contract defect remained.
 
+## PR validation
+
+- PR: #3343, stacked on #3338.
+- `pr_validate` exact head/base override: description, supply chain, test
+  environment, vocabulary, lint, and 93.1% patch coverage passed. The external
+  Codex step was intentionally skipped because this task uses the recorded
+  author-owned review.
+- Full unit: 23,868 passed, 132 skipped, 18 failed. All 18 failures reproduce
+  unchanged on base #3338: 16 extraction tests require undeclared `torch`, one
+  image precision test requires undeclared `mflux`, and one existing disk-stream
+  CLI assertion receives no warning. There is no head-only failure; these are
+  not fixed here to preserve the PR boundary.
+
 ## Remaining work
 
 1. Complete author-owned adversarial review and fix only in-contract findings.

--- a/.agents/handoffs/vector-deepseek-v41-fast-hc.md
+++ b/.agents/handoffs/vector-deepseek-v41-fast-hc.md
@@ -1,0 +1,74 @@
+# Vector handoff — DeepSeek V4.1 fast hyper-connections
+
+Date: 2026-09-11
+
+Owner: Vector  
+Host: Studio  
+Branch: `vector/deepseek-v41-fast-hc`  
+Worktree: `/private/tmp/rapid-mlx-deepseek-v41-fast-hc`  
+Base dependency: PR #3338 (`vector/deepseek-v41-engram-offload`)
+
+## Intention and boundary
+
+Raise DeepSeek V4.1 fixed-K4 decode throughput toward 40 tok/s by optimizing
+only the native target's mHC mix, residual expansion, and collapse-normalize
+path. Non-goals are drafter weights/training, quantization, catalog behavior,
+adaptive verification, and other model families.
+
+## Reference-first check
+
+- vLLM: searched the current DeepSeek V4.1 implementation. It contains the
+  architecture and speculative configuration but no reusable Apple Metal mHC
+  kernel.
+- SGLang: searched the current tree; no DeepSeek V4.1 mHC implementation was
+  available to adapt.
+- MLX-LM: Rapid already carries its older V4 fused Sinkhorn/collapse precedent,
+  but V4.1 staggers the `pre` coefficient across sublayers, so that same-cycle
+  kernel cannot be reused safely.
+- oMLX: reviewed the current V4.1 single-pass mHC implementation and adapted its
+  compiled mix graph, four-way Sinkhorn, post-mix, and collapse-normalize Metal
+  pattern to Rapid's staggered runtime. Its file-level MIT license and source
+  revision are retained in the modified source and native-runtime NOTICE.
+
+## Verified facts
+
+- Focused tests: 11 passed; related native load tests: 29 passed.
+- Release-width BF16 kernel parity: elementwise equal at row counts 1 and 5.
+- FP32 maximum focused error: `2.38e-7`.
+- Real model, fixed K4, 16-token paired probe: 9.60 tok/s legacy versus 34.90
+  tok/s warm fast path, identical emitted tokens.
+- Four-domain 128-token suite, two repeats: 21.46 tok/s all-repeat weighted;
+  26.39 tok/s warm-repeat weighted; all four outputs repeat-stable.
+- Warm domain results: code 34.88, reasoning 25.04, structured 21.45, Chinese
+  27.53 tok/s.
+- Peak MLX memory: 171.13 GB with Engram SSD offload.
+
+## Author-owned adversarial review
+
+- Round 1, numerical/layout/licensing: corrected the initial repository-level
+  Apache attribution to the kernel file's actual MIT boundary; retained the
+  exact source revision and bundled license text. No numerical defect found.
+- Round 2, compatibility/fallback: exercised the release shape on CPU and
+  unsupported/empty layouts on Metal. All remained on the portable path; no
+  change required beyond the added CPU regression test.
+- Round 3, benchmark/scope: checked that cold and warm numbers are reported
+  separately, that the prior 19.39 tok/s comparison uses the same four-domain
+  K4 shape, and that no drafter, quantization, or catalog change entered the
+  diff. No in-contract defect remained.
+
+## Remaining work
+
+1. Complete author-owned adversarial review and fix only in-contract findings.
+2. Run PR validation, commit, push, and open the stacked PR.
+3. Rebase onto `main` after #3338 lands, then queue.
+4. Separately re-evaluate the full 4-bit DSpark head under Engram offload; its
+   metadata currently needs explicit 2-bit overrides for target-shared embed
+   and head tensors. That is the next 40 tok/s experiment, not part of this PR.
+
+## Risks
+
+- First use includes Metal compilation and page warming; publish both cold and
+  warm measurements rather than quoting only 34.9 tok/s.
+- Low-acceptance domains remain below 30 tok/s. Kernel work alone does not prove
+  a universal 40 tok/s claim.
+- The PR is stacked on #3338 and must not merge first.

--- a/.agents/handoffs/vector-deepseek-v41-fast-hc.md
+++ b/.agents/handoffs/vector-deepseek-v41-fast-hc.md
@@ -2,10 +2,14 @@
 
 Date: 2026-09-11
 
-Owner: Vector  
-Host: Studio  
-Branch: `vector/deepseek-v41-fast-hc`  
-Worktree: `/private/tmp/rapid-mlx-deepseek-v41-fast-hc`  
+Owner: Vector
+
+Host: Studio
+
+Branch: `vector/deepseek-v41-fast-hc`
+
+Worktree: `/private/tmp/rapid-mlx-deepseek-v41-fast-hc`
+
 Base dependency: PR #3338 (`vector/deepseek-v41-engram-offload`)
 
 ## Intention and boundary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,6 +484,7 @@ jobs:
             tests/test_deepseek_v41_affine_route_qmv.py \
             tests/test_deepseek_v41_dspark.py \
             tests/test_deepseek_v41_engram_offload.py \
+            tests/test_deepseek_v41_hyper_connections.py \
             tests/test_deepseek_v41_native_load.py \
             tests/test_dspark_scheduler.py \
             tests/test_scheduler_admission_policy.py \

--- a/docs/engineering/performance/2026-09-11-deepseek-v41-fast-hc.md
+++ b/docs/engineering/performance/2026-09-11-deepseek-v41-fast-hc.md
@@ -1,0 +1,94 @@
+# DeepSeek V4.1 Flash fast hyper-connections
+
+Date: 2026-09-11
+
+Status: the release-layout Metal path passes kernel parity, real-model output
+stability, and the four-domain throughput gate. It is enabled automatically for
+the native V4.1 runtime on supported Apple Silicon layouts; portable and
+non-release layouts retain the operation-based implementation.
+
+## Question and boundary
+
+DeepSeek V4.1 evaluates two hyper-connection cycles in each of 40 target layers.
+The former path materialized the residual mixing graph and performed stream
+collapse and RMS normalization as separate operations. This experiment asks
+whether compiling the coefficient graph and fusing the two bandwidth-bound
+operations can materially lower target verification time without changing the
+fixed-K4 target-authoritative contract.
+
+Only the native V4.1 hyper-connection path changes. Draft weights, target
+weights, quantization, the model catalog, other model families, and adaptive
+verification remain unchanged.
+
+## Environment
+
+- Apple M3 Ultra, 256 GiB unified memory (`hw.memsize=274877906944`)
+- macOS 26.5.2 (25F84)
+- Target: local 212.93 GB REAP12.5 native affine 2-bit checkpoint
+- Engram tables: affine 2-bit SSD offload
+- Draft: pinned 4-bit-dense/2-bit-expert DSpark sidecar
+- Verification: fixed K=4, packed MTP, exact affine-2bit target down projection
+- Model load: 163.52 seconds; peak qualification memory: 171.13 GB
+
+No model was downloaded or relocated for this experiment. Both artifacts were
+already present in the Studio storage hierarchy.
+
+## Correctness
+
+Focused Metal tests cover BF16, FP16, and FP32 post-mix and collapse-normalize
+paths, four-way Sinkhorn, empty tensors, and unsupported multiplicities. At the
+release width of 5120, BF16 fused and operation-based post-mix and
+collapse-normalize outputs are elementwise equal for one-row and five-row
+inputs. FP32 maximum absolute error in the focused suite is `2.38e-7`.
+
+The four 128-token prompts are token-for-token stable across two consecutive
+K4 runs. As in the existing fixed-shape product contract, K4 is
+target-authoritative but is not required to match sequential AR because a
+different target batch shape can cross low-margin decisions.
+
+## Reproduction
+
+```shell
+python3.11 scripts/qualify_deepseek_v41_dspark_suite.py \
+  --target <reap12.5-target> \
+  --overlay <pinned-mixed-dspark-sidecar> \
+  --engram-ssd-offload \
+  --tokens 128 --repeats 2 --verify-k 4 \
+  --collect-target-margins
+```
+
+The Studio was otherwise idle when the qualification began. The first repeat
+includes Metal compilation and warm-tier page warming; the second repeat is the
+steady-state result users see after warmup.
+
+## Result
+
+| Domain | First K4 tok/s | Warm K4 tok/s | Accepted tokens/block | Repeat stable |
+| --- | ---: | ---: | ---: | --- |
+| Code | 26.13 | 34.88 | 2.88 | yes |
+| Reasoning | 15.91 | 25.04 | 1.78 | yes |
+| Structured | 14.27 | 21.45 | 1.37 | yes |
+| Chinese | 19.96 | 27.53 | 2.05 | yes |
+
+Across both repeats, K4 produces 1,016 transitions in 47.348 seconds, or
+**21.46 tok/s**. The warm repeat produces 508 transitions in 19.247 seconds,
+or **26.39 tok/s**. The prior identically shaped four-domain qualification was
+19.39 tok/s across both repeats, so the conservative all-repeat result improves
+by **10.7%** and the steady-state result by **36.1%**.
+
+Sequential AR now reaches a weighted **15.07 tok/s**, showing that the target
+kernel improvement benefits non-speculative generation as well. A same-process
+16-token code probe isolates the hot-path effect: the operation-based path is
+9.60 tok/s and the warmed fused path is 34.90 tok/s with identical output and
+the same three accepted draft tokens per block.
+
+## Decision and next bottleneck
+
+The fast path is worthwhile as a default for its strict release layout: it is
+transparent to unsupported devices and shapes, preserves output stability, and
+raises both AR and K4 throughput. High-acceptance code already reaches about 35
+tok/s. The remaining gap to a four-domain 40 tok/s is dominated by draft
+acceptance: target verification takes roughly 90 ms per K4 block after warmup,
+while reasoning and structured prompts need many more blocks because they
+accept only 1.78 and 1.37 draft tokens per block. The next experiment should
+improve the draft head rather than widen this kernel PR.

--- a/scripts/qualify_deepseek_v41_dspark_suite.py
+++ b/scripts/qualify_deepseek_v41_dspark_suite.py
@@ -99,6 +99,11 @@ def parse_args() -> argparse.Namespace:
         "--verify-k", type=_positive_int, choices=range(2, 7), default=4
     )
     parser.add_argument("--eval-interval", type=_positive_int, default=40)
+    parser.add_argument(
+        "--engram-ssd-offload",
+        action="store_true",
+        help="Keep affine Engram tables on SSD during 256 GiB qualification.",
+    )
     parser.add_argument("--collect-target-margins", action="store_true")
     parser.add_argument("--skip-ar", action="store_true")
     return parser.parse_args()
@@ -111,8 +116,14 @@ def _validate_inputs(args) -> None:
             raise SystemExit(f"--{label.replace('_', '-')} must be a directory: {path}")
 
 
-def _prepare_target(target: Path, overlay: Path, eval_interval: int):
-    model, _ = load(str(target.resolve()), lazy=False)
+def _prepare_target(
+    target: Path, overlay: Path, eval_interval: int, *, engram_ssd_offload: bool = False
+):
+    model, _ = load(
+        str(target.resolve()),
+        lazy=False,
+        engram_ssd_offload=engram_ssd_offload,
+    )
     model.eval_interval = eval_interval
     model._dspark_overlay_path = str(overlay.resolve())
     # AR and speculative decoding must use the same target kernels. Installing
@@ -127,7 +138,12 @@ def main() -> None:
     _validate_inputs(args)
 
     started = time.perf_counter()
-    model, replaced = _prepare_target(args.target, args.overlay, args.eval_interval)
+    model, replaced = _prepare_target(
+        args.target,
+        args.overlay,
+        args.eval_interval,
+        engram_ssd_offload=args.engram_ssd_offload,
+    )
     tokenizer = PreTrainedTokenizerFast(
         tokenizer_file=str(args.target.resolve() / "tokenizer.json")
     )

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -169,6 +169,7 @@ def test_deepseek_v41_product_coverage_runs_on_apple_silicon() -> None:
     assert "tests/test_deepseek_v41_artifacts.py" in apple_run
     assert "tests/test_deepseek_v41_affine_route_qmv.py" in apple_run
     assert "tests/test_deepseek_v41_dspark.py" in apple_run
+    assert "tests/test_deepseek_v41_hyper_connections.py" in apple_run
     assert "tests/test_deepseek_v41_native_load.py" in apple_run
 
 

--- a/tests/test_deepseek_v41_hyper_connections.py
+++ b/tests/test_deepseek_v41_hyper_connections.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 pytest.importorskip("mlx")
@@ -8,6 +10,7 @@ pytestmark = pytest.mark.requires_mlx
 import mlx.core as mx
 
 from vllm_mlx.models.deepseek_v41_native import hyper_connections as hc
+from vllm_mlx.models.deepseek_v41_native import model as model_module
 
 
 def _requires_metal() -> None:
@@ -176,3 +179,58 @@ def test_release_layout_stays_portable_on_cpu(monkeypatch) -> None:
     assert expanded.shape == residual.shape
     assert normalized.shape == x.shape
     assert sinkhorn.shape == comb.shape
+
+
+def test_block_uses_fused_pre_norm_for_attention_and_ffn(monkeypatch) -> None:
+    calls = []
+    pre = mx.ones((1, 1, 4), dtype=mx.float32)
+    post = mx.ones((1, 1, 4), dtype=mx.float32)
+    comb = mx.eye(4, dtype=mx.float32)[None, None]
+
+    def fake_mixes(*_args):
+        calls.append("mixes")
+        return pre, post, comb
+
+    def fake_pre_norm(x, mix, weight, eps):
+        calls.append(("pre_norm", mix, weight, eps))
+        return mx.sum(x, axis=2)
+
+    def fake_post(value, _residual, _post, _comb):
+        calls.append("post")
+        return mx.repeat(value[:, :, None, :], 4, axis=2)
+
+    monkeypatch.setattr(model_module, "hc_mixes", fake_mixes)
+    monkeypatch.setattr(model_module, "hc_pre_norm", fake_pre_norm)
+    monkeypatch.setattr(model_module, "hc_post", fake_post)
+
+    block = SimpleNamespace(
+        hc_attn_fn=mx.zeros((24, 32)),
+        hc_ffn_fn=mx.zeros((24, 32)),
+        hc_attn_scale=mx.ones((3,)),
+        hc_ffn_scale=mx.ones((3,)),
+        hc_attn_base=mx.zeros((24,)),
+        hc_ffn_base=mx.zeros((24,)),
+        hc_mult=4,
+        hc_iters=20,
+        norm_eps=1e-6,
+        hc_eps=1e-6,
+        attn_norm=SimpleNamespace(weight=mx.ones((8,)), eps=1e-6),
+        ffn_norm=SimpleNamespace(weight=mx.ones((8,)), eps=1e-6),
+        attn=lambda value, *_args: value + 1,
+        ffn=lambda value: value + 2,
+    )
+    x = mx.ones((1, 1, 4, 8), dtype=mx.float32)
+
+    output, next_pre = model_module.Block.__call__(block, x, pre, 0, None, None)
+    mx.eval(output, next_pre)
+
+    assert output.shape == x.shape
+    assert next_pre is pre
+    assert calls[0] == "mixes"
+    assert calls[2:4] == ["post", "mixes"]
+    assert calls[-1] == "post"
+    pre_norm_calls = [call for call in calls if isinstance(call, tuple)]
+    assert pre_norm_calls[0][1] is pre
+    assert pre_norm_calls[1][1] is pre
+    assert pre_norm_calls[0][2] is block.attn_norm.weight
+    assert pre_norm_calls[1][2] is block.ffn_norm.weight

--- a/tests/test_deepseek_v41_hyper_connections.py
+++ b/tests/test_deepseek_v41_hyper_connections.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mlx")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.core as mx
+
+from vllm_mlx.models.deepseek_v41_native import hyper_connections as hc
+
+
+def _requires_metal() -> None:
+    if not hc._metal_fast_path_available():
+        pytest.skip("custom hyper-connection kernels require Metal")
+
+
+def _reference_hc_mixes(x, fn, scale, base, hc_mult, iters, norm_eps, hc_eps):
+    flat = x.reshape(*x.shape[:2], -1).astype(mx.float32)
+    inverse_rms = mx.rsqrt(mx.mean(mx.square(flat), axis=-1, keepdims=True) + norm_eps)
+    mixes = (flat @ fn.astype(mx.float32).T) * inverse_rms
+    m = mixes.astype(mx.float32)
+    pre = mx.sigmoid(m[..., :hc_mult] * scale[0] + base[:hc_mult]) + hc_eps
+    post = 2 * mx.sigmoid(
+        m[..., hc_mult : 2 * hc_mult] * scale[1] + base[hc_mult : 2 * hc_mult]
+    )
+    comb = (m[..., 2 * hc_mult :] * scale[2] + base[2 * hc_mult :]).reshape(
+        *m.shape[:-1], hc_mult, hc_mult
+    )
+    comb = mx.softmax(comb, axis=-1) + hc_eps
+    return pre, post, hc._sinkhorn_reference(comb, hc_eps, iters)
+
+
+def test_compiled_hc_mixes_matches_reference_decode_shape() -> None:
+    mx.random.seed(40)
+    x = mx.random.uniform(shape=(1, 1, 4, 64)).astype(mx.bfloat16)
+    fn = mx.random.uniform(shape=(24, 256)).astype(mx.float32)
+    scale = mx.random.uniform(shape=(3,)).astype(mx.float32)
+    base = mx.random.uniform(shape=(24,)).astype(mx.float32)
+
+    actual = hc.hc_mixes(x, fn, scale, base, 4, 20, 1e-6, 1e-6)
+    expected = _reference_hc_mixes(x, fn, scale, base, 4, 20, 1e-6, 1e-6)
+    mx.eval(*actual, *expected)
+
+    for accelerated, reference in zip(actual, expected, strict=True):
+        assert mx.allclose(accelerated, reference, rtol=0, atol=2e-7).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16, mx.float32])
+def test_fused_hc_post_matches_reference(dtype) -> None:
+    _requires_metal()
+    mx.random.seed(41)
+    x = mx.random.uniform(shape=(2, 3, 64)).astype(dtype)
+    residual = mx.random.uniform(shape=(2, 3, 4, 64)).astype(dtype)
+    post = mx.random.uniform(shape=(2, 3, 4)).astype(mx.float32)
+    comb = mx.random.uniform(shape=(2, 3, 4, 4)).astype(mx.float32)
+
+    actual = hc.hc_post(x, residual, post, comb)
+    expected = hc._hc_post_reference(x, residual, post, comb)
+    mx.eval(actual, expected)
+
+    assert actual.shape == residual.shape
+    atol = 3e-7 if dtype == mx.float32 else 0
+    assert mx.allclose(actual, expected, rtol=0, atol=atol).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16, mx.float32])
+def test_fused_hc_pre_norm_matches_rounded_reference(dtype) -> None:
+    _requires_metal()
+    mx.random.seed(42)
+    x = mx.random.uniform(shape=(2, 3, 4, 64)).astype(dtype)
+    pre = mx.random.uniform(shape=(2, 3, 4)).astype(mx.float32)
+    weight = mx.random.uniform(shape=(64,)).astype(mx.float32)
+
+    actual = hc.hc_pre_norm(x, pre, weight, 1e-6)
+    expected = hc._hc_pre_norm_reference(x, pre, weight, 1e-6)
+    mx.eval(actual, expected)
+
+    assert actual.shape == (2, 3, 64)
+    atol = 3e-7 if dtype == mx.float32 else 0
+    assert mx.allclose(actual, expected, rtol=0, atol=atol).item()
+
+
+def test_fused_sinkhorn_matches_reference() -> None:
+    _requires_metal()
+    mx.random.seed(43)
+    comb = mx.random.uniform(shape=(2, 3, 4, 4)).astype(mx.float32)
+
+    actual = hc._sinkhorn(comb, 1e-6, 20)
+    expected = hc._sinkhorn_reference(comb, 1e-6, 20)
+    mx.eval(actual, expected)
+
+    assert mx.allclose(actual, expected, rtol=0, atol=2e-7).item()
+
+
+def test_non_release_layouts_stay_on_portable_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hc,
+        "_fused_hc_post",
+        lambda *_args: pytest.fail("unexpected Metal post-mix path"),
+    )
+    monkeypatch.setattr(
+        hc,
+        "_fused_hc_pre_norm",
+        lambda *_args: pytest.fail("unexpected Metal pre-norm path"),
+    )
+    x = mx.ones((1, 1, 32), dtype=mx.float32)
+    residual = mx.ones((1, 1, 2, 32), dtype=mx.float32)
+    post = mx.ones((1, 1, 2), dtype=mx.float32)
+    comb = mx.ones((1, 1, 2, 2), dtype=mx.float32)
+    pre = mx.ones((1, 1, 2), dtype=mx.float32)
+    weight = mx.ones((32,), dtype=mx.float32)
+
+    expanded = hc.hc_post(x, residual, post, comb)
+    normalized = hc.hc_pre_norm(residual, pre, weight, 1e-6)
+    mx.eval(expanded, normalized)
+
+    assert expanded.shape == residual.shape
+    assert normalized.shape == x.shape
+
+
+def test_empty_release_layout_stays_on_portable_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hc,
+        "_fused_hc_post",
+        lambda *_args: pytest.fail("unexpected Metal post-mix path"),
+    )
+    monkeypatch.setattr(
+        hc,
+        "_fused_hc_pre_norm",
+        lambda *_args: pytest.fail("unexpected Metal pre-norm path"),
+    )
+    x = mx.zeros((1, 0, 16), dtype=mx.float32)
+    residual = mx.zeros((1, 0, 4, 16), dtype=mx.float32)
+    post = mx.zeros((1, 0, 4), dtype=mx.float32)
+    comb = mx.zeros((1, 0, 4, 4), dtype=mx.float32)
+    pre = mx.zeros((1, 0, 4), dtype=mx.float32)
+    weight = mx.ones((16,), dtype=mx.float32)
+
+    expanded = hc.hc_post(x, residual, post, comb)
+    normalized = hc.hc_pre_norm(residual, pre, weight, 1e-6)
+    mx.eval(expanded, normalized)
+
+    assert expanded.shape == residual.shape
+    assert normalized.shape == x.shape
+
+
+def test_release_layout_stays_portable_on_cpu(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hc,
+        "_fused_hc_post",
+        lambda *_args: pytest.fail("unexpected Metal post-mix path"),
+    )
+    monkeypatch.setattr(
+        hc,
+        "_fused_hc_pre_norm",
+        lambda *_args: pytest.fail("unexpected Metal pre-norm path"),
+    )
+    previous = mx.default_device()
+    try:
+        mx.set_default_device(mx.cpu)
+        x = mx.ones((1, 1, 16), dtype=mx.float32)
+        residual = mx.ones((1, 1, 4, 16), dtype=mx.float32)
+        post = mx.ones((1, 1, 4), dtype=mx.float32)
+        comb = mx.ones((1, 1, 4, 4), dtype=mx.float32)
+        pre = mx.ones((1, 1, 4), dtype=mx.float32)
+        weight = mx.ones((16,), dtype=mx.float32)
+
+        expanded = hc.hc_post(x, residual, post, comb)
+        normalized = hc.hc_pre_norm(residual, pre, weight, 1e-6)
+        sinkhorn = hc._sinkhorn(comb, 1e-6, 20)
+        mx.eval(expanded, normalized, sinkhorn)
+    finally:
+        mx.set_default_device(previous)
+
+    assert expanded.shape == residual.shape
+    assert normalized.shape == x.shape
+    assert sinkhorn.shape == comb.shape

--- a/tests/test_qualify_deepseek_v41_dspark_suite.py
+++ b/tests/test_qualify_deepseek_v41_dspark_suite.py
@@ -120,7 +120,13 @@ def test_prepare_target_installs_shared_ar_and_k4_kernel(monkeypatch, tmp_path) 
     module = _load_script()
     model = SimpleNamespace()
     calls = []
-    monkeypatch.setattr(module, "load", lambda path, lazy: (model, None))
+    load_calls = []
+
+    def fake_load(path, *, lazy, engram_ssd_offload):
+        load_calls.append((path, lazy, engram_ssd_offload))
+        return model, None
+
+    monkeypatch.setattr(module, "load", fake_load)
     monkeypatch.setattr(
         module,
         "_install_direct_down_qmv",
@@ -128,12 +134,16 @@ def test_prepare_target_installs_shared_ar_and_k4_kernel(monkeypatch, tmp_path) 
     )
 
     prepared, replaced = module._prepare_target(
-        tmp_path / "target", tmp_path / "overlay", 17
+        tmp_path / "target",
+        tmp_path / "overlay",
+        17,
+        engram_ssd_offload=True,
     )
 
     assert prepared is model
     assert replaced == 40
     assert calls == [model]
+    assert load_calls == [(str((tmp_path / "target").resolve()), False, True)]
     assert model.eval_interval == 17
     assert model._dspark_overlay_path == str((tmp_path / "overlay").resolve())
 

--- a/vllm_mlx/models/deepseek_v41_native/NOTICE
+++ b/vllm_mlx/models/deepseek_v41_native/NOTICE
@@ -10,3 +10,8 @@ MIT-licensed DeepSeek V4.1 reference inference implementation. The Rapid-MLX
 implementation adds a strict data-only sidecar loader, target weight sharing,
 memory admission, validation, and benchmark integration.
 See LICENSE-DSPARK in this directory.
+
+The hyper-connection Metal kernels in hyper_connections.py include modified
+MIT-licensed code from jundot/omlx revision
+75466d33a3f9e1bf4b8257738bcadd4658526bcb. See LICENSE-DSPARK in this
+directory for the MIT license text.

--- a/vllm_mlx/models/deepseek_v41_native/hyper_connections.py
+++ b/vllm_mlx/models/deepseek_v41_native/hyper_connections.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Modified by Rapid-MLX contributors for the native V4.1 runtime.
 """Hyper-Connections — the residual stream is ``hc_mult`` (=4) parallel copies.
 
 V4.1 keeps V4's Sinkhorn machinery but **staggers** the coefficients: the mixes a
@@ -20,9 +22,84 @@ plausible but wrong.
 
 from __future__ import annotations
 
+from functools import cache
+
 import mlx.core as mx
 
 
+def _metal_fast_path_available() -> bool:
+    """Return whether custom Metal kernels can execute on the active device."""
+    return (
+        mx.default_device() == mx.gpu
+        and hasattr(mx, "metal")
+        and mx.metal.is_available()
+    )
+
+
+_SINKHORN_SOURCE = r"""
+    const uint row = thread_position_in_grid.x;
+    if (row >= ROWS) return;
+    float values[16];
+    for (int i = 0; i < 16; ++i) values[i] = x[row * 16 + i];
+    for (int iteration = 0; iteration < ITERS; ++iteration) {
+        if (iteration > 0) {
+            for (int r = 0; r < 4; ++r) {
+                float total = 0.0f;
+                for (int c = 0; c < 4; ++c) total += values[r * 4 + c];
+                total += eps[0];
+                for (int c = 0; c < 4; ++c) values[r * 4 + c] /= total;
+            }
+        }
+        for (int c = 0; c < 4; ++c) {
+            float total = 0.0f;
+            for (int r = 0; r < 4; ++r) total += values[r * 4 + c];
+            total += eps[0];
+            for (int r = 0; r < 4; ++r) values[r * 4 + c] /= total;
+        }
+    }
+    for (int i = 0; i < 16; ++i) y[row * 16 + i] = values[i];
+"""
+
+
+@cache
+def _sinkhorn_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_deepseek_v41_sinkhorn",
+        input_names=["x", "eps"],
+        output_names=["y"],
+        source=_SINKHORN_SOURCE,
+        header="#pragma clang fp reassociate(off)\n#pragma clang fp contract(off)\n",
+    )
+
+
+def _sinkhorn_reference(comb: mx.array, eps: float, iters: int) -> mx.array:
+    comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    for _ in range(max(iters - 1, 0)):
+        comb = comb / (comb.sum(axis=-1, keepdims=True) + eps)
+        comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    return comb
+
+
+def _sinkhorn(comb: mx.array, eps: float, iters: int) -> mx.array:
+    if (
+        comb.shape[-2:] != (4, 4)
+        or comb.dtype != mx.float32
+        or not comb.size
+        or not _metal_fast_path_available()
+    ):
+        return _sinkhorn_reference(comb, eps, iters)
+    rows = comb.size // 16
+    return _sinkhorn_kernel()(
+        inputs=[comb, mx.array([eps], mx.float32)],
+        template=[("ROWS", rows), ("ITERS", max(1, iters))],
+        grid=(rows, 1, 1),
+        threadgroup=(32, 1, 1),
+        output_shapes=[comb.shape],
+        output_dtypes=[mx.float32],
+    )[0]
+
+
+@mx.compile
 def split_sinkhorn(
     mixes: mx.array,
     hc_scale: mx.array,
@@ -47,13 +124,11 @@ def split_sinkhorn(
     # row softmax + eps, one column normalization, then (iters-1) full sweeps;
     # the eps sits inside the divisions, as in the kernel
     comb = mx.softmax(comb, axis=-1) + eps
-    comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
-    for _ in range(sinkhorn_iters - 1):
-        comb = comb / (comb.sum(axis=-1, keepdims=True) + eps)
-        comb = comb / (comb.sum(axis=-2, keepdims=True) + eps)
+    comb = _sinkhorn(comb, eps, sinkhorn_iters)
     return pre, post, comb
 
 
+@mx.compile
 def hc_mixes(
     x: mx.array,
     hc_fn: mx.array,
@@ -73,13 +148,15 @@ def hc_mixes(
     return split_sinkhorn(mixes, hc_scale, hc_base, hc_mult, sinkhorn_iters, hc_eps)
 
 
+@mx.compile
 def hc_pre(x: mx.array, pre_mix: mx.array) -> mx.array:
     """Collapse the hc copies into one: [b,s,hc,d] x [b,s,hc] -> [b,s,d], fp32 sum."""
     y = mx.sum(pre_mix[..., None].astype(mx.float32) * x.astype(mx.float32), axis=2)
     return y.astype(x.dtype)
 
 
-def hc_post(
+@mx.compile
+def _hc_post_reference(
     x: mx.array, residual: mx.array, post: mx.array, comb: mx.array
 ) -> mx.array:
     """out[k] = post[k]*x + sum_j comb[j,k]*residual[j].
@@ -90,6 +167,156 @@ def hc_post(
     prod = comb[..., None] * residual[..., :, None, :]  # [b, s, j, k, d]
     out = post[..., None] * x[..., None, :] + mx.sum(prod, axis=2)
     return out.astype(x.dtype)
+
+
+_HC_POST_SOURCE = r"""
+    const uint z = thread_position_in_grid.x;
+    if (z >= ROWS * D) return;
+    const uint row = z / D, d = z % D;
+    float residual_values[4];
+    for (uint i = 0; i < 4; ++i)
+        residual_values[i] = float(residual[(row * 4 + i) * D + d]);
+    const float value = float(x[z]);
+    for (uint j = 0; j < 4; ++j) {
+        float sum = 0.0f;
+        for (uint i = 0; i < 4; ++i)
+            sum = fma(comb[row * 16 + i * 4 + j], residual_values[i], sum);
+        y[(row * 4 + j) * D + d] = T(post[row * 4 + j] * value + sum);
+    }
+"""
+
+
+@cache
+def _hc_post_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_deepseek_v41_hc_post",
+        input_names=["x", "residual", "post", "comb"],
+        output_names=["y"],
+        source=_HC_POST_SOURCE,
+        header="#pragma clang fp contract(off)\n",
+    )
+
+
+def _fused_hc_post(
+    x: mx.array, residual: mx.array, post: mx.array, comb: mx.array
+) -> mx.array:
+    return _hc_post_kernel()(
+        inputs=[x, residual, post, comb],
+        template=[("T", x.dtype), ("ROWS", x.size // x.shape[-1]), ("D", x.shape[-1])],
+        grid=(x.size, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[residual.shape],
+        output_dtypes=[x.dtype],
+    )[0]
+
+
+def hc_post(
+    x: mx.array, residual: mx.array, post: mx.array, comb: mx.array
+) -> mx.array:
+    """Expand into four residual streams, using Metal for the release layout."""
+    if (
+        x.ndim == 3
+        and x.size
+        and x.dtype in (mx.bfloat16, mx.float16, mx.float32)
+        and residual.dtype == x.dtype
+        and residual.shape == (*x.shape[:-1], 4, x.shape[-1])
+        and post.shape == (*x.shape[:-1], 4)
+        and comb.shape == (*x.shape[:-1], 4, 4)
+        and post.dtype == mx.float32
+        and comb.dtype == mx.float32
+        and _metal_fast_path_available()
+    ):
+        return _fused_hc_post(x, residual, post, comb)
+    return _hc_post_reference(x, residual, post, comb)
+
+
+_HC_PRE_NORM_SOURCE = r"""
+    const uint row = threadgroup_position_in_grid.x;
+    const uint tid = thread_position_in_threadgroup.x;
+    const uint lane = thread_index_in_simdgroup;
+    const uint simd = simdgroup_index_in_threadgroup;
+    threadgroup float sums[8];
+    float values[(D + 255) / 256];
+    float total = 0.0f;
+    for (uint t = 0; t < (D + 255) / 256; ++t) {
+        const uint d = tid + 256 * t;
+        float value = 0.0f;
+        if (d < D) {
+            for (uint i = 0; i < 4; ++i)
+                value = fma(float(x[(row * 4 + i) * D + d]), pre[row * 4 + i], value);
+            value = float(T(value));
+        }
+        values[t] = value;
+        total += value * value;
+    }
+    total = simd_sum(total);
+    if (lane == 0) sums[simd] = total;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simd == 0) {
+        float sum = lane < 8 ? sums[lane] : 0.0f;
+        sum = simd_sum(sum);
+        if (lane == 0) sums[0] = rsqrt(sum / float(D) + eps[0]);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint t = 0; t < (D + 255) / 256; ++t) {
+        const uint d = tid + 256 * t;
+        if (d < D) y[row * D + d] = T((values[t] * sums[0]) * float(weight[d]));
+    }
+"""
+
+
+@cache
+def _hc_pre_norm_kernel():
+    return mx.fast.metal_kernel(
+        name="rapid_deepseek_v41_hc_pre_norm",
+        input_names=["x", "pre", "weight", "eps"],
+        output_names=["y"],
+        source=_HC_PRE_NORM_SOURCE,
+        header="#pragma clang fp contract(off)\n",
+    )
+
+
+def _fused_hc_pre_norm(
+    x: mx.array, pre: mx.array, weight: mx.array, eps: float
+) -> mx.array:
+    width = x.shape[-1]
+    rows = x.size // (4 * width)
+    return _hc_pre_norm_kernel()(
+        inputs=[x, pre, weight, mx.array([eps], mx.float32)],
+        template=[("T", x.dtype), ("D", width)],
+        grid=(rows * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(*x.shape[:-2], width)],
+        output_dtypes=[x.dtype],
+    )[0]
+
+
+@mx.compile
+def _hc_pre_norm_reference(
+    x: mx.array, pre: mx.array, weight: mx.array, eps: float
+) -> mx.array:
+    h = hc_pre(x, pre)
+    hf = h.astype(mx.float32)
+    variance = mx.mean(mx.square(hf), axis=-1, keepdims=True)
+    return (weight * hf * mx.rsqrt(variance + eps)).astype(h.dtype)
+
+
+def hc_pre_norm(x: mx.array, pre: mx.array, weight: mx.array, eps: float) -> mx.array:
+    """Collapse the four streams and RMS-normalize in one Metal dispatch."""
+    if (
+        x.ndim == 4
+        and x.size
+        and x.shape[-2] == 4
+        and x.shape[-1] <= 8192
+        and x.dtype in (mx.bfloat16, mx.float16, mx.float32)
+        and pre.dtype == mx.float32
+        and pre.shape == x.shape[:-1]
+        and weight.shape == (x.shape[-1],)
+        and weight.dtype in (mx.bfloat16, mx.float16, mx.float32)
+        and _metal_fast_path_available()
+    ):
+        return _fused_hc_pre_norm(x, pre, weight, eps)
+    return _hc_pre_norm_reference(x, pre, weight, eps)
 
 
 def make_identity_pre_mix(b: int, s: int, hc_mult: int) -> mx.array:

--- a/vllm_mlx/models/deepseek_v41_native/model.py
+++ b/vllm_mlx/models/deepseek_v41_native/model.py
@@ -27,7 +27,12 @@ from .attention import Attention
 from .cache import ModelCache
 from .config import ModelArgs
 from .engram import Engram, EngramHasher
-from .hyper_connections import hc_mixes, hc_post, hc_pre, make_identity_pre_mix
+from .hyper_connections import (
+    hc_mixes,
+    hc_post,
+    hc_pre_norm,
+    make_identity_pre_mix,
+)
 from .layers import RMSNorm
 from .moe import MoE
 
@@ -87,8 +92,8 @@ class Block(nn.Module):
             self.norm_eps,
             self.hc_eps,
         )
-        h = hc_pre(x, pre_mix)
-        h = self.attn(self.attn_norm(h), start_pos, cache, shared)
+        h = hc_pre_norm(x, pre_mix, self.attn_norm.weight, self.attn_norm.eps)
+        h = self.attn(h, start_pos, cache, shared)
         x = hc_post(h, residual, attn_post, attn_comb)
 
         residual = x
@@ -102,8 +107,8 @@ class Block(nn.Module):
             self.norm_eps,
             self.hc_eps,
         )
-        h = hc_pre(x, attn_pre)
-        h = self.ffn(self.ffn_norm(h))
+        h = hc_pre_norm(x, attn_pre, self.ffn_norm.weight, self.ffn_norm.eps)
+        h = self.ffn(h)
         x = hc_post(h, residual, ffn_post, ffn_comb)
         return x, ffn_pre
 
@@ -199,8 +204,9 @@ class Model(nn.Module):
             if self.eval_interval and execution_index % self.eval_interval == 0:
                 mx.eval(h, pre_mix)
 
-        h = hc_pre(h, pre_mix)  # collapse with the last ffn_pre
-        h = self.norm(h)
+        h = hc_pre_norm(
+            h, pre_mix, self.norm.weight, self.norm.eps
+        )  # collapse with the last ffn_pre
         if last_logit_only:
             h = h[:, -1:]
         logits = self.head(h.astype(mx.float32))  # fp32 logits, as the reference


### PR DESCRIPTION
## Why

Make DeepSeek V4.1 Flash materially faster on supported Apple Silicon systems, for both ordinary autoregressive generation and fixed-K4 DSpark decoding, without changing model weights or the target-authoritative verification contract.

## What changed

- Compile the V4.1 hyper-connection coefficient graph.
- Fuse four-stream residual expansion into one Metal dispatch.
- Fuse stream collapse and RMS normalization into one Metal dispatch.
- Keep operation-based fallbacks for CPU, non-Metal, empty, non-four-way, and unsupported layouts.
- Add an SSD-Engram option to the existing qualification script so the 256 GiB result is directly reproducible.

## Measured improvement

Environment: Apple M3 Ultra, 256 GiB, macOS 26.5.2; local 212.93 GB affine-2bit target; affine-2bit Engram SSD offload; pinned mixed-precision DSpark sidecar; packed fixed K=4; 128 output tokens per prompt; two repeats across code, arithmetic reasoning, JSON-only structured output, and Chinese.

- Prior identically shaped four-domain result: **19.39 tok/s**.
- New all-repeat weighted result, including first-use compilation/warmup: **21.46 tok/s** (**+10.7%**).
- New warm-repeat weighted result: **26.39 tok/s** (**+36.1%** versus the prior result).
- Warm domains: code **34.88**, reasoning **25.04**, structured **21.45**, Chinese **27.53 tok/s**.
- Sequential AR weighted result: **15.07 tok/s**.
- Same-process 16-token code isolation: **9.60 → 34.90 tok/s**, identical output, same three accepted draft tokens per block.
- Peak MLX memory: **171.13 GB**.

The four K4 outputs are token-for-token stable across consecutive repeats. This does not claim universal 40 tok/s: high-acceptance code is near 35 tok/s, while lower-acceptance domains identify drafter quality as the next bottleneck.

## Verification

- `ruff check` and `ruff format --check` on all changed Python files
- 12 focused hyper-connection tests across BF16/FP16/FP32, release-width parity, CPU fallback, unsupported layouts, and empty tensors
- 29 native V4.1 loader tests
- 11 qualification-script tests
- Standard four-domain 128-token qualification with two consecutive repeats
- Four author-owned adversarial review rounds; no unresolved in-scope finding

## Scope and compatibility

Only the native DeepSeek V4.1 hyper-connection runtime and its qualification tooling change. Non-goals: draft weights or training, target quantization, model catalog changes, adaptive verification, and other model families.

SSD Engram offload from #3338 provides the 256 GiB qualification envelope. That dependency is now merged; this branch has been rebased onto and retargeted to `main`.
