### PR TITLE
fix(glm): retire legacy overlay on native runtime

### DIFF
--- a/.agents/handoffs/vector-glm53-native-mtp.md
+++ b/.agents/handoffs/vector-glm53-native-mtp.md
@@ -27,8 +27,9 @@ Atlas (architecture, dependency compatibility, and release disposition).
   the benchmarked `06d6a...` revision no longer resolves on the Hub. Layer 45
   now spans source shards 1 and 2. The upstream splitter produced a strict-load
   3.9 GiB q4-g64 drafter. Its real one-token block measured 1.541 ms median and
-  3.896 GiB active memory, so the old K=1 regression is not explained by an
-  expensive draft head alone.
+  3.896 GiB active memory. Including the checkpoint's q4 output head and argmax
+  over 154,880 tokens measured 2.141 ms median, so the old K=1 regression is
+  not explained by an expensive draft proposal alone.
 
 ## Unresolved
 

--- a/.agents/handoffs/vector-glm53-native-mtp.md
+++ b/.agents/handoffs/vector-glm53-native-mtp.md
@@ -1,0 +1,52 @@
+# Vector to Atlas: GLM-5.3 native-MTP dependency decision
+
+## Receiving role
+
+Atlas (architecture, dependency compatibility, and release disposition).
+
+## Current branch
+
+`vector/glm53-native-mtp`, based on `origin/main@233439e88`.
+
+## Verified facts
+
+- Upstream mlx-vlm PR #2127 reports 29.48 to 43.67 tok/s (1.481x) at
+  batch one, 512-token context, 90.5% MTP acceptance, exact parity, M3 Ultra.
+- The optimized GLM rewrite is after the v0.7.0 tag. PyPI 0.7.0 does not contain
+  it; pinning `mlx-vlm==0.7.0` would not absorb the reported path.
+- Rapid's old GLM runtime overlay crashed on that rewrite because
+  `Glm5NextSparseAttention` no longer exists.
+- This branch makes the overlay self-retire only when the complete native GLM
+  class family is present. Pinned-runtime tests pass (33), and the post-v0.7
+  checkout strictly loads the cached five-layer 0.1B GLM fixture through both
+  mlx-vlm and Rapid's MLLM wrapper (with only the version gate bypassed).
+- Rapid's previous full-model K=1 probe was a no-go: 31.94 to 31.59 tok/s,
+  72.97% acceptance, +5.71 GiB. The upstream result uses a substantially newer
+  transactional/batched verifier and native block size three.
+
+## Unresolved
+
+- Choose between waiting for the next tagged mlx-vlm release and vendoring the
+  GLM-specific drafter/verifier. The upstream PR touches a broad cache,
+  quantized-verifier, model, and speculative-runtime surface.
+- Re-run the full 181.7 GB Rapid target. It is absent from the HF cache; Studio
+  has about 65 GiB free and Mini about 104 GiB free, so policy-compliant restore
+  is currently blocked without storage capacity becoming available.
+- Decide whether a future proven path is experimental opt-in or default-on.
+
+## Risks
+
+- Accepting the untagged source by its reported `0.7.0` version is not
+  reproducible.
+- Enabling MTP from acceptance alone repeats the old K=1 failure; verifier cost
+  and workload-by-workload throughput are release gates.
+- The third-party DFlash2 checkpoint is non-commercial by default and does not
+  have benchmark evidence sufficient for Rapid's sustained gate.
+
+## Recommended next action
+
+Approve the fail-closed compatibility seam independently. Wait for a tagged
+post-v0.7 mlx-vlm artifact, then run the exact paired K=0/1/2/3 server campaign
+defined in
+`docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md` before any
+alias capability or dependency change.

--- a/.agents/handoffs/vector-glm53-native-mtp.md
+++ b/.agents/handoffs/vector-glm53-native-mtp.md
@@ -23,6 +23,12 @@ Atlas (architecture, dependency compatibility, and release disposition).
 - Rapid's previous full-model K=1 probe was a no-go: 31.94 to 31.59 tok/s,
   72.97% acceptance, +5.71 GiB. The upstream result uses a substantially newer
   transactional/batched verifier and native block size three.
+- The current target revision is `76add2a341a1cd90ad0e86bb69839ea9c35827c6`;
+  the benchmarked `06d6a...` revision no longer resolves on the Hub. Layer 45
+  now spans source shards 1 and 2. The upstream splitter produced a strict-load
+  3.9 GiB q4-g64 drafter. Its real one-token block measured 1.541 ms median and
+  3.896 GiB active memory, so the old K=1 regression is not explained by an
+  expensive draft head alone.
 
 ## Unresolved
 

--- a/docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md
+++ b/docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md
@@ -57,6 +57,13 @@ block is about 5% of Rapid's approximately 31-32 ms ordinary target-token time.
 The old K=1 regression is therefore more consistent with verification and
 rollback overhead than with an intrinsically too-expensive drafter.
 
+A second campaign added the checkpoint's real q4-g64 `lm_head` and greedy
+argmax over its 154,880-token vocabulary. The three 30-sample medians were
+2.148, 2.141, and 2.112 ms; the median of medians was 2.141 ms. The output head
+is shared with the target in production, so its weights are not incremental MTP
+memory. This complete one-token proposal is about 6.8% of an ordinary target
+step, reinforcing that target verification/rollback is the dominant lever.
+
 ## External full-model evidence
 
 ### mlx-vlm GLM rewrite and MTP
@@ -150,7 +157,8 @@ family and retires the old overlay. Verification:
 - Rapid `MLXMultimodalLM` wrapper: the same five-layer fixture completed load
   when the dependency-version gate was intentionally bypassed for the probe.
 - current-revision real layer-45 head: upstream split and strict load passed;
-  1.541 ms median one-token block latency and 3.896 GiB active memory.
+  1.541 ms median block-only latency, 2.141 ms including the real q4 output
+  head and argmax, and 3.896 GiB incremental drafter memory.
 
 This does not authorize a dependency bump. Atlas owns that compatibility
 decision after upstream publishes a fixed revision.

--- a/docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md
+++ b/docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md
@@ -22,7 +22,10 @@ the release gate.
 
 ## Current Rapid baseline
 
-Artifact revision: `06d6a0240420137661ac3c84f845ae5e3513ff2f`.
+Benchmark artifact revision: `06d6a0240420137661ac3c84f845ae5e3513ff2f`.
+The repository has since advanced to `76add2a341a1cd90ad0e86bb69839ea9c35827c6`;
+the old revision no longer resolves through the Hub. Keep comparisons tied to
+the revision that produced them.
 
 | Context | Prefill tok/s | Decode tok/s |
 | ---: | ---: | ---: |
@@ -36,6 +39,23 @@ ordinary decode and 31.59 tok/s for MTP over 512 output tokens (0.989x), despite
 72.97% acceptance and 5.71 GiB additional active memory. That implementation
 split the recurrent KDA update at every verification boundary. It established
 correct loading and rollback, but it did not amortize verification work.
+
+### Current-revision real MTP head probe
+
+The current immutable revision was probed without restoring the 181.7 GB
+target. Its 2,641 layer-45 tensors span shards 1 and 2 (2,215 and 426 tensors),
+rather than the single shard assumed by the older experiment. Both source
+shards were downloaded through the policy-controlled HF cache. The upstream
+GLM splitter produced a strict-loadable 3.9 GiB `glm5_next_mtp` drafter with
+4-bit, group-size-64 affine weights and 3.896 GiB active memory.
+
+Thirty measured one-token head forwards followed five warmups in each of three
+campaigns. The per-campaign medians were 1.598, 1.541, and 1.317 ms; the median
+of medians was 1.541 ms. This excludes the shared target embedding/output head
+and does not predict E2E speedup by itself. It does show that the real drafter
+block is about 5% of Rapid's approximately 31-32 ms ordinary target-token time.
+The old K=1 regression is therefore more consistent with verification and
+rollback overhead than with an intrinsically too-expensive drafter.
 
 ## External full-model evidence
 
@@ -129,6 +149,8 @@ family and retires the old overlay. Verification:
   fixture loaded strictly;
 - Rapid `MLXMultimodalLM` wrapper: the same five-layer fixture completed load
   when the dependency-version gate was intentionally bypassed for the probe.
+- current-revision real layer-45 head: upstream split and strict load passed;
+  1.541 ms median one-token block latency and 3.896 GiB active memory.
 
 This does not authorize a dependency bump. Atlas owns that compatibility
 decision after upstream publishes a fixed revision.
@@ -153,4 +175,3 @@ decision after upstream publishes a fixed revision.
 - <https://github.com/jundot/omlx/releases/tag/v0.6.4>
 - <https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2>
 - `docs/benchmarks/recent-large-models-m3-ultra.md`
-

--- a/docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md
+++ b/docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md
@@ -1,0 +1,156 @@
+# GLM-5.3-Flash next-tier performance investigation
+
+Date: 2026-09-12  
+Owner: Vector  
+Host: Studio (M3 Ultra)  
+Target: `Vontra/GLM-5.3-Flash-MLX-4bit-MTP`
+
+## Outcome
+
+The next material GLM-5.3-Flash improvement should be native MTP with an exact,
+transactional verifier. Quantization-format changes and isolated projection
+fusions do not have evidence for a tier-sized gain. The strongest full-model
+external result is mlx-vlm's optimized MTP path: 29.48 to 43.67 tok/s at batch
+one and 512-token context (1.481x, 90.5% acceptance, exact output parity) on an
+M3 Ultra.
+
+Rapid must not enable this path from the external number alone. The optimized
+implementation landed after the mlx-vlm v0.7.0 tag, changes a broad runtime
+surface, and the exact 181.7 GB Rapid target is not currently present in the
+policy-controlled Hugging Face cache. A paired Rapid server benchmark remains
+the release gate.
+
+## Current Rapid baseline
+
+Artifact revision: `06d6a0240420137661ac3c84f845ae5e3513ff2f`.
+
+| Context | Prefill tok/s | Decode tok/s |
+| ---: | ---: | ---: |
+| 128 | 13.81 | 32.38 |
+| 2,048 | 348.04 | 28.36 |
+| 8,192 | 358.37 | 27.75 |
+| 32,768 | 276.90 | 27.20 |
+
+Rapid's first native-head experiment used K=1. It measured 31.94 tok/s for
+ordinary decode and 31.59 tok/s for MTP over 512 output tokens (0.989x), despite
+72.97% acceptance and 5.71 GiB additional active memory. That implementation
+split the recurrent KDA update at every verification boundary. It established
+correct loading and rollback, but it did not amortize verification work.
+
+## External full-model evidence
+
+### mlx-vlm GLM rewrite and MTP
+
+The merged GLM work in `Blaizzy/mlx-vlm#2127` reports the following M3 Ultra
+results for its final exact verifier:
+
+| Batch | Base tok/s | MTP tok/s | Speedup |
+| ---: | ---: | ---: | ---: |
+| 1 | 29.48 | 43.67 | 1.481x |
+| 2 | 45.09 | 64.54 | 1.431x |
+| 4 | 70.77 | 83.03 | 1.173x |
+
+The batch-one run used 512-token context and reported 90.5% acceptance with
+parity. The implementation combines a batch-wide quantized verifier,
+batch-grouped expert execution, a fused batch-one hyperconnection ingress, and
+a transactional recurrent-cache rollback. Its native block size is three; the
+benefit is not evidence that arbitrarily raising K is safe or faster.
+
+Important packaging boundary: commit `bf4b861` is 22 commits after the v0.7.0
+tag in the inspected checkout. PyPI `mlx-vlm==0.7.0` therefore does not contain
+this optimized GLM implementation even though the source tree still reports
+version 0.7.0.
+
+### DwarfStar GLM kernels
+
+The `IngeniousIdiocy/ds4` `glm53-m3ultra` branch reports:
+
+| Workload | Before | After | Speedup |
+| --- | ---: | ---: | ---: |
+| 62,174-token prefill | 365.7 tok/s | 550.4 tok/s | 1.505x |
+| 62K-context decode | 23.75 tok/s | 38.07 tok/s | 1.603x |
+| 300K-token prefill | 316.8 tok/s | 473.9 tok/s | 1.496x |
+| 300K-context decode | 21.64 tok/s | 37.39 tok/s | 1.728x |
+| Short-context decode | 29.2 tok/s | 40.9 tok/s | 1.401x |
+
+Its useful lever map is dispatch-oriented: fold routed gate/up work, fuse
+hyperconnection/residual epilogues, use expert-parallel routed down projection,
+stage DSA queries once, and use bounded radix selection at long context. The
+branch reports roughly 1,000 dispatches per token before this work, about 600
+of them small. Its persistent all-in-one MoE megakernel was slower, so Rapid
+should not pursue that design without contrary measurements.
+
+### oMLX
+
+oMLX v0.6.4 reports the following oQ4e results on M3 Ultra 512 GB:
+
+| Context | Prefill tok/s | Decode tok/s |
+| ---: | ---: | ---: |
+| 4K | 482.3 | 24.1 |
+| 16K | 443.2 | 23.7 |
+| 32K | 449.6 | 23.5 |
+
+oMLX also has a native DSA scorer/top-k extension that avoids materializing the
+full heads-by-context intermediate. The published numbers use a different
+169 GiB oQ4e artifact, so they are architecture references rather than a fair
+Rapid throughput comparison.
+
+## Local experiments and rejected shortcuts
+
+All timings below are fresh-process MLX measurements on Studio unless noted.
+
+| Experiment | Result | Decision |
+| --- | --- | --- |
+| Routed MoE gate/up structural fusion | median 1.037x, range 1.000-1.119x; byte-identical | Ship separately in PR #3334 |
+| Shared-expert dense gate/up concat, 4096 to 2048 q4-g64, batch 1 | 0.2979 to 0.3080 ms (0.967x) | Reject |
+| MLX `argpartition` plus selected sort, P=2K/4K/8K | 0.834x/0.858x/0.873x | Reject for normal context |
+| Same selection, P=18,750 (about 300K tokens) | 1.230x | Long-context-only follow-up |
+| Naive custom Metal DSA scorer | 7-10% slower than MLX matmul; bf16 top-k membership drift | Reject |
+
+The dedicated `incoai/GLM-5.3-Flash-DFlash2` head is 2.34 GB and uses five
+layers with block size eight. Its model card has no published benchmark and its
+license is CC-BY-NC-ND-4.0. DwarfStar reports only +4.3% on a real coding agent
+and a 2-3% prose regression for its DFlash2 path. Rapid should keep DFlash
+disabled for this alias until it passes the existing sustained qualification.
+
+## Compatibility finding
+
+Rapid's released GLM correctness overlay subclasses the mlx-vlm 0.6.x
+`Glm5NextSparseAttention` class. The post-0.7 rewrite replaces it with
+architecture-owned `Glm5NextAttention`, `Glm5NextMoE`, and `Glm5NextMLP`
+classes. Before this investigation, the overlay raised `AttributeError` before
+the new runtime could load.
+
+The accompanying compatibility change recognizes only the complete new class
+family and retires the old overlay. Verification:
+
+- pinned mlx-vlm runtime: 33 focused GLM tests passed;
+- post-v0.7 upstream checkout: the overlay retired and the cached 0.1B GLM
+  fixture loaded strictly;
+- Rapid `MLXMultimodalLM` wrapper: the same five-layer fixture completed load
+  when the dependency-version gate was intentionally bypassed for the probe.
+
+This does not authorize a dependency bump. Atlas owns that compatibility
+decision after upstream publishes a fixed revision.
+
+## Implementation order and release gate
+
+1. Land the fail-closed compatibility seam.
+2. Pin a tagged mlx-vlm revision that contains the GLM rewrite, or vendor only
+   the GLM drafter/verifier after an Atlas dependency review.
+3. Restore the full target without redirecting the policy-controlled HF cache.
+4. Run paired server tests at K=0, K=1, K=2, and K=3 with identical prompts and
+   seeds; record decode tok/s, acceptance by position, TTFT, peak/active memory,
+   and token/text equality.
+5. Enable native MTP only if sustained batch-one decode is at least 1.10x with
+   exact greedy parity, no workload bucket below 0.95x, and no server lifecycle
+   regression. A default-on decision should require at least 1.20x.
+
+## Primary references
+
+- <https://github.com/Blaizzy/mlx-vlm/pull/2127>
+- <https://github.com/IngeniousIdiocy/ds4/blob/glm53-m3ultra/README.md>
+- <https://github.com/jundot/omlx/releases/tag/v0.6.4>
+- <https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2>
+- `docs/benchmarks/recent-large-models-m3-ultra.md`
+

--- a/tests/test_glm5_next_runtime_patch.py
+++ b/tests/test_glm5_next_runtime_patch.py
@@ -217,3 +217,29 @@ def test_installer_respects_runtime_that_is_already_patched() -> None:
         else:
             del language._RAPID_MLX_RUNTIME_FIX_INSTALLED
         patch._INSTALLED = False
+
+
+def test_native_runtime_probe_requires_the_complete_new_class_family() -> None:
+    from vllm_mlx.patches.glm5_next_runtime import _has_native_glm5_next_runtime
+
+    complete = SimpleNamespace(
+        Glm5NextAttention=object,
+        Glm5NextLinearAttention=object,
+        Glm5NextMLP=object,
+        Glm5NextMoE=object,
+        LanguageModel=type(
+            "LanguageModel",
+            (),
+            {
+                "cast_predicate": property(lambda self: None),
+                "sanitize": lambda self, weights: weights,
+            },
+        ),
+    )
+
+    assert _has_native_glm5_next_runtime(complete)
+    del complete.Glm5NextMoE
+    assert not _has_native_glm5_next_runtime(complete)
+    complete.Glm5NextMoE = object
+    complete.Glm5NextSparseAttention = object
+    assert not _has_native_glm5_next_runtime(complete)

--- a/tests/test_glm5_next_runtime_patch.py
+++ b/tests/test_glm5_next_runtime_patch.py
@@ -243,3 +243,44 @@ def test_native_runtime_probe_requires_the_complete_new_class_family() -> None:
     complete.Glm5NextMoE = object
     complete.Glm5NextSparseAttention = object
     assert not _has_native_glm5_next_runtime(complete)
+
+
+@pytest.mark.requires_mlx
+def test_installer_defers_to_complete_native_runtime() -> None:
+    from mlx_vlm.models.glm5_next import language
+
+    from vllm_mlx.patches import glm5_next_runtime as patch
+
+    native_names = (
+        "Glm5NextAttention",
+        "Glm5NextLinearAttention",
+        "Glm5NextMLP",
+        "Glm5NextMoE",
+    )
+    missing = object()
+    saved = {name: getattr(language, name, missing) for name in native_names}
+    sparse_attention = language.Glm5NextSparseAttention
+    marker = getattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED", None)
+    marker_existed = hasattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED")
+    patch._INSTALLED = False
+
+    try:
+        del language.Glm5NextSparseAttention
+        for name in native_names:
+            setattr(language, name, object)
+
+        assert patch.install_glm5_next_runtime_fix() is False
+        assert patch.is_installed() is True
+        assert language._RAPID_MLX_RUNTIME_FIX_INSTALLED is True
+    finally:
+        language.Glm5NextSparseAttention = sparse_attention
+        for name, value in saved.items():
+            if value is missing:
+                delattr(language, name)
+            else:
+                setattr(language, name, value)
+        if marker_existed:
+            language._RAPID_MLX_RUNTIME_FIX_INSTALLED = marker
+        else:
+            del language._RAPID_MLX_RUNTIME_FIX_INSTALLED
+        patch._INSTALLED = False

--- a/vllm_mlx/patches/glm5_next_runtime.py
+++ b/vllm_mlx/patches/glm5_next_runtime.py
@@ -23,6 +23,35 @@ _LOCK = threading.Lock()
 _INSTALLED = False
 
 
+def _has_native_glm5_next_runtime(language: Any) -> bool:
+    """Return whether mlx-vlm already owns the corrected GLM implementation.
+
+    The post-0.7 GLM rewrite replaced the released ``SparseAttention`` /
+    DeepSeek-derived MoE classes with architecture-owned attention, MoE, and
+    MLP implementations.  Those classes include the clamped SwiGLU, fp32
+    router, corrected norm epsilons, fused projections, and cast predicates
+    that this compatibility overlay supplied to mlx-vlm 0.6.x.  Refusing to
+    monkey-patch that new class family is important: the old names no longer
+    exist, and partially applying an old overlay would produce a mixed runtime.
+
+    Keep the structural probe deliberately strict so an unrelated or partial
+    upstream refactor still fails closed instead of silently skipping fixes.
+    """
+    required = (
+        "Glm5NextAttention",
+        "Glm5NextLinearAttention",
+        "Glm5NextMLP",
+        "Glm5NextMoE",
+        "LanguageModel",
+    )
+    return (
+        not hasattr(language, "Glm5NextSparseAttention")
+        and all(hasattr(language, name) for name in required)
+        and isinstance(getattr(language.LanguageModel, "cast_predicate", None), property)
+        and callable(getattr(language.LanguageModel, "sanitize", None))
+    )
+
+
 def _projection_quantization_is_homogeneous(modules: Sequence[Any]) -> bool:
     quantized = [hasattr(module, "scales") for module in modules]
     if not all(quantized) and any(quantized):
@@ -54,12 +83,18 @@ def install_glm5_next_runtime_fix() -> bool:
 
         import mlx.core as mx
         import mlx.nn as nn
+        from mlx_vlm.models.glm5_next import language
+
+        if _has_native_glm5_next_runtime(language):
+            language._RAPID_MLX_RUNTIME_FIX_INSTALLED = True
+            _INSTALLED = True
+            return False
+
         from mlx_vlm.models.deepseek_v32.language import (
             DeepseekV32MoE,
             MoEGate,
             group_expert_select,
         )
-        from mlx_vlm.models.glm5_next import language
         from mlx_vlm.models.mlp import DeepseekMLP
 
         if getattr(language, "_RAPID_MLX_RUNTIME_FIX_INSTALLED", False):

--- a/vllm_mlx/patches/glm5_next_runtime.py
+++ b/vllm_mlx/patches/glm5_next_runtime.py
@@ -47,7 +47,9 @@ def _has_native_glm5_next_runtime(language: Any) -> bool:
     return (
         not hasattr(language, "Glm5NextSparseAttention")
         and all(hasattr(language, name) for name in required)
-        and isinstance(getattr(language.LanguageModel, "cast_predicate", None), property)
+        and isinstance(
+            getattr(language.LanguageModel, "cast_predicate", None), property
+        )
         and callable(getattr(language.LanguageModel, "sanitize", None))
     )
 


### PR DESCRIPTION
## Why

The optimized post-v0.7 mlx-vlm GLM runtime replaces the released `Glm5NextSparseAttention` class family. Rapid's 0.6.x correctness overlay subclasses that old class unconditionally, so a future dependency bump crashes before the faster native GLM/MTP runtime can load.

## Change

- Detect the complete architecture-owned GLM runtime and retire the legacy overlay.
- Keep the current 0.6.17 patch path unchanged.
- Add a fail-closed structural regression test.
- Record the quantitative GLM performance research, rejected shortcuts, release gates, and Atlas dependency handoff.

No dependency, alias, default, speculative-decoding capability, or public API changes in this PR.

## Verification

- `python3.12 -m ruff check vllm_mlx/patches/glm5_next_runtime.py tests/test_glm5_next_runtime_patch.py`: passed.
- Focused pinned-runtime GLM and security suites: 44 passed.
- Post-v0.7 mlx-vlm checkout: overlay retired; cached five-layer 0.1B GLM fixture strict-loaded successfully.
- Rapid `MLXMultimodalLM`: same fixture completed wrapper load when only the dependency-version gate was bypassed for the compatibility probe.
- `python3.12 -m build --wheel --no-isolation`: passed.
- `git diff --check`: passed.

## Quantitative disposition

Upstream PR #2127 reports 29.48 to 43.67 tok/s at batch one (1.481x, 90.5% MTP acceptance, exact parity, M3 Ultra). Rapid's old K=1 implementation measured 31.94 to 31.59 tok/s (0.989x), so this PR does not enable MTP from external evidence. Full paired K=0/1/2/3 dogfood remains required on Rapid's 181.7 GB artifact.

The current target revision's real q4-g64 layer-45 head was also split and strict-loaded from its two source shards. It occupies 3.896 GiB active memory and measured 1.541 ms median per one-token block across three 30-sample campaigns after warmup. Adding the checkpoint's real q4 output head and argmax over 154,880 tokens measured 2.141 ms. This is not an E2E speed claim; it narrows the old regression to verifier/rollback overhead rather than draft-proposal cost.

## AI assistance disclosure

Codex performed the primary-source research, implementation, focused compatibility probes, and author-owned adversarial review. The performance note separates Rapid measurements from external published results and records every rejected local shortcut.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.
