### PR TITLE
perf(deepseek): keep DSpark stages lazy

### DIFF
--- a/docs/engineering/performance/2026-09-12-deepseek-v41-lazy-dspark-stages.md
+++ b/docs/engineering/performance/2026-09-12-deepseek-v41-lazy-dspark-stages.md
@@ -1,0 +1,39 @@
+# DeepSeek V4.1 lazy DSpark stages
+
+Date: 2026-09-12
+
+## Scope
+
+This experiment removes the forced MLX materialization between the three
+DSpark proposal stages. The final proposal logits and confidence output remain
+the synchronization boundary. Model weights, fixed K4 policy, target
+verification, and generated tokens are unchanged.
+
+## Environment
+
+- Apple M3 Ultra, 256 GB unified memory
+- DeepSeek V4.1 Flash native REAP 2-bit target
+- Mixed 4-bit dense / 2-bit routed-expert DSpark sidecar
+- Engram SSD offload and fast hyper-connections enabled
+- Four 64-token prompts: code, reasoning, JSON-only structured output, Chinese
+- Both variants warmed for every prompt before measurement
+- Four paired repeats per prompt, alternating lazy/eager and eager/lazy order
+
+## Result
+
+Across 16 paired measurements, weighted decode throughput increased from
+18.883 to 19.006 tok/s, a 0.65% improvement. All paired runs emitted identical
+tokens and had identical accepted-draft counts. Peak MLX memory was 157.26 GB.
+
+The gain was larger on low-acceptance prompts that execute more speculative
+blocks, but remained small: most individual pairs improved by roughly 0.5% to
+1.4%. This is a safe reduction in fixed synchronization overhead, not the main
+path to the 40 tok/s research target; draft acceptance remains dominant.
+
+## Benchmark caution
+
+An earlier activation-kernel probe appeared to improve throughput by 35% when
+the baseline always ran first. After warming every prompt shape and alternating
+the paired order, it instead regressed weighted throughput by 0.9%. Kernel and
+graph performance claims for this runtime must therefore use per-shape warmup
+and alternating paired order.

--- a/vllm_mlx/models/deepseek_v41_native/dspark.py
+++ b/vllm_mlx/models/deepseek_v41_native/dspark.py
@@ -632,7 +632,6 @@ class DSpark:
                 ]
             )
             hidden = _hc_post(ffn, hidden, post, combine)
-            mx.eval(hidden, pre)
         base = f"mtp.{self.layers[-1]}"
         collapsed = _hc_pre(hidden, pre)
         logits = self.w.linear(


### PR DESCRIPTION
## User-visible goal

Reduce DeepSeek V4.1 Flash DSpark K4 decode latency without changing model weights, draft policy, verification, or output.

## Why

The three DSpark stages form one dependent MLX graph, and final proposal logits already provide the required materialization boundary. Forcing a host/GPU synchronization after every intermediate stage adds latency because no CPU decision consumes those intermediate tensors. Deferring evaluation is therefore safe while reducing fixed per-block overhead.

## What changed

- Remove the forced MLX materialization between the three DSpark proposal stages.
- Keep proposal logits and confidence output as the final synchronization boundary.
- Record the reproducible paired benchmark and measurement caveat.

## Quantitative result

On an M3 Ultra with 256 GB unified memory, the released REAP 2-bit target, mixed 4-bit/2-bit DSpark sidecar, Engram SSD offload, and fast hyper-connections:

- 16 warmed paired measurements across code, reasoning, JSON-only output, and Chinese
- alternating candidate/baseline order
- weighted decode: 18.883 to 19.006 tok/s (+0.65%)
- identical generated tokens and accepted-draft counts in every pair
- 157.26 GB peak MLX memory

This is a small fixed-overhead reduction, not a claim that the broader 40 tok/s research target is reached.

## Scope and non-goals

The diff is limited to the DSpark stage evaluation boundary and its performance record. It does not change training, quantization, artifacts, catalog behavior, defaults, target kernels, or other model families.

## Validation

- ruff check and format check passed
- 125 DeepSeek V4.1 focused/related tests passed
- git diff --check passed
- author adversarial review checked deferred-error behavior, memory growth, deterministic output, benchmark order bias, and scope