### PR TITLE
fix(mtp): refuse continuous self-MTP when there is only one lane

### DIFF
--- a/tests/test_continuous_mtp_routing.py
+++ b/tests/test_continuous_mtp_routing.py
@@ -228,6 +228,51 @@ def test_install_plan_is_default_off_and_fails_closed_without_mutation():
     assert vars(model) == before
 
 
+def test_single_lane_deployment_refuses_instead_of_raising():
+    """``--max-num-seqs 1`` is a deployment choice, not a programming error.
+
+    The planner runs lazily, from the first request's batch-generator build, so
+    letting ``BatchedMTPConfig`` raise on ``min_batch_lanes > max_lanes`` there
+    aborted that request's generation step and left it waiting for tokens that
+    never came. One lane has to refuse like any other missing capability and
+    keep the singleton verifier.
+    """
+    model = _Model()
+    before = dict(vars(model))
+
+    single = plan_router_install(model, enabled=True, max_lanes=1, hard_reserve_bytes=0)
+    at_minimum = plan_router_install(
+        model, enabled=True, max_lanes=2, hard_reserve_bytes=0
+    )
+
+    assert single.admitted is False
+    assert single.router is None
+    assert single.fallback is ContinuousMTPIntegrationRoute.LEGACY_MTP
+    assert "at least 2 completion lanes" in " ".join(single.reasons)
+    # The boundary itself still admits: two lanes are enough to amortize.
+    assert at_minimum.admitted is True
+    assert vars(model) == before
+
+
+def test_single_lane_without_legacy_mtp_falls_back_to_plain_decode():
+    class _PlainOnly:
+        batched_mtp_capability = _descriptor()
+
+        def __call__(self, *args, **kwargs):
+            return args, kwargs
+
+        def mtp_batch_forward(self, *args, **kwargs):
+            return args, kwargs
+
+    decision = plan_router_install(
+        _PlainOnly(), enabled=True, max_lanes=1, hard_reserve_bytes=0
+    )
+
+    assert decision.admitted is False
+    assert decision.fallback is ContinuousMTPIntegrationRoute.PLAIN_DECODE
+    assert "this deployment has 1" in " ".join(decision.reasons)
+
+
 def test_install_plan_threads_attested_dynamic_membership():
     admitted = plan_router_install(
         _Model(),

--- a/vllm_mlx/spec_decode/mtp/continuous_routing.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_routing.py
@@ -329,6 +329,30 @@ def plan_router_install(
         cache_quantized=cache_quantized,
         cache_windowed=cache_windowed,
     )
+    # Lane capacity is a deployment fact (``--max-num-seqs``), not a programming
+    # error: serving a single user with one lane is a normal way to run. The
+    # config contract raises on ``min_batch_lanes > max_lanes``, and this
+    # planner runs lazily, when the first request builds the batch generator —
+    # so a one-lane server used to abort that request's generation step with
+    # ``min_batch_lanes cannot exceed max_lanes`` and hang the request instead
+    # of falling back. Refuse like every other missing capability and let the
+    # caller keep the mature singleton verifier.
+    if max_lanes < min_batch_lanes:
+        return ContinuousMTPRouterInstallDecision(
+            admitted=False,
+            router=None,
+            fallback=(
+                ContinuousMTPIntegrationRoute.LEGACY_MTP
+                if legacy
+                else ContinuousMTPIntegrationRoute.PLAIN_DECODE
+            ),
+            reasons=(
+                f"continuous self-MTP needs at least {min_batch_lanes} completion "
+                f"lanes to amortize ragged bookkeeping; this deployment has "
+                f"{max_lanes}",
+            ),
+        )
+
     router = ContinuousMTPIntegrationRouter(
         config=BatchedMTPConfig(
             enabled=enabled,


### PR DESCRIPTION
## What was broken

`rapid-mlx serve <any qwen3.5-family alias> --max-num-seqs 1` hung every
request. The server started, `/health` reported `ready: true`, and then the
first completion died inside the generation step:

```
ERROR:rapid_mlx.scheduler:Error in batch generation step: min_batch_lanes cannot exceed max_lanes
  File "vllm_mlx/scheduler.py", line 8172, in _schedule_waiting
  File "vllm_mlx/scheduler.py", line 4803, in _create_batch_generator
  File "vllm_mlx/scheduler.py", line 887, in _install_continuous_mtp_router
  File "vllm_mlx/spec_decode/mtp/batched.py", line 98, in __post_init__
ValueError: min_batch_lanes cannot exceed max_lanes
```

The client never sees an error — it waits for tokens that are never produced.
Reproduced on an M4 Pro 48 GB with `qwen3.8-27b-4bit`.

## Root cause

`_install_continuous_mtp_router` derives `max_lanes` from `--max-num-seqs`
and passes the planner's fixed `min_batch_lanes=2`, which is the deliberate
policy documented at that call site: one-user traffic keeps the mature
singleton verifier because the continuous coordinator cannot amortize its
ragged bookkeeping at B=1. But `plan_router_install` handed that pair
straight to `BatchedMTPConfig`, whose contract refuses
`min_batch_lanes > max_lanes` by raising — and the planner runs lazily, when
the first request builds the batch generator, so the raise landed in
`_schedule_waiting` where no fallback could see it. The scheduler already
guards `max_lanes < 1`; one lane fell through the gap between that guard and
the config contract.

## Fix

Lane capacity is a deployment fact, not a programming error: serving a single
user with one lane is a normal way to run rapid-mlx. `plan_router_install`
now refuses insufficient lane capacity the same way it refuses every other
missing capability — `admitted=False` with a reason — so the caller keeps
vendored MTP (or plain decode for a model with no legacy MTP surface):

```
[MTP-continuous] planning router refused; retaining legacy_mtp: continuous
self-MTP needs at least 2 completion lanes to amortize ragged bookkeeping;
this deployment has 1
```

No config contract is relaxed: a coordinator still cannot be constructed
with fewer lanes than it needs, and `max_lanes=2` — the boundary — still
admits.

## Test plan

- [x] `pytest tests/test_continuous_mtp_routing.py tests/test_batched_self_mtp_contract.py` → 67 passed
- [x] Negative control: dropping the guard fails both new tests with the original `ValueError`
- [x] M4 Pro 48 GB, `serve qwen3.8-27b-4bit --max-num-seqs 1`: completions stream normally; server log shows the refusal above and the `legacy_mtp` fallback, so single-lane deployments keep MTP speedup
- [x] Same build, default `--max-num-seqs`: unchanged (22.2 tok/s decode, 105 tok/s prefill on that host)