### PR TITLE
perf(prefill): align the prompt-cache snapshot split to whole prefill tiles

### DIFF
--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -145,6 +145,22 @@ class TestPromptCacheSnapshot:
         assert scheduler._resolve_snapshot_boundary(request) == 686
         assert request._cache_snapshot_boundary == 686
 
+    def test_boundary_inside_the_reused_prefix_is_left_alone(self):
+        """A prefix that already covers the boundary leaves nothing to split.
+
+        The turn reuses 622 tokens and the message boundary sits at 600, so the
+        prefill starts past it: there is no local segment to round, and moving
+        the boundary would only walk the snapshot backwards into cache the
+        request is already reusing.
+        """
+        scheduler = _make_scheduler_with_cache()
+        scheduler._prefill_tile_rows_cached = 32
+        request = self._boundary_request(prompt_len=700, boundary=600)
+        request.cached_tokens = 622
+
+        assert scheduler._resolve_snapshot_boundary(request) == 600
+        assert not hasattr(request, "_cache_snapshot_boundary")
+
     def test_internal_n_minus_one_boundary_is_not_aligned(self):
         """Its tail is one token on the single-row path, not a tile."""
         scheduler = _make_scheduler_with_cache()

--- a/tests/test_prompt_cache_snapshot.py
+++ b/tests/test_prompt_cache_snapshot.py
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from vllm_mlx.request import Request, SamplingParams
-from vllm_mlx.scheduler import Scheduler, SchedulerConfig
+from vllm_mlx.scheduler import _PREFILL_TILE_ROWS, Scheduler, SchedulerConfig
 
 
 def _make_scheduler_with_cache():
@@ -80,6 +80,174 @@ class TestPromptCacheSnapshot:
         assert boundary == 3
         assert request._cache_snapshot_boundary == 3
         assert request._cache_snapshot_is_internal is True
+
+    def _boundary_request(self, prompt_len: int = 64, boundary: int = 0):
+        request = Request(
+            request_id="req-tile-align",
+            prompt="ignored",
+            prompt_token_ids=list(range(prompt_len)),
+            sampling_params=SamplingParams(max_tokens=4),
+        )
+        request.prefix_boundary = boundary
+        return request
+
+    def test_boundary_is_rounded_down_to_whole_tiles(self):
+        """An unaligned split costs a whole extra prefill tile."""
+        scheduler = _make_scheduler_with_cache()
+        scheduler._prefill_tile_rows_cached = 32
+        request = self._boundary_request(boundary=40)
+
+        assert scheduler._resolve_snapshot_boundary(request) == 32
+        assert request._cache_snapshot_boundary == 32
+
+    def test_boundary_inside_the_first_tile_falls_back_to_n_minus_one(self):
+        """Below one tile the snapshot cannot pay for the tile it costs.
+
+        Dropping it is not a plain loss: the bounded N-1 fallback takes over,
+        which costs one extra single-token forward instead of a tile and covers
+        the whole prompt, so an exact repeat is served from cache outright.
+        """
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        scheduler._prefill_tile_rows_cached = 32
+        request = self._boundary_request(boundary=17)
+
+        assert scheduler._resolve_snapshot_boundary(request) == 63
+        assert request._cache_snapshot_boundary == 63
+        assert request._cache_snapshot_is_internal is True
+
+    def test_dropped_boundary_leaves_no_snapshot_when_n_minus_one_is_off(self):
+        scheduler = _make_scheduler_with_cache()
+        scheduler._prefill_tile_rows_cached = 32
+        request = self._boundary_request(boundary=17)
+
+        assert scheduler._resolve_snapshot_boundary(request) == 0
+        assert request._cache_snapshot_boundary == 0
+        assert not hasattr(request, "_cache_snapshot_is_internal")
+
+    def test_alignment_is_relative_to_the_reused_prefix(self):
+        """The prefill is charged for the segment after the reused prefix.
+
+        A continuing turn that reuses 622 tokens and carries boundary 633 has
+        an 11-token segment to split.  Flooring the absolute boundary would put
+        the snapshot at 608 -- behind the prefix the request is reusing.
+        """
+        scheduler = _make_scheduler_with_cache()
+        scheduler._prefill_tile_rows_cached = 32
+        request = self._boundary_request(prompt_len=700, boundary=633)
+        request.cached_tokens = 622
+
+        assert scheduler._resolve_snapshot_boundary(request) == 0
+        assert request._cache_snapshot_boundary == 0
+
+        request.prefix_boundary = 692
+        assert scheduler._resolve_snapshot_boundary(request) == 686
+        assert request._cache_snapshot_boundary == 686
+
+    def test_internal_n_minus_one_boundary_is_not_aligned(self):
+        """Its tail is one token on the single-row path, not a tile."""
+        scheduler = _make_scheduler_with_cache()
+        scheduler.config.hybrid_cache_entries = 8
+        scheduler.config.non_trimmable_exact_prefix_reuse = True
+        scheduler._prefill_tile_rows_cached = 32
+        request = self._boundary_request()
+
+        assert scheduler._resolve_snapshot_boundary(request) == 63
+        assert request._cache_snapshot_is_internal is True
+
+    def test_unquantized_weights_keep_their_exact_boundary(self):
+        """The 32-row step was only measured on quantized matmuls."""
+        import mlx.core as mx
+
+        scheduler = _make_scheduler_with_cache()
+        scheduler.model = SimpleNamespace(
+            parameters=lambda: {"weight": mx.zeros((4, 4), mx.bfloat16)}
+        )
+        assert scheduler._prefill_tile_rows() == 1
+
+        request = self._boundary_request(boundary=17)
+        assert scheduler._resolve_snapshot_boundary(request) == 17
+
+    def test_quantized_weights_are_detected_from_the_packing_dtype(self):
+        """Packed 4-bit weights are uint32 words wherever they are nested."""
+        import mlx.core as mx
+
+        scheduler = _make_scheduler_with_cache()
+        scheduler.model = SimpleNamespace(
+            parameters=lambda: {
+                "layers": [
+                    {
+                        "mlp": {
+                            "weight": mx.zeros((4, 4), mx.uint32),
+                            "scales": mx.zeros((4, 1), mx.bfloat16),
+                        }
+                    }
+                ]
+            }
+        )
+        assert scheduler._prefill_tile_rows() == _PREFILL_TILE_ROWS
+
+    def test_free_split_is_preserved_even_when_unaligned(self):
+        """Rounding is for splits that cost a tile, not for every odd offset.
+
+        33 pending tokens cost two tiles whether or not they are split at 1, so
+        rounding there would forfeit reuse for nothing.
+        """
+        scheduler = _make_scheduler_with_cache()
+        scheduler._prefill_tile_rows_cached = 32
+        request = self._boundary_request(prompt_len=33, boundary=1)
+
+        assert scheduler._resolve_snapshot_boundary(request) == 1
+        assert not hasattr(request, "_cache_snapshot_boundary")
+
+    def test_extra_tile_predicate_matches_the_tile_arithmetic(self):
+        """The premise the rounding rests on, asserted rather than commented."""
+        tile = _PREFILL_TILE_ROWS
+
+        def tiles(count: int) -> int:
+            return -(-count // tile)
+
+        saw_free_unaligned = False
+        saw_waste = False
+        for n in range(2, 4 * tile + 2):
+            for b in range(1, n):
+                extra = Scheduler._extra_prefill_tiles(b, n, tile)
+                assert extra == tiles(b) + tiles(n - b) - tiles(n)
+                assert extra in (0, 1), f"n={n} b={b} extra={extra}"
+                if b % tile == 0:
+                    assert extra == 0, f"aligned split n={n} b={b} costs a tile"
+                elif extra == 0:
+                    saw_free_unaligned = True
+                else:
+                    saw_waste = True
+        assert saw_waste, "unaligned splits never cost extra - the premise is wrong"
+        assert saw_free_unaligned, "no unaligned split is free - rounding is trivial"
+        assert Scheduler._extra_prefill_tiles(1, tile + 1, tile) == 0
+
+    def test_unreadable_weights_answer_conservatively_without_caching(self):
+        """A traversal failure is not evidence, so it must not stick."""
+        import mlx.core as mx
+
+        scheduler = _make_scheduler_with_cache()
+        scheduler.model = SimpleNamespace()  # no .parameters()
+        assert scheduler._prefill_tile_rows() == 1
+        assert scheduler._prefill_tile_rows_cached is None
+
+        scheduler.model = SimpleNamespace(
+            parameters=lambda: {"weight": mx.zeros((4, 4), mx.uint32)}
+        )
+        assert scheduler._prefill_tile_rows() == _PREFILL_TILE_ROWS
+
+    def test_unquantized_weights_are_not_inferred_from_a_scales_name(self):
+        """A parameter named ``scales`` is not proof of packed weights."""
+        import mlx.core as mx
+
+        scheduler = _make_scheduler_with_cache()
+        scheduler.model = SimpleNamespace(
+            parameters=lambda: {"encoder": {"scales": mx.zeros((4,), mx.float32)}}
+        )
+        assert scheduler._prefill_tile_rows() == 1
 
     def test_valid_semantic_boundary_is_preserved(self):
         scheduler = _make_scheduler_with_cache()

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -245,6 +245,11 @@ def _assemble_stop_tokens(
     return stop_tokens
 
 
+# Rows per tile in MLX's quantized matmuls; see
+# ``Scheduler._prefill_tile_rows`` for the measurements behind it.
+_PREFILL_TILE_ROWS = 32
+
+
 @dataclass
 class SchedulerConfig:
     """Configuration for the scheduler."""
@@ -3764,6 +3769,8 @@ class Scheduler:
         """
         self.model = model
         self.tokenizer = tokenizer
+        # Derived from the weights once, on the first segmented prefill.
+        self._prefill_tile_rows_cached: int | None = None
         self.config = config or SchedulerConfig()
         self._tool_logits_processor_factory = tool_logits_processor_factory
         self.model_config = model_config
@@ -8029,6 +8036,102 @@ class Scheduler:
             return request.prompt_token_ids
         return tokens_to_process
 
+    def _prefill_tile_rows(self) -> int:
+        """Rows the prefill's matmuls are quantized to, 1 when there is none.
+
+        MLX feeds prompt rows to its quantized matmuls in tiles, so a segment
+        of ``n`` tokens costs ``ceil(n / tile)`` tiles rather than ``n`` tokens
+        of work.  One 17408x5120 4-bit projection takes 1074us for any row
+        count from 13 to 32 and 2116us from 33 to 64 on an M4 Pro (359us and
+        681us on an M3 Ultra -- same steps, different constants), and the whole
+        27B model inherits it: 32 prompt tokens prefill in 336ms, 33 in 640ms.
+
+        Only quantized weights are known to step at 32.  A checkpoint with no
+        quantized parameters keeps its exact boundary rather than forfeiting
+        reuse for a tile that has not been measured.
+        """
+        tile = self._prefill_tile_rows_cached
+        if tile is not None:
+            return tile
+        try:
+            import mlx.core as mx
+            from mlx.utils import tree_flatten
+
+            # The packing dtype is the fact worth testing: MLX stores
+            # quantized weights as uint32 words of packed values, and nothing
+            # else in a checkpoint is a uint32 parameter.  A parameter *named*
+            # ``scales`` proves nothing by itself.
+            quantized = any(
+                isinstance(param, mx.array) and param.dtype == mx.uint32
+                for _, param in tree_flatten(self.model.parameters())
+            )
+        except (ImportError, AttributeError, TypeError, ValueError) as exc:
+            # A model this traversal cannot read is not evidence of anything,
+            # so answer conservatively but do NOT cache it: a transient failure
+            # during initialization would otherwise disable alignment for the
+            # process lifetime.
+            logger.debug(
+                "[prefill_tile] weight inspection failed, assuming unquantized "
+                "for this request: %r",
+                exc,
+            )
+            return 1
+        tile = _PREFILL_TILE_ROWS if quantized else 1
+        self._prefill_tile_rows_cached = tile
+        return tile
+
+    @staticmethod
+    def _extra_prefill_tiles(split: int, pending: int, tile: int) -> int:
+        """Tiles a prefill split at ``split`` costs beyond one unsplit pass."""
+
+        def tiles(count: int) -> int:
+            return -(-count // tile)
+
+        return tiles(split) + tiles(pending - split) - tiles(pending)
+
+    def _tile_aligned_boundary(self, request: Request, boundary: int) -> int:
+        """Round a snapshot boundary down so its prefill stays whole-tile.
+
+        The boundary is an absolute prompt offset, but what the prefill is
+        charged for is the segment after the reused prefix, so the rounding is
+        applied there and translated back -- flooring the absolute offset would
+        instead walk the snapshot backwards into the reused prefix on every
+        continuing turn.  A split at a tile multiple is exactly free
+        (``b / q + ceil((n - b) / q) == ceil(n / q)`` for ``b % q == 0``); an
+        unaligned one costs a whole extra tile, which on a single-tile prompt
+        doubles TTFT.  Rounding trades at most ``q - 1`` tokens of next-turn
+        reuse for that.
+
+        A segment shorter than one tile is dropped entirely: reusing it later
+        saves one tile at most, while splitting for it spends one tile on every
+        request, including the ones that never get a follow-up.  Dropping it
+        also hands the request to the bounded N-1 fallback below, which costs a
+        single extra one-token forward and covers the whole prompt rather than a
+        fraction of it.
+        """
+        cached = request.cached_tokens or 0
+        local = boundary - cached
+        if local <= 0:
+            # Already inside the reused prefix: the prefill is not segmented
+            # for this boundary, so there is no tile to align.
+            return boundary
+        tile = self._prefill_tile_rows()
+        # A tile multiple is always free, but it is not the only free split:
+        # 33 pending tokens cost two tiles whether or not they are split at 1,
+        # because both halves round up into tiles the unsplit pass also pays
+        # for.  Keep any split that costs nothing -- it is strictly more reuse
+        # than the rounded one.
+        pending = max(len(request.prompt_token_ids or []) - cached, local + 1)
+        if self._extra_prefill_tiles(local, pending, tile) == 0:
+            return boundary
+        aligned = local - (local % tile)
+        if aligned <= 0:
+            request._cache_snapshot_boundary = 0
+            return 0
+        boundary = cached + aligned
+        request._cache_snapshot_boundary = boundary
+        return boundary
+
     def _resolve_snapshot_boundary(self, request: Request) -> int:
         """Return a usable prompt boundary, arming N-1 reuse when needed.
 
@@ -8047,6 +8150,8 @@ class Scheduler:
                 len(prompt_tokens),
             )
             snapshot_boundary = 0
+        elif snapshot_boundary > 0:
+            snapshot_boundary = self._tile_aligned_boundary(request, snapshot_boundary)
 
         if (
             snapshot_boundary <= 0

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -8126,11 +8126,8 @@ class Scheduler:
             return boundary
         aligned = local - (local % tile)
         if aligned <= 0:
-            request._cache_snapshot_boundary = 0
             return 0
-        boundary = cached + aligned
-        request._cache_snapshot_boundary = boundary
-        return boundary
+        return cached + aligned
 
     def _resolve_snapshot_boundary(self, request: Request) -> int:
         """Return a usable prompt boundary, arming N-1 reuse when needed.
@@ -8141,6 +8138,11 @@ class Scheduler:
         """
         prompt_tokens = request.prompt_token_ids or []
         snapshot_boundary = int(getattr(request, "prefix_boundary", 0) or 0)
+        # The snapshot machinery reads ``_cache_snapshot_boundary`` and falls
+        # back to the caller's ``prefix_boundary``, so a boundary moved below
+        # has to be recorded -- and only then, so an untouched boundary keeps
+        # reading through to the caller's value.
+        override_boundary = False
         if snapshot_boundary >= len(prompt_tokens):
             logger.debug(
                 "[boundary_snapshot] ignoring out-of-range boundary "
@@ -8151,7 +8153,9 @@ class Scheduler:
             )
             snapshot_boundary = 0
         elif snapshot_boundary > 0:
-            snapshot_boundary = self._tile_aligned_boundary(request, snapshot_boundary)
+            aligned_boundary = self._tile_aligned_boundary(request, snapshot_boundary)
+            override_boundary = aligned_boundary != snapshot_boundary
+            snapshot_boundary = aligned_boundary
 
         if (
             snapshot_boundary <= 0
@@ -8162,7 +8166,7 @@ class Scheduler:
             and len(prompt_tokens) > 1
         ):
             snapshot_boundary = len(prompt_tokens) - 1
-            request._cache_snapshot_boundary = snapshot_boundary
+            override_boundary = True
             request._cache_snapshot_is_internal = True
             logger.debug(
                 "[boundary_snapshot] armed internal N-1 boundary request=%s "
@@ -8171,6 +8175,8 @@ class Scheduler:
                 snapshot_boundary,
                 len(prompt_tokens),
             )
+        if override_boundary:
+            request._cache_snapshot_boundary = snapshot_boundary
         return snapshot_boundary
 
     def _max_running_sequences(self) -> int:


### PR DESCRIPTION
## What

Splitting a prefill at the per-message snapshot boundary (#427) costs a whole
extra pass over the model whenever the first segment is not a multiple of the
quantized matmul's row tile. MLX charges prompt rows in tiles of 32 rather than
per token, so the split is free only when it lands on a tile multiple — and the
boundary lands wherever the chat template's stable prefix ends, which is
unaligned about 31 times out of 32.

This keeps any split that costs nothing, rounds the rest down to a whole tile —
measured on the segment after the reused prefix, which is what the prefill is
actually charged for — and drops the boundary entirely when that segment is
shorter than one tile.

A tile multiple is always free, but it is not the only free split: 33 pending
tokens cost two tiles whether or not they are split at 1, because both halves
round up into tiles the unsplit pass pays for anyway. Those splits are preserved
as they are — strictly more reuse than the rounded offset, for the same
prefill.

## Why

The tile is not a heuristic — it is the kernel's row granularity, and it is
visible at every level:

| measurement (M4 Pro) | result |
| --- | --- |
| one 17408x5120 4-bit projection, 13..32 rows | 1074 us (flat) |
| same projection, 33..64 rows | 2116 us (flat) |
| same projection, 1 row | 202 us |
| 27B model, 32-token prompt | 336 ms |
| 27B model, 33-token prompt | 640 ms |
| `mx.quantized_matmul` `[512, 512]` vs `[1024]` | equal |
| `mx.quantized_matmul` `[16, 14]` vs `[30]` | 2x |

The same steps appear on an M3 Ultra with different constants (359 us / 681 us
per projection), which is the point: the tile belongs to the MLX kernel, not to
the host GPU, so this needs no per-machine tuning and applies unchanged from M2
to M6. The alignment is derived from the loaded weights rather than the chip —
a checkpoint with no quantized parameters keeps its exact boundary, since the
32-row step has only been measured on quantized matmuls.

Arithmetically the rounding cannot lose: `b / q + ceil((n - b) / q) ==
ceil(n / q)` exactly when `b % q == 0`, and is one tile worse otherwise, so
rounding trades at most `q - 1` tokens of next-turn reuse for a whole tile of
prefill on *every* request — including the ones that never get a follow-up.
A dropped boundary is not a plain loss either: the request falls through to the
existing bounded N-1 fallback, which costs one extra single-token forward and
covers the whole prompt, so an exact repeat is then served from cache outright.

## Measurements

M4 Pro mini, `qwen3.8-27b-4bit`, prefix cache wiped between runs, with the tile
constant as the only toggle (`_PREFILL_TILE_ROWS = 1` reproduces today's
behaviour):

| scenario | before | after | delta |
| --- | --- | --- | --- |
| short prompt, cold TTFT | 642.2 ms | 401.7 ms | **-37%** |
| short prompt, exact repeat | 394.9 ms | 84.3 ms | **-79%** |
| multi-turn (~500-token shared prefix), later turns | 699.0 ms | 410.1 ms | **-41%** |
| long prompt, cold TTFT | 6023.3 ms | 6010.6 ms | unchanged |

The long cold prompt is unchanged because its segments already span many tiles.
That is also why the configured prefill step sizes (512/1024/8192) were never
the problem — they are all tile multiples already. The snapshot boundary was the
only splitter that could land off-tile.

## Test plan

- [x] `tests/test_prompt_cache_snapshot.py` — rounding, the free-but-unaligned
  split being preserved, the sub-tile drop and its N-1 fallback, alignment
  relative to the reused prefix (the regression that flooring the absolute
  offset would cause), the internal N-1 boundary staying unaligned, unquantized
  weights keeping their exact boundary (including a model with an unrelated
  parameter named `scales`), quantized detection from the uint32 packing dtype,
  and a property test that pins the tile-cost predicate to the arithmetic
- [x] `tests/test_prefix_boundary_path_parity.py` + `tests/test_pflash_scheduler.py` pass unchanged (79 tests total)
- [x] `ruff check` + `ruff format` clean
- [x] End-to-end A/B on an M4 Pro mini with a real server, table above
