### PR TITLE
fix(moe): release projection buffers during fusion

### DIFF
--- a/docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md
+++ b/docs/engineering/performance/2026-09-12-glm53-flash-next-tier.md
@@ -15,10 +15,72 @@ one and 512-token context (1.481x, 90.5% acceptance, exact output parity) on an
 M3 Ultra.
 
 Rapid must not enable this path from the external number alone. The optimized
-implementation landed after the mlx-vlm v0.7.0 tag, changes a broad runtime
-surface, and the exact 181.7 GB Rapid target is not currently present in the
-policy-controlled Hugging Face cache. A paired Rapid server benchmark remains
-the release gate.
+implementation landed after the mlx-vlm v0.7.0 tag and changes a broad runtime
+surface. The exact 181.7 GB Rapid target is now present in the policy-controlled
+Hugging Face cache, and the K=0 production path has completed a paired server
+benchmark. K=1/2/3 MTP still requires the same full-model release gate.
+
+## Current-revision production-path E2E
+
+The exact current snapshot
+`76add2a341a1cd90ad0e86bb69839ea9c35827c6` was dogfooded through the Rapid
+OpenAI-compatible server at `d5c66fb9542b48f0d60c9f8177d0de4e7cd17901`
+on the 256 GB M3 Ultra Studio. The environment used Python 3.12.13, MLX 0.32.2,
+mlx-lm 0.31.3, and mlx-vlm 0.6.17. Prefix state was cleared before every run;
+each row is the median of three batch-one requests generating 256 tokens.
+
+| Prompt | Unfused prefill | Fused prefill | Unfused decode | Fused decode | Decode ratio |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 128 | 155.72 | 153.69 | 29.45 | 29.91 | 1.016x |
+| 2,048 | 373.80 | 373.31 | 25.81 | 26.25 | 1.017x |
+| 8,192 | 360.65 | 360.82 | 25.48 | 25.77 | 1.011x |
+| 32,768 | 269.62 | 276.16 | 25.17 | 25.12 | 0.998x |
+
+The 32K decode delta is -0.19%, which is treated as noise rather than a win.
+The other three buckets improve 1.1-1.7%, while prefill is effectively
+unchanged as expected for a decode-dispatch optimization. After the campaign,
+both modes reported 180.6 GB active Metal memory and 195.58 GB peak. The first
+128-token request in each fresh process included deferred Metal compilation;
+the table uses the specified three-run median and does not discard that run.
+
+Artifact SHA-256 values from the machine-local JSON records:
+
+- unfused: `cc6c97311c3056af140529caf41f295b8006c58b1dd4977752a27874075a0bb7`
+- fused: `4c13eb3b63c1bc11c0b26991daa692ba84f18a2377b5515eb5b13c2066b33575`
+
+The paired servers used the following command; add
+`RAPID_MLX_MOE_GATE_UP_FUSION=0` for the unfused side:
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+python -m vllm_mlx.cli serve \
+  "$HF_HUB_CACHE/models--Vontra--GLM-5.3-Flash-MLX-4bit-MTP/snapshots/76add2a341a1cd90ad0e86bb69839ea9c35827c6" \
+  --served-model-name glm5.3-flash-4bit \
+  --host 127.0.0.1 --port 8465 --no-thinking
+```
+
+The client used the exact tokenizer-counted prompt construction and streamed
+SSE accounting in `scripts/bench_service_prefill.py`, with target lengths
+128/2,048/8,192/32,768, `temperature=0`, `max_tokens=256`, and three runs per
+length. `/v1/cache/clear` ran before every timed request; `/v1/status` supplied
+the Metal memory figures.
+
+### Load-time memory regression and fix
+
+The original fusion implementation materialized the complete
+`named_modules()` result before rewriting the 42 routed MoE layers. That list
+kept every removed `up_proj` module and its old buffers strongly referenced, so
+the documented per-layer `mx.clear_cache()` did not actually bound the
+transient. With other model-serving apps stopped, the exact checkpoint reached
+Ready and then exited without a Python traceback under memory pressure.
+
+An A/B run with `RAPID_MLX_MOE_GATE_UP_FUSION=0` stayed healthy. The corrected
+scan retains only eligible parent `SwitchGLU` modules, allowing each removed
+projection to die before that layer's cache drain. With all 42 layers fused,
+the server stayed healthy, completed all 12 requests through 32K, and shut down
+cleanly. A weak-reference regression test verifies that at least one removed
+projection has been released at the first per-layer cache drain; the focused
+GLM/fusion suite passed 52 tests.
 
 ## Current Rapid baseline
 

--- a/tests/test_moe_gate_up_fusion.py
+++ b/tests/test_moe_gate_up_fusion.py
@@ -12,6 +12,8 @@ kill-switch.
 
 from __future__ import annotations
 
+import weakref
+
 import pytest
 
 mx = pytest.importorskip("mlx.core")
@@ -89,6 +91,22 @@ class TestBitExactness:
 
 
 class TestRewriteSemantics:
+    def test_removed_up_projection_is_released_per_layer(self, monkeypatch):
+        """The module scan must not pin old expert buffers until fusion ends."""
+        model = TinyMoE(n_layers=2)
+        mx.eval(model.parameters())
+        old_ups = [weakref.ref(layer.up_proj) for layer in model.layers]
+        released_at_clear = []
+
+        monkeypatch.setattr(
+            moe_fusion.mx,
+            "clear_cache",
+            lambda: released_at_clear.append(any(ref() is None for ref in old_ups)),
+        )
+
+        assert moe_fusion.fuse_gate_up(model) == 2
+        assert released_at_clear[0] is True
+
     def test_originals_dropped_and_container_reused(self):
         model = TinyMoE()
         mx.eval(model.parameters())

--- a/vllm_mlx/moe_fusion.py
+++ b/vllm_mlx/moe_fusion.py
@@ -207,10 +207,6 @@ def fuse_gate_up(model: Any) -> int:
     if not families:
         return 0
 
-    try:
-        modules = [m for _, m in model.named_modules()]
-    except Exception:  # noqa: BLE001 — unusual model containers: no fusion
-        return 0
     # Exact type only: a subclass may override __call__ and never consult
     # gate_up_proj, so fusing it would silently waste memory (or worse if
     # it reads gate_proj directly).
@@ -222,11 +218,20 @@ def fuse_gate_up(model: Any) -> int:
         gather_sort,
         scatter_unsort,
     ) in families:
-        targets = [
-            m
-            for m in modules
-            if type(m) is switch_glu_cls and _can_fuse(m, quantized_cls, plain_cls)
-        ]
+        try:
+            # Keep only the parent SwitchGLUs alive.  Retaining the complete
+            # named_modules() result also retains every original up_proj after
+            # it has been removed from its parent, defeating the per-layer
+            # mx.clear_cache() below.  On a 200B-class MoE that load-time
+            # transient is large enough for macOS to kill the process.
+            targets = [
+                module
+                for _, module in model.named_modules()
+                if type(module) is switch_glu_cls
+                and _can_fuse(module, quantized_cls, plain_cls)
+            ]
+        except Exception:  # noqa: BLE001 — unusual model containers: no fusion
+            continue
         if not targets:
             continue
         _ensure_call_patch(switch_glu_cls, gather_sort, scatter_unsort)


### PR DESCRIPTION
## Why

The gate/up fusion promised to release old expert buffers one layer at a time, but it first retained every entry from `named_modules()`. On the 181.7 GB GLM-5.3-Flash-Next checkpoint, those strong references kept all removed `up_proj` modules alive through the entire rewrite. The server reached Ready and then exited under memory pressure with no Python traceback on the 256 GB M3 Ultra Studio.

## What changed

- Retain only eligible parent `SwitchGLU` modules during the scan, so each removed projection can be released before that layer cache drain.
- Add a weak-reference regression test that observes release at the first drain.
- Record the full-model A/B methodology and quantitative results in the GLM performance note.

## Verification

- [x] `ruff check vllm_mlx/moe_fusion.py tests/test_moe_gate_up_fusion.py`
- [x] `ruff format --check vllm_mlx/moe_fusion.py tests/test_moe_gate_up_fusion.py`
- [x] 52 focused GLM/fusion tests passed
- [x] Pre-fix default fusion: exact 181.7 GB checkpoint reached Ready, then exited under memory pressure
- [x] Fusion disabled: server remained healthy
- [x] Fixed fusion: all 42 layers fused; server remained healthy and completed 12 cold-cache requests through 32K context

## Full-model performance

M3 Ultra 256 GB, MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.6.17, batch 1, 256 decode tokens, three cold-cache runs per row (median):

| Prompt | Unfused decode | Fused decode | Ratio |
| ---: | ---: | ---: | ---: |
| 128 | 29.45 tok/s | 29.91 tok/s | 1.016x |
| 2,048 | 25.81 tok/s | 26.25 tok/s | 1.017x |
| 8,192 | 25.48 tok/s | 25.77 tok/s | 1.011x |
| 32,768 | 25.17 tok/s | 25.12 tok/s | 0.998x |

The 32K -0.19% delta is noise-level, not claimed as a win. Prefill is unchanged as expected. Both completed campaigns reported 180.6 GB active and 195.58 GB peak Metal memory. The primary user benefit is restoring reliable default-on fusion for the largest supported MoE while retaining the measured 1.1-1.7% decode gain in the shorter three buckets.