### PR TITLE
fix(video): use bundled ffmpeg from video extra

### DIFF
--- a/tests/test_ltx23_video.py
+++ b/tests/test_ltx23_video.py
@@ -95,6 +95,37 @@ def test_ffmpeg_resolver_uses_homebrew_fallback_when_path_is_missing(
     assert _resolve_ffmpeg() == str(homebrew_link)
 
 
+def test_ffmpeg_resolver_uses_binary_from_declared_video_extra(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundled = tmp_path / "ffmpeg-macos-aarch64"
+    bundled.write_bytes(b"#!/bin/sh\n")
+    bundled.chmod(0o755)
+    monkeypatch.delenv("FFMPEG_BINARY", raising=False)
+    monkeypatch.setattr(video_lane.shutil, "which", lambda _: None)
+    monkeypatch.setattr(video_lane, "_FFMPEG_FALLBACK_PATHS", ())
+    imageio_ffmpeg = ModuleType("imageio_ffmpeg")
+    imageio_ffmpeg.get_ffmpeg_exe = lambda: str(bundled)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "imageio_ffmpeg", imageio_ffmpeg)
+
+    assert _resolve_ffmpeg() == str(bundled)
+
+
+def test_ffmpeg_resolver_rejects_unusable_video_extra_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundled = tmp_path / "ffmpeg-macos-aarch64"
+    bundled.write_bytes(b"not executable")
+    monkeypatch.delenv("FFMPEG_BINARY", raising=False)
+    monkeypatch.setattr(video_lane.shutil, "which", lambda _: None)
+    monkeypatch.setattr(video_lane, "_FFMPEG_FALLBACK_PATHS", ())
+    imageio_ffmpeg = ModuleType("imageio_ffmpeg")
+    imageio_ffmpeg.get_ffmpeg_exe = lambda: str(bundled)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "imageio_ffmpeg", imageio_ffmpeg)
+
+    assert _resolve_ffmpeg() is None
+
+
 def test_ffmpeg_resolver_honors_executable_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/vllm_mlx/runtime/video_lane.py
+++ b/vllm_mlx/runtime/video_lane.py
@@ -28,6 +28,19 @@ _FFMPEG_FALLBACK_PATHS = (
 )
 
 
+def _resolve_imageio_ffmpeg() -> str | None:
+    """Return the executable bundled by the declared video extra, if usable."""
+    try:
+        import imageio_ffmpeg
+
+        candidate = Path(imageio_ffmpeg.get_ffmpeg_exe()).expanduser()
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError):
+        return None
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate.absolute())
+    return None
+
+
 def _resolve_ffmpeg() -> str | None:
     """Resolve the ffmpeg binary consistently across the video lane."""
     override = os.environ.get("FFMPEG_BINARY", "").strip()
@@ -52,7 +65,7 @@ def _resolve_ffmpeg() -> str | None:
     for candidate in _FFMPEG_FALLBACK_PATHS:
         if candidate.is_file() and os.access(candidate, os.X_OK):
             return str(candidate)
-    return None
+    return _resolve_imageio_ffmpeg()
 
 
 def validate_video_request(


### PR DESCRIPTION
## Why

A clean `rapid-mlx[video]` installation already includes an executable ffmpeg through its declared `imageio[ffmpeg]` dependency, but Rapid-MLX only searched `PATH` and fixed system locations. On a new Mac without Homebrew, video startup therefore failed and told the user to install a second ffmpeg copy.

## What

- Keep explicit `FFMPEG_BINARY`, `PATH`, and standard system locations at their existing precedence.
- Fall back to the executable returned by the installed video dependency's supported discovery API.
- Accept that candidate only when it is a real executable file; dependency errors fail closed.

## Design precedent

Use the dependency's supported executable discovery API instead of duplicating its platform-specific wheel layout. Rapid-MLX retains its existing explicit-override precedence and validates the returned path before executing it.

## Scope

Only ffmpeg discovery for the video lane and focused regression tests. No codec, generation, model, endpoint, or packaging-policy changes.

## Test plan

- [x] `python3.12 -m pytest -q tests/test_ltx23_video.py tests/test_video_encoding.py tests/test_wan_video.py` (82 passed)
- [x] `python3.12 -m ruff check vllm_mlx/runtime/video_lane.py tests/test_ltx23_video.py`
- [x] MZR-3 clean-machine control with `PATH=/usr/bin:/bin`: resolver selected the bundled executable and Wan runtime preflight returned no issue
- [x] `git diff --check`
