### PR TITLE
fix(audio): find uv for Kokoro runtime setup

### DIFF
--- a/tests/test_kokoro_g2p_bootstrap.py
+++ b/tests/test_kokoro_g2p_bootstrap.py
@@ -70,6 +70,47 @@ def test_installer_env_targets_running_interpreter(source, prefix, is_venv, expe
     assert source == original
 
 
+def test_installer_env_finds_official_user_local_uv(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    uv = tmp_path / ".local" / "bin" / "uv"
+    uv.parent.mkdir(parents=True)
+    uv.write_text("#!/bin/sh\n")
+    uv.chmod(0o755)
+    monkeypatch.setattr(
+        runtime_requirements.shutil, "which", lambda *args, **kwargs: None
+    )
+
+    source = {"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
+    env = _installer_env(source, "/opt/venv", True)
+
+    assert env["PATH"] == f"/usr/bin:/bin:{uv.parent}"
+    assert env["VIRTUAL_ENV"] == "/opt/venv"
+    assert source == {"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
+
+
+def test_installer_env_does_not_override_uv_already_on_path(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    user_uv = tmp_path / ".local" / "bin" / "uv"
+    user_uv.parent.mkdir(parents=True)
+    user_uv.write_text("#!/bin/sh\n")
+    user_uv.chmod(0o755)
+    monkeypatch.setattr(
+        runtime_requirements.shutil,
+        "which",
+        lambda name, *, path: "/managed/bin/uv",
+    )
+
+    env = _installer_env(
+        {"HOME": str(tmp_path), "PATH": "/managed/bin:/usr/bin"},
+        "/opt/venv",
+        True,
+    )
+
+    assert env["PATH"] == "/managed/bin:/usr/bin"
+
+
 def _fake_spacy(monkeypatch, state):
     util = types.ModuleType("spacy.util")
     util.is_package = lambda name: bool(state.get("installed"))

--- a/vllm_mlx/audio/runtime_requirements.py
+++ b/vllm_mlx/audio/runtime_requirements.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import importlib
 import logging
 import os
+import shutil
 import signal
 import subprocess
 import sys
+from pathlib import Path
 
 from vllm_mlx.audio.registry import AudioRuntimeRequirement
 
@@ -47,6 +49,18 @@ def _installer_env(
         env["VIRTUAL_ENV"] = prefix
     else:
         env.pop("VIRTUAL_ENV", None)
+
+    # ``uv venv`` intentionally creates environments without pip. spaCy can
+    # use uv instead, but non-interactive shells do not always inherit the
+    # user-local bin directory where uv's official installer places it.
+    if shutil.which("uv", path=env.get("PATH", "")) is None:
+        home = env.get("HOME")
+        user_uv = Path(home, ".local", "bin", "uv") if home else None
+        if user_uv and user_uv.is_file() and os.access(user_uv, os.X_OK):
+            current_path = env.get("PATH", "")
+            env["PATH"] = os.pathsep.join(
+                part for part in (current_path, str(user_uv.parent)) if part
+            )
     return env
 
 


### PR DESCRIPTION
## Why

Kokoro's first `rapid-mlx pull` prepares its English spaCy pipeline. A clean environment created by uv intentionally has no pip, and an SSH/non-interactive shell may omit uv's standard user-local bin directory from `PATH`. In that supported setup, preparation failed with a misleading missing-audio-extra error even though `rapid-mlx[audio]` was installed.

## What

- Continue targeting the running virtual environment through `VIRTUAL_ENV`.
- If uv is not already discoverable, expose an executable from its standard user-local install location to the child installer only.
- Preserve an existing managed uv on `PATH`; do not mutate the parent environment.

## Design precedent

The downstream pipeline installer already supports either pip or uv. This change supplies that existing mechanism with the standard uv install location instead of adding a second downloader or changing the runtime artifact contract.

## Scope

Only the environment used by the explicit audio runtime-preparation subprocess and focused contracts. No inference-time downloads, voice behavior, model aliases, or dependency-version changes.

## Test plan

- [x] `python3.12 -m pytest -q tests/test_kokoro_g2p_bootstrap.py tests/test_pull_audio_runtime_assets.py` (53 passed)
- [x] `python3.12 -m ruff check vllm_mlx/audio/runtime_requirements.py tests/test_kokoro_g2p_bootstrap.py`
- [x] Fresh uv venv on MZR-3 with no pip and `PATH=/usr/bin:/bin`: `rapid-mlx pull kokoro` prepared `en_core_web_sm`; `spacy.load()` succeeded
- [x] `git diff --check`
