### PR TITLE
perf(mtp): log the depth controller's learned curves

### DIFF
--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1360,6 +1360,178 @@ def test_starvation_probe_resets_when_ev_pick_changes():
 
 
 # ---------------------------------------------------------------------------
+# 5c. DepthController diagnostics (the learned curves, for DEBUG logs)
+# ---------------------------------------------------------------------------
+
+
+def _seeded_controller(max_k=3, cost_ms=(65.0, 73.0, 88.0, 110.0), accept=0.8):
+    """A controller fed a realistic cost curve and acceptance stream.
+
+    ``cost_ms`` is indexed by depth and ``accept`` is the per-position
+    acceptance rate; both are applied often enough to pass
+    ``ACCEPTANCE_MIN_SAMPLES`` so the frontier actually moves.
+    """
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        DepthController,
+        reset_controllers,
+    )
+
+    reset_controllers()
+    ctrl = DepthController(max_k=max_k)
+    hits = round(accept * 10)
+    for depth in range(0, max_k + 1):
+        credit = 0
+        for _ in range(200):
+            # Bresenham: ``hits`` accepts per 10 rounds, spread evenly rather
+            # than blocked, so the EWMA settles on the requested rate instead
+            # of on wherever a run of rejections happened to leave it.
+            credit += hits
+            accepted = credit >= 10
+            if accepted:
+                credit -= 10
+            ctrl.record(
+                depth,
+                cost_ms[depth],
+                [True] * depth if accepted else [False] * depth,
+            )
+    if max_k >= 1:
+        # An EWMA of a repeating pattern ripples rather than converging;
+        # ``ACCEPTANCE_EWMA_ALPHA`` bounds that ripple well inside 0.1.
+        assert ctrl.acc.acceptance(1) == pytest.approx(accept, abs=0.1)
+    return ctrl
+
+
+def test_acceptance_sample_string_reports_only_trusted_positions():
+    """Positions past the frontier read back an inherited rate, not a
+    measured one, so publishing them would pass off the search policy as
+    data. The string stops at the frontier for that reason."""
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        ACCEPTANCE_MIN_SAMPLES,
+        AcceptanceModel,
+    )
+
+    acc = AcceptanceModel()
+    assert acc.sample_string() == ""
+
+    for _ in range(ACCEPTANCE_MIN_SAMPLES):
+        acc.observe(2, 1)  # position 1 accepted, position 2 rejected
+
+    assert acc.frontier() == 2
+    assert acc.sample_string() == "1:1.00 2:0.00"
+    # Position 3 answers (inheriting 0.00) but is not reported.
+    assert acc.acceptance(3) == pytest.approx(0.0)
+
+
+def test_expected_tps_string_is_empty_until_two_depths_are_sampled():
+    """One cost sample gives a point, not a slope; a tok/s figure derived
+    from it would be an extrapolation reported as a measurement."""
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        DepthController,
+        reset_controllers,
+    )
+
+    reset_controllers()
+    ctrl = DepthController(max_k=3)
+    for _ in range(6):
+        ctrl.record(0, 65.0, [])
+
+    assert ctrl.expected_tps_string() == ""
+    assert "expected_tps=[]" in ctrl.diagnostics()
+
+
+def test_expected_tps_string_is_the_quantity_the_pick_maximizes():
+    """The printed curve has to be the comparator's own, or the log
+    explains a decision the controller did not make. Check the argmax of
+    the string equals ``pick_k``'s selection."""
+    ctrl = _seeded_controller()
+
+    parts = dict(
+        (int(k), float(v))
+        for k, v in (p.split(":") for p in ctrl.expected_tps_string().split())
+    )
+    assert set(parts) == set(range(0, min(ctrl.frontier() + 1, ctrl.max_k) + 1))
+    # tok/s, not tok/ms: a 65ms park round is ~15 tok/s.
+    assert parts[0] == pytest.approx(1000.0 / 65.0, rel=0.05)
+
+    best = max(parts, key=lambda n: parts[n])
+    assert ctrl._selected() == best
+
+
+def test_diagnostics_carries_every_curve_a_depth_choice_depends_on():
+    """A depth pick is a function of cost, acceptance and the resulting
+    EV; a log missing any one of them cannot be used to second-guess it."""
+    ctrl = _seeded_controller()
+
+    line = ctrl.diagnostics()
+    for field in ("cost=[", "acceptance=[", "expected_tps=[", "probe_interval="):
+        assert field in line
+    assert "cost=[]" not in line
+    assert "acceptance=[]" not in line
+    assert "expected_tps=[]" not in line
+
+
+def test_record_logs_diagnostics_on_the_configured_cadence(caplog):
+    """``diagnostics()`` was unreachable from a running server before
+    this -- nothing called it -- so the curves could not be read off a
+    DEBUG run at all."""
+    import logging
+
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        DIAGNOSTICS_LOG_INTERVAL,
+        DepthController,
+        reset_controllers,
+    )
+
+    reset_controllers()
+    ctrl = DepthController(max_k=3)
+    with caplog.at_level(
+        logging.DEBUG, logger="vllm_mlx.spec_decode.mtp.draft_k_controller_v2"
+    ):
+        for _ in range(DIAGNOSTICS_LOG_INTERVAL - 1):
+            ctrl.record(1, 73.0, [True])
+        assert not [r for r in caplog.records if "[MTP-controller]" in r.message]
+
+        ctrl.record(1, 73.0, [True])
+        hits = [r for r in caplog.records if "[MTP-controller]" in r.message]
+
+    assert len(hits) == 1
+    assert f"rounds={DIAGNOSTICS_LOG_INTERVAL}" in hits[0].getMessage()
+
+
+def test_record_does_not_build_the_diagnostics_line_below_debug(monkeypatch):
+    """The line walks both models' curves, so paying for it on a default
+    INFO server would be a per-round cost for output nobody reads."""
+    from vllm_mlx.spec_decode.mtp.draft_k_controller_v2 import (
+        DIAGNOSTICS_LOG_INTERVAL,
+        DepthController,
+        reset_controllers,
+    )
+
+    reset_controllers()
+    ctrl = DepthController(max_k=3)
+    calls = []
+    monkeypatch.setattr(
+        type(ctrl),
+        "diagnostics",
+        lambda self: calls.append(1) or "",
+    )
+
+    import logging
+
+    logger = logging.getLogger("vllm_mlx.spec_decode.mtp.draft_k_controller_v2")
+    old_level, logger.level = logger.level, logging.INFO
+    old_propagate, logger.propagate = logger.propagate, False
+    try:
+        for _ in range(DIAGNOSTICS_LOG_INTERVAL):
+            ctrl.record(1, 73.0, [True])
+    finally:
+        logger.level = old_level
+        logger.propagate = old_propagate
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
 # 6. MTP head builder
 # ---------------------------------------------------------------------------
 

--- a/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
+++ b/vllm_mlx/spec_decode/mtp/draft_k_controller_v2.py
@@ -110,6 +110,14 @@ COST_SEED_MIN_SAMPLES = 4
 # converge), resets to base on any EV-pick shift.
 STARVATION_PROBE_INTERVAL = 4
 
+# Rounds between controller diagnostic logs. Ollama logs its learned curves
+# once per request (``speculate_stats.go:64-84``); the controller sees rounds,
+# not request boundaries, so pace it at roughly one typical response instead --
+# often enough to watch a depth decision drift, rare enough that a DEBUG run
+# stays readable. Only the cost/acceptance/EV curves explain a depth choice, so
+# without them a bad pick is undiagnosable from logs alone.
+DIAGNOSTICS_LOG_INTERVAL = 128
+
 
 # ---------------------------------------------------------------------------
 # CostModel — per-K target-forward wall-time EWMA.
@@ -302,6 +310,17 @@ class AcceptanceModel:
             if j < len(self._seen) and self._seen[j] >= ACCEPTANCE_MIN_SAMPLES:
                 return self._rate[j]
         return 1.0
+
+    def sample_string(self) -> str:
+        """Per-position rates over the trusted window ``[1, frontier]``.
+
+        Deeper positions have no data of their own -- :meth:`acceptance`
+        answers for them by inheriting the deepest trusted rate, which is a
+        search policy, not a measurement, so it is not reported as one.
+        """
+        return " ".join(
+            f"{i}:{self.acceptance(i):.2f}" for i in range(1, self.frontier() + 1)
+        )
 
     def expected_committed(self, n: int) -> float:
         """Expected committed tokens at depth N: the current token
@@ -610,6 +629,10 @@ class DepthController:
                 else:
                     break
             self.acc.observe(len(accepts), accepted)
+        if self.round_count % DIAGNOSTICS_LOG_INTERVAL == 0 and logger.isEnabledFor(
+            logging.DEBUG
+        ):
+            logger.debug("[MTP-controller] %s", self.diagnostics())
 
     # ------------------------------------------------------------------
     # Internals
@@ -654,13 +677,35 @@ class DepthController:
                 return n
         return -1
 
+    def expected_tps_string(self) -> str:
+        """EV per depth over the searched window ``[0, limit]``, in tok/s.
+
+        This is the quantity :meth:`pick_k` maximizes, so printing it says why
+        a depth won -- cost alone cannot, since the depth with the lowest cost
+        is never the pick. Empty until two depths have been sampled, because
+        interpolating a one-point cost curve would report a slope that was
+        never measured.
+        """
+        if not self.cost.ready():
+            return ""
+        limit = min(self.frontier() + 1, self.max_k)
+        # ``observe`` folds a sample only for a positive wall time and
+        # ``cost`` interpolates between samples, so every cost the ready
+        # model reports is positive and the division below is safe.
+        return " ".join(
+            f"{n}:{1000.0 * self.acc.expected_committed(n) / self.cost.cost(n):.1f}"
+            for n in range(0, limit + 1)
+        )
+
     def diagnostics(self) -> str:
-        """Human-readable snapshot for INFO logs."""
+        """Human-readable snapshot of the learned curves and probe state."""
         return (
             f"K_scheduled={self.scheduled} frontier={self.frontier()} "
             f"max_k={self.max_k} rounds={self.round_count} "
             f"parks={self.park_count} "
             f"cost=[{self.cost.sample_string()}] "
+            f"acceptance=[{self.acc.sample_string()}] "
+            f"expected_tps=[{self.expected_tps_string()}] "
             f"probe_interval={self._probe_interval} "
             f"starve_interval={self._round_probe_interval} "
             f"starve_probes={self.starvation_probe_count}"


### PR DESCRIPTION
`DepthController.diagnostics()` has never had a caller, so the curves a
depth choice is made from could not be read off a running server at all.
That mattered while measuring Qwen3.8-27B-4bit MTP decode on an M4 Pro:
Ollama's MLX runner prints its own `cost="0:65ms 1:73ms 2:88ms 3:110ms"
acceptance="1:0.82 2:0.89"` at DEBUG, and we had nothing to compare it
against beyond end-to-end tokens per second, which cannot say whether a
depth lost on cost or on acceptance.

Add the two missing curves to `diagnostics()` and log it every 128 rounds
at DEBUG, pacing it at roughly one typical response since the controller
sees rounds rather than request boundaries. The fields mirror Ollama's
`speculate_stats.go` so the two logs can be read side by side.

Both new strings are deliberately narrow about what they publish:

* Acceptance reports only `[1, frontier]`. Past the frontier
  `acceptance()` still answers, by inheriting the deepest trusted rate --
  that is the outward-search policy, not a measurement, and printing it
  as one would invite tuning against a number nothing observed.
* Expected TPS is the quantity `pick_k` maximizes, so it is what actually
  explains a pick; cost alone never can, because the cheapest depth is
  never the chosen one. It stays empty until two depths have been sampled,
  so a one-point cost curve is never reported as a slope.

The line is only built when DEBUG is enabled -- it walks both models'
curves, so an INFO server should not pay for output nobody reads.

With this in place the same M4 Pro reports `cost=[0:67ms 1:73ms 2:99ms
3:123ms] acceptance=[1:0.77 2:0.70] expected_tps=[0:15.0 1:23.5 2:23.2
3:21.8]`, which says plainly that our depth-1 cost is at parity and the
remaining gap is depth-2 acceptance -- a conclusion that was not
available before.

Test plan:
- [x] `pytest tests/test_mtp_spec_decode.py` -- 140 passed
- [x] 6 new tests: acceptance stops at the frontier, EV string empty on one sample, EV argmax equals `pick_k`'s selection, all curves present, the cadence fires exactly once per interval, and nothing is built below DEBUG
- [x] `scripts/check_mypy_error_budget.py` -- no growth
- [x] `ruff check` + `ruff format`
- [x] read off a real server: 27B 4-bit MTP on an M4 Pro at `--log-level DEBUG`, curve above

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>