### PR TITLE
fix(doctor): report cold imports and HF cache size accurately

### DIFF
--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -23,6 +23,7 @@ import json
 import os
 import plistlib
 import shlex
+import stat
 import subprocess
 import sys
 import threading
@@ -3072,6 +3073,40 @@ def test_bounded_timeout_uses_only_one_millisecond_after_deadline(monkeypatch):
     assert eh._bounded_timeout(2.0) == 0.001
 
 
+def test_deep_doctor_allows_slow_cold_optional_imports(monkeypatch):
+    monkeypatch.setattr(eh.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(eh, "_DOCTOR_DEADLINE", 129.9)
+
+    assert eh._bounded_timeout(eh._IMPORT_PROBE_TIMEOUT_S) == 20.0
+
+
+def test_deep_doctor_timeout_recommends_direct_import_not_same_retry(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        eh,
+        "_import_probe_outcome",
+        lambda *args, **kwargs: eh._ImportProbeOutcome.TIMED_OUT,
+    )
+    monkeypatch.setattr(eh, "_import_probe_was_interrupted", lambda *args: False)
+    monkeypatch.setattr(eh, "_DOCTOR_DEEP_MODE", True)
+    section = eh.Section("test")
+    runtime = tmp_path / "bin" / "python"
+
+    assert eh._add_inconclusive_import(
+        section,
+        label="mlx-vlm",
+        version="0.6.17",
+        runtime=runtime,
+        module="mlx_vlm",
+        sidecar_root=None,
+    )
+
+    detail = section.checks[0].detail
+    assert "doctor --deep" not in detail
+    assert eh._runtime_import_command(runtime, "mlx_vlm") in detail
+
+
 def test_run_all_serializes_process_global_probe_state(monkeypatch):
     active = 0
     peak_active = 0
@@ -3730,21 +3765,33 @@ def test_dir_size_walk_aborts_inside_flat_directory(tmp_path: Path):
     )
 
 
+def test_dir_size_walk_does_not_follow_hf_snapshot_symlinks(tmp_path: Path):
+    blobs = tmp_path / "models--owner--model" / "blobs"
+    snapshot = tmp_path / "models--owner--model" / "snapshots" / "revision"
+    blobs.mkdir(parents=True)
+    snapshot.mkdir(parents=True)
+    blob = blobs / "digest"
+    blob.write_bytes(b"x" * 4096)
+    (snapshot / "model.safetensors").symlink_to(blob)
+
+    assert eh._dir_size_gb(tmp_path) == pytest.approx(4096 / (1024**3))
+
+
 def test_dir_size_walk_cannot_outlive_shared_doctor_deadline(tmp_path, monkeypatch):
     (tmp_path / "first.bin").write_bytes(b"x")
     (tmp_path / "second.bin").write_bytes(b"x")
     clock = [100.0]
     stat_calls = 0
 
-    def fake_getsize(_path):
+    def fake_lstat(_path):
         nonlocal stat_calls
         stat_calls += 1
         clock[0] += 0.02
-        return 1
+        return SimpleNamespace(st_mode=stat.S_IFREG, st_size=1)
 
     monkeypatch.setattr(eh.time, "monotonic", lambda: clock[0])
     monkeypatch.setattr(eh, "_DOCTOR_DEADLINE", 100.01)
-    monkeypatch.setattr(eh.os.path, "getsize", fake_getsize)
+    monkeypatch.setattr(eh.os, "lstat", fake_lstat)
 
     assert eh._dir_size_gb(tmp_path, budget_s=1.5) is None
     assert stat_calls == 1

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -33,6 +33,7 @@ import plistlib
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
 import threading
@@ -283,6 +284,7 @@ _RUNTIME_OVERRIDE_REPAIR_HINT_TEMPLATE = (
 )
 _DOCTOR_BUDGET_S = 5.0
 _DOCTOR_DEEP_BUDGET_S = 30.0
+_IMPORT_PROBE_TIMEOUT_S = 20.0
 # Leave enough scheduling-budget headroom for subprocess timeout cleanup, report
 # assembly, and CLI rendering.  ``subprocess.run(timeout=...)`` only starts
 # terminating the child at its timeout and can return a few milliseconds
@@ -290,6 +292,7 @@ _DOCTOR_DEEP_BUDGET_S = 30.0
 # for rendering and cleanup.
 _DOCTOR_COMPLETION_HEADROOM_S = 0.1
 _DOCTOR_DEADLINE: float | None = None
+_DOCTOR_DEEP_MODE = False
 _DOCTOR_RUN_LOCK = threading.Lock()
 _RUNTIME_CONTEXTS: dict[Path, tuple[Path, dict[str, str]]] = {}
 _RUNTIME_DISTRIBUTION_CACHE: dict[Path, bool] = {}
@@ -1122,12 +1125,17 @@ def _add_inconclusive_import(
     )
     version_text = f" {version}" if version else ""
     verify = _runtime_import_command(runtime, module)
+    retry = (
+        "rerun `rapid-mlx doctor --deep` to allow cold optional imports more time"
+        if outcome is _ImportProbeOutcome.TIMED_OUT and not _DOCTOR_DEEP_MODE
+        else f"verify with `{verify}`"
+    )
     section.add(
         f"{label}{version_text} importability unknown — doctor probe {reason}",
         CheckStatus.WARN,
         detail=(
             f"distribution={label} module={module} outcome={outcome.value}; "
-            f"rerun doctor after cold imports settle or verify with `{verify}`; "
+            f"{retry}; "
             "this result does not indicate that reinstall or rollback is needed"
         ),
     )
@@ -1216,7 +1224,7 @@ def _runtime_module_importable(
             command,
             capture_output=True,
             text=True,
-            timeout=_bounded_timeout(10),
+            timeout=_bounded_timeout(_IMPORT_PROBE_TIMEOUT_S),
             env={
                 "HOME": os.environ.get("HOME", str(Path.home())),
                 "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
@@ -1565,13 +1573,13 @@ def _dir_size_gb(path: Path, *, budget_s: float = _CACHE_WALK_BUDGET_S) -> float
 
         Otherwise the total in GB.
 
-    Walks with ``os.walk(..., followlinks=False)`` so LM-Studio-style symlinks
-    don't double-count. The deadline is checked **inside** the per-file loop,
-    not just between directories: HF cache's ``blobs/`` subdir is flat with
-    thousands of entries, so a per-directory deadline would let a single
-    cold-cache stat() storm blow past the 1.5 s budget. Codex review round 2
-    caught the per-directory variant as a contract violation; this version
-    aborts on the very next file once the deadline expires.
+    Walks with ``os.walk(..., followlinks=False)`` and sizes entries with
+    ``lstat`` so snapshot symlinks do not count their shared blobs twice. The
+    deadline is checked **inside** the per-file loop, not just between
+    directories: HF cache's ``blobs/`` subdir is flat with thousands of
+    entries, so a per-directory deadline would let a single cold-cache stat()
+    storm blow past the 1.5 s budget. This version aborts on the very next file
+    once the deadline expires.
     """
     import time as _time
 
@@ -1589,7 +1597,9 @@ def _dir_size_gb(path: Path, *, budget_s: float = _CACHE_WALK_BUDGET_S) -> float
                     # useful (lower bound only). Caller renders "unknown".
                     return None
                 try:
-                    total += os.path.getsize(os.path.join(root, f))
+                    file_stat = os.lstat(os.path.join(root, f))
+                    if stat.S_ISREG(file_stat.st_mode):
+                        total += file_stat.st_size
                 except OSError:
                     # Broken symlink, permission denied — skip silently;
                     # this probe is "is the cache enormous?", not "audit
@@ -3845,10 +3855,11 @@ def _run_all_serialized(
     report as a single ✗ row labelled with the exception class — that's
     still a useful signal ("doctor is broken, file a bug").
     """
-    global _DOCTOR_DEADLINE, _RUNTIME_SELECTION_DONE
+    global _DOCTOR_DEADLINE, _DOCTOR_DEEP_MODE, _RUNTIME_SELECTION_DONE
     report = Report()
     try:
         _DOCTOR_DEADLINE = caller_deadline
+        _DOCTOR_DEEP_MODE = deep
         _RUNTIME_SELECTION_DONE = False
         _RUNTIME_PROBE_CACHE.clear()
         _RUNTIME_PROBE_TIMEOUTS.clear()
@@ -3939,6 +3950,7 @@ def _run_all_serialized(
                 )
     finally:
         _DOCTOR_DEADLINE = None
+        _DOCTOR_DEEP_MODE = False
     return report
 
 


### PR DESCRIPTION
## Why

Clean-machine dogfood exposed two misleading `doctor` results. The HF cache size walker followed snapshot file symlinks and counted the same blob twice. Separately, `doctor --deep` retained the normal import probe's 10-second cap, so a healthy cold `mlx-vlm` import could still be reported as unknown even though deep mode has a 30-second budget.

## What

- Size only regular files through `lstat`, excluding snapshot symlinks while retaining the bounded walk.
- Let deep mode spend up to 20 seconds on one cold optional import; the normal five-second shared deadline remains unchanged.
- Point a normal timed-out result explicitly to `rapid-mlx doctor --deep`.

## Design precedent

Content-addressed caches count their physical blobs once and treat snapshot links as references. Fast diagnostics retain a strict global deadline; an explicitly requested deep pass uses its larger budget to verify cold optional imports instead of reproducing the fast-pass timeout.

## Scope

Only diagnostic measurement, timeout behavior, copy, and focused contracts. No model loading, cache mutation, dependency changes, or repair actions.

## Test plan

- [x] `python3.12 -m pytest -q tests/test_doctor_env_health.py tests/test_doctor_report_contract.py` (333 passed)
- [x] `python3.12 -m ruff check vllm_mlx/doctor/env_health.py tests/test_doctor_env_health.py`
- [x] MZR-3 `doctor --deep`: all vision/audio/embedding imports verified; cache reports 27.8 GB versus 28 GB from `du` (previously 55.6 GB)
- [x] `git diff --check`
