### PR TITLE
fix(audio): restore Silero VAD with qualified runtime

### DIFF
--- a/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
+++ b/apps/rapid-mac/Tests/RapidTests/SidecarBuildScriptTests.swift
@@ -156,7 +156,7 @@ struct SidecarBuildScriptTests {
 
         #expect(pyproject.contains("\naudio-desktop = ["),
                 "The bounded desktop audio dependency group must remain separately installable.")
-        #expect(pyproject.contains(#""mlx-audio>=0.2.9,<0.4.4""#))
+        #expect(pyproject.contains(#""mlx-audio>=0.5.3,<0.6""#))
         #expect(pyproject.contains(#""soundfile>=0.12.0""#))
         #expect(script.contains(#""${RAPID_MLX_INSTALL_TARGET}[audio-desktop]""#),
                 "The desktop sidecar must install the bounded desktop audio dependency set.")

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -210,9 +210,9 @@ Install with: pip install 'rapid-mlx[audio]'
 ## Installation
 
 ```bash
-# Core audio support — stay inside the supported range
-# (mlx-audio 0.4.4 has a Kokoro istftnet regression; the pin excludes it)
-pip install 'mlx-audio>=0.2.9,<0.4.4'
+# Core audio support — 0.5.3 adds the Silero VAD runtime used by Whisper
+# while retaining the Kokoro istftnet fix
+pip install 'mlx-audio>=0.5.3,<0.6'
 
 # Required dependencies for TTS
 pip install sounddevice soundfile scipy misaki spacy num2words phonemizer-fork numba tiktoken loguru
@@ -821,8 +821,8 @@ Tested on Apple M2 Max (32GB).
 pip install 'rapid-mlx[audio]'
 ```
 This installs `mlx-audio` with the supported version pin
-(`mlx-audio>=0.2.9,<0.4.4` — 0.4.4 has a Kokoro istftnet regression that
-breaks every Kokoro request).
+(`mlx-audio>=0.5.3,<0.6`). This range includes the Silero VAD runtime used
+to reject silent Whisper input and excludes the historical Kokoro regression.
 
 ### Model download slow
 Models are downloaded from HuggingFace on first use. Use `huggingface-cli download` to pre-download:
@@ -843,7 +843,6 @@ mlx-audio 0.2.9 exactly had a Kokoro g2p bug: non-English languages
 (Spanish, Chinese, Japanese, etc.) crashed with `ValueError: too many
 values to unpack` because English g2p returned a tuple `(phonemes, tokens)`
 while other languages returned just a string. Newer releases inside the
-supported range (`mlx-audio>=0.2.9,<0.4.4`, e.g. 0.4.3 — what a fresh
-`pip install 'rapid-mlx[audio]'` resolves to) no longer contain the buggy
-unpacking. If you hit this error, upgrade `mlx-audio` within the pinned
-range instead of hand-patching the package.
+supported range (`mlx-audio>=0.5.3,<0.6`) no longer contain the buggy
+unpacking. If you hit this error, upgrade `mlx-audio` within the pinned range
+instead of hand-patching the package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ all = [
     "mlx-embeddings>=0.1.0",
     # dflash (text-only path covered by mlx-vlm above; listed for clarity)
     # audio
-    "mlx-audio>=0.2.9,<0.4.4",
+    "mlx-audio>=0.5.3,<0.6",
     "f5-tts-mlx==0.2.6",
     "sounddevice>=0.4.0",
     "soundfile>=0.12.0",
@@ -303,7 +303,7 @@ test = [
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
     "mlx-vlm==0.6.17; platform_system == 'Darwin'",
-    "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
+    "mlx-audio>=0.5.3,<0.6; platform_system == 'Darwin'",
     # Powers the property-based invariant suite in tests/property/ — encodes
     # numeric/validation invariants over the whole input space (e.g. the
     # #1208-class quantized-KV round-trip bounds) that example tests can't.
@@ -402,7 +402,7 @@ dev = [
     "aiohttp>=3.9.0",
     "pillow>=10.0.0",
     "mlx-vlm==0.6.17; platform_system == 'Darwin'",
-    "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
+    "mlx-audio>=0.5.3,<0.6; platform_system == 'Darwin'",
     # Mirror of the [test] entry — keep `dev` a strict superset of `test`
     # (enforced by tests/test_pr_validate_test_env.py).
     "hypothesis>=6.100.0",
@@ -437,19 +437,11 @@ guided = [
 ]
 # Audio dependencies for TTS/STT (mlx-audio)
 audio = [
-    # R7-H3 (Bo 0.8.8 dogfood): pin BELOW 0.4.4. The 0.4.4 release
-    # regressed ``mlx_audio.tts.models.kokoro.istftnet.SineGen`` so the
-    # internal interpolation step produces an off-by-one length mismatch
-    # versus the noise tensor — every Kokoro request ends with
-    # ``[broadcast_shapes] Shapes (1,36600,1) and (1,36900,9) cannot be
-    # broadcast`` deep inside the istftnet generator. The rapid-mlx
-    # route's catch-all collapsed that into the opaque ``No audio
-    # generated`` 500 (the chunk loop swallowed the upstream raise).
-    # 0.4.3 (and earlier) does NOT have the regression — the same
-    # request returns a 73 KB WAV. Cap the upper bound until upstream
-    # ships a fix so every fresh ``pip install rapid-mlx[audio]``
-    # works out of the box.
-    "mlx-audio>=0.2.9,<0.4.4",
+    # 0.5.3 is the first qualified release that includes the Silero VAD
+    # architecture used by Rapid's Whisper silence guard and also contains
+    # the fix for the 0.4.4 Kokoro istftnet length regression. Keep a minor
+    # cap so audio runtime/API changes are adopted deliberately.
+    "mlx-audio>=0.5.3,<0.6",
     # F5-TTS (pure-MLX, no torch): EN+ZH multilingual + zero-shot voice cloning.
     # Fills the Chinese expressive/cloneable TTS gap. Standalone package (not an
     # mlx_audio family) — wired directly in audio/tts.py's `f5` branch.
@@ -500,7 +492,7 @@ audio = [
 # less capable while preventing the signed app from absorbing llvmlite,
 # spaCy, espeak, and language dictionaries it cannot drive from its UI.
 audio-desktop = [
-    "mlx-audio>=0.2.9,<0.4.4",
+    "mlx-audio>=0.5.3,<0.6",
     # vllm_mlx.audio.tts encodes the in-memory result with libsndfile.
     "soundfile>=0.12.0",
 ]

--- a/scripts/pr_validate/_test_env.py
+++ b/scripts/pr_validate/_test_env.py
@@ -89,7 +89,7 @@ REQUIRED_TEST_PACKAGES: tuple[tuple[str, str, str], ...] = (
     ),
     (
         "mlx_audio",
-        "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
+        "mlx-audio>=0.5.3,<0.6; platform_system == 'Darwin'",
         "audio route tests expect mlx-audio importability",
     ),
 )
@@ -175,7 +175,7 @@ TRUSTED_TEST_PINS: tuple[str, ...] = (
     "aiohttp>=3.9.0,<4",
     "pillow>=10.0.0,<13",
     "mlx-vlm>=0.6.3,<0.7; platform_system == 'Darwin'",
-    "mlx-audio>=0.2.9,<0.4.4; platform_system == 'Darwin'",
+    "mlx-audio>=0.5.3,<0.6; platform_system == 'Darwin'",
 )
 
 

--- a/tests/test_audio_desktop_extra.py
+++ b/tests/test_audio_desktop_extra.py
@@ -29,7 +29,7 @@ def test_audio_desktop_extra_stays_bounded() -> None:
     names = {_dependency_name(spec) for spec in specs}
 
     assert names == {"mlx-audio", "soundfile"}
-    assert "mlx-audio>=0.2.9,<0.4.4" in specs
+    assert "mlx-audio>=0.5.3,<0.6" in specs
     assert "soundfile>=0.12.0" in specs
 
 

--- a/tests/test_audio_r7_c_bundle.py
+++ b/tests/test_audio_r7_c_bundle.py
@@ -9,9 +9,9 @@ Three findings:
   in the upsample interpolation produces ``noise_amp`` shape
   ``(1, 36600, 1)`` while ``sine_waves`` is ``(1, 36900, 9)`` —
   ``noise = noise_amp * mx.random.normal(sine_waves.shape)`` then
-  raises ``[broadcast_shapes] ... cannot be broadcast``. ``mlx-audio
-  ==0.4.3`` does NOT have the regression. Fix pins the dep to
-  ``<0.4.4``. The catch-all also now logs the FULL traceback at
+  raises ``[broadcast_shapes] ... cannot be broadcast``. The original
+  fix pinned below 0.4.4; the current supported line starts at 0.5.3,
+  where the regression is fixed. The catch-all also logs the FULL traceback at
   ``exception`` level so future incidents are diagnosable from the
   operator log (the pre-fix log had only the leaf message).
 
@@ -543,19 +543,18 @@ class TestSpeechCatchAllShape:
 
 
 # ---------------------------------------------------------------------------
-# R7-H3 — pyproject pins mlx-audio<0.4.4
+# R7-H3 — pyproject excludes the broken mlx-audio line
 # ---------------------------------------------------------------------------
 
 
 class TestMlxAudioVersionPin:
-    """The R7-H3 fix is upstream — mlx-audio 0.4.4 broke
-    ``istftnet.SineGen``. Pin the dep below 0.4.4 in pyproject.toml so
-    a fresh ``pip install rapid-mlx[audio]`` doesn't pull the broken
-    release. The test parses pyproject.toml verbatim so a future
-    contributor that loosens the bound trips CI.
+    """The supported line contains both the Kokoro and Silero fixes.
+
+    The test parses pyproject.toml verbatim so a future contributor cannot
+    silently re-admit the broken 0.4.x releases or an unqualified new major.
     """
 
-    def test_mlx_audio_upper_bound_pins_below_0_4_4(self):
+    def test_mlx_audio_pin_starts_at_qualified_0_5_3_line(self):
         from pathlib import Path
 
         try:
@@ -572,13 +571,19 @@ class TestMlxAudioVersionPin:
             f"Expected exactly one mlx-audio pin, found {mlx_audio_specs}"
         )
         spec = mlx_audio_specs[0]
-        # Both the floor AND the upper-bound matter. The floor is
-        # historical; the upper-bound is the R7-H3 fix.
-        assert "<0.4.4" in spec, (
-            f"R7-H3 regression: mlx-audio must be pinned ``<0.4.4`` to "
-            f"avoid the istftnet SineGen broadcast_shapes regression. "
-            f"Current pin: {spec!r}"
+        assert ">=0.5.3" in spec and "<0.6" in spec, (
+            "mlx-audio must retain the qualified 0.5.3 minor line for the "
+            f"Kokoro and Silero fixes; current pin: {spec!r}"
         )
+
+    def test_installed_audio_runtime_contains_silero_vad(self):
+        import importlib.util
+
+        if importlib.util.find_spec("mlx_audio") is None:
+            pytest.skip("audio extra is not installed in this test lane")
+        assert (
+            importlib.util.find_spec("mlx_audio.vad.models.silero_vad") is not None
+        ), "the supported mlx-audio runtime must include the Silero VAD architecture"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor_env_health.py
+++ b/tests/test_doctor_env_health.py
@@ -3190,14 +3190,14 @@ def test_unsupported_mlx_audio_version_marks_warning():
     audio_row = next(c for c in section.checks if "mlx-audio" in c.label)
     assert audio_row.status is eh.CheckStatus.WARN
     assert "0.4.6" in audio_row.label
-    assert "requires mlx-audio>=0.2.9,<0.4.4" in audio_row.label
+    assert "requires mlx-audio>=0.5.3,<0.6" in audio_row.label
 
 
 def test_supported_mlx_audio_version_marks_ok():
     """A version inside the declared audio range remains healthy."""
 
     def fake_ver(dist: str, runtime=None) -> str | None:
-        return "0.4.3" if dist == "mlx-audio" else None
+        return "0.5.3" if dist == "mlx-audio" else None
 
     with (
         mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
@@ -3223,7 +3223,7 @@ def test_healthy_complete_audio_dependency_stack_marks_ok():
     """When every audio dependency imports and mlx-audio is in range, all
     audio rows are OK."""
     with (
-        mock.patch.object(eh, "_safe_version", return_value="0.4.3"),
+        mock.patch.object(eh, "_safe_version", return_value="0.5.3"),
         mock.patch.object(eh, "_module_available", return_value=True),
     ):
         section = eh.section_optional_packages()
@@ -3244,7 +3244,7 @@ def test_incomplete_audio_dependency_import_stack_marks_warning():
     WARN, not OK — the audio feature set is not actually usable."""
 
     def fake_ver(dist: str, runtime=None) -> str | None:
-        return "0.4.3" if dist == "mlx-audio" else None
+        return "0.5.3" if dist == "mlx-audio" else None
 
     with (
         mock.patch.object(eh, "_safe_version", side_effect=fake_ver),
@@ -3266,7 +3266,7 @@ def test_audio_dependency_timeout_is_inconclusive_not_incomplete(monkeypatch):
     runtime = Path(sys.executable)
 
     def fake_ver(dist: str, runtime=None) -> str | None:
-        return "0.4.3" if dist == "mlx-audio" else None
+        return "0.5.3" if dist == "mlx-audio" else None
 
     def module_available(module, _runtime=None, *, real_import=False):
         if module == "f5_tts_mlx":
@@ -3391,7 +3391,7 @@ def test_bundled_sidecar_grades_audio_against_desktop_extra(tmp_path: Path):
     healthy build as incomplete."""
 
     def fake_ver(dist: str, runtime=None) -> str | None:
-        return "0.4.3" if dist == "mlx-audio" else None
+        return "0.5.3" if dist == "mlx-audio" else None
 
     # Everything outside the audio-desktop extra is absent, exactly like the
     # real bundle.
@@ -3572,7 +3572,7 @@ def test_runtime_override_broken_audio_row_uses_the_runtime_hint(tmp_path: Path)
     remediation the user reads is the runtime one, not the app one."""
 
     def fake_ver(dist: str, runtime=None) -> str | None:
-        return "0.4.3" if dist == "mlx-audio" else None
+        return "0.5.3" if dist == "mlx-audio" else None
 
     exe = _stage_sidecar_bundle(tmp_path, slot="runtime-override")
     with (
@@ -3599,7 +3599,7 @@ def test_bundled_sidecar_still_flags_a_genuinely_broken_audio_install(
     missing soundfile is still inside the audio-desktop contract."""
 
     def fake_ver(dist: str, runtime=None) -> str | None:
-        return "0.4.3" if dist == "mlx-audio" else None
+        return "0.5.3" if dist == "mlx-audio" else None
 
     exe = _stage_sidecar_bundle(tmp_path)
     with (

--- a/tests/test_mlx_bound_guard.py
+++ b/tests/test_mlx_bound_guard.py
@@ -78,7 +78,7 @@ class TestExtractMlxBounds:
         }
 
     def test_ignores_non_mlx_and_prefix_lookalikes(self):
-        text = _pp("mlx-audio>=0.2.9,<0.4.4", "transformers<5.13", "mlxfoo==1.0")
+        text = _pp("mlx-audio>=0.5.3,<0.6", "transformers<5.13", "mlxfoo==1.0")
         bounds = guard.extract_mlx_bounds(text)
         assert bounds["mlx"] == set()
         assert bounds["mlx-lm"] == set()

--- a/vllm_mlx/doctor/env_health.py
+++ b/vllm_mlx/doctor/env_health.py
@@ -2345,16 +2345,15 @@ def section_optional_packages() -> Section:
             # respecting Rapid-MLX's supported audio range. Presence alone
             # must not make doctor report that environment as healthy.
             if dist == "mlx-audio" and not (
-                _version_at_least(ver, (0, 2, 9))
-                and not _version_at_least(ver, (0, 4, 4))
+                _version_at_least(ver, (0, 5, 3)) and not _version_at_least(ver, (0, 6))
             ):
                 s.add(
                     f"{label} {ver} unsupported — rapid-mlx requires "
-                    f"mlx-audio>=0.2.9,<0.4.4 (`{hint}`)",
+                    f"mlx-audio>=0.5.3,<0.6 (`{hint}`)",
                     CheckStatus.WARN,
                     detail=(
                         f"distribution={dist} version={ver} "
-                        f"supported=>=0.2.9,<0.4.4 hint={hint}"
+                        f"supported=>=0.5.3,<0.6 hint={hint}"
                     ),
                 )
                 continue


### PR DESCRIPTION
## Why

MZR-3 audio dogfood showed that successful Whisper requests logged `Model type silero_vad not supported for vad`. The supported `mlx-audio` 0.4.3 runtime does not contain the Silero architecture, so Rapid's silence-hallucination guard was not merely noisy: it retried, failed, and fell back on every transcription.

## What

- Move every declared engine, test, development, and Desktop audio surface to the qualified `mlx-audio>=0.5.3,<0.6` line.
- Keep the dependency declarations, doctor compatibility check, validation environment, Desktop build contract, and user documentation synchronized.
- Lock in that the installed audio runtime actually contains the Silero architecture.

## Design precedent

Use the audio runtime's supported VAD loader and model format rather than vendoring or patching a second implementation. The minimum version is the first line qualified here with both the Silero architecture and the historical Kokoro synthesis correction; the minor ceiling keeps later API changes deliberate.

## Scope

Only the audio runtime version contract and its validation/documentation. No STT/TTS route, threshold, model alias, or transcription policy changes.

## Test plan

- [x] MZR-3 real Whisper speech transcription succeeds on 0.5.3
- [x] MZR-3 two-second silent WAV returns empty text through the real Silero guard
- [x] MZR-3 real Kokoro synthesis succeeds: 24 kHz mono, 3.75 seconds, 180,044 bytes
- [x] MZR-3 focused audio suite: 218 passed, 3 skipped; one unrelated existing lane-status assertion also fails on the 0.4.3 control
- [x] Focused dependency/doctor contracts: 38 passed
- [x] No `ERROR`, traceback, or unsupported-VAD log during real speech/silence controls
- [x] Full validator unit suite: 23,966 passed; four-model stress/agent matrix executed successfully. Its performance-only result was intentionally inconclusive because a dependency-changing PR cannot be compared with the validator's source-only base worktree.
- [x] Final dependency-qualified validator run: MERGE-SAFE; 314 targeted and 23,965 full-unit tests passed. The already-recorded four-model matrix was not repeated.
- [x] `git diff --check`
