### PR TITLE
perf(qwen4): submit bounded short forwards per layer

### DIFF
--- a/tests/test_qwen4_eager_dispatch.py
+++ b/tests/test_qwen4_eager_dispatch.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only contracts for short-forward Qwen4 eager dispatch."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from vllm_mlx.models import qwen4_exp
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_eager_dispatch_default_and_small_row_gate(monkeypatch):
+    previous = qwen4_exp.set_qwen4_eager_dispatch(True)
+    try:
+        monkeypatch.setattr(qwen4_exp, "_EAGER_DISPATCH_MAX_ROWS", 64)
+        assert qwen4_exp.qwen4_eager_dispatch_admitted(1, 1)
+        assert qwen4_exp.qwen4_eager_dispatch_admitted(4, 16)
+        assert not qwen4_exp.qwen4_eager_dispatch_admitted(1, 65)
+    finally:
+        qwen4_exp.set_qwen4_eager_dispatch(previous)
+
+
+def test_eager_dispatch_runtime_disable_and_validation():
+    previous = qwen4_exp.set_qwen4_eager_dispatch(False)
+    try:
+        assert not qwen4_exp.qwen4_eager_dispatch_admitted(1, 1)
+        with pytest.raises(TypeError, match="state must be a boolean"):
+            qwen4_exp.set_qwen4_eager_dispatch(1)
+        with pytest.raises(TypeError, match="dimensions must be integers"):
+            qwen4_exp.qwen4_eager_dispatch_admitted(True, 1)
+        with pytest.raises(ValueError, match="dimensions must be positive"):
+            qwen4_exp.qwen4_eager_dispatch_admitted(1, 0)
+    finally:
+        qwen4_exp.set_qwen4_eager_dispatch(previous)
+
+
+def test_decoder_submits_every_admitted_layer_without_host_sync():
+    tree = ast.parse(
+        (ROOT / "vllm_mlx" / "models" / "qwen4_exp.py").read_text(encoding="utf-8")
+    )
+    model_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Qwen4ExpTextModel"
+    )
+    forward = next(
+        node
+        for node in model_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__call__"
+    )
+    calls = [node for node in ast.walk(forward) if isinstance(node, ast.Call)]
+    async_calls = [
+        node
+        for node in calls
+        if isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "mx"
+        and node.func.attr == "async_eval"
+    ]
+    forbidden = [
+        node
+        for node in calls
+        if isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"eval", "item", "tolist"}
+    ]
+
+    assert len(async_calls) == 1
+    assert forbidden == []
+
+
+def test_eager_decoder_forward_is_value_exact_and_submits_each_layer(monkeypatch):
+    class _Layer:
+        is_linear = False
+
+        def __call__(self, hidden, **_kwargs):
+            return hidden + 1
+
+    model = qwen4_exp.Qwen4ExpTextModel.__new__(qwen4_exp.Qwen4ExpTextModel)
+    object.__setattr__(model, "args", SimpleNamespace(hc_count=1))
+    object.__setattr__(model, "embed_tokens", lambda inputs: inputs[..., None])
+    object.__setattr__(model, "layers", [_Layer(), _Layer(), _Layer()])
+    object.__setattr__(model, "hyper_connection_mixer", lambda hidden: hidden)
+
+    original_async_eval = mx.async_eval
+    submitted = []
+
+    def _record_submission(value):
+        submitted.append(value)
+        return original_async_eval(value)
+
+    monkeypatch.setattr(mx, "async_eval", _record_submission)
+    previous_device = mx.default_device()
+    previous_dispatch = qwen4_exp.set_qwen4_eager_dispatch(False)
+    mx.set_default_device(mx.cpu)
+    try:
+        inputs = mx.array([[1]])
+        embeddings = mx.array([[[2.0]]])
+        reference = model(inputs, cache=[None] * 3, input_embeddings=embeddings)
+        assert submitted == []
+
+        qwen4_exp.set_qwen4_eager_dispatch(True)
+        candidate = model(inputs, cache=[None] * 3, input_embeddings=embeddings)
+        mx.eval(reference, candidate)
+
+        assert len(submitted) == 3
+        assert mx.array_equal(reference, candidate).item()
+    finally:
+        qwen4_exp.set_qwen4_eager_dispatch(previous_dispatch)
+        mx.set_default_device(previous_device)

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -66,6 +66,49 @@ _FAST_RMSNORM_DEFAULT = (
     else "stock"
 )
 
+# Submit each short Qwen4 decoder layer as soon as its graph is constructed.
+# This is scheduling-only: ``async_eval`` does not materialize the value on the
+# host or alter the graph result.  The 64-row ceiling deliberately excludes
+# prefill slabs, which already keep the device occupied and do not benefit from
+# per-layer submission.  Enabled by default for the private Rapid lane after
+# the same 48-layer Qwen4 path was qualified bit-exact in mlx-lm-unified;
+# operators retain an immediate fail-open escape hatch.
+_EAGER_DISPATCH = os.environ.get(
+    "RAPID_MLX_QWEN4_EAGER_DISPATCH",
+    os.environ.get("MLX_QWEN4_EAGER_DISPATCH", "1"),
+).strip().lower() in {"1", "true", "yes", "on"}
+_EAGER_DISPATCH_MAX_ROWS = max(
+    1,
+    int(
+        os.environ.get(
+            "RAPID_MLX_QWEN4_EAGER_DISPATCH_MAX_ROWS",
+            os.environ.get("MLX_QWEN4_EAGER_DISPATCH_MAX_ROWS", "64"),
+        )
+    ),
+)
+
+
+def set_qwen4_eager_dispatch(enabled: bool) -> bool:
+    """Set short-forward eager dispatch and return its previous state."""
+    if not isinstance(enabled, bool):
+        raise TypeError("Qwen4 eager dispatch state must be a boolean")
+    global _EAGER_DISPATCH
+    previous = _EAGER_DISPATCH
+    _EAGER_DISPATCH = enabled
+    return previous
+
+
+def qwen4_eager_dispatch_admitted(batch: int, length: int) -> bool:
+    """Return the no-sync admission decision for one decoder forward."""
+    if any(
+        isinstance(value, bool) or not isinstance(value, int)
+        for value in (batch, length)
+    ):
+        raise TypeError("Qwen4 eager dispatch dimensions must be integers")
+    if batch < 1 or length < 1:
+        raise ValueError("Qwen4 eager dispatch dimensions must be positive")
+    return _EAGER_DISPATCH and batch * length <= _EAGER_DISPATCH_MAX_ROWS
+
 
 @dataclass
 class TextModelArgs(BaseModelArgs):
@@ -1890,6 +1933,9 @@ class Qwen4ExpTextModel(nn.Module):
             else cache[attention_index][0]
         )
         attention_mask = create_attention_mask(hidden_states, attention_cache)
+        eager_dispatch = qwen4_eager_dispatch_admitted(
+            int(hidden_states.shape[0]), int(hidden_states.shape[1])
+        )
         for layer, layer_cache in zip(self.layers, cache):
             hidden_states = layer(
                 hidden_states,
@@ -1899,6 +1945,8 @@ class Qwen4ExpTextModel(nn.Module):
                 record_rollback=record_rollback,
                 record_qsa_rollback=record_qsa_rollback,
             )
+            if eager_dispatch:
+                mx.async_eval(hidden_states)
         output = self.hyper_connection_mixer(hidden_states)
         return (output, hidden_states) if return_hidden else output
 


### PR DESCRIPTION
## Why

Short Qwen4 decode forwards can leave device work waiting while Python constructs the next layer. On the composed qualification source, bounded per-layer submission improved median decode from 30.85 to 36.82 tok/s at 16K, 29.75 to 35.22 tok/s at 32K, and 26.73 to 31.32 tok/s at 64K. All 18 fixed-length ABBA cells passed output, memory, exclusivity, engagement, and thermal gates.

## Scope

- Submit each completed Qwen4 layer with `mx.async_eval` when `batch * sequence_length <= 64`.
- Add a process-level setter and `RAPID_MLX_QWEN4_EAGER_DISPATCH=0` opt-out.
- Add four CPU contract tests for defaults, opt-out, admission, and per-layer submission.

## Non-goals

- Server scheduling, compiled replay, cache reuse, and MTP admission.
- Applying eager submission to long prefill forwards.

## Acceptance

- Eligible short forwards submit once per completed layer.
- Ineligible or explicitly disabled forwards retain the existing path.
- Model outputs and cache behavior are unchanged.

## Verification

- `tests/test_qwen4_eager_dispatch.py`: 4 passed on CPU.
- Ruff check and format check pass for both changed files; `git diff --check` passes.
- The isolated PR head has CPU validation. The GPU results above are from composed source `f3e089b5`; executable AST checks match this PR's dispatch gate and model call path to that source.
- Composed-source semantic gates: 8/8 multi-turn pairs and 100/100 domain pairs matched exactly; all 216 responses ended naturally, with no candidate-specific qualitative regression.
- Bounded repository self-validation returned `MERGE-SAFE`: lint passed, and all four targeted failures reproduced on upstream `main`. Automated review, the full unit suite, and stress E2E were explicitly skipped; advisory diff coverage was unavailable because `pytest-cov` is not installed.

## Behaviour delta

Eligible Qwen4 forwards: deferred graph submission → bounded per-layer asynchronous submission by default. Set `RAPID_MLX_QWEN4_EAGER_DISPATCH=0` to retain the previous behavior.

## AI assistance disclosure

Codex generated and reviewed both changed Python files under the contributor's direction. The result was verified with the focused CPU suite, Ruff, diff checks, source-equivalence checks, and the separately identified composed-source GPU and semantic campaign.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Focused tests pass locally (4 tests)
- [x] Ruff check and format check pass
- [x] Critical gate tests cover disabled, ineligible, and eligible production behavior
- [x] No documentation update is required for the bounded internal scheduling change
- [x] No breaking API change
- [x] Bounded repository self-validation returned `MERGE-SAFE`

## Author
