### PR TITLE
fix(mtp): charge resident lanes only for projected cache growth

### DIFF
--- a/tests/test_batched_self_mtp_contract.py
+++ b/tests/test_batched_self_mtp_contract.py
@@ -301,7 +301,9 @@ def test_resident_metadata_preserves_preexisting_positional_lane_signature():
     assert lane.terminal is True
     assert lane.resident_cache is False
     assert lane.estimated_bytes(2) == 50
-    resident = LaneAdmission("resident", 10, 20, sampling, False, True, resident_cache=True)
+    resident = LaneAdmission(
+        "resident", 10, 20, sampling, False, True, resident_cache=True
+    )
     assert resident.sampling is sampling
     assert resident.estimated_bytes(2) == 40
 

--- a/tests/test_batched_self_mtp_contract.py
+++ b/tests/test_batched_self_mtp_contract.py
@@ -293,6 +293,19 @@ def test_lane_metadata_contracts_fail_closed(changes, message):
         LaneAdmission(**values)
 
 
+def test_resident_metadata_preserves_preexisting_positional_lane_signature():
+    sampling = SamplingContract(greedy=False)
+    lane = LaneAdmission("old-caller", 10, 20, sampling, False, True)
+    assert lane.sampling is sampling
+    assert lane.cache_ready is False
+    assert lane.terminal is True
+    assert lane.resident_cache is False
+    assert lane.estimated_bytes(2) == 50
+    resident = LaneAdmission("resident", 10, 20, sampling, False, True, resident_cache=True)
+    assert resident.sampling is sampling
+    assert resident.estimated_bytes(2) == 40
+
+
 def test_terminal_empty_and_plain_on_pressure_routes_are_explicit():
     terminal = assess_lane(
         LaneAdmission("done", terminal=True),

--- a/tests/test_batched_self_mtp_contract.py
+++ b/tests/test_batched_self_mtp_contract.py
@@ -136,6 +136,35 @@ def test_admission_lowers_depth_to_admit_more_lanes():
     assert decision.estimated_bytes == 120
 
 
+def test_resident_cache_is_not_charged_twice_at_cycle_admission():
+    resident = LaneAdmission(
+        "resident",
+        base_bytes=500,
+        bytes_per_draft_token=20,
+        resident_cache=True,
+    )
+    joining = LaneAdmission(
+        "joining",
+        base_bytes=500,
+        bytes_per_draft_token=20,
+    )
+
+    assert resident.estimated_bytes(2) == 40
+    assert joining.estimated_bytes(2) == 540
+
+    decision = plan_admission(
+        [resident, joining],
+        config=_config(min_batch_lanes=1),
+        capabilities=_capabilities(),
+        free_bytes=200,
+    )
+
+    assert decision.route is BatchedMTPRoute.BATCHED_MTP
+    assert decision.batched_lane_ids == ("resident",)
+    assert decision.queued_lane_ids == ("joining",)
+    assert decision.estimated_bytes == 40
+
+
 def test_admission_keeps_ineligible_lanes_plain_and_overflow_queued():
     lanes = [
         LaneAdmission("plain", cache_ready=False),
@@ -254,6 +283,7 @@ def test_sampling_contract_requires_real_booleans(changes):
         ({"base_bytes": True}, "estimates must be integers"),
         ({"bytes_per_draft_token": -1}, "cannot be negative"),
         ({"cache_ready": 1}, "flags must be booleans"),
+        ({"resident_cache": 1}, "flags must be booleans"),
     ],
 )
 def test_lane_metadata_contracts_fail_closed(changes, message):

--- a/tests/test_continuous_mtp_routing.py
+++ b/tests/test_continuous_mtp_routing.py
@@ -1086,11 +1086,23 @@ def test_resident_metadata_preserves_preexisting_positional_request_signature():
     sampling = SamplingContract(greedy=False)
     apc_hit = _apc_hit((1, 2))
     request = ContinuousMTPRequestMetadata(
-        "old-caller", 7, (1, 2), 8, frozenset({9}), sampling, .5,
-        10, 20, False, True, False, True, apc_hit,
+        "old-caller",
+        7,
+        (1, 2),
+        8,
+        frozenset({9}),
+        sampling,
+        0.5,
+        10,
+        20,
+        False,
+        True,
+        False,
+        True,
+        apc_hit,
     )
     assert request.sampling is sampling
-    assert request.temperature == .5
+    assert request.temperature == 0.5
     assert request.base_bytes == 10
     assert request.bytes_per_draft_token == 20
     assert request.cache_ready is False

--- a/tests/test_continuous_mtp_routing.py
+++ b/tests/test_continuous_mtp_routing.py
@@ -1082,6 +1082,25 @@ def test_request_metadata_rejects_ambiguous_scheduler_facts(changes, message):
         ContinuousMTPRequestMetadata(**values)
 
 
+def test_resident_metadata_preserves_preexisting_positional_request_signature():
+    sampling = SamplingContract(greedy=False)
+    apc_hit = _apc_hit((1, 2))
+    request = ContinuousMTPRequestMetadata(
+        "old-caller", 7, (1, 2), 8, frozenset({9}), sampling, .5,
+        10, 20, False, True, False, True, apc_hit,
+    )
+    assert request.sampling is sampling
+    assert request.temperature == .5
+    assert request.base_bytes == 10
+    assert request.bytes_per_draft_token == 20
+    assert request.cache_ready is False
+    assert request.cache_quantized is True
+    assert request.cache_windowed is False
+    assert request.terminal is True
+    assert request.apc_hit is apc_hit
+    assert request.resident_cache is False
+
+
 def test_router_rejects_duplicate_lane_and_uid_identity():
     router = _router()
     with pytest.raises(ValueError, match="lane_id values must be unique"):

--- a/vllm_mlx/scheduler.py
+++ b/vllm_mlx/scheduler.py
@@ -1027,6 +1027,11 @@ def _install_continuous_mtp_router(
             temperature=float(params.temperature),
             base_bytes=sum(int(getattr(cache, "nbytes", 0)) for cache in caches),
             bytes_per_draft_token=0,
+            # Non-empty caches are already represented in the live Metal/RSS
+            # headroom probe. Preserve that ownership fact even though the
+            # current fresh-cohort gate normally refuses such a lane; APC and
+            # future reattach paths may legitimately present one.
+            resident_cache=any(_cache_offset(cache) for cache in caches),
             cache_ready=cache_ready,
             cache_quantized=cache_quantized,
             cache_windowed=cache_windowed,
@@ -1124,6 +1129,7 @@ def _install_continuous_mtp_router(
                 lane_id=metadata.lane_id,
                 base_bytes=metadata.base_bytes,
                 bytes_per_draft_token=metadata.bytes_per_draft_token,
+                resident_cache=metadata.resident_cache,
                 sampling=metadata.sampling,
                 cache_ready=metadata.cache_ready,
                 terminal=False,

--- a/vllm_mlx/spec_decode/mtp/batched.py
+++ b/vllm_mlx/spec_decode/mtp/batched.py
@@ -123,10 +123,11 @@ class LaneAdmission:
     lane_id: str
     base_bytes: int = 0
     bytes_per_draft_token: int = 0
-    resident_cache: bool = False
     sampling: SamplingContract = SamplingContract()
     cache_ready: bool = True
     terminal: bool = False
+    # Append new metadata to preserve the preexisting positional constructor.
+    resident_cache: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.lane_id, str) or not self.lane_id:

--- a/vllm_mlx/spec_decode/mtp/batched.py
+++ b/vllm_mlx/spec_decode/mtp/batched.py
@@ -123,6 +123,7 @@ class LaneAdmission:
     lane_id: str
     base_bytes: int = 0
     bytes_per_draft_token: int = 0
+    resident_cache: bool = False
     sampling: SamplingContract = SamplingContract()
     cache_ready: bool = True
     terminal: bool = False
@@ -137,13 +138,24 @@ class LaneAdmission:
             raise ValueError("lane memory estimates must be integers")
         if self.base_bytes < 0 or self.bytes_per_draft_token < 0:
             raise ValueError("lane memory estimates cannot be negative")
-        if not isinstance(self.cache_ready, bool) or not isinstance(
-            self.terminal, bool
+        if (
+            not isinstance(self.cache_ready, bool)
+            or not isinstance(self.terminal, bool)
+            or not isinstance(self.resident_cache, bool)
         ):
             raise ValueError("lane lifecycle flags must be booleans")
 
     def estimated_bytes(self, draft_tokens: int) -> int:
-        return self.base_bytes + self.bytes_per_draft_token * draft_tokens
+        """Return incremental bytes not already visible in live memory.
+
+        ``free_bytes`` is measured after resident caches have been allocated.
+        Charging ``base_bytes`` again for an active lane can permanently queue
+        the only lane while it waits for itself to free memory.  A new or
+        joining lane still pays the complete base allocation; both pay the
+        next verification transient.
+        """
+        base = 0 if self.resident_cache else self.base_bytes
+        return base + self.bytes_per_draft_token * draft_tokens
 
 
 @dataclass(frozen=True)

--- a/vllm_mlx/spec_decode/mtp/continuous_routing.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_routing.py
@@ -70,6 +70,7 @@ class ContinuousMTPRequestMetadata:
     temperature: float = 0.0
     base_bytes: int = 0
     bytes_per_draft_token: int = 0
+    resident_cache: bool = False
     cache_ready: bool = True
     cache_quantized: bool = False
     cache_windowed: bool = False
@@ -209,6 +210,7 @@ class ContinuousMTPIntegrationRouter:
                     lane_id=request.lane_id,
                     base_bytes=request.base_bytes,
                     bytes_per_draft_token=request.bytes_per_draft_token,
+                    resident_cache=request.resident_cache,
                     sampling=request.sampling,
                     cache_ready=request.cache_ready,
                     terminal=request.terminal,

--- a/vllm_mlx/spec_decode/mtp/continuous_routing.py
+++ b/vllm_mlx/spec_decode/mtp/continuous_routing.py
@@ -70,12 +70,13 @@ class ContinuousMTPRequestMetadata:
     temperature: float = 0.0
     base_bytes: int = 0
     bytes_per_draft_token: int = 0
-    resident_cache: bool = False
     cache_ready: bool = True
     cache_quantized: bool = False
     cache_windowed: bool = False
     terminal: bool = False
     apc_hit: ContinuousMTPAPCHit | None = None
+    # Append new metadata to preserve the preexisting positional constructor.
+    resident_cache: bool = False
 
     def __post_init__(self) -> None:
         if not isinstance(self.uid, int) or isinstance(self.uid, bool):


### PR DESCRIPTION
## Why

Continuous self-MTP can reject a lane whose cache is already resident because admission charges the full cache again even though available memory already accounts for it. This makes warm resident lanes look more expensive than joining lanes.

## Scope

- Track whether the request owns a resident cache through scheduler and routing metadata.
- Charge resident lanes only for projected verification growth.
- Continue charging joining lanes for base cache plus projected growth.
- Preserve positional constructors and the existing single-lane refusal merged in #3350.

## Non-goals

- Expanding supported MTP models or cohort shapes.
- Replacing the conservative full-cache growth estimate with allocator telemetry.
- Claiming a throughput gain from the B1 Qwen4 ladder, which does not exercise multi-lane admission.

## Acceptance

- Resident and joining lanes receive distinct, explicit memory charges.
- Existing callers that construct metadata positionally retain their field mapping.
- #3350's single-lane guard and current routing contracts remain intact.

## Verification

- 187 focused CPU tests passed across admission, routing, scheduler, driver, generation-batch, qualification, and runtime suites.
- Ruff check and format check pass for all five changed files; `git diff --check` passes.
- Tests cover resident versus joining budgets and legacy positional construction.
- Bounded repository self-validation returned `MERGE-SAFE`: lint passed and 213 diff-aware targeted tests passed. Automated review, the full unit suite, and stress E2E were explicitly skipped; advisory diff coverage was unavailable because `pytest-cov` is not installed.

## Behaviour delta

Resident lane admission charge: base cache plus growth → projected growth only. Joining lane admission remains base cache plus projected growth.

## AI assistance disclosure

Codex generated and reviewed all changed Python files under the contributor's direction. The result was verified with 187 focused CPU tests, Ruff, diff checks, and explicit resident/joining accounting cases.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Focused tests pass locally (187 tests)
- [x] Ruff check and format check pass
- [x] Critical scheduler tests cover resident, joining, and positional-constructor regressions
- [x] No documentation update is required for the internal accounting correction
- [x] No breaking API change
- [x] Bounded repository self-validation returned `MERGE-SAFE`

## Author
