### PR TITLE
feat(qwen4): load validated PLE rows from a bounded sidecar

### DIFF
--- a/scripts/test_qwen4_ple_sidecar.py
+++ b/scripts/test_qwen4_ple_sidecar.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Small synthetic sidecars and CPU-only Rapid load/lookup contracts."""
+# ruff: noqa: B023, SIM117
+
 from __future__ import annotations
 
-from contextlib import ExitStack
 import gc
 import hashlib
 import importlib.util
 import json
 import os
-from pathlib import Path
 import signal
 import struct
 import sys
@@ -17,6 +17,8 @@ import threading
 import time
 import unittest
 import weakref
+from contextlib import ExitStack
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -24,276 +26,417 @@ import numpy as np
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
-spec = importlib.util.spec_from_file_location('vllm_mlx.models.qwen4_ple_sidecar', ROOT/'vllm_mlx/models/qwen4_ple_sidecar.py')
+spec = importlib.util.spec_from_file_location(
+    "vllm_mlx.models.qwen4_ple_sidecar", ROOT / "vllm_mlx/models/qwen4_ple_sidecar.py"
+)
 sidecar = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = sidecar
 spec.loader.exec_module(sidecar)
 
 
 def tiny_config():
-    return dict(model_type='qwen4_exp', text_config=dict(hidden_size=8, num_hidden_layers=2,
-        vocab_size=32, num_attention_heads=2, num_key_value_heads=1, head_dim=4,
-        linear_num_key_heads=1, linear_num_value_heads=3, linear_key_head_dim=4,
-        linear_value_head_dim=4, linear_conv_kernel_dim=3, num_experts=4,
-        num_experts_per_tok=2, moe_intermediate_size=4, shared_expert_intermediate_size=4,
-        hc_count=4, hc_lowrank=3, layer_types=['linear_attention','full_attention'],
-        indexer_n_heads=2, indexer_kv_heads=1, indexer_head_dim=4, indexer_budget=8,
-        indexer_compress_ratio=2, ple_layer_ids=[1], eos_token_id=31, ple_embed_dim=32,
-        ngram_size=2, heads_per_ngram=1, ngram_vocab_size_base=7,
-        make_ngram_vocab_size_divisible_by=2, split_ngram_parts=2))
+    return dict(
+        model_type="qwen4_exp",
+        text_config=dict(
+            hidden_size=8,
+            num_hidden_layers=2,
+            vocab_size=32,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=4,
+            linear_num_key_heads=1,
+            linear_num_value_heads=3,
+            linear_key_head_dim=4,
+            linear_value_head_dim=4,
+            linear_conv_kernel_dim=3,
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=4,
+            shared_expert_intermediate_size=4,
+            hc_count=4,
+            hc_lowrank=3,
+            layer_types=["linear_attention", "full_attention"],
+            indexer_n_heads=2,
+            indexer_kv_heads=1,
+            indexer_head_dim=4,
+            indexer_budget=8,
+            indexer_compress_ratio=2,
+            ple_layer_ids=[1],
+            eos_token_id=31,
+            ple_embed_dim=32,
+            ngram_size=2,
+            heads_per_ngram=1,
+            ngram_vocab_size_base=7,
+            make_ngram_vocab_size_divisible_by=2,
+            split_ngram_parts=2,
+        ),
+    )
 
 
 class Artifact:
     def __init__(self, root):
         self.root = Path(root)
-        self.path = self.root / 'ple_rows.bin'
-        self.prefix = 'language_model.model.layers.0.ple.ple_embedding.ngram_embedding'
+        self.path = self.root / "ple_rows.bin"
+        self.prefix = "language_model.model.layers.0.ple.ple_embedding.ngram_embedding"
         rng = np.random.default_rng(9)
         self.words = rng.integers(0, 2**32, (8, 4), dtype=np.uint32)
-        self.scales = np.full((8, 1), 0x3d80, dtype=np.uint16)
-        self.biases = np.full((8, 1), 0xbe00, dtype=np.uint16)
-        self.packed = np.concatenate([self.words.view(np.uint8), self.scales.view(np.uint8), self.biases.view(np.uint8)], axis=1)
+        self.scales = np.full((8, 1), 0x3D80, dtype=np.uint16)
+        self.biases = np.full((8, 1), 0xBE00, dtype=np.uint16)
+        self.packed = np.concatenate(
+            [
+                self.words.view(np.uint8),
+                self.scales.view(np.uint8),
+                self.biases.view(np.uint8),
+            ],
+            axis=1,
+        )
         self.path.write_bytes(self.packed.tobytes())
         self.tensors = {}
-        header, data = {}, b''
+        header, data = {}, b""
         for shard in range(2):
-            for part, array, dtype in [('weight', self.words, 'U32'), ('scales', self.scales, 'BF16'), ('biases', self.biases, 'BF16')]:
-                key = f'{self.prefix}.shard_{shard}.{part}'
-                values = array[shard*4:shard*4+4]
+            for part, array, dtype in [
+                ("weight", self.words, "U32"),
+                ("scales", self.scales, "BF16"),
+                ("biases", self.biases, "BF16"),
+            ]:
+                key = f"{self.prefix}.shard_{shard}.{part}"
+                values = array[shard * 4 : shard * 4 + 4]
                 raw = values.tobytes()
-                header[key] = dict(dtype=dtype, shape=list(values.shape), data_offsets=[len(data), len(data)+len(raw)])
+                header[key] = dict(
+                    dtype=dtype,
+                    shape=list(values.shape),
+                    data_offsets=[len(data), len(data) + len(raw)],
+                )
                 self.tensors[key] = values
                 data += raw
         raw_header = json.dumps(header).encode()
-        (self.root/'model-ple.safetensors').write_bytes(struct.pack('<Q',len(raw_header))+raw_header+data)
-        self.index = {'weight_map': {name:'model-ple.safetensors' for name in header}}
+        (self.root / "model-ple.safetensors").write_bytes(
+            struct.pack("<Q", len(raw_header)) + raw_header + data
+        )
+        self.index = {"weight_map": {name: "model-ple.safetensors" for name in header}}
         self.config = tiny_config()
-        (self.root/'config.json').write_text(json.dumps(self.config))
-        self.manifest = dict(format='qwen4-ple-rows', version=1, tensor_prefix=self.prefix, dims=32,
-            group_size=32,bits=4,mode='affine',weight_bytes=16,scales_bytes=2,biases_bytes=2,
-            row_bytes=20,num_shards=2,rows_per_shard=4,total_rows=8,data_offset=0,
-            shard_sha256=[hashlib.sha256(self.packed[i*4:i*4+4].tobytes()).hexdigest() for i in range(2)])
+        (self.root / "config.json").write_text(json.dumps(self.config))
+        self.manifest = dict(
+            format="qwen4-ple-rows",
+            version=1,
+            tensor_prefix=self.prefix,
+            dims=32,
+            group_size=32,
+            bits=4,
+            mode="affine",
+            weight_bytes=16,
+            scales_bytes=2,
+            biases_bytes=2,
+            row_bytes=20,
+            num_shards=2,
+            rows_per_shard=4,
+            total_rows=8,
+            data_offset=0,
+            shard_sha256=[
+                hashlib.sha256(self.packed[i * 4 : i * 4 + 4].tobytes()).hexdigest()
+                for i in range(2)
+            ],
+        )
         self.save_index()
 
     def save_index(self):
-        blob=json.dumps(self.index).encode()
-        (self.root/'model.safetensors.index.json').write_bytes(blob)
-        self.manifest['source_index_sha256']=hashlib.sha256(blob).hexdigest()
+        blob = json.dumps(self.index).encode()
+        (self.root / "model.safetensors.index.json").write_bytes(blob)
+        self.manifest["source_index_sha256"] = hashlib.sha256(blob).hexdigest()
         self.save_manifest()
 
     def save_manifest(self):
-        Path(str(self.path)+'.manifest.json').write_text(json.dumps(self.manifest))
+        Path(str(self.path) + ".manifest.json").write_text(json.dumps(self.manifest))
 
 
 class SidecarContracts(unittest.TestCase):
     def setUp(self):
-        self.tmp=tempfile.TemporaryDirectory(); self.addCleanup(self.tmp.cleanup)
-        self.a=Artifact(self.tmp.name)
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.a = Artifact(self.tmp.name)
 
     def test_validation_and_exact_integer_affine(self):
-        receipt=sidecar.validate_artifact(self.a.root,self.a.path)
-        self.assertGreaterEqual(receipt['checked_rows'],4)
-        actual=sidecar.dequant_rows_numpy(self.a.packed,32)
-        q=((self.a.words[...,None] >> (np.arange(8,dtype=np.uint32)*4)) &15).reshape(8,32)
+        receipt = sidecar.validate_artifact(self.a.root, self.a.path)
+        self.assertGreaterEqual(receipt["checked_rows"], 4)
+        actual = sidecar.dequant_rows_numpy(self.a.packed, 32)
+        q = (
+            (self.a.words[..., None] >> (np.arange(8, dtype=np.uint32) * 4)) & 15
+        ).reshape(8, 32)
         # All these values are exactly representable; this independent formula
         # uses float64 arithmetic before the final expected BF16 bit view.
-        expected=(q.astype(np.float64)/16-0.125).astype(np.float32).view(np.uint32)
-        self.assertTrue(np.array_equal(actual,(expected>>16).astype(np.uint16)))
+        expected = (
+            (q.astype(np.float64) / 16 - 0.125).astype(np.float32).view(np.uint32)
+        )
+        self.assertTrue(np.array_equal(actual, (expected >> 16).astype(np.uint16)))
 
     def test_nested_load_reader_ownership_and_original_cleanup_exception(self):
-        outer=SimpleNamespace(close=mock.Mock())
-        inner=SimpleNamespace(close=mock.Mock(side_effect=RuntimeError('cleanup failed')))
+        outer = SimpleNamespace(close=mock.Mock())
+        inner = SimpleNamespace(
+            close=mock.Mock(side_effect=RuntimeError("cleanup failed"))
+        )
         with sidecar._bound_load_source(self.a.root):
             sidecar.own_load_reader(outer)
-            with self.assertRaisesRegex(ValueError,'original failure'):
-                with sidecar._bound_load_source(self.a.root/'inner'):
+            with self.assertRaisesRegex(ValueError, "original failure"):
+                with sidecar._bound_load_source(self.a.root / "inner"):
                     sidecar.own_load_reader(inner)
-                    raise ValueError('original failure')
+                    raise ValueError("original failure")
             sidecar.require_load_source(self.a.root)
             outer.close.assert_not_called()
         inner.close.assert_called_once()
         outer.close.assert_not_called()
         self.assertIsNone(sidecar._LOAD_READERS.get())
-        with self.assertRaisesRegex(ValueError,'bound load'):
+        with self.assertRaisesRegex(ValueError, "bound load"):
             sidecar.own_load_reader(outer)
 
     def test_concurrent_load_reader_ownership_is_isolated(self):
-        readers=[SimpleNamespace(close=mock.Mock()),SimpleNamespace(close=mock.Mock())]
-        barrier=threading.Barrier(2)
-        errors=[]
+        readers = [
+            SimpleNamespace(close=mock.Mock()),
+            SimpleNamespace(close=mock.Mock()),
+        ]
+        barrier = threading.Barrier(2)
+        errors = []
+
         def worker(index):
             try:
-                with sidecar._bound_load_source(self.a.root/str(index)):
+                with sidecar._bound_load_source(self.a.root / str(index)):
                     sidecar.own_load_reader(readers[index])
                     barrier.wait(timeout=2)
-                    if index==0: raise ValueError('failed load')
+                    if index == 0:
+                        raise ValueError("failed load")
             except BaseException as exc:
-                errors.append((index,str(exc)))
-        threads=[threading.Thread(target=worker,args=(i,)) for i in range(2)]
-        for thread in threads: thread.start()
-        for thread in threads: thread.join(3)
+                errors.append((index, str(exc)))
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(3)
         self.assertFalse(any(thread.is_alive() for thread in threads))
-        self.assertEqual(errors,[(0,'failed load')])
+        self.assertEqual(errors, [(0, "failed load")])
         readers[0].close.assert_called_once()
         readers[1].close.assert_not_called()
         self.assertIsNone(sidecar._LOAD_READERS.get())
 
     def test_lookup_shape_bounds_close_and_cache(self):
-        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,cache_bytes=2*532)
+        reader = sidecar.PLESidecarReader(self.a.root, self.a.path, cache_bytes=2 * 532)
         self.addCleanup(reader.close)
-        ids=np.array([[0,1,0],[2,7,2]],dtype=np.int64)
-        self.assertTrue(np.array_equal(reader.lookup_bits(ids),sidecar.dequant_rows_numpy(self.a.packed,32)[ids]))
-        reader.lookup_bits(np.array([7],dtype=np.int64))
-        self.assertGreater(reader.stats['cache_hits'],0)
-        self.assertGreater(reader.stats['cache_evictions'],0)
-        self.assertLessEqual(reader.stats['cache_charged_bytes'],2*532)
-        for ids in (np.array([-1]),np.array([8])):
-            with self.assertRaises(IndexError): reader.lookup_bits(ids)
-        with self.assertRaises(ValueError): reader.lookup_bits(np.array([0.5]))
-        self.assertEqual(reader.lookup_bits(np.array([],dtype=np.int64)).shape,(0,32))
+        ids = np.array([[0, 1, 0], [2, 7, 2]], dtype=np.int64)
+        self.assertTrue(
+            np.array_equal(
+                reader.lookup_bits(ids),
+                sidecar.dequant_rows_numpy(self.a.packed, 32)[ids],
+            )
+        )
+        reader.lookup_bits(np.array([7], dtype=np.int64))
+        self.assertGreater(reader.stats["cache_hits"], 0)
+        self.assertGreater(reader.stats["cache_evictions"], 0)
+        self.assertLessEqual(reader.stats["cache_charged_bytes"], 2 * 532)
+        for ids in (np.array([-1]), np.array([8])):
+            with self.assertRaises(IndexError):
+                reader.lookup_bits(ids)
+        with self.assertRaises(ValueError):
+            reader.lookup_bits(np.array([0.5]))
+        self.assertEqual(
+            reader.lookup_bits(np.array([], dtype=np.int64)).shape, (0, 32)
+        )
         reader.close()
-        with self.assertRaises(RuntimeError): reader.lookup_bits(np.array([0]))
+        with self.assertRaises(RuntimeError):
+            reader.lookup_bits(np.array([0]))
 
     def test_corrupt_edge_and_index_refused(self):
-        raw=bytearray(self.a.path.read_bytes()); raw[0]^=1; self.a.path.write_bytes(raw)
-        with self.assertRaisesRegex(ValueError,'content mismatch'): sidecar.validate_artifact(self.a.root,self.a.path,random_rows=0)
-        self.a.manifest['source_index_sha256']='0'*64; self.a.save_manifest()
-        with self.assertRaisesRegex(ValueError,'digest'): sidecar.validate_artifact(self.a.root,self.a.path)
+        raw = bytearray(self.a.path.read_bytes())
+        raw[0] ^= 1
+        self.a.path.write_bytes(raw)
+        with self.assertRaisesRegex(ValueError, "content mismatch"):
+            sidecar.validate_artifact(self.a.root, self.a.path, random_rows=0)
+        self.a.manifest["source_index_sha256"] = "0" * 64
+        self.a.save_manifest()
+        with self.assertRaisesRegex(ValueError, "digest"):
+            sidecar.validate_artifact(self.a.root, self.a.path)
 
     def test_geometry_dtype_and_missing_source_refused(self):
-        self.a.manifest['row_bytes']=99; self.a.save_manifest()
-        with self.assertRaises(ValueError): sidecar.validate_artifact(self.a.root,self.a.path)
-        self.a.manifest['row_bytes']=20; self.a.index['weight_map'].pop(next(iter(self.a.index['weight_map'])))
+        self.a.manifest["row_bytes"] = 99
+        self.a.save_manifest()
+        with self.assertRaises(ValueError):
+            sidecar.validate_artifact(self.a.root, self.a.path)
+        self.a.manifest["row_bytes"] = 20
+        self.a.index["weight_map"].pop(next(iter(self.a.index["weight_map"])))
         self.a.save_index()
-        with self.assertRaisesRegex(ValueError,'exactly'): sidecar.validate_artifact(self.a.root,self.a.path)
+        with self.assertRaisesRegex(ValueError, "exactly"):
+            sidecar.validate_artifact(self.a.root, self.a.path)
 
     def test_nonfinite_parameters_refused(self):
-        packed=self.a.packed.copy(); packed[0,16:18]=np.array([0x7f80],dtype=np.uint16).view(np.uint8)
-        with self.assertRaisesRegex(ValueError,'nonfinite'): sidecar.dequant_rows_numpy(packed,32)
+        packed = self.a.packed.copy()
+        packed[0, 16:18] = np.array([0x7F80], dtype=np.uint16).view(np.uint8)
+        with self.assertRaisesRegex(ValueError, "nonfinite"):
+            sidecar.dequant_rows_numpy(packed, 32)
 
     def test_reader_detects_changed_file(self):
-        reader=sidecar.PLESidecarReader(self.a.root,self.a.path); self.addCleanup(reader.close)
-        self.a.path.write_bytes(self.a.path.read_bytes()+b'x')
-        with self.assertRaisesRegex(RuntimeError,'changed'): reader.lookup_bits(np.array([0]))
+        reader = sidecar.PLESidecarReader(self.a.root, self.a.path)
+        self.addCleanup(reader.close)
+        self.a.path.write_bytes(self.a.path.read_bytes() + b"x")
+        with self.assertRaisesRegex(RuntimeError, "changed"):
+            reader.lookup_bits(np.array([0]))
 
     def test_atomic_replacement_during_validation_refused(self):
-        original=sidecar.validate_artifact
-        def replace(*args,**kwargs):
-            receipt=original(*args,**kwargs)
-            other=self.a.path.with_suffix('.replacement'); other.write_bytes(self.a.path.read_bytes())
+        original = sidecar.validate_artifact
+
+        def replace(*args, **kwargs):
+            receipt = original(*args, **kwargs)
+            other = self.a.path.with_suffix(".replacement")
+            other.write_bytes(self.a.path.read_bytes())
             other.replace(self.a.path)
             return receipt
-        with mock.patch.object(sidecar,'validate_artifact',side_effect=replace):
-            with self.assertRaisesRegex(RuntimeError,'changed during'): sidecar.PLESidecarReader(self.a.root,self.a.path)
 
-    @unittest.skipUnless(hasattr(os, 'fork'), 'requires POSIX fork')
+        with mock.patch.object(sidecar, "validate_artifact", side_effect=replace):
+            with self.assertRaisesRegex(RuntimeError, "changed during"):
+                sidecar.PLESidecarReader(self.a.root, self.a.path)
+
+    @unittest.skipUnless(hasattr(os, "fork"), "requires POSIX fork")
     def test_forked_reader_refuses_lookup_and_closes_with_inherited_locked_mutex(self):
-        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,random_rows=0,cache_bytes=1064)
+        reader = sidecar.PLESidecarReader(
+            self.a.root, self.a.path, random_rows=0, cache_bytes=1064
+        )
         self.addCleanup(reader.close)
-        ids=np.array([0],dtype=np.int64)
-        expected=reader.lookup_bits(ids)
-        for operation in ('lookup', 'close', 'concurrent_close'):
+        ids = np.array([0], dtype=np.int64)
+        expected = reader.lookup_bits(ids)
+        for operation in ("lookup", "close", "concurrent_close"):
             # Simulate fork while a different parent thread owns the mutex.
             # The parent's lock stays held until the child exits. An alarm is
             # a test failure, never an accepted refusal or an unbounded hang.
             with reader._lock:
-                child=os.fork()
+                child = os.fork()
                 if child == 0:
-                    signal.signal(signal.SIGALRM,lambda *_: os._exit(124))
+                    signal.signal(signal.SIGALRM, lambda *_: os._exit(124))
                     signal.alarm(2)
                     try:
-                        if operation == 'lookup':
+                        if operation == "lookup":
                             try:
                                 reader.lookup_bits(ids)
                             except RuntimeError as exc:
-                                if 'inherited across fork' not in str(exc):
+                                if "inherited across fork" not in str(exc):
                                     os._exit(2)
                             else:
                                 os._exit(3)
-                        elif operation == 'close':
+                        elif operation == "close":
                             reader.close()
                             reader.close()
-                            if reader._fd is not None or reader.stats['cache_rows'] != 0:
+                            if (
+                                reader._fd is not None
+                                or reader.stats["cache_rows"] != 0
+                            ):
                                 os._exit(4)
                         else:
-                            original_close=sidecar.os.close
-                            calls=[]; errors=[]
+                            original_close = sidecar.os.close
+                            calls = []
+                            errors = []
+
                             def delayed_close(fd):
                                 calls.append(fd)
-                                time.sleep(.02)
+                                time.sleep(0.02)
                                 original_close(fd)
+
                             def closer():
-                                try: reader.close()
-                                except BaseException as exc: errors.append(exc)
-                            sidecar.os.close=delayed_close
-                            threads=[threading.Thread(target=closer) for _ in range(2)]
-                            for thread in threads: thread.start()
-                            for thread in threads: thread.join(.5)
-                            if any(thread.is_alive() for thread in threads) or errors or len(calls)!=1:
+                                try:
+                                    reader.close()
+                                except BaseException as exc:
+                                    errors.append(exc)
+
+                            sidecar.os.close = delayed_close
+                            threads = [
+                                threading.Thread(target=closer) for _ in range(2)
+                            ]
+                            for thread in threads:
+                                thread.start()
+                            for thread in threads:
+                                thread.join(0.5)
+                            if (
+                                any(thread.is_alive() for thread in threads)
+                                or errors
+                                or len(calls) != 1
+                            ):
                                 os._exit(6)
                     except BaseException:
                         os._exit(5)
                     os._exit(0)
-                _, status=os.waitpid(child,0)
-            self.assertEqual(os.waitstatus_to_exitcode(status),0,operation)
+                _, status = os.waitpid(child, 0)
+            self.assertEqual(os.waitstatus_to_exitcode(status), 0, operation)
             # Child close must not close the parent's fd or clear its cache.
             os.fstat(reader._fd)
-            self.assertEqual(reader.stats['cache_rows'],1)
-            self.assertTrue(np.array_equal(reader.lookup_bits(ids),expected))
+            self.assertEqual(reader.stats["cache_rows"], 1)
+            self.assertTrue(np.array_equal(reader.lookup_bits(ids), expected))
 
-    @unittest.skipUnless(hasattr(os, 'fork'), 'requires POSIX fork')
+    @unittest.skipUnless(hasattr(os, "fork"), "requires POSIX fork")
     def test_fork_waits_for_parent_descriptor_close_publication(self):
-        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,random_rows=0)
+        reader = sidecar.PLESidecarReader(self.a.root, self.a.path, random_rows=0)
         self.addCleanup(reader.close)
-        closed=threading.Event(); finish=threading.Event()
-        original_close=sidecar.os.close
-        errors=[]
+        closed = threading.Event()
+        finish = threading.Event()
+        original_close = sidecar.os.close
+        errors = []
+
         def delayed_close(fd):
             original_close(fd)
             closed.set()
-            if not finish.wait(2): raise RuntimeError('close publication timeout')
+            if not finish.wait(2):
+                raise RuntimeError("close publication timeout")
+
         def closer():
-            try: reader.close()
-            except BaseException as exc: errors.append(exc)
-        with mock.patch.object(sidecar.os,'close',side_effect=delayed_close):
-            thread=threading.Thread(target=closer); thread.start()
-            self.assertTrue(closed.wait(1))
-            timer=threading.Timer(.05,finish.set); timer.start()
             try:
-                child=os.fork()
-                if child==0:
-                    signal.signal(signal.SIGALRM,lambda *_: os._exit(124)); signal.alarm(2)
+                reader.close()
+            except BaseException as exc:
+                errors.append(exc)
+
+        with mock.patch.object(sidecar.os, "close", side_effect=delayed_close):
+            thread = threading.Thread(target=closer)
+            thread.start()
+            self.assertTrue(closed.wait(1))
+            timer = threading.Timer(0.05, finish.set)
+            timer.start()
+            try:
+                child = os.fork()
+                if child == 0:
+                    signal.signal(signal.SIGALRM, lambda *_: os._exit(124))
+                    signal.alarm(2)
                     # The before-fork resource barrier must wait until the fd
                     # is both closed and published as None, not snapshot stale
                     # fd ownership that could later close an unrelated file.
-                    if reader._fd is not None: os._exit(7)
-                    reader.close(); os._exit(0)
-                _,status=os.waitpid(child,0)
+                    if reader._fd is not None:
+                        os._exit(7)
+                    reader.close()
+                    os._exit(0)
+                _, status = os.waitpid(child, 0)
             finally:
-                finish.set(); thread.join(2); timer.join(2)
+                finish.set()
+                thread.join(2)
+                timer.join(2)
         self.assertFalse(thread.is_alive())
-        self.assertEqual(errors,[])
-        self.assertEqual(os.waitstatus_to_exitcode(status),0)
+        self.assertEqual(errors, [])
+        self.assertEqual(os.waitstatus_to_exitcode(status), 0)
 
-    @unittest.skipUnless(hasattr(os, 'fork'), 'requires POSIX fork')
+    @unittest.skipUnless(hasattr(os, "fork"), "requires POSIX fork")
     def test_resource_guard_allows_cyclic_reader_finalizer_reentrancy(self):
-        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,random_rows=0)
-        reader.cycle=reader
-        fd=reader._fd
-        child=os.fork()
-        if child==0:
-            signal.signal(signal.SIGALRM,lambda *_: os._exit(124)); signal.alarm(2)
-            ref=weakref.ref(reader)
+        reader = sidecar.PLESidecarReader(self.a.root, self.a.path, random_rows=0)
+        reader.cycle = reader
+        fd = reader._fd
+        child = os.fork()
+        if child == 0:
+            signal.signal(signal.SIGALRM, lambda *_: os._exit(124))
+            signal.alarm(2)
+            ref = weakref.ref(reader)
             del reader
             with sidecar._RESOURCE_LOCK:
                 gc.collect()
-            if ref() is not None: os._exit(8)
-            try: os.fstat(fd)
-            except OSError: os._exit(0)
+            if ref() is not None:
+                os._exit(8)
+            try:
+                os.fstat(fd)
+            except OSError:
+                os._exit(0)
             os._exit(9)
         try:
-            _,status=os.waitpid(child,0)
-            self.assertEqual(os.waitstatus_to_exitcode(status),0)
+            _, status = os.waitpid(child, 0)
+            self.assertEqual(os.waitstatus_to_exitcode(status), 0)
             os.fstat(fd)
         finally:
             reader.close()
@@ -304,166 +447,272 @@ class CPULoadContracts(SidecarContracts):
     @classmethod
     def setUpClass(cls):
         import mlx.core as mx
+
         mx.set_default_device(mx.cpu)
-        cls.mx=mx
+        cls.mx = mx
         from vllm_mlx.models import qwen4_exp
-        cls.qwen=qwen4_exp
+
+        cls.qwen = qwen4_exp
 
     def test_full_strict_cpu_loader_removes_all_resident_ple_parameters(self):
         from mlx.utils import tree_flatten
-        from mlx_lm.utils import load_model
-        mx=self.mx
-        base=self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
-        target={key:value for key,value in tree_flatten(base.parameters()) if self.a.prefix not in key}
-        mx.save_safetensors(str(self.a.root/'model-target.safetensors'),target)
-        self.a.index['weight_map'].update({key:'model-target.safetensors' for key in target})
+
+        mx = self.mx
+        base = self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
+        target = {
+            key: value
+            for key, value in tree_flatten(base.parameters())
+            if self.a.prefix not in key
+        }
+        mx.save_safetensors(str(self.a.root / "model-target.safetensors"), target)
+        self.a.index["weight_map"].update(
+            {key: "model-target.safetensors" for key in target}
+        )
         self.a.save_index()
-        self.a.config['model_file']='forbidden.py'
-        (self.a.root/'forbidden.py').write_text("raise RuntimeError('custom model executed')")
-        (self.a.root/'config.json').write_text(json.dumps(self.a.config))
+        self.a.config["model_file"] = "forbidden.py"
+        (self.a.root / "forbidden.py").write_text(
+            "raise RuntimeError('custom model executed')"
+        )
+        (self.a.root / "config.json").write_text(json.dumps(self.a.config))
         from vllm_mlx.models.qwen4_ple_nvme import load_file_backed_qwen4
-        loaded,_=load_file_backed_qwen4(self.a.root,self.a.path,cache_bytes=1064)
-        self.assertIs(type(loaded),self.qwen.Model)
-        flat=tree_flatten(loaded.parameters())
-        self.assertFalse(any(self.a.prefix in key for key,_ in flat))
-        table=loaded.model.layers[0].ple.ple_embedding.ngram_embedding
+
+        loaded, _ = load_file_backed_qwen4(self.a.root, self.a.path, cache_bytes=1064)
+        self.assertIs(type(loaded), self.qwen.Model)
+        flat = tree_flatten(loaded.parameters())
+        self.assertFalse(any(self.a.prefix in key for key, _ in flat))
+        table = loaded.model.layers[0].ple.ple_embedding.ngram_embedding
         self.assertIsNotNone(table._reader._fd)
         self.assertIsNone(sidecar._LOAD_READERS.get())
-        self.assertEqual(table.parameters(),{})
-        self.assertEqual(loaded._ple_offload_receipt['removed_tensors'],6)
-        self.assertEqual(loaded._ple_offload_receipt['resident_ple_tensors'],0)
-        ids=np.array([[0,7,0]],dtype=np.int64)
-        actual=table(mx.array(ids)).view(mx.uint16); mx.eval(actual)
-        self.assertTrue(np.array_equal(np.asarray(actual),sidecar.dequant_rows_numpy(self.a.packed,32)[ids]))
-        table(mx.array([[7]],dtype=mx.int64)); mx.eval(table(mx.array([[7]],dtype=mx.int64)))
-        self.assertGreater(table.stats['cache_hits'],0)
-        self.assertLessEqual(table.stats['cache_charged_bytes'],1064)
+        self.assertEqual(table.parameters(), {})
+        self.assertEqual(loaded._ple_offload_receipt["removed_tensors"], 6)
+        self.assertEqual(loaded._ple_offload_receipt["resident_ple_tensors"], 0)
+        ids = np.array([[0, 7, 0]], dtype=np.int64)
+        actual = table(mx.array(ids)).view(mx.uint16)
+        mx.eval(actual)
+        self.assertTrue(
+            np.array_equal(
+                np.asarray(actual), sidecar.dequant_rows_numpy(self.a.packed, 32)[ids]
+            )
+        )
+        table(mx.array([[7]], dtype=mx.int64))
+        mx.eval(table(mx.array([[7]], dtype=mx.int64)))
+        self.assertGreater(table.stats["cache_hits"], 0)
+        self.assertLessEqual(table.stats["cache_charged_bytes"], 1064)
         table.close()
-        self.assertEqual(mx.default_device(),mx.cpu)
+        self.assertEqual(mx.default_device(), mx.cpu)
 
     def test_strict_load_failure_closes_reader_even_with_retained_traceback(self):
         from mlx.utils import tree_flatten
+
         from vllm_mlx.models import qwen4_ple_nvme as adapter
-        mx=self.mx
-        model=self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
-        target={key:value for key,value in tree_flatten(model.parameters()) if self.a.prefix not in key}
-        target.pop('language_model.model.embed_tokens.weight')
-        mx.save_safetensors(str(self.a.root/'model-target.safetensors'),target)
-        self.a.index['weight_map'].update({key:'model-target.safetensors' for key in target})
+
+        mx = self.mx
+        model = self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
+        target = {
+            key: value
+            for key, value in tree_flatten(model.parameters())
+            if self.a.prefix not in key
+        }
+        target.pop("language_model.model.embed_tokens.weight")
+        mx.save_safetensors(str(self.a.root / "model-target.safetensors"), target)
+        self.a.index["weight_map"].update(
+            {key: "model-target.safetensors" for key in target}
+        )
         self.a.save_index()
-        refs=[]; original_reader=adapter.PLESidecarReader
-        def track(*args,**kwargs):
-            reader=original_reader(*args,**kwargs)
+        refs = []
+        original_reader = adapter.PLESidecarReader
+
+        def track(*args, **kwargs):
+            reader = original_reader(*args, **kwargs)
             refs.append(weakref.ref(reader))
             return reader
-        held_error=None
-        with mock.patch.object(adapter,'PLESidecarReader',side_effect=track):
+
+        held_error = None
+        with mock.patch.object(adapter, "PLESidecarReader", side_effect=track):
             try:
-                adapter.load_file_backed_qwen4(self.a.root,self.a.path)
+                adapter.load_file_backed_qwen4(self.a.root, self.a.path)
             except ValueError as exc:
-                held_error=exc
+                held_error = exc
         self.assertIsNotNone(held_error)
-        self.assertIn('embed_tokens.weight',str(held_error))
-        reader=refs[0]()
+        self.assertIn("embed_tokens.weight", str(held_error))
+        reader = refs[0]()
         self.assertIsNotNone(reader)  # retained partial model in traceback
         self.assertIsNone(reader._fd)
-        self.assertEqual(reader.stats['cache_rows'],0)
+        self.assertEqual(reader.stats["cache_rows"], 0)
         self.assertIsNone(sidecar._LOAD_READERS.get())
-        self.assertEqual(mx.default_device(),mx.cpu)
+        self.assertEqual(mx.default_device(), mx.cpu)
 
     def test_loader_identity_failure_remains_inside_reader_ownership_scope(self):
-        from vllm_mlx.models import qwen4_ple_nvme as adapter
         import mlx_lm.utils as utils
-        reader=SimpleNamespace(close=mock.Mock())
-        def wrong_model(*args,**kwargs):
+
+        from vllm_mlx.models import qwen4_ple_nvme as adapter
+
+        reader = SimpleNamespace(close=mock.Mock())
+
+        def wrong_model(*args, **kwargs):
             sidecar.own_load_reader(reader)
-            return SimpleNamespace(),self.a.config
-        with mock.patch.object(utils,'load_model',side_effect=wrong_model):
-            with self.assertRaisesRegex(RuntimeError,'exact vendored'):
-                adapter.load_file_backed_qwen4(self.a.root,self.a.path)
+            return SimpleNamespace(), self.a.config
+
+        with mock.patch.object(utils, "load_model", side_effect=wrong_model):
+            with self.assertRaisesRegex(RuntimeError, "exact vendored"):
+                adapter.load_file_backed_qwen4(self.a.root, self.a.path)
         reader.close.assert_called_once()
 
     def test_installer_cleanup_error_does_not_replace_original_validation_error(self):
         from vllm_mlx.models import qwen4_ple_nvme as adapter
-        model=self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
-        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,random_rows=0)
-        real_close=reader.close
+
+        model = self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
+        reader = sidecar.PLESidecarReader(self.a.root, self.a.path, random_rows=0)
+        real_close = reader.close
         self.addCleanup(real_close)
-        reader.close=mock.Mock(side_effect=OSError('cleanup failed'))
-        with mock.patch.object(adapter,'PLESidecarReader',return_value=reader):
-            with self.assertRaisesRegex(ValueError,'missing or invalid'):
+        reader.close = mock.Mock(side_effect=OSError("cleanup failed"))
+        with mock.patch.object(adapter, "PLESidecarReader", return_value=reader):
+            with self.assertRaisesRegex(ValueError, "missing or invalid"):
                 with sidecar._bound_load_source(self.a.root):
-                    adapter.install_file_backed_ple(model,{},self.a.path,self.a.root)
+                    adapter.install_file_backed_ple(model, {}, self.a.path, self.a.root)
 
     def test_arbitrary_source_override_refused_before_model_construction(self):
-        args=self.qwen.ModelArgs.from_dict(dict(self.a.config,ple_nvme_sidecar=str(self.a.path),
-                                                ple_nvme_model_path=str(self.a.root)))
-        with self.assertRaisesRegex(ValueError,'source must be bound'):
+        args = self.qwen.ModelArgs.from_dict(
+            dict(
+                self.a.config,
+                ple_nvme_sidecar=str(self.a.path),
+                ple_nvme_model_path=str(self.a.root),
+            )
+        )
+        with self.assertRaisesRegex(ValueError, "source must be bound"):
             self.qwen.Model(args)
-        with sidecar._bound_load_source(self.a.root/'different'):
-            with self.assertRaisesRegex(ValueError,'source must be bound'):
+        with sidecar._bound_load_source(self.a.root / "different"):
+            with self.assertRaisesRegex(ValueError, "source must be bound"):
                 self.qwen.Model(args)
 
     def _production_lane(self, stack, *, load_error=None, tokenizer_error=None):
-        from vllm_mlx.utils import tokenizer as loader
-        from vllm_mlx.models import qwen4_ple_nvme as adapter
-        from vllm_mlx import model_aliases
-        from vllm_mlx.utils import chat_template_registry
         import mlx_lm.utils as mlx_utils
-        stack.enter_context(mock.patch.dict('os.environ', {'RAPID_MLX_QWEN4_PLE_NVME':str(self.a.path),
-                                                          'RAPID_MLX_QWEN4_PLE_CACHE_BYTES':'1064'}))
-        stack.enter_context(mock.patch.object(model_aliases,'resolve_profile',return_value=None))
-        for name in ('_resolve_subfolder_checkpoint','_local_snapshot_if_cached'):
-            stack.enter_context(mock.patch.object(loader,name,return_value=str(self.a.root.resolve())))
-        for name in ('validate_local_model_file','_try_inject_mtp_post_load','_apply_chat_template_sidecar',
-                     'augment_eos_token_ids_from_generation_config','repair_byte_level_decoder','_post_load_ubc_evict'):
-            stack.enter_context(mock.patch.object(loader,name))
-        stack.enter_context(mock.patch.object(loader,'_model_requires_remote_code',return_value=False))
-        stack.enter_context(mock.patch.object(loader,'apply_remote_code_policy',return_value=({},False)))
-        stack.enter_context(mock.patch.object(loader,'_neutralize_unbundled_template_types',return_value={}))
-        stack.enter_context(mock.patch.object(chat_template_registry,'resolve_chat_template'))
-        model=SimpleNamespace()
-        safe=stack.enter_context(mock.patch.object(adapter,'load_file_backed_qwen4',
-            return_value=(model,self.a.config),side_effect=load_error))
-        close=stack.enter_context(mock.patch.object(adapter,'close_file_backed_ple'))
-        stack.enter_context(mock.patch.object(mlx_utils,'load_tokenizer',
-            return_value=SimpleNamespace(chat_template='existing'),side_effect=tokenizer_error))
-        fallback=stack.enter_context(mock.patch.object(loader,'_load_model_with_fallback_impl'))
-        return loader,safe,close,fallback,model
+
+        from vllm_mlx import model_aliases
+        from vllm_mlx.models import qwen4_ple_nvme as adapter
+        from vllm_mlx.utils import chat_template_registry
+        from vllm_mlx.utils import tokenizer as loader
+
+        stack.enter_context(
+            mock.patch.dict(
+                "os.environ",
+                {
+                    "RAPID_MLX_QWEN4_PLE_NVME": str(self.a.path),
+                    "RAPID_MLX_QWEN4_PLE_CACHE_BYTES": "1064",
+                },
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(model_aliases, "resolve_profile", return_value=None)
+        )
+        for name in ("_resolve_subfolder_checkpoint", "_local_snapshot_if_cached"):
+            stack.enter_context(
+                mock.patch.object(loader, name, return_value=str(self.a.root.resolve()))
+            )
+        for name in (
+            "validate_local_model_file",
+            "_try_inject_mtp_post_load",
+            "_apply_chat_template_sidecar",
+            "augment_eos_token_ids_from_generation_config",
+            "repair_byte_level_decoder",
+            "_post_load_ubc_evict",
+        ):
+            stack.enter_context(mock.patch.object(loader, name))
+        stack.enter_context(
+            mock.patch.object(loader, "_model_requires_remote_code", return_value=False)
+        )
+        stack.enter_context(
+            mock.patch.object(
+                loader, "apply_remote_code_policy", return_value=({}, False)
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(
+                loader, "_neutralize_unbundled_template_types", return_value={}
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(chat_template_registry, "resolve_chat_template")
+        )
+        model = SimpleNamespace()
+        safe = stack.enter_context(
+            mock.patch.object(
+                adapter,
+                "load_file_backed_qwen4",
+                return_value=(model, self.a.config),
+                side_effect=load_error,
+            )
+        )
+        close = stack.enter_context(mock.patch.object(adapter, "close_file_backed_ple"))
+        stack.enter_context(
+            mock.patch.object(
+                mlx_utils,
+                "load_tokenizer",
+                return_value=SimpleNamespace(chat_template="existing"),
+                side_effect=tokenizer_error,
+            )
+        )
+        fallback = stack.enter_context(
+            mock.patch.object(loader, "_load_model_with_fallback_impl")
+        )
+        return loader, safe, close, fallback, model
 
     def test_production_optin_binds_resolved_source_and_never_falls_back(self):
         with ExitStack() as stack:
-            loader,safe,close,fallback,model=self._production_lane(stack)
-            result=loader.load_model_with_fallback('alias',lazy=True,return_config=True,return_source=True)
-            safe.assert_called_once_with(str(self.a.root.resolve()),str(self.a.path),cache_bytes=1064,lazy=True)
-            self.assertIs(result[0],model)
-            self.assertEqual(result[-1],str(self.a.root.resolve()))
-            fallback.assert_not_called(); close.assert_not_called()
+            loader, safe, close, fallback, model = self._production_lane(stack)
+            result = loader.load_model_with_fallback(
+                "alias", lazy=True, return_config=True, return_source=True
+            )
+            safe.assert_called_once_with(
+                str(self.a.root.resolve()),
+                str(self.a.path),
+                cache_bytes=1064,
+                lazy=True,
+            )
+            self.assertIs(result[0], model)
+            self.assertEqual(result[-1], str(self.a.root.resolve()))
+            fallback.assert_not_called()
+            close.assert_not_called()
         with ExitStack() as stack:
-            loader,safe,close,fallback,model=self._production_lane(stack,load_error=ValueError('invalid sidecar'))
-            with self.assertRaisesRegex(ValueError,'invalid sidecar'):
-                loader.load_model_with_fallback('alias')
+            loader, safe, close, fallback, model = self._production_lane(
+                stack, load_error=ValueError("invalid sidecar")
+            )
+            with self.assertRaisesRegex(ValueError, "invalid sidecar"):
+                loader.load_model_with_fallback("alias")
             fallback.assert_not_called()
 
     def test_production_postload_failure_closes_reader(self):
         with ExitStack() as stack:
-            loader,safe,close,fallback,model=self._production_lane(stack,tokenizer_error=RuntimeError('tokenizer failed'))
-            with self.assertRaisesRegex(RuntimeError,'tokenizer failed'):
-                loader.load_model_with_fallback('alias')
+            loader, safe, close, fallback, model = self._production_lane(
+                stack, tokenizer_error=RuntimeError("tokenizer failed")
+            )
+            with self.assertRaisesRegex(RuntimeError, "tokenizer failed"):
+                loader.load_model_with_fallback("alias")
             close.assert_called_once_with(model)
             fallback.assert_not_called()
 
     def test_bad_sanitized_tensor_refuses_before_replacement(self):
-        mx=self.mx
-        model=self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
-        weights={key.replace('.shard_', '.shards.'): mx.array(values).view(mx.bfloat16) if not key.endswith('.weight') else mx.array(values)
-                 for key,values in self.a.tensors.items()}
+        mx = self.mx
+        model = self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
+        weights = {
+            key.replace(".shard_", ".shards."): mx.array(values).view(mx.bfloat16)
+            if not key.endswith(".weight")
+            else mx.array(values)
+            for key, values in self.a.tensors.items()
+        }
         weights.pop(next(iter(weights)))
         from vllm_mlx.models.qwen4_ple_nvme import install_file_backed_ple
-        with sidecar._bound_load_source(self.a.root), self.assertRaisesRegex(ValueError,'missing or invalid'):
-            install_file_backed_ple(model,weights,self.a.path,self.a.root)
-        self.assertIsInstance(model.model.layers[0].ple.ple_embedding.ngram_embedding,self.qwen.ShardedEmbedding)
+
+        with (
+            sidecar._bound_load_source(self.a.root),
+            self.assertRaisesRegex(ValueError, "missing or invalid"),
+        ):
+            install_file_backed_ple(model, weights, self.a.path, self.a.root)
+        self.assertIsInstance(
+            model.model.layers[0].ple.ple_embedding.ngram_embedding,
+            self.qwen.ShardedEmbedding,
+        )
 
 
-if __name__=='__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_qwen4_ple_sidecar.py
+++ b/scripts/test_qwen4_ple_sidecar.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small synthetic sidecars and CPU-only Rapid load/lookup contracts."""
+from __future__ import annotations
+
+from contextlib import ExitStack
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import struct
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+spec = importlib.util.spec_from_file_location('vllm_mlx.models.qwen4_ple_sidecar', ROOT/'vllm_mlx/models/qwen4_ple_sidecar.py')
+sidecar = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = sidecar
+spec.loader.exec_module(sidecar)
+
+
+def tiny_config():
+    return dict(model_type='qwen4_exp', text_config=dict(hidden_size=8, num_hidden_layers=2,
+        vocab_size=32, num_attention_heads=2, num_key_value_heads=1, head_dim=4,
+        linear_num_key_heads=1, linear_num_value_heads=3, linear_key_head_dim=4,
+        linear_value_head_dim=4, linear_conv_kernel_dim=3, num_experts=4,
+        num_experts_per_tok=2, moe_intermediate_size=4, shared_expert_intermediate_size=4,
+        hc_count=4, hc_lowrank=3, layer_types=['linear_attention','full_attention'],
+        indexer_n_heads=2, indexer_kv_heads=1, indexer_head_dim=4, indexer_budget=8,
+        indexer_compress_ratio=2, ple_layer_ids=[1], eos_token_id=31, ple_embed_dim=32,
+        ngram_size=2, heads_per_ngram=1, ngram_vocab_size_base=7,
+        make_ngram_vocab_size_divisible_by=2, split_ngram_parts=2))
+
+
+class Artifact:
+    def __init__(self, root):
+        self.root = Path(root)
+        self.path = self.root / 'ple_rows.bin'
+        self.prefix = 'language_model.model.layers.0.ple.ple_embedding.ngram_embedding'
+        rng = np.random.default_rng(9)
+        self.words = rng.integers(0, 2**32, (8, 4), dtype=np.uint32)
+        self.scales = np.full((8, 1), 0x3d80, dtype=np.uint16)
+        self.biases = np.full((8, 1), 0xbe00, dtype=np.uint16)
+        self.packed = np.concatenate([self.words.view(np.uint8), self.scales.view(np.uint8), self.biases.view(np.uint8)], axis=1)
+        self.path.write_bytes(self.packed.tobytes())
+        self.tensors = {}
+        header, data = {}, b''
+        for shard in range(2):
+            for part, array, dtype in [('weight', self.words, 'U32'), ('scales', self.scales, 'BF16'), ('biases', self.biases, 'BF16')]:
+                key = f'{self.prefix}.shard_{shard}.{part}'
+                values = array[shard*4:shard*4+4]
+                raw = values.tobytes()
+                header[key] = dict(dtype=dtype, shape=list(values.shape), data_offsets=[len(data), len(data)+len(raw)])
+                self.tensors[key] = values
+                data += raw
+        raw_header = json.dumps(header).encode()
+        (self.root/'model-ple.safetensors').write_bytes(struct.pack('<Q',len(raw_header))+raw_header+data)
+        self.index = {'weight_map': {name:'model-ple.safetensors' for name in header}}
+        self.config = tiny_config()
+        (self.root/'config.json').write_text(json.dumps(self.config))
+        self.manifest = dict(format='qwen4-ple-rows', version=1, tensor_prefix=self.prefix, dims=32,
+            group_size=32,bits=4,mode='affine',weight_bytes=16,scales_bytes=2,biases_bytes=2,
+            row_bytes=20,num_shards=2,rows_per_shard=4,total_rows=8,data_offset=0,
+            shard_sha256=[hashlib.sha256(self.packed[i*4:i*4+4].tobytes()).hexdigest() for i in range(2)])
+        self.save_index()
+
+    def save_index(self):
+        blob=json.dumps(self.index).encode()
+        (self.root/'model.safetensors.index.json').write_bytes(blob)
+        self.manifest['source_index_sha256']=hashlib.sha256(blob).hexdigest()
+        self.save_manifest()
+
+    def save_manifest(self):
+        Path(str(self.path)+'.manifest.json').write_text(json.dumps(self.manifest))
+
+
+class SidecarContracts(unittest.TestCase):
+    def setUp(self):
+        self.tmp=tempfile.TemporaryDirectory(); self.addCleanup(self.tmp.cleanup)
+        self.a=Artifact(self.tmp.name)
+
+    def test_validation_and_exact_integer_affine(self):
+        receipt=sidecar.validate_artifact(self.a.root,self.a.path)
+        self.assertGreaterEqual(receipt['checked_rows'],4)
+        actual=sidecar.dequant_rows_numpy(self.a.packed,32)
+        q=((self.a.words[...,None] >> (np.arange(8,dtype=np.uint32)*4)) &15).reshape(8,32)
+        # All these values are exactly representable; this independent formula
+        # uses float64 arithmetic before the final expected BF16 bit view.
+        expected=(q.astype(np.float64)/16-0.125).astype(np.float32).view(np.uint32)
+        self.assertTrue(np.array_equal(actual,(expected>>16).astype(np.uint16)))
+
+    def test_lookup_shape_bounds_close_and_cache(self):
+        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,cache_bytes=2*532)
+        self.addCleanup(reader.close)
+        ids=np.array([[0,1,0],[2,7,2]],dtype=np.int64)
+        self.assertTrue(np.array_equal(reader.lookup_bits(ids),sidecar.dequant_rows_numpy(self.a.packed,32)[ids]))
+        reader.lookup_bits(np.array([7],dtype=np.int64))
+        self.assertGreater(reader.stats['cache_hits'],0)
+        self.assertGreater(reader.stats['cache_evictions'],0)
+        self.assertLessEqual(reader.stats['cache_charged_bytes'],2*532)
+        for ids in (np.array([-1]),np.array([8])):
+            with self.assertRaises(IndexError): reader.lookup_bits(ids)
+        with self.assertRaises(ValueError): reader.lookup_bits(np.array([0.5]))
+        self.assertEqual(reader.lookup_bits(np.array([],dtype=np.int64)).shape,(0,32))
+        reader.close()
+        with self.assertRaises(RuntimeError): reader.lookup_bits(np.array([0]))
+
+    def test_corrupt_edge_and_index_refused(self):
+        raw=bytearray(self.a.path.read_bytes()); raw[0]^=1; self.a.path.write_bytes(raw)
+        with self.assertRaisesRegex(ValueError,'content mismatch'): sidecar.validate_artifact(self.a.root,self.a.path,random_rows=0)
+        self.a.manifest['source_index_sha256']='0'*64; self.a.save_manifest()
+        with self.assertRaisesRegex(ValueError,'digest'): sidecar.validate_artifact(self.a.root,self.a.path)
+
+    def test_geometry_dtype_and_missing_source_refused(self):
+        self.a.manifest['row_bytes']=99; self.a.save_manifest()
+        with self.assertRaises(ValueError): sidecar.validate_artifact(self.a.root,self.a.path)
+        self.a.manifest['row_bytes']=20; self.a.index['weight_map'].pop(next(iter(self.a.index['weight_map'])))
+        self.a.save_index()
+        with self.assertRaisesRegex(ValueError,'exactly'): sidecar.validate_artifact(self.a.root,self.a.path)
+
+    def test_nonfinite_parameters_refused(self):
+        packed=self.a.packed.copy(); packed[0,16:18]=np.array([0x7f80],dtype=np.uint16).view(np.uint8)
+        with self.assertRaisesRegex(ValueError,'nonfinite'): sidecar.dequant_rows_numpy(packed,32)
+
+    def test_reader_detects_changed_file(self):
+        reader=sidecar.PLESidecarReader(self.a.root,self.a.path); self.addCleanup(reader.close)
+        self.a.path.write_bytes(self.a.path.read_bytes()+b'x')
+        with self.assertRaisesRegex(RuntimeError,'changed'): reader.lookup_bits(np.array([0]))
+
+    def test_atomic_replacement_during_validation_refused(self):
+        original=sidecar.validate_artifact
+        def replace(*args,**kwargs):
+            receipt=original(*args,**kwargs)
+            other=self.a.path.with_suffix('.replacement'); other.write_bytes(self.a.path.read_bytes())
+            other.replace(self.a.path)
+            return receipt
+        with mock.patch.object(sidecar,'validate_artifact',side_effect=replace):
+            with self.assertRaisesRegex(RuntimeError,'changed during'): sidecar.PLESidecarReader(self.a.root,self.a.path)
+
+
+class CPULoadContracts(SidecarContracts):
+    @classmethod
+    def setUpClass(cls):
+        import mlx.core as mx
+        mx.set_default_device(mx.cpu)
+        cls.mx=mx
+        from vllm_mlx.models import qwen4_exp
+        cls.qwen=qwen4_exp
+
+    def test_full_strict_cpu_loader_removes_all_resident_ple_parameters(self):
+        from mlx.utils import tree_flatten
+        from mlx_lm.utils import load_model
+        mx=self.mx
+        base=self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
+        target={key:value for key,value in tree_flatten(base.parameters()) if self.a.prefix not in key}
+        mx.save_safetensors(str(self.a.root/'model-target.safetensors'),target)
+        self.a.index['weight_map'].update({key:'model-target.safetensors' for key in target})
+        self.a.save_index()
+        self.a.config['model_file']='forbidden.py'
+        (self.a.root/'forbidden.py').write_text("raise RuntimeError('custom model executed')")
+        (self.a.root/'config.json').write_text(json.dumps(self.a.config))
+        from vllm_mlx.models.qwen4_ple_nvme import load_file_backed_qwen4
+        loaded,_=load_file_backed_qwen4(self.a.root,self.a.path,cache_bytes=1064)
+        self.assertIs(type(loaded),self.qwen.Model)
+        flat=tree_flatten(loaded.parameters())
+        self.assertFalse(any(self.a.prefix in key for key,_ in flat))
+        table=loaded.model.layers[0].ple.ple_embedding.ngram_embedding
+        self.assertEqual(table.parameters(),{})
+        self.assertEqual(loaded._ple_offload_receipt['removed_tensors'],6)
+        self.assertEqual(loaded._ple_offload_receipt['resident_ple_tensors'],0)
+        ids=np.array([[0,7,0]],dtype=np.int64)
+        actual=table(mx.array(ids)).view(mx.uint16); mx.eval(actual)
+        self.assertTrue(np.array_equal(np.asarray(actual),sidecar.dequant_rows_numpy(self.a.packed,32)[ids]))
+        table(mx.array([[7]],dtype=mx.int64)); mx.eval(table(mx.array([[7]],dtype=mx.int64)))
+        self.assertGreater(table.stats['cache_hits'],0)
+        self.assertLessEqual(table.stats['cache_charged_bytes'],1064)
+        table.close()
+        self.assertEqual(mx.default_device(),mx.cpu)
+
+    def test_arbitrary_source_override_refused_before_model_construction(self):
+        args=self.qwen.ModelArgs.from_dict(dict(self.a.config,ple_nvme_sidecar=str(self.a.path),
+                                                ple_nvme_model_path=str(self.a.root)))
+        with self.assertRaisesRegex(ValueError,'source must be bound'):
+            self.qwen.Model(args)
+        with sidecar._bound_load_source(self.a.root/'different'):
+            with self.assertRaisesRegex(ValueError,'source must be bound'):
+                self.qwen.Model(args)
+
+    def _production_lane(self, stack, *, load_error=None, tokenizer_error=None):
+        from vllm_mlx.utils import tokenizer as loader
+        from vllm_mlx.models import qwen4_ple_nvme as adapter
+        from vllm_mlx import model_aliases
+        from vllm_mlx.utils import chat_template_registry
+        import mlx_lm.utils as mlx_utils
+        stack.enter_context(mock.patch.dict('os.environ', {'RAPID_MLX_QWEN4_PLE_NVME':str(self.a.path),
+                                                          'RAPID_MLX_QWEN4_PLE_CACHE_BYTES':'1064'}))
+        stack.enter_context(mock.patch.object(model_aliases,'resolve_profile',return_value=None))
+        for name in ('_resolve_subfolder_checkpoint','_local_snapshot_if_cached'):
+            stack.enter_context(mock.patch.object(loader,name,return_value=str(self.a.root.resolve())))
+        for name in ('validate_local_model_file','_try_inject_mtp_post_load','_apply_chat_template_sidecar',
+                     'augment_eos_token_ids_from_generation_config','repair_byte_level_decoder','_post_load_ubc_evict'):
+            stack.enter_context(mock.patch.object(loader,name))
+        stack.enter_context(mock.patch.object(loader,'_model_requires_remote_code',return_value=False))
+        stack.enter_context(mock.patch.object(loader,'apply_remote_code_policy',return_value=({},False)))
+        stack.enter_context(mock.patch.object(loader,'_neutralize_unbundled_template_types',return_value={}))
+        stack.enter_context(mock.patch.object(chat_template_registry,'resolve_chat_template'))
+        model=SimpleNamespace()
+        safe=stack.enter_context(mock.patch.object(adapter,'load_file_backed_qwen4',
+            return_value=(model,self.a.config),side_effect=load_error))
+        close=stack.enter_context(mock.patch.object(adapter,'close_file_backed_ple'))
+        stack.enter_context(mock.patch.object(mlx_utils,'load_tokenizer',
+            return_value=SimpleNamespace(chat_template='existing'),side_effect=tokenizer_error))
+        fallback=stack.enter_context(mock.patch.object(loader,'_load_model_with_fallback_impl'))
+        return loader,safe,close,fallback,model
+
+    def test_production_optin_binds_resolved_source_and_never_falls_back(self):
+        with ExitStack() as stack:
+            loader,safe,close,fallback,model=self._production_lane(stack)
+            result=loader.load_model_with_fallback('alias',lazy=True,return_config=True,return_source=True)
+            safe.assert_called_once_with(str(self.a.root.resolve()),str(self.a.path),cache_bytes=1064,lazy=True)
+            self.assertIs(result[0],model)
+            self.assertEqual(result[-1],str(self.a.root.resolve()))
+            fallback.assert_not_called(); close.assert_not_called()
+        with ExitStack() as stack:
+            loader,safe,close,fallback,model=self._production_lane(stack,load_error=ValueError('invalid sidecar'))
+            with self.assertRaisesRegex(ValueError,'invalid sidecar'):
+                loader.load_model_with_fallback('alias')
+            fallback.assert_not_called()
+
+    def test_production_postload_failure_closes_reader(self):
+        with ExitStack() as stack:
+            loader,safe,close,fallback,model=self._production_lane(stack,tokenizer_error=RuntimeError('tokenizer failed'))
+            with self.assertRaisesRegex(RuntimeError,'tokenizer failed'):
+                loader.load_model_with_fallback('alias')
+            close.assert_called_once_with(model)
+            fallback.assert_not_called()
+
+    def test_bad_sanitized_tensor_refuses_before_replacement(self):
+        mx=self.mx
+        model=self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
+        weights={key.replace('.shard_', '.shards.'): mx.array(values).view(mx.bfloat16) if not key.endswith('.weight') else mx.array(values)
+                 for key,values in self.a.tensors.items()}
+        weights.pop(next(iter(weights)))
+        from vllm_mlx.models.qwen4_ple_nvme import install_file_backed_ple
+        with sidecar._bound_load_source(self.a.root), self.assertRaisesRegex(ValueError,'missing or invalid'):
+            install_file_backed_ple(model,weights,self.a.path,self.a.root)
+        self.assertIsInstance(model.model.layers[0].ple.ple_embedding.ngram_embedding,self.qwen.ShardedEmbedding)
+
+
+if __name__=='__main__':
+    unittest.main()

--- a/scripts/test_qwen4_ple_sidecar.py
+++ b/scripts/test_qwen4_ple_sidecar.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
+import gc
 import hashlib
 import importlib.util
 import json
+import os
 from pathlib import Path
+import signal
 import struct
 import sys
 import tempfile
+import threading
+import time
 import unittest
+import weakref
 from types import SimpleNamespace
 from unittest import mock
 
@@ -141,6 +147,119 @@ class SidecarContracts(unittest.TestCase):
             return receipt
         with mock.patch.object(sidecar,'validate_artifact',side_effect=replace):
             with self.assertRaisesRegex(RuntimeError,'changed during'): sidecar.PLESidecarReader(self.a.root,self.a.path)
+
+    @unittest.skipUnless(hasattr(os, 'fork'), 'requires POSIX fork')
+    def test_forked_reader_refuses_lookup_and_closes_with_inherited_locked_mutex(self):
+        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,random_rows=0,cache_bytes=1064)
+        self.addCleanup(reader.close)
+        ids=np.array([0],dtype=np.int64)
+        expected=reader.lookup_bits(ids)
+        for operation in ('lookup', 'close', 'concurrent_close'):
+            # Simulate fork while a different parent thread owns the mutex.
+            # The parent's lock stays held until the child exits. An alarm is
+            # a test failure, never an accepted refusal or an unbounded hang.
+            with reader._lock:
+                child=os.fork()
+                if child == 0:
+                    signal.signal(signal.SIGALRM,lambda *_: os._exit(124))
+                    signal.alarm(2)
+                    try:
+                        if operation == 'lookup':
+                            try:
+                                reader.lookup_bits(ids)
+                            except RuntimeError as exc:
+                                if 'inherited across fork' not in str(exc):
+                                    os._exit(2)
+                            else:
+                                os._exit(3)
+                        elif operation == 'close':
+                            reader.close()
+                            reader.close()
+                            if reader._fd is not None or reader.stats['cache_rows'] != 0:
+                                os._exit(4)
+                        else:
+                            original_close=sidecar.os.close
+                            calls=[]; errors=[]
+                            def delayed_close(fd):
+                                calls.append(fd)
+                                time.sleep(.02)
+                                original_close(fd)
+                            def closer():
+                                try: reader.close()
+                                except BaseException as exc: errors.append(exc)
+                            sidecar.os.close=delayed_close
+                            threads=[threading.Thread(target=closer) for _ in range(2)]
+                            for thread in threads: thread.start()
+                            for thread in threads: thread.join(.5)
+                            if any(thread.is_alive() for thread in threads) or errors or len(calls)!=1:
+                                os._exit(6)
+                    except BaseException:
+                        os._exit(5)
+                    os._exit(0)
+                _, status=os.waitpid(child,0)
+            self.assertEqual(os.waitstatus_to_exitcode(status),0,operation)
+            # Child close must not close the parent's fd or clear its cache.
+            os.fstat(reader._fd)
+            self.assertEqual(reader.stats['cache_rows'],1)
+            self.assertTrue(np.array_equal(reader.lookup_bits(ids),expected))
+
+    @unittest.skipUnless(hasattr(os, 'fork'), 'requires POSIX fork')
+    def test_fork_waits_for_parent_descriptor_close_publication(self):
+        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,random_rows=0)
+        self.addCleanup(reader.close)
+        closed=threading.Event(); finish=threading.Event()
+        original_close=sidecar.os.close
+        errors=[]
+        def delayed_close(fd):
+            original_close(fd)
+            closed.set()
+            if not finish.wait(2): raise RuntimeError('close publication timeout')
+        def closer():
+            try: reader.close()
+            except BaseException as exc: errors.append(exc)
+        with mock.patch.object(sidecar.os,'close',side_effect=delayed_close):
+            thread=threading.Thread(target=closer); thread.start()
+            self.assertTrue(closed.wait(1))
+            timer=threading.Timer(.05,finish.set); timer.start()
+            try:
+                child=os.fork()
+                if child==0:
+                    signal.signal(signal.SIGALRM,lambda *_: os._exit(124)); signal.alarm(2)
+                    # The before-fork resource barrier must wait until the fd
+                    # is both closed and published as None, not snapshot stale
+                    # fd ownership that could later close an unrelated file.
+                    if reader._fd is not None: os._exit(7)
+                    reader.close(); os._exit(0)
+                _,status=os.waitpid(child,0)
+            finally:
+                finish.set(); thread.join(2); timer.join(2)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors,[])
+        self.assertEqual(os.waitstatus_to_exitcode(status),0)
+
+    @unittest.skipUnless(hasattr(os, 'fork'), 'requires POSIX fork')
+    def test_resource_guard_allows_cyclic_reader_finalizer_reentrancy(self):
+        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,random_rows=0)
+        reader.cycle=reader
+        fd=reader._fd
+        child=os.fork()
+        if child==0:
+            signal.signal(signal.SIGALRM,lambda *_: os._exit(124)); signal.alarm(2)
+            ref=weakref.ref(reader)
+            del reader
+            with sidecar._RESOURCE_LOCK:
+                gc.collect()
+            if ref() is not None: os._exit(8)
+            try: os.fstat(fd)
+            except OSError: os._exit(0)
+            os._exit(9)
+        try:
+            _,status=os.waitpid(child,0)
+            self.assertEqual(os.waitstatus_to_exitcode(status),0)
+            os.fstat(fd)
+        finally:
+            reader.close()
+            del reader.cycle
 
 
 class CPULoadContracts(SidecarContracts):

--- a/scripts/test_qwen4_ple_sidecar.py
+++ b/scripts/test_qwen4_ple_sidecar.py
@@ -100,6 +100,44 @@ class SidecarContracts(unittest.TestCase):
         expected=(q.astype(np.float64)/16-0.125).astype(np.float32).view(np.uint32)
         self.assertTrue(np.array_equal(actual,(expected>>16).astype(np.uint16)))
 
+    def test_nested_load_reader_ownership_and_original_cleanup_exception(self):
+        outer=SimpleNamespace(close=mock.Mock())
+        inner=SimpleNamespace(close=mock.Mock(side_effect=RuntimeError('cleanup failed')))
+        with sidecar._bound_load_source(self.a.root):
+            sidecar.own_load_reader(outer)
+            with self.assertRaisesRegex(ValueError,'original failure'):
+                with sidecar._bound_load_source(self.a.root/'inner'):
+                    sidecar.own_load_reader(inner)
+                    raise ValueError('original failure')
+            sidecar.require_load_source(self.a.root)
+            outer.close.assert_not_called()
+        inner.close.assert_called_once()
+        outer.close.assert_not_called()
+        self.assertIsNone(sidecar._LOAD_READERS.get())
+        with self.assertRaisesRegex(ValueError,'bound load'):
+            sidecar.own_load_reader(outer)
+
+    def test_concurrent_load_reader_ownership_is_isolated(self):
+        readers=[SimpleNamespace(close=mock.Mock()),SimpleNamespace(close=mock.Mock())]
+        barrier=threading.Barrier(2)
+        errors=[]
+        def worker(index):
+            try:
+                with sidecar._bound_load_source(self.a.root/str(index)):
+                    sidecar.own_load_reader(readers[index])
+                    barrier.wait(timeout=2)
+                    if index==0: raise ValueError('failed load')
+            except BaseException as exc:
+                errors.append((index,str(exc)))
+        threads=[threading.Thread(target=worker,args=(i,)) for i in range(2)]
+        for thread in threads: thread.start()
+        for thread in threads: thread.join(3)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(errors,[(0,'failed load')])
+        readers[0].close.assert_called_once()
+        readers[1].close.assert_not_called()
+        self.assertIsNone(sidecar._LOAD_READERS.get())
+
     def test_lookup_shape_bounds_close_and_cache(self):
         reader=sidecar.PLESidecarReader(self.a.root,self.a.path,cache_bytes=2*532)
         self.addCleanup(reader.close)
@@ -289,6 +327,8 @@ class CPULoadContracts(SidecarContracts):
         flat=tree_flatten(loaded.parameters())
         self.assertFalse(any(self.a.prefix in key for key,_ in flat))
         table=loaded.model.layers[0].ple.ple_embedding.ngram_embedding
+        self.assertIsNotNone(table._reader._fd)
+        self.assertIsNone(sidecar._LOAD_READERS.get())
         self.assertEqual(table.parameters(),{})
         self.assertEqual(loaded._ple_offload_receipt['removed_tensors'],6)
         self.assertEqual(loaded._ple_offload_receipt['resident_ple_tensors'],0)
@@ -300,6 +340,60 @@ class CPULoadContracts(SidecarContracts):
         self.assertLessEqual(table.stats['cache_charged_bytes'],1064)
         table.close()
         self.assertEqual(mx.default_device(),mx.cpu)
+
+    def test_strict_load_failure_closes_reader_even_with_retained_traceback(self):
+        from mlx.utils import tree_flatten
+        from vllm_mlx.models import qwen4_ple_nvme as adapter
+        mx=self.mx
+        model=self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
+        target={key:value for key,value in tree_flatten(model.parameters()) if self.a.prefix not in key}
+        target.pop('language_model.model.embed_tokens.weight')
+        mx.save_safetensors(str(self.a.root/'model-target.safetensors'),target)
+        self.a.index['weight_map'].update({key:'model-target.safetensors' for key in target})
+        self.a.save_index()
+        refs=[]; original_reader=adapter.PLESidecarReader
+        def track(*args,**kwargs):
+            reader=original_reader(*args,**kwargs)
+            refs.append(weakref.ref(reader))
+            return reader
+        held_error=None
+        with mock.patch.object(adapter,'PLESidecarReader',side_effect=track):
+            try:
+                adapter.load_file_backed_qwen4(self.a.root,self.a.path)
+            except ValueError as exc:
+                held_error=exc
+        self.assertIsNotNone(held_error)
+        self.assertIn('embed_tokens.weight',str(held_error))
+        reader=refs[0]()
+        self.assertIsNotNone(reader)  # retained partial model in traceback
+        self.assertIsNone(reader._fd)
+        self.assertEqual(reader.stats['cache_rows'],0)
+        self.assertIsNone(sidecar._LOAD_READERS.get())
+        self.assertEqual(mx.default_device(),mx.cpu)
+
+    def test_loader_identity_failure_remains_inside_reader_ownership_scope(self):
+        from vllm_mlx.models import qwen4_ple_nvme as adapter
+        import mlx_lm.utils as utils
+        reader=SimpleNamespace(close=mock.Mock())
+        def wrong_model(*args,**kwargs):
+            sidecar.own_load_reader(reader)
+            return SimpleNamespace(),self.a.config
+        with mock.patch.object(utils,'load_model',side_effect=wrong_model):
+            with self.assertRaisesRegex(RuntimeError,'exact vendored'):
+                adapter.load_file_backed_qwen4(self.a.root,self.a.path)
+        reader.close.assert_called_once()
+
+    def test_installer_cleanup_error_does_not_replace_original_validation_error(self):
+        from vllm_mlx.models import qwen4_ple_nvme as adapter
+        model=self.qwen.Model(self.qwen.ModelArgs.from_dict(self.a.config))
+        reader=sidecar.PLESidecarReader(self.a.root,self.a.path,random_rows=0)
+        real_close=reader.close
+        self.addCleanup(real_close)
+        reader.close=mock.Mock(side_effect=OSError('cleanup failed'))
+        with mock.patch.object(adapter,'PLESidecarReader',return_value=reader):
+            with self.assertRaisesRegex(ValueError,'missing or invalid'):
+                with sidecar._bound_load_source(self.a.root):
+                    adapter.install_file_backed_ple(model,{},self.a.path,self.a.root)
 
     def test_arbitrary_source_override_refused_before_model_construction(self):
         args=self.qwen.ModelArgs.from_dict(dict(self.a.config,ple_nvme_sidecar=str(self.a.path),

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -221,11 +221,26 @@ class TextModelArgs(BaseModelArgs):
 class ModelArgs(BaseModelArgs):
     model_type: str
     text_config: dict[str, Any]
+    # Per-load options: supplied through mlx-lm model_config, never inferred
+    # from a process-global env flag or persisted into the source artifact.
+    ple_nvme_sidecar: str | None = None
+    ple_nvme_model_path: str | None = None
+    ple_nvme_cache_bytes: int = 0
+
+    def __post_init__(self):
+        if bool(self.ple_nvme_sidecar) != bool(self.ple_nvme_model_path):
+            raise ValueError("PLE offload requires both sidecar and source model path")
+        if any(value is not None and (not isinstance(value, str) or not value)
+               for value in (self.ple_nvme_sidecar, self.ple_nvme_model_path)):
+            raise ValueError("PLE offload paths must be nonempty strings")
+        if isinstance(self.ple_nvme_cache_bytes, bool) or not isinstance(self.ple_nvme_cache_bytes, int) or not 0 <= self.ple_nvme_cache_bytes <= 512 * 1024**2:
+            raise ValueError("PLE row cache must be between0 and512 MiB")
 
     @classmethod
     def from_dict(cls, params):
         if "text_config" not in params:
-            return cls(model_type=params["model_type"], text_config=params)
+            return cls(model_type=params["model_type"], text_config=params,
+                       **{key: params[key] for key in ("ple_nvme_sidecar", "ple_nvme_model_path", "ple_nvme_cache_bytes") if key in params})
         return super().from_dict(params)
 
 
@@ -2026,6 +2041,11 @@ class Model(nn.Module):
         super().__init__()
         self.args = args
         self.model_type = args.model_type
+        if args.ple_nvme_sidecar:
+            from .qwen4_ple_sidecar import require_load_source, validate_artifact
+
+            require_load_source(args.ple_nvme_model_path)
+            validate_artifact(args.ple_nvme_model_path, args.ple_nvme_sidecar)
         self.language_model = TextModel(TextModelArgs.from_dict(args.text_config))
 
     def __call__(
@@ -2067,7 +2087,16 @@ class Model(nn.Module):
             elif not key.startswith("language_model."):
                 key = f"language_model.{key}"
             mapped[key] = value
-        return self.language_model.sanitize(mapped)
+        sanitized = self.language_model.sanitize(mapped)
+        if self.args.ple_nvme_sidecar:
+            from .qwen4_ple_nvme import install_file_backed_ple
+
+            sanitized = install_file_backed_ple(
+                self, sanitized, self.args.ple_nvme_sidecar,
+                self.args.ple_nvme_model_path,
+                cache_bytes=self.args.ple_nvme_cache_bytes,
+            )
+        return sanitized
 
     @property
     def quant_predicate(self):

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -230,17 +230,34 @@ class ModelArgs(BaseModelArgs):
     def __post_init__(self):
         if bool(self.ple_nvme_sidecar) != bool(self.ple_nvme_model_path):
             raise ValueError("PLE offload requires both sidecar and source model path")
-        if any(value is not None and (not isinstance(value, str) or not value)
-               for value in (self.ple_nvme_sidecar, self.ple_nvme_model_path)):
+        if any(
+            value is not None and (not isinstance(value, str) or not value)
+            for value in (self.ple_nvme_sidecar, self.ple_nvme_model_path)
+        ):
             raise ValueError("PLE offload paths must be nonempty strings")
-        if isinstance(self.ple_nvme_cache_bytes, bool) or not isinstance(self.ple_nvme_cache_bytes, int) or not 0 <= self.ple_nvme_cache_bytes <= 512 * 1024**2:
+        if (
+            isinstance(self.ple_nvme_cache_bytes, bool)
+            or not isinstance(self.ple_nvme_cache_bytes, int)
+            or not 0 <= self.ple_nvme_cache_bytes <= 512 * 1024**2
+        ):
             raise ValueError("PLE row cache must be between0 and512 MiB")
 
     @classmethod
     def from_dict(cls, params):
         if "text_config" not in params:
-            return cls(model_type=params["model_type"], text_config=params,
-                       **{key: params[key] for key in ("ple_nvme_sidecar", "ple_nvme_model_path", "ple_nvme_cache_bytes") if key in params})
+            return cls(
+                model_type=params["model_type"],
+                text_config=params,
+                **{
+                    key: params[key]
+                    for key in (
+                        "ple_nvme_sidecar",
+                        "ple_nvme_model_path",
+                        "ple_nvme_cache_bytes",
+                    )
+                    if key in params
+                },
+            )
         return super().from_dict(params)
 
 
@@ -2092,7 +2109,9 @@ class Model(nn.Module):
             from .qwen4_ple_nvme import install_file_backed_ple
 
             sanitized = install_file_backed_ple(
-                self, sanitized, self.args.ple_nvme_sidecar,
+                self,
+                sanitized,
+                self.args.ple_nvme_sidecar,
                 self.args.ple_nvme_model_path,
                 cache_bytes=self.args.ple_nvme_cache_bytes,
             )

--- a/vllm_mlx/models/qwen4_ple_nvme.py
+++ b/vllm_mlx/models/qwen4_ple_nvme.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rapid's parameter-free PLE adapter, installed after sanitize before quantize."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .qwen4_ple_sidecar import (ADAPTER_VERSION, PLESidecarReader, _bound_load_source, require_load_source, validate_artifact)
+
+
+class FileBackedPLEEmbedding(nn.Module):
+    is_file_backed = True
+    adapter_version = ADAPTER_VERSION
+
+    def __init__(self, reader: PLESidecarReader):
+        super().__init__()
+        self._reader = reader
+        self.rows_per_shard = reader.manifest['rows_per_shard']
+        self.dims = reader.manifest['dims']
+
+    @property
+    def stats(self):
+        return self._reader.stats
+
+    def __call__(self, indices):
+        # Rapid retains its existing exact MLX n-gram hashing. Only the table
+        # lookup changes; all selected ids are validated before file access.
+        mx.eval(indices)
+        bits = self._reader.lookup_bits(np.asarray(indices))
+        return mx.array(bits).view(mx.bfloat16)
+
+    def close(self):
+        self._reader.close()
+
+
+def install_file_backed_ple(model, weights: dict, sidecar_path, model_path, *, cache_bytes=0):
+    """Remove exactly one validated set of sanitized shards.N triples.
+
+    This runs from Model.sanitize before mlx-lm quantizes/evaluates parameters.
+    No original shard module or tensor is retained by the replacement reader.
+    """
+    from .qwen4_exp import ShardedEmbedding
+
+    require_load_source(model_path)
+    matches = [(index, layer.ple.ple_embedding)
+               for index, layer in enumerate(model.language_model.model.layers)
+               if getattr(layer, 'ple', None) is not None]
+    if len(matches) != 1:
+        raise ValueError('PLE offload requires exactly one Rapid PLE layer')
+    index, embedding = matches[0]
+    resident = embedding.ngram_embedding
+    if not isinstance(resident, ShardedEmbedding):
+        raise ValueError('PLE load hook requires an unmodified Rapid ShardedEmbedding')
+    reader = PLESidecarReader(model_path, sidecar_path, cache_bytes=cache_bytes)
+    try:
+        manifest = reader.manifest
+        prefix = f'language_model.model.layers.{index}.ple.ple_embedding.ngram_embedding'
+        geometry = (resident.rows_per_shard, len(resident.shards), int(resident.shards[0].weight.shape[-1]))
+        if prefix != manifest['tensor_prefix'] or geometry != (manifest['rows_per_shard'], manifest['num_shards'], manifest['dims']):
+            raise ValueError('PLE sidecar geometry differs from the instantiated Rapid table')
+        expected = {}
+        for shard in range(manifest['num_shards']):
+            if tuple(resident.shards[shard].weight.shape) != (manifest['rows_per_shard'], manifest['dims']):
+                raise ValueError('Rapid PLE shard dimensions are inconsistent')
+            for part, width, dtype in [('weight', manifest['dims'] // 8, mx.uint32),
+                                        ('scales', manifest['dims'] // 32, mx.bfloat16),
+                                        ('biases', manifest['dims'] // 32, mx.bfloat16)]:
+                key = f'{prefix}.shards.{shard}.{part}'
+                value = weights.get(key)
+                if value is None or tuple(value.shape) != (manifest['rows_per_shard'], width) or value.dtype != dtype:
+                    raise ValueError(f'missing or invalid sanitized PLE tensor {key}')
+                expected[key] = True
+        present = {key for key in weights if key.startswith(prefix + '.')}
+        if present != set(expected):
+            raise ValueError('unexpected PLE tensor aliases; refuse partial removal')
+        pruned = {key: value for key, value in weights.items() if key not in expected}
+        replacement = FileBackedPLEEmbedding(reader)
+        if replacement.parameters():
+            raise AssertionError('file-backed PLE replacement owns MLX parameters')
+        embedding.ngram_embedding = replacement
+        model._ple_offload_receipt = dict(reader.receipt, removed_tensors=len(expected), resident_ple_tensors=0,
+                                         cache_max_bytes=cache_bytes)
+        return pruned
+    except BaseException:
+        reader.close()
+        raise
+
+
+def load_file_backed_qwen4(model_path, sidecar_path, *, cache_bytes=0, lazy=False):
+    """Production-accessible strict loader; bind PLE to the actual load source.
+
+    Callers supply one model path. They cannot independently override the PLE
+    source identity. The context is local to this load/thread and never changes
+    mlx-lm classes or global loader functions.
+    """
+    from mlx_lm.utils import load_model
+    from .qwen4_exp import Model, ModelArgs
+
+    if isinstance(cache_bytes, bool) or not isinstance(cache_bytes, int) or not 0 <= cache_bytes <= 512 * 1024**2:
+        raise ValueError('PLE row cache must be between0 and512 MiB')
+    model_path = Path(model_path).resolve()
+    sidecar_path = Path(sidecar_path).resolve()
+    if os.environ.get('MLX_QWEN4_PLE_NVME'):
+        raise ValueError('clear MLX_QWEN4_PLE_NVME for Rapid; use its per-load PLE helper or RAPID_MLX_QWEN4_PLE_NVME')
+    validate_artifact(model_path, sidecar_path)
+    # Both older and newer mlx-lm loaders honor this override before resolving
+    # custom architecture files; force the exact vendored getter on either API.
+    options = dict(ple_nvme_sidecar=str(sidecar_path), ple_nvme_model_path=str(model_path),
+                   ple_nvme_cache_bytes=cache_bytes, model_file=None)
+    with _bound_load_source(model_path):
+        model, config = load_model(model_path, strict=True, lazy=lazy, model_config=options,
+                                   get_model_classes=lambda config: (Model, ModelArgs))
+    if type(model) is not Model or not getattr(model, '_ple_offload_receipt', None):
+        raise RuntimeError('PLE load did not return the exact vendored Rapid model with an offload receipt')
+    return model, config
+
+
+def close_file_backed_ple(model):
+    for _, module in model.named_modules():
+        if isinstance(module, FileBackedPLEEmbedding):
+            module.close()

--- a/vllm_mlx/models/qwen4_ple_nvme.py
+++ b/vllm_mlx/models/qwen4_ple_nvme.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Rapid's parameter-free PLE adapter, installed after sanitize before quantize."""
+
 from __future__ import annotations
 
 import os
@@ -9,7 +10,14 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from .qwen4_ple_sidecar import (ADAPTER_VERSION, PLESidecarReader, _bound_load_source, own_load_reader, require_load_source, validate_artifact)
+from .qwen4_ple_sidecar import (
+    ADAPTER_VERSION,
+    PLESidecarReader,
+    _bound_load_source,
+    own_load_reader,
+    require_load_source,
+    validate_artifact,
+)
 
 
 class FileBackedPLEEmbedding(nn.Module):
@@ -19,8 +27,8 @@ class FileBackedPLEEmbedding(nn.Module):
     def __init__(self, reader: PLESidecarReader):
         super().__init__()
         self._reader = reader
-        self.rows_per_shard = reader.manifest['rows_per_shard']
-        self.dims = reader.manifest['dims']
+        self.rows_per_shard = reader.manifest["rows_per_shard"]
+        self.dims = reader.manifest["dims"]
 
     @property
     def stats(self):
@@ -37,7 +45,9 @@ class FileBackedPLEEmbedding(nn.Module):
         self._reader.close()
 
 
-def install_file_backed_ple(model, weights: dict, sidecar_path, model_path, *, cache_bytes=0):
+def install_file_backed_ple(
+    model, weights: dict, sidecar_path, model_path, *, cache_bytes=0
+):
     """Remove exactly one validated set of sanitized shards.N triples.
 
     This runs from Model.sanitize before mlx-lm quantizes/evaluates parameters.
@@ -46,45 +56,72 @@ def install_file_backed_ple(model, weights: dict, sidecar_path, model_path, *, c
     from .qwen4_exp import ShardedEmbedding
 
     require_load_source(model_path)
-    matches = [(index, layer.ple.ple_embedding)
-               for index, layer in enumerate(model.language_model.model.layers)
-               if getattr(layer, 'ple', None) is not None]
+    matches = [
+        (index, layer.ple.ple_embedding)
+        for index, layer in enumerate(model.language_model.model.layers)
+        if getattr(layer, "ple", None) is not None
+    ]
     if len(matches) != 1:
-        raise ValueError('PLE offload requires exactly one Rapid PLE layer')
+        raise ValueError("PLE offload requires exactly one Rapid PLE layer")
     index, embedding = matches[0]
     resident = embedding.ngram_embedding
     if not isinstance(resident, ShardedEmbedding):
-        raise ValueError('PLE load hook requires an unmodified Rapid ShardedEmbedding')
+        raise ValueError("PLE load hook requires an unmodified Rapid ShardedEmbedding")
     reader = PLESidecarReader(model_path, sidecar_path, cache_bytes=cache_bytes)
     try:
         own_load_reader(reader)
         manifest = reader.manifest
-        prefix = f'language_model.model.layers.{index}.ple.ple_embedding.ngram_embedding'
-        geometry = (resident.rows_per_shard, len(resident.shards), int(resident.shards[0].weight.shape[-1]))
-        if prefix != manifest['tensor_prefix'] or geometry != (manifest['rows_per_shard'], manifest['num_shards'], manifest['dims']):
-            raise ValueError('PLE sidecar geometry differs from the instantiated Rapid table')
+        prefix = (
+            f"language_model.model.layers.{index}.ple.ple_embedding.ngram_embedding"
+        )
+        geometry = (
+            resident.rows_per_shard,
+            len(resident.shards),
+            int(resident.shards[0].weight.shape[-1]),
+        )
+        if prefix != manifest["tensor_prefix"] or geometry != (
+            manifest["rows_per_shard"],
+            manifest["num_shards"],
+            manifest["dims"],
+        ):
+            raise ValueError(
+                "PLE sidecar geometry differs from the instantiated Rapid table"
+            )
         expected = {}
-        for shard in range(manifest['num_shards']):
-            if tuple(resident.shards[shard].weight.shape) != (manifest['rows_per_shard'], manifest['dims']):
-                raise ValueError('Rapid PLE shard dimensions are inconsistent')
-            for part, width, dtype in [('weight', manifest['dims'] // 8, mx.uint32),
-                                        ('scales', manifest['dims'] // 32, mx.bfloat16),
-                                        ('biases', manifest['dims'] // 32, mx.bfloat16)]:
-                key = f'{prefix}.shards.{shard}.{part}'
+        for shard in range(manifest["num_shards"]):
+            if tuple(resident.shards[shard].weight.shape) != (
+                manifest["rows_per_shard"],
+                manifest["dims"],
+            ):
+                raise ValueError("Rapid PLE shard dimensions are inconsistent")
+            for part, width, dtype in [
+                ("weight", manifest["dims"] // 8, mx.uint32),
+                ("scales", manifest["dims"] // 32, mx.bfloat16),
+                ("biases", manifest["dims"] // 32, mx.bfloat16),
+            ]:
+                key = f"{prefix}.shards.{shard}.{part}"
                 value = weights.get(key)
-                if value is None or tuple(value.shape) != (manifest['rows_per_shard'], width) or value.dtype != dtype:
-                    raise ValueError(f'missing or invalid sanitized PLE tensor {key}')
+                if (
+                    value is None
+                    or tuple(value.shape) != (manifest["rows_per_shard"], width)
+                    or value.dtype != dtype
+                ):
+                    raise ValueError(f"missing or invalid sanitized PLE tensor {key}")
                 expected[key] = True
-        present = {key for key in weights if key.startswith(prefix + '.')}
+        present = {key for key in weights if key.startswith(prefix + ".")}
         if present != set(expected):
-            raise ValueError('unexpected PLE tensor aliases; refuse partial removal')
+            raise ValueError("unexpected PLE tensor aliases; refuse partial removal")
         pruned = {key: value for key, value in weights.items() if key not in expected}
         replacement = FileBackedPLEEmbedding(reader)
         if replacement.parameters():
-            raise AssertionError('file-backed PLE replacement owns MLX parameters')
+            raise AssertionError("file-backed PLE replacement owns MLX parameters")
         embedding.ngram_embedding = replacement
-        model._ple_offload_receipt = dict(reader.receipt, removed_tensors=len(expected), resident_ple_tensors=0,
-                                         cache_max_bytes=cache_bytes)
+        model._ple_offload_receipt = dict(
+            reader.receipt,
+            removed_tensors=len(expected),
+            resident_ple_tensors=0,
+            cache_max_bytes=cache_bytes,
+        )
         return pruned
     except BaseException:
         try:
@@ -102,24 +139,42 @@ def load_file_backed_qwen4(model_path, sidecar_path, *, cache_bytes=0, lazy=Fals
     mlx-lm classes or global loader functions.
     """
     from mlx_lm.utils import load_model
+
     from .qwen4_exp import Model, ModelArgs
 
-    if isinstance(cache_bytes, bool) or not isinstance(cache_bytes, int) or not 0 <= cache_bytes <= 512 * 1024**2:
-        raise ValueError('PLE row cache must be between0 and512 MiB')
+    if (
+        isinstance(cache_bytes, bool)
+        or not isinstance(cache_bytes, int)
+        or not 0 <= cache_bytes <= 512 * 1024**2
+    ):
+        raise ValueError("PLE row cache must be between0 and512 MiB")
     model_path = Path(model_path).resolve()
     sidecar_path = Path(sidecar_path).resolve()
-    if os.environ.get('MLX_QWEN4_PLE_NVME'):
-        raise ValueError('clear MLX_QWEN4_PLE_NVME for Rapid; use its per-load PLE helper or RAPID_MLX_QWEN4_PLE_NVME')
+    if os.environ.get("MLX_QWEN4_PLE_NVME"):
+        raise ValueError(
+            "clear MLX_QWEN4_PLE_NVME for Rapid; use its per-load PLE helper or RAPID_MLX_QWEN4_PLE_NVME"
+        )
     validate_artifact(model_path, sidecar_path)
     # Both older and newer mlx-lm loaders honor this override before resolving
     # custom architecture files; force the exact vendored getter on either API.
-    options = dict(ple_nvme_sidecar=str(sidecar_path), ple_nvme_model_path=str(model_path),
-                   ple_nvme_cache_bytes=cache_bytes, model_file=None)
+    options = dict(
+        ple_nvme_sidecar=str(sidecar_path),
+        ple_nvme_model_path=str(model_path),
+        ple_nvme_cache_bytes=cache_bytes,
+        model_file=None,
+    )
     with _bound_load_source(model_path):
-        model, config = load_model(model_path, strict=True, lazy=lazy, model_config=options,
-                                   get_model_classes=lambda config: (Model, ModelArgs))
-        if type(model) is not Model or not getattr(model, '_ple_offload_receipt', None):
-            raise RuntimeError('PLE load did not return the exact vendored Rapid model with an offload receipt')
+        model, config = load_model(
+            model_path,
+            strict=True,
+            lazy=lazy,
+            model_config=options,
+            get_model_classes=lambda config: (Model, ModelArgs),
+        )
+        if type(model) is not Model or not getattr(model, "_ple_offload_receipt", None):
+            raise RuntimeError(
+                "PLE load did not return the exact vendored Rapid model with an offload receipt"
+            )
     return model, config
 
 

--- a/vllm_mlx/models/qwen4_ple_nvme.py
+++ b/vllm_mlx/models/qwen4_ple_nvme.py
@@ -9,7 +9,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from .qwen4_ple_sidecar import (ADAPTER_VERSION, PLESidecarReader, _bound_load_source, require_load_source, validate_artifact)
+from .qwen4_ple_sidecar import (ADAPTER_VERSION, PLESidecarReader, _bound_load_source, own_load_reader, require_load_source, validate_artifact)
 
 
 class FileBackedPLEEmbedding(nn.Module):
@@ -57,6 +57,7 @@ def install_file_backed_ple(model, weights: dict, sidecar_path, model_path, *, c
         raise ValueError('PLE load hook requires an unmodified Rapid ShardedEmbedding')
     reader = PLESidecarReader(model_path, sidecar_path, cache_bytes=cache_bytes)
     try:
+        own_load_reader(reader)
         manifest = reader.manifest
         prefix = f'language_model.model.layers.{index}.ple.ple_embedding.ngram_embedding'
         geometry = (resident.rows_per_shard, len(resident.shards), int(resident.shards[0].weight.shape[-1]))
@@ -86,7 +87,10 @@ def install_file_backed_ple(model, weights: dict, sidecar_path, model_path, *, c
                                          cache_max_bytes=cache_bytes)
         return pruned
     except BaseException:
-        reader.close()
+        try:
+            reader.close()
+        except BaseException:
+            pass
         raise
 
 
@@ -114,8 +118,8 @@ def load_file_backed_qwen4(model_path, sidecar_path, *, cache_bytes=0, lazy=Fals
     with _bound_load_source(model_path):
         model, config = load_model(model_path, strict=True, lazy=lazy, model_config=options,
                                    get_model_classes=lambda config: (Model, ModelArgs))
-    if type(model) is not Model or not getattr(model, '_ple_offload_receipt', None):
-        raise RuntimeError('PLE load did not return the exact vendored Rapid model with an offload receipt')
+        if type(model) is not Model or not getattr(model, '_ple_offload_receipt', None):
+            raise RuntimeError('PLE load did not return the exact vendored Rapid model with an offload receipt')
     return model, config
 
 

--- a/vllm_mlx/models/qwen4_ple_sidecar.py
+++ b/vllm_mlx/models/qwen4_ple_sidecar.py
@@ -24,6 +24,7 @@ import numpy as np
 
 ADAPTER_VERSION = 1
 _LOAD_SOURCE = ContextVar('rapid_qwen4_ple_load_source', default=None)
+_LOAD_READERS = ContextVar('rapid_qwen4_ple_load_readers', default=None)
 # Serialize descriptor publication with fork. Unlike per-reader locks, this
 # mutex is replaced in the child; no callback retains individual readers.
 _RESOURCE_LOCK = threading.RLock()
@@ -50,10 +51,30 @@ if hasattr(os, 'register_at_fork'):
 @contextmanager
 def _bound_load_source(model_path):
     token = _LOAD_SOURCE.set(Path(model_path).resolve())
+    readers = []
+    readers_token = _LOAD_READERS.set(readers)
     try:
         yield
+    except BaseException:
+        # A strict weight-load/evaluation failure may retain the partial model
+        # in its traceback. Release external descriptors now, not at GC time.
+        # Cleanup must never replace the original load exception.
+        for reader in reversed(readers):
+            try:
+                reader.close()
+            except BaseException:
+                pass
+        raise
     finally:
+        _LOAD_READERS.reset(readers_token)
         _LOAD_SOURCE.reset(token)
+
+
+def own_load_reader(reader):
+    readers = _LOAD_READERS.get()
+    if readers is None:
+        raise ValueError('PLE reader requires a bound load ownership scope')
+    readers.append(reader)
 
 
 def require_load_source(model_path):

--- a/vllm_mlx/models/qwen4_ple_sidecar.py
+++ b/vllm_mlx/models/qwen4_ple_sidecar.py
@@ -24,6 +24,27 @@ import numpy as np
 
 ADAPTER_VERSION = 1
 _LOAD_SOURCE = ContextVar('rapid_qwen4_ple_load_source', default=None)
+# Serialize descriptor publication with fork. Unlike per-reader locks, this
+# mutex is replaced in the child; no callback retains individual readers.
+_RESOURCE_LOCK = threading.RLock()
+
+
+def _before_fork():
+    _RESOURCE_LOCK.acquire()
+
+
+def _after_fork_parent():
+    _RESOURCE_LOCK.release()
+
+
+def _after_fork_child():
+    global _RESOURCE_LOCK
+    _RESOURCE_LOCK = threading.RLock()
+
+
+if hasattr(os, 'register_at_fork'):
+    os.register_at_fork(before=_before_fork, after_in_parent=_after_fork_parent,
+                        after_in_child=_after_fork_child)
 
 
 @contextmanager
@@ -207,12 +228,13 @@ class PLESidecarReader:
         before = self._stat_identity(os.stat(sidecar_path))
         self.receipt = validate_artifact(model_path, sidecar_path, random_rows=random_rows)
         self.manifest = self.receipt['manifest']
-        self._fd = os.open(sidecar_path, os.O_RDONLY)
-        self._identity = self._stat_identity(os.fstat(self._fd))
-        if self._identity != before:
-            os.close(self._fd)
-            self._fd = None
-            raise RuntimeError('PLE sidecar changed during validation')
+        with _RESOURCE_LOCK:
+            self._fd = os.open(sidecar_path, os.O_RDONLY)
+            self._identity = self._stat_identity(os.fstat(self._fd))
+            if self._identity != before:
+                os.close(self._fd)
+                self._fd = None
+                raise RuntimeError('PLE sidecar changed during validation')
         self._pid = os.getpid()
         self._lock = threading.Lock()
         self.lookups = self.rows = self.unique_rows = self.bytes_read = 0
@@ -238,18 +260,34 @@ class PLESidecarReader:
         return stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns
 
     def close(self):
+        # A fork can inherit this mutex while a vanished parent thread owns
+        # it. The child's descriptor table and Python cache are private copies;
+        # close that inherited descriptor without touching the parent mutex.
+        if os.getpid() != self._pid:
+            with _RESOURCE_LOCK:
+                if self._fd is not None:
+                    os.close(self._fd)
+                    self._fd = None
+                self._cache.clear()
+            return
         with self._lock:
-            if self._fd is not None:
-                os.close(self._fd)
-                self._fd = None
+            with _RESOURCE_LOCK:
+                if self._fd is not None:
+                    os.close(self._fd)
+                    self._fd = None
             self._cache.clear()
 
     def __del__(self):
-        if getattr(self, '_fd', None) is not None:
-            os.close(self._fd)
-            self._fd = None
+        with _RESOURCE_LOCK:
+            if getattr(self, '_fd', None) is not None:
+                os.close(self._fd)
+                self._fd = None
 
     def lookup_bits(self, indices) -> np.ndarray:
+        # Refuse before acquiring an inherited lock, which may stay locked
+        # forever in a child whose owning parent thread no longer exists.
+        if os.getpid() != self._pid:
+            raise RuntimeError('PLE reader is inherited across fork')
         values = np.asarray(indices)
         if values.dtype.kind not in 'iu':
             raise ValueError('PLE indices must be integers')

--- a/vllm_mlx/models/qwen4_ple_sidecar.py
+++ b/vllm_mlx/models/qwen4_ple_sidecar.py
@@ -6,25 +6,26 @@ qwen4_ple_nvme mechanism. This adapter deliberately retains Rapid's hash path.
 Artifact binding uses the index digest, complete tensor geometry, every shard's
 edge rows and a random row sample; it is not an exhaustive content digest.
 """
+
 from __future__ import annotations
 
-from collections import OrderedDict
-from contextlib import contextmanager
-from contextvars import ContextVar
 import fnmatch
 import hashlib
 import json
 import os
-from pathlib import Path
 import re
 import struct
 import threading
+from collections import OrderedDict
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
 
 import numpy as np
 
 ADAPTER_VERSION = 1
-_LOAD_SOURCE = ContextVar('rapid_qwen4_ple_load_source', default=None)
-_LOAD_READERS = ContextVar('rapid_qwen4_ple_load_readers', default=None)
+_LOAD_SOURCE = ContextVar("rapid_qwen4_ple_load_source", default=None)
+_LOAD_READERS = ContextVar("rapid_qwen4_ple_load_readers", default=None)
 # Serialize descriptor publication with fork. Unlike per-reader locks, this
 # mutex is replaced in the child; no callback retains individual readers.
 _RESOURCE_LOCK = threading.RLock()
@@ -43,9 +44,12 @@ def _after_fork_child():
     _RESOURCE_LOCK = threading.RLock()
 
 
-if hasattr(os, 'register_at_fork'):
-    os.register_at_fork(before=_before_fork, after_in_parent=_after_fork_parent,
-                        after_in_child=_after_fork_child)
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(
+        before=_before_fork,
+        after_in_parent=_after_fork_parent,
+        after_in_child=_after_fork_child,
+    )
 
 
 @contextmanager
@@ -73,88 +77,118 @@ def _bound_load_source(model_path):
 def own_load_reader(reader):
     readers = _LOAD_READERS.get()
     if readers is None:
-        raise ValueError('PLE reader requires a bound load ownership scope')
+        raise ValueError("PLE reader requires a bound load ownership scope")
     readers.append(reader)
 
 
 def require_load_source(model_path):
     if _LOAD_SOURCE.get() != Path(model_path).resolve():
-        raise ValueError('PLE source must be bound by load_file_backed_qwen4; arbitrary source overrides are refused')
+        raise ValueError(
+            "PLE source must be bound by load_file_backed_qwen4; arbitrary source overrides are refused"
+        )
 
 
 def _positive_int(value, name, *, zero=False):
-    if isinstance(value, bool) or not isinstance(value, int) or value < (0 if zero else 1):
-        raise ValueError(f'{name} must be a {"nonnegative" if zero else "positive"} integer')
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < (0 if zero else 1)
+    ):
+        raise ValueError(
+            f"{name} must be a {'nonnegative' if zero else 'positive'} integer"
+        )
     return value
 
 
 def load_manifest(sidecar_path) -> dict:
     path = Path(sidecar_path)
-    if fnmatch.fnmatch(path.name, 'model*.safetensors'):
-        raise ValueError('PLE sidecar must not match the model weight-file glob')
-    manifest = json.loads(Path(str(path) + '.manifest.json').read_text())
-    if manifest.get('format') != 'qwen4-ple-rows' or manifest.get('version') != 1:
-        raise ValueError('unsupported PLE sidecar manifest format/version')
-    if {k: manifest.get(k) for k in ('bits', 'group_size', 'mode')} != dict(bits=4, group_size=32, mode='affine'):
-        raise ValueError('PLE sidecar requires affine q4/group32')
-    dims = _positive_int(manifest.get('dims'), 'dims')
+    if fnmatch.fnmatch(path.name, "model*.safetensors"):
+        raise ValueError("PLE sidecar must not match the model weight-file glob")
+    manifest = json.loads(Path(str(path) + ".manifest.json").read_text())
+    if manifest.get("format") != "qwen4-ple-rows" or manifest.get("version") != 1:
+        raise ValueError("unsupported PLE sidecar manifest format/version")
+    if {k: manifest.get(k) for k in ("bits", "group_size", "mode")} != dict(
+        bits=4, group_size=32, mode="affine"
+    ):
+        raise ValueError("PLE sidecar requires affine q4/group32")
+    dims = _positive_int(manifest.get("dims"), "dims")
     if dims % 32:
-        raise ValueError('PLE dimensions must be divisible by32')
-    geometry = dict(weight_bytes=dims // 2, scales_bytes=dims // 16, biases_bytes=dims // 16,
-                    row_bytes=dims // 2 + dims // 8)
+        raise ValueError("PLE dimensions must be divisible by32")
+    geometry = dict(
+        weight_bytes=dims // 2,
+        scales_bytes=dims // 16,
+        biases_bytes=dims // 16,
+        row_bytes=dims // 2 + dims // 8,
+    )
     for name, expected in geometry.items():
         if manifest.get(name) != expected:
-            raise ValueError(f'invalid PLE {name}: expected {expected}')
-    shards = _positive_int(manifest.get('num_shards'), 'num_shards')
-    rows = _positive_int(manifest.get('rows_per_shard'), 'rows_per_shard')
-    if manifest.get('total_rows') != rows * shards:
-        raise ValueError('invalid PLE total row count')
-    offset = _positive_int(manifest.get('data_offset'), 'data_offset', zero=True)
-    digests = manifest.get('shard_sha256', [])
-    if len(digests) != shards or any(not isinstance(d, str) or not re.fullmatch('[0-9a-f]{64}', d) for d in digests):
-        raise ValueError('PLE manifest requires one SHA256 per shard')
-    if path.stat().st_size != offset + rows * shards * geometry['row_bytes']:
-        raise ValueError('PLE sidecar file size differs from manifest')
+            raise ValueError(f"invalid PLE {name}: expected {expected}")
+    shards = _positive_int(manifest.get("num_shards"), "num_shards")
+    rows = _positive_int(manifest.get("rows_per_shard"), "rows_per_shard")
+    if manifest.get("total_rows") != rows * shards:
+        raise ValueError("invalid PLE total row count")
+    offset = _positive_int(manifest.get("data_offset"), "data_offset", zero=True)
+    digests = manifest.get("shard_sha256", [])
+    if len(digests) != shards or any(
+        not isinstance(d, str) or not re.fullmatch("[0-9a-f]{64}", d) for d in digests
+    ):
+        raise ValueError("PLE manifest requires one SHA256 per shard")
+    if path.stat().st_size != offset + rows * shards * geometry["row_bytes"]:
+        raise ValueError("PLE sidecar file size differs from manifest")
     return manifest
 
 
 def _source_refs(model_path: Path, manifest: dict, weight_map: dict) -> dict:
-    prefix = manifest['tensor_prefix']
-    parts = {'weight': ('U32', manifest['dims'] // 8, 4),
-             'scales': ('BF16', manifest['dims'] // 32, 2),
-             'biases': ('BF16', manifest['dims'] // 32, 2)}
-    expected = {f'{prefix}.shard_{i}.{part}' for i in range(manifest['num_shards']) for part in parts}
-    present = {key for key in weight_map if key.startswith(prefix + '.')}
+    prefix = manifest["tensor_prefix"]
+    parts = {
+        "weight": ("U32", manifest["dims"] // 8, 4),
+        "scales": ("BF16", manifest["dims"] // 32, 2),
+        "biases": ("BF16", manifest["dims"] // 32, 2),
+    }
+    expected = {
+        f"{prefix}.shard_{i}.{part}"
+        for i in range(manifest["num_shards"])
+        for part in parts
+    }
+    present = {key for key in weight_map if key.startswith(prefix + ".")}
     if present != expected:
-        raise ValueError('PLE source index does not contain exactly the expected shard triples')
+        raise ValueError(
+            "PLE source index does not contain exactly the expected shard triples"
+        )
     headers, refs = {}, {}
     for name in sorted(expected):
         source = (model_path / weight_map[name]).resolve()
         if not source.is_relative_to(model_path.resolve()):
-            raise ValueError('PLE source tensor path escapes model directory')
+            raise ValueError("PLE source tensor path escapes model directory")
         if source not in headers:
-            with source.open('rb') as stream:
+            with source.open("rb") as stream:
                 raw = stream.read(8)
                 if len(raw) != 8:
-                    raise ValueError('truncated safetensors header length')
-                size = struct.unpack('<Q', raw)[0]
+                    raise ValueError("truncated safetensors header length")
+                size = struct.unpack("<Q", raw)[0]
                 if size > min(source.stat().st_size - 8, 64 * 1024**2):
-                    raise ValueError('invalid safetensors header length')
+                    raise ValueError("invalid safetensors header length")
                 headers[source] = (json.loads(stream.read(size)), 8 + size)
         header, data_start = headers[source]
         info = header.get(name, {})
-        shard, part = name.split('.shard_')[1].split('.')
+        shard, part = name.split(".shard_")[1].split(".")
         dtype, columns, itemsize = parts[part]
-        shape = [manifest['rows_per_shard'], columns]
-        if info.get('dtype') != dtype or info.get('shape') != shape:
-            raise ValueError(f'PLE source dtype/shape mismatch at {name}')
-        offsets = info.get('data_offsets', [])
-        if len(offsets) != 2 or any(isinstance(v, bool) or not isinstance(v, int) for v in offsets):
-            raise ValueError(f'invalid source offsets at {name}')
+        shape = [manifest["rows_per_shard"], columns]
+        if info.get("dtype") != dtype or info.get("shape") != shape:
+            raise ValueError(f"PLE source dtype/shape mismatch at {name}")
+        offsets = info.get("data_offsets", [])
+        if len(offsets) != 2 or any(
+            isinstance(v, bool) or not isinstance(v, int) for v in offsets
+        ):
+            raise ValueError(f"invalid source offsets at {name}")
         start, end = offsets
         row_bytes = columns * itemsize
-        if start < 0 or end - start != shape[0] * row_bytes or data_start + end > source.stat().st_size:
-            raise ValueError(f'PLE source byte range mismatch at {name}')
+        if (
+            start < 0
+            or end - start != shape[0] * row_bytes
+            or data_start + end > source.stat().st_size
+        ):
+            raise ValueError(f"PLE source byte range mismatch at {name}")
         refs[int(shard), part] = (source, data_start + start, row_bytes)
     return refs
 
@@ -163,99 +197,137 @@ def validate_artifact(model_path, sidecar_path, *, random_rows=256) -> dict:
     """Validate before constructing a model or importing MLX."""
     model_path, sidecar_path = Path(model_path).resolve(), Path(sidecar_path).resolve()
     manifest = load_manifest(sidecar_path)
-    index_bytes = (model_path / 'model.safetensors.index.json').read_bytes()
-    if hashlib.sha256(index_bytes).hexdigest() != manifest.get('source_index_sha256'):
-        raise ValueError('PLE sidecar source index digest mismatch')
-    config = json.loads((model_path / 'config.json').read_text())
-    text = config.get('text_config', config)
-    layer_ids = text.get('ple_layer_ids', [])
-    if config.get('model_type') != 'qwen4_exp' or len(layer_ids) != 1:
-        raise ValueError('this PLE loader requires exactly one Qwen4 PLE layer')
-    prefix = f'language_model.model.layers.{layer_ids[0] - 1}.ple.ple_embedding.ngram_embedding'
-    heads = (text.get('ngram_size', 3) - 1) * text.get('heads_per_ngram', 8)
-    embed_dim = text.get('ple_embed_dim')
+    index_bytes = (model_path / "model.safetensors.index.json").read_bytes()
+    if hashlib.sha256(index_bytes).hexdigest() != manifest.get("source_index_sha256"):
+        raise ValueError("PLE sidecar source index digest mismatch")
+    config = json.loads((model_path / "config.json").read_text())
+    text = config.get("text_config", config)
+    layer_ids = text.get("ple_layer_ids", [])
+    if config.get("model_type") != "qwen4_exp" or len(layer_ids) != 1:
+        raise ValueError("this PLE loader requires exactly one Qwen4 PLE layer")
+    prefix = f"language_model.model.layers.{layer_ids[0] - 1}.ple.ple_embedding.ngram_embedding"
+    heads = (text.get("ngram_size", 3) - 1) * text.get("heads_per_ngram", 8)
+    embed_dim = text.get("ple_embed_dim")
     if not isinstance(embed_dim, int) or heads <= 0 or embed_dim % heads:
-        raise ValueError('invalid PLE head/embedding configuration')
-    if manifest['tensor_prefix'] != prefix or manifest['dims'] != embed_dim // heads or manifest['num_shards'] != text.get('split_ngram_parts', 128):
-        raise ValueError('PLE manifest geometry/prefix differs from model config')
-    refs = _source_refs(model_path, manifest, json.loads(index_bytes)['weight_map'])
-    _positive_int(random_rows, 'random_rows', zero=True)
+        raise ValueError("invalid PLE head/embedding configuration")
+    if (
+        manifest["tensor_prefix"] != prefix
+        or manifest["dims"] != embed_dim // heads
+        or manifest["num_shards"] != text.get("split_ngram_parts", 128)
+    ):
+        raise ValueError("PLE manifest geometry/prefix differs from model config")
+    refs = _source_refs(model_path, manifest, json.loads(index_bytes)["weight_map"])
+    _positive_int(random_rows, "random_rows", zero=True)
     if random_rows > 4096:
-        raise ValueError('PLE random validation sample exceeds4096 rows')
-    rows_per_shard = manifest['rows_per_shard']
-    picks = {i * rows_per_shard + edge for i in range(manifest['num_shards']) for edge in (0, rows_per_shard - 1)}
-    picks.update(map(int, np.random.default_rng().integers(0, manifest['total_rows'], size=random_rows)))
+        raise ValueError("PLE random validation sample exceeds4096 rows")
+    rows_per_shard = manifest["rows_per_shard"]
+    picks = {
+        i * rows_per_shard + edge
+        for i in range(manifest["num_shards"])
+        for edge in (0, rows_per_shard - 1)
+    }
+    picks.update(
+        map(
+            int,
+            np.random.default_rng().integers(
+                0, manifest["total_rows"], size=random_rows
+            ),
+        )
+    )
     handles = {}
     try:
-        with sidecar_path.open('rb') as sidecar:
+        with sidecar_path.open("rb") as sidecar:
             for row in sorted(picks):
                 shard, local = divmod(row, rows_per_shard)
                 pieces = []
-                for part in ('weight', 'scales', 'biases'):
+                for part in ("weight", "scales", "biases"):
                     path, start, width = refs[shard, part]
                     if path not in handles:
-                        handles[path] = path.open('rb')
+                        handles[path] = path.open("rb")
                     stream = handles[path]
                     stream.seek(start + local * width)
                     pieces.append(stream.read(width))
-                sidecar.seek(manifest['data_offset'] + row * manifest['row_bytes'])
-                if sidecar.read(manifest['row_bytes']) != b''.join(pieces):
-                    raise ValueError(f'PLE sidecar/source content mismatch at row {row}')
+                sidecar.seek(manifest["data_offset"] + row * manifest["row_bytes"])
+                if sidecar.read(manifest["row_bytes"]) != b"".join(pieces):
+                    raise ValueError(
+                        f"PLE sidecar/source content mismatch at row {row}"
+                    )
                 # Nonfinite quantization parameters are outside the supported
                 # single-round parity domain, including on validated edge rows.
-                dequant_rows_numpy(np.frombuffer(b''.join(pieces), dtype=np.uint8)[None, :], manifest['dims'])
+                dequant_rows_numpy(
+                    np.frombuffer(b"".join(pieces), dtype=np.uint8)[None, :],
+                    manifest["dims"],
+                )
     finally:
         for stream in handles.values():
             stream.close()
-    return {'adapter_version': ADAPTER_VERSION, 'manifest': manifest, 'checked_rows': len(picks),
-            'content_validation': 'every shard edge plus random rows; not exhaustive',
-            'source_index_sha256': manifest['source_index_sha256'], 'sidecar': str(sidecar_path)}
+    return {
+        "adapter_version": ADAPTER_VERSION,
+        "manifest": manifest,
+        "checked_rows": len(picks),
+        "content_validation": "every shard edge plus random rows; not exhaustive",
+        "source_index_sha256": manifest["source_index_sha256"],
+        "sidecar": str(sidecar_path),
+    }
 
 
 def dequant_rows_numpy(rows: np.ndarray, dims: int) -> np.ndarray:
     """Affine q4/g32 -> BF16 bits with one FP32->BF16 round-to-nearest-even."""
     if dims <= 0 or dims % 32:
-        raise ValueError('PLE dequant dimensions must be a positive multiple of32')
+        raise ValueError("PLE dequant dimensions must be a positive multiple of32")
     rows = np.asarray(rows)
-    if rows.dtype != np.uint8 or rows.ndim != 2 or rows.shape[1] != dims // 2 + dims // 8:
-        raise ValueError('invalid packed PLE row shape/dtype')
+    if (
+        rows.dtype != np.uint8
+        or rows.ndim != 2
+        or rows.shape[1] != dims // 2 + dims // 8
+    ):
+        raise ValueError("invalid packed PLE row shape/dtype")
     weight_bytes, group_bytes = dims // 2, dims // 16
-    words = np.ascontiguousarray(rows[:, :weight_bytes]).view('<u4')
-    scale_bits = np.ascontiguousarray(rows[:, weight_bytes:weight_bytes + group_bytes]).view('<u2')
-    bias_bits = np.ascontiguousarray(rows[:, weight_bytes + group_bytes:]).view('<u2')
+    words = np.ascontiguousarray(rows[:, :weight_bytes]).view("<u4")
+    scale_bits = np.ascontiguousarray(
+        rows[:, weight_bytes : weight_bytes + group_bytes]
+    ).view("<u2")
+    bias_bits = np.ascontiguousarray(rows[:, weight_bytes + group_bytes :]).view("<u2")
     scales = (scale_bits.astype(np.uint32) << 16).view(np.float32)
     biases = (bias_bits.astype(np.uint32) << 16).view(np.float32)
     if not np.isfinite(scales).all() or not np.isfinite(biases).all():
-        raise ValueError('nonfinite PLE quantization parameters')
+        raise ValueError("nonfinite PLE quantization parameters")
     shifts = np.arange(8, dtype=np.uint32) * np.uint32(4)
-    quant = ((words[..., None] >> shifts) & np.uint32(15)).reshape(-1, dims).astype(np.float32)
-    with np.errstate(over='ignore', invalid='ignore'):
+    quant = (
+        ((words[..., None] >> shifts) & np.uint32(15))
+        .reshape(-1, dims)
+        .astype(np.float32)
+    )
+    with np.errstate(over="ignore", invalid="ignore"):
         values = quant * np.repeat(scales, 32, axis=1) + np.repeat(biases, 32, axis=1)
     if not np.isfinite(values).all():
-        raise ValueError('PLE affine dequantization overflow')
+        raise ValueError("PLE affine dequantization overflow")
     bits = values.view(np.uint32)
     rounded = ((bits + np.uint32(0x7FFF) + ((bits >> 16) & 1)) >> 16).astype(np.uint16)
     if ((rounded & 0x7F80) == 0x7F80).any():
-        raise ValueError('PLE BF16 dequantization overflow')
+        raise ValueError("PLE BF16 dequantization overflow")
     return rounded
 
 
 class PLESidecarReader:
     """Bounded selected-row pread reader; no resident table or MLX arrays."""
+
     def __init__(self, model_path, sidecar_path, *, random_rows=256, cache_bytes=0):
-        _positive_int(cache_bytes, 'cache_bytes', zero=True)
+        _positive_int(cache_bytes, "cache_bytes", zero=True)
         if cache_bytes > 512 * 1024**2:
-            raise ValueError('PLE row cache must not exceed512 MiB')
+            raise ValueError("PLE row cache must not exceed512 MiB")
         before = self._stat_identity(os.stat(sidecar_path))
-        self.receipt = validate_artifact(model_path, sidecar_path, random_rows=random_rows)
-        self.manifest = self.receipt['manifest']
+        self.receipt = validate_artifact(
+            model_path, sidecar_path, random_rows=random_rows
+        )
+        self.manifest = self.receipt["manifest"]
         with _RESOURCE_LOCK:
             self._fd = os.open(sidecar_path, os.O_RDONLY)
             self._identity = self._stat_identity(os.fstat(self._fd))
             if self._identity != before:
                 os.close(self._fd)
                 self._fd = None
-                raise RuntimeError('PLE sidecar changed during validation')
+                raise RuntimeError("PLE sidecar changed during validation")
         self._pid = os.getpid()
         self._lock = threading.Lock()
         self.lookups = self.rows = self.unique_rows = self.bytes_read = 0
@@ -263,18 +335,25 @@ class PLESidecarReader:
         self.cache_bytes = cache_bytes
         # Charge512 bytes per entry for Python key/bytes/OrderedDict overhead,
         # in addition to payload; conservative on the supported CPython runtime.
-        self._cache_charge = self.manifest['row_bytes'] + 512
+        self._cache_charge = self.manifest["row_bytes"] + 512
         self._cache_capacity = cache_bytes // self._cache_charge
         self._cache = OrderedDict()
 
     @property
     def stats(self):
-        return dict(lookups=int(self.lookups), rows=int(self.rows), unique_rows=int(self.unique_rows),
-                    bytes_read=int(self.bytes_read), cache_hits=int(self.cache_hits),
-                    cache_misses=int(self.cache_misses), cache_evictions=int(self.cache_evictions),
-                    cache_rows=len(self._cache), cache_max_bytes=self.cache_bytes,
-                    cache_charged_bytes=len(self._cache) * self._cache_charge,
-                    cache_payload_bytes=len(self._cache) * self.manifest['row_bytes'])
+        return dict(
+            lookups=int(self.lookups),
+            rows=int(self.rows),
+            unique_rows=int(self.unique_rows),
+            bytes_read=int(self.bytes_read),
+            cache_hits=int(self.cache_hits),
+            cache_misses=int(self.cache_misses),
+            cache_evictions=int(self.cache_evictions),
+            cache_rows=len(self._cache),
+            cache_max_bytes=self.cache_bytes,
+            cache_charged_bytes=len(self._cache) * self._cache_charge,
+            cache_payload_bytes=len(self._cache) * self.manifest["row_bytes"],
+        )
 
     @staticmethod
     def _stat_identity(stat):
@@ -300,7 +379,7 @@ class PLESidecarReader:
 
     def __del__(self):
         with _RESOURCE_LOCK:
-            if getattr(self, '_fd', None) is not None:
+            if getattr(self, "_fd", None) is not None:
                 os.close(self._fd)
                 self._fd = None
 
@@ -308,32 +387,40 @@ class PLESidecarReader:
         # Refuse before acquiring an inherited lock, which may stay locked
         # forever in a child whose owning parent thread no longer exists.
         if os.getpid() != self._pid:
-            raise RuntimeError('PLE reader is inherited across fork')
+            raise RuntimeError("PLE reader is inherited across fork")
         values = np.asarray(indices)
-        if values.dtype.kind not in 'iu':
-            raise ValueError('PLE indices must be integers')
-        if values.size and (values.min() < 0 or values.max() >= self.manifest['total_rows']):
-            raise IndexError('PLE index outside vocabulary')
-        unique, inverse = np.unique(values.astype(np.int64).reshape(-1), return_inverse=True)
-        dims, row_bytes = self.manifest['dims'], self.manifest['row_bytes']
+        if values.dtype.kind not in "iu":
+            raise ValueError("PLE indices must be integers")
+        if values.size and (
+            values.min() < 0 or values.max() >= self.manifest["total_rows"]
+        ):
+            raise IndexError("PLE index outside vocabulary")
+        unique, inverse = np.unique(
+            values.astype(np.int64).reshape(-1), return_inverse=True
+        )
+        dims, row_bytes = self.manifest["dims"], self.manifest["row_bytes"]
         output = np.empty((unique.size, dims), dtype=np.uint16)
         with self._lock:
             if self._fd is None or os.getpid() != self._pid:
-                raise RuntimeError('PLE reader is closed or inherited across fork')
+                raise RuntimeError("PLE reader is closed or inherited across fork")
             if self._stat_identity(os.fstat(self._fd)) != self._identity:
-                raise RuntimeError('PLE sidecar changed after validation')
+                raise RuntimeError("PLE sidecar changed after validation")
             # Only4096 packed rows + dequant scratch are staged at once.
             for begin in range(0, unique.size, 4096):
-                batch = unique[begin:begin + 4096]
+                batch = unique[begin : begin + 4096]
                 packed = np.empty((len(batch), row_bytes), dtype=np.uint8)
                 for i, row in enumerate(batch):
                     key = int(row)
                     raw = self._cache.pop(key, None)
                     if raw is None:
                         self.cache_misses += 1
-                        raw = os.pread(self._fd, row_bytes, self.manifest['data_offset'] + key * row_bytes)
+                        raw = os.pread(
+                            self._fd,
+                            row_bytes,
+                            self.manifest["data_offset"] + key * row_bytes,
+                        )
                         if len(raw) != row_bytes:
-                            raise RuntimeError('short PLE sidecar read')
+                            raise RuntimeError("short PLE sidecar read")
                         self.bytes_read += row_bytes
                     else:
                         self.cache_hits += 1
@@ -343,10 +430,10 @@ class PLESidecarReader:
                             self._cache.popitem(last=False)
                             self.cache_evictions += 1
                     packed[i] = np.frombuffer(raw, dtype=np.uint8)
-                output[begin:begin + len(batch)] = dequant_rows_numpy(packed, dims)
+                output[begin : begin + len(batch)] = dequant_rows_numpy(packed, dims)
             if self._stat_identity(os.fstat(self._fd)) != self._identity:
                 self._cache.clear()
-                raise RuntimeError('PLE sidecar changed during lookup')
+                raise RuntimeError("PLE sidecar changed during lookup")
             self.lookups += 1
             self.rows += values.size
             self.unique_rows += unique.size

--- a/vllm_mlx/models/qwen4_ple_sidecar.py
+++ b/vllm_mlx/models/qwen4_ple_sidecar.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Read-only Qwen4 q4/g32 PLE sidecars; metadata/NumPy only, no MLX import.
+
+Layout and single-round BF16 dequantization follow the lab's unified
+qwen4_ple_nvme mechanism. This adapter deliberately retains Rapid's hash path.
+Artifact binding uses the index digest, complete tensor geometry, every shard's
+edge rows and a random row sample; it is not an exhaustive content digest.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+from contextlib import contextmanager
+from contextvars import ContextVar
+import fnmatch
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import struct
+import threading
+
+import numpy as np
+
+ADAPTER_VERSION = 1
+_LOAD_SOURCE = ContextVar('rapid_qwen4_ple_load_source', default=None)
+
+
+@contextmanager
+def _bound_load_source(model_path):
+    token = _LOAD_SOURCE.set(Path(model_path).resolve())
+    try:
+        yield
+    finally:
+        _LOAD_SOURCE.reset(token)
+
+
+def require_load_source(model_path):
+    if _LOAD_SOURCE.get() != Path(model_path).resolve():
+        raise ValueError('PLE source must be bound by load_file_backed_qwen4; arbitrary source overrides are refused')
+
+
+def _positive_int(value, name, *, zero=False):
+    if isinstance(value, bool) or not isinstance(value, int) or value < (0 if zero else 1):
+        raise ValueError(f'{name} must be a {"nonnegative" if zero else "positive"} integer')
+    return value
+
+
+def load_manifest(sidecar_path) -> dict:
+    path = Path(sidecar_path)
+    if fnmatch.fnmatch(path.name, 'model*.safetensors'):
+        raise ValueError('PLE sidecar must not match the model weight-file glob')
+    manifest = json.loads(Path(str(path) + '.manifest.json').read_text())
+    if manifest.get('format') != 'qwen4-ple-rows' or manifest.get('version') != 1:
+        raise ValueError('unsupported PLE sidecar manifest format/version')
+    if {k: manifest.get(k) for k in ('bits', 'group_size', 'mode')} != dict(bits=4, group_size=32, mode='affine'):
+        raise ValueError('PLE sidecar requires affine q4/group32')
+    dims = _positive_int(manifest.get('dims'), 'dims')
+    if dims % 32:
+        raise ValueError('PLE dimensions must be divisible by32')
+    geometry = dict(weight_bytes=dims // 2, scales_bytes=dims // 16, biases_bytes=dims // 16,
+                    row_bytes=dims // 2 + dims // 8)
+    for name, expected in geometry.items():
+        if manifest.get(name) != expected:
+            raise ValueError(f'invalid PLE {name}: expected {expected}')
+    shards = _positive_int(manifest.get('num_shards'), 'num_shards')
+    rows = _positive_int(manifest.get('rows_per_shard'), 'rows_per_shard')
+    if manifest.get('total_rows') != rows * shards:
+        raise ValueError('invalid PLE total row count')
+    offset = _positive_int(manifest.get('data_offset'), 'data_offset', zero=True)
+    digests = manifest.get('shard_sha256', [])
+    if len(digests) != shards or any(not isinstance(d, str) or not re.fullmatch('[0-9a-f]{64}', d) for d in digests):
+        raise ValueError('PLE manifest requires one SHA256 per shard')
+    if path.stat().st_size != offset + rows * shards * geometry['row_bytes']:
+        raise ValueError('PLE sidecar file size differs from manifest')
+    return manifest
+
+
+def _source_refs(model_path: Path, manifest: dict, weight_map: dict) -> dict:
+    prefix = manifest['tensor_prefix']
+    parts = {'weight': ('U32', manifest['dims'] // 8, 4),
+             'scales': ('BF16', manifest['dims'] // 32, 2),
+             'biases': ('BF16', manifest['dims'] // 32, 2)}
+    expected = {f'{prefix}.shard_{i}.{part}' for i in range(manifest['num_shards']) for part in parts}
+    present = {key for key in weight_map if key.startswith(prefix + '.')}
+    if present != expected:
+        raise ValueError('PLE source index does not contain exactly the expected shard triples')
+    headers, refs = {}, {}
+    for name in sorted(expected):
+        source = (model_path / weight_map[name]).resolve()
+        if not source.is_relative_to(model_path.resolve()):
+            raise ValueError('PLE source tensor path escapes model directory')
+        if source not in headers:
+            with source.open('rb') as stream:
+                raw = stream.read(8)
+                if len(raw) != 8:
+                    raise ValueError('truncated safetensors header length')
+                size = struct.unpack('<Q', raw)[0]
+                if size > min(source.stat().st_size - 8, 64 * 1024**2):
+                    raise ValueError('invalid safetensors header length')
+                headers[source] = (json.loads(stream.read(size)), 8 + size)
+        header, data_start = headers[source]
+        info = header.get(name, {})
+        shard, part = name.split('.shard_')[1].split('.')
+        dtype, columns, itemsize = parts[part]
+        shape = [manifest['rows_per_shard'], columns]
+        if info.get('dtype') != dtype or info.get('shape') != shape:
+            raise ValueError(f'PLE source dtype/shape mismatch at {name}')
+        offsets = info.get('data_offsets', [])
+        if len(offsets) != 2 or any(isinstance(v, bool) or not isinstance(v, int) for v in offsets):
+            raise ValueError(f'invalid source offsets at {name}')
+        start, end = offsets
+        row_bytes = columns * itemsize
+        if start < 0 or end - start != shape[0] * row_bytes or data_start + end > source.stat().st_size:
+            raise ValueError(f'PLE source byte range mismatch at {name}')
+        refs[int(shard), part] = (source, data_start + start, row_bytes)
+    return refs
+
+
+def validate_artifact(model_path, sidecar_path, *, random_rows=256) -> dict:
+    """Validate before constructing a model or importing MLX."""
+    model_path, sidecar_path = Path(model_path).resolve(), Path(sidecar_path).resolve()
+    manifest = load_manifest(sidecar_path)
+    index_bytes = (model_path / 'model.safetensors.index.json').read_bytes()
+    if hashlib.sha256(index_bytes).hexdigest() != manifest.get('source_index_sha256'):
+        raise ValueError('PLE sidecar source index digest mismatch')
+    config = json.loads((model_path / 'config.json').read_text())
+    text = config.get('text_config', config)
+    layer_ids = text.get('ple_layer_ids', [])
+    if config.get('model_type') != 'qwen4_exp' or len(layer_ids) != 1:
+        raise ValueError('this PLE loader requires exactly one Qwen4 PLE layer')
+    prefix = f'language_model.model.layers.{layer_ids[0] - 1}.ple.ple_embedding.ngram_embedding'
+    heads = (text.get('ngram_size', 3) - 1) * text.get('heads_per_ngram', 8)
+    embed_dim = text.get('ple_embed_dim')
+    if not isinstance(embed_dim, int) or heads <= 0 or embed_dim % heads:
+        raise ValueError('invalid PLE head/embedding configuration')
+    if manifest['tensor_prefix'] != prefix or manifest['dims'] != embed_dim // heads or manifest['num_shards'] != text.get('split_ngram_parts', 128):
+        raise ValueError('PLE manifest geometry/prefix differs from model config')
+    refs = _source_refs(model_path, manifest, json.loads(index_bytes)['weight_map'])
+    _positive_int(random_rows, 'random_rows', zero=True)
+    if random_rows > 4096:
+        raise ValueError('PLE random validation sample exceeds4096 rows')
+    rows_per_shard = manifest['rows_per_shard']
+    picks = {i * rows_per_shard + edge for i in range(manifest['num_shards']) for edge in (0, rows_per_shard - 1)}
+    picks.update(map(int, np.random.default_rng().integers(0, manifest['total_rows'], size=random_rows)))
+    handles = {}
+    try:
+        with sidecar_path.open('rb') as sidecar:
+            for row in sorted(picks):
+                shard, local = divmod(row, rows_per_shard)
+                pieces = []
+                for part in ('weight', 'scales', 'biases'):
+                    path, start, width = refs[shard, part]
+                    if path not in handles:
+                        handles[path] = path.open('rb')
+                    stream = handles[path]
+                    stream.seek(start + local * width)
+                    pieces.append(stream.read(width))
+                sidecar.seek(manifest['data_offset'] + row * manifest['row_bytes'])
+                if sidecar.read(manifest['row_bytes']) != b''.join(pieces):
+                    raise ValueError(f'PLE sidecar/source content mismatch at row {row}')
+                # Nonfinite quantization parameters are outside the supported
+                # single-round parity domain, including on validated edge rows.
+                dequant_rows_numpy(np.frombuffer(b''.join(pieces), dtype=np.uint8)[None, :], manifest['dims'])
+    finally:
+        for stream in handles.values():
+            stream.close()
+    return {'adapter_version': ADAPTER_VERSION, 'manifest': manifest, 'checked_rows': len(picks),
+            'content_validation': 'every shard edge plus random rows; not exhaustive',
+            'source_index_sha256': manifest['source_index_sha256'], 'sidecar': str(sidecar_path)}
+
+
+def dequant_rows_numpy(rows: np.ndarray, dims: int) -> np.ndarray:
+    """Affine q4/g32 -> BF16 bits with one FP32->BF16 round-to-nearest-even."""
+    if dims <= 0 or dims % 32:
+        raise ValueError('PLE dequant dimensions must be a positive multiple of32')
+    rows = np.asarray(rows)
+    if rows.dtype != np.uint8 or rows.ndim != 2 or rows.shape[1] != dims // 2 + dims // 8:
+        raise ValueError('invalid packed PLE row shape/dtype')
+    weight_bytes, group_bytes = dims // 2, dims // 16
+    words = np.ascontiguousarray(rows[:, :weight_bytes]).view('<u4')
+    scale_bits = np.ascontiguousarray(rows[:, weight_bytes:weight_bytes + group_bytes]).view('<u2')
+    bias_bits = np.ascontiguousarray(rows[:, weight_bytes + group_bytes:]).view('<u2')
+    scales = (scale_bits.astype(np.uint32) << 16).view(np.float32)
+    biases = (bias_bits.astype(np.uint32) << 16).view(np.float32)
+    if not np.isfinite(scales).all() or not np.isfinite(biases).all():
+        raise ValueError('nonfinite PLE quantization parameters')
+    shifts = np.arange(8, dtype=np.uint32) * np.uint32(4)
+    quant = ((words[..., None] >> shifts) & np.uint32(15)).reshape(-1, dims).astype(np.float32)
+    with np.errstate(over='ignore', invalid='ignore'):
+        values = quant * np.repeat(scales, 32, axis=1) + np.repeat(biases, 32, axis=1)
+    if not np.isfinite(values).all():
+        raise ValueError('PLE affine dequantization overflow')
+    bits = values.view(np.uint32)
+    rounded = ((bits + np.uint32(0x7FFF) + ((bits >> 16) & 1)) >> 16).astype(np.uint16)
+    if ((rounded & 0x7F80) == 0x7F80).any():
+        raise ValueError('PLE BF16 dequantization overflow')
+    return rounded
+
+
+class PLESidecarReader:
+    """Bounded selected-row pread reader; no resident table or MLX arrays."""
+    def __init__(self, model_path, sidecar_path, *, random_rows=256, cache_bytes=0):
+        _positive_int(cache_bytes, 'cache_bytes', zero=True)
+        if cache_bytes > 512 * 1024**2:
+            raise ValueError('PLE row cache must not exceed512 MiB')
+        before = self._stat_identity(os.stat(sidecar_path))
+        self.receipt = validate_artifact(model_path, sidecar_path, random_rows=random_rows)
+        self.manifest = self.receipt['manifest']
+        self._fd = os.open(sidecar_path, os.O_RDONLY)
+        self._identity = self._stat_identity(os.fstat(self._fd))
+        if self._identity != before:
+            os.close(self._fd)
+            self._fd = None
+            raise RuntimeError('PLE sidecar changed during validation')
+        self._pid = os.getpid()
+        self._lock = threading.Lock()
+        self.lookups = self.rows = self.unique_rows = self.bytes_read = 0
+        self.cache_hits = self.cache_misses = self.cache_evictions = 0
+        self.cache_bytes = cache_bytes
+        # Charge512 bytes per entry for Python key/bytes/OrderedDict overhead,
+        # in addition to payload; conservative on the supported CPython runtime.
+        self._cache_charge = self.manifest['row_bytes'] + 512
+        self._cache_capacity = cache_bytes // self._cache_charge
+        self._cache = OrderedDict()
+
+    @property
+    def stats(self):
+        return dict(lookups=int(self.lookups), rows=int(self.rows), unique_rows=int(self.unique_rows),
+                    bytes_read=int(self.bytes_read), cache_hits=int(self.cache_hits),
+                    cache_misses=int(self.cache_misses), cache_evictions=int(self.cache_evictions),
+                    cache_rows=len(self._cache), cache_max_bytes=self.cache_bytes,
+                    cache_charged_bytes=len(self._cache) * self._cache_charge,
+                    cache_payload_bytes=len(self._cache) * self.manifest['row_bytes'])
+
+    @staticmethod
+    def _stat_identity(stat):
+        return stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns
+
+    def close(self):
+        with self._lock:
+            if self._fd is not None:
+                os.close(self._fd)
+                self._fd = None
+            self._cache.clear()
+
+    def __del__(self):
+        if getattr(self, '_fd', None) is not None:
+            os.close(self._fd)
+            self._fd = None
+
+    def lookup_bits(self, indices) -> np.ndarray:
+        values = np.asarray(indices)
+        if values.dtype.kind not in 'iu':
+            raise ValueError('PLE indices must be integers')
+        if values.size and (values.min() < 0 or values.max() >= self.manifest['total_rows']):
+            raise IndexError('PLE index outside vocabulary')
+        unique, inverse = np.unique(values.astype(np.int64).reshape(-1), return_inverse=True)
+        dims, row_bytes = self.manifest['dims'], self.manifest['row_bytes']
+        output = np.empty((unique.size, dims), dtype=np.uint16)
+        with self._lock:
+            if self._fd is None or os.getpid() != self._pid:
+                raise RuntimeError('PLE reader is closed or inherited across fork')
+            if self._stat_identity(os.fstat(self._fd)) != self._identity:
+                raise RuntimeError('PLE sidecar changed after validation')
+            # Only4096 packed rows + dequant scratch are staged at once.
+            for begin in range(0, unique.size, 4096):
+                batch = unique[begin:begin + 4096]
+                packed = np.empty((len(batch), row_bytes), dtype=np.uint8)
+                for i, row in enumerate(batch):
+                    key = int(row)
+                    raw = self._cache.pop(key, None)
+                    if raw is None:
+                        self.cache_misses += 1
+                        raw = os.pread(self._fd, row_bytes, self.manifest['data_offset'] + key * row_bytes)
+                        if len(raw) != row_bytes:
+                            raise RuntimeError('short PLE sidecar read')
+                        self.bytes_read += row_bytes
+                    else:
+                        self.cache_hits += 1
+                    if self._cache_capacity:
+                        self._cache[key] = raw
+                        while len(self._cache) > self._cache_capacity:
+                            self._cache.popitem(last=False)
+                            self.cache_evictions += 1
+                    packed[i] = np.frombuffer(raw, dtype=np.uint8)
+                output[begin:begin + len(batch)] = dequant_rows_numpy(packed, dims)
+            if self._stat_identity(os.fstat(self._fd)) != self._identity:
+                self._cache.clear()
+                raise RuntimeError('PLE sidecar changed during lookup')
+            self.lookups += 1
+            self.rows += values.size
+            self.unique_rows += unique.size
+        return output[inverse].reshape(*values.shape, dims)

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1314,6 +1314,38 @@ def load_model_with_fallback(
                 model_name,
             )
 
+    if ple_sidecar := os.environ.get("RAPID_MLX_QWEN4_PLE_NVME"):
+        # Explicit strict lane, before both native selection and permissive
+        # fallback. The helper binds PLE to this resolved checkpoint path.
+        from mlx_lm.utils import load_tokenizer
+        from ..models.qwen4_ple_nvme import load_file_backed_qwen4
+
+        cache_bytes = int(os.environ.get("RAPID_MLX_QWEN4_PLE_CACHE_BYTES", "0"))
+        model, config = load_file_backed_qwen4(
+            model_name, ple_sidecar, cache_bytes=cache_bytes, lazy=lazy,
+        )
+        try:
+            tokenizer_config = _neutralize_unbundled_template_types(
+                model_name, tokenizer_config or {},
+            )
+            tokenizer = load_tokenizer(
+                Path(model_name), tokenizer_config,
+                eos_token_ids=config.get("eos_token_id"),
+            )
+            _try_inject_mtp_post_load(model, model_name)
+            if not getattr(tokenizer, "chat_template", None):
+                _apply_chat_template_sidecar(Path(model_name), tokenizer)
+            augment_eos_token_ids_from_generation_config(tokenizer, model_name)
+            repair_byte_level_decoder(tokenizer)
+            result = (model, tokenizer, config) if return_config else (model, tokenizer)
+            _resolve_loaded_template(result)
+            _post_load_ubc_evict(model_name)
+            return (*result, str(model_name)) if return_source else result
+        except BaseException:
+            from ..models.qwen4_ple_nvme import close_file_backed_ple
+            close_file_backed_ple(model)
+            raise
+
     if lazy:
         from mlx_lm import load as _mlx_lm_load
 

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -1318,18 +1318,24 @@ def load_model_with_fallback(
         # Explicit strict lane, before both native selection and permissive
         # fallback. The helper binds PLE to this resolved checkpoint path.
         from mlx_lm.utils import load_tokenizer
+
         from ..models.qwen4_ple_nvme import load_file_backed_qwen4
 
         cache_bytes = int(os.environ.get("RAPID_MLX_QWEN4_PLE_CACHE_BYTES", "0"))
         model, config = load_file_backed_qwen4(
-            model_name, ple_sidecar, cache_bytes=cache_bytes, lazy=lazy,
+            model_name,
+            ple_sidecar,
+            cache_bytes=cache_bytes,
+            lazy=lazy,
         )
         try:
             tokenizer_config = _neutralize_unbundled_template_types(
-                model_name, tokenizer_config or {},
+                model_name,
+                tokenizer_config or {},
             )
             tokenizer = load_tokenizer(
-                Path(model_name), tokenizer_config,
+                Path(model_name),
+                tokenizer_config,
                 eos_token_ids=config.get("eos_token_id"),
             )
             _try_inject_mtp_post_load(model, model_name)
@@ -1343,6 +1349,7 @@ def load_model_with_fallback(
             return (*result, str(model_name)) if return_source else result
         except BaseException:
             from ..models.qwen4_ple_nvme import close_file_backed_ple
+
             close_file_backed_ple(model)
             raise
 


### PR DESCRIPTION
## Why

Qwen4 PLE shard tensors consume substantial resident memory even though each forward selects only a small set of embedding rows. Rapid lacked a source-bound, bounded file-backed loader that preserves its native model and sharded ABI while refusing unsafe artifacts and inherited resources.

## Scope

- Add an opt-in q4/group32 PLE sidecar format and validator bound to the resolved checkpoint.
- Replace resident PLE tensors before weight evaluation and read only selected rows.
- Bound row dequantization chunks to 4096 rows and the optional packed-row LRU to 512 MiB.
- Refuse descriptor replacement, post-fork lookup, malformed geometry, invalid source binding, and non-finite quantization parameters.
- Close only readers owned by a failed strict load, including traceback-retained partial models.

## Non-goals

- A new n-gram hash, model implementation, worker pool, or MoE expert streaming path.
- Claiming an isolated PLE speedup; both composed benchmark arms used PLE offload.
- Exhaustive whole-file content hashing. Validation checks index binding, geometry, edge rows, and a random sample.

## Acceptance

- A valid sidecar removes resident PLE tensors and returns selected rows with the intended FP32-dequantize/one-BF16-round storage math.
- Cache charge never exceeds its configured bound.
- Forked children refuse inherited readers before taking inherited locks.
- Failed strict loads preserve the original exception and close their scoped readers.

## Verification

- `scripts/test_qwen4_ple_sidecar.py`: 32 passed on CPU, including real held-lock forks and traceback-retained load failures.
- Ruff check and format check pass for all five changed files; `git diff --check` passes.
- Composed-source multi-turn run: 1,302 lookups, 285,952 unique rows, and 65,484-byte maximum charge under a 65,536-byte limit.
- Composed-source 10x10 run: 15,622 lookups, 412,560 unique rows, and 67,108,860-byte maximum charge under a 67,108,864-byte limit.
- The isolated PR head has CPU validation. The composed GPU source was `f3e089b5`; both benchmark arms used PLE, so these are engagement and lifecycle receipts rather than an isolated speed comparison.
- Bounded repository self-validation returned `MERGE-SAFE`: lint passed, and all four targeted failures reproduced on upstream `main`. Automated review, the full unit suite, and stress E2E were explicitly skipped; advisory diff coverage was unavailable because `pytest-cov` is not installed.

## AI assistance disclosure

Codex generated and reviewed all changed Python files under the contributor's direction. The result was verified with 32 focused CPU tests, real fork negative controls, Ruff, diff checks, source-equivalence checks, and separately identified composed-source engagement receipts.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Focused tests pass locally (32 tests)
- [x] Ruff check and format check pass
- [x] Critical load and resource tests include malformed-input, fork, descriptor-reuse, and failure-cleanup negative controls
- [x] No user-facing default changes; the loader is opt-in
- [x] No breaking API change
- [x] Bounded repository self-validation returned `MERGE-SAFE`

## Author
