### PR TITLE
fix(qwen4): normalize direct-gamma RMSNorm checkpoints

### DIFF
--- a/scripts/test_qwen4_norm_convention_cpu.py
+++ b/scripts/test_qwen4_norm_convention_cpu.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Checkpoint-convention regressions; CPU is selected before model imports."""
 
-from pathlib import Path
-from dataclasses import asdict
 import json
 import sys
 import tempfile
 import unittest
+from dataclasses import asdict
+from pathlib import Path
 from unittest import mock
 
 import mlx.core as mx
@@ -19,7 +19,9 @@ import numpy as np
 from mlx.utils import tree_flatten
 
 from vllm_mlx.models.qwen4_exp import (
-    Model, ModelArgs, ZeroCenteredRMSNorm,
+    Model,
+    ModelArgs,
+    ZeroCenteredRMSNorm,
 )
 from vllm_mlx.models.qwen4_norm_convention import (
     normalize_qwen4_checkpoint,
@@ -27,18 +29,41 @@ from vllm_mlx.models.qwen4_norm_convention import (
 
 
 def tiny_model():
-    return Model(ModelArgs.from_dict(dict(model_type="qwen4_exp", text_config=dict(
-        hidden_size=8, num_hidden_layers=2, vocab_size=32,
-        num_attention_heads=2, num_key_value_heads=1, head_dim=4,
-        linear_num_key_heads=1, linear_num_value_heads=3,
-        linear_key_head_dim=4, linear_value_head_dim=4, linear_conv_kernel_dim=3,
-        num_experts=4, num_experts_per_tok=2, moe_intermediate_size=4,
-        shared_expert_intermediate_size=4, hc_count=4, hc_lowrank=3,
-        layer_types=["linear_attention", "full_attention"], indexer_n_heads=2,
-        indexer_kv_heads=1, indexer_head_dim=4, indexer_budget=8,
-        indexer_compress_ratio=2, ple_layer_ids=[], eos_token_id=31,
-        mtp_num_hidden_layers=1,
-    ))))
+    return Model(
+        ModelArgs.from_dict(
+            dict(
+                model_type="qwen4_exp",
+                text_config=dict(
+                    hidden_size=8,
+                    num_hidden_layers=2,
+                    vocab_size=32,
+                    num_attention_heads=2,
+                    num_key_value_heads=1,
+                    head_dim=4,
+                    linear_num_key_heads=1,
+                    linear_num_value_heads=3,
+                    linear_key_head_dim=4,
+                    linear_value_head_dim=4,
+                    linear_conv_kernel_dim=3,
+                    num_experts=4,
+                    num_experts_per_tok=2,
+                    moe_intermediate_size=4,
+                    shared_expert_intermediate_size=4,
+                    hc_count=4,
+                    hc_lowrank=3,
+                    layer_types=["linear_attention", "full_attention"],
+                    indexer_n_heads=2,
+                    indexer_kv_heads=1,
+                    indexer_head_dim=4,
+                    indexer_budget=8,
+                    indexer_compress_ratio=2,
+                    ple_layer_ids=[],
+                    eos_token_id=31,
+                    mtp_num_hidden_layers=1,
+                ),
+            )
+        )
+    )
 
 
 def checkpoint(model, *, direct):
@@ -62,15 +87,22 @@ class ConventionTests(unittest.TestCase):
             (path / "config.json").write_text(json.dumps(asdict(model.args)))
             mx.save_safetensors(str(path / "model.safetensors"), weights)
             loaded, _ = load_model(
-                path, lazy=False, strict=True,
+                path,
+                lazy=False,
+                strict=True,
                 model_config={"model_file": None},
                 get_model_classes=lambda config: (Model, ModelArgs),
             )
-        self.assertEqual(loaded.language_model.norm_convention_receipt["source_convention"], "direct_gamma")
+        self.assertEqual(
+            loaded.language_model.norm_convention_receipt["source_convention"],
+            "direct_gamma",
+        )
         for _path, module in loaded.named_modules():
             if type(module) is ZeroCenteredRMSNorm:
                 self.assertEqual(module.weight.dtype, mx.float32)
-                np.testing.assert_array_equal(np.array(module.weight), np.zeros(module.weight.shape))
+                np.testing.assert_array_equal(
+                    np.array(module.weight), np.zeros(module.weight.shape)
+                )
 
     def test_direct_gamma_checkpoint_recentered_before_strict_load(self):
         model = tiny_model()
@@ -85,12 +117,19 @@ class ConventionTests(unittest.TestCase):
         self.assertEqual(receipt["source_convention"], "direct_gamma")
         self.assertEqual(receipt["anchor_count"], 2)
         self.assertGreater(receipt["recentered_tensors"], 2)
-        self.assertIs(sanitized["language_model.model.layers.0.linear_attn.norm.weight"], untouched)
+        self.assertIs(
+            sanitized["language_model.model.layers.0.linear_attn.norm.weight"],
+            untouched,
+        )
         self.assertEqual(sanitized[key].dtype, mx.float32)
-        np.testing.assert_array_equal(np.array(1 + sanitized[key]), np.array(gamma.astype(mx.float32)))
+        np.testing.assert_array_equal(
+            np.array(1 + sanitized[key]), np.array(gamma.astype(mx.float32))
+        )
         norm = model.model.layers[1].self_attn.indexer.q_layernorm
         x = mx.array([[0.25, -0.5, 0.75, 1.0]], dtype=mx.float32)
-        expected = x * mx.rsqrt(mx.mean(mx.square(x), axis=-1, keepdims=True) + norm.eps)
+        expected = x * mx.rsqrt(
+            mx.mean(mx.square(x), axis=-1, keepdims=True) + norm.eps
+        )
         expected = expected * gamma.astype(mx.float32)
         np.testing.assert_array_equal(np.array(norm(x)), np.array(expected))
 
@@ -144,7 +183,9 @@ class ConventionTests(unittest.TestCase):
             with self.subTest(bad=bad):
                 model = tiny_model()
                 weights = checkpoint(model, direct=True)
-                key = "language_model.model.layers.0.attn_hyper_connection.hc_norm.weight"
+                key = (
+                    "language_model.model.layers.0.attn_hyper_connection.hc_norm.weight"
+                )
                 if bad is None:
                     del weights[key]
                 else:
@@ -157,9 +198,13 @@ class ConventionTests(unittest.TestCase):
             with self.subTest(gain=gain):
                 model = tiny_model()
                 weights = checkpoint(model, direct=True)
-                key = "language_model.model.layers.1.self_attn.indexer.q_layernorm.weight"
+                key = (
+                    "language_model.model.layers.1.self_attn.indexer.q_layernorm.weight"
+                )
                 weights[key] = mx.full(weights[key].shape, gain)
-                with self.assertRaisesRegex(ValueError, "cannot be represented exactly"):
+                with self.assertRaisesRegex(
+                    ValueError, "cannot be represented exactly"
+                ):
                     model.sanitize(weights)
 
     def test_raw_anchor_outliers_do_not_require_every_mean_below_half(self):
@@ -174,6 +219,7 @@ class ConventionTests(unittest.TestCase):
                     layer.attn_hyper_connection = nn.Module()
                     layer.attn_hyper_connection.hc_norm = ZeroCenteredRMSNorm(4)
                     self.layers.append(layer)
+
         for direct in (False, True):
             model = Anchors()
             weights = dict(tree_flatten(model.parameters()))
@@ -181,7 +227,10 @@ class ConventionTests(unittest.TestCase):
                 mean = 0.765625 if index == 0 else 0.0390625
                 weights[key] = mx.full((4,), mean + int(direct))
             receipt = normalize_qwen4_checkpoint(model, weights, ZeroCenteredRMSNorm)
-            self.assertEqual(receipt["source_convention"], "direct_gamma" if direct else "zero_centered")
+            self.assertEqual(
+                receipt["source_convention"],
+                "direct_gamma" if direct else "zero_centered",
+            )
 
     def test_mtp_inherits_backbone_convention_not_its_ambiguous_means(self):
         from vllm_mlx.spec_decode.mtp import qwen4_exp_inject as inject
@@ -193,12 +242,18 @@ class ConventionTests(unittest.TestCase):
                 mtp = inject._build_mtp(model.language_model)
                 weights = checkpoint(mtp, direct=direct)
                 # Learned MTP direct gains can be well below the anchor band.
-                gamma = mx.full(mtp.pre_fc_norm_embedding.weight.shape, 0.1, dtype=mx.bfloat16).astype(mx.float32)
+                gamma = mx.full(
+                    mtp.pre_fc_norm_embedding.weight.shape, 0.1, dtype=mx.bfloat16
+                ).astype(mx.float32)
                 weights["pre_fc_norm_embedding.weight"] = gamma if direct else gamma - 1
                 with tempfile.TemporaryDirectory() as directory:
                     path = Path(directory) / "mtp.safetensors"
-                    mx.save_safetensors(str(path), {f"mtp.{k}": v for k, v in weights.items()})
-                    self.assertTrue(inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=path))
+                    mx.save_safetensors(
+                        str(path), {f"mtp.{k}": v for k, v in weights.items()}
+                    )
+                    self.assertTrue(
+                        inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=path)
+                    )
                 actual = model.language_model.mtp.pre_fc_norm_embedding.weight
                 np.testing.assert_array_equal(np.array(1 + actual), np.array(gamma))
 
@@ -210,9 +265,14 @@ class ConventionTests(unittest.TestCase):
             mtp = inject._build_mtp(model.language_model)
             with tempfile.TemporaryDirectory() as directory:
                 path = Path(directory) / "mtp.safetensors"
-                mx.save_safetensors(str(path), {f"mtp.{k}": v for k, v in tree_flatten(mtp.parameters())})
+                mx.save_safetensors(
+                    str(path),
+                    {f"mtp.{k}": v for k, v in tree_flatten(mtp.parameters())},
+                )
                 with self.assertLogs(inject.logger, level="ERROR"):
-                    self.assertFalse(inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=path))
+                    self.assertFalse(
+                        inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=path)
+                    )
                 self.assertFalse(hasattr(model.language_model, "mtp"))
 
 

--- a/scripts/test_qwen4_norm_convention_cpu.py
+++ b/scripts/test_qwen4_norm_convention_cpu.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Checkpoint-convention regressions; CPU is selected before model imports."""
+
+from pathlib import Path
+from dataclasses import asdict
+import json
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+import mlx.core as mx
+
+mx.set_default_device(mx.cpu)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mlx.nn as nn
+import numpy as np
+from mlx.utils import tree_flatten
+
+from vllm_mlx.models.qwen4_exp import (
+    Model, ModelArgs, ZeroCenteredRMSNorm,
+)
+from vllm_mlx.models.qwen4_norm_convention import (
+    normalize_qwen4_checkpoint,
+)
+
+
+def tiny_model():
+    return Model(ModelArgs.from_dict(dict(model_type="qwen4_exp", text_config=dict(
+        hidden_size=8, num_hidden_layers=2, vocab_size=32,
+        num_attention_heads=2, num_key_value_heads=1, head_dim=4,
+        linear_num_key_heads=1, linear_num_value_heads=3,
+        linear_key_head_dim=4, linear_value_head_dim=4, linear_conv_kernel_dim=3,
+        num_experts=4, num_experts_per_tok=2, moe_intermediate_size=4,
+        shared_expert_intermediate_size=4, hc_count=4, hc_lowrank=3,
+        layer_types=["linear_attention", "full_attention"], indexer_n_heads=2,
+        indexer_kv_heads=1, indexer_head_dim=4, indexer_budget=8,
+        indexer_compress_ratio=2, ple_layer_ids=[], eos_token_id=31,
+        mtp_num_hidden_layers=1,
+    ))))
+
+
+def checkpoint(model, *, direct):
+    weights = dict(tree_flatten(model.parameters()))
+    for path, module in model.named_modules():
+        if type(module) is ZeroCenteredRMSNorm:
+            weights[f"{path}.weight"] = mx.full(
+                module.weight.shape, 1.0 if direct else 0.0, dtype=mx.bfloat16
+            )
+    return weights
+
+
+class ConventionTests(unittest.TestCase):
+    def test_installed_strict_loader_preserves_converted_fp32_residuals(self):
+        from mlx_lm.utils import load_model
+
+        model = tiny_model()
+        weights = checkpoint(model, direct=True)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            (path / "config.json").write_text(json.dumps(asdict(model.args)))
+            mx.save_safetensors(str(path / "model.safetensors"), weights)
+            loaded, _ = load_model(
+                path, lazy=False, strict=True,
+                model_config={"model_file": None},
+                get_model_classes=lambda config: (Model, ModelArgs),
+            )
+        self.assertEqual(loaded.language_model.norm_convention_receipt["source_convention"], "direct_gamma")
+        for _path, module in loaded.named_modules():
+            if type(module) is ZeroCenteredRMSNorm:
+                self.assertEqual(module.weight.dtype, mx.float32)
+                np.testing.assert_array_equal(np.array(module.weight), np.zeros(module.weight.shape))
+
+    def test_direct_gamma_checkpoint_recentered_before_strict_load(self):
+        model = tiny_model()
+        weights = checkpoint(model, direct=True)
+        key = "language_model.model.layers.1.self_attn.indexer.q_layernorm.weight"
+        gamma = mx.array([0.1, 0.3, 0.75, 1.5], dtype=mx.bfloat16)
+        weights[key] = gamma
+        untouched = weights["language_model.model.layers.0.linear_attn.norm.weight"]
+        sanitized = model.sanitize(weights)
+        model.load_weights(list(sanitized.items()), strict=True)
+        receipt = model.language_model.norm_convention_receipt
+        self.assertEqual(receipt["source_convention"], "direct_gamma")
+        self.assertEqual(receipt["anchor_count"], 2)
+        self.assertGreater(receipt["recentered_tensors"], 2)
+        self.assertIs(sanitized["language_model.model.layers.0.linear_attn.norm.weight"], untouched)
+        self.assertEqual(sanitized[key].dtype, mx.float32)
+        np.testing.assert_array_equal(np.array(1 + sanitized[key]), np.array(gamma.astype(mx.float32)))
+        norm = model.model.layers[1].self_attn.indexer.q_layernorm
+        x = mx.array([[0.25, -0.5, 0.75, 1.0]], dtype=mx.float32)
+        expected = x * mx.rsqrt(mx.mean(mx.square(x), axis=-1, keepdims=True) + norm.eps)
+        expected = expected * gamma.astype(mx.float32)
+        np.testing.assert_array_equal(np.array(norm(x)), np.array(expected))
+
+    def test_native_zero_centered_checkpoint_unchanged(self):
+        model = tiny_model()
+        weights = checkpoint(model, direct=False)
+        sanitized = model.sanitize(weights)
+        self.assertTrue(all(sanitized[key] is value for key, value in weights.items()))
+        receipt = model.language_model.norm_convention_receipt
+        self.assertEqual(receipt["source_convention"], "zero_centered")
+        self.assertEqual(receipt["recentered_tensors"], 0)
+        model.load_weights(list(sanitized.items()), strict=True)
+
+    def test_repeat_canonical_sanitize_cannot_overwrite_source_receipt(self):
+        model = tiny_model()
+        source = checkpoint(model, direct=True)
+        sanitized = model.sanitize(source)
+        receipt = model.language_model.norm_convention_receipt
+        # A non-norm key-remapping utility call must retain the load decision.
+        model.sanitize({"language_model.model.unrelated.weight": mx.zeros((1,))})
+        self.assertIs(model.language_model.norm_convention_receipt, receipt)
+        with self.assertRaisesRegex(ValueError, "source convention changed"):
+            model.sanitize(sanitized)
+        self.assertIs(model.language_model.norm_convention_receipt, receipt)
+        # Repeating the original source input is harmless and deterministic.
+        repeated = model.sanitize(source)
+        for key, value in sanitized.items():
+            np.testing.assert_array_equal(np.array(repeated[key]), np.array(value))
+
+    def test_mixed_anchor_populations_refused_without_mutating_weights(self):
+        model = tiny_model()
+        weights = checkpoint(model, direct=True)
+        key = "language_model.model.layers.0.attn_hyper_connection.hc_norm.weight"
+        weights[key] = mx.zeros_like(weights[key])
+        before = weights.copy()
+        with self.assertRaisesRegex(ValueError, "ambiguous or mixed"):
+            model.sanitize(weights)
+        self.assertTrue(all(weights[key] is value for key, value in before.items()))
+
+    def test_ambiguous_anchor_population_refused(self):
+        model = tiny_model()
+        weights = checkpoint(model, direct=True)
+        for key in weights:
+            if key.endswith("attn_hyper_connection.hc_norm.weight"):
+                weights[key] = mx.full(weights[key].shape, 0.5)
+        with self.assertRaisesRegex(ValueError, "ambiguous or mixed"):
+            model.sanitize(weights)
+
+    def test_missing_anchor_and_nonfinite_anchor_refused(self):
+        for bad in (None, float("nan"), float("inf")):
+            with self.subTest(bad=bad):
+                model = tiny_model()
+                weights = checkpoint(model, direct=True)
+                key = "language_model.model.layers.0.attn_hyper_connection.hc_norm.weight"
+                if bad is None:
+                    del weights[key]
+                else:
+                    weights[key] = mx.full(weights[key].shape, bad)
+                with self.assertRaises(ValueError):
+                    model.sanitize(weights)
+
+    def test_unrepresentable_tiny_or_negative_zero_gain_refused(self):
+        for gain in (1e-12, -1e-12, -0.0):
+            with self.subTest(gain=gain):
+                model = tiny_model()
+                weights = checkpoint(model, direct=True)
+                key = "language_model.model.layers.1.self_attn.indexer.q_layernorm.weight"
+                weights[key] = mx.full(weights[key].shape, gain)
+                with self.assertRaisesRegex(ValueError, "cannot be represented exactly"):
+                    model.sanitize(weights)
+
+    def test_raw_anchor_outliers_do_not_require_every_mean_below_half(self):
+        # A valid raw counterpart may have trained anchor outliers >0.5;
+        # retain the established 90% vote + median admission contract.
+        class Anchors(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = []
+                for _ in range(48):
+                    layer = nn.Module()
+                    layer.attn_hyper_connection = nn.Module()
+                    layer.attn_hyper_connection.hc_norm = ZeroCenteredRMSNorm(4)
+                    self.layers.append(layer)
+        for direct in (False, True):
+            model = Anchors()
+            weights = dict(tree_flatten(model.parameters()))
+            for index, key in enumerate(weights):
+                mean = 0.765625 if index == 0 else 0.0390625
+                weights[key] = mx.full((4,), mean + int(direct))
+            receipt = normalize_qwen4_checkpoint(model, weights, ZeroCenteredRMSNorm)
+            self.assertEqual(receipt["source_convention"], "direct_gamma" if direct else "zero_centered")
+
+    def test_mtp_inherits_backbone_convention_not_its_ambiguous_means(self):
+        from vllm_mlx.spec_decode.mtp import qwen4_exp_inject as inject
+
+        for direct in (False, True):
+            with self.subTest(direct=direct), mock.patch.object(nn, "quantize"):
+                model = tiny_model()
+                model.sanitize(checkpoint(model, direct=direct))
+                mtp = inject._build_mtp(model.language_model)
+                weights = checkpoint(mtp, direct=direct)
+                # Learned MTP direct gains can be well below the anchor band.
+                gamma = mx.full(mtp.pre_fc_norm_embedding.weight.shape, 0.1, dtype=mx.bfloat16).astype(mx.float32)
+                weights["pre_fc_norm_embedding.weight"] = gamma if direct else gamma - 1
+                with tempfile.TemporaryDirectory() as directory:
+                    path = Path(directory) / "mtp.safetensors"
+                    mx.save_safetensors(str(path), {f"mtp.{k}": v for k, v in weights.items()})
+                    self.assertTrue(inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=path))
+                actual = model.language_model.mtp.pre_fc_norm_embedding.weight
+                np.testing.assert_array_equal(np.array(1 + actual), np.array(gamma))
+
+    def test_mtp_without_admitted_backbone_refused(self):
+        from vllm_mlx.spec_decode.mtp import qwen4_exp_inject as inject
+
+        with mock.patch.object(nn, "quantize"):
+            model = tiny_model()
+            mtp = inject._build_mtp(model.language_model)
+            with tempfile.TemporaryDirectory() as directory:
+                path = Path(directory) / "mtp.safetensors"
+                mx.save_safetensors(str(path), {f"mtp.{k}": v for k, v in tree_flatten(mtp.parameters())})
+                with self.assertLogs(inject.logger, level="ERROR"):
+                    self.assertFalse(inject.inject_qwen4_exp_mtp_support(model, mtp_sidecar=path))
+                self.assertFalse(hasattr(model.language_model, "mtp"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_qwen4_exp_vendored.py
+++ b/tests/test_qwen4_exp_vendored.py
@@ -2016,6 +2016,9 @@ def test_qwen4_mtp_inject_loads_complete_local_tensor_contract(tmp_path, monkeyp
     args = _ple_args()
     args.mtp_num_hidden_layers = 1
     model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
+    model.language_model.norm_convention_receipt = {
+        "source_convention": "zero_centered"
+    }
     monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
     expected_mtp = inject._build_mtp(model.language_model)
     checkpoint = tmp_path / "mtp.safetensors"
@@ -2056,6 +2059,9 @@ def test_qwen4_mtp_inject_fails_closed_on_guards_tensor_mismatch_and_exception(
     args.mtp_num_hidden_layers = 1
     model = Model(ModelArgs(model_type="qwen4_exp", text_config=asdict(args)))
     assert inject.inject_qwen4_exp_mtp_support(model) is False
+    model.language_model.norm_convention_receipt = {
+        "source_convention": "zero_centered"
+    }
 
     monkeypatch.setattr(nn, "quantize", lambda *_args, **_kwargs: None)
     bad_checkpoint = tmp_path / "bad.safetensors"

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -2000,6 +2000,13 @@ class TextModel(nn.Module):
                 shard, leaf = suffix.split(".", 1)
                 key = f"{prefix}.ngram_embedding.shards.{int(shard)}.{leaf}"
             sanitized[key] = value
+        from .qwen4_norm_convention import normalize_qwen4_checkpoint
+
+        receipt = normalize_qwen4_checkpoint(
+            self, sanitized, ZeroCenteredRMSNorm
+        )
+        if receipt is not None:
+            self.norm_convention_receipt = receipt
         return sanitized
 
     @property

--- a/vllm_mlx/models/qwen4_exp.py
+++ b/vllm_mlx/models/qwen4_exp.py
@@ -2002,9 +2002,7 @@ class TextModel(nn.Module):
             sanitized[key] = value
         from .qwen4_norm_convention import normalize_qwen4_checkpoint
 
-        receipt = normalize_qwen4_checkpoint(
-            self, sanitized, ZeroCenteredRMSNorm
-        )
+        receipt = normalize_qwen4_checkpoint(self, sanitized, ZeroCenteredRMSNorm)
         if receipt is not None:
             self.norm_convention_receipt = receipt
         return sanitized

--- a/vllm_mlx/models/qwen4_norm_convention.py
+++ b/vllm_mlx/models/qwen4_norm_convention.py
@@ -47,7 +47,9 @@ def apply_qwen4_norm_convention(model, weights, norm_type, convention, *, prefix
             gamma = value.astype(mx.float32)
             residual = gamma - 1.0
             restored = 1.0 + residual
-            if not bool(mx.all(restored.view(mx.uint32) == gamma.view(mx.uint32)).item()):
+            if not bool(
+                mx.all(restored.view(mx.uint32) == gamma.view(mx.uint32)).item()
+            ):
                 raise ValueError(
                     f"Qwen4 RMSNorm gain cannot be represented exactly as an FP32 residual: {key}"
                 )
@@ -63,14 +65,17 @@ def normalize_qwen4_checkpoint(model, weights, norm_type):
     conversion/key-remapping tools. A norm-bearing mapping must include every
     instantiated attention HC anchor; strict model loading checks other keys.
     """
-    prefix = "language_model." if any(
-        key.startswith("language_model.") for key in weights
-    ) else ""
+    prefix = (
+        "language_model."
+        if any(key.startswith("language_model.") for key in weights)
+        else ""
+    )
     targets = _norm_targets(model, norm_type, prefix)
     if not (targets.keys() & weights.keys()):
         return None
     anchors = {
-        key: module for key, module in targets.items()
+        key: module
+        for key, module in targets.items()
         if key.endswith(".attn_hyper_connection.hc_norm.weight")
     }
     if not anchors or not anchors.keys() <= weights.keys():

--- a/vllm_mlx/models/qwen4_norm_convention.py
+++ b/vllm_mlx/models/qwen4_norm_convention.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Admit raw or converted Qwen4 RMSNorm storage before loading parameters.
+
+The anchor vote and median bands follow oMLX's Qwen4 compatibility loader.
+Unified MLX likewise distinguishes raw residuals from converted direct gains.
+This is evidence of a checkpoint-wide convention, not a way to prove that
+arbitrary mixtures in individual trained norm tensors are impossible.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+def _norm_targets(model, norm_type, prefix=""):
+    return {
+        f"{prefix}{path}.weight": module
+        for path, module in model.named_modules()
+        if type(module) is norm_type
+    }
+
+
+def apply_qwen4_norm_convention(model, weights, norm_type, convention, *, prefix=""):
+    """Map only the exact zero-centered norm class into its residual ABI.
+
+    MTP must inherit the backbone decision: its learned gains cannot reliably
+    classify the source convention independently. Gated GDN norms are a
+    different class, already direct-gamma, and are never changed here.
+    """
+    if convention not in ("zero_centered", "direct_gamma"):
+        raise ValueError("Qwen4 RMSNorm requires an admitted backbone convention")
+    replacements = {}
+    for key, module in _norm_targets(model, norm_type, prefix).items():
+        if key not in weights:
+            continue  # The strict checkpoint loader owns missing-key errors.
+        value = weights[key]
+        if (
+            not isinstance(value, mx.array)
+            or not mx.issubdtype(value.dtype, mx.floating)
+            or value.shape != module.weight.shape
+            or not bool(mx.all(mx.isfinite(value)).item())
+        ):
+            raise ValueError(f"invalid Qwen4 RMSNorm tensor: {key}")
+        if convention == "direct_gamma":
+            # BF16 subtraction loses small trained MTP gains. Keep the
+            # residual in FP32, as in the established oMLX loader.
+            gamma = value.astype(mx.float32)
+            residual = gamma - 1.0
+            restored = 1.0 + residual
+            if not bool(mx.all(restored.view(mx.uint32) == gamma.view(mx.uint32)).item()):
+                raise ValueError(
+                    f"Qwen4 RMSNorm gain cannot be represented exactly as an FP32 residual: {key}"
+                )
+            replacements[key] = residual
+    weights.update(replacements)
+    return len(replacements)
+
+
+def normalize_qwen4_checkpoint(model, weights, norm_type):
+    """Detect complete backbone anchor evidence, then canonicalize once.
+
+    Partial mappings containing no actual norm parameters remain usable by
+    conversion/key-remapping tools. A norm-bearing mapping must include every
+    instantiated attention HC anchor; strict model loading checks other keys.
+    """
+    prefix = "language_model." if any(
+        key.startswith("language_model.") for key in weights
+    ) else ""
+    targets = _norm_targets(model, norm_type, prefix)
+    if not (targets.keys() & weights.keys()):
+        return None
+    anchors = {
+        key: module for key, module in targets.items()
+        if key.endswith(".attn_hyper_connection.hc_norm.weight")
+    }
+    if not anchors or not anchors.keys() <= weights.keys():
+        raise ValueError("Qwen4 RMSNorm convention requires complete backbone anchors")
+    means = []
+    for key, module in anchors.items():
+        value = weights[key]
+        if (
+            not isinstance(value, mx.array)
+            or not mx.issubdtype(value.dtype, mx.floating)
+            or value.shape != module.weight.shape
+            or not bool(mx.all(mx.isfinite(value)).item())
+        ):
+            raise ValueError(f"invalid Qwen4 RMSNorm anchor: {key}")
+        means.append(float(mx.mean(value.astype(mx.float32)).item()))
+    ordered = sorted(means)
+    n = len(ordered)
+    median = (ordered[(n - 1) // 2] + ordered[n // 2]) / 2
+    ones_vote = sum(value > 0.5 for value in means) / n
+    if ones_vote >= 0.9 and 0.75 <= median <= 1.5:
+        convention = "direct_gamma"
+    elif ones_vote <= 0.1 and -0.5 <= median <= 0.25:
+        convention = "zero_centered"
+    else:
+        raise ValueError(
+            "ambiguous or mixed Qwen4 RMSNorm checkpoint convention: "
+            f"{n} anchors, median={median:.6g}, direct-gamma vote={ones_vote:.3f}"
+        )
+    previous = getattr(model, "norm_convention_receipt", None)
+    if previous and previous["source_convention"] != convention:
+        # Re-sanitizing already canonicalized weights must not overwrite the
+        # source convention subsequently used for the original MTP sidecar.
+        raise ValueError(
+            "Qwen4 RMSNorm source convention changed on an admitted model; "
+            "load a different checkpoint into a fresh model"
+        )
+    converted = apply_qwen4_norm_convention(
+        model, weights, norm_type, convention, prefix=prefix
+    )
+    return {
+        "source_convention": convention,
+        "runtime_convention": "zero_centered",
+        "anchor_count": n,
+        "anchor_median": median,
+        "direct_gamma_vote": ones_vote,
+        "recentered_tensors": converted,
+        "detection": "complete_attention_hc_anchor_vote_v1",
+    }

--- a/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
@@ -180,6 +180,14 @@ def inject_qwen4_exp_mtp_support(
             for file in _mtp_weight_files(mtp_sidecar):
                 weights.update(_sanitize_mtp_weights(mx.load(str(file))))
 
+            from vllm_mlx.models.qwen4_exp import ZeroCenteredRMSNorm
+            from vllm_mlx.models.qwen4_norm_convention import apply_qwen4_norm_convention
+
+            receipt = getattr(inner, "norm_convention_receipt", None) or {}
+            apply_qwen4_norm_convention(
+                mtp, weights, ZeroCenteredRMSNorm, receipt.get("source_convention")
+            )
+
             expected = dict(tree_flatten(mtp.parameters()))
             missing = set(expected) - set(weights)
             unexpected = set(weights) - set(expected)

--- a/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen4_exp_inject.py
@@ -181,7 +181,9 @@ def inject_qwen4_exp_mtp_support(
                 weights.update(_sanitize_mtp_weights(mx.load(str(file))))
 
             from vllm_mlx.models.qwen4_exp import ZeroCenteredRMSNorm
-            from vllm_mlx.models.qwen4_norm_convention import apply_qwen4_norm_convention
+            from vllm_mlx.models.qwen4_norm_convention import (
+                apply_qwen4_norm_convention,
+            )
 
             receipt = getattr(inner, "norm_convention_receipt", None) or {}
             apply_qwen4_norm_convention(


### PR DESCRIPTION
## Why

The measured Qwen4 checkpoint stores direct RMSNorm gamma values, while Rapid's vendored Qwen4 class uses a zero-centered `1 + weight` ABI. Loading direct gamma unchanged produces the wrong effective gains and incoherent output.

## Scope

- Infer the checkpoint-wide convention from all 48 attention-HC normalization anchors.
- Convert a unanimous direct-gamma checkpoint to zero-centered weights before model update.
- Pass the same convention receipt into the MTP model and refuse base/MTP conflicts.
- Leave native direct-gamma GDN normalization tensors unchanged.

## Non-goals

- Guessing a convention from isolated tensors or silently accepting mixed anchors.
- Changing Rapid's vendored RMSNorm class.
- Rewriting GDN weights that already use direct gamma.

## Acceptance

- Direct-gamma checkpoints load with the intended effective gains.
- Zero-centered checkpoints remain unchanged.
- Ambiguous/mixed checkpoints and base/MTP convention conflicts fail explicitly.
- All normalization tensors round-trip exactly through the selected conversion in FP32.

## Verification

- `scripts/test_qwen4_norm_convention_cpu.py`: 11 passed on CPU; two explicit MTP sidecar integration tests also pass.
- Ruff check and format check pass for all five changed files; `git diff --check` passes.
- Real checkpoint diagnostic: 48/48 attention-HC anchors voted direct gamma; all 157 normalization tensors completed exact FP32 round trips.
- On composed source `f3e089b5`, 8/8 multi-turn pairs and 100/100 domain pairs matched exactly between eager arms; all 216 responses ended naturally.
- The isolated PR head has CPU validation; the composed GPU results are identified separately.
- Bounded repository self-validation returned `MERGE-SAFE`: lint passed, and all four targeted failures reproduced on upstream `main`. Automated review, the full unit suite, and stress E2E were explicitly skipped; advisory diff coverage was unavailable because `pytest-cov` is not installed.

## Behaviour delta

Qwen4 checkpoint load: raw normalization assignment → checkpoint-wide convention validation and direct-gamma conversion when all attention-HC anchors agree. Ambiguous or conflicting convention evidence now fails the load.

## AI assistance disclosure

Codex generated and reviewed all changed Python files under the contributor's direction. The result was verified with focused CPU tests, Ruff, diff checks, a real-checkpoint convention diagnostic, and the separately identified composed-source semantic campaign.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Focused tests pass locally (11 custom and 2 MTP integration tests)
- [x] Ruff check and format check pass
- [x] Critical load tests cover direct, zero-centered, mixed, and base/MTP conflict cases
- [x] No documentation update is required for the checkpoint compatibility correction
- [x] No breaking API change
- [x] Bounded repository self-validation returned `MERGE-SAFE`

## Author
