### PR TITLE
fix(tools): reject parser debris as scalar arguments

### DIFF
--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -184,9 +184,7 @@ class TestSalvageForcedScalarArguments:
         )
         assert _salvage_forced_scalar_arguments("weather", debris, [_WEATHER]) is None
         assert (
-            _salvage_forced_scalar_arguments(
-                "weather", json.dumps(debris), [_WEATHER]
-            )
+            _salvage_forced_scalar_arguments("weather", json.dumps(debris), [_WEATHER])
             is None
         )
         # The sentinel is independently disqualifying even if truncation drops
@@ -194,6 +192,14 @@ class TestSalvageForcedScalarArguments:
         assert (
             _salvage_forced_scalar_arguments(
                 "weather", "<malformed_json_arguments>truncated", [_WEATHER]
+            )
+            is None
+        )
+        # Registered wire markers are independently disqualifying.  This keeps
+        # the marker-registry arm covered even if the sentinel check changes.
+        assert (
+            _salvage_forced_scalar_arguments(
+                "weather", "truncated</parameter></function>", [_WEATHER]
             )
             is None
         )

--- a/tests/test_2502_forced_scalar_args.py
+++ b/tests/test_2502_forced_scalar_args.py
@@ -173,6 +173,39 @@ class TestSalvageForcedScalarArguments:
             == '{"url": "https://example.com"}'
         )
 
+    def test_parser_wire_fragment_never_salvages_as_user_string(self):
+        # MZR-3 dogfood: Qwen3.5-4B deterministically emitted this recovery
+        # sentinel after a malformed named forced call.  It is valid JSON once
+        # quoted, and ``string`` accepts it, but it is parser protocol debris —
+        # never an executable city argument.
+        debris = (
+            '<malformed_json_arguments>{"name": "weather", "arguments": 0}\n'
+            "</parameter>\n</function>"
+        )
+        assert _salvage_forced_scalar_arguments("weather", debris, [_WEATHER]) is None
+        assert (
+            _salvage_forced_scalar_arguments(
+                "weather", json.dumps(debris), [_WEATHER]
+            )
+            is None
+        )
+        # The sentinel is independently disqualifying even if truncation drops
+        # every closing wire marker.
+        assert (
+            _salvage_forced_scalar_arguments(
+                "weather", "<malformed_json_arguments>truncated", [_WEATHER]
+            )
+            is None
+        )
+
+    def test_angle_bracket_prose_without_wire_marker_still_salvages(self):
+        # Keep the gate tied to known parser markers, not arbitrary angle
+        # brackets that can be legitimate user data.
+        value = "temperature < 20 C"
+        assert _salvage_forced_scalar_arguments("weather", value, [_WEATHER]) == (
+            '{"city": "temperature < 20 C"}'
+        )
+
     def test_unknown_tool_never_guesses(self):
         assert _salvage_forced_scalar_arguments("other", "x", [_WEATHER]) is None
 
@@ -354,6 +387,15 @@ class TestRepairForcedCallArgumentsScalar:
         tc = _call("1")
         err = _repair_forced_call_arguments([tc], "", "ping", [_no_required_schema()])
         assert err is None
+        assert tc.function.arguments == "{}"
+
+    def test_parser_wire_fragment_fails_closed_instead_of_becoming_argument(self):
+        tc = _call(
+            '<malformed_json_arguments>{"name":"weather","arguments":0}'
+            "</parameter></function>"
+        )
+        err = _repair_forced_call_arguments([tc], "", "weather", [_WEATHER])
+        assert err is not None
         assert tc.function.arguments == "{}"
 
 

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3083,6 +3083,21 @@ def _salvage_forced_scalar_arguments(
     if isinstance(value, float) and not math.isfinite(value):
         return None
 
+    # A parser-wire fragment is not a user scalar.  Small models sometimes
+    # recover from a malformed forced-call body by emitting the body itself as
+    # a quoted value, for example ``<malformed_json_arguments>...`` followed by
+    # ``</parameter></function>``.  The single-property salvage above would
+    # otherwise wrap that protocol debris as ``{"city": "..."}``; it then
+    # satisfies JSON Schema's plain ``string`` type and is returned as an
+    # executable 200 response.  Reuse the route's complete wire-marker registry
+    # so every supported parser family fails closed here.  Ordinary strings
+    # that merely discuss JSON or contain angle brackets remain salvageable.
+    if isinstance(value, str) and (
+        "<malformed_json_arguments>" in value
+        or _contains_tool_wire_literal(value)
+    ):
+        return None
+
     # Type-match gate: the scalar must fit the single required property's type.
     if ptype == "string":
         if isinstance(value, (str,)) and not isinstance(value, bool):

--- a/vllm_mlx/routes/chat.py
+++ b/vllm_mlx/routes/chat.py
@@ -3093,8 +3093,7 @@ def _salvage_forced_scalar_arguments(
     # so every supported parser family fails closed here.  Ordinary strings
     # that merely discuss JSON or contain angle brackets remain salvageable.
     if isinstance(value, str) and (
-        "<malformed_json_arguments>" in value
-        or _contains_tool_wire_literal(value)
+        "<malformed_json_arguments>" in value or _contains_tool_wire_literal(value)
     ):
         return None
 


### PR DESCRIPTION
## Why

A real MZR-3 dogfood request against Qwen3.5-4B showed that a named forced tool call could recover malformed parser protocol text as the sole string parameter and return HTTP 200. The payload was JSON-schema-valid as a string, but executing it would send protocol debris to the tool instead of the requested city.

## What changed

- Refuse scalar salvage when the candidate contains the model malformed-arguments sentinel or a registered tool-wire marker.
- Preserve legitimate bare strings, including URLs and ordinary angle-bracket prose.
- Add the exact dogfood payload plus truncated-marker and negative-control coverage.

## Design precedent

Mature inference servers keep parser-framed output on the parser path and fail closed when tool arguments are not a valid executable object. This change applies that boundary specifically to Rapid-MLX scalar recovery rather than broadening parser behavior or guessing user intent.

## Scope

Allowed: OpenAI chat named/required tool argument recovery and focused tests.

Non-goals: model prompting, parser-family rewrites, JSON-schema policy, Desktop UI.

## Verification

- ruff: clean
- focused tool-choice suites: 172 passed
- exact real-model MZR-3: the formerly deterministic corrupt 200 now fails closed with 422; a valid named call still returns get_weather with city=San Francisco
- stream cancellation released the engine and the immediate recovery request succeeded
- two simultaneous requests both returned their exact expected values
- full pr_validate and exact-head CI before queueing

## Risk

Low and fail-closed. Proper object arguments bypass scalar salvage unchanged; only malformed scalar recovery candidates containing protocol markers are rejected.