### PR TITLE
fix(mtp): feed the Qwen3.5 MTP head the hidden it was trained on

### DIFF
--- a/tests/test_mtp_self_contained_repo.py
+++ b/tests/test_mtp_self_contained_repo.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from vllm_mlx.spec_decode.mtp.qwen3_5_inject import (
+    BASE_HIDDEN_VARIANT_DEFAULT,
     _find_mtp_weights_file,
     _load_mtplx_runtime_contract,
 )
@@ -78,3 +79,37 @@ def test_rejects_unknown_mtplx_contract_values(tmp_path: Path):
     )
 
     assert _load_mtplx_runtime_contract(weights) == {}
+
+
+def test_manifest_without_a_hidden_variant_takes_the_trained_contract(tmp_path: Path):
+    """An MTPLX manifest may pin only the fields it disagrees with.
+
+    Whatever it leaves out has to land on the same default a sidecar with
+    no manifest at all gets, or the two paths drift and the same head is
+    driven two different ways depending on whether an unrelated field was
+    worth writing down.
+    """
+    weights = tmp_path / "mtp.safetensors"
+    weights.touch()
+    (tmp_path / "mtplx_runtime.json").write_text(
+        json.dumps({"mtp_contract": {"mtp_position_mode": "local"}}),
+        encoding="utf-8",
+    )
+
+    assert _load_mtplx_runtime_contract(weights) == {
+        "base_hidden_variant": BASE_HIDDEN_VARIANT_DEFAULT,
+        "hidden_variant": BASE_HIDDEN_VARIANT_DEFAULT,
+        "concat_order": "embedding_hidden",
+        "mtp_position_mode": "local",
+    }
+
+
+def test_the_default_base_hidden_is_the_tensor_the_output_head_scores():
+    """Qwen3-Next MTP heads are trained on the backbone's final hidden.
+
+    ``mlx_lm.models.qwen3_5.TextModel.__call__`` ends in
+    ``self.norm(hidden_states)``, and vLLM's ``qwen3_next_mtp.py`` hands
+    ``pre_fc_norm_hidden`` the post-norm tensor its ``compute_logits``
+    scores. Pinning the constant keeps a future edit to it deliberate.
+    """
+    assert BASE_HIDDEN_VARIANT_DEFAULT == "post_norm"

--- a/tests/test_mtp_spec_decode.py
+++ b/tests/test_mtp_spec_decode.py
@@ -1664,6 +1664,105 @@ def test_inject_mtp_support_loads_synthetic_sidecar():
             )
 
 
+def _write_synthetic_sidecar(model, tmp_dir, contract=None):
+    """Persist ``model``'s freshly built MTP head as a loadable sidecar.
+
+    Returns the sidecar path. ``contract``, when given, is written beside
+    it as the ``mtp_contract`` of an ``mtplx_runtime.json`` manifest so the
+    test can pin a non-default runtime contract.
+    """
+    import json
+    from pathlib import Path
+
+    import mlx.core as _mx
+    from mlx.utils import tree_flatten
+
+    from vllm_mlx.spec_decode.mtp.head import build_mtp_module
+
+    args = model.args
+    template = build_mtp_module(args, int(args.mtp_num_hidden_layers))
+    _mx.eval(template.parameters())
+    sidecar = Path(tmp_dir) / "mtp.safetensors"
+    _mx.save_safetensors(str(sidecar), dict(tree_flatten(template.parameters())))
+    if contract is not None:
+        (Path(tmp_dir) / "mtplx_runtime.json").write_text(
+            json.dumps({"mtp_contract": contract}), encoding="utf-8"
+        )
+    return sidecar
+
+
+def test_return_hidden_hands_the_drafter_the_tensor_the_lm_head_scored():
+    """Default contract: the drafter sees the backbone's FINAL hidden state.
+
+    A Qwen3-Next-style MTP head is trained on whatever the target's own
+    output head consumes -- post-norm for this family (``TextModel.__call__``
+    ends in ``self.norm(...)``; vLLM's ``qwen3_next_mtp.py`` feeds
+    ``pre_fc_norm_hidden`` the same post-norm tensor its ``compute_logits``
+    scores). Handing the head the pre-norm hidden instead is silent: it
+    still drafts fluent tokens, they are just accepted less often, so no
+    functional test catches it -- only this identity does.
+    """
+    import mlx.core as _mx
+
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        model = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    assert model.args.tie_word_embeddings is False, (
+        "this assertion re-scores through ``lm_head``; a tied checkpoint "
+        "would score through ``embed_tokens.as_linear`` instead"
+    )
+    assert inject_mtp_support(model, allow_random_init=True) is True
+
+    logits, hidden = model(_mx.array([[3, 7, 11]]), return_hidden=True)
+    _mx.eval(logits, hidden)
+
+    assert _mx.allclose(model.lm_head(hidden), logits, atol=1e-4, rtol=1e-4), (
+        "return_hidden must yield the tensor lm_head just scored; "
+        "re-scoring it through the same head has to reproduce the logits"
+    )
+
+
+def test_mtplx_manifest_can_still_pin_the_pre_norm_base_hidden():
+    """The escape hatch survives the default flip -- and proves it bites.
+
+    An artifact exported against the pre-norm hidden pins
+    ``base_hidden_variant`` in its manifest. Asserting BOTH that the
+    pinned hidden reproduces the logits only after the backbone norm AND
+    that it does not reproduce them without one is what makes the default
+    test above discriminating rather than vacuous.
+    """
+    import tempfile
+
+    import mlx.core as _mx
+
+    from vllm_mlx.spec_decode.mtp.qwen3_5_inject import inject_mtp_support
+
+    try:
+        model = _build_tiny_qwen3_5_text_model()
+    except (TypeError, AttributeError) as exc:
+        pytest.skip(f"Qwen3.5 TextModelArgs schema mismatch: {exc}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        sidecar = _write_synthetic_sidecar(
+            model, tmp, contract={"base_hidden_variant": "pre_norm"}
+        )
+        assert inject_mtp_support(model, mtp_sidecar=str(sidecar)) is True
+
+        logits, hidden = model(_mx.array([[3, 7, 11]]), return_hidden=True)
+        _mx.eval(logits, hidden)
+
+        assert _mx.allclose(
+            model.lm_head(model.model.norm(hidden)), logits, atol=1e-4, rtol=1e-4
+        ), "a pinned pre_norm hidden must be exactly the input to the backbone norm"
+        assert not _mx.allclose(model.lm_head(hidden), logits, atol=1e-4, rtol=1e-4), (
+            "pre-norm and post-norm hidden must be distinguishable at the head"
+        )
+
+
 def test_inject_mtp_support_refuses_synthetic_sidecar_missing_tensor():
     """Coverage check: dropping one required tensor must fail the inject.
 

--- a/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
+++ b/vllm_mlx/spec_decode/mtp/qwen3_5_inject.py
@@ -56,6 +56,33 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+# Which backbone hidden state the MTP head is fed for its ``pre_fc_norm_hidden``
+# input. Qwen3-Next-style MTP heads are TRAINED on the backbone's final hidden
+# state -- the very tensor ``lm_head`` scores -- which for this family is
+# post-norm: ``Qwen3_5TextModel.__call__`` ends in ``self.norm(hidden_states)``,
+# and vLLM's ``qwen3_next_mtp.py`` hands ``Qwen3NextModel``'s post-norm return
+# value straight to ``pre_fc_norm_hidden`` (its ``compute_logits`` applies no
+# further norm). mlx-vlm's ``qwen3_5_mtp`` drafter takes the same tensor.
+# ``pre_fc_norm_hidden`` is the head's OWN norm on top of that, not a stand-in
+# for the backbone's.
+#
+# Feeding the un-normalized hidden instead is silent: the head still emits
+# fluent tokens, they are just accepted less often, so only acceptance
+# telemetry shows it. Measured greedy at K pinned to 2, aggregated over six
+# unrelated prompts (~1.4k tokens, ~600 rounds -- one prompt is a single
+# deterministic trajectory and moves several percent on its own):
+#
+#   Qwen3.8-27B-4bit  pre 2.340 -> post 2.436 tok/round  d1 0.787 -> 0.828
+#   Qwen3.5-9B-4bit   pre 2.376 -> post 2.400 tok/round  d1 0.795 -> 0.818
+#
+# at an unchanged round cost, so the tok/round gain is the throughput gain.
+# Both families move the same way, which is what makes it the contract rather
+# than one checkpoint's quirk. An MTPLX artifact that really was exported
+# against the pre-norm hidden can still pin ``base_hidden_variant`` in its
+# ``mtplx_runtime.json``.
+BASE_HIDDEN_VARIANT_DEFAULT = "post_norm"
+
+
 BATCHED_MTP_CAPABILITY = MappingProxyType(
     {
         "protocol_version": 1,
@@ -385,12 +412,13 @@ def _find_mtp_weights_file(sidecar_dir: Path) -> Path | None:
 def _load_mtplx_runtime_contract(weights_file: Path) -> dict[str, Any]:
     """Return the colocated MTPLX MTP contract, or an empty mapping.
 
-    Ordinary mlx-community sidecars have no runtime manifest and retain the
-    upstream mlx-lm PR #990 contract (pre-norm hidden, cache-relative MTP
-    positions).  MTPLX combined artifacts carry ``mtplx_runtime.json`` next
-    to ``mtp.safetensors``; silently treating their post-norm head as the
-    PR #990 variant produces plausible but low-acceptance drafts.  Read only
-    the closed contract fields we implement and fail closed on malformed
+    Ordinary mlx-community sidecars have no runtime manifest and take the
+    defaults below, which are the Qwen3-Next MTP training contract:
+    post-norm base hidden, cache-relative MTP positions.  MTPLX combined
+    artifacts carry ``mtplx_runtime.json`` next to ``mtp.safetensors`` and
+    may pin a different variant; a head fed the wrong hidden still emits
+    plausible tokens, so the only symptom is low acceptance.  Read only the
+    closed contract fields we implement and fail closed on malformed
     metadata.
     """
 
@@ -407,7 +435,7 @@ def _load_mtplx_runtime_contract(weights_file: Path) -> dict[str, Any]:
     contract = payload.get("mtp_contract")
     if not isinstance(contract, dict):
         return {}
-    base_hidden = contract.get("base_hidden_variant", "pre_norm")
+    base_hidden = contract.get("base_hidden_variant", BASE_HIDDEN_VARIANT_DEFAULT)
     hidden = contract.get("hidden_variant", base_hidden)
     concat = contract.get("concat_order", "embedding_hidden")
     position = contract.get("mtp_position_mode", "cache")
@@ -564,7 +592,9 @@ def inject_mtp_support(
     runtime_contract = (
         _load_mtplx_runtime_contract(weights_file) if weights_file is not None else {}
     )
-    base_hidden_variant = runtime_contract.get("base_hidden_variant", "pre_norm")
+    base_hidden_variant = runtime_contract.get(
+        "base_hidden_variant", BASE_HIDDEN_VARIANT_DEFAULT
+    )
     mtp_concat_order = runtime_contract.get("concat_order", "embedding_hidden")
 
     # --- Step 3: Match the MTP module's quantization to the SIDECAR ---
@@ -909,9 +939,9 @@ def inject_mtp_support(
         The forward is inlined from
         ``mlx_lm.models.qwen3_5.Qwen3_5TextModel.__call__`` so that:
 
-        * ``return_hidden=True`` can return the pre-norm hidden state
-          the MTP head consumes (the upstream forward returns only the
-          post-norm output).
+        * ``return_hidden=True`` can return the hidden state the MTP
+          head consumes alongside the logits (the upstream forward
+          returns only the logits), in either norm variant.
         * ``n_confirmed`` is accepted on the signature for ABI parity
           with PR #990 (the generator passes ``n_confirmed=1`` during
           verify forwards). It is currently a no-op below this layer
@@ -970,9 +1000,6 @@ def inject_mtp_support(
                         if c is not None and hasattr(c, "n_confirmed_for_mtp"):
                             c.n_confirmed_for_mtp = 0
 
-            # Return PRE-norm hidden so MTP can apply its own
-            # ``pre_fc_norm_hidden`` — matches PR #990's contract that
-            # ``mtp_forward(hidden, ...)`` consumes pre-norm hidden.
             normed = inner_m.norm(hidden_states)
             if self.args.tie_word_embeddings:
                 out = inner_m.embed_tokens.as_linear(normed)
@@ -980,6 +1007,11 @@ def inject_mtp_support(
                 out = self.lm_head(normed)
 
             if return_hidden:
+                # Hand the drafter the same tensor ``lm_head`` just scored.
+                # ``pre_fc_norm_hidden`` in the MTP head is the head's own
+                # norm over the backbone's FINAL hidden state, not a
+                # substitute for the backbone's ``norm`` -- see
+                # ``BASE_HIDDEN_VARIANT_DEFAULT``.
                 hidden = normed if base_hidden_variant == "post_norm" else hidden_states
                 return out, hidden
             return out


### PR DESCRIPTION
## What

`base_hidden_variant` now defaults to `post_norm` for the Qwen3.5 / 3.6 / 3.8 MTP injector, so the MTP head is handed the target's **final** hidden state — the same tensor the target's own output head scores — instead of the pre-norm hidden.

## Why

A Qwen3-Next-style MTP head is trained on the backbone's final hidden state:

- `mlx_lm.models.qwen3_5.TextModel.__call__` ends in `self.norm(hidden_states)` and scores *that* through `lm_head`.
- vLLM's `qwen3_next_mtp.py` feeds `pre_fc_norm_hidden` the tensor returned by `Qwen3NextModel.forward` (post-norm — `hidden_states, _ = self.norm(hidden_states, residual)`), and its `compute_logits` applies no further norm to that same tensor.
- mlx-vlm's `qwen3_5_mtp` drafter takes `hidden = lm.model(...)`, likewise post-norm.

`pre_fc_norm_hidden` is the head's **own** RMSNorm layered on top of the backbone's final hidden — not a stand-in for the backbone's `norm`. Because an RMSNorm absorbs the magnitude difference, the wrong input never looks broken: the head keeps drafting fluent tokens, they are simply accepted less often. No functional test, and no user-visible output, can see it. Only acceptance telemetry can — which is why this sat undetected.

## Measurement

Greedy, `num_speculative_tokens` pinned to 2 with `disable_auto_k`, one knob changed between arms, M4 Pro mini. Aggregated over six unrelated prompts (~1.4k tokens, ~600 rounds per arm):

| model | pre_norm | post_norm | Δ tok/round | d1 accept |
|---|---|---|---|---|
| `rapid-mlx/Qwen3.8-27B-4bit-MTP-MLX` | 2.340 tok/round | **2.436** | **+4.1%** | 0.787 → 0.828 |
| `mlx-community/Qwen3.5-9B-4bit` + `-MTP-4bit` | 2.376 tok/round | **2.400** | **+1.0%** | 0.795 → 0.818 |

Round cost is unchanged in both arms, so the tok/round gain is the throughput gain (27B: 23.04 → 23.76 tok/s decode). Total completion tokens were identical per arm (1430 / 1423), so the arms generated the same amount of text.

Note on methodology: a single 256-token greedy prompt is one deterministic trajectory. Any change that perturbs numerics lands on a *different* continuation and the round count moves a few percent for reasons unrelated to draft quality — the first one-prompt A/B put 27B and 9B on **opposite** sides. Six prompts is what separates the effect from trajectory luck; both families then move the same way, and both move position-1 acceptance, which is the quantity draft quality actually controls.

## Machine independence

This changes *which tensor* is passed to the head. There is no kernel, no shape, no scheduling and no host tuning in the diff, so M2 through M6 and every backend get the same effect.

## Compatibility

- An MTPLX artifact genuinely exported against the pre-norm hidden still pins `base_hidden_variant` in its `mtplx_runtime.json`; that escape hatch is untouched and now has a test.
- A manifest that omits `base_hidden_variant` now takes the same default as a sidecar with no manifest at all. Previously the two paths would have drifted apart the moment the default moved, so they are pinned to one constant, `BASE_HIDDEN_VARIANT_DEFAULT`.
- Other MTP families are untouched: `hy3_inject.py` documents a pre-final-norm contract of its own, and `gemma4_inject.py` / `qwen4_exp_inject.py` have their own. Only the Qwen3.5-family injector changes.

## Test plan

- [x] `test_return_hidden_hands_the_drafter_the_tensor_the_lm_head_scored` — re-scoring the returned hidden through the target's own `lm_head` must reproduce the logits it already returned. This is the identity the defect broke.
- [x] `test_mtplx_manifest_can_still_pin_the_pre_norm_base_hidden` — the pinned pre-norm hidden is exactly the input to the backbone norm, **and** is not accepted by the head-identity assertion above. The negative half is what keeps the first test from being vacuous.
- [x] `test_manifest_without_a_hidden_variant_takes_the_trained_contract` + `test_the_default_base_hidden_is_the_tensor_the_output_head_scores`.
- [x] Negative control: with the constant reverted to `pre_norm`, the head-identity test and the constant test both fail; the manifest tests still pass.
- [x] `tests/test_mtp_spec_decode.py`, `test_mtp_self_contained_repo.py`, `test_mtp_inject_and_install.py`, `test_mtp_lossless.py`, `test_mtp_prepared_state.py`, `test_batched_self_mtp_contract.py` — 235 passed.
- [x] Hands-on A/B on a real server on two checkpoints, table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)