### PR TITLE
feat(glm): add Apple-native mixed quantization MVP

### DIFF
--- a/.agents/handoffs/vector-glm53-rmq.md
+++ b/.agents/handoffs/vector-glm53-rmq.md
@@ -2,7 +2,7 @@
 
 - Receiving role: Atlas
 - Branch: `vector/glm53-rmq-mvp`
-- PR: not opened yet
+- PR: #3372
 - Host: Studio (M3 Ultra, 256 GB)
 
 ## Verified

--- a/.agents/handoffs/vector-glm53-rmq.md
+++ b/.agents/handoffs/vector-glm53-rmq.md
@@ -1,0 +1,36 @@
+# Vector handoff: GLM-5.3 RMQ
+
+- Receiving role: Atlas
+- Branch: `vector/glm53-rmq-mvp`
+- PR: not opened yet
+- Host: Studio (M3 Ultra, 256 GB)
+
+## Verified
+
+- RMQ planner emits fusion-safe MLX affine Q4/Q8 group-64 decisions.
+- Official GLM E4M3 128x128 block-FP8 is supported tensor-by-tensor.
+- Real official layer-45 dequantization and Q4 output match mlx-vlm exactly.
+- Unit tests pass (14/14); ruff and diff checks pass.
+- Full-plan payload projects to 186,198,375,288 bytes, 4.20 GiB above the
+  current uniform-Q4 payload.
+- Uniform-Q4 MTP reached 37.15 tok/s versus 28.63 tok/s autoregressive on the
+  first 128-token probe (+29.8%), with identical greedy output.
+- A standalone higher-precision MTP did not improve acceptance against a Q4
+  target. Target/draft precision symmetry is now an explicit design rule.
+
+## Remaining and risks
+
+- The complete official 62-shard source cannot fit the currently available HF
+  cache. Do not redirect the cache or delete other models to bypass policy.
+- The tested GLM MTP runtime is mlx-vlm post-0.7 commit `d2a1434a...`; Rapid is
+  pinned to 0.6.17. Product integration needs a tagged dependency or an Atlas
+  decision to vendor it.
+- Tiny-fixture quality results validate numerics, not full-model intelligence.
+- Short-prompt prefill cost regresses when a separate drafter is loaded.
+
+## Next action
+
+Atlas should review the format/product boundary. Once source capacity and a
+tagged GLM MTP runtime are available, Vector should emit the full target and
+target-matched sidecar, then run the release gate recorded in
+`docs/engineering/performance/2026-09-12-glm53-rmq-mvp.md`.

--- a/.agents/handoffs/vector-glm53-rmq.md
+++ b/.agents/handoffs/vector-glm53-rmq.md
@@ -27,6 +27,9 @@
   decision to vendor it.
 - Tiny-fixture quality results validate numerics, not full-model intelligence.
 - Short-prompt prefill cost regresses when a separate drafter is loaded.
+- The two current E2E probes are decode diagnostics, not a realistic quality
+  suite. Coding execution, knowledge answer keys, instruction checks, blind
+  creative-writing review, and long-context tasks remain mandatory.
 
 ## Next action
 

--- a/docs/engineering/performance/2026-09-12-glm53-rmq-mvp.md
+++ b/docs/engineering/performance/2026-09-12-glm53-rmq-mvp.md
@@ -119,7 +119,26 @@ python -m ruff check vllm_mlx/quantization/glm53_rmq.py \
 
 Do not ship a quality or oQ4e superiority claim from these measurements. The
 release gate is a full RMQ target plus its target-matched sidecar, evaluated on
-reviewed math/code/chat prompts for output quality, acceptance, prefill,
-decode, end-to-end latency, and peak memory. Runtime integration also waits on
-a tagged mlx-vlm release containing the GLM-5-Next MTP implementation, unless
-Atlas explicitly approves vendoring the post-0.7 runtime.
+complete, realistic tasks for output quality, acceptance, prefill, decode,
+end-to-end latency, and peak memory.
+
+The task suite must include:
+
+- coding tasks whose emitted programs are executed against hidden unit tests;
+- multi-step math/reasoning with reviewed final-answer keys;
+- closed-book knowledge questions with atomic factual claims and answer keys;
+- instruction-following tasks with machine-checkable format and constraint checks;
+- creative writing judged blind against a fixed coherence, style, constraint,
+  and non-repetition rubric;
+- long-context retrieval and synthesis rather than prompt-only microbenchmarks.
+
+Speculative decoding is gated separately from quantization quality. With one
+fixed target, MTP on/off must produce token-identical complete greedy answers;
+task success must also remain identical. RMQ is compared with the source
+teacher and uniform Q4 using task scores, not acceptance or logit similarity
+alone. Report medians across the suite and per-category tails; the single
++29.8% decode probe above is not an aggregate product-performance claim.
+
+Runtime integration also waits on a tagged mlx-vlm release containing the
+GLM-5-Next MTP implementation, unless Atlas explicitly approves vendoring the
+post-0.7 runtime.

--- a/docs/engineering/performance/2026-09-12-glm53-rmq-mvp.md
+++ b/docs/engineering/performance/2026-09-12-glm53-rmq-mvp.md
@@ -1,0 +1,125 @@
+# GLM-5.3 RMQ MVP: target-matched Apple quantization
+
+Date: 2026-09-12
+
+Owner: Vector
+
+Status: converter and policy MVP; full-checkpoint conversion pending source capacity
+
+## Decision
+
+RMQ v1 uses only MLX-native affine Q4 and Q8 with group size 64. Routed
+experts stay Q4; token ranking, sparse-index selection, recurrent/attention
+state, shared experts, dense MLPs, and MTP always-active paths use Q8. Router,
+norm, correction, convolution, and vision state remain floating point.
+
+The target and its MTP drafter must use the same precision decision for the
+corresponding domain. A higher-precision drafter by itself is not a reliable
+way to raise acceptance against a lower-precision target: shared quantization
+error can make the lower-precision pair agree more often.
+
+Q6 was excluded after measuring the actual production matrix shapes. It was
+not consistently faster than Q8 and would add a third kernel/storage format.
+
+## Environment
+
+- Mac Studio, Apple M3 Ultra, 28 CPU cores, 256 GB unified memory
+- macOS 26.5.2 (25F84)
+- MLX 0.32.2
+- target: `Vontra/GLM-5.3-Flash-MLX-4bit-MTP`, revision
+  `76add2a341a1cd90ad0e86bb69839ea9c35827c6`
+- official FP8 source: `zai-org/GLM-5.3-Flash`, revision
+  `3f1971b7b5f7a528c9c4ef6212c8785298a8c24a`
+- GLM MTP reference runtime: mlx-vlm commit
+  `d2a1434a03e4c9975b0d505e7178e0cfc4082a83` (post-0.7, not yet tagged)
+- greedy decoding, one process per measurement
+
+The reference target has a 181,693,692,792-byte tensor payload. Header-only
+projection of RMQ v1 is 186,198,375,288 bytes: +4,504,682,496 bytes (+4.20
+GiB). The plan contains 311.65B Q4 parameters, 9.01B Q8 parameters, and 0.66B
+floating-point parameters.
+
+## End-to-end MTP probe
+
+The first prompt was a profit-margin reasoning problem (51 prompt tokens,
+128 generated tokens). The second requested an O(n) Python sliding-window
+function (36 prompt tokens, 96 generated tokens). All compared outputs were
+identical under greedy decoding.
+
+| Draft | Size | Math acceptance | Math generation | Code acceptance | Code generation |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| none | 0 | n/a | 28.63 tok/s | n/a | not rerun |
+| uniform Q4, block 2 | 3.9 GiB | 76.4% | 37.15 tok/s | 86.3% | 35.28 tok/s |
+| official-source Q8 experts, BF16/Q8 always-active, block 2 | 7.9 GiB | 76.4% | 33.51 tok/s | 82.7% | 33.20 tok/s |
+| Q4 experts + high-fidelity always-active paths, block 2 | 4.1 GiB | 76.4% | 35.53 tok/s | 82.7% | 35.38 tok/s |
+| uniform Q4, block 3 | 3.9 GiB | 66.0% of drafts | 34.14 tok/s | not run | not run |
+
+For the math prompt, uniform-Q4 MTP improved generation by 29.8% over plain
+autoregressive decoding. Block 3 lost to block 2 because the second recursive
+draft reduced acceptance enough to outweigh fewer target calls. Q8-only draft
+did not improve acceptance against the Q4 target. This is evidence for a
+joint target/draft recipe, not a claim that Q4 is intrinsically higher quality.
+
+Short-prompt prefill regressed because the drafter is separately prefetched:
+6.00 prompt tok/s without a drafter versus 2.84 with Q4 MTP on the math probe.
+Production policy must amortize or skip MTP for short generations instead of
+advertising decode-only throughput as request throughput.
+
+## Quality smoke on the 0.1B architecture fixture
+
+Across four English teacher-forced prompts, versus BF16:
+
+| Checkpoint | Top-1 agreement | Mean KL | Logit RMSE |
+| --- | ---: | ---: | ---: |
+| uniform Q4 | 76.04% | 0.030434 | 0.218872 |
+| RMQ Q4/Q8 | 94.55% | 0.001896 | 0.070710 |
+
+RMQ raised top-1 agreement by 18.51 percentage points, reduced KL by 93.77%,
+and reduced logit RMSE by 67.69%. This tiny fixture is an architecture/numeric
+smoke only; it is not a full-model capability benchmark.
+
+## Converter verification
+
+`scripts/glm53_rmq_convert.py` is fail-closed for arbitrary pre-quantized
+inputs but accepts the official E4M3 128x128 block-FP8 source. It validates the
+inverse-scale grid, reconstructs one source tensor at a time, and immediately
+quantizes to its planned MLX representation.
+
+An actual layer-45 expert tensor from the pinned official source
+(`4096x2048`, inverse-scale grid `32x16`) was compared with mlx-vlm's reference
+FP8 decoder. Reconstructed BF16 and all three Q4 affine outputs had maximum
+absolute difference 0.0.
+
+The complete Q8 sidecar conversion consumed the two MTP source shards only
+(10.0 GiB download), produced 7.9 GiB, completed in 8.17 seconds, and peaked
+at 15.0 GiB RSS. The whole RMQ target has not been emitted because the 62-shard
+official source does not fit the currently available HF cache. Storage policy
+forbids redirecting the cache or deleting other models to work around that.
+
+## Reproduction
+
+Planner projection:
+
+```bash
+PYTHONPATH=. python scripts/glm53_rmq_convert.py \
+  --source /path/to/GLM-5.3-Flash-MLX-4bit-MTP \
+  --inspect-quantized-shapes
+```
+
+Policy and converter tests:
+
+```bash
+python -m pytest -q tests/test_glm53_rmq.py tests/test_glm53_rmq_convert.py
+python -m ruff check vllm_mlx/quantization/glm53_rmq.py \
+  scripts/glm53_rmq_convert.py tests/test_glm53_rmq.py \
+  tests/test_glm53_rmq_convert.py
+```
+
+## Release gate
+
+Do not ship a quality or oQ4e superiority claim from these measurements. The
+release gate is a full RMQ target plus its target-matched sidecar, evaluated on
+reviewed math/code/chat prompts for output quality, acceptance, prefill,
+decode, end-to-end latency, and peak memory. Runtime integration also waits on
+a tagged mlx-vlm release containing the GLM-5-Next MTP implementation, unless
+Atlas explicitly approves vendoring the post-0.7 runtime.

--- a/scripts/benchmark_glm53_rmq.py
+++ b/scripts/benchmark_glm53_rmq.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Compare BF16, uniform Q4, and RMQ GLM checkpoints on one Apple host.
+
+The default prompts are an architecture smoke, not a model-quality benchmark.
+For release evidence pass a reviewed JSON prompt list with ``--prompts`` and
+run the same command in fresh processes on the full checkpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import time
+from pathlib import Path
+
+import mlx.core as mx
+
+from vllm_mlx.patches.glm5_next_forget_gate_quant import (
+    install_glm5_next_forget_gate_quant_fix,
+)
+from vllm_mlx.patches.glm5_next_runtime import install_glm5_next_runtime_fix
+
+DEFAULT_PROMPTS = [
+    "Explain why the sky is blue in two sentences.",
+    "Write a Python function that returns the nth Fibonacci number.",
+    "If a contract starts on January 1 and lasts 90 days, describe the end-date calculation.",
+    "Solve 37 * 19 and show a compact check.",
+]
+
+
+def _load(path: Path):
+    from mlx_vlm.utils import load
+
+    started = time.perf_counter()
+    model, processor = load(str(path), lazy=False, strict=True)
+    return model, processor, time.perf_counter() - started
+
+
+def _log_softmax(logits: mx.array) -> mx.array:
+    logits = logits.astype(mx.float32)
+    return logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+
+
+def _teacher_forced(reference, candidate, processor, prompts: list[str]) -> dict:
+    agreements = []
+    kls = []
+    rmses = []
+    for prompt in prompts:
+        ids = processor.encode(prompt, add_special_tokens=True)
+        tokens = mx.array([ids])
+        ref = reference(tokens).logits
+        got = candidate(tokens).logits
+        ref_logp = _log_softmax(ref)
+        got_logp = _log_softmax(got)
+        ref_prob = mx.exp(ref_logp)
+        agreement = mx.mean(mx.argmax(ref, axis=-1) == mx.argmax(got, axis=-1))
+        kl = mx.mean(mx.sum(ref_prob * (ref_logp - got_logp), axis=-1))
+        rmse = mx.sqrt(mx.mean((ref.astype(mx.float32) - got.astype(mx.float32)) ** 2))
+        mx.eval(agreement, kl, rmse)
+        agreements.append(float(agreement.item()))
+        kls.append(float(kl.item()))
+        rmses.append(float(rmse.item()))
+    return {
+        "top1_agreement": statistics.fmean(agreements),
+        "kl_divergence": statistics.fmean(kls),
+        "logit_rmse": statistics.fmean(rmses),
+    }
+
+
+def _generation(model, processor, prompts: list[str], max_tokens: int) -> dict:
+    from mlx_vlm import generate
+
+    # Compile/materialize the common single-request path before measurement.
+    generate(model, processor, "Warm up.", max_tokens=4, temperature=0, verbose=False)
+    prompt_tps = []
+    generation_tps = []
+    outputs = []
+    for prompt in prompts:
+        result = generate(
+            model,
+            processor,
+            prompt,
+            max_tokens=max_tokens,
+            temperature=0,
+            verbose=False,
+        )
+        prompt_tps.append(float(result.prompt_tps))
+        generation_tps.append(float(result.generation_tps))
+        outputs.append(result.text)
+    digest = hashlib.sha256("\n---\n".join(outputs).encode()).hexdigest()
+    return {
+        "median_prompt_tps": statistics.median(prompt_tps),
+        "median_generation_tps": statistics.median(generation_tps),
+        "output_sha256": digest,
+        "outputs": outputs,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bf16", type=Path, required=True)
+    parser.add_argument("--q4", type=Path, required=True)
+    parser.add_argument("--rmq", type=Path, required=True)
+    parser.add_argument("--prompts", type=Path)
+    parser.add_argument("--max-tokens", type=int, default=32)
+    args = parser.parse_args()
+
+    if args.prompts:
+        prompts = json.loads(args.prompts.read_text())
+        if (
+            not isinstance(prompts, list)
+            or not prompts
+            or not all(isinstance(prompt, str) and prompt for prompt in prompts)
+        ):
+            raise SystemExit("--prompts must contain a non-empty JSON string list")
+    else:
+        prompts = DEFAULT_PROMPTS
+
+    install_glm5_next_runtime_fix()
+    install_glm5_next_forget_gate_quant_fix()
+    models = {}
+    processors = {}
+    report = {"models": {}, "prompt_count": len(prompts)}
+    for label, path in (("bf16", args.bf16), ("q4", args.q4), ("rmq", args.rmq)):
+        models[label], processors[label], load_seconds = _load(path)
+        report["models"][label] = {
+            "path": str(path.resolve()),
+            "load_seconds": load_seconds,
+            "active_memory_bytes_after_load": int(mx.get_active_memory()),
+        }
+
+    for label in ("q4", "rmq"):
+        report["models"][label]["teacher_forced_vs_bf16"] = _teacher_forced(
+            models["bf16"], models[label], processors["bf16"], prompts
+        )
+    for label in ("bf16", "q4", "rmq"):
+        report["models"][label]["generation"] = _generation(
+            models[label], processors[label], prompts, args.max_tokens
+        )
+    report["warning"] = (
+        "Tiny-fixture throughput is an architecture smoke and must not be used as a "
+        "full GLM-5.3 performance claim."
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_glm53_rmq_kernels.py
+++ b/scripts/benchmark_glm53_rmq_kernels.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Measure MLX affine Q4/Q6/Q8 cost on production GLM-5.3 matrix shapes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+
+import mlx.core as mx
+
+SHAPES = {
+    "kda_fused_input": (24896, 4096),
+    "kda_recurrent_out": (8192, 128),
+    "sparse_kv_b": (32768, 512),
+    "routed_expert_down": (4096, 2048),
+    "lm_head": (154880, 4096),
+}
+
+
+def _measure(out_features: int, in_features: int, bits: int, tokens: int, repeats: int):
+    packed = mx.zeros((out_features, in_features * bits // 32), dtype=mx.uint32)
+    scales = mx.ones((out_features, in_features // 64), dtype=mx.bfloat16)
+    biases = mx.zeros_like(scales)
+    inputs = mx.ones((tokens, in_features), dtype=mx.bfloat16)
+    mx.eval(packed, scales, biases, inputs)
+
+    def run():
+        value = mx.quantized_matmul(
+            inputs,
+            packed,
+            scales,
+            biases,
+            transpose=True,
+            group_size=64,
+            bits=bits,
+            mode="affine",
+        )
+        mx.eval(value)
+
+    for _ in range(3):
+        run()
+    samples = []
+    for _ in range(repeats):
+        started = time.perf_counter_ns()
+        run()
+        samples.append((time.perf_counter_ns() - started) / 1e6)
+    result = {
+        "median_ms": statistics.median(samples),
+        "min_ms": min(samples),
+        "max_ms": max(samples),
+    }
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokens", type=int, action="append", default=[])
+    parser.add_argument("--repeats", type=int, default=11)
+    args = parser.parse_args()
+    token_counts = args.tokens or [1, 128]
+    report = {
+        "device": mx.device_info(),
+        "group_size": 64,
+        "repeats": args.repeats,
+        "results": {},
+    }
+    for label, (out_features, in_features) in SHAPES.items():
+        report["results"][label] = {}
+        for tokens in token_counts:
+            rows = {}
+            for bits in (4, 6, 8):
+                rows[f"q{bits}"] = _measure(
+                    out_features, in_features, bits, tokens, args.repeats
+                )
+                mx.clear_cache()
+            baseline = rows["q4"]["median_ms"]
+            for row in rows.values():
+                row["relative_to_q4"] = row["median_ms"] / baseline
+            report["results"][label][str(tokens)] = rows
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/glm53_rmq_convert.py
+++ b/scripts/glm53_rmq_convert.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+"""Stream a source GLM-5.3 checkpoint into the RMQ MLX layout.
+
+The converter is fail-closed and processes one tensor at a time. It accepts
+BF16/FP16/FP32 or the official E4M3 128x128 block-FP8 layout, but refuses an
+already-repacked integer checkpoint because a second quantization pass cannot
+restore lost information. RMQ's policy and fusion-domain constraints live in
+``vllm_mlx.quantization.glm53_rmq`` and are independently unit tested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mmap
+import os
+import resource
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+from vllm_mlx.quantization.glm53_rmq import (
+    TensorDescriptor,
+    module_paths,
+    mtp_module_paths,
+    plan_tensors,
+    summarize_plan,
+)
+
+DEFAULT_MAX_SHARD_BYTES = 4 * 1024**3
+_NP_DTYPES = {
+    "F16": np.float16,
+    "F32": np.float32,
+    "F64": np.float64,
+    "I8": np.int8,
+    "I16": np.int16,
+    "I32": np.int32,
+    "I64": np.int64,
+    "U8": np.uint8,
+    "U16": np.uint16,
+    "U32": np.uint32,
+    "U64": np.uint64,
+    "BOOL": np.bool_,
+}
+_DTYPE_BYTES = {
+    "BOOL": 1,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "I8": 1,
+    "U8": 1,
+    "BF16": 2,
+    "F16": 2,
+    "I16": 2,
+    "U16": 2,
+    "F32": 4,
+    "I32": 4,
+    "U32": 4,
+    "F64": 8,
+    "I64": 8,
+    "U64": 8,
+}
+_AUX_NAMES = (
+    "chat_template.jinja",
+    "generation_config.json",
+    "preprocessor_config.json",
+    "processor_config.json",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+)
+_FP8_BLOCK_SIZE = 128
+_FLOAT_SOURCE_DTYPES = frozenset({"BF16", "F16", "F32", "F64"})
+
+
+def _is_supported_block_fp8(config: dict) -> bool:
+    quantization = config.get("quantization_config") or {}
+    return (
+        isinstance(quantization, dict)
+        and quantization.get("quant_method") == "fp8"
+        and quantization.get("fmt", "e4m3") == "e4m3"
+        and quantization.get("weight_block_size") == [128, 128]
+    )
+
+
+def peak_rss_bytes() -> int:
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return rss if sys.platform == "darwin" else rss * 1024
+
+
+def _inside(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _safe_source_file(snapshot: Path, relative: Path) -> Path:
+    if relative.is_absolute() or len(relative.parts) != 1:
+        raise RuntimeError(f"source contains a non-flat shard path: {relative}")
+    candidate = snapshot / relative
+    if not candidate.is_file():
+        raise RuntimeError(f"missing source file: {relative}")
+    resolved = candidate.resolve()
+    allowed = [snapshot.resolve()]
+    if snapshot.parent.name == "snapshots":
+        blobs = snapshot.parent.parent / "blobs"
+        if blobs.is_dir():
+            allowed.append(blobs.resolve())
+    if not any(_inside(resolved, root) or resolved == root for root in allowed):
+        raise RuntimeError(f"source file escapes its model cache root: {relative}")
+    return resolved
+
+
+def _read_layout(path: Path) -> tuple[int, dict]:
+    with (
+        path.open("rb") as handle,
+        mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mapped,
+    ):
+        if len(mapped) < 8:
+            raise RuntimeError(f"truncated safetensors file: {path}")
+        header_len = int(np.frombuffer(mapped[:8], dtype=np.uint64)[0])
+        header = json.loads(mapped[8 : 8 + header_len].decode("utf-8"))
+    return header_len, header
+
+
+def _source_manifest(
+    source: Path,
+) -> tuple[dict[str, str], dict[str, tuple[int, dict]]]:
+    index_path = source / "model.safetensors.index.json"
+    if index_path.is_file():
+        weight_map = json.loads(index_path.read_text()).get("weight_map")
+        if not isinstance(weight_map, dict) or not weight_map:
+            raise RuntimeError("source index has an empty weight_map")
+    else:
+        files = sorted(source.glob("*.safetensors"))
+        if len(files) != 1:
+            raise RuntimeError("source needs one safetensors file or a canonical index")
+        _, header = _read_layout(_safe_source_file(source, Path(files[0].name)))
+        weight_map = {name: files[0].name for name in header if name != "__metadata__"}
+        if not weight_map:
+            raise RuntimeError("source safetensors file contains no weights")
+
+    layouts: dict[str, tuple[int, dict]] = {}
+    resolved_shards: dict[str, Path] = {}
+    for name, shard_name in weight_map.items():
+        if not isinstance(name, str) or not isinstance(shard_name, str):
+            raise RuntimeError("source weight_map must contain string keys and values")
+        shard = resolved_shards.get(shard_name)
+        if shard is None:
+            shard = _safe_source_file(source, Path(shard_name))
+            resolved_shards[shard_name] = shard
+        if str(shard) not in layouts:
+            layouts[str(shard)] = _read_layout(shard)
+        if name not in layouts[str(shard)][1]:
+            raise RuntimeError(
+                f"weight {name!r} is absent from declared shard {shard_name}"
+            )
+    return dict(weight_map), layouts
+
+
+def _descriptors(
+    source: Path,
+) -> tuple[list[TensorDescriptor], dict[str, str], dict[str, tuple[int, dict]]]:
+    weight_map, layouts = _source_manifest(source)
+    descriptors = []
+    resolved_shards: dict[str, Path] = {}
+    for name in sorted(weight_map):
+        shard_name = weight_map[name]
+        shard = resolved_shards.get(shard_name)
+        if shard is None:
+            shard = _safe_source_file(source, Path(shard_name))
+            resolved_shards[shard_name] = shard
+        info = layouts[str(shard)][1][name]
+        descriptors.append(
+            TensorDescriptor(name, tuple(int(v) for v in info["shape"]), info["dtype"])
+        )
+    return descriptors, weight_map, layouts
+
+
+def _tensor_bytes(path: Path, header_len: int, header: dict, name: str) -> bytes:
+    info = header[name]
+    begin = 8 + header_len + int(info["data_offsets"][0])
+    end = 8 + header_len + int(info["data_offsets"][1])
+    with (
+        path.open("rb") as handle,
+        mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mapped,
+    ):
+        return bytes(mapped[begin:end])
+
+
+def _mlx_from_bytes(data: bytes, dtype: str, shape: tuple[int, ...]) -> mx.array:
+    dtype = dtype.upper()
+    if dtype == "F8_E4M3":
+        return mx.array(np.frombuffer(data, dtype=np.uint8).reshape(shape))
+    if dtype == "BF16":
+        return mx.array(np.frombuffer(data, dtype=np.uint16).reshape(shape)).view(
+            mx.bfloat16
+        )
+    np_dtype = _NP_DTYPES.get(dtype)
+    if np_dtype is None:
+        raise RuntimeError(f"unsupported source dtype: {dtype}")
+    return mx.array(np.frombuffer(data, dtype=np_dtype).reshape(shape))
+
+
+def _load_tensor(
+    source: Path,
+    weight_map: dict[str, str],
+    layouts: dict[str, tuple[int, dict]],
+    name: str,
+) -> mx.array:
+    shard = _safe_source_file(source, Path(weight_map[name]))
+    header_len, header = layouts[str(shard)]
+    info = header[name]
+    raw = _tensor_bytes(shard, header_len, header, name)
+    try:
+        return _mlx_from_bytes(
+            raw,
+            str(info["dtype"]),
+            tuple(int(value) for value in info["shape"]),
+        )
+    finally:
+        del raw
+
+
+def _logical_source_descriptors(
+    packed: list[TensorDescriptor], config: dict
+) -> tuple[list[TensorDescriptor], dict[str, str]]:
+    """Pair official block-FP8 weights with their inverse-scale grids."""
+    if not _is_supported_block_fp8(config):
+        return packed, {}
+
+    by_name = {item.name: item for item in packed}
+    fp8_scales: dict[str, str] = {}
+    logical = []
+    for item in packed:
+        if item.name.endswith(".weight_scale_inv"):
+            weight = item.name[: -len("_scale_inv")]
+            if weight not in by_name:
+                raise RuntimeError(f"orphan FP8 scale tensor: {item.name}")
+            continue
+        if item.dtype.upper() == "F8_E4M3":
+            if not item.name.endswith(".weight"):
+                raise RuntimeError(f"unsupported non-weight FP8 tensor: {item.name}")
+            scale = item.name + "_scale_inv"
+            scale_desc = by_name.get(scale)
+            if scale_desc is None:
+                raise RuntimeError(f"missing FP8 inverse scale for {item.name}")
+            expected = tuple(
+                (value + _FP8_BLOCK_SIZE - 1) // _FP8_BLOCK_SIZE for value in item.shape
+            )
+            if (
+                len(item.shape) != 2
+                or scale_desc.shape != expected
+                or scale_desc.dtype.upper() not in _FLOAT_SOURCE_DTYPES
+            ):
+                raise RuntimeError(
+                    f"invalid FP8 scale grid for {item.name}: got shape "
+                    f"{scale_desc.shape} dtype {scale_desc.dtype}, expected "
+                    f"{expected} with a floating dtype"
+                )
+            logical.append(TensorDescriptor(item.name, item.shape, "BF16"))
+            fp8_scales[item.name] = scale
+        else:
+            logical.append(item)
+    return logical, fp8_scales
+
+
+def _restore_block_fp8(weight: mx.array, scale_inv: mx.array) -> mx.array:
+    if weight.dtype != mx.uint8 or weight.ndim != 2:
+        raise RuntimeError("block-FP8 weights must be 2D E4M3 byte arrays")
+    rows, columns = weight.shape
+    expected = (
+        (rows + _FP8_BLOCK_SIZE - 1) // _FP8_BLOCK_SIZE,
+        (columns + _FP8_BLOCK_SIZE - 1) // _FP8_BLOCK_SIZE,
+    )
+    if scale_inv.shape != expected:
+        raise RuntimeError(
+            f"block-FP8 scale shape mismatch: got {scale_inv.shape}, expected {expected}"
+        )
+    pad_rows = (-rows) % _FP8_BLOCK_SIZE
+    pad_columns = (-columns) % _FP8_BLOCK_SIZE
+    decoded = mx.from_fp8(weight, dtype=mx.bfloat16)
+    if pad_rows or pad_columns:
+        decoded = mx.pad(decoded, ((0, pad_rows), (0, pad_columns)))
+    decoded = decoded.reshape(
+        (rows + pad_rows) // _FP8_BLOCK_SIZE,
+        _FP8_BLOCK_SIZE,
+        (columns + pad_columns) // _FP8_BLOCK_SIZE,
+        _FP8_BLOCK_SIZE,
+    )
+    decoded = (decoded * scale_inv[:, None, :, None]).reshape(
+        rows + pad_rows, columns + pad_columns
+    )
+    return decoded[:rows, :columns]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+class _ShardWriter:
+    def __init__(self, output: Path, max_bytes: int):
+        self.output = output
+        self.max_bytes = max_bytes
+        self.buffers: list[dict[str, mx.array]] = []
+        self.buffer_bytes = 0
+        self.files: list[Path] = []
+        self.weight_map: dict[str, str] = {}
+        self.payload_bytes = 0
+
+    def add(self, tensors: dict[str, mx.array]) -> None:
+        size = sum(int(value.nbytes) for value in tensors.values())
+        if self.buffers and self.buffer_bytes + size > self.max_bytes:
+            self._flush()
+        self.buffers.append(tensors)
+        self.buffer_bytes += size
+        self.payload_bytes += size
+
+    def _flush(self) -> None:
+        if not self.buffers:
+            return
+        path = self.output / f"model-{len(self.files) + 1:05d}-of-00000.safetensors"
+        payload: dict[str, mx.array] = {}
+        for tensors in self.buffers:
+            payload.update(tensors)
+        mx.save_safetensors(str(path), payload, metadata={"format": "mlx"})
+        self.files.append(path)
+        for name in payload:
+            self.weight_map[name] = path.name
+        self.buffers = []
+        self.buffer_bytes = 0
+
+    def finish(self) -> None:
+        self._flush()
+        count = len(self.files)
+        old_to_new = {}
+        for i, old in enumerate(self.files, 1):
+            new = self.output / f"model-{i:05d}-of-{count:05d}.safetensors"
+            old.replace(new)
+            old_to_new[old.name] = new.name
+        self.weight_map = {
+            key: old_to_new[value] for key, value in self.weight_map.items()
+        }
+
+
+def _load_sensitivity(path: Path | None) -> dict[str, float]:
+    if path is None:
+        return {}
+    payload = json.loads(path.read_text())
+    scores = payload.get("scores", payload) if isinstance(payload, dict) else None
+    if not isinstance(scores, dict):
+        raise RuntimeError(
+            "sensitivity JSON must be an object or contain a scores object"
+        )
+    return {str(key): float(value) for key, value in scores.items()}
+
+
+def inspect(source: Path, sensitivity_path: Path | None = None) -> dict[str, object]:
+    source = source.expanduser().resolve()
+    config = json.loads((source / "config.json").read_text())
+    if config.get("model_type") != "glm5_next":
+        raise RuntimeError("RMQ v1 accepts only model_type=glm5_next")
+    if (config.get("quantization") or config.get("quantization_config")) and not (
+        _is_supported_block_fp8(config)
+    ):
+        raise RuntimeError("RMQ requires BF16 or supported block-FP8 source weights")
+    packed, _, _ = _descriptors(source)
+    descriptors, _ = _logical_source_descriptors(packed, config)
+    plan = plan_tensors(descriptors, config, _load_sensitivity(sensitivity_path))
+    summary = summarize_plan(plan)
+    summary.update(
+        {
+            "source": str(source),
+            "source_tensors": len(packed),
+            "logical_tensors": len(descriptors),
+            "source_payload_bytes": sum(
+                item.parameters * _DTYPE_BYTES[item.dtype.upper()] for item in packed
+            ),
+            "source_format": (
+                "block-fp8-e4m3-128x128" if _is_supported_block_fp8(config) else "float"
+            ),
+        }
+    )
+    return summary
+
+
+def inspect_quantized_shapes(
+    source: Path, sensitivity_path: Path | None = None
+) -> dict[str, object]:
+    """Project RMQ storage from packed headers without requantizing payloads."""
+    source = source.expanduser().resolve()
+    config = json.loads((source / "config.json").read_text())
+    quantization = config.get("quantization") or config.get("quantization_config")
+    if config.get("model_type") != "glm5_next" or not isinstance(quantization, dict):
+        raise RuntimeError("shape projection requires a quantized glm5_next checkpoint")
+    group_size = int(quantization.get("group_size") or 0)
+    if group_size != 64:
+        raise RuntimeError("RMQ shape projection currently requires group_size=64")
+
+    packed, _, _ = _descriptors(source)
+    by_name = {item.name: item for item in packed}
+    logical = []
+    inferred_bits: dict[int, int] = {}
+    for item in packed:
+        if item.name.endswith((".scales", ".biases")):
+            base = item.name.rsplit(".", 1)[0] + ".weight"
+            if base in by_name:
+                continue
+        if item.name.endswith(".weight") and item.dtype.upper() == "U32":
+            base = item.name.removesuffix(".weight")
+            scales = by_name.get(f"{base}.scales")
+            if scales is None or len(scales.shape) != len(item.shape):
+                raise RuntimeError(
+                    f"packed weight has no compatible scales: {item.name}"
+                )
+            original_width = scales.shape[-1] * group_size
+            bits_numerator = item.shape[-1] * 32
+            if not original_width or bits_numerator % original_width:
+                raise RuntimeError(f"cannot infer packed width for {item.name}")
+            bits = bits_numerator // original_width
+            if bits not in (2, 3, 4, 5, 6, 8):
+                raise RuntimeError(f"unsupported inferred Q{bits} for {item.name}")
+            inferred_bits[bits] = inferred_bits.get(bits, 0) + 1
+            shape = (*item.shape[:-1], original_width)
+            logical.append(TensorDescriptor(item.name, shape, scales.dtype))
+        else:
+            logical.append(item)
+
+    planning_config = dict(config)
+    planning_config.pop("quantization", None)
+    planning_config.pop("quantization_config", None)
+    plan = plan_tensors(logical, planning_config, _load_sensitivity(sensitivity_path))
+    summary = summarize_plan(plan)
+    source_payload_bytes = sum(
+        item.parameters * _DTYPE_BYTES[item.dtype.upper()] for item in packed
+    )
+    summary.update(
+        {
+            "source": str(source),
+            "source_tensors": len(packed),
+            "logical_tensors": len(logical),
+            "source_payload_bytes": source_payload_bytes,
+            "projected_delta_bytes": int(summary["projected_storage_bytes"])
+            - source_payload_bytes,
+            "inferred_source_quantized_weights": dict(sorted(inferred_bits.items())),
+            "projection_only": True,
+        }
+    )
+    return summary
+
+
+def _write_metadata(
+    source: Path,
+    output: Path,
+    plan,
+    writer: _ShardWriter,
+    summary: dict[str, object],
+) -> None:
+    config = json.loads((source / "config.json").read_text())
+    quantization: dict[str, object] = {
+        "group_size": 64,
+        "bits": 4,
+        "mode": "affine",
+    }
+    for item in plan:
+        if item.spec.quantized and item.spec.bits != 4:
+            paths = (
+                *module_paths(item.tensor.name),
+                *mtp_module_paths(item.tensor.name, config),
+            )
+            for path in paths:
+                quantization[path] = item.spec.as_config()
+    config["quantization"] = quantization
+    config["quantization_config"] = quantization
+    config["rapid_quantization"] = {
+        "method": "rmq-v1",
+        "apple_native_formats": ["q4-g64-affine", "q8-g64-affine"],
+        "fusion_domain_locked": True,
+        "source_format": "bf16-or-block-fp8",
+        "requantized_source_rejected": True,
+        "plan": summary,
+    }
+    (output / "config.json").write_text(json.dumps(config, indent=2) + "\n")
+    for name in _AUX_NAMES:
+        candidate = source / name
+        if candidate.is_file():
+            _safe_source_file(source, Path(name))
+            shutil.copyfile(candidate, output / name)
+    index = {
+        "metadata": {"total_size": writer.payload_bytes},
+        "weight_map": dict(sorted(writer.weight_map.items())),
+    }
+    (output / "model.safetensors.index.json").write_text(
+        json.dumps(index, indent=2) + "\n"
+    )
+    sums = []
+    for path in sorted(output.iterdir()):
+        if path.is_file() and path.name != "SHA256SUMS.txt":
+            sums.append(f"{_sha256(path)}  {path.name}\n")
+    (output / "SHA256SUMS.txt").write_text("".join(sums))
+
+
+def convert(
+    source: Path,
+    output: Path,
+    *,
+    sensitivity_path: Path | None = None,
+    max_shard_bytes: int = DEFAULT_MAX_SHARD_BYTES,
+    max_rss_bytes: int = 220 * 1024**3,
+) -> dict[str, object]:
+    source = source.expanduser().resolve()
+    output = output.expanduser().resolve()
+    if output.exists():
+        raise RuntimeError(f"output already exists: {output}")
+    if not (source / "config.json").is_file():
+        raise RuntimeError("source has no config.json")
+    if max_shard_bytes <= 0 or max_rss_bytes <= 0:
+        raise ValueError("shard and RSS limits must be positive")
+
+    config = json.loads((source / "config.json").read_text())
+    if config.get("model_type") != "glm5_next":
+        raise RuntimeError("RMQ v1 accepts only model_type=glm5_next")
+    if (config.get("quantization") or config.get("quantization_config")) and not (
+        _is_supported_block_fp8(config)
+    ):
+        raise RuntimeError(
+            "RMQ refuses requantization; provide BF16 or official block-FP8 weights"
+        )
+
+    packed, weight_map, layouts = _descriptors(source)
+    descriptors, fp8_scales = _logical_source_descriptors(packed, config)
+    plan = plan_tensors(descriptors, config, _load_sensitivity(sensitivity_path))
+    summary = summarize_plan(plan)
+    needed = int(summary["projected_storage_bytes"] * 1.10) + 1024**3
+    output.parent.mkdir(parents=True, exist_ok=True)
+    free = shutil.disk_usage(output.parent).free
+    if free < needed:
+        raise RuntimeError(
+            f"insufficient output space: {free / 1024**3:.1f} GiB free, "
+            f"{needed / 1024**3:.1f} GiB required"
+        )
+
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{output.name}.staging-", dir=output.parent)
+    )
+    started = time.monotonic()
+    writer = _ShardWriter(staging, max_shard_bytes)
+    try:
+        by_name = {item.tensor.name: item for item in plan}
+        for name in sorted(by_name):
+            if peak_rss_bytes() > max_rss_bytes:
+                raise RuntimeError("RMQ conversion exceeded the configured RSS guard")
+            item = by_name[name]
+            array = _load_tensor(source, weight_map, layouts, name)
+            if name in fp8_scales:
+                scale_inv = _load_tensor(source, weight_map, layouts, fp8_scales[name])
+                array = _restore_block_fp8(array, scale_inv)
+                del scale_inv
+            if item.spec.quantized:
+                qweight, scales, biases = mx.quantize(
+                    array,
+                    group_size=int(item.spec.group_size),
+                    bits=int(item.spec.bits),
+                    mode=str(item.spec.mode),
+                )
+                mx.eval(qweight, scales, biases)
+                base = name.removesuffix(".weight")
+                writer.add(
+                    {
+                        name: qweight,
+                        f"{base}.scales": scales,
+                        f"{base}.biases": biases,
+                    }
+                )
+            else:
+                mx.eval(array)
+                writer.add({name: array})
+            del array
+        writer.finish()
+        _write_metadata(source, staging, plan, writer, summary)
+        os.replace(staging, output)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return {
+        **summary,
+        "source": str(source),
+        "output": str(output),
+        "output_payload_bytes": writer.payload_bytes,
+        "peak_rss_bytes": peak_rss_bytes(),
+        "wall_seconds": round(time.monotonic() - started, 3),
+        "status": "ok",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--sensitivity", type=Path)
+    parser.add_argument("--inspect-only", action="store_true")
+    parser.add_argument("--inspect-quantized-shapes", action="store_true")
+    parser.add_argument("--max-shard-bytes", type=int, default=DEFAULT_MAX_SHARD_BYTES)
+    parser.add_argument("--max-rss-gib", type=float, default=220.0)
+    args = parser.parse_args()
+    if args.inspect_only and args.inspect_quantized_shapes:
+        parser.error("choose only one inspection mode")
+    if args.inspect_quantized_shapes:
+        result = inspect_quantized_shapes(args.source, args.sensitivity)
+    elif args.inspect_only:
+        result = inspect(args.source, args.sensitivity)
+    else:
+        if args.output is None:
+            parser.error("--output is required unless --inspect-only is used")
+        result = convert(
+            args.source,
+            args.output,
+            sensitivity_path=args.sensitivity,
+            max_shard_bytes=args.max_shard_bytes,
+            max_rss_bytes=int(args.max_rss_gib * 1024**3),
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_glm53_rmq.py
+++ b/tests/test_glm53_rmq.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import pytest
 
+import vllm_mlx.quantization.glm53_rmq as rmq
 from vllm_mlx.quantization.glm53_rmq import (
+    QuantSpec,
     TensorDescriptor,
     fusion_domain,
     module_path,
     module_paths,
     mtp_module_paths,
     plan_tensors,
+    projected_storage_bytes,
     summarize_plan,
 )
 
@@ -80,6 +83,18 @@ def test_invalid_sensitivity_fails_closed():
         plan_tensors([tensor], CONFIG, {tensor.name: 1.1})
 
 
+def test_invalid_quant_specs_fail_closed():
+    with pytest.raises(ValueError, match="floating-point"):
+        QuantSpec(bits=None).as_config()
+    assert QuantSpec(bits=8, group_size=64, mode="affine").as_config() == {
+        "bits": 8,
+        "group_size": 64,
+        "mode": "affine",
+    }
+    with pytest.raises(ValueError, match="Q7"):
+        rmq._q(7, "invalid")
+
+
 def test_non_native_width_and_vision_stay_float():
     tensors = [
         td("model.language_model.layers.1.mlp.down_proj.weight", (64, 96)),
@@ -87,6 +102,18 @@ def test_non_native_width_and_vision_stay_float():
     ]
     plan = plan_tensors(tensors, CONFIG)
     assert [item.spec.bits for item in plan] == [None, None]
+
+
+def test_remaining_policy_fallbacks_and_float_storage():
+    tensors = [
+        td("model.language_model.layers.1.buffer.weight", dtype="U8"),
+        td("model.language_model.layers.1.mlp.down_proj.weight"),
+        td("model.language_model.layers.1.other.weight"),
+        td("model.language_model.layers.1.float_state", (64,), "F32"),
+    ]
+    plan = plan_tensors(tensors, CONFIG)
+    assert [item.spec.bits for item in plan] == [None, 8, 4, None]
+    assert projected_storage_bytes([plan[-1]]) == 64 * 4
 
 
 def test_module_path_matches_mlx_vlm_tree_and_summary_is_stable():
@@ -133,6 +160,7 @@ def test_fusion_domain_is_explicit_and_narrow():
     ("source", "expected"),
     [
         ("eh_proj", ("eh_proj",)),
+        ("shared_head.norm", ("shared_head_norm",)),
         (
             "mlp.experts.7.down_proj",
             ("mtp_block.mlp.switch_mlp.down_proj",),

--- a/tests/test_glm53_rmq.py
+++ b/tests/test_glm53_rmq.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pytest
+
+from vllm_mlx.quantization.glm53_rmq import (
+    TensorDescriptor,
+    fusion_domain,
+    module_path,
+    module_paths,
+    mtp_module_paths,
+    plan_tensors,
+    summarize_plan,
+)
+
+CONFIG = {"model_type": "glm5_next", "text_config": {"num_hidden_layers": 45}}
+
+
+def td(name: str, shape=(64, 64), dtype="BF16") -> TensorDescriptor:
+    return TensorDescriptor(name, tuple(shape), dtype)
+
+
+def test_glm53_rmq_static_precision_floors():
+    tensors = [
+        td("lm_head.weight", (1024, 64)),
+        td("model.language_model.embed_tokens.weight", (1024, 64)),
+        td("model.language_model.layers.3.self_attn.indexer.wk.weight"),
+        td("model.language_model.layers.4.self_attn.q_proj.weight"),
+        td("model.language_model.layers.4.self_attn.f_b_proj.weight"),
+        td("model.language_model.layers.4.mlp.experts.0.down_proj.weight"),
+        td("model.language_model.layers.4.mlp.shared_experts.down_proj.weight"),
+        td("model.language_model.layers.4.mlp.gate.weight", (288, 4096)),
+        td("model.language_model.layers.45.mlp.experts.0.down_proj.weight"),
+        td("model.language_model.layers.4.self_attn.dt_bias", (64,), "F32"),
+    ]
+    bits = [item.spec.bits for item in plan_tensors(tensors, CONFIG)]
+    assert bits == [8, 8, 8, 8, 8, 4, 8, None, 4, None]
+
+
+def test_mtp_precision_matches_the_corresponding_target_domains():
+    tensors = [
+        td("model.language_model.layers.44.mlp.experts.0.down_proj.weight"),
+        td("model.language_model.layers.45.mlp.experts.0.down_proj.weight"),
+        td("model.language_model.layers.44.mlp.shared_experts.down_proj.weight"),
+        td("model.language_model.layers.45.mlp.shared_experts.down_proj.weight"),
+        td("model.language_model.layers.45.self_attn.o_proj.weight"),
+    ]
+    assert [item.spec.bits for item in plan_tensors(tensors, CONFIG)] == [
+        4,
+        4,
+        8,
+        8,
+        8,
+    ]
+
+
+def test_sensitivity_raise_is_locked_across_kda_fusion_domain():
+    tensors = [
+        td(f"model.language_model.layers.4.self_attn.{name}.weight")
+        for name in ("q_proj", "k_proj", "v_proj", "f_a_proj", "g_a_proj", "b_proj")
+    ]
+    domain = "layer:4:kda-fused-input"
+    plan = plan_tensors(tensors, CONFIG, {tensors[0].name: 0.9})
+    assert {item.spec.bits for item in plan} == {8}
+    assert {item.fusion_domain for item in plan} == {domain}
+
+
+def test_routed_expert_projection_cannot_mix_bits():
+    tensors = [
+        td(f"model.language_model.layers.10.mlp.experts.{i}.down_proj.weight")
+        for i in range(4)
+    ]
+    plan = plan_tensors(tensors, CONFIG, {tensors[2].name: 0.6})
+    assert {item.spec.bits for item in plan} == {8}
+    assert {item.fusion_domain for item in plan} == {"layer:10:routed:down_proj"}
+
+
+def test_invalid_sensitivity_fails_closed():
+    tensor = td("model.language_model.layers.1.self_attn.q_proj.weight")
+    with pytest.raises(ValueError, match="within"):
+        plan_tensors([tensor], CONFIG, {tensor.name: 1.1})
+
+
+def test_non_native_width_and_vision_stay_float():
+    tensors = [
+        td("model.language_model.layers.1.mlp.down_proj.weight", (64, 96)),
+        td("model.visual.blocks.0.attn.qkv.weight", (192, 64)),
+    ]
+    plan = plan_tensors(tensors, CONFIG)
+    assert [item.spec.bits for item in plan] == [None, None]
+
+
+def test_module_path_matches_mlx_vlm_tree_and_summary_is_stable():
+    name = "model.language_model.layers.2.self_attn.q_proj.weight"
+    assert module_path(name) == "language_model.model.layers.2.self_attn.q_proj"
+    plan = plan_tensors([td(name), td("lm_head.weight")], CONFIG)
+    summary = summarize_plan(plan)
+    assert summary["fusion_domains"] == 1
+    assert set(summary["formats"]) == {"q8-g64"}
+    assert summary["projected_storage_bytes"] > 0
+
+
+def test_module_path_tracks_glm_forget_gate_sanitizer():
+    name = "model.language_model.layers.2.self_attn.f_a_proj.weight"
+    assert (
+        module_path(name)
+        == "language_model.model.layers.2.self_attn.forget_gate.f_a_proj"
+    )
+
+
+def test_module_paths_track_split_attention_and_fused_experts():
+    kv_b = "model.language_model.layers.3.self_attn.kv_b_proj.weight"
+    assert module_paths(kv_b) == (
+        "language_model.model.layers.3.self_attn.embed_q",
+        "language_model.model.layers.3.self_attn.unembed_out",
+    )
+    expert = "model.language_model.layers.3.mlp.experts.7.down_proj.weight"
+    assert module_paths(expert) == (
+        "language_model.model.layers.3.mlp.switch_mlp.down_proj",
+    )
+
+
+def test_fusion_domain_is_explicit_and_narrow():
+    assert (
+        fusion_domain("model.language_model.layers.7.self_attn.f_a_proj.weight")
+        == "layer:7:kda-fused-input"
+    )
+    assert (
+        fusion_domain("model.language_model.layers.7.self_attn.f_b_proj.weight") is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("eh_proj", ("eh_proj",)),
+        (
+            "mlp.experts.7.down_proj",
+            ("mtp_block.mlp.switch_mlp.down_proj",),
+        ),
+        (
+            "mlp.shared_experts.gate_proj",
+            ("mtp_block.mlp.shared_experts.gate_up_proj",),
+        ),
+        (
+            "self_attn.kv_a_proj_with_mqa",
+            ("mtp_block.self_attn.qkv_a_proj",),
+        ),
+        (
+            "self_attn.kv_b_proj",
+            ("mtp_block.self_attn.embed_q", "mtp_block.self_attn.unembed_out"),
+        ),
+        (
+            "self_attn.indexer.wk",
+            ("mtp_block.self_attn.indexer.wk",),
+        ),
+    ],
+)
+def test_mtp_module_paths_match_post_split_sanitizer(source, expected):
+    name = f"model.language_model.layers.45.{source}.weight"
+    assert mtp_module_paths(name, CONFIG) == expected
+    assert mtp_module_paths(name.replace("layers.45", "layers.44"), CONFIG) == ()

--- a/tests/test_glm53_rmq_convert.py
+++ b/tests/test_glm53_rmq_convert.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-import mlx.core as mx
 import pytest
 
 from vllm_mlx.quantization.glm53_rmq import TensorDescriptor
+
+mx = pytest.importorskip("mlx.core")
 
 
 def _converter_module():

--- a/tests/test_glm53_rmq_convert.py
+++ b/tests/test_glm53_rmq_convert.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import mlx.core as mx
+import pytest
+
+from vllm_mlx.quantization.glm53_rmq import TensorDescriptor
+
+
+def _converter_module():
+    path = Path(__file__).parents[1] / "scripts" / "glm53_rmq_convert.py"
+    spec = importlib.util.spec_from_file_location("glm53_rmq_convert", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+CONVERTER = _converter_module()
+FP8_CONFIG = {
+    "model_type": "glm5_next",
+    "quantization_config": {
+        "quant_method": "fp8",
+        "fmt": "e4m3",
+        "weight_block_size": [128, 128],
+    },
+}
+
+
+def test_official_block_fp8_is_a_supported_source_format():
+    assert CONVERTER._is_supported_block_fp8(FP8_CONFIG)
+    assert not CONVERTER._is_supported_block_fp8(
+        {"quantization_config": {"quant_method": "fp8"}}
+    )
+
+
+def test_fp8_descriptors_pair_weight_and_scale_grid():
+    weight = TensorDescriptor("layers.0.proj.weight", (129, 257), "F8_E4M3")
+    scale = TensorDescriptor("layers.0.proj.weight_scale_inv", (2, 3), "F32")
+    logical, scales = CONVERTER._logical_source_descriptors([weight, scale], FP8_CONFIG)
+    assert logical == [TensorDescriptor(weight.name, weight.shape, "BF16")]
+    assert scales == {weight.name: scale.name}
+
+
+def test_fp8_descriptor_rejects_a_wrong_scale_grid():
+    weight = TensorDescriptor("layers.0.proj.weight", (129, 257), "F8_E4M3")
+    scale = TensorDescriptor("layers.0.proj.weight_scale_inv", (1, 3), "F32")
+    with pytest.raises(RuntimeError, match="invalid FP8 scale grid"):
+        CONVERTER._logical_source_descriptors([weight, scale], FP8_CONFIG)
+
+
+def test_fp8_descriptor_rejects_an_integer_scale_grid():
+    weight = TensorDescriptor("layers.0.proj.weight", (128, 128), "F8_E4M3")
+    scale = TensorDescriptor("layers.0.proj.weight_scale_inv", (1, 1), "U8")
+    with pytest.raises(RuntimeError, match="floating dtype"):
+        CONVERTER._logical_source_descriptors([weight, scale], FP8_CONFIG)
+
+
+def test_block_fp8_restore_applies_each_128_square_inverse_scale():
+    source = mx.ones((128, 256), dtype=mx.bfloat16)
+    encoded = mx.to_fp8(source)
+    scales = mx.array([[2.0, 3.0]], dtype=mx.float32)
+    restored = CONVERTER._restore_block_fp8(encoded, scales)
+    mx.eval(restored)
+    assert restored.shape == source.shape
+    assert float(restored[0, 0]) == 2.0
+    assert float(restored[0, 200]) == 3.0

--- a/vllm_mlx/quantization/__init__.py
+++ b/vllm_mlx/quantization/__init__.py
@@ -1,0 +1,1 @@
+"""Checkpoint quantization planning helpers."""

--- a/vllm_mlx/quantization/glm53_rmq.py
+++ b/vllm_mlx/quantization/glm53_rmq.py
@@ -47,12 +47,12 @@ class QuantSpec:
         return self.bits is not None
 
     def as_config(self) -> dict[str, int | str]:
-        if not self.quantized:
+        if self.bits is None or self.group_size is None or self.mode is None:
             raise ValueError("floating-point tensors have no quantization config")
         return {
-            "bits": int(self.bits),
-            "group_size": int(self.group_size),
-            "mode": str(self.mode),
+            "bits": self.bits,
+            "group_size": self.group_size,
+            "mode": self.mode,
         }
 
 
@@ -260,10 +260,12 @@ def plan_tensors(
         domain = fusion_domain(tensor.name)
         spec = _base_spec(tensor, config)
         if spec.quantized:
+            assert spec.bits is not None
             score = _score_for(tensor.name, domain, sensitivity)
-            spec = _q(_raised_bits(int(spec.bits), score), spec.reason)
+            spec = _q(_raised_bits(spec.bits, score), spec.reason)
             if domain is not None:
-                domain_bits[domain] = max(domain_bits.get(domain, 0), int(spec.bits))
+                assert spec.bits is not None
+                domain_bits[domain] = max(domain_bits.get(domain, 0), spec.bits)
         provisional.append(TensorPlan(tensor, spec, domain))
 
     result: list[TensorPlan] = []
@@ -288,8 +290,9 @@ def projected_storage_bytes(plan: Sequence[TensorPlan]) -> int:
             bytes_per = 4 if item.tensor.dtype.upper() == "F32" else 2
             total += params * bytes_per
             continue
-        bits = int(item.spec.bits)
-        groups = params // int(item.spec.group_size)
+        assert item.spec.bits is not None and item.spec.group_size is not None
+        bits = item.spec.bits
+        groups = params // item.spec.group_size
         total += math.ceil(params * bits / 8) + groups * 4
     return total
 

--- a/vllm_mlx/quantization/glm53_rmq.py
+++ b/vllm_mlx/quantization/glm53_rmq.py
@@ -1,0 +1,327 @@
+"""Apple-native mixed-precision planning for GLM-5.3-Flash.
+
+RMQ deliberately emits only MLX affine Q4/Q8 group-64 weights.  The small
+format vocabulary keeps generated checkpoints on MLX's native quantized
+matmul path.  Plans are also grouped by runtime fusion domain: a sensitivity
+override may raise a whole domain, but can never silently split the six KDA
+input projections or the experts consumed by one ``SwitchLinear``.
+
+This module plans a conversion. It does not claim that an already-repacked
+integer checkpoint can regain information; conversion must start from BF16 or
+the official block-FP8 source representation.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+_LAYER_RE = re.compile(r"\.layers\.(\d+)\.")
+_EXPERT_RE = re.compile(r"\.mlp\.experts\.\d+\.(down_proj|gate_proj|up_proj)\.weight$")
+
+_KDA_FUSED_INPUTS = (
+    ".self_attn.q_proj.weight",
+    ".self_attn.k_proj.weight",
+    ".self_attn.v_proj.weight",
+    ".self_attn.f_a_proj.weight",
+    ".self_attn.g_a_proj.weight",
+    ".self_attn.b_proj.weight",
+)
+
+_FLOAT_DTYPES = frozenset({"BF16", "F16", "F32"})
+
+
+@dataclass(frozen=True)
+class QuantSpec:
+    """One MLX-native storage decision."""
+
+    bits: int | None
+    group_size: int | None = None
+    mode: str | None = None
+    reason: str = ""
+
+    @property
+    def quantized(self) -> bool:
+        return self.bits is not None
+
+    def as_config(self) -> dict[str, int | str]:
+        if not self.quantized:
+            raise ValueError("floating-point tensors have no quantization config")
+        return {
+            "bits": int(self.bits),
+            "group_size": int(self.group_size),
+            "mode": str(self.mode),
+        }
+
+
+@dataclass(frozen=True)
+class TensorDescriptor:
+    name: str
+    shape: tuple[int, ...]
+    dtype: str
+
+    @property
+    def parameters(self) -> int:
+        return math.prod(self.shape)
+
+
+@dataclass(frozen=True)
+class TensorPlan:
+    tensor: TensorDescriptor
+    spec: QuantSpec
+    fusion_domain: str | None
+
+
+def _q(bits: int, reason: str) -> QuantSpec:
+    if bits not in (4, 8):
+        raise ValueError(f"RMQ supports only Q4/Q8, got Q{bits}")
+    return QuantSpec(bits=bits, group_size=64, mode="affine", reason=reason)
+
+
+def _fp(reason: str) -> QuantSpec:
+    return QuantSpec(bits=None, reason=reason)
+
+
+def layer_index(name: str) -> int | None:
+    match = _LAYER_RE.search(name)
+    return int(match.group(1)) if match else None
+
+
+def module_paths(name: str) -> tuple[str, ...]:
+    """Translate one source weight to its post-sanitize mlx-vlm modules."""
+    path = name.removesuffix(".weight")
+    if path.startswith("model.language_model."):
+        path = "language_model.model." + path.removeprefix("model.language_model.")
+    elif path == "lm_head":
+        path = "language_model.lm_head"
+    expert = re.search(r"\.mlp\.experts\.\d+\.(down_proj|gate_proj|up_proj)$", path)
+    if expert:
+        prefix = path[: expert.start()]
+        return (f"{prefix}.mlp.switch_mlp.{expert.group(1)}",)
+    if path.endswith(".self_attn.kv_b_proj"):
+        prefix = path.removesuffix(".kv_b_proj")
+        return (f"{prefix}.embed_q", f"{prefix}.unembed_out")
+    for projection in ("f_a_proj", "f_b_proj"):
+        old = f".self_attn.{projection}"
+        if path.endswith(old):
+            path = path.removesuffix(old) + f".self_attn.forget_gate.{projection}"
+    return (path,)
+
+
+def module_path(name: str) -> str:
+    """Return the primary post-sanitize module path for compatibility."""
+    return module_paths(name)[0]
+
+
+def mtp_module_paths(name: str, config: Mapping) -> tuple[str, ...]:
+    """Return layer-45 paths after extraction into the standalone drafter."""
+    idx = layer_index(name)
+    text = config.get("text_config") or {}
+    n_layers = int(
+        text.get("num_hidden_layers") or config.get("num_hidden_layers") or 0
+    )
+    if idx is None or not n_layers or idx < n_layers:
+        return ()
+    marker = f".layers.{idx}."
+    suffix = name.split(marker, 1)[1].removesuffix(".weight")
+    if suffix in ("enorm", "hnorm", "eh_proj"):
+        return (suffix,)
+    if suffix == "shared_head.norm":
+        return ("shared_head_norm",)
+    if re.fullmatch(r"mlp\.experts\.\d+\.(down_proj|gate_proj|up_proj)", suffix):
+        projection = suffix.rsplit(".", 1)[1]
+        return (f"mtp_block.mlp.switch_mlp.{projection}",)
+    if suffix in ("mlp.shared_experts.gate_proj", "mlp.shared_experts.up_proj"):
+        return ("mtp_block.mlp.shared_experts.gate_up_proj",)
+    if suffix == "self_attn.kv_b_proj":
+        return (
+            "mtp_block.self_attn.embed_q",
+            "mtp_block.self_attn.unembed_out",
+        )
+    if suffix in ("self_attn.q_a_proj", "self_attn.kv_a_proj_with_mqa"):
+        return ("mtp_block.self_attn.qkv_a_proj",)
+    return (f"mtp_block.{suffix}",)
+
+
+def fusion_domain(name: str) -> str | None:
+    """Return the runtime unit that must retain homogeneous quantization."""
+    idx = layer_index(name)
+    if idx is None:
+        return None
+    if name.endswith(_KDA_FUSED_INPUTS):
+        return f"layer:{idx}:kda-fused-input"
+    expert = _EXPERT_RE.search(name)
+    if expert:
+        return f"layer:{idx}:routed:{expert.group(1)}"
+    return None
+
+
+def _score_for(
+    name: str,
+    domain: str | None,
+    sensitivity: Mapping[str, float],
+) -> float:
+    values = [float(sensitivity.get(name, 0.0))]
+    module = module_path(name)
+    values.append(float(sensitivity.get(module, 0.0)))
+    if domain is not None:
+        values.append(float(sensitivity.get(domain, 0.0)))
+    score = max(values)
+    if not math.isfinite(score) or not 0.0 <= score <= 1.0:
+        raise ValueError(f"sensitivity for {name} must be finite and within [0, 1]")
+    return score
+
+
+def _base_spec(tensor: TensorDescriptor, config: Mapping) -> QuantSpec:
+    name, shape, dtype = tensor.name, tensor.shape, tensor.dtype.upper()
+    text = config.get("text_config") or {}
+    n_layers = int(
+        text.get("num_hidden_layers") or config.get("num_hidden_layers") or 0
+    )
+    idx = layer_index(name)
+
+    if dtype not in _FLOAT_DTYPES:
+        return _fp("non-floating state or buffer")
+    if not name.endswith(".weight") or len(shape) != 2:
+        return _fp("non-matrix parameter")
+    if shape[-1] % 64:
+        return _fp("input width is not divisible by the native group size")
+    if name.startswith("model.visual."):
+        return _fp("preserve the vision tower in source precision")
+    if name.endswith(".mlp.gate.weight"):
+        return _fp("router logits remain in source precision")
+
+    # A preserved GLM MTP block is stored immediately after the trunk layers.
+    # Its routed experts still dominate its storage and decode cost, so keep
+    # those Q4 exactly like the target routed experts.  The always-active MTP
+    # glue, attention, and shared expert take the Q8 fidelity floor below.
+    # Target/draft precision symmetry matters: independently raising only the
+    # drafter can reduce acceptance by removing errors shared with the target.
+    if idx is not None and n_layers and idx >= n_layers:
+        if _EXPERT_RE.search(name):
+            return _q(4, "target-matched MTP routed expert")
+        return _q(8, "MTP always-active fidelity floor")
+
+    if name == "lm_head.weight" or name.endswith(".embed_tokens.weight"):
+        return _q(8, "token ranking and embedding fidelity")
+
+    if ".self_attn.indexer." in name and name.endswith(
+        (".wq_b.weight", ".wk.weight", ".weights_proj.weight")
+    ):
+        return _q(8, "sparse-index top-k selection fidelity")
+
+    if name.endswith(_KDA_FUSED_INPUTS):
+        return _q(8, "KDA recurrent input and fusion domain")
+    if any(
+        part in name
+        for part in (
+            ".self_attn.f_b_proj.weight",
+            ".self_attn.g_b_proj.weight",
+            ".self_attn.o_proj.weight",
+            ".self_attn.q_a_proj.weight",
+            ".self_attn.q_b_proj.weight",
+            ".self_attn.kv_a_proj_with_mqa.weight",
+            ".self_attn.kv_b_proj.weight",
+        )
+    ):
+        return _q(8, "attention or recurrent-state fidelity")
+
+    if ".mlp.shared_experts." in name:
+        return _q(8, "always-active shared expert")
+    if _EXPERT_RE.search(name):
+        return _q(4, "bandwidth-dominant routed expert")
+
+    if ".mlp." in name and name.endswith(
+        (".gate_proj.weight", ".up_proj.weight", ".down_proj.weight")
+    ):
+        return _q(8, "dense always-active MLP")
+    return _q(4, "native affine baseline")
+
+
+def _raised_bits(base: int, score: float) -> int:
+    if score >= 0.55:
+        return 8
+    return base
+
+
+def plan_tensors(
+    tensors: Sequence[TensorDescriptor],
+    config: Mapping,
+    sensitivity: Mapping[str, float] | None = None,
+) -> list[TensorPlan]:
+    """Build a deterministic RMQ plan, preserving every fusion invariant."""
+    sensitivity = sensitivity or {}
+    provisional: list[TensorPlan] = []
+    domain_bits: dict[str, int] = {}
+
+    for tensor in tensors:
+        domain = fusion_domain(tensor.name)
+        spec = _base_spec(tensor, config)
+        if spec.quantized:
+            score = _score_for(tensor.name, domain, sensitivity)
+            spec = _q(_raised_bits(int(spec.bits), score), spec.reason)
+            if domain is not None:
+                domain_bits[domain] = max(domain_bits.get(domain, 0), int(spec.bits))
+        provisional.append(TensorPlan(tensor, spec, domain))
+
+    result: list[TensorPlan] = []
+    for item in provisional:
+        if item.spec.quantized and item.fusion_domain is not None:
+            bits = domain_bits[item.fusion_domain]
+            item = TensorPlan(
+                item.tensor,
+                _q(bits, item.spec.reason + "; fusion-domain locked"),
+                item.fusion_domain,
+            )
+        result.append(item)
+    return result
+
+
+def projected_storage_bytes(plan: Sequence[TensorPlan]) -> int:
+    """Estimate tensor payload bytes, including affine scale/bias tables."""
+    total = 0
+    for item in plan:
+        params = item.tensor.parameters
+        if not item.spec.quantized:
+            bytes_per = 4 if item.tensor.dtype.upper() == "F32" else 2
+            total += params * bytes_per
+            continue
+        bits = int(item.spec.bits)
+        groups = params // int(item.spec.group_size)
+        total += math.ceil(params * bits / 8) + groups * 4
+    return total
+
+
+def summarize_plan(plan: Sequence[TensorPlan]) -> dict[str, object]:
+    by_format: dict[str, dict[str, int]] = {}
+    for item in plan:
+        label = (
+            "fp"
+            if not item.spec.quantized
+            else f"q{item.spec.bits}-g{item.spec.group_size}"
+        )
+        bucket = by_format.setdefault(label, {"tensors": 0, "parameters": 0})
+        bucket["tensors"] += 1
+        bucket["parameters"] += item.tensor.parameters
+    return {
+        "formats": dict(sorted(by_format.items())),
+        "projected_storage_bytes": projected_storage_bytes(plan),
+        "fusion_domains": len({p.fusion_domain for p in plan if p.fusion_domain}),
+    }
+
+
+__all__ = [
+    "QuantSpec",
+    "TensorDescriptor",
+    "TensorPlan",
+    "fusion_domain",
+    "layer_index",
+    "module_path",
+    "module_paths",
+    "mtp_module_paths",
+    "plan_tensors",
+    "projected_storage_bytes",
+    "summarize_plan",
+]


### PR DESCRIPTION
## Why\n\nUniform Q4 leaves measurable GLM-5.3 logit fidelity on the table, while independently increasing only MTP precision does not improve acceptance against a Q4 target. This adds a reproducible target-matched Q4/Q8 design and the converter needed to test a higher-quality Apple-native checkpoint.\n\n## Summary\n\n- add an RMQ v1 planner using only MLX affine Q4/Q8 group-64 formats\n- lock precision across KDA and SwitchLinear fusion domains\n- keep routed experts Q4 and quality-sensitive always-active paths Q8\n- consume BF16 or official E4M3 128x128 block-FP8 source tensors without integer requantization\n- emit per-module target and post-split MTP path metadata\n- add numeric, storage, kernel, and checkpoint benchmark tools\n- record full quantitative evidence and realistic release gates\n\n## Quantitative evidence\n\nOn M3 Ultra with the current 4-bit target, uniform-Q4 MTP block 2 produced 37.15 tok/s versus 28.63 tok/s autoregressive on the 128-token math probe: +29.8%, identical greedy output, 76.4% draft acceptance. A standalone Q8 MTP produced only 33.51 tok/s with the same acceptance, showing that higher draft precision by itself does not improve a Q4 target.\n\nOn the 0.1B architecture fixture, RMQ versus BF16 reached 94.55% top-1 agreement versus uniform Q4 at 76.04%; mean KL fell 93.77% and logit RMSE fell 67.69%. This is a numeric smoke, not a full-model intelligence claim.\n\nThe full RMQ plan projects to 186,198,375,288 payload bytes, +4.20 GiB over the current uniform-Q4 payload. A real official layer-45 FP8 expert tensor matched the mlx-vlm reference decoder and Q4 converter exactly: maximum absolute difference 0.0.\n\nThe +29.8% number is an MTP decode probe on the existing Q4 trunk, not an RMQ speed claim or aggregate product claim.\n\n## Verification\n\n- local prvalidate verdict: MERGE-SAFE\n- 24 focused tests passed\n- full local suite: 23,993 passed, 111 skipped, 22 deselected, 6 xfailed, 1 xpassed\n- Apple Silicon CI, Python 3.10/3.11/3.12, type checks, lint, engine contracts, and 100% changed-lines coverage passed\n- tiny BF16 conversion emitted the exact projected payload and strict-loaded\n- Ruff and git diff --check passed\n\n## Real-task release gate\n\nBefore any RMQ checkpoint becomes a default alias or supports a product performance claim, test the full target plus its target-matched drafter on:\n\n- complete coding tasks executed against hidden unit tests\n- multi-step math with reviewed answer keys\n- closed-book knowledge questions with atomic factual keys\n- instruction-following checks with machine-verifiable constraints\n- creative writing scored blind against a fixed coherence, style, constraint, and factuality rubric\n- long-context retrieval and synthesis\n\nFor speculative decoding, MTP on/off on the same target must produce token-identical complete greedy answers and unchanged task success. Report per-category quality, tails, prompt processing, decode, acceptance, memory, and total latency. Acceptance and logit similarity alone are not quality evidence.\n\n## Release boundary\n\nThis PR establishes the format, converter, evidence, and safety gates. It does not enable RMQ as a default alias or claim superiority over oQ4e. Full-model quality/performance validation still requires the full source checkpoint and a tagged mlx-vlm release with GLM-5-Next MTP support.