### PR TITLE
fix(ci): isolate GUI test lifecycle state

### DIFF
--- a/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift
@@ -1,9 +1,16 @@
 import AppKit
-import Darwin
 import XCTest
 
 @MainActor
 final class ImageGenerationPixelTests: XCTestCase {
+    private var activeHarness: RapidUITestHarness?
+
+    override func tearDown() {
+        activeHarness?.shutDown()
+        activeHarness = nil
+        super.tearDown()
+    }
+
     func testMemoryConfirmationRetriesAreSpacedBoundedAndRearmed() {
         var policy = MemoryConfirmationRetryPolicy()
 
@@ -28,55 +35,18 @@ final class ImageGenerationPixelTests: XCTestCase {
 
     func testTwoImageRendersDrawDistinctThumbnailPixels() throws {
         continueAfterFailure = false
-        let testHome = FileManager.default.temporaryDirectory
-            .appendingPathComponent("rapid-xcui-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: testHome, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: testHome) }
-
-        let rapidMacRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Tests
-            .deletingLastPathComponent() // RapidUITests
-            .deletingLastPathComponent() // Tests
-            .deletingLastPathComponent() // rapid-mac
-        let fakeSidecar = rapidMacRoot.appendingPathComponent("scripts/fake-rapid-mlx.sh").path
-        let appURL = rapidMacRoot.appendingPathComponent("build/Rapid-MLX Desktop.app")
-        let eventLog = testHome.appendingPathComponent("fake-events.jsonl")
-        // ServerManager deliberately sanitizes arbitrary FAKE_* variables
-        // before spawning a sidecar. The fake's checked-in config file is the
-        // durable channel shared with the AX GoldenFlow harness.
-        let fakeConfig: [String: String] = [
-            "FAKE_EVENT_LOG": eventLog.path,
-            "FAKE_IMAGE_STEPS": "8",
-            "FAKE_IMAGE_STEP_MS": "300",
-        ]
-        let fakeConfigData = try JSONSerialization.data(withJSONObject: fakeConfig)
-        try fakeConfigData.write(to: testHome.appendingPathComponent(".rapid-golden-fake.json"))
-        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: fakeSidecar))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: appURL.path))
-        let app = XCUIApplication(url: appURL)
-        app.launchArguments += [
-            "-com.rapidmlx.rapid.telemetry.enabled", "false",
-        ]
-        app.launchEnvironment = [
-            "HOME": testHome.path,
-            "CFFIXED_USER_HOME": testHome.path,
-            "RAPID_BIN": fakeSidecar,
-            "FAKE_EVENT_LOG": eventLog.path,
-            "FAKE_IMAGE_STEPS": "8",
-            "FAKE_IMAGE_STEP_MS": "300",
-            // This XCUITest runs immediately before the AX GoldenFlows in CI.
-            // Keep its fake away from the product's canonical :8000 and from
-            // the operator-ownership regression fixture exercised there.
-            "RAPID_DESKTOP_PORT": "65000",
-            "RAPID_DESKTOP_NO_PORT_SWEEP": "1",
-        ]
-        app.launch()
-        defer {
-            app.terminate()
-            terminateFakeSidecars(recordedIn: eventLog, alias: "fake-image-alias")
-        }
-        XCTAssertTrue(app.windows["Rapid-MLX"].waitForExistence(timeout: 20))
-        dismissFirstRunIfNeeded(in: app)
+        let harness = try RapidUITestHarness(
+            testName: "image-generation-pixels",
+            fakeSettings: [
+                "FAKE_IMAGE_STEPS": "8",
+                "FAKE_IMAGE_STEP_MS": "300",
+            ],
+            sidecarAlias: "fake-image-alias"
+        )
+        activeHarness = harness
+        harness.launch()
+        let app = harness.app
+        let eventLog = harness.eventLog
         let images = element("Sidebar.Images", in: app)
         XCTAssertTrue(images.waitForExistence(timeout: 10))
         images.click()
@@ -90,21 +60,7 @@ final class ImageGenerationPixelTests: XCTestCase {
             picker.label.contains("fake-image-alias")
         })
 
-        let readiness = element("Readiness.Action", in: app)
-        XCTAssertTrue(readiness.waitForExistence(timeout: 20))
-        readiness.click()
-        let memoryConfirmation = element("MemoryWarning.Confirm", in: app)
-        var memoryConfirmationPolicy = MemoryConfirmationRetryPolicy()
-        XCTAssertTrue(waitUntil(timeout: 30) {
-            let serverStarted = {
-                guard let events = try? String(contentsOf: eventLog, encoding: .utf8) else { return false }
-                return events.contains(#""event": "server_started""#)
-                && events.contains(#""alias": "fake-image-alias""#)
-            }
-            if serverStarted() { return true }
-            memoryConfirmationPolicy.follow(memoryConfirmation)
-            return serverStarted()
-        })
+        harness.startModel()
 
         let prompt = element("Images.Prompt", in: app)
         XCTAssertTrue(prompt.waitForExistence(timeout: 20))
@@ -151,53 +107,6 @@ final class ImageGenerationPixelTests: XCTestCase {
             meanSquaredDistance.squareRoot(), 10,
             "The two records exist but their rendered thumbnail interiors are indistinguishable"
         )
-    }
-
-    /// XCUITest termination does not guarantee that an app-owned child has
-    /// exited before the next workflow step starts. Reap only the exact fake
-    /// PIDs recorded by this test, after verifying their command still names
-    /// this fixture alias; this is both deterministic and PID-reuse safe.
-    private func terminateFakeSidecars(recordedIn eventLog: URL, alias: String) {
-        guard let text = try? String(contentsOf: eventLog, encoding: .utf8) else { return }
-        let pids: Set<Int32> = Set(text.split(separator: "\n").compactMap { line in
-            guard let data = line.data(using: .utf8),
-                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  object["event"] as? String == "server_started",
-                  object["alias"] as? String == alias,
-                  let pid = object["pid"] as? NSNumber else { return nil }
-            return pid.int32Value
-        })
-
-        for pid in pids where processCommand(pid: pid).contains("serve \(alias)") {
-            Darwin.kill(pid, SIGTERM)
-            for _ in 0..<20 where Darwin.kill(pid, 0) == 0 {
-                Thread.sleep(forTimeInterval: 0.05)
-            }
-            if Darwin.kill(pid, 0) == 0,
-               processCommand(pid: pid).contains("serve \(alias)") {
-                Darwin.kill(pid, SIGKILL)
-            }
-        }
-    }
-
-    private func processCommand(pid: Int32) -> String {
-        let process = Process()
-        let output = Pipe()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-p", String(pid), "-o", "command="]
-        process.standardOutput = output
-        process.standardError = FileHandle.nullDevice
-        guard (try? process.run()) != nil else { return "" }
-        process.waitUntilExit()
-        return String(
-            data: output.fileHandleForReading.readDataToEndOfFile(),
-            encoding: .utf8
-        ) ?? ""
-    }
-
-    private func dismissFirstRunIfNeeded(in app: XCUIApplication) {
-        let skip = element("Quickstart.Skip", in: app)
-        if skip.waitForExistence(timeout: 10) { skip.click() }
     }
 
     private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {

--- a/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
+++ b/apps/rapid-mac/Tests/RapidUITests/Tests/RapidUITestHarness.swift
@@ -163,7 +163,11 @@ final class RapidUITestHarness {
         return (descriptor, Int(UInt16(bigEndian: address.sin_port)))
     }
 
-    init(testName: String, fakeSettings: [String: String]) throws {
+    init(
+        testName: String,
+        fakeSettings: [String: String],
+        sidecarAlias explicitSidecarAlias: String? = nil
+    ) throws {
         let reservedPort = try Self.reserveLoopbackPort()
         var reservationTransferred = false
         defer {
@@ -187,9 +191,11 @@ final class RapidUITestHarness {
         eventLog = testHome.appendingPathComponent("fake-events.jsonl")
         sidecarPIDFile = testHome.appendingPathComponent("fake-sidecar.pid")
         dropEventFile = testHome.appendingPathComponent("xcui-drop-event.txt")
-        sidecarAlias = fakeSettings["FAKE_VISION_CHAT"] == "1"
-            ? "qwen3-vl-2b-4bit"
-            : "fake-alias"
+        sidecarAlias = explicitSidecarAlias ?? (
+            fakeSettings["FAKE_VISION_CHAT"] == "1"
+                ? "qwen3-vl-2b-4bit"
+                : "fake-alias"
+        )
 
         var config = fakeSettings
         config["FAKE_EVENT_LOG"] = eventLog.path
@@ -240,6 +246,7 @@ final class RapidUITestHarness {
 
     func shutDown() {
         app.terminate()
+        _ = app.wait(for: .notRunning, timeout: 5)
         releasePortReservation()
         terminateFakeSidecars()
         restorePasteboardIfOwned()

--- a/apps/rapid-mac/scripts/fake-rapid-mlx.sh
+++ b/apps/rapid-mac/scripts/fake-rapid-mlx.sh
@@ -48,6 +48,27 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlsplit
 
 
+def _start_parent_watchdog():
+    """Mirror the production sidecar's orphan-reaping contract in GUI tests."""
+    raw_parent = os.environ.get("RAPID_MLX_WATCHDOG_PPID", "")
+    try:
+        expected_parent = int(raw_parent)
+    except ValueError:
+        return
+    if expected_parent <= 1:
+        return
+
+    def watch():
+        while os.getppid() == expected_parent:
+            time.sleep(0.1)
+        # The Desktop supervisor is gone.  Avoid Python shutdown machinery:
+        # another request thread may be blocked inside a deliberately held
+        # test response, and the production contract is immediate retirement.
+        os._exit(0)
+
+    threading.Thread(target=watch, name="parent-watchdog", daemon=True).start()
+
+
 if sys.argv[1:] == ["launch", "list", "--json"]:
     print(json.dumps([
         {"id": "cline", "name": "Cline", "kind": "config_writer", "config_path": "~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"},
@@ -1392,6 +1413,11 @@ def main():
                     stream.write(f"{args.alias}\n")
         _emit_catalog(args.subcommand, args.alias)
         sys.exit(0)
+
+    # The production sidecar retires itself when its Desktop supervisor dies.
+    # Keep the fixture faithful so a failed/crashed XCUITest cannot poison the
+    # next job with an orphan listener.
+    _start_parent_watchdog()
 
     # XCUITest cleanup must not depend on reaching the later readiness event:
     # record ownership as soon as this process commits to the long-lived serve

--- a/apps/rapid-mac/scripts/gui-golden-flows.sh
+++ b/apps/rapid-mac/scripts/gui-golden-flows.sh
@@ -2079,6 +2079,13 @@ flow_fresh_install() {
     start_model
     send_prompt "Say hello in one short sentence." "post-value-consent"
     wait_identifier TelemetryConsent.PostValueBanner "$OUT/post-value-consent-visible.json"
+    # The first reply can expose its final text and the consent banner before
+    # the streaming task releases model residency.  A structural baseline
+    # taken in that interval records the transient disabled Unload control and
+    # flakes according to scheduler speed.  Prove the send state is idle, then
+    # recapture the still-visible invitation before comparing the steady UI.
+    wait_send_idle "$OUT/post-value-consent-complete.json"
+    wait_identifier TelemetryConsent.PostValueBanner "$OUT/post-value-consent-visible.json"
     # Streaming completion and scroll anchoring settle independently. Capture
     # the structural baseline only after the transcript reaches its stable tail.
     settle_transcript_at_bottom "$OUT/post-value-consent-visible.json" \

--- a/tests/test_fake_sidecar_image_catalog.py
+++ b/tests/test_fake_sidecar_image_catalog.py
@@ -50,15 +50,33 @@ child = subprocess.Popen(
     start_new_session=True,
 )
 print(child.pid, flush=True)
+sys.stdin.buffer.read(1)
 """
-    launcher = subprocess.run(
+    launcher = subprocess.Popen(
         [sys.executable, "-c", launcher_code, str(FAKE), str(port)],
-        capture_output=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        check=True,
     )
-    child_pid = int(launcher.stdout.strip())
+    assert launcher.stdout is not None
+    child_pid = int(launcher.stdout.readline().strip())
     try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                    break
+            except OSError:
+                if launcher.poll() is not None:
+                    pytest.fail("supervisor exited before the fake sidecar served")
+                time.sleep(0.05)
+        else:
+            pytest.fail("fake sidecar did not serve before supervisor retirement")
+
+        assert launcher.stdin is not None
+        launcher.stdin.close()
+        launcher.wait(timeout=5)
         deadline = time.monotonic() + 5
         while time.monotonic() < deadline:
             try:
@@ -69,6 +87,9 @@ print(child.pid, flush=True)
         else:
             pytest.fail("fake sidecar survived its recorded Desktop supervisor")
     finally:
+        if launcher.poll() is None:
+            launcher.terminate()
+            launcher.wait(timeout=5)
         try:
             os.kill(child_pid, signal.SIGTERM)
         except ProcessLookupError:

--- a/tests/test_fake_sidecar_image_catalog.py
+++ b/tests/test_fake_sidecar_image_catalog.py
@@ -15,8 +15,10 @@ Stdlib + bash only, so it runs on the Linux CI lane that never sees a Mac.
 
 import json
 import os
+import signal
 import socket
 import subprocess
+import sys
 import time
 import urllib.request
 from pathlib import Path
@@ -28,6 +30,49 @@ FAKE = ROOT / "apps/rapid-mac/scripts/fake-rapid-mlx.sh"
 GOLDEN_FLOWS = ROOT / "apps/rapid-mac/scripts/gui-golden-flows.sh"
 IMAGE_TAGS = {"[image:gen]", "[image:edit]", "[image:both]"}
 FIXTURE_IMAGE_TAG = "[image:both]"
+
+
+def test_serve_retires_when_desktop_supervisor_exits(tmp_path):
+    """A failed UI test must not leave a listener that poisons the next run."""
+    with socket.socket() as reservation:
+        reservation.bind(("127.0.0.1", 0))
+        port = reservation.getsockname()[1]
+
+    launcher_code = """
+import os, subprocess, sys
+fake, port = sys.argv[1:]
+env = dict(os.environ, RAPID_MLX_WATCHDOG_PPID=str(os.getpid()))
+child = subprocess.Popen(
+    [fake, "serve", "fake-image-alias", "--host", "127.0.0.1", "--port", port],
+    env=env,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    start_new_session=True,
+)
+print(child.pid, flush=True)
+"""
+    launcher = subprocess.run(
+        [sys.executable, "-c", launcher_code, str(FAKE), str(port)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    child_pid = int(launcher.stdout.strip())
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("fake sidecar survived its recorded Desktop supervisor")
+    finally:
+        try:
+            os.kill(child_pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
 
 
 # --- Mirrors of the Swift gates, byte-for-byte ---------------------------

--- a/tests/test_gui_preflight_contract.py
+++ b/tests/test_gui_preflight_contract.py
@@ -334,9 +334,10 @@ def test_fresh_install_settles_transcript_before_structural_baseline():
     assert 'die "Jump to latest did not physically settle' in helper
 
     banner = fresh_install.index("wait_identifier TelemetryConsent.PostValueBanner")
+    idle = fresh_install.index('wait_send_idle "$OUT/post-value-consent-complete.json"')
     settle = fresh_install.index("settle_transcript_at_bottom")
     baseline = fresh_install.index("baseline fresh-install.post-value-consent")
-    assert banner < settle < baseline
+    assert banner < idle < settle < baseline
 
 
 def test_transcript_settler_waits_for_physical_scroll_stability(tmp_path):

--- a/tests/test_rapid_mac_xcui_target.py
+++ b/tests/test_rapid_mac_xcui_target.py
@@ -58,8 +58,8 @@ def test_pixel_assertion_uses_element_screenshots_and_crops_chrome():
     assert "older.screenshot()" in source
     assert 'element("Images.ModelPicker", in: app)' in source
     assert 'picker.label.contains("fake-image-alias")' in source
-    assert 'events.contains(#""event": "server_started""#)' in source
-    assert 'events.contains(#""alias": "fake-image-alias""#)' in source
+    assert "harness.startModel()" in source
+    assert 'sidecarAlias: "fake-image-alias"' in source
     assert "imageResponseCount(in: eventLog) == 1" in source
     assert "imageResponseCount(in: eventLog) == 2" in source
     assert "waitForNonExistence" not in source
@@ -95,13 +95,15 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert "CODE_SIGN_IDENTITY=-" in runner
     assert "CODE_SIGNING_ALLOWED=NO" not in runner
     assert '${test_selection[@]+"${test_selection[@]}"}' in runner
-    assert "XCUIApplication(url: appURL)" in source
-    assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in source
-    assert source.count('"CFFIXED_USER_HOME": testHome.path') == 1
-    assert '"RAPID_BIN"' in source
-    assert "fake-rapid-mlx.sh" in source
-    assert 'appendingPathComponent(".rapid-golden-fake.json")' in source
-    assert '"FAKE_EVENT_LOG": eventLog.path' in source
+    assert "XCUIApplication(url: appURL)" in harness
+    assert 'appendingPathComponent("build/Rapid-MLX Desktop.app")' in harness
+    assert harness.count('"CFFIXED_USER_HOME": testHome.path') == 1
+    assert '"RAPID_BIN"' in harness
+    assert "fake-rapid-mlx.sh" in harness
+    assert 'appendingPathComponent(".rapid-golden-fake.json")' in harness
+    assert 'config["FAKE_EVENT_LOG"] = eventLog.path' in harness
+    assert 'sidecarAlias: "fake-image-alias"' in source
+    assert "explicitSidecarAlias ?? (" in harness
     assert 'config["FAKE_PID_FILE"] = sidecarPIDFile.path' in harness
     assert "String(contentsOf: sidecarPIDFile" in harness
     assert 'element("MemoryWarning.Confirm")' in harness
@@ -176,13 +178,14 @@ def test_xcui_runner_launches_production_bundle_with_fake_sidecar():
     assert 'element("ChatView.Attachment.Remove.Pasted image.png")' in chat_source
     assert "port: 65_001" not in chat_source
     assert "port: 65_002" not in chat_source
-    assert '"RAPID_DESKTOP_PORT": "65000"' in source
-    assert '"RAPID_DESKTOP_NO_PORT_SWEEP": "1"' in source
-    assert (
-        'terminateFakeSidecars(recordedIn: eventLog, alias: "fake-image-alias")'
-        in source
-    )
-    assert "isExecutableFile" in source
+    assert '"RAPID_DESKTOP_PORT": String(reservedPort.port)' in harness
+    assert '"RAPID_DESKTOP_NO_PORT_SWEEP": "1"' in harness
+    assert "override func tearDown()" in source
+    assert "activeHarness?.shutDown()" in source
+    assert "activeHarness = harness" in source
+    assert "app.wait(for: .notRunning, timeout: 5)" in harness
+    assert "terminateFakeSidecars()" in harness
+    assert "isExecutableFile" in harness
     assert "RapidUITests-$(date +%s)-$$.xcresult" in runner
 
 
@@ -208,10 +211,10 @@ def test_xcui_runner_can_reserve_its_loopback_listener():
 
 
 def test_swift_source_parent_traversal_resolves_rapid_mac_fixture():
-    source = MAC / "Tests/RapidUITests/Tests/ImageGenerationPixelTests.swift"
+    source = MAC / "Tests/RapidUITests/Tests/RapidUITestHarness.swift"
     source_text = source.read_text()
     traversal_expression = source_text.split(
-        "let rapidMacRoot = URL(fileURLWithPath: #filePath)", 1
+        "rapidMacRoot = URL(fileURLWithPath: #filePath)", 1
     )[1].split("let fakeSidecar", 1)[0]
     traversal_count = traversal_expression.count(".deletingLastPathComponent()")
 


### PR DESCRIPTION
## Why

A detailed current-main dogfood exposed two deterministic sources of false GUI failures:

- the image XCUITest used a fixed port and could leave its fake sidecar alive after a failed assertion, poisoning later jobs;
- the fresh-install baseline could snapshot the first reply after its text appeared but before streaming released the resident model.

The product image/video paths themselves passed with real models; these harness races made that evidence unreliable.

## Scope

- Reuse the shared XCUITest harness for image-generation pixels, including OS-assigned reserved ports, PID evidence, and teardown.
- Make the fake sidecar mirror the production parent-watchdog contract, so it exits if its Desktop supervisor disappears.
- Run image cleanup from XCTest teardown even when a fail-fast assertion aborts the Swift test body.
- Wait for the first chat response to be idle before capturing the fresh-install structural baseline.
- Update focused executable/static contracts.

## Non-goals

- No product image, chat, model, memory-policy, or UI behavior changes.
- No timeout inflation.
- No golden baseline changes.
- No retry-until-green behavior.

## Design precedent

The repository already has one lifecycle authority in `RapidUITestHarness`: reserve an ephemeral loopback port before launch, transfer the reservation immediately before model start, retain PID evidence, and reap only the owned fixture. This change removes the image test's older duplicate fixed-port implementation and makes the fake process honor the same supervisor-death contract as the shipped sidecar.

## Acceptance

- Two consecutive image renders prove distinct thumbnail pixels.
- A failed/crashed GUI runner cannot leave an orphan fake listener.
- Image tests do not rely on a globally fixed port.
- Fresh-install baselines are captured only after the response is idle.
- Existing user-visible behavior and baselines remain unchanged.

## Verification

- `bash -n` on both changed harness scripts
- Ruff check/format: clean
- Focused Python contracts: 50 passed, including a live-listener supervisor-death test
- Release Desktop build with `SKIP_SIDECAR=1`: passed
- Native image XCUITest: passed twice after environment cleanup (32.4s, 26.9s)
- Post-test process audit: no Rapid app or fake-image sidecar remained
- Fresh-install GUI golden flow: passed 3/3
- Native chat attachment XCUITest: 6/6 passed (348.2s)
- `git diff --check`: clean

## AI assistance disclosure

Codex diagnosed, implemented, reviewed, and exercised this change. The complete diff and real GUI evidence were reviewed on the exact head.

> By submitting this PR I confirm I can explain the intent, risk, and behavior of every non-generated change in this PR. For any generated / boilerplate / scaffolded sections, I've identified them above and can describe how I verified them.

## Checklist

- [x] Tests pass locally
- [x] Lint passes
- [x] No breaking API changes
