### PR TITLE
bench(glm): gate MTP on real task quality

### DIFF
--- a/.agents/handoffs/vector-glm53-real-task-mtp.md
+++ b/.agents/handoffs/vector-glm53-real-task-mtp.md
@@ -1,0 +1,44 @@
+# Vector handoff: GLM-5.3 real-task MTP qualification
+
+## Receiving role
+
+Atlas, for runtime architecture and dependency integration.
+
+## Branch
+
+`vector/glm53-real-eval`, based on `origin/main@e28f68c41`.
+
+## Verified facts
+
+- A reproducible six-category harness now executes coding hidden tests and
+  grades knowledge, math, instruction following, creative constraints, and
+  long-context retrieval.
+- Same-target Q4 MTP block-total 2 preserved reasoning and final content on
+  6/6 deterministic tasks.
+- Median decode improvement was 1.240x; median end-to-end completion
+  throughput improvement was 1.191x; the minimum task gain was 1.127x.
+- Comparable no-budget AR and MTP each passed only 4/6 because coding and
+  creative writing exhausted 1,024 tokens in reasoning without a final answer.
+- Budgeted AR passed 6/6. The speculative server rejects `thinking_budget`
+  with HTTP 500 before generation.
+- MTP long-context peak Metal memory was 188.679 GB versus 184.141 GB for AR.
+
+## Unresolved
+
+- The post-0.7 GLM runtime is not in the currently pinned release dependency.
+- Thinking-budget enforcement inside a speculative block needs transactional
+  truncation/rollback, or a safe request-scoped AR fallback.
+- Creative prose still needs blind human review before any quality claim.
+
+## Risks
+
+Removing the server guard without teaching the speculative batch about the
+forced thinking-end token can silently cross the budget boundary and corrupt
+the drafter/target cache transaction. High acceptance and exact no-budget
+output do not make that safe.
+
+## Next action
+
+Atlas should select the integration design after a tagged mlx-vlm release is
+available. Re-run this harness with per-task thinking budgets on the integrated
+server; require 6/6 exact-output parity before enabling GLM MTP experimentally.

--- a/docs/engineering/performance/2026-09-12-glm53-real-task-mtp.md
+++ b/docs/engineering/performance/2026-09-12-glm53-real-task-mtp.md
@@ -1,0 +1,127 @@
+# GLM-5.3 real-task MTP qualification
+
+Date: 2026-09-12
+
+Owner: Vector
+
+Host: Studio, Apple M3 Ultra, 256 GiB, macOS 26.5.2 (25F84)
+
+## Outcome
+
+The cached uniform-Q4 GLM-5.3 target and its target-matched Q4 MTP head have a
+real decode win, but the current post-0.7 mlx-vlm runtime is not yet eligible
+for Rapid production. On six deterministic tasks, block-total 2 MTP preserved
+both the reasoning and final response exactly and raised median decode
+throughput by 1.240x. Median end-to-end completion throughput rose 1.191x, and
+the slowest task still rose 1.127x.
+
+The release gate nevertheless failed. Without a thinking budget, coding and
+creative-writing prompts spent the complete 1,024-token allowance in reasoning
+and produced no final answer. The AR server passed all six tasks when given the
+per-task thinking budgets in the harness, but the speculative server rejects
+the same request with HTTP 500:
+
+```text
+thinking_budget is not supported with speculative decoding in the server.
+```
+
+This is a product-quality blocker, not benchmark noise. Do not trade complete
+answers for a higher token rate, and do not enable GLM MTP by default until the
+speculative transaction can enforce the thinking boundary or safely fall back
+to AR for that request.
+
+## Environment
+
+- target: `Vontra/GLM-5.3-Flash-MLX-4bit-MTP`, revision
+  `76add2a341a1cd90ad0e86bb69839ea9c35827c6`
+- Q4 drafter: layer-45 sidecar produced from the same revision, 3.9 GiB
+- mlx-vlm source: `d2a1434a03e4c9975b0d505e7178e0cfc4082a83`
+- Python 3.12.13, MLX 0.32.2, mlx-lm 0.31.3
+- batch one, greedy temperature zero, thinking enabled, no thinking budget
+- one server process at a time; one warm-up request before measured tasks
+- MTP `block_size=2`: one draft token plus the verifier bonus
+
+The full target and drafter were already local. The campaign ran offline and
+did not download or relocate Hugging Face data.
+
+## Results
+
+Every MTP response had byte-identical reasoning and final content to AR.
+`Total ratio` is baseline request latency divided by candidate request latency,
+so values above one are faster. Coding and creative writing correctly remain
+failed rows because both modes exhausted the output limit without a final
+answer under the comparable no-budget policy.
+
+| Task | AR pass | MTP pass | AR decode | MTP decode | Decode ratio | AR total | MTP total | Total ratio |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Coding, hidden tests | no | no | 26.24 | 32.48 | 1.238x | 39.69 s | 32.14 s | 1.235x |
+| Creative constraints | no | no | 27.50 | 32.56 | 1.184x | 37.80 s | 32.01 s | 1.181x |
+| Instruction following | yes | yes | 29.01 | 36.03 | 1.242x | 5.33 s | 4.44 s | 1.201x |
+| Closed-book knowledge | yes | yes | 28.83 | 36.04 | 1.250x | 8.20 s | 6.68 s | 1.229x |
+| Long-context contract | yes | yes | 25.03 | 33.95 | 1.356x | 17.00 s | 14.67 s | 1.158x |
+| Multi-step math | yes | yes | 28.75 | 32.60 | 1.134x | 12.56 s | 11.14 s | 1.127x |
+
+Peak Metal memory was 184.141 GB for the AR process and 188.679 GB after the
+MTP long-context task, a 4.538 GB increase. The six-task smoke is intended to
+catch trajectory and completion regressions; it is not a broad intelligence
+benchmark or an RMQ quality claim.
+
+## Budgeted AR control
+
+With the harness per-task thinking budgets enabled, the same AR checkpoint
+passed 6/6:
+
+- coding: emitted a complete function and passed 8/8 hidden cases;
+- knowledge: 5/5 atomic facts;
+- math: 4/4 recurrence values;
+- instruction following: 3/3 exact fields;
+- creative writing: 6/6 machine-checkable constraints, with blind style review
+  still required for a release claim;
+- long context: 4/4 fields retrieved from clause 47 among 80 clauses.
+
+The first coding control with a 512-token maximum was truncated mid-function.
+The harness therefore treats `finish_reason=length` and incomplete executable
+output as failures even when the visible prefix appears correct.
+
+## Reproduction
+
+Start post-0.7 mlx-vlm once without a drafter and once with the target-matched
+Q4 drafter. Use the same immutable target path for both server preload and the
+request `model` field; a short, unknown model name asks mlx-vlm to unload and
+switch models.
+
+```bash
+python scripts/benchmark_glm53_real_tasks.py \
+  --model /path/to/immutable/target/snapshot \
+  --label ar-no-thinking-budget \
+  --omit-thinking-budget \
+  --output /private/tmp/glm53-real-ar.json
+
+python scripts/benchmark_glm53_real_tasks.py \
+  --model /path/to/immutable/target/snapshot \
+  --label mtp-block2-q4-no-thinking-budget \
+  --omit-thinking-budget \
+  --output /private/tmp/glm53-real-mtp.json
+
+python scripts/benchmark_glm53_real_tasks.py \
+  --compare /private/tmp/glm53-real-ar.json \
+  /private/tmp/glm53-real-mtp.json
+```
+
+The comparator fails unless every baseline and candidate task passes, complete
+reasoning and output are identical, quality does not regress, and every task
+retains at least 95% of baseline end-to-end completion throughput.
+
+The coding grader is Apple-host-only and fails closed without `sandbox-exec`.
+Generated code is AST-filtered, run with imports and dangerous builtins denied,
+denied network and writes outside its temporary directory, and bounded by CPU,
+file-size, process-count, descriptor, and wall-time limits.
+
+## Next engineering gate
+
+Supporting a forced thinking-end token inside a speculative block is not a
+one-line removal of the server guard. A block can already have drafted and
+verified tokens beyond the budget boundary; forcing the next token requires a
+transactionally correct truncate/rollback or a request-scoped transition to AR.
+Atlas should choose one of these designs when the tagged GLM MTP runtime is
+integrated. Until then the alias remains fail-closed.

--- a/scripts/benchmark_glm53_real_tasks.py
+++ b/scripts/benchmark_glm53_real_tasks.py
@@ -171,6 +171,15 @@ def _python_code(text: str) -> str | None:
 
 
 def _safe_python(tree: ast.AST) -> str | None:
+    if isinstance(tree, ast.Module):
+        for statement in tree.body:
+            is_docstring = (
+                isinstance(statement, ast.Expr)
+                and isinstance(statement.value, ast.Constant)
+                and isinstance(statement.value.value, str)
+            )
+            if not isinstance(statement, ast.FunctionDef) and not is_docstring:
+                return f"forbidden top-level syntax: {type(statement).__name__}"
     for node in ast.walk(tree):
         if isinstance(node, _FORBIDDEN_NODES):
             return f"forbidden syntax: {type(node).__name__}"
@@ -178,6 +187,12 @@ def _safe_python(tree: ast.AST) -> str | None:
             return f"forbidden dunder name: {node.id}"
         if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
             return f"forbidden dunder attribute: {node.attr}"
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, int)
+            and abs(node.value) > 10_000_000
+        ):
+            return "forbidden oversized integer literal"
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
             if node.func.id in _FORBIDDEN_CALLS:
                 return f"forbidden call: {node.func.id}"

--- a/scripts/benchmark_glm53_real_tasks.py
+++ b/scripts/benchmark_glm53_real_tasks.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Run a small, reproducible GLM-5.3 real-task qualification suite.
+
+This is deliberately not a synthetic token-throughput benchmark.  Every task
+has either an executable/structured grader or an explicit blind-review flag.
+Two artifacts can be compared offline so a speculative path must preserve task
+success and deterministic output, rather than merely report high acceptance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import resource
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True)
+class Grade:
+    passed: bool
+    score: float
+    detail: str
+    manual_review_required: bool = False
+
+
+@dataclass(frozen=True)
+class Task:
+    task_id: str
+    category: str
+    prompt: str
+    max_tokens: int
+    thinking_budget: int
+    grade: Callable[[str], Grade]
+
+
+def _json_object(text: str) -> dict[str, Any] | None:
+    """Extract one JSON object without accepting trailing prose as an answer."""
+
+    stripped = text.strip()
+    candidates = [stripped]
+    fenced = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", stripped, re.DOTALL)
+    if fenced:
+        candidates.insert(0, fenced.group(1))
+    for candidate in candidates:
+        try:
+            value = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            return value
+    return None
+
+
+def _grade_exact_json(expected: dict[str, Any]) -> Callable[[str], Grade]:
+    def grade(text: str) -> Grade:
+        value = _json_object(text)
+        if value is None:
+            return Grade(False, 0.0, "response is not one JSON object")
+        correct = sum(value.get(key) == answer for key, answer in expected.items())
+        score = correct / len(expected)
+        extras = sorted(set(value) - set(expected))
+        passed = score == 1.0 and not extras and len(value) == len(expected)
+        detail = f"{correct}/{len(expected)} fields correct"
+        if extras:
+            detail += f"; unexpected keys: {extras}"
+        return Grade(passed, score if not extras else score * 0.9, detail)
+
+    return grade
+
+
+def _grade_knowledge(text: str) -> Grade:
+    value = _json_object(text)
+    if value is None:
+        return Grade(False, 0.0, "response is not one JSON object")
+    aliases = {
+        "element_74": {"tungsten", "wolfram"},
+        "treaty_1648": {"peace of westphalia", "treaty of westphalia"},
+        "largest_moon": {"ganymede"},
+        "author_beloved": {"toni morrison"},
+        "capital_burkina_faso": {"ouagadougou"},
+    }
+    correct = sum(
+        isinstance(value.get(key), str) and value[key].strip().casefold() in accepted
+        for key, accepted in aliases.items()
+    )
+    extras = sorted(set(value) - set(aliases))
+    score = correct / len(aliases)
+    passed = correct == len(aliases) and len(value) == len(aliases) and not extras
+    return Grade(
+        passed, score if not extras else score * 0.9, f"{correct}/5 facts correct"
+    )
+
+
+def _grade_instruction(text: str) -> Grade:
+    stripped = text.strip()
+    expected = {"alpha": "desserts", "beta": 6, "gamma": [23, 29, 31]}
+    value = _json_object(stripped)
+    if value is None:
+        return Grade(False, 0.0, "response is not one JSON object")
+    field_score = sum(value.get(key) == answer for key, answer in expected.items())
+    raw_json = stripped.startswith("{") and stripped.endswith("}")
+    ordered = list(value) == list(expected)
+    exact_keys = set(value) == set(expected) and len(value) == len(expected)
+    score = (field_score + int(raw_json) + int(ordered)) / 5
+    failures = []
+    if not raw_json:
+        failures.append("Markdown or prose present")
+    if not ordered:
+        failures.append("key order")
+    if not exact_keys:
+        failures.append("key set")
+    detail = f"{field_score}/3 values correct"
+    if failures:
+        detail += "; failed: " + ", ".join(failures)
+    return Grade(
+        field_score == 3 and raw_json and ordered and exact_keys, score, detail
+    )
+
+
+_FORBIDDEN_NODES = (
+    ast.AsyncFunctionDef,
+    ast.Await,
+    ast.ClassDef,
+    ast.Delete,
+    ast.Global,
+    ast.Import,
+    ast.ImportFrom,
+    ast.Nonlocal,
+    ast.Try,
+    ast.With,
+)
+_FORBIDDEN_CALLS = {
+    "breakpoint",
+    "compile",
+    "eval",
+    "exec",
+    "getattr",
+    "globals",
+    "help",
+    "input",
+    "locals",
+    "open",
+    "setattr",
+    "vars",
+    "__import__",
+}
+
+
+def _python_code(text: str) -> str | None:
+    matches = re.findall(r"```(?:python|py)?\s*\n(.*?)```", text, re.DOTALL)
+    candidate = matches[0].strip() if matches else text.strip()
+    try:
+        ast.parse(candidate)
+    except SyntaxError:
+        return None
+    return candidate
+
+
+def _safe_python(tree: ast.AST) -> str | None:
+    for node in ast.walk(tree):
+        if isinstance(node, _FORBIDDEN_NODES):
+            return f"forbidden syntax: {type(node).__name__}"
+        if isinstance(node, ast.Name) and node.id.startswith("__"):
+            return f"forbidden dunder name: {node.id}"
+        if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
+            return f"forbidden dunder attribute: {node.attr}"
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in _FORBIDDEN_CALLS:
+                return f"forbidden call: {node.func.id}"
+    return None
+
+
+def _grade_interval_code(text: str) -> Grade:
+    code = _python_code(text)
+    if code is None:
+        return Grade(False, 0.0, "no parseable Python program")
+    tree = ast.parse(code)
+    safety_error = _safe_python(tree)
+    if safety_error:
+        return Grade(False, 0.0, safety_error)
+    names = {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
+    if "coalesce_intervals" not in names:
+        return Grade(False, 0.0, "missing coalesce_intervals function")
+
+    hidden_tests = """
+assert coalesce_intervals([]) == []
+assert coalesce_intervals([(1, 2)]) == [(1, 2)]
+assert coalesce_intervals([(5, 7), (1, 3), (2, 6)]) == [(1, 7)]
+assert coalesce_intervals([(1, 2), (2, 4), (8, 9)]) == [(1, 4), (8, 9)]
+assert coalesce_intervals([(-5, -2), (-3, 1), (10, 11)]) == [(-5, 1), (10, 11)]
+assert coalesce_intervals([(3, 3), (1, 1), (2, 2)]) == [(1, 1), (2, 2), (3, 3)]
+original = [(4, 8), (1, 2)]
+snapshot = list(original)
+assert coalesce_intervals(original) == [(1, 2), (4, 8)]
+assert original == snapshot
+"""
+    sandbox = shutil.which("sandbox-exec")
+    if sandbox is None:
+        return Grade(False, 0.0, "coding grader requires macOS sandbox-exec")
+
+    def limit_candidate() -> None:
+        resource.setrlimit(resource.RLIMIT_CPU, (2, 2))
+        resource.setrlimit(resource.RLIMIT_FSIZE, (1 << 20, 1 << 20))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (32, 32))
+        resource.setrlimit(resource.RLIMIT_NPROC, (16, 16))
+
+    with tempfile.TemporaryDirectory(prefix="rapid-glm53-code-") as directory:
+        program = Path(directory) / "candidate.py"
+        program.write_text(code + "\n" + hidden_tests, encoding="utf-8")
+        profile = "\n".join(
+            (
+                "(version 1)",
+                "(allow default)",
+                "(deny network*)",
+                "(deny file-write*)",
+                f'(allow file-write* (subpath "{directory}"))',
+            )
+        )
+        try:
+            completed = subprocess.run(
+                [sandbox, "-p", profile, sys.executable, "-I", "-S", str(program)],
+                cwd=directory,
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+                env={"PYTHONDONTWRITEBYTECODE": "1"},
+                preexec_fn=limit_candidate,
+            )
+        except subprocess.TimeoutExpired:
+            return Grade(False, 0.0, "hidden tests timed out")
+    if completed.returncode:
+        error = completed.stderr.strip().splitlines()[-1:] or ["unknown failure"]
+        return Grade(False, 0.0, f"hidden tests failed: {error[0][:160]}")
+    return Grade(True, 1.0, "8/8 hidden tests passed")
+
+
+def _grade_creative(text: str) -> Grade:
+    stripped = text.strip()
+    words = re.findall(r"\b[\w'-]+\b", stripped)
+    checks = {
+        "120-170 words": 120 <= len(words) <= 170,
+        "second person": bool(re.search(r"\b(?:you|your|yours)\b", stripped, re.I)),
+        "required phrase": "the elevator remembered" in stripped.lower(),
+        "no dream cliché": not bool(re.search(r"\bdream\w*\b", stripped, re.I)),
+        "exact ending": stripped.endswith("The doors opened onto Tuesday."),
+        "no heading": not stripped.startswith("#") and "Title:" not in stripped[:80],
+    }
+    score = sum(checks.values()) / len(checks)
+    failures = [name for name, ok in checks.items() if not ok]
+    detail = f"{sum(checks.values())}/{len(checks)} constraints; {len(words)} words"
+    if failures:
+        detail += "; failed: " + ", ".join(failures)
+    return Grade(not failures, score, detail, manual_review_required=True)
+
+
+def _long_context_prompt() -> str:
+    clauses = []
+    for number in range(1, 81):
+        if number == 47:
+            body = (
+                "If cumulative verified delay exceeds 45 calendar days, the Supplier "
+                "must fund the first 3,200,000 dollars of acceleration costs. The Owner "
+                "must issue written notice within 7 business days after verification."
+            )
+        else:
+            body = (
+                f"Package {number:02d} is reviewed at the monthly coordination meeting. "
+                f"Routine records are retained for {90 + number} days, and ordinary "
+                "questions receive a written response within 12 business days."
+            )
+        clauses.append(f"CLAUSE {number:02d}. {body}")
+    contract = "\n\n".join(clauses)
+    return f"""Read the contract excerpt below. Return exactly one JSON object with keys
+clause, trigger_days, acceleration_cap_usd, and notice_business_days. Use JSON numbers,
+not words. Do not include commentary.
+
+{contract}
+
+Question: Which clause assigns acceleration costs after cumulative verified delay, and
+what are its trigger, cap, and notice deadline?"""
+
+
+def build_suite() -> list[Task]:
+    return [
+        Task(
+            "coding.interval_coalescing",
+            "coding",
+            """Write a complete Python function named coalesce_intervals(intervals).
+Each item is a (start, end) integer tuple with start <= end. Return sorted, merged tuples;
+touching intervals merge, but gaps of one do not. Do not mutate the input. Use no imports.
+            Return only executable Python code, preferably in one Python fence.""",
+            1024,
+            256,
+            _grade_interval_code,
+        ),
+        Task(
+            "knowledge.atomic_facts",
+            "knowledge",
+            """Answer from general knowledge. Return exactly one JSON object, no prose,
+with these keys: element_74, treaty_1648, largest_moon, author_beloved,
+and capital_burkina_faso. Values must be the conventional English answer strings.""",
+            384,
+            128,
+            _grade_knowledge,
+        ),
+        Task(
+            "math.inventory_recurrence",
+            "math",
+            """A warehouse starts Monday with 240 units. Each evening it discards 10%
+of the units then present. Tuesday morning it receives 34 units, Wednesday morning 35,
+and Thursday morning 36, each before that day's discard. Return exactly
+one JSON object with keys monday_close, tuesday_close, wednesday_close, thursday_close.
+Use JSON integers and no commentary.""",
+            384,
+            192,
+            _grade_exact_json(
+                {
+                    "monday_close": 216,
+                    "tuesday_close": 225,
+                    "wednesday_close": 234,
+                    "thursday_close": 243,
+                }
+            ),
+        ),
+        Task(
+            "instruction.exact_transform",
+            "instruction_following",
+            """Return exactly one JSON object with exactly three keys in this order:
+alpha, beta, gamma. alpha is the reverse of 'stressed'. beta is the number of vowels in
+'coordination'. gamma is an array containing the first three prime numbers greater than
+20. Do not use a Markdown fence or add commentary.""",
+            256,
+            96,
+            _grade_instruction,
+        ),
+        Task(
+            "creative.constrained_flash",
+            "creative_writing",
+            """Write a 120-170 word second-person speculative-fiction scene. Include
+the exact phrase 'the elevator remembered'. Never use the word dream or its variants.
+Do not add a title or heading. End with this exact sentence: The doors opened onto Tuesday.""",
+            1024,
+            192,
+            _grade_creative,
+        ),
+        Task(
+            "long_context.contract_clause",
+            "long_context",
+            _long_context_prompt(),
+            384,
+            128,
+            _grade_exact_json(
+                {
+                    "clause": 47,
+                    "trigger_days": 45,
+                    "acceleration_cap_usd": 3_200_000,
+                    "notice_business_days": 7,
+                }
+            ),
+        ),
+    ]
+
+
+def _post_task(
+    client: httpx.Client,
+    *,
+    base_url: str,
+    model: str,
+    task: Task,
+    use_thinking_budget: bool,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": task.prompt}],
+        "temperature": 0,
+        "max_tokens": task.max_tokens,
+        "stream": False,
+        "enable_thinking": True,
+    }
+    if use_thinking_budget:
+        payload["thinking_budget"] = task.thinking_budget
+    started = time.perf_counter()
+    response = client.post(
+        f"{base_url.rstrip('/')}/chat/completions",
+        json=payload,
+    )
+    elapsed = time.perf_counter() - started
+    response.raise_for_status()
+    data = response.json()
+    server_metrics: dict[str, Any] = {}
+    try:
+        metrics_url = httpx.URL(base_url).copy_with(path="/metrics", query=None)
+        metrics_response = client.get(metrics_url)
+        metrics_response.raise_for_status()
+        latest = metrics_response.json().get("latest") or {}
+        server_metrics = {
+            key: latest.get(key)
+            for key in (
+                "prompt_eval_time_s",
+                "prefill_tok_s",
+                "ttft_s",
+                "decode_elapsed_s",
+                "request_elapsed_s",
+                "request_tok_s",
+                "decode_tok_s",
+                "peak_memory_gb",
+            )
+        }
+    except (httpx.HTTPError, json.JSONDecodeError, AttributeError):
+        pass
+    choice = data["choices"][0]
+    message = choice["message"]
+    text = message.get("content") or ""
+    reasoning = message.get("reasoning_content") or message.get("reasoning") or ""
+    usage = data.get("usage") or {}
+    completion_tokens = int(usage.get("completion_tokens") or 0)
+    grade = task.grade(text)
+    return {
+        "task_id": task.task_id,
+        "category": task.category,
+        "max_tokens": task.max_tokens,
+        "thinking_budget": task.thinking_budget if use_thinking_budget else None,
+        "elapsed_s": elapsed,
+        "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+        "completion_tokens": completion_tokens,
+        "client_completion_tps": completion_tokens / elapsed if elapsed else 0.0,
+        "finish_reason": choice.get("finish_reason"),
+        "output": text,
+        "reasoning": reasoning,
+        "server_metrics": server_metrics,
+        "grade": asdict(grade),
+    }
+
+
+def run_suite(args: argparse.Namespace) -> int:
+    selected = set(args.task or [])
+    suite = [task for task in build_suite() if not selected or task.task_id in selected]
+    unknown = selected - {task.task_id for task in suite}
+    if unknown:
+        raise SystemExit(f"unknown task ids: {sorted(unknown)}")
+    results = []
+    with httpx.Client(timeout=args.timeout) as client:
+        if not args.no_warmup:
+            warmup = Task(
+                "warmup",
+                "warmup",
+                "Return exactly the word READY.",
+                128,
+                64,
+                lambda text: Grade(text.strip() == "READY", 1.0, "warmup"),
+            )
+            _post_task(
+                client,
+                base_url=args.base_url,
+                model=args.model,
+                task=warmup,
+                use_thinking_budget=not args.omit_thinking_budget,
+            )
+        for task in suite:
+            result = _post_task(
+                client,
+                base_url=args.base_url,
+                model=args.model,
+                task=task,
+                use_thinking_budget=not args.omit_thinking_budget,
+            )
+            results.append(result)
+            grade = result["grade"]
+            mark = "PASS" if grade["passed"] else "FAIL"
+            print(
+                f"{mark:4} {task.task_id:36} score={grade['score']:.3f} "
+                f"{result['client_completion_tps']:.2f} tok/s "
+                f"({result['completion_tokens']} tokens, {result['elapsed_s']:.2f}s)"
+            )
+    artifact = {
+        "schema_version": 1,
+        "label": args.label,
+        "model": args.model,
+        "base_url": args.base_url,
+        "temperature": 0,
+        "thinking": True,
+        "thinking_budget_mode": ("off" if args.omit_thinking_budget else "per-task"),
+        "results": results,
+    }
+    Path(args.output).write_text(
+        json.dumps(artifact, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    passed = sum(result["grade"]["passed"] for result in results)
+    print(f"wrote {args.output}; {passed}/{len(results)} tasks passed")
+    return 0 if passed == len(results) else 2
+
+
+def compare_artifacts(paths: list[str]) -> int:
+    left, right = [json.loads(Path(path).read_text(encoding="utf-8")) for path in paths]
+    if left.get("thinking_budget_mode") != right.get("thinking_budget_mode"):
+        raise SystemExit("artifacts use different thinking-budget policies")
+    left_rows = {row["task_id"]: row for row in left["results"]}
+    right_rows = {row["task_id"]: row for row in right["results"]}
+    if set(left_rows) != set(right_rows):
+        raise SystemExit("artifacts contain different task ids")
+    rows = []
+    for task_id in sorted(left_rows):
+        baseline = left_rows[task_id]
+        candidate = right_rows[task_id]
+        same_request = all(
+            baseline.get(key) == candidate.get(key)
+            for key in ("max_tokens", "thinking_budget", "prompt_tokens")
+        )
+        exact_output = baseline["output"] == candidate["output"]
+        exact_reasoning = baseline.get("reasoning", "") == candidate.get(
+            "reasoning", ""
+        )
+        ratio = (
+            candidate["client_completion_tps"] / baseline["client_completion_tps"]
+            if baseline["client_completion_tps"]
+            else 0.0
+        )
+        score_delta = candidate["grade"]["score"] - baseline["grade"]["score"]
+        rows.append(
+            {
+                "task_id": task_id,
+                "category": baseline["category"],
+                "same_request": same_request,
+                "exact_output": exact_output,
+                "exact_reasoning": exact_reasoning,
+                "baseline_passed": baseline["grade"]["passed"],
+                "candidate_passed": candidate["grade"]["passed"],
+                "score_delta": score_delta,
+                "throughput_ratio": ratio,
+            }
+        )
+        print(
+            f"{'SAME' if same_request and exact_output and exact_reasoning else 'DIFF':4} "
+            f"{task_id:36} "
+            f"quality_delta={score_delta:+.3f} speed={ratio:.3f}x"
+        )
+    ratios = [row["throughput_ratio"] for row in rows]
+    gate_passed = all(
+        row["same_request"]
+        and row["exact_output"]
+        and row["exact_reasoning"]
+        and row["baseline_passed"]
+        and row["candidate_passed"]
+        and row["score_delta"] >= 0
+        and row["throughput_ratio"] >= 0.95
+        for row in rows
+    )
+    summary = {
+        "schema_version": 1,
+        "baseline": paths[0],
+        "candidate": paths[1],
+        "gate_passed": gate_passed,
+        "exact_outputs": sum(row["exact_output"] for row in rows),
+        "exact_reasoning": sum(row["exact_reasoning"] for row in rows),
+        "task_count": len(rows),
+        "median_throughput_ratio": statistics.median(ratios),
+        "minimum_throughput_ratio": min(ratios),
+        "rows": rows,
+    }
+    print(json.dumps(summary, indent=2))
+    return 0 if gate_passed else 3
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8465/v1")
+    parser.add_argument("--model", default="glm5.3-flash-4bit")
+    parser.add_argument("--label", default="unlabeled")
+    parser.add_argument("--output", default="glm53-real-tasks.json")
+    parser.add_argument("--timeout", type=float, default=600.0)
+    parser.add_argument("--task", action="append", help="run only this task id")
+    parser.add_argument("--no-warmup", action="store_true")
+    parser.add_argument(
+        "--omit-thinking-budget",
+        action="store_true",
+        help="omit thinking_budget for runtimes that cannot combine it with MTP",
+    )
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("BASELINE_JSON", "CANDIDATE_JSON"),
+        help="compare two existing artifacts instead of calling a server",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.compare:
+        return compare_artifacts(args.compare)
+    return run_suite(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_glm53_real_tasks.py
+++ b/tests/test_benchmark_glm53_real_tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -30,6 +31,10 @@ def test_exact_json_grader_rejects_prose_and_extra_keys() -> None:
     assert not grader('{"answer": 42, "comment": "ok"}').passed
 
 
+@pytest.mark.skipif(
+    shutil.which("sandbox-exec") is None,
+    reason="successful code execution requires the macOS sandbox",
+)
 def test_coding_grader_executes_hidden_cases() -> None:
     good = """```python
 def coalesce_intervals(intervals):

--- a/tests/test_benchmark_glm53_real_tasks.py
+++ b/tests/test_benchmark_glm53_real_tasks.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+def _module():
+    path = Path(__file__).parents[1] / "scripts" / "benchmark_glm53_real_tasks.py"
+    spec = importlib.util.spec_from_file_location("benchmark_glm53_real_tasks", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bench = _module()
+
+
+def test_exact_json_grader_rejects_prose_and_extra_keys() -> None:
+    grader = bench._grade_exact_json({"answer": 42})
+    assert grader('{"answer": 42}').passed
+    assert not grader('Result: {"answer": 42}').passed
+    assert not grader('{"answer": 42, "comment": "ok"}').passed
+
+
+def test_coding_grader_executes_hidden_cases() -> None:
+    good = """```python
+def coalesce_intervals(intervals):
+    result = []
+    for start, end in sorted(intervals):
+        if result and start <= result[-1][1]:
+            result[-1] = (result[-1][0], max(result[-1][1], end))
+        else:
+            result.append((start, end))
+    return result
+```"""
+    assert bench._grade_interval_code(good).passed
+    assert not bench._grade_interval_code(
+        "def coalesce_intervals(intervals):\n    return intervals"
+    ).passed
+
+
+def test_coding_grader_rejects_unsafe_or_hanging_code() -> None:
+    assert (
+        "forbidden"
+        in bench._grade_interval_code(
+            "import os\ndef coalesce_intervals(intervals):\n    return []"
+        ).detail
+    )
+    assert (
+        "forbidden"
+        in bench._grade_interval_code(
+            "def coalesce_intervals(intervals):\n    return open('/tmp/x')"
+        ).detail
+    )
+
+
+def test_coding_grader_fails_closed_without_apple_sandbox(monkeypatch) -> None:
+    monkeypatch.setattr(bench.shutil, "which", lambda _name: None)
+    result = bench._grade_interval_code(
+        "def coalesce_intervals(intervals):\n    return []"
+    )
+    assert not result.passed
+    assert "sandbox-exec" in result.detail
+
+
+def test_creative_grader_enforces_hard_constraints() -> None:
+    body = " ".join(["You crossed the quiet lobby"] * 22)
+    text = (
+        f"{body} and the elevator remembered every version of your name. "
+        "The doors opened onto Tuesday."
+    )
+    result = bench._grade_creative(text)
+    assert result.passed
+    assert result.manual_review_required
+    assert not bench._grade_creative(text.replace("Tuesday.", "Monday.")).passed
+    assert not bench._grade_creative(text.replace("quiet", "dreaming", 1)).passed
+
+
+def test_instruction_grader_enforces_raw_json_and_key_order() -> None:
+    raw = '{"alpha": "desserts", "beta": 6, "gamma": [23, 29, 31]}'
+    assert bench._grade_instruction(raw).passed
+    assert not bench._grade_instruction(f"```json\n{raw}\n```").passed
+    reordered = '{"beta": 6, "alpha": "desserts", "gamma": [23, 29, 31]}'
+    assert not bench._grade_instruction(reordered).passed
+
+
+def test_compare_requires_exact_output_and_no_quality_regression(
+    tmp_path: Path,
+) -> None:
+    def artifact(path: Path, output: str, passed: bool, tps: float) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "results": [
+                        {
+                            "task_id": "knowledge.x",
+                            "category": "knowledge",
+                            "max_tokens": 10,
+                            "thinking_budget": None,
+                            "prompt_tokens": 4,
+                            "output": output,
+                            "client_completion_tps": tps,
+                            "grade": {"passed": passed, "score": float(passed)},
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    artifact(baseline, "same", True, 10.0)
+    artifact(candidate, "same", True, 12.0)
+    assert bench.compare_artifacts([str(baseline), str(candidate)]) == 0
+    artifact(candidate, "different", True, 12.0)
+    assert bench.compare_artifacts([str(baseline), str(candidate)]) == 3
+
+
+@pytest.mark.parametrize("use_budget", [False, True])
+def test_post_task_records_request_and_server_metrics(use_budget: bool) -> None:
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/metrics":
+            return httpx.Response(
+                200,
+                json={"latest": {"decode_tok_s": 12.5, "peak_memory_gb": 3.0}},
+            )
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"content": '{"answer": 42}', "reasoning": "r"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 5},
+            },
+        )
+
+    task = bench.Task(
+        "test",
+        "knowledge",
+        "prompt",
+        20,
+        7,
+        bench._grade_exact_json({"answer": 42}),
+    )
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        result = bench._post_task(
+            client,
+            base_url="http://example.test/v1",
+            model="model",
+            task=task,
+            use_thinking_budget=use_budget,
+        )
+
+    payload = json.loads(requests[0].content)
+    assert payload.get("thinking_budget") == (7 if use_budget else None)
+    assert result["thinking_budget"] == (7 if use_budget else None)
+    assert result["server_metrics"]["decode_tok_s"] == 12.5
+    assert result["reasoning"] == "r"

--- a/tests/test_benchmark_glm53_real_tasks.py
+++ b/tests/test_benchmark_glm53_real_tasks.py
@@ -65,6 +65,18 @@ def test_coding_grader_rejects_unsafe_or_hanging_code() -> None:
             "def coalesce_intervals(intervals):\n    return open('/tmp/x')"
         ).detail
     )
+    assert (
+        "forbidden top-level"
+        in bench._grade_interval_code(
+            "print('side effect')\ndef coalesce_intervals(intervals):\n    return []"
+        ).detail
+    )
+    assert (
+        "oversized"
+        in bench._grade_interval_code(
+            "def coalesce_intervals(intervals):\n    return [0] * 1000000000"
+        ).detail
+    )
 
 
 def test_coding_grader_fails_closed_without_apple_sandbox(monkeypatch) -> None:


### PR DESCRIPTION
## Why\n\nSynthetic MTP acceptance and token throughput can hide incomplete or degraded answers. GLM-5.3 especially needs a quality-aware gate because useful coding and prose requests often need a bounded reasoning phase.\n\n## What\n\n- add a six-category deterministic real-task harness\n- execute generated coding answers against eight sandboxed hidden tests\n- grade atomic knowledge, multi-step math, exact instruction following, constrained creative writing, and long-context contract retrieval\n- capture server prefill, decode, total latency, and peak-memory telemetry\n- compare A/B artifacts only when request policy matches\n- require identical reasoning and final output plus unchanged task success\n- document the full-model Studio dogfood and the current release blocker\n\n## Full-model result\n\nM3 Ultra, batch one, greedy, cached uniform-Q4 target at revision 76add2a341a1cd90ad0e86bb69839ea9c35827c6, target-matched Q4 MTP head, post-0.7 mlx-vlm source d2a1434a.\n\nWith the same no-budget requests:\n\n| Category | Decode speedup | End-to-end speedup | Exact reasoning/output | Task result |\n| --- | ---: | ---: | --- | --- |\n| Coding | 1.238x | 1.235x | yes | fail: 1024-token reasoning exhaustion |\n| Creative writing | 1.184x | 1.181x | yes | fail: 1024-token reasoning exhaustion |\n| Instruction following | 1.242x | 1.201x | yes | pass |\n| Knowledge | 1.250x | 1.229x | yes | pass |\n| Long context | 1.356x | 1.158x | yes | pass |\n| Math | 1.134x | 1.127x | yes | pass |\n\nMedian decode speedup: 1.240x. Median end-to-end completion-throughput speedup: 1.191x. Minimum end-to-end task speedup: 1.127x. Peak Metal memory: 188.679 GB MTP versus 184.141 GB AR.\n\nThe comparable gate is intentionally red at 4/6. Budgeted AR passes 6/6, including 8/8 hidden coding tests, but the speculative server rejects thinking_budget with HTTP 500. This PR does not enable MTP; it records the exact product-quality blocker.\n\n## Safety\n\nThe coding grader fails closed without macOS sandbox-exec. Candidate code is AST-filtered, denied network and writes outside its temporary directory, and bounded by CPU, file-size, process-count, descriptor, and wall-time limits.\n\n## Verification\n\n- python3.12 -m pytest -q tests/test_benchmark_glm53_real_tasks.py: 9 passed\n- Ruff check and format check passed\n- git diff --check passed\n- two clean full-model server processes, one AR and one MTP; both shut down cleanly\n- no model downloads or HF cache relocation