### PR TITLE
perf: fuse Qwen3.6 MoE router top-k

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,7 @@ jobs:
             tests/test_routing_groups_0131.py \
             tests/test_qwen4_exp_vendored.py \
             tests/test_qwen4_fused_gdn_decode.py \
+            tests/test_qwen35_moe_router.py \
             tests/test_qsa_block_sparse.py \
             tests/test_qsa_indexed_splitk.py \
             tests/test_mtp_cli_wiring.py \

--- a/docs/engineering/performance/2026-09-12-qwen36-35b-fused-router.md
+++ b/docs/engineering/performance/2026-09-12-qwen36-35b-fused-router.md
@@ -1,0 +1,112 @@
+# Qwen3.6-35B-A3B fused MoE router qualification
+
+Date: 2026-09-12
+
+Target: `mlx-community/Qwen3.6-35B-A3B-4bit` at revision
+`38740b847e4cb78f352aba30aa41c76e08e6eb46`
+
+Host: Mac Studio, Apple M3 Ultra, 256 GB unified memory
+
+OS: macOS 26.5.2 (25F84)
+
+Runtime: MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.6.17
+
+Code base: `e28f68c41fdb8f71c618f7c26109e82bd920cf73`
+
+## Decision
+
+Ship a default-on, fail-closed Metal fast path for Qwen3.5-family MoE routing
+at decode and small verification widths. The model's router projection and
+precise softmax remain unchanged. The following composed tail is collapsed
+into one launch:
+
+1. top-k `argpartition`;
+2. selected-score gather;
+3. selected-score reduction;
+4. score normalization.
+
+Only rank-three, unsharded, normalized MoE blocks with 32-aligned expert counts
+between 32 and 512, top-k at most 16, BF16/FP16 activations, and at most eight
+rows are eligible. Wider prefill, unknown layouts, other model instances, and
+failed install-time probes retain the stock path. Set
+`RAPID_MLX_QWEN35_MOE_ROUTER=0` to disable.
+
+## Correctness
+
+The kernel deliberately reproduces the stock `argpartition` order, including
+equal-probability ties, rather than returning only the same expert set. It also
+uses the input dtype and stock reduction order for score normalization.
+
+The test campaign compared both indices and scores with `mx.array_equal` for:
+
+- BF16 and FP16;
+- one, four, and eight rows;
+- 50 randomized samples per dtype/width pair;
+- an all-equal tie case across eight rows.
+
+All comparisons were bit-exact. The real-checkpoint alternating generation
+campaign emitted one token hash across both paths.
+
+## Performance
+
+The primary experiment loaded the checkpoint once, applied the existing MoE
+gate/up and GDN projection fusions, compiled both router paths, then alternated
+stock and fused 128-token greedy generations in eight adjacent pairs at
+concurrency one. The raw prompt contained 26 tokens. Two A/B/B/A warmup pairs
+were excluded. This avoids model-load differences and reduces sensitivity to
+thermal drift.
+
+| Metric | Result |
+| --- | ---: |
+| Paired speedup, median | **1.051x (+5.1%)** |
+| Paired speedup, mean | **1.049x (+4.9%)** |
+| Positive pairs | **8 / 8** |
+| Pair range | +1.9% to +7.1% |
+| Output token hashes | 1 across all runs |
+
+The eight measured speedup ratios were `1.0451`, `1.0572`, `1.0596`, `1.0711`,
+`1.0283`, `1.0658`, `1.0194`, and `1.0432`.
+
+The ordinary text-serving baseline with all previously shipped fusions was
+about 103 tok/s on the same host before this change. Absolute throughput moved
+during the campaign because another resident workload intermittently used the
+GPU; the within-process adjacent ratio is therefore the landing metric.
+
+The multimodal server lane previously did not apply the already-qualified MoE
+gate/up fusion to this architecture. Enrolling both that fusion and the router
+fast path raised repeated 256-token greedy decode from a median 63.7 tok/s to
+66.6 tok/s (**+4.5%**) in separate process runs. Repeated steady outputs had
+the same content hash in both conditions.
+
+## Reproduction
+
+Resolve the target only through the configured Hugging Face cache. The primary
+paired command is:
+
+```bash
+PYTHONPATH=. python3.12 scripts/large-model-run.py \
+  --working-set-gb 32 --reserve-gb 12 -- \
+  python3.12 scripts/benchmark_qwen35_moe_router.py \
+    --model /path/to/immutable/snapshot \
+    --pairs 8 --warmup-pairs 2 --max-tokens 128
+```
+
+For a separate server comparison, start text-only routing with speculative
+decode and PFlash off, temperature zero, thinking disabled, and a 512-token
+output. The stock-router comparison adds:
+
+```bash
+RAPID_MLX_QWEN35_MOE_ROUTER=0 python3.12 -m vllm_mlx.server \
+  --model /path/to/immutable/snapshot \
+  --no-mllm --no-spec-decode --pflash off
+```
+
+For the multimodal lane, compare the default with both new enrollments
+disabled:
+
+```bash
+RAPID_MLX_MOE_GATE_UP_FUSION=0 \
+RAPID_MLX_QWEN35_MOE_ROUTER=0 \
+python3.12 -m vllm_mlx.server \
+  --model /path/to/immutable/snapshot --mllm --pflash off
+```

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -6,6 +6,7 @@ summary statistics, and limitations.
 
 ## Reports
 
+- [Qwen3.6-35B-A3B fused MoE router qualification](2026-09-12-qwen36-35b-fused-router.md)
 - [DeepSeek V4.1 Flash Engram SSD offload qualification](2026-09-11-deepseek-v41-engram-offload.md)
 - [Qwen3.8 27B MTP FP16 checkpoint qualification](2026-09-07-qwen38-mtp-fp16.md)
 - [Qwen4 fp32-input fast RMSNorm qualification](2026-09-06-qwen4-fast-rmsnorm.md)

--- a/scripts/benchmark_qwen35_moe_router.py
+++ b/scripts/benchmark_qwen35_moe_router.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Paired real-checkpoint benchmark for the Qwen3.5 MoE router fast path."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import statistics
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PROMPT = (
+    "Implement an LRU cache in Python with get and put in O(1). Explain "
+    "invariants and include tests. Be detailed."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Local snapshot path")
+    parser.add_argument("--pairs", type=int, default=8)
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--warmup-pairs", type=int, default=2)
+    args = parser.parse_args()
+    if args.pairs < 1 or args.warmup_pairs < 1 or args.max_tokens < 1:
+        parser.error("pairs, warmup-pairs, and max-tokens must be positive")
+    return args
+
+
+def token_digest(tokens: list[int]) -> str:
+    return hashlib.sha256(",".join(map(str, tokens)).encode("ascii")).hexdigest()
+
+
+def main() -> int:
+    args = parse_args()
+    model_path = Path(args.model).expanduser().resolve()
+    if not model_path.is_dir():
+        raise SystemExit(f"--model must be a cached local snapshot: {args.model}")
+
+    import mlx.core as mx
+    from mlx_lm import load
+    from mlx_lm.generate import stream_generate
+    from mlx_lm.sample_utils import make_sampler
+
+    from vllm_mlx.gdn_in_proj_fusion import fuse_gdn_in_proj
+    from vllm_mlx.moe_fusion import fuse_gate_up
+    from vllm_mlx.qwen35_moe_router import _TAG, install_qwen35_moe_router
+
+    model, tokenizer = load(model_path)
+    existing_fusions = {
+        "moe_gate_up_layers": fuse_gate_up(model),
+        "gdn_projection_layers": fuse_gdn_in_proj(model),
+    }
+    enrolled = install_qwen35_moe_router(model)
+    blocks = [
+        module
+        for _, module in model.named_modules()
+        if bool(getattr(module, _TAG, False))
+    ]
+    if not enrolled or len(blocks) != enrolled:
+        raise RuntimeError("the target did not enroll in the fused Qwen MoE router")
+
+    sampler = make_sampler(temp=0.0)
+
+    def run(enabled: bool) -> dict[str, Any]:
+        for block in blocks:
+            setattr(block, _TAG, enabled)
+        mx.random.seed(0)
+        tokens = []
+        last = None
+        for response in stream_generate(
+            model,
+            tokenizer,
+            args.prompt,
+            max_tokens=args.max_tokens,
+            sampler=sampler,
+        ):
+            tokens.append(int(response.token))
+            last = response
+        if last is None:
+            raise RuntimeError("generation emitted no tokens")
+        return {
+            "enabled": enabled,
+            "generation_tps": float(last.generation_tps),
+            "tokens": len(tokens),
+            "token_sha256": token_digest(tokens),
+        }
+
+    # Compile both graphs before measurement. A/B/B/A also balances which path
+    # runs first while the host reaches its sustained thermal state.
+    for _ in range(args.warmup_pairs):
+        for enabled in (False, True, True, False):
+            run(enabled)
+
+    pairs = []
+    hashes = set()
+    for pair_index in range(args.pairs):
+        order = (False, True) if pair_index % 2 == 0 else (True, False)
+        samples = {}
+        for enabled in order:
+            sample = run(enabled)
+            samples[enabled] = sample
+            hashes.add(sample["token_sha256"])
+        stock = samples[False]["generation_tps"]
+        fused = samples[True]["generation_tps"]
+        pairs.append(
+            {
+                "pair": pair_index,
+                "stock_tps": stock,
+                "fused_tps": fused,
+                "speedup": fused / stock,
+                "stock_hash": samples[False]["token_sha256"],
+                "fused_hash": samples[True]["token_sha256"],
+            }
+        )
+
+    ratios = [pair["speedup"] for pair in pairs]
+    result = {
+        "model": str(model_path),
+        "machine": platform.machine(),
+        "max_tokens": args.max_tokens,
+        "prompt_tokens": len(tokenizer.encode(args.prompt)),
+        "pairs": pairs,
+        "summary": {
+            "median_speedup": statistics.median(ratios),
+            "mean_speedup": statistics.mean(ratios),
+            "positive_pairs": sum(ratio > 1.0 for ratio in ratios),
+            "token_hashes": len(hashes),
+        },
+        "existing_fusions": existing_fusions,
+        "router_layers": enrolled,
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if len(hashes) == 1 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -144,11 +144,12 @@ def test_apple_coverage_roster_contains_only_tracked_tests() -> None:
 
 
 def test_qwen4_fused_gdn_coverage_runs_on_apple_silicon() -> None:
-    """Qwen4 Metal fast paths must contribute to the changed-lines union."""
+    """Qwen-family Metal fast paths must contribute to changed-lines coverage."""
     _, workflow = _workflow()
     apple_run = workflow["jobs"]["test-apple-silicon"]["steps"][-2]["run"]
 
     assert "tests/test_qwen4_fused_gdn_decode.py" in apple_run
+    assert "tests/test_qwen35_moe_router.py" in apple_run
     assert "tests/test_qsa_block_sparse.py" in apple_run
     assert "tests/test_qsa_indexed_splitk.py" in apple_run
 

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -157,6 +157,10 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # fires, which tier engages — none of that changes. Read by
         # ``moe_fusion.fuse_gate_up()`` only.
         "RAPID_MLX_MOE_GATE_UP_FUSION",
+        # Opt-out of the bit-exact Qwen3.5-family MoE router-tail fusion.
+        # This changes only a launch-count optimization after model loading;
+        # it cannot select a model, parser, tier, or serving lane.
+        "RAPID_MLX_QWEN35_MOE_ROUTER",
         # Opt-in direct QSA block-sparse attention on an already-selected
         # Qwen4-Exp model. This changes only the prefill kernel after a measured
         # context crossover; model, parser, tier, and engine routing are

--- a/tests/test_qwen35_moe_router.py
+++ b/tests/test_qwen35_moe_router.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness and enrollment tests for the fused Qwen MoE router."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+import vllm_mlx.qwen35_moe_router as router
+
+
+def _stock(probs: mx.array, top_k: int = 8) -> tuple[mx.array, mx.array]:
+    indices = mx.argpartition(probs, kth=-top_k, axis=-1)[..., -top_k:]
+    scores = mx.take_along_axis(probs, indices, axis=-1)
+    return indices, scores / scores.sum(axis=-1, keepdims=True)
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("rows", [1, 4, 8])
+def test_kernel_is_bit_exact_for_decode_widths(dtype, rows):
+    mx.random.seed(36 + rows)
+    for _ in range(50):
+        logits = (mx.random.normal((1, rows, 256)) * 2).astype(dtype)
+        probs = mx.softmax(logits, axis=-1, precise=True)
+        expected_i, expected_s = _stock(probs)
+        actual_i, actual_s = router.fused_router_topk(probs, 8)
+        mx.eval(expected_i, expected_s, actual_i, actual_s)
+        assert mx.array_equal(actual_i, expected_i)
+        assert mx.array_equal(actual_s, expected_s)
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_kernel_matches_argpartition_tie_order():
+    probs = mx.ones((1, 8, 256), dtype=mx.bfloat16)
+    expected_i, expected_s = _stock(probs)
+    actual_i, actual_s = router.fused_router_topk(probs, 8)
+    mx.eval(expected_i, expected_s, actual_i, actual_s)
+    assert mx.array_equal(actual_i, expected_i)
+    assert mx.array_equal(actual_s, expected_s)
+
+
+def test_eligibility_is_model_local_and_decode_only():
+    block = SimpleNamespace(
+        num_experts=256,
+        top_k=8,
+        norm_topk_prob=True,
+        sharding_group=None,
+    )
+    decode = mx.zeros((1, 1, 2048), dtype=mx.bfloat16)
+    verify = mx.zeros((1, 8, 2048), dtype=mx.float16)
+    prefill = mx.zeros((1, 9, 2048), dtype=mx.bfloat16)
+
+    assert not router._eligible(decode, block)
+    setattr(block, router._TAG, True)
+    assert router._eligible(decode, block)
+    assert router._eligible(verify, block)
+    assert not router._eligible(prefill, block)
+    assert not router._eligible(mx.zeros((2048,), dtype=mx.bfloat16), block)
+    block.num_experts = 250
+    assert not router._eligible(decode, block)
+
+
+def test_kernel_wrapper_rejects_unqualified_shapes():
+    with pytest.raises(ValueError, match="rank"):
+        router.fused_router_topk(mx.zeros((256,), dtype=mx.bfloat16), 8)
+    with pytest.raises(ValueError, match="shape"):
+        router.fused_router_topk(mx.zeros((1, 9, 256), dtype=mx.bfloat16), 8)
+    with pytest.raises(ValueError, match="shape"):
+        router.fused_router_topk(mx.zeros((1, 1, 250), dtype=mx.bfloat16), 8)
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_install_tags_only_blocks_from_the_loaded_model(monkeypatch):
+    from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
+
+    block = Qwen3NextSparseMoeBlock.__new__(Qwen3NextSparseMoeBlock)
+    nn.Module.__init__(block)
+    block.num_experts = 256
+    block.top_k = 8
+    block.norm_topk_prob = True
+    block.sharding_group = None
+
+    model = SimpleNamespace(named_modules=lambda: iter((("mlp", block),)))
+    monkeypatch.setattr(router, "_patch_class", lambda _cls: None)
+    assert router.install_qwen35_moe_router(model) == 1
+    assert getattr(block, router._TAG) is True
+
+
+def test_install_honors_disable_switch(monkeypatch):
+    monkeypatch.setenv("RAPID_MLX_QWEN35_MOE_ROUTER", "0")
+    model = SimpleNamespace(named_modules=lambda: iter(()))
+    assert router.install_qwen35_moe_router(model) == 0
+
+
+def test_mllm_load_enrolls_qwen_moe_optimizations(monkeypatch):
+    import mlx_vlm
+    import mlx_vlm.utils
+
+    from vllm_mlx import moe_fusion
+    from vllm_mlx.models import mllm
+    from vllm_mlx.utils import tokenizer as tokenizer_utils
+
+    model = SimpleNamespace(config=SimpleNamespace())
+    processor = SimpleNamespace(tokenizer=SimpleNamespace())
+    fused = []
+    routed = []
+    monkeypatch.setattr(mllm, "_require_mlx_vlm", lambda: None)
+    monkeypatch.setattr(mlx_vlm, "load", lambda *args, **kwargs: (model, processor))
+    monkeypatch.setattr(
+        mlx_vlm.utils,
+        "load_config",
+        lambda *args, **kwargs: {"model_type": "qwen3_5_moe"},
+    )
+    monkeypatch.setattr(moe_fusion, "fuse_gate_up", fused.append)
+    monkeypatch.setattr(router, "install_qwen35_moe_router", routed.append)
+    monkeypatch.setattr(
+        tokenizer_utils,
+        "augment_eos_token_ids_from_generation_config",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        tokenizer_utils,
+        "repair_byte_level_decoder",
+        lambda *args, **kwargs: None,
+    )
+
+    mllm.MLXMultimodalLM("local/qwen-moe").load()
+
+    assert fused == [model]
+    assert routed == [model]

--- a/tests/test_qwen35_moe_router.py
+++ b/tests/test_qwen35_moe_router.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import mlx.core as mx
-import mlx.nn as nn
 import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.nn as nn
 
 import vllm_mlx.qwen35_moe_router as router
 
@@ -94,6 +97,10 @@ def test_install_honors_disable_switch(monkeypatch):
     monkeypatch.setenv("RAPID_MLX_QWEN35_MOE_ROUTER", "0")
     model = SimpleNamespace(named_modules=lambda: iter(()))
     assert router.install_qwen35_moe_router(model) == 0
+
+
+def test_install_ignores_non_module_model_placeholder():
+    assert router.install_qwen35_moe_router(object()) == 0
 
 
 def test_mllm_load_enrolls_qwen_moe_optimizations(monkeypatch):

--- a/tests/test_qwen35_moe_router.py
+++ b/tests/test_qwen35_moe_router.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import builtins
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -44,6 +46,15 @@ def test_kernel_matches_argpartition_tie_order():
     mx.eval(expected_i, expected_s, actual_i, actual_s)
     assert mx.array_equal(actual_i, expected_i)
     assert mx.array_equal(actual_s, expected_s)
+
+
+def test_probe_rejects_a_numerically_different_kernel(monkeypatch):
+    def wrong(probs, top_k):
+        shape = (*probs.shape[:-1], top_k)
+        return mx.zeros(shape, dtype=mx.uint32), mx.zeros(shape, dtype=probs.dtype)
+
+    monkeypatch.setattr(router, "fused_router_topk", wrong)
+    assert not router._probe(256, 8, mx.bfloat16)
 
 
 def test_eligibility_is_model_local_and_decode_only():
@@ -101,6 +112,95 @@ def test_install_honors_disable_switch(monkeypatch):
 
 def test_install_ignores_non_module_model_placeholder():
     assert router.install_qwen35_moe_router(object()) == 0
+
+
+def test_install_fails_closed_without_metal(monkeypatch):
+    monkeypatch.setattr(mx.metal, "is_available", lambda: False)
+    assert router.install_qwen35_moe_router(object()) == 0
+
+
+def test_install_fails_closed_when_text_backend_class_is_unavailable(monkeypatch):
+    original_import = builtins.__import__
+
+    def rejecting_import(name, *args, **kwargs):
+        if name == "mlx_lm.models.qwen3_next":
+            raise ImportError("backend class unavailable")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", rejecting_import)
+    monkeypatch.delitem(
+        sys.modules, "mlx_vlm.models.qwen3_5_moe.language", raising=False
+    )
+    model = SimpleNamespace(named_modules=lambda: iter(()))
+    assert router.install_qwen35_moe_router(model) == 0
+
+
+def test_install_enrolls_already_loaded_vision_backend_class(monkeypatch):
+    class VisionBlock:
+        pass
+
+    block = VisionBlock()
+    block.num_experts = 256
+    block.top_k = 8
+    block.norm_topk_prob = True
+    module = SimpleNamespace(Qwen3_5MoeSparseMoeBlock=VisionBlock)
+    monkeypatch.setitem(sys.modules, "mlx_vlm.models.qwen3_5_moe.language", module)
+    monkeypatch.setattr(router, "_probe", lambda *args: True)
+    monkeypatch.setattr(router, "_patch_class", lambda _cls: None)
+    model = SimpleNamespace(named_modules=lambda: iter((("mlp", block),)))
+
+    assert router.install_qwen35_moe_router(model) == 1
+    assert getattr(block, router._TAG)
+
+
+@pytest.mark.parametrize("probe_result", [False, RuntimeError("probe failed")])
+def test_install_fails_closed_when_parity_probe_does_not_pass(
+    monkeypatch, probe_result
+):
+    from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
+
+    block = Qwen3NextSparseMoeBlock.__new__(Qwen3NextSparseMoeBlock)
+    nn.Module.__init__(block)
+    block.num_experts = 256
+    block.top_k = 8
+    block.norm_topk_prob = True
+    model = SimpleNamespace(named_modules=lambda: iter((("mlp", block),)))
+
+    def probe(*args):
+        if isinstance(probe_result, Exception):
+            raise probe_result
+        return probe_result
+
+    monkeypatch.setattr(router, "_probe", probe)
+    assert router.install_qwen35_moe_router(model) == 0
+    assert not getattr(block, router._TAG, False)
+
+
+def test_patched_class_keeps_stock_fallback_and_matches_fused_composition(monkeypatch):
+    class Block:
+        def __call__(self, x):
+            return "stock"
+
+    block = Block()
+    block.num_experts = 256
+    block.top_k = 8
+    block.norm_topk_prob = True
+    block.sharding_group = None
+    setattr(block, router._TAG, True)
+    block.gate = lambda x: mx.zeros((*x.shape[:-1], 256), dtype=x.dtype)
+    block.switch_mlp = lambda x, indices: mx.ones((*x.shape[:-1], 8, 2), dtype=x.dtype)
+    block.shared_expert = lambda x: mx.ones((*x.shape[:-1], 2), dtype=x.dtype)
+    block.shared_expert_gate = lambda x: mx.zeros((*x.shape[:-1], 2), dtype=x.dtype)
+    indices = mx.zeros((1, 1, 8), dtype=mx.uint32)
+    scores = mx.full((1, 1, 8), 0.125, dtype=mx.bfloat16)
+    monkeypatch.setattr(router, "fused_router_topk", lambda *_: (indices, scores))
+
+    router._patch_class(Block)
+    assert block(mx.zeros((1, 9, 2), dtype=mx.bfloat16)) == "stock"
+    output = block(mx.zeros((1, 1, 2), dtype=mx.bfloat16))
+    mx.eval(output)
+    assert mx.array_equal(output, mx.full((1, 1, 2), 1.5, dtype=mx.bfloat16))
+    router._patch_class(Block)
 
 
 def test_mllm_load_enrolls_qwen_moe_optimizations(monkeypatch):

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1868,7 +1868,7 @@ class BatchedEngine(BaseEngine):
             # other MoE families and prefill widths keep their stock path.
             from ..qwen35_moe_router import install_qwen35_moe_router
 
-            self._model_load_executor.submit(
+            self._model_load_executor.submit(  # type: ignore[attr-defined]
                 install_qwen35_moe_router, self._model
             ).result()
 

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1862,6 +1862,16 @@ class BatchedEngine(BaseEngine):
 
             self._model_load_executor.submit(fuse_gate_up, self._model).result()
 
+            # Collapse Qwen3.5-family short-row MoE top-k selection and score
+            # normalization into one launch.  The installer tags only the
+            # compatible blocks in this model after a real Metal parity probe;
+            # other MoE families and prefill widths keep their stock path.
+            from ..qwen35_moe_router import install_qwen35_moe_router
+
+            self._model_load_executor.submit(
+                install_qwen35_moe_router, self._model
+            ).result()
+
             # Fuse the four GatedDeltaNet input projections into one
             # quantized matmul at decode widths, byte-exact (see
             # vllm_mlx/gdn_in_proj_fusion.py; measured +2.0%/+0.9% decode

--- a/vllm_mlx/models/mllm.py
+++ b/vllm_mlx/models/mllm.py
@@ -1603,19 +1603,23 @@ class MLXMultimodalLM:
                 if isinstance(self.config, dict)
                 else getattr(self.config, "model_type", None)
             )
-            if config_model_type == "glm5_next":
-                # Keep GLM's MLLM lane at parity with BatchedEngine's text
-                # lane: collapse each eligible MoE gate/up pair into one
-                # gather_qmm. GLM-5.3-Flash always routes through this wrapper,
-                # so without this step its 42 sparse expert layers issue an
-                # extra quantized projection for every generated token. Keep
-                # the first rollout architecture-scoped; other MoE VLMs need
-                # their own real-model qualification before enrollment.
+            if config_model_type in {"glm5_next", "qwen3_5_moe"}:
+                # Keep qualified MLLM MoE lanes at parity with BatchedEngine's
+                # text lane: collapse each eligible gate/up pair into one
+                # gather_qmm. GLM-5.3-Flash and Qwen3.5-family MoE both route
+                # through this wrapper, so otherwise every sparse layer issues
+                # an extra quantized projection for every generated token.
+                # Other MoE VLMs still need real-model qualification.
                 # Server use runs this method on the model-owning mllm-step
                 # worker, preserving the stream contract from #170.
                 from ..moe_fusion import fuse_gate_up
 
                 fuse_gate_up(self.model)
+
+            if config_model_type == "qwen3_5_moe":
+                from ..qwen35_moe_router import install_qwen35_moe_router
+
+                install_qwen35_moe_router(self.model)
 
             # Augment the wrapped tokenizer's EOS set with the chat-
             # template terminator ids from ``generation_config.json``.

--- a/vllm_mlx/qwen35_moe_router.py
+++ b/vllm_mlx/qwen35_moe_router.py
@@ -210,11 +210,12 @@ def install_qwen35_moe_router(model: Any) -> int:
         vlm_block = getattr(vlm_qwen, "Qwen3_5MoeSparseMoeBlock", None)
         if vlm_block is not None:
             block_classes.append(vlm_block)
-    if not block_classes:
+    named_modules = getattr(model, "named_modules", None)
+    if not block_classes or not callable(named_modules):
         return 0
 
     blocks = [
-        module for _, module in model.named_modules() if type(module) in block_classes
+        module for _, module in named_modules() if type(module) in block_classes
     ]
     if not blocks:
         return 0

--- a/vllm_mlx/qwen35_moe_router.py
+++ b/vllm_mlx/qwen35_moe_router.py
@@ -214,9 +214,7 @@ def install_qwen35_moe_router(model: Any) -> int:
     if not block_classes or not callable(named_modules):
         return 0
 
-    blocks = [
-        module for _, module in named_modules() if type(module) in block_classes
-    ]
+    blocks = [module for _, module in named_modules() if type(module) in block_classes]
     if not blocks:
         return 0
     signatures = {

--- a/vllm_mlx/qwen35_moe_router.py
+++ b/vllm_mlx/qwen35_moe_router.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import Any
+from collections.abc import Callable
+from typing import Any, cast
 
 import mlx.core as mx
 
@@ -169,7 +170,7 @@ def _probe(num_experts: int, top_k: int, dtype: mx.Dtype) -> bool:
 def _patch_class(block_class: type) -> None:
     if getattr(block_class, "_rapid_qwen35_router_patched", False):
         return
-    original = block_class.__call__
+    original = cast(Callable[[Any, mx.array], mx.array], block_class.__call__)
 
     def patched(self, x: mx.array) -> mx.array:
         if not _eligible(x, self):
@@ -180,11 +181,12 @@ def _patch_class(block_class: type) -> None:
         routed = (routed * scores[..., None]).sum(axis=-2)
         shared = self.shared_expert(x)
         shared = mx.sigmoid(self.shared_expert_gate(x)) * shared
-        return routed + shared
+        return cast(mx.array, routed + shared)
 
-    block_class.__call__ = patched
-    block_class._rapid_qwen35_router_patched = True
-    block_class._rapid_qwen35_router_original_call = original
+    dynamic_class = cast(Any, block_class)
+    dynamic_class.__call__ = patched
+    dynamic_class._rapid_qwen35_router_patched = True
+    dynamic_class._rapid_qwen35_router_original_call = original
 
 
 def install_qwen35_moe_router(model: Any) -> int:

--- a/vllm_mlx/qwen35_moe_router.py
+++ b/vllm_mlx/qwen35_moe_router.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fuse short-row Qwen3.5-family MoE top-k routing on Metal.
+
+The stock routing tail uses separate ``argpartition``, gather, sum, and divide
+operations after the router softmax.  Decode repeats that tiny chain in every
+MoE layer.  This module replaces only that tail with one Metal launch while
+leaving the model's router projection and precise softmax unchanged.
+
+Per-model enrollment and an install-time parity probe ensure that the
+process-global class patch cannot accidentally enroll a later, incompatible
+model.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_KERNEL = None
+_MAX_ROWS = 8
+_MAX_EXPERTS = 512
+_MAX_TOP_K = 16
+_TAG = "_rapid_qwen35_fused_router"
+
+_SOURCE = r"""
+    constexpr uint PER = uint(NE) / 32;
+    const uint lane = thread_position_in_threadgroup.x;
+    const uint row = threadgroup_position_in_grid.y;
+    const device T* g = probs + row * uint(NE);
+
+    float vals[PER];
+    bool taken[PER];
+    for (uint i = 0; i < PER; ++i) {
+        vals[i] = float(g[lane * PER + i]);
+        taken[i] = false;
+    }
+
+    float sel_p[K];
+    uint sel_i[K];
+    for (uint j = 0; j < K; ++j) {
+        float best = -INFINITY;
+        uint best_i = uint(NE);
+        for (uint i = 0; i < PER; ++i) {
+            if (!taken[i] && vals[i] >= best) {
+                best = vals[i];
+                best_i = lane * PER + i;
+            }
+        }
+        const float group_best = simd_max(best);
+        const uint candidate = (best == group_best) ? best_i : 0u;
+        const uint group_best_i = simd_max(candidate);
+        if (best == group_best && best_i == group_best_i) {
+            taken[best_i - lane * PER] = true;
+        }
+        sel_p[j] = group_best;
+        sel_i[j] = group_best_i;
+    }
+
+    if (lane == 0) {
+        T total = T(0);
+        // Match the stock top-k tail's ascending order for the reduction.
+        for (int j = int(K) - 1; j >= 0; --j) {
+            total += T(sel_p[uint(j)]);
+        }
+        for (uint j = 0; j < K; ++j) {
+            // mlx.argpartition returns this top-k tail from the smallest
+            // selected probability to the largest for the eligible shape.
+            // Reverse the descending selection so the expert reduction keeps
+            // the stock accumulation order, not merely the same expert set.
+            const uint out = uint(K) - 1u - j;
+            indices[row * uint(K) + out] = sel_i[j];
+            scores[row * uint(K) + out] = T(sel_p[j]) / total;
+        }
+    }
+"""
+
+
+def _kernel():
+    global _KERNEL
+    if _KERNEL is None:
+        _KERNEL = mx.fast.metal_kernel(
+            name="rapid_qwen35_moe_router_topk",
+            input_names=["probs"],
+            output_names=["indices", "scores"],
+            source=_SOURCE,
+        )
+    return _KERNEL
+
+
+def fused_router_topk(probs: mx.array, top_k: int) -> tuple[mx.array, mx.array]:
+    """Return stock-ordered top-k indices and normalized scores."""
+    shape = probs.shape
+    if probs.ndim < 2 or probs.dtype not in (mx.bfloat16, mx.float16):
+        raise ValueError("fused Qwen router requires rank >= 2 BF16/FP16 probabilities")
+    rows = 1
+    for dim in shape[:-1]:
+        rows *= int(dim)
+    num_experts = int(shape[-1])
+    if not (
+        rows <= _MAX_ROWS
+        and 32 <= num_experts <= _MAX_EXPERTS
+        and num_experts % 32 == 0
+        and 1 <= top_k <= _MAX_TOP_K
+    ):
+        raise ValueError("unsupported fused Qwen router shape")
+    outputs = _kernel()(
+        inputs=[probs],
+        template=[("T", probs.dtype), ("NE", num_experts), ("K", top_k)],
+        grid=(32, rows, 1),
+        threadgroup=(32, 1, 1),
+        output_shapes=[(*shape[:-1], top_k), (*shape[:-1], top_k)],
+        output_dtypes=[mx.uint32, probs.dtype],
+    )
+    return outputs[0], outputs[1]
+
+
+def _eligible(x: mx.array, block: Any) -> bool:
+    rows = 1
+    for dim in x.shape[:-1]:
+        rows *= int(dim)
+    num_experts = int(getattr(block, "num_experts", 0))
+    top_k = int(getattr(block, "top_k", 0))
+    return (
+        getattr(block, _TAG, False)
+        and x.ndim == 3
+        and getattr(block, "sharding_group", None) is None
+        and bool(getattr(block, "norm_topk_prob", True))
+        and rows <= _MAX_ROWS
+        and num_experts >= 32
+        and num_experts <= _MAX_EXPERTS
+        and num_experts % 32 == 0
+        and 1 <= top_k <= _MAX_TOP_K
+        and x.dtype in (mx.bfloat16, mx.float16)
+    )
+
+
+def _composed(probs: mx.array, top_k: int) -> tuple[mx.array, mx.array]:
+    indices = mx.argpartition(probs, kth=-top_k, axis=-1)[..., -top_k:]
+    scores = mx.take_along_axis(probs, indices, axis=-1)
+    return indices, scores / scores.sum(axis=-1, keepdims=True)
+
+
+def _probe(num_experts: int, top_k: int, dtype: mx.Dtype) -> bool:
+    # No RNG: model loading must not perturb the caller's sampling state.
+    base = mx.arange(num_experts, dtype=mx.float32)
+    logits = mx.stack([mx.sin(base * 0.731 + row) for row in range(_MAX_ROWS)])
+    inputs = [
+        mx.softmax(logits.astype(dtype), axis=-1, precise=True),
+        mx.ones((_MAX_ROWS, num_experts), dtype=dtype),
+    ]
+    for probs in inputs:
+        expected_i, expected_s = _composed(probs, top_k)
+        actual_i, actual_s = fused_router_topk(probs, top_k)
+        mx.eval(expected_i, expected_s, actual_i, actual_s)
+        if not (
+            bool(mx.array_equal(expected_i, actual_i))
+            and bool(mx.array_equal(expected_s, actual_s))
+        ):
+            return False
+    return True
+
+
+def _patch_class(block_class: type) -> None:
+    if getattr(block_class, "_rapid_qwen35_router_patched", False):
+        return
+    original = block_class.__call__
+
+    def patched(self, x: mx.array) -> mx.array:
+        if not _eligible(x, self):
+            return original(self, x)
+        gates = mx.softmax(self.gate(x), axis=-1, precise=True)
+        indices, scores = fused_router_topk(gates, self.top_k)
+        routed = self.switch_mlp(x, indices)
+        routed = (routed * scores[..., None]).sum(axis=-2)
+        shared = self.shared_expert(x)
+        shared = mx.sigmoid(self.shared_expert_gate(x)) * shared
+        return routed + shared
+
+    block_class.__call__ = patched
+    block_class._rapid_qwen35_router_patched = True
+    block_class._rapid_qwen35_router_original_call = original
+
+
+def install_qwen35_moe_router(model: Any) -> int:
+    """Enroll compatible blocks from one loaded model; return their count."""
+    if os.environ.get("RAPID_MLX_QWEN35_MOE_ROUTER", "1") == "0":
+        return 0
+    if not mx.metal.is_available():
+        return 0
+    block_classes = []
+    try:
+        from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
+    except ImportError:
+        pass
+    else:
+        block_classes.append(Qwen3NextSparseMoeBlock)
+    # mlx-vlm keeps a separate Qwen implementation rather than re-exporting
+    # mlx-lm's class.  Import it only when mlx-vlm is already resident so a
+    # text-only install does not turn vision into a hard dependency.
+    vlm_qwen = sys.modules.get("mlx_vlm.models.qwen3_5_moe.language")
+    if vlm_qwen is not None:
+        vlm_block = getattr(vlm_qwen, "Qwen3_5MoeSparseMoeBlock", None)
+        if vlm_block is not None:
+            block_classes.append(vlm_block)
+    if not block_classes:
+        return 0
+
+    blocks = [
+        module for _, module in model.named_modules() if type(module) in block_classes
+    ]
+    if not blocks:
+        return 0
+    signatures = {
+        (int(block.num_experts), int(block.top_k))
+        for block in blocks
+        if getattr(block, "norm_topk_prob", True)
+        and 32 <= int(getattr(block, "num_experts", 0)) <= _MAX_EXPERTS
+        and int(getattr(block, "num_experts", 0)) % 32 == 0
+        and 1 <= int(getattr(block, "top_k", 0)) <= _MAX_TOP_K
+    }
+    try:
+        if not signatures or any(
+            not _probe(num_experts, top_k, dtype)
+            for num_experts, top_k in signatures
+            for dtype in (mx.bfloat16, mx.float16)
+        ):
+            logger.warning(
+                "Qwen MoE fused router parity probe failed; using stock path"
+            )
+            return 0
+    except Exception:
+        logger.warning(
+            "Qwen MoE fused router probe failed; using stock path", exc_info=True
+        )
+        return 0
+
+    for block_class in block_classes:
+        if any(type(block) is block_class for block in blocks):
+            _patch_class(block_class)
+    enrolled = 0
+    for block in blocks:
+        num_experts = int(getattr(block, "num_experts", 0))
+        top_k = int(getattr(block, "top_k", 0))
+        if (
+            getattr(block, "norm_topk_prob", True)
+            and num_experts >= 32
+            and num_experts <= _MAX_EXPERTS
+            and num_experts % 32 == 0
+            and 1 <= top_k <= _MAX_TOP_K
+        ):
+            setattr(block, _TAG, True)
+            enrolled += 1
+    if enrolled:
+        logger.info("[qwen35_router] fused top-k enrolled: %d MoE layers", enrolled)
+    return enrolled


### PR DESCRIPTION
## User-visible goal

Make Qwen3.6-35B-A3B respond faster in both text-only serving and the normal multimodal path without changing generated tokens.

## What changed

- Fuse the short-row MoE top-k selection, score gather, reduction, and normalization into one Metal launch.
- Enroll only compatible Qwen3.5-family MoE blocks after BF16 and FP16 install-time parity probes.
- Apply the already-qualified routed gate/up fusion to the Qwen multimodal lane.
- Add a local-snapshot-only paired benchmark and reproducible performance report.

## Quantitative result

On an M3 Ultra with 256 GB unified memory using `mlx-community/Qwen3.6-35B-A3B-4bit@38740b847e4cb78f352aba30aa41c76e08e6eb46`:

- Text lane router A/B: **+5.1% median** and **+4.9% mean** across eight adjacent pairs; all 8/8 pairs improved.
- Text throughput with previously shipped fusions was about 103 tok/s before this change; the new path reached 108–114 tok/s during stable portions of the campaign.
- Multimodal lane: **63.7 → 66.6 tok/s median (+4.5%)** after enrolling both qualified optimizations.
- Kernel indices and normalized scores were bit-exact for BF16/FP16 at rows 1/4/8, including equal-probability ties.
- All alternating real-checkpoint runs produced one token hash.

The paired ratio is the primary claim because an unrelated resident workload caused absolute host throughput to drift during the campaign.

## Scope and safety

Eligible calls are rank-three, unsharded, normalized MoE blocks with 32–512 experts, 32-aligned expert counts, top-k <= 16, BF16/FP16 activations, and at most eight rows. Prefill and unknown layouts remain stock. Failed probes leave the model unmodified. `RAPID_MLX_QWEN35_MOE_ROUTER=0` is the rollback switch.

Non-goals: no model catalog, download, quantization, UI, API, scheduler, or speculative-decoding policy changes.

## Validation

- `132 passed` across router, MoE fusion, GDN fusion, MLLM loader, and text/MLLM routing suites.
- Ruff passed for every changed Python file.
- `git diff --check` passed.
- Checked-in benchmark smoke: +5.6% median across two short pairs with identical token hashes.
