### PR TITLE
perf: fuse Qwen3.6 GDN single-token decode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,6 +499,7 @@ jobs:
             tests/test_qwen4_exp_vendored.py \
             tests/test_qwen4_fused_gdn_decode.py \
             tests/test_qwen35_moe_router.py \
+            tests/test_qwen35_fused_gdn_decode.py \
             tests/test_qsa_block_sparse.py \
             tests/test_qsa_indexed_splitk.py \
             tests/test_mtp_cli_wiring.py \

--- a/docs/engineering/performance/2026-09-12-qwen36-35b-fused-gdn-decode.md
+++ b/docs/engineering/performance/2026-09-12-qwen36-35b-fused-gdn-decode.md
@@ -1,0 +1,106 @@
+# Qwen3.6-35B-A3B fused GDN decode qualification
+
+Date: 2026-09-12
+
+Target: `mlx-community/Qwen3.6-35B-A3B-4bit` at revision
+`38740b847e4cb78f352aba30aa41c76e08e6eb46`
+
+Host: Mac Studio, Apple M3 Ultra, 256 GB unified memory
+
+OS: macOS 26.5.2 (25F84)
+
+Runtime: MLX 0.32.2, mlx-lm 0.31.3, mlx-vlm 0.6.17
+
+Measured code base: Rapid-MLX PR #3381 at `1d662e5f1`; the production change
+was subsequently rebased onto `main` after #3381 landed.
+
+## Decision
+
+Ship a default-on, fail-closed Metal specialization for the Qwen3.5-family
+GatedDeltaNet recurrence at single-token text decode. It combines causal
+convolution and cache shift, Q/K normalization, gated-delta state update, and
+gated RMSNorm. The already-qualified fused input projection feeds the kernel;
+the quantized output projection remains stock.
+
+Only BF16 `(batch=1, length=1)` inputs with initialized, non-ragged caches and
+the qualified 16-key-head / 32-value-head / 128-dimension / four-tap geometry
+are eligible. Prefill, batching, masks, training, sharding, MTP verification,
+unknown geometry, and failed probes remain stock. Set
+`RAPID_MLX_QWEN35_FUSED_GDN_DECODE=0` to disable.
+
+## Numerical qualification
+
+Mathematical equivalence was not accepted as sufficient. The implementation
+reproduces the stock operation order at every rounding boundary:
+
+- Q/K RMSNorm accumulates mean-of-squares in FP32, casts to BF16, then applies
+  the distinct query and key scales in BF16;
+- the output epilogue forms the FP32 SiLU gate first and multiplies the
+  normalized value second;
+- convolution state remains BF16 and recurrent state remains FP32.
+
+The install-time Metal probe runs eight sequential states and compares output,
+convolution cache, and recurrent state with `array_equal`. Its input includes a
+sigmoid edge value that distinguishes fast and precise exponential forms.
+
+Additional real-weight evidence:
+
+- 32 sequential single-layer steps had exact output and both cache slots;
+- a 20-token whole-model audit compared every eligible layer at every decode
+  transition and found no output or state difference;
+- five complete greedy chat-template cases emitted the same token sequence
+  with the path on and off: coding, creative writing, arithmetic reasoning,
+  compact JSON, and a tool-call instruction.
+
+The five cases establish preservation relative to the existing checkpoint;
+they are not a standalone claim about the checkpoint's absolute task quality.
+
+## Performance
+
+The model was loaded once. Existing gate/up, GDN input-projection, and router
+fusions were enabled on both sides. Four alternating warmup generations were
+excluded, followed by six adjacent stock/fused pairs. Each measured generation
+used greedy decoding, concurrency one, and a 128-token ceiling.
+
+| Metric | Stock | Fused |
+| --- | ---: | ---: |
+| Median decode | 114.65 tok/s | 128.00 tok/s |
+| Mean decode | 114.62 tok/s | 128.09 tok/s |
+| Observed range | 113.85–115.14 tok/s | 127.76–128.80 tok/s |
+| Positive adjacent pairs |  | 6 / 6 |
+
+The median of the six paired speedup ratios was **1.117x (+11.7%)**; the mean
+was **1.117x (+11.7%)**. Compared with the pre-optimization checkpoint path of
+about 89 tok/s, the combined gate/up, router, projection, and recurrence work
+now reaches about 128 tok/s, roughly **+44%** end to end on this host.
+
+## Rejected experiments
+
+- Fusing the shared expert's dense gate/up projections preserved all five
+  token sequences but regressed median decode by about 1%; it is not included.
+- A custom routed-expert weighted reduction was about 15% faster in isolation
+  but could not reproduce the stock BF16/FP16 reduction bit-for-bit across
+  serial, reverse, tree, and FP32 accumulation variants; it is not included.
+- The first fused-GDN prototype used a mathematically equivalent FP32 multiply
+  association in its output gate. A real hidden-state audit caught a one-BF16-
+  ULP layer-output difference that eventually changed greedy tokens. Matching
+  the stock association removed the difference before qualification.
+
+## Reproduction
+
+Resolve the target through the configured Hugging Face cache and pass only its
+immutable local snapshot path:
+
+```bash
+PYTHONPATH=. python3.12 scripts/large-model-run.py \
+  --working-set-gb 32 --reserve-gb 12 -- \
+  python3.12 scripts/benchmark_qwen35_fused_gdn_decode.py \
+    --model /path/to/immutable/snapshot \
+    --pairs 6 --max-tokens 128 --quality-max-tokens 512
+```
+
+The benchmark exits nonzero unless all five quality cases are token-identical.
+It also rejects a performance run when either side has more than 5% throughput
+coefficient of variation or fewer than five of six adjacent pairs improve.
+Absolute throughput should be measured on an otherwise idle GPU; adjacent
+within-process ratios are the landing metric.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -6,6 +6,7 @@ summary statistics, and limitations.
 
 ## Reports
 
+- [Qwen3.6-35B-A3B fused GDN decode qualification](2026-09-12-qwen36-35b-fused-gdn-decode.md)
 - [Qwen3.6-35B-A3B fused MoE router qualification](2026-09-12-qwen36-35b-fused-router.md)
 - [DeepSeek V4.1 Flash Engram SSD offload qualification](2026-09-11-deepseek-v41-engram-offload.md)
 - [Qwen3.8 27B MTP FP16 checkpoint qualification](2026-09-07-qwen38-mtp-fp16.md)

--- a/scripts/benchmark_qwen35_fused_gdn_decode.py
+++ b/scripts/benchmark_qwen35_fused_gdn_decode.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Paired speed and token-parity gate for Qwen3.5-family fused GDN decode."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import statistics
+from pathlib import Path
+
+PROMPTS = {
+    "coding": "Implement a correct Python LRU cache with O(1) get and put, plus tests.",
+    "creative": "Write a vivid 180-word scene about a lighthouse keeper hearing music below the ice.",
+    "reasoning": "A shop marks an item up 25%, then discounts it 20%. Explain the net percentage change.",
+    "json": 'Return only compact JSON with keys "prime" and "explanation" for whether 221 is prime.',
+    "tool": "You have a weather(location) tool. State the exact tool call needed for weather in Kyoto.",
+}
+
+
+def _digest(tokens: list[int]) -> str:
+    return hashlib.sha256(",".join(map(str, tokens)).encode("ascii")).hexdigest()
+
+
+def _coefficient_of_variation(samples: list[float]) -> float:
+    mean = statistics.mean(samples)
+    return statistics.pstdev(samples) / mean if mean > 0.0 else float("inf")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--pairs", type=int, default=6)
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--quality-max-tokens", type=int, default=512)
+    args = parser.parse_args()
+    model_path = args.model.expanduser().resolve()
+    if not model_path.is_dir():
+        parser.error("--model must be a cached local snapshot")
+    if args.pairs < 1 or min(args.max_tokens, args.quality_max_tokens) < 32:
+        parser.error("pairs must be positive and token limits must be at least 32")
+
+    import mlx.core as mx
+    from mlx_lm import load
+    from mlx_lm.generate import stream_generate
+    from mlx_lm.sample_utils import make_sampler
+
+    from vllm_mlx.gdn_in_proj_fusion import fuse_gdn_in_proj
+    from vllm_mlx.moe_fusion import fuse_gate_up
+    from vllm_mlx.qwen35_fused_gdn_decode import (
+        _TAG,
+        install_qwen35_fused_gdn_decode,
+    )
+    from vllm_mlx.qwen35_moe_router import install_qwen35_moe_router
+
+    model, tokenizer = load(model_path)
+    existing = {
+        "gate_up": fuse_gate_up(model),
+        "gdn_projection": fuse_gdn_in_proj(model),
+        "moe_router": install_qwen35_moe_router(model),
+    }
+    enrolled = install_qwen35_fused_gdn_decode(model)
+    layers = [m for _, m in model.named_modules() if getattr(m, _TAG, False)]
+    if enrolled == 0 or len(layers) != enrolled:
+        raise RuntimeError("checkpoint did not enroll in fused GDN decode")
+    sampler = make_sampler(temp=0.0)
+
+    def render(prompt: str) -> str:
+        return tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+    def run(
+        enabled: bool, prompt: str, *, max_tokens: int = args.max_tokens
+    ) -> dict[str, object]:
+        for layer in layers:
+            setattr(layer, _TAG, enabled)
+        mx.random.seed(0)
+        responses = list(
+            stream_generate(
+                model,
+                tokenizer,
+                render(prompt),
+                max_tokens=max_tokens,
+                sampler=sampler,
+            )
+        )
+        tokens = [int(response.token) for response in responses]
+        return {
+            "tps": float(responses[-1].generation_tps),
+            "tokens": tokens,
+            "hash": _digest(tokens),
+        }
+
+    for enabled in (False, True, True, False):
+        run(enabled, PROMPTS["coding"])
+
+    quality = {}
+    for name, prompt in PROMPTS.items():
+        stock = run(False, prompt, max_tokens=args.quality_max_tokens)
+        fused = run(True, prompt, max_tokens=args.quality_max_tokens)
+        quality[name] = {
+            "tokens": len(stock["tokens"]),
+            "same_tokens": stock["tokens"] == fused["tokens"],
+            "stock_hash": stock["hash"],
+            "fused_hash": fused["hash"],
+        }
+
+    pairs = []
+    for index in range(args.pairs):
+        order = (False, True) if index % 2 == 0 else (True, False)
+        samples = {enabled: run(enabled, PROMPTS["coding"]) for enabled in order}
+        stock_tps = float(samples[False]["tps"])
+        fused_tps = float(samples[True]["tps"])
+        pairs.append(
+            {
+                "stock_tps": stock_tps,
+                "fused_tps": fused_tps,
+                "speedup": fused_tps / stock_tps,
+            }
+        )
+    ratios = [sample["speedup"] for sample in pairs]
+    stock_samples = [sample["stock_tps"] for sample in pairs]
+    fused_samples = [sample["fused_tps"] for sample in pairs]
+    stock_cv = _coefficient_of_variation(stock_samples)
+    fused_cv = _coefficient_of_variation(fused_samples)
+    positive_pairs = sum(ratio > 1.0 for ratio in ratios)
+    performance_valid = (
+        stock_cv <= 0.05
+        and fused_cv <= 0.05
+        and positive_pairs >= max(1, args.pairs - 1)
+    )
+    result = {
+        "model": str(model_path),
+        "machine": platform.machine(),
+        "max_tokens": args.max_tokens,
+        "quality_max_tokens": args.quality_max_tokens,
+        "existing_fusions": existing,
+        "gdn_layers": enrolled,
+        "quality": quality,
+        "pairs": pairs,
+        "summary": {
+            "median_speedup": statistics.median(ratios),
+            "mean_speedup": statistics.mean(ratios),
+            "positive_pairs": positive_pairs,
+            "stock_tps_cv": stock_cv,
+            "fused_tps_cv": fused_cv,
+            "performance_valid": performance_valid,
+            "quality_cases_exact": sum(
+                bool(case["same_tokens"]) for case in quality.values()
+            ),
+        },
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if result["summary"]["quality_cases_exact"] != len(PROMPTS):
+        return 1
+    return 0 if performance_valid else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bench_qwen35_fused_gdn.py
+++ b/tests/test_bench_qwen35_fused_gdn.py
@@ -1,0 +1,19 @@
+"""Contracts for the Qwen3.5-family paired benchmark."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.benchmark_qwen35_fused_gdn_decode import _coefficient_of_variation
+
+
+def test_coefficient_of_variation_accepts_stable_samples():
+    assert _coefficient_of_variation([114.2, 114.8, 114.5]) < 0.01
+
+
+def test_coefficient_of_variation_exposes_noisy_host():
+    assert _coefficient_of_variation([19.7, 93.1, 23.5, 112.9]) > 0.5
+
+
+def test_coefficient_of_variation_rejects_zero_mean():
+    assert _coefficient_of_variation([0.0, 0.0]) == pytest.approx(float("inf"))

--- a/tests/test_ci_apple_coverage_union.py
+++ b/tests/test_ci_apple_coverage_union.py
@@ -150,6 +150,7 @@ def test_qwen4_fused_gdn_coverage_runs_on_apple_silicon() -> None:
 
     assert "tests/test_qwen4_fused_gdn_decode.py" in apple_run
     assert "tests/test_qwen35_moe_router.py" in apple_run
+    assert "tests/test_qwen35_fused_gdn_decode.py" in apple_run
     assert "tests/test_qsa_block_sparse.py" in apple_run
     assert "tests/test_qsa_indexed_splitk.py" in apple_run
 

--- a/tests/test_no_out_of_band_routing.py
+++ b/tests/test_no_out_of_band_routing.py
@@ -161,6 +161,9 @@ ALLOWED_RAPID_MLX_ENV_VARS: frozenset[str] = frozenset(
         # This changes only a launch-count optimization after model loading;
         # it cannot select a model, parser, tier, or serving lane.
         "RAPID_MLX_QWEN35_MOE_ROUTER",
+        # Opt-out of the bit-exact Qwen3.5-family GDN decode kernel. It changes
+        # only the implementation of an already-selected model's recurrence.
+        "RAPID_MLX_QWEN35_FUSED_GDN_DECODE",
         # Opt-in direct QSA block-sparse attention on an already-selected
         # Qwen4-Exp model. This changes only the prefill kernel after a measured
         # context crossover; model, parser, tier, and engine routing are

--- a/tests/test_qwen35_fused_gdn_decode.py
+++ b/tests/test_qwen35_fused_gdn_decode.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for Qwen3.5-family fused GDN single-token decode."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+pytestmark = pytest.mark.requires_mlx
+
+import mlx.nn as nn
+
+from vllm_mlx import gdn_in_proj_fusion
+from vllm_mlx import qwen35_fused_gdn_decode as fused
+from vllm_mlx.kernels import qwen4_fused_gdn_decode as shared_kernel
+
+
+class _Cache:
+    def __init__(self):
+        self.cache = [
+            mx.zeros((1, 3, fused._CONV_DIM), dtype=mx.bfloat16),
+            mx.zeros((1, 32, 128, 128), dtype=mx.float32),
+        ]
+        self.lengths = None
+        self.advanced = 0
+
+    def __getitem__(self, index):
+        return self.cache[index]
+
+    def __setitem__(self, index, value):
+        self.cache[index] = value
+
+    def advance(self, amount):
+        self.advanced += amount
+
+
+def _layer(**overrides):
+    values = {
+        fused._TAG: True,
+        "training": False,
+        "hidden_size": 2048,
+        "sharding_group": None,
+        "in_proj_fused": object(),
+        "num_k_heads": 16,
+        "num_v_heads": 32,
+        "head_k_dim": 128,
+        "head_v_dim": 128,
+        "conv_kernel_size": 4,
+        "conv1d": SimpleNamespace(
+            weight=mx.zeros((fused._CONV_DIM, 4, 1), dtype=mx.bfloat16)
+        ),
+        "A_log": mx.zeros((32,), dtype=mx.bfloat16),
+        "dt_bias": mx.zeros((32,), dtype=mx.bfloat16),
+        "norm": SimpleNamespace(weight=mx.ones((128,), dtype=mx.bfloat16), eps=1e-6),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_admission_is_single_token_bf16_and_complete_cache_only():
+    layer = _layer()
+    cache = _Cache()
+    decode = mx.zeros((1, 1, 2048), dtype=mx.bfloat16)
+    assert fused._eligible(layer, decode, None, cache)
+    assert not fused._eligible(
+        layer, mx.zeros((1, 2, 2048), dtype=mx.bfloat16), None, cache
+    )
+    assert not fused._eligible(
+        layer, mx.zeros((1, 1, 2048), dtype=mx.float16), None, cache
+    )
+    assert not fused._eligible(layer, decode, mx.ones((1, 1)), cache)
+    cache.lengths = mx.array([1])
+    assert not fused._eligible(layer, decode, None, cache)
+
+    class BrokenInput:
+        @property
+        def shape(self):
+            raise OSError("shape unavailable")
+
+    assert not fused._eligible(layer, BrokenInput(), None, _Cache())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("num_v_heads", 48),
+        ("head_k_dim", 64),
+        ("conv_kernel_size", 3),
+        ("hidden_size", 4096),
+        ("in_proj_fused", None),
+    ],
+)
+def test_structural_gate_rejects_unknown_geometry(field, value):
+    layer = _layer(**{field: value})
+    if field == "in_proj_fused":
+        delattr(layer, field)
+    assert not fused._structurally_eligible(layer)
+
+
+def test_structural_gate_fails_closed_on_unknown_object():
+    assert not fused._structurally_eligible(object())
+
+
+def test_install_honors_kill_switch(monkeypatch):
+    monkeypatch.setenv("RAPID_MLX_QWEN35_FUSED_GDN_DECODE", "0")
+    assert fused.install_qwen35_fused_gdn_decode(object()) == 0
+
+
+def test_install_ignores_non_module_placeholder():
+    assert fused.install_qwen35_fused_gdn_decode(object()) == 0
+
+
+def test_install_fails_closed_when_probe_raises(monkeypatch):
+    from mlx_lm.models.qwen3_5 import GatedDeltaNet
+
+    layer = GatedDeltaNet.__new__(GatedDeltaNet)
+    nn.Module.__init__(layer)
+    for name, value in vars(_layer()).items():
+        if name not in {"training", fused._TAG}:
+            setattr(layer, name, value)
+    layer.eval()
+    model = SimpleNamespace(named_modules=lambda: iter((("gdn", layer),)))
+    monkeypatch.setattr(
+        fused,
+        "probe_qwen35_fused_gdn_decode",
+        lambda: (_ for _ in ()).throw(OSError("probe unavailable")),
+    )
+
+    assert fused.install_qwen35_fused_gdn_decode(model) == 0
+    assert not getattr(layer, fused._TAG, False)
+
+
+def test_install_fails_closed_when_probe_has_no_exact_candidate(monkeypatch):
+    from mlx_lm.models.qwen3_5 import GatedDeltaNet
+
+    layer = GatedDeltaNet.__new__(GatedDeltaNet)
+    nn.Module.__init__(layer)
+    for name, value in vars(_layer()).items():
+        if name not in {"training", fused._TAG}:
+            setattr(layer, name, value)
+    layer.eval()
+    model = SimpleNamespace(named_modules=lambda: iter((("gdn", layer),)))
+    monkeypatch.setattr(fused, "probe_qwen35_fused_gdn_decode", lambda: None)
+
+    assert fused.install_qwen35_fused_gdn_decode(model) == 0
+    assert not getattr(layer, fused._TAG, False)
+
+
+def test_install_tags_only_exact_qwen35_layers(monkeypatch):
+    from mlx_lm.models.qwen3_5 import GatedDeltaNet
+
+    layer = GatedDeltaNet.__new__(GatedDeltaNet)
+    nn.Module.__init__(layer)
+    for name, value in vars(_layer()).items():
+        if name in {"training", fused._TAG}:
+            continue
+        setattr(layer, name, value)
+    layer.eval()
+    model = SimpleNamespace(named_modules=lambda: iter((("gdn", layer),)))
+    monkeypatch.setattr(fused, "probe_qwen35_fused_gdn_decode", lambda: 16)
+    monkeypatch.setattr(fused, "_patch_class", lambda _class: None)
+    assert fused.install_qwen35_fused_gdn_decode(model) == 1
+    assert getattr(layer, fused._TAG)
+    assert layer._rapid_qwen35_fused_gdn_threadgroup_y == 16
+
+
+def test_shared_kernel_keeps_qwen4_and_qwen35_compile_time_paths():
+    source = shared_kernel._SOURCE
+    assert "if constexpr (Q35)" in source
+    assert "float gate = zg * mlx_sigmoid_precise<float>(zg);" in source
+    assert "float x = gate * float(normalized);" in source
+    assert (
+        "float x = float(normalized) * "
+        "mlx_sigmoid_precise<float>(float(z[hv * DV + d]));"
+    ) in source
+
+
+def test_shared_kernel_rejects_non_integral_head_ratio_before_dispatch():
+    with pytest.raises(ValueError, match="divisible"):
+        shared_kernel.fused_gdn_decode(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            1e-6,
+            threadgroup_y=4,
+            num_key_heads=3,
+            num_value_heads=4,
+        )
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_real_metal_probe_matches_output_and_both_states(monkeypatch):
+    monkeypatch.setattr(fused, "_PROBE_COMPLETE", False)
+    monkeypatch.setattr(fused, "_PROBED_THREADGROUP_Y", None)
+    assert fused.probe_qwen35_fused_gdn_decode() in {4, 8, 16, 32}
+
+
+def test_probe_returns_process_cached_result(monkeypatch):
+    monkeypatch.setattr(fused, "_PROBE_COMPLETE", True)
+    monkeypatch.setattr(fused, "_PROBED_THREADGROUP_Y", 8)
+    assert fused.probe_qwen35_fused_gdn_decode() == 8
+
+
+def test_probe_observes_result_completed_while_waiting_for_lock(monkeypatch):
+    class CompletingLock:
+        def __enter__(self):
+            fused._PROBE_COMPLETE = True
+            fused._PROBED_THREADGROUP_Y = 16
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(fused, "_PROBE_COMPLETE", False)
+    monkeypatch.setattr(fused, "_PROBED_THREADGROUP_Y", None)
+    monkeypatch.setattr(fused, "_PROBE_LOCK", CompletingLock())
+    assert fused.probe_qwen35_fused_gdn_decode() == 16
+
+
+def test_probe_skips_candidate_exception_and_fails_closed(monkeypatch):
+    monkeypatch.setattr(fused, "_PROBE_COMPLETE", False)
+    monkeypatch.setattr(fused, "_PROBED_THREADGROUP_Y", None)
+    monkeypatch.setattr(fused, "_THREADGROUP_Y_CANDIDATES", (4,))
+    monkeypatch.setattr(fused, "fused_gdn_runtime_supported", lambda: True)
+    monkeypatch.setattr(
+        fused,
+        "_probe_candidate",
+        lambda _candidate: (_ for _ in ()).throw(OSError("compile failed")),
+    )
+    assert fused.probe_qwen35_fused_gdn_decode() is None
+
+
+def test_real_probe_rejects_mismatched_kernel_output(monkeypatch):
+    def wrong(*args, **kwargs):
+        return (
+            mx.zeros((1, 1, fused._VALUE_DIM), dtype=mx.bfloat16),
+            mx.zeros((1, 3, fused._CONV_DIM), dtype=mx.bfloat16),
+            mx.zeros((1, 32, 128, 128), dtype=mx.float32),
+        )
+
+    monkeypatch.setattr(fused, "fused_gdn_decode", wrong)
+    assert not fused._probe_candidate(4)
+
+
+def test_patched_call_falls_back_when_request_is_not_eligible():
+    class FakeGdn:
+        def __call__(self, inputs, mask=None, cache=None):
+            return "stock"
+
+    fused._patch_class(FakeGdn)
+    assert FakeGdn()(mx.zeros((1, 2, 8), dtype=mx.bfloat16)) == "stock"
+    fused._patch_class(FakeGdn)
+
+
+def test_patched_call_commits_fresh_cache_only_after_dispatch(monkeypatch):
+    class FakeGdn:
+        def __call__(self, inputs, mask=None, cache=None):
+            return "stock"
+
+    layer = FakeGdn()
+    template = _layer()
+    for name, value in vars(template).items():
+        setattr(layer, name, value)
+    layer._rapid_qwen35_fused_gdn_threadgroup_y = 32
+    layer.out_proj = lambda value: value
+    cache = _Cache()
+    qkv = mx.zeros((1, 1, fused._CONV_DIM), dtype=mx.bfloat16)
+    z = mx.zeros((1, 1, fused._VALUE_DIM), dtype=mx.bfloat16)
+    gates = mx.zeros((1, 1, fused._NUM_VALUE_HEADS), dtype=mx.bfloat16)
+    next_conv = mx.ones_like(cache[0])
+    next_state = mx.ones_like(cache[1])
+    output = mx.ones((1, 1, fused._VALUE_DIM), dtype=mx.bfloat16)
+    monkeypatch.setattr(
+        gdn_in_proj_fusion, "_fused_projections", lambda *_: (qkv, z, gates, gates)
+    )
+    monkeypatch.setattr(
+        fused,
+        "fused_gdn_decode",
+        lambda *args, **kwargs: (output, next_conv, next_state),
+    )
+    fused._patch_class(FakeGdn)
+    result = layer(mx.zeros((1, 1, 2048), dtype=mx.bfloat16), cache=cache)
+    assert result is output
+    assert cache[0] is next_conv
+    assert cache[1] is next_state
+    assert cache.advanced == 1
+
+
+def test_patched_call_falls_back_before_cache_mutation_on_projection_error(monkeypatch):
+    class FakeGdn:
+        def __call__(self, inputs, mask=None, cache=None):
+            return "stock"
+
+    layer = FakeGdn()
+    for name, value in vars(_layer()).items():
+        setattr(layer, name, value)
+    layer._rapid_qwen35_fused_gdn_threadgroup_y = 32
+    cache = _Cache()
+    original_conv, original_state = cache[0], cache[1]
+    monkeypatch.setattr(
+        gdn_in_proj_fusion,
+        "_fused_projections",
+        lambda *_: (_ for _ in ()).throw(OSError("projection unavailable")),
+    )
+    fused._patch_class(FakeGdn)
+
+    assert layer(mx.zeros((1, 1, 2048), dtype=mx.bfloat16), cache=cache) == "stock"
+    assert cache[0] is original_conv
+    assert cache[1] is original_state
+    assert cache.advanced == 0
+
+
+def test_engine_installs_gdn_decode_only_after_projection_fusion():
+    from vllm_mlx.engine.batched import BatchedEngine
+
+    source = inspect.getsource(BatchedEngine._start_llm)
+    projection = source.index("fuse_gdn_in_proj")
+    decode = source.index("install_qwen35_fused_gdn_decode")
+    assert projection < decode

--- a/vllm_mlx/engine/batched.py
+++ b/vllm_mlx/engine/batched.py
@@ -1884,8 +1884,18 @@ class BatchedEngine(BaseEngine):
             _sc = self._scheduler_config
             if _sc is None or getattr(_sc, "spec_decode", "none") != "mtp":
                 from ..gdn_in_proj_fusion import fuse_gdn_in_proj
+                from ..qwen35_fused_gdn_decode import (
+                    install_qwen35_fused_gdn_decode,
+                )
 
                 self._model_load_executor.submit(fuse_gdn_in_proj, self._model).result()
+                # Collapse the qualified Qwen3.5-family single-token GDN
+                # recurrence after its input projections have been fused.
+                # The installer runs an output + both-cache bit-parity probe;
+                # prefill, batching, MTP, and unknown layouts stay stock.
+                self._model_load_executor.submit(  # type: ignore[attr-defined]
+                    install_qwen35_fused_gdn_decode, self._model
+                ).result()
 
         # Capture persistence identity from the exact immutable snapshot
         # selected by the loader before this engine is published through

--- a/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
+++ b/vllm_mlx/kernels/qwen4_fused_gdn_decode.py
@@ -258,38 +258,66 @@ _SOURCE = r"""
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  for (uint d = tid; d < (uint)DK; d += NT) {
-    T qv = static_cast<T>(sq[d]);
-    T kv = static_cast<T>(sk[d]);
-    sq_squared[d] = static_cast<T>(qv * qv);
-    sk_squared[d] = static_cast<T>(kv * kv);
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if constexpr (Q35) {
+    // Qwen3.5-family uses mx.fast.rms_norm: float32 mean-of-squares and
+    // reciprocal sqrt, cast back to T, then separate q/k scaling in T.
+    if (simdgroup_index_in_threadgroup == 0u) {
+      float pq = 0.0f, pk = 0.0f;
+      uint base = 4u * lane;
+      for (int i = 0; i < 4; ++i) {
+        pq += sq[base + i] * sq[base + i];
+        pk += sk[base + i] * sk[base + i];
+      }
+      pq = simd_sum(pq);
+      pk = simd_sum(pk);
+      if (lane == 0u) {
+        shr[0] = metal::precise::rsqrt(pq / float(DK) + 1.0e-6f);
+        shr[1] = metal::precise::rsqrt(pk / float(DK) + 1.0e-6f);
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    T qscale = static_cast<T>(1.0f / float(DK));
+    T kscale = static_cast<T>(metal::precise::rsqrt(float(DK)));
+    for (uint d = tid; d < (uint)DK; d += NT) {
+      T q_normalized = static_cast<T>(sq[d] * shr[0]);
+      T k_normalized = static_cast<T>(sk[d] * shr[1]);
+      sq[d] = float(static_cast<T>(q_normalized * qscale));
+      sk[d] = float(static_cast<T>(k_normalized * kscale));
+    }
+  } else {
+    for (uint d = tid; d < (uint)DK; d += NT) {
+      T qv = static_cast<T>(sq[d]);
+      T kv = static_cast<T>(sk[d]);
+      sq_squared[d] = static_cast<T>(qv * qv);
+      sk_squared[d] = static_cast<T>(kv * kv);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
 
-  if (simdgroup_index_in_threadgroup == 0u) {
-    T pq = static_cast<T>(0), pk = static_cast<T>(0);
-    uint base = 4u * lane;
-    for (int i = 0; i < 4; ++i) {
-      pq = static_cast<T>(sq_squared[base + i] + pq);
-      pk = static_cast<T>(sk_squared[base + i] + pk);
+    if (simdgroup_index_in_threadgroup == 0u) {
+      T pq = static_cast<T>(0), pk = static_cast<T>(0);
+      uint base = 4u * lane;
+      for (int i = 0; i < 4; ++i) {
+        pq = static_cast<T>(sq_squared[base + i] + pq);
+        pk = static_cast<T>(sk_squared[base + i] + pk);
+      }
+      pq = static_cast<T>(simd_sum(float(pq)));
+      pk = static_cast<T>(simd_sum(float(pk)));
+      if (lane == 0u) {
+        T eps = static_cast<T>(1.0e-6f);
+        T qdenom = pq + eps;
+        T kdenom = pk + eps;
+        shr[0] = float(static_cast<T>(metal::precise::rsqrt(qdenom)));
+        shr[1] = float(static_cast<T>(metal::precise::rsqrt(kdenom)));
+      }
     }
-    pq = static_cast<T>(simd_sum(float(pq)));
-    pk = static_cast<T>(simd_sum(float(pk)));
-    if (lane == 0u) {
-      T eps = static_cast<T>(1.0e-6f);
-      T qdenom = pq + eps;
-      T kdenom = pk + eps;
-      shr[0] = float(static_cast<T>(metal::precise::rsqrt(qdenom)));
-      shr[1] = float(static_cast<T>(metal::precise::rsqrt(kdenom)));
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    T qscale = static_cast<T>(0.08838834764831845f);
+    for (uint d = tid; d < (uint)DK; d += NT) {
+      T q_normalized = static_cast<T>(static_cast<T>(sq[d]) * static_cast<T>(shr[0]));
+      T k_normalized = static_cast<T>(static_cast<T>(sk[d]) * static_cast<T>(shr[1]));
+      sq[d] = float(static_cast<T>(q_normalized * qscale));
+      sk[d] = float(k_normalized);
     }
-  }
-  threadgroup_barrier(mem_flags::mem_threadgroup);
-  T qscale = static_cast<T>(0.08838834764831845f);
-  for (uint d = tid; d < (uint)DK; d += NT) {
-    T q_normalized = static_cast<T>(static_cast<T>(sq[d]) * static_cast<T>(shr[0]));
-    T k_normalized = static_cast<T>(static_cast<T>(sk[d]) * static_cast<T>(shr[1]));
-    sq[d] = float(static_cast<T>(q_normalized * qscale));
-    sk[d] = float(k_normalized);
   }
   threadgroup_barrier(mem_flags::mem_threadgroup);
 
@@ -331,8 +359,17 @@ _SOURCE = r"""
     normalized = norm_weight[d] * normalized;
     // Exhaustive bf16 sweep: the precise float32 sigmoid matches mx.sigmoid
     // on every finite bf16-valued gate; the fast form differs on ~1%.
-    float x = float(normalized) * mlx_sigmoid_precise<float>(float(z[hv * DV + d]));
-    output[hv * DV + d] = static_cast<T>(x);
+    if constexpr (Q35) {
+      // Match _precise_swiglu's operation order: form the float32 SiLU
+      // gate first, then multiply it by the normalized value.
+      float zg = float(z[hv * DV + d]);
+      float gate = zg * mlx_sigmoid_precise<float>(zg);
+      float x = gate * float(normalized);
+      output[hv * DV + d] = static_cast<T>(x);
+    } else {
+      float x = float(normalized) * mlx_sigmoid_precise<float>(float(z[hv * DV + d]));
+      output[hv * DV + d] = static_cast<T>(x);
+    }
   }
 """
 
@@ -361,7 +398,7 @@ def _kernel():
     )
 
 
-def qwen4_fused_gdn_decode(
+def fused_gdn_decode(
     qkv,
     z,
     beta,
@@ -375,13 +412,24 @@ def qwen4_fused_gdn_decode(
     norm_eps: float,
     *,
     threadgroup_y: int,
+    num_key_heads: int = NUM_KEY_HEADS,
+    num_value_heads: int = NUM_VALUE_HEADS,
+    key_head_dim: int = KEY_HEAD_DIM,
+    value_head_dim: int = VALUE_HEAD_DIM,
+    conv_kernel: int = CONV_KERNEL,
+    qwen35_semantics: bool = False,
 ):
-    """Run the fused graph after structural admission succeeds."""
+    """Run one qualified fused-GDN geometry and numerical specialization."""
     if threadgroup_y not in _THREADGROUP_Y_CANDIDATES:
         raise ValueError(
             f"unsupported threadgroup_y {threadgroup_y}; "
             f"expected one of {_THREADGROUP_Y_CANDIDATES}"
         )
+    if num_value_heads % num_key_heads != 0:
+        raise ValueError("num_value_heads must be divisible by num_key_heads")
+    key_dim = num_key_heads * key_head_dim
+    value_dim = num_value_heads * value_head_dim
+    conv_dim = 2 * key_dim + value_dim
     outputs = _kernel()(
         inputs=[
             qkv,
@@ -398,24 +446,57 @@ def qwen4_fused_gdn_decode(
         ],
         template=[
             ("T", qkv.dtype),
-            ("HK", NUM_KEY_HEADS),
-            ("HV", NUM_VALUE_HEADS),
-            ("DK", KEY_HEAD_DIM),
-            ("DV", VALUE_HEAD_DIM),
-            ("K", CONV_KERNEL),
+            ("HK", num_key_heads),
+            ("HV", num_value_heads),
+            ("DK", key_head_dim),
+            ("DV", value_head_dim),
+            ("K", conv_kernel),
             ("TY", threadgroup_y),
-            ("RATIO", NUM_VALUE_HEADS // NUM_KEY_HEADS),
+            ("RATIO", num_value_heads // num_key_heads),
+            ("Q35", qwen35_semantics),
         ],
-        grid=(32, threadgroup_y, NUM_VALUE_HEADS),
+        grid=(32, threadgroup_y, num_value_heads),
         threadgroup=(32, threadgroup_y, 1),
         output_shapes=[
-            (1, 1, VALUE_DIM),
-            (1, CONV_KERNEL - 1, CONV_DIM),
-            (1, NUM_VALUE_HEADS, VALUE_HEAD_DIM, KEY_HEAD_DIM),
+            (1, 1, value_dim),
+            (1, conv_kernel - 1, conv_dim),
+            (1, num_value_heads, value_head_dim, key_head_dim),
         ],
         output_dtypes=[qkv.dtype, qkv.dtype, mx.float32],
     )
     return tuple(outputs)
+
+
+def qwen4_fused_gdn_decode(
+    qkv,
+    z,
+    beta,
+    alpha,
+    conv_state,
+    conv_weight,
+    a_log,
+    dt_bias,
+    recurrent_state,
+    norm_weight,
+    norm_eps: float,
+    *,
+    threadgroup_y: int,
+):
+    """Run the original Qwen4 specialization after admission succeeds."""
+    return fused_gdn_decode(
+        qkv,
+        z,
+        beta,
+        alpha,
+        conv_state,
+        conv_weight,
+        a_log,
+        dt_bias,
+        recurrent_state,
+        norm_weight,
+        norm_eps,
+        threadgroup_y=threadgroup_y,
+    )
 
 
 def fused_gdn_runtime_supported() -> bool:
@@ -496,6 +577,7 @@ __all__ = [
     "FusedGdnAdmission",
     "admit_qwen4_fused_gdn_decode",
     "fused_gdn_runtime_supported",
+    "fused_gdn_decode",
     "probe_qwen4_fused_gdn_decode",
     "qwen4_fused_gdn_decode",
 ]

--- a/vllm_mlx/qwen35_fused_gdn_decode.py
+++ b/vllm_mlx/qwen35_fused_gdn_decode.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fuse Qwen3.5-family GatedDeltaNet single-token decode on Metal.
+
+The input projections remain owned by :mod:`gdn_in_proj_fusion`.  This module
+collapses the remaining causal convolution, Q/K normalization, recurrent
+update, and gated RMSNorm into one launch.  The output projection stays on the
+stock path.
+
+Enrollment is model-local and fail-closed.  A real Metal probe must reproduce
+the stock output, convolution cache, and FP32 recurrent state bit-for-bit
+before any layer is tagged.  Prefill, batching, masks, training, sharding,
+ragged caches, unknown geometry, and speculative verification stay stock.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from threading import Lock
+from typing import Any, cast
+
+import mlx.core as mx
+
+from .kernels.qwen4_fused_gdn_decode import (
+    fused_gdn_decode,
+    fused_gdn_runtime_supported,
+)
+
+logger = logging.getLogger(__name__)
+
+_NUM_KEY_HEADS = 16
+_NUM_VALUE_HEADS = 32
+_KEY_HEAD_DIM = 128
+_VALUE_HEAD_DIM = 128
+_CONV_KERNEL = 4
+_KEY_DIM = _NUM_KEY_HEADS * _KEY_HEAD_DIM
+_VALUE_DIM = _NUM_VALUE_HEADS * _VALUE_HEAD_DIM
+_CONV_DIM = 2 * _KEY_DIM + _VALUE_DIM
+_THREADGROUP_Y_CANDIDATES = (32, 16, 8, 4)
+_TAG = "_rapid_qwen35_fused_gdn_decode"
+
+_PROBE_LOCK = Lock()
+_PROBE_COMPLETE = False
+_PROBED_THREADGROUP_Y: int | None = None
+
+
+def _bytes_equal(left: mx.array, right: mx.array) -> bool:
+    return bool(mx.array_equal(left, right).item())
+
+
+def _stock_step(
+    *,
+    nn: Any,
+    gated_delta_update: Callable[..., Any],
+    conv: Any,
+    qkv: mx.array,
+    z: mx.array,
+    beta: mx.array,
+    alpha: mx.array,
+    conv_state: mx.array,
+    recurrent_state: mx.array,
+    a_log: mx.array,
+    dt_bias: mx.array,
+    norm_weight: mx.array,
+    norm_eps: float,
+) -> tuple[mx.array, mx.array, mx.array]:
+    conv_input = mx.concatenate([conv_state, qkv], axis=1)
+    next_conv_state = mx.contiguous(conv_input[:, -(_CONV_KERNEL - 1) :, :])
+    convolved = nn.silu(conv(conv_input))
+    query, key, value = [
+        part.reshape(1, 1, heads, dim)
+        for part, heads, dim in zip(
+            mx.split(convolved, [_KEY_DIM, 2 * _KEY_DIM], axis=-1),
+            [_NUM_KEY_HEADS, _NUM_KEY_HEADS, _NUM_VALUE_HEADS],
+            [_KEY_HEAD_DIM, _KEY_HEAD_DIM, _VALUE_HEAD_DIM],
+            strict=True,
+        )
+    ]
+    inv_scale = _KEY_HEAD_DIM**-0.5
+    query = (inv_scale**2) * mx.fast.rms_norm(query, None, 1e-6)
+    key = inv_scale * mx.fast.rms_norm(key, None, 1e-6)
+    output, next_recurrent_state = gated_delta_update(
+        query,
+        key,
+        value,
+        alpha,
+        beta,
+        a_log,
+        dt_bias,
+        recurrent_state,
+        None,
+        use_kernel=True,
+    )
+    normalized = mx.fast.rms_norm(output, norm_weight, norm_eps)
+    gate = nn.silu(
+        z.reshape(1, 1, _NUM_VALUE_HEADS, _VALUE_HEAD_DIM).astype(mx.float32)
+    )
+    output = (gate * normalized.astype(mx.float32)).astype(qkv.dtype)
+    return output.reshape(1, 1, _VALUE_DIM), next_conv_state, next_recurrent_state
+
+
+def _probe_candidate(threadgroup_y: int) -> bool:
+    import mlx.nn as nn
+    from mlx_lm.models.gated_delta import gated_delta_update
+
+    dtype = mx.bfloat16
+    conv = nn.Conv1d(
+        _CONV_DIM,
+        _CONV_DIM,
+        kernel_size=_CONV_KERNEL,
+        groups=_CONV_DIM,
+        bias=False,
+    )
+    conv.weight = (
+        mx.random.normal((_CONV_DIM, _CONV_KERNEL, 1), key=mx.random.key(3501)) * 0.1
+    ).astype(dtype)
+    a_log = mx.random.normal((_NUM_VALUE_HEADS,), key=mx.random.key(3502)).astype(dtype)
+    dt_bias = mx.random.normal((_NUM_VALUE_HEADS,), key=mx.random.key(3503)).astype(
+        dtype
+    )
+    norm_weight = mx.random.normal((_VALUE_HEAD_DIM,), key=mx.random.key(3504)).astype(
+        dtype
+    )
+    stock_conv = mx.zeros((1, _CONV_KERNEL - 1, _CONV_DIM), dtype=dtype)
+    fused_conv = mx.array(stock_conv)
+    stock_state = mx.zeros(
+        (1, _NUM_VALUE_HEADS, _VALUE_HEAD_DIM, _KEY_HEAD_DIM), dtype=mx.float32
+    )
+    fused_state = mx.array(stock_state)
+
+    for step in range(8):
+        qkv = (
+            mx.random.normal((1, 1, _CONV_DIM), key=mx.random.key(3600 + step)) * 0.3
+        ).astype(dtype)
+        z = (
+            mx.random.normal((1, 1, _VALUE_DIM), key=mx.random.key(3700 + step)) * 2.0
+        ).astype(dtype)
+        # Pin the sigmoid edge where fast and precise forms are known to differ.
+        z = mx.concatenate([mx.array([[[-6.84375]]], dtype=dtype), z[..., 1:]], -1)
+        beta = mx.random.normal(
+            (1, 1, _NUM_VALUE_HEADS), key=mx.random.key(3800 + step)
+        ).astype(dtype)
+        alpha = mx.random.normal(
+            (1, 1, _NUM_VALUE_HEADS), key=mx.random.key(3900 + step)
+        ).astype(dtype)
+        stock_output, stock_conv, stock_state = _stock_step(
+            nn=nn,
+            gated_delta_update=gated_delta_update,
+            conv=conv,
+            qkv=qkv,
+            z=z,
+            beta=beta,
+            alpha=alpha,
+            conv_state=stock_conv,
+            recurrent_state=stock_state,
+            a_log=a_log,
+            dt_bias=dt_bias,
+            norm_weight=norm_weight,
+            norm_eps=1e-6,
+        )
+        fused_output, fused_conv, fused_state = fused_gdn_decode(
+            qkv,
+            z,
+            beta,
+            alpha,
+            fused_conv,
+            conv.weight,
+            a_log,
+            dt_bias,
+            fused_state,
+            norm_weight,
+            1e-6,
+            threadgroup_y=threadgroup_y,
+            num_key_heads=_NUM_KEY_HEADS,
+            num_value_heads=_NUM_VALUE_HEADS,
+            key_head_dim=_KEY_HEAD_DIM,
+            value_head_dim=_VALUE_HEAD_DIM,
+            conv_kernel=_CONV_KERNEL,
+            qwen35_semantics=True,
+        )
+        mx.eval(
+            stock_output,
+            fused_output,
+            stock_conv,
+            fused_conv,
+            stock_state,
+            fused_state,
+        )
+        pairs = (
+            (stock_output, fused_output),
+            (stock_conv, fused_conv),
+            (stock_state, fused_state),
+        )
+        equal = tuple(_bytes_equal(left, right) for left, right in pairs)
+        if not all(equal):
+            logger.debug(
+                "Qwen3.5 fused GDN probe mismatch: ty=%d step=%d "
+                "output=%s conv=%s state=%s max_abs=%s",
+                threadgroup_y,
+                step,
+                equal[0],
+                equal[1],
+                equal[2],
+                tuple(
+                    float(mx.max(mx.abs(left - right)).item()) for left, right in pairs
+                ),
+            )
+            return False
+    return True
+
+
+def probe_qwen35_fused_gdn_decode() -> int | None:
+    """Return a bit-exact supported threadgroup geometry, once per process."""
+    global _PROBE_COMPLETE, _PROBED_THREADGROUP_Y
+    if _PROBE_COMPLETE:
+        return _PROBED_THREADGROUP_Y
+    with _PROBE_LOCK:
+        if _PROBE_COMPLETE:
+            return _PROBED_THREADGROUP_Y
+        if fused_gdn_runtime_supported():
+            for candidate in _THREADGROUP_Y_CANDIDATES:
+                try:
+                    if _probe_candidate(candidate):
+                        _PROBED_THREADGROUP_Y = candidate
+                        break
+                except Exception:
+                    # This is an optional launch-count optimization.  Any
+                    # compile, runtime, or dependency drift must leave model
+                    # loading on the stock implementation.
+                    logger.debug(
+                        "Qwen3.5 fused GDN probe candidate failed: ty=%d",
+                        candidate,
+                        exc_info=True,
+                    )
+                    continue
+        _PROBE_COMPLETE = True
+        return _PROBED_THREADGROUP_Y
+
+
+def _shape(value: Any) -> tuple[int, ...]:
+    return tuple(getattr(value, "shape", ()))
+
+
+def _eligible(self: Any, inputs: mx.array, mask: Any, cache: Any) -> bool:
+    try:
+        return bool(
+            getattr(self, _TAG, False)
+            and inputs.shape == (1, 1, self.hidden_size)
+            and inputs.dtype == mx.bfloat16
+            and mask is None
+            and cache is not None
+            and cache[0] is not None
+            and cache[1] is not None
+            and getattr(cache, "lengths", None) is None
+            and getattr(self, "sharding_group", None) is None
+            and not self.training
+            and hasattr(self, "in_proj_fused")
+            and _shape(cache[0]) == (1, _CONV_KERNEL - 1, _CONV_DIM)
+            and cache[0].dtype == mx.bfloat16
+            and _shape(cache[1])
+            == (1, _NUM_VALUE_HEADS, _VALUE_HEAD_DIM, _KEY_HEAD_DIM)
+            and cache[1].dtype == mx.float32
+        )
+    except Exception:
+        return False
+
+
+def _patch_class(gdn_class: type) -> None:
+    if getattr(gdn_class, "_rapid_qwen35_fused_gdn_patched", False):
+        return
+    original = cast(Callable[..., mx.array], gdn_class.__call__)
+
+    def patched(self: Any, inputs: mx.array, mask: Any = None, cache: Any = None):
+        if not _eligible(self, inputs, mask, cache):
+            return original(self, inputs, mask, cache)
+        try:
+            from .gdn_in_proj_fusion import _fused_projections
+
+            qkv, z, beta, alpha = _fused_projections(self, inputs)
+            output, conv_state, recurrent_state = fused_gdn_decode(
+                qkv,
+                z,
+                beta,
+                alpha,
+                cache[0],
+                self.conv1d.weight,
+                self.A_log,
+                self.dt_bias,
+                cache[1],
+                self.norm.weight,
+                self.norm.eps,
+                threadgroup_y=self._rapid_qwen35_fused_gdn_threadgroup_y,
+                num_key_heads=_NUM_KEY_HEADS,
+                num_value_heads=_NUM_VALUE_HEADS,
+                key_head_dim=_KEY_HEAD_DIM,
+                value_head_dim=_VALUE_HEAD_DIM,
+                conv_kernel=_CONV_KERNEL,
+                qwen35_semantics=True,
+            )
+        except Exception:
+            return original(self, inputs, mask, cache)
+        cache[0] = conv_state
+        cache[1] = recurrent_state
+        cache.advance(1)
+        return self.out_proj(output)
+
+    dynamic_class = cast(Any, gdn_class)
+    dynamic_class.__call__ = patched
+    dynamic_class._rapid_qwen35_fused_gdn_patched = True
+    dynamic_class._rapid_qwen35_fused_gdn_original_call = original
+
+
+def _structurally_eligible(layer: Any) -> bool:
+    try:
+        return bool(
+            (
+                layer.num_k_heads,
+                layer.num_v_heads,
+                layer.head_k_dim,
+                layer.head_v_dim,
+                layer.conv_kernel_size,
+            )
+            == (
+                _NUM_KEY_HEADS,
+                _NUM_VALUE_HEADS,
+                _KEY_HEAD_DIM,
+                _VALUE_HEAD_DIM,
+                _CONV_KERNEL,
+            )
+            and layer.hidden_size == 2048
+            and hasattr(layer, "in_proj_fused")
+            and _shape(layer.conv1d.weight) == (_CONV_DIM, _CONV_KERNEL, 1)
+            and _shape(layer.A_log) == (_NUM_VALUE_HEADS,)
+            and _shape(layer.dt_bias) == (_NUM_VALUE_HEADS,)
+            and _shape(layer.norm.weight) == (_VALUE_HEAD_DIM,)
+        )
+    except Exception:
+        return False
+
+
+def install_qwen35_fused_gdn_decode(model: Any) -> int:
+    """Enroll exact Qwen3.5-family GDN layers and return their count."""
+    if os.environ.get("RAPID_MLX_QWEN35_FUSED_GDN_DECODE", "1") == "0":
+        return 0
+    try:
+        from mlx_lm.models.qwen3_5 import GatedDeltaNet
+
+        layers = [
+            module
+            for _, module in model.named_modules()
+            if type(module) is GatedDeltaNet and _structurally_eligible(module)
+        ]
+    except Exception:
+        return 0
+    if not layers:
+        return 0
+    try:
+        threadgroup_y = probe_qwen35_fused_gdn_decode()
+    except Exception:
+        logger.warning(
+            "Qwen3.5 fused GDN probe raised; using stock decode",
+            exc_info=True,
+        )
+        return 0
+    if threadgroup_y is None:
+        logger.warning("Qwen3.5 fused GDN parity probe failed; using stock decode")
+        return 0
+    _patch_class(GatedDeltaNet)
+    for layer in layers:
+        setattr(layer, _TAG, True)
+        layer._rapid_qwen35_fused_gdn_threadgroup_y = threadgroup_y
+    logger.info("[qwen35_gdn] fused decode enrolled: %d GDN layers", len(layers))
+    return len(layers)
+
+
+__all__ = [
+    "install_qwen35_fused_gdn_decode",
+    "probe_qwen35_fused_gdn_decode",
+]


### PR DESCRIPTION
## User impact

Qwen3.6-35B-A3B single-user text decode becomes materially faster without changing model output. This collapses the causal convolution, Q/K normalization, recurrent state update, and gated RMSNorm in each eligible GatedDeltaNet layer into one qualified Metal launch.

## Why

Single-token decode is dominated by repeated small GatedDeltaNet launches. This specialization is the narrowest exact optimization because it removes those launch boundaries while retaining the stock projection and every unsupported serving shape.

## Measured result

On an M3 Ultra 256 GB with the immutable mlx-community/Qwen3.6-35B-A3B-4bit snapshot:

- median decode: **114.65 → 128.00 tok/s**
- median paired speedup: **1.117x (+11.7%)**
- stable paired runs: **6/6 improved**
- combined with the preceding gate/up, projection, and router work now on main: approximately **89 → 128 tok/s (+44%)**

A later run performed while another 8-bit model server occupied the GPU varied from 19–113 tok/s and was explicitly rejected as invalid. The checked-in benchmark now fails runs with more than 5% throughput coefficient of variation or fewer than 5/6 positive pairs.

## Quality and safety

- 32 sequential real-weight layer steps: bit-exact output, BF16 convolution cache, and FP32 recurrent state
- 20-token whole-model audit: every eligible layer and state transition exact
- five real chat-template tasks at up to 512 tokens: coding, creative writing, reasoning, compact JSON, and tool instruction all emitted identical token sequences with the optimization on and off
- install-time Metal parity probe checks output and both state slots across eight sequential steps
- exact model geometry, BF16, batch 1, and token width 1 only
- prefill, batching, masks, sharding, training, ragged caches, MTP verification, failed probes, and unknown layouts remain stock
- rollback: RAPID_MLX_QWEN35_FUSED_GDN_DECODE=0

## Validation

- ruff check and format: pass
- shrink-only mypy budget: pass, no growth
- PR-focused engine/Metal/regression suite: **151 passed**
- changed-lines coverage: **100% (150/150)**
- diff check: pass

## Scope

This PR is based directly on main after the router optimization landed. It does not change model catalog, downloads, public APIs, batching, prefill, speculative decoding, or checkpoint weights.
