### PR TITLE
docs(perf): qualify budgeted GLM-5.3 MTP

### DIFF
--- a/.agents/handoffs/vector-glm53-real-task-mtp.md
+++ b/.agents/handoffs/vector-glm53-real-task-mtp.md
@@ -6,7 +6,8 @@ Atlas, for runtime architecture and dependency integration.
 
 ## Branch
 
-`vector/glm53-real-eval`, based on `origin/main@e28f68c41`.
+`docs/glm53-budget-mtp-qualification`, based on
+`origin/main@a42e5fbf8`.
 
 ## Verified facts
 
@@ -19,26 +20,38 @@ Atlas, for runtime architecture and dependency integration.
   throughput improvement was 1.191x; the minimum task gain was 1.127x.
 - Comparable no-budget AR and MTP each passed only 4/6 because coding and
   creative writing exhausted 1,024 tokens in reasoning without a final answer.
-- Budgeted AR passed 6/6. The speculative server rejects `thinking_budget`
-  with HTTP 500 before generation.
+- Budgeted AR passed 6/6. A new positioned-target transaction passed 18/18
+  task runs with byte-identical reasoning and final output versus AR.
+- Three-run per-category MTP medians were 29.702, 31.746, 30.399, 30.617,
+  29.865, and 11.491 tok/s. Their median was 30.132 tok/s versus 26.322 for AR
+  (1.145x); every category improved.
+- Upstream mlx-vlm PR #2231 fixes strict quantized `lm_head` loading, #2232
+  provides the safe AR fallback, and #2233 keeps singleton greedy MTP active
+  through the thinking budget. Their CI and maintainer review remain upstream.
+- oMLX depth-2 reached a 31.664 tok/s median of category medians, 1.051x the
+  Rapid candidate, but passed only 6/6, 5/6, and 5/6 across repeated runs and
+  changed temperature-zero outputs. Rapid remained 18/18 and AR-exact.
 - MTP long-context peak Metal memory was 188.679 GB versus 184.141 GB for AR.
 
 ## Unresolved
 
 - The post-0.7 GLM runtime is not in the currently pinned release dependency.
-- Thinking-budget enforcement inside a speculative block needs transactional
-  truncation/rollback, or a safe request-scoped AR fallback.
+- Rapid still pins a released mlx-vlm version without these three upstream
+  changes. No release dependency is available to integrate yet.
+- A same-width oMLX depth-1 rerun is still needed on an idle Studio; the first
+  attempt was invalidated by a concurrent 37 GB CI inference server.
 - Creative prose still needs blind human review before any quality claim.
 
 ## Risks
 
-Removing the server guard without teaching the speculative batch about the
-forced thinking-end token can silently cross the budget boundary and corrupt
-the drafter/target cache transaction. High acceptance and exact no-budget
-output do not make that safe.
+Do not infer quality from oMLX's small throughput lead: its deeper/custom verify
+path changed greedy trajectories and failed the creative task twice. Do not
+vendor only part of the upstream three-PR chain; strict loading, safe fallback,
+and positioned rollback are separate necessary pieces.
 
 ## Next action
 
-Atlas should select the integration design after a tagged mlx-vlm release is
-available. Re-run this harness with per-task thinking budgets on the integrated
-server; require 6/6 exact-output parity before enabling GLM MTP experimentally.
+Atlas should update the Rapid dependency only after a tagged mlx-vlm release
+contains #2231, #2232, and #2233. Re-run the six-task harness through Rapid and
+require 18/18 across three runs with AR-exact reasoning/final output before
+enabling GLM MTP experimentally.

--- a/docs/engineering/performance/2026-09-12-glm53-real-task-mtp.md
+++ b/docs/engineering/performance/2026-09-12-glm53-real-task-mtp.md
@@ -9,11 +9,10 @@ Host: Studio, Apple M3 Ultra, 256 GiB, macOS 26.5.2 (25F84)
 ## Outcome
 
 The cached uniform-Q4 GLM-5.3 target and its target-matched Q4 MTP head have a
-real decode win, but the current post-0.7 mlx-vlm runtime is not yet eligible
-for Rapid production. On six deterministic tasks, block-total 2 MTP preserved
-both the reasoning and final response exactly and raised median decode
-throughput by 1.240x. Median end-to-end completion throughput rose 1.191x, and
-the slowest task still rose 1.127x.
+real decode win. On six deterministic tasks, block-total 2 MTP preserved both
+the reasoning and final response exactly and raised median decode throughput
+by 1.240x. Median end-to-end completion throughput rose 1.191x, and the slowest
+task still rose 1.127x.
 
 The release gate nevertheless failed. Without a thinking budget, coding and
 creative-writing prompts spent the complete 1,024-token allowance in reasoning
@@ -25,10 +24,11 @@ the same request with HTTP 500:
 thinking_budget is not supported with speculative decoding in the server.
 ```
 
-This is a product-quality blocker, not benchmark noise. Do not trade complete
-answers for a higher token rate, and do not enable GLM MTP by default until the
-speculative transaction can enforce the thinking boundary or safely fall back
-to AR for that request.
+This was a product-quality blocker, not benchmark noise. A follow-up
+transactional implementation now passes the budgeted gate, preserves every AR
+byte, and keeps a measured 1.145x median task-throughput gain. It is proposed
+upstream in mlx-vlm PRs #2231, #2232, and #2233; it is not Rapid production
+behavior until those changes are released and Rapid updates its dependency.
 
 ## Environment
 
@@ -83,6 +83,75 @@ The first coding control with a 512-token maximum was truncated mid-function.
 The harness therefore treats `finish_reason=length` and incomplete executable
 output as failures even when the visible prefix appears correct.
 
+## Budgeted speculative follow-up
+
+The follow-up implementation snapshots `ThinkingBudgetCriteria` by absolute
+output position and restores it after a draft rejection. A forced
+`\n</think>` therefore participates in the same target/drafter transaction as
+ordinary tokens. Only singleton greedy MTP takes this path; sampled requests
+and multi-row budget cohorts retain the complete-request AR fallback from
+mlx-vlm PR #2232.
+
+Candidate source: mlx-vlm commit
+`f45792a96b5ae0a62c2a474977910e26e6877315` (PR #2233), stacked on safe-fallback
+commit `acc638ab9bf777dbae8a4c99f8c70cdfd5457198` (PR #2232). The strict
+quantized `lm_head` loader is PR #2231. Target, Q4 sidecar, host, temperature,
+task prompts, budgets, and 1,024-token ceiling were unchanged from the AR
+control. The per-task budgets were 256, 128, 192, 96, 192, and 128 tokens in
+table order.
+
+Three independent warm runs passed all six tasks. All 18 reasoning strings and
+all 18 final answers were byte-identical to budgeted AR.
+
+| Task | MTP run 1 | MTP run 2 | MTP run 3 | MTP median | AR | Ratio |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Coding, hidden tests | 33.249 | 29.702 | 28.741 | 29.702 | 27.788 | 1.069x |
+| Closed-book knowledge | 31.914 | 31.746 | 31.703 | 31.746 | 26.572 | 1.195x |
+| Multi-step math | 30.399 | 30.419 | 30.247 | 30.399 | 26.072 | 1.166x |
+| Instruction following | 30.541 | 30.649 | 30.617 | 30.617 | 24.996 | 1.225x |
+| Creative constraints | 29.759 | 29.978 | 29.865 | 29.865 | 27.227 | 1.097x |
+| Long-context contract | 11.485 | 11.491 | 11.509 | 11.491 | 10.025 | 1.146x |
+
+The median of the six per-task medians was 30.132 tok/s versus 26.322 tok/s for
+AR, a 1.145x gain. Every category improved; the range was 1.069x to 1.225x.
+Peak Metal memory was 188.674 GB.
+
+The relevant regression set completed with 1,374 passed and 1 skipped. It
+covers forced-close rollback, reset of a pending forced token, sampled and
+multi-row fallback, and single-projection positioned target sampling.
+
+### Current oMLX comparison
+
+oMLX `0.7.0.dev2` at commit `b390b31` was run from a clean local server against
+the same target checkpoint, prompts, per-task budgets, temperature, and output
+limits. Native Lightning MTP was capped at draft depth 2. That is a useful
+best-runtime comparison, but not a same-width comparison: oMLX can draft two
+tokens plus a verifier bonus, while the qualified Rapid candidate uses one
+draft token plus a bonus.
+
+| Task | oMLX run 1 | oMLX run 2 | oMLX run 3 | oMLX median | Task passes |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Coding, hidden tests | 34.239 | 34.191 | 34.292 | 34.239 | 3/3 |
+| Closed-book knowledge | 35.002 | 34.881 | 32.615 | 34.881 | 3/3 |
+| Multi-step math | 32.768 | 32.914 | 32.799 | 32.799 | 3/3 |
+| Instruction following | 30.243 | 30.530 | 30.619 | 30.530 | 3/3 |
+| Creative constraints | 29.500 | 29.305 | 30.715 | 29.500 | 1/3 |
+| Long-context contract | 12.283 | 11.847 | 11.829 | 11.847 | 3/3 |
+
+The median of oMLX's per-task medians was 31.664 tok/s, 1.051x the Rapid
+candidate. That number is not a quality-qualified win: oMLX passed 6/6, 5/6,
+and 5/6 across the three runs. Its creative score fell to 0.833 and then 0.667;
+the last run exhausted all 1,024 tokens. Despite temperature zero, every
+reasoning string differed from AR and three of six final answers differed in
+the first run. Output lengths also changed between repeated oMLX runs. Its log
+showed adaptive depth changes and a custom M=2..6 verify-QMM path; this report
+does not claim which one caused the trajectory drift.
+
+A same-width oMLX depth-1 run was attempted, but the Studio CI runner started a
+37 GB Qwen3.6-35B-8bit server during the suite. Throughput collapsed mid-run,
+so the complete artifact was marked contended and excluded rather than folded
+into the comparison.
+
 ## Reproduction
 
 Start post-0.7 mlx-vlm once without a drafter and once with the target-matched
@@ -108,6 +177,24 @@ python scripts/benchmark_glm53_real_tasks.py \
   /private/tmp/glm53-real-mtp.json
 ```
 
+The budgeted positioned-MTP server used:
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+PYTHONPATH=/path/to/mlx-vlm-at-f45792a \
+python -m mlx_vlm.server \
+  --model /path/to/immutable/target/snapshot \
+  --draft-model /path/to/target-matched-q4-mtp-sidecar \
+  --draft-kind mtp --draft-block-size 2 \
+  --host 127.0.0.1 --port 8465 --max-tokens 1024 --enable-thinking
+
+python scripts/benchmark_glm53_real_tasks.py \
+  --base-url http://127.0.0.1:8465/v1 \
+  --model /path/to/immutable/target/snapshot \
+  --label mtp-budget-positioned \
+  --output /private/tmp/glm53-real-mtp-budget-positioned.json
+```
+
 The comparator fails unless every baseline and candidate task passes, complete
 reasoning and output are identical, quality does not regress, and every task
 retains at least 95% of baseline end-to-end completion throughput.
@@ -119,9 +206,10 @@ file-size, process-count, descriptor, and wall-time limits.
 
 ## Next engineering gate
 
-Supporting a forced thinking-end token inside a speculative block is not a
-one-line removal of the server guard. A block can already have drafted and
-verified tokens beyond the budget boundary; forcing the next token requires a
-transactionally correct truncate/rollback or a request-scoped transition to AR.
-Atlas should choose one of these designs when the tagged GLM MTP runtime is
-integrated. Until then the alias remains fail-closed.
+The transaction and safe fallback now exist upstream. Atlas should not vendor a
+partial copy or point a release at an untagged Git commit. Once mlx-vlm ships a
+release containing #2231, #2232, and #2233, update Rapid's pin, run this exact
+six-task gate through the Rapid server, and only then enable GLM MTP. The next
+performance investigation should target exact verify/backbone dispatch cost;
+do not adopt oMLX's deeper/custom-QMM path without first recovering repeated
+temperature-zero determinism and 18/18 quality.

--- a/docs/engineering/performance/README.md
+++ b/docs/engineering/performance/README.md
@@ -7,6 +7,7 @@ summary statistics, and limitations.
 ## Reports
 
 - [Qwen3.6-35B-A3B fused MoE router qualification](2026-09-12-qwen36-35b-fused-router.md)
+- [GLM-5.3 real-task MTP qualification](2026-09-12-glm53-real-task-mtp.md)
 - [DeepSeek V4.1 Flash Engram SSD offload qualification](2026-09-11-deepseek-v41-engram-offload.md)
 - [Qwen3.8 27B MTP FP16 checkpoint qualification](2026-09-07-qwen38-mtp-fp16.md)
 - [Qwen4 fp32-input fast RMSNorm qualification](2026-09-06-qwen4-fast-rmsnorm.md)


### PR DESCRIPTION
## Why

The previous release gate stopped at a reproducible HTTP 500 for budgeted speculative requests, so release owners need the resolved quality/performance evidence and remaining dependency boundary in one durable place before enabling GLM-5.3 MTP.

## Outcome

Records the completed GLM-5.3 thinking-budget MTP qualification and the current release boundary. This is documentation/handoff only; it does not enable an untagged dependency in production.

## New measured result

M3 Ultra 256 GB, same cached uniform-Q4 target and target-matched Q4 head, batch one, temperature 0, per-task thinking budgets, max 1,024 tokens:

- positioned-budget MTP passed 18/18 tasks across three warm runs
- all reasoning and final output was byte-identical to budgeted AR
- median of per-category medians: 30.132 vs 26.322 tok/s, **+14.5%**
- every category improved: +6.9% to +22.5%
- peak Metal memory: 188.674 GB

The report includes every per-run category number, immutable model/runtime revisions, the exact server/harness commands, safety fallbacks, and upstream dependency chain:

- Blaizzy/mlx-vlm#2231: strict quantized `lm_head` loading
- Blaizzy/mlx-vlm#2232: safe AR fallback for unsupported budget cohorts
- Blaizzy/mlx-vlm#2233: singleton greedy positioned-budget MTP

## Competitor dogfood

The same suite was run three times on oMLX 0.7.0.dev2 with native depth-2 MTP. Its category median was 31.664 tok/s (5.1% above the Rapid candidate), but it passed 6/6, 5/6, and 5/6; the last creative task exhausted 1,024 tokens. Temperature-zero reasoning changed on every task and output lengths changed between runs. The report therefore keeps the speed result but does not call it a quality-qualified win.

A same-width oMLX depth-1 attempt was discarded after a concurrent 37 GB CI model server contaminated the run.

## Release decision

Keep Rapid fail-closed until a tagged mlx-vlm release contains all three upstream PRs. Then re-run the same gate through Rapid and require 18/18 plus AR-exact output before experimental enablement.

## Verification

- `python3 -m pytest -q tests/test_benchmark_glm53_real_tasks.py`: 9 passed
- `git diff --check`
- docs/handoff diff reviewed for machine paths, secrets, and unsupported claims
